### PR TITLE
docs(cli): add explain reference and define compliance coverage semantics

### DIFF
--- a/docs/reference/cli/explain.md
+++ b/docs/reference/cli/explain.md
@@ -1,0 +1,109 @@
+# assay explain
+
+Explain how a trace is evaluated against policy rules, step by step.
+
+---
+
+## Synopsis
+
+```bash
+assay explain --trace <TRACE> --policy <POLICY> [OPTIONS]
+```
+
+---
+
+## Description
+
+`assay explain` loads a trace and policy, evaluates each tool call, and prints why steps were allowed or blocked.
+
+Use it for:
+- fast triage of blocked traces
+- rule-level debugging (`rule_id`, `rule_type`, explanation context)
+- compliance-oriented reporting with `--compliance-pack`
+
+---
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--trace`, `-t <FILE>` | Trace input (JSON, JSONL, or object with `tools`/`tool_calls`) |
+| `--policy`, `-p <FILE>` | Policy file used for evaluation |
+| `--format`, `-f <FORMAT>` | Output format: `terminal` (default), `markdown`, `html`, `json` |
+| `--output`, `-o <FILE>` | Write output to file instead of stdout |
+| `--blocked-only` | Show only blocked steps |
+| `--verbose` | Show all rule evaluations per step |
+| `--compliance-pack <REF>` | Add article hints + coverage summary from a compliance pack (for `terminal`/`markdown`) |
+
+---
+
+## Compliance Pack Output
+
+When `--compliance-pack` is provided:
+- `terminal` and `markdown` outputs include:
+  - **Compliance Coverage** (`<applicable>/<total>` + percentage)
+  - **Blocking Rule Hints** (`rule_id -> article`)
+- `json` and `html` outputs are unchanged in this slice.
+
+Definition:
+- **`total`** = number of rules in the loaded compliance pack.
+- **`applicable`** = number of unique evaluated `rule_id`s in the trace explanation that resolve to an article reference (pack mapping first, native fallback mapping second).
+
+---
+
+## Examples
+
+### Basic explain
+
+```bash
+assay explain --trace traces/session.jsonl --policy policy.yaml
+```
+
+### Blocked-only markdown report
+
+```bash
+assay explain \
+  --trace traces/session.jsonl \
+  --policy policy.yaml \
+  --blocked-only \
+  --format markdown \
+  --output reports/explain.md
+```
+
+### Explain with compliance hints
+
+```bash
+assay explain \
+  --trace traces/session.jsonl \
+  --policy policy.yaml \
+  --compliance-pack eu-ai-act-baseline \
+  --format terminal
+```
+
+Expected terminal tail:
+
+```text
+Compliance Coverage:
+  eu-ai-act-baseline: 3/8 rules applicable (37.5%)
+
+Compliance Hints:
+  - deny_list -> Article 15(3) - Robustness and accuracy
+```
+
+Expected markdown tail:
+
+```md
+## Compliance Coverage
+- eu-ai-act-baseline: 3/8 rules applicable (37.5%)
+
+### Blocking Rule Hints
+- `deny_list` -> Article 15(3) - Robustness and accuracy
+```
+
+---
+
+## Exit Code
+
+- `0` if all steps are allowed
+- `1` if one or more steps are blocked
+

--- a/docs/reference/cli/explain.md
+++ b/docs/reference/cli/explain.md
@@ -31,8 +31,8 @@ Use it for:
 | `--policy`, `-p <FILE>` | Policy file used for evaluation |
 | `--format`, `-f <FORMAT>` | Output format: `terminal` (default), `markdown`, `html`, `json` |
 | `--output`, `-o <FILE>` | Write output to file instead of stdout |
-| `--blocked-only` | Show only blocked steps |
-| `--verbose` | Show all rule evaluations per step |
+| `--blocked-only` | Show only blocked steps (terminal output only) |
+| `--verbose` | Show all rule evaluations per step (terminal output only) |
 | `--compliance-pack <REF>` | Add article hints + coverage summary from a compliance pack (for `terminal`/`markdown`) |
 
 ---
@@ -59,13 +59,22 @@ Definition:
 assay explain --trace traces/session.jsonl --policy policy.yaml
 ```
 
-### Blocked-only markdown report
+### Blocked-only terminal report
 
 ```bash
 assay explain \
   --trace traces/session.jsonl \
   --policy policy.yaml \
   --blocked-only \
+  --format terminal
+```
+
+### Markdown report (full explanation)
+
+```bash
+assay explain \
+  --trace traces/session.jsonl \
+  --policy policy.yaml \
   --format markdown \
   --output reports/explain.md
 ```
@@ -106,4 +115,3 @@ Expected markdown tail:
 
 - `0` if all steps are allowed
 - `1` if one or more steps are blocked
-

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -26,6 +26,7 @@ assay --version
 | Command | Description |
 |---------|-------------|
 | [`assay run`](run.md) | Run tests against traces |
+| [`assay explain`](explain.md) | Explain why trace steps were allowed/blocked |
 | [`assay bundle`](bundle.md) | Create/verify replay bundles |
 | [`assay replay`](replay.md) | Replay from a replay bundle |
 | [`assay import`](import.md) | Import sessions from MCP Inspector, etc. |
@@ -162,6 +163,14 @@ See [Configuration](../config/index.md) for full reference.
     Run tests against traces. The main command for CI/CD.
 
     [:octicons-arrow-right-24: Full reference](run.md)
+
+-   :material-file-search-outline:{ .lg .middle } __assay explain__
+
+    ---
+
+    Explain blocked/allowed trace steps and evaluated rules.
+
+    [:octicons-arrow-right-24: Full reference](explain.md)
 
 -   :material-import:{ .lg .middle } __assay import__
 


### PR DESCRIPTION
## Summary
- add dedicated CLI reference page for `assay explain`
- document new `--compliance-pack` option with terminal/markdown behavior
- define compliance coverage semantics explicitly (`applicable` vs `total`)
- link `assay explain` from CLI index overview/cards

## Why
Follow-up to P1-B: make output semantics and usage reproducible in docs, especially the meaning of `applicable`.

## Files
- `docs/reference/cli/explain.md` (new)
- `docs/reference/cli/index.md` (link + card)
