### PR TITLE
feat(dx-wave-a3): canonicalize init/template config writing

### DIFF
--- a/crates/assay-cli/src/cli/commands/init.rs
+++ b/crates/assay-cli/src/cli/commands/init.rs
@@ -69,7 +69,7 @@ pub async fn run(args: InitArgs) -> anyhow::Result<i32> {
     let config_template = if args.hello_trace {
         crate::templates::HELLO_EVAL_YAML
     } else {
-        crate::templates::ASSAY_CONFIG_DEFAULT_YAML
+        crate::templates::EVAL_CONFIG_DEFAULT_YAML
     };
     write_file_if_missing(&args.config, config_template)?;
 
@@ -218,12 +218,13 @@ fn run_from_trace(args: &InitArgs, trace_path: &std::path::Path) -> anyhow::Resu
 suite: "generated"
 model: "trace"
 tests:
-  - id: "generated_args_valid"
+  - id: "generated_from_trace"
     input:
       prompt: "__generated_from_trace__"
     expected:
-      type: args_valid
-      policy: "policy.yaml"
+      type: regex_match
+      pattern: ".*"
+      flags: ["s"]
 "#
     .to_string();
     write_file_if_missing(&args.config, &config_content)?;

--- a/crates/assay-cli/src/cli/commands/init.rs
+++ b/crates/assay-cli/src/cli/commands/init.rs
@@ -214,11 +214,18 @@ fn run_from_trace(args: &InitArgs, trace_path: &std::path::Path) -> anyhow::Resu
     }
 
     // 4. Write eval.yaml config
-    let trace_rel = escape_yaml_double_quoted(&trace_path.display().to_string());
-    let config_content = format!(
-        "version: 2\nsuite: \"generated\"\npolicy: \"policy.yaml\"\ntrace_file: \"{}\"\n",
-        trace_rel
-    );
+    let config_content = r#"configVersion: 1
+suite: "generated"
+model: "trace"
+tests:
+  - id: "generated_args_valid"
+    input:
+      prompt: "__generated_from_trace__"
+    expected:
+      type: args_valid
+      policy: "policy.yaml"
+"#
+    .to_string();
     write_file_if_missing(&args.config, &config_content)?;
 
     // 5. Gitignore
@@ -260,13 +267,4 @@ fn run_from_trace(args: &InitArgs, trace_path: &std::path::Path) -> anyhow::Resu
     println!("\n   Tip: For EU AI Act compliance scanning, add: --pack eu-ai-act-baseline");
 
     Ok(exit_codes::OK)
-}
-
-fn escape_yaml_double_quoted(input: &str) -> String {
-    input
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
 }

--- a/crates/assay-cli/src/templates.rs
+++ b/crates/assay-cli/src/templates.rs
@@ -1,4 +1,4 @@
-pub const CI_EVAL_YAML: &str = r#"version: 1
+pub const CI_EVAL_YAML: &str = r#"configVersion: 1
 suite: "ci_smoke"
 model: "trace"
 tests:
@@ -20,8 +20,8 @@ tests:
       prompt: "ci_semantic"
     expected:
       type: semantic_similarity_to
-      text: "Hello Semantic"
-      threshold: 0.99
+      semantic_similarity_to: "Hello Semantic"
+      min_score: 0.99
 "#;
 
 pub const CI_SCHEMA_JSON: &str = r#"{
@@ -38,7 +38,7 @@ pub const CI_TRACES_JSONL: &str = r#"{"schema_version": 1, "type": "assay.trace"
 {"schema_version": 1, "type": "assay.trace", "request_id": "ci_3", "prompt": "ci_semantic", "response": "Hello Semantic", "model": "trace", "provider": "trace", "meta": {"assay": {"embeddings": {"model":"trace-embed","response":[1.0,0.0,0.0],"reference":[1.0,0.0,0.0],"source_response":"trace","source_reference":"trace"}}}}
 "#;
 
-pub const HELLO_EVAL_YAML: &str = r#"version: 1
+pub const HELLO_EVAL_YAML: &str = r#"configVersion: 1
 suite: "hello_smoke"
 model: "trace"
 tests:
@@ -129,7 +129,15 @@ pub const GITLAB_CI_YML: &str = r#"assay:
 
 pub const GITIGNORE: &str = "/.eval/\n/out/\n*.db\n*.db-shm\n*.db-wal\n/assay\n";
 
-pub const ASSAY_CONFIG_DEFAULT_YAML: &str = r#"version: 2
-policy: "policy.yaml"
-baseline: ".assay/baseline.json"
+pub const ASSAY_CONFIG_DEFAULT_YAML: &str = r#"configVersion: 1
+suite: "starter"
+model: "trace"
+tests:
+  - id: "starter_regex"
+    input:
+      prompt: "replace_with_real_prompt"
+    expected:
+      type: regex_match
+      pattern: ".*"
+      flags: ["s"]
 "#;

--- a/crates/assay-cli/src/templates.rs
+++ b/crates/assay-cli/src/templates.rs
@@ -129,7 +129,7 @@ pub const GITLAB_CI_YML: &str = r#"assay:
 
 pub const GITIGNORE: &str = "/.eval/\n/out/\n*.db\n*.db-shm\n*.db-wal\n/assay\n";
 
-pub const ASSAY_CONFIG_DEFAULT_YAML: &str = r#"configVersion: 1
+pub const EVAL_CONFIG_DEFAULT_YAML: &str = r#"configVersion: 1
 suite: "starter"
 model: "trace"
 tests:

--- a/crates/assay-cli/tests/contract_init_ci.rs
+++ b/crates/assay-cli/tests/contract_init_ci.rs
@@ -58,7 +58,9 @@ fn test_init_ci_contract() {
         "CI eval scaffold must write canonical min_score field"
     );
     assert!(
-        !ci_eval.contains("\nversion: 1"),
+        !ci_eval
+            .lines()
+            .any(|line| line.trim_start().starts_with("version: 1")),
         "Legacy version alias should not be emitted in generated scaffold"
     );
     assert!(

--- a/crates/assay-cli/tests/contract_init_ci.rs
+++ b/crates/assay-cli/tests/contract_init_ci.rs
@@ -41,4 +41,32 @@ fn test_init_ci_contract() {
         !content.contains("curl -fsSL"),
         "Must not use pipe-to-shell installation"
     );
+
+    let ci_eval_path = temp.path().join("ci-eval.yaml");
+    assert!(ci_eval_path.exists(), "ci-eval.yaml must be generated");
+    let ci_eval = fs::read_to_string(ci_eval_path).unwrap();
+    assert!(
+        ci_eval.contains("configVersion: 1"),
+        "CI eval scaffold must write canonical configVersion field"
+    );
+    assert!(
+        ci_eval.contains("semantic_similarity_to: \"Hello Semantic\""),
+        "CI eval scaffold must write canonical semantic_similarity_to field"
+    );
+    assert!(
+        ci_eval.contains("min_score: 0.99"),
+        "CI eval scaffold must write canonical min_score field"
+    );
+    assert!(
+        !ci_eval.contains("\nversion: 1"),
+        "Legacy version alias should not be emitted in generated scaffold"
+    );
+    assert!(
+        !ci_eval.contains("\n      text:"),
+        "Legacy semantic field alias should not be emitted in generated scaffold"
+    );
+    assert!(
+        !ci_eval.contains("\n      threshold:"),
+        "Legacy threshold field alias should not be emitted in generated scaffold"
+    );
 }

--- a/crates/assay-cli/tests/contract_init_hello_trace.rs
+++ b/crates/assay-cli/tests/contract_init_hello_trace.rs
@@ -99,7 +99,9 @@ fn test_init_default_writes_canonical_eval_config() {
         "default scaffold must write canonical configVersion field"
     );
     assert!(
-        !eval.contains("\nversion: "),
+        !eval
+            .lines()
+            .any(|line| line.trim_start().starts_with("version: ")),
         "default scaffold must not emit legacy version alias"
     );
 
@@ -145,7 +147,9 @@ fn test_init_from_trace_writes_canonical_eval_config() {
         "from-trace scaffold must write canonical configVersion field"
     );
     assert!(
-        !eval.contains("\nversion: "),
+        !eval
+            .lines()
+            .any(|line| line.trim_start().starts_with("version: ")),
         "from-trace scaffold must not emit legacy version alias"
     );
 

--- a/crates/assay-cli/tests/contract_init_hello_trace.rs
+++ b/crates/assay-cli/tests/contract_init_hello_trace.rs
@@ -1,3 +1,4 @@
+use assay_core::config::load_config;
 use assert_cmd::Command;
 use std::fs;
 use tempfile::tempdir;
@@ -80,4 +81,81 @@ fn test_init_hello_trace_respects_config_parent_directory() {
         .arg("nested/traces/hello.jsonl")
         .assert()
         .success();
+}
+
+#[test]
+fn test_init_default_writes_canonical_eval_config() {
+    let temp = tempdir().expect("temp dir");
+
+    #[allow(deprecated)]
+    let mut init = Command::cargo_bin("assay").expect("assay binary");
+    init.current_dir(temp.path()).arg("init").assert().success();
+
+    let eval_path = temp.path().join("eval.yaml");
+    assert!(eval_path.exists(), "default init must create eval.yaml");
+    let eval = fs::read_to_string(&eval_path).expect("read eval.yaml");
+    assert!(
+        eval.contains("configVersion: 1"),
+        "default scaffold must write canonical configVersion field"
+    );
+    assert!(
+        !eval.contains("\nversion: "),
+        "default scaffold must not emit legacy version alias"
+    );
+
+    let cfg = load_config(&eval_path, false, true)
+        .expect("generated eval.yaml should parse in strict mode");
+    assert_eq!(cfg.version, 1, "generated config must parse as version 1");
+    assert_eq!(cfg.suite, "starter");
+    assert_eq!(cfg.model, "trace");
+    assert!(
+        !cfg.tests.is_empty(),
+        "generated starter config must contain at least one test"
+    );
+}
+
+#[test]
+fn test_init_from_trace_writes_canonical_eval_config() {
+    let temp = tempdir().expect("temp dir");
+    let trace_path = temp.path().join("events.jsonl");
+    fs::write(
+        &trace_path,
+        r#"{"type":"file_open","path":"/workspace/app.py","pid":1,"timestamp":1}
+"#,
+    )
+    .expect("write events trace");
+
+    #[allow(deprecated)]
+    let mut init = Command::cargo_bin("assay").expect("assay binary");
+    init.current_dir(temp.path())
+        .arg("init")
+        .arg("--from-trace")
+        .arg("events.jsonl")
+        .assert()
+        .success();
+
+    let eval_path = temp.path().join("eval.yaml");
+    assert!(
+        eval_path.exists(),
+        "init --from-trace must create eval.yaml"
+    );
+    let eval = fs::read_to_string(&eval_path).expect("read eval.yaml");
+    assert!(
+        eval.contains("configVersion: 1"),
+        "from-trace scaffold must write canonical configVersion field"
+    );
+    assert!(
+        !eval.contains("\nversion: "),
+        "from-trace scaffold must not emit legacy version alias"
+    );
+
+    let cfg = load_config(&eval_path, false, true)
+        .expect("generated eval.yaml from --from-trace should parse in strict mode");
+    assert_eq!(cfg.version, 1, "generated config must parse as version 1");
+    assert_eq!(cfg.suite, "generated");
+    assert_eq!(cfg.model, "trace");
+    assert!(
+        !cfg.tests.is_empty(),
+        "generated config from --from-trace must contain tests"
+    );
 }

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -22,7 +22,8 @@ PR order for the new track:
 
 Current branch focus:
 - PR-A1 (open): move run/ci hot-path error triage to typed boundary mapping with unit coverage.
-- PR-A2 (in progress): remove run/ci strict-mode env mutation and enforce deny-deprecations via explicit options.
+- PR-A2 (open): remove run/ci strict-mode env mutation and enforce deny-deprecations via explicit options.
+- PR-A3 (in progress): canonicalize init/template config writing (`configVersion`, semantic fields) with contract tests.
 
 ---
 

--- a/docs/DX-REVIEW-MATERIALS.md
+++ b/docs/DX-REVIEW-MATERIALS.md
@@ -28,7 +28,7 @@ assay init --ci github
 - Output: "Scanning project...", "Generating Assay Policy & Config...".
 - Gegenereerde bestanden:
   - `policy.yaml` — uit pack (default pack: veilige baseline; `--pack` kiest pack).
-  - `assay.yaml` (of `--config`) — [templates.rs ASSAY_CONFIG_DEFAULT_YAML](https://github.com/Rul1an/assay/blob/main/crates/assay-cli/src/templates.rs): `version: 2`, `policy: "policy.yaml"`, `baseline: ".assay/baseline.json"`.
+  - `eval.yaml` (of `--config`) — [templates.rs ASSAY_CONFIG_DEFAULT_YAML](https://github.com/Rul1an/assay/blob/main/crates/assay-cli/src/templates.rs): canonieke eval scaffold (`configVersion: 1`, `suite`, `model`, starter `tests`).
   - Optioneel `.gitignore` (`.assay`, `*.db`, etc.) bij `--gitignore`.
 
 **init --ci:**
@@ -37,13 +37,14 @@ assay init --ci github
   - `ci-eval.yaml` — smoke suite (regex, json_schema, semantic_similarity).
   - `schemas/ci_answer.schema.json` — JSON Schema voor ci_smoke_schema.
   - `traces/ci.jsonl` — voorbeeldtrace voor replay.
-  - `.github/workflows/assay.yml` — **let op:** template gebruikt nog `Rul1an/assay-action@v1` en v1.4.0; aanbevolen is `Rul1an/assay/assay-action@v2` (zie [guides/github-action](getting-started/ci-integration.md)).
+  - `.github/workflows/assay.yml` — template gebruikt `Rul1an/assay/assay-action@v2` (zie [guides/github-action](getting-started/ci-integration.md)).
 
 **Defaults (veiligheid en bruikbaarheid):**
 
 - Policy pack: blocking defaults (Exec/Shell/Python geblokkeerd in typische baseline).
 - Config: verwijst naar policy + baseline path; geen onveilige defaults in gegenereerde YAML.
-- **Reviewpunten:** Template workflow versie (v1 vs v2), of `assay init --ci` een "blessed" quickstart is t.o.v. `assay init-ci`.
+- Config: canonieke v1 eval scaffold (`configVersion: 1`) met starter test.
+- **Reviewpunten:** parity tussen generated scaffold en CLI/docs contracten.
 
 **Relevante code:**
 

--- a/docs/DX-REVIEW-MATERIALS.md
+++ b/docs/DX-REVIEW-MATERIALS.md
@@ -28,7 +28,7 @@ assay init --ci github
 - Output: "Scanning project...", "Generating Assay Policy & Config...".
 - Gegenereerde bestanden:
   - `policy.yaml` — uit pack (default pack: veilige baseline; `--pack` kiest pack).
-  - `eval.yaml` (of `--config`) — [templates.rs ASSAY_CONFIG_DEFAULT_YAML](https://github.com/Rul1an/assay/blob/main/crates/assay-cli/src/templates.rs): canonieke eval scaffold (`configVersion: 1`, `suite`, `model`, starter `tests`).
+  - `eval.yaml` (of `--config`) — [templates.rs EVAL_CONFIG_DEFAULT_YAML](https://github.com/Rul1an/assay/blob/main/crates/assay-cli/src/templates.rs): canonieke eval scaffold (`configVersion: 1`, `suite`, `model`, starter `tests`).
   - Optioneel `.gitignore` (`.assay`, `*.db`, etc.) bij `--gitignore`.
 
 **init --ci:**
@@ -49,7 +49,7 @@ assay init --ci github
 **Relevante code:**
 
 - [crates/assay-cli/src/cli/commands/init.rs](https://github.com/Rul1an/assay/blob/main/crates/assay-cli/src/cli/commands/init.rs) — init flow, pack selection, write_file_if_missing.
-- [crates/assay-cli/src/templates.rs](https://github.com/Rul1an/assay/blob/main/crates/assay-cli/src/templates.rs) — ASSAY_CONFIG_DEFAULT_YAML, CI_WORKFLOW_YML, CI_EVAL_YAML, CI_TRACES_JSONL.
+- [crates/assay-cli/src/templates.rs](https://github.com/Rul1an/assay/blob/main/crates/assay-cli/src/templates.rs) — EVAL_CONFIG_DEFAULT_YAML, CI_WORKFLOW_YML, CI_EVAL_YAML, CI_TRACES_JSONL.
 - [docs/reference/cli/init.md](reference/cli/init.md) — init documentatie.
 
 ### A.2 Minimale voorbeeldrepo: 0 → CI gate

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -142,9 +142,8 @@ pub struct RunOptions {
 Current state: mixed `version` shapes/values across templates.
 
 **Fix direction**: read-compatible, write-canonical.
-- Eval config: `version: 1` (int)
+- Eval config: `configVersion: 1` (canonical key, int)
 - Policy: `version: "1.0"` (string)
-- Assay config: `version: 2` (int)
 
 ### D6 - "Pack" naming collision
 

--- a/docs/reference/cli/init.md
+++ b/docs/reference/cli/init.md
@@ -36,6 +36,8 @@ With `--from-trace`, generates a policy directly from recorded agent behavior in
 assay init
 ```
 
+Creates `eval.yaml` with a canonical v1 scaffold (`configVersion: 1`) and a starter smoke test template you can replace with real prompts/expectations.
+
 ### Fast first signal (hello trace)
 Creates `eval.yaml`, `traces/hello.jsonl`, and `policy.yaml` (if missing).
 When `--config` points to another directory, the hello trace is written relative to that config path.


### PR DESCRIPTION
## Why
Wave A3 from RFC-001 hardens canonical config writing in `init` and templates.

The goal is read-compat / write-canonical behavior so generated scaffolds no longer emit legacy aliases or invalid default config shapes.

## What changed
### Canonical scaffold output
- `CI_EVAL_YAML` now writes canonical eval keys:
  - `configVersion: 1` (instead of `version: 1`)
  - `semantic_similarity_to` + `min_score` (instead of `text` + `threshold` aliases)
- `HELLO_EVAL_YAML` now writes `configVersion: 1`.
- `ASSAY_CONFIG_DEFAULT_YAML` changed from legacy/invalid shape to canonical parseable eval scaffold:
  - `configVersion: 1`
  - `suite`, `model`, and starter `tests` block.

### init --from-trace config output
- Replaced ad-hoc `version: 2`/top-level fields with a canonical eval config shape:
  - `configVersion: 1`
  - `suite`, `model`, and `tests` block.

### Contract tests
- Extended init CI contract test to assert canonical generated fields in `ci-eval.yaml`.
- Added default init contract test to ensure generated `eval.yaml` parses in strict mode.
- Added from-trace init contract test to ensure generated `eval.yaml` is canonical and parseable.

### Docs alignment
- Updated init CLI docs and DX docs to match canonical scaffold behavior.
- Updated RFC-001 wording where it referenced legacy default key/value in this area.

## Scope (stacked PR)
Base: `codex/rfc001-wave-a2-strict-options`
Head: `codex/rfc001-wave-a3-canonical-init-templates`

Changed files:
- `crates/assay-cli/src/cli/commands/init.rs`
- `crates/assay-cli/src/templates.rs`
- `crates/assay-cli/tests/contract_init_ci.rs`
- `crates/assay-cli/tests/contract_init_hello_trace.rs`
- `docs/reference/cli/init.md`
- `docs/DX-IMPLEMENTATION-PLAN.md`
- `docs/DX-REVIEW-MATERIALS.md`
- `docs/architecture/RFC-001-dx-ux-governance.md`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p assay-cli --test contract_init_ci -- --nocapture`
- `cargo test -p assay-cli --test contract_init_hello_trace -- --nocapture`
- `cargo check -p assay-cli`

## Contract impact
- No run/summary/SARIF/JUnit output schema changes.
- This PR only hardens generated init/template content and parity docs/tests.
