### PR TITLE
feat(doctor): enhance diagnostics with Phase 5 features (PR5.5)

### DIFF
--- a/crates/assay-cli/src/diagnostics/format.rs
+++ b/crates/assay-cli/src/diagnostics/format.rs
@@ -40,6 +40,30 @@ pub fn format_text(report: &DiagnosticReport) -> String {
     ));
     s.push_str(&format!("  Details:    {}\n", report.backend.reason));
 
+    // Phase 5 hardening features
+    s.push_str("\nSandbox Hardening (v2.3):\n");
+    let f = &report.sandbox_features;
+    s.push_str(&format!(
+        "  Env Scrubbing:      {}\n",
+        if f.env_scrubbing { "✓" } else { "✗" }
+    ));
+    s.push_str(&format!(
+        "  Scoped /tmp:        {}\n",
+        if f.scoped_tmp { "✓" } else { "✗" }
+    ));
+    s.push_str(&format!(
+        "  Fork-safe pre_exec: {}\n",
+        if f.fork_safe_preexec { "✓" } else { "✗" }
+    ));
+    s.push_str(&format!(
+        "  Deny Conflict Det:  {}\n",
+        if f.deny_conflict_detection {
+            "✓"
+        } else {
+            "✗"
+        }
+    ));
+
     s.push_str("\nStatus: ");
     match report.status {
         SystemStatus::Ready => s.push_str("✓ READY\n"),

--- a/crates/assay-cli/src/diagnostics/report.rs
+++ b/crates/assay-cli/src/diagnostics/report.rs
@@ -11,6 +11,7 @@ pub struct DiagnosticReport {
     pub bpf_lsm: BpfLsmStatus,
     pub helper: HelperStatus,
     pub backend: BackendSelection,
+    pub sandbox_features: SandboxFeatures,
     pub status: SystemStatus,
     pub suggestions: Vec<String>,
 }
@@ -20,7 +21,7 @@ pub struct LandlockStatus {
     pub available: bool,
     pub fs_enforce: bool,
     pub net_enforce: bool,
-    pub abi_version: Option<i32>,
+    pub abi_version: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -50,4 +51,28 @@ pub enum SystemStatus {
     Ready,
     Degraded,
     Unsupported,
+}
+
+/// Phase 5 sandbox hardening features status
+#[derive(Debug, Serialize, Clone)]
+pub struct SandboxFeatures {
+    /// Environment variable scrubbing enabled
+    pub env_scrubbing: bool,
+    /// Scoped /tmp with proper permissions
+    pub scoped_tmp: bool,
+    /// Fork-safe pre_exec (no allocations)
+    pub fork_safe_preexec: bool,
+    /// Deny-wins conflict detection
+    pub deny_conflict_detection: bool,
+}
+
+impl Default for SandboxFeatures {
+    fn default() -> Self {
+        Self {
+            env_scrubbing: true,
+            scoped_tmp: true,
+            fork_safe_preexec: true,
+            deny_conflict_detection: true,
+        }
+    }
 }


### PR DESCRIPTION
### PR5.5: Doctor Deep Dive (v2)

**Goal**: Enhanced `assay doctor` command with Phase 5 hardening diagnostics.

**Changes**:
- Added `SandboxFeatures` struct reporting Phase 5 hardening status:
  - Environment variable scrubbing
  - Scoped /tmp isolation
  - Fork-safe pre_exec
  - Deny-wins conflict detection
- Read actual Landlock ABI version from `/sys/kernel/security/landlock/abi_version`
- Net enforcement now properly reports ABI >= 4 requirement
- Added "Sandbox Hardening (v2.3)" section to doctor output

**Example output**:
```
Sandbox Hardening (v2.3):
  Env Scrubbing:      ✓
  Scoped /tmp:        ✓
  Fork-safe pre_exec: ✓
  Deny Conflict Det:  ✓
```