### PR TITLE
feat(e9d.1): harden replay coverage contract and exit-profile stability

### DIFF
--- a/crates/assay-cli/src/cli/commands/bundle.rs
+++ b/crates/assay-cli/src/cli/commands/bundle.rs
@@ -7,7 +7,7 @@ use assay_core::replay::{
 };
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 pub async fn run(args: BundleArgs, _legacy_mode: bool) -> anyhow::Result<i32> {
@@ -52,6 +52,8 @@ fn cmd_create(args: BundleCreateArgs) -> anyhow::Result<i32> {
     let mut baseline_digest: Option<String> = None;
     let mut trace_digest: Option<String> = None;
     let mut trace_path: Option<String> = None;
+    let mut config_snapshot_present = false;
+    let mut trace_snapshot_present = false;
 
     if let Some(run_json_path) = find_run_json(&source_root, args.from.as_ref()) {
         let run_bytes = std::fs::read(&run_json_path)?;
@@ -131,6 +133,7 @@ fn cmd_create(args: BundleCreateArgs) -> anyhow::Result<i32> {
             .and_then(|s| s.to_str())
             .unwrap_or("eval.yaml");
         entries_map.insert(format!("files/{}", name), bytes.clone());
+        config_snapshot_present = true;
         let hash = format!("sha256:{}", hex::encode(Sha256::digest(&bytes)));
         if config_digest.is_none() {
             config_digest = Some(hash.clone());
@@ -149,6 +152,7 @@ fn cmd_create(args: BundleCreateArgs) -> anyhow::Result<i32> {
             .unwrap_or("trace.jsonl");
         let bundle_trace_path = format!("files/{}", name);
         entries_map.insert(bundle_trace_path.clone(), bytes.clone());
+        trace_snapshot_present = true;
         if trace_digest.is_none() {
             trace_digest = Some(format!("sha256:{}", hex::encode(Sha256::digest(&bytes))));
         }
@@ -177,6 +181,9 @@ fn cmd_create(args: BundleCreateArgs) -> anyhow::Result<i32> {
     for (path, data) in entries_map {
         entries.push(BundleEntry { path, data });
     }
+    replay_coverage = replay_coverage.map(|coverage| {
+        enforce_bundle_input_coverage(coverage, config_snapshot_present, trace_snapshot_present)
+    });
     let file_manifest = build_file_manifest(&entries)?;
 
     let run_id = args
@@ -534,6 +541,45 @@ fn extract_replay_coverage(v: &Value) -> Option<ReplayCoverage> {
             Some(reason)
         },
     })
+}
+
+fn enforce_bundle_input_coverage(
+    mut coverage: ReplayCoverage,
+    config_snapshot_present: bool,
+    trace_snapshot_present: bool,
+) -> ReplayCoverage {
+    // "complete_tests" are only complete when mandatory replay inputs are present in bundle.
+    if !config_snapshot_present {
+        mark_all_incomplete(&mut coverage, "config snapshot missing from bundle");
+    }
+    if !trace_snapshot_present {
+        mark_all_incomplete(&mut coverage, "trace snapshot missing from bundle");
+    }
+    coverage
+}
+
+fn mark_all_incomplete(coverage: &mut ReplayCoverage, reason_message: &str) {
+    let mut all = BTreeSet::new();
+    for test_id in &coverage.complete_tests {
+        all.insert(test_id.clone());
+    }
+    for test_id in &coverage.incomplete_tests {
+        all.insert(test_id.clone());
+    }
+
+    if all.is_empty() {
+        return;
+    }
+
+    let reason = coverage.reason.get_or_insert_with(BTreeMap::new);
+    for test_id in &all {
+        reason
+            .entry(test_id.clone())
+            .or_insert_with(|| reason_message.to_string());
+    }
+
+    coverage.complete_tests.clear();
+    coverage.incomplete_tests = all.into_iter().collect();
 }
 
 fn truncate_reason(message: &str, max_chars: usize) -> String {

--- a/crates/assay-cli/src/exit_codes.rs
+++ b/crates/assay-cli/src/exit_codes.rs
@@ -150,6 +150,10 @@ impl ReasonCode {
         match self {
             ReasonCode::Success => EXIT_SUCCESS,
 
+            // Keep replay missing-dependency deterministic across profiles.
+            // This avoids compat-profile drift for the offline replay contract.
+            ReasonCode::EReplayMissingDependency => EXIT_CONFIG_ERROR,
+
             // In V1, we often conflated errors.
             // E.g., Trace Not Found might have been 3 (Infra) or 1 (General).
             // User spec says: "Trace Not Found is now exit code 2 ... not 3".
@@ -373,6 +377,18 @@ mod tests {
             EXIT_TEST_FAILURE
         );
         assert_eq!(ReasonCode::EArgSchema.exit_code(), EXIT_TEST_FAILURE);
+    }
+
+    #[test]
+    fn test_replay_missing_dependency_profile_stability() {
+        assert_eq!(
+            ReasonCode::EReplayMissingDependency.exit_code_for(ExitCodeVersion::V1),
+            EXIT_CONFIG_ERROR
+        );
+        assert_eq!(
+            ReasonCode::EReplayMissingDependency.exit_code_for(ExitCodeVersion::V2),
+            EXIT_CONFIG_ERROR
+        );
     }
 
     #[test]

--- a/crates/assay-cli/tests/contract_exit_codes.rs
+++ b/crates/assay-cli/tests/contract_exit_codes.rs
@@ -1,6 +1,7 @@
 #![allow(deprecated)]
 use assay_core::replay::{
-    build_file_manifest, write_bundle_tar_gz, BundleEntry, ReplayCoverage, ReplayManifest,
+    build_file_manifest, read_bundle_tar_gz, write_bundle_tar_gz, BundleEntry, ReplayCoverage,
+    ReplayManifest,
 };
 use assert_cmd::Command;
 use serde_json::Value;
@@ -390,6 +391,111 @@ tests:
         .as_str()
         .unwrap_or_default()
         .starts_with("sha256:"));
+
+    let summary = read_summary_json(dir.path());
+    assert_eq!(summary["exit_code"], 2);
+    assert_eq!(summary["reason_code"], "E_REPLAY_MISSING_DEPENDENCY");
+    assert_eq!(summary["provenance"]["replay"], true);
+    assert_eq!(summary["provenance"]["replay_mode"], "offline");
+}
+
+#[test]
+fn contract_bundle_create_marks_missing_trace_as_incomplete_for_offline_replay() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("assay.yaml"),
+        r#"version: 1
+suite: replay-missing-trace
+model: dummy
+tests:
+  - id: t1
+    input: { prompt: "hi" }
+    expected: { type: must_contain, must_contain: ["passed"] }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("trace.jsonl"),
+        r#"{"type":"episode_start","episode_id":"t1","timestamp":1000,"input":{"prompt":"hi"}}
+{"type":"episode_end","episode_id":"t1","timestamp":2000,"final_output":"passed"}
+"#,
+    )
+    .unwrap();
+
+    let mut run_cmd = Command::cargo_bin("assay").unwrap();
+    run_cmd
+        .current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("run")
+        .arg("--config")
+        .arg("assay.yaml")
+        .arg("--trace-file")
+        .arg("trace.jsonl")
+        .arg("--strict")
+        .assert()
+        .success();
+
+    // Build a bundle from a run directory where trace input is missing.
+    fs::remove_file(dir.path().join("trace.jsonl")).unwrap();
+
+    let mut bundle_cmd = Command::cargo_bin("assay").unwrap();
+    bundle_cmd
+        .current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("bundle")
+        .arg("create")
+        .arg("--from")
+        .arg(".")
+        .arg("--output")
+        .arg("replay-missing-trace.tar.gz")
+        .assert()
+        .success();
+
+    let bundle_file = std::fs::File::open(dir.path().join("replay-missing-trace.tar.gz")).unwrap();
+    let bundle = read_bundle_tar_gz(bundle_file).unwrap();
+    let coverage = bundle
+        .manifest
+        .replay_coverage
+        .expect("bundle manifest must include replay_coverage");
+    assert!(
+        coverage.complete_tests.is_empty(),
+        "missing trace snapshot must force complete_tests to be empty"
+    );
+    assert!(
+        coverage.incomplete_tests.iter().any(|t| t == "t1"),
+        "missing trace snapshot must mark test as incomplete"
+    );
+    let reason = coverage
+        .reason
+        .as_ref()
+        .and_then(|m| m.get("t1"))
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        reason.contains("trace snapshot missing"),
+        "expected trace-missing reason, got: {}",
+        reason
+    );
+
+    fs::remove_file(dir.path().join("run.json")).unwrap();
+    fs::remove_file(dir.path().join("summary.json")).unwrap();
+
+    let mut replay_cmd = Command::cargo_bin("assay").unwrap();
+    replay_cmd
+        .current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("replay")
+        .arg("--bundle")
+        .arg("replay-missing-trace.tar.gz")
+        .assert()
+        .code(2);
+
+    let run = read_run_json(dir.path());
+    assert_schema(&run);
+    assert_eq!(run["exit_code"], 2);
+    assert_eq!(run["reason_code"], "E_REPLAY_MISSING_DEPENDENCY");
+    assert_eq!(run["provenance"]["replay"], true);
+    assert_eq!(run["provenance"]["replay_mode"], "offline");
 
     let summary = read_summary_json(dir.path());
     assert_eq!(summary["exit_code"], 2);

--- a/docs/generated/module-summary.txt
+++ b/docs/generated/module-summary.txt
@@ -14,4 +14,3 @@
 | assay-ebpf | eBPF programs | lsm hooks |
 | assay-sim | Attack simulation | scenarios |
 | assay-common | Shared types | exports |
-


### PR DESCRIPTION
## Summary
- harden `bundle create` replay coverage so tests are only `complete` when mandatory bundle inputs are present
- add contract test proving missing trace snapshot leads to offline replay exit 2 (`E_REPLAY_MISSING_DEPENDENCY`) with provenance in `run.json` and `summary.json`
- lock `E_REPLAY_MISSING_DEPENDENCY` to exit code 2 for both V1 and V2 profiles, with regression test

## Why
This implements the first post-E9c hardening slice focused on correctness and contract stability (H2/H3/H4).

## Validation
- cargo fmt --all
- cargo test -p assay-cli
- cargo clippy -p assay-cli --all-targets -- -D warnings

## Notes
Unrelated local workspace changes were intentionally left untouched.
