### PR TITLE
refactor(generate-e5-g2): extract args/model DTO layer (no logic move)

### DIFF
--- a/crates/assay-cli/src/cli/commands/generate/args.rs
+++ b/crates/assay-cli/src/cli/commands/generate/args.rs
@@ -1,0 +1,91 @@
+use anyhow::Result;
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args, Debug, Clone)]
+#[command(about = "Generate policy from trace or profile")]
+pub struct GenerateArgs {
+    /// Input trace file (single-run mode)
+    #[arg(short, long)]
+    pub input: Option<PathBuf>,
+
+    /// Profile file (multi-run mode)
+    #[arg(long)]
+    pub profile: Option<PathBuf>,
+
+    #[arg(short, long, default_value = "policy.yaml")]
+    pub output: PathBuf,
+
+    #[arg(long, default_value = "Generated Policy")]
+    pub name: String,
+
+    #[arg(long, default_value = "yaml")]
+    pub format: String,
+
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Show policy diff versus existing output file
+    #[arg(long)]
+    pub diff: bool,
+
+    // Single-run heuristics
+    #[arg(long)]
+    pub heuristics: bool,
+
+    #[arg(long, default_value_t = 3.8)]
+    pub entropy_threshold: f64,
+
+    // Profile stability
+    /// Minimum stability to auto-allow (profile mode)
+    #[arg(long, default_value_t = 0.7)]
+    pub min_stability: f64,
+
+    /// Below this, mark as needs_review if --new-is-risky
+    #[arg(long, default_value_t = 0.6)]
+    pub review_threshold: f64,
+
+    /// Treat low-stability items as risky (else skip them)
+    #[arg(long)]
+    pub new_is_risky: bool,
+
+    /// Smoothing parameter (Laplace) for display
+    #[arg(long, default_value_t = 1.0)]
+    pub alpha: f64,
+
+    /// Minimum runs before anything can be auto-allowed (safety belt)
+    #[arg(long, default_value_t = 1)]
+    pub min_runs: u32,
+
+    /// Z-score for Wilson lower bound gating (1.96 ≈ 95% confidence)
+    #[arg(long, default_value_t = 1.96)]
+    pub wilson_z: f64,
+}
+
+impl GenerateArgs {
+    pub fn validate(&self) -> Result<()> {
+        if self.min_stability < 0.0 || self.min_stability > 1.0 {
+            anyhow::bail!("--min-stability must be between 0.0 and 1.0");
+        }
+        if self.review_threshold < 0.0 || self.review_threshold > 1.0 {
+            anyhow::bail!("--review-threshold must be between 0.0 and 1.0");
+        }
+        if self.min_stability < self.review_threshold {
+            anyhow::bail!(
+                "--min-stability ({}) must be >= --review-threshold ({})",
+                self.min_stability,
+                self.review_threshold
+            );
+        }
+        if self.alpha <= 0.0 {
+            anyhow::bail!("--alpha must be positive");
+        }
+        if self.wilson_z <= 0.0 {
+            anyhow::bail!("--wilson-z must be positive");
+        }
+        if self.entropy_threshold < 0.0 {
+            anyhow::bail!("--entropy-threshold must be non-negative");
+        }
+        Ok(())
+    }
+}

--- a/crates/assay-cli/src/cli/commands/generate/model.rs
+++ b/crates/assay-cli/src/cli/commands/generate/model.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct Policy {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub _meta: Option<Meta>,
+    pub files: Section,
+    pub network: NetSection,
+    pub processes: Section,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct Meta {
+    pub name: String,
+    pub generated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_runs: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_stability: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_runs: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct Section {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow: Vec<Entry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub needs_review: Vec<Entry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deny: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct NetSection {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow_destinations: Vec<Entry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub needs_review: Vec<Entry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deny_destinations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum Entry {
+    Simple(String),
+    WithMeta {
+        pattern: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        count: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        stability: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        runs_seen: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        risk: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reasons: Option<Vec<String>>,
+    },
+}
+
+pub fn serialize(policy: &Policy, format: &str) -> Result<String> {
+    Ok(match format {
+        "json" => serde_json::to_string_pretty(policy)?,
+        _ => serde_yaml::to_string(policy)?,
+    })
+}


### PR DESCRIPTION
## Why
G2 step for RFC-003 (`generate` decomposition): extract DTO/Args layer first, with no logic movement, using G1 freeze tests as stop-line.

## Scope
- `crates/assay-cli/src/cli/commands/generate.rs`
- `crates/assay-cli/src/cli/commands/generate/args.rs`
- `crates/assay-cli/src/cli/commands/generate/model.rs`

## What Changed
- Extracted `GenerateArgs` + `impl validate()` into `generate/args.rs`.
- Extracted output DTOs and serialization into `generate/model.rs`:
  - `Policy`, `Meta`, `Section`, `NetSection`, `Entry`, `serialize(...)`.
- Kept `generate.rs` as orchestration + existing logic.
- Added module wiring + `pub use` in `generate.rs` to preserve module surface.

## Old -> New Mapping
- `generate.rs::GenerateArgs` -> `generate/args.rs::GenerateArgs`
- `generate.rs::{Policy, Meta, Section, NetSection, Entry, serialize}` -> `generate/model.rs::*`

## Non-goals
- No ingest/profile/diff logic moves in this PR.
- No clap/serde attr changes.
- No defaults changed.
- No output/exit/schema contract changes.

## Validation
- `cargo test -p assay-cli --test contract_generate_g1 -- --nocapture`
- `cargo test -p assay-cli generate -- --nocapture`
- `cargo check -p assay-cli`
- `cargo clippy -p assay-cli -- -D warnings`

## Contract Notes
- G1 freeze tests remain green unchanged.
- Demo artifacts untouched (`demo/`, `.github/workflows/demo.yml`, `my-agent/`).
