### PR TITLE
feat(dx-wave-c2): reduce runner clone overhead + emit runner_clone_ms

### DIFF
--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -75,6 +75,11 @@ name = "suite_run_worstcase"
 path = "benches/suite_run_worstcase.rs"
 harness = false
 
+[[bench]]
+name = "profile_store_harness"
+path = "benches/profile_store_harness.rs"
+harness = false
+
 [dev-dependencies]
 tempfile = "3"
 regex = "1"

--- a/crates/assay-cli/benches/profile_store_harness.rs
+++ b/crates/assay-cli/benches/profile_store_harness.rs
@@ -1,0 +1,225 @@
+//! Criterion benchmark harness for profile store load/merge paths.
+//! Run with:
+//!   cargo bench -p assay-cli --bench profile_store_harness
+//! Select workloads with:
+//!   ASSAY_PROFILE_PERF_WORKLOAD=small|typical-pr|large|small,typical-pr,large
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use tempfile::TempDir;
+
+#[derive(Clone, Copy)]
+struct Workload {
+    name: &'static str,
+    initial_entries: usize,
+    delta_entries: usize,
+}
+
+const SMALL: Workload = Workload {
+    name: "small",
+    initial_entries: 1_000,
+    delta_entries: 200,
+};
+
+const TYPICAL_PR: Workload = Workload {
+    name: "typical-pr",
+    initial_entries: 10_000,
+    delta_entries: 1_000,
+};
+
+const LARGE: Workload = Workload {
+    name: "large",
+    initial_entries: 50_000,
+    delta_entries: 5_000,
+};
+
+struct Fixture {
+    _temp: TempDir,
+    profile_path: PathBuf,
+    delta_trace_path: PathBuf,
+}
+
+fn selected_workloads() -> Vec<Workload> {
+    match std::env::var("ASSAY_PROFILE_PERF_WORKLOAD").ok().as_deref() {
+        Some("small") => vec![SMALL],
+        Some("typical-pr") => vec![TYPICAL_PR],
+        Some("large") => vec![LARGE],
+        Some("small,typical-pr,large") => vec![SMALL, TYPICAL_PR, LARGE],
+        _ => vec![SMALL, TYPICAL_PR],
+    }
+}
+
+fn assay_bin() -> PathBuf {
+    if let Some(p) = option_env!("CARGO_BIN_EXE_assay") {
+        return PathBuf::from(p);
+    }
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let release = manifest.join("../../target/release/assay");
+    let debug = manifest.join("../../target/debug/assay");
+    if release.exists() {
+        release
+    } else {
+        debug
+    }
+}
+
+fn run_cmd(bin: &Path, cwd: &Path, args: &[String]) {
+    let mut cmd = Command::new(bin);
+    cmd.current_dir(cwd).stdin(Stdio::null()).args(args);
+    let out = cmd.output().expect("assay command must run");
+    assert!(
+        out.status.success(),
+        "assay command failed: args={:?}\nstdout={}\nstderr={}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn build_initial_trace(path: &Path, entries: usize) {
+    let mut lines = Vec::with_capacity(entries);
+    for i in 0..entries {
+        lines.push(event_line(i as u64, i as u64));
+    }
+    std::fs::write(path, lines.join("\n")).expect("write initial trace");
+}
+
+fn build_delta_trace(path: &Path, initial_entries: usize, delta_entries: usize) {
+    let mut lines = Vec::with_capacity(delta_entries);
+    for i in 0..delta_entries {
+        let logical_idx = if i % 2 == 0 {
+            i % initial_entries
+        } else {
+            initial_entries + i
+        };
+        lines.push(event_line(logical_idx as u64, (initial_entries + i) as u64));
+    }
+    std::fs::write(path, lines.join("\n")).expect("write delta trace");
+}
+
+fn event_line(logical_idx: u64, ts_idx: u64) -> String {
+    let ts = 1_700_000_000_u64.saturating_add(ts_idx);
+    match logical_idx % 3 {
+        0 => format!(
+            r#"{{"type":"file_open","path":"/workspace/file_{logical_idx}.txt","timestamp":{ts}}}"#
+        ),
+        1 => format!(
+            r#"{{"type":"net_connect","dest":"https://svc-{logical_idx}.example.com:443","timestamp":{ts}}}"#
+        ),
+        _ => format!(r#"{{"type":"proc_exec","path":"/bin/tool_{logical_idx}","timestamp":{ts}}}"#),
+    }
+}
+
+fn prepare_fixture(bin: &Path, workload: Workload) -> Fixture {
+    let temp = TempDir::new().expect("temp dir");
+    let profile_path = temp.path().join("profile.yaml");
+    let initial_trace_path = temp.path().join("initial.jsonl");
+    let delta_trace_path = temp.path().join("delta.jsonl");
+
+    build_initial_trace(&initial_trace_path, workload.initial_entries);
+    build_delta_trace(
+        &delta_trace_path,
+        workload.initial_entries,
+        workload.delta_entries,
+    );
+
+    run_cmd(
+        bin,
+        temp.path(),
+        &[
+            "profile".to_string(),
+            "init".to_string(),
+            "--output".to_string(),
+            profile_path.display().to_string(),
+        ],
+    );
+    run_cmd(
+        bin,
+        temp.path(),
+        &[
+            "profile".to_string(),
+            "update".to_string(),
+            "--profile".to_string(),
+            profile_path.display().to_string(),
+            "--input".to_string(),
+            initial_trace_path.display().to_string(),
+            "--run-id".to_string(),
+            "bootstrap-run".to_string(),
+        ],
+    );
+
+    Fixture {
+        _temp: temp,
+        profile_path,
+        delta_trace_path,
+    }
+}
+
+fn bench_profile_load(c: &mut Criterion) {
+    let bin = assay_bin();
+    if !bin.exists() {
+        eprintln!("assay binary not found at {:?}; run cargo build first", bin);
+        return;
+    }
+
+    for workload in selected_workloads() {
+        let fixture = prepare_fixture(&bin, workload);
+        c.bench_function(&format!("profile/load/{}", workload.name), |b| {
+            b.iter(|| {
+                run_cmd(
+                    &bin,
+                    fixture._temp.path(),
+                    &[
+                        "profile".to_string(),
+                        "show".to_string(),
+                        "--profile".to_string(),
+                        fixture.profile_path.display().to_string(),
+                        "--format".to_string(),
+                        "summary".to_string(),
+                    ],
+                );
+            });
+        });
+    }
+}
+
+fn bench_profile_merge(c: &mut Criterion) {
+    let bin = assay_bin();
+    if !bin.exists() {
+        eprintln!("assay binary not found at {:?}; run cargo build first", bin);
+        return;
+    }
+
+    for workload in selected_workloads() {
+        let fixture = prepare_fixture(&bin, workload);
+        let run_seq = AtomicU64::new(1);
+        c.bench_function(&format!("profile/merge/{}", workload.name), |b| {
+            b.iter(|| {
+                let run_id = format!("bench-run-{}", run_seq.fetch_add(1, Ordering::Relaxed));
+                run_cmd(
+                    &bin,
+                    fixture._temp.path(),
+                    &[
+                        "profile".to_string(),
+                        "update".to_string(),
+                        "--profile".to_string(),
+                        fixture.profile_path.display().to_string(),
+                        "--input".to_string(),
+                        fixture.delta_trace_path.display().to_string(),
+                        "--run-id".to_string(),
+                        run_id,
+                    ],
+                );
+            });
+        });
+    }
+}
+
+criterion_group!(
+    profile_store_harness,
+    bench_profile_load,
+    bench_profile_merge
+);
+criterion_main!(profile_store_harness);

--- a/crates/assay-cli/src/cli/commands/evidence/mapping.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mapping.rs
@@ -306,6 +306,7 @@ mod tests {
             updated_at: "2026-01-26T23:00:00Z".into(),
             total_runs: 1,
             run_ids: vec!["run1".into()],
+            run_id_digests: vec![],
             scope: None,
             entries: Default::default(),
         };

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -405,6 +405,7 @@ fn build_performance_metrics(
         verify_ms: None,
         lint_ms: None,
         runner_clone_ms: artifacts.runner_clone_ms,
+        runner_clone_count: None,
         profile_store_ms: None,
         run_id_memory_bytes: None,
         cache_hit_rate,

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -404,7 +404,7 @@ fn build_performance_metrics(
         total_duration_ms: total_ms,
         verify_ms: None,
         lint_ms: None,
-        runner_clone_ms: None,
+        runner_clone_ms: artifacts.runner_clone_ms,
         profile_store_ms: None,
         run_id_memory_bytes: None,
         cache_hit_rate,
@@ -467,6 +467,7 @@ mod tests {
             suite: "demo".to_string(),
             results: vec![row("t1", Some(10), true, TestStatus::Pass)],
             order_seed: None,
+            runner_clone_ms: Some(13),
         };
         let timings = PipelineTimings {
             total_ms: 120,
@@ -483,6 +484,7 @@ mod tests {
         assert_eq!(phases.ingest_ms, Some(12));
         assert_eq!(phases.eval_ms, Some(90));
         assert_eq!(phases.report_ms, Some(30));
+        assert_eq!(performance.runner_clone_ms, Some(13));
     }
 
     #[test]
@@ -499,6 +501,7 @@ mod tests {
                 row("t6", Some(50), false, TestStatus::Pass),
             ],
             order_seed: None,
+            runner_clone_ms: None,
         };
 
         let performance = build_performance_metrics(&artifacts, None, Some(7));
@@ -526,6 +529,7 @@ mod tests {
                 row("c", Some(42), false, TestStatus::Pass),
             ],
             order_seed: None,
+            runner_clone_ms: None,
         };
 
         let performance = build_performance_metrics(&artifacts, None, Some(1));

--- a/crates/assay-cli/src/cli/commands/profile_simulation_test.rs
+++ b/crates/assay-cli/src/cli/commands/profile_simulation_test.rs
@@ -133,9 +133,11 @@ fn test_run_id_ring_buffer() {
     // But run_ids should be capped
     assert_eq!(profile.run_ids.len(), MAX_RUN_IDS);
 
-    // Check oldest and newest logic robustly
-    // Old runs should be evicted
-    assert!(!profile.has_run("run-0"));
+    // Old raw IDs are evicted from the short ring...
+    assert_eq!(profile.run_ids[0], "run-50");
+    // ...but dedupe should still detect recent history via digest ring.
+    assert!(profile.has_run("run-0"));
+    assert_eq!(profile.run_id_digests.len(), MAX_RUN_IDS + 50);
 
     // Newest run should be present
     let newest_id = format!("run-{}", MAX_RUN_IDS + 50 - 1);

--- a/crates/assay-core/src/report/mod.rs
+++ b/crates/assay-core/src/report/mod.rs
@@ -17,4 +17,7 @@ pub struct RunArtifacts {
     /// Seed used for test order randomization (E7.2). Present when run used a seed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub order_seed: Option<u64>,
+    /// Time spent creating per-task runner clones in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_clone_ms: Option<u64>,
 }

--- a/crates/assay-core/src/report/summary.rs
+++ b/crates/assay-core/src/report/summary.rs
@@ -238,6 +238,10 @@ pub struct PerformanceMetrics {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_clone_ms: Option<u64>,
 
+    /// Number of runner clone operations performed during suite execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_clone_count: Option<u64>,
+
     /// Profile store phase duration in milliseconds (Wave C trigger surface).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_store_ms: Option<u64>,
@@ -363,6 +367,7 @@ impl Summary {
             verify_ms: None,
             lint_ms: None,
             runner_clone_ms: None,
+            runner_clone_count: None,
             profile_store_ms: None,
             run_id_memory_bytes: None,
             cache_hit_rate: None,

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -32,8 +32,10 @@ Current branch focus:
 - PR-B1/B2/B3 (merged to `main` via #204/#205/#209): pipeline unification + dispatch decoupling + `--preset` rename with compat aliases.
 - Wave C kickoff:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
-  - PR-C1 (#213, in review): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
-  - PR-C2 (current branch): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
+  - PR-C1 (#213, open): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
+  - PR-C2 (#214, open): runner clone overhead measurement surfaced in summary performance metrics.
+  - PR-C3 (current branch): profile-store harness + runtime load/merge/save telemetry and trigger warnings.
+  - PR-C4 (next): bounded run-id digest tracking beyond short ring buffer + memory/eviction visibility.
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -32,7 +32,8 @@ Current branch focus:
 - PR-B1/B2/B3 (merged to `main` via #204/#205/#209): pipeline unification + dispatch decoupling + `--preset` rename with compat aliases.
 - Wave C kickoff:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
-  - PR-C1 (current branch): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
+  - PR-C1 (#213, in review): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
+  - PR-C2 (current branch): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
 
 ---
 

--- a/docs/PERFORMANCE-BUDGETS.md
+++ b/docs/PERFORMANCE-BUDGETS.md
@@ -33,6 +33,18 @@ All classes:
 ASSAY_PERF_WORKLOAD=small,typical-pr,large cargo bench -p assay-evidence --bench verify_lint_harness
 ```
 
+Profile-store harness (C3):
+
+```bash
+cargo bench -p assay-cli --bench profile_store_harness
+```
+
+Profile-store single class:
+
+```bash
+ASSAY_PROFILE_PERF_WORKLOAD=large cargo bench -p assay-cli --bench profile_store_harness
+```
+
 ## Trigger Budgets (Ubuntu Baseline)
 
 These are trigger thresholds, not pass/fail release gates.
@@ -40,16 +52,25 @@ These are trigger thresholds, not pass/fail release gates.
 The harness emits `verify/*`, `lint/*`, and `verify+lint/*` series per workload. Trigger checks for C1
 must use the explicit `verify+lint/*` series from the same Criterion run.
 
+Measurement protocol (to keep comparisons stable):
+- Runner: `ubuntu-latest` as baseline.
+- Percentiles: use both `p50` and `p95`.
+- Warm/cold split:
+  - cold = first run after clean build/artifact state
+  - warm = repeated runs on same runner/workdir
+  - trigger decisions use warm `p95` and cold `p50` together when relevant.
+
 - C1 trigger:
   - verify+lint `p95 > 5s` on `large`
   - or verify+lint `p50 > 2s` on `typical-pr`
 - C2 trigger:
   - runner clone/build overhead > 10% of suite runtime on >=1000 tests
 - C3 trigger:
-  - profile merge `p95 > 1s` at >=10k entries
-  - or profile load `p95 > 500ms`
+  - profile merge `p95 > 1s` at >=10k entries (`profile/merge/typical-pr` or higher)
+  - or profile load `p95 > 500ms` (`profile/load/typical-pr` or higher)
 - C4 trigger:
   - run-id tracking evictions cause determinism or duplicate-merge issues
+  - hard bound for duplicate protection window: `N = 5000` recent run IDs
 
 ## Guardrails
 

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -1,6 +1,6 @@
 # RFC-001: DX/UX & Governance - Core Invariants + Debt-Ranked Execution Plan
 
-> **Status**: Active (Wave A merged, Wave B in progress)
+> **Status**: Active (Wave A/B merged, Wave C in progress)
 > **Date**: 2026-02-07
 > **Owner**: DX/Governance track
 > **Motivation**: Keep Assay's state-of-the-art core (replay/evidence/enforcement) strong while preventing CLI/plumbing debt from eroding the product wedge.
@@ -366,3 +366,5 @@ Security posture retained:
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
 - 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
+- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with conflict resolution plus benchmark realism hardening.
+- 2026-02-08: Wave C2 started to remove duplicate per-task runner cloning and surface `runner_clone_ms` as a measured trigger signal.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -297,7 +297,7 @@ Current state: 6 `.clone()` calls on Arc-wrapped fields per task (`engine/runner
 **Trigger**: Profile corpus growth causes ring buffer evictions that break replay determinism or cause duplicate-merge errors.
 
 **Invariant guardrail** (protects I1):
-- Double-merge of same `run_id` must be impossible across N runs (define N as a hard bound)
+- Double-merge of same `run_id` must be impossible across a hard bound **N = 5000** recent run IDs (bounded digest window)
 - Replacing the ring buffer must not break determinism or introduce memory blowups
 
 **Bounded structure options** (choose one):
@@ -366,5 +366,7 @@ Security posture retained:
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
 - 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
-- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with conflict resolution plus benchmark realism hardening.
-- 2026-02-08: Wave C2 started to remove duplicate per-task runner cloning and surface `runner_clone_ms` as a measured trigger signal.
+- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with benchmark realism hardening.
+- 2026-02-08: Wave C runner overhead instrumentation added as additive summary metrics (`runner_clone_ms`, `runner_clone_count`) to make C2 trigger measurable on real suites.
+- 2026-02-08: Wave C profile-store instrumentation added in `assay profile update` (load/merge/save timings + trigger warnings + optional JSON export via `ASSAY_PROFILE_PERF_JSON`).
+- 2026-02-08: Wave C run-id tracking hardened with a bounded digest ring beyond the short run-id window, plus memory/eviction visibility signals in profile perf telemetry.


### PR DESCRIPTION
Why
Wave C2 from RFC-001 targets measurable runner clone/build overhead after C1 harness/budgets are in place.

What changed
- Removed duplicate per-task cloning path in core runner by dropping RunnerRef reconstruction loop.
- `clone_for_task` now returns a task-ready `Runner` directly (single clone path per test).
- Added `runner_clone_ms` to `RunArtifacts` and populated it during `run_suite` task setup.
- Wired summary performance mapping so `PerformanceMetrics.runner_clone_ms` is sourced from artifacts.
- Updated DX/RFC execution notes to mark C2 in progress.

Scope
- crates/assay-core/src/engine/runner.rs
- crates/assay-core/src/report/mod.rs
- crates/assay-cli/src/cli/commands/pipeline.rs
- docs/DX-IMPLEMENTATION-PLAN.md
- docs/architecture/RFC-001-dx-ux-governance.md

Validation
- cargo fmt --all
- cargo check -p assay-core -p assay-cli
- cargo test -p assay-cli cli::commands::pipeline::tests -- --nocapture

Contract notes
- No run.json/SARIF/JUnit contract changes.
- Summary performance surface is additive/optional (`runner_clone_ms` remains optional).
- Semantics of pass/fail/reason mapping unchanged.

Next
C3: profile store scaling triggers and measured write/load path instrumentation under Wave C guardrails.
