### PR TITLE
fix(init): colocate --hello-trace output with --config path

### DIFF
--- a/crates/assay-cli/src/cli/commands/init.rs
+++ b/crates/assay-cli/src/cli/commands/init.rs
@@ -136,8 +136,13 @@ pub async fn run(args: InitArgs) -> anyhow::Result<i32> {
 }
 
 fn hello_trace_path_for_config(config_path: &Path) -> PathBuf {
-    let base = config_path.parent().unwrap_or_else(|| Path::new("."));
-    base.join("traces/hello.jsonl")
+    match config_path.parent() {
+        Some(parent) if parent.as_os_str().is_empty() || parent == Path::new(".") => {
+            PathBuf::from("traces/hello.jsonl")
+        }
+        Some(parent) => parent.join("traces/hello.jsonl"),
+        None => PathBuf::from("traces/hello.jsonl"),
+    }
 }
 
 fn write_file_if_missing(path: &Path, content: &str) -> anyhow::Result<()> {

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,6 +17,8 @@ Generates a runnable smoke setup:
 - `traces/hello.jsonl` with a deterministic trace fixture
 - `policy.yaml` with the default policy pack (created if not already present)
 
+If you pass `--config <path>`, the hello trace is written relative to that config directory.
+
 The hello trace is demo-only and non-sensitive. Treat real traces as potentially sensitive data and apply your redaction/recording guidelines.
 
 ## 2. Validate

--- a/docs/reference/cli/init.md
+++ b/docs/reference/cli/init.md
@@ -38,10 +38,15 @@ assay init
 
 ### Fast first signal (hello trace)
 Creates `eval.yaml`, `traces/hello.jsonl`, and `policy.yaml` (if missing).
+When `--config` points to another directory, the hello trace is written relative to that config path.
 
 ```bash
 assay init --hello-trace
 assay validate --config eval.yaml --trace-file traces/hello.jsonl
+
+# Config in a nested directory:
+assay init --hello-trace --config nested/eval.yaml
+assay validate --config nested/eval.yaml --trace-file nested/traces/hello.jsonl
 ```
 
 ### From existing trace


### PR DESCRIPTION
## Why
`assay init --hello-trace` wrote `traces/hello.jsonl` relative to CWD, even when `--config` pointed to another directory. That created split scaffolds and confusing first-run behavior.

## What changed
- derive hello trace output path from the parent directory of `--config`
- keep default behavior unchanged when `--config` is `eval.yaml` in CWD
- update init and quickstart docs to document the path behavior
- add contract test coverage for nested config paths

## Scope
- `crates/assay-cli/src/cli/commands/init.rs`
- `crates/assay-cli/tests/contract_init_hello_trace.rs`
- `docs/reference/cli/init.md`
- `docs/getting-started/quickstart.md`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p assay-cli --test contract_init_hello_trace -- --nocapture`
- `cargo check -p assay-cli`
