### PR TITLE
ci: always publish required CI check for docs-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [ main, "debug/**" ]
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - ".gitignore"
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary
Remove `pull_request.paths-ignore` from `.github/workflows/ci.yml` so the required `CI` check is always published, including docs-only PRs.

## Why
Docs-only PRs skipped the entire CI workflow, which left branch protection waiting on an expected status check (`CIExpected / Waiting for status to be reported`).

## Change
- `.github/workflows/ci.yml`
  - remove:
    - `docs/**`
    - `**.md`
    - `.gitignore`
  from `pull_request.paths-ignore`.

## Expected behavior
- Every PR now emits the `CI` check run.
- Docs-only PRs no longer get stuck on missing required status `CI`.
