### PR TITLE
feat(evidence): CICD Starter Pack + merge-gates (ADR-023)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,16 @@ jobs:
       - name: Check open core boundary
         run: ./scripts/ci/check-open-core-boundary.sh
 
+  vendored-packs:
+    name: Vendored Pack Sync
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Check vendored pack files are in sync
+        run: ./scripts/check-vendored-packs.sh
+
   perf:
     name: Criterion benches (store + suite)
     runs-on: ubuntu-latest
@@ -444,6 +454,6 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
-    needs: [deps-security, clippy, open-core-boundary, perf, test, ebpf-smoke-ubuntu]
+    needs: [deps-security, clippy, open-core-boundary, vendored-packs, perf, test, ebpf-smoke-ubuntu]
     steps:
       - run: echo "All required CI jobs passed."

--- a/crates/assay-cli/src/cli/commands/evidence/lint.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/lint.rs
@@ -7,6 +7,9 @@ use assay_evidence::VerifyLimits;
 use clap::Args;
 use std::fs::File;
 
+/// Default pack when --pack is omitted (ADR-023).
+const DEFAULT_PACK: &str = "cicd-starter";
+
 #[derive(Debug, Args, Clone)]
 pub struct LintArgs {
     /// Bundle to lint (omit when using --explain)
@@ -56,7 +59,7 @@ pub fn cmd_lint(args: LintArgs) -> Result<i32> {
 
     let limits = VerifyLimits::default();
 
-    // Load packs: explicit --pack or default cicd-starter (ADR-023)
+    // Load packs: explicit --pack or default (ADR-023)
     let (packs, is_default_pack) = if let Some(pack_refs) = &args.pack {
         match load_packs(pack_refs) {
             Ok(p) => (p, false),
@@ -66,7 +69,7 @@ pub fn cmd_lint(args: LintArgs) -> Result<i32> {
             }
         }
     } else {
-        match load_packs(&["cicd-starter".to_string()]) {
+        match load_packs(&[DEFAULT_PACK.to_string()]) {
             Ok(p) => (p, true),
             Err(e) => {
                 eprintln!("Default pack loading failed: {}", e);
@@ -141,7 +144,7 @@ pub fn cmd_lint(args: LintArgs) -> Result<i32> {
                     .packs
                     .iter()
                     .map(|p| {
-                        let suffix = if is_default_pack && p.name == "cicd-starter" {
+                        let suffix = if is_default_pack && p.name == DEFAULT_PACK {
                             " (default)"
                         } else {
                             ""
@@ -237,7 +240,7 @@ fn load_packs_for_lint(
 ) -> Result<Vec<LoadedPack>, assay_evidence::lint::packs::PackError> {
     let refs: Vec<String> = pack_refs
         .clone()
-        .unwrap_or_else(|| vec!["cicd-starter".to_string()]);
+        .unwrap_or_else(|| vec![DEFAULT_PACK.to_string()]);
     load_packs(&refs)
 }
 

--- a/crates/assay-evidence/packs/cicd-starter.yaml
+++ b/crates/assay-evidence/packs/cicd-starter.yaml
@@ -1,0 +1,85 @@
+# Vendored from packs/open/cicd-starter/pack.yaml (ADR-023)
+name: cicd-starter
+version: "1.0.0"
+kind: quality
+description: Minimal traceability for CI pipelines — compatibility floor for adoption
+author: Assay Team
+license: Apache-2.0
+
+requires:
+  assay_min_version: ">=2.10.0"
+  evidence_schema_version: "1.0"
+
+rules:
+  - id: CICD-001
+    severity: error
+    description: Evidence bundle contains at least one recorded event
+    help_markdown: |
+      ## CICD-001: Event Presence
+      The bundle must contain at least one event. An empty bundle indicates
+      no evidence was captured for this run.
+
+      **How to fix:**
+      - Ensure your CI runs `assay evidence export` (or equivalent) before lint.
+      - Verify the evidence pipeline emits at least one CloudEvents event.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_count
+      min: 1
+
+  - id: CICD-002
+    severity: warning
+    description: Events include assay profile lifecycle (started/finished pair)
+    help_markdown: |
+      ## CICD-002: Lifecycle Traceability
+      At least one `assay.profile.started` and one `assay.profile.finished` event
+      should exist. These represent CI-run boundaries. If you use custom lifecycle
+      types, see the pack README for pattern customization.
+
+      **How to fix:**
+      - Ensure your evidence pipeline emits profile start/finish events.
+      - Assay's default export includes these when using `assay run` or trace replay.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_pairs
+      start_pattern: "assay.profile.started"
+      finish_pattern: "assay.profile.finished"
+
+  - id: CICD-003
+    severity: warning
+    description: At least one event contains correlation ID (traceparent, tracestate, run_id)
+    help_markdown: |
+      ## CICD-003: Correlation (W3C Trace Context)
+      Events should include traceparent, tracestate, or run_id to link evidence
+      to external observability (e.g. OpenTelemetry).
+
+      **How to fix:**
+      - If using OpenTelemetry: propagate traceparent into the event envelope.
+      - Otherwise: set run_id (UUID or deterministic ID) for each run in event data.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_field_present
+      paths_any_of:
+        - /traceparent
+        - /tracestate
+        - /run_id
+        - /data/traceparent
+        - /data/tracestate
+        - /data/run_id
+
+  - id: CICD-004
+    severity: info
+    description: At least one event contains build identity (build_id or version)
+    help_markdown: |
+      ## CICD-004: Build Identity
+      Build identity fields support provenance maturity and help you build
+      toward SLSA-style attestations.
+
+      **How to fix:**
+      - Add `build_id` or `version` to event data in your evidence pipeline.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_field_present
+      paths_any_of:
+        - /data/build_id
+        - /data/version

--- a/crates/assay-evidence/packs/cicd-starter.yaml
+++ b/crates/assay-evidence/packs/cicd-starter.yaml
@@ -47,25 +47,27 @@ rules:
 
   - id: CICD-003
     severity: warning
-    description: At least one event contains correlation ID (traceparent, tracestate, run_id)
+    description: At least one event contains correlation ID (traceparent, tracestate, run_id, assayrunid)
     help_markdown: |
       ## CICD-003: Correlation (W3C Trace Context)
-      Events should include traceparent, tracestate, or run_id to link evidence
-      to external observability (e.g. OpenTelemetry).
+      Events should include a correlation identifier—traceparent, tracestate,
+      run_id, or assayrunid—to link evidence to external observability.
 
       **How to fix:**
       - If using OpenTelemetry: propagate traceparent into the event envelope.
       - Otherwise: set run_id (UUID or deterministic ID) for each run in event data.
+      - Assay-native events include assayrunid by default.
       - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
     check:
       type: event_field_present
       paths_any_of:
+        - /assayrunid
+        - /run_id
         - /traceparent
         - /tracestate
-        - /run_id
+        - /data/run_id
         - /data/traceparent
         - /data/tracestate
-        - /data/run_id
 
   - id: CICD-004
     severity: info

--- a/crates/assay-evidence/src/lint/packs/mod.rs
+++ b/crates/assay-evidence/src/lint/packs/mod.rs
@@ -21,6 +21,10 @@ pub use schema::{CheckDefinition, PackDefinition, PackKind, PackRequirements, Pa
 /// truth; sync changes manually or via build script.
 pub static BUILTIN_PACKS: &[(&str, &str)] = &[
     (
+        "cicd-starter",
+        include_str!("../../../packs/cicd-starter.yaml"),
+    ),
+    (
         "eu-ai-act-baseline",
         include_str!("../../../packs/eu-ai-act-baseline.yaml"),
     ),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,9 +1,10 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-02-10):** Q2 items verified against codebase — all P0/P1/P2 DX features delivered.
+> **Status sync (2026-02):** Q2 items verified — all P0/P1/P2 DX features delivered.
 > Code health (RFC-002) and generate decomposition (RFC-003 G1–G6) merged.
 > Golden path, drift-aware feedback, GitHub Action v2.1 confirmed complete.
-> Remaining structural items tracked in [RFC-004](architecture/RFC-004-open-items-convergence-q1-2026.md).
+> **Starter packs (ADR-023)** merged PR #289 — cicd-starter default pack, assayrunid fix, vendored drift CI, --explain UX.
+> Next: [Sim Engine Hardening (ADR-024)](architecture/ADR-024-Sim-Engine-Hardening.md). Structural items in [RFC-004](architecture/RFC-004-open-items-convergence-q1-2026.md).
 
 **Strategic Focus:** Agent Runtime Evidence & Control Plane.
 **Core Value:** Verifiable Evidence (Open Standard) + Governance Platform.
@@ -326,9 +327,9 @@ Per [ADR-018](./architecture/ADR-018-GitHub-Action-v2.1.md):
 
 See [ADR-018](./architecture/ADR-018-GitHub-Action-v2.1.md) for full specification.
 
-### F. Starter Packs (OSS) (P1)
+### F. Starter Packs (OSS) (P1) ✅ Complete
 
-CICD-hygiene pack as compatibility floor for adoption—minimal traceability so teams get first value from `assay evidence lint` with minimal config. See [ADR-023](./architecture/ADR-023-CICD-Starter-Pack.md).
+CICD-hygiene pack as compatibility floor for adoption—minimal traceability so teams get first value from `assay evidence lint` with minimal config. See [ADR-023](./architecture/ADR-023-CICD-Starter-Pack.md). Merged PR #289.
 
 ```bash
 assay evidence lint --pack cicd-starter bundle.tar.gz
@@ -357,7 +358,7 @@ assay evidence lint --pack cicd-starter,eu-ai-act-baseline bundle.tar.gz
 
 ### G. Sim Engine Hardening (P2)
 
-Configurable verification limits and time budget enforcement for `assay sim`—resource-control best practices (OWASP-aligned, fail-fast under load).
+Configurable verification limits and time budget enforcement for `assay sim`—resource-control best practices (OWASP-aligned, fail-fast under load). See [ADR-024](./architecture/ADR-024-Sim-Engine-Hardening.md).
 
 ```bash
 assay sim run --suite quick --target bundle.tar.gz

--- a/docs/architecture/ADR-023-CICD-Starter-Pack.md
+++ b/docs/architecture/ADR-023-CICD-Starter-Pack.md
@@ -1,0 +1,273 @@
+# ADR-023: CICD Starter Pack (Adoption Floor)
+
+## Status
+
+Accepted (February 2026)
+
+## Context
+
+Per [ADR-016](./ADR-016-Pack-Taxonomy.md) and the [ROADMAP §F](../ROADMAP.md#f-starter-packs-oss-p1), the open core requires a **compatibility floor for adoption**—a lightweight pack that gives teams first value from `assay evidence lint` with minimal config, before they graduate to compliance packs (eu-ai-act-baseline, soc2-baseline).
+
+Challenges:
+- eu-ai-act-baseline and soc2-baseline are **compliance-focused** (regulatory mapping, disclaimers); they assume prior familiarity with evidence format and lint workflow.
+- New teams need a **zero-friction first signal**: "Does my CI produce valid, traceable evidence?" without regulatory framing.
+- A starter pack must be **composable** with compliance packs so teams can add `--pack eu-ai-act-baseline` when they need Article 12 coverage.
+
+## Decision
+
+### 1. Pack identity and kind
+
+We introduce **`cicd-starter`** as a **quality** pack:
+
+| Field | Value | Rationale |
+|-------|-------|-----------|
+| `name` | `cicd-starter` | Clear, CI-focused; distinct from compliance pack names |
+| `kind` | `quality` | No disclaimer; light best-practice checks; see [ADR-016](./ADR-016-Pack-Taxonomy.md) |
+| `version` | `1.0.0` | Initial release |
+
+**No disclaimer** — `kind: quality` packs do not require a legal disclaimer per SPEC-Pack-Engine-v1. The pack README SHALL include a short note: "These checks verify evidence hygiene for CI pipelines. They do not constitute compliance certification."
+
+### 2. Rule set (minimal traceability)
+
+Only **existing** check types from [SPEC-Pack-Engine-v1](./SPEC-Pack-Engine-v1.md): `event_count`, `event_pairs`, `event_field_present`. No new engine behaviour.
+
+| Rule ID | Check | Severity | Evidence required |
+|---------|-------|----------|-------------------|
+| CICD-001 | Bundle has ≥1 event | error | ≥1 event in bundle |
+| CICD-002 | Lifecycle pair present | warning | `assay.profile.started` + `assay.profile.finished` |
+| CICD-003 | Correlation ID present | warning | `traceparent`, `tracestate`, or `run_id` (top-level or in data) |
+| CICD-004 | Build identity present | info | `data.build_id` or `data.version` |
+
+**Rationale:**
+- CICD-001: Empty bundle = no evidence; fail fast.
+- CICD-002: Exact `assay.profile.started` / `assay.profile.finished` for beginners—avoids "mysterious pass" from unrelated `*.started` events. README explains how to customize patterns for custom lifecycle types.
+- CICD-003: Canonical top-level W3C fields (`traceparent`, `tracestate`, `run_id`) + `/data/*` fallback; semantically distinct from build metadata.
+- CICD-004: Build identity (build_id, version) supports provenance maturity; info severity as optional signal toward SLSA/attestation readiness.
+
+### 3. Check definitions (normative)
+
+```yaml
+# cicd-starter@1.0.0
+name: cicd-starter
+version: "1.0.0"
+kind: quality
+description: Minimal traceability for CI pipelines — compatibility floor for adoption
+author: Assay Team
+license: Apache-2.0
+
+requires:
+  assay_min_version: ">=2.10.0"
+  evidence_schema_version: "1.0"
+
+rules:
+  - id: CICD-001
+    severity: error
+    description: Evidence bundle contains at least one recorded event
+    help_markdown: |
+      ## CICD-001: Event Presence
+      The bundle must contain at least one event. An empty bundle indicates
+      no evidence was captured for this run.
+
+      **How to fix:**
+      - Ensure your CI runs `assay evidence export` (or equivalent) before lint.
+      - Verify the evidence pipeline emits at least one CloudEvents event.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_count
+      min: 1
+
+  - id: CICD-002
+    severity: warning
+    description: Events include assay profile lifecycle (started/finished pair)
+    help_markdown: |
+      ## CICD-002: Lifecycle Traceability
+      At least one `assay.profile.started` and one `assay.profile.finished` event
+      should exist. These represent CI-run boundaries. If you use custom lifecycle
+      types, see the pack README for pattern customization.
+
+      **How to fix:**
+      - Ensure your evidence pipeline emits profile start/finish events.
+      - Assay's default export includes these when using `assay run` or trace replay.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_pairs
+      start_pattern: "assay.profile.started"
+      finish_pattern: "assay.profile.finished"
+
+  - id: CICD-003
+    severity: warning
+    description: At least one event contains correlation ID (traceparent, tracestate, run_id)
+    help_markdown: |
+      ## CICD-003: Correlation (W3C Trace Context)
+      Events should include traceparent, tracestate, or run_id to link evidence
+      to external observability (e.g. OpenTelemetry).
+
+      **How to fix:**
+      - If using OpenTelemetry: propagate traceparent into the event envelope.
+      - Otherwise: set run_id (UUID or deterministic ID) for each run in event data.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_field_present
+      paths_any_of:
+        - /traceparent
+        - /tracestate
+        - /run_id
+        - /data/traceparent
+        - /data/tracestate
+        - /data/run_id
+
+  - id: CICD-004
+    severity: info
+    description: At least one event contains build identity (build_id or version)
+    help_markdown: |
+      ## CICD-004: Build Identity
+      Build identity fields support provenance maturity and help you build
+      toward SLSA-style attestations.
+
+      **How to fix:**
+      - Add `build_id` or `version` to event data in your evidence pipeline.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_field_present
+      paths_any_of:
+        - /data/build_id
+        - /data/version
+```
+
+### 4. Pack layout and delivery
+
+| Item | Specification |
+|------|---------------|
+| **Source location** | `packs/open/cicd-starter/` with `pack.yaml`, `README.md`, `LICENSE` (Apache-2.0) |
+| **Built-in** | Yes. Add to `BUILTIN_PACKS` in `assay-evidence` so `--pack cicd-starter` works without local discovery. |
+| **Vendoring (normative)** | `packs/open/*` MUST be vendored into `crates/assay-evidence/packs/*` (copy or symlink) for `include_str!` and `cargo publish`. This is a repo rule; same pattern as eu-ai-act-baseline, soc2-baseline. |
+
+### 5. Default pack and CLI UX
+
+**`cicd-starter` SHALL be the default pack** when no `--pack` is specified. This eliminates choice friction and aligns with PLG best practice ("run lint" without configuration).
+
+**Header output:** When using the default, the lint output SHALL show:
+```
+Packs: cicd-starter@1.0.0 (default)
+Hint: Use --pack eu-ai-act-baseline to add compliance mapping.
+```
+
+```bash
+# Default: cicd-starter (no --pack needed)
+assay evidence lint bundle.tar.gz
+
+# Explicit pack (equivalent)
+assay evidence lint bundle.tar.gz --pack cicd-starter
+
+# Starter + compliance (graduation path)
+assay evidence lint bundle.tar.gz --pack cicd-starter,eu-ai-act-baseline
+assay evidence lint bundle.tar.gz --pack eu-ai-act-baseline   # overrides default
+```
+
+No collision: cicd-starter rule IDs (CICD-001 through CICD-004) are distinct from eu-ai-act (EU12-*) and soc2 (invariant.*).
+
+### 6. Documentation
+
+#### Pack README (normative structure)
+
+| Section | Content |
+|---------|---------|
+| **Rules table** | Rule ID \| Check \| Severity \| Evidence required |
+| **Quickstart** | "First signal in <5 min" with copy/paste GitHub Action snippet |
+| **Action snippet** | **Pinned to commit SHA** (supply-chain hardening); default `fail_on: error`; note that **warnings won't fail CI by default—use `--fail-on warning` to enforce** |
+| **Advanced** | Reusable workflow (`workflow_call`) with inputs: `bundle_path`, `pack`, `fail_on`; link to GH docs |
+| **Next steps** | Buttons/links: `--pack soc2-baseline`, `--pack eu-ai-act-baseline` for graduation |
+| **Provenance** | These checks help build toward **provenance maturity** (SLSA, attestations); prepares evidence hygiene for attestation workflows |
+| **CICD-002 customization** | How to extend patterns if using custom lifecycle event types |
+
+#### Severity and exit-code UX
+
+- Warnings (CICD-002, CICD-003) do **not** fail CI by default.
+- README SHALL state: "Set `--fail-on warning` to enforce warnings in CI."
+
+## Consequences
+
+### Positive
+
+- Teams get first value from `assay evidence lint` without regulatory context.
+- Composable with compliance packs; clear graduation path.
+- No new check types; leverages existing engine.
+- `kind: quality` avoids disclaimer overhead for non-compliance use.
+
+### Negative
+
+- Overlap with eu-ai-act-baseline (EU12-001 ≈ CICD-001; EU12-002 ≈ CICD-002; EU12-003 ≈ CICD-003). Acceptable: starter is adoption wedge; compliance pack is regulatory mapping. Teams using both get deduplicated findings.
+
+### Neutral
+
+- Rule severity (error for CICD-001, warning for CICD-002/003, info for CICD-004) may be tuned based on feedback. Minor version bump if changed.
+- CICD-004 is optional (info); implementers may ship v1.0.0 with three rules and add CICD-004 in a patch if preferred.
+
+## Acceptance Criteria
+
+- [ ] Pack at `packs/open/cicd-starter/` with pack.yaml, README, LICENSE
+- [ ] Added to `BUILTIN_PACKS`; `assay evidence lint --pack cicd-starter bundle.tar.gz` works
+- [ ] **Default pack**: When no `--pack` specified, cicd-starter is used; header shows "Packs: cicd-starter@1.0.0 (default)" + hint
+- [ ] CICD-002 uses exact `assay.profile.started` / `assay.profile.finished`; CICD-003 uses canonical paths (traceparent, tracestate, run_id) + data fallback
+- [ ] Each rule help_markdown includes "How to fix" bullets + verify command
+- [ ] Pack README: Rules table (with Evidence required); pinned GH Action snippet; `--fail-on warning` note; Next steps (soc2, eu-ai-act); provenance framing; CICD-002 customization
+- [ ] `packs/open/cicd-starter/` vendored to `crates/assay-evidence/packs/cicd-starter.yaml`
+- [ ] ROADMAP §F status table updated on merge
+
+## Appendix A: README template (normative)
+
+The pack README at `packs/open/cicd-starter/README.md` SHALL follow this structure:
+
+```markdown
+# CICD Starter Pack
+
+**License:** Apache-2.0 | **Version:** 1.0.0
+Minimal traceability for CI pipelines — compatibility floor for adoption.
+
+## Rules
+
+| Rule ID | Check | Severity | Evidence required |
+|---------|-------|----------|-------------------|
+| CICD-001 | Event presence | error | ≥1 event |
+| CICD-002 | Lifecycle pair | warning | assay.profile.started + .finished |
+| CICD-003 | Correlation ID | warning | traceparent, tracestate, or run_id |
+| CICD-004 | Build identity | info | data.build_id or data.version |
+
+## Quickstart (copy/paste)
+
+    - uses: Rul1an/assay/assay-action@v2   # Pin to commit SHA in production
+      with:
+        pack: cicd-starter
+        fail_on: error   # Use 'warning' to enforce CICD-002/003 in CI
+
+(Bundles auto-discovered; set `bundles` to override glob.)
+
+**Note:** Warnings won't fail CI by default. Set `fail_on: warning` to enforce.
+
+## Next steps
+
+- `--pack soc2-baseline` — SOC2 Common Criteria checks
+- `--pack eu-ai-act-baseline` — EU AI Act Article 12 mapping
+
+## Provenance
+
+These checks help build toward provenance maturity (SLSA, attestations).
+```
+
+(Full README SHALL also include CICD-002 customization for custom lifecycle types.)
+
+## Open-core / monetization bridge
+
+With cicd-starter as the adoption wedge, the graduation path is:
+
+- **OSS:** cicd-starter + eu-ai-act-baseline + soc2-baseline (marketing-grade entry)
+- **Pro/Enterprise:** Pack registry (private packs, signed); policy gates; evidence retention; SARIF + GH Advanced Security; attestation/SLSA packs as upsell after CICD-004
+
+## References
+
+- [ADR-013: EU AI Act Compliance Pack](./ADR-013-EU-AI-Act-Pack.md)
+- [ADR-016: Pack Taxonomy](./ADR-016-Pack-Taxonomy.md)
+- [ADR-021: Local Pack Discovery](./ADR-021-Local-Pack-Discovery.md)
+- [ADR-022: SOC2 Baseline Pack](./ADR-022-SOC2-Baseline-Pack.md)
+- [SPEC-Pack-Engine-v1](./SPEC-Pack-Engine-v1.md)
+- [ROADMAP §F: Starter Packs (OSS)](../ROADMAP.md#f-starter-packs-oss-p1)

--- a/docs/architecture/ADR-024-Sim-Engine-Hardening.md
+++ b/docs/architecture/ADR-024-Sim-Engine-Hardening.md
@@ -1,0 +1,150 @@
+# ADR-024: Sim Engine Hardening (Limits + Time Budget)
+
+## Status
+
+Proposed (February 2026)
+
+## Context
+
+The `assay sim` attack simulation suite ([ROADMAP §G](../ROADMAP.md#g-sim-engine-hardening-p2)) validates that evidence bundle verification correctly blocks integrity attacks (bitflip, truncate, inject, zip bomb, etc.). Per OWASP and resource-control best practices:
+
+1. **Configurable limits**: Users and CI must be able to override verification limits (e.g. stricter `max_bundle_bytes` for constrained environments).
+2. **Time budget**: Suite already has `TimeBudget` (60s default), but it is hardcoded; configurable budget supports predictable CI behavior.
+3. **Limits coverage**: Integrity attacks currently use `verify_bundle` (default limits). They should use `verify_bundle_with_limits` so that limit-based blocks are exercised and distinguishable from structural/integrity blocks.
+4. **Regression-proof limits test**: The zip bomb attack creates ~1.1GB; if limits were relaxed, it could bypass. A dynamic `limit + 1` bytes attack ensures limits are actually enforced.
+
+Current gaps:
+
+- `SuiteConfig.verify_limits` exists but is never passed to attacks (CLI has `// TODO(sim-verify-limits)`)
+- No `--limits` or `--limits-file` CLI flags
+- `TimeBudget` is fixed at 60s; no `--time-budget` override
+- "Blocked by verify limits" is not distinguishable from "Blocked by integrity check" in attack results
+
+## Decision
+
+### 1. CLI: Limits and Budget Flags
+
+Add to `assay sim run`:
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--limits` | JSON string | Partial `VerifyLimits` overrides. Merged with defaults. |
+| `--limits-file` | Path | Path to JSON file with limits. Overrides `--limits` if both given. |
+| `--time-budget` | Seconds | Suite time budget. Default: 60. |
+
+**Parse rules:**
+
+- Invalid JSON → exit code 3 (config error)
+- Unknown keys in `--limits` JSON → reject with clear error
+- `--limits-file` path missing → exit 3
+- Schema: subset of `VerifyLimits` fields; partial merge (only provided fields override)
+
+**Example:**
+
+```bash
+assay sim run --suite quick --target bundle.tar.gz
+assay sim run --suite quick --limits '{"max_bundle_bytes": 10485760}' --target bundle.tar.gz
+assay sim run --suite quick --limits-file .assay/sim-limits.json --target bundle.tar.gz
+assay sim run --suite quick --time-budget 120 --target bundle.tar.gz
+```
+
+### 2. Limits Model
+
+- **Source**: `assay_evidence::VerifyLimits` (existing struct)
+- **Merge**: Start with `VerifyLimits::default()`, then apply overrides from `--limits` or `--limits-file`
+- **JSON schema** (informative): Same field names as `VerifyLimits`; only override provided keys
+- **Stable schema**: Document in ADR; breaking changes require version bump
+
+### 3. Integrity Attacks: Pass Limits and Budget
+
+- `check_integrity_attacks` receives `VerifyLimits` and `TimeBudget`
+- Use `verify_bundle_with_limits(cursor, limits)` instead of `verify_bundle`
+- Before each attack iteration: `if budget.exceeded() { skip remaining; report time_budget }`
+- **Exit semantics**: Attack blocked by `LimitBundleBytes` / `LimitDecodeBytes` etc. → `AttackStatus::Blocked` (correct). Not a bypass.
+
+### 4. Dynamic `bundle_size` Attack (Regression-Proof)
+
+Add integrity attack:
+
+- **Name**: `integrity.limit_bundle_bytes`
+- **Behavior**: Generate bundle of `limits.max_bundle_bytes + 1` bytes (compressed). Verification must fail with `LimitBundleBytes`.
+- **Purpose**: If limits were accidentally bypassed or default raised, this test fails → regression caught.
+- **Config**: Use `cfg.verify_limits`; if None, use default (100MB). Attack generates 100MB+1.
+
+### 5. Exit Codes and Status Distinction
+
+| Scenario | Status | Exit (suite) |
+|----------|--------|--------------|
+| Attack blocked by integrity check | `Blocked` | 0 |
+| Attack blocked by verify limits | `Blocked` | 0 |
+| Attack bypassed verification | `Bypassed` | 1 |
+| Time budget exceeded | `Error` | 2 |
+| Config/parse error | — | 3 |
+
+**Rationale**: "Blocked by limits" and "blocked by integrity" are both correct outcomes. Distinction can be inferred from `error_code` (e.g. `LimitBundleBytes`) in the attack result for diagnostics; no need to split `Blocked` into subtypes.
+
+### 6. Time Budget Check Points
+
+Budget checks before:
+
+- Integrity attacks (start)
+- After integrity phase (existing)
+- After differential phase (existing)
+- Before chaos phase (existing)
+- Before each expensive verify/iteration in integrity loop (new: optional micro-check if iteration count is high)
+
+**Design**: Single global `TimeBudget` for the whole suite. No per-attack budget to avoid fragmentation.
+
+### 7. `--limits-file` / `@path` Convenience
+
+- `--limits-file path` reads JSON from file
+- Future: `--limits @path` as shorthand (optional, not required for v1)
+
+## Consequences
+
+### Positive
+
+- CI can run sim with stricter limits (e.g. 10MB) to catch regressions quickly
+- Resource-exhaustion attacks (zip bomb, limit bypass) are regression-tested
+- Time budget prevents runaway suites in flaky environments
+- Aligns with OWASP "fail fast under load" guidance
+
+### Negative
+
+- Additional CLI surface; must document limits schema
+- `--limits` JSON escaping in shell can be awkward; `--limits-file` mitigates
+
+### Neutral
+
+- Differential tests already use `verify_bundle_with_limits` with custom `max_events`; no change needed
+- Chaos attacks use subprocess isolation; budget check before phase is sufficient
+
+## Implementation Notes
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `crates/assay-cli/src/cli/args.rs` | Add `--limits`, `--limits-file`, `--time-budget` to `SimRunArgs` |
+| `crates/assay-cli/src/cli/commands/sim.rs` | Parse limits, pass to `SuiteConfig` |
+| `crates/assay-sim/src/suite.rs` | Accept configurable `TimeBudget`; pass `verify_limits` to integrity |
+| `crates/assay-sim/src/attacks/integrity.rs` | Use `verify_bundle_with_limits`; add `limit_bundle_bytes` attack; budget check |
+| `crates/assay-evidence/src/bundle/writer.rs` | `VerifyLimits` already exists; add `impl Serialize/Deserialize` if not present |
+
+### VerifyLimits Serde
+
+If `VerifyLimits` does not implement `Serialize`/`Deserialize`, add behind optional `serde` feature or in assay-evidence for sim use. Partial deserialize: use `#[serde(default)]` for missing fields so partial JSON works.
+
+### Test Plan
+
+1. `assay sim run --suite quick --limits '{"max_bundle_bytes": 1000}'` → zip bomb and limit_bundle_bytes blocked
+2. `assay sim run --suite quick --limits-file /nonexistent` → exit 3
+3. `assay sim run --suite quick --limits 'invalid'` → exit 3
+4. `assay sim run --suite quick --time-budget 1` → time_budget Error after quick phase (if < 1s)
+5. Existing quick suite test: no regressions with default limits
+
+## References
+
+- [ROADMAP §G](../ROADMAP.md#g-sim-engine-hardening-p2)
+- [assay-evidence VerifyLimits](https://github.com/Rul1an/assay/blob/main/crates/assay-evidence/src/bundle/writer.rs)
+- OWASP: Resource exhaustion, fail-fast principles

--- a/packs/open/cicd-starter/LICENSE
+++ b/packs/open/cicd-starter/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form of making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to, the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf of
+      any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025-2026 Assay Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packs/open/cicd-starter/README.md
+++ b/packs/open/cicd-starter/README.md
@@ -68,5 +68,5 @@ Then: `assay evidence lint --pack cicd-starter,./custom-pack.yaml bundle.tar.gz`
 
 ## Reference
 
-- [ADR-023: CICD Starter Pack](../../docs/architecture/ADR-023-CICD-Starter-Pack.md)
-- [SPEC-Pack-Engine-v1](../../docs/architecture/SPEC-Pack-Engine-v1.md)
+- [ADR-023: CICD Starter Pack](../../../docs/architecture/ADR-023-CICD-Starter-Pack.md)
+- [SPEC-Pack-Engine-v1](../../../docs/architecture/SPEC-Pack-Engine-v1.md)

--- a/packs/open/cicd-starter/README.md
+++ b/packs/open/cicd-starter/README.md
@@ -1,0 +1,72 @@
+# CICD Starter Pack
+
+**License:** Apache-2.0 | **Version:** 1.0.0
+Minimal traceability for CI pipelines — compatibility floor for adoption.
+
+These checks verify evidence hygiene for CI pipelines. They do not constitute compliance certification.
+
+## Rules
+
+| Rule ID | Check | Severity | Evidence required |
+|---------|-------|----------|-------------------|
+| CICD-001 | Event presence | error | ≥1 event |
+| CICD-002 | Lifecycle pair | warning | assay.profile.started + .finished |
+| CICD-003 | Correlation ID | warning | traceparent, tracestate, or run_id |
+| CICD-004 | Build identity | info | data.build_id or data.version |
+
+## Quickstart (copy/paste)
+
+```yaml
+- uses: Rul1an/assay/assay-action@v2   # Pin to commit SHA in production
+  with:
+    pack: cicd-starter
+    fail_on: error   # Use 'warning' to enforce CICD-002/003 in CI
+```
+
+(Bundles are auto-discovered; set `bundles` input to override the glob pattern.)
+
+**Note:** Warnings (CICD-002, CICD-003) won't fail CI by default. Set `fail_on: warning` to enforce.
+
+## CLI
+
+```bash
+# Default pack (when no --pack specified)
+assay evidence lint bundle.tar.gz
+
+# Explicit
+assay evidence lint bundle.tar.gz --pack cicd-starter
+```
+
+## Next steps
+
+- `--pack soc2-baseline` — SOC2 Common Criteria checks
+- `--pack eu-ai-act-baseline` — EU AI Act Article 12 mapping
+
+## Provenance
+
+These checks help build toward **provenance maturity** (SLSA, attestations). Even without DSSE/in-toto checks, the pack prepares evidence hygiene for future attestation workflows.
+
+## CICD-002: Custom lifecycle types
+
+The default patterns `assay.profile.started` and `assay.profile.finished` match Assay's standard evidence. If you use custom lifecycle event types, create a derived pack that overrides the check:
+
+```yaml
+# custom-pack.yaml
+name: my-cicd
+version: "1.0.0"
+kind: quality
+# ... base fields ...
+rules:
+  - id: CICD-002
+    check:
+      type: event_pairs
+      start_pattern: "myapp.run.started"    # Your custom type
+      finish_pattern: "myapp.run.finished"
+```
+
+Then: `assay evidence lint --pack cicd-starter,./custom-pack.yaml bundle.tar.gz` (order: cicd-starter loads first; composition rules apply).
+
+## Reference
+
+- [ADR-023: CICD Starter Pack](../../docs/architecture/ADR-023-CICD-Starter-Pack.md)
+- [SPEC-Pack-Engine-v1](../../docs/architecture/SPEC-Pack-Engine-v1.md)

--- a/packs/open/cicd-starter/README.md
+++ b/packs/open/cicd-starter/README.md
@@ -11,7 +11,7 @@ These checks verify evidence hygiene for CI pipelines. They do not constitute co
 |---------|-------|----------|-------------------|
 | CICD-001 | Event presence | error | ≥1 event |
 | CICD-002 | Lifecycle pair | warning | assay.profile.started + .finished |
-| CICD-003 | Correlation ID | warning | traceparent, tracestate, or run_id |
+| CICD-003 | Correlation ID | warning | assayrunid, traceparent, tracestate, or run_id |
 | CICD-004 | Build identity | info | data.build_id or data.version |
 
 ## Quickstart (copy/paste)

--- a/packs/open/cicd-starter/pack.yaml
+++ b/packs/open/cicd-starter/pack.yaml
@@ -46,25 +46,27 @@ rules:
 
   - id: CICD-003
     severity: warning
-    description: At least one event contains correlation ID (traceparent, tracestate, run_id)
+    description: At least one event contains correlation ID (traceparent, tracestate, run_id, assayrunid)
     help_markdown: |
       ## CICD-003: Correlation (W3C Trace Context)
-      Events should include traceparent, tracestate, or run_id to link evidence
-      to external observability (e.g. OpenTelemetry).
+      Events should include a correlation identifier—traceparent, tracestate,
+      run_id, or assayrunid—to link evidence to external observability.
 
       **How to fix:**
       - If using OpenTelemetry: propagate traceparent into the event envelope.
       - Otherwise: set run_id (UUID or deterministic ID) for each run in event data.
+      - Assay-native events include assayrunid by default.
       - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
     check:
       type: event_field_present
       paths_any_of:
+        - /assayrunid
+        - /run_id
         - /traceparent
         - /tracestate
-        - /run_id
+        - /data/run_id
         - /data/traceparent
         - /data/tracestate
-        - /data/run_id
 
   - id: CICD-004
     severity: info

--- a/packs/open/cicd-starter/pack.yaml
+++ b/packs/open/cicd-starter/pack.yaml
@@ -1,0 +1,84 @@
+name: cicd-starter
+version: "1.0.0"
+kind: quality
+description: Minimal traceability for CI pipelines — compatibility floor for adoption
+author: Assay Team
+license: Apache-2.0
+
+requires:
+  assay_min_version: ">=2.10.0"
+  evidence_schema_version: "1.0"
+
+rules:
+  - id: CICD-001
+    severity: error
+    description: Evidence bundle contains at least one recorded event
+    help_markdown: |
+      ## CICD-001: Event Presence
+      The bundle must contain at least one event. An empty bundle indicates
+      no evidence was captured for this run.
+
+      **How to fix:**
+      - Ensure your CI runs `assay evidence export` (or equivalent) before lint.
+      - Verify the evidence pipeline emits at least one CloudEvents event.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_count
+      min: 1
+
+  - id: CICD-002
+    severity: warning
+    description: Events include assay profile lifecycle (started/finished pair)
+    help_markdown: |
+      ## CICD-002: Lifecycle Traceability
+      At least one `assay.profile.started` and one `assay.profile.finished` event
+      should exist. These represent CI-run boundaries. If you use custom lifecycle
+      types, see the pack README for pattern customization.
+
+      **How to fix:**
+      - Ensure your evidence pipeline emits profile start/finish events.
+      - Assay's default export includes these when using `assay run` or trace replay.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_pairs
+      start_pattern: "assay.profile.started"
+      finish_pattern: "assay.profile.finished"
+
+  - id: CICD-003
+    severity: warning
+    description: At least one event contains correlation ID (traceparent, tracestate, run_id)
+    help_markdown: |
+      ## CICD-003: Correlation (W3C Trace Context)
+      Events should include traceparent, tracestate, or run_id to link evidence
+      to external observability (e.g. OpenTelemetry).
+
+      **How to fix:**
+      - If using OpenTelemetry: propagate traceparent into the event envelope.
+      - Otherwise: set run_id (UUID or deterministic ID) for each run in event data.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_field_present
+      paths_any_of:
+        - /traceparent
+        - /tracestate
+        - /run_id
+        - /data/traceparent
+        - /data/tracestate
+        - /data/run_id
+
+  - id: CICD-004
+    severity: info
+    description: At least one event contains build identity (build_id or version)
+    help_markdown: |
+      ## CICD-004: Build Identity
+      Build identity fields support provenance maturity and help you build
+      toward SLSA-style attestations.
+
+      **How to fix:**
+      - Add `build_id` or `version` to event data in your evidence pipeline.
+      - Re-run: `assay evidence lint bundle.tar.gz --pack cicd-starter`
+    check:
+      type: event_field_present
+      paths_any_of:
+        - /data/build_id
+        - /data/version

--- a/scripts/check-vendored-packs.sh
+++ b/scripts/check-vendored-packs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Check that vendored packs in crates/assay-evidence/packs/ match packs/open/ source.
+# Fails CI if drift detected. Add new pack pairs when adding packs to packs/open/.
+#
+# Note: mandate-baseline has no packs/open/ source (internal/mandate-specific);
+# it is vendored only. Do not add it here.
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$REPO_ROOT"
+
+fail=0
+
+check_pair() {
+  local src="$1"
+  local vend="$2"
+
+  if [[ ! -f "$src" ]]; then
+    echo "ERROR: missing source pack: $src"
+    fail=1
+    return
+  fi
+  if [[ ! -f "$vend" ]]; then
+    echo "ERROR: missing vendored pack: $vend"
+    fail=1
+    return
+  fi
+
+  # Compare ignoring the "Vendored from ..." header line (if present).
+  if ! diff -q <(grep -v '^# Vendored from ' "$vend") "$src" >/dev/null 2>&1; then
+    echo "ERROR: vendored pack drift detected:"
+    echo "  src : $src"
+    echo "  vend: $vend"
+    echo
+    diff -u <(grep -v '^# Vendored from ' "$vend") "$src" || true
+    echo
+    echo "Fix: copy $src -> $vend (preserve optional '# Vendored from ...' header)."
+    fail=1
+  fi
+}
+
+check_pair "packs/open/cicd-starter/pack.yaml" "crates/assay-evidence/packs/cicd-starter.yaml"
+check_pair "packs/open/eu-ai-act-baseline/pack.yaml" "crates/assay-evidence/packs/eu-ai-act-baseline.yaml"
+check_pair "packs/open/soc2-baseline/pack.yaml" "crates/assay-evidence/packs/soc2-baseline.yaml"
+
+exit "$fail"


### PR DESCRIPTION
## Description

Implements ADR-023 CICD Starter Pack with adoption-floor UX and merge-gates from review.

### Core (commit 1)
- **Pack**: `cicd-starter` (kind: quality) in `packs/open/cicd-starter/` + vendored to `assay-evidence/packs/`
- **Default pack**: `cicd-starter` when no `--pack` specified (PLG)
- **Rules**: CICD-001 (event count), CICD-002 (profile lifecycle), CICD-003 (correlation), CICD-004 (build identity)
- **ROADMAP §F**: Starter Packs marked complete

### Merge-gates (commit 2)
- **Assay-native fix**: Add `/assayrunid` to CICD-003 — Assay-produced bundles no longer get false CICD-003 warnings
- **Vendored drift CI**: `scripts/check-vendored-packs.sh` + new `vendored-packs` job; fails if `packs/open/*/pack.yaml` drifts from `crates/assay-evidence/packs/*.yaml`
- **--explain UX**: `assay evidence lint --explain CICD-003` (or canonical id) prints rule help; hint per finding
- **Default hint**: "Next: add compliance packs — --pack eu-ai-act-baseline or --pack soc2-baseline"

## Type of Change
- [x] New feature

## Verification
- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] `./scripts/check-vendored-packs.sh` passes
- [x] `assay evidence lint bundle.tar.gz` — default pack, CICD-003 gone for Assay-native
- [x] `assay evidence lint --explain CICD-003` — rule help output

## Related
- [ADR-023: CICD Starter Pack](docs/architecture/ADR-023-CICD-Starter-Pack.md)

Made with [Cursor](https://cursor.com)