### PR TITLE
refactor(sim): deduplicate attack test-bundle generation

### DIFF
--- a/crates/assay-sim/src/attacks/chaos.rs
+++ b/crates/assay-sim/src/attacks/chaos.rs
@@ -1,7 +1,7 @@
+use super::test_bundle::create_single_event_bundle;
 use crate::report::{AttackResult, AttackStatus};
 use anyhow::Result;
-use assay_evidence::{verify_bundle, BundleWriter, VerifyError};
-use chrono::{TimeZone, Utc};
+use assay_evidence::{verify_bundle, VerifyError};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use std::io::{self, Cursor, ErrorKind, Read};
@@ -88,7 +88,7 @@ pub fn malformed_gzip_stream() -> Vec<u8> {
 /// and verifies the outcome is either `Blocked` or `Error` (never `Bypassed`, never panic).
 pub fn check_chaos_attacks(seed: u64) -> Result<Vec<AttackResult>> {
     let mut results = Vec::new();
-    let valid_bundle = create_test_bundle()?;
+    let valid_bundle = create_single_event_bundle()?;
     let iterations = 20;
 
     // 1. IO chaos reader iterations
@@ -176,20 +176,4 @@ pub fn check_chaos_attacks(seed: u64) -> Result<Vec<AttackResult>> {
     }
 
     Ok(results)
-}
-
-fn create_test_bundle() -> Result<Vec<u8>> {
-    let mut buffer = Vec::new();
-    let mut writer = BundleWriter::new(&mut buffer);
-    let mut event = assay_evidence::types::EvidenceEvent::new(
-        "assay.test",
-        "urn:test",
-        "run",
-        0,
-        serde_json::json!({}),
-    );
-    event.time = Utc.timestamp_opt(1700000000, 0).unwrap();
-    writer.add_event(event);
-    writer.finish()?;
-    Ok(buffer)
 }

--- a/crates/assay-sim/src/attacks/integrity.rs
+++ b/crates/assay-sim/src/attacks/integrity.rs
@@ -1,16 +1,17 @@
+use super::test_bundle::create_single_event_bundle;
 use crate::mutators::inject::InjectFile;
 use crate::mutators::Mutator;
 use crate::report::SimReport;
 use anyhow::Result;
 use assay_evidence::types::EvidenceEvent;
-use assay_evidence::{verify_bundle, BundleWriter, VerifyError};
+use assay_evidence::{verify_bundle, VerifyError};
 use chrono::{TimeZone, Utc};
 use rand::Rng;
 use rand::SeedableRng;
 use std::io::Cursor;
 
 pub fn check_integrity_attacks(report: &mut SimReport, seed: u64) -> Result<()> {
-    let valid_bundle = create_test_bundle()?;
+    let valid_bundle = create_single_event_bundle()?;
 
     // 1. BitFlip (Harder)
     run_attack(report, "integrity.bitflip", || {
@@ -127,14 +128,6 @@ pub fn check_integrity_attacks(report: &mut SimReport, seed: u64) -> Result<()> 
     })?;
 
     Ok(())
-}
-
-fn create_test_bundle() -> Result<Vec<u8>> {
-    let mut buffer = Vec::new();
-    let mut writer = BundleWriter::new(&mut buffer);
-    writer.add_event(create_event(0));
-    writer.finish()?;
-    Ok(buffer)
 }
 
 fn create_event(seq: u64) -> EvidenceEvent {

--- a/crates/assay-sim/src/attacks/mod.rs
+++ b/crates/assay-sim/src/attacks/mod.rs
@@ -1,3 +1,4 @@
 pub mod chaos;
 pub mod differential;
 pub mod integrity;
+mod test_bundle;

--- a/crates/assay-sim/src/attacks/test_bundle.rs
+++ b/crates/assay-sim/src/attacks/test_bundle.rs
@@ -1,0 +1,80 @@
+use anyhow::Result;
+use assay_evidence::types::EvidenceEvent;
+use assay_evidence::BundleWriter;
+use chrono::{TimeZone, Utc};
+
+pub(crate) fn create_single_event_bundle() -> Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    let mut event = EvidenceEvent::new("assay.test", "urn:test", "run", 0, serde_json::json!({}));
+    event.time = Utc.timestamp_opt(1700000000, 0).unwrap();
+    writer.add_event(event);
+    writer.finish()?;
+    Ok(buffer)
+}
+
+pub(crate) fn create_differential_bundle() -> Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    for seq in 0..3u64 {
+        let mut event = EvidenceEvent::new(
+            "assay.test",
+            "urn:test",
+            "diffrun",
+            seq,
+            serde_json::json!({"seq": seq}),
+        );
+        event.time = Utc.timestamp_opt(1700000000 + seq as i64, 0).unwrap();
+        writer.add_event(event);
+    }
+    writer.finish()?;
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn legacy_single_event_bundle() -> Result<Vec<u8>> {
+        let mut buffer = Vec::new();
+        let mut writer = BundleWriter::new(&mut buffer);
+        let mut event =
+            EvidenceEvent::new("assay.test", "urn:test", "run", 0, serde_json::json!({}));
+        event.time = Utc.timestamp_opt(1700000000, 0).unwrap();
+        writer.add_event(event);
+        writer.finish()?;
+        Ok(buffer)
+    }
+
+    fn legacy_differential_bundle() -> Result<Vec<u8>> {
+        let mut buffer = Vec::new();
+        let mut writer = BundleWriter::new(&mut buffer);
+        for seq in 0..3u64 {
+            let mut event = EvidenceEvent::new(
+                "assay.test",
+                "urn:test",
+                "diffrun",
+                seq,
+                serde_json::json!({"seq": seq}),
+            );
+            event.time = Utc.timestamp_opt(1700000000 + seq as i64, 0).unwrap();
+            writer.add_event(event);
+        }
+        writer.finish()?;
+        Ok(buffer)
+    }
+
+    #[test]
+    fn single_event_bundle_matches_legacy_bytes() {
+        let legacy = legacy_single_event_bundle().unwrap();
+        let shared = create_single_event_bundle().unwrap();
+        assert_eq!(shared, legacy);
+    }
+
+    #[test]
+    fn differential_bundle_matches_legacy_bytes() {
+        let legacy = legacy_differential_bundle().unwrap();
+        let shared = create_differential_bundle().unwrap();
+        assert_eq!(shared, legacy);
+    }
+}


### PR DESCRIPTION
Why
P1 code-health slice: remove duplicated create_test_bundle() implementations in sim attacks without changing behavior.

What changed
- Added shared private helper module: crates/assay-sim/src/attacks/test_bundle.rs
- Introduced two deterministic helper functions:
  - create_single_event_bundle()
  - create_differential_bundle()
- Replaced local create_test_bundle() implementations in:
  - crates/assay-sim/src/attacks/integrity.rs
  - crates/assay-sim/src/attacks/chaos.rs
  - crates/assay-sim/src/attacks/differential.rs
- Added byte-for-byte compatibility tests in the helper module against legacy builders.

Behavior lock / non-goals
- No CLI/output/schema changes.
- No mutation/verification logic changes.
- Only fixture construction deduplicated.

Validation
- cargo fmt --all
- cargo check -p assay-sim
- cargo test -p assay-sim -- --nocapture
