### PR TITLE
refactor(cli): derive watch/replay RunArgs from shared defaults

### DIFF
--- a/crates/assay-cli/src/cli/args.rs
+++ b/crates/assay-cli/src/cli/args.rs
@@ -341,6 +341,34 @@ pub struct RunArgs {
     pub no_verify: bool,
 }
 
+impl Default for RunArgs {
+    fn default() -> Self {
+        Self {
+            config: PathBuf::from("eval.yaml"),
+            db: PathBuf::from(".eval/eval.db"),
+            rerun_failures: 0,
+            quarantine_mode: "warn".to_string(),
+            trace_file: None,
+            redact_prompts: false,
+            baseline: None,
+            export_baseline: None,
+            strict: false,
+            embedder: "none".to_string(),
+            embedding_model: "text-embedding-3-small".to_string(),
+            refresh_embeddings: false,
+            incremental: false,
+            refresh_cache: false,
+            no_cache: false,
+            explain_skip: false,
+            judge: JudgeArgs::default(),
+            replay_strict: false,
+            deny_deprecations: false,
+            exit_codes: crate::exit_codes::ExitCodeVersion::default(),
+            no_verify: false,
+        }
+    }
+}
+
 #[derive(Parser, Clone)]
 pub struct CiArgs {
     #[arg(long, default_value = "eval.yaml")]
@@ -467,6 +495,21 @@ pub struct JudgeArgs {
     /// Start with env (VERDICT_JUDGE_API_KEY could be supported but OPENAI_API_KEY is primary)
     #[arg(long, hide = true)]
     pub judge_api_key: Option<String>,
+}
+
+impl Default for JudgeArgs {
+    fn default() -> Self {
+        Self {
+            judge: "none".to_string(),
+            no_judge: false,
+            judge_model: None,
+            judge_samples: 3,
+            judge_refresh: false,
+            judge_temperature: 0.0,
+            judge_max_tokens: 800,
+            judge_api_key: None,
+        }
+    }
 }
 
 #[derive(Parser, Clone)]

--- a/crates/assay-cli/src/cli/commands/replay.rs
+++ b/crates/assay-cli/src/cli/commands/replay.rs
@@ -668,6 +668,7 @@ impl Drop for ReplayWorkspace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::exit_codes::ExitCodeVersion;
     use assay_core::replay::{ReplayCoverage, ReplayManifest};
 
     #[test]
@@ -701,5 +702,33 @@ mod tests {
         assert_eq!(value["provenance"]["bundle_digest"], "sha256:abc");
         assert_eq!(value["provenance"]["replay_mode"], "offline");
         assert_eq!(value["provenance"]["source_run_id"], "123");
+    }
+
+    #[test]
+    fn replay_run_args_overrides_and_inherits_defaults() {
+        let args = replay_run_args(
+            PathBuf::from("custom/eval.yaml"),
+            Some(PathBuf::from("custom/trace.jsonl")),
+            PathBuf::from("custom/eval.db"),
+            true,
+            ExitCodeVersion::V1,
+        );
+
+        assert_eq!(args.config, PathBuf::from("custom/eval.yaml"));
+        assert_eq!(args.trace_file, Some(PathBuf::from("custom/trace.jsonl")));
+        assert_eq!(args.db, PathBuf::from("custom/eval.db"));
+        assert_eq!(args.quarantine_mode, "off");
+        assert!(args.refresh_cache);
+        assert!(args.no_cache);
+        assert!(args.judge.no_judge);
+        assert!(args.replay_strict);
+        assert_eq!(args.exit_codes, ExitCodeVersion::V1);
+
+        // Inherited from RunArgs defaults.
+        assert_eq!(args.embedder, "none");
+        assert_eq!(args.embedding_model, "text-embedding-3-small");
+        assert!(!args.strict);
+        assert!(!args.redact_prompts);
+        assert!(!args.no_verify);
     }
 }

--- a/crates/assay-cli/src/cli/commands/replay.rs
+++ b/crates/assay-cli/src/cli/commands/replay.rs
@@ -1,4 +1,4 @@
-use super::super::args::{ReplayArgs, RunArgs};
+use super::super::args::{JudgeArgs, ReplayArgs, RunArgs};
 use crate::exit_codes::{ReasonCode, RunOutcome};
 use anyhow::Context;
 use assay_core::replay::{read_bundle_tar_gz, verify_bundle, ReplayManifest};
@@ -223,17 +223,23 @@ fn replay_run_args(
     replay_strict: bool,
     exit_codes: crate::exit_codes::ExitCodeVersion,
 ) -> RunArgs {
-    let mut args = RunArgs::default();
-    args.config = config;
-    args.db = db;
-    args.quarantine_mode = "off".to_string();
-    args.trace_file = trace_file;
-    args.refresh_cache = true;
-    args.no_cache = true;
-    args.judge.no_judge = true;
-    args.replay_strict = replay_strict;
-    args.exit_codes = exit_codes;
-    args
+    let judge = JudgeArgs {
+        no_judge: true,
+        ..JudgeArgs::default()
+    };
+
+    RunArgs {
+        config,
+        db,
+        quarantine_mode: "off".to_string(),
+        trace_file,
+        refresh_cache: true,
+        no_cache: true,
+        judge,
+        replay_strict,
+        exit_codes,
+        ..RunArgs::default()
+    }
 }
 
 fn write_missing_dependency(

--- a/crates/assay-cli/src/cli/commands/replay.rs
+++ b/crates/assay-cli/src/cli/commands/replay.rs
@@ -1,4 +1,4 @@
-use super::super::args::{JudgeArgs, ReplayArgs, RunArgs};
+use super::super::args::{ReplayArgs, RunArgs};
 use crate::exit_codes::{ReasonCode, RunOutcome};
 use anyhow::Context;
 use assay_core::replay::{read_bundle_tar_gz, verify_bundle, ReplayManifest};
@@ -223,38 +223,17 @@ fn replay_run_args(
     replay_strict: bool,
     exit_codes: crate::exit_codes::ExitCodeVersion,
 ) -> RunArgs {
-    RunArgs {
-        config,
-        db,
-        rerun_failures: 0,
-        quarantine_mode: "off".to_string(),
-        trace_file,
-        redact_prompts: false,
-        baseline: None,
-        export_baseline: None,
-        strict: false,
-        embedder: "none".to_string(),
-        embedding_model: "text-embedding-3-small".to_string(),
-        refresh_embeddings: false,
-        incremental: false,
-        refresh_cache: true,
-        no_cache: true,
-        explain_skip: false,
-        judge: JudgeArgs {
-            judge: "none".to_string(),
-            no_judge: true,
-            judge_model: None,
-            judge_samples: 3,
-            judge_refresh: false,
-            judge_temperature: 0.0,
-            judge_max_tokens: 800,
-            judge_api_key: None,
-        },
-        replay_strict,
-        deny_deprecations: false,
-        exit_codes,
-        no_verify: false,
-    }
+    let mut args = RunArgs::default();
+    args.config = config;
+    args.db = db;
+    args.quarantine_mode = "off".to_string();
+    args.trace_file = trace_file;
+    args.refresh_cache = true;
+    args.no_cache = true;
+    args.judge.no_judge = true;
+    args.replay_strict = replay_strict;
+    args.exit_codes = exit_codes;
+    args
 }
 
 fn write_missing_dependency(

--- a/crates/assay-cli/src/cli/commands/watch.rs
+++ b/crates/assay-cli/src/cli/commands/watch.rs
@@ -238,14 +238,15 @@ async fn run_once(args: &WatchArgs, legacy_mode: bool) -> Result<i32> {
 }
 
 fn run_args_from_watch(args: &WatchArgs) -> RunArgs {
-    let mut run_args = RunArgs::default();
-    run_args.config = args.config.clone();
-    run_args.db = args.db.clone();
-    run_args.trace_file = args.trace_file.clone();
-    run_args.baseline = args.baseline.clone();
-    run_args.strict = args.strict;
-    run_args.replay_strict = args.replay_strict;
-    run_args
+    RunArgs {
+        config: args.config.clone(),
+        db: args.db.clone(),
+        trace_file: args.trace_file.clone(),
+        baseline: args.baseline.clone(),
+        strict: args.strict,
+        replay_strict: args.replay_strict,
+        ..RunArgs::default()
+    }
 }
 
 pub(crate) fn collect_watch_paths(args: &WatchArgs, legacy_mode: bool) -> Result<Vec<PathBuf>> {

--- a/crates/assay-cli/src/cli/commands/watch.rs
+++ b/crates/assay-cli/src/cli/commands/watch.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-use crate::cli::args::{JudgeArgs, RunArgs, WatchArgs};
+use crate::cli::args::{RunArgs, WatchArgs};
 
 const POLL_INTERVAL_MS: u64 = 250;
 const MIN_DEBOUNCE_MS: u64 = 50;
@@ -230,42 +230,22 @@ fn refresh_watch_targets(
 }
 
 async fn run_once(args: &WatchArgs, legacy_mode: bool) -> Result<i32> {
-    let run_args = RunArgs {
-        config: args.config.clone(),
-        db: args.db.clone(),
-        rerun_failures: 0,
-        quarantine_mode: "warn".to_string(),
-        trace_file: args.trace_file.clone(),
-        redact_prompts: false,
-        baseline: args.baseline.clone(),
-        export_baseline: None,
-        strict: args.strict,
-        embedder: "none".to_string(),
-        embedding_model: "text-embedding-3-small".to_string(),
-        refresh_embeddings: false,
-        incremental: false,
-        refresh_cache: false,
-        no_cache: false,
-        explain_skip: false,
-        judge: JudgeArgs {
-            judge: "none".to_string(),
-            no_judge: false,
-            judge_model: None,
-            judge_samples: 3,
-            judge_refresh: false,
-            judge_temperature: 0.0,
-            judge_max_tokens: 800,
-            judge_api_key: None,
-        },
-        replay_strict: args.replay_strict,
-        deny_deprecations: false,
-        exit_codes: crate::exit_codes::ExitCodeVersion::default(),
-        no_verify: false,
-    };
+    let run_args = run_args_from_watch(args);
 
     let code = super::run::run(run_args, legacy_mode).await?;
     eprintln!("Result: exit {}", code);
     Ok(code)
+}
+
+fn run_args_from_watch(args: &WatchArgs) -> RunArgs {
+    let mut run_args = RunArgs::default();
+    run_args.config = args.config.clone();
+    run_args.db = args.db.clone();
+    run_args.trace_file = args.trace_file.clone();
+    run_args.baseline = args.baseline.clone();
+    run_args.strict = args.strict;
+    run_args.replay_strict = args.replay_strict;
+    run_args
 }
 
 pub(crate) fn collect_watch_paths(args: &WatchArgs, legacy_mode: bool) -> Result<Vec<PathBuf>> {
@@ -374,6 +354,33 @@ mod tests {
         assert_eq!(normalize_debounce_ms(MIN_DEBOUNCE_MS), MIN_DEBOUNCE_MS);
         assert_eq!(normalize_debounce_ms(350), 350);
         assert_eq!(normalize_debounce_ms(MAX_DEBOUNCE_MS), MAX_DEBOUNCE_MS);
+    }
+
+    #[test]
+    fn run_args_from_watch_uses_run_defaults() {
+        let args = WatchArgs {
+            config: PathBuf::from("eval.yaml"),
+            trace_file: Some(PathBuf::from("traces/dev.jsonl")),
+            baseline: Some(PathBuf::from(".assay/baseline.json")),
+            db: PathBuf::from(".eval/eval.db"),
+            strict: true,
+            replay_strict: true,
+            clear: false,
+            debounce_ms: 350,
+        };
+
+        let run_args = super::run_args_from_watch(&args);
+        assert_eq!(run_args.config, args.config);
+        assert_eq!(run_args.db, args.db);
+        assert_eq!(run_args.trace_file, args.trace_file);
+        assert_eq!(run_args.baseline, args.baseline);
+        assert!(run_args.strict);
+        assert!(run_args.replay_strict);
+
+        // Defaults stay inherited from RunArgs::default().
+        assert_eq!(run_args.quarantine_mode, "warn");
+        assert_eq!(run_args.embedder, "none");
+        assert_eq!(run_args.embedding_model, "text-embedding-3-small");
     }
 
     #[test]


### PR DESCRIPTION
Why
Manual RunArgs construction in watch/replay duplicated defaults from run and risked drift.

What changed
- Added Default implementations for RunArgs and JudgeArgs in args.rs
- Updated watch run path to build RunArgs via helper + struct update from defaults
- Updated replay_run_args to start from shared defaults and override replay-specific fields
- Added watch unit coverage that asserts watch uses RunArgs defaults for non-overridden fields

Scope
- crates/assay-cli/src/cli/args.rs
- crates/assay-cli/src/cli/commands/watch.rs
- crates/assay-cli/src/cli/commands/replay.rs

Validation
- cargo fmt --all -- --check
- cargo check -p assay-cli
- cargo test -p assay-cli watch:: -- --nocapture