### PR TITLE
docs(cli): harden generate/explain parity contracts

### DIFF
--- a/crates/assay-cli/tests/contract_docs_generate_explain.rs
+++ b/crates/assay-cli/tests/contract_docs_generate_explain.rs
@@ -1,0 +1,73 @@
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+fn workspace_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+#[test]
+fn docs_reference_includes_generate_and_explain_contract_flags() {
+    let root = workspace_root();
+    let index = fs::read_to_string(root.join("docs/reference/cli/index.md")).expect("read index");
+    let explain =
+        fs::read_to_string(root.join("docs/reference/cli/explain.md")).expect("read explain doc");
+    let generate =
+        fs::read_to_string(root.join("docs/reference/cli/generate.md")).expect("read generate doc");
+
+    assert!(
+        index.contains("[`assay generate`](generate.md)"),
+        "CLI index must link to assay generate"
+    );
+    assert!(
+        index.contains("[`assay explain`](explain.md)"),
+        "CLI index must link to assay explain"
+    );
+
+    assert!(
+        explain.contains("--compliance-pack"),
+        "explain docs must include compliance-pack option"
+    );
+    assert!(
+        generate.contains("--diff"),
+        "generate docs must include diff option"
+    );
+}
+
+#[test]
+fn cli_help_exposes_generate_diff_and_explain_compliance_pack() {
+    #[allow(deprecated)]
+    let mut generate_help = Command::cargo_bin("assay").expect("assay binary");
+    let generate_output = generate_help
+        .arg("generate")
+        .arg("--help")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let generate_stdout = String::from_utf8(generate_output).expect("utf8 generate help");
+    assert!(
+        generate_stdout.contains("--diff"),
+        "generate help must expose --diff"
+    );
+
+    #[allow(deprecated)]
+    let mut explain_help = Command::cargo_bin("assay").expect("assay binary");
+    let explain_output = explain_help
+        .arg("explain")
+        .arg("--help")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let explain_stdout = String::from_utf8(explain_output).expect("utf8 explain help");
+    assert!(
+        explain_stdout.contains("--compliance-pack"),
+        "explain help must expose --compliance-pack"
+    );
+}

--- a/docs/reference/cli/generate.md
+++ b/docs/reference/cli/generate.md
@@ -1,0 +1,73 @@
+# assay generate
+
+Generate policy scaffolding from trace or profile inputs.
+
+---
+
+## Synopsis
+
+```bash
+assay generate [OPTIONS]
+```
+
+---
+
+## Description
+
+`assay generate` supports two modes:
+
+- single-run mode from `--input` trace events
+- profile mode from `--profile` stability data
+
+For parity hardening, the key reviewer-facing surface is `--diff`: it previews how generated policy output differs from an existing output file.
+
+---
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--input`, `-i <FILE>` | Input trace file (single-run mode). |
+| `--profile <FILE>` | Profile file (multi-run mode). |
+| `--output`, `-o <FILE>` | Output path. Default: `policy.yaml`. |
+| `--name <NAME>` | Policy name metadata. |
+| `--format <FMT>` | Output format (`yaml` default). |
+| `--dry-run` | Do not write output file. |
+| `--diff` | Show policy diff versus existing output file. |
+| `--heuristics` | Enable heuristics in single-run generation. |
+| `--entropy-threshold <N>` | Entropy threshold for heuristics. |
+| `--min-stability <N>` | Minimum stability to auto-allow in profile mode. |
+| `--review-threshold <N>` | Threshold below which entries can be marked risky. |
+| `--new-is-risky` | Treat low-stability entries as risky instead of skipping. |
+| `--alpha <N>` | Smoothing parameter for profile mode. |
+| `--min-runs <N>` | Minimum runs before auto-allow. |
+| `--wilson-z <N>` | Wilson lower-bound confidence parameter. |
+
+---
+
+## Examples
+
+### Trace input
+
+```bash
+assay generate --input traces/session.jsonl --output policy.yaml
+```
+
+### Diff preview (no write)
+
+```bash
+assay generate --input traces/session.jsonl --output policy.yaml --diff --dry-run
+```
+
+### Profile input
+
+```bash
+assay generate --profile .assay/profile.json --min-stability 0.8 --new-is-risky
+```
+
+---
+
+## Exit Behavior
+
+- exits non-zero on invalid inputs/arguments
+- with `--dry-run`, does not write files

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -26,6 +26,7 @@ assay --version
 | Command | Description |
 |---------|-------------|
 | [`assay run`](run.md) | Run tests against traces |
+| [`assay generate`](generate.md) | Generate policy scaffolding from trace/profile input |
 | [`assay explain`](explain.md) | Explain why trace steps were allowed/blocked |
 | [`assay bundle`](bundle.md) | Create/verify replay bundles |
 | [`assay replay`](replay.md) | Replay from a replay bundle |
@@ -65,6 +66,16 @@ assay run --config eval.yaml --trace-file traces/golden.jsonl
 
 # CI reports
 assay ci --config eval.yaml --trace-file traces/golden.jsonl --sarif sarif.json --junit junit.xml
+```
+
+### Generate Policy (With Diff Preview)
+
+```bash
+# Generate policy from trace
+assay generate --input traces/session.jsonl --output policy.yaml
+
+# Preview changes against existing policy file
+assay generate --input traces/session.jsonl --output policy.yaml --diff --dry-run
 ```
 
 ### Replay Bundles
@@ -179,6 +190,14 @@ See [Configuration](../config/index.md) for full reference.
     Explain blocked/allowed trace steps and evaluated rules.
 
     [:octicons-arrow-right-24: Full reference](explain.md)
+
+-   :material-source-branch:{ .lg .middle } __assay generate__
+
+    ---
+
+    Generate policy scaffolding from traces/profiles and preview diffs.
+
+    [:octicons-arrow-right-24: Full reference](generate.md)
 
 -   :material-import:{ .lg .middle } __assay import__
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,6 +175,8 @@ nav:
     - assay init: reference/cli/init.md
     - assay validate: reference/cli/validate.md
     - assay run: reference/cli/run.md
+    - assay generate: reference/cli/generate.md
+    - assay explain: reference/cli/explain.md
     - assay doctor: reference/cli/doctor.md
     - assay watch: reference/cli/watch.md
     - assay sandbox: reference/cli/sandbox.md


### PR DESCRIPTION
## Why
P1-A/P1-B parity hardening: keep docs/examples aligned with the actual CLI contract for `assay generate` and `assay explain`, without changing runtime behavior.

## Scope (clean slice)
Changed files:
- `docs/reference/cli/generate.md` (new)
- `docs/reference/cli/index.md`
- `mkdocs.yml`
- `crates/assay-cli/tests/contract_docs_generate_explain.rs` (new)

Out of scope (unchanged):
- `crates/assay-cli/src/cli/commands/generate.rs`
- `crates/assay-cli/src/cli/commands/explain.rs`
- `crates/assay-cli/src/cli/args.rs`
- run/ci/action output contracts (`run.json` / `summary.json`)

## What changed
- Added dedicated CLI reference page for `assay generate`.
- Added `assay generate` + `assay explain` to MkDocs CLI nav.
- Updated CLI index with generate overview and diff-preview examples.
- Added parity contract test that asserts:
  - docs contain `--diff` and `--compliance-pack`
  - CLI help exposes `--diff` and `--compliance-pack`

## Validation
- `cargo test -p assay-cli --test contract_docs_generate_explain -- --nocapture`
- `cargo run -p assay-cli -- generate --help`
- `cargo run -p assay-cli -- explain --help`
- `cargo check -p assay-cli`
- `cargo fmt --all -- --check`

## Reviewer Notes
This PR is documentation+contract parity only. It intentionally does not modify runtime command logic.
