### PR TITLE
feat(phase5): SOTA Phase 5 Hardener (Process Tree & Forensics)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
           sudo apt-get install -y mold clang
 
       - name: Sccache
+        id: sccache
+        continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Rust cache
@@ -52,6 +54,13 @@ jobs:
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
+
+      - name: Disable Sccache if unavailable
+        if: steps.sccache.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=" >> $GITHUB_ENV
 
       - name: Configure Linker (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install mold (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold clang
+
       - name: Sccache
         uses: mozilla-actions/sccache-action@v0.0.6
 
@@ -45,6 +52,12 @@ jobs:
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
+
+      - name: Configure Linker (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
 
       # Optimized single-pass test (builds implicitly)
       - name: Test Workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,23 +29,26 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             . -> target
+          cache-on-failure: true
 
-      # Exclude assay-ebpf to prevent host-target mismatch errors
-      - name: Build and Test Workspace
+      - name: Configure Environment
+        shell: bash
         run: |
-          cargo build --workspace --exclude assay-ebpf --exclude assay-it
-          cargo test --workspace --exclude assay-ebpf --exclude assay-it
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
 
-      - name: Test assay-cli
-        run: cargo test -p assay-cli
-
-      - name: Test assay-mcp-server
-        run: cargo test -p assay-mcp-server
+      # Optimized single-pass test (builds implicitly)
+      - name: Test Workspace
+        run: cargo test --locked --workspace --exclude assay-ebpf --exclude assay-it
 
   ebpf-smoke:
     name: eBPF monitor smoke (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
           sudo apt-get install -y mold clang
 
       - name: Sccache
-        id: sccache
-        continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Rust cache
@@ -46,21 +44,16 @@ jobs:
         with:
           workspaces: |
             . -> target
+          cache-directories: |
+            ~/.sccache
           cache-on-failure: true
 
       - name: Configure Environment
         shell: bash
         run: |
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "SCCACHE_DIR=$HOME/.sccache" >> $GITHUB_ENV
           echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
-
-      - name: Disable Sccache if unavailable
-        if: steps.sccache.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "SCCACHE_GHA_ENABLED=false" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=" >> $GITHUB_ENV
 
       - name: Configure Linker (Linux)
         if: runner.os == 'Linux'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "globset",
  "humantime",
  "libc",
+ "nix",
  "predicates",
  "regex",
  "serde",
@@ -137,18 +138,25 @@ dependencies = [
 [[package]]
 name = "assay-common"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "assay-core"
 version = "1.9.0"
 dependencies = [
  "anyhow",
+ "assay-common",
  "async-trait",
  "chrono",
  "dirs",
  "globset",
  "hex",
  "jsonschema",
+ "libc",
  "md5",
  "nix",
  "procfs",
@@ -231,6 +239,7 @@ dependencies = [
 name = "assay-monitor"
 version = "1.8.0"
 dependencies = [
+ "anyhow",
  "assay-common",
  "aya",
  "thiserror 1.0.69",

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -37,6 +37,7 @@ tokio-stream = "0.1"
 futures = "0.3"
 globset = "0.4"
 libc = "0.2"
+nix = { version = "0.27", features = ["signal", "process"] }
 
 
 

--- a/crates/assay-cli/src/cgroup.rs
+++ b/crates/assay-cli/src/cgroup.rs
@@ -1,0 +1,187 @@
+use std::path::{Path, PathBuf};
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::time::{SystemTime, UNIX_EPOCH};
+use anyhow::{Context, Result, anyhow};
+
+/// Manages Cgroup V2 operations for Assay.
+pub struct CgroupManager {
+    root_path: PathBuf,
+}
+
+/// Represents an active ephemeral Cgroup session.
+pub struct SessionCgroup {
+    path: PathBuf,
+    id: u64, // Inode number (cgroup ID)
+}
+
+impl CgroupManager {
+    /// Checks if Cgroup V2 is available and resolves the correct nesting root.
+    /// SOTA Hardening: Detects current cgroup scope to support systemd slices.
+    pub fn new() -> Result<Self> {
+        let mount_point = PathBuf::from("/sys/fs/cgroup");
+
+        if !mount_point.exists() || !mount_point.is_dir() {
+            return Err(anyhow!("Cgroup V2 mount not found"));
+        }
+
+        // P0 Fix: Robust parsing of /proc/self/cgroup
+        // We look for the line starting with "0::" (Unified hierarchy)
+        let content = fs::read_to_string("/proc/self/cgroup")
+            .context("Failed to read /proc/self/cgroup")?;
+
+        let self_cgroup_line = content.lines()
+            .find(|line| line.starts_with("0::"))
+            .ok_or_else(|| anyhow!("Could not find Unified Hierarchy (0::) in /proc/self/cgroup"))?;
+
+        let self_cgroup_path = self_cgroup_line.split("::").nth(1)
+            .ok_or_else(|| anyhow!("Invalid cgroup line format"))?;
+
+        // Handle root case "0::/" -> "" (empty relative path)
+        let relative_path = if self_cgroup_path == "/" {
+            Path::new("")
+        } else {
+            self_cgroup_path.strip_prefix('/').unwrap_or(self_cgroup_path).as_ref()
+        };
+
+        let root_path = mount_point.join(relative_path);
+
+        if !root_path.exists() {
+             return Err(anyhow!("Could not verify own cgroup path: {:?}", root_path));
+        }
+
+        Ok(Self { root_path })
+    }
+
+    /// Creates a new ephemeral cgroup.
+    pub fn create_session(&self) -> Result<SessionCgroup> {
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+        let name = format!("assay-session-{}", timestamp);
+        let path = self.root_path.join(&name);
+
+        // P0: Best-effort remove if collision (unlikely with timestamp)
+        if path.exists() {
+            let _ = fs::remove_dir(&path);
+        }
+
+        fs::create_dir(&path).context("Failed to create cgroup session dir")?;
+
+        // Best effort enable pids controller
+        let subtree = self.root_path.join("cgroup.subtree_control");
+        if subtree.exists() {
+             // Ignoring errors as we might lack delegation
+             let _ = fs::write(&subtree, "+pids");
+        }
+
+        let meta = fs::metadata(&path)?;
+        Ok(SessionCgroup { path, id: meta.ino() })
+    }
+}
+
+impl SessionCgroup {
+    pub fn id(&self) -> u64 { self.id }
+
+    pub fn add_process(&self, pid: u32) -> Result<()> {
+        let procs_path = self.path.join("cgroup.procs");
+        fs::write(&procs_path, pid.to_string()).context("Failed to add PID")?;
+        Ok(())
+    }
+
+    pub fn freeze(&self) -> Result<()> {
+        let p = self.path.join("cgroup.freeze");
+        if p.exists() { fs::write(p, "1")?; }
+        Ok(())
+    }
+
+    pub fn thaw(&self) -> Result<()> {
+        let p = self.path.join("cgroup.freeze");
+        if p.exists() { fs::write(p, "0")?; }
+        Ok(())
+    }
+
+    pub fn kill(&self) -> Result<()> {
+        let p = self.path.join("cgroup.kill");
+        if p.exists() {
+            fs::write(p, "1")?;
+        } else {
+             return Err(anyhow!("cgroup.kill missing"));
+        }
+        Ok(())
+    }
+
+    /// P0 Hardening: Graceful kill using pidfd to avoid PID reuse races.
+    pub fn kill_graceful(&self, grace_ms: u64) -> Result<()> {
+        let _ = self.freeze();
+
+        let procs = fs::read_to_string(self.path.join("cgroup.procs"))?;
+        let mut pids: Vec<i32> = procs.lines()
+            .filter_map(|l| l.trim().parse::<i32>().ok())
+            .collect();
+        // SOTA: Dedupe to prevent double-signaling (which is harmless but sloppy)
+        pids.sort_unstable();
+        pids.dedup();
+
+        // Send SIGTERM via pidfd if possible
+        for &pid in &pids {
+            if pid <= 0 { continue; }
+
+            #[cfg(target_os = "linux")]
+            unsafe {
+                // syscall(SYS_pidfd_open, pid, 0)
+                let fd = libc::syscall(libc::SYS_pidfd_open, pid, 0) as i32;
+                if fd >= 0 {
+                    // syscall(SYS_pidfd_send_signal, fd, SIGTERM, NULL, 0)
+                    let _ = libc::syscall(libc::SYS_pidfd_send_signal, fd, libc::SIGTERM, std::ptr::null::<libc::siginfo_t>(), 0);
+                    libc::close(fd);
+                } else {
+                    // Fallback to classic kill if pidfd fails
+                    libc::kill(pid, libc::SIGTERM);
+                }
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+               use nix::sys::signal::{kill, Signal};
+               use nix::unistd::Pid;
+               let _ = kill(Pid::from_raw(pid), Signal::SIGTERM);
+            }
+        }
+
+        let _ = self.thaw();
+        std::thread::sleep(std::time::Duration::from_millis(grace_ms));
+        self.kill()
+    }
+
+    pub fn set_pids_max(&self, max: u32) -> Result<()> {
+        let p = self.path.join("pids.max");
+        if p.exists() { fs::write(p, max.to_string())?; }
+        Ok(())
+    }
+
+    /// P0 Hardening: Reliable cleanup
+    pub fn remove(&self) -> Result<()> {
+        if !self.path.exists() { return Ok(()); }
+
+        // Retry loop for cgroup removal (busy/not empty)
+        for _ in 0..3 {
+            match fs::remove_dir(&self.path) {
+                Ok(_) => return Ok(()),
+                Err(_) => {
+                    // Try to kill remainders if still exists
+                    let _ = self.kill();
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+            }
+        }
+        // Final attempt
+        fs::remove_dir(&self.path).context("Failed to remove cgroup after retries")
+    }
+}
+
+impl Drop for SessionCgroup {
+    fn drop(&mut self) {
+        if let Err(e) = self.remove() {
+            eprintln!("Values to clean up cgroup session: {:?}", e);
+        }
+    }
+}

--- a/crates/assay-cli/src/cgroup.rs
+++ b/crates/assay-cli/src/cgroup.rs
@@ -78,7 +78,7 @@ impl CgroupManager {
         #[cfg(unix)]
         let id = meta.ino();
         #[cfg(not(unix))]
-        let id = 0; // Stub for non-Unix
+        let id = { let _ = meta; 0 }; // Stub for non-Unix
         Ok(SessionCgroup { path, id })
     }
 }

--- a/crates/assay-cli/src/main.rs
+++ b/crates/assay-cli/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 mod cli;
 pub mod packs;
 mod templates;
+pub mod cgroup;
 
 use cli::args::Cli;
 use cli::commands::dispatch;

--- a/crates/assay-common/Cargo.toml
+++ b/crates/assay-common/Cargo.toml
@@ -3,4 +3,11 @@ name = "assay-common"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["std"]
+std = ["serde/std", "chrono/std", "serde_json/std"]
+
 [dependencies]
+serde = { version = "1.0", features = ["derive"], default-features = false }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+chrono = { version = "0.4", features = ["serde"], default-features = false, optional = true }

--- a/crates/assay-common/Cargo.toml
+++ b/crates/assay-common/Cargo.toml
@@ -3,11 +3,11 @@ name = "assay-common"
 version = "0.1.0"
 edition = "2021"
 
-[features]
-default = ["std"]
-std = ["serde/std", "chrono/std", "serde_json/std"]
-
 [dependencies]
 serde = { version = "1.0", features = ["derive"], default-features = false }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 chrono = { version = "0.4", features = ["serde"], default-features = false, optional = true }
+
+[features]
+default = ["std"]
+std = ["serde/std", "chrono/std", "dep:serde_json"]

--- a/crates/assay-common/src/exports.rs
+++ b/crates/assay-common/src/exports.rs
@@ -1,0 +1,120 @@
+// Serializable export types for incident bundles
+
+use serde::Serialize;
+use std::collections::HashMap;
+use std::string::String;
+use std::vec::Vec;
+use std::option::Option; // Option is usually in core prelude, but to be safe. Actually Option/Result are usually available.
+// String and Vec are the main ones missing in no_std default.
+
+/// Exported process node (from ProcessTreeTracker)
+#[derive(Debug, Clone, Serialize)]
+pub struct ProcessNodeExport {
+    pub pid: u32,
+    pub parent_pid: Option<u32>,
+    pub children: Vec<u32>,
+    pub exe: Option<String>,
+    pub cmdline: Option<String>,
+    pub cwd: Option<String>,
+    pub state: ProcessStateExport,
+    pub depth: u32,
+}
+
+/// Process state for export
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessStateExport {
+    Running,
+    Exited,
+    Killed,
+}
+
+/// Exported process tree
+#[derive(Debug, Clone, Serialize)]
+pub struct ProcessTreeExport {
+    /// Root PIDs (explicitly monitored)
+    pub roots: Vec<u32>,
+
+    /// All nodes in the tree
+    pub nodes: HashMap<u32, ProcessNodeExport>,
+
+    /// Total count of nodes
+    pub total_count: usize,
+}
+
+impl Default for ProcessTreeExport {
+    fn default() -> Self {
+        Self {
+            roots: Vec::new(),
+            nodes: HashMap::new(),
+            total_count: 0,
+        }
+    }
+}
+
+/// Kill result export (from kill_tree)
+#[derive(Debug, Clone, Serialize)]
+pub struct KillResultExport {
+    /// PIDs successfully killed
+    pub killed: Vec<u32>,
+
+    /// PIDs that failed to kill
+    pub failed: Vec<KillFailureExport>,
+
+    /// Total attempted
+    pub attempted: usize,
+
+    /// Overall success
+    pub success: bool,
+
+    /// Duration in milliseconds
+    pub duration_ms: u64,
+
+    /// Kill order used
+    pub order: String,
+
+    /// Kill mode used
+    pub mode: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KillFailureExport {
+    pub pid: u32,
+    pub error: String,
+    pub retries: u32,
+}
+
+/// Event record for incident bundles
+#[derive(Debug, Clone, Serialize)]
+pub struct EventRecordExport {
+    /// ISO timestamp
+    pub timestamp: String,
+
+    /// Process ID
+    pub pid: u32,
+
+    /// Event type name
+    pub event_type: String,
+
+    /// Event-specific details
+    pub details: serde_json::Value,
+}
+
+impl EventRecordExport {
+    /// Create from a decoded event.
+    /// Note: This simplifies the previous implementation by avoiding circular dependency on super::events.
+    /// The caller is responsible for converting their specific Event enum to this strict output format.
+    pub fn new(
+        pid: u32,
+        timestamp: chrono::DateTime<chrono::Utc>,
+        event_type: String,
+        details: serde_json::Value
+    ) -> Self {
+        Self {
+            timestamp: timestamp.to_rfc3339(),
+            pid,
+            event_type,
+            details,
+        }
+    }
+}

--- a/crates/assay-common/src/lib.rs
+++ b/crates/assay-common/src/lib.rs
@@ -1,7 +1,16 @@
 #![no_std]
 
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
+pub mod exports;
+
 pub const EVENT_OPENAT: u32 = 1;
 pub const EVENT_CONNECT: u32 = 2;
+pub const EVENT_FORK: u32 = 3;
+pub const EVENT_EXEC: u32 = 4;
+pub const EVENT_EXIT: u32 = 5;
 
 pub const DATA_LEN: usize = 256;
 

--- a/crates/assay-core/Cargo.toml
+++ b/crates/assay-core/Cargo.toml
@@ -16,6 +16,7 @@ kill-switch-capture = ["kill-switch", "dep:procfs"]
 runtime-monitor = []
 
 [dependencies]
+assay-common = { path = "../assay-common", version = "0.1.0" }
 anyhow = "1"
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -46,8 +47,9 @@ schemars = "1.2.0"
 
 # Unix-specifics for Kill Switch P0
 # nix moved to main dependencies to satisfy dep:nix feature
-# [target.'cfg(unix)'.dependencies]
-# nix = { ... }
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.27", features = ["fs"] }
+libc = "0.2"
 
 # Linux-specifics for process inspection
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/assay-core/src/incident.rs
+++ b/crates/assay-core/src/incident.rs
@@ -79,8 +79,6 @@ impl IncidentBuilder {
     /// Enforces 0700 on directory and 0600 on file.
     #[cfg(unix)]
     pub fn atomic_write(&self, output_dir: &Path) -> Result<PathBuf> {
-        use std::os::unix::io::FromRawFd;
-
         let dir_path_str = output_dir.to_str().ok_or_else(|| anyhow!("Invalid path"))?;
 
         // 1. Ensure directory exists

--- a/crates/assay-core/src/incident.rs
+++ b/crates/assay-core/src/incident.rs
@@ -96,7 +96,7 @@ impl IncidentBuilder {
             Mode::empty()
         ).context("Failed to open output directory securely")?;
 
-        // SAFTEY: We wrap the raw FD immediately to ensure RAII closure.
+        // SAFETY: We wrap the raw FD immediately to ensure RAII closure.
         let dir_file = unsafe { std::fs::File::from_raw_fd(dir_raw_fd) };
 
         // 3. Verify Directory Permissions (fstat on fd)

--- a/crates/assay-core/src/incident.rs
+++ b/crates/assay-core/src/incident.rs
@@ -1,0 +1,185 @@
+use anyhow::{Context, Result, anyhow};
+use assay_common::exports::{EventRecordExport, ProcessTreeExport};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use nix::fcntl::{open, openat, OFlag, renameat};
+#[cfg(unix)]
+use nix::sys::stat::{Mode, fchmod};
+
+use uuid::Uuid;
+
+#[cfg(not(unix))]
+trait PermissionsExt {} // Stub
+
+#[derive(Debug, Serialize)]
+pub struct IncidentBundle {
+    pub metadata: IncidentMetadata,
+    pub tree: ProcessTreeExport,
+    pub events: Vec<EventRecordExport>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IncidentMetadata {
+    pub timestamp: String,
+    pub session_id: String,
+    pub kernel_version: String,
+    pub assay_version: String,
+}
+
+pub struct IncidentBuilder {
+    bundle: IncidentBundle,
+}
+
+impl IncidentBuilder {
+    pub fn new(session_id: String) -> Self {
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Simple kernel version retrieval
+        let kernel_version = std::fs::read_to_string("/proc/version")
+            .unwrap_or_else(|_| "unknown".to_string())
+            .trim()
+            .to_string();
+
+        Self {
+            bundle: IncidentBundle {
+                metadata: IncidentMetadata {
+                    timestamp: now,
+                    session_id,
+                    kernel_version,
+                    assay_version: env!("CARGO_PKG_VERSION").to_string(),
+                },
+                tree: ProcessTreeExport::default(),
+                events: Vec::new(),
+            }
+        }
+    }
+
+    pub fn with_tree(mut self, tree: ProcessTreeExport) -> Self {
+        self.bundle.tree = tree;
+        self
+    }
+
+    pub fn with_events(mut self, events: Vec<EventRecordExport>) -> Self {
+        self.bundle.events = events;
+        self
+    }
+
+    /// Writes the bundle atomically to the specified directory.
+    /// Creates a temp file, sets permissions (0600), then moves it.
+    /// Enforces 0700 on parent directory for security.
+    /// Secure Atomic Write (SOTA P0)
+    /// Uses low-level O_NOFOLLOW/openat to prevent symlink attacks.
+    /// Enforces 0700 on directory and 0600 on file.
+    #[cfg(unix)]
+    pub fn atomic_write(&self, output_dir: &Path) -> Result<PathBuf> {
+        use std::os::unix::io::FromRawFd;
+
+        let dir_path_str = output_dir.to_str().ok_or_else(|| anyhow!("Invalid path"))?;
+
+        // 1. Ensure directory exists
+        if !output_dir.exists() {
+             fs::create_dir_all(output_dir).context("Failed to create output dir")?;
+             let mut perms = fs::metadata(output_dir)?.permissions();
+             perms.set_mode(0o700);
+             fs::set_permissions(output_dir, perms).context("Failed to secure new output dir")?;
+        }
+
+        // 2. Open Directory securely (O_DIRECTORY | O_NOFOLLOW)
+        let dir_raw_fd = open(
+            dir_path_str,
+            OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW,
+            Mode::empty()
+        ).context("Failed to open output directory securely")?;
+
+        // SAFTEY: We wrap the raw FD immediately to ensure RAII closure.
+        let dir_file = unsafe { std::fs::File::from_raw_fd(dir_raw_fd) };
+
+        // 3. Verify Directory Permissions (fstat on fd)
+        let dir_meta = dir_file.metadata()?;
+        let current_mode = dir_meta.permissions().mode();
+        if (current_mode & 0o777) != 0o700 {
+            // P0: Enforce 0700 always (via fd to avoid TOCTOU)
+            fchmod(dir_file.as_raw_fd(), Mode::from_bits_truncate(0o700))
+                .context("Failed to fchmod output directory")?;
+        }
+
+        // SOTA: Guaranteed unique filename to prevent overwrites (collision free)
+        let suffix = Uuid::new_v4().simple().to_string();
+        let filename = format!("incident_{}_{}.json", self.bundle.metadata.session_id, suffix);
+        let tmp_filename = format!(".tmp_{}", filename);
+
+        let content = serde_json::to_string_pretty(&self.bundle)
+            .context("Failed to serialize incident bundle")?;
+
+        // 4. Open Temp File (openat relative to dir_fd, O_CREAT|O_EXCL|O_NOFOLLOW, 0600)
+        let tmp_fd = openat(
+            dir_file.as_raw_fd(),
+            tmp_filename.as_str(),
+            OFlag::O_CREAT | OFlag::O_WRONLY | OFlag::O_EXCL | OFlag::O_NOFOLLOW,
+            Mode::from_bits_truncate(0o600)
+        ).context("Failed to create temp file securely")?;
+
+        let mut tmp_file = unsafe { std::fs::File::from_raw_fd(tmp_fd) };
+
+        // 5. Write and Fsync
+        use std::io::Write;
+        tmp_file.write_all(content.as_bytes())?;
+        tmp_file.sync_all()?;
+
+        // 6. Atomic Rename (renameat)
+        renameat(
+            Some(dir_file.as_raw_fd()),
+            tmp_filename.as_str(),
+            Some(dir_file.as_raw_fd()),
+            filename.as_str()
+        ).context("Failed to rename atomic file")?;
+
+        // 7. Sync Parent Directory
+        dir_file.sync_all()?;
+
+        Ok(output_dir.join(filename))
+    }
+
+    #[cfg(not(unix))]
+    pub fn atomic_write(&self, _output_dir: &Path) -> Result<PathBuf> {
+        Err(anyhow!("Incident bundles only supported on Unix"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn test_atomic_write_security() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let builder = IncidentBuilder::new("test-session".to_string());
+
+        // Write info
+        let path = builder.atomic_write(temp_dir.path())?;
+
+        // Check 1: File exists
+        assert!(path.exists());
+        assert!(path.file_name().unwrap().to_str().unwrap().contains("test-session"));
+
+        // Check 2: Permissions (0600)
+        let perms = fs::metadata(&path)?.permissions();
+        let mode = perms.mode() & 0o777;
+        assert_eq!(mode, 0o600, "Incident bundle permissions must be 0600");
+
+        // Check 3: Content
+        let content = fs::read_to_string(&path)?;
+        let json: serde_json::Value = serde_json::from_str(&content)?;
+        assert_eq!(json["metadata"]["session_id"], "test-session");
+
+        Ok(())
+    }
+}

--- a/crates/assay-core/src/lib.rs
+++ b/crates/assay-core/src/lib.rs
@@ -37,3 +37,6 @@ pub mod trace;
 pub mod discovery;
 #[cfg(feature = "kill-switch")]
 pub mod kill_switch;
+
+#[cfg(unix)]
+pub mod incident;

--- a/crates/assay-ebpf/Cargo.toml
+++ b/crates/assay-ebpf/Cargo.toml
@@ -11,7 +11,7 @@ ebpf = []
 [dependencies]
 aya-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.13.0" }
 aya-log-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.13.0" }
-assay-common = { path = "../assay-common" }
+assay-common = { path = "../assay-common", default-features = false }
 
 [[bin]]
 name = "assay-ebpf"

--- a/crates/assay-ebpf/src/main.rs
+++ b/crates/assay-ebpf/src/main.rs
@@ -9,8 +9,14 @@ use aya_ebpf::{
     helpers::{
         bpf_get_current_cgroup_id,
         bpf_get_current_ancestor_cgroup_id,
+        bpf_get_current_pid_tgid,
     },
 };
+
+#[inline(always)]
+fn current_tgid() -> u32 {
+    unsafe { (bpf_get_current_pid_tgid() >> 32) as u32 }
+}
 
 
 #[map]

--- a/crates/assay-monitor/Cargo.toml
+++ b/crates/assay-monitor/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 assay-common = { path = "../assay-common" }
 thiserror = "1"
+anyhow = "1"
 tokio = { version = "1", features = ["sync"] }
 tokio-stream = "0.1"
 

--- a/crates/assay-monitor/src/lib.rs
+++ b/crates/assay-monitor/src/lib.rs
@@ -5,6 +5,8 @@ pub mod events;
 
 #[cfg(target_os = "linux")]
 mod loader;
+#[cfg(target_os = "linux")]
+pub mod tracepoint;
 
 use assay_common::MonitorEvent;
 
@@ -58,6 +60,25 @@ impl Monitor {
         #[cfg(not(target_os = "linux"))]
         {
             let _ = pids;
+            Err(MonitorError::NotSupported)
+        }
+    }
+
+    pub fn configure_defaults(&mut self) -> Result<(), MonitorError> {
+        #[cfg(target_os = "linux")]
+        return self.inner.configure_defaults();
+
+        #[cfg(not(target_os = "linux"))]
+        Ok(())
+    }
+
+    pub fn set_monitored_cgroups(&mut self, cgroups: &[u64]) -> Result<(), MonitorError> {
+        #[cfg(target_os = "linux")]
+        return self.inner.set_monitored_cgroups(cgroups);
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = cgroups;
             Err(MonitorError::NotSupported)
         }
     }

--- a/crates/assay-monitor/src/lib.rs
+++ b/crates/assay-monitor/src/lib.rs
@@ -2,6 +2,7 @@ mod error;
 pub use error::MonitorError;
 
 pub mod events;
+pub mod tree;
 
 #[cfg(target_os = "linux")]
 mod loader;

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -86,12 +86,11 @@ impl LinuxMonitor {
             .try_into()?;
 
         openat.load()?;
-        openat.load()?;
         openat.attach("syscalls", "sys_enter_openat")?;
 
         // SOTA: Try to attach openat2 (best effort, modern kernels only)
         if let Some(openat2) = self.bpf.program_mut("assay_monitor_openat2") {
-            if let Ok(mut link) = openat2.try_into() as Result<TracePoint, _> {
+            if let Ok(link) = openat2.try_into() as Result<&mut TracePoint, _> {
                 let _ = link.load();
                 // If this fails (kernel too old), we just continue
                 let _ = link.attach("syscalls", "sys_enter_openat2");

--- a/crates/assay-monitor/src/tracepoint.rs
+++ b/crates/assay-monitor/src/tracepoint.rs
@@ -1,0 +1,82 @@
+use std::fs;
+use std::path::Path;
+use anyhow::{Result, Context};
+use std::collections::HashMap;
+
+/// Resolves field offsets forsyscall tracepoints by reading the kernel's format file.
+pub struct TracepointResolver;
+
+impl TracepointResolver {
+    /// Resolves common offsets for openat and connect syscalls.
+    /// Returns a map of CONFIG keys to offsets.
+    pub fn resolve_default_offsets() -> HashMap<u32, u32> {
+        let mut map = HashMap::new();
+
+        // Key 0: openat filename
+        // Key 1: connect sockaddr
+        // Key 2: fork parent
+        // Key 3: fork child
+        // Key 4: openat2 filename (SOTA)
+
+        let openat_fn = Self::find_offset("syscalls", "sys_enter_openat", "filename").unwrap_or(24);
+        map.insert(0, openat_fn);
+
+        let connect_sa = Self::find_offset("syscalls", "sys_enter_connect", "uservaddr").unwrap_or(24);
+        // Note: Field name for connect might be different on some kernels (uservaddr vs addr)
+        // If uservaddr fails, try addr? For now keep simple fallback.
+        map.insert(1, connect_sa);
+
+        let fork_parent = Self::find_offset("sched", "sched_process_fork", "parent_pid").unwrap_or(24);
+        map.insert(2, fork_parent);
+
+        let fork_child = Self::find_offset("sched", "sched_process_fork", "child_pid").unwrap_or(44);
+        map.insert(3, fork_child);
+
+        let openat2_fn = Self::find_offset("syscalls", "sys_enter_openat2", "filename").unwrap_or(24);
+        map.insert(4, openat2_fn);
+
+        map
+    }
+
+    /// Reads /sys/kernel/debug/tracing/events/<category>/<name>/format and finds the offset of <field>.
+        Self::parse_format_file(&path, field)
+    }
+
+    fn parse_format_file(path: &str, field_name: &str) -> Result<u32> {
+        let content = fs::read_to_string(path)?;
+
+        for line in content.lines() {
+            let line = line.trim();
+            // Format: field:const char *filename; offset:16; size:8; signed:0;
+            if line.starts_with("field:") {
+                let parts: Vec<&str> = line.split(';').collect();
+                if parts.len() < 2 { continue; }
+
+                // Parse "field:..." part to extract name
+                // "field:const char *filename" -> last token is "filename" or "*filename"
+                let declaration = parts[0].strip_prefix("field:").unwrap_or("").trim();
+                // Remove array brackets if present
+                let decl_clean = declaration.split('[').next().unwrap_or(declaration);
+                // Get last token (variable name)
+                let actual_name = decl_clean.split_whitespace().last().unwrap_or("");
+                // Remove pointer indirection
+                let actual_name = actual_name.trim_start_matches('*');
+
+                if actual_name == field_name {
+                     // Found it! Parse offset.
+                     // Search for "offset:N" part
+                     for part in parts.iter().skip(1) {
+                         let part = part.trim();
+                         if part.starts_with("offset:") {
+                             let val_str = part.strip_prefix("offset:").unwrap_or("0");
+                             let val = val_str.parse::<u32>().context("Failed to parse offset")?;
+                             return Ok(val);
+                         }
+                     }
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!("Field '{}' not found in format file '{}'", field_name, path))
+    }
+}

--- a/crates/assay-monitor/src/tracepoint.rs
+++ b/crates/assay-monitor/src/tracepoint.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{Result, Context};
 use std::collections::HashMap;
 
-/// Resolves field offsets forsyscall tracepoints by reading the kernel's format file.
+/// Resolves field offsets for syscall tracepoints by reading the kernel's format file.
 pub struct TracepointResolver;
 
 impl TracepointResolver {

--- a/crates/assay-monitor/src/tree/mod.rs
+++ b/crates/assay-monitor/src/tree/mod.rs
@@ -1,0 +1,5 @@
+pub mod node;
+pub mod tracker;
+
+pub use tracker::ProcessTreeTracker;
+pub use tracker::TrackerConfig;

--- a/crates/assay-monitor/src/tree/node.rs
+++ b/crates/assay-monitor/src/tree/node.rs
@@ -1,0 +1,120 @@
+use std::collections::HashSet;
+use std::fs;
+use assay_common::exports::{ProcessNodeExport, ProcessStateExport};
+
+#[derive(Debug, Clone)]
+pub struct ProcessNode {
+    pub pid: u32,
+    pub parent_pid: Option<u32>,
+    pub children: HashSet<u32>,
+    pub exe: Option<String>,
+    pub cmdline: Option<String>,
+    pub cwd: Option<String>,
+    pub state: ProcessState,
+    pub depth: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessState {
+    Running,
+    Exited,
+    Killed,
+}
+
+impl ProcessNode {
+    pub fn new_root(pid: u32) -> Self {
+        Self {
+            pid,
+            parent_pid: None,
+            children: HashSet::new(),
+            exe: None,
+            cmdline: None,
+            cwd: None,
+            state: ProcessState::Running,
+            depth: 0,
+        }
+    }
+
+    pub fn new_child(pid: u32, parent_pid: u32, parent_depth: u32) -> Self {
+        Self {
+            pid,
+            parent_pid: Some(parent_pid),
+            children: HashSet::new(),
+            exe: None,
+            cmdline: None,
+            cwd: None,
+            state: ProcessState::Running,
+            depth: parent_depth + 1,
+        }
+    }
+
+    pub fn refresh_metadata(&mut self) {
+        if self.state != ProcessState::Running {
+            return;
+        }
+        self.cmdline = read_cmdline(self.pid).ok();
+        self.exe = std::fs::read_link(format!("/proc/{}/exe", self.pid))
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned());
+        self.cwd = std::fs::read_link(format!("/proc/{}/cwd", self.pid))
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned());
+    }
+}
+
+pub fn read_cmdline(pid: u32) -> std::io::Result<String> {
+    let path = format!("/proc/{}/cmdline", pid);
+    let content = fs::read_to_string(path)?;
+    // cmdline is null-separated, join with spaces
+    Ok(content.replace('\0', " ").trim().to_string())
+}
+
+/// Reads children of a PID by scanning /proc
+/// Note: This is expensive and racy. Only used for initial scan.
+pub fn read_children(ppid: u32) -> std::io::Result<Vec<u32>> {
+    let mut children = Vec::new();
+    for entry in fs::read_dir("/proc")? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let s = name.to_string_lossy();
+        if let Ok(pid) = s.parse::<u32>() {
+            if let Ok(stat) = fs::read_to_string(format!("/proc/{}/stat", pid)) {
+                // PPID is the 4th field in /proc/[pid]/stat
+                // Comm can contain spaces and parenthesis, tricky parsing
+                // Robust way: find last ')' then 2nd field after
+                if let Some(end_comm) = stat.rfind(')') {
+                     let rest = &stat[end_comm+1..];
+                     let mut parts = rest.split_whitespace();
+                     // State is parts[0], PPID is parts[1]
+                     if let Some(ppid_str) = parts.nth(1) {
+                         if let Ok(p) = ppid_str.parse::<u32>() {
+                             if p == ppid {
+                                 children.push(pid);
+                             }
+                         }
+                     }
+                }
+            }
+        }
+    }
+    Ok(children)
+}
+
+impl From<&ProcessNode> for ProcessNodeExport {
+    fn from(node: &ProcessNode) -> Self {
+        Self {
+            pid: node.pid,
+            parent_pid: node.parent_pid,
+            children: node.children.iter().copied().collect(),
+            exe: node.exe.clone(),
+            cmdline: node.cmdline.clone(),
+            cwd: node.cwd.clone(),
+            state: match node.state {
+                ProcessState::Running => ProcessStateExport::Running,
+                ProcessState::Exited => ProcessStateExport::Exited,
+                ProcessState::Killed => ProcessStateExport::Killed,
+            },
+            depth: node.depth,
+        }
+    }
+}

--- a/crates/assay-monitor/src/tree/tracker.rs
+++ b/crates/assay-monitor/src/tree/tracker.rs
@@ -1,0 +1,164 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{RwLock};
+use assay_common::exports::ProcessTreeExport;
+use super::node::{ProcessNode, ProcessNodeExport, read_children};
+
+/// Configuration for the tracker
+#[derive(Debug, Clone)]
+pub struct TrackerConfig {
+    /// Maximum tree depth to prevent recursion issues in visuals
+    pub max_depth: u32,
+
+    /// Scan existing children on root attach
+    pub scan_existing_children: bool,
+
+    /// Refresh process metadata (exe, cmdline) on attach
+    pub refresh_metadata: bool,
+}
+
+impl Default for TrackerConfig {
+    fn default() -> Self {
+        Self {
+            max_depth: 20,
+            scan_existing_children: true,
+            refresh_metadata: true,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TrackerError {
+    #[error("PID {0} already tracked")]
+    AlreadyTracked(u32),
+
+    #[error("Lock poisoned")]
+    LockPoisoned,
+}
+
+pub type TrackerResult<T> = Result<T, TrackerError>;
+
+/// Thread-safe process tree tracker (Forensics Only).
+pub struct ProcessTreeTracker {
+    inner: RwLock<TrackerInner>,
+    config: TrackerConfig,
+}
+
+struct TrackerInner {
+    nodes: HashMap<u32, ProcessNode>,
+    roots: HashSet<u32>,
+}
+
+impl ProcessTreeTracker {
+    pub fn new(config: TrackerConfig) -> Self {
+        Self {
+            inner: RwLock::new(TrackerInner {
+                nodes: HashMap::new(),
+                roots: HashSet::new(),
+            }),
+            config,
+        }
+    }
+
+    pub fn track_root(&self, pid: u32) -> TrackerResult<()> {
+        let mut inner = self.inner.write().map_err(|_| TrackerError::LockPoisoned)?;
+
+        if inner.nodes.contains_key(&pid) {
+            return Err(TrackerError::AlreadyTracked(pid));
+        }
+
+        let mut node = ProcessNode::new_root(pid);
+        if self.config.refresh_metadata {
+            node.refresh_metadata();
+        }
+
+        inner.roots.insert(pid);
+        inner.nodes.insert(pid, node);
+
+        if self.config.scan_existing_children {
+            drop(inner);
+            self.scan_children(pid)?;
+        }
+        Ok(())
+    }
+
+    pub fn on_fork(&self, parent_pid: u32, child_pid: u32) -> TrackerResult<()> {
+        let mut inner = self.inner.write().map_err(|_| TrackerError::LockPoisoned)?;
+
+        let parent_depth = match inner.nodes.get(&parent_pid) {
+            Some(parent) => parent.depth,
+            None => return Ok(()), // Parent not tracked, ignore
+        };
+
+        if parent_depth >= self.config.max_depth {
+            return Ok(()); // Depth exceeded, ignore for visuals
+        }
+
+        if inner.nodes.contains_key(&child_pid) {
+            return Ok(());
+        }
+
+        let mut child_node = ProcessNode::new_child(child_pid, parent_pid, parent_depth);
+        if self.config.refresh_metadata {
+            child_node.refresh_metadata();
+        }
+
+        if let Some(parent) = inner.nodes.get_mut(&parent_pid) {
+            parent.children.insert(child_pid);
+        }
+
+        inner.nodes.insert(child_pid, child_node);
+        Ok(())
+    }
+
+    pub fn on_exit(&self, pid: u32) -> TrackerResult<()> {
+        let mut inner = self.inner.write().map_err(|_| TrackerError::LockPoisoned)?;
+
+        // Remove from parent
+        let parent_pid = inner.nodes.get(&pid).and_then(|n| n.parent_pid);
+        if let Some(ppid) = parent_pid {
+            if let Some(parent) = inner.nodes.get_mut(&ppid) {
+                parent.children.remove(&pid);
+            }
+        }
+
+        // We do *not* remove the node entirely if we want forensics history.
+        // But for memory management we might want to "mark exited" instead of drop?
+        // SOTA: Keep dead nodes for the session report?
+        // Prototype removed them. I will follow prototype: Remove from active tree (memory),
+        // but typically IncidentBundle is built *during* the event or at the end.
+        // If we remove them, we lose the tree structure for the report unless we snapshotted it.
+        // Actually, let's keep them but mark state=Exited.
+
+        if let Some(node) = inner.nodes.get_mut(&pid) {
+            node.state = super::node::ProcessState::Exited;
+        }
+
+        // Remove from roots if it was a root? No, keep logic consistent.
+        // If we want to prune memory, we need a separate "gc_dead()"
+
+        Ok(())
+    }
+
+    /// Scan existing children (recursive)
+    fn scan_children(&self, pid: u32) -> TrackerResult<()> {
+        let children = read_children(pid).unwrap_or_default();
+        for child_pid in children {
+            if let Err(_) = self.on_fork(pid, child_pid) {
+                continue;
+            }
+            let _ = self.scan_children(child_pid);
+        }
+        Ok(())
+    }
+
+    pub fn export(&self) -> TrackerResult<ProcessTreeExport> {
+        let inner = self.inner.read().map_err(|_| TrackerError::LockPoisoned)?;
+        Ok(ProcessTreeExport {
+            roots: inner.roots.iter().copied().collect(),
+            nodes: inner.nodes.iter()
+                .map(|(&pid, node)| (pid, node.into()))
+                .collect(),
+            total_count: inner.nodes.len(),
+        })
+    }
+}

--- a/crates/assay-monitor/src/tree/tracker.rs
+++ b/crates/assay-monitor/src/tree/tracker.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::sync::{RwLock};
 use assay_common::exports::ProcessTreeExport;
 use super::node::{ProcessNode, read_children};


### PR DESCRIPTION
Implements the 'Cgroup-first SOTA' design (Variant A) for robust process tracking and forensics.

### Key Features
*   **Monitoring**: Uses `bpf_get_current_ancestor_cgroup_id` to scan up to `MAX_ANCESTOR_DEPTH` (default 10) levels, preventing nested cgroup bypasses.
*   **Enforcement**: `kill_graceful` uses `pidfd` (via direct syscalls) to prevent PID reuse race conditions.
*   **Hardening**: Secure Atomic Writes using `openat`, `O_NOFOLLOW`, `O_EXCL`, and `renameat`. Enforces `0700` on parent directory via `fchmod`.
*   **Coverage**: Added `sys_enter_openat2` probe coverage.
*   **Architecture**: Full Cgroup-first architecture for process membership.