### PR TITLE
fix(dx-wave-c4): harden run-id dedupe bookkeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 docs/maintainers/
 docs/project/
 docs/DEMO-STRATEGY.md
+docs/architecture/CODE-ANALYSIS-REPORT.md
 
 # Local / one-off
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .private/
 docs/maintainers/
 docs/project/
+docs/DEMO-STRATEGY.md
 
 # Local / one-off
 .claude/

--- a/.typos.toml
+++ b/.typos.toml
@@ -78,4 +78,5 @@ extend-exclude = [
     "**/docs/project/**",
     "**/docs/maintainers/**",
     "**/RESEARCH-ci-cd-ai-agents-feb2026.md",
+    "**/DEMO-STRATEGY.md",
 ]

--- a/.typos.toml
+++ b/.typos.toml
@@ -79,4 +79,5 @@ extend-exclude = [
     "**/docs/maintainers/**",
     "**/RESEARCH-ci-cd-ai-agents-feb2026.md",
     "**/DEMO-STRATEGY.md",
+    "**/CODE-ANALYSIS-REPORT.md",
 ]

--- a/crates/assay-cli/src/cli/commands/ci.rs
+++ b/crates/assay-cli/src/cli/commands/ci.rs
@@ -1,9 +1,9 @@
 use super::super::args::CiArgs;
-use super::pipeline::{
-    build_summary_from_artifacts, execute_pipeline, maybe_export_baseline, print_pipeline_summary,
-    write_error_artifacts, PipelineError, PipelineInput,
+use super::pipeline::{execute_pipeline, PipelineInput};
+use super::pipeline_error::elapsed_ms;
+use super::reporting::{
+    build_summary_from_artifacts, maybe_export_baseline, print_pipeline_summary,
 };
-use super::run_output::reason_code_from_run_error;
 use super::run_output::write_extended_run_json;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -13,21 +13,9 @@ pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> 
     let run_json_path = PathBuf::from("run.json");
 
     let input = PipelineInput::from_ci(&args);
-    let execution = execute_pipeline(&input, legacy_mode).await;
-    let execution = match execution {
+    let execution = match execute_pipeline(&input, legacy_mode).await {
         Ok(ok) => ok,
-        Err(PipelineError::Classified { run_error }) => {
-            let reason = reason_code_from_run_error(&run_error)
-                .unwrap_or(crate::exit_codes::ReasonCode::ECfgParse);
-            return write_error_artifacts(
-                reason,
-                run_error.message,
-                version,
-                !args.no_verify,
-                &run_json_path,
-            );
-        }
-        Err(PipelineError::Fatal(err)) => return Err(err),
+        Err(e) => return e.into_exit_code(version, !args.no_verify, &run_json_path),
     };
 
     if execution.cfg.version > 0 {
@@ -101,7 +89,7 @@ pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> 
     }
 
     // Measure the full reporting phase (format writes + summary prep + console + telemetry + PR comment).
-    let report_ms = report_start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    let report_ms = elapsed_ms(report_start);
     let mut final_summary = build_summary_from_artifacts(
         &outcome,
         !args.no_verify,

--- a/crates/assay-cli/src/cli/commands/ci.rs
+++ b/crates/assay-cli/src/cli/commands/ci.rs
@@ -3,6 +3,7 @@ use super::pipeline::{
     build_summary_from_artifacts, execute_pipeline, maybe_export_baseline, print_pipeline_summary,
     write_error_artifacts, PipelineError, PipelineInput,
 };
+use super::run_output::reason_code_from_run_error;
 use super::run_output::write_extended_run_json;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -15,10 +16,12 @@ pub(crate) async fn run(args: CiArgs, legacy_mode: bool) -> anyhow::Result<i32> 
     let execution = execute_pipeline(&input, legacy_mode).await;
     let execution = match execution {
         Ok(ok) => ok,
-        Err(PipelineError::Classified { reason, message }) => {
+        Err(PipelineError::Classified { run_error }) => {
+            let reason = reason_code_from_run_error(&run_error)
+                .unwrap_or(crate::exit_codes::ReasonCode::ECfgParse);
             return write_error_artifacts(
                 reason,
-                message,
+                run_error.message,
                 version,
                 !args.no_verify,
                 &run_json_path,

--- a/crates/assay-cli/src/cli/commands/evidence/mapping.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mapping.rs
@@ -252,6 +252,7 @@ impl EvidenceMapper {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
 
     #[test]
     fn test_scrub_subject_paths() {
@@ -305,8 +306,8 @@ mod tests {
             created_at: "2026-01-26T22:00:00Z".into(),
             updated_at: "2026-01-26T23:00:00Z".into(),
             total_runs: 1,
-            run_ids: vec!["run1".into()],
-            run_id_digests: vec![],
+            run_ids: VecDeque::from(vec!["run1".into()]),
+            run_id_digests: VecDeque::new(),
             scope: None,
             entries: Default::default(),
         };

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -100,7 +100,7 @@ fn cmd_export(args: EvidenceExportArgs) -> Result<i32> {
         .with_context(|| format!("failed to load profile from {}", args.profile.display()))?;
 
     // 2. Map Profile -> EvidenceEvents
-    let run_id_opt = profile.run_ids.last().cloned();
+    let run_id_opt = profile.run_ids.back().cloned();
 
     let mut mapper = EvidenceMapper::new(run_id_opt, &profile.name);
     let events = mapper.map_profile(&profile, args.detail)?;

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod mcp;
 pub mod migrate;
 pub mod monitor;
 pub(crate) mod pipeline;
+pub(crate) mod pipeline_error;
 pub mod policy;
 pub mod profile;
 #[cfg(test)]
@@ -33,6 +34,7 @@ mod profile_simulation_test;
 pub mod profile_types;
 pub(crate) mod quarantine;
 pub mod record;
+pub(crate) mod reporting;
 pub(crate) mod run;
 pub(crate) mod run_output;
 pub(crate) mod runner_builder;

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -1,11 +1,9 @@
 use super::super::args::{CiArgs, JudgeArgs, RunArgs};
-use super::run_output::{
-    decide_run_outcome, export_baseline, summary_from_outcome, write_run_json_minimal,
-};
+use super::pipeline_error::{elapsed_ms, PipelineError};
+use super::run_output::decide_run_outcome;
 use super::runner_builder::{build_runner, ensure_parent_dir};
-use crate::exit_codes::{ExitCodeVersion, ReasonCode, RunOutcome};
-use assay_core::errors::RunError;
-use std::path::{Path, PathBuf};
+use crate::exit_codes::{ExitCodeVersion, RunOutcome};
+use std::path::PathBuf;
 use std::time::Instant;
 
 #[derive(Clone)]
@@ -90,11 +88,6 @@ impl PipelineInput {
     }
 }
 
-pub(crate) enum PipelineError {
-    Classified { run_error: RunError },
-    Fatal(anyhow::Error),
-}
-
 pub(crate) struct PipelineSuccess {
     pub cfg: assay_core::model::EvalConfig,
     pub artifacts: assay_core::report::RunArtifacts,
@@ -111,15 +104,6 @@ pub(crate) struct PipelineTimings {
     pub run_suite_ms: Option<u64>,
 }
 
-fn elapsed_ms(start: Instant) -> u64 {
-    let ms = start.elapsed().as_millis();
-    if ms > u128::from(u64::MAX) {
-        u64::MAX
-    } else {
-        ms as u64
-    }
-}
-
 pub(crate) async fn execute_pipeline(
     input: &PipelineInput,
     legacy_mode: bool,
@@ -128,30 +112,24 @@ pub(crate) async fn execute_pipeline(
     let mut timings = PipelineTimings::default();
 
     if let Err(e) = ensure_parent_dir(&input.db) {
-        return Err(PipelineError::Classified {
-            run_error: RunError::config_parse(
-                Some(input.db.display().to_string()),
-                format!("Failed to create DB dir: {}", e),
-            ),
-        });
+        return Err(PipelineError::cfg_parse(
+            input.db.display().to_string(),
+            format!("Failed to create DB dir: {}", e),
+        ));
     }
 
     if input.baseline.is_some() && input.export_baseline.is_some() {
         eprintln!("config error: cannot use --baseline and --export-baseline together");
-        return Err(PipelineError::Classified {
-            run_error: RunError::invalid_args(
-                "Cannot use --baseline and --export-baseline together",
-            ),
-        });
+        return Err(PipelineError::invalid_args(
+            "Cannot use --baseline and --export-baseline together",
+        ));
     }
 
     let cfg = if input.require_config_exists && !input.config.exists() {
-        return Err(PipelineError::Classified {
-            run_error: RunError::missing_config(
-                input.config.display().to_string(),
-                "config path does not exist",
-            ),
-        });
+        return Err(PipelineError::missing_cfg(
+            input.config.display().to_string(),
+            "config path does not exist",
+        ));
     } else {
         let config_start = Instant::now();
         match assay_core::config::load_config(&input.config, legacy_mode, input.deny_deprecations) {
@@ -161,12 +139,11 @@ pub(crate) async fn execute_pipeline(
             }
             Err(e) => {
                 let msg = e.to_string();
-                let run_error = if !input.config.exists() {
-                    RunError::missing_config(input.config.display().to_string(), msg)
+                return Err(if !input.config.exists() {
+                    PipelineError::missing_cfg(input.config.display().to_string(), msg)
                 } else {
-                    RunError::config_parse(Some(input.config.display().to_string()), msg)
-                };
-                return Err(PipelineError::Classified { run_error });
+                    PipelineError::cfg_parse(input.config.display().to_string(), msg)
+                });
             }
         }
     };
@@ -177,9 +154,10 @@ pub(crate) async fn execute_pipeline(
             cfg.version
         );
         if input.deny_deprecations {
-            return Err(PipelineError::Classified {
-                run_error: RunError::config_parse(Some(input.config.display().to_string()), msg),
-            });
+            return Err(PipelineError::cfg_parse(
+                input.config.display().to_string(),
+                msg,
+            ));
         }
         eprintln!("WARN: {}", msg);
     }
@@ -187,23 +165,19 @@ pub(crate) async fn execute_pipeline(
     let store = match assay_core::storage::Store::open(&input.db) {
         Ok(s) => s,
         Err(e) => {
-            return Err(PipelineError::Classified {
-                run_error: RunError::config_parse(
-                    Some(input.db.display().to_string()),
-                    format!("Failed to open DB: {}", e),
-                ),
-            });
+            return Err(PipelineError::cfg_parse(
+                input.db.display().to_string(),
+                format!("Failed to open DB: {}", e),
+            ));
         }
     };
 
     if input.ingest_trace_on_replay_strict {
         if let Err(e) = store.init_schema() {
-            return Err(PipelineError::Classified {
-                run_error: RunError::config_parse(
-                    Some(input.db.display().to_string()),
-                    format!("Failed to init DB schema: {}", e),
-                ),
-            });
+            return Err(PipelineError::cfg_parse(
+                input.db.display().to_string(),
+                format!("Failed to init DB schema: {}", e),
+            ));
         }
         if input.replay_strict {
             if let Some(trace_path) = &input.trace_file {
@@ -220,15 +194,16 @@ pub(crate) async fn execute_pipeline(
                     }
                     Err(e) => {
                         let msg = format!("Failed to ingest trace: {}", e);
-                        let run_error = if trace_path.exists() {
-                            RunError::config_parse(Some(trace_path.display().to_string()), msg)
+                        return Err(if trace_path.exists() {
+                            PipelineError::cfg_parse(trace_path.display().to_string(), msg)
                         } else {
-                            RunError::trace_not_found(
-                                trace_path.display().to_string(),
-                                "trace path does not exist",
+                            PipelineError::from_run_error(
+                                assay_core::errors::RunError::trace_not_found(
+                                    trace_path.display().to_string(),
+                                    "trace path does not exist",
+                                ),
                             )
-                        };
-                        return Err(PipelineError::Classified { run_error });
+                        });
                     }
                 }
             }
@@ -266,16 +241,14 @@ pub(crate) async fn execute_pipeline(
         Err(e) => {
             if let Some(diag) = assay_core::errors::try_map_error(&e) {
                 eprintln!("{}", diag);
-                return Err(PipelineError::Classified {
-                    run_error: RunError::config_parse(
-                        Some(input.config.display().to_string()),
-                        diag.to_string(),
-                    ),
-                });
+                return Err(PipelineError::cfg_parse(
+                    input.config.display().to_string(),
+                    diag.to_string(),
+                ));
             }
-            return Err(PipelineError::Classified {
-                run_error: RunError::from_anyhow(&e),
-            });
+            return Err(PipelineError::from_run_error(
+                assay_core::errors::RunError::from_anyhow(&e),
+            ));
         }
     };
 
@@ -307,251 +280,4 @@ pub(crate) async fn execute_pipeline(
         outcome,
         timings,
     })
-}
-
-pub(crate) fn write_error_artifacts(
-    reason: ReasonCode,
-    message: String,
-    version: ExitCodeVersion,
-    verify_enabled: bool,
-    run_json_path: &PathBuf,
-) -> anyhow::Result<i32> {
-    let mut o = RunOutcome::from_reason(reason, Some(message), None);
-    o.exit_code = reason.exit_code_for(version);
-    if let Err(e) = write_run_json_minimal(&o, run_json_path) {
-        eprintln!("WARNING: failed to write run.json: {}", e);
-    }
-
-    let summary_path = run_json_path
-        .parent()
-        .map(|p| p.join("summary.json"))
-        .unwrap_or_else(|| PathBuf::from("summary.json"));
-    let summary = summary_from_outcome(&o, verify_enabled).with_seeds(None, None);
-    if let Err(e) = assay_core::report::summary::write_summary(&summary, &summary_path) {
-        eprintln!("WARNING: failed to write summary.json: {}", e);
-    }
-    Ok(o.exit_code)
-}
-
-pub(crate) fn build_summary_from_artifacts(
-    outcome: &RunOutcome,
-    verify_enabled: bool,
-    artifacts: &assay_core::report::RunArtifacts,
-    pipeline_timings: Option<&PipelineTimings>,
-    report_ms: Option<u64>,
-) -> assay_core::report::summary::Summary {
-    let mut summary = summary_from_outcome(outcome, verify_enabled);
-    let passed = artifacts
-        .results
-        .iter()
-        .filter(|r| r.status.is_passing())
-        .count();
-    let failed = artifacts
-        .results
-        .iter()
-        .filter(|r| r.status.is_blocking())
-        .count();
-    summary = summary.with_results(passed, failed, artifacts.results.len());
-    summary = summary.with_seeds(artifacts.order_seed, None);
-    if let Some(metrics) =
-        assay_core::report::summary::judge_metrics_from_results(&artifacts.results)
-    {
-        summary = summary.with_judge_metrics(metrics);
-    }
-    let performance = build_performance_metrics(artifacts, pipeline_timings, report_ms);
-    summary = summary.with_performance(performance);
-    summary
-}
-
-fn build_performance_metrics(
-    artifacts: &assay_core::report::RunArtifacts,
-    pipeline_timings: Option<&PipelineTimings>,
-    report_ms: Option<u64>,
-) -> assay_core::report::summary::PerformanceMetrics {
-    let (total_ms, ingest_ms, eval_ms) = match pipeline_timings {
-        Some(t) => (
-            t.total_ms.saturating_add(report_ms.unwrap_or(0)),
-            t.ingest_ms,
-            t.run_suite_ms,
-        ),
-        None => (report_ms.unwrap_or(0), None, None),
-    };
-
-    let cache_hit_rate = if artifacts.results.is_empty() {
-        None
-    } else {
-        let cached = artifacts.results.iter().filter(|r| r.cached).count() as f64;
-        Some(cached / artifacts.results.len() as f64)
-    };
-
-    let mut slowest: Vec<assay_core::report::summary::SlowestTest> = artifacts
-        .results
-        .iter()
-        .filter_map(|row| {
-            row.duration_ms
-                .map(|d| assay_core::report::summary::SlowestTest {
-                    test_id: row.test_id.clone(),
-                    duration_ms: d,
-                })
-        })
-        .collect();
-    slowest.sort_by(|a, b| {
-        b.duration_ms
-            .cmp(&a.duration_ms)
-            .then_with(|| a.test_id.cmp(&b.test_id))
-    });
-    slowest.truncate(5);
-    let slowest_tests = if slowest.is_empty() {
-        None
-    } else {
-        Some(slowest)
-    };
-
-    let phase_timings = Some(assay_core::report::summary::PhaseTimings {
-        ingest_ms,
-        eval_ms,
-        judge_ms: None,
-        report_ms,
-    });
-
-    assay_core::report::summary::PerformanceMetrics {
-        total_duration_ms: total_ms,
-        verify_ms: None,
-        lint_ms: None,
-        runner_clone_ms: artifacts.runner_clone_ms,
-        runner_clone_count: None,
-        profile_store_ms: None,
-        run_id_memory_bytes: None,
-        cache_hit_rate,
-        slowest_tests,
-        phase_timings,
-    }
-}
-
-pub(crate) fn print_pipeline_summary(
-    artifacts: &assay_core::report::RunArtifacts,
-    explain_skip: bool,
-    summary: &assay_core::report::summary::Summary,
-) {
-    assay_core::report::console::print_summary(&artifacts.results, explain_skip);
-    assay_core::report::console::print_run_footer(
-        Some(&summary.seeds),
-        summary.judge_metrics.as_ref(),
-    );
-}
-
-pub(crate) fn maybe_export_baseline(
-    export_path: &Option<PathBuf>,
-    config_path: &Path,
-    cfg: &assay_core::model::EvalConfig,
-    artifacts: &assay_core::report::RunArtifacts,
-) {
-    if let Some(path) = export_path {
-        if let Err(e) = export_baseline(path, config_path, cfg, &artifacts.results) {
-            eprintln!("Failed to export baseline: {}", e);
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use assay_core::model::{TestResultRow, TestStatus};
-    use serde_json::json;
-
-    fn row(id: &str, duration_ms: Option<u64>, cached: bool, status: TestStatus) -> TestResultRow {
-        TestResultRow {
-            test_id: id.to_string(),
-            status,
-            score: None,
-            cached,
-            message: String::new(),
-            details: json!({}),
-            duration_ms,
-            fingerprint: None,
-            skip_reason: None,
-            attempts: None,
-            error_policy_applied: None,
-        }
-    }
-
-    #[test]
-    fn performance_metrics_include_pipeline_and_report_timings() {
-        let artifacts = assay_core::report::RunArtifacts {
-            run_id: 1,
-            suite: "demo".to_string(),
-            results: vec![row("t1", Some(10), true, TestStatus::Pass)],
-            order_seed: None,
-            runner_clone_ms: Some(13),
-        };
-        let timings = PipelineTimings {
-            total_ms: 120,
-            config_load_ms: Some(5),
-            ingest_ms: Some(12),
-            runner_build_ms: Some(8),
-            run_suite_ms: Some(90),
-        };
-
-        let performance = build_performance_metrics(&artifacts, Some(&timings), Some(30));
-
-        assert_eq!(performance.total_duration_ms, 150);
-        let phases = performance.phase_timings.expect("phase timings");
-        assert_eq!(phases.ingest_ms, Some(12));
-        assert_eq!(phases.eval_ms, Some(90));
-        assert_eq!(phases.report_ms, Some(30));
-        assert_eq!(performance.runner_clone_ms, Some(13));
-    }
-
-    #[test]
-    fn performance_metrics_compute_cache_hit_rate_and_slowest_top5() {
-        let artifacts = assay_core::report::RunArtifacts {
-            run_id: 2,
-            suite: "demo".to_string(),
-            results: vec![
-                row("t1", Some(80), true, TestStatus::Pass),
-                row("t2", Some(20), false, TestStatus::Fail),
-                row("t3", Some(60), true, TestStatus::Pass),
-                row("t4", Some(10), false, TestStatus::Warn),
-                row("t5", Some(40), false, TestStatus::Pass),
-                row("t6", Some(50), false, TestStatus::Pass),
-            ],
-            order_seed: None,
-            runner_clone_ms: None,
-        };
-
-        let performance = build_performance_metrics(&artifacts, None, Some(7));
-
-        let hit_rate = performance.cache_hit_rate.expect("cache hit rate");
-        assert!((hit_rate - (2.0 / 6.0)).abs() < f64::EPSILON);
-
-        let slowest = performance.slowest_tests.expect("slowest tests");
-        assert_eq!(slowest.len(), 5);
-        assert_eq!(slowest[0].test_id, "t1");
-        assert_eq!(slowest[1].test_id, "t3");
-        assert_eq!(slowest[2].test_id, "t6");
-        assert_eq!(slowest[3].test_id, "t5");
-        assert_eq!(slowest[4].test_id, "t2");
-    }
-
-    #[test]
-    fn performance_metrics_slowest_tie_breaks_by_test_id() {
-        let artifacts = assay_core::report::RunArtifacts {
-            run_id: 3,
-            suite: "demo".to_string(),
-            results: vec![
-                row("b", Some(42), false, TestStatus::Pass),
-                row("a", Some(42), false, TestStatus::Pass),
-                row("c", Some(42), false, TestStatus::Pass),
-            ],
-            order_seed: None,
-            runner_clone_ms: None,
-        };
-
-        let performance = build_performance_metrics(&artifacts, None, Some(1));
-        let slowest = performance.slowest_tests.expect("slowest tests");
-        assert_eq!(slowest.len(), 3);
-        assert_eq!(slowest[0].test_id, "a");
-        assert_eq!(slowest[1].test_id, "b");
-        assert_eq!(slowest[2].test_id, "c");
-    }
 }

--- a/crates/assay-cli/src/cli/commands/pipeline_error.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline_error.rs
@@ -1,0 +1,66 @@
+use super::reporting::write_error_artifacts;
+use super::run_output::reason_code_from_run_error;
+use crate::exit_codes::{ExitCodeVersion, ReasonCode};
+use assay_core::errors::RunError;
+use std::path::Path;
+use std::time::Instant;
+
+pub(crate) enum PipelineError {
+    Classified { run_error: RunError },
+    Fatal(anyhow::Error),
+}
+
+pub(crate) fn elapsed_ms(start: Instant) -> u64 {
+    let ms = start.elapsed().as_millis();
+    if ms > u128::from(u64::MAX) {
+        u64::MAX
+    } else {
+        ms as u64
+    }
+}
+
+impl PipelineError {
+    pub(crate) fn cfg_parse(path: impl Into<String>, msg: impl Into<String>) -> Self {
+        Self::Classified {
+            run_error: RunError::config_parse(Some(path.into()), msg.into()),
+        }
+    }
+
+    pub(crate) fn missing_cfg(path: impl Into<String>, msg: impl Into<String>) -> Self {
+        Self::Classified {
+            run_error: RunError::missing_config(path.into(), msg.into()),
+        }
+    }
+
+    pub(crate) fn invalid_args(msg: impl Into<String>) -> Self {
+        Self::Classified {
+            run_error: RunError::invalid_args(msg.into()),
+        }
+    }
+
+    pub(crate) fn from_run_error(run_error: RunError) -> Self {
+        Self::Classified { run_error }
+    }
+
+    pub(crate) fn into_exit_code(
+        self,
+        version: ExitCodeVersion,
+        verify_enabled: bool,
+        run_json_path: &Path,
+    ) -> anyhow::Result<i32> {
+        match self {
+            Self::Classified { run_error } => {
+                let reason =
+                    reason_code_from_run_error(&run_error).unwrap_or(ReasonCode::ECfgParse);
+                write_error_artifacts(
+                    reason,
+                    run_error.message,
+                    version,
+                    verify_enabled,
+                    run_json_path,
+                )
+            }
+            Self::Fatal(err) => Err(err),
+        }
+    }
+}

--- a/crates/assay-cli/src/cli/commands/profile.rs
+++ b/crates/assay-cli/src/cli/commands/profile.rs
@@ -261,7 +261,7 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
 
     // Update metadata
     profile.total_runs += 1;
-    profile.add_run_id(args.run_id.clone());
+    let run_id_digest_evicted = profile.add_run_id(args.run_id.clone());
     profile.updated_at = chrono::Utc::now().to_rfc3339();
 
     // Save
@@ -317,7 +317,7 @@ fn cmd_update(args: UpdateArgs) -> Result<i32> {
             perf.merge_ms
         );
     }
-    if perf.run_id_digest_window_len >= MAX_RUN_ID_DIGESTS {
+    if run_id_digest_evicted {
         eprintln!(
             "WARNING: run-id digest window is full ({} entries); old run-id dedupe evidence will be evicted over time",
             perf.run_id_digest_window_len

--- a/crates/assay-cli/src/cli/commands/profile.rs
+++ b/crates/assay-cli/src/cli/commands/profile.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::time::Instant;
 
+use super::pipeline_error::elapsed_ms;
 use super::profile_types::*;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -483,10 +484,6 @@ fn show_summary(profile: &Profile, top_n: usize) {
             show_top_stable(&profile.entries.network, profile.total_runs, top_n);
         }
     }
-}
-
-fn elapsed_ms(start: Instant) -> u64 {
-    start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 fn show_stability_distribution(

--- a/crates/assay-cli/src/cli/commands/profile_types.rs
+++ b/crates/assay-cli/src/cli/commands/profile_types.rs
@@ -65,10 +65,10 @@ impl Profile {
     }
 
     pub fn add_run_id(&mut self, run_id: String) -> bool {
-        let digest = run_id_digest(&run_id);
         if self.run_ids.iter().any(|id| id == &run_id) {
             return false;
         }
+        let digest = run_id_digest(&run_id);
         if self.run_id_digests.iter().any(|d| d == &digest) {
             return false;
         }

--- a/crates/assay-cli/src/cli/commands/profile_types.rs
+++ b/crates/assay-cli/src/cli/commands/profile_types.rs
@@ -5,7 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
+use std::mem;
 
 pub const PROFILE_VERSION: &str = "1.0";
 pub const MAX_RUN_IDS: usize = 200;
@@ -31,10 +32,10 @@ pub struct Profile {
 
     /// Idempotency: last N run IDs (ring buffer)
     #[serde(default)]
-    pub run_ids: Vec<String>,
+    pub run_ids: VecDeque<String>,
     /// Stable digest ring to keep duplicate detection beyond run_ids window.
     #[serde(default)]
-    pub run_id_digests: Vec<String>,
+    pub run_id_digests: VecDeque<String>,
 
     pub entries: ProfileEntries,
 }
@@ -49,8 +50,8 @@ impl Profile {
             updated_at: now,
             scope,
             total_runs: 0,
-            run_ids: Vec::new(),
-            run_id_digests: Vec::new(),
+            run_ids: VecDeque::new(),
+            run_id_digests: VecDeque::new(),
             entries: ProfileEntries::default(),
         }
     }
@@ -63,21 +64,25 @@ impl Profile {
         self.run_id_digests.iter().any(|d| d == &digest)
     }
 
-    pub fn add_run_id(&mut self, run_id: String) {
-        if self.has_run(&run_id) {
-            return;
-        }
-
+    pub fn add_run_id(&mut self, run_id: String) -> bool {
         let digest = run_id_digest(&run_id);
-        self.run_ids.push(run_id);
+        if self.run_ids.iter().any(|id| id == &run_id) {
+            return false;
+        }
+        if self.run_id_digests.iter().any(|d| d == &digest) {
+            return false;
+        }
+        self.run_ids.push_back(run_id);
         if self.run_ids.len() > MAX_RUN_IDS {
-            self.run_ids.remove(0);
+            let _ = self.run_ids.pop_front();
         }
 
-        self.run_id_digests.push(digest);
+        self.run_id_digests.push_back(digest);
         if self.run_id_digests.len() > MAX_RUN_ID_DIGESTS {
-            self.run_id_digests.remove(0);
+            let _ = self.run_id_digests.pop_front();
+            return true;
         }
+        false
     }
 
     pub fn total_entries(&self) -> usize {
@@ -85,13 +90,16 @@ impl Profile {
     }
 
     pub fn run_id_memory_bytes_estimate(&self) -> u64 {
-        let raw_ids: usize = self.run_ids.iter().map(std::string::String::len).sum();
-        let digests: usize = self
+        let raw_data: usize = self.run_ids.iter().map(std::string::String::capacity).sum();
+        let digest_data: usize = self
             .run_id_digests
             .iter()
-            .map(std::string::String::len)
+            .map(std::string::String::capacity)
             .sum();
-        (raw_ids + digests) as u64
+        let raw_slots = self.run_ids.capacity() * mem::size_of::<String>();
+        let digest_slots = self.run_id_digests.capacity() * mem::size_of::<String>();
+        let deques_overhead = 2 * mem::size_of::<VecDeque<String>>();
+        (raw_data + digest_data + raw_slots + digest_slots + deques_overhead) as u64
     }
 }
 
@@ -251,7 +259,7 @@ mod tests {
     fn idempotency() {
         let mut p = Profile::new("test", None);
         assert!(!p.has_run("run-1"));
-        p.add_run_id("run-1".into());
+        assert!(!p.add_run_id("run-1".into()));
         assert!(p.has_run("run-1"));
     }
 
@@ -259,7 +267,7 @@ mod tests {
     fn ring_buffer() {
         let mut p = Profile::new("test", None);
         for i in 0..(MAX_RUN_IDS + 10) {
-            p.add_run_id(format!("run-{}", i));
+            let _ = p.add_run_id(format!("run-{}", i));
         }
         assert_eq!(p.run_ids.len(), MAX_RUN_IDS);
         assert!(p.has_run("run-0"));
@@ -271,12 +279,23 @@ mod tests {
     fn digest_ring_buffer_eviction() {
         let mut p = Profile::new("test", None);
         for i in 0..(MAX_RUN_ID_DIGESTS + 50) {
-            p.add_run_id(format!("run-{}", i));
+            let _ = p.add_run_id(format!("run-{}", i));
         }
         assert_eq!(p.run_id_digests.len(), MAX_RUN_ID_DIGESTS);
         assert!(!p.has_run("run-0"));
         let newest = format!("run-{}", MAX_RUN_ID_DIGESTS + 49);
         assert!(p.has_run(&newest));
+    }
+
+    #[test]
+    fn digest_eviction_signal_only_when_overflowing() {
+        let mut p = Profile::new("test", None);
+        let mut last_evicted = false;
+        for i in 0..MAX_RUN_ID_DIGESTS {
+            last_evicted = p.add_run_id(format!("run-{}", i));
+        }
+        assert!(!last_evicted);
+        assert!(p.add_run_id(format!("run-{}", MAX_RUN_ID_DIGESTS)));
     }
 
     #[test]

--- a/crates/assay-cli/src/cli/commands/reporting.rs
+++ b/crates/assay-cli/src/cli/commands/reporting.rs
@@ -1,0 +1,251 @@
+use super::pipeline::PipelineTimings;
+use super::run_output::{export_baseline, summary_from_outcome, write_run_json_minimal};
+use crate::exit_codes::{ExitCodeVersion, ReasonCode, RunOutcome};
+use std::path::{Path, PathBuf};
+
+pub(crate) fn write_error_artifacts(
+    reason: ReasonCode,
+    message: String,
+    version: ExitCodeVersion,
+    verify_enabled: bool,
+    run_json_path: &Path,
+) -> anyhow::Result<i32> {
+    let mut o = RunOutcome::from_reason(reason, Some(message), None);
+    o.exit_code = reason.exit_code_for(version);
+    if let Err(e) = write_run_json_minimal(&o, &run_json_path.to_path_buf()) {
+        eprintln!("WARNING: failed to write run.json: {}", e);
+    }
+
+    let summary_path = run_json_path
+        .parent()
+        .map(|p| p.join("summary.json"))
+        .unwrap_or_else(|| PathBuf::from("summary.json"));
+    let summary = summary_from_outcome(&o, verify_enabled).with_seeds(None, None);
+    if let Err(e) = assay_core::report::summary::write_summary(&summary, &summary_path) {
+        eprintln!("WARNING: failed to write summary.json: {}", e);
+    }
+    Ok(o.exit_code)
+}
+
+pub(crate) fn build_summary_from_artifacts(
+    outcome: &RunOutcome,
+    verify_enabled: bool,
+    artifacts: &assay_core::report::RunArtifacts,
+    pipeline_timings: Option<&PipelineTimings>,
+    report_ms: Option<u64>,
+) -> assay_core::report::summary::Summary {
+    let mut summary = summary_from_outcome(outcome, verify_enabled);
+    let passed = artifacts
+        .results
+        .iter()
+        .filter(|r| r.status.is_passing())
+        .count();
+    let failed = artifacts
+        .results
+        .iter()
+        .filter(|r| r.status.is_blocking())
+        .count();
+    summary = summary.with_results(passed, failed, artifacts.results.len());
+    summary = summary.with_seeds(artifacts.order_seed, None);
+    if let Some(metrics) =
+        assay_core::report::summary::judge_metrics_from_results(&artifacts.results)
+    {
+        summary = summary.with_judge_metrics(metrics);
+    }
+    let performance = build_performance_metrics(artifacts, pipeline_timings, report_ms);
+    summary = summary.with_performance(performance);
+    summary
+}
+
+fn build_performance_metrics(
+    artifacts: &assay_core::report::RunArtifacts,
+    pipeline_timings: Option<&PipelineTimings>,
+    report_ms: Option<u64>,
+) -> assay_core::report::summary::PerformanceMetrics {
+    let (total_ms, ingest_ms, eval_ms) = match pipeline_timings {
+        Some(t) => (
+            t.total_ms.saturating_add(report_ms.unwrap_or(0)),
+            t.ingest_ms,
+            t.run_suite_ms,
+        ),
+        None => (report_ms.unwrap_or(0), None, None),
+    };
+
+    let cache_hit_rate = if artifacts.results.is_empty() {
+        None
+    } else {
+        let cached = artifacts.results.iter().filter(|r| r.cached).count() as f64;
+        Some(cached / artifacts.results.len() as f64)
+    };
+
+    let mut slowest: Vec<assay_core::report::summary::SlowestTest> = artifacts
+        .results
+        .iter()
+        .filter_map(|row| {
+            row.duration_ms
+                .map(|d| assay_core::report::summary::SlowestTest {
+                    test_id: row.test_id.clone(),
+                    duration_ms: d,
+                })
+        })
+        .collect();
+    slowest.sort_by(|a, b| {
+        b.duration_ms
+            .cmp(&a.duration_ms)
+            .then_with(|| a.test_id.cmp(&b.test_id))
+    });
+    slowest.truncate(5);
+    let slowest_tests = if slowest.is_empty() {
+        None
+    } else {
+        Some(slowest)
+    };
+
+    let phase_timings = Some(assay_core::report::summary::PhaseTimings {
+        ingest_ms,
+        eval_ms,
+        judge_ms: None,
+        report_ms,
+    });
+
+    assay_core::report::summary::PerformanceMetrics {
+        total_duration_ms: total_ms,
+        verify_ms: None,
+        lint_ms: None,
+        runner_clone_ms: artifacts.runner_clone_ms,
+        runner_clone_count: None,
+        profile_store_ms: None,
+        run_id_memory_bytes: None,
+        cache_hit_rate,
+        slowest_tests,
+        phase_timings,
+    }
+}
+
+pub(crate) fn print_pipeline_summary(
+    artifacts: &assay_core::report::RunArtifacts,
+    explain_skip: bool,
+    summary: &assay_core::report::summary::Summary,
+) {
+    assay_core::report::console::print_summary(&artifacts.results, explain_skip);
+    assay_core::report::console::print_run_footer(
+        Some(&summary.seeds),
+        summary.judge_metrics.as_ref(),
+    );
+}
+
+pub(crate) fn maybe_export_baseline(
+    export_path: &Option<PathBuf>,
+    config_path: &Path,
+    cfg: &assay_core::model::EvalConfig,
+    artifacts: &assay_core::report::RunArtifacts,
+) {
+    if let Some(path) = export_path {
+        if let Err(e) = export_baseline(path, config_path, cfg, &artifacts.results) {
+            eprintln!("Failed to export baseline: {}", e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_core::model::{TestResultRow, TestStatus};
+    use serde_json::json;
+
+    fn row(id: &str, duration_ms: Option<u64>, cached: bool, status: TestStatus) -> TestResultRow {
+        TestResultRow {
+            test_id: id.to_string(),
+            status,
+            score: None,
+            cached,
+            message: String::new(),
+            details: json!({}),
+            duration_ms,
+            fingerprint: None,
+            skip_reason: None,
+            attempts: None,
+            error_policy_applied: None,
+        }
+    }
+
+    #[test]
+    fn performance_metrics_include_pipeline_and_report_timings() {
+        let artifacts = assay_core::report::RunArtifacts {
+            run_id: 1,
+            suite: "demo".to_string(),
+            results: vec![row("t1", Some(10), true, TestStatus::Pass)],
+            order_seed: None,
+            runner_clone_ms: Some(13),
+        };
+        let timings = PipelineTimings {
+            total_ms: 120,
+            config_load_ms: Some(5),
+            ingest_ms: Some(12),
+            runner_build_ms: Some(8),
+            run_suite_ms: Some(90),
+        };
+
+        let performance = build_performance_metrics(&artifacts, Some(&timings), Some(30));
+
+        assert_eq!(performance.total_duration_ms, 150);
+        let phases = performance.phase_timings.expect("phase timings");
+        assert_eq!(phases.ingest_ms, Some(12));
+        assert_eq!(phases.eval_ms, Some(90));
+        assert_eq!(phases.report_ms, Some(30));
+        assert_eq!(performance.runner_clone_ms, Some(13));
+    }
+
+    #[test]
+    fn performance_metrics_compute_cache_hit_rate_and_slowest_top5() {
+        let artifacts = assay_core::report::RunArtifacts {
+            run_id: 2,
+            suite: "demo".to_string(),
+            results: vec![
+                row("t1", Some(80), true, TestStatus::Pass),
+                row("t2", Some(20), false, TestStatus::Fail),
+                row("t3", Some(60), true, TestStatus::Pass),
+                row("t4", Some(10), false, TestStatus::Warn),
+                row("t5", Some(40), false, TestStatus::Pass),
+                row("t6", Some(50), false, TestStatus::Pass),
+            ],
+            order_seed: None,
+            runner_clone_ms: None,
+        };
+
+        let performance = build_performance_metrics(&artifacts, None, Some(7));
+
+        let hit_rate = performance.cache_hit_rate.expect("cache hit rate");
+        assert!((hit_rate - (2.0 / 6.0)).abs() < f64::EPSILON);
+
+        let slowest = performance.slowest_tests.expect("slowest tests");
+        assert_eq!(slowest.len(), 5);
+        assert_eq!(slowest[0].test_id, "t1");
+        assert_eq!(slowest[1].test_id, "t3");
+        assert_eq!(slowest[2].test_id, "t6");
+        assert_eq!(slowest[3].test_id, "t5");
+        assert_eq!(slowest[4].test_id, "t2");
+    }
+
+    #[test]
+    fn performance_metrics_slowest_tie_breaks_by_test_id() {
+        let artifacts = assay_core::report::RunArtifacts {
+            run_id: 3,
+            suite: "demo".to_string(),
+            results: vec![
+                row("b", Some(42), false, TestStatus::Pass),
+                row("a", Some(42), false, TestStatus::Pass),
+                row("c", Some(42), false, TestStatus::Pass),
+            ],
+            order_seed: None,
+            runner_clone_ms: None,
+        };
+
+        let performance = build_performance_metrics(&artifacts, None, Some(1));
+        let slowest = performance.slowest_tests.expect("slowest tests");
+        assert_eq!(slowest.len(), 3);
+        assert_eq!(slowest[0].test_id, "a");
+        assert_eq!(slowest[1].test_id, "b");
+        assert_eq!(slowest[2].test_id, "c");
+    }
+}

--- a/crates/assay-cli/src/cli/commands/run.rs
+++ b/crates/assay-cli/src/cli/commands/run.rs
@@ -1,9 +1,9 @@
 use super::super::args::RunArgs;
-use super::pipeline::{
-    build_summary_from_artifacts, execute_pipeline, maybe_export_baseline, print_pipeline_summary,
-    write_error_artifacts, PipelineError, PipelineInput,
+use super::pipeline::{execute_pipeline, PipelineInput};
+use super::pipeline_error::elapsed_ms;
+use super::reporting::{
+    build_summary_from_artifacts, maybe_export_baseline, print_pipeline_summary,
 };
-use super::run_output::reason_code_from_run_error;
 use super::run_output::write_extended_run_json;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -13,21 +13,9 @@ pub(crate) async fn run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32>
     let run_json_path = PathBuf::from("run.json");
 
     let input = PipelineInput::from_run(&args);
-    let execution = execute_pipeline(&input, legacy_mode).await;
-    let execution = match execution {
+    let execution = match execute_pipeline(&input, legacy_mode).await {
         Ok(ok) => ok,
-        Err(PipelineError::Classified { run_error }) => {
-            let reason = reason_code_from_run_error(&run_error)
-                .unwrap_or(crate::exit_codes::ReasonCode::ECfgParse);
-            return write_error_artifacts(
-                reason,
-                run_error.message,
-                version,
-                !args.no_verify,
-                &run_json_path,
-            );
-        }
-        Err(PipelineError::Fatal(err)) => return Err(err),
+        Err(e) => return e.into_exit_code(version, !args.no_verify, &run_json_path),
     };
 
     let cfg = execution.cfg;
@@ -50,7 +38,7 @@ pub(crate) async fn run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32>
     maybe_export_baseline(&args.export_baseline, &args.config, &cfg, &artifacts);
 
     // Measure the full reporting phase (outputs + summary prep + console + baseline export).
-    let report_ms = report_start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    let report_ms = elapsed_ms(report_start);
     summary = build_summary_from_artifacts(
         &outcome,
         !args.no_verify,

--- a/crates/assay-cli/tests/contract_run_ci_parity.rs
+++ b/crates/assay-cli/tests/contract_run_ci_parity.rs
@@ -1,0 +1,196 @@
+#![allow(deprecated)]
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn read_json(path: &Path) -> Value {
+    let content = fs::read_to_string(path).expect("missing json file");
+    serde_json::from_str(&content).expect("invalid json")
+}
+
+fn read_run_json(dir: &Path) -> Value {
+    read_json(&dir.join("run.json"))
+}
+
+fn read_summary_json(dir: &Path) -> Value {
+    read_json(&dir.join("summary.json"))
+}
+
+fn run_assay(dir: &Path, subcmd: &str, args: &[&str], expected_code: i32) {
+    let mut cmd = Command::cargo_bin("assay").expect("cargo bin");
+    cmd.current_dir(dir)
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg(subcmd);
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.assert().code(expected_code);
+}
+
+fn assert_failure_contract(run: &Value, summary: &Value) {
+    assert!(
+        run.get("exit_code").and_then(Value::as_i64).is_some(),
+        "run.json must include integer exit_code"
+    );
+    assert!(
+        run.get("reason_code").and_then(Value::as_str).is_some(),
+        "run.json must include reason_code"
+    );
+    assert_eq!(
+        run.get("exit_code"),
+        summary.get("exit_code"),
+        "run.json and summary.json must agree on exit code"
+    );
+    assert_eq!(
+        run.get("reason_code"),
+        summary.get("reason_code"),
+        "run.json and summary.json must agree on reason code"
+    );
+}
+
+#[test]
+fn parity_missing_config_run_vs_ci() {
+    let run_dir = tempdir().expect("tempdir");
+    let ci_dir = tempdir().expect("tempdir");
+
+    run_assay(run_dir.path(), "run", &["--config", "missing.yaml"], 2);
+    run_assay(ci_dir.path(), "ci", &["--config", "missing.yaml"], 2);
+
+    let run_run = read_run_json(run_dir.path());
+    let run_summary = read_summary_json(run_dir.path());
+    let ci_run = read_run_json(ci_dir.path());
+    let ci_summary = read_summary_json(ci_dir.path());
+
+    assert_failure_contract(&run_run, &run_summary);
+    assert_failure_contract(&ci_run, &ci_summary);
+    assert_eq!(run_run["reason_code"], "E_MISSING_CONFIG");
+    assert_eq!(ci_run["reason_code"], "E_MISSING_CONFIG");
+}
+
+#[test]
+fn parity_invalid_args_baseline_export_run_vs_ci() {
+    let run_dir = tempdir().expect("tempdir");
+    let ci_dir = tempdir().expect("tempdir");
+
+    run_assay(
+        run_dir.path(),
+        "run",
+        &["--baseline", "a.json", "--export-baseline", "b.json"],
+        2,
+    );
+    run_assay(
+        ci_dir.path(),
+        "ci",
+        &["--baseline", "a.json", "--export-baseline", "b.json"],
+        2,
+    );
+
+    let run_run = read_run_json(run_dir.path());
+    let run_summary = read_summary_json(run_dir.path());
+    let ci_run = read_run_json(ci_dir.path());
+    let ci_summary = read_summary_json(ci_dir.path());
+
+    assert_failure_contract(&run_run, &run_summary);
+    assert_failure_contract(&ci_run, &ci_summary);
+    assert_eq!(run_run["reason_code"], "E_INVALID_ARGS");
+    assert_eq!(ci_run["reason_code"], "E_INVALID_ARGS");
+}
+
+#[test]
+fn parity_deny_deprecations_run_vs_ci() {
+    let run_dir = tempdir().expect("tempdir");
+    let ci_dir = tempdir().expect("tempdir");
+    let eval = r#"configVersion: 1
+suite: strict-deprecations
+model: dummy
+tests:
+  - id: t1
+    input: { prompt: "hi" }
+    expected:
+      type: args_valid
+      policy: policy.yaml
+"#;
+    fs::write(run_dir.path().join("eval.yaml"), eval).expect("write eval");
+    fs::write(ci_dir.path().join("eval.yaml"), eval).expect("write eval");
+
+    run_assay(
+        run_dir.path(),
+        "run",
+        &["--config", "eval.yaml", "--deny-deprecations"],
+        2,
+    );
+    run_assay(
+        ci_dir.path(),
+        "ci",
+        &["--config", "eval.yaml", "--deny-deprecations"],
+        2,
+    );
+
+    let run_run = read_run_json(run_dir.path());
+    let run_summary = read_summary_json(run_dir.path());
+    let ci_run = read_run_json(ci_dir.path());
+    let ci_summary = read_summary_json(ci_dir.path());
+
+    assert_failure_contract(&run_run, &run_summary);
+    assert_failure_contract(&ci_run, &ci_summary);
+    assert_eq!(run_run["reason_code"], "E_CFG_PARSE");
+    assert_eq!(ci_run["reason_code"], "E_CFG_PARSE");
+}
+
+#[test]
+fn ci_report_outputs_contract_default_names_and_non_blocking_failures() {
+    let dir = tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join("assay.yaml"),
+        "suite: test\nmodel: dummy\ntests:\n  - id: pass\n    input: hello",
+    )
+    .expect("write config");
+
+    run_assay(dir.path(), "ci", &["--config", "assay.yaml"], 0);
+    assert!(
+        dir.path().join("junit.xml").exists(),
+        "ci must write default junit.xml"
+    );
+    assert!(
+        dir.path().join("sarif.json").exists(),
+        "ci must write default sarif.json"
+    );
+
+    let bad_path = dir.path().join("bad_output");
+    fs::create_dir(&bad_path).expect("create bad output");
+    run_assay(
+        dir.path(),
+        "ci",
+        &[
+            "--config",
+            "assay.yaml",
+            "--junit",
+            "bad_output",
+            "--sarif",
+            "bad_output",
+        ],
+        0,
+    );
+
+    let run = read_run_json(dir.path());
+    let warnings = run
+        .get("warnings")
+        .and_then(Value::as_array)
+        .expect("warnings must be present for report write failures");
+    assert!(
+        warnings
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|w| w.contains("Failed to write JUnit")),
+        "run.json warnings must include JUnit write failure"
+    );
+    assert!(
+        warnings
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|w| w.contains("Failed to write SARIF")),
+        "run.json warnings must include SARIF write failure"
+    );
+}

--- a/crates/assay-core/src/errors/mod.rs
+++ b/crates/assay-core/src/errors/mod.rs
@@ -266,7 +266,7 @@ pub fn try_map_error(err: &anyhow::Error) -> Option<Diagnostic> {
         return Some(
             Diagnostic::new(
                 diagnostic::codes::E_BASE_MISMATCH,
-                "Baseline incompatbile with current run",
+                "Baseline incompatible with current run",
             )
             .with_context(serde_json::json!({ "raw_error": msg }))
             .with_fix_step("Regenerate baseline on main branch: assay ci --export-baseline ...")

--- a/crates/assay-core/src/providers/trace.rs
+++ b/crates/assay-core/src/providers/trace.rs
@@ -205,10 +205,6 @@ impl TraceClient {
                                         if is_model {
                                             state.input_is_model = true;
                                         }
-                                        // DEBUG: remove me
-                                        /*
-                                        eprintln!("DEBUG: TraceClient extracted prompt: '{}' is_model={}", state.input.as_ref().unwrap(), is_model);
-                                        */
                                     }
                                 }
 
@@ -360,7 +356,6 @@ impl TraceClient {
         keys.sort();
         let mut hasher = sha2::Sha256::new();
         for k in keys {
-            use sha2::Digest;
             hasher.update(k.as_bytes());
             if let Some(v) = traces.get(k) {
                 // hash validation relevant parts of response

--- a/crates/assay-core/src/storage/judge_cache.rs
+++ b/crates/assay-core/src/storage/judge_cache.rs
@@ -1,3 +1,4 @@
+use super::now_rfc3339ish;
 use crate::storage::Store;
 use rusqlite::params;
 
@@ -56,13 +57,4 @@ impl JudgeCache {
         )?;
         Ok(())
     }
-}
-
-fn now_rfc3339ish() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    format!("unix:{}", secs)
 }

--- a/crates/assay-core/src/storage/mod.rs
+++ b/crates/assay-core/src/storage/mod.rs
@@ -4,3 +4,12 @@ pub mod schema;
 pub mod store;
 
 pub use store::Store;
+
+pub(crate) fn now_rfc3339ish() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    format!("unix:{}", secs)
+}

--- a/crates/assay-core/src/storage/store.rs
+++ b/crates/assay-core/src/storage/store.rs
@@ -1,3 +1,4 @@
+use super::now_rfc3339ish;
 use crate::model::{AttemptRow, EvalConfig, LlmResponse, TestResultRow, TestStatus};
 use crate::trace::schema::{EpisodeEnd, EpisodeStart, StepEntry, ToolCallEntry, TraceEvent};
 use anyhow::Context;
@@ -747,15 +748,6 @@ impl Store {
         .context("update episode outcome")?;
         Ok(())
     }
-}
-
-fn now_rfc3339ish() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    format!("unix:{}", secs)
 }
 
 fn status_to_outcome(s: &TestStatus) -> &'static str {

--- a/crates/assay-sim/src/report.rs
+++ b/crates/assay-sim/src/report.rs
@@ -13,10 +13,10 @@ pub struct SimReport {
 #[derive(Debug, Serialize, Clone, Default)]
 pub struct SimSummary {
     pub total: usize,
-    pub passed: usize,   // New: For invariants
+    pub passed: usize,   // For invariant checks
     pub blocked: usize,  // For attacks
     pub bypassed: usize, // For attacks
-    pub failed: usize,   // New: For invariants
+    pub failed: usize,   // For invariant checks
     pub errors: usize,
 }
 
@@ -27,13 +27,13 @@ pub struct AttackResult {
     pub error_class: Option<String>,
     pub error_code: Option<String>,
     pub message: Option<String>,
-    pub duration_ms: u64, // New: DX requirement
+    pub duration_ms: u64,
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub enum AttackStatus {
-    Passed,   // New: Invariant held
-    Failed,   // New: Invariant broken
+    Passed,   // Invariant held
+    Failed,   // Invariant broken
     Blocked,  // Attack was stopped
     Bypassed, // Attack succeeded
     Error,    // Infrastructure error

--- a/docs/DEMO-STRATEGY.md
+++ b/docs/DEMO-STRATEGY.md
@@ -1,0 +1,453 @@
+# Demo Strategy: Assay Developer-Focused Launch
+
+> **Status**: Draft
+> **Date**: 2026-02-08
+> **Goal**: Maximaal developer-bereik met reproduceerbare, CI-geautomatiseerde terminal demo's.
+
+---
+
+## 1) Recording Tooling
+
+### Primair: VHS (Charmbracelet)
+
+Scriptbare `.tape` files — volledig reproduceerbaar, versiebeheer in git.
+
+- Output: GIF, MP4, WebM, PNG-frames in één run
+- CI: officiële `charmbracelet/vhs-action` — demo's worden automatisch opnieuw gegenereerd bij code-wijzigingen
+- Precieze controle over typing snelheid, pauzes, window grootte, thema
+- Installatie: `brew install charmbracelet/tap/vhs`
+
+### Aanvullend: asciinema (v3)
+
+Voor docs-site embedding waar interactieve playback en tekst-selecteerbaarheid belangrijk zijn.
+
+- Rust rewrite (v3, sep 2025) — snelle startup, single binary
+- Interactieve JS-player met pause/seek/speed control
+- Tekst is kopieerbaar uit de player (dev credibility)
+- Tiny file sizes (text-based asciicast format)
+- Self-hostable player component
+
+### Vergelijking
+
+| Feature | VHS | asciinema v3 | Terminalizer | t-rec |
+|---------|-----|-------------|-------------|-------|
+| Taal | Go | Rust | Node.js | Rust |
+| Opname | Scripted (tape) | Live capture | Live capture | Screenshot |
+| Deterministisch | Ja | Nee | Nee | Nee |
+| GIF | Ja | Via converter | Ja | Ja |
+| MP4/WebM | Ja | Nee | Nee | MP4 |
+| SVG | Nee | Via svg-term-cli | Nee | Nee |
+| Interactieve player | Nee | Ja (JS) | Ja (web) | Nee |
+| Tekst selecteerbaar | Nee | Ja | Nee | Nee |
+| CI automation | Officiële GH Action | Handmatig | Handmatig | Handmatig |
+| Actief onderhouden | Ja | Ja | Nee | Matig |
+
+**Besluit:** VHS voor alle GIF/video assets (README, social, landing page). Asciinema voor docs-site (interactief, copy-paste).
+
+---
+
+## 2) Demo Inhoud: 5 Scenes
+
+Elke scene is een apart GIF + samen vormen ze een volledige MP4 walkthrough. Structuur volgt het "input → output" patroon dat het best converteert bij devtools (bron: Evil Martians studie, 100 landing pages).
+
+### Scene 1: "Zero to Gate" (Hero GIF — 8s)
+
+**Doel:** Van niks naar werkende CI gate. Dit is de "< 5 min to first PR gate" wedge claim, live bewezen.
+
+```tape
+# demo/hero.tape
+Output demo/output/hero.gif
+Output demo/output/hero.mp4
+Set FontSize 16
+Set Width 1000
+Set Height 600
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 40ms
+
+Type "mkdir my-agent && cd my-agent"
+Enter
+Sleep 500ms
+
+Type "assay init --hello-trace --ci github"
+Enter
+Sleep 3s
+
+Type "assay run --config eval.yaml"
+Enter
+Sleep 3s
+```
+
+**Wat de dev ziet:** Scaffolding met emoji-output (detectie, generatie, klaar) → test pass met exit code 0.
+
+### Scene 2: "Break & Fix" (Probleem → Oplossing — 12s)
+
+**Doel:** Toon wat er gebeurt als een AI agent iets onveiligs doet, en hoe Assay dat vangt. Developers geloven tools die falen, niet tools die altijd groen zijn.
+
+```tape
+# demo/break-fix.tape
+Output demo/output/break-fix.gif
+Set FontSize 16
+Set Width 1000
+Set Height 600
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 40ms
+
+# Run met unsafe trace → FAIL
+Type "assay run --config eval.yaml --trace-file traces/unsafe.jsonl"
+Enter
+Sleep 3s
+
+Sleep 1s
+
+# Run met safe trace → PASS
+Type "assay run --config eval.yaml --trace-file traces/safe.jsonl"
+Enter
+Sleep 3s
+```
+
+**Bron:** `examples/demo/` bevat al `unsafe-policy.yaml`, `common-mistake.yaml`, en `safe-policy.yaml`.
+
+### Scene 3: "Evidence Lint" (Compliance — 6s)
+
+**Doel:** Audit/compliance scanning in één commando — differentiator die niemand anders heeft.
+
+```tape
+# demo/evidence-lint.tape
+Output demo/output/evidence-lint.gif
+Set FontSize 16
+Set Width 1000
+Set Height 600
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 40ms
+
+Type "assay evidence lint bundle.tar.gz --pack eu-ai-act-baseline"
+Enter
+Sleep 4s
+```
+
+**Output:** Verified badge → findings met article references → SARIF summary.
+
+### Scene 4: "Attack Simulation" (Security — 6s)
+
+**Doel:** Visueel indrukwekkend — ASCII tabel met attack vectors en blocked/bypassed status.
+
+```tape
+# demo/sim.tape
+Output demo/output/sim.gif
+Set FontSize 16
+Set Width 1000
+Set Height 600
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 40ms
+
+Type "assay sim run --suite quick --target bundle.tar.gz --seed 42"
+Enter
+Sleep 4s
+```
+
+**Output:** Tabel met bitflip/truncate/inject → "Blocked/Passed/Bypassed" per vector.
+
+### Scene 5: "Evidence Explorer TUI" (Wow-factor — 8s)
+
+**Doel:** Interactieve TUI — de visuele "money shot" die deelbaar is.
+
+```tape
+# demo/explore.tape
+Output demo/output/explore.gif
+Set FontSize 16
+Set Width 1000
+Set Height 700
+Set Theme "Catppuccin Mocha"
+
+Type "assay evidence explore bundle.tar.gz"
+Enter
+Sleep 2s
+
+# Navigeer door events
+Type "j"
+Sleep 300ms
+Type "j"
+Sleep 300ms
+Type "j"
+Sleep 300ms
+Enter
+Sleep 2s
+
+Type "q"
+Sleep 500ms
+```
+
+---
+
+## 3) Asset Pipeline
+
+### Directory structuur
+
+```
+demo/
+  ├── hero.tape
+  ├── break-fix.tape
+  ├── evidence-lint.tape
+  ├── sim.tape
+  ├── explore.tape
+  ├── full-walkthrough.tape    # Alle scenes achter elkaar → MP4
+  ├── fixtures/                # Pre-built bundles/traces voor reproduceerbare output
+  │   ├── bundle.tar.gz
+  │   ├── traces/
+  │   │   ├── safe.jsonl
+  │   │   └── unsafe.jsonl
+  │   └── eval.yaml
+  └── output/                  # Gegenereerde assets (git-ignored of CI-committed)
+      ├── hero.gif
+      ├── hero.mp4
+      ├── break-fix.gif
+      ├── evidence-lint.gif
+      ├── sim.gif
+      ├── explore.gif
+      └── full-walkthrough.mp4
+```
+
+### CI Automation
+
+```yaml
+# .github/workflows/demo.yml
+name: Regenerate Demo Assets
+on:
+  push:
+    paths:
+      - 'demo/*.tape'
+      - 'crates/assay-cli/**'
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  vhs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: charmbracelet/vhs-action@v2
+        with:
+          path: 'demo/hero.tape'
+      - uses: charmbracelet/vhs-action@v2
+        with:
+          path: 'demo/break-fix.tape'
+      - uses: charmbracelet/vhs-action@v2
+        with:
+          path: 'demo/evidence-lint.tape'
+      - uses: charmbracelet/vhs-action@v2
+        with:
+          path: 'demo/sim.tape'
+      - uses: charmbracelet/vhs-action@v2
+        with:
+          path: 'demo/explore.tape'
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: regenerate demo assets"
+          file_pattern: 'demo/output/*'
+```
+
+Demo GIF's worden automatisch opnieuw gegenereerd als CLI output verandert. README toont altijd actuele output.
+
+---
+
+## 4) Formaat per Kanaal
+
+| Kanaal | Formaat | Lengte | Link naar | Asset |
+|--------|---------|--------|-----------|-------|
+| GitHub README | GIF (hero) | 8s loop | — | `hero.gif` |
+| Landing page hero | MP4 autoplay muted loop | 15s | — | `hero.mp4` |
+| Hacker News | Link naar repo | — | GitHub repo | README met hero GIF |
+| Twitter/X | MP4 video | 30-45s | Repo of landing page | `full-walkthrough.mp4` of samengesteld |
+| Reddit | GIF of link post | 8s | GitHub repo | `hero.gif` of `sim.gif` |
+| dev.to | Embedded GIF's in artikel | 6-8s per stuk | Repo + docs | Alle scenes apart |
+| LinkedIn | Native MP4 | 30-90s | Landing page | `full-walkthrough.mp4` |
+| Docs site | asciinema player | Interactief | — | `.cast` bestanden |
+| Discord | Quick GIF | 4-6s | Repo | `sim.gif` of `hero.gif` |
+
+---
+
+## 5) Hacker News Launch
+
+### Timing
+
+**Dinsdag** — 60% hogere gemiddelde peak score dan andere dagen (bron: Show HN survival study, 605 posts).
+
+### Titel
+
+```
+Show HN: Assay – Policy-as-Code for AI agents (deterministic replay, evidence bundles, eBPF enforcement)
+```
+
+### Post body
+
+Eerste persoon, technisch, understated:
+
+```
+I've been building Assay to solve a problem I kept hitting:
+how do you test AI agents deterministically in CI,
+and prove to auditors what they actually did?
+
+Core loop:
+1. Record agent traces (MCP transcripts, API calls)
+2. Generate policies from observed behavior
+3. Replay deterministically in CI — same trace + same flags = identical outcome
+4. Produce evidence bundles for compliance (EU AI Act, SOC2)
+5. Attack simulation to prove your gates actually work
+
+Written in Rust. Runs offline. No vendor lock-in. No signup.
+
+The evidence bundle format uses content-addressed events (JCS canonicalization,
+SHA-256, Merkle root) — so you can cryptographically prove what an agent did.
+
+https://github.com/...
+```
+
+### Kritieke regels
+
+- **Link naar GitHub repo**, niet landing page — HN overindexeert op OSS
+- **Geen superlatieven** ("fastest", "best", "first") — HN prikt er doorheen
+- **Technische diepte** in comments, niet marketing-speak
+- **Eerste persoon** ("I built", "I've been working on")
+- **Reageer op elk comment** de eerste 2-3 uur
+- **README moet gepolijst zijn** met werkende hero GIF voor je post
+
+### Aanvullende kanalen (zelfde week)
+
+| Dag | Kanaal | Format |
+|-----|--------|--------|
+| Di | Hacker News (Show HN) | Repo link |
+| Di | Twitter/X thread | GIF + korte thread (3-4 tweets) |
+| Wo | r/rust | "I built X in Rust" post met GIF |
+| Wo | r/programming + r/netsec | Cross-post (max 2-3 subs) |
+| Do | dev.to | Technisch artikel "How I built..." |
+| Vr | LinkedIn | Native MP4 video, compliance angle |
+
+---
+
+## 6) Landing Page Structuur
+
+Gebaseerd op Evil Martians studie (100 devtool landing pages, 2025):
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Hero                                                │
+│  "Policy-as-Code for AI Agents"                     │
+│  [hero.mp4 autoplay muted loop]                     │
+│  CTA: [Get Started]  [Docs]                         │
+├─────────────────────────────────────────────────────┤
+│  Input → Output                                      │
+│  Links: eval.yaml snippet (4 regels)                │
+│  Rechts: terminal output (pass/fail met kleuren)    │
+├─────────────────────────────────────────────────────┤
+│  3 Pillars (iconen + korte tekst)                   │
+│  ┌──────────────┬──────────────┬──────────────┐     │
+│  │ Deterministic│  Evidence    │  Attack      │     │
+│  │ Replay       │  Bundles     │  Simulation  │     │
+│  │ < 5 min to   │  Audit-ready │  Prove your  │     │
+│  │ first gate   │  compliance  │  gates work  │     │
+│  └──────────────┴──────────────┴──────────────┘     │
+├─────────────────────────────────────────────────────┤
+│  Code Example (kopieerbaar)                          │
+│  $ assay init --hello-trace --ci github             │
+│  $ assay run --config eval.yaml                     │
+│  $ assay evidence lint bundle.tar.gz                │
+│  $ assay sim run --suite quick                      │
+├─────────────────────────────────────────────────────┤
+│  Social proof: GitHub stars + "Used by" logos       │
+├─────────────────────────────────────────────────────┤
+│  Footer: "Open source. No vendor lock-in.           │
+│           Runs offline. Written in Rust."           │
+└─────────────────────────────────────────────────────┘
+```
+
+### Wat NIET doen
+
+- Geen pricing op de landing page (eerst adoptie)
+- Geen "book a demo" CTA (devs haten dat)
+- Geen marketing-jargon of buzzwords
+- Geen feature matrix met 50 items
+- Geen flashy animaties — clean en simpel wint
+
+---
+
+## 7) Bleeding Edge
+
+### VHS + CI Auto-Update (nu implementeerbaar)
+
+`.tape` files in repo → CI regenereert GIF's bij elke release → README toont altijd actuele output. Competitief voordeel: de meeste projecten hebben verouderde demo GIF's.
+
+### asciinema-player in Docs (nu implementeerbaar)
+
+Self-hosted JS player component op docs-site. Per feature-sectie een mini-demo die afspeelt on click. `data-start-at` en `data-speed` attributen voor precieze controle.
+
+### "Try in Codespace" Button (lage effort, hoge conversie)
+
+GitHub Codespace met pre-installed Assay + voorbeelden. Dev klikt → terminal → `assay init --hello-trace && assay run`. Hoogste conversie maar kost Codespace minutes.
+
+### Interactieve Browser Demo (toekomst)
+
+WebContainer-based playground of pre-recorded asciinema cast met interactieve player. Assay is Rust/native, dus echte WASM-versie is complex — maar gesimuleerde output met pre-recorded casts is haalbaar.
+
+### AI-Narrated Video (optioneel)
+
+AI text-to-speech (ElevenLabs, OpenAI TTS) over VHS-gegenereerde MP4. Script de narration naast het tape file voor synchronisatie. Produceert YouTube/social-ready content met minimale effort.
+
+---
+
+## 8) Demo Design Principes
+
+### Lengte
+
+| Context | Optimale lengte |
+|---------|----------------|
+| Hero GIF (README/landing) | 4-8 seconden, loopend |
+| Feature GIF | 6-12 seconden |
+| Social video (Twitter/LinkedIn) | 30-60 seconden |
+| YouTube walkthrough | 2-3 minuten max |
+
+De gemiddelde paginabezoek-duur is < 60 seconden. De hero demo moet waarde communiceren in de eerste 2-3 seconden.
+
+### Wat haakt in de eerste 5 seconden
+
+1. **Snelheid/performance contrast** — laat de tool snel runnen met zichtbare timing
+2. **Input → output** — commando tonen, direct resultaat
+3. **One-liner magic** — één commando dat iets indrukwekkends doet
+4. **Zichtbare, betekenisvolle output** — kleuren, structuur, professionele formatting
+
+### Tone
+
+- Geen marketing-speak
+- Technische diepte boven glans
+- Laat het product spreken, niet de copy
+- Understated > overclaimed
+
+---
+
+## 9) Uitvoeringsplan
+
+| Stap | Actie | Afhankelijkheid |
+|------|-------|-----------------|
+| 1 | Maak `demo/` directory + `demo/fixtures/` met test data | — |
+| 2 | Schrijf `hero.tape` — test lokaal met `vhs demo/hero.tape` | VHS geinstalleerd |
+| 3 | Schrijf overige 4 tape files | Fixtures klaar |
+| 4 | Genereer alle GIF's — embed hero in README | Tape files werken |
+| 5 | Zet `vhs-action` CI workflow op | GIF's committed |
+| 6 | Maak asciinema recordings voor docs-site | — |
+| 7 | Polijst README met hero GIF + install instructions | GIF klaar |
+| 8 | Schrijf HN post (eerste persoon, technisch) | README klaar |
+| 9 | Prepareer Twitter thread + Reddit posts | Assets klaar |
+| 10 | Launch op dinsdag 9:00 EST | Alles klaar |
+
+---
+
+## Bronnen
+
+- [VHS (Charmbracelet)](https://github.com/charmbracelet/vhs) — Terminal recorder
+- [VHS GitHub Action](https://github.com/charmbracelet/vhs-action) — CI automation
+- [asciinema v3](https://github.com/asciinema/asciinema) — Interactive terminal recording
+- [Evil Martians: 100 devtool landing pages](https://evilmartians.com/chronicles/we-studied-100-devtool-landing-pages-here-is-what-actually-works-in-2025) — Landing page patterns
+- [Markepear: Dev tool HN launch](https://www.markepear.dev/blog/dev-tool-hacker-news-launch) — HN strategie
+- [Markepear: Developer marketing guide](https://www.markepear.dev/blog/developer-marketing-guide) — Dev marketing
+- [Markepear: Landing page examples](https://www.markepear.dev/examples/landing-page) — Voorbeelden
+- [Show HN Survival Study](https://asof.app/research/show-hn-survival) — 605 posts geanalyseerd
+- [GIF duration best practices](https://fastmakergif.com/blog/gif-frame-rate-duration-best-practices) — Optimale lengte

--- a/docs/architecture/CODE-ANALYSIS-REPORT.md
+++ b/docs/architecture/CODE-ANALYSIS-REPORT.md
@@ -1,0 +1,178 @@
+# Code Analysis Report: Degradation, Redundancy, Unnecessary Code & AI Comments
+
+> **Date**: 2026-02-09
+> **Scope**: Full workspace (`assay-cli`, `assay-core`, `assay-evidence`, `assay-metrics`, `assay-sim`, `assay-registry`)
+> **Branch**: `codex/e9c-1-spec-contract-alignment`
+
+---
+
+## Totaal
+
+| Categorie | P1 | P2 | P3 | Totaal |
+|-----------|----|----|-----|--------|
+| Redundancy | 6 | 10 | 4 | 20 |
+| AI Comments | 0 | 2 | 9 | 11 |
+| Unnecessary Code | 1 | 4 | 8 | 13 |
+| Degradation | 3 | 6 | 5 | 14 |
+| **Totaal** | **10** | **22** | **26** | **58** |
+
+---
+
+## P1 — Fix Now
+
+### Redundancy
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 1 | `commands/run.rs:17-31` / `ci.rs:17-31` | Identieke 15-regel error handling match blocks (al in PLAN-pipeline-decomposition) |
+| 2 | `storage/store.rs:73-110, 131-170, 199-238` | `TestResultRow` deserialisatie 3x copy-paste met subtiele inconsistentie |
+| 3 | `storage/store.rs:520-595` vs `796-868` | `EpisodeGraph` loading (steps + tool_calls SQL) 2x identiek |
+| 4 | `lint/engine.rs:214` vs `packs/executor.rs:174` vs `packs/schema.rs:49` | `severity_priority()` 3x gedupliceerd |
+| 5 | `lint/mod.rs:11` vs `packs/schema.rs:30` | Twee incompatibele `Severity` enums (`Warn` vs `Warning`) — dwingt `convert_severity()` glue af |
+| 6 | `sim/attacks/{integrity,chaos,differential}.rs` | `create_test_bundle()` 3x in hetzelfde crate |
+
+### Unnecessary Code
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 7 | `lint/packs/checks.rs:456-483` | 27-regel `json_pointer_get()` herimplement `serde_json::Value::pointer()` |
+
+### Degradation
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 8 | `commands/monitor.rs:67-663` | 596-regel monolithische `run()` functie |
+| 9 | `providers/trace.rs:19-378` | 359-regel `from_path()` parsing functie (8-9 niveaus nesting) |
+| 10 | `engine/runner.rs:160-357` | 197-regel `run_test_with_policy()` (5 concerns, 5 niveaus nesting) |
+
+---
+
+## P2 — Fix Soon
+
+### Redundancy
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 11 | `storage/store.rs:752` vs `judge_cache.rs:61` | `now_rfc3339ish()` character-for-character identiek |
+| 12 | `llm/openai.rs:100-132` vs `embedder/openai.rs:58-90` | Identiek VCR/HTTP branching pattern |
+| 13 | `engine/runner.rs:107-132, 244-256` | Error-case `TestResultRow` constructie 3x gedupliceerd |
+| 14 | `lint/sarif.rs:400` + `lint/mod.rs:18` + `packs/schema.rs:40` | `as_sarif_level()` / `severity_to_sarif_level()` 3x |
+| 15 | `args_valid.rs:52` + `sequence_valid.rs:69` + `tool_blocklist.rs:24` | Tool call extractie boilerplate 3x identiek |
+| 16 | `packs/loader.rs:203` vs `packs/checks.rs:121` | Semver vergelijking 2x met verschillende precisie |
+| 17 | `registry/client.rs:396` vs `registry/verify.rs:169` | `compute_digest()` 2x bijna identiek |
+| 18 | `evidence/packs/schema.rs:436` vs `registry/reference.rs:221` | Pack name validatie divergeert tussen crates |
+| 19 | `args_valid.rs:30-36` vs `sequence_valid.rs:30-36` | Deprecated policy warning block identiek |
+| 20 | `commands/fix.rs` vs `doctor.rs` | Identieke `print_unified_diff()` + overlappende concern ownership |
+
+### AI Comments
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 21 | `sim/report.rs:16-38` | `// New:` prefix markers — AI-gegenereerd diff-referentie |
+| 22 | `providers/trace.rs:208-211` | `// DEBUG: remove me` commented-out debug block |
+
+### Unnecessary Code
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 23 | `storage/store.rs:258-262` | Dead match arm: `_ => TestStatus::Pass` waar SQL al op 'pass' filtert |
+| 24 | `storage/store.rs:297-320` | `insert_run()` vs `create_run()` bijna identiek, inconsistente timestamp formats |
+| 25 | `sim/corpus.rs` (29 regels) | Geheel placeholder/stub — elke methode is een no-op |
+| 26 | `registry/verify.rs:302-315` | `verify_dsse_signature()` deprecated, `#[allow(dead_code)]`, 0 callers |
+
+### Degradation
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 27 | `commands/generate.rs` (1167 regels) | Types, logic, CLI args, diffing, serialisatie in een bestand |
+| 28 | `commands/pipeline.rs` → `runner_builder.rs` | `PipelineInput` destructured terug naar 14 individuele args |
+| 29 | `storage/store.rs:299` vs `:308` | Inconsistente timestamp formats (`chrono::to_rfc3339` vs `"unix:N"`) in dezelfde kolom |
+| 30 | `storage/store.rs:21-749` + `795-868` | Twee `impl Store` blocks gescheiden door helpers |
+| 31 | `metrics/judge.rs:5` EPSILON=1e-9 vs `semantic.rs:6` EPSILON=1e-6 | 3 ordes van grootte verschil, zelfde doel |
+| 32 | `metrics/sequence_valid.rs:130-133` | `_ => {}` catch-all slokt onbekende rule variants op met TODO |
+
+---
+
+## P3 — Nice to Have
+
+### Redundancy
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 33 | `helpers.rs` / `util.rs` | `util.rs` is re-export shim voor `helpers.rs` |
+| 34 | `commands/init.rs:92-121 / 236-259` | CI scaffolding match 2x in hetzelfde bestand |
+| 35 | `lint/packs/checks.rs:442-449` | `convert_severity()` glue functie afgedwongen door dual-enum |
+| 36 | `commands/baseline.rs:52-75 / 126-148` | Identieke baseline entry extractie in hetzelfde bestand |
+
+### AI Comments
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 37 | `providers/trace.rs:48-53` | Stream-of-consciousness "Let's use serde_json::Value to sniff" |
+| 38 | `engine/runner.rs:389-392` | "Assuming self.incremental is available" — uncertain note over bestaand veld |
+| 39 | `report/summary.rs` (10+ locaties) | Doc comments die function names herhalen (`/// Set results summary`) |
+| 40 | `errors/mod.rs:237-248` | Genummerde stappen en design notes in code |
+| 41 | `errors/diagnostic.rs:73-74` | "we didn't yet" toekomstige-werk note |
+| 42 | `commands/config_path.rs` | 5x `=====` section dividers |
+| 43 | `commands/monitor.rs:731-747` | 12 regels stream-of-consciousness in test die alleen `assert!(2+2==4)` doet |
+| 44 | `commands/runner_builder.rs:193` | "Load baseline if provided" herhaalt code |
+| 45 | `lint/packs/checks.rs:12-28` | Doc comments als `/// Pack name.` op veld `pack_name` |
+
+### Unnecessary Code
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 46 | `commands/pipeline_error.rs:13-20` | Overflow check voor 584-miljoen-jaar duratie |
+| 47 | `commands/quarantine.rs:22-24` | Ongeimplementeerde stub die success returnt |
+| 48 | `commands/discover.rs:103` | Onnodige `.clone()` op servers |
+| 49 | `errors/mod.rs:164-166` | `classify_message` triviale wrapper voor `legacy_classify_message` |
+| 50 | `errors/diagnostic.rs:73-76` | `format_plain()` identieke pass-through naar `format_terminal()` |
+| 51 | `providers/trace.rs:5` + `:363` | Dubbele `use sha2::Digest` import |
+| 52 | `registry/verify.rs:197-202` | `compute_digest_raw()` deprecated since 2.11.0, dead |
+| 53 | `metrics/judge.rs:87` | `_rationale` wordt geextraheerd en dan weggegooid |
+
+### Degradation
+
+| # | Locatie | Probleem |
+|---|---------|----------|
+| 54 | `commands/run.rs:33-48` + `ci.rs` | Summary 2x gebouwd, eerste wordt weggegooid |
+| 55 | `errors/mod.rs` (6 factory methods) | `detail` gekloond in zowel `message` als `detail` veld |
+| 56 | `errors/mod.rs:269` | Typo "incompatbile" → "incompatible" (user-facing) |
+| 57 | `lint/sarif.rs:55-60` | Doc comment adverteert deprecated `workingDirectory` |
+| 58 | `engine/runner.rs:231-232` | Onnodige `.clone()` op values die direct moved kunnen worden |
+
+---
+
+## Prioritering
+
+### Quick wins (< 1 uur, hoog rendement)
+
+1. `json_pointer_get()` → `serde_json::Value::pointer()` (27 regels weg)
+2. `now_rfc3339ish()` naar gedeelde util (identiek in 2 bestanden)
+3. `// DEBUG: remove me` + `// New:` markers verwijderen
+4. Severity enums unificeren (`Warn` → `Warning` of andersom)
+5. Typo "incompatbile" fixen
+6. Dead code verwijderen: `corpus.rs`, `verify_dsse_signature`, `compute_digest_raw`
+
+### Al gepland (in PLAN-pipeline-decomposition.md)
+
+- #1 error handling, `elapsed_ms` dedup, reporting extractie
+
+### Architectureel (aparte sprint)
+
+- `monitor.rs` 596-regelfunctie opsplitsen
+- `trace.rs` 359-regelfunctie opsplitsen
+- `generate.rs` 1167 regels decomponeren
+- `store.rs` TestResultRow/EpisodeGraph dedup + timestamp consistentie
+- `runner.rs` `run_test_with_policy()` opsplitsen
+
+---
+
+## Relatie met Bestaande Plannen
+
+| Finding | Gedekt door |
+|---------|-------------|
+| #1 (error handling run/ci) | PLAN-pipeline-decomposition Step 1 |
+| #28 (PipelineInput→14 args) | PLAN-pipeline-decomposition (impliciet) |
+| #54 (summary 2x gebouwd) | PLAN-pipeline-decomposition Step 4 (optioneel) |
+| Overige | Nieuw werk |

--- a/docs/architecture/PLAN-pipeline-decomposition.md
+++ b/docs/architecture/PLAN-pipeline-decomposition.md
@@ -1,0 +1,277 @@
+# Plan: Pipeline Decomposition (Post mod.rs Refactor)
+
+> **Status**: Proposed
+> **Date**: 2026-02-08
+> **Predecessor**: mod.rs refactor (done — mod.rs now 46 lines, dispatch in own file)
+> **RFC**: RFC-001-dx-ux-governance.md, Wave B1/B2
+> **Constraint**: No behavior changes, no output-contract changes, `cargo test --workspace` green after each step.
+
+---
+
+## Problem
+
+The mod.rs extraction succeeded (1173 → 46 lines), but created a new concentration point. `pipeline.rs` (557 lines) now combines 5 distinct concerns that were previously mixed in mod.rs. Additionally, `run.rs` and `ci.rs` contain identical error-handling and report-timing patterns.
+
+## Verified Findings
+
+### F1 — `pipeline.rs` is a new god-module (557 lines, 5 concerns)
+
+| Lines | Concern | Target |
+|-------|---------|--------|
+| 11–91 | `PipelineInput` + `from_run`/`from_ci` | stays in pipeline.rs |
+| 93–96 | `PipelineError` enum | → `pipeline_error.rs` |
+| 123–310 | `execute_pipeline()` | stays in pipeline.rs |
+| 312–334 | `write_error_artifacts()` | → `reporting.rs` |
+| 336–364 | `build_summary_from_artifacts()` | → `reporting.rs` |
+| 366–429 | `build_performance_metrics()` | → `reporting.rs` |
+| 431–441 | `print_pipeline_summary()` | → `reporting.rs` |
+| 443–454 | `maybe_export_baseline()` | → `reporting.rs` |
+| 456–557 | Tests (performance metrics) | → `reporting.rs` |
+
+**After extraction:** `pipeline.rs` drops from 557 → ~250 lines (input mapping + execution only).
+
+### F2 — Identical error-handling block in run.rs and ci.rs
+
+Lines 17–31 in both files are identical 15-line `match` blocks:
+
+```rust
+// run.rs:17 and ci.rs:17 — identical
+let execution = match execution {
+    Ok(ok) => ok,
+    Err(PipelineError::Classified { run_error }) => {
+        let reason = reason_code_from_run_error(&run_error)
+            .unwrap_or(ReasonCode::ECfgParse);
+        return write_error_artifacts(reason, run_error.message, ...);
+    }
+    Err(PipelineError::Fatal(err)) => return Err(err),
+};
+```
+
+**Fix:** Method on `PipelineError` that encapsulates this mapping.
+
+### F3 — Duplicate `elapsed_ms()` definitions
+
+Two identical helper functions:
+- `pipeline.rs:114–121` (7 lines, with bounds check)
+- `profile.rs:488–490` (1-liner, inline `min()`)
+
+Plus two inline occurrences of the same pattern:
+- `run.rs:53`: `report_start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64`
+- `ci.rs:104`: identical
+
+**Fix:** One shared `elapsed_ms()` in a tiny util, used everywhere.
+
+### F4 — Repetitive `PipelineError::Classified` construction (10 instances)
+
+All 10 follow the same pattern in `execute_pipeline()`:
+```rust
+return Err(PipelineError::Classified {
+    run_error: RunError::config_parse(Some(path), msg),
+});
+```
+
+**Fix:** Small constructor methods on `PipelineError` (`cfg_err`, `missing_cfg`, `invalid_args`, `from_run_error`).
+
+### F5 — Report-timing + summary rebuild duplication
+
+Both `run.rs` and `ci.rs`:
+1. Create `report_start = Instant::now()`
+2. Write output formats (run.json, summary, etc.)
+3. Measure `report_ms = elapsed(report_start)`
+4. Rebuild summary with `build_summary_from_artifacts(..., Some(report_ms))`
+5. Write final summary
+
+The difference: ci.rs additionally writes JUnit, SARIF, OTel, PR comment. Both need the same summary finalization pattern.
+
+**Fix:** `finalize_and_write_summary()` helper in `reporting.rs` that takes the pre-built summary and writes with timing.
+
+---
+
+## Target Structure
+
+```
+commands/
+  mod.rs               (46 lines)  — unchanged
+  dispatch.rs          (54 lines)  — unchanged
+  pipeline.rs         (~250 lines) — PipelineInput + execute_pipeline only
+  pipeline_error.rs    (~50 lines) — PipelineError + constructor methods + error→reason mapping
+  reporting.rs        (~200 lines) — summary building, error artifacts, console output, perf metrics
+  reporting_tests.rs  (~100 lines) — performance metric tests (from pipeline.rs)
+  run.rs              (~40 lines)  — thin: input → pipeline → report
+  ci.rs              (~140 lines)  — thin: input → pipeline → CI outputs → report
+  run_output.rs       (445 lines)  — unchanged
+  runner_builder.rs   (262 lines)  — unchanged
+```
+
+Alternatively, `reporting_tests.rs` can stay as `#[cfg(test)] mod tests` inside `reporting.rs`.
+
+---
+
+## Steps
+
+### Step 1: Extract `pipeline_error.rs`
+
+Move from `pipeline.rs`:
+- `PipelineError` enum (lines 93–96)
+- `elapsed_ms()` helper (lines 114–121) — make `pub(crate)`
+
+Add constructor methods:
+```rust
+impl PipelineError {
+    pub(crate) fn cfg_parse(path: impl Into<String>, msg: impl Into<String>) -> Self {
+        Self::Classified {
+            run_error: RunError::config_parse(Some(path.into()), msg.into()),
+        }
+    }
+
+    pub(crate) fn missing_cfg(path: impl Into<String>, msg: impl Into<String>) -> Self {
+        Self::Classified {
+            run_error: RunError::missing_config(path.into(), msg.into()),
+        }
+    }
+
+    pub(crate) fn invalid_args(msg: impl Into<String>) -> Self {
+        Self::Classified {
+            run_error: RunError::invalid_args(msg.into()),
+        }
+    }
+
+    pub(crate) fn from_run_error(run_error: RunError) -> Self {
+        Self::Classified { run_error }
+    }
+
+    /// Map pipeline error to exit code + write error artifacts.
+    /// Shared between run.rs and ci.rs.
+    pub(crate) fn into_exit_code(
+        self,
+        version: ExitCodeVersion,
+        verify_enabled: bool,
+        run_json_path: &Path,
+    ) -> anyhow::Result<i32> {
+        match self {
+            Self::Classified { run_error } => {
+                let reason = reason_code_from_run_error(&run_error)
+                    .unwrap_or(ReasonCode::ECfgParse);
+                write_error_artifacts(reason, run_error.message, version, verify_enabled, run_json_path)
+            }
+            Self::Fatal(err) => Err(err),
+        }
+    }
+}
+```
+
+**Update `pipeline.rs`:** Replace 10 verbose `PipelineError::Classified { run_error: RunError::... }` constructions with one-liner constructors.
+
+**Update `run.rs` and `ci.rs`:** Replace 15-line match block with:
+```rust
+let execution = match execute_pipeline(&input, legacy_mode).await {
+    Ok(ok) => ok,
+    Err(e) => return e.into_exit_code(version, !args.no_verify, &run_json_path),
+};
+```
+
+**Verification:**
+- `cargo build -p assay-cli`
+- `cargo test -p assay-cli`
+- Identical behavior: error exit codes and run.json/summary.json content unchanged
+
+### Step 2: Extract `reporting.rs`
+
+Move from `pipeline.rs`:
+- `write_error_artifacts()` (lines 312–334)
+- `build_summary_from_artifacts()` (lines 336–364)
+- `build_performance_metrics()` (lines 366–429)
+- `print_pipeline_summary()` (lines 431–441)
+- `maybe_export_baseline()` (lines 443–454)
+- `#[cfg(test)] mod tests` (lines 456–557)
+
+All functions remain `pub(crate)`. Imports from `run_output` and `assay_core::report`.
+
+**Update `pipeline.rs`:** Remove moved functions, add `use super::reporting::*` where needed (only `write_error_artifacts` if referenced by `pipeline_error.rs`).
+
+**Update `run.rs` and `ci.rs`:** Change imports from `super::pipeline::` to `super::reporting::` for summary/printing/baseline functions.
+
+**Verification:**
+- `cargo build -p assay-cli`
+- `cargo test -p assay-cli` (especially performance metric tests)
+
+### Step 3: Deduplicate `elapsed_ms()`
+
+- Remove `elapsed_ms()` from `pipeline.rs` (moved to `pipeline_error.rs` in step 1)
+- Remove `elapsed_ms()` from `profile.rs:488–490`
+- Both import from `pipeline_error::elapsed_ms`
+- Replace inline occurrences in `run.rs:53` and `ci.rs:104` with `elapsed_ms(report_start)`
+
+**Verification:**
+- `cargo build -p assay-cli`
+- `cargo test -p assay-cli -p assay-evidence`
+
+### Step 4: Summary finalization helper (optional, only if Step 1–3 feel clean)
+
+If after steps 1–3 the report-timing pattern in `run.rs` and `ci.rs` still feels duplicated, extract:
+
+```rust
+// reporting.rs
+pub(crate) fn finalize_summary(
+    base_summary: Summary,
+    report_start: Instant,
+    summary_path: &Path,
+) -> anyhow::Result<()> {
+    let report_ms = elapsed_ms(report_start);
+    let summary = base_summary.with_report_ms(report_ms);
+    write_summary(&summary, summary_path)
+}
+```
+
+**Decision gate:** Only do this if run.rs and ci.rs still have >5 lines of identical summary-writing code after steps 1–3. If the duplication is small (3–4 lines), leave it — premature abstraction.
+
+---
+
+## What This Does NOT Change
+
+- `run_output.rs` (445 lines) — separate concern (outcome decision + run.json formatting), no overlap with pipeline
+- `runner_builder.rs` (262 lines) — separate concern (Runner construction), no overlap
+- Any output contract (`run.json`, `summary.json`, SARIF, JUnit)
+- Any exit code behavior
+- Any test behavior
+
+---
+
+## Verification Checklist
+
+- [ ] `cargo build -p assay-cli` compiles after each step
+- [ ] `cargo test -p assay-cli` passes after each step (especially `performance_metrics_*` tests)
+- [ ] `cargo clippy -p assay-cli -- -D warnings` clean after each step
+- [ ] `pipeline.rs` < 260 lines after step 2
+- [ ] `run.rs` < 50 lines, `ci.rs` < 150 lines after step 1
+- [ ] No `elapsed_ms` duplication after step 3
+- [ ] Zero `PipelineError::Classified { run_error: RunError::` verbose constructions after step 1
+- [ ] `run.rs` and `ci.rs` error handling blocks < 5 lines each after step 1
+- [ ] `cargo test --workspace` green
+
+---
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Import churn breaks replay.rs | replay.rs uses `super::run_output::` not `super::pipeline::` — not affected |
+| Tests break during move | Move tests with their functions, run after each step |
+| Circular imports between pipeline_error.rs and reporting.rs | `pipeline_error.rs` only depends on `assay_core::errors::RunError` + `exit_codes`, not on reporting |
+| Over-extraction | Step 4 has explicit decision gate — skip if duplication is small |
+
+---
+
+## Line Count Budget
+
+| File | Before | After | Delta |
+|------|--------|-------|-------|
+| pipeline.rs | 557 | ~250 | -307 |
+| pipeline_error.rs | — | ~50 | +50 |
+| reporting.rs | — | ~300 | +300 |
+| run.rs | 64 | ~40 | -24 |
+| ci.rs | 207 | ~140 | -67 |
+| profile.rs | 654 | 651 | -3 |
+| **Net** | **1482** | **~1431** | **-51** |
+
+Net line reduction is small — this is about separation of concerns, not line golf.


### PR DESCRIPTION
Why
Post-merge hardening follow-up for Wave C4 run-id tracking.
The previous C4 slice landed correctly, but there were a few valid quality/perf issues in dedupe bookkeeping and telemetry behavior.

What changed
- Switched run-id buffers to `VecDeque` to avoid `remove(0)` shifting costs on eviction.
- Removed redundant double digest work in `add_run_id` by computing digest once and checking/inserting against that value.
- Changed `add_run_id` to return an eviction signal and now emit the digest-window warning only when an eviction actually occurs (no repeated full-window spam).
- Improved `run_id_memory_bytes_estimate` to include queue slot/capacity overhead, not just string length sums.
- Updated evidence export run-id lookup for deque-backed storage (`back()` instead of `last()`).

Scope
- crates/assay-cli/src/cli/commands/profile_types.rs
- crates/assay-cli/src/cli/commands/profile.rs
- crates/assay-cli/src/cli/commands/evidence/mod.rs
- crates/assay-cli/src/cli/commands/evidence/mapping.rs

Validation
- cargo fmt --all
- cargo check -p assay-cli
- cargo test -p assay-cli profile -- --nocapture
- cargo clippy -p assay-cli -- -D warnings

Contract notes
- No run.json / summary.json / SARIF / JUnit schema changes.
- Behavior remains additive/safe; this is a correctness/perf hardening follow-up.
