### PR TITLE
Release v1.7.0: Strict Deprecation Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-## [v1.6.0] - 2026-XX-XX
+## [v1.7.0] - 2026-01-09
+
+### 🛡️ Strict Deprecation Mode
+- **Refined Deprecations**: Formal deprecation of v1.x constraints syntax.
+- **Strict Mode**: New `--deny-deprecations` flag (and `ASSAY_STRICT_DEPRECATIONS=1` env var) to enforce strict compliance in CI.
+- **Migration Guide**: New detailed [v1-to-v2 Migration Guide](docs/migration/v1-to-v2.md).
+- **Startup Warnings**: Server/Proxy now emit clear warnings when loading legacy policies.
+
+### Added
+- **CLI**: `assay policy validate --deny-deprecations` (and for `run`/`wrap` modes).
+- **Docs**: Comprehensive `docs/migration/v1-to-v2.md`.
+
+## [v1.6.0] - 2026-01-09
 
 ### Added
 - **Policy v2.0 (JSON Schema)**: Official support for JSON Schema constraints (`schemas:`) replacing regex loops.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write  # required for SARIF upload
+      security-events: write
 
     steps:
       - uses: actions/checkout@v4
@@ -80,18 +80,13 @@ jobs:
         run: |
           curl -fsSL https://getassay.dev/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+          # Optional: pin version if supported by installer
 
-          # Optional: pin a specific version for stable CI
-          # assay --version
-          # If your installer supports version pinning, use it here.
-
-      # Fast check: policy syntax + schema compilation
-      - name: Validate policy file
+      - name: Validate policy file (syntax + schema compile)
         run: |
           # Adjust to your policy path:
-          assay policy validate --input policy.yaml
+          assay policy validate --input policy.yaml --deny-deprecations
 
-      # Full check: emits SARIF for GitHub Code Scanning
       - name: Assay validate (SARIF)
         run: |
           assay validate --format sarif --output results.sarif
@@ -103,8 +98,7 @@ jobs:
         with:
           sarif_file: results.sarif
 
-      # Hard fail for PR gating (human-readable output)
-      - name: Fail on issues
+      - name: Fail on issues (PR gating)
         run: |
           assay validate --format text
 ```
@@ -146,22 +140,18 @@ constraints:
 
 ## Migration to v2.0 (JSON Schema)
 
-Assay v1.6.0 introduces JSON Schema based policies for stricter validation.
+Assay v1.7.0 formally deprecates the v1.x constraints syntax in favor of standard JSON Schema.
 
-1. **Auto-migrate (Preview)**:
-   ```bash
-   assay policy migrate --input v1-policy.yaml --dry-run
-   ```
-2. **Apply migration**:
+1. **Auto-migrate**:
    ```bash
    assay policy migrate --input v1-policy.yaml
    ```
-3. **Verify**:
+2. **Verify usage**:
    ```bash
-   assay validate --input v1-policy.yaml
+   assay policy validate --input v1-policy.yaml --deny-deprecations
    ```
 
-See `docs/policies.md` for full syntax reference.
+See the full [Migration Guide](docs/migration/v1-to-v2.md) for details.
 
 ## Documentation
 

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -22,11 +22,11 @@ serde_json = "1"
 clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "io-std", "io-util", "fs"] }
-assay-core = { path = "../assay-core", version = "1.6.0" }
+assay-core = { path = "../assay-core", version = "1.7.0" }
 dialoguer = "0.11"
 similar = "2"
 serde_yaml = "0.9"
-assay-metrics = { path = "../assay-metrics", version = "1.6.0" }
+assay-metrics = { path = "../assay-metrics", version = "1.7.0" }
 chrono = "0.4.42"
 dirs = "5.0"
 

--- a/crates/assay-cli/src/cli/args.rs
+++ b/crates/assay-cli/src/cli/args.rs
@@ -64,6 +64,10 @@ pub struct ValidateArgs {
 
     #[arg(long)]
     pub output: Option<std::path::PathBuf>,
+
+    /// Fail if deprecated v1 policy format is detected
+    #[arg(long)]
+    pub deny_deprecations: bool,
 }
 
 #[derive(Parser, Clone)]
@@ -224,6 +228,10 @@ pub struct RunArgs {
     /// strict replay mode: use trace-file as truth, forbid network, auto-ingest to DB
     #[arg(long)]
     pub replay_strict: bool,
+
+    /// Fail if deprecated v1 policy format is detected
+    #[arg(long)]
+    pub deny_deprecations: bool,
 }
 
 #[derive(Parser, Clone)]
@@ -293,6 +301,10 @@ pub struct CiArgs {
     /// strict replay mode: use trace-file as truth, forbid network, auto-ingest to DB
     #[arg(long)]
     pub replay_strict: bool,
+
+    /// Fail if deprecated v1 policy format is detected
+    #[arg(long)]
+    pub deny_deprecations: bool,
 }
 
 #[derive(clap::Args, Clone)]
@@ -651,6 +663,10 @@ pub struct McpWrapArgs {
     /// Command to wrap (use -- to separate args)
     #[arg(required = true, last = true, allow_hyphen_values = true)]
     pub command: Vec<String>,
+
+    /// Fail if deprecated v1 policy format is detected
+    #[arg(long)]
+    pub deny_deprecations: bool,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -718,6 +734,10 @@ pub struct PolicyValidateArgs {
     /// Policy file path (YAML)
     #[arg(short, long)]
     pub input: PathBuf,
+
+    /// Fail if deprecated v1 policy format is detected
+    #[arg(long)]
+    pub deny_deprecations: bool,
 }
 
 #[derive(clap::Args, Clone, Debug)]

--- a/crates/assay-cli/src/cli/commands/mcp.rs
+++ b/crates/assay-cli/src/cli/commands/mcp.rs
@@ -14,6 +14,10 @@ pub async fn run(args: McpArgs) -> anyhow::Result<i32> {
 }
 
 async fn cmd_wrap(args: McpWrapArgs) -> anyhow::Result<i32> {
+    if args.deny_deprecations {
+        std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
+    }
+
     if args.command.is_empty() {
         anyhow::bail!("No command specified. Usage: assay mcp wrap -- <cmd> [args]");
     }

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -65,6 +65,9 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
 }
 
 async fn cmd_run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32> {
+    if args.deny_deprecations {
+        std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
+    }
     ensure_parent_dir(&args.db)?;
 
     // Argument validation
@@ -136,6 +139,9 @@ async fn cmd_run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32> {
 }
 
 async fn cmd_ci(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> {
+    if args.deny_deprecations {
+        std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
+    }
     ensure_parent_dir(&args.db)?;
 
     // Argument Validation

--- a/crates/assay-cli/src/cli/commands/policy/validate.rs
+++ b/crates/assay-cli/src/cli/commands/policy/validate.rs
@@ -3,6 +3,10 @@ use crate::cli::args::PolicyValidateArgs;
 use crate::cli::commands::exit_codes;
 
 pub async fn run(args: PolicyValidateArgs) -> Result<i32> {
+    if args.deny_deprecations {
+        std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
+    }
+
     // Let core handle parsing + auto-migration warnings.
     let policy = assay_core::mcp::policy::McpPolicy::from_file(&args.input)
         .with_context(|| format!("failed to load policy {}", args.input.display()))?;

--- a/crates/assay-cli/src/cli/commands/validate.rs
+++ b/crates/assay-cli/src/cli/commands/validate.rs
@@ -8,6 +8,10 @@ use crate::cli::commands::exit_codes;
 use crate::cli::util::{decide_exit, infer_policy_path, normalize_severity};
 
 pub async fn run(args: ValidateArgs, legacy_mode: bool) -> anyhow::Result<i32> {
+    if args.deny_deprecations {
+        std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
+    }
+
     // 1. Load Config
     let cfg = match load_config(&args.config, legacy_mode, true) {
         Ok(c) => c,

--- a/crates/assay-core/Cargo.toml
+++ b/crates/assay-core/Cargo.toml
@@ -32,4 +32,5 @@ tempfile = "3.23.0"
 
 [dev-dependencies]
 tempfile = "3.23.0"
+serial_test = "3"
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/crates/assay-core/src/mcp/policy.rs
+++ b/crates/assay-core/src/mcp/policy.rs
@@ -227,7 +227,6 @@ impl McpPolicy {
             policy.migrate_constraints_to_schemas();
         }
 
-
         Ok(policy)
     }
 

--- a/crates/assay-core/src/mcp/tests.rs
+++ b/crates/assay-core/src/mcp/tests.rs
@@ -190,3 +190,33 @@ fn test_defs_resolution() {
         panic!("Expected Deny for ref violation");
     }
 }
+
+#[test]
+fn test_is_v1_format() {
+    // V1 Explicit
+    let v1 = McpPolicy {
+        version: "1.0".to_string(),
+        ..Default::default()
+    };
+    assert!(v1.is_v1_format());
+
+    // V1 Implied by constraints
+    let v1_implied = McpPolicy {
+        constraints: vec![ConstraintRule {
+            tool: "t".into(),
+            params: std::collections::BTreeMap::new(),
+        }],
+        ..Default::default()
+    };
+    assert!(v1_implied.is_v1_format());
+
+    // V2
+    let v2 = McpPolicy {
+        version: "2.0".to_string(),
+        ..Default::default()
+    };
+    assert!(!v2.is_v1_format());
+
+    let empty = McpPolicy::default();
+    assert!(!empty.is_v1_format());
+}

--- a/crates/assay-mcp-server/Cargo.toml
+++ b/crates/assay-mcp-server/Cargo.toml
@@ -17,8 +17,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 tokio = { version = "1.0", features = ["full", "fs"] }
-assay-core = { path = "../assay-core", version = "1.6.0" }
-assay-metrics = { path = "../assay-metrics", version = "1.6.0" }
+assay-core = { path = "../assay-core", version = "1.7.0" }
+assay-metrics = { path = "../assay-metrics", version = "1.7.0" }
 sha2 = "0.10"
 hex = "0.4"
 moka = { version = "0.12", features = ["sync"] }

--- a/crates/assay-metrics/Cargo.toml
+++ b/crates/assay-metrics/Cargo.toml
@@ -11,7 +11,7 @@ description = "Metrics library for Assay"
 anyhow = "1"
 async-trait = "0.1"
 serde_json = "1"
-assay-core = { path = "../assay-core", version = "1.6.0" }
+assay-core = { path = "../assay-core", version = "1.7.0" }
 regex = "1"
 jsonschema = "0.19"
 serde_yaml = "0.9"

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -47,30 +47,35 @@ constraints:
 ### v2.0 (New)
 
 ```yaml
-version: "2.0-schema"
+```yaml
+version: "2.0"
 tools:
   deny: ["exec_command"]
-  arg_constraints:
-    read_file:
+schemas:
+  read_file:
+    type: object
+    additionalProperties: false
+    properties:
       path:
         type: string
         pattern: "^/data/.*"
+    required: ["path"]
 ```
 
 Alternatively, you can provide a full schema for the tool arguments:
 
 ```yaml
-version: "2.0-schema"
-tools:
-  arg_constraints:
-    read_file:
-      type: object
-      properties:
-        path:
-          type: string
-          pattern: "^/data/.*"
-      required: ["path"]
-      additionalProperties: false
+```yaml
+version: "2.0"
+schemas:
+  read_file:
+    type: object
+    properties:
+      path:
+        type: string
+        pattern: "^/data/.*"
+    required: ["path"]
+    additionalProperties: false
 ```
 
 ## Strict Mode (CI/CD)

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -1,0 +1,91 @@
+# Migrating from v1 to v2 Policies
+
+Assay v2.0 introduces a new, standardized policy format based on [JSON Schema](https://json-schema.org/). This replaces the ad-hoc `constraints` syntax used in v1.x.
+
+**Status:**
+- **v1.6.0**: v2 format support introduced.
+- **v1.7.0**: v1 format is deprecated. Startup warnings are emitted. Strict mode available.
+- **v2.0.0**: v1 format support will be removed.
+
+## Improving Security & Standards
+
+The v1 format used regex-based constraints which were simple but limited. They couldn't easily handle nested objects, arrays, or type validation.
+The v2 format leverages full JSON Schema, allowing you to:
+- Validate complex nested argument structures.
+- Enforce types (string, integer, array).
+- Use standard validation keywords (`minLength`, `pattern`, `enum`).
+- Benefit from the vast ecosystem of JSON Schema tools.
+
+## Migration Tool
+
+Assay includes a built-in migration tool to automatically convert your existing policies.
+
+```bash
+# Preview changes (dry run)
+assay policy migrate --input policy.yaml --dry-run
+
+# Apply migration (overwrites input file)
+assay policy migrate --input policy.yaml
+```
+
+## Manual Migration Guide
+
+If you prefer to migrate manually, here is how the syntax maps.
+
+### v1.x (Legacy)
+
+```yaml
+version: "1.0"
+deny: ["exec_command"]
+constraints:
+  - tool: read_file
+    params:
+      path:
+        matches: "^/data/.*"
+```
+
+### v2.0 (New)
+
+```yaml
+version: "2.0-schema"
+tools:
+  deny: ["exec_command"]
+  arg_constraints:
+    read_file:
+      path:
+        type: string
+        pattern: "^/data/.*"
+```
+
+Alternatively, you can provide a full schema for the tool arguments:
+
+```yaml
+version: "2.0-schema"
+tools:
+  arg_constraints:
+    read_file:
+      type: object
+      properties:
+        path:
+          type: string
+          pattern: "^/data/.*"
+      required: ["path"]
+      additionalProperties: false
+```
+
+## Strict Mode (CI/CD)
+
+To ensure no new v1 policies are introduced into your codebase, enabling strict mode in your CI pipeline is recommended.
+
+**CLI Flag:**
+```bash
+assay policy validate --deny-deprecations --input policy.yaml
+```
+
+**Environment Variable:**
+```bash
+export ASSAY_STRICT_DEPRECATIONS=1
+assay run ...
+```
+
+This will cause Assay to exit with an error if any legacy v1 policy constructs are detected.

--- a/examples/demo/filesystem-mcp-hardened-fixed.yaml
+++ b/examples/demo/filesystem-mcp-hardened-fixed.yaml
@@ -1,39 +1,46 @@
-# Assay MCP Policy: Filesystem MCP Server - Hardened (Corrected for v1.5.1)
-version: "1.0"
-name: "filesystem-mcp-hardened"
-metadata:
-  description: "Defense-in-depth for official Filesystem MCP - addresses CVE-2025-53109/53110"
-  original_author: "Jan 2026 Policy Pack"
-
+version: '2.0'
+name: filesystem-mcp-hardened
 tools:
   allow:
-    - read_file
-    - read_multiple_files
-    - list_directory
-    - search_files
-    - get_file_info
-    - list_allowed_directories
-
+  - read_file
+  - read_multiple_files
+  - list_directory
+  - search_files
+  - get_file_info
+  - list_allowed_directories
   deny:
-    - write_file
-    - create_directory
-    - move_file
-    - create_symlink
-    - read_symlink
-
-constraints:
-  - tool: read_file
-    params:
+  - write_file
+  - create_directory
+  - move_file
+  - create_symlink
+  - read_symlink
+allow: null
+deny: null
+schemas:
+  list_directory:
+    additionalProperties: true
+    properties:
       path:
-        matches: "^(/workspace/|/home/[^/]+/projects/|/Users/[^/]+/Developer/|/tmp/assay-).*"
-
-  - tool: list_directory
-    params:
+        minLength: 1
+        pattern: ^(/workspace|/home/[^/]+/projects|/Users/[^/]+/Developer).*
+        type: string
+    required:
+    - path
+    type: object
+  read_file:
+    additionalProperties: true
+    properties:
       path:
-        matches: "^(/workspace|/home/[^/]+/projects|/Users/[^/]+/Developer).*"
-
-# NOTE: 'audit' field is not supported in policy.yaml (configure in runner).
-# NOTE: Granular limits (per-tool) are not yet supported in engine.
+        minLength: 1
+        pattern: ^(/workspace/|/home/[^/]+/projects/|/Users/[^/]+/Developer/|/tmp/assay-).*
+        type: string
+    required:
+    - path
+    type: object
+constraints: []
+enforcement:
+  unconstrained_tools: warn
 limits:
   max_requests_total: 200
-  # max_calls_per_tool: 50  <-- Unsupported
+  max_tool_calls_total: null
+signatures: null

--- a/examples/demo/safe-policy.yaml
+++ b/examples/demo/safe-policy.yaml
@@ -1,18 +1,27 @@
-version: "1.0"
-name: "safe-demo"
-
-# FIXED: This config blocks RCE and restricts file access.
-
-allow:
-  - "*"
-
-deny:
-  - "exec"
-  - "shell"
-  - "spawn"
-
-constraints:
-  - tool: "read_file"
-    params:
+version: '2.0'
+name: safe-demo
+tools:
+  allow:
+  - '*'
+  deny:
+  - exec
+  - shell
+  - spawn
+allow: null
+deny: null
+schemas:
+  read_file:
+    additionalProperties: true
+    properties:
       path:
-        matches: "^/app/.*"
+        minLength: 1
+        pattern: ^/app/.*
+        type: string
+    required:
+    - path
+    type: object
+constraints: []
+enforcement:
+  unconstrained_tools: warn
+limits: null
+signatures: null

--- a/examples/policies/dev.yaml
+++ b/examples/policies/dev.yaml
@@ -1,28 +1,32 @@
-version: "1.0"
-name: "mcp-dev"
-
-# Setup: Permissive but sane.
-# Use this for local development.
-
-allow:
-  - "*"
-
-deny:
-  # RCE Prevention (Always block these)
-  - "exec"
-  - "shell"
-  - "bash"
-  - "cmd"
-  - "powershell"
-  - "spawn"
-  - "python_sandbox"
-
-constraints:
-  # Basic containment to project root
-  - tool: "read_file"
-    params:
+version: '2.0'
+name: mcp-dev
+tools:
+  allow:
+  - '*'
+  deny:
+  - exec
+  - shell
+  - bash
+  - cmd
+  - powershell
+  - spawn
+  - python_sandbox
+allow: null
+deny: null
+schemas:
+  read_file:
+    additionalProperties: true
+    properties:
       path:
-        matches: "^/app/.*|^/data/.*|^/workspace/.*"
-
+        minLength: 1
+        pattern: ^/app/.*|^/data/.*|^/workspace/.*
+        type: string
+    required:
+    - path
+    type: object
+constraints: []
+enforcement:
+  unconstrained_tools: warn
+limits: null
 signatures:
   check_descriptions: true

--- a/examples/policies/filesystem-readonly.yaml
+++ b/examples/policies/filesystem-readonly.yaml
@@ -1,29 +1,41 @@
-version: "1.0"
-name: "filesystem-readonly"
-
-# Strategy: Allow everything, but lock down the dangerous parts.
-
-deny:
-  # RCE Prevention
-  - "exec"
-  - "shell"
-  - "bash"
-  - "spawn"
-
-  # Mutation Prevention (Read-Only)
-  - "write_file"
-  - "append_file"
-  - "delete_file"
-  - "move_file"
-
-constraints:
-  # Scope validation: Only allow reads in safe directories
-  - tool: "read_file"
-    params:
+version: '2.0'
+name: filesystem-readonly
+tools:
+  allow: null
+  deny:
+  - exec
+  - shell
+  - bash
+  - spawn
+  - write_file
+  - append_file
+  - delete_file
+  - move_file
+allow: null
+deny: null
+schemas:
+  list_dir:
+    additionalProperties: true
+    properties:
       path:
-        matches: "^/app/.*|^/data/.*"
-
-  - tool: "list_dir"
-    params:
+        minLength: 1
+        pattern: ^/app/.*|^/data/.*
+        type: string
+    required:
+    - path
+    type: object
+  read_file:
+    additionalProperties: true
+    properties:
       path:
-        matches: "^/app/.*|^/data/.*"
+        minLength: 1
+        pattern: ^/app/.*|^/data/.*
+        type: string
+    required:
+    - path
+    type: object
+constraints: []
+enforcement:
+  unconstrained_tools: warn
+limits: null
+signatures: null

--- a/examples/policies/github-minimal.yaml
+++ b/examples/policies/github-minimal.yaml
@@ -1,32 +1,34 @@
-version: "1.0"
-name: "github-minimal"
-
-# Strategy: Allowlist functionality. Implicitly blocks everything else.
-
-allow:
-  # Core Utils
-  - "get_time"
-  - "echo"
-
-  # GitHub Read Operations
-  - "search_issues"
-  - "list_pull_requests"
-  - "get_issue"
-  - "get_pull_request"
-
-  # GitHub Write Operations (Controlled)
-  - "create_issue"
-  - "create_issue_comment"
-
-deny:
-  # Explicitly block high-risk GitHub actions even if added to allowlist by accident
-  - "delete_repo"
-  - "create_repo"
-  - "push"
-
-constraints:
-  # Prevent massive automated commenting
-  - tool: "create_issue_comment"
-    params:
+version: '2.0'
+name: github-minimal
+tools:
+  allow:
+  - get_time
+  - echo
+  - search_issues
+  - list_pull_requests
+  - get_issue
+  - get_pull_request
+  - create_issue
+  - create_issue_comment
+  deny:
+  - delete_repo
+  - create_repo
+  - push
+allow: null
+deny: null
+schemas:
+  create_issue_comment:
+    additionalProperties: true
+    properties:
       body:
-        matches: "^.{1,1000}$" # Max 1000 chars
+        minLength: 1
+        pattern: ^.{1,1000}$
+        type: string
+    required:
+    - body
+    type: object
+constraints: []
+enforcement:
+  unconstrained_tools: warn
+limits: null
+signatures: null

--- a/examples/policies/hardened.yaml
+++ b/examples/policies/hardened.yaml
@@ -1,36 +1,44 @@
-version: "1.0"
-name: "mcp-hardened"
-
-# Setup: Allowlist only. Strict containment.
-# Use this for CI or Production Agent Gates.
-
-allow:
-  # Essential Tools Only (Explicit Allow)
-  - "read_file"
-  - "list_directory"
-  - "search_files"
-  - "get_time"
-
-deny:
-  # Explicit deny for high-risk categories (redundant but safe)
-  - "exec*"
-  - "shell*"
-  - "write_file"
-  - "delete_file"
-  - "replace_file"
-  - "move_file"
-
-constraints:
-  # Strict containment (No /workspace root access)
-  - tool: "read_file"
-    params:
+version: '2.0'
+name: mcp-hardened
+tools:
+  allow:
+  - read_file
+  - list_directory
+  - search_files
+  - get_time
+  deny:
+  - exec*
+  - shell*
+  - write_file
+  - delete_file
+  - replace_file
+  - move_file
+allow: null
+deny: null
+schemas:
+  list_directory:
+    additionalProperties: true
+    properties:
       path:
-        matches: "^/app/.*|^/data/.*"
-
-  - tool: "list_directory"
-    params:
+        minLength: 1
+        pattern: ^/app/.*|^/data/.*
+        type: string
+    required:
+    - path
+    type: object
+  read_file:
+    additionalProperties: true
+    properties:
       path:
-        matches: "^/app/.*|^/data/.*"
-
+        minLength: 1
+        pattern: ^/app/.*|^/data/.*
+        type: string
+    required:
+    - path
+    type: object
+constraints: []
+enforcement:
+  unconstrained_tools: warn
+limits: null
 signatures:
   check_descriptions: true


### PR DESCRIPTION
## Summary
This PR implements the v1.7.0 'Deprecation Polish' release.

### Features
- **Strict Deprecation Mode**: Added `--deny-deprecations` flag and `ASSAY_STRICT_DEPRECATIONS=1` env var.
- **Core Improvements**: One-time warning emission for v1 policies.
- **Documentation**: New `docs/migration/v1-to-v2.md` guide.
- **Migration**: Automated migration of all `examples/` to v2.0 JSON Schema format.

### Verification
- Full test suite passed (`cargo test --workspace`).
- Manual verification of strict mode behavior (fails on v1, passes on v2).
- CI/CD workflow updated.