### PR TITLE
fix(doctor): align dry-run exit code with diagnostics contract

### DIFF
--- a/crates/assay-cli/src/cli/commands/doctor.rs
+++ b/crates/assay-cli/src/cli/commands/doctor.rs
@@ -278,7 +278,7 @@ async fn run_doctor_fix(
 
     if applied == 0 {
         println!("No fixes applied.");
-        return Ok(0);
+        return Ok(if initial_errors == 0 { 0 } else { 1 });
     }
 
     if args.dry_run {

--- a/docs/reference/cli/doctor.md
+++ b/docs/reference/cli/doctor.md
@@ -29,6 +29,7 @@ assay doctor [OPTIONS]
 Notes:
 - `--fix` currently supports text output mode.
 - `--yes` and `--dry-run` require `--fix`.
+- `--dry-run` previews fixes but still returns non-zero when blocking diagnostics remain.
 
 ---
 
@@ -53,6 +54,7 @@ assay doctor --config eval.yaml --trace-file traces/main.jsonl --fix --dry-run -
 - Applying patch suggestions generated from diagnostics.
 - Creating a missing trace file for trace-path errors.
 - Previewing unified diffs in dry-run mode.
+- Preserving doctor exit semantics in dry-run mode (blocking diagnostics still exit with code `1`).
 
 After apply, doctor re-runs diagnostics and reports remaining error count.
 


### PR DESCRIPTION
## Why
`assay doctor --fix --dry-run` previewed changes but returned exit code `0` even when blocking diagnostics remained. That drifted from the documented doctor exit contract and could hide broken setup in CI/scripts.

## What changed
- dry-run fix mode now preserves diagnostics exit semantics:
  - returns `1` when blocking diagnostics remain
  - returns `0` only when no blocking diagnostics exist
- parse-error dry-run path now also returns non-zero (preview only, no writes)
- `--fix` with no auto-fixable operations now returns non-zero if errors still exist
- updated doctor CLI docs to explicitly state dry-run exit behavior
- extended E2E coverage for parse-error dry-run no-write + exit code behavior

## Scope
- `crates/assay-cli/src/cli/commands/doctor.rs`
- `crates/assay-cli/tests/doctor_fix_e2e.rs`
- `docs/reference/cli/doctor.md`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p assay-cli --test doctor_fix_e2e -- --nocapture`
- `cargo check -p assay-cli`
