### PR TITLE
feat(action-v2.1): add compliance pack failure modes + contract tests

### DIFF
--- a/.github/workflows/action-v2-test.yml
+++ b/.github/workflows/action-v2-test.yml
@@ -167,3 +167,61 @@ jobs:
             echo "ERROR: expected pack_error_kind=missing_pack"
             exit 1
           fi
+
+  test-invalid-pack-fails-cleanly:
+    name: Test (invalid compliance pack failure mode)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Build Assay CLI
+        run: cargo build --release -p assay-cli
+
+      - name: Setup evidence directory with fixture
+        run: |
+          mkdir -p .assay/evidence
+          cp tests/fixtures/evidence/test-bundle.tar.gz .assay/evidence/
+
+      - name: Create invalid pack file
+        run: |
+          cat > invalid-pack.yaml <<'EOF'
+          name: broken-pack
+          kind: compliance
+          version: "1.0.0"
+          rules:
+            - id: BAD-001
+              message: "missing required fields on purpose"
+          EOF
+
+      - name: Add CLI to PATH
+        run: echo "${{ github.workspace }}/target/release" >> "$GITHUB_PATH"
+
+      - name: Run action with invalid pack (expected failure)
+        id: assay_invalid_pack
+        continue-on-error: true
+        uses: ./assay-action
+        with:
+          bundles: '.assay/evidence/*.tar.gz'
+          fail_on: none
+          pack: ./invalid-pack.yaml
+
+      - name: Validate invalid-pack failure mode outputs
+        run: |
+          echo "Step outcome: ${{ steps.assay_invalid_pack.outcome }}"
+          echo "Pack status: ${{ steps.assay_invalid_pack.outputs.pack_status }}"
+          echo "Pack error kind: ${{ steps.assay_invalid_pack.outputs.pack_error_kind }}"
+
+          if [ "${{ steps.assay_invalid_pack.outcome }}" != "failure" ]; then
+            echo "ERROR: expected action step to fail on invalid pack"
+            exit 1
+          fi
+
+          if [ "${{ steps.assay_invalid_pack.outputs.pack_status }}" != "invalid_pack" ]; then
+            echo "ERROR: expected pack_status=invalid_pack"
+            exit 1
+          fi
+
+          if [ "${{ steps.assay_invalid_pack.outputs.pack_error_kind }}" != "invalid_pack" ]; then
+            echo "ERROR: expected pack_error_kind=invalid_pack"
+            exit 1
+          fi

--- a/.github/workflows/action-v2-test.yml
+++ b/.github/workflows/action-v2-test.yml
@@ -79,3 +79,91 @@ jobs:
           fi
 
       # Artifact upload is handled by the action itself (tar + upload)
+
+  test-with-pack:
+    name: Test (with compliance pack)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Build Assay CLI
+        run: cargo build --release -p assay-cli
+
+      - name: Setup evidence directory with fixture
+        run: |
+          mkdir -p .assay/evidence
+          cp tests/fixtures/evidence/test-bundle.tar.gz .assay/evidence/
+
+      - name: Add CLI to PATH
+        run: echo "${{ github.workspace }}/target/release" >> "$GITHUB_PATH"
+
+      - name: Test action with compliance pack
+        id: assay_pack
+        uses: ./assay-action
+        with:
+          bundles: '.assay/evidence/*.tar.gz'
+          fail_on: none
+          pack: eu-ai-act-baseline
+
+      - name: Validate pack outputs
+        run: |
+          echo "Pack status: ${{ steps.assay_pack.outputs.pack_status }}"
+          echo "Resolved packs: ${{ steps.assay_pack.outputs.resolved_pack_refs }}"
+          echo "Pack score: ${{ steps.assay_pack.outputs.pack_score }}"
+
+          if [ "${{ steps.assay_pack.outputs.pack_status }}" != "success" ]; then
+            echo "ERROR: expected pack_status=success"
+            exit 1
+          fi
+
+          if [ -z "${{ steps.assay_pack.outputs.resolved_pack_refs }}" ]; then
+            echo "ERROR: expected resolved_pack_refs to be set"
+            exit 1
+          fi
+
+  test-missing-pack-fails-cleanly:
+    name: Test (missing compliance pack failure mode)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Build Assay CLI
+        run: cargo build --release -p assay-cli
+
+      - name: Setup evidence directory with fixture
+        run: |
+          mkdir -p .assay/evidence
+          cp tests/fixtures/evidence/test-bundle.tar.gz .assay/evidence/
+
+      - name: Add CLI to PATH
+        run: echo "${{ github.workspace }}/target/release" >> "$GITHUB_PATH"
+
+      - name: Run action with missing pack (expected failure)
+        id: assay_missing_pack
+        continue-on-error: true
+        uses: ./assay-action
+        with:
+          bundles: '.assay/evidence/*.tar.gz'
+          fail_on: none
+          pack: definitely-not-a-real-pack
+
+      - name: Validate failure mode outputs
+        run: |
+          echo "Step outcome: ${{ steps.assay_missing_pack.outcome }}"
+          echo "Pack status: ${{ steps.assay_missing_pack.outputs.pack_status }}"
+          echo "Pack error kind: ${{ steps.assay_missing_pack.outputs.pack_error_kind }}"
+
+          if [ "${{ steps.assay_missing_pack.outcome }}" != "failure" ]; then
+            echo "ERROR: expected action step to fail on missing pack"
+            exit 1
+          fi
+
+          if [ "${{ steps.assay_missing_pack.outputs.pack_status }}" != "missing_pack" ]; then
+            echo "ERROR: expected pack_status=missing_pack"
+            exit 1
+          fi
+
+          if [ "${{ steps.assay_missing_pack.outputs.pack_error_kind }}" != "missing_pack" ]; then
+            echo "ERROR: expected pack_error_kind=missing_pack"
+            exit 1
+          fi

--- a/.github/workflows/perf_pr.yml
+++ b/.github/workflows/perf_pr.yml
@@ -1,4 +1,6 @@
-# PR: vergelijk met main-baseline via start-point + clone-thresholds.
+# PR: vergelijk altijd met main-baseline via start-point + clone-thresholds.
+# Gebruik expliciet `main` als start-point zodat feature/base branches die in
+# Bencher gearchiveerd zijn geen 404 "Head Version not found" veroorzaken.
 # Alleen same-repo PRs (secrets niet beschikbaar op forks).
 # Vereist: BENCHER_PROJECT, BENCHER_API_TOKEN.
 #
@@ -55,8 +57,7 @@ jobs:
                 --project "$BENCHER_PROJECT" \
                 --token "$BENCHER_API_TOKEN" \
                 --branch "$GITHUB_HEAD_REF" \
-                --start-point "$GITHUB_BASE_REF" \
-                --start-point-hash '${{ github.event.pull_request.base.sha }}' \
+                --start-point main \
                 --start-point-clone-thresholds \
                 --start-point-reset \
                 --testbed ubuntu-latest \
@@ -79,8 +80,7 @@ jobs:
                 --project "$BENCHER_PROJECT" \
                 --token "$BENCHER_API_TOKEN" \
                 --branch "$GITHUB_HEAD_REF" \
-                --start-point "$GITHUB_BASE_REF" \
-                --start-point-hash '${{ github.event.pull_request.base.sha }}' \
+                --start-point main \
                 --start-point-clone-thresholds \
                 --start-point-reset \
                 --testbed ubuntu-latest \

--- a/assay-action/README.md
+++ b/assay-action/README.md
@@ -163,7 +163,10 @@ jobs:
 | `findings_error` | Error count |
 | `findings_warn` | Warning count |
 | `reports_dir` | Reports directory path |
+| `resolved_pack_refs` | Resolved pack refs as `name@version` |
 | `pack_score` | Compliance score (0-100) |
+| `pack_status` | `disabled`, `success`, `missing_pack`, `invalid_pack`, `runtime_error` |
+| `pack_error_kind` | Machine-readable pack error category |
 | `coverage_percent` | Evidence coverage % |
 | `bundle_url` | BYOS URL (if pushed) |
 | `attestation_url` | Attestation URL (if generated) |
@@ -195,6 +198,15 @@ permissions:
 - **Fork PRs**: Verify + lint only (no writes)
 - **Same-repo PRs**: Verify + lint + SARIF + PR comment
 - **Default branch push**: All features (baseline, BYOS, attestation, badge)
+
+## Pack Failure Modes
+
+When `pack` is configured, the action distinguishes:
+- `missing_pack`: unknown pack name or missing file path
+- `invalid_pack`: pack schema/validation/parsing error
+- `runtime_error`: unexpected lint/runtime failure
+
+Use `pack_status` and `pack_error_kind` outputs for CI routing.
 
 ## Documentation
 

--- a/assay-action/README.md
+++ b/assay-action/README.md
@@ -208,6 +208,10 @@ When `pack` is configured, the action distinguishes:
 
 Use `pack_status` and `pack_error_kind` outputs for CI routing.
 
+Behavior note:
+- compliance pack load/validation/runtime errors fail the action step
+- policy findings still follow normal `fail_on` threshold behavior
+
 ## Documentation
 
 - [Full Guide](https://github.com/Rul1an/assay/blob/main/docs/guides/github-action.md)

--- a/assay-action/action.yml
+++ b/assay-action/action.yml
@@ -807,6 +807,7 @@ runs:
 
         # Lint with packs (generates pack-enhanced SARIF). Use --fail-on none so
         # policy findings do not masquerade as pack-loading/config errors.
+        # Pack-loading/config/runtime failures still fail this step with exit 3.
         while IFS= read -r bundle || [ -n "$bundle" ]; do
           [ -z "$bundle" ] && continue
           echo "Linting with packs: $bundle"
@@ -875,7 +876,7 @@ runs:
         SARIF="$REPORTS_DIR/pack-lint.sarif"
 
         # Extract pack metadata from SARIF (run-wide, deterministic).
-        RESOLVED_PACKS=$(jq -r '[.runs[].tool.driver.properties.assayPacks[]? | "\(.name)@\(.version)"] | unique | join(",")' "$SARIF" 2>/dev/null || echo "")
+        RESOLVED_PACKS=$(jq -r '[.runs[].tool.driver.properties.assayPacks[]? | "\(.name)@\(.version)"] | sort | unique | join(",")' "$SARIF" 2>/dev/null || echo "")
         PACK_APPLIED="$RESOLVED_PACKS"
         PACK_SCORE=$(jq -r '[.runs[].properties.complianceScore?] | if length == 0 then 100 else (add / length | floor) end' "$SARIF" 2>/dev/null || echo "100")
         PACK_ARTICLES=$(jq -r '[.runs[].tool.driver.rules[]?.properties.article_ref // empty] | unique | sort | join(",")' "$SARIF" 2>/dev/null || echo "")

--- a/assay-action/action.yml
+++ b/assay-action/action.yml
@@ -172,12 +172,21 @@ outputs:
   pack_applied:
     description: 'Comma-separated list of applied pack IDs'
     value: ${{ steps.pack-lint.outputs.pack_applied }}
+  resolved_pack_refs:
+    description: 'Resolved pack references as name@version list'
+    value: ${{ steps.pack-lint.outputs.resolved_pack_refs }}
   pack_score:
     description: 'Compliance score (0-100) across all packs'
     value: ${{ steps.pack-lint.outputs.pack_score }}
   pack_articles:
     description: 'Comma-separated list of covered articles (e.g., "12(1),12(2)(a)")'
     value: ${{ steps.pack-lint.outputs.pack_articles }}
+  pack_status:
+    description: 'Compliance pack status: disabled, success, missing_pack, invalid_pack, runtime_error'
+    value: ${{ steps.pack-lint.outputs.pack_status || 'disabled' }}
+  pack_error_kind:
+    description: 'Pack error category when pack_status is not success'
+    value: ${{ steps.pack-lint.outputs.pack_error_kind }}
   bundle_url:
     description: 'URL of pushed evidence bundle in BYOS (if store set)'
     value: ${{ steps.byos-push.outputs.bundle_url }}
@@ -793,24 +802,66 @@ runs:
         set -euo pipefail
         export PATH="$HOME/.assay/bin:$PATH"
 
-        # Lint with packs (generates pack-enhanced SARIF)
+        PACK_STATUS="success"
+        PACK_ERROR_KIND=""
+
+        # Lint with packs (generates pack-enhanced SARIF). Use --fail-on none so
+        # policy findings do not masquerade as pack-loading/config errors.
         while IFS= read -r bundle || [ -n "$bundle" ]; do
           [ -z "$bundle" ] && continue
           echo "Linting with packs: $bundle"
-          assay evidence lint \
+          OUT_SARIF="$REPORTS_DIR/pack-lint-$(basename "$bundle" .tar.gz).sarif"
+          OUT_ERR="$REPORTS_DIR/pack-lint-$(basename "$bundle" .tar.gz).stderr.log"
+
+          if assay evidence lint \
             --format sarif \
+            --fail-on none \
             --pack "$PACKS" \
-            --output "$REPORTS_DIR/pack-lint-$(basename "$bundle" .tar.gz).sarif" \
-            "$bundle" || true
+            "$bundle" > "$OUT_SARIF" 2> "$OUT_ERR"; then
+            :
+          else
+            EXIT_CODE=$?
+            ERR_MSG=$(head -n 2 "$OUT_ERR" | tr '\n' ' ' | sed 's/  */ /g')
+
+            if [ "$EXIT_CODE" -eq 3 ]; then
+              if grep -qi "not found" "$OUT_ERR"; then
+                PACK_STATUS="missing_pack"
+                PACK_ERROR_KIND="missing_pack"
+              else
+                PACK_STATUS="invalid_pack"
+                PACK_ERROR_KIND="invalid_pack"
+              fi
+            else
+              PACK_STATUS="runtime_error"
+              PACK_ERROR_KIND="runtime_error"
+            fi
+
+            echo "::error::Compliance pack lint failed (${PACK_ERROR_KIND}): ${ERR_MSG:-unknown error}"
+            break
+          fi
         done < "$BUNDLES_FILE"
+
+        if [ "$PACK_STATUS" != "success" ]; then
+          echo "pack_applied=" >> $GITHUB_OUTPUT
+          echo "resolved_pack_refs=" >> $GITHUB_OUTPUT
+          echo "pack_score=0" >> $GITHUB_OUTPUT
+          echo "pack_articles=" >> $GITHUB_OUTPUT
+          echo "pack_status=$PACK_STATUS" >> $GITHUB_OUTPUT
+          echo "pack_error_kind=$PACK_ERROR_KIND" >> $GITHUB_OUTPUT
+          exit 3
+        fi
 
         # Merge SARIF files (or copy if only one)
         SARIF_FILES=$(ls "$REPORTS_DIR"/pack-lint-*.sarif 2>/dev/null || echo "")
         if [ -z "$SARIF_FILES" ]; then
+          echo "::error::No SARIF files generated for compliance packs."
           echo "pack_applied=" >> $GITHUB_OUTPUT
-          echo "pack_score=100" >> $GITHUB_OUTPUT
+          echo "resolved_pack_refs=" >> $GITHUB_OUTPUT
+          echo "pack_score=0" >> $GITHUB_OUTPUT
           echo "pack_articles=" >> $GITHUB_OUTPUT
-          exit 0
+          echo "pack_status=runtime_error" >> $GITHUB_OUTPUT
+          echo "pack_error_kind=runtime_error" >> $GITHUB_OUTPUT
+          exit 3
         fi
 
         # Count SARIF files and merge if multiple
@@ -823,15 +874,19 @@ runs:
         fi
         SARIF="$REPORTS_DIR/pack-lint.sarif"
 
-        # Extract pack metadata from SARIF
-        PACK_APPLIED=$(jq -r '[.runs[0].tool.driver.rules[]?.properties.pack // empty] | unique | join(",")' "$SARIF" 2>/dev/null || echo "")
-        PACK_SCORE=$(jq -r '.runs[0].properties.complianceScore // 100' "$SARIF" 2>/dev/null || echo "100")
-        PACK_ARTICLES=$(jq -r '[.runs[0].tool.driver.rules[]?.properties.article_ref // empty] | unique | sort | join(",")' "$SARIF" 2>/dev/null || echo "")
-        DISCLAIMER=$(jq -r '.runs[0].properties.disclaimer // empty' "$SARIF" 2>/dev/null || echo "")
+        # Extract pack metadata from SARIF (run-wide, deterministic).
+        RESOLVED_PACKS=$(jq -r '[.runs[].tool.driver.properties.assayPacks[]? | "\(.name)@\(.version)"] | unique | join(",")' "$SARIF" 2>/dev/null || echo "")
+        PACK_APPLIED="$RESOLVED_PACKS"
+        PACK_SCORE=$(jq -r '[.runs[].properties.complianceScore?] | if length == 0 then 100 else (add / length | floor) end' "$SARIF" 2>/dev/null || echo "100")
+        PACK_ARTICLES=$(jq -r '[.runs[].tool.driver.rules[]?.properties.article_ref // empty] | unique | sort | join(",")' "$SARIF" 2>/dev/null || echo "")
+        DISCLAIMER=$(jq -r '[.runs[].properties.disclaimer // empty] | unique | map(select(length > 0)) | join("\n\n---\n\n")' "$SARIF" 2>/dev/null || echo "")
 
         echo "pack_applied=$PACK_APPLIED" >> $GITHUB_OUTPUT
+        echo "resolved_pack_refs=$RESOLVED_PACKS" >> $GITHUB_OUTPUT
         echo "pack_score=$PACK_SCORE" >> $GITHUB_OUTPUT
         echo "pack_articles=$PACK_ARTICLES" >> $GITHUB_OUTPUT
+        echo "pack_status=success" >> $GITHUB_OUTPUT
+        echo "pack_error_kind=" >> $GITHUB_OUTPUT
 
         # Store disclaimer for Job Summary (multiline safe)
         if [ -n "$DISCLAIMER" ]; then
@@ -1094,8 +1149,11 @@ runs:
       shell: bash
       env:
         PACK_APPLIED: ${{ steps.pack-lint.outputs.pack_applied }}
+        RESOLVED_PACK_REFS: ${{ steps.pack-lint.outputs.resolved_pack_refs }}
         PACK_SCORE: ${{ steps.pack-lint.outputs.pack_score }}
         PACK_ARTICLES: ${{ steps.pack-lint.outputs.pack_articles }}
+        PACK_STATUS: ${{ steps.pack-lint.outputs.pack_status }}
+        PACK_ERROR_KIND: ${{ steps.pack-lint.outputs.pack_error_kind }}
         PACK_DISCLAIMER: ${{ steps.pack-lint.outputs.pack_disclaimer }}
         ATTESTATION_ID: ${{ steps.export-attestation.outputs.attestation_id }}
         ATTESTATION_URL: ${{ steps.export-attestation.outputs.attestation_url }}
@@ -1107,13 +1165,23 @@ runs:
       run: |
         {
           # Compliance Pack Results
-          if [ -n "$PACK_APPLIED" ]; then
+          if [ -n "$PACK_APPLIED" ] || [ -n "$PACK_STATUS" ]; then
             echo ""
             echo "## Compliance Pack Results"
             echo ""
             echo "| Pack | Score | Articles |"
             echo "|------|-------|----------|"
             echo "| $PACK_APPLIED | ${PACK_SCORE:-100}% | ${PACK_ARTICLES:-N/A} |"
+            if [ -n "$RESOLVED_PACK_REFS" ]; then
+              echo ""
+              echo "- Resolved packs: \`$RESOLVED_PACK_REFS\`"
+            fi
+            if [ -n "$PACK_STATUS" ]; then
+              echo "- Status: \`$PACK_STATUS\`"
+            fi
+            if [ -n "$PACK_ERROR_KIND" ]; then
+              echo "- Error kind: \`$PACK_ERROR_KIND\`"
+            fi
 
             # MANDATORY: Display disclaimer if present
             if [ -n "$PACK_DISCLAIMER" ]; then

--- a/docs/guides/github-action.md
+++ b/docs/guides/github-action.md
@@ -123,7 +123,10 @@ jobs:
 | `findings_warn` | Warning count |
 | `reports_dir` | Reports directory path |
 | `pack_applied` | Applied pack IDs (v2.1) |
+| `resolved_pack_refs` | Resolved pack refs as `name@version` (v2.1) |
 | `pack_score` | Compliance score 0-100 (v2.1) |
+| `pack_status` | Pack status: `disabled`, `success`, `missing_pack`, `invalid_pack`, `runtime_error` (v2.1) |
+| `pack_error_kind` | Pack error category when pack status is non-success (v2.1) |
 | `bundle_url` | BYOS bundle URL (v2.1) |
 | `attestation_id` | Attestation UUID (v2.1) |
 
@@ -470,6 +473,15 @@ Verify IAM trust relationship includes your repo:
   }
 }
 ```
+
+### Compliance pack step fails
+
+Check action outputs:
+- `pack_status=missing_pack`: pack ref not found (typo or missing file path)
+- `pack_status=invalid_pack`: pack schema/validation error
+- `pack_status=runtime_error`: unexpected lint/runtime failure
+
+The action also exposes `pack_error_kind` for machine-readable CI triage.
 
 ## Security Notes
 

--- a/docs/guides/github-action.md
+++ b/docs/guides/github-action.md
@@ -483,6 +483,10 @@ Check action outputs:
 
 The action also exposes `pack_error_kind` for machine-readable CI triage.
 
+Behavior note:
+- pack loading/validation/runtime errors fail the action step
+- policy findings continue to follow the normal `fail_on` threshold
+
 ## Security Notes
 
 - **Write operations** (baseline, BYOS push, attestation) only run on push to default branch


### PR DESCRIPTION
## Why
Action v2.1 compliance-pack handling needed clearer contract behavior for CI routing and reviewer confidence.

## What changed
- add machine-readable pack outputs: `resolved_pack_refs`, `pack_status`, `pack_error_kind`
- harden `pack-lint` step to distinguish failure classes:
  - `missing_pack`
  - `invalid_pack`
  - `runtime_error`
- keep findings threshold separate from pack loading by using `--fail-on none` in pack lint step
- enrich job summary with resolved packs and pack status/error kind
- add workflow contract tests:
  - happy path with `eu-ai-act-baseline`
  - expected failure path with missing pack
- update action docs (`assay-action/README.md`, `docs/guides/github-action.md`)

## Scope
Only this branch delta vs `codex/p0-dx-magnets-clean`:
- `.github/workflows/action-v2-test.yml`
- `assay-action/action.yml`
- `assay-action/README.md`
- `docs/guides/github-action.md`

## Validation
- pre-commit checks passed on commit/push (yaml lint, action workflow lint, cargo fmt/clippy gates)
- new contract tests added in `action-v2-test.yml` for success and missing-pack failure mode
