### PR TITLE
chore(core-e4d): normalize AllowedOnError comment

### DIFF
--- a/crates/assay-core/src/model.rs
+++ b/crates/assay-core/src/model.rs
@@ -546,7 +546,7 @@ pub enum TestStatus {
     Error,
     Skipped,
     Unstable,
-    /// New: Action was allowed despite error (fail-open mode)
+    /// Action was allowed despite an upstream error (fail-open mode).
     AllowedOnError,
 }
 


### PR DESCRIPTION
## Why
E4D quick-win from RFC-002 code-health: remove AI-style wording from a core enum comment while preserving semantics.

## Scope
- `crates/assay-core/src/model.rs`
- Comment text only on `TestStatus::AllowedOnError`
- No logic/code path changes

## Non-goals
- No behavior, schema, or output changes
- No enum variant changes

## Validation
- `cargo fmt --all`
- `cargo check -p assay-core`
- `cargo test -p assay-core --lib -- --nocapture`

## Contract notes
Comment-only cleanup; runtime and serialization semantics unchanged.
