### PR TITLE
chore(deny): ignore RUSTSEC-2023-0071 for jsonwebtoken 10 bump

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,7 +23,11 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 # Ignore specific advisories (add RUSTSEC-YYYY-NNNN here if needed)
 # Only list advisories that currently match a crate in the tree; remove when dep is upgraded or removed.
-ignore = []
+ignore = [
+    # rsa: transitive via jsonwebtoken (assay-mcp-server). No safe upgrade; timing sidechannel.
+    # JWT verification is server-side; accept risk for MCP auth until jsonwebtoken/rsa offer a fix.
+    "RUSTSEC-2023-0071",
+]
 
 # =============================================================================
 # [bans] - Crate bans and duplicate detection


### PR DESCRIPTION
Unblocks PR #116 (chore(deps): bump jsonwebtoken 9.3.1 → 10.3.0).

**Problem:** Dependency Security fails with `rsa` RUSTSEC-2023-0071 (timing sidechannel). `rsa` is transitive from `jsonwebtoken`; no safe upgrade available.

**Change:** Add `RUSTSEC-2023-0071` to `deny.toml` ignore with short justification. JWT verification in assay-mcp-server is server-side; risk accepted until upstream fix.

After merge, PR #116 should rebase on main so it gets this and the kernel-matrix _actions chown fix (PR #127).

Made with [Cursor](https://cursor.com)