### PR TITLE
refactor(generate-e5-g3): extract ingest/aggregation layer (no behavior drift)

### DIFF
--- a/crates/assay-cli/src/cli/commands/generate.rs
+++ b/crates/assay-cli/src/cli/commands/generate.rs
@@ -12,141 +12,18 @@
 
 use anyhow::Result;
 use std::collections::BTreeMap;
-use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
-use super::events::Event;
 use super::heuristics::{self, HeuristicsConfig};
 use super::profile_types::{self, stability_smoothed, Profile, ProfileEntry};
 
 mod args;
+mod ingest;
 mod model;
 
 pub use args::GenerateArgs;
+pub use ingest::{aggregate, read_events, Aggregated};
 pub use model::{serialize, Entry, Meta, NetSection, Policy, Section};
-
-// ─────────────────────────────────────────────────────────────────────────────
-// CLI Args
-// ─────────────────────────────────────────────────────────────────────────────
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Single-Run Aggregation
-// ─────────────────────────────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, Default)]
-pub struct Stats {
-    pub count: u32,
-    pub first_seen: u64,
-    pub last_seen: u64,
-}
-
-impl Stats {
-    fn update(&mut self, ts: u64) {
-        self.count += 1;
-        if ts > 0 {
-            if self.first_seen == 0 || ts < self.first_seen {
-                self.first_seen = ts;
-            }
-            if ts > self.last_seen {
-                self.last_seen = ts;
-            }
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct Aggregated {
-    pub files: BTreeMap<String, Stats>,
-    pub network: BTreeMap<String, Stats>,
-    pub processes: BTreeMap<String, Stats>,
-}
-
-impl Aggregated {
-    pub fn total(&self) -> usize {
-        self.files.len() + self.network.len() + self.processes.len()
-    }
-}
-
-pub fn read_events(path: &PathBuf) -> Result<Vec<Event>> {
-    let reader: Box<dyn BufRead> = if path.to_string_lossy() == "-" {
-        Box::new(BufReader::new(std::io::stdin()))
-    } else {
-        Box::new(BufReader::new(std::fs::File::open(path)?))
-    };
-    let mut events = Vec::new();
-    let mut total_lines = 0;
-    let mut error_count = 0;
-
-    for (i, line) in reader.lines().enumerate() {
-        let line = line?;
-        if line.trim().is_empty() || line.starts_with('#') {
-            continue;
-        }
-        total_lines += 1;
-        match serde_json::from_str(&line) {
-            Ok(e) => events.push(e),
-            Err(_) => {
-                error_count += 1;
-                if error_count <= 3 {
-                    eprintln!("warning: skipping line {}: unparsable event", i + 1);
-                }
-            }
-        }
-    }
-
-    if error_count > 3 {
-        eprintln!("warning: skipped {} unparsable lines total", error_count);
-    }
-
-    if events.is_empty() && error_count > 0 {
-        anyhow::bail!(
-            "no valid events found ({} lines skipped, 0 ok)",
-            error_count
-        );
-    }
-
-    if total_lines > 0 {
-        let error_rate = error_count as f64 / total_lines as f64;
-        if error_rate > 0.5 {
-            eprintln!(
-                "warning: high error rate ({:.1}%) - check input format",
-                error_rate * 100.0
-            );
-        }
-    }
-
-    Ok(events)
-}
-
-pub fn aggregate(events: &[Event]) -> Aggregated {
-    let mut agg = Aggregated::default();
-    for ev in events {
-        match ev {
-            Event::FileOpen {
-                path, timestamp, ..
-            } => agg
-                .files
-                .entry(path.clone())
-                .or_default()
-                .update(*timestamp),
-            Event::NetConnect {
-                dest, timestamp, ..
-            } => agg
-                .network
-                .entry(dest.clone())
-                .or_default()
-                .update(*timestamp),
-            Event::ProcExec {
-                path, timestamp, ..
-            } => agg
-                .processes
-                .entry(path.clone())
-                .or_default()
-                .update(*timestamp),
-        }
-    }
-    agg
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Generate from Single Run

--- a/crates/assay-cli/src/cli/commands/generate/ingest.rs
+++ b/crates/assay-cli/src/cli/commands/generate/ingest.rs
@@ -1,0 +1,121 @@
+use anyhow::Result;
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use super::super::events::Event;
+
+#[derive(Debug, Clone, Default)]
+pub struct Stats {
+    pub count: u32,
+    pub first_seen: u64,
+    pub last_seen: u64,
+}
+
+impl Stats {
+    fn update(&mut self, ts: u64) {
+        self.count += 1;
+        if ts > 0 {
+            if self.first_seen == 0 || ts < self.first_seen {
+                self.first_seen = ts;
+            }
+            if ts > self.last_seen {
+                self.last_seen = ts;
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Aggregated {
+    pub files: BTreeMap<String, Stats>,
+    pub network: BTreeMap<String, Stats>,
+    pub processes: BTreeMap<String, Stats>,
+}
+
+impl Aggregated {
+    pub fn total(&self) -> usize {
+        self.files.len() + self.network.len() + self.processes.len()
+    }
+}
+
+pub fn read_events(path: &PathBuf) -> Result<Vec<Event>> {
+    let reader: Box<dyn BufRead> = if path.to_string_lossy() == "-" {
+        Box::new(BufReader::new(std::io::stdin()))
+    } else {
+        Box::new(BufReader::new(std::fs::File::open(path)?))
+    };
+    let mut events = Vec::new();
+    let mut total_lines = 0;
+    let mut error_count = 0;
+
+    for (i, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() || line.starts_with('#') {
+            continue;
+        }
+        total_lines += 1;
+        match serde_json::from_str(&line) {
+            Ok(e) => events.push(e),
+            Err(_) => {
+                error_count += 1;
+                if error_count <= 3 {
+                    eprintln!("warning: skipping line {}: unparsable event", i + 1);
+                }
+            }
+        }
+    }
+
+    if error_count > 3 {
+        eprintln!("warning: skipped {} unparsable lines total", error_count);
+    }
+
+    if events.is_empty() && error_count > 0 {
+        anyhow::bail!(
+            "no valid events found ({} lines skipped, 0 ok)",
+            error_count
+        );
+    }
+
+    if total_lines > 0 {
+        let error_rate = error_count as f64 / total_lines as f64;
+        if error_rate > 0.5 {
+            eprintln!(
+                "warning: high error rate ({:.1}%) - check input format",
+                error_rate * 100.0
+            );
+        }
+    }
+
+    Ok(events)
+}
+
+pub fn aggregate(events: &[Event]) -> Aggregated {
+    let mut agg = Aggregated::default();
+    for ev in events {
+        match ev {
+            Event::FileOpen {
+                path, timestamp, ..
+            } => agg
+                .files
+                .entry(path.clone())
+                .or_default()
+                .update(*timestamp),
+            Event::NetConnect {
+                dest, timestamp, ..
+            } => agg
+                .network
+                .entry(dest.clone())
+                .or_default()
+                .update(*timestamp),
+            Event::ProcExec {
+                path, timestamp, ..
+            } => agg
+                .processes
+                .entry(path.clone())
+                .or_default()
+                .update(*timestamp),
+        }
+    }
+    agg
+}


### PR DESCRIPTION
## Why
G3 step for RFC-003 (`generate` decomposition): extract single-run ingest and aggregation helpers after G1/G2 safety gates.

## Scope
- `crates/assay-cli/src/cli/commands/generate.rs`
- `crates/assay-cli/src/cli/commands/generate/ingest.rs`

## What Changed
- Extracted ingest/aggregation types and functions into `generate/ingest.rs`:
  - `Stats`
  - `Aggregated`
  - `read_events(...)`
  - `aggregate(...)`
- Wired `mod ingest;` in `generate.rs` and re-exported the same symbols.
- Kept `generate.rs` orchestration + generation logic unchanged.

## Old -> New Mapping
- `generate.rs::{Stats, Aggregated, read_events, aggregate}` -> `generate/ingest.rs::*`

## Non-goals
- No warning/error string changes.
- No parse tolerance changes.
- No exit behavior changes.
- No profile/diff/classification logic moves.

## Validation
- `cargo test -p assay-cli --test contract_generate_g1 -- --nocapture`
- `cargo test -p assay-cli generate -- --nocapture`
- `cargo check -p assay-cli`
- `cargo clippy -p assay-cli -- -D warnings`

## Contract Notes
- G1 freeze tests remain green unchanged.
- Ingest warning/error text and line-numbering behavior preserved.
- Demo artifacts untouched (`demo/`, `.github/workflows/demo.yml`, `my-agent/`).
