### PR TITLE
feat(dx-wave-c0): add perf trigger metrics and wave-c guardrails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
+ "criterion",
  "ed25519-dalek",
  "flate2",
  "futures",

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -75,6 +75,11 @@ name = "suite_run_worstcase"
 path = "benches/suite_run_worstcase.rs"
 harness = false
 
+[[bench]]
+name = "profile_store_harness"
+path = "benches/profile_store_harness.rs"
+harness = false
+
 [dev-dependencies]
 tempfile = "3"
 regex = "1"

--- a/crates/assay-cli/benches/profile_store_harness.rs
+++ b/crates/assay-cli/benches/profile_store_harness.rs
@@ -1,0 +1,225 @@
+//! Criterion benchmark harness for profile store load/merge paths.
+//! Run with:
+//!   cargo bench -p assay-cli --bench profile_store_harness
+//! Select workloads with:
+//!   ASSAY_PROFILE_PERF_WORKLOAD=small|typical-pr|large|small,typical-pr,large
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use tempfile::TempDir;
+
+#[derive(Clone, Copy)]
+struct Workload {
+    name: &'static str,
+    initial_entries: usize,
+    delta_entries: usize,
+}
+
+const SMALL: Workload = Workload {
+    name: "small",
+    initial_entries: 1_000,
+    delta_entries: 200,
+};
+
+const TYPICAL_PR: Workload = Workload {
+    name: "typical-pr",
+    initial_entries: 10_000,
+    delta_entries: 1_000,
+};
+
+const LARGE: Workload = Workload {
+    name: "large",
+    initial_entries: 50_000,
+    delta_entries: 5_000,
+};
+
+struct Fixture {
+    _temp: TempDir,
+    profile_path: PathBuf,
+    delta_trace_path: PathBuf,
+}
+
+fn selected_workloads() -> Vec<Workload> {
+    match std::env::var("ASSAY_PROFILE_PERF_WORKLOAD").ok().as_deref() {
+        Some("small") => vec![SMALL],
+        Some("typical-pr") => vec![TYPICAL_PR],
+        Some("large") => vec![LARGE],
+        Some("small,typical-pr,large") => vec![SMALL, TYPICAL_PR, LARGE],
+        _ => vec![SMALL, TYPICAL_PR],
+    }
+}
+
+fn assay_bin() -> PathBuf {
+    if let Some(p) = option_env!("CARGO_BIN_EXE_assay") {
+        return PathBuf::from(p);
+    }
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let release = manifest.join("../../target/release/assay");
+    let debug = manifest.join("../../target/debug/assay");
+    if release.exists() {
+        release
+    } else {
+        debug
+    }
+}
+
+fn run_cmd(bin: &Path, cwd: &Path, args: &[String]) {
+    let mut cmd = Command::new(bin);
+    cmd.current_dir(cwd).stdin(Stdio::null()).args(args);
+    let out = cmd.output().expect("assay command must run");
+    assert!(
+        out.status.success(),
+        "assay command failed: args={:?}\nstdout={}\nstderr={}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn build_initial_trace(path: &Path, entries: usize) {
+    let mut lines = Vec::with_capacity(entries);
+    for i in 0..entries {
+        lines.push(event_line(i as u64, i as u64));
+    }
+    std::fs::write(path, lines.join("\n")).expect("write initial trace");
+}
+
+fn build_delta_trace(path: &Path, initial_entries: usize, delta_entries: usize) {
+    let mut lines = Vec::with_capacity(delta_entries);
+    for i in 0..delta_entries {
+        let logical_idx = if i % 2 == 0 {
+            i % initial_entries
+        } else {
+            initial_entries + i
+        };
+        lines.push(event_line(logical_idx as u64, (initial_entries + i) as u64));
+    }
+    std::fs::write(path, lines.join("\n")).expect("write delta trace");
+}
+
+fn event_line(logical_idx: u64, ts_idx: u64) -> String {
+    let ts = 1_700_000_000_u64.saturating_add(ts_idx);
+    match logical_idx % 3 {
+        0 => format!(
+            r#"{{"type":"file_open","path":"/workspace/file_{logical_idx}.txt","timestamp":{ts}}}"#
+        ),
+        1 => format!(
+            r#"{{"type":"net_connect","dest":"https://svc-{logical_idx}.example.com:443","timestamp":{ts}}}"#
+        ),
+        _ => format!(r#"{{"type":"proc_exec","path":"/bin/tool_{logical_idx}","timestamp":{ts}}}"#),
+    }
+}
+
+fn prepare_fixture(bin: &Path, workload: Workload) -> Fixture {
+    let temp = TempDir::new().expect("temp dir");
+    let profile_path = temp.path().join("profile.yaml");
+    let initial_trace_path = temp.path().join("initial.jsonl");
+    let delta_trace_path = temp.path().join("delta.jsonl");
+
+    build_initial_trace(&initial_trace_path, workload.initial_entries);
+    build_delta_trace(
+        &delta_trace_path,
+        workload.initial_entries,
+        workload.delta_entries,
+    );
+
+    run_cmd(
+        bin,
+        temp.path(),
+        &[
+            "profile".to_string(),
+            "init".to_string(),
+            "--output".to_string(),
+            profile_path.display().to_string(),
+        ],
+    );
+    run_cmd(
+        bin,
+        temp.path(),
+        &[
+            "profile".to_string(),
+            "update".to_string(),
+            "--profile".to_string(),
+            profile_path.display().to_string(),
+            "--input".to_string(),
+            initial_trace_path.display().to_string(),
+            "--run-id".to_string(),
+            "bootstrap-run".to_string(),
+        ],
+    );
+
+    Fixture {
+        _temp: temp,
+        profile_path,
+        delta_trace_path,
+    }
+}
+
+fn bench_profile_load(c: &mut Criterion) {
+    let bin = assay_bin();
+    if !bin.exists() {
+        eprintln!("assay binary not found at {:?}; run cargo build first", bin);
+        return;
+    }
+
+    for workload in selected_workloads() {
+        let fixture = prepare_fixture(&bin, workload);
+        c.bench_function(&format!("profile/load/{}", workload.name), |b| {
+            b.iter(|| {
+                run_cmd(
+                    &bin,
+                    fixture._temp.path(),
+                    &[
+                        "profile".to_string(),
+                        "show".to_string(),
+                        "--profile".to_string(),
+                        fixture.profile_path.display().to_string(),
+                        "--format".to_string(),
+                        "summary".to_string(),
+                    ],
+                );
+            });
+        });
+    }
+}
+
+fn bench_profile_merge(c: &mut Criterion) {
+    let bin = assay_bin();
+    if !bin.exists() {
+        eprintln!("assay binary not found at {:?}; run cargo build first", bin);
+        return;
+    }
+
+    for workload in selected_workloads() {
+        let fixture = prepare_fixture(&bin, workload);
+        let run_seq = AtomicU64::new(1);
+        c.bench_function(&format!("profile/merge/{}", workload.name), |b| {
+            b.iter(|| {
+                let run_id = format!("bench-run-{}", run_seq.fetch_add(1, Ordering::Relaxed));
+                run_cmd(
+                    &bin,
+                    fixture._temp.path(),
+                    &[
+                        "profile".to_string(),
+                        "update".to_string(),
+                        "--profile".to_string(),
+                        fixture.profile_path.display().to_string(),
+                        "--input".to_string(),
+                        fixture.delta_trace_path.display().to_string(),
+                        "--run-id".to_string(),
+                        run_id,
+                    ],
+                );
+            });
+        });
+    }
+}
+
+criterion_group!(
+    profile_store_harness,
+    bench_profile_load,
+    bench_profile_merge
+);
+criterion_main!(profile_store_harness);

--- a/crates/assay-cli/src/cli/commands/ci.rs
+++ b/crates/assay-cli/src/cli/commands/ci.rs
@@ -5,6 +5,7 @@ use super::pipeline::{
 };
 use super::run_output::write_extended_run_json;
 use std::path::PathBuf;
+use std::time::Instant;
 
 pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> {
     let version = args.exit_codes;
@@ -34,6 +35,8 @@ pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> 
     let artifacts = execution.artifacts;
     // Determine outcome first (safety against report write failures)
     let mut outcome = execution.outcome;
+    let timings = execution.timings;
+    let report_start = Instant::now();
 
     // Write output formats (best effort); SARIF outcome needed for run.json/summary sarif.omitted
     if let Err(e) = (|| -> anyhow::Result<()> {
@@ -70,7 +73,14 @@ pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> 
         .parent()
         .map(|p| p.join("summary.json"))
         .unwrap_or_else(|| PathBuf::from("summary.json"));
-    let mut summary = build_summary_from_artifacts(&outcome, !args.no_verify, &artifacts);
+    let report_ms = report_start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    let mut summary = build_summary_from_artifacts(
+        &outcome,
+        !args.no_verify,
+        &artifacts,
+        Some(&timings),
+        Some(report_ms),
+    );
     summary = summary.with_sarif_omitted(sarif_omitted);
     assay_core::report::summary::write_summary(&summary, &summary_path)?;
 

--- a/crates/assay-cli/src/cli/commands/evidence/mapping.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mapping.rs
@@ -306,6 +306,7 @@ mod tests {
             updated_at: "2026-01-26T23:00:00Z".into(),
             total_runs: 1,
             run_ids: vec!["run1".into()],
+            run_id_digests: vec![],
             scope: None,
             entries: Default::default(),
         };

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -404,7 +404,8 @@ fn build_performance_metrics(
         total_duration_ms: total_ms,
         verify_ms: None,
         lint_ms: None,
-        runner_clone_ms: None,
+        runner_clone_ms: artifacts.runner_clone_ms,
+        runner_clone_count: None,
         profile_store_ms: None,
         run_id_memory_bytes: None,
         cache_hit_rate,
@@ -467,6 +468,7 @@ mod tests {
             suite: "demo".to_string(),
             results: vec![row("t1", Some(10), true, TestStatus::Pass)],
             order_seed: None,
+            runner_clone_ms: Some(13),
         };
         let timings = PipelineTimings {
             total_ms: 120,
@@ -483,6 +485,7 @@ mod tests {
         assert_eq!(phases.ingest_ms, Some(12));
         assert_eq!(phases.eval_ms, Some(90));
         assert_eq!(phases.report_ms, Some(30));
+        assert_eq!(performance.runner_clone_ms, Some(13));
     }
 
     #[test]
@@ -499,6 +502,7 @@ mod tests {
                 row("t6", Some(50), false, TestStatus::Pass),
             ],
             order_seed: None,
+            runner_clone_ms: None,
         };
 
         let performance = build_performance_metrics(&artifacts, None, Some(7));
@@ -526,6 +530,7 @@ mod tests {
                 row("c", Some(42), false, TestStatus::Pass),
             ],
             order_seed: None,
+            runner_clone_ms: None,
         };
 
         let performance = build_performance_metrics(&artifacts, None, Some(1));

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -6,6 +6,7 @@ use super::run_output::{
 use super::runner_builder::{build_runner, ensure_parent_dir};
 use crate::exit_codes::{ExitCodeVersion, ReasonCode, RunOutcome};
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 #[derive(Clone)]
 pub(crate) struct PipelineInput {
@@ -98,12 +99,34 @@ pub(crate) struct PipelineSuccess {
     pub cfg: assay_core::model::EvalConfig,
     pub artifacts: assay_core::report::RunArtifacts,
     pub outcome: RunOutcome,
+    pub timings: PipelineTimings,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PipelineTimings {
+    pub total_ms: u64,
+    pub config_load_ms: Option<u64>,
+    pub ingest_ms: Option<u64>,
+    pub runner_build_ms: Option<u64>,
+    pub run_suite_ms: Option<u64>,
+}
+
+fn elapsed_ms(start: Instant) -> u64 {
+    let ms = start.elapsed().as_millis();
+    if ms > u128::from(u64::MAX) {
+        u64::MAX
+    } else {
+        ms as u64
+    }
 }
 
 pub(crate) async fn execute_pipeline(
     input: &PipelineInput,
     legacy_mode: bool,
 ) -> Result<PipelineSuccess, PipelineError> {
+    let pipeline_start = Instant::now();
+    let mut timings = PipelineTimings::default();
+
     if let Err(e) = ensure_parent_dir(&input.db) {
         return Err(PipelineError::Classified {
             reason: ReasonCode::ECfgParse,
@@ -125,8 +148,12 @@ pub(crate) async fn execute_pipeline(
             message: format!("Config file not found: {}", input.config.display()),
         });
     } else {
+        let config_start = Instant::now();
         match assay_core::config::load_config(&input.config, legacy_mode, input.deny_deprecations) {
-            Ok(c) => c,
+            Ok(c) => {
+                timings.config_load_ms = Some(elapsed_ms(config_start));
+                c
+            }
             Err(e) => {
                 let msg = e.to_string();
                 return Err(PipelineError::Classified {
@@ -170,8 +197,10 @@ pub(crate) async fn execute_pipeline(
         }
         if input.replay_strict {
             if let Some(trace_path) = &input.trace_file {
+                let ingest_start = Instant::now();
                 match assay_core::trace::ingest::ingest_into_store(&store, trace_path) {
                     Ok(stats) => {
+                        timings.ingest_ms = Some(elapsed_ms(ingest_start));
                         eprintln!(
                             "auto-ingest: loaded {} events into {} (from {})",
                             stats.event_count,
@@ -198,6 +227,7 @@ pub(crate) async fn execute_pipeline(
         input.rerun_failures
     };
 
+    let runner_build_start = Instant::now();
     let runner = build_runner(
         store,
         &input.trace_file,
@@ -215,6 +245,7 @@ pub(crate) async fn execute_pipeline(
         input.replay_strict,
     )
     .await;
+    timings.runner_build_ms = Some(elapsed_ms(runner_build_start));
 
     let runner = match runner {
         Ok(r) => r,
@@ -239,10 +270,12 @@ pub(crate) async fn execute_pipeline(
         eprintln!("Running {} tests...", total);
     }
     let progress = assay_core::report::console::default_progress_sink(total);
+    let run_suite_start = Instant::now();
     let mut artifacts = runner
         .run_suite(&cfg, progress)
         .await
         .map_err(PipelineError::Fatal)?;
+    timings.run_suite_ms = Some(elapsed_ms(run_suite_start));
 
     if input.redact_prompts {
         let policy = assay_core::redaction::RedactionPolicy::new(true);
@@ -252,11 +285,13 @@ pub(crate) async fn execute_pipeline(
     }
 
     let outcome = decide_run_outcome(&artifacts.results, input.strict, input.exit_codes);
+    timings.total_ms = elapsed_ms(pipeline_start);
 
     Ok(PipelineSuccess {
         cfg,
         artifacts,
         outcome,
+        timings,
     })
 }
 
@@ -288,6 +323,8 @@ pub(crate) fn build_summary_from_artifacts(
     outcome: &RunOutcome,
     verify_enabled: bool,
     artifacts: &assay_core::report::RunArtifacts,
+    pipeline_timings: Option<&PipelineTimings>,
+    report_ms: Option<u64>,
 ) -> assay_core::report::summary::Summary {
     let mut summary = summary_from_outcome(outcome, verify_enabled);
     let passed = artifacts
@@ -307,7 +344,69 @@ pub(crate) fn build_summary_from_artifacts(
     {
         summary = summary.with_judge_metrics(metrics);
     }
+    let performance = build_performance_metrics(artifacts, pipeline_timings, report_ms);
+    summary = summary.with_performance(performance);
     summary
+}
+
+fn build_performance_metrics(
+    artifacts: &assay_core::report::RunArtifacts,
+    pipeline_timings: Option<&PipelineTimings>,
+    report_ms: Option<u64>,
+) -> assay_core::report::summary::PerformanceMetrics {
+    let (total_ms, ingest_ms, eval_ms) = match pipeline_timings {
+        Some(t) => (
+            t.total_ms.saturating_add(report_ms.unwrap_or(0)),
+            t.ingest_ms,
+            t.run_suite_ms,
+        ),
+        None => (report_ms.unwrap_or(0), None, None),
+    };
+
+    let cache_hit_rate = if artifacts.results.is_empty() {
+        None
+    } else {
+        let cached = artifacts.results.iter().filter(|r| r.cached).count() as f64;
+        Some(cached / artifacts.results.len() as f64)
+    };
+
+    let mut slowest: Vec<assay_core::report::summary::SlowestTest> = artifacts
+        .results
+        .iter()
+        .filter_map(|row| {
+            row.duration_ms
+                .map(|d| assay_core::report::summary::SlowestTest {
+                    test_id: row.test_id.clone(),
+                    duration_ms: d,
+                })
+        })
+        .collect();
+    slowest.sort_by(|a, b| b.duration_ms.cmp(&a.duration_ms));
+    slowest.truncate(5);
+    let slowest_tests = if slowest.is_empty() {
+        None
+    } else {
+        Some(slowest)
+    };
+
+    let phase_timings = Some(assay_core::report::summary::PhaseTimings {
+        ingest_ms,
+        eval_ms,
+        judge_ms: None,
+        report_ms,
+    });
+
+    assay_core::report::summary::PerformanceMetrics {
+        total_duration_ms: total_ms,
+        verify_ms: None,
+        lint_ms: None,
+        runner_clone_ms: None,
+        profile_store_ms: None,
+        run_id_memory_bytes: None,
+        cache_hit_rate,
+        slowest_tests,
+        phase_timings,
+    }
 }
 
 pub(crate) fn print_pipeline_summary(
@@ -332,5 +431,83 @@ pub(crate) fn maybe_export_baseline(
         if let Err(e) = export_baseline(path, config_path, cfg, &artifacts.results) {
             eprintln!("Failed to export baseline: {}", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_core::model::{TestResultRow, TestStatus};
+    use serde_json::json;
+
+    fn row(id: &str, duration_ms: Option<u64>, cached: bool, status: TestStatus) -> TestResultRow {
+        TestResultRow {
+            test_id: id.to_string(),
+            status,
+            score: None,
+            cached,
+            message: String::new(),
+            details: json!({}),
+            duration_ms,
+            fingerprint: None,
+            skip_reason: None,
+            attempts: None,
+            error_policy_applied: None,
+        }
+    }
+
+    #[test]
+    fn performance_metrics_include_pipeline_and_report_timings() {
+        let artifacts = assay_core::report::RunArtifacts {
+            run_id: 1,
+            suite: "demo".to_string(),
+            results: vec![row("t1", Some(10), true, TestStatus::Pass)],
+            order_seed: None,
+        };
+        let timings = PipelineTimings {
+            total_ms: 120,
+            config_load_ms: Some(5),
+            ingest_ms: Some(12),
+            runner_build_ms: Some(8),
+            run_suite_ms: Some(90),
+        };
+
+        let performance = build_performance_metrics(&artifacts, Some(&timings), Some(30));
+
+        assert_eq!(performance.total_duration_ms, 150);
+        let phases = performance.phase_timings.expect("phase timings");
+        assert_eq!(phases.ingest_ms, Some(12));
+        assert_eq!(phases.eval_ms, Some(90));
+        assert_eq!(phases.report_ms, Some(30));
+    }
+
+    #[test]
+    fn performance_metrics_compute_cache_hit_rate_and_slowest_top5() {
+        let artifacts = assay_core::report::RunArtifacts {
+            run_id: 2,
+            suite: "demo".to_string(),
+            results: vec![
+                row("t1", Some(80), true, TestStatus::Pass),
+                row("t2", Some(20), false, TestStatus::Fail),
+                row("t3", Some(60), true, TestStatus::Pass),
+                row("t4", Some(10), false, TestStatus::Warn),
+                row("t5", Some(40), false, TestStatus::Pass),
+                row("t6", Some(50), false, TestStatus::Pass),
+            ],
+            order_seed: None,
+        };
+
+        let performance = build_performance_metrics(&artifacts, None, Some(7));
+
+        let hit_rate = performance.cache_hit_rate.expect("cache hit rate");
+        assert!((hit_rate - (2.0 / 6.0)).abs() < f64::EPSILON);
+
+        let slowest = performance.slowest_tests.expect("slowest tests");
+        assert_eq!(slowest.len(), 5);
+        assert_eq!(slowest[0].test_id, "t1");
+        assert_eq!(slowest[1].test_id, "t3");
+        assert_eq!(slowest[2].test_id, "t6");
+        assert_eq!(slowest[3].test_id, "t5");
+        assert_eq!(slowest[4].test_id, "t2");
     }
 }

--- a/crates/assay-cli/src/cli/commands/profile_simulation_test.rs
+++ b/crates/assay-cli/src/cli/commands/profile_simulation_test.rs
@@ -133,9 +133,11 @@ fn test_run_id_ring_buffer() {
     // But run_ids should be capped
     assert_eq!(profile.run_ids.len(), MAX_RUN_IDS);
 
-    // Check oldest and newest logic robustly
-    // Old runs should be evicted
-    assert!(!profile.has_run("run-0"));
+    // Old raw IDs are evicted from the short ring...
+    assert_eq!(profile.run_ids[0], "run-50");
+    // ...but dedupe should still detect recent history via digest ring.
+    assert!(profile.has_run("run-0"));
+    assert_eq!(profile.run_id_digests.len(), MAX_RUN_IDS + 50);
 
     // Newest run should be present
     let newest_id = format!("run-{}", MAX_RUN_IDS + 50 - 1);

--- a/crates/assay-core/src/report/mod.rs
+++ b/crates/assay-core/src/report/mod.rs
@@ -17,4 +17,7 @@ pub struct RunArtifacts {
     /// Seed used for test order randomization (E7.2). Present when run used a seed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order_seed: Option<u64>,
+    /// Time spent creating per-task runner clones in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_clone_ms: Option<u64>,
 }

--- a/crates/assay-core/src/report/summary.rs
+++ b/crates/assay-core/src/report/summary.rs
@@ -238,6 +238,10 @@ pub struct PerformanceMetrics {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_clone_ms: Option<u64>,
 
+    /// Number of runner clone operations performed during suite execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_clone_count: Option<u64>,
+
     /// Profile store phase duration in milliseconds (Wave C trigger surface).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_store_ms: Option<u64>,
@@ -363,6 +367,7 @@ impl Summary {
             verify_ms: None,
             lint_ms: None,
             runner_clone_ms: None,
+            runner_clone_count: None,
             profile_store_ms: None,
             run_id_memory_bytes: None,
             cache_hit_rate: None,

--- a/crates/assay-core/src/report/summary.rs
+++ b/crates/assay-core/src/report/summary.rs
@@ -226,6 +226,26 @@ pub struct PerformanceMetrics {
     /// Total run duration in milliseconds
     pub total_duration_ms: u64,
 
+    /// Evidence verify duration in milliseconds (Wave C trigger surface).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify_ms: Option<u64>,
+
+    /// Evidence lint duration in milliseconds (Wave C trigger surface).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lint_ms: Option<u64>,
+
+    /// Runner clone overhead estimate in milliseconds (Wave C trigger surface).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_clone_ms: Option<u64>,
+
+    /// Profile store phase duration in milliseconds (Wave C trigger surface).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_store_ms: Option<u64>,
+
+    /// Run-id tracker memory footprint estimate in bytes (Wave C trigger surface).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id_memory_bytes: Option<u64>,
+
     /// Cache hit rate (0.0 to 1.0)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_hit_rate: Option<f64>,
@@ -340,10 +360,21 @@ impl Summary {
     pub fn with_duration(mut self, duration_ms: u64) -> Self {
         self.performance = Some(PerformanceMetrics {
             total_duration_ms: duration_ms,
+            verify_ms: None,
+            lint_ms: None,
+            runner_clone_ms: None,
+            profile_store_ms: None,
+            run_id_memory_bytes: None,
             cache_hit_rate: None,
             slowest_tests: None,
             phase_timings: None,
         });
+        self
+    }
+
+    /// Set full performance metrics payload.
+    pub fn with_performance(mut self, performance: PerformanceMetrics) -> Self {
+        self.performance = Some(performance);
         self
     }
 

--- a/crates/assay-evidence/Cargo.toml
+++ b/crates/assay-evidence/Cargo.toml
@@ -51,6 +51,11 @@ jsonschema = "0.40"
 tempfile = "3"
 assert_fs = "1.0"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+criterion = "0.8"
+
+[[bench]]
+name = "verify_lint_harness"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/assay-evidence/benches/verify_lint_harness.rs
+++ b/crates/assay-evidence/benches/verify_lint_harness.rs
@@ -1,0 +1,152 @@
+use assay_evidence::bundle::writer::{verify_bundle_with_limits, BundleWriter, VerifyLimits};
+use assay_evidence::lint::engine::lint_bundle;
+use assay_evidence::types::EvidenceEvent;
+use chrono::{TimeZone, Utc};
+use criterion::{criterion_group, criterion_main, Criterion};
+use serde_json::json;
+use std::hint::black_box;
+use std::io::Cursor;
+
+#[derive(Clone, Copy)]
+struct Workload {
+    name: &'static str,
+    events: usize,
+    payload_bytes: usize,
+}
+
+const SMALL: Workload = Workload {
+    name: "small",
+    events: 1_000,
+    payload_bytes: 128,
+};
+
+const TYPICAL_PR: Workload = Workload {
+    name: "typical-pr",
+    events: 10_000,
+    payload_bytes: 256,
+};
+
+const LARGE: Workload = Workload {
+    name: "large",
+    events: 100_000,
+    payload_bytes: 512,
+};
+
+const ENTROPY_ALPHABET: &[u8; 64] =
+    b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+
+fn selected_workloads() -> Vec<Workload> {
+    match std::env::var("ASSAY_PERF_WORKLOAD").ok().as_deref() {
+        Some("small") => vec![SMALL],
+        Some("typical-pr") => vec![TYPICAL_PR],
+        Some("large") => vec![LARGE],
+        Some("small,typical-pr,large") => vec![SMALL, TYPICAL_PR, LARGE],
+        _ => vec![SMALL, TYPICAL_PR],
+    }
+}
+
+fn build_bundle(workload: Workload) -> Vec<u8> {
+    let mut bundle = Vec::new();
+    let mut writer = BundleWriter::new(&mut bundle);
+
+    for seq in 0..workload.events {
+        let payload_blob = low_compressibility_payload(workload.payload_bytes, seq as u64);
+        let time = Utc
+            .timestamp_opt(1_700_000_000_i64 + seq as i64, 0)
+            .unwrap();
+        let event = EvidenceEvent::new(
+            "assay.tool.decision",
+            "urn:assay:perf-harness",
+            format!("run-{}", workload.name),
+            seq as u64,
+            json!({
+                "tool": "fs.read",
+                "args": { "path": "/workspace/demo.txt", "blob": payload_blob },
+                "decision": "allow",
+            }),
+        )
+        .with_time(time);
+        writer.add_event(event);
+    }
+
+    writer.finish().expect("bundle generation must succeed");
+    bundle
+}
+
+fn bench_verify(c: &mut Criterion) {
+    for workload in selected_workloads() {
+        let bundle = build_bundle(workload);
+        c.bench_function(&format!("verify/{}", workload.name), |b| {
+            b.iter(|| {
+                let result = verify_bundle_with_limits(
+                    Cursor::new(black_box(bundle.as_slice())),
+                    VerifyLimits::default(),
+                )
+                .expect("verify must succeed");
+                black_box(result.manifest.event_count);
+            });
+        });
+    }
+}
+
+fn bench_lint(c: &mut Criterion) {
+    for workload in selected_workloads() {
+        let bundle = build_bundle(workload);
+        c.bench_function(&format!("lint/{}", workload.name), |b| {
+            b.iter(|| {
+                let report = lint_bundle(
+                    Cursor::new(black_box(bundle.as_slice())),
+                    VerifyLimits::default(),
+                )
+                .expect("lint must succeed");
+                black_box(report.summary.total);
+            });
+        });
+    }
+}
+
+fn bench_verify_and_lint(c: &mut Criterion) {
+    for workload in selected_workloads() {
+        let bundle = build_bundle(workload);
+        c.bench_function(&format!("verify+lint/{}", workload.name), |b| {
+            b.iter(|| {
+                let verified = verify_bundle_with_limits(
+                    Cursor::new(black_box(bundle.as_slice())),
+                    VerifyLimits::default(),
+                )
+                .expect("verify must succeed");
+                black_box(verified.manifest.event_count);
+
+                let report = lint_bundle(
+                    Cursor::new(black_box(bundle.as_slice())),
+                    VerifyLimits::default(),
+                )
+                .expect("lint must succeed");
+                black_box(report.summary.total);
+            });
+        });
+    }
+}
+
+fn low_compressibility_payload(payload_bytes: usize, seed: u64) -> String {
+    let mut s = String::with_capacity(payload_bytes);
+    let mut x = seed
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add(0xD1B5_4A32_D192_ED03);
+    while s.len() < payload_bytes {
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        let idx = (x.wrapping_mul(0x2545_F491_4F6C_DD1D) & 63) as usize;
+        s.push(ENTROPY_ALPHABET[idx] as char);
+    }
+    s
+}
+
+criterion_group!(
+    verify_lint_harness,
+    bench_verify,
+    bench_lint,
+    bench_verify_and_lint
+);
+criterion_main!(verify_lint_harness);

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -29,9 +29,13 @@ Current blocker gates (re-assessed on implemented code):
 Current branch focus:
 - PR-A1 (merged to `main` via #198): typed boundary mapping for run/ci hot-path triage with unit coverage.
 - PR-A2/A3 (merged to `main` via #202): strict-mode env mutation removal + canonical init/template config writing.
-- PR-B1 (#204, in review): shared `run_pipeline` unification for `assay run` and `assay ci`.
-- PR-B2 (#205, in review): move command dispatch business logic out of `commands/mod.rs`.
-- PR-B3 (current branch): rename `init --pack` to `--preset` with backward-compatible aliases.
+- PR-B1/B2/B3 (merged to `main` via #204/#205/#209): pipeline unification + dispatch decoupling + `--preset` rename with compat aliases.
+- Wave C kickoff:
+  - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
+  - PR-C1 (#213, open): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
+  - PR-C2 (#214, open): runner clone overhead measurement surfaced in summary performance metrics.
+  - PR-C3 (current branch): profile-store harness + runtime load/merge/save telemetry and trigger warnings.
+  - PR-C4 (next): bounded run-id digest tracking beyond short ring buffer + memory/eviction visibility.
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -20,6 +20,12 @@ PR order for the new track:
 4. PR-B1/B2/B3: pipeline unification + coupling reduction + `--pack` to `--preset`.
 5. PR-C*: perf/scale only when benchmark data justifies it.
 
+Current blocker gates (re-assessed on implemented code):
+- **Wave A blocker**: A1 must become truly typed at classification boundary (stable fields first, substring fallback explicit/legacy only).
+- **Wave A blocker**: A1 boundary errors need stable forensic fields (path/status/provider) to avoid message-only support triage.
+- **Wave B blocker**: B1 requires explicit run-vs-ci parity contract tests for exit/reason and output invariants.
+- **P2 alerts (non-blocking)**: replay coupling wording update, A2 scope clarity (run/ci vs CLI-wide), B3 deprecation timeline as governance.
+
 Current branch focus:
 - PR-A1 (merged to `main` via #198): typed boundary mapping for run/ci hot-path triage with unit coverage.
 - PR-A2/A3 (merged to `main` via #202): strict-mode env mutation removal + canonical init/template config writing.

--- a/docs/PERFORMANCE-BUDGETS.md
+++ b/docs/PERFORMANCE-BUDGETS.md
@@ -1,0 +1,79 @@
+# Performance Budgets (Wave C Harness)
+
+This document defines the reproducible workload classes and baseline budgets used to gate Wave C optimization work.
+
+## Workload Classes
+
+| Class | Bundle Size Target | Event Count | Rule Count Target | Usage |
+|------|---------------------|-------------|-------------------|-------|
+| `small` | ~1 MB | 1k | ~10 | Fast local smoke/perf sanity |
+| `typical-pr` | ~10 MB | 10k | ~50 | Default CI-level perf guardrail |
+| `large` | 50 MB+ | 100k+ | 500+ | Scale trigger for C1/C3/C4 |
+
+Bundle size targets are **logical payload targets** (uncompressed event content). The harness uses
+deterministic low-compressibility payloads so compressed tar sizes do not collapse unrealistically.
+
+## Harness Commands
+
+Default (`small` + `typical-pr`):
+
+```bash
+cargo bench -p assay-evidence --bench verify_lint_harness
+```
+
+Single class (example: `large`):
+
+```bash
+ASSAY_PERF_WORKLOAD=large cargo bench -p assay-evidence --bench verify_lint_harness
+```
+
+All classes:
+
+```bash
+ASSAY_PERF_WORKLOAD=small,typical-pr,large cargo bench -p assay-evidence --bench verify_lint_harness
+```
+
+Profile-store harness (C3):
+
+```bash
+cargo bench -p assay-cli --bench profile_store_harness
+```
+
+Profile-store single class:
+
+```bash
+ASSAY_PROFILE_PERF_WORKLOAD=large cargo bench -p assay-cli --bench profile_store_harness
+```
+
+## Trigger Budgets (Ubuntu Baseline)
+
+These are trigger thresholds, not pass/fail release gates.
+
+The harness emits `verify/*`, `lint/*`, and `verify+lint/*` series per workload. Trigger checks for C1
+must use the explicit `verify+lint/*` series from the same Criterion run.
+
+Measurement protocol (to keep comparisons stable):
+- Runner: `ubuntu-latest` as baseline.
+- Percentiles: use both `p50` and `p95`.
+- Warm/cold split:
+  - cold = first run after clean build/artifact state
+  - warm = repeated runs on same runner/workdir
+  - trigger decisions use warm `p95` and cold `p50` together when relevant.
+
+- C1 trigger:
+  - verify+lint `p95 > 5s` on `large`
+  - or verify+lint `p50 > 2s` on `typical-pr`
+- C2 trigger:
+  - runner clone/build overhead > 10% of suite runtime on >=1000 tests
+- C3 trigger:
+  - profile merge `p95 > 1s` at >=10k entries (`profile/merge/typical-pr` or higher)
+  - or profile load `p95 > 500ms` (`profile/load/typical-pr` or higher)
+- C4 trigger:
+  - run-id tracking evictions cause determinism or duplicate-merge issues
+  - hard bound for duplicate protection window: `N = 5000` recent run IDs
+
+## Guardrails
+
+- No semantic changes to verify/lint/run outputs in Wave C.
+- Any optimization PR must include before/after benchmark output from this harness.
+- Golden equivalence tests are required for verify/lint behavior changes.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -1,6 +1,6 @@
 # RFC-001: DX/UX & Governance - Core Invariants + Debt-Ranked Execution Plan
 
-> **Status**: Active (Wave A merged, Wave B in progress)
+> **Status**: Active (Wave A/B merged, Wave C in progress)
 > **Date**: 2026-02-07
 > **Owner**: DX/Governance track
 > **Motivation**: Keep Assay's state-of-the-art core (replay/evidence/enforcement) strong while preventing CLI/plumbing debt from eroding the product wedge.
@@ -297,7 +297,7 @@ Current state: 6 `.clone()` calls on Arc-wrapped fields per task (`engine/runner
 **Trigger**: Profile corpus growth causes ring buffer evictions that break replay determinism or cause duplicate-merge errors.
 
 **Invariant guardrail** (protects I1):
-- Double-merge of same `run_id` must be impossible across N runs (define N as a hard bound)
+- Double-merge of same `run_id` must be impossible across a hard bound **N = 5000** recent run IDs (bounded digest window)
 - Replacing the ring buffer must not break determinism or introduce memory blowups
 
 **Bounded structure options** (choose one):
@@ -366,3 +366,7 @@ Security posture retained:
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
 - 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
+- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with benchmark realism hardening.
+- 2026-02-08: Wave C runner overhead instrumentation added as additive summary metrics (`runner_clone_ms`, `runner_clone_count`) to make C2 trigger measurable on real suites.
+- 2026-02-08: Wave C profile-store instrumentation added in `assay profile update` (load/merge/save timings + trigger warnings + optional JSON export via `ASSAY_PROFILE_PERF_JSON`).
+- 2026-02-08: Wave C run-id tracking hardened with a bounded digest ring beyond the short run-id window, plus memory/eviction visibility signals in profile perf telemetry.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -201,6 +201,25 @@ Current state:
 
 **Stop line**: no perf rewrites; no output-contract behavior change.
 
+### Wave A/B Risk Controls (Current-State Reassessment)
+
+These controls reflect the implemented code state (not the original plan-only assumptions).
+
+#### P1 blockers (must close for "Wave A/B done")
+
+- **A1 is not fully typed yet**: `RunErrorKind` exists, but assignment is still primarily substring-driven in `classify_message`.
+  Required close condition: classify from typed context first (stable fields), with substring parsing only as explicit legacy fallback.
+- **A1 lacks stable forensic fields**: boundary errors need stable details (`path`, `status`, `provider`, etc.) so support/debug does not rely on free-form message strings.
+- **B1 needs explicit parity fence tests**: shared pipeline must have dedicated run-vs-ci contract tests for exit/reason behavior and output invariants (`run.json`, `summary.json`, SARIF/JUnit + non-blocking report-write behavior).
+
+#### P2 alerts (track, but not ship blockers)
+
+- **A1 source-of-truth wording**: risk is classifier hotspot fragility (message drift), not dual mapping layers.
+- **B1 replay coupling wording**: old `super::cmd_run` note is obsolete; coupling remains via direct `run::run` and `run_output::*` helpers.
+- **A2 scope clarity**: run/ci strict-path env mutation is largely addressed; CLI-wide env cleanup remains separate scope.
+- **A3 legacy-output flag**: not required if canonical output + contract tests stay stable.
+- **B3 deprecation deadline**: governance policy item, not a contract blocker while aliases are supported and tested.
+
 ### Wave C — Performance / Scale (Data-triggered)
 
 **Goal**: Optimize only with measured evidence. No speculative performance work.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -201,23 +201,106 @@ Current state:
 
 **Stop line**: no perf rewrites; no output-contract behavior change.
 
-### Wave C - Performance / Scale (Data-triggered)
+### Wave C — Performance / Scale (Data-triggered)
 
-**Goal**: optimize only with evidence.
+**Goal**: Optimize only with measured evidence. No speculative performance work.
+**Prerequisite**: Wave B merged. C0 (harness) must land before any C1–C4 work starts.
 
-| Task | Trigger | Files |
-|------|---------|-------|
-| C1: Single-pass streaming verify+lint | verify/lint CI cost > 5s | evidence lint/verify engine |
-| C2: `RunnerRef` shared refs | profiling shows clone overhead | core runner |
-| C3: Profile store batch ops | >10k profile entries | storage store |
-| C4: Stable run-id tracking beyond ring buffer | corpus growth pressure | storage layer |
+#### C0: Reproducible perf harness + budgets (required first)
 
-**Acceptance criteria**:
-- [ ] Benchmarked improvements on realistic workloads
-- [ ] No regression in determinism/integrity
-- [ ] Criterion coverage updated
+Without a harness, the "data-triggered" claim is unenforceable. This is the smallest investment with the biggest payoff — it makes all other C-tasks reviewable.
 
-**Stop line**: do not start without measured bottleneck evidence.
+**Deliverables**:
+- Fixture generator for bundles/events/profile corpora at defined workload classes:
+  - `small`: 1MB bundle, 1k events, 10 rules
+  - `typical-pr`: 10MB bundle, 10k events, 50 rules
+  - `large`: 50MB+ bundle, 100k+ events, 500+ rules
+- Criterion benches: `cargo bench -p assay-evidence -- verify_lint`
+- Performance budgets document: p50/p95 targets per workload class, per runner (ubuntu-latest baseline)
+
+**Files**: new bench in `assay-evidence/benches/`, fixture generator, `docs/PERFORMANCE-BUDGETS.md`
+
+#### C1: Single-pass streaming verify+lint
+
+**Trigger** (any of):
+- verify+lint p95 > 5s on ubuntu-latest for `large` workload class (>=50MB or >=100k events or >=500 rules)
+- verify+lint p50 > 2s on `typical-pr` workload class
+
+**Scope definition** — "single-pass" means one decompress + one tar walk:
+1. Read `manifest.json`
+2. Stream entries (no full buffer in memory)
+3. Verify hashes/sizes per entry against manifest
+4. Scan for forbidden patterns
+5. Collect lint events
+6. Produce identical error/warning set as current multi-pass
+
+**Invariant guardrails** (protects I2 + I4):
+- `VerifyLimits` (max entry size, max total uncompressed, max files) remain enforced — streaming is the opportunity to make limits _better_, not weaker
+- Golden tests: verify+lint output on reference bundles must be byte-identical before and after
+- No semantic changes to verify/lint outputs; only performance and memory behavior may change
+
+**Files**: `assay-evidence/src/lint/engine.rs`, `assay-evidence/src/verify.rs`
+
+#### C2: `RunnerRef` shared refs (no per-task clone)
+
+**Trigger**:
+- Runner clone/build overhead > 10% of total suite runtime on a suite of >=1000 tests
+
+**Measurement points** (add behind `debug`/`perf` feature flag):
+- `runner_build_ms`: time to construct runner
+- `runner_clone_count`: number of Arc field clones per suite
+- `runner_clone_ms`: cumulative clone time
+
+Current state: 6 `.clone()` calls on Arc-wrapped fields per task (`engine/runner.rs:529-543`, `768-791`). At current suite sizes (<100 tests) this is negligible.
+
+**Files**: `assay-core/src/engine/runner.rs`
+
+#### C3: Profile store scaling
+
+**Trigger** (any of):
+- Profile merge of 1 run > 1s p95 at >=10k entries
+- Profile load > 500ms p95
+
+**Decision required before implementation**: identify the actual bottleneck:
+- Write path: merge/update complexity
+- Read path: lookups per event (hot path)
+- Serialization: load/serialize cost
+
+**Storage strategy options** (decide based on profiling, not upfront):
+- SQLite (already used for eval DB — one DB or two?)
+- Append-only log + compaction
+- Current YAML with batch operations
+
+**Files**: `assay-core/src/storage/store.rs` (884 lines, no in-file tests — tests should be added as part of this work regardless of which storage strategy is chosen)
+
+#### C4: Stable run-id tracking beyond ring buffer
+
+**Trigger**: Profile corpus growth causes ring buffer evictions that break replay determinism or cause duplicate-merge errors.
+
+**Invariant guardrail** (protects I1):
+- Double-merge of same `run_id` must be impossible across N runs (define N as a hard bound)
+- Replacing the ring buffer must not break determinism or introduce memory blowups
+
+**Bounded structure options** (choose one):
+- Stable hash-set on disk (SQLite) — deterministic, no false positives, proven
+- Bloom filter + periodic reset with epoch — space-efficient but false positives affect UX (false "already merged" errors); only acceptable if error path is graceful
+
+**Files**: `assay-core/src/storage/`
+
+#### Acceptance criteria (all C tasks)
+
+- [ ] C0 harness exists and produces reproducible results before any C1–C4 work starts
+- [ ] Benchmarked improvement on the relevant workload class (p50 and p95)
+- [ ] Golden tests prove semantic equivalence of outputs (verify/lint/run results)
+- [ ] No regression in determinism (I1) or integrity (I2)
+- [ ] Criterion benches updated with before/after
+- [ ] No new dependencies without justification
+
+#### Non-goal
+
+No semantic changes to verify/lint/run outputs. Only performance and memory behavior may change, and must be proven equivalent via golden tests on reference fixtures.
+
+**Stop line**: Do not start C1–C4 without C0 harness in place. Do not start any C-task without measured bottleneck evidence on the defined workload classes.
 
 ---
 
@@ -253,6 +336,7 @@ Security posture retained:
 - No full codebase `thiserror` migration; only core->cli boundary typing.
 - No cross-platform atomic write rewrite in this RFC scope.
 - No broad Arc-free runner rewrite without scale evidence.
+- No semantic changes to verify/lint/run outputs in Wave C; only performance/memory behavior, proven equivalent via golden tests.
 
 ---
 
@@ -261,3 +345,4 @@ Security posture retained:
 - 2026-02-07: Draft created from codebase audit + owner review. Wave A scoped for immediate execution.
 - 2026-02-08: Wave A merged to `main` (`#198`, `#202`). Wave B started.
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
+- 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -208,6 +208,7 @@ nav:
     - architecture/index.md
     - Crate Structure: architecture/crates.md
     - Data Flow: architecture/data-flow.md
+    - Performance Budgets: PERFORMANCE-BUDGETS.md
     - ADRs: architecture/adrs.md
 
   - Contributing:


### PR DESCRIPTION
Why
Wave C starts with a contract-safe C0 slice: expose measurable performance signals in run/ci summary output and codify Wave C trigger guardrails in RFC-001.

What changed
- Added additive performance trigger fields on `PerformanceMetrics` (all optional):
  - `verify_ms`, `lint_ms`, `runner_clone_ms`, `profile_store_ms`, `run_id_memory_bytes`
- Added `Summary::with_performance(...)` to set full performance payload.
- Instrumented shared pipeline execution timings:
  - `config_load_ms`, `ingest_ms`, `runner_build_ms`, `run_suite_ms`, `total_ms`
- Wired run/ci summary generation to include:
  - phase timings (`ingest_ms`, `eval_ms`, `report_ms`)
  - `cache_hit_rate`
  - deterministic top-5 `slowest_tests`
- Added pipeline unit tests for performance metrics computation.
- Updated RFC-001 Wave C section with concrete triggers, workload classes, C0 harness prerequisite, and non-goal/guardrails.

Scope
Code:
- crates/assay-core/src/report/summary.rs
- crates/assay-cli/src/cli/commands/pipeline.rs
- crates/assay-cli/src/cli/commands/run.rs
- crates/assay-cli/src/cli/commands/ci.rs

Docs:
- docs/architecture/RFC-001-dx-ux-governance.md

Validation
- cargo fmt --all
- cargo check -p assay-cli -p assay-core
- cargo test -p assay-core summary -- --nocapture
- cargo test -p assay-cli run_outcome_tests -- --nocapture
- cargo test -p assay-cli cli::commands::pipeline::tests -- --nocapture

Contract notes
- Additive-only summary fields (backward-compatible by default).
- No run.json / SARIF / JUnit contract changes.
- No change to enforcement semantics; this is observability + planning hardening.

Next
- C1 PR: introduce C0 perf harness fixtures/bench budgets in `assay-evidence` as the gate for streaming verify+lint optimization.
