### PR TITLE
fix(ci): ensure .dockerignore excludes target before eBPF Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,13 @@ jobs:
             cargo install bpf-linker --locked
           fi
 
+      - name: Ensure Docker context excludes target
+        shell: bash
+        run: |
+          # Avoid "can't stat .../target/..." when Docker builds (branches without .dockerignore, e.g. Dependabot pre-rebase)
+          touch .dockerignore
+          grep -q '^/target$' .dockerignore || echo '/target' >> .dockerignore
+
       - name: Verify LSM blocking (CI Mode - strict on self-hosted)
         shell: bash
         env:


### PR DESCRIPTION
Add workflow step that ensures `.dockerignore` contains `/target` before the eBPF self-hosted job runs `verify_lsm_docker.sh` (which runs `docker build`). So branches that don't have `.dockerignore` (e.g. Dependabot PR #118 before rebase) never hit "can't stat .../target/...".

Made with [Cursor](https://cursor.com)