### PR TITLE
refactor(evidence): unify severity model and remove lint duplication

### DIFF
--- a/crates/assay-evidence/src/lint/engine.rs
+++ b/crates/assay-evidence/src/lint/engine.rs
@@ -199,8 +199,8 @@ fn truncate_findings(
 
     // Sort by severity priority (highest first to keep)
     findings.sort_by(|a, b| {
-        let a_priority = severity_priority(&a.severity);
-        let b_priority = severity_priority(&b.severity);
+        let a_priority = a.severity.priority();
+        let b_priority = b.severity.priority();
         b_priority.cmp(&a_priority)
     });
 
@@ -209,15 +209,6 @@ fn truncate_findings(
     findings.truncate(max_results);
 
     (findings, true, truncated_count)
-}
-
-/// Get severity priority for sorting.
-fn severity_priority(severity: &Severity) -> u8 {
-    match severity {
-        Severity::Info => 0,
-        Severity::Warn => 1,
-        Severity::Error => 2,
-    }
 }
 
 #[cfg(test)]

--- a/crates/assay-evidence/src/lint/mod.rs
+++ b/crates/assay-evidence/src/lint/mod.rs
@@ -4,17 +4,28 @@ pub mod rules;
 pub mod sarif;
 
 use crate::bundle::writer::Manifest;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Severity {
+    #[serde(rename = "error", alias = "Error")]
     Error,
+    #[serde(rename = "warn", alias = "Warn", alias = "warning", alias = "Warning")]
     Warn,
+    #[serde(rename = "info", alias = "Info")]
     Info,
 }
 
 impl Severity {
+    pub fn priority(&self) -> u8 {
+        match self {
+            Severity::Info => 0,
+            Severity::Warn => 1,
+            Severity::Error => 2,
+        }
+    }
+
     pub fn as_sarif_level(&self) -> &str {
         match self {
             Severity::Error => "error",

--- a/crates/assay-evidence/src/lint/mod.rs
+++ b/crates/assay-evidence/src/lint/mod.rs
@@ -9,11 +9,11 @@ use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Severity {
-    #[serde(rename = "error", alias = "Error")]
+    #[serde(alias = "error", alias = "Error")]
     Error,
-    #[serde(rename = "warn", alias = "Warn", alias = "warning", alias = "Warning")]
+    #[serde(alias = "warn", alias = "Warn", alias = "warning", alias = "Warning")]
     Warn,
-    #[serde(rename = "info", alias = "Info")]
+    #[serde(alias = "info", alias = "Info")]
     Info,
 }
 

--- a/crates/assay-evidence/src/lint/packs/checks.rs
+++ b/crates/assay-evidence/src/lint/packs/checks.rs
@@ -146,7 +146,7 @@ fn check_json_path_exists(
         };
 
         for path in paths {
-            if json_pointer_get(&json, path).is_some() {
+            if value_pointer(&json, path).is_some() {
                 return CheckResult {
                     passed: true,
                     finding: None,
@@ -263,7 +263,7 @@ fn check_event_field_present(
         };
 
         for path in paths {
-            if json_pointer_get(&json, path).is_some() {
+            if value_pointer(&json, path).is_some() {
                 return CheckResult {
                     passed: true,
                     finding: None,
@@ -343,7 +343,7 @@ fn check_manifest_field(
         }
     };
 
-    let has_field = json_pointer_get(&manifest_json, path).is_some();
+    let has_field = value_pointer(&manifest_json, path).is_some();
 
     if has_field {
         CheckResult {
@@ -355,7 +355,7 @@ fn check_manifest_field(
         let severity = if required {
             rule.severity
         } else {
-            Severity::Warning
+            Severity::Warn
         };
 
         CheckResult {
@@ -421,7 +421,7 @@ fn create_finding_with_severity(
 
     LintFinding {
         rule_id: canonical_id,
-        severity: convert_severity(severity),
+        severity,
         message,
         location,
         fingerprint,
@@ -439,33 +439,23 @@ fn create_finding_with_severity(
     )
 }
 
-/// Convert pack severity to lint severity.
-fn convert_severity(severity: Severity) -> crate::lint::Severity {
-    match severity {
-        Severity::Error => crate::lint::Severity::Error,
-        Severity::Warning => crate::lint::Severity::Warn,
-        Severity::Info => crate::lint::Severity::Info,
-    }
-}
-
 /// Compile a glob pattern.
 fn compile_glob(pattern: &str) -> Option<GlobMatcher> {
     Glob::new(pattern).ok().map(|g| g.compile_matcher())
 }
 
-/// Get a value using serde_json's RFC 6901 JSON Pointer implementation.
-fn json_pointer_get<'a>(
-    value: &'a serde_json::Value,
-    pointer: &str,
-) -> Option<&'a serde_json::Value> {
+fn value_pointer<'a>(value: &'a serde_json::Value, pointer: &str) -> Option<&'a serde_json::Value> {
     if pointer.is_empty() || pointer == "/" {
         return Some(value);
     }
-    if pointer.starts_with('/') {
-        return value.pointer(pointer);
-    }
-    let normalized = format!("/{}", pointer);
-    value.pointer(&normalized)
+    let normalized;
+    let pointer = if pointer.starts_with('/') {
+        pointer
+    } else {
+        normalized = format!("/{}", pointer);
+        normalized.as_str()
+    };
+    value.pointer(pointer)
 }
 
 // Extension trait to add pack metadata to LintFinding
@@ -507,7 +497,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_json_pointer_get() {
+    fn test_value_pointer() {
         let json: serde_json::Value = serde_json::json!({
             "run_id": "abc123",
             "data": {
@@ -518,11 +508,11 @@ mod tests {
             }
         });
 
-        assert!(json_pointer_get(&json, "/run_id").is_some());
-        assert!(json_pointer_get(&json, "/data/traceparent").is_some());
-        assert!(json_pointer_get(&json, "/data/nested/deep").is_some());
-        assert!(json_pointer_get(&json, "/missing").is_none());
-        assert!(json_pointer_get(&json, "/data/missing").is_none());
+        assert!(value_pointer(&json, "/run_id").is_some());
+        assert!(value_pointer(&json, "/data/traceparent").is_some());
+        assert!(value_pointer(&json, "/data/nested/deep").is_some());
+        assert!(value_pointer(&json, "/missing").is_none());
+        assert!(value_pointer(&json, "/data/missing").is_none());
     }
 
     #[test]

--- a/crates/assay-evidence/src/lint/packs/checks.rs
+++ b/crates/assay-evidence/src/lint/packs/checks.rs
@@ -509,6 +509,7 @@ mod tests {
         });
 
         assert!(value_pointer(&json, "/run_id").is_some());
+        assert!(value_pointer(&json, "run_id").is_some());
         assert!(value_pointer(&json, "/data/traceparent").is_some());
         assert!(value_pointer(&json, "/data/nested/deep").is_some());
         assert!(value_pointer(&json, "/missing").is_none());

--- a/crates/assay-evidence/src/lint/packs/executor.rs
+++ b/crates/assay-evidence/src/lint/packs/executor.rs
@@ -151,8 +151,8 @@ impl PackExecutor {
 
         // Sort by severity (lowest first for truncation)
         findings.sort_by(|a, b| {
-            let a_priority = severity_priority(&a.severity);
-            let b_priority = severity_priority(&b.severity);
+            let a_priority = a.severity.priority();
+            let b_priority = b.severity.priority();
             a_priority.cmp(&b_priority)
         });
 
@@ -162,21 +162,12 @@ impl PackExecutor {
 
         // Re-sort for display (highest severity first)
         findings.sort_by(|a, b| {
-            let a_priority = severity_priority(&a.severity);
-            let b_priority = severity_priority(&b.severity);
+            let a_priority = a.severity.priority();
+            let b_priority = b.severity.priority();
             b_priority.cmp(&a_priority)
         });
 
         (findings, true, truncated_count)
-    }
-}
-
-/// Get severity priority for sorting.
-fn severity_priority(severity: &crate::lint::Severity) -> u8 {
-    match severity {
-        crate::lint::Severity::Info => 0,
-        crate::lint::Severity::Warn => 1,
-        crate::lint::Severity::Error => 2,
     }
 }
 

--- a/crates/assay-evidence/src/lint/packs/executor.rs
+++ b/crates/assay-evidence/src/lint/packs/executor.rs
@@ -149,14 +149,14 @@ impl PackExecutor {
             return (findings, false, 0);
         }
 
-        // Sort by severity (lowest first for truncation)
+        // Sort by severity (highest first), then truncate so lowest severities are dropped first.
         findings.sort_by(|a, b| {
             let a_priority = a.severity.priority();
             let b_priority = b.severity.priority();
-            a_priority.cmp(&b_priority)
+            b_priority.cmp(&a_priority)
         });
 
-        // Truncate lowest severity first
+        // Keep highest-severity results first.
         let truncated_count = findings.len() - max_results;
         findings.truncate(max_results);
 

--- a/crates/assay-evidence/src/lint/packs/schema.rs
+++ b/crates/assay-evidence/src/lint/packs/schema.rs
@@ -50,7 +50,7 @@ where
         "warning" | "Warning" | "warn" | "Warn" => Ok(Severity::Warn),
         "info" | "Info" => Ok(Severity::Info),
         _ => Err(D::Error::custom(format!(
-            "invalid severity '{}'; expected error|warning|info",
+            "invalid severity '{}'; expected error|warning|warn|info",
             raw
         ))),
     }

--- a/crates/assay-evidence/src/lint/sarif.rs
+++ b/crates/assay-evidence/src/lint/sarif.rs
@@ -71,7 +71,7 @@ pub fn to_sarif_with_options(report: &LintReport, options: SarifOptions) -> serd
                     "text": r.description
                 },
                 "defaultConfiguration": {
-                    "level": severity_to_sarif_level(&r.default_severity)
+                    "level": r.default_severity.as_sarif_level()
                 }
             });
 
@@ -395,12 +395,4 @@ fn extract_tag(findings: &[super::LintFinding], rule_id: &str, prefix: &str) -> 
                 .and_then(|t| t.strip_prefix(prefix))
                 .map(|s| s.to_string())
         })
-}
-
-fn severity_to_sarif_level(severity: &super::Severity) -> &'static str {
-    match severity {
-        super::Severity::Error => "error",
-        super::Severity::Warn => "warning",
-        super::Severity::Info => "note",
-    }
 }


### PR DESCRIPTION
Why
Follow-up on the code-health pass to remove duplicated severity logic in assay-evidence and reduce pack-vs-lint severity drift risk.

What changed
- Unified pack schema severity onto the shared lint Severity type.
- Preserved pack YAML compatibility via pack-specific serde mapping (warning/warn accepted).
- Removed duplicated severity conversion glue in pack checks.
- Removed duplicated severity-priority helpers in lint engine and pack executor (use Severity::priority()).
- Removed duplicated SARIF severity mapper in lint SARIF generator (use Severity::as_sarif_level()).
- Simplified JSON pointer access helper to delegate to serde_json Value::pointer.

Validation
- cargo check -p assay-evidence
- cargo test -p assay-evidence lint::packs -- --nocapture
- cargo test -p assay-evidence --test lint_test -- --nocapture
- cargo check -p assay-cli

Contract notes
- No run.json/summary.json/SARIF schema changes.
- No CLI flag or behavior changes.
