### PR TITLE
feat(dx-wave-c4): harden run-id tracking beyond ring buffer

### DIFF
--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -75,6 +75,11 @@ name = "suite_run_worstcase"
 path = "benches/suite_run_worstcase.rs"
 harness = false
 
+[[bench]]
+name = "profile_store_harness"
+path = "benches/profile_store_harness.rs"
+harness = false
+
 [dev-dependencies]
 tempfile = "3"
 regex = "1"

--- a/crates/assay-cli/benches/profile_store_harness.rs
+++ b/crates/assay-cli/benches/profile_store_harness.rs
@@ -1,0 +1,225 @@
+//! Criterion benchmark harness for profile store load/merge paths.
+//! Run with:
+//!   cargo bench -p assay-cli --bench profile_store_harness
+//! Select workloads with:
+//!   ASSAY_PROFILE_PERF_WORKLOAD=small|typical-pr|large|small,typical-pr,large
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use tempfile::TempDir;
+
+#[derive(Clone, Copy)]
+struct Workload {
+    name: &'static str,
+    initial_entries: usize,
+    delta_entries: usize,
+}
+
+const SMALL: Workload = Workload {
+    name: "small",
+    initial_entries: 1_000,
+    delta_entries: 200,
+};
+
+const TYPICAL_PR: Workload = Workload {
+    name: "typical-pr",
+    initial_entries: 10_000,
+    delta_entries: 1_000,
+};
+
+const LARGE: Workload = Workload {
+    name: "large",
+    initial_entries: 50_000,
+    delta_entries: 5_000,
+};
+
+struct Fixture {
+    _temp: TempDir,
+    profile_path: PathBuf,
+    delta_trace_path: PathBuf,
+}
+
+fn selected_workloads() -> Vec<Workload> {
+    match std::env::var("ASSAY_PROFILE_PERF_WORKLOAD").ok().as_deref() {
+        Some("small") => vec![SMALL],
+        Some("typical-pr") => vec![TYPICAL_PR],
+        Some("large") => vec![LARGE],
+        Some("small,typical-pr,large") => vec![SMALL, TYPICAL_PR, LARGE],
+        _ => vec![SMALL, TYPICAL_PR],
+    }
+}
+
+fn assay_bin() -> PathBuf {
+    if let Some(p) = option_env!("CARGO_BIN_EXE_assay") {
+        return PathBuf::from(p);
+    }
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let release = manifest.join("../../target/release/assay");
+    let debug = manifest.join("../../target/debug/assay");
+    if release.exists() {
+        release
+    } else {
+        debug
+    }
+}
+
+fn run_cmd(bin: &Path, cwd: &Path, args: &[String]) {
+    let mut cmd = Command::new(bin);
+    cmd.current_dir(cwd).stdin(Stdio::null()).args(args);
+    let out = cmd.output().expect("assay command must run");
+    assert!(
+        out.status.success(),
+        "assay command failed: args={:?}\nstdout={}\nstderr={}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn build_initial_trace(path: &Path, entries: usize) {
+    let mut lines = Vec::with_capacity(entries);
+    for i in 0..entries {
+        lines.push(event_line(i as u64, i as u64));
+    }
+    std::fs::write(path, lines.join("\n")).expect("write initial trace");
+}
+
+fn build_delta_trace(path: &Path, initial_entries: usize, delta_entries: usize) {
+    let mut lines = Vec::with_capacity(delta_entries);
+    for i in 0..delta_entries {
+        let logical_idx = if i % 2 == 0 {
+            i % initial_entries
+        } else {
+            initial_entries + i
+        };
+        lines.push(event_line(logical_idx as u64, (initial_entries + i) as u64));
+    }
+    std::fs::write(path, lines.join("\n")).expect("write delta trace");
+}
+
+fn event_line(logical_idx: u64, ts_idx: u64) -> String {
+    let ts = 1_700_000_000_u64.saturating_add(ts_idx);
+    match logical_idx % 3 {
+        0 => format!(
+            r#"{{"type":"file_open","path":"/workspace/file_{logical_idx}.txt","timestamp":{ts}}}"#
+        ),
+        1 => format!(
+            r#"{{"type":"net_connect","dest":"https://svc-{logical_idx}.example.com:443","timestamp":{ts}}}"#
+        ),
+        _ => format!(r#"{{"type":"proc_exec","path":"/bin/tool_{logical_idx}","timestamp":{ts}}}"#),
+    }
+}
+
+fn prepare_fixture(bin: &Path, workload: Workload) -> Fixture {
+    let temp = TempDir::new().expect("temp dir");
+    let profile_path = temp.path().join("profile.yaml");
+    let initial_trace_path = temp.path().join("initial.jsonl");
+    let delta_trace_path = temp.path().join("delta.jsonl");
+
+    build_initial_trace(&initial_trace_path, workload.initial_entries);
+    build_delta_trace(
+        &delta_trace_path,
+        workload.initial_entries,
+        workload.delta_entries,
+    );
+
+    run_cmd(
+        bin,
+        temp.path(),
+        &[
+            "profile".to_string(),
+            "init".to_string(),
+            "--output".to_string(),
+            profile_path.display().to_string(),
+        ],
+    );
+    run_cmd(
+        bin,
+        temp.path(),
+        &[
+            "profile".to_string(),
+            "update".to_string(),
+            "--profile".to_string(),
+            profile_path.display().to_string(),
+            "--input".to_string(),
+            initial_trace_path.display().to_string(),
+            "--run-id".to_string(),
+            "bootstrap-run".to_string(),
+        ],
+    );
+
+    Fixture {
+        _temp: temp,
+        profile_path,
+        delta_trace_path,
+    }
+}
+
+fn bench_profile_load(c: &mut Criterion) {
+    let bin = assay_bin();
+    if !bin.exists() {
+        eprintln!("assay binary not found at {:?}; run cargo build first", bin);
+        return;
+    }
+
+    for workload in selected_workloads() {
+        let fixture = prepare_fixture(&bin, workload);
+        c.bench_function(&format!("profile/load/{}", workload.name), |b| {
+            b.iter(|| {
+                run_cmd(
+                    &bin,
+                    fixture._temp.path(),
+                    &[
+                        "profile".to_string(),
+                        "show".to_string(),
+                        "--profile".to_string(),
+                        fixture.profile_path.display().to_string(),
+                        "--format".to_string(),
+                        "summary".to_string(),
+                    ],
+                );
+            });
+        });
+    }
+}
+
+fn bench_profile_merge(c: &mut Criterion) {
+    let bin = assay_bin();
+    if !bin.exists() {
+        eprintln!("assay binary not found at {:?}; run cargo build first", bin);
+        return;
+    }
+
+    for workload in selected_workloads() {
+        let fixture = prepare_fixture(&bin, workload);
+        let run_seq = AtomicU64::new(1);
+        c.bench_function(&format!("profile/merge/{}", workload.name), |b| {
+            b.iter(|| {
+                let run_id = format!("bench-run-{}", run_seq.fetch_add(1, Ordering::Relaxed));
+                run_cmd(
+                    &bin,
+                    fixture._temp.path(),
+                    &[
+                        "profile".to_string(),
+                        "update".to_string(),
+                        "--profile".to_string(),
+                        fixture.profile_path.display().to_string(),
+                        "--input".to_string(),
+                        fixture.delta_trace_path.display().to_string(),
+                        "--run-id".to_string(),
+                        run_id,
+                    ],
+                );
+            });
+        });
+    }
+}
+
+criterion_group!(
+    profile_store_harness,
+    bench_profile_load,
+    bench_profile_merge
+);
+criterion_main!(profile_store_harness);

--- a/crates/assay-cli/src/cli/args.rs
+++ b/crates/assay-cli/src/cli/args.rs
@@ -526,13 +526,15 @@ pub struct InitArgs {
     #[arg(long)]
     pub gitignore: bool,
 
-    /// Policy pack to use: default | hardened | dev
-    #[arg(long, default_value = "default")]
-    pub pack: String,
+    /// Starter preset to use: default | hardened | dev
+    /// Backward-compatible alias: --pack
+    #[arg(long = "preset", alias = "pack", default_value = "default")]
+    pub preset: String,
 
-    /// List available packs and exit
-    #[arg(long)]
-    pub list_packs: bool,
+    /// List available presets and exit
+    /// Backward-compatible alias: --list-packs
+    #[arg(long = "list-presets", alias = "list-packs")]
+    pub list_presets: bool,
 
     /// Generate policy from an existing trace file (JSONL events)
     #[arg(long)]

--- a/crates/assay-cli/src/cli/commands/evidence/mapping.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mapping.rs
@@ -306,6 +306,7 @@ mod tests {
             updated_at: "2026-01-26T23:00:00Z".into(),
             total_runs: 1,
             run_ids: vec!["run1".into()],
+            run_id_digests: vec![],
             scope: None,
             entries: Default::default(),
         };

--- a/crates/assay-cli/src/cli/commands/init.rs
+++ b/crates/assay-cli/src/cli/commands/init.rs
@@ -3,7 +3,7 @@ use crate::exit_codes;
 use std::path::{Path, PathBuf};
 
 pub async fn run(args: InitArgs) -> anyhow::Result<i32> {
-    if args.list_packs {
+    if args.list_presets {
         for p in crate::packs::list() {
             println!("{}\t{}", p.name, p.description);
         }
@@ -53,8 +53,8 @@ pub async fn run(args: InitArgs) -> anyhow::Result<i32> {
     println!("\n🏗️  Generating Assay Policy & Config...");
 
     // Write Policy Pack
-    let pack = crate::packs::get(&args.pack)
-        .ok_or_else(|| anyhow::anyhow!("unknown pack '{}'. Use --list-packs.", args.pack))?;
+    let pack = crate::packs::get(&args.preset)
+        .ok_or_else(|| anyhow::anyhow!("unknown preset '{}'. Use --list-presets.", args.preset))?;
 
     // Write policy file (respecting existing)
     let policy_path = Path::new("policy.yaml");
@@ -63,7 +63,11 @@ pub async fn run(args: InitArgs) -> anyhow::Result<i32> {
     } else {
         std::fs::write(policy_path, pack.policy_yaml)
             .map_err(|e| anyhow::anyhow!("failed to write {}: {}", policy_path.display(), e))?;
-        println!("   Created {} (pack: {})", policy_path.display(), pack.name);
+        println!(
+            "   Created {} (preset: {})",
+            policy_path.display(),
+            pack.name
+        );
     }
 
     let config_template = if args.hello_trace {

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -405,6 +405,7 @@ fn build_performance_metrics(
         verify_ms: None,
         lint_ms: None,
         runner_clone_ms: artifacts.runner_clone_ms,
+        runner_clone_count: artifacts.runner_clone_count,
         profile_store_ms: None,
         run_id_memory_bytes: None,
         cache_hit_rate,

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -405,7 +405,7 @@ fn build_performance_metrics(
         verify_ms: None,
         lint_ms: None,
         runner_clone_ms: artifacts.runner_clone_ms,
-        runner_clone_count: artifacts.runner_clone_count,
+        runner_clone_count: None,
         profile_store_ms: None,
         run_id_memory_bytes: None,
         cache_hit_rate,

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -404,7 +404,7 @@ fn build_performance_metrics(
         total_duration_ms: total_ms,
         verify_ms: None,
         lint_ms: None,
-        runner_clone_ms: None,
+        runner_clone_ms: artifacts.runner_clone_ms,
         profile_store_ms: None,
         run_id_memory_bytes: None,
         cache_hit_rate,
@@ -467,6 +467,7 @@ mod tests {
             suite: "demo".to_string(),
             results: vec![row("t1", Some(10), true, TestStatus::Pass)],
             order_seed: None,
+            runner_clone_ms: Some(13),
         };
         let timings = PipelineTimings {
             total_ms: 120,
@@ -483,6 +484,7 @@ mod tests {
         assert_eq!(phases.ingest_ms, Some(12));
         assert_eq!(phases.eval_ms, Some(90));
         assert_eq!(phases.report_ms, Some(30));
+        assert_eq!(performance.runner_clone_ms, Some(13));
     }
 
     #[test]
@@ -499,6 +501,7 @@ mod tests {
                 row("t6", Some(50), false, TestStatus::Pass),
             ],
             order_seed: None,
+            runner_clone_ms: None,
         };
 
         let performance = build_performance_metrics(&artifacts, None, Some(7));
@@ -526,6 +529,7 @@ mod tests {
                 row("c", Some(42), false, TestStatus::Pass),
             ],
             order_seed: None,
+            runner_clone_ms: None,
         };
 
         let performance = build_performance_metrics(&artifacts, None, Some(1));

--- a/crates/assay-cli/src/cli/commands/profile.rs
+++ b/crates/assay-cli/src/cli/commands/profile.rs
@@ -9,8 +9,10 @@
 
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::time::Instant;
 
 use super::profile_types::*;
 
@@ -151,6 +153,18 @@ pub fn run(args: ProfileArgs) -> Result<i32> {
     }
 }
 
+#[derive(Debug, Serialize)]
+struct ProfilePerfMetrics {
+    load_profile_ms: u64,
+    read_events_ms: u64,
+    aggregate_ms: u64,
+    merge_ms: u64,
+    save_profile_ms: u64,
+    profile_store_ms: u64,
+    total_ms: u64,
+    run_entries: usize,
+}
+
 fn cmd_init(args: InitArgs) -> Result<i32> {
     if args.output.exists() {
         anyhow::bail!("profile already exists: {}", args.output.display());
@@ -193,9 +207,13 @@ fn enforce_scope(profile: &mut Profile, new_scope: Option<&String>, force: bool)
 }
 
 fn cmd_update(args: UpdateArgs) -> Result<i32> {
+    let total_start = Instant::now();
+
     // Load existing profile
+    let load_start = Instant::now();
     let mut profile = load_profile(&args.profile)
         .with_context(|| format!("failed to load profile: {}", args.profile.display()))?;
+    let load_profile_ms = elapsed_ms(load_start);
 
     // Enforce scope guard
     enforce_scope(&mut profile, args.scope.as_ref(), args.force)?;
@@ -210,13 +228,18 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
     }
 
     // Read events
+    let read_start = Instant::now();
     let events = read_events(&args.input)?;
+    let read_events_ms = elapsed_ms(read_start);
     if events.is_empty() {
         eprintln!("Warning: no events in input");
     }
 
     // Aggregate this run (deduplicated per artifact)
+    let aggregate_start = Instant::now();
     let run_data = aggregate_run(&events);
+    let aggregate_ms = elapsed_ms(aggregate_start);
+    let run_entries = run_data.files.len() + run_data.network.len() + run_data.processes.len();
 
     if args.verbose {
         eprintln!(
@@ -229,7 +252,9 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
     }
 
     // Merge into profile
+    let merge_start = Instant::now();
     let (new_count, updated_count) = merge_run(&mut profile, &run_data);
+    let merge_ms = elapsed_ms(merge_start);
 
     // Update metadata
     profile.total_runs += 1;
@@ -237,12 +262,62 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
     profile.updated_at = chrono::Utc::now().to_rfc3339();
 
     // Save
+    let save_start = Instant::now();
     save_profile(&profile, &args.profile)?;
+    let save_profile_ms = elapsed_ms(save_start);
+
+    let profile_store_ms = load_profile_ms
+        .saturating_add(merge_ms)
+        .saturating_add(save_profile_ms);
+    let total_ms = elapsed_ms(total_start);
+    let perf = ProfilePerfMetrics {
+        load_profile_ms,
+        read_events_ms,
+        aggregate_ms,
+        merge_ms,
+        save_profile_ms,
+        profile_store_ms,
+        total_ms,
+        run_entries,
+    };
 
     eprintln!(
         "Updated profile: {} total runs, {} new entries, {} updated",
         profile.total_runs, new_count, updated_count
     );
+
+    if args.verbose || profile_store_ms >= 500 {
+        eprintln!(
+            "profile-perf: load={}ms read={}ms aggregate={}ms merge={}ms save={}ms store={}ms total={}ms entries={}",
+            perf.load_profile_ms,
+            perf.read_events_ms,
+            perf.aggregate_ms,
+            perf.merge_ms,
+            perf.save_profile_ms,
+            perf.profile_store_ms,
+            perf.total_ms,
+            perf.run_entries
+        );
+    }
+    if perf.load_profile_ms > 500 {
+        eprintln!(
+            "WARNING: profile load is slow ({}ms > 500ms trigger)",
+            perf.load_profile_ms
+        );
+    }
+    if perf.merge_ms > 1_000 {
+        eprintln!(
+            "WARNING: profile merge is slow ({}ms > 1000ms trigger)",
+            perf.merge_ms
+        );
+    }
+
+    if let Ok(path) = std::env::var("ASSAY_PROFILE_PERF_JSON") {
+        let json = serde_json::to_string_pretty(&perf)?;
+        std::fs::write(&path, json)
+            .with_context(|| format!("failed to write profile perf json: {}", path))?;
+        eprintln!("Wrote profile perf metrics: {}", path);
+    }
 
     Ok(0)
 }
@@ -396,6 +471,10 @@ fn show_summary(profile: &Profile, top_n: usize) {
             show_top_stable(&profile.entries.network, profile.total_runs, top_n);
         }
     }
+}
+
+fn elapsed_ms(start: Instant) -> u64 {
+    start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 fn show_stability_distribution(

--- a/crates/assay-cli/src/cli/commands/profile.rs
+++ b/crates/assay-cli/src/cli/commands/profile.rs
@@ -163,6 +163,9 @@ struct ProfilePerfMetrics {
     profile_store_ms: u64,
     total_ms: u64,
     run_entries: usize,
+    run_id_window_len: usize,
+    run_id_digest_window_len: usize,
+    run_id_memory_bytes: u64,
 }
 
 fn cmd_init(args: InitArgs) -> Result<i32> {
@@ -279,6 +282,9 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
         profile_store_ms,
         total_ms,
         run_entries,
+        run_id_window_len: profile.run_ids.len(),
+        run_id_digest_window_len: profile.run_id_digests.len(),
+        run_id_memory_bytes: profile.run_id_memory_bytes_estimate(),
     };
 
     eprintln!(
@@ -309,6 +315,12 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
         eprintln!(
             "WARNING: profile merge is slow ({}ms > 1000ms trigger)",
             perf.merge_ms
+        );
+    }
+    if perf.run_id_digest_window_len >= MAX_RUN_ID_DIGESTS {
+        eprintln!(
+            "WARNING: run-id digest window is full ({} entries); old run-id dedupe evidence will be evicted over time",
+            perf.run_id_digest_window_len
         );
     }
 

--- a/crates/assay-cli/src/cli/commands/profile_simulation_test.rs
+++ b/crates/assay-cli/src/cli/commands/profile_simulation_test.rs
@@ -133,9 +133,11 @@ fn test_run_id_ring_buffer() {
     // But run_ids should be capped
     assert_eq!(profile.run_ids.len(), MAX_RUN_IDS);
 
-    // Check oldest and newest logic robustly
-    // Old runs should be evicted
-    assert!(!profile.has_run("run-0"));
+    // Old raw IDs are evicted from the short ring...
+    assert_eq!(profile.run_ids[0], "run-50");
+    // ...but dedupe should still detect recent history via digest ring.
+    assert!(profile.has_run("run-0"));
+    assert_eq!(profile.run_id_digests.len(), MAX_RUN_IDS + 50);
 
     // Newest run should be present
     let newest_id = format!("run-{}", MAX_RUN_IDS + 50 - 1);

--- a/crates/assay-cli/tests/contract_init_ci.rs
+++ b/crates/assay-cli/tests/contract_init_ci.rs
@@ -72,3 +72,41 @@ fn test_init_ci_contract() {
         "Legacy threshold field alias should not be emitted in generated scaffold"
     );
 }
+
+#[test]
+fn test_init_preset_and_pack_alias_contract() {
+    let temp = tempdir().unwrap();
+
+    #[allow(deprecated)]
+    let mut preset_cmd = Command::cargo_bin("assay").unwrap();
+    preset_cmd
+        .current_dir(temp.path())
+        .arg("init")
+        .arg("--preset")
+        .arg("hardened")
+        .assert()
+        .success();
+
+    let policy_path = temp.path().join("policy.yaml");
+    assert!(
+        policy_path.exists(),
+        "init --preset must create policy scaffold"
+    );
+
+    let temp_alias = tempdir().unwrap();
+    #[allow(deprecated)]
+    let mut pack_alias_cmd = Command::cargo_bin("assay").unwrap();
+    pack_alias_cmd
+        .current_dir(temp_alias.path())
+        .arg("init")
+        .arg("--pack")
+        .arg("hardened")
+        .assert()
+        .success();
+
+    let alias_policy_path = temp_alias.path().join("policy.yaml");
+    assert!(
+        alias_policy_path.exists(),
+        "init --pack alias must remain backward-compatible"
+    );
+}

--- a/crates/assay-core/src/engine/runner.rs
+++ b/crates/assay-core/src/engine/runner.rs
@@ -84,15 +84,13 @@ impl Runner {
         }
 
         let total = tests.len();
-        let mut runner_clone_count = 0_u64;
-        let mut runner_clone_ms = 0_u64;
+        let mut clone_overhead_ms: u128 = 0;
         for tc in tests.iter() {
             let permit = sem.clone().acquire_owned().await?;
-            let clone_start = Instant::now();
+            let clone_started = Instant::now();
             let this = self.clone_for_task();
-            let clone_elapsed = clone_start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
-            runner_clone_ms = runner_clone_ms.saturating_add(clone_elapsed);
-            runner_clone_count = runner_clone_count.saturating_add(1);
+            clone_overhead_ms =
+                clone_overhead_ms.saturating_add(clone_started.elapsed().as_millis());
             let cfg = cfg.clone();
             let tc = tc.clone();
             join_set.spawn(async move {
@@ -155,8 +153,7 @@ impl Runner {
             suite: cfg.suite.clone(),
             results: rows,
             order_seed: cfg.settings.seed,
-            runner_clone_ms: Some(runner_clone_ms),
-            runner_clone_count: Some(runner_clone_count),
+            runner_clone_ms: Some(clone_overhead_ms.min(u128::from(u64::MAX)) as u64),
         })
     }
 
@@ -535,13 +532,14 @@ impl Runner {
         Ok(resp)
     }
 
-    fn clone_for_task(&self) -> RunnerRef {
-        RunnerRef {
+    fn clone_for_task(&self) -> Runner {
+        Runner {
             store: self.store.clone(),
             cache: self.cache.clone(),
             client: self.client.clone(),
             metrics: self.metrics.clone(),
             policy: self.policy.clone(),
+            _network_guard: None,
             embedder: self.embedder.clone(),
             refresh_embeddings: self.refresh_embeddings,
             incremental: self.incremental,
@@ -756,45 +754,5 @@ impl Runner {
             .await?;
 
         Ok(())
-    }
-}
-
-#[derive(Clone)]
-struct RunnerRef {
-    store: Store,
-    cache: VcrCache,
-    client: Arc<dyn LlmClient>,
-    metrics: Vec<Arc<dyn Metric>>,
-    policy: RunPolicy,
-    embedder: Option<Arc<dyn crate::providers::embedder::Embedder>>,
-    refresh_embeddings: bool,
-    incremental: bool,
-    refresh_cache: bool,
-    judge: Option<crate::judge::JudgeService>,
-    baseline: Option<crate::baseline::Baseline>,
-}
-
-impl RunnerRef {
-    async fn run_test_with_policy(
-        &self,
-        cfg: &EvalConfig,
-        tc: &TestCase,
-        run_id: i64,
-    ) -> anyhow::Result<TestResultRow> {
-        let runner = Runner {
-            store: self.store.clone(),
-            cache: self.cache.clone(),
-            client: self.client.clone(),
-            metrics: self.metrics.clone(),
-            policy: self.policy.clone(),
-            _network_guard: None,
-            embedder: self.embedder.clone(),
-            refresh_embeddings: self.refresh_embeddings,
-            incremental: self.incremental,
-            refresh_cache: self.refresh_cache,
-            judge: self.judge.clone(),
-            baseline: self.baseline.clone(),
-        };
-        runner.run_test_with_policy(cfg, tc, run_id).await
     }
 }

--- a/crates/assay-core/src/report/mod.rs
+++ b/crates/assay-core/src/report/mod.rs
@@ -17,10 +17,7 @@ pub struct RunArtifacts {
     /// Seed used for test order randomization (E7.2). Present when run used a seed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order_seed: Option<u64>,
-    /// Estimated time spent cloning runner refs for test tasks.
+    /// Time spent creating per-task runner clones in milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_clone_ms: Option<u64>,
-    /// Number of clone operations used to produce per-task runner refs.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub runner_clone_count: Option<u64>,
 }

--- a/crates/assay-core/src/report/mod.rs
+++ b/crates/assay-core/src/report/mod.rs
@@ -17,4 +17,7 @@ pub struct RunArtifacts {
     /// Seed used for test order randomization (E7.2). Present when run used a seed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order_seed: Option<u64>,
+    /// Time spent creating per-task runner clones in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_clone_ms: Option<u64>,
 }

--- a/crates/assay-evidence/benches/verify_lint_harness.rs
+++ b/crates/assay-evidence/benches/verify_lint_harness.rs
@@ -32,6 +32,9 @@ const LARGE: Workload = Workload {
     payload_bytes: 512,
 };
 
+const ENTROPY_ALPHABET: &[u8; 64] =
+    b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+
 fn selected_workloads() -> Vec<Workload> {
     match std::env::var("ASSAY_PERF_WORKLOAD").ok().as_deref() {
         Some("small") => vec![SMALL],
@@ -45,9 +48,9 @@ fn selected_workloads() -> Vec<Workload> {
 fn build_bundle(workload: Workload) -> Vec<u8> {
     let mut bundle = Vec::new();
     let mut writer = BundleWriter::new(&mut bundle);
-    let payload_blob = "x".repeat(workload.payload_bytes);
 
     for seq in 0..workload.events {
+        let payload_blob = low_compressibility_payload(workload.payload_bytes, seq as u64);
         let time = Utc
             .timestamp_opt(1_700_000_000_i64 + seq as i64, 0)
             .unwrap();
@@ -102,5 +105,48 @@ fn bench_lint(c: &mut Criterion) {
     }
 }
 
-criterion_group!(verify_lint_harness, bench_verify, bench_lint);
+fn bench_verify_and_lint(c: &mut Criterion) {
+    for workload in selected_workloads() {
+        let bundle = build_bundle(workload);
+        c.bench_function(&format!("verify+lint/{}", workload.name), |b| {
+            b.iter(|| {
+                let verified = verify_bundle_with_limits(
+                    Cursor::new(black_box(bundle.as_slice())),
+                    VerifyLimits::default(),
+                )
+                .expect("verify must succeed");
+                black_box(verified.manifest.event_count);
+
+                let report = lint_bundle(
+                    Cursor::new(black_box(bundle.as_slice())),
+                    VerifyLimits::default(),
+                )
+                .expect("lint must succeed");
+                black_box(report.summary.total);
+            });
+        });
+    }
+}
+
+fn low_compressibility_payload(payload_bytes: usize, seed: u64) -> String {
+    let mut s = String::with_capacity(payload_bytes);
+    let mut x = seed
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add(0xD1B5_4A32_D192_ED03);
+    while s.len() < payload_bytes {
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        let idx = (x.wrapping_mul(0x2545_F491_4F6C_DD1D) & 63) as usize;
+        s.push(ENTROPY_ALPHABET[idx] as char);
+    }
+    s
+}
+
+criterion_group!(
+    verify_lint_harness,
+    bench_verify,
+    bench_lint,
+    bench_verify_and_lint
+);
 criterion_main!(verify_lint_harness);

--- a/docs/AIcontext/entry-points.md
+++ b/docs/AIcontext/entry-points.md
@@ -39,8 +39,8 @@ All CLI commands are defined in `crates/assay-cli/src/cli/args.rs` and dispatche
 **Key Options**:
 - `--ci [github|gitlab]`: Generate CI scaffolding
 - `--gitignore`: Generate `.gitignore` for Assay artifacts
-- `--pack <default|hardened|dev>`: Select starter policy pack
-- `--list-packs`: List available packs
+- `--preset <default|hardened|dev>`: Select starter policy preset (backward alias: `--pack`)
+- `--list-presets`: List available presets (backward alias: `--list-packs`)
 - `--from-trace <PATH>`: Generate config/policy from an existing trace
 - `--heuristics`: Enable heuristics for `--from-trace`
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -32,9 +32,10 @@ Current branch focus:
 - PR-B1/B2/B3 (merged to `main` via #204/#205/#209): pipeline unification + dispatch decoupling + `--preset` rename with compat aliases.
 - Wave C kickoff:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
-  - PR-C1 (#213, in review): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
-  - PR-C2 (#217, in review): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
+  - PR-C1 (#213, open): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
+  - PR-C2 (#214, open): runner clone overhead measurement surfaced in summary performance metrics.
   - PR-C3 (current branch): profile-store harness + runtime load/merge/save telemetry and trigger warnings.
+  - PR-C4 (next): bounded run-id digest tracking beyond short ring buffer + memory/eviction visibility.
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -32,7 +32,8 @@ Current branch focus:
 - PR-B1/B2/B3 (merged to `main` via #204/#205/#209): pipeline unification + dispatch decoupling + `--preset` rename with compat aliases.
 - Wave C kickoff:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
-  - PR-C1 (current branch): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
+  - PR-C1 (#213, in review): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
+  - PR-C2 (current branch): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -33,7 +33,8 @@ Current branch focus:
 - Wave C kickoff:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
   - PR-C1 (#213, in review): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
-  - PR-C2 (current branch): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
+  - PR-C2 (#217, in review): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
+  - PR-C3 (current branch): profile-store perf harness for merge/load triggers (`profile_store_harness` bench).
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -34,7 +34,7 @@ Current branch focus:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
   - PR-C1 (#213, in review): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
   - PR-C2 (#217, in review): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
-  - PR-C3 (current branch): profile-store perf harness for merge/load triggers (`profile_store_harness` bench).
+  - PR-C3 (current branch): profile-store harness + runtime load/merge/save telemetry and trigger warnings.
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -24,7 +24,8 @@ Current branch focus:
 - PR-A1 (merged to `main` via #198): typed boundary mapping for run/ci hot-path triage with unit coverage.
 - PR-A2/A3 (merged to `main` via #202): strict-mode env mutation removal + canonical init/template config writing.
 - PR-B1 (#204, in review): shared `run_pipeline` unification for `assay run` and `assay ci`.
-- PR-B2 (current branch): move command dispatch business logic out of `commands/mod.rs`.
+- PR-B2 (#205, in review): move command dispatch business logic out of `commands/mod.rs`.
+- PR-B3 (current branch): rename `init --pack` to `--preset` with backward-compatible aliases.
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -20,17 +20,22 @@ PR order for the new track:
 4. PR-B1/B2/B3: pipeline unification + coupling reduction + `--pack` to `--preset`.
 5. PR-C*: perf/scale only when benchmark data justifies it.
 
+Current blocker gates (re-assessed on implemented code):
+- **Wave A blocker**: A1 must become truly typed at classification boundary (stable fields first, substring fallback explicit/legacy only).
+- **Wave A blocker**: A1 boundary errors need stable forensic fields (path/status/provider) to avoid message-only support triage.
+- **Wave B blocker**: B1 requires explicit run-vs-ci parity contract tests for exit/reason and output invariants.
+- **P2 alerts (non-blocking)**: replay coupling wording update, A2 scope clarity (run/ci vs CLI-wide), B3 deprecation timeline as governance.
+
 Current branch focus:
 - PR-A1 (merged to `main` via #198): typed boundary mapping for run/ci hot-path triage with unit coverage.
 - PR-A2/A3 (merged to `main` via #202): strict-mode env mutation removal + canonical init/template config writing.
-- PR-B1 (#204, in review): shared `run_pipeline` unification for `assay run` and `assay ci`.
-- PR-B2 (current branch): move command dispatch business logic out of `commands/mod.rs`.
+- PR-B1/B2/B3 (merged to `main` via #204/#205/#209): pipeline unification + dispatch decoupling + `--preset` rename with compat aliases.
 - Wave C kickoff:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
   - PR-C1 (#213, open): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
   - PR-C2 (#214, open): runner clone overhead measurement surfaced in summary performance metrics.
-  - PR-C3 (#215, open): profile load/merge/save timing metrics and trigger warnings.
-  - PR-C4 (#216, open): bounded run-id digest tracking beyond short ring buffer + memory/eviction visibility.
+  - PR-C3 (current branch): profile-store harness + runtime load/merge/save telemetry and trigger warnings.
+  - PR-C4 (next): bounded run-id digest tracking beyond short ring buffer + memory/eviction visibility.
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -30,7 +30,7 @@ Current branch focus:
   - PR-C1 (#213, open): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
   - PR-C2 (#214, open): runner clone overhead measurement surfaced in summary performance metrics.
   - PR-C3 (#215, open): profile load/merge/save timing metrics and trigger warnings.
-  - PR-C4 (next): bounded run-id digest tracking beyond short ring buffer + memory/eviction visibility.
+  - PR-C4 (#216, open): bounded run-id digest tracking beyond short ring buffer + memory/eviction visibility.
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -20,6 +20,12 @@ PR order for the new track:
 4. PR-B1/B2/B3: pipeline unification + coupling reduction + `--pack` to `--preset`.
 5. PR-C*: perf/scale only when benchmark data justifies it.
 
+Current blocker gates (re-assessed on implemented code):
+- **Wave A blocker**: A1 must become truly typed at classification boundary (stable fields first, substring fallback explicit/legacy only).
+- **Wave A blocker**: A1 boundary errors need stable forensic fields (path/status/provider) to avoid message-only support triage.
+- **Wave B blocker**: B1 requires explicit run-vs-ci parity contract tests for exit/reason and output invariants.
+- **P2 alerts (non-blocking)**: replay coupling wording update, A2 scope clarity (run/ci vs CLI-wide), B3 deprecation timeline as governance.
+
 Current branch focus:
 - PR-A1 (merged to `main` via #198): typed boundary mapping for run/ci hot-path triage with unit coverage.
 - PR-A2/A3 (merged to `main` via #202): strict-mode env mutation removal + canonical init/template config writing.

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -20,14 +20,19 @@ PR order for the new track:
 4. PR-B1/B2/B3: pipeline unification + coupling reduction + `--pack` to `--preset`.
 5. PR-C*: perf/scale only when benchmark data justifies it.
 
+Current blocker gates (re-assessed on implemented code):
+- **Wave A blocker**: A1 must become truly typed at classification boundary (stable fields first, substring fallback explicit/legacy only).
+- **Wave A blocker**: A1 boundary errors need stable forensic fields (path/status/provider) to avoid message-only support triage.
+- **Wave B blocker**: B1 requires explicit run-vs-ci parity contract tests for exit/reason and output invariants.
+- **P2 alerts (non-blocking)**: replay coupling wording update, A2 scope clarity (run/ci vs CLI-wide), B3 deprecation timeline as governance.
+
 Current branch focus:
 - PR-A1 (merged to `main` via #198): typed boundary mapping for run/ci hot-path triage with unit coverage.
 - PR-A2/A3 (merged to `main` via #202): strict-mode env mutation removal + canonical init/template config writing.
-- PR-B1 (#204, in review): shared `run_pipeline` unification for `assay run` and `assay ci`.
-- PR-B2 (current branch): move command dispatch business logic out of `commands/mod.rs`.
+- PR-B1/B2/B3 (merged to `main` via #204/#205/#209): pipeline unification + dispatch decoupling + `--preset` rename with compat aliases.
 - Wave C kickoff:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
-  - PR-C1 (next): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
+  - PR-C1 (current branch): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -29,7 +29,8 @@ Current branch focus:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
   - PR-C1 (#213, open): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
   - PR-C2 (#214, open): runner clone overhead measurement surfaced in summary performance metrics.
-  - PR-C3 (next): profile load/merge/save timing metrics and trigger warnings.
+  - PR-C3 (#215, open): profile load/merge/save timing metrics and trigger warnings.
+  - PR-C4 (next): bounded run-id digest tracking beyond short ring buffer + memory/eviction visibility.
 
 ---
 

--- a/docs/PERFORMANCE-BUDGETS.md
+++ b/docs/PERFORMANCE-BUDGETS.md
@@ -10,6 +10,9 @@ This document defines the reproducible workload classes and baseline budgets use
 | `typical-pr` | ~10 MB | 10k | ~50 | Default CI-level perf guardrail |
 | `large` | 50 MB+ | 100k+ | 500+ | Scale trigger for C1/C3/C4 |
 
+Bundle size targets are **logical payload targets** (uncompressed event content). The harness uses
+deterministic low-compressibility payloads so compressed tar sizes do not collapse unrealistically.
+
 ## Harness Commands
 
 Default (`small` + `typical-pr`):
@@ -33,6 +36,9 @@ ASSAY_PERF_WORKLOAD=small,typical-pr,large cargo bench -p assay-evidence --bench
 ## Trigger Budgets (Ubuntu Baseline)
 
 These are trigger thresholds, not pass/fail release gates.
+
+The harness emits `verify/*`, `lint/*`, and `verify+lint/*` series per workload. Trigger checks for C1
+must use the explicit `verify+lint/*` series from the same Criterion run.
 
 - C1 trigger:
   - verify+lint `p95 > 5s` on `large`

--- a/docs/PERFORMANCE-BUDGETS.md
+++ b/docs/PERFORMANCE-BUDGETS.md
@@ -33,6 +33,18 @@ All classes:
 ASSAY_PERF_WORKLOAD=small,typical-pr,large cargo bench -p assay-evidence --bench verify_lint_harness
 ```
 
+Profile-store harness (C3):
+
+```bash
+cargo bench -p assay-cli --bench profile_store_harness
+```
+
+Profile-store single class:
+
+```bash
+ASSAY_PROFILE_PERF_WORKLOAD=large cargo bench -p assay-cli --bench profile_store_harness
+```
+
 ## Trigger Budgets (Ubuntu Baseline)
 
 These are trigger thresholds, not pass/fail release gates.
@@ -46,8 +58,8 @@ must use the explicit `verify+lint/*` series from the same Criterion run.
 - C2 trigger:
   - runner clone/build overhead > 10% of suite runtime on >=1000 tests
 - C3 trigger:
-  - profile merge `p95 > 1s` at >=10k entries
-  - or profile load `p95 > 500ms`
+  - profile merge `p95 > 1s` at >=10k entries (`profile/merge/typical-pr` or higher)
+  - or profile load `p95 > 500ms` (`profile/load/typical-pr` or higher)
 - C4 trigger:
   - run-id tracking evictions cause determinism or duplicate-merge issues
 

--- a/docs/PERFORMANCE-BUDGETS.md
+++ b/docs/PERFORMANCE-BUDGETS.md
@@ -10,6 +10,9 @@ This document defines the reproducible workload classes and baseline budgets use
 | `typical-pr` | ~10 MB | 10k | ~50 | Default CI-level perf guardrail |
 | `large` | 50 MB+ | 100k+ | 500+ | Scale trigger for C1/C3/C4 |
 
+Bundle size targets are **logical payload targets** (uncompressed event content). The harness uses
+deterministic low-compressibility payloads so compressed tar sizes do not collapse unrealistically.
+
 ## Harness Commands
 
 Default (`small` + `typical-pr`):
@@ -30,9 +33,24 @@ All classes:
 ASSAY_PERF_WORKLOAD=small,typical-pr,large cargo bench -p assay-evidence --bench verify_lint_harness
 ```
 
+Profile-store harness (C3):
+
+```bash
+cargo bench -p assay-cli --bench profile_store_harness
+```
+
+Profile-store single class:
+
+```bash
+ASSAY_PROFILE_PERF_WORKLOAD=large cargo bench -p assay-cli --bench profile_store_harness
+```
+
 ## Trigger Budgets (Ubuntu Baseline)
 
 These are trigger thresholds, not pass/fail release gates.
+
+The harness emits `verify/*`, `lint/*`, and `verify+lint/*` series per workload. Trigger checks for C1
+must use the explicit `verify+lint/*` series from the same Criterion run.
 
 Measurement protocol (to keep comparisons stable):
 - Runner: `ubuntu-latest` as baseline.
@@ -48,8 +66,8 @@ Measurement protocol (to keep comparisons stable):
 - C2 trigger:
   - runner clone/build overhead > 10% of suite runtime on >=1000 tests
 - C3 trigger:
-  - profile merge `p95 > 1s` at >=10k entries
-  - or profile load `p95 > 500ms`
+  - profile merge `p95 > 1s` at >=10k entries (`profile/merge/typical-pr` or higher)
+  - or profile load `p95 > 500ms` (`profile/load/typical-pr` or higher)
 - C4 trigger:
   - run-id tracking evictions cause determinism or duplicate-merge issues
   - hard bound for duplicate protection window: `N = 5000` recent run IDs

--- a/docs/PERFORMANCE-BUDGETS.md
+++ b/docs/PERFORMANCE-BUDGETS.md
@@ -52,6 +52,14 @@ These are trigger thresholds, not pass/fail release gates.
 The harness emits `verify/*`, `lint/*`, and `verify+lint/*` series per workload. Trigger checks for C1
 must use the explicit `verify+lint/*` series from the same Criterion run.
 
+Measurement protocol (to keep comparisons stable):
+- Runner: `ubuntu-latest` as baseline.
+- Percentiles: use both `p50` and `p95`.
+- Warm/cold split:
+  - cold = first run after clean build/artifact state
+  - warm = repeated runs on same runner/workdir
+  - trigger decisions use warm `p95` and cold `p50` together when relevant.
+
 - C1 trigger:
   - verify+lint `p95 > 5s` on `large`
   - or verify+lint `p50 > 2s` on `typical-pr`
@@ -62,6 +70,7 @@ must use the explicit `verify+lint/*` series from the same Criterion run.
   - or profile load `p95 > 500ms` (`profile/load/typical-pr` or higher)
 - C4 trigger:
   - run-id tracking evictions cause determinism or duplicate-merge issues
+  - hard bound for duplicate protection window: `N = 5000` recent run IDs
 
 ## Guardrails
 

--- a/docs/PERFORMANCE-BUDGETS.md
+++ b/docs/PERFORMANCE-BUDGETS.md
@@ -34,6 +34,14 @@ ASSAY_PERF_WORKLOAD=small,typical-pr,large cargo bench -p assay-evidence --bench
 
 These are trigger thresholds, not pass/fail release gates.
 
+Measurement protocol (to keep comparisons stable):
+- Runner: `ubuntu-latest` as baseline.
+- Percentiles: use both `p50` and `p95`.
+- Warm/cold split:
+  - cold = first run after clean build/artifact state
+  - warm = repeated runs on same runner/workdir
+  - trigger decisions use warm `p95` and cold `p50` together when relevant.
+
 - C1 trigger:
   - verify+lint `p95 > 5s` on `large`
   - or verify+lint `p50 > 2s` on `typical-pr`
@@ -44,6 +52,7 @@ These are trigger thresholds, not pass/fail release gates.
   - or profile load `p95 > 500ms`
 - C4 trigger:
   - run-id tracking evictions cause determinism or duplicate-merge issues
+  - hard bound for duplicate protection window: `N = 5000` recent run IDs
 
 ## Guardrails
 

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -368,3 +368,4 @@ Security posture retained:
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
 - 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with conflict resolution plus benchmark realism hardening.
 - 2026-02-08: Wave C2 started to remove duplicate per-task runner cloning and surface `runner_clone_ms` as a measured trigger signal.
+- 2026-02-08: Wave C3 started with a reproducible `profile_store_harness` benchmark for profile merge/load trigger measurement at 10k+ entry scale.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -1,6 +1,6 @@
 # RFC-001: DX/UX & Governance - Core Invariants + Debt-Ranked Execution Plan
 
-> **Status**: Active (Wave A merged, Wave B in progress)
+> **Status**: Active (Wave A/B merged, Wave C in progress)
 > **Date**: 2026-02-07
 > **Owner**: DX/Governance track
 > **Motivation**: Keep Assay's state-of-the-art core (replay/evidence/enforcement) strong while preventing CLI/plumbing debt from eroding the product wedge.
@@ -366,3 +366,5 @@ Security posture retained:
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
 - 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
+- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with conflict resolution plus benchmark realism hardening.
+- 2026-02-08: Wave C2 started to remove duplicate per-task runner cloning and surface `runner_clone_ms` as a measured trigger signal.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -1,6 +1,6 @@
 # RFC-001: DX/UX & Governance - Core Invariants + Debt-Ranked Execution Plan
 
-> **Status**: Active (Wave A merged, Wave B in progress)
+> **Status**: Active (Wave A/B merged, Wave C in progress)
 > **Date**: 2026-02-07
 > **Owner**: DX/Governance track
 > **Motivation**: Keep Assay's state-of-the-art core (replay/evidence/enforcement) strong while preventing CLI/plumbing debt from eroding the product wedge.
@@ -201,6 +201,25 @@ Current state:
 
 **Stop line**: no perf rewrites; no output-contract behavior change.
 
+### Wave A/B Risk Controls (Current-State Reassessment)
+
+These controls reflect the implemented code state (not the original plan-only assumptions).
+
+#### P1 blockers (must close for "Wave A/B done")
+
+- **A1 is not fully typed yet**: `RunErrorKind` exists, but assignment is still primarily substring-driven in `classify_message`.
+  Required close condition: classify from typed context first (stable fields), with substring parsing only as explicit legacy fallback.
+- **A1 lacks stable forensic fields**: boundary errors need stable details (`path`, `status`, `provider`, etc.) so support/debug does not rely on free-form message strings.
+- **B1 needs explicit parity fence tests**: shared pipeline must have dedicated run-vs-ci contract tests for exit/reason behavior and output invariants (`run.json`, `summary.json`, SARIF/JUnit + non-blocking report-write behavior).
+
+#### P2 alerts (track, but not ship blockers)
+
+- **A1 source-of-truth wording**: risk is classifier hotspot fragility (message drift), not dual mapping layers.
+- **B1 replay coupling wording**: old `super::cmd_run` note is obsolete; coupling remains via direct `run::run` and `run_output::*` helpers.
+- **A2 scope clarity**: run/ci strict-path env mutation is largely addressed; CLI-wide env cleanup remains separate scope.
+- **A3 legacy-output flag**: not required if canonical output + contract tests stay stable.
+- **B3 deprecation deadline**: governance policy item, not a contract blocker while aliases are supported and tested.
+
 ### Wave C — Performance / Scale (Data-triggered)
 
 **Goal**: Optimize only with measured evidence. No speculative performance work.
@@ -345,7 +364,9 @@ Security posture retained:
 - 2026-02-07: Draft created from codebase audit + owner review. Wave A scoped for immediate execution.
 - 2026-02-08: Wave A merged to `main` (`#198`, `#202`). Wave B started.
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
+- 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
+- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with benchmark realism hardening.
 - 2026-02-08: Wave C runner overhead instrumentation added as additive summary metrics (`runner_clone_ms`, `runner_clone_count`) to make C2 trigger measurable on real suites.
 - 2026-02-08: Wave C profile-store instrumentation added in `assay profile update` (load/merge/save timings + trigger warnings + optional JSON export via `ASSAY_PROFILE_PERF_JSON`).
 - 2026-02-08: Wave C run-id tracking hardened with a bounded digest ring beyond the short run-id window, plus memory/eviction visibility signals in profile perf telemetry.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -278,7 +278,7 @@ Current state: 6 `.clone()` calls on Arc-wrapped fields per task (`engine/runner
 **Trigger**: Profile corpus growth causes ring buffer evictions that break replay determinism or cause duplicate-merge errors.
 
 **Invariant guardrail** (protects I1):
-- Double-merge of same `run_id` must be impossible across N runs (define N as a hard bound)
+- Double-merge of same `run_id` must be impossible across a hard bound **N = 5000** recent run IDs (bounded digest window)
 - Replacing the ring buffer must not break determinism or introduce memory blowups
 
 **Bounded structure options** (choose one):
@@ -348,3 +348,4 @@ Security posture retained:
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
 - 2026-02-08: Wave C runner overhead instrumentation added as additive summary metrics (`runner_clone_ms`, `runner_clone_count`) to make C2 trigger measurable on real suites.
 - 2026-02-08: Wave C profile-store instrumentation added in `assay profile update` (load/merge/save timings + trigger warnings + optional JSON export via `ASSAY_PROFILE_PERF_JSON`).
+- 2026-02-08: Wave C run-id tracking hardened with a bounded digest ring beyond the short run-id window, plus memory/eviction visibility signals in profile perf telemetry.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -201,6 +201,25 @@ Current state:
 
 **Stop line**: no perf rewrites; no output-contract behavior change.
 
+### Wave A/B Risk Controls (Current-State Reassessment)
+
+These controls reflect the implemented code state (not the original plan-only assumptions).
+
+#### P1 blockers (must close for "Wave A/B done")
+
+- **A1 is not fully typed yet**: `RunErrorKind` exists, but assignment is still primarily substring-driven in `classify_message`.
+  Required close condition: classify from typed context first (stable fields), with substring parsing only as explicit legacy fallback.
+- **A1 lacks stable forensic fields**: boundary errors need stable details (`path`, `status`, `provider`, etc.) so support/debug does not rely on free-form message strings.
+- **B1 needs explicit parity fence tests**: shared pipeline must have dedicated run-vs-ci contract tests for exit/reason behavior and output invariants (`run.json`, `summary.json`, SARIF/JUnit + non-blocking report-write behavior).
+
+#### P2 alerts (track, but not ship blockers)
+
+- **A1 source-of-truth wording**: risk is classifier hotspot fragility (message drift), not dual mapping layers.
+- **B1 replay coupling wording**: old `super::cmd_run` note is obsolete; coupling remains via direct `run::run` and `run_output::*` helpers.
+- **A2 scope clarity**: run/ci strict-path env mutation is largely addressed; CLI-wide env cleanup remains separate scope.
+- **A3 legacy-output flag**: not required if canonical output + contract tests stay stable.
+- **B3 deprecation deadline**: governance policy item, not a contract blocker while aliases are supported and tested.
+
 ### Wave C — Performance / Scale (Data-triggered)
 
 **Goal**: Optimize only with measured evidence. No speculative performance work.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -201,6 +201,25 @@ Current state:
 
 **Stop line**: no perf rewrites; no output-contract behavior change.
 
+### Wave A/B Risk Controls (Current-State Reassessment)
+
+These controls reflect the implemented code state (not the original plan-only assumptions).
+
+#### P1 blockers (must close for "Wave A/B done")
+
+- **A1 is not fully typed yet**: `RunErrorKind` exists, but assignment is still primarily substring-driven in `classify_message`.
+  Required close condition: classify from typed context first (stable fields), with substring parsing only as explicit legacy fallback.
+- **A1 lacks stable forensic fields**: boundary errors need stable details (`path`, `status`, `provider`, etc.) so support/debug does not rely on free-form message strings.
+- **B1 needs explicit parity fence tests**: shared pipeline must have dedicated run-vs-ci contract tests for exit/reason behavior and output invariants (`run.json`, `summary.json`, SARIF/JUnit + non-blocking report-write behavior).
+
+#### P2 alerts (track, but not ship blockers)
+
+- **A1 source-of-truth wording**: risk is classifier hotspot fragility (message drift), not dual mapping layers.
+- **B1 replay coupling wording**: old `super::cmd_run` note is obsolete; coupling remains via direct `run::run` and `run_output::*` helpers.
+- **A2 scope clarity**: run/ci strict-path env mutation is largely addressed; CLI-wide env cleanup remains separate scope.
+- **A3 legacy-output flag**: not required if canonical output + contract tests stay stable.
+- **B3 deprecation deadline**: governance policy item, not a contract blocker while aliases are supported and tested.
+
 ### Wave C — Performance / Scale (Data-triggered)
 
 **Goal**: Optimize only with measured evidence. No speculative performance work.
@@ -345,4 +364,5 @@ Security posture retained:
 - 2026-02-07: Draft created from codebase audit + owner review. Wave A scoped for immediate execution.
 - 2026-02-08: Wave A merged to `main` (`#198`, `#202`). Wave B started.
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
+- 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -261,3 +261,4 @@ Security posture retained:
 - 2026-02-07: Draft created from codebase audit + owner review. Wave A scoped for immediate execution.
 - 2026-02-08: Wave A merged to `main` (`#198`, `#202`). Wave B started.
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
+- 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -368,4 +368,4 @@ Security posture retained:
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
 - 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with conflict resolution plus benchmark realism hardening.
 - 2026-02-08: Wave C2 started to remove duplicate per-task runner cloning and surface `runner_clone_ms` as a measured trigger signal.
-- 2026-02-08: Wave C3 started with a reproducible `profile_store_harness` benchmark for profile merge/load trigger measurement at 10k+ entry scale.
+- 2026-02-08: Wave C3 added both reproducible profile-store harness coverage and runtime profile load/merge/save telemetry (`ASSAY_PROFILE_PERF_JSON`) for trigger diagnostics.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -345,4 +345,5 @@ Security posture retained:
 - 2026-02-07: Draft created from codebase audit + owner review. Wave A scoped for immediate execution.
 - 2026-02-08: Wave A merged to `main` (`#198`, `#202`). Wave B started.
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
+- 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -297,7 +297,7 @@ Current state: 6 `.clone()` calls on Arc-wrapped fields per task (`engine/runner
 **Trigger**: Profile corpus growth causes ring buffer evictions that break replay determinism or cause duplicate-merge errors.
 
 **Invariant guardrail** (protects I1):
-- Double-merge of same `run_id` must be impossible across N runs (define N as a hard bound)
+- Double-merge of same `run_id` must be impossible across a hard bound **N = 5000** recent run IDs (bounded digest window)
 - Replacing the ring buffer must not break determinism or introduce memory blowups
 
 **Bounded structure options** (choose one):
@@ -366,6 +366,7 @@ Security posture retained:
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
 - 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
-- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with conflict resolution plus benchmark realism hardening.
-- 2026-02-08: Wave C2 started to remove duplicate per-task runner cloning and surface `runner_clone_ms` as a measured trigger signal.
-- 2026-02-08: Wave C3 added both reproducible profile-store harness coverage and runtime profile load/merge/save telemetry (`ASSAY_PROFILE_PERF_JSON`) for trigger diagnostics.
+- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with benchmark realism hardening.
+- 2026-02-08: Wave C runner overhead instrumentation added as additive summary metrics (`runner_clone_ms`, `runner_clone_count`) to make C2 trigger measurable on real suites.
+- 2026-02-08: Wave C profile-store instrumentation added in `assay profile update` (load/merge/save timings + trigger warnings + optional JSON export via `ASSAY_PROFILE_PERF_JSON`).
+- 2026-02-08: Wave C run-id tracking hardened with a bounded digest ring beyond the short run-id window, plus memory/eviction visibility signals in profile perf telemetry.

--- a/docs/architecture/architecture-autofix.md
+++ b/docs/architecture/architecture-autofix.md
@@ -9,7 +9,7 @@
 How to explain this release to users in 4 commands:
 
 ```bash
-$ assay init --pack default    # Generate secure config
+$ assay init --preset default  # Generate secure config
 $ assay validate               # Find issues
 $ assay fix --dry-run          # Preview fixes
 $ assay fix --yes              # Apply fixes
@@ -35,7 +35,7 @@ Assay v1.5.0 transforms the tool from a passive validator to an active **Self-Co
 
 ## 4. Security Capabilities (The "Why")
 
-### Policy Packs (`assay init --pack`)
+### Policy Presets (`assay init --preset`)
 These packs are designed to map to common threat vectors (OWASP for LLMs).
 
 #### `default` (Balanced)

--- a/docs/reference/cli/init.md
+++ b/docs/reference/cli/init.md
@@ -14,7 +14,7 @@ assay init [OPTIONS]
 
 Scans your directory for known project types (MCP, Python, Node.js) and generates a security policy and config. Optionally generates CI scaffolding and `.gitignore`.
 
-With `--from-trace`, generates a policy directly from recorded agent behavior instead of using a preset pack.
+With `--from-trace`, generates a policy directly from recorded agent behavior instead of using a starter preset.
 
 ## Options
 
@@ -23,8 +23,8 @@ With `--from-trace`, generates a policy directly from recorded agent behavior in
 | `--config <FILE>` | Config filename. Default: `eval.yaml`. |
 | `--ci [PROVIDER]` | Generate CI scaffolding. `github` (default) or `gitlab`. |
 | `--gitignore` | Generate `.gitignore` for artifacts/db. |
-| `--pack <PACK>` | Policy pack: `default`, `hardened`, `dev`. Default: `default`. |
-| `--list-packs` | List available packs and exit. |
+| `--preset <PRESET>` | Starter preset: `default`, `hardened`, `dev`. Default: `default`. |
+| `--list-presets` | List available presets and exit. |
 | `--from-trace <FILE>` | Generate policy from an existing trace file (JSONL). |
 | `--heuristics` | Enable entropy/risk analysis when generating from trace. Requires `--from-trace`. |
 | `--hello-trace` | Generate a runnable hello trace and smoke suite scaffold. |
@@ -68,5 +68,8 @@ assay init --ci gitlab
 
 ### Hardened policy
 ```bash
+assay init --preset hardened --ci --gitignore
+
+# Backward-compatible alias (deprecated)
 assay init --pack hardened --ci --gitignore
 ```


### PR DESCRIPTION
## Why
Wave C4 from RFC-001 hardens run-id tracking beyond the short raw-ID ring buffer, so duplicate-merge protection remains deterministic at scale.

This follows the Wave C best-practice guardrails:
- data-triggered, bounded change
- no output contract changes
- explicit hard bound (`N=5000`) with visibility metrics

## What changed
- Added bounded digest window for run IDs in profile state:
  - `run_id_digests` (SHA-256 hex)
  - `MAX_RUN_ID_DIGESTS = 5000`
- Kept short raw ID ring (`MAX_RUN_IDS = 200`) for readability while extending duplicate detection horizon through digest lookup.
- Added memory/eviction visibility in profile perf telemetry:
  - `run_id_window_len`
  - `run_id_digest_window_len`
  - `run_id_memory_bytes`
  - warning when digest window is full.
- Updated tests for new semantics:
  - ring behavior with digest-backed detection
  - explicit digest eviction behavior
- Updated Wave C docs with explicit hard bound and measurement protocol alignment.

## Scope
Code:
- `crates/assay-cli/src/cli/commands/profile_types.rs`
- `crates/assay-cli/src/cli/commands/profile.rs`
- `crates/assay-cli/src/cli/commands/profile_simulation_test.rs`
- `crates/assay-cli/src/cli/commands/evidence/mapping.rs`

Docs:
- `docs/DX-IMPLEMENTATION-PLAN.md`
- `docs/PERFORMANCE-BUDGETS.md`
- `docs/architecture/RFC-001-dx-ux-governance.md`

## Validation
- `cargo fmt --all`
- `cargo test -p assay-cli profile -- --nocapture`
- `cargo check -p assay-cli`

## Contract notes
- No `run.json`/`summary.json`/SARIF/JUnit schema changes.
- No verify/lint semantic behavior changes.
