### PR TITLE
feat(explain): add --compliance-pack hints and coverage summary (P1-B)

### DIFF
--- a/crates/assay-cli/src/cli/commands/explain.rs
+++ b/crates/assay-cli/src/cli/commands/explain.rs
@@ -12,7 +12,9 @@
 
 use anyhow::{Context, Result};
 use assay_core::explain;
+use assay_evidence::lint::packs;
 use clap::Args;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 #[derive(Args, Debug)]
@@ -40,6 +42,23 @@ pub struct ExplainArgs {
     /// Show rule evaluation details for all steps
     #[arg(long)]
     pub verbose: bool,
+
+    /// Optional compliance pack used for article hints and coverage summary
+    #[arg(long)]
+    pub compliance_pack: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ComplianceSummary {
+    pack_name: String,
+    applicable: usize,
+    total: usize,
+}
+
+#[derive(Debug, Clone)]
+struct ComplianceOutput {
+    summary: ComplianceSummary,
+    blocking_hints: Vec<(String, String)>,
 }
 
 /// Trace input formats
@@ -107,9 +126,14 @@ pub async fn run(args: ExplainArgs) -> Result<i32> {
     // Run explanation
     let explainer = explain::TraceExplainer::new(policy);
     let explanation = explainer.explain(&tool_calls);
+    let compliance = if let Some(pack_ref) = args.compliance_pack.as_deref() {
+        Some(build_compliance_output(&explanation, pack_ref)?)
+    } else {
+        None
+    };
 
     // Format output
-    let output = match args.format.as_str() {
+    let mut output = match args.format.as_str() {
         "markdown" | "md" => explanation.to_markdown(),
         "html" => explanation.to_html(),
         "json" => serde_json::to_string_pretty(&explanation)?,
@@ -132,6 +156,7 @@ pub async fn run(args: ExplainArgs) -> Result<i32> {
             }
         }
     };
+    append_compliance_section(&mut output, args.format.as_str(), compliance.as_ref());
 
     // Write output
     if let Some(output_path) = args.output {
@@ -145,6 +170,129 @@ pub async fn run(args: ExplainArgs) -> Result<i32> {
 
     // Exit code: 0 if all allowed, 1 if any blocked
     Ok(if explanation.blocked_steps > 0 { 1 } else { 0 })
+}
+
+fn native_rule_article_ref(rule_id: &str) -> Option<&'static str> {
+    if rule_id == "deny_list" {
+        return Some("Article 15(3) - Robustness and accuracy");
+    }
+    if rule_id == "allow_list" {
+        return Some("Article 12(1) - Record-keeping");
+    }
+    if rule_id.starts_with("max_calls_") {
+        return Some("Article 14(4) - Human oversight");
+    }
+    if rule_id.starts_with("before_") {
+        return Some("Article 12(2) - Traceability");
+    }
+    if rule_id.starts_with("never_after_") {
+        return Some("Article 15(1) - Safety");
+    }
+    if rule_id.starts_with("sequence_") {
+        return Some("Article 14(3) - Oversight");
+    }
+    None
+}
+
+fn article_for_rule(rule_id: &str, pack_articles: &BTreeMap<String, String>) -> Option<String> {
+    if let Some(v) = pack_articles.get(rule_id) {
+        return Some(v.clone());
+    }
+    native_rule_article_ref(rule_id).map(str::to_string)
+}
+
+fn build_compliance_output(
+    explanation: &explain::TraceExplanation,
+    pack_ref: &str,
+) -> Result<ComplianceOutput> {
+    let loaded = packs::load_pack(pack_ref)
+        .with_context(|| format!("Failed to load compliance pack '{}'", pack_ref))?;
+
+    let mut pack_articles = BTreeMap::new();
+    for rule in &loaded.definition.rules {
+        if let Some(article) = &rule.article_ref {
+            pack_articles.insert(rule.id.clone(), article.clone());
+        }
+    }
+
+    let mut evaluated_rule_ids = BTreeSet::new();
+    for step in &explanation.steps {
+        for eval in &step.rules_evaluated {
+            evaluated_rule_ids.insert(eval.rule_id.clone());
+        }
+    }
+
+    let applicable = evaluated_rule_ids
+        .iter()
+        .filter(|rid| article_for_rule(rid, &pack_articles).is_some())
+        .count();
+
+    let mut blocking_hints = Vec::new();
+    for rid in &explanation.blocking_rules {
+        if let Some(article) = article_for_rule(rid, &pack_articles) {
+            blocking_hints.push((rid.clone(), article));
+        }
+    }
+
+    Ok(ComplianceOutput {
+        summary: ComplianceSummary {
+            pack_name: loaded.definition.name,
+            applicable,
+            total: loaded.definition.rules.len(),
+        },
+        blocking_hints,
+    })
+}
+
+fn append_compliance_section(
+    output: &mut String,
+    format: &str,
+    compliance: Option<&ComplianceOutput>,
+) {
+    let Some(compliance) = compliance else {
+        return;
+    };
+
+    // Keep JSON/HTML machine-formats untouched in this slice.
+    if format == "json" || format == "html" {
+        return;
+    }
+
+    let pct = if compliance.summary.total == 0 {
+        0.0
+    } else {
+        (compliance.summary.applicable as f64 / compliance.summary.total as f64) * 100.0
+    };
+
+    if format == "markdown" || format == "md" {
+        output.push_str("\n\n## Compliance Coverage\n");
+        output.push_str(&format!(
+            "- {}: {}/{} rules applicable ({:.1}%)\n",
+            compliance.summary.pack_name,
+            compliance.summary.applicable,
+            compliance.summary.total,
+            pct
+        ));
+        if !compliance.blocking_hints.is_empty() {
+            output.push_str("\n### Blocking Rule Hints\n");
+            for (rule, article) in &compliance.blocking_hints {
+                output.push_str(&format!("- `{}` -> {}\n", rule, article));
+            }
+        }
+        return;
+    }
+
+    output.push_str("\n\nCompliance Coverage:\n");
+    output.push_str(&format!(
+        "  {}: {}/{} rules applicable ({:.1}%)\n",
+        compliance.summary.pack_name, compliance.summary.applicable, compliance.summary.total, pct
+    ));
+    if !compliance.blocking_hints.is_empty() {
+        output.push_str("\nCompliance Hints:\n");
+        for (rule, article) in &compliance.blocking_hints {
+            output.push_str(&format!("  - {} -> {}\n", rule, article));
+        }
+    }
 }
 
 fn parse_trace(content: &str) -> Result<Vec<explain::ToolCall>> {
@@ -319,5 +467,46 @@ mod tests {
         let calls = parse_trace(content).unwrap();
         assert_eq!(calls[0].tool, "Search");
         assert_eq!(calls[1].tool, "Create");
+    }
+
+    #[test]
+    fn test_article_for_rule_native_mapping() {
+        let pack_articles = BTreeMap::new();
+        assert!(article_for_rule("deny_list", &pack_articles)
+            .unwrap()
+            .contains("Article 15(3)"));
+        assert!(article_for_rule("sequence_deploy_validate", &pack_articles)
+            .unwrap()
+            .contains("Article 14(3)"));
+    }
+
+    #[test]
+    fn test_article_for_rule_pack_override() {
+        let mut pack_articles = BTreeMap::new();
+        pack_articles.insert("deny_list".to_string(), "12(9)".to_string());
+        assert_eq!(
+            article_for_rule("deny_list", &pack_articles).as_deref(),
+            Some("12(9)")
+        );
+    }
+
+    #[test]
+    fn test_append_compliance_section_terminal() {
+        let mut s = "base".to_string();
+        let c = ComplianceOutput {
+            summary: ComplianceSummary {
+                pack_name: "eu-ai-act-baseline".to_string(),
+                applicable: 3,
+                total: 8,
+            },
+            blocking_hints: vec![(
+                "deny_list".to_string(),
+                "Article 15(3) - Robustness and accuracy".to_string(),
+            )],
+        };
+        append_compliance_section(&mut s, "terminal", Some(&c));
+        assert!(s.contains("Compliance Coverage:"));
+        assert!(s.contains("3/8 rules applicable"));
+        assert!(s.contains("deny_list -> Article 15(3)"));
     }
 }

--- a/crates/assay-cli/src/cli/commands/explain.rs
+++ b/crates/assay-cli/src/cli/commands/explain.rs
@@ -350,12 +350,12 @@ fn format_verbose(explanation: &explain::TraceExplanation) -> String {
 
     for step in &explanation.steps {
         let icon = match step.verdict {
-            explain::StepVerdict::Allowed => "✅",
-            explain::StepVerdict::Blocked => "❌",
-            explain::StepVerdict::Warning => "⚠️",
+            explain::StepVerdict::Allowed => "OK",
+            explain::StepVerdict::Blocked => "BLOCKED",
+            explain::StepVerdict::Warning => "WARN",
         };
 
-        lines.push(format!("─── Step {} ───", step.index));
+        lines.push(format!("--- Step {} ---", step.index));
         lines.push(format!("  Tool: {} {}", step.tool, icon));
 
         if let Some(args) = &step.args {
@@ -370,7 +370,7 @@ fn format_verbose(explanation: &explain::TraceExplanation) -> String {
 
         lines.push("  Rules Evaluated:".to_string());
         for eval in &step.rules_evaluated {
-            let status = if eval.passed { "✓" } else { "✗" };
+            let status = if eval.passed { "PASS" } else { "FAIL" };
             lines.push(format!(
                 "    {} [{}] {}",
                 status, eval.rule_type, eval.rule_id
@@ -388,21 +388,18 @@ fn format_blocked_only(explanation: &explain::TraceExplanation) -> String {
     let mut lines = Vec::new();
 
     if explanation.blocked_steps == 0 {
-        lines.push("✅ All steps allowed".to_string());
+        lines.push("All steps allowed".to_string());
         return lines.join("\n");
     }
 
-    lines.push(format!(
-        "❌ {} blocked step(s):\n",
-        explanation.blocked_steps
-    ));
+    lines.push(format!("{} blocked step(s):\n", explanation.blocked_steps));
 
     for step in &explanation.steps {
         if step.verdict != explain::StepVerdict::Blocked {
             continue;
         }
 
-        lines.push(format!("[{}] {} ❌ BLOCKED", step.index, step.tool));
+        lines.push(format!("[{}] {} BLOCKED", step.index, step.tool));
 
         for eval in &step.rules_evaluated {
             if !eval.passed {


### PR DESCRIPTION
## Summary
- add `--compliance-pack <ref>` to `assay explain`
- load compliance pack metadata and annotate blocked rules with article hints
- append compliance coverage summary to terminal/markdown output
- keep json/html output unchanged in this slice

## Why
This is P1-B from the DX roadmap: explanations should carry compliance context so blocked tool calls are easier to interpret in governance terms.

## Scope
- File changed: `crates/assay-cli/src/cli/commands/explain.rs`
- No schema/output contract changes for `run.json` / `summary.json`

## Validation
- `cargo test -p assay-cli explain::tests -- --nocapture`
- `cargo clippy -p assay-cli -- -D warnings`
