### PR TITLE
fix(ci): chown _work/_actions on self-hosted to fix Kernel Matrix checkout EPERM

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -256,6 +256,14 @@ jobs:
           sudo mkdir -p "$GITHUB_WORKSPACE"
           sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true
 
+          # Fix actions cache so checkout can load (self-hosted may have root-owned _actions)
+          if [ -d "/opt/actions-runner/_work/_actions" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "/opt/actions-runner/_work/_actions" 2>/dev/null || true
+          fi
+          if [ -n "${RUNNER_WORKDIR:-}" ] && [ -d "${RUNNER_WORKDIR}/_actions" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "${RUNNER_WORKDIR}/_actions" 2>/dev/null || true
+          fi
+
           # runner internals (best effort)
           if [ -n "${RUNNER_WORKDIR:-}" ]; then
             # sudo rm -rf "${RUNNER_WORKDIR}/_temp" "${RUNNER_WORKDIR}/_tool" "${RUNNER_WORKDIR}/_actions" 2>/dev/null || true


### PR DESCRIPTION
Fixes Kernel Matrix (5.15) failure on self-hosted runner:

```
Error: Access to the path '/opt/actions-runner/_work/_actions/actions/checkout/.../licensed-generate.sh' is denied.
```

**Changes:** In `.github/workflows/kernel-matrix.yml`, Emergency cleanup (FIX PERMS) step now chowns `/opt/actions-runner/_work/_actions` and `${RUNNER_WORKDIR}/_actions` so `actions/checkout` can load cached action files.

**Best option:** Merge to main so all branches (including #123) get the fix; Kernel Matrix will pass after rebase.

Made with [Cursor](https://cursor.com)