### PR TITLE
feat(evidence): ADR-024 E1 — VerifyLimitsOverrides (Sim Hardening foundation)

### DIFF
--- a/crates/assay-evidence/src/bundle.rs
+++ b/crates/assay-evidence/src/bundle.rs
@@ -5,5 +5,5 @@ pub mod writer;
 pub use reader::{BundleInfo, BundleReader};
 pub use writer::{
     verify_bundle, verify_bundle_with_limits, AlgorithmMeta, BundleWriter, ErrorClass, ErrorCode,
-    FileMeta, Manifest, VerifyError, VerifyLimits, VerifyResult,
+    FileMeta, Manifest, VerifyError, VerifyLimits, VerifyLimitsOverrides, VerifyResult,
 };

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -524,10 +524,10 @@ pub struct VerifyLimits {
 impl Default for VerifyLimits {
     fn default() -> Self {
         Self {
-            max_bundle_bytes: 100 * 1024 * 1024,  // 100 MB compressed
-            max_decode_bytes: 1024 * 1024 * 1024, // 1 GB uncompressed (10x ratio)
-            max_manifest_bytes: 10 * 1024 * 1024, // 10 MB
-            max_events_bytes: 500 * 1024 * 1024,  // 500 MB
+            max_bundle_bytes: 100_u64 * 1024 * 1024,  // 100 MB compressed
+            max_decode_bytes: 1024_u64 * 1024 * 1024, // 1 GB uncompressed (10x ratio)
+            max_manifest_bytes: 10_u64 * 1024 * 1024, // 10 MB
+            max_events_bytes: 500_u64 * 1024 * 1024,  // 500 MB
             max_events: 100_000,
             max_line_bytes: 1024 * 1024, // 1 MB
             max_path_len: 256,
@@ -554,8 +554,8 @@ pub struct VerifyLimitsOverrides {
 
 impl VerifyLimits {
     /// Apply overrides onto these defaults. Only `Some` values override.
-    pub fn apply(self, overrides: VerifyLimitsOverrides) -> VerifyLimits {
-        VerifyLimits {
+    pub fn apply(self, overrides: VerifyLimitsOverrides) -> Self {
+        Self {
             max_bundle_bytes: overrides.max_bundle_bytes.unwrap_or(self.max_bundle_bytes),
             max_decode_bytes: overrides.max_decode_bytes.unwrap_or(self.max_decode_bytes),
             max_manifest_bytes: overrides

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -509,7 +509,7 @@ impl From<serde_json::Error> for VerifyError {
 }
 
 /// Resource limits for bundle verification.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VerifyLimits {
     pub max_bundle_bytes: u64,
     pub max_decode_bytes: u64, // New: Limit uncompressed size
@@ -1234,6 +1234,42 @@ mod tests {
             "unknown field should fail: {}",
             err
         );
+    }
+
+    #[test]
+    fn test_verify_limits_overrides_empty_roundtrip() {
+        let overrides: VerifyLimitsOverrides = serde_json::from_str("{}").unwrap();
+        let limits = VerifyLimits::default().apply(overrides);
+        assert_eq!(
+            limits,
+            VerifyLimits::default(),
+            "empty overrides = identity"
+        );
+    }
+
+    #[test]
+    fn test_verify_limits_overrides_drift_guard() {
+        // Destructure both structs so adding a field to one without the other fails to compile.
+        let VerifyLimits {
+            max_bundle_bytes: _,
+            max_decode_bytes: _,
+            max_manifest_bytes: _,
+            max_events_bytes: _,
+            max_events: _,
+            max_line_bytes: _,
+            max_path_len: _,
+            max_json_depth: _,
+        } = VerifyLimits::default();
+        let VerifyLimitsOverrides {
+            max_bundle_bytes: _,
+            max_decode_bytes: _,
+            max_manifest_bytes: _,
+            max_events_bytes: _,
+            max_events: _,
+            max_line_bytes: _,
+            max_path_len: _,
+            max_json_depth: _,
+        } = VerifyLimitsOverrides::default();
     }
 
     #[test]

--- a/crates/assay-evidence/src/bundle/writer.rs
+++ b/crates/assay-evidence/src/bundle/writer.rs
@@ -1249,27 +1249,23 @@ mod tests {
 
     #[test]
     fn test_verify_limits_overrides_drift_guard() {
-        // Destructure both structs so adding a field to one without the other fails to compile.
-        let VerifyLimits {
-            max_bundle_bytes: _,
-            max_decode_bytes: _,
-            max_manifest_bytes: _,
-            max_events_bytes: _,
-            max_events: _,
-            max_line_bytes: _,
-            max_path_len: _,
-            max_json_depth: _,
-        } = VerifyLimits::default();
-        let VerifyLimitsOverrides {
-            max_bundle_bytes: _,
-            max_decode_bytes: _,
-            max_manifest_bytes: _,
-            max_events_bytes: _,
-            max_events: _,
-            max_line_bytes: _,
-            max_path_len: _,
-            max_json_depth: _,
-        } = VerifyLimitsOverrides::default();
+        // Single field list: adding a field to one struct without the other fails to compile.
+        macro_rules! verify_limits_drift_guard {
+            ($($field:ident),+ $(,)?) => {{
+                let VerifyLimits { $($field: _,)+ } = VerifyLimits::default();
+                let VerifyLimitsOverrides { $($field: _,)+ } = VerifyLimitsOverrides::default();
+            }};
+        }
+        verify_limits_drift_guard!(
+            max_bundle_bytes,
+            max_decode_bytes,
+            max_manifest_bytes,
+            max_events_bytes,
+            max_events,
+            max_line_bytes,
+            max_path_len,
+            max_json_depth,
+        );
     }
 
     #[test]

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -13,7 +13,7 @@ pub mod types;
 pub use bundle::{
     verify_bundle, verify_bundle_with_limits, AlgorithmMeta, BundleInfo, BundleReader,
     BundleWriter, ErrorClass, ErrorCode, FileMeta, Manifest, VerifyError, VerifyLimits,
-    VerifyResult,
+    VerifyLimitsOverrides, VerifyResult,
 };
 pub use lint::packs::{load_pack, load_packs, LoadedPack, PackError, PackSource};
 pub use ndjson::{read_events, write_events, NdjsonEvents};

--- a/docs/architecture/ADR-024-Sim-Engine-Hardening.md
+++ b/docs/architecture/ADR-024-Sim-Engine-Hardening.md
@@ -28,32 +28,49 @@ Add to `assay sim run`:
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--limits` | JSON string | Partial `VerifyLimits` overrides. Merged with defaults. |
-| `--limits-file` | Path | Path to JSON file with limits. Overrides `--limits` if both given. |
-| `--time-budget` | Seconds | Suite time budget. Default: 60. |
+| `--limits` | JSON string or `@path` | Partial limits overrides. If value starts with `@`, treat as file path and load from file (equivalent to `--limits-file`). Otherwise parse as JSON string. Shell escaping can be awkward; prefer `--limits-file` or `--limits @.assay/limits.json`. |
+| `--limits-file` | Path | Path to JSON file with limits. **Recommended** for CI. Overrides `--limits` if both given. |
+| `--time-budget` | Seconds | Suite time budget. Default: 60. Must be > 0; reject ≤0 with exit 3. |
+| `--print-config` | Flag | Print effective merged limits and time budget (debug / CI diagnostics). |
 
 **Parse rules:**
 
 - Invalid JSON → exit code 3 (config error)
-- Unknown keys in `--limits` JSON → reject with clear error
+- Unknown keys in `--limits` / `--limits-file` JSON → reject with clear "unknown field" error (exit 3)
 - `--limits-file` path missing → exit 3
-- Schema: subset of `VerifyLimits` fields; partial merge (only provided fields override)
+- `--time-budget` ≤ 0 → exit 3
+- Schema: `VerifyLimitsOverrides` with `deny_unknown_fields`; partial merge
 
-**Example:**
+**Examples (prefer file-based config for CI):**
 
 ```bash
 assay sim run --suite quick --target bundle.tar.gz
-assay sim run --suite quick --limits '{"max_bundle_bytes": 10485760}' --target bundle.tar.gz
 assay sim run --suite quick --limits-file .assay/sim-limits.json --target bundle.tar.gz
+assay sim run --suite quick --limits @.assay/sim-limits.json --target bundle.tar.gz  # file via @
+assay sim run --suite quick --limits '{"max_bundle_bytes": 10485760}' --target bundle.tar.gz  # JSON string
 assay sim run --suite quick --time-budget 120 --target bundle.tar.gz
+assay sim run --suite quick --print-config --target bundle.tar.gz  # effective limits + budget
 ```
 
 ### 2. Limits Model
 
 - **Source**: `assay_evidence::VerifyLimits` (existing struct)
-- **Merge**: Start with `VerifyLimits::default()`, then apply overrides from `--limits` or `--limits-file`
-- **JSON schema** (informative): Same field names as `VerifyLimits`; only override provided keys
-- **Stable schema**: Document in ADR; breaking changes require version bump
+- **Parsing**: Use a `VerifyLimitsOverrides` struct with `Option<T>` fields + `#[serde(deny_unknown_fields)]`. Unknown keys in JSON → hard fail (exit 3) with clear "unknown field" error. Partial deserialize: only provided keys override; merge with `VerifyLimits::default()`.
+- **Merge precedence**: `VerifyLimits::default()` → apply `--limits` (if given) → apply `--limits-file` (overrides `--limits` if both given).
+- **Stable schema**: Document in ADR; breaking changes require version bump.
+
+**Limits schema (field names + semantics):**
+
+| Field | Unit | Semantics |
+|-------|------|-----------|
+| `max_bundle_bytes` | bytes | **Container/compressed** size limit (input stream). Verification fails with `LimitBundleBytes` when the raw gzip stream exceeds this before decompression. |
+| `max_decode_bytes` | bytes | **Decoded/unpacked** size limit (decompressed). Zip-bomb protection; fails with `LimitDecodeBytes` when inflated data exceeds this. |
+| `max_manifest_bytes` | bytes | Max manifest.json size |
+| `max_events_bytes` | bytes | Max events.ndjson size |
+| `max_events` | count | Max event count |
+| `max_line_bytes` | bytes | Max single line length |
+| `max_path_len` | chars | Max path component length |
+| `max_json_depth` | levels | Max JSON recursion depth |
 
 ### 3. Integrity Attacks: Pass Limits and Budget
 
@@ -67,9 +84,11 @@ assay sim run --suite quick --time-budget 120 --target bundle.tar.gz
 Add integrity attack:
 
 - **Name**: `integrity.limit_bundle_bytes`
-- **Behavior**: Generate bundle of `limits.max_bundle_bytes + 1` bytes (compressed). Verification must fail with `LimitBundleBytes`.
+- **Target**: `max_bundle_bytes` (container/compressed size). The verifier enforces this on the raw gzip input stream *before* decompression; exceeding it yields `LimitBundleBytes`.
+- **Behavior**: Generate a bundle whose **compressed** size equals `limits.max_bundle_bytes + 1` bytes. Verification must fail with `LimitBundleBytes`. (Note: `max_decode_bytes` targets decompressed size—zip bombs; this attack targets the input-stream limit.)
 - **Purpose**: If limits were accidentally bypassed or default raised, this test fails → regression caught.
-- **Config**: Use `cfg.verify_limits`; if None, use default (100MB). Attack generates 100MB+1.
+- **Optional addition**: `integrity.limit_decode_bytes` — craft a payload that is small compressed but inflates to > `max_decode_bytes` (classic zip-bomb pattern) to explicitly regression-test the decode limit. Quick tier: target ~20MB decode with tier-specific `max_decode_bytes`; avoids the full ~1.1GB zip bomb in quick, but still validates `LimitDecodeBytes` is enforced.
+- **Quick-suite safety**: To avoid generating 100MB+ in the quick tier, use **tier-specific defaults** when no explicit `--limits` are given: Quick → `max_bundle_bytes: 5_242_880` (5MB); Nightly/Stress/Chaos → full default (100MB). Attack generates limit+1, so quick stays fast (~5MB). Rationale: 5MB keeps the quick suite under ~30s on typical CI runners; 1MB would risk false limits-hit on slow I/O, 10MB would bloat quick runtime.
 
 ### 5. Exit Codes and Status Distinction
 
@@ -81,7 +100,13 @@ Add integrity attack:
 | Time budget exceeded | `Error` | 2 |
 | Config/parse error | — | 3 |
 
-**Rationale**: "Blocked by limits" and "blocked by integrity" are both correct outcomes. Distinction can be inferred from `error_code` (e.g. `LimitBundleBytes`) in the attack result for diagnostics; no need to split `Blocked` into subtypes.
+**Rationale**: "Blocked by limits" and "blocked by integrity" are both correct outcomes. No need to split `Blocked` into subtypes.
+
+**Machine-readable output contract** (normative): Attack result metadata must include:
+- `blocked_by`: string — error code when status is Blocked (e.g. `LimitBundleBytes`, `LimitDecodeBytes`, `IntegrityHashMismatch`)
+- `phase`: string — `integrity` | `differential` | `chaos`
+- `skipped_phases`: array of strings — when time budget exceeded, list phases that were skipped (e.g. `["differential", "chaos"]`)
+- `time_budget_exceeded`: boolean — true when exit 2
 
 ### 6. Time Budget Check Points
 
@@ -91,14 +116,22 @@ Budget checks before:
 - After integrity phase (existing)
 - After differential phase (existing)
 - Before chaos phase (existing)
-- Before each expensive verify/iteration in integrity loop (new: optional micro-check if iteration count is high)
+- In integrity loop: check *after* each expensive verify (not every iteration—keep checks cheap; avoid hot-loop overhead)
 
 **Design**: Single global `TimeBudget` for the whole suite. No per-attack budget to avoid fragmentation.
 
-### 7. `--limits-file` / `@path` Convenience
+**Budget-exceeded output**: When time budget is exceeded, output must clearly show:
+- Which phases were skipped (e.g. "skipped: differential, chaos") — both human-readable and in `skipped_phases` metadata
+- Time consumed / remaining
+- A deterministic message: "budget exceeded during integrity phase after N/M cases" (or equivalent)
+- `time_budget_exceeded: true` in result metadata for downstream tooling (CI dashboards, telemetry)
 
-- `--limits-file path` reads JSON from file
-- Future: `--limits @path` as shorthand (optional, not required for v1)
+### 7. `--limits` @path Parsing
+
+**Unambiguous rule**: When `--limits` is given:
+- If the value **starts with `@`**, interpret the remainder as a file path and load JSON from that file (equivalent to `--limits-file path`).
+- Otherwise, parse the value as a JSON string.
+- This avoids support/UX confusion; no separate `@path` shorthand flag needed.
 
 ## Consequences
 
@@ -112,12 +145,25 @@ Budget checks before:
 ### Negative
 
 - Additional CLI surface; must document limits schema
-- `--limits` JSON escaping in shell can be awkward; `--limits-file` mitigates
+- `--limits` JSON escaping in shell can be awkward; `--limits-file` is recommended
+- Tier-specific default limits add a small config dimension (Quick vs other tiers)
 
 ### Neutral
 
 - Differential tests already use `verify_bundle_with_limits` with custom `max_events`; no change needed
 - Chaos attacks use subprocess isolation; budget check before phase is sufficient
+
+## Epics
+
+| Epic | Scope | Deps |
+|------|-------|------|
+| **E1** | `VerifyLimitsOverrides` in assay-evidence; `apply()` merge with defaults; `deny_unknown_fields` | — |
+| **E2** | CLI: `--limits`, `--limits-file`, `--time-budget`, `--print-config`; `@path` parsing; merge precedence; exit 3 on parse error | E1 |
+| **E3** | SuiteConfig: configurable `TimeBudget`; tier-default limits (Quick: 5MB); pass to integrity | E1 |
+| **E4** | Integrity attacks: `verify_bundle_with_limits`; budget check; `blocked_by` in results | E1, E3 |
+| **E5** | Dynamic `integrity.limit_bundle_bytes` attack | E4 |
+| **E6** | Report metadata: `time_budget_exceeded`, `blocked_by`, `phase`, `skipped_phases`; budget-exceeded UX | E4 |
+| **E7** | `--print-config` impl; test plan execution | E2, E6 |
 
 ## Implementation Notes
 
@@ -125,23 +171,41 @@ Budget checks before:
 
 | File | Change |
 |------|--------|
-| `crates/assay-cli/src/cli/args.rs` | Add `--limits`, `--limits-file`, `--time-budget` to `SimRunArgs` |
-| `crates/assay-cli/src/cli/commands/sim.rs` | Parse limits, pass to `SuiteConfig` |
-| `crates/assay-sim/src/suite.rs` | Accept configurable `TimeBudget`; pass `verify_limits` to integrity |
-| `crates/assay-sim/src/attacks/integrity.rs` | Use `verify_bundle_with_limits`; add `limit_bundle_bytes` attack; budget check |
-| `crates/assay-evidence/src/bundle/writer.rs` | `VerifyLimits` already exists; add `impl Serialize/Deserialize` if not present |
+| `crates/assay-cli/src/cli/args.rs` | Add `--limits`, `--limits-file`, `--time-budget`, `--print-config` to `SimRunArgs` |
+| `crates/assay-cli/src/cli/commands/sim.rs` | Parse limits via `VerifyLimitsOverrides`; `--limits @path` when value starts with `@`; merge precedence; pass to `SuiteConfig` |
+| `crates/assay-sim/src/suite.rs` | Accept configurable `TimeBudget`; pass `verify_limits` to integrity; tier-default limits (Quick: 5MB) |
+| `crates/assay-sim/src/attacks/integrity.rs` | Use `verify_bundle_with_limits`; add `limit_bundle_bytes` (+ optional `limit_decode_bytes`) attack; budget check; `blocked_by` in results |
+| `crates/assay-sim/src/report.rs` | `time_budget_exceeded`, `blocked_by` in result metadata |
+| `crates/assay-evidence` | `VerifyLimitsOverrides` struct with `deny_unknown_fields` (serde already present) |
 
-### VerifyLimits Serde
+### VerifyLimitsOverrides (assay-evidence)
 
-If `VerifyLimits` does not implement `Serialize`/`Deserialize`, add behind optional `serde` feature or in assay-evidence for sim use. Partial deserialize: use `#[serde(default)]` for missing fields so partial JSON works.
+**Location**: `crates/assay-evidence` — where `VerifyLimits` lives. assay-evidence already depends on serde; add `VerifyLimitsOverrides` there to keep schema co-located and avoid drift.
+
+```rust
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VerifyLimitsOverrides {
+    max_bundle_bytes: Option<u64>,
+    max_decode_bytes: Option<u64>,
+    // ... other Option<T> fields
+}
+```
+
+- `deny_unknown_fields` → unknown keys hard fail
+- Partial merge: `defaults.apply(overrides)` (only `Some` values override)
 
 ### Test Plan
 
 1. `assay sim run --suite quick --limits '{"max_bundle_bytes": 1000}'` → zip bomb and limit_bundle_bytes blocked
 2. `assay sim run --suite quick --limits-file /nonexistent` → exit 3
 3. `assay sim run --suite quick --limits 'invalid'` → exit 3
-4. `assay sim run --suite quick --time-budget 1` → time_budget Error after quick phase (if < 1s)
-5. Existing quick suite test: no regressions with default limits
+4. `assay sim run --suite quick --limits '{"max_bundle_bytess": 1}'` → exit 3 with "unknown field" (deny_unknown_fields)
+5. `assay sim run --suite quick --limits '{"max_bundle_bytes": 1000}' --limits-file .assay/stricter.json` → file wins; test merge precedence
+6. `assay sim run --suite quick --time-budget 0` → exit 3 (reject ≤0)
+7. `assay sim run --suite quick --time-budget 1` → exit 2 with "budget exceeded" marker; assert output contains "skipped:" (regression: UX marker must not disappear)
+8. `assay sim run --suite quick --print-config --target bundle.tar.gz` → output includes effective limits keys and time budget; smoke test presence (not exact string match)
+9. Existing quick suite test: no regressions with tier defaults; limit_bundle_bytes generates ~5MB in quick (not 100MB+)
 
 ## References
 

--- a/docs/architecture/PR-STRATEGY-ADR-024.md
+++ b/docs/architecture/PR-STRATEGY-ADR-024.md
@@ -1,0 +1,53 @@
+# PR Strategy: ADR-024 Sim Engine Hardening
+
+**Branch:** `feat/adr-024-sim-hardening`
+**ADR:** [ADR-024](./ADR-024-Sim-Engine-Hardening.md)
+
+---
+
+## Recommendation: 2 PRs
+
+| PR | Epics | Scope | Rationale |
+|----|-------|-------|------------|
+| **PR 1** | E1 | VerifyLimitsOverrides | Foundation; no behavior change; merge early to avoid drift |
+| **PR 2** | E2–E6 (+E7) | CLI + Suite + Integrity + attacks + UX | End-to-end feature; coherent user-facing change |
+
+---
+
+## PR 1: Epic 1 (Foundation)
+
+**Scope:** `VerifyLimitsOverrides` in assay-evidence only.
+
+**Why now:**
+- Fully tested, review-pack verified
+- No user-facing behavior change
+- Reduces branch drift; keeps main in sync
+- Unblocks E2–E7 (assay-sim/assay-cli can depend on the type)
+
+**Size:** ~180 lines (struct + impl + 4 tests + VERIFICATION doc)
+
+**Merge criteria:** VERIFICATION-ADR-024-E1.md checklist + CI green.
+
+---
+
+## PR 2: Epics 2–6 (Feature)
+
+**Scope:** CLI flags, tier-default limits, configurable TimeBudget, integrity attacks with limits, limit_bundle_bytes, report metadata, budget-exceeded UX.
+
+**Why batched:**
+- E2 (CLI) without E3/E4 = flags that don’t do anything
+- E2+E3+E4 = minimal “limits work” unit
+- E5 adds visible regression-proof attack
+- E6 adds UX polish; E7 (print-config + test plan) fits naturally
+
+**Depends on:** PR 1 merged.
+
+**Size:** Est. 400–600 lines across assay-cli, assay-sim.
+
+---
+
+## Not Recommended
+
+- **Single PR (E1–E7):** Large review, higher merge conflicts, harder bisect
+- **PR per epic (7 PRs):** E2 alone adds dead CLI surface; excessive overhead
+- **E1 with E2:** E2 needs E3/E4 to be useful; partial batch adds confusion

--- a/docs/architecture/VERIFICATION-ADR-024-E1.md
+++ b/docs/architecture/VERIFICATION-ADR-024-E1.md
@@ -24,7 +24,7 @@
 | `test_verify_limits_overrides_merge` | Partial JSON → only provided fields override; defaults preserved |
 | `test_verify_limits_overrides_deny_unknown_fields` | `{"max_bundle_bytess": 1}` → deserialize fails |
 | `test_verify_limits_overrides_empty_roundtrip` | `{}` → all None → apply yields identity (equals default) |
-| `test_verify_limits_overrides_drift_guard` | Destructure both structs → compile fails if field count drifts |
+| `test_verify_limits_overrides_drift_guard` | Single macro lists fields once; compile fails if one struct gains a field without the other |
 
 ### ADR Alignment
 

--- a/docs/architecture/VERIFICATION-ADR-024-E1.md
+++ b/docs/architecture/VERIFICATION-ADR-024-E1.md
@@ -1,0 +1,159 @@
+# Review Pack: ADR-024 Epic 1 (VerifyLimitsOverrides)
+
+**Branch:** `feat/adr-024-sim-hardening`
+**Epic:** E1 — `VerifyLimitsOverrides` in assay-evidence; `apply()` merge; `deny_unknown_fields`
+**ADR:** [ADR-024 Sim Engine Hardening](./ADR-024-Sim-Engine-Hardening.md)
+
+---
+
+## Review Checklist
+
+### Functional
+
+| Criterion | Location | Verify |
+|-----------|----------|--------|
+| `VerifyLimitsOverrides` exists with all 8 fields as `Option<T>` | `writer.rs` L544–553 | Fields match `VerifyLimits` 1:1 |
+| `#[serde(deny_unknown_fields)]` present | `writer.rs` L543 | Unknown keys fail deserialize |
+| `VerifyLimits::apply(overrides)` performs partial merge | `writer.rs` L556–571 | Only `Some` overrides; others from `self` |
+| Re-exported from `assay_evidence` | `lib.rs` | `use assay_evidence::VerifyLimitsOverrides` works |
+
+### Tests
+
+| Test | Purpose |
+|------|---------|
+| `test_verify_limits_overrides_merge` | Partial JSON → only provided fields override; defaults preserved |
+| `test_verify_limits_overrides_deny_unknown_fields` | `{"max_bundle_bytess": 1}` → deserialize fails |
+| `test_verify_limits_overrides_empty_roundtrip` | `{}` → all None → apply yields identity (equals default) |
+| `test_verify_limits_overrides_drift_guard` | Destructure both structs → compile fails if field count drifts |
+
+### ADR Alignment
+
+| ADR § | Requirement | Status |
+|-------|-------------|--------|
+| Limits Model | `VerifyLimitsOverrides` + `deny_unknown_fields` | ✓ |
+| Merge | `defaults.apply(overrides)`; only provided keys override | ✓ |
+| Location | assay-evidence (co-located with VerifyLimits) | ✓ |
+
+---
+
+## Verification Commands
+
+```bash
+# Run Epic 1 unit tests
+cargo test -p assay-evidence --lib verify_limits_overrides
+
+# Run full assay-evidence test suite
+cargo test -p assay-evidence --lib
+
+# Clippy
+cargo clippy -p assay-evidence -- -D warnings
+```
+
+---
+
+## Line-by-Line Snippet (paste & sanity check)
+
+```rust
+/// Resource limits for bundle verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VerifyLimits {
+    pub max_bundle_bytes: u64,
+    pub max_decode_bytes: u64,
+    pub max_manifest_bytes: u64,
+    pub max_events_bytes: u64,
+    pub max_events: usize,
+    pub max_line_bytes: usize,
+    pub max_path_len: usize,
+    pub max_json_depth: usize,
+}
+
+impl Default for VerifyLimits {
+    fn default() -> Self {
+        Self {
+            max_bundle_bytes: 100 * 1024 * 1024,  // 100 MB compressed
+            max_decode_bytes: 1024 * 1024 * 1024, // 1 GB uncompressed
+            max_manifest_bytes: 10 * 1024 * 1024, // 10 MB
+            max_events_bytes: 500 * 1024 * 1024,  // 500 MB
+            max_events: 100_000,
+            max_line_bytes: 1024 * 1024,          // 1 MB
+            max_path_len: 256,
+            max_json_depth: 64,
+        }
+    }
+}
+
+/// Partial overrides for `VerifyLimits`. Used for CLI/config JSON parsing.
+/// Unknown keys cause deserialization to fail (deny_unknown_fields).
+/// Merge with `VerifyLimits::default().apply(overrides)`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VerifyLimitsOverrides {
+    pub max_bundle_bytes: Option<u64>,
+    pub max_decode_bytes: Option<u64>,
+    pub max_manifest_bytes: Option<u64>,
+    pub max_events_bytes: Option<u64>,
+    pub max_events: Option<usize>,
+    pub max_line_bytes: Option<usize>,
+    pub max_path_len: Option<usize>,
+    pub max_json_depth: Option<usize>,
+}
+
+impl VerifyLimits {
+    /// Apply overrides onto these defaults. Only `Some` values override.
+    pub fn apply(self, overrides: VerifyLimitsOverrides) -> VerifyLimits {
+        VerifyLimits {
+            max_bundle_bytes: overrides.max_bundle_bytes.unwrap_or(self.max_bundle_bytes),
+            max_decode_bytes: overrides.max_decode_bytes.unwrap_or(self.max_decode_bytes),
+            max_manifest_bytes: overrides.max_manifest_bytes.unwrap_or(self.max_manifest_bytes),
+            max_events_bytes: overrides.max_events_bytes.unwrap_or(self.max_events_bytes),
+            max_events: overrides.max_events.unwrap_or(self.max_events),
+            max_line_bytes: overrides.max_line_bytes.unwrap_or(self.max_line_bytes),
+            max_path_len: overrides.max_path_len.unwrap_or(self.max_path_len),
+            max_json_depth: overrides.max_json_depth.unwrap_or(self.max_json_depth),
+        }
+    }
+}
+```
+
+**Checklist per line:**
+- `VerifyLimits`: `u64` × 4, `usize` × 4; `PartialEq, Eq` for roundtrip test ✓
+- `VerifyLimitsOverrides`: `Option<u64>` × 4, `Option<usize>` × 4 ✓
+- `Deserialize` on Overrides (not Serialize—CLI input only) ✓
+- `#[serde(deny_unknown_fields)]` ✓
+- `apply()`: `unwrap_or(self.X)` — defaults win when override is `None` ✓
+
+---
+
+## Manual Smoke
+
+```rust
+use assay_evidence::{VerifyLimits, VerifyLimitsOverrides};
+
+// Partial override
+let overrides: VerifyLimitsOverrides = serde_json::from_str(r#"{"max_bundle_bytes": 1000}"#)?;
+let limits = VerifyLimits::default().apply(overrides);
+assert_eq!(limits.max_bundle_bytes, 1000);
+assert_eq!(limits.max_decode_bytes, 1024 * 1024 * 1024); // default preserved
+
+// Unknown key → error
+let err = serde_json::from_str::<VerifyLimitsOverrides>(r#"{"typo": 1}"#).unwrap_err();
+```
+
+---
+
+## Merge Gates
+
+- [ ] `cargo test -p assay-evidence --lib` passes
+- [ ] `cargo clippy -p assay-evidence -- -D warnings` passes
+- [ ] `VerifyLimitsOverrides` re-export works from assay-sim / assay-cli (compile check)
+- [ ] Empty roundtrip + drift-guard tests pass
+
+## Future Pitfalls (Epic 2+)
+
+- `{"max_bundle_bytes": -1}` / `1.5` → serde rejects; CLI should surface error cleanly
+- Error message quality: avoid opaque serde errors in CLI
+
+## Acceptance
+
+- [ ] All checklist items pass
+- [ ] ADR-024 Epics table present; E1 marked implemented


### PR DESCRIPTION
## Description

Implements **Epic 1** of [ADR-024 Sim Engine Hardening](docs/architecture/ADR-024-Sim-Engine-Hardening.md): `VerifyLimitsOverrides` in assay-evidence.

- `VerifyLimitsOverrides` struct with 8 `Option<T>` fields, `#[serde(deny_unknown_fields)]`
- `VerifyLimits::apply(overrides)` for partial merge with defaults
- `PartialEq, Eq` on `VerifyLimits` for roundtrip assertions
- Tests: merge, deny_unknown_fields, empty roundtrip, drift-guard (compile-time field sync)
- Review pack: `VERIFICATION-ADR-024-E1.md`
- PR strategy: `PR-STRATEGY-ADR-024.md` (2-PR plan: E1 now, E2–E6 next)

No user-facing behavior change. Foundation for E2 (CLI flags) and E3–E6 (limits in sim suite).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor

## Verification
- [x] `cargo test -p assay-evidence --lib` (191 passed)
- [x] `cargo clippy -p assay-evidence -- -D warnings`
- [x] VERIFICATION-ADR-024-E1.md checklist

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
