### PR TITLE
feat(E6a.3): no-pass-through invariant — sensitive headers + E2E test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,11 @@ jobs:
         if: runner.os == 'Linux'
         run: cargo test --locked --workspace --exclude assay-ebpf --exclude assay-it
 
+      # E6a.3 no-pass-through: E2E invariant test (requires test-outbound feature)
+      - name: Test MCP no-pass-through E2E (E6a.3)
+        if: runner.os == 'Linux'
+        run: cargo test -p assay-mcp-server --features test-outbound --no-fail-fast no_passthrough
+
       # Non-Linux: Exclude OS-specific crates (assay-monitor, assay-cli)
       # Windows/macOS automatically use bundled sqlite via cfg() in Cargo.toml
       - name: Test Workspace (Cross-Platform)

--- a/crates/assay-mcp-server/Cargo.toml
+++ b/crates/assay-mcp-server/Cargo.toml
@@ -12,6 +12,9 @@ workspace = true
 
 [features]
 experimental = ["assay-core/experimental"]
+# Test-only: adds assay_test_outbound tool for E6a.3 no-pass-through E2E test.
+# Use: cargo test -p assay-mcp-server --features test-outbound
+test-outbound = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/assay-mcp-server/src/auth/jwks.rs
+++ b/crates/assay-mcp-server/src/auth/jwks.rs
@@ -41,6 +41,7 @@ impl JwksProvider {
                 .max_capacity(100)
                 .time_to_live(Duration::from_secs(3600)) // 1 hour TTL
                 .build(),
+            // E6a.3 no-pass-through: outbound requests use no request-derived headers (allowlist-only).
             client: Client::builder()
                 .timeout(Duration::from_secs(5))
                 .user_agent("assay-mcp-server/0.1")

--- a/crates/assay-mcp-server/src/auth/mod.rs
+++ b/crates/assay-mcp-server/src/auth/mod.rs
@@ -1,9 +1,13 @@
 pub mod config;
 pub mod jwks;
+pub mod sensitive_headers;
 pub mod validation;
 
 pub use config::{AuthConfig, AuthMode};
 pub use jwks::JwksProvider;
+pub use sensitive_headers::{
+    build_downstream_headers, is_sensitive, strip_sensitive_headers, SENSITIVE_HEADER_NAMES,
+};
 pub use validation::{Claims, TokenValidator};
 
 #[cfg(test)]

--- a/crates/assay-mcp-server/src/auth/sensitive_headers.rs
+++ b/crates/assay-mcp-server/src/auth/sensitive_headers.rs
@@ -1,0 +1,125 @@
+//! No pass-through of inbound auth to downstream (E6a.3).
+//!
+//! **Security invariant:** Inbound authentication material MUST NOT be forwarded to any
+//! downstream HTTP call (LLM/judge/proxy). Outbound requests MUST be built from an allowlist
+//! of headers or pass through [strip_sensitive_headers] before send. Tests enforce this invariant.
+//!
+//! **PR packet (review/sign-off):**
+//! 1. **Header set (denylist):** [SENSITIVE_HEADER_NAMES] — comparison is case-insensitive.
+//! 2. **Outbound callsites:** (a) JWKS in [crate::auth::jwks] — no request-derived headers.
+//!    (b) Test-only outbound in [crate::tools::test_outbound] — uses [build_downstream_headers] only.
+//! 3. **E2E proof:** `tests/no_passthrough_e2e.rs` — inbound auth in initialize, then outbound call;
+//!    assert mock received no sensitive header names (audit-grade failure message on leak).
+
+use std::collections::HashSet;
+
+/// Header names that must never be forwarded from inbound to downstream (case-insensitive).
+/// Covers common credential/cookie leak paths (RFC and de-facto).
+/// Includes response-style names (set-cookie, cookie2) defensively; some proxies misroute headers.
+pub const SENSITIVE_HEADER_NAMES: &[&str] = &[
+    "authorization",
+    "x-api-key",
+    "proxy-authorization",
+    "cookie",
+    "cookie2",
+    "x-auth-token",
+    "x-access-token",
+    "x-forwarded-authorization",
+    "set-cookie",
+];
+
+fn sensitive_set() -> HashSet<&'static str> {
+    SENSITIVE_HEADER_NAMES.iter().copied().collect()
+}
+
+/// Returns true if the header name is sensitive (case-insensitive).
+#[inline]
+pub fn is_sensitive(name: &str) -> bool {
+    sensitive_set().contains(name.to_lowercase().as_str())
+}
+
+/// Strip all sensitive headers from a map (case-insensitive name check).
+/// Prefer [build_downstream_headers] (allowlist) for new code; use this only when
+/// you must filter an existing set. Contract: downstream headers are never "forward inbound";
+/// they are built from scratch or explicitly filtered.
+pub fn strip_sensitive_headers<K, V>(headers: &[(K, V)]) -> Vec<(K, V)>
+where
+    K: AsRef<str> + Clone,
+    V: Clone,
+{
+    let set = sensitive_set();
+    headers
+        .iter()
+        .filter(|(k, _)| !set.contains(k.as_ref().to_lowercase().as_str()))
+        .cloned()
+        .collect()
+}
+
+/// Build headers for a downstream HTTP request from an allowlist only.
+/// No inbound auth is ever included. Use this at every outbound call site.
+#[inline]
+pub fn build_downstream_headers() -> Vec<(&'static str, String)> {
+    // Allowlist: only safe headers we explicitly add (e.g. user-agent, accept).
+    // Empty by default; extend when we need content-type, traceparent, etc.
+    vec![]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_sensitive_case_insensitive() {
+        assert!(is_sensitive("Authorization"));
+        assert!(is_sensitive("authorization"));
+        assert!(is_sensitive("AUTHORIZATION"));
+        assert!(is_sensitive("x-Api-Key"));
+        assert!(is_sensitive("X-Forwarded-Authorization"));
+        assert!(is_sensitive("Cookie"));
+        assert!(is_sensitive("set-cookie"));
+        assert!(!is_sensitive("content-type"));
+        assert!(!is_sensitive("accept"));
+        assert!(!is_sensitive("user-agent"));
+    }
+
+    #[test]
+    fn strip_removes_all_sensitive_names() {
+        let headers: Vec<(String, String)> = vec![
+            ("Authorization".into(), "Bearer INBOUND".into()),
+            ("x-api-key".into(), "secret".into()),
+            ("Content-Type".into(), "application/json".into()),
+            ("cookie".into(), "session=INBOUND".into()),
+            ("X-Auth-Token".into(), "token".into()),
+            ("Accept".into(), "*/*".into()),
+        ];
+        let out = strip_sensitive_headers(&headers);
+        let names: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(!names
+            .iter()
+            .any(|n| n.eq_ignore_ascii_case("authorization")));
+        assert!(!names.iter().any(|n| n.eq_ignore_ascii_case("x-api-key")));
+        assert!(!names.iter().any(|n| n.eq_ignore_ascii_case("cookie")));
+        assert!(!names.iter().any(|n| n.eq_ignore_ascii_case("x-auth-token")));
+        assert!(names.contains(&"Content-Type"));
+        assert!(names.contains(&"Accept"));
+    }
+
+    #[test]
+    fn build_downstream_headers_empty_by_default() {
+        let h = build_downstream_headers();
+        assert!(h.is_empty());
+    }
+
+    #[test]
+    fn strip_removes_duplicate_sensitive_headers() {
+        let headers: Vec<(String, String)> = vec![
+            ("Authorization".into(), "Bearer A".into()),
+            ("Content-Type".into(), "application/json".into()),
+            ("authorization".into(), "Bearer B".into()),
+        ];
+        let out = strip_sensitive_headers(&headers);
+        let names: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(names.len(), 1);
+        assert_eq!(names[0], "Content-Type");
+    }
+}

--- a/crates/assay-mcp-server/src/auth/sensitive_headers.rs
+++ b/crates/assay-mcp-server/src/auth/sensitive_headers.rs
@@ -12,6 +12,7 @@
 //!    assert mock received no sensitive header names (audit-grade failure message on leak).
 
 use std::collections::HashSet;
+use std::sync::OnceLock;
 
 /// Header names that must never be forwarded from inbound to downstream (case-insensitive).
 /// Covers common credential/cookie leak paths (RFC and de-facto).
@@ -28,8 +29,10 @@ pub const SENSITIVE_HEADER_NAMES: &[&str] = &[
     "set-cookie",
 ];
 
-fn sensitive_set() -> HashSet<&'static str> {
-    SENSITIVE_HEADER_NAMES.iter().copied().collect()
+static SENSITIVE_SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+
+fn sensitive_set() -> &'static HashSet<&'static str> {
+    SENSITIVE_SET.get_or_init(|| SENSITIVE_HEADER_NAMES.iter().copied().collect())
 }
 
 /// Returns true if the header name is sensitive (case-insensitive).

--- a/crates/assay-mcp-server/src/tools/test_outbound.rs
+++ b/crates/assay-mcp-server/src/tools/test_outbound.rs
@@ -1,0 +1,33 @@
+//! Test-only outbound hook for E6a.3 no-pass-through E2E test.
+//! When ASSAY_TEST_OUTBOUND_URL is set, performs one GET using [crate::auth::build_downstream_headers]
+//! only (no inbound auth forwarded). Single callsite for outbound header construction.
+#![cfg(feature = "test-outbound")]
+
+use crate::auth::build_downstream_headers;
+use serde_json::Value;
+
+pub async fn test_outbound(_args: &Value) -> anyhow::Result<Value> {
+    let url = match std::env::var("ASSAY_TEST_OUTBOUND_URL") {
+        Ok(u) if !u.is_empty() => u,
+        _ => {
+            return Ok(
+                serde_json::json!({ "allowed": true, "skipped": "ASSAY_TEST_OUTBOUND_URL not set" }),
+            )
+        }
+    };
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()?;
+    let mut req = client.get(&url);
+    // SECURITY-INVARIANT: outbound headers only from build_downstream_headers(); never forward inbound.
+    for (name, value) in build_downstream_headers() {
+        req = req.header(name, value);
+    }
+    let resp = req.send().await?;
+    let status = resp.status().as_u16();
+    Ok(serde_json::json!({
+        "allowed": true,
+        "outbound_status": status,
+        "outbound_headers_from_allowlist_only": true
+    }))
+}

--- a/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
+++ b/crates/assay-mcp-server/tests/no_passthrough_e2e.rs
@@ -1,0 +1,145 @@
+//! E6a.3 no-pass-through E2E test.
+//!
+//! Invariant: inbound auth (e.g. from initialize params) must never appear on any outbound
+//! HTTP request. We send inbound auth, trigger the test-only outbound call, then assert
+//! the mock received no sensitive headers. Run with: cargo test -p assay-mcp-server --features test-outbound no_passthrough
+
+use assay_mcp_server::auth::SENSITIVE_HEADER_NAMES;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn sensitive_names_lower() -> std::collections::HashSet<String> {
+    SENSITIVE_HEADER_NAMES
+        .iter()
+        .map(|s| s.to_lowercase())
+        .collect()
+}
+
+/// Audit-grade failure: which header names were leaked (values not logged).
+fn assert_no_sensitive_headers(requests: &[wiremock::Request]) {
+    let sensitive = sensitive_names_lower();
+    for (i, req) in requests.iter().enumerate() {
+        let mut leaked: Vec<String> = req
+            .headers
+            .iter()
+            .filter(|(name, _)| sensitive.contains(&name.as_str().to_lowercase()))
+            .map(|(name, _)| name.as_str().to_lowercase())
+            .collect();
+        if !leaked.is_empty() {
+            let mut received_names: Vec<String> = req
+                .headers
+                .iter()
+                .map(|(name, _)| name.as_str().to_lowercase())
+                .collect();
+            received_names.sort();
+            leaked.sort();
+            panic!(
+                "E6a.3 no-pass-through violated: request #{} contained sensitive header(s) \
+                 that must not be forwarded: [{}]. Received header names (values redacted): [{}].",
+                i + 1,
+                leaked.join(", "),
+                received_names.join(", ")
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_no_passthrough_e2e() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    let policy_root = "../../tests/fixtures/mcp";
+    let outbound_url = mock_server.uri();
+
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            "assay-mcp-server",
+            "--features",
+            "test-outbound",
+        ])
+        .status()
+        .expect("Failed to build server");
+    assert!(status.success(), "Build with test-outbound must succeed");
+
+    let mut child = Command::new("cargo")
+        .args([
+            "run",
+            "-q",
+            "-p",
+            "assay-mcp-server",
+            "--features",
+            "test-outbound",
+            "--",
+            "--policy-root",
+            policy_root,
+        ])
+        .env("ASSAY_TEST_OUTBOUND_URL", outbound_url.as_str())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("Failed to spawn server");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let mut reader = BufReader::new(stdout);
+
+    // 1. Initialize with inbound auth + multiple sensitive params (server must not forward any to downstream)
+    let req_init = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "test", "version": "1.0" },
+            "authorization": "Bearer INBOUND_TOKEN_NEVER_FORWARD",
+            "x-api-key": "INBOUND_X_API_KEY_NEVER_FORWARD",
+            "cookie": "session=INBOUND_COOKIE_NEVER_FORWARD",
+            "x-forwarded-authorization": "Bearer INBOUND_FWD_AUTH_NEVER_FORWARD"
+        },
+        "id": 1
+    });
+    writeln!(stdin, "{}", req_init).unwrap();
+    stdin.flush().unwrap();
+
+    let mut line = String::new();
+    if reader.read_line(&mut line).unwrap() == 0 {
+        reader.read_line(&mut line).unwrap();
+    }
+    let resp: serde_json::Value = serde_json::from_str(line.trim()).expect("Parse init response");
+    assert!(resp.get("result").is_some(), "Init failed: {:?}", resp);
+
+    // 2. Call test-only outbound tool (single callsite uses build_downstream_headers only)
+    let req_call = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": { "name": "assay_test_outbound", "arguments": {} },
+        "id": 2
+    });
+    writeln!(stdin, "{}", req_call).unwrap();
+    stdin.flush().unwrap();
+
+    line.clear();
+    reader.read_line(&mut line).unwrap();
+    let resp: serde_json::Value = serde_json::from_str(line.trim()).expect("Parse tool response");
+    assert!(resp.get("result").is_some(), "Tool call failed: {:?}", resp);
+
+    drop(stdin);
+    let _ = child.wait();
+
+    let received = mock_server.received_requests().await.unwrap();
+    assert_eq!(
+        received.len(),
+        1,
+        "expected exactly one outbound request (tool must not have skipped; check ASSAY_TEST_OUTBOUND_URL)"
+    );
+    assert_no_sensitive_headers(&received);
+}


### PR DESCRIPTION
### Summary

Implements **E6a.3 no-pass-through**: inbound auth (and other sensitive headers) must never be forwarded to any downstream HTTP call (LLM/judge/proxy). Adds a denylist of sensitive header names, an allowlist-first `build_downstream_headers()` for outbound requests, and an E2E test that proves the invariant.

### Security rationale

- **Allowlist-first:** Outbound headers are built only from `build_downstream_headers()` (empty by default; extensible). No "clone inbound and strip" — we never forward inbound.
- **Single callsite:** JWKS uses no request-derived headers; the only other outbound path (test-only) uses `build_downstream_headers()` only. SECURITY-INVARIANT comment at that call site.
- **Test-only hook:** The tool `assay_test_outbound` exists only under `cfg(feature = "test-outbound")` and is gated in both **compilation** and **registration** (list_tools + handle_call). Default builds and workspace tests do not enable the feature → tool is not in production.

### How to test

- **Unit:** `cargo test -p assay-mcp-server --features test-outbound` (sensitive_headers + existing tests).
- **E2E (no-pass-through):**
  `cargo test -p assay-mcp-server --features test-outbound no_passthrough`
  Starts server with `ASSAY_TEST_OUTBOUND_URL` → mock; sends initialize with multiple sensitive params; calls `assay_test_outbound`; asserts mock received exactly one request and no sensitive header names.
- **CI:** New step runs the E2E with the feature on Linux; normal `cargo test --workspace` does not use the feature.

### Why feature-gated

The test hook must perform a real outbound GET to a URL (the mock). That path is only for tests; we do not want it in production binaries. Feature `test-outbound` ensures the tool is compiled and registered only when explicitly enabled (e.g. in CI or when running the E2E test). No default feature enables it.

### Checklist

- [x] Tool and registration behind `cfg(feature = "test-outbound")`
- [x] E2E asserts exactly one outbound request + no sensitive headers on mock
- [x] Allowlist-first; set-cookie/cookie2 documented as defensive
- [x] CI runs E2E with feature; no secrets in failure output (header names only)
