### PR TITLE
refactor(registry-e2c): freeze digest contracts and dedup helpers

### DIFF
--- a/crates/assay-registry/src/digest.rs
+++ b/crates/assay-registry/src/digest.rs
@@ -1,0 +1,86 @@
+use std::io::{Cursor, Read};
+
+use sha2::{Digest, Sha256};
+
+use crate::canonicalize::{compute_canonical_digest, CanonicalizeError};
+
+pub(crate) fn sha256_hex_reader<R: Read>(mut reader: R) -> std::io::Result<String> {
+    let mut hasher = Sha256::new();
+    let mut buf = [0_u8; 8192];
+
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+pub(crate) fn sha256_hex_bytes(bytes: &[u8]) -> String {
+    // In-memory hashing should be infallible; keep a single hashing implementation.
+    sha256_hex_reader(Cursor::new(bytes)).expect("hashing in-memory bytes via cursor must not fail")
+}
+
+pub(crate) fn compute_canonical_or_raw_digest<F>(content: &str, on_canonical_error: F) -> String
+where
+    F: FnOnce(&CanonicalizeError),
+{
+    match compute_canonical_digest(content) {
+        Ok(digest) => digest,
+        Err(e) => {
+            on_canonical_error(&e);
+            sha256_hex_bytes(content.as_bytes())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    struct ChunkedReader<'a> {
+        data: &'a [u8],
+        pos: usize,
+        max_chunk: usize,
+    }
+
+    impl<'a> Read for ChunkedReader<'a> {
+        fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+            if self.pos >= self.data.len() {
+                return Ok(0);
+            }
+            let n = out
+                .len()
+                .min(self.max_chunk)
+                .min(self.data.len().saturating_sub(self.pos));
+            out[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
+
+    #[test]
+    fn sha256_reader_matches_bytes_digest() {
+        let payload = b"\x00\x01hello\xffbinary\n";
+        let from_bytes = sha256_hex_bytes(payload);
+        let from_reader = sha256_hex_reader(Cursor::new(payload)).expect("reader hashing");
+        assert_eq!(from_bytes, from_reader);
+    }
+
+    #[test]
+    fn sha256_reader_chunked_stream_parity() {
+        let payload = b"abcdefghijklmnopqrstuvwxyz0123456789";
+        let from_bytes = sha256_hex_bytes(payload);
+        let chunked = ChunkedReader {
+            data: payload,
+            pos: 0,
+            max_chunk: 3,
+        };
+        let from_chunked = sha256_hex_reader(chunked).expect("chunked reader hashing");
+        assert_eq!(from_bytes, from_chunked);
+    }
+}

--- a/crates/assay-registry/src/lib.rs
+++ b/crates/assay-registry/src/lib.rs
@@ -49,6 +49,7 @@ pub mod auth;
 pub mod cache;
 pub mod canonicalize;
 pub mod client;
+mod digest;
 pub mod error;
 pub mod lockfile;
 pub mod reference;

--- a/crates/assay-registry/src/verify.rs
+++ b/crates/assay-registry/src/verify.rs
@@ -187,7 +187,6 @@ pub fn compute_digest_strict(content: &str) -> Result<String, CanonicalizeError>
 /// **Deprecated**: Use `compute_digest` for canonical JCS digest per SPEC §6.2.
 /// This function is only for backward compatibility with pre-v1.0.2 digests.
 #[deprecated(since = "2.11.0", note = "use compute_digest for canonical JCS digest")]
-#[allow(dead_code)]
 pub fn compute_digest_raw(content: &str) -> String {
     sha256_hex_bytes(content.as_bytes())
 }
@@ -294,7 +293,7 @@ fn verify_dsse_signature_bytes(
 ///
 /// **Deprecated**: Use `verify_dsse_signature_bytes` which properly handles
 /// canonical byte comparison per SPEC §6.3.
-#[allow(dead_code)]
+#[cfg(test)]
 fn verify_dsse_signature(
     content: &str,
     envelope: &DsseEnvelope,


### PR DESCRIPTION
Why
E2C digest dedup slice for RFC-002.

This PR intentionally includes:
- E2C1 test freeze (digest parity contracts)
- E2C2 extract-only helper migration
- E2C3 wrapper/dead-code hygiene (no behavior change)

Scope
- Added shared digest helper module: `crates/assay-registry/src/digest.rs`
- Migrated digest callsites in:
  - `crates/assay-registry/src/client.rs`
  - `crates/assay-registry/src/verify.rs`
- Wired module in `crates/assay-registry/src/lib.rs`
- E2C3 cleanup in `verify.rs`:
  - removed `#[allow(dead_code)]` from deprecated `compute_digest_raw` (still public + tested)
  - constrained legacy `verify_dsse_signature` helper to `#[cfg(test)]`

Old -> New mapping
- `client.rs::compute_digest`:
  - old: local canonical-or-raw match + inline SHA256 fallback
  - new: `compute_canonical_or_raw_digest(content, |_| {})`
- `verify.rs::compute_digest`:
  - old: local canonical-or-raw match + warn + inline SHA256 fallback
  - new: `compute_canonical_or_raw_digest(content, |e| tracing::warn!(...))`
- `verify.rs::compute_digest_raw`:
  - old: inline SHA256 bytes hashing
  - new: `sha256_hex_bytes(content.as_bytes())`
- `verify.rs::compute_key_id`:
  - old: inline SHA256 bytes hashing
  - new: `sha256_hex_bytes(spki_bytes)`

Contracts frozen / coverage
- Existing digest parity + shape tests:
  - `client::tests::test_compute_digest_parity_with_verify_module`
  - `client::tests::test_compute_digest_has_lowercase_hex_shape`
- Added streaming semantics tests in helper:
  - `digest::tests::sha256_reader_matches_bytes_digest`
  - `digest::tests::sha256_reader_chunked_stream_parity`

Non-goals
- No digest algorithm change.
- No schema/output changes.
- No error mapping changes.

Validation
- `cargo fmt --all`
- `cargo test -p assay-registry compute_digest -- --nocapture`
- `cargo test -p assay-registry sha256_reader -- --nocapture`
- `cargo check -p assay-registry`
- `cargo clippy -p assay-registry -- -D warnings`

Notes
- Full `cargo test -p assay-registry` in this sandbox still hits pre-existing wiremock port-bind restrictions (`Operation not permitted`); full suite is expected in CI.
- Demo artifacts left untouched: `demo/`, `.github/workflows/demo.yml`.
