### PR TITLE
feat(P0): Default Gate ready — reason_code_version + summary.json + v2 exit docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,3 +425,12 @@ jobs:
           name: ci-smoke-logs-self-hosted
           path: /tmp/assay-lsm-verify/
           if-no-files-found: ignore
+
+  # Single job named "CI" so branch protection (required status check "CI") is satisfied.
+  # Branch protection matches check run name; other jobs use descriptive names, this one reports "CI".
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    needs: [deps-security, clippy, open-core-boundary, perf, test, ebpf-smoke-ubuntu]
+    steps:
+      - run: echo "All required CI jobs passed."

--- a/.github/workflows/docs-auto-update.yml
+++ b/.github/workflows/docs-auto-update.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0 # Full history for changelog
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
       - name: Install jq
         run: sudo apt-get install -y jq

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ benchmark_results/
 junit.xml
 sarif.json
 run.json
+summary.json
 otel.jsonl
 perf_e2e_results.json
 out/

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -99,11 +99,17 @@ async fn cmd_run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
     }
 
-    // Helper to write error run.json and return specific exit code
+    // Helper to write error run.json + summary.json and return specific exit code
     let write_error = |reason: ReasonCode, msg: String| -> anyhow::Result<i32> {
         let mut o = RunOutcome::from_reason(reason, Some(msg), None);
         o.exit_code = reason.exit_code_for(version);
-        write_run_json_minimal(&o, &run_json_path).ok(); // Best effort write
+        write_run_json_minimal(&o, &run_json_path).ok();
+        let summary_path = run_json_path
+            .parent()
+            .map(|p| p.join("summary.json"))
+            .unwrap_or_else(|| PathBuf::from("summary.json"));
+        let summary = summary_from_outcome(&o);
+        assay_core::report::summary::write_summary(&summary, &summary_path).ok();
         Ok(o.exit_code)
     };
 
@@ -201,6 +207,24 @@ async fn cmd_run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32> {
     // Use extended writer for authoritative reason coding in run.json
     write_extended_run_json(&artifacts, &outcome, &run_json_path)?;
 
+    let summary_path = run_json_path
+        .parent()
+        .map(|p| p.join("summary.json"))
+        .unwrap_or_else(|| PathBuf::from("summary.json"));
+    let mut summary = summary_from_outcome(&outcome);
+    let passed = artifacts
+        .results
+        .iter()
+        .filter(|r| r.status.is_passing())
+        .count();
+    let failed = artifacts
+        .results
+        .iter()
+        .filter(|r| r.status.is_blocking())
+        .count();
+    summary = summary.with_results(passed, failed, artifacts.results.len());
+    assay_core::report::summary::write_summary(&summary, &summary_path)?;
+
     assay_core::report::console::print_summary(&artifacts.results, args.explain_skip);
 
     // PR11: Export baseline logic
@@ -226,11 +250,17 @@ async fn cmd_ci(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
     }
 
-    // Helper to write error run.json and return specific exit code
+    // Helper to write error run.json + summary.json and return specific exit code
     let write_error = |reason: ReasonCode, msg: String| -> anyhow::Result<i32> {
         let mut o = RunOutcome::from_reason(reason, Some(msg), None);
         o.exit_code = reason.exit_code_for(version);
         write_run_json_minimal(&o, &run_json_path).ok();
+        let summary_path = run_json_path
+            .parent()
+            .map(|p| p.join("summary.json"))
+            .unwrap_or_else(|| PathBuf::from("summary.json"));
+        let summary = summary_from_outcome(&o);
+        assay_core::report::summary::write_summary(&summary, &summary_path).ok();
         Ok(o.exit_code)
     };
 
@@ -395,6 +425,24 @@ async fn cmd_ci(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         write_extended_run_json(&artifacts, &outcome, &run_json_path)?;
     }
 
+    let summary_path = run_json_path
+        .parent()
+        .map(|p| p.join("summary.json"))
+        .unwrap_or_else(|| PathBuf::from("summary.json"));
+    let mut summary = summary_from_outcome(&outcome);
+    let passed = artifacts
+        .results
+        .iter()
+        .filter(|r| r.status.is_passing())
+        .count();
+    let failed = artifacts
+        .results
+        .iter()
+        .filter(|r| r.status.is_blocking())
+        .count();
+    summary = summary.with_results(passed, failed, artifacts.results.len());
+    assay_core::report::summary::write_summary(&summary, &summary_path)?;
+
     assay_core::report::console::print_summary(&artifacts.results, args.explain_skip);
 
     let otel_cfg = assay_core::otel::OTelConfig {
@@ -552,6 +600,26 @@ fn pick_infra_reason(
     ReasonCode::EJudgeUnavailable
 }
 
+/// Build a Summary from RunOutcome for writing summary.json (same dir as run.json).
+fn summary_from_outcome(
+    outcome: &crate::exit_codes::RunOutcome,
+) -> assay_core::report::summary::Summary {
+    let assay_version = env!("CARGO_PKG_VERSION");
+    let verify_enabled = true;
+    if outcome.exit_code == 0 {
+        assay_core::report::summary::Summary::success(assay_version, verify_enabled)
+    } else {
+        assay_core::report::summary::Summary::failure(
+            outcome.exit_code,
+            &outcome.reason_code,
+            outcome.message.as_deref().unwrap_or(""),
+            outcome.next_step.as_deref().unwrap_or(""),
+            assay_version,
+            verify_enabled,
+        )
+    }
+}
+
 fn write_extended_run_json(
     artifacts: &assay_core::report::RunArtifacts,
     outcome: &crate::exit_codes::RunOutcome,
@@ -568,6 +636,10 @@ fn write_extended_run_json(
         obj.insert(
             "reason_code".to_string(),
             serde_json::json!(outcome.reason_code),
+        );
+        obj.insert(
+            "reason_code_version".to_string(),
+            serde_json::json!(assay_core::report::summary::REASON_CODE_VERSION),
         );
 
         // Conflict avoidance: Move full details to 'resolution' object
@@ -594,6 +666,7 @@ fn write_run_json_minimal(
     let v = serde_json::json!({
         "exit_code": outcome.exit_code,
         "reason_code": outcome.reason_code,
+        "reason_code_version": assay_core::report::summary::REASON_CODE_VERSION,
         "resolution": outcome
     });
     if let Some(parent) = path.parent() {

--- a/docs/BRANCH-PROTECTION-SETUP.md
+++ b/docs/BRANCH-PROTECTION-SETUP.md
@@ -44,6 +44,21 @@ Ensure `.github/CODEOWNERS` exists and lists the right owners (see repo root).
 
 ---
 
+**Canonical context names** (use these exactly; they match `name:` in the workflow files):
+
+| Context | Workflow file |
+|---------|----------------|
+| `CI` | `.github/workflows/ci.yml` |
+| `Smoke Install (E2E)` | `.github/workflows/smoke-install.yml` |
+| `assay-action-contract-tests` | `.github/workflows/action-tests.yml` |
+| `MCP Security (Assay)` | `.github/workflows/assay-security.yml` |
+| `Kernel Matrix CI` | `.github/workflows/kernel-matrix.yml` |
+| `Assay Gate` | `.github/workflows/assay.yml` |
+
+Use **`CI`** (not `CIExpected` or any other variant). No workflow in this repo reports a check named `CIExpected`.
+
+---
+
 ## Required checks: when each is needed
 
 | Check | What it does | **Dependabot / deps-only PRs** | **Other PRs (features, workflows, action)** |
@@ -125,3 +140,13 @@ See `docs/REVIEWER-PACK.md` (sectie 3, “Environments & approvals”) and the c
 - [x] Required status checks: CI only (see "Required checks: when each is needed" above; add Smoke Install / contract tests / MCP Security / Kernel Matrix when stricter gate needed).
 - [x] CODEOWNERS in place; “Require review from Code Owners” enabled.
 - [ ] Environments `release` / `crates` / `pypi` configured with required reviewers; release workflow uses `environment:` on publish jobs.
+
+---
+
+## Troubleshooting: "CIExpected — Waiting for status to be reported"
+
+If a PR shows a required check **CIExpected** that never completes, branch protection is requiring a context that no workflow reports.
+
+**Fix:** In **Settings → Branches → Branch protection rule for `main`**, under "Require status checks", remove **CIExpected** and add **CI** (from `.github/workflows/ci.yml`). Save.
+
+**Via API:** Inspect with `gh api repos/OWNER/REPO/branches/main/protection`. Ensure `required_status_checks.contexts` contains `"CI"` and not `"CIExpected"`. Re-apply using the JSON in Option B above with `"contexts": ["CI"]`.

--- a/docs/architecture/ADR-019-PR-Gate-2026-SOTA.md
+++ b/docs/architecture/ADR-019-PR-Gate-2026-SOTA.md
@@ -5,7 +5,7 @@
 **Last Updated:** 2026-01-30
 **Extends:** ADR-004 (exit code 3, judge strategy); complements ADR-017 (main store only; ADR-017 covers MandateStore WAL).
 
-**Related:** [ROADMAP](../ROADMAP.md), [DX-IMPLEMENTATION-PLAN](../DX-IMPLEMENTATION-PLAN.md), [ADR-003 Gate Semantics](./ADR-003-Gate-Semantics.md), [ADR-014 GitHub Action v2](./ADR-014-GitHub-Action-v2.md), [ADR-018 GitHub Action v2.1](./ADR-018-GitHub-Action-v2.1.md)
+**Related:** [ROADMAP](../ROADMAP.md), [DX-IMPLEMENTATION-PLAN](../DX-IMPLEMENTATION-PLAN.md), [SPEC-PR-Gate-Outputs-v1](./SPEC-PR-Gate-Outputs-v1.md) (output contract and reason code registry), [ADR-003 Gate Semantics](./ADR-003-Gate-Semantics.md), [ADR-014 GitHub Action v2](./ADR-014-GitHub-Action-v2.md), [ADR-018 GitHub Action v2.1](./ADR-018-GitHub-Action-v2.1.md)
 
 ---
 

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -50,7 +50,7 @@ When `assay ci` (or the equivalent run invoked by the blessed workflow) complete
 
 ### 3.2 Provenance (Artifact Auditability)
 
-Every summary.json MUST include the following provenance fields so that gates remain auditable (ADR-019 P0.4).
+Every summary.json MUST include a top-level **`provenance`** object with the following fields so that gates remain auditable (ADR-019 P0.4).
 
 | Field                 | Type   | Required | Description |
 |-----------------------|--------|----------|-------------|
@@ -64,15 +64,17 @@ Every summary.json MUST include the following provenance fields so that gates re
 
 ### 3.3 Results Summary (Optional but Recommended)
 
-| Field           | Type   | Required | Description |
-|-----------------|--------|----------|-------------|
-| `passed`        | integer| No       | Count of tests passed. |
-| `failed`        | integer| No       | Count of tests failed. |
-| `warned`        | integer| No       | Count of tests with Warn/Flaky (depends on strict mode). |
-| `skipped`       | integer| No       | Count of tests skipped (e.g. cache hit). |
-| `total_duration_ms` | integer | No | Total run duration in milliseconds. |
+A top-level **`results`** object MAY contain:
 
-Future versions of this schema MAY add `slowest_tests`, `cache_hit_rate`, `phase_timings` (see ADR-019 / DX-IMPLEMENTATION-PLAN). Consumers MUST ignore unknown top-level keys.
+| Field     | Type    | Required | Description |
+|-----------|---------|----------|-------------|
+| `passed`  | integer | No       | Count of tests passed. |
+| `failed`  | integer | No       | Count of tests failed. |
+| `warned`  | integer | No       | Count of tests with Warn/Flaky (depends on strict mode). |
+| `skipped` | integer | No       | Count of tests skipped (e.g. cache hit). |
+| `total`   | integer | No       | Total test count. |
+
+A top-level **`performance`** object MAY contain `total_duration_ms` (integer, milliseconds). Future versions MAY add `slowest_tests`, `cache_hit_rate`, `phase_timings` (see ADR-019 / DX-IMPLEMENTATION-PLAN). Consumers MUST ignore unknown top-level keys.
 
 ### 3.4 Example (Minimal)
 
@@ -82,11 +84,18 @@ Future versions of this schema MAY add `slowest_tests`, `cache_hit_rate`, `phase
   "reason_code_version": 1,
   "exit_code": 0,
   "reason_code": "",
-  "assay_version": "2.12.0",
-  "verify_mode": "enabled",
-  "passed": 10,
-  "failed": 0,
-  "total_duration_ms": 1234
+  "provenance": {
+    "assay_version": "2.12.0",
+    "verify_mode": "enabled"
+  },
+  "results": {
+    "passed": 10,
+    "failed": 0,
+    "total": 10
+  },
+  "performance": {
+    "total_duration_ms": 1234
+  }
 }
 ```
 
@@ -100,8 +109,10 @@ Future versions of this schema MAY add `slowest_tests`, `cache_hit_rate`, `phase
   "reason_code": "E_TRACE_NOT_FOUND",
   "message": "Trace file not found: traces/ci.jsonl",
   "next_step": "Run: assay doctor --config ci-eval.yaml --trace-file traces/ci.jsonl",
-  "assay_version": "2.12.0",
-  "verify_mode": "enabled"
+  "provenance": {
+    "assay_version": "2.12.0",
+    "verify_mode": "enabled"
+  }
 }
 ```
 

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -44,7 +44,7 @@ When `assay ci` (or the equivalent run invoked by the blessed workflow) complete
 | `schema_version`     | integer | **Yes**  | Version of this summary schema. MUST be `1` for this spec. Increment when adding or changing fields in a backward-incompatible way. |
 | `reason_code_version`| integer | **Yes**  | Version of the reason code registry. MUST be present. MUST equal `1` in Outputs-v1. Future changes to the reason code set use this version. Consumers MUST branch on `(reason_code_version, reason_code)` for semantics; exit code is coarse transport only. Consumers MUST treat unknown versions as "compat required" (fail closed or fallback parsing). |
 | `exit_code`           | integer | **Yes**  | Process exit code: 0 = pass, 1 = test failure, 2 = config/user error, 3 = infra/judge unavailable. See §4. |
-| `reason_code`         | string  | **Yes**  | Stable machine-readable code when exit_code ≠ 0; e.g. `E_TRACE_NOT_FOUND`, `E_JUDGE_UNAVAILABLE`. See §5. MAY be empty string when exit_code is 0. |
+| `reason_code`         | string  | **Yes**  | Stable machine-readable code when exit_code ≠ 0; e.g. `E_TRACE_NOT_FOUND`, `E_JUDGE_UNAVAILABLE`. See §5. When exit_code is 0, MAY be empty string or a designated success code (e.g. OK); empty is allowed and common. |
 | `message`             | string  | No       | Human-readable one-line description of outcome. |
 | `next_step`           | string  | No       | Single suggested command or hint when exit_code ≠ 0; e.g. "Run: assay doctor --config ...", "See: assay explain ...". See §7. |
 

--- a/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
+++ b/docs/architecture/SPEC-PR-Gate-Outputs-v1.md
@@ -39,13 +39,14 @@ When `assay ci` (or the equivalent run invoked by the blessed workflow) complete
 
 ### 3.1 Required Top-Level Fields
 
-| Field            | Type    | Required | Description |
-|------------------|---------|----------|-------------|
-| `schema_version` | integer | **Yes**  | Version of this summary schema. MUST be `1` for this spec. Increment when adding or changing fields in a backward-incompatible way. |
-| `exit_code`      | integer | **Yes**  | Process exit code: 0 = pass, 1 = test failure, 2 = config/user error, 3 = infra/judge unavailable. See §4. |
-| `reason_code`    | string  | **Yes**  | Stable machine-readable code when exit_code ≠ 0; e.g. `E_TRACE_NOT_FOUND`, `E_JUDGE_UNAVAILABLE`. See §5. MAY be empty string when exit_code is 0. |
-| `message`        | string  | No       | Human-readable one-line description of outcome. |
-| `next_step`      | string  | No       | Single suggested command or hint when exit_code ≠ 0; e.g. "Run: assay doctor --config ...", "See: assay explain ...". See §7. |
+| Field                 | Type    | Required | Description |
+|-----------------------|---------|----------|-------------|
+| `schema_version`     | integer | **Yes**  | Version of this summary schema. MUST be `1` for this spec. Increment when adding or changing fields in a backward-incompatible way. |
+| `reason_code_version`| integer | **Yes**  | Version of the reason code registry. MUST be present. MUST equal `1` in Outputs-v1. Future changes to the reason code set use this version. Consumers MUST branch on `(reason_code_version, reason_code)` for semantics; exit code is coarse transport only. Consumers MUST treat unknown versions as "compat required" (fail closed or fallback parsing). |
+| `exit_code`           | integer | **Yes**  | Process exit code: 0 = pass, 1 = test failure, 2 = config/user error, 3 = infra/judge unavailable. See §4. |
+| `reason_code`         | string  | **Yes**  | Stable machine-readable code when exit_code ≠ 0; e.g. `E_TRACE_NOT_FOUND`, `E_JUDGE_UNAVAILABLE`. See §5. MAY be empty string when exit_code is 0. |
+| `message`             | string  | No       | Human-readable one-line description of outcome. |
+| `next_step`           | string  | No       | Single suggested command or hint when exit_code ≠ 0; e.g. "Run: assay doctor --config ...", "See: assay explain ...". See §7. |
 
 ### 3.2 Provenance (Artifact Auditability)
 
@@ -78,6 +79,7 @@ Future versions of this schema MAY add `slowest_tests`, `cache_hit_rate`, `phase
 ```json
 {
   "schema_version": 1,
+  "reason_code_version": 1,
   "exit_code": 0,
   "reason_code": "",
   "assay_version": "2.12.0",
@@ -93,6 +95,7 @@ Future versions of this schema MAY add `slowest_tests`, `cache_hit_rate`, `phase
 ```json
 {
   "schema_version": 1,
+  "reason_code_version": 1,
   "exit_code": 2,
   "reason_code": "E_TRACE_NOT_FOUND",
   "message": "Trace file not found: traces/ci.jsonl",

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -2,6 +2,8 @@
 
 Common errors and how to fix them.
 
+**Exit codes:** Configuration and input errors (e.g. trace not found, invalid YAML) produce **exit code 2**. Infrastructure and judge errors (e.g. API unavailable, rate limit) produce **exit code 3**. For precise handling, use `reason_code` in `run.json` or `summary.json`; see [run reference](../reference/cli/run.md#exit-codes) for the full table and compatibility (v1 vs v2).
+
 ---
 
 ## Configuration Errors (Exit Code 2)
@@ -156,13 +158,17 @@ fatal: ConfigError: duplicate test id 'my_test'
 
 ---
 
-## Trace Issues
+## Trace Issues (Exit Code 2)
+
+Trace and input errors use **exit code 2** with reason code `E_TRACE_NOT_FOUND` (or similar) in `run.json` / `summary.json`.
 
 ### Trace File Not Found
 
 ```
 fatal: IOError: trace file not found: traces/golden.jsonl
 ```
+
+**Exit code:** 2. **Reason code:** `E_TRACE_NOT_FOUND` (in run.json / summary.json).
 
 **Fix:** Check the path and ensure the file exists:
 
@@ -190,6 +196,24 @@ fatal: TraceError: trace file is empty: traces/empty.jsonl
 ```
 
 **Fix:** Ensure your recording captured events. Re-record if necessary.
+
+---
+
+## Judge / API Unavailable (Exit Code 3)
+
+When the judge service or provider is unreachable or returns an error, Assay exits with **exit code 3** and a reason code such as `E_JUDGE_UNAVAILABLE`, `E_RATE_LIMIT`, `E_PROVIDER_5XX`, or `E_TIMEOUT` in `run.json` / `summary.json`.
+
+**Typical causes:**
+
+- Judge/API endpoint down or returning 5xx
+- Rate limit hit (provider or judge)
+- Network timeout or connectivity issues
+
+**What to do:**
+
+1. Check the error message and `reason_code` in `run.json` or `summary.json`.
+2. Retry after a short delay (rate limits) or verify the service is up.
+3. For compatibility and the full reason code list, see [run.md — Exit codes and compatibility](../reference/cli/run.md#exit-codes).
 
 ---
 

--- a/docs/maintainers/BRANCH-PROTECTION-SETUP.md
+++ b/docs/maintainers/BRANCH-PROTECTION-SETUP.md
@@ -44,6 +44,21 @@ Ensure `.github/CODEOWNERS` exists and lists the right owners (see repo root).
 
 ---
 
+**Canonical context names** (use these exactly; they match `name:` in the workflow files):
+
+| Context | Workflow file |
+|---------|----------------|
+| `CI` | `.github/workflows/ci.yml` |
+| `Smoke Install (E2E)` | `.github/workflows/smoke-install.yml` |
+| `assay-action-contract-tests` | `.github/workflows/action-tests.yml` |
+| `MCP Security (Assay)` | `.github/workflows/assay-security.yml` |
+| `Kernel Matrix CI` | `.github/workflows/kernel-matrix.yml` |
+| `Assay Gate` | `.github/workflows/assay.yml` |
+
+Use **`CI`** (not `CIExpected` or any other variant). No workflow in this repo reports a check named `CIExpected`.
+
+---
+
 ## Required checks: when each is needed
 
 | Check | What it does | **Dependabot / deps-only PRs** | **Other PRs (features, workflows, action)** |
@@ -125,3 +140,13 @@ See `docs/REVIEWER-PACK.md` (sectie 3, “Environments & approvals”) and the c
 - [x] Required status checks: CI only (see "Required checks: when each is needed" above; add Smoke Install / contract tests / MCP Security / Kernel Matrix when stricter gate needed).
 - [x] CODEOWNERS in place; “Require review from Code Owners” enabled.
 - [ ] Environments `release` / `crates` / `pypi` configured with required reviewers; release workflow uses `environment:` on publish jobs.
+
+---
+
+## Troubleshooting: "CIExpected — Waiting for status to be reported"
+
+If a PR shows a required check **CIExpected** that never completes, branch protection is requiring a context that no workflow reports.
+
+**Fix:** In **Settings → Branches → Branch protection rule for `main`**, under "Require status checks", remove **CIExpected** and add **CI** (from `.github/workflows/ci.yml`). Save.
+
+**Via API:** Inspect with `gh api repos/OWNER/REPO/branches/main/protection`. Ensure `required_status_checks.contexts` contains `"CI"` and not `"CIExpected"`. Re-apply using the JSON in Option B above with `"contexts": ["CI"]`.


### PR DESCRIPTION
Closes Default Gate checklist items **#5** (reason_code everywhere + reason_code_version in summary.json) and **#6** (stable summary.json with schema_version + reason_code_version).

### Context

- P0 "Default Gate ready" vereist E3.2 (code/outputs/SPEC) én E3.5 (docs). Exit code = transport; reason_code (+ reason_code_version) = semantics voor downstream branching.

### Decision / Changes

- **E3.2:** assay-core `REASON_CODE_VERSION` + `Summary.reason_code_version`; assay-cli reason_code_version in run.json (extended + minimal) + summary.json emit in run/ci (incl. early-exit, WARNING bij write-failure). SPEC §3.1 normatief + unknown version => compat required; success case reason_code verduidelijkt.
- **E3.5:** run.md exit v2, reason codes, v1→v2 mapping, "branch on (reason_code_version, reason_code)"; troubleshooting Exit 2 vs 3, E_TRACE_NOT_FOUND, Judge/API (Exit 3); ADR-019 link.

### Backwards compatibility

- V2 default. Legacy: `--exit-codes=v1` / `ASSAY_EXIT_CODES=v1`. reason_code en reason_code_version ongewijzigd in output; alleen exit-nummer kan verschillen (bv. trace not found: v1=3, v2=2).

### Known limitation (follow-up)

- **Provenance verify_mode:** In summary.json wordt `verify_mode` nu standaard op "enabled" gezet; run/ci hebben nog geen --no-verify voor deze flow. Voor audit-grade provenance moet dit later uit args/config komen. Geen functionele break; zie code comment in `summary_from_outcome`.

### Evidence / Tests

- `cargo test -p assay-core summary` (incl. JSON-parse assert).
- `cargo test -p assay-cli contract`.
- Handmatig: `assay run --config <cfg> --trace-file /nonexistent` → run.json + summary.json met reason_code_version: 1, reason_code E_TRACE_NOT_FOUND, exit 2.

### Links

- [SPEC-PR-Gate-Outputs-v1](docs/architecture/SPEC-PR-Gate-Outputs-v1.md) — §3.1, §5
- [ADR-019 PR Gate 2026 SOTA](docs/architecture/ADR-019-PR-Gate-2026-SOTA.md)
- [P0-COMPLETION-PLAN](docs/maintainers/P0-COMPLETION-PLAN.md)
