### PR TITLE
chore(core-e4b): tighten error-mapping comments

### DIFF
--- a/crates/assay-core/src/errors/mod.rs
+++ b/crates/assay-core/src/errors/mod.rs
@@ -233,21 +233,17 @@ impl RunError {
     }
 }
 
-/// Helper to map common anyhow errors to structured Diagnostics
+/// Maps selected anyhow errors to structured diagnostics with actionable fixes.
 pub fn try_map_error(err: &anyhow::Error) -> Option<Diagnostic> {
-    // 1) First, try to downcast if it's already a Diagnostic
+    // Preserve existing typed diagnostics.
     if let Some(diag) = err.downcast_ref::<Diagnostic>() {
         return Some(diag.clone());
     }
 
     let msg = err.to_string();
 
-    // Mapping embedded dimension mismatch
-    // "embedding dims mismatch" is a string we expect from runners/providers
-    // Ideally providers return typed errors, but string matching is pragmatic for v0.3.x
+    // Best-effort mapping for embedding dimension mismatch messages.
     if msg.contains("embedding dims mismatch") || msg.contains("dimension mismatch") {
-        // We could try to parse "expected A, got B" if the message format is stable
-        // For now, actionable generic advice
         return Some(
             Diagnostic::new(
                 diagnostic::codes::E_EMB_DIMS,
@@ -261,7 +257,7 @@ pub fn try_map_error(err: &anyhow::Error) -> Option<Diagnostic> {
         );
     }
 
-    // Baseline mismatch
+    // Baseline schema/version incompatibility.
     if msg.contains("Baseline mismatch") || (msg.contains("baseline") && msg.contains("schema")) {
         return Some(
             Diagnostic::new(


### PR DESCRIPTION
## Why
E4B low-risk cleanup from RFC-002: reduce noisy/numbered design comments in core error mapping code while keeping behavior unchanged.

## Scope
- File: `crates/assay-core/src/errors/mod.rs`
- Comment-only cleanup in `try_map_error`.

## Changes
- Replaced numbered/verbose comments with concise behavior-oriented comments.
- No code path changes and no diagnostic mapping condition changes.

## Non-goals
- No change to `RunError` classification behavior.
- No change to diagnostic code/message/fix-step outputs.
- No contract/output/schema impact.

## Validation
- `cargo fmt --all`
- `cargo test -p assay-core --lib -- --nocapture`
- `cargo check -p assay-core`
- `cargo clippy -p assay-core -- -D warnings`

## Notes
- Demo assets intentionally untouched: `demo/`, `.github/workflows/demo.yml`.
