### PR TITLE
fix(monitor): avoid partial move of --ebpf args in linux monitor path

### DIFF
--- a/crates/assay-cli/src/cli/commands/monitor.rs
+++ b/crates/assay-cli/src/cli/commands/monitor.rs
@@ -393,8 +393,8 @@ async fn run_linux(args: MonitorArgs) -> anyhow::Result<i32> {
         kill_config = p.kill_switch;
     }
 
-    let ebpf_path = match args.ebpf {
-        Some(p) => p,
+    let ebpf_path = match args.ebpf.as_ref() {
+        Some(p) => p.clone(),
         None => {
             // Heuristic: default to the output location of `cargo xtask build-ebpf`
             // User can override with --ebpf


### PR DESCRIPTION
## Why
A recent refactor introduced a compile regression in assay-cli on Linux CI:

- `args.ebpf` was moved out of `args` and `args` was later borrowed in the event loop (`log_monitor_event(&event, &args)`), causing E0382.

This blocked unrelated PRs (including docs-only PR #273) because workspace build checks failed.

## What changed
- In `crates/assay-cli/src/cli/commands/monitor.rs`, changed:
  - `match args.ebpf { Some(p) => p, ... }`
  - to `match args.ebpf.as_ref() { Some(p) => p.clone(), ... }`
- Behavior remains identical; only ownership semantics changed.

## Validation
- `cargo check -p assay-cli`

## Scope
- Single-file hotfix, no contract/schema/output changes.
