### PR TITLE
refactor(metrics-e2a): unify tool-call extraction across metrics

### DIFF
--- a/crates/assay-metrics/src/args_valid.rs
+++ b/crates/assay-metrics/src/args_valid.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::tool_calls::extract_tool_calls_best_effort;
+
 pub struct ArgsValidMetric;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -25,67 +27,6 @@ struct StructuredPolicy {
 enum PolicySource {
     SchemaMap(HashMap<String, serde_json::Value>),
     Structured(StructuredPolicy),
-}
-
-fn parse_tool_call_entry(v: &serde_json::Value, idx: usize) -> Option<ToolCallRecord> {
-    if let Ok(call) = serde_json::from_value::<ToolCallRecord>(v.clone()) {
-        return Some(call);
-    }
-    let obj = v.as_object()?;
-    let tool_name = obj
-        .get("tool_name")
-        .or(obj.get("tool"))
-        .and_then(|x| x.as_str())
-        .map(ToString::to_string)?;
-
-    let args = obj
-        .get("args")
-        .cloned()
-        .unwrap_or_else(|| serde_json::json!({}));
-    let id = obj
-        .get("id")
-        .and_then(|x| x.as_str())
-        .map(ToString::to_string)
-        .unwrap_or_else(|| format!("legacy-{}", idx));
-    let index = obj
-        .get("index")
-        .and_then(|x| x.as_u64())
-        .map(|x| x as usize)
-        .unwrap_or(idx);
-    let ts_ms = obj
-        .get("ts_ms")
-        .or(obj.get("timestamp"))
-        .and_then(|x| x.as_u64())
-        .unwrap_or(0);
-    let result = obj.get("result").cloned();
-    let error = obj.get("error").cloned();
-
-    Some(ToolCallRecord {
-        id,
-        tool_name,
-        args,
-        result,
-        error,
-        index,
-        ts_ms,
-    })
-}
-
-fn extract_tool_calls(resp: &LlmResponse) -> Vec<ToolCallRecord> {
-    let Some(val) = resp.meta.get("tool_calls") else {
-        return Vec::new();
-    };
-    if let Ok(calls) = serde_json::from_value::<Vec<ToolCallRecord>>(val.clone()) {
-        return calls;
-    }
-    val.as_array()
-        .map(|arr| {
-            arr.iter()
-                .enumerate()
-                .filter_map(|(idx, entry)| parse_tool_call_entry(entry, idx))
-                .collect()
-        })
-        .unwrap_or_default()
 }
 
 fn matches_tool_pattern(tool_name: &str, pattern: &str) -> bool {
@@ -249,7 +190,7 @@ impl Metric for ArgsValidMetric {
         };
 
         // No calls -> valid args (vacuously true)
-        let tool_calls: Vec<ToolCallRecord> = extract_tool_calls(resp);
+        let tool_calls: Vec<ToolCallRecord> = extract_tool_calls_best_effort(resp);
 
         let mut errors: Vec<serde_json::Value> = Vec::new();
 
@@ -591,7 +532,7 @@ schemas:
             ..Default::default()
         };
 
-        let calls = extract_tool_calls(&resp);
+        let calls = extract_tool_calls_best_effort(&resp);
         assert_eq!(calls.len(), 2, "non-parseable entries must be skipped");
 
         assert_eq!(calls[0].tool_name, "alpha");
@@ -617,12 +558,12 @@ schemas:
             meta: serde_json::json!({}),
             ..Default::default()
         };
-        assert!(extract_tool_calls(&missing).is_empty());
+        assert!(extract_tool_calls_best_effort(&missing).is_empty());
 
         let non_array = LlmResponse {
             meta: serde_json::json!({"tool_calls": {"tool_name": "x"}}),
             ..Default::default()
         };
-        assert!(extract_tool_calls(&non_array).is_empty());
+        assert!(extract_tool_calls_best_effort(&non_array).is_empty());
     }
 }

--- a/crates/assay-metrics/src/lib.rs
+++ b/crates/assay-metrics/src/lib.rs
@@ -8,6 +8,7 @@ mod must_contain;
 mod must_not_contain;
 mod regex_match;
 mod semantic;
+mod tool_calls;
 
 pub mod args_valid;
 pub mod sequence_valid;

--- a/crates/assay-metrics/src/lib.rs
+++ b/crates/assay-metrics/src/lib.rs
@@ -6,6 +6,7 @@ mod json_schema;
 mod judge;
 mod must_contain;
 mod must_not_contain;
+mod policy_warning;
 mod regex_match;
 mod semantic;
 mod tool_calls;

--- a/crates/assay-metrics/src/policy_warning.rs
+++ b/crates/assay-metrics/src/policy_warning.rs
@@ -1,0 +1,86 @@
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+type WarningKey = (String, String);
+
+fn warning_cache() -> &'static Mutex<HashSet<WarningKey>> {
+    static CACHE: OnceLock<Mutex<HashSet<WarningKey>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn should_emit_deprecated_policy_warning_impl(
+    metric_name: &str,
+    policy_path: &str,
+    suppressed: bool,
+) -> bool {
+    if suppressed {
+        return false;
+    }
+
+    let key = (metric_name.to_string(), policy_path.to_string());
+    let mut cache = warning_cache()
+        .lock()
+        .expect("policy warning cache mutex must not be poisoned");
+    cache.insert(key)
+}
+
+pub(crate) fn should_emit_deprecated_policy_warning(metric_name: &str, policy_path: &str) -> bool {
+    let suppressed = std::env::var("MCP_CONFIG_LEGACY").is_ok();
+    should_emit_deprecated_policy_warning_impl(metric_name, policy_path, suppressed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn unique_key(label: &str) -> (String, String) {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let id = NEXT.fetch_add(1, Ordering::Relaxed);
+        (
+            format!("{}_metric_{}", label, id),
+            format!("/tmp/{}_policy_{}.yaml", label, id),
+        )
+    }
+
+    #[test]
+    fn emits_once_per_metric_and_path() {
+        let (metric, path) = unique_key("once");
+
+        assert!(should_emit_deprecated_policy_warning_impl(
+            &metric, &path, false
+        ));
+        assert!(!should_emit_deprecated_policy_warning_impl(
+            &metric, &path, false
+        ));
+    }
+
+    #[test]
+    fn emits_for_different_metrics_and_paths() {
+        let (metric_a, path_a) = unique_key("metric_a");
+        let (metric_b, path_b) = unique_key("metric_b");
+        let (_, path_c) = unique_key("metric_a_second_path");
+
+        assert!(should_emit_deprecated_policy_warning_impl(
+            &metric_a, &path_a, false
+        ));
+        assert!(should_emit_deprecated_policy_warning_impl(
+            &metric_b, &path_b, false
+        ));
+        assert!(should_emit_deprecated_policy_warning_impl(
+            &metric_a, &path_c, false
+        ));
+    }
+
+    #[test]
+    fn suppressed_mode_does_not_consume_key() {
+        let (metric, path) = unique_key("suppressed");
+
+        assert!(!should_emit_deprecated_policy_warning_impl(
+            &metric, &path, true
+        ));
+        assert!(should_emit_deprecated_policy_warning_impl(
+            &metric, &path, false
+        ));
+    }
+}

--- a/crates/assay-metrics/src/sequence_valid.rs
+++ b/crates/assay-metrics/src/sequence_valid.rs
@@ -2,6 +2,8 @@ use assay_core::metrics_api::{Metric, MetricResult};
 use assay_core::model::{Expected, LlmResponse, TestCase, ToolCallRecord};
 use async_trait::async_trait;
 
+use crate::tool_calls::extract_tool_calls_canonical_or_empty;
+
 pub struct SequenceValidMetric;
 
 #[async_trait]
@@ -66,11 +68,7 @@ impl Metric for SequenceValidMetric {
         }
 
         // Parse Tool Calls
-        let tool_calls: Vec<ToolCallRecord> = if let Some(val) = resp.meta.get("tool_calls") {
-            serde_json::from_value(val.clone()).unwrap_or_default()
-        } else {
-            Vec::new()
-        };
+        let tool_calls: Vec<ToolCallRecord> = extract_tool_calls_canonical_or_empty(resp);
 
         // Sort by index
         let mut actual_sequence = tool_calls.clone();

--- a/crates/assay-metrics/src/tool_blocklist.rs
+++ b/crates/assay-metrics/src/tool_blocklist.rs
@@ -2,6 +2,8 @@ use assay_core::metrics_api::{Metric, MetricResult};
 use assay_core::model::{Expected, LlmResponse, TestCase, ToolCallRecord};
 use async_trait::async_trait;
 
+use crate::tool_calls::extract_tool_calls_canonical_or_empty;
+
 pub struct ToolBlocklistMetric;
 
 #[async_trait]
@@ -21,11 +23,7 @@ impl Metric for ToolBlocklistMetric {
             _ => return Ok(MetricResult::pass(1.0)), // N/A
         };
 
-        let tool_calls: Vec<ToolCallRecord> = if let Some(val) = resp.meta.get("tool_calls") {
-            serde_json::from_value(val.clone()).unwrap_or_default()
-        } else {
-            Vec::new()
-        };
+        let tool_calls: Vec<ToolCallRecord> = extract_tool_calls_canonical_or_empty(resp);
 
         for call in tool_calls {
             if blocked.contains(&call.tool_name) {

--- a/crates/assay-metrics/src/tool_calls.rs
+++ b/crates/assay-metrics/src/tool_calls.rs
@@ -1,0 +1,136 @@
+use assay_core::model::{LlmResponse, ToolCallRecord};
+
+fn parse_best_effort_entry(v: &serde_json::Value, idx: usize) -> Option<ToolCallRecord> {
+    if let Ok(call) = serde_json::from_value::<ToolCallRecord>(v.clone()) {
+        return Some(call);
+    }
+    let obj = v.as_object()?;
+    let tool_name = obj
+        .get("tool_name")
+        .or(obj.get("tool"))
+        .and_then(|x| x.as_str())
+        .map(ToString::to_string)?;
+
+    let args = obj
+        .get("args")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+    let id = obj
+        .get("id")
+        .and_then(|x| x.as_str())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| format!("legacy-{}", idx));
+    let index = obj
+        .get("index")
+        .and_then(|x| x.as_u64())
+        .map(|x| x as usize)
+        .unwrap_or(idx);
+    let ts_ms = obj
+        .get("ts_ms")
+        .or(obj.get("timestamp"))
+        .and_then(|x| x.as_u64())
+        .unwrap_or(0);
+    let result = obj.get("result").cloned();
+    let error = obj.get("error").cloned();
+
+    Some(ToolCallRecord {
+        id,
+        tool_name,
+        args,
+        result,
+        error,
+        index,
+        ts_ms,
+    })
+}
+
+/// Canonical-only extraction: deserialize exact ToolCallRecord list or return empty.
+pub(crate) fn extract_tool_calls_canonical_or_empty(resp: &LlmResponse) -> Vec<ToolCallRecord> {
+    let Some(val) = resp.meta.get("tool_calls") else {
+        return Vec::new();
+    };
+    serde_json::from_value(val.clone()).unwrap_or_default()
+}
+
+/// Best-effort extraction: canonical parse first, then lenient legacy entry mapping.
+pub(crate) fn extract_tool_calls_best_effort(resp: &LlmResponse) -> Vec<ToolCallRecord> {
+    let Some(val) = resp.meta.get("tool_calls") else {
+        return Vec::new();
+    };
+    if let Ok(calls) = serde_json::from_value::<Vec<ToolCallRecord>>(val.clone()) {
+        return calls;
+    }
+    val.as_array()
+        .map(|arr| {
+            arr.iter()
+                .enumerate()
+                .filter_map(|(idx, entry)| parse_best_effort_entry(entry, idx))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_or_empty_parses_only_canonical_records() {
+        let canonical = LlmResponse {
+            meta: serde_json::json!({
+                "tool_calls": [{
+                    "id": "c1",
+                    "tool_name": "exec",
+                    "args": {"command": "ls"},
+                    "result": {"ok": true},
+                    "error": null,
+                    "index": 0,
+                    "ts_ms": 10
+                }]
+            }),
+            ..Default::default()
+        };
+        let calls = extract_tool_calls_canonical_or_empty(&canonical);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].tool_name, "exec");
+
+        let malformed = LlmResponse {
+            meta: serde_json::json!({"tool_calls": {"tool_name": "exec"}}),
+            ..Default::default()
+        };
+        assert!(extract_tool_calls_canonical_or_empty(&malformed).is_empty());
+    }
+
+    #[test]
+    fn best_effort_accepts_legacy_and_skips_unparsable_entries() {
+        let resp = LlmResponse {
+            meta: serde_json::json!({
+                "tool_calls": [
+                    {"tool": "a", "args": {"x": 1}},
+                    {"args": {"missing": true}},
+                    {"tool_name": "b", "args": ["x"], "error": {"code": "E_FAIL"}}
+                ]
+            }),
+            ..Default::default()
+        };
+
+        let calls = extract_tool_calls_best_effort(&resp);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].tool_name, "a");
+        assert_eq!(calls[0].id, "legacy-0");
+        assert_eq!(calls[0].index, 0);
+        assert_eq!(calls[1].tool_name, "b");
+        assert_eq!(calls[1].args, serde_json::json!(["x"]));
+        assert_eq!(calls[1].error, Some(serde_json::json!({"code":"E_FAIL"})));
+    }
+
+    #[test]
+    fn extractors_return_empty_when_tool_calls_missing() {
+        let resp = LlmResponse {
+            meta: serde_json::json!({}),
+            ..Default::default()
+        };
+        assert!(extract_tool_calls_canonical_or_empty(&resp).is_empty());
+        assert!(extract_tool_calls_best_effort(&resp).is_empty());
+    }
+}


### PR DESCRIPTION
Why
E2A from RFC-002: remove duplicated tool_calls extraction logic across metrics while freezing existing strict-vs-lenient behavior.

Scope
- Add shared helper module: crates/assay-metrics/src/tool_calls.rs
- Route call sites through shared helpers in:
  - crates/assay-metrics/src/args_valid.rs (best-effort / lenient)
  - crates/assay-metrics/src/sequence_valid.rs (canonical-or-empty / strict)
  - crates/assay-metrics/src/tool_blocklist.rs (canonical-or-empty / strict)
- No schema/output/contract changes.

Contract definitions (explicit)
- extract_tool_calls_best_effort: accepts canonical + legacy/minimal shapes, skips unparsable entries, never panics.
- extract_tool_calls_canonical_or_empty: accepts only canonical shape; malformed/non-canonical input returns empty list (fail-open), never panics.

Behavior invariants frozen by tests
- Order preserved.
- Canonical field mapping preserved (id, index, tool_name, args, result, error, ts_ms).
- Missing/non-array/malformed handling preserved per strict/lenient contract.
- Strict paths remain fail-open to empty list (never panic, never hard error).

Field parity assertions (explicit)
- args_valid best-effort preserves mapping + order:
  - extract_tool_calls_best_effort_preserves_order_and_field_mapping
- strict paths remain canonical-or-empty (malformed => []):
  - sequence_valid::test_malformed_tool_calls_fail_open_to_empty_sequence
  - tool_blocklist::malformed_or_legacy_tool_calls_are_canonical_or_empty

PR structure
1. test(metrics): freeze tool_calls extraction semantics
2. refactor(metrics-e2a): extract shared tool-call parsing helpers

Validation
- cargo fmt --all
- cargo test -p assay-metrics -- --nocapture
- cargo check -p assay-metrics
- cargo clippy -p assay-metrics -- -D warnings

Notes
- Includes stacked follow-up from #246 (policy warning dedup with explicit key semantics `(metric_name, policy_path)`) since #246 merged into this branch.
- Left user demo work untouched: demo/, .github/workflows/demo.yml.
