### PR TITLE
feat(dx-wave-b3): rename init pack flag to preset (compat)

### DIFF
--- a/crates/assay-cli/src/cli/args.rs
+++ b/crates/assay-cli/src/cli/args.rs
@@ -526,13 +526,15 @@ pub struct InitArgs {
     #[arg(long)]
     pub gitignore: bool,
 
-    /// Policy pack to use: default | hardened | dev
-    #[arg(long, default_value = "default")]
-    pub pack: String,
+    /// Starter preset to use: default | hardened | dev
+    /// Backward-compatible alias: --pack
+    #[arg(long = "preset", alias = "pack", default_value = "default")]
+    pub preset: String,
 
-    /// List available packs and exit
-    #[arg(long)]
-    pub list_packs: bool,
+    /// List available presets and exit
+    /// Backward-compatible alias: --list-packs
+    #[arg(long = "list-presets", alias = "list-packs")]
+    pub list_presets: bool,
 
     /// Generate policy from an existing trace file (JSONL events)
     #[arg(long)]

--- a/crates/assay-cli/src/cli/commands/init.rs
+++ b/crates/assay-cli/src/cli/commands/init.rs
@@ -3,7 +3,7 @@ use crate::exit_codes;
 use std::path::{Path, PathBuf};
 
 pub async fn run(args: InitArgs) -> anyhow::Result<i32> {
-    if args.list_packs {
+    if args.list_presets {
         for p in crate::packs::list() {
             println!("{}\t{}", p.name, p.description);
         }
@@ -53,8 +53,8 @@ pub async fn run(args: InitArgs) -> anyhow::Result<i32> {
     println!("\n🏗️  Generating Assay Policy & Config...");
 
     // Write Policy Pack
-    let pack = crate::packs::get(&args.pack)
-        .ok_or_else(|| anyhow::anyhow!("unknown pack '{}'. Use --list-packs.", args.pack))?;
+    let pack = crate::packs::get(&args.preset)
+        .ok_or_else(|| anyhow::anyhow!("unknown preset '{}'. Use --list-presets.", args.preset))?;
 
     // Write policy file (respecting existing)
     let policy_path = Path::new("policy.yaml");
@@ -63,7 +63,11 @@ pub async fn run(args: InitArgs) -> anyhow::Result<i32> {
     } else {
         std::fs::write(policy_path, pack.policy_yaml)
             .map_err(|e| anyhow::anyhow!("failed to write {}: {}", policy_path.display(), e))?;
-        println!("   Created {} (pack: {})", policy_path.display(), pack.name);
+        println!(
+            "   Created {} (preset: {})",
+            policy_path.display(),
+            pack.name
+        );
     }
 
     let config_template = if args.hello_trace {

--- a/crates/assay-cli/tests/contract_init_ci.rs
+++ b/crates/assay-cli/tests/contract_init_ci.rs
@@ -72,3 +72,41 @@ fn test_init_ci_contract() {
         "Legacy threshold field alias should not be emitted in generated scaffold"
     );
 }
+
+#[test]
+fn test_init_preset_and_pack_alias_contract() {
+    let temp = tempdir().unwrap();
+
+    #[allow(deprecated)]
+    let mut preset_cmd = Command::cargo_bin("assay").unwrap();
+    preset_cmd
+        .current_dir(temp.path())
+        .arg("init")
+        .arg("--preset")
+        .arg("hardened")
+        .assert()
+        .success();
+
+    let policy_path = temp.path().join("policy.yaml");
+    assert!(
+        policy_path.exists(),
+        "init --preset must create policy scaffold"
+    );
+
+    let temp_alias = tempdir().unwrap();
+    #[allow(deprecated)]
+    let mut pack_alias_cmd = Command::cargo_bin("assay").unwrap();
+    pack_alias_cmd
+        .current_dir(temp_alias.path())
+        .arg("init")
+        .arg("--pack")
+        .arg("hardened")
+        .assert()
+        .success();
+
+    let alias_policy_path = temp_alias.path().join("policy.yaml");
+    assert!(
+        alias_policy_path.exists(),
+        "init --pack alias must remain backward-compatible"
+    );
+}

--- a/docs/AIcontext/entry-points.md
+++ b/docs/AIcontext/entry-points.md
@@ -39,8 +39,8 @@ All CLI commands are defined in `crates/assay-cli/src/cli/args.rs` and dispatche
 **Key Options**:
 - `--ci [github|gitlab]`: Generate CI scaffolding
 - `--gitignore`: Generate `.gitignore` for Assay artifacts
-- `--pack <default|hardened|dev>`: Select starter policy pack
-- `--list-packs`: List available packs
+- `--preset <default|hardened|dev>`: Select starter policy preset (backward alias: `--pack`)
+- `--list-presets`: List available presets (backward alias: `--list-packs`)
 - `--from-trace <PATH>`: Generate config/policy from an existing trace
 - `--heuristics`: Enable heuristics for `--from-trace`
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -24,7 +24,8 @@ Current branch focus:
 - PR-A1 (merged to `main` via #198): typed boundary mapping for run/ci hot-path triage with unit coverage.
 - PR-A2/A3 (merged to `main` via #202): strict-mode env mutation removal + canonical init/template config writing.
 - PR-B1 (#204, in review): shared `run_pipeline` unification for `assay run` and `assay ci`.
-- PR-B2 (current branch): move command dispatch business logic out of `commands/mod.rs`.
+- PR-B2 (#205, in review): move command dispatch business logic out of `commands/mod.rs`.
+- PR-B3 (current branch): rename `init --pack` to `--preset` with backward-compatible aliases.
 
 ---
 

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -261,3 +261,4 @@ Security posture retained:
 - 2026-02-07: Draft created from codebase audit + owner review. Wave A scoped for immediate execution.
 - 2026-02-08: Wave A merged to `main` (`#198`, `#202`). Wave B started.
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
+- 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).

--- a/docs/architecture/architecture-autofix.md
+++ b/docs/architecture/architecture-autofix.md
@@ -9,7 +9,7 @@
 How to explain this release to users in 4 commands:
 
 ```bash
-$ assay init --pack default    # Generate secure config
+$ assay init --preset default  # Generate secure config
 $ assay validate               # Find issues
 $ assay fix --dry-run          # Preview fixes
 $ assay fix --yes              # Apply fixes
@@ -35,7 +35,7 @@ Assay v1.5.0 transforms the tool from a passive validator to an active **Self-Co
 
 ## 4. Security Capabilities (The "Why")
 
-### Policy Packs (`assay init --pack`)
+### Policy Presets (`assay init --preset`)
 These packs are designed to map to common threat vectors (OWASP for LLMs).
 
 #### `default` (Balanced)

--- a/docs/reference/cli/init.md
+++ b/docs/reference/cli/init.md
@@ -14,7 +14,7 @@ assay init [OPTIONS]
 
 Scans your directory for known project types (MCP, Python, Node.js) and generates a security policy and config. Optionally generates CI scaffolding and `.gitignore`.
 
-With `--from-trace`, generates a policy directly from recorded agent behavior instead of using a preset pack.
+With `--from-trace`, generates a policy directly from recorded agent behavior instead of using a starter preset.
 
 ## Options
 
@@ -23,8 +23,8 @@ With `--from-trace`, generates a policy directly from recorded agent behavior in
 | `--config <FILE>` | Config filename. Default: `eval.yaml`. |
 | `--ci [PROVIDER]` | Generate CI scaffolding. `github` (default) or `gitlab`. |
 | `--gitignore` | Generate `.gitignore` for artifacts/db. |
-| `--pack <PACK>` | Policy pack: `default`, `hardened`, `dev`. Default: `default`. |
-| `--list-packs` | List available packs and exit. |
+| `--preset <PRESET>` | Starter preset: `default`, `hardened`, `dev`. Default: `default`. |
+| `--list-presets` | List available presets and exit. |
 | `--from-trace <FILE>` | Generate policy from an existing trace file (JSONL). |
 | `--heuristics` | Enable entropy/risk analysis when generating from trace. Requires `--from-trace`. |
 | `--hello-trace` | Generate a runnable hello trace and smoke suite scaffold. |
@@ -68,5 +68,8 @@ assay init --ci gitlab
 
 ### Hardened policy
 ```bash
+assay init --preset hardened --ci --gitignore
+
+# Backward-compatible alias (deprecated)
 assay init --pack hardened --ci --gitignore
 ```


### PR DESCRIPTION
## Why
Wave B3 from RFC-001 resolves `pack` naming collision on `assay init` by moving scaffold selection to `--preset`, while preserving backward compatibility for existing users/scripts.

## What Changed
- CLI flag migration (migration-safe):
  - `assay init --preset <default|hardened|dev>` (new canonical flag)
  - `assay init --pack ...` remains supported as alias
  - `assay init --list-presets` (new canonical list flag)
  - `assay init --list-packs` remains supported as alias
- Updated init command messaging to use "preset" terminology.
- Added contract coverage for both canonical and alias forms.
- Updated user and architecture docs to reflect canonical usage and compatibility aliases.

## Scope
Code:
- `crates/assay-cli/src/cli/args.rs`
- `crates/assay-cli/src/cli/commands/init.rs`
- `crates/assay-cli/tests/contract_init_ci.rs`

Docs:
- `docs/reference/cli/init.md`
- `docs/AIcontext/entry-points.md`
- `docs/architecture/architecture-autofix.md`
- `docs/DX-IMPLEMENTATION-PLAN.md`
- `docs/architecture/RFC-001-dx-ux-governance.md`

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p assay-cli`
- `cargo clippy -p assay-cli -- -D warnings`
- `cargo test -p assay-cli --test contract_init_ci -- --nocapture`
- `cargo test -p assay-cli --test contract_init_hello_trace -- --nocapture`

## Contract Notes
- No `run.json` / `summary.json` / SARIF/JUnit contract changes.
- Backward compatibility for existing `assay init --pack` usage is retained.
