### PR TITLE
fix(ci): eBPF self-hosted pre-clean target to avoid EPERM on checkout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Exclude build artifacts so Docker build context does not try to stat them
+# (avoids "can't stat .../target/debug/.fingerprint/..." when target is root-owned on self-hosted)
+/target
+.git
+.gitignore
+*.log
+.DS_Store
+.assay-test
+.repro_artifacts
+site/
+venv/
+.venv/
+__pycache__/
+dist/
+build/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+.coverage
+.eval
+*.rs.bk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,10 @@ jobs:
       - name: Pre-clean workspace ownership
         shell: bash
         run: |
-          sudo chown -R "$(id -u)":"$(id -g)" "$GITHUB_WORKSPACE" || true
-          sudo chown -R "$(id -u)":"$(id -g)" "$(dirname "$GITHUB_WORKSPACE")" || true
+          # Remove target/ with sudo so checkout can delete workspace (avoids EPERM on root-owned fingerprints)
+          sudo rm -rf "$GITHUB_WORKSPACE/target" 2>/dev/null || true
+          sudo chown -R "$(id -u)":"$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
+          sudo chown -R "$(id -u)":"$(id -g)" "$(dirname "$GITHUB_WORKSPACE")" 2>/dev/null || true
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
Remove `target/` with sudo before chown in the eBPF self-hosted job so checkout can delete the workspace when a previous run left root-owned `target/debug/.fingerprint` files (EPERM).

- Add `sudo rm -rf "$GITHUB_WORKSPACE/target"` before chown
- Suppress chown stderr so job continues if some paths are busy

Fixes failed **eBPF monitor smoke (Linux - Self-Hosted)** on PRs #114, #115, #117, #118, #122, #123.

Made with [Cursor](https://cursor.com)