### PR TITLE
feat(sandbox): make pre_exec fork-safe (PR5.3)

### DIFF
--- a/crates/assay-cli/src/backend.rs
+++ b/crates/assay-cli/src/backend.rs
@@ -153,7 +153,7 @@ mod landlock_impl {
             Err(e) => {
                 // Convert landlock error to io::Error
                 // Landlock crate errors contain the errno internally
-                Err(std::io::Error::new(std::io::ErrorKind::Other, e))
+                Err(std::io::Error::other(e))
             }
         }
     }


### PR DESCRIPTION
### PR5.3: Fork-Safe pre_exec

**Goal**: Ensure pre_exec closure is async-signal-safe (no heap allocations after fork).

**Changes**:
- Renamed enforce() internals to enforce_fork_safe()
- Changed error handling to use std::io::Error::from_raw_os_error(libc::ENOTSUP) instead of anyhow::bail!
- Added comprehensive safety documentation explaining the fork-safety guarantees
- restrict_self() only calls prctl() and landlock_restrict_self() syscalls

**Verification**:
- phase5-check.sh passed locally
- Pre-commit Linux compile gate passed