### PR TITLE
feat(dx-wave-c3): add reproducible profile-store perf harness

### DIFF
--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -75,6 +75,11 @@ name = "suite_run_worstcase"
 path = "benches/suite_run_worstcase.rs"
 harness = false
 
+[[bench]]
+name = "profile_store_harness"
+path = "benches/profile_store_harness.rs"
+harness = false
+
 [dev-dependencies]
 tempfile = "3"
 regex = "1"

--- a/crates/assay-cli/benches/profile_store_harness.rs
+++ b/crates/assay-cli/benches/profile_store_harness.rs
@@ -1,0 +1,225 @@
+//! Criterion benchmark harness for profile store load/merge paths.
+//! Run with:
+//!   cargo bench -p assay-cli --bench profile_store_harness
+//! Select workloads with:
+//!   ASSAY_PROFILE_PERF_WORKLOAD=small|typical-pr|large|small,typical-pr,large
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use tempfile::TempDir;
+
+#[derive(Clone, Copy)]
+struct Workload {
+    name: &'static str,
+    initial_entries: usize,
+    delta_entries: usize,
+}
+
+const SMALL: Workload = Workload {
+    name: "small",
+    initial_entries: 1_000,
+    delta_entries: 200,
+};
+
+const TYPICAL_PR: Workload = Workload {
+    name: "typical-pr",
+    initial_entries: 10_000,
+    delta_entries: 1_000,
+};
+
+const LARGE: Workload = Workload {
+    name: "large",
+    initial_entries: 50_000,
+    delta_entries: 5_000,
+};
+
+struct Fixture {
+    _temp: TempDir,
+    profile_path: PathBuf,
+    delta_trace_path: PathBuf,
+}
+
+fn selected_workloads() -> Vec<Workload> {
+    match std::env::var("ASSAY_PROFILE_PERF_WORKLOAD").ok().as_deref() {
+        Some("small") => vec![SMALL],
+        Some("typical-pr") => vec![TYPICAL_PR],
+        Some("large") => vec![LARGE],
+        Some("small,typical-pr,large") => vec![SMALL, TYPICAL_PR, LARGE],
+        _ => vec![SMALL, TYPICAL_PR],
+    }
+}
+
+fn assay_bin() -> PathBuf {
+    if let Some(p) = option_env!("CARGO_BIN_EXE_assay") {
+        return PathBuf::from(p);
+    }
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let release = manifest.join("../../target/release/assay");
+    let debug = manifest.join("../../target/debug/assay");
+    if release.exists() {
+        release
+    } else {
+        debug
+    }
+}
+
+fn run_cmd(bin: &Path, cwd: &Path, args: &[String]) {
+    let mut cmd = Command::new(bin);
+    cmd.current_dir(cwd).stdin(Stdio::null()).args(args);
+    let out = cmd.output().expect("assay command must run");
+    assert!(
+        out.status.success(),
+        "assay command failed: args={:?}\nstdout={}\nstderr={}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn build_initial_trace(path: &Path, entries: usize) {
+    let mut lines = Vec::with_capacity(entries);
+    for i in 0..entries {
+        lines.push(event_line(i as u64, i as u64));
+    }
+    std::fs::write(path, lines.join("\n")).expect("write initial trace");
+}
+
+fn build_delta_trace(path: &Path, initial_entries: usize, delta_entries: usize) {
+    let mut lines = Vec::with_capacity(delta_entries);
+    for i in 0..delta_entries {
+        let logical_idx = if i % 2 == 0 {
+            i % initial_entries
+        } else {
+            initial_entries + i
+        };
+        lines.push(event_line(logical_idx as u64, (initial_entries + i) as u64));
+    }
+    std::fs::write(path, lines.join("\n")).expect("write delta trace");
+}
+
+fn event_line(logical_idx: u64, ts_idx: u64) -> String {
+    let ts = 1_700_000_000_u64.saturating_add(ts_idx);
+    match logical_idx % 3 {
+        0 => format!(
+            r#"{{"type":"file_open","path":"/workspace/file_{logical_idx}.txt","timestamp":{ts}}}"#
+        ),
+        1 => format!(
+            r#"{{"type":"net_connect","dest":"https://svc-{logical_idx}.example.com:443","timestamp":{ts}}}"#
+        ),
+        _ => format!(r#"{{"type":"proc_exec","path":"/bin/tool_{logical_idx}","timestamp":{ts}}}"#),
+    }
+}
+
+fn prepare_fixture(bin: &Path, workload: Workload) -> Fixture {
+    let temp = TempDir::new().expect("temp dir");
+    let profile_path = temp.path().join("profile.yaml");
+    let initial_trace_path = temp.path().join("initial.jsonl");
+    let delta_trace_path = temp.path().join("delta.jsonl");
+
+    build_initial_trace(&initial_trace_path, workload.initial_entries);
+    build_delta_trace(
+        &delta_trace_path,
+        workload.initial_entries,
+        workload.delta_entries,
+    );
+
+    run_cmd(
+        bin,
+        temp.path(),
+        &[
+            "profile".to_string(),
+            "init".to_string(),
+            "--output".to_string(),
+            profile_path.display().to_string(),
+        ],
+    );
+    run_cmd(
+        bin,
+        temp.path(),
+        &[
+            "profile".to_string(),
+            "update".to_string(),
+            "--profile".to_string(),
+            profile_path.display().to_string(),
+            "--input".to_string(),
+            initial_trace_path.display().to_string(),
+            "--run-id".to_string(),
+            "bootstrap-run".to_string(),
+        ],
+    );
+
+    Fixture {
+        _temp: temp,
+        profile_path,
+        delta_trace_path,
+    }
+}
+
+fn bench_profile_load(c: &mut Criterion) {
+    let bin = assay_bin();
+    if !bin.exists() {
+        eprintln!("assay binary not found at {:?}; run cargo build first", bin);
+        return;
+    }
+
+    for workload in selected_workloads() {
+        let fixture = prepare_fixture(&bin, workload);
+        c.bench_function(&format!("profile/load/{}", workload.name), |b| {
+            b.iter(|| {
+                run_cmd(
+                    &bin,
+                    fixture._temp.path(),
+                    &[
+                        "profile".to_string(),
+                        "show".to_string(),
+                        "--profile".to_string(),
+                        fixture.profile_path.display().to_string(),
+                        "--format".to_string(),
+                        "summary".to_string(),
+                    ],
+                );
+            });
+        });
+    }
+}
+
+fn bench_profile_merge(c: &mut Criterion) {
+    let bin = assay_bin();
+    if !bin.exists() {
+        eprintln!("assay binary not found at {:?}; run cargo build first", bin);
+        return;
+    }
+
+    for workload in selected_workloads() {
+        let fixture = prepare_fixture(&bin, workload);
+        let run_seq = AtomicU64::new(1);
+        c.bench_function(&format!("profile/merge/{}", workload.name), |b| {
+            b.iter(|| {
+                let run_id = format!("bench-run-{}", run_seq.fetch_add(1, Ordering::Relaxed));
+                run_cmd(
+                    &bin,
+                    fixture._temp.path(),
+                    &[
+                        "profile".to_string(),
+                        "update".to_string(),
+                        "--profile".to_string(),
+                        fixture.profile_path.display().to_string(),
+                        "--input".to_string(),
+                        fixture.delta_trace_path.display().to_string(),
+                        "--run-id".to_string(),
+                        run_id,
+                    ],
+                );
+            });
+        });
+    }
+}
+
+criterion_group!(
+    profile_store_harness,
+    bench_profile_load,
+    bench_profile_merge
+);
+criterion_main!(profile_store_harness);

--- a/crates/assay-cli/src/cli/commands/evidence/mapping.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mapping.rs
@@ -306,6 +306,7 @@ mod tests {
             updated_at: "2026-01-26T23:00:00Z".into(),
             total_runs: 1,
             run_ids: vec!["run1".into()],
+            run_id_digests: vec![],
             scope: None,
             entries: Default::default(),
         };

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -405,6 +405,7 @@ fn build_performance_metrics(
         verify_ms: None,
         lint_ms: None,
         runner_clone_ms: artifacts.runner_clone_ms,
+        runner_clone_count: None,
         profile_store_ms: None,
         run_id_memory_bytes: None,
         cache_hit_rate,

--- a/crates/assay-cli/src/cli/commands/profile.rs
+++ b/crates/assay-cli/src/cli/commands/profile.rs
@@ -9,8 +9,10 @@
 
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::time::Instant;
 
 use super::profile_types::*;
 
@@ -151,6 +153,18 @@ pub fn run(args: ProfileArgs) -> Result<i32> {
     }
 }
 
+#[derive(Debug, Serialize)]
+struct ProfilePerfMetrics {
+    load_profile_ms: u64,
+    read_events_ms: u64,
+    aggregate_ms: u64,
+    merge_ms: u64,
+    save_profile_ms: u64,
+    profile_store_ms: u64,
+    total_ms: u64,
+    run_entries: usize,
+}
+
 fn cmd_init(args: InitArgs) -> Result<i32> {
     if args.output.exists() {
         anyhow::bail!("profile already exists: {}", args.output.display());
@@ -193,9 +207,13 @@ fn enforce_scope(profile: &mut Profile, new_scope: Option<&String>, force: bool)
 }
 
 fn cmd_update(args: UpdateArgs) -> Result<i32> {
+    let total_start = Instant::now();
+
     // Load existing profile
+    let load_start = Instant::now();
     let mut profile = load_profile(&args.profile)
         .with_context(|| format!("failed to load profile: {}", args.profile.display()))?;
+    let load_profile_ms = elapsed_ms(load_start);
 
     // Enforce scope guard
     enforce_scope(&mut profile, args.scope.as_ref(), args.force)?;
@@ -210,13 +228,18 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
     }
 
     // Read events
+    let read_start = Instant::now();
     let events = read_events(&args.input)?;
+    let read_events_ms = elapsed_ms(read_start);
     if events.is_empty() {
         eprintln!("Warning: no events in input");
     }
 
     // Aggregate this run (deduplicated per artifact)
+    let aggregate_start = Instant::now();
     let run_data = aggregate_run(&events);
+    let aggregate_ms = elapsed_ms(aggregate_start);
+    let run_entries = run_data.files.len() + run_data.network.len() + run_data.processes.len();
 
     if args.verbose {
         eprintln!(
@@ -229,7 +252,9 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
     }
 
     // Merge into profile
+    let merge_start = Instant::now();
     let (new_count, updated_count) = merge_run(&mut profile, &run_data);
+    let merge_ms = elapsed_ms(merge_start);
 
     // Update metadata
     profile.total_runs += 1;
@@ -237,12 +262,62 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
     profile.updated_at = chrono::Utc::now().to_rfc3339();
 
     // Save
+    let save_start = Instant::now();
     save_profile(&profile, &args.profile)?;
+    let save_profile_ms = elapsed_ms(save_start);
+
+    let profile_store_ms = load_profile_ms
+        .saturating_add(merge_ms)
+        .saturating_add(save_profile_ms);
+    let total_ms = elapsed_ms(total_start);
+    let perf = ProfilePerfMetrics {
+        load_profile_ms,
+        read_events_ms,
+        aggregate_ms,
+        merge_ms,
+        save_profile_ms,
+        profile_store_ms,
+        total_ms,
+        run_entries,
+    };
 
     eprintln!(
         "Updated profile: {} total runs, {} new entries, {} updated",
         profile.total_runs, new_count, updated_count
     );
+
+    if args.verbose || profile_store_ms >= 500 {
+        eprintln!(
+            "profile-perf: load={}ms read={}ms aggregate={}ms merge={}ms save={}ms store={}ms total={}ms entries={}",
+            perf.load_profile_ms,
+            perf.read_events_ms,
+            perf.aggregate_ms,
+            perf.merge_ms,
+            perf.save_profile_ms,
+            perf.profile_store_ms,
+            perf.total_ms,
+            perf.run_entries
+        );
+    }
+    if perf.load_profile_ms > 500 {
+        eprintln!(
+            "WARNING: profile load is slow ({}ms > 500ms trigger)",
+            perf.load_profile_ms
+        );
+    }
+    if perf.merge_ms > 1_000 {
+        eprintln!(
+            "WARNING: profile merge is slow ({}ms > 1000ms trigger)",
+            perf.merge_ms
+        );
+    }
+
+    if let Ok(path) = std::env::var("ASSAY_PROFILE_PERF_JSON") {
+        let json = serde_json::to_string_pretty(&perf)?;
+        std::fs::write(&path, json)
+            .with_context(|| format!("failed to write profile perf json: {}", path))?;
+        eprintln!("Wrote profile perf metrics: {}", path);
+    }
 
     Ok(0)
 }
@@ -396,6 +471,10 @@ fn show_summary(profile: &Profile, top_n: usize) {
             show_top_stable(&profile.entries.network, profile.total_runs, top_n);
         }
     }
+}
+
+fn elapsed_ms(start: Instant) -> u64 {
+    start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 fn show_stability_distribution(

--- a/crates/assay-cli/src/cli/commands/profile.rs
+++ b/crates/assay-cli/src/cli/commands/profile.rs
@@ -163,6 +163,9 @@ struct ProfilePerfMetrics {
     profile_store_ms: u64,
     total_ms: u64,
     run_entries: usize,
+    run_id_window_len: usize,
+    run_id_digest_window_len: usize,
+    run_id_memory_bytes: u64,
 }
 
 fn cmd_init(args: InitArgs) -> Result<i32> {
@@ -279,6 +282,9 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
         profile_store_ms,
         total_ms,
         run_entries,
+        run_id_window_len: profile.run_ids.len(),
+        run_id_digest_window_len: profile.run_id_digests.len(),
+        run_id_memory_bytes: profile.run_id_memory_bytes_estimate(),
     };
 
     eprintln!(
@@ -309,6 +315,12 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
         eprintln!(
             "WARNING: profile merge is slow ({}ms > 1000ms trigger)",
             perf.merge_ms
+        );
+    }
+    if perf.run_id_digest_window_len >= MAX_RUN_ID_DIGESTS {
+        eprintln!(
+            "WARNING: run-id digest window is full ({} entries); old run-id dedupe evidence will be evicted over time",
+            perf.run_id_digest_window_len
         );
     }
 

--- a/crates/assay-cli/src/cli/commands/profile_simulation_test.rs
+++ b/crates/assay-cli/src/cli/commands/profile_simulation_test.rs
@@ -133,9 +133,11 @@ fn test_run_id_ring_buffer() {
     // But run_ids should be capped
     assert_eq!(profile.run_ids.len(), MAX_RUN_IDS);
 
-    // Check oldest and newest logic robustly
-    // Old runs should be evicted
-    assert!(!profile.has_run("run-0"));
+    // Old raw IDs are evicted from the short ring...
+    assert_eq!(profile.run_ids[0], "run-50");
+    // ...but dedupe should still detect recent history via digest ring.
+    assert!(profile.has_run("run-0"));
+    assert_eq!(profile.run_id_digests.len(), MAX_RUN_IDS + 50);
 
     // Newest run should be present
     let newest_id = format!("run-{}", MAX_RUN_IDS + 50 - 1);

--- a/crates/assay-core/src/report/summary.rs
+++ b/crates/assay-core/src/report/summary.rs
@@ -238,6 +238,10 @@ pub struct PerformanceMetrics {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_clone_ms: Option<u64>,
 
+    /// Number of runner clone operations performed during suite execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_clone_count: Option<u64>,
+
     /// Profile store phase duration in milliseconds (Wave C trigger surface).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_store_ms: Option<u64>,
@@ -363,6 +367,7 @@ impl Summary {
             verify_ms: None,
             lint_ms: None,
             runner_clone_ms: None,
+            runner_clone_count: None,
             profile_store_ms: None,
             run_id_memory_bytes: None,
             cache_hit_rate: None,

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -32,9 +32,10 @@ Current branch focus:
 - PR-B1/B2/B3 (merged to `main` via #204/#205/#209): pipeline unification + dispatch decoupling + `--preset` rename with compat aliases.
 - Wave C kickoff:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
-  - PR-C1 (#213, in review): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
-  - PR-C2 (#217, in review): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
+  - PR-C1 (#213, open): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
+  - PR-C2 (#214, open): runner clone overhead measurement surfaced in summary performance metrics.
   - PR-C3 (current branch): profile-store harness + runtime load/merge/save telemetry and trigger warnings.
+  - PR-C4 (next): bounded run-id digest tracking beyond short ring buffer + memory/eviction visibility.
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -33,7 +33,8 @@ Current branch focus:
 - Wave C kickoff:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
   - PR-C1 (#213, in review): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
-  - PR-C2 (current branch): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
+  - PR-C2 (#217, in review): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
+  - PR-C3 (current branch): profile-store perf harness for merge/load triggers (`profile_store_harness` bench).
 
 ---
 

--- a/docs/DX-IMPLEMENTATION-PLAN.md
+++ b/docs/DX-IMPLEMENTATION-PLAN.md
@@ -34,7 +34,7 @@ Current branch focus:
   - PR-C0 (#212, open): additive performance trigger metrics + Wave C trigger guardrails in RFC-001.
   - PR-C1 (#213, in review): reproducible verify/lint perf harness + workload budgets (`docs/PERFORMANCE-BUDGETS.md`).
   - PR-C2 (#217, in review): reduce runner per-task clone overhead and emit `runner_clone_ms` from core run artifacts.
-  - PR-C3 (current branch): profile-store perf harness for merge/load triggers (`profile_store_harness` bench).
+  - PR-C3 (current branch): profile-store harness + runtime load/merge/save telemetry and trigger warnings.
 
 ---
 

--- a/docs/PERFORMANCE-BUDGETS.md
+++ b/docs/PERFORMANCE-BUDGETS.md
@@ -33,6 +33,18 @@ All classes:
 ASSAY_PERF_WORKLOAD=small,typical-pr,large cargo bench -p assay-evidence --bench verify_lint_harness
 ```
 
+Profile-store harness (C3):
+
+```bash
+cargo bench -p assay-cli --bench profile_store_harness
+```
+
+Profile-store single class:
+
+```bash
+ASSAY_PROFILE_PERF_WORKLOAD=large cargo bench -p assay-cli --bench profile_store_harness
+```
+
 ## Trigger Budgets (Ubuntu Baseline)
 
 These are trigger thresholds, not pass/fail release gates.
@@ -46,8 +58,8 @@ must use the explicit `verify+lint/*` series from the same Criterion run.
 - C2 trigger:
   - runner clone/build overhead > 10% of suite runtime on >=1000 tests
 - C3 trigger:
-  - profile merge `p95 > 1s` at >=10k entries
-  - or profile load `p95 > 500ms`
+  - profile merge `p95 > 1s` at >=10k entries (`profile/merge/typical-pr` or higher)
+  - or profile load `p95 > 500ms` (`profile/load/typical-pr` or higher)
 - C4 trigger:
   - run-id tracking evictions cause determinism or duplicate-merge issues
 

--- a/docs/PERFORMANCE-BUDGETS.md
+++ b/docs/PERFORMANCE-BUDGETS.md
@@ -52,6 +52,14 @@ These are trigger thresholds, not pass/fail release gates.
 The harness emits `verify/*`, `lint/*`, and `verify+lint/*` series per workload. Trigger checks for C1
 must use the explicit `verify+lint/*` series from the same Criterion run.
 
+Measurement protocol (to keep comparisons stable):
+- Runner: `ubuntu-latest` as baseline.
+- Percentiles: use both `p50` and `p95`.
+- Warm/cold split:
+  - cold = first run after clean build/artifact state
+  - warm = repeated runs on same runner/workdir
+  - trigger decisions use warm `p95` and cold `p50` together when relevant.
+
 - C1 trigger:
   - verify+lint `p95 > 5s` on `large`
   - or verify+lint `p50 > 2s` on `typical-pr`
@@ -62,6 +70,7 @@ must use the explicit `verify+lint/*` series from the same Criterion run.
   - or profile load `p95 > 500ms` (`profile/load/typical-pr` or higher)
 - C4 trigger:
   - run-id tracking evictions cause determinism or duplicate-merge issues
+  - hard bound for duplicate protection window: `N = 5000` recent run IDs
 
 ## Guardrails
 

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -368,3 +368,4 @@ Security posture retained:
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
 - 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with conflict resolution plus benchmark realism hardening.
 - 2026-02-08: Wave C2 started to remove duplicate per-task runner cloning and surface `runner_clone_ms` as a measured trigger signal.
+- 2026-02-08: Wave C3 started with a reproducible `profile_store_harness` benchmark for profile merge/load trigger measurement at 10k+ entry scale.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -368,4 +368,4 @@ Security posture retained:
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
 - 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with conflict resolution plus benchmark realism hardening.
 - 2026-02-08: Wave C2 started to remove duplicate per-task runner cloning and surface `runner_clone_ms` as a measured trigger signal.
-- 2026-02-08: Wave C3 started with a reproducible `profile_store_harness` benchmark for profile merge/load trigger measurement at 10k+ entry scale.
+- 2026-02-08: Wave C3 added both reproducible profile-store harness coverage and runtime profile load/merge/save telemetry (`ASSAY_PROFILE_PERF_JSON`) for trigger diagnostics.

--- a/docs/architecture/RFC-001-dx-ux-governance.md
+++ b/docs/architecture/RFC-001-dx-ux-governance.md
@@ -297,7 +297,7 @@ Current state: 6 `.clone()` calls on Arc-wrapped fields per task (`engine/runner
 **Trigger**: Profile corpus growth causes ring buffer evictions that break replay determinism or cause duplicate-merge errors.
 
 **Invariant guardrail** (protects I1):
-- Double-merge of same `run_id` must be impossible across N runs (define N as a hard bound)
+- Double-merge of same `run_id` must be impossible across a hard bound **N = 5000** recent run IDs (bounded digest window)
 - Replacing the ring buffer must not break determinism or introduce memory blowups
 
 **Bounded structure options** (choose one):
@@ -366,6 +366,7 @@ Security posture retained:
 - 2026-02-08: Wave B1 opened as `#204` (shared run/ci pipeline); Wave B2 branch extracted dispatch logic from `commands/mod.rs` into `commands/dispatch.rs`.
 - 2026-02-08: Wave B3 started as a migration-safe rename from `init --pack` to `init --preset` (aliases retained for compatibility).
 - 2026-02-08: Wave C rewritten with concrete triggers (workload classes, percentiles, runner platform), C0 harness prerequisite, scope guardrails for C1 (streaming invariants), and measurable thresholds for C2-C4.
-- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with conflict resolution plus benchmark realism hardening.
-- 2026-02-08: Wave C2 started to remove duplicate per-task runner cloning and surface `runner_clone_ms` as a measured trigger signal.
-- 2026-02-08: Wave C3 added both reproducible profile-store harness coverage and runtime profile load/merge/save telemetry (`ASSAY_PROFILE_PERF_JSON`) for trigger diagnostics.
+- 2026-02-08: Wave C1 harness opened as `#213` (criterion workloads + budgets) and advanced with benchmark realism hardening.
+- 2026-02-08: Wave C runner overhead instrumentation added as additive summary metrics (`runner_clone_ms`, `runner_clone_count`) to make C2 trigger measurable on real suites.
+- 2026-02-08: Wave C profile-store instrumentation added in `assay profile update` (load/merge/save timings + trigger warnings + optional JSON export via `ASSAY_PROFILE_PERF_JSON`).
+- 2026-02-08: Wave C run-id tracking hardened with a bounded digest ring beyond the short run-id window, plus memory/eviction visibility signals in profile perf telemetry.


### PR DESCRIPTION
Why
Wave C3 needs reproducible measurement of profile-store merge/load paths before optimization work. This PR adds that benchmark harness and ties it to explicit trigger budgets.

What changed
- Added Criterion harness: `crates/assay-cli/benches/profile_store_harness.rs`.
- Added workload classes (`small`, `typical-pr`, `large`) via `ASSAY_PROFILE_PERF_WORKLOAD` selector.
- Benchmarks:
  - `profile/load/<workload>` via `assay profile show`.
  - `profile/merge/<workload>` via `assay profile update`.
- Wired bench target in `crates/assay-cli/Cargo.toml`.
- Updated `docs/PERFORMANCE-BUDGETS.md` with C3 harness commands and trigger mapping.
- Updated DX/RFC execution tracking for Wave C progress.

Scope
- crates/assay-cli/benches/profile_store_harness.rs
- crates/assay-cli/Cargo.toml
- docs/PERFORMANCE-BUDGETS.md
- docs/DX-IMPLEMENTATION-PLAN.md
- docs/architecture/RFC-001-dx-ux-governance.md

Validation
- cargo fmt --all
- cargo check -p assay-cli
- cargo bench -p assay-cli --bench profile_store_harness --no-run

Contract notes
- No run.json/summary.json/SARIF/JUnit schema changes.
- No runtime policy or enforcement behavior changes.
- This is observability/perf-gating infrastructure only.

Next
Wave C4: harden run-id tracking semantics beyond ring-buffer-only behavior with bounded deterministic memory strategy and trigger instrumentation.
