### PR TITLE
refactor(registry-e3b): keep legacy DSSE helper test-local

### DIFF
--- a/crates/assay-registry/src/verify.rs
+++ b/crates/assay-registry/src/verify.rs
@@ -342,8 +342,8 @@ mod tests {
         SigningKey::generate(&mut rand::thread_rng())
     }
 
-    // Legacy compatibility helper kept test-local: production path uses
-    // canonical bytes via verify_dsse_signature_bytes.
+    // Legacy compatibility helper kept test-local: production path verifies
+    // canonical bytes via verify_dsse_signature_bytes; callers canonicalize.
     fn verify_dsse_signature_legacy_for_tests(
         content: &str,
         envelope: &DsseEnvelope,

--- a/crates/assay-registry/src/verify.rs
+++ b/crates/assay-registry/src/verify.rs
@@ -289,21 +289,6 @@ fn verify_dsse_signature_bytes(
     )
 }
 
-/// Legacy: Verify DSSE signature over content string.
-///
-/// **Deprecated**: Use `verify_dsse_signature_bytes` which properly handles
-/// canonical byte comparison per SPEC §6.3.
-#[cfg(test)]
-fn verify_dsse_signature(
-    content: &str,
-    envelope: &DsseEnvelope,
-    trust_store: &TrustStore,
-) -> RegistryResult<()> {
-    // Canonicalize content first
-    let canonical_bytes = canonicalize_for_dsse(content)?;
-    verify_dsse_signature_bytes(&canonical_bytes, envelope, trust_store)
-}
-
 /// Verify a single signature.
 fn verify_single_signature(
     pae: &[u8],
@@ -355,6 +340,17 @@ mod tests {
 
     fn generate_keypair() -> SigningKey {
         SigningKey::generate(&mut rand::thread_rng())
+    }
+
+    // Legacy compatibility helper kept test-local: production path uses
+    // canonical bytes via verify_dsse_signature_bytes.
+    fn verify_dsse_signature_legacy_for_tests(
+        content: &str,
+        envelope: &DsseEnvelope,
+        trust_store: &TrustStore,
+    ) -> RegistryResult<()> {
+        let canonical_bytes = canonicalize_for_dsse(content)?;
+        verify_dsse_signature_bytes(&canonical_bytes, envelope, trust_store)
     }
 
     #[test]
@@ -689,7 +685,7 @@ mod tests {
         .unwrap();
         let content_str = String::from_utf8(canonical.clone()).unwrap();
 
-        let result = verify_dsse_signature(&content_str, &envelope, &trust_store);
+        let result = verify_dsse_signature_legacy_for_tests(&content_str, &envelope, &trust_store);
         assert!(result.is_ok(), "DSSE signature should verify: {:?}", result);
     }
 
@@ -732,7 +728,7 @@ mod tests {
         .unwrap();
         let tampered_str = String::from_utf8(tampered_canonical).unwrap();
 
-        let result = verify_dsse_signature(&tampered_str, &envelope, &trust_store);
+        let result = verify_dsse_signature_legacy_for_tests(&tampered_str, &envelope, &trust_store);
         assert!(
             matches!(result, Err(RegistryError::DigestMismatch { .. })),
             "Should return DigestMismatch for payload != content: {:?}",
@@ -758,7 +754,7 @@ mod tests {
         .unwrap();
         let content_str = String::from_utf8(canonical).unwrap();
 
-        let result = verify_dsse_signature(&content_str, &envelope, &trust_store);
+        let result = verify_dsse_signature_legacy_for_tests(&content_str, &envelope, &trust_store);
         assert!(
             matches!(result, Err(RegistryError::KeyNotTrusted { .. })),
             "Should return KeyNotTrusted for unknown key: {:?}",
@@ -776,7 +772,7 @@ mod tests {
         };
 
         let trust_store = TrustStore::new();
-        let result = verify_dsse_signature("test", &envelope, &trust_store);
+        let result = verify_dsse_signature_legacy_for_tests("test", &envelope, &trust_store);
 
         assert!(
             matches!(result, Err(RegistryError::SignatureInvalid { .. })),
@@ -802,7 +798,7 @@ mod tests {
 
         let trust_store = TrustStore::new();
         let content_str = String::from_utf8(canonical).unwrap();
-        let result = verify_dsse_signature(&content_str, &envelope, &trust_store);
+        let result = verify_dsse_signature_legacy_for_tests(&content_str, &envelope, &trust_store);
 
         assert!(
             matches!(result, Err(RegistryError::SignatureInvalid { .. })),
@@ -857,7 +853,7 @@ mod tests {
             .unwrap();
 
         let content_str = String::from_utf8(canonical).unwrap();
-        let result = verify_dsse_signature(&content_str, &envelope, &trust_store);
+        let result = verify_dsse_signature_legacy_for_tests(&content_str, &envelope, &trust_store);
 
         assert!(
             matches!(result, Err(RegistryError::SignatureInvalid { .. })),
@@ -1034,7 +1030,7 @@ mod tests {
             .block_on(trust_store.add_pinned_key(&trusted_key))
             .unwrap();
 
-        let legacy_ok = verify_dsse_signature(content, &envelope, &trust_store);
+        let legacy_ok = verify_dsse_signature_legacy_for_tests(content, &envelope, &trust_store);
         assert!(
             legacy_ok.is_ok(),
             "legacy helper should canonicalize input before verification: {:?}",
@@ -1050,7 +1046,8 @@ mod tests {
         );
 
         let tampered_content = "z: 4\na: 1\nm: 2";
-        let legacy_err = verify_dsse_signature(tampered_content, &envelope, &trust_store);
+        let legacy_err =
+            verify_dsse_signature_legacy_for_tests(tampered_content, &envelope, &trust_store);
         assert!(
             matches!(legacy_err, Err(RegistryError::DigestMismatch { .. })),
             "legacy helper should keep mismatch classification: {:?}",


### PR DESCRIPTION
## Why
E3B for RFC-002: rationalize legacy DSSE helper placement without changing digest/DSSE semantics.

## Scope
- File: `crates/assay-registry/src/verify.rs`
- Extract-only cleanup:
  - Move legacy DSSE helper out of production module scope into `#[cfg(test)] mod tests`.
  - Keep production source-of-truth on `verify_dsse_signature_bytes`.

## Old -> New mapping
- Old: top-level `#[cfg(test)] fn verify_dsse_signature(...)` near production functions.
- New: `fn verify_dsse_signature_legacy_for_tests(...)` inside test module only.
- Behavior: identical canonicalization + bytes verification path.

## Non-goals
- No canonicalization rule changes.
- No digest algorithm changes.
- No DSSE error mapping changes (`DigestMismatch` etc).

## Contract gates
- `cargo test -p assay-registry compute_digest -- --nocapture`
- `cargo test -p assay-registry verify_dsse_signature -- --nocapture`
- `cargo check -p assay-registry`
- `cargo clippy -p assay-registry -- -D warnings`

## Notes
- Full `cargo test -p assay-registry` remains sandbox-limited due pre-existing wiremock port-bind restrictions; targeted scope tests above are green.
- Demo assets untouched: `demo/`, `.github/workflows/demo.yml`.
