### PR TITLE
docs(rfc-003): add generate decomposition plan and refresh RFC-002 status

### DIFF
--- a/docs/architecture/CODE-ANALYSIS-REPORT.md
+++ b/docs/architecture/CODE-ANALYSIS-REPORT.md
@@ -15,9 +15,10 @@ next execution order, see:
 
 High-level refresh:
 
-- P1s already closed in recent merges: #1, #2, #3, #4, #5, #6, #7, #9, #10
-- P1 still open/in progress: #8 (`monitor.rs` monolith; helper extraction in progress)
-- Remaining work is now concentrated in `store.rs`, `generate.rs`, metrics dedup, and low-risk cleanup slices.
+- P1s closed in recent merges: #1, #2, #3, #4, #5, #6, #7, #9, #10
+- P2/P3 batches from RFC-002 E1-E4 delivered (store consistency, metrics dedup, registry cleanup, comment cleanup).
+- P1 still open/in progress: #8 (`monitor.rs` monolith; helper extraction in progress).
+- Current next structural focus: `generate.rs` decomposition (tracked in RFC-003).
 
 ---
 

--- a/docs/architecture/RFC-002-code-health-remediation-q1-2026.md
+++ b/docs/architecture/RFC-002-code-health-remediation-q1-2026.md
@@ -1,6 +1,6 @@
 # RFC-002: Code Health Remediation Plan (Q1 2026)
 
-- Status: Proposed
+- Status: Active (E1-E4 delivered, E5 planned)
 - Date: 2026-02-09
 - Owner: DX/Core
 - Scope: `assay-cli`, `assay-core`, `assay-evidence`, `assay-metrics`, `assay-sim`, `assay-registry`
@@ -10,7 +10,7 @@
 
 ## 1. Context
 
-After completing the runner/trace decompositions (D1/D2), the remaining technical debt is concentrated in:
+After completing the runner/trace decompositions (D1/D2), the code-health backlog was concentrated in:
 
 1. `store.rs` (duplicatie + timestamp-inconsistentie + structuur)
 2. `monitor.rs` (still monolithic; helper extraction in progress)
@@ -19,10 +19,11 @@ After completing the runner/trace decompositions (D1/D2), the remaining technica
 5. small but risky inconsistencies (registry digest helpers, pack name validation, deprecated wrappers)
 
 Doel van deze RFC: de resterende punten afbouwen met minimale regressierisico's en maximale reviewbaarheid.
+Current state: E1-E4 are delivered; E5 (`generate.rs` decomposition) moves to a dedicated follow-up RFC.
 
-## 2. Verified Snapshot (2026-02-09)
+## 2. Verified Snapshot (2026-02-09, refreshed)
 
-Based on current code inspection:
+Based on merged slices on `main`:
 
 - P1 findings opgelost:
   - run/ci error-handler duplicatie (pipeline error API)
@@ -32,14 +33,14 @@ Based on current code inspection:
   - sim attack bundle dedup
   - trace `from_path` decompositie
   - runner `run_test_with_policy` decompositie
-- P1 finding gedeeltelijk:
-  - monitor monoliet: helper-extractie gestart, event loop/Tier1-flow nog groot
-- Open kern:
-  - `store.rs` timestamp canonicalisatie + structuur
-  - metrics tool-call extractie duplicatie
-  - registry dead/deprecated digest/signature paden
-  - `generate.rs` opsplitsing
-  - comment/dead-code cleanup batch
+- Delivered in RFC-002 execution:
+  - E1 Store consistency (`#242`)
+  - E2 Metrics extraction + warning dedup (`#245`, `#246`)
+  - E3 Registry digest/signature cleanup (`#247`, `#250`, `#252`)
+  - E4 Comment/noise cleanup batch (`#253`, `#254`, `#255`, `#256`)
+- Remaining structural backlog outside delivered E1-E4:
+  - `monitor.rs` monolith (helper extraction is partial)
+  - `generate.rs` decomposition (moved to RFC-003)
 
 ## 3. Research Baseline (Best Practices, SOTA, Feb 2026)
 
@@ -86,9 +87,9 @@ Rationale: aligns with SQLite textual datetime practice and avoids downstream pa
 
 Geen "single giant PR" voor monolieten. Maximaal 1 concern per PR, met diffstat en contract-gates in de PR-body.
 
-## 5. Execution Plan (Next Steps)
+## 5. Execution Plan (RFC-002 Delivery + Next)
 
-## E1 - Store Consistency Slice (P1/P2)
+## E1 - Store Consistency Slice (P1/P2) - Delivered
 
 Scope:
 
@@ -120,7 +121,7 @@ E1 characterization contract checklist:
 - Freeze canonical timestamp contract (UTC + fixed precision)
 - Verify no conflict/side-effect drift from dedup (insert behavior + error path unchanged)
 
-## E2 - Metrics Extract Helper Slice (P2)
+## E2 - Metrics Extract Helper Slice (P2) - Delivered
 
 Scope:
 
@@ -140,7 +141,7 @@ Stop-line:
 - Geen metric contract-wijziging
 - Geen score/reason drift
 
-## E3 - Registry Dead/Legacy Cleanup (P2/P3)
+## E3 - Registry Dead/Legacy Cleanup (P2/P3) - Delivered
 
 Scope:
 
@@ -156,7 +157,7 @@ Stop-line:
 
 - DSSE verify semantics identiek
 
-## E4 - Comment/Noise/Low-risk Cleanup (P3)
+## E4 - Comment/Noise/Low-risk Cleanup (P3) - Delivered
 
 Scope:
 
@@ -168,9 +169,12 @@ Gate:
 
 - crate-local tests + clippy clean
 
-## E5 - Generate Decomposition RFC (separate)
+## E5 - Generate Decomposition RFC (separate, active follow-up)
 
 `generate.rs` wordt als aparte traject-RFC behandeld wegens omvang en cross-concern risico.
+Active follow-up document:
+
+- `docs/architecture/RFC-003-generate-decomposition-q1-2026.md`
 
 ## 6. Risk Controls
 
@@ -193,9 +197,9 @@ Gate:
 
 RFC-002 is "Done" wanneer E1-E4 gemerged zijn en:
 
-- Open P1 findings uit CODE-ANALYSIS rapport = 0
+- Open P1 findings uit de RFC-002 targetset = 0
 - Minimaal 6 P2 findings opgelost zonder contractwijziging
-- Geen nieuwe monoliet > bestaande baseline in kritieke commands/core paden
+- Geen regressie in output-contracten (`run.json`, `summary.json`, SARIF, JUnit)
 
 ## 9. Out of Scope
 

--- a/docs/architecture/RFC-003-generate-decomposition-q1-2026.md
+++ b/docs/architecture/RFC-003-generate-decomposition-q1-2026.md
@@ -1,0 +1,217 @@
+# RFC-003: Generate Command Decomposition Plan (Q1 2026)
+
+- Status: Proposed
+- Date: 2026-02-09
+- Owner: DX/Core
+- Scope: `crates/assay-cli/src/cli/commands/generate.rs`
+- Related:
+  - `docs/architecture/RFC-002-code-health-remediation-q1-2026.md` (E5)
+  - `docs/architecture/CODE-ANALYSIS-REPORT.md` (#27)
+
+## 1. Context
+
+`generate.rs` is currently ~1166 lines and combines multiple concerns:
+
+1. CLI argument model and validation
+2. Policy/output DTOs and serialization
+3. Trace ingestion (`read_events`) and aggregation
+4. Profile-based classification logic
+5. Policy diffing and reporting
+6. Top-level command orchestration (`run`)
+7. Unit tests for several subsystems
+
+This makes behavior changes harder to review and increases accidental drift risk when touching one concern.
+
+## 2. Current Shape (Verified)
+
+Current file: `crates/assay-cli/src/cli/commands/generate.rs` (1166 lines).
+
+High-level concern map:
+
+- Args + validation: `GenerateArgs`, `validate`
+- Model DTOs: `Policy`, `Meta`, `Section`, `NetSection`, `Entry`
+- Single-run path: `read_events`, `aggregate`, `generate_from_trace`
+- Profile path: `generate_from_profile`, `classify_entry`, `make_entry_profile`
+- Diff path: `PolicyDiff` helpers, `diff_policies`, `print_policy_diff`
+- Entry point: `run`
+- Tests: classification + diff behavior
+
+## 3. Constraints (Hard Stop-Lines)
+
+1. No output contract changes:
+   - No schema drift in generated policy format (yaml/json)
+   - No CLI flag behavior changes
+   - No change in exit code behavior (`run` still returns `Result<i32>`, with `Ok(0)` on success)
+2. No semantic drift in classification:
+   - Wilson/laplace/min_runs/new_is_risky logic remains identical
+3. No diff-output semantic drift:
+   - Added/removed/changed calculation remains identical
+4. No hidden tolerance changes:
+   - `read_events` parse/skip/error-rate behavior unchanged
+
+## 4. Research Baseline (Best Practices, Feb 2026)
+
+Primary guidance used for this plan:
+
+1. Rust API Guidelines: keep modules focused and APIs explicit (`C-CONV`, `C-STRUCT`, `C-ITER`).
+   - https://rust-lang.github.io/api-guidelines/checklist.html
+2. Clippy docs: prefer specific maintainability lints and tests over abstract complexity scores.
+   - https://rust-lang.github.io/rust-clippy/stable/index.html
+3. Test execution discipline: deterministic, fast feedback loops (`nextest` and targeted gates).
+   - https://www.nexte.st/
+
+Applied policy for this RFC:
+
+- Test-first characterization on behavior-sensitive paths
+- Extract-only changes per phase
+- Small, linear PRs with explicit non-goals
+
+## 5. Target Module Layout
+
+Proposed end-state under `crates/assay-cli/src/cli/commands/generate/`:
+
+- `mod.rs`:
+  - public `run(args: GenerateArgs) -> Result<i32>`
+  - module wiring/re-exports
+- `args.rs`:
+  - `GenerateArgs`
+  - `GenerateArgs::validate`
+- `model.rs`:
+  - `Policy`, `Meta`, `Section`, `NetSection`, `Entry`
+  - `serialize`
+- `ingest.rs`:
+  - `Stats`, `Aggregated`
+  - `read_events`, `aggregate`
+- `profile.rs`:
+  - `generate_from_trace`, `generate_from_profile`
+  - `classify_entry`, `make_entry_profile`, `make_entry_simple`
+- `diff.rs`:
+  - `EntryFingerprint`, `EntryChange`, `SectionDiff`, `PolicyDiff`
+  - `parse_existing_policy`, `diff_policies`, `print_policy_diff`
+- `tests.rs` (or per-module `#[cfg(test)]`):
+  - migrated existing tests with identical assertions
+
+Compatibility requirement:
+
+- Keep command dispatch path unchanged (`generate::run` remains callable from command router).
+
+## 6. Execution Plan
+
+### G1 - Freeze Tests (Behavior Characterization)
+
+Add targeted characterization tests before moving logic:
+
+1. `read_events` contract:
+   - skip empty/comment lines
+   - unparsable lines count/warn behavior
+   - hard error when all lines invalid
+2. `run` mode gating:
+   - requires exactly one of `--input` or `--profile`
+3. classification invariants:
+   - stable allow/review/skip transitions
+   - risk override precedence
+   - min-runs gate behavior
+4. diff invariants:
+   - added/removed/changed semantics unchanged
+
+Gate:
+
+- `cargo test -p assay-cli generate -- --nocapture`
+- `cargo check -p assay-cli`
+
+### G2 - Extract DTO/Args Layer (No Logic Moves Yet)
+
+Scope:
+
+- Move args + model DTOs + `serialize` to `args.rs` / `model.rs`
+- Keep function bodies unchanged
+
+Gate:
+
+- `cargo test -p assay-cli generate -- --nocapture`
+- `cargo clippy -p assay-cli -- -D warnings`
+
+### G3 - Extract Ingestion/Aggregation
+
+Scope:
+
+- Move `Stats`, `Aggregated`, `read_events`, `aggregate` into `ingest.rs`
+- Preserve all warning/error strings
+
+Gate:
+
+- `cargo test -p assay-cli generate -- --nocapture`
+- `cargo check -p assay-cli`
+
+### G4 - Extract Profile/Classification Logic
+
+Scope:
+
+- Move profile generation/classification helpers into `profile.rs`
+- Keep algorithm and ordering unchanged
+
+Gate:
+
+- `cargo test -p assay-cli generate -- --nocapture`
+- `cargo clippy -p assay-cli -- -D warnings`
+
+### G5 - Extract Diff Subsystem
+
+Scope:
+
+- Move diff structs/helpers into `diff.rs`
+- Keep summary output format and counts unchanged
+
+Gate:
+
+- `cargo test -p assay-cli generate -- --nocapture`
+- `cargo check -p assay-cli`
+
+### G6 - Final Orchestration Cleanup
+
+Scope:
+
+- Reduce `mod.rs` to orchestration only
+- Keep `run` signature and return semantics unchanged
+
+Gate:
+
+- `cargo test -p assay-cli generate -- --nocapture`
+- `cargo test -p assay-cli --lib -- --nocapture`
+- `cargo clippy -p assay-cli -- -D warnings`
+
+## 7. PR Slicing Strategy
+
+Recommended PR sequence:
+
+1. PR-G1: tests-only freeze
+2. PR-G2: args/model extraction
+3. PR-G3: ingest extraction
+4. PR-G4: profile extraction
+5. PR-G5: diff extraction
+6. PR-G6: final `mod.rs` cleanup
+
+Each PR must include:
+
+- In-scope section
+- Non-goals section
+- Contract gates section
+- Output impact statement (`none`)
+
+## 8. Risks and Mitigations
+
+1. Risk: subtle classification drift during extraction
+   - Mitigation: G1 characterization tests and unchanged helper signatures
+2. Risk: diff noise or changed reporting semantics
+   - Mitigation: freeze diff tests and keep summary formatting assertions
+3. Risk: accidental CLI behavior drift
+   - Mitigation: mode-gating tests and unchanged `run` entrypoint
+
+## 9. Definition of Done
+
+RFC-003 is done when:
+
+1. `generate.rs` orchestration module is reduced and concerns are split into focused modules
+2. Existing behavior is preserved under frozen tests
+3. No output/schema/exit behavior changes are introduced
+4. All G1-G6 gates are green on CI


### PR DESCRIPTION
## Why
RFC-002 E1-E4 are merged. The next structural step is `generate.rs` decomposition, which needs a dedicated RFC before any code movement.

## What changed
- Added `docs/architecture/RFC-003-generate-decomposition-q1-2026.md`.
  - Defines phased G1-G6 decomposition of `crates/assay-cli/src/cli/commands/generate.rs`.
  - Uses test-first and extract-only sequencing.
  - Adds explicit stop-lines and per-phase gates.
- Refreshed `docs/architecture/RFC-002-code-health-remediation-q1-2026.md`.
  - Marks E1-E4 as delivered.
  - Links E5 follow-up to RFC-003.
- Updated `docs/architecture/CODE-ANALYSIS-REPORT.md` status refresh to reflect delivered slices and current focus.

## Scope
- Docs/RFC only.
- No code path, schema, or runtime behavior changes.

## Validation
- pre-commit hooks passed on commit/push (fmt/typos/clippy gates in this repo).

## Non-goals
- No `generate.rs` implementation changes in this PR.
- No monitor refactor work in this PR.
