### PR TITLE
chore(core-e4a): clean stale comments in runner and diagnostics

### DIFF
--- a/crates/assay-core/src/engine/runner.rs
+++ b/crates/assay-core/src/engine/runner.rs
@@ -434,9 +434,7 @@ impl Runner {
             metric_versions: &metric_versions,
         });
 
-        // Incremental Check
-        // Note: Global --incremental flag should be checked here.
-        // Assuming self.incremental is available.
+        // Incremental cache check.
         if self.incremental && !self.refresh_cache {
             if let Some(prev) = self.store.get_last_passing_by_fingerprint(&fp.hex)? {
                 // Return Skipped Result

--- a/crates/assay-core/src/errors/diagnostic.rs
+++ b/crates/assay-core/src/errors/diagnostic.rs
@@ -71,7 +71,7 @@ impl Diagnostic {
     }
 
     pub fn format_plain(&self) -> String {
-        // Strip out any ansi codes if we added them (we didn't yet), just text
+        // Plain output path currently mirrors terminal formatting.
         self.format_terminal()
     }
 }


### PR DESCRIPTION
## Why
E4A low-risk cleanup from RFC-002: remove stale/uncertain comments without code-path changes.

## Scope
- `crates/assay-core/src/engine/runner.rs`
- `crates/assay-core/src/errors/diagnostic.rs`
- Comment-only cleanup; no behavior changes.

## Changes
- Replace uncertain incremental comment in runner with concise, accurate description.
- Replace speculative ANSI/planned-work note in diagnostic formatter with neutral description.

## Non-goals
- No retry/fingerprint logic changes.
- No diagnostic formatting behavior changes.
- No contract/output/schema changes.

## Validation
- `cargo fmt --all`
- `cargo test -p assay-core --lib -- --nocapture`
- `cargo check -p assay-core`
- `cargo clippy -p assay-core -- -D warnings`

## Notes
- Demo assets intentionally untouched: `demo/`, `.github/workflows/demo.yml`.
