### PR TITLE
feat(evidence): E2 Phase 3 verify --eval (evaluation sidecar verification)

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -52,9 +52,29 @@ pub struct EvidenceExportArgs {
 
 #[derive(Debug, Args, Clone)]
 pub struct EvidenceVerifyArgs {
-    /// Bundle path, or "-" for stdin
+    /// Bundle path, or "-" for stdin. Required when using --eval.
     #[arg(value_name = "BUNDLE", default_value = "-")]
     pub bundle: std::path::PathBuf,
+
+    /// Evaluation sidecar to verify against bundle (ADR-025 E2 Phase 3)
+    #[arg(long, value_name = "PATH")]
+    pub eval: Option<std::path::PathBuf>,
+
+    /// Packs to resolve for digest verification (comma-separated)
+    #[arg(long, value_delimiter = ',')]
+    pub pack: Option<Vec<String>>,
+
+    /// Fail if pack digests cannot be verified
+    #[arg(long)]
+    pub strict: bool,
+
+    /// Machine-readable JSON output
+    #[arg(long)]
+    pub json: bool,
+
+    /// Only exit code, no output
+    #[arg(long, short = 'q')]
+    pub quiet: bool,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -134,6 +154,11 @@ fn cmd_export(args: EvidenceExportArgs) -> Result<i32> {
 }
 
 fn cmd_verify(args: EvidenceVerifyArgs) -> Result<i32> {
+    if let Some(eval_path) = &args.eval {
+        return cmd_verify_eval(&args, eval_path);
+    }
+
+    // Legacy: bundle-only verify
     if args.bundle.to_string_lossy() == "-" {
         let mut buf = Vec::new();
         io::stdin().read_to_end(&mut buf)?;
@@ -146,11 +171,116 @@ fn cmd_verify(args: EvidenceVerifyArgs) -> Result<i32> {
     let f = File::open(&args.bundle)
         .with_context(|| format!("failed to open bundle {}", args.bundle.display()))?;
 
-    // BundleReader::open verifies by default
     let _ = assay_evidence::bundle::BundleReader::open(f)?;
 
     eprintln!("Bundle verified ({}): OK", args.bundle.display());
     Ok(0)
+}
+
+fn cmd_verify_eval(args: &EvidenceVerifyArgs, eval_path: &std::path::Path) -> Result<i32> {
+    use assay_evidence::evaluation::verify_evaluation;
+    use assay_evidence::lint::packs::load_packs;
+
+    if args.bundle.to_string_lossy() == "-" {
+        anyhow::bail!("--bundle is required when using --eval (cannot use stdin)");
+    }
+
+    let eval_json = std::fs::read_to_string(eval_path)
+        .with_context(|| format!("failed to read evaluation {}", eval_path.display()))?;
+    let evaluation: assay_evidence::evaluation::Evaluation =
+        serde_json::from_str(&eval_json).context("invalid evaluation JSON")?;
+
+    let f = File::open(&args.bundle)
+        .with_context(|| format!("failed to open bundle {}", args.bundle.display()))?;
+    let verify_result =
+        assay_evidence::bundle::verify_bundle(f).context("bundle verification failed")?;
+    let manifest = verify_result.manifest;
+
+    let pack_digests = if let Some(ref pack_refs) = args.pack {
+        match load_packs(pack_refs) {
+            Ok(packs) => Some(
+                packs
+                    .iter()
+                    .map(|p| {
+                        (
+                            format!("{}@{}", p.definition.name, p.definition.version),
+                            p.digest.clone(),
+                        )
+                    })
+                    .collect(),
+            ),
+            Err(e) => {
+                if args.strict {
+                    anyhow::bail!("pack resolution failed: {}", e);
+                }
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let result = verify_evaluation(&evaluation, &manifest, pack_digests, args.strict)
+        .context("evaluation verification failed")?;
+
+    if args.quiet {
+        return Ok(if result.ok { 0 } else { 1 });
+    }
+
+    if args.json {
+        let out = serde_json::json!({
+            "ok": result.ok,
+            "bundle": {
+                "bundle_digest_match": result.bundle_digest_match,
+                "manifest_digest_match": result.manifest_digest_match,
+            },
+            "results": {
+                "results_digest_verified": result.results_digest_verified,
+                "results_digest_verifiable": result.results_digest_verifiable,
+            },
+            "packs": {
+                "verified": result.packs_verified,
+                "unverifiable": result.packs_unverifiable,
+                "mismatched": result.packs_mismatched,
+            },
+            "warnings": result.warnings,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(if result.ok { 0 } else { 1 });
+    }
+
+    if result.ok {
+        eprintln!("✅ Evaluation verified");
+        eprintln!("   bundle_digest: match");
+        eprintln!("   manifest_digest: match");
+        eprintln!(
+            "   results_digest: {}",
+            if result.results_digest_verified {
+                "verified"
+            } else if result.results_digest_verifiable {
+                "mismatch (see errors)"
+            } else {
+                "not verifiable (no report_inline)"
+            }
+        );
+        eprintln!(
+            "   packs: {} ok / {} unverifiable / {} mismatched",
+            result.packs_verified, result.packs_unverifiable, result.packs_mismatched
+        );
+        for w in &result.warnings {
+            eprintln!("   ⚠️  {}", w);
+        }
+        Ok(0)
+    } else {
+        eprintln!("❌ Evaluation verification failed");
+        for e in &result.errors {
+            eprintln!("   {}", e);
+        }
+        for w in &result.warnings {
+            eprintln!("   ⚠️  {}", w);
+        }
+        Ok(1)
+    }
 }
 
 fn cmd_show(args: EvidenceShowArgs) -> Result<i32> {

--- a/crates/assay-evidence/src/evaluation.rs
+++ b/crates/assay-evidence/src/evaluation.rs
@@ -1,0 +1,611 @@
+//! Consumer evaluation sidecar (ADR-025 E2 Phase 3).
+//!
+//! Evaluation attestations written by lint/soak; NOT in manifest (tamper-evidence).
+//! Schema: evaluation-v1.
+
+use crate::bundle::manifest::Manifest;
+use crate::crypto::jcs;
+use crate::lint::{LintReport, LintSummary, Severity};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Schema version for evaluation-v1.
+pub const EVALUATION_V1: &str = "evaluation-v1";
+
+/// Subject digest (attestation-shaped).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SubjectDigest {
+    pub sha256: String,
+}
+
+/// Subject entry for attestation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SubjectEntry {
+    pub name: String,
+    pub digest: SubjectDigest,
+}
+
+/// Pack applied in evaluation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PackApplied {
+    pub name: String,
+    pub version: String,
+    pub kind: String,
+    pub digest: String,
+    pub source: String,
+}
+
+/// Decision policy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DecisionPolicy {
+    pub pass_on_severity_at_or_above: String,
+}
+
+/// Evaluation inputs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvaluationInputs {
+    pub bundle_digest: String,
+    pub manifest_digest: String,
+    pub packs_applied: Vec<PackApplied>,
+    pub decision_policy: DecisionPolicy,
+}
+
+/// Canonical report payload for results_digest verification (JCS digest).
+/// Embedded inline in evaluation for portable/audit-proof verification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReportInline {
+    pub schema_version: String,
+    pub report: serde_json::Value,
+}
+
+/// Evaluation outputs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvaluationOutputs {
+    pub status: String,
+    pub summary: LintSummary,
+    pub results_digest: String,
+    /// Inline report for offline results_digest verification (ADR-025 E2 Phase 3).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub report_inline: Option<ReportInline>,
+}
+
+/// Consumer evaluation (sidecar JSON).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Evaluation {
+    pub schema_version: String,
+    pub evaluation_id: String,
+    pub created_at: String,
+    pub subject: Vec<SubjectEntry>,
+    pub command: EvaluationCommand,
+    pub inputs: EvaluationInputs,
+    pub outputs: EvaluationOutputs,
+}
+
+/// Command that produced the evaluation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EvaluationCommand {
+    pub name: String,
+    pub version: String,
+    pub args: Vec<String>,
+}
+
+/// Compute logical bundle digest from manifest (ADR-025 E2).
+/// sha256(JCS({run_root, algorithms, files})).
+pub fn compute_bundle_digest(manifest: &Manifest) -> Result<String> {
+    let input = serde_json::json!({
+        "run_root": manifest.run_root,
+        "algorithms": &manifest.algorithms,
+        "files": &manifest.files,
+    });
+    let bytes = jcs::to_vec(&input)?;
+    Ok(format!("sha256:{}", hex::encode(Sha256::digest(&bytes))))
+}
+
+/// Compute manifest digest: sha256(JCS(manifest)).
+pub fn compute_manifest_digest(manifest: &Manifest) -> Result<String> {
+    let bytes = jcs::to_vec(manifest)?;
+    Ok(format!("sha256:{}", hex::encode(Sha256::digest(&bytes))))
+}
+
+/// Canonical report structure for digest computation (lint-report-v1).
+/// Must match exactly for results_digest verification.
+fn canonical_report_json(report: &LintReport) -> serde_json::Value {
+    serde_json::json!({
+        "bundle_meta": {
+            "bundle_id": report.bundle_meta.bundle_id,
+            "run_root": report.bundle_meta.run_root,
+            "event_count": report.bundle_meta.event_count,
+        },
+        "verified": report.verified,
+        "findings": report.findings.iter().map(|f| serde_json::json!({
+            "rule_id": f.rule_id,
+            "severity": f.severity.to_string(),
+            "message": f.message,
+            "location": f.location,
+            "fingerprint": f.fingerprint,
+        })).collect::<Vec<_>>(),
+        "summary": &report.summary,
+    })
+}
+
+/// Compute results digest from lint report: sha256(JCS(canonical_report)).
+pub fn compute_results_digest(report: &LintReport) -> Result<String> {
+    let canonical = canonical_report_json(report);
+    let bytes = jcs::to_vec(&canonical)?;
+    Ok(format!("sha256:{}", hex::encode(Sha256::digest(&bytes))))
+}
+
+/// Compute results digest from inline report payload.
+pub fn compute_results_digest_from_inline(report_json: &serde_json::Value) -> Result<String> {
+    let bytes = jcs::to_vec(report_json)?;
+    Ok(format!("sha256:{}", hex::encode(Sha256::digest(&bytes))))
+}
+
+/// Build evaluation from lint result.
+pub fn build_evaluation_from_lint(
+    report: &LintReport,
+    packs_applied: Vec<PackApplied>,
+    command_name: &str,
+    command_version: &str,
+    command_args: Vec<String>,
+    fail_on: Severity,
+    evaluation_id: String,
+) -> Result<Evaluation> {
+    let bundle_digest = compute_bundle_digest(&report.bundle_meta)?;
+    let manifest_digest = compute_manifest_digest(&report.bundle_meta)?;
+    let results_digest = compute_results_digest(report)?;
+
+    let status = if report.has_findings_at_or_above(&fail_on) {
+        "fail"
+    } else {
+        "pass"
+    };
+
+    let subject = vec![
+        SubjectEntry {
+            name: "bundle.tar.gz".into(),
+            digest: SubjectDigest {
+                sha256: bundle_digest
+                    .strip_prefix("sha256:")
+                    .unwrap_or(&bundle_digest)
+                    .to_string(),
+            },
+        },
+        SubjectEntry {
+            name: "manifest.json".into(),
+            digest: SubjectDigest {
+                sha256: manifest_digest
+                    .strip_prefix("sha256:")
+                    .unwrap_or(&manifest_digest)
+                    .to_string(),
+            },
+        },
+    ];
+
+    Ok(Evaluation {
+        schema_version: EVALUATION_V1.to_string(),
+        evaluation_id,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        subject,
+        command: EvaluationCommand {
+            name: command_name.into(),
+            version: command_version.into(),
+            args: command_args,
+        },
+        inputs: EvaluationInputs {
+            bundle_digest: bundle_digest.clone(),
+            manifest_digest: manifest_digest.clone(),
+            packs_applied,
+            decision_policy: DecisionPolicy {
+                pass_on_severity_at_or_above: fail_on.to_string(),
+            },
+        },
+        outputs: EvaluationOutputs {
+            status: status.into(),
+            summary: report.summary.clone(),
+            results_digest: results_digest.clone(),
+            report_inline: Some(ReportInline {
+                schema_version: "lint-report-v1".into(),
+                report: canonical_report_json(report),
+            }),
+        },
+    })
+}
+
+/// Result of evaluation verification.
+#[derive(Debug, Clone, Serialize)]
+pub struct VerifyEvalResult {
+    pub ok: bool,
+    pub bundle_digest_match: bool,
+    pub manifest_digest_match: bool,
+    pub results_digest_verified: bool,
+    pub results_digest_verifiable: bool,
+    pub packs_verified: usize,
+    pub packs_unverifiable: usize,
+    pub packs_mismatched: usize,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+/// Verify evaluation sidecar against bundle (ADR-025 E2 Phase 3).
+///
+/// Checks: bundle_digest, manifest_digest, results_digest (if report_inline), optionally pack digests.
+/// Exit codes: 0=OK, 1=verification failed, 2=infra error.
+pub fn verify_evaluation(
+    evaluation: &Evaluation,
+    manifest: &Manifest,
+    pack_digests: Option<Vec<(String, String)>>,
+    strict: bool,
+) -> Result<VerifyEvalResult> {
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    // Schema checks
+    if evaluation.schema_version != EVALUATION_V1 {
+        errors.push(format!(
+            "schema_version must be \"{}\", got \"{}\"",
+            EVALUATION_V1, evaluation.schema_version
+        ));
+    }
+
+    if uuid::Uuid::parse_str(&evaluation.evaluation_id).is_err() {
+        errors.push(format!(
+            "evaluation_id must be UUID, got \"{}\"",
+            evaluation.evaluation_id
+        ));
+    }
+
+    if chrono::DateTime::parse_from_rfc3339(&evaluation.created_at).is_err() {
+        errors.push(format!(
+            "created_at must be RFC3339, got \"{}\"",
+            evaluation.created_at
+        ));
+    }
+
+    let digest_ok = |s: &str| -> bool {
+        s.starts_with("sha256:") && s.len() == 71 && s[7..].chars().all(|c| c.is_ascii_hexdigit())
+    };
+
+    if !digest_ok(&evaluation.inputs.bundle_digest) {
+        errors.push(format!(
+            "inputs.bundle_digest invalid format (expected sha256:<64 hex>): \"{}\"",
+            evaluation.inputs.bundle_digest
+        ));
+    }
+    if !digest_ok(&evaluation.inputs.manifest_digest) {
+        errors.push(format!(
+            "inputs.manifest_digest invalid format (expected sha256:<64 hex>): \"{}\"",
+            evaluation.inputs.manifest_digest
+        ));
+    }
+    if !digest_ok(&evaluation.outputs.results_digest) {
+        errors.push(format!(
+            "outputs.results_digest invalid format (expected sha256:<64 hex>): \"{}\"",
+            evaluation.outputs.results_digest
+        ));
+    }
+
+    if !errors.is_empty() {
+        return Ok(VerifyEvalResult {
+            ok: false,
+            bundle_digest_match: false,
+            manifest_digest_match: false,
+            results_digest_verified: false,
+            results_digest_verifiable: false,
+            packs_verified: 0,
+            packs_unverifiable: 0,
+            packs_mismatched: 0,
+            errors,
+            warnings,
+        });
+    }
+
+    // 1) Bundle bindings
+    let bundle_digest_expected = compute_bundle_digest(manifest)?;
+    let manifest_digest_expected = compute_manifest_digest(manifest)?;
+
+    let bundle_digest_match = normalize_digest(&evaluation.inputs.bundle_digest)
+        == normalize_digest(&bundle_digest_expected);
+    let manifest_digest_match = normalize_digest(&evaluation.inputs.manifest_digest)
+        == normalize_digest(&manifest_digest_expected);
+
+    if !bundle_digest_match {
+        errors.push(format!(
+            "bundle_digest mismatch: eval={} expected={}",
+            evaluation.inputs.bundle_digest, bundle_digest_expected
+        ));
+    }
+    if !manifest_digest_match {
+        errors.push(format!(
+            "manifest_digest mismatch: eval={} expected={}",
+            evaluation.inputs.manifest_digest, manifest_digest_expected
+        ));
+    }
+
+    // 2) Results digest
+    let (results_digest_verified, results_digest_verifiable) =
+        if let Some(ref ri) = evaluation.outputs.report_inline {
+            let computed = compute_results_digest_from_inline(&ri.report)?;
+            (
+                normalize_digest(&evaluation.outputs.results_digest) == normalize_digest(&computed),
+                true,
+            )
+        } else {
+            warnings.push("no report_inline: results_digest not verifiable".into());
+            (false, false)
+        };
+
+    if results_digest_verifiable && !results_digest_verified {
+        errors.push(format!(
+            "results_digest mismatch: eval={} recomputed differs",
+            evaluation.outputs.results_digest
+        ));
+    }
+
+    // 3) Pack digests
+    let (packs_verified, packs_unverifiable, packs_mismatched) =
+        if let Some(ref expected) = pack_digests {
+            let mut verified = 0;
+            let mut unverifiable = 0;
+            let mut mismatched = 0;
+            let expected_map: std::collections::HashMap<_, _> = expected
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+
+            for pa in &evaluation.inputs.packs_applied {
+                let key = format!("{}@{}", pa.name, pa.version);
+                match expected_map.get(key.as_str()) {
+                    Some(exp) => {
+                        if normalize_digest(&pa.digest) == normalize_digest(exp) {
+                            verified += 1;
+                        } else {
+                            mismatched += 1;
+                            errors.push(format!(
+                                "packs_applied digest mismatch: {} eval={} expected={}",
+                                key, pa.digest, exp
+                            ));
+                        }
+                    }
+                    None => {
+                        unverifiable += 1;
+                        warnings.push(format!("pack {} not resolvable for digest check", key));
+                        if strict {
+                            errors.push(format!("--strict: pack {} not resolvable", key));
+                        }
+                    }
+                }
+            }
+            (verified, unverifiable, mismatched)
+        } else {
+            let n = evaluation.inputs.packs_applied.len();
+            if strict && n > 0 {
+                errors.push(format!(
+                    "--strict: {} pack(s) unverifiable (pass --pack to resolve)",
+                    n
+                ));
+            }
+            (0, n, 0)
+        };
+
+    let ok = errors.is_empty();
+
+    Ok(VerifyEvalResult {
+        ok,
+        bundle_digest_match,
+        manifest_digest_match,
+        results_digest_verified,
+        results_digest_verifiable,
+        packs_verified,
+        packs_unverifiable,
+        packs_mismatched,
+        errors,
+        warnings,
+    })
+}
+
+fn normalize_digest(d: &str) -> String {
+    if d.starts_with("sha256:") {
+        d.to_lowercase()
+    } else {
+        format!("sha256:{}", d.to_lowercase())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bundle::manifest::{AlgorithmMeta, FileMeta};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_compute_bundle_digest_deterministic() {
+        use crate::types::ProducerMeta;
+
+        let manifest = Manifest {
+            schema_version: 1,
+            bundle_id: "sha256:abc".into(),
+            producer: ProducerMeta::default(),
+            run_id: "run1".into(),
+            event_count: 1,
+            run_root: "sha256:def".into(),
+            algorithms: AlgorithmMeta::default(),
+            files: {
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "events.ndjson".into(),
+                    FileMeta {
+                        path: "events.ndjson".into(),
+                        sha256: "sha256:123".into(),
+                        bytes: 100,
+                    },
+                );
+                m
+            },
+            x_assay: None,
+        };
+
+        let d1 = compute_bundle_digest(&manifest).unwrap();
+        let d2 = compute_bundle_digest(&manifest).unwrap();
+        assert_eq!(d1, d2);
+        assert!(d1.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn test_build_evaluation_from_lint() {
+        use crate::bundle::manifest::AlgorithmMeta;
+        use crate::lint::{LintReport, LintSummary};
+        use crate::types::ProducerMeta;
+
+        let manifest = Manifest {
+            schema_version: 1,
+            bundle_id: "sha256:abc".into(),
+            producer: ProducerMeta::default(),
+            run_id: "run1".into(),
+            event_count: 0,
+            run_root: "sha256:def".into(),
+            algorithms: AlgorithmMeta::default(),
+            files: BTreeMap::new(),
+            x_assay: None,
+        };
+
+        let report = LintReport {
+            tool_version: "1.0".into(),
+            bundle_meta: manifest,
+            verified: true,
+            findings: vec![],
+            summary: LintSummary {
+                total: 0,
+                errors: 0,
+                warnings: 0,
+                infos: 0,
+            },
+        };
+
+        let eval = build_evaluation_from_lint(
+            &report,
+            vec![],
+            "assay evidence lint",
+            "1.0",
+            vec!["bundle.tar.gz".into()],
+            Severity::Error,
+            "test-id-123".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(eval.schema_version, EVALUATION_V1);
+        assert_eq!(eval.evaluation_id, "test-id-123");
+        assert_eq!(eval.outputs.status, "pass");
+        assert_eq!(eval.subject.len(), 2);
+        assert!(eval.inputs.bundle_digest.starts_with("sha256:"));
+        assert!(eval.outputs.results_digest.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn test_verify_evaluation_ok() {
+        use crate::bundle::manifest::AlgorithmMeta;
+        use crate::lint::{LintReport, LintSummary};
+        use crate::types::ProducerMeta;
+
+        let manifest = Manifest {
+            schema_version: 1,
+            bundle_id: "sha256:abc".into(),
+            producer: ProducerMeta::default(),
+            run_id: "run1".into(),
+            event_count: 0,
+            run_root: "sha256:def".into(),
+            algorithms: AlgorithmMeta::default(),
+            files: BTreeMap::new(),
+            x_assay: None,
+        };
+
+        let report = LintReport {
+            tool_version: "1.0".into(),
+            bundle_meta: manifest.clone(),
+            verified: true,
+            findings: vec![],
+            summary: LintSummary {
+                total: 0,
+                errors: 0,
+                warnings: 0,
+                infos: 0,
+            },
+        };
+
+        let eval = build_evaluation_from_lint(
+            &report,
+            vec![],
+            "assay evidence lint",
+            "1.0",
+            vec!["bundle.tar.gz".into()],
+            Severity::Error,
+            uuid::Uuid::nil().to_string(),
+        )
+        .unwrap();
+
+        let result = verify_evaluation(&eval, &manifest, None, false).unwrap();
+        assert!(result.ok);
+        assert!(result.bundle_digest_match);
+        assert!(result.manifest_digest_match);
+        assert!(result.results_digest_verified);
+        assert!(result.results_digest_verifiable);
+    }
+
+    #[test]
+    fn test_verify_evaluation_bundle_digest_mismatch() {
+        use crate::bundle::manifest::AlgorithmMeta;
+        use crate::lint::LintSummary;
+        use crate::types::ProducerMeta;
+
+        let manifest = Manifest {
+            schema_version: 1,
+            bundle_id: "sha256:abc".into(),
+            producer: ProducerMeta::default(),
+            run_id: "run1".into(),
+            event_count: 0,
+            run_root: "sha256:def".into(),
+            algorithms: AlgorithmMeta::default(),
+            files: BTreeMap::new(),
+            x_assay: None,
+        };
+
+        let eval = Evaluation {
+            schema_version: EVALUATION_V1.to_string(),
+            evaluation_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            subject: vec![],
+            command: EvaluationCommand {
+                name: "assay evidence lint".into(),
+                version: "1.0".into(),
+                args: vec![],
+            },
+            inputs: EvaluationInputs {
+                bundle_digest:
+                    "sha256:wrong123456789012345678901234567890123456789012345678901234567890"
+                        .into(),
+                manifest_digest: compute_manifest_digest(&manifest).unwrap(),
+                packs_applied: vec![],
+                decision_policy: DecisionPolicy {
+                    pass_on_severity_at_or_above: "error".into(),
+                },
+            },
+            outputs: EvaluationOutputs {
+                status: "pass".into(),
+                summary: LintSummary {
+                    total: 0,
+                    errors: 0,
+                    warnings: 0,
+                    infos: 0,
+                },
+                results_digest:
+                    "sha256:0000000000000000000000000000000000000000000000000000000000000000".into(),
+                report_inline: None,
+            },
+        };
+
+        let result = verify_evaluation(&eval, &manifest, None, false).unwrap();
+        assert!(!result.ok);
+        assert!(!result.bundle_digest_match);
+    }
+}

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bundle;
 pub mod crypto;
 pub mod diff;
+pub mod evaluation;
 pub mod json_strict;
 pub mod lint;
 pub mod mandate;
@@ -15,6 +16,7 @@ pub use bundle::{
     BundleReader, BundleWriter, ErrorClass, ErrorCode, FileMeta, Manifest, ProvenanceInput,
     VerifyError, VerifyLimits, VerifyLimitsOverrides, VerifyResult, XAssayExtension,
 };
+pub use evaluation::{verify_evaluation, VerifyEvalResult};
 pub use lint::packs::{load_pack, load_packs, LoadedPack, PackError, PackSource};
 pub use ndjson::{read_events, write_events, NdjsonEvents};
 pub use store::{BundleMeta, BundleStore, ObjectStoreBundleStore, StoreError, StoreSpec};

--- a/crates/assay-evidence/src/lint/mod.rs
+++ b/crates/assay-evidence/src/lint/mod.rs
@@ -103,7 +103,7 @@ impl LintFinding {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LintSummary {
     pub total: usize,
     pub errors: usize,

--- a/crates/assay-evidence/tests/verify_eval_test.rs
+++ b/crates/assay-evidence/tests/verify_eval_test.rs
@@ -1,0 +1,85 @@
+//! Integration tests for `assay evidence verify --eval` (ADR-025 E2 Phase 3).
+
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::evaluation::verify_evaluation;
+use assay_evidence::lint::engine::{lint_bundle_with_options, LintOptions};
+use assay_evidence::lint::packs::load_packs;
+use assay_evidence::types::EvidenceEvent;
+use assay_evidence::VerifyLimits;
+use chrono::{TimeZone, Utc};
+use std::io::Cursor;
+
+fn create_bundle_bytes() -> Vec<u8> {
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    for seq in 0..2u64 {
+        let mut event = EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "run_verify_eval",
+            seq,
+            serde_json::json!({"seq": seq}),
+        );
+        event.time = Utc.timestamp_opt(1700000000 + seq as i64, 0).unwrap();
+        writer.add_event(event);
+    }
+    writer.finish().unwrap();
+    buffer
+}
+
+#[test]
+fn test_verify_eval_roundtrip() {
+    let bundle_bytes = create_bundle_bytes();
+    let packs = load_packs(&["cicd-starter".into()]).unwrap();
+    let options = LintOptions {
+        packs,
+        max_results: Some(500),
+        bundle_path: Some("bundle.tar.gz".into()),
+    };
+
+    let result =
+        lint_bundle_with_options(Cursor::new(&bundle_bytes), VerifyLimits::default(), options)
+            .unwrap();
+
+    let packs_applied: Vec<_> = result
+        .pack_meta
+        .as_ref()
+        .map(|m| {
+            m.packs
+                .iter()
+                .map(|p| assay_evidence::evaluation::PackApplied {
+                    name: p.name.clone(),
+                    version: p.version.clone(),
+                    kind: format!("{}", p.kind),
+                    digest: p.digest.clone(),
+                    source: if p.source_url.is_some() {
+                        "file"
+                    } else {
+                        "builtin"
+                    }
+                    .into(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let eval = assay_evidence::evaluation::build_evaluation_from_lint(
+        &result.report,
+        packs_applied,
+        "assay evidence lint",
+        "1.0",
+        vec!["bundle.tar.gz".into()],
+        assay_evidence::lint::Severity::Error,
+        "550e8400-e29b-41d4-a716-446655440000".into(),
+    )
+    .unwrap();
+
+    let verify_result = assay_evidence::bundle::verify_bundle(Cursor::new(&bundle_bytes)).unwrap();
+    let manifest = verify_result.manifest;
+
+    let result = verify_evaluation(&eval, &manifest, None, false).unwrap();
+    assert!(result.ok, "errors: {:?}", result.errors);
+    assert!(result.bundle_digest_match);
+    assert!(result.manifest_digest_match);
+    assert!(result.results_digest_verified);
+}

--- a/docs/architecture/REVIEW-PACK-verify-eval.md
+++ b/docs/architecture/REVIEW-PACK-verify-eval.md
@@ -1,0 +1,138 @@
+# Review Pack: `assay evidence verify --eval` (ADR-025 E2 Phase 3)
+
+MVP for tamper-evident evaluation sidecar verification. Use this pack for PR review or self-check before merge.
+
+---
+
+## Scope
+
+| Item | Description |
+|------|-------------|
+| **Feature** | `assay evidence verify --eval eval.json bundle.tar.gz` |
+| **ADR** | ADR-025-E2 Phase 3 (consumer sidecar) |
+| **Goal** | Prove (a) eval belongs to this bundle, (b) pack inputs not swapped, (c) results_digest corresponds to report |
+
+---
+
+## Files to Review
+
+| Path | Purpose |
+|------|---------|
+| `crates/assay-evidence/src/evaluation.rs` | Schema, `verify_evaluation()`, `ReportInline`, digest helpers |
+| `crates/assay-evidence/src/lib.rs` | Re-exports `verify_evaluation`, `VerifyEvalResult` |
+| `crates/assay-cli/src/cli/commands/evidence/mod.rs` | `EvidenceVerifyArgs`, `cmd_verify`, `cmd_verify_eval` |
+| `crates/assay-evidence/tests/verify_eval_test.rs` | Integration roundtrip test |
+| `crates/assay-evidence/src/evaluation.rs` (tests) | Unit: `test_verify_evaluation_ok`, `test_verify_evaluation_bundle_digest_mismatch` |
+
+---
+
+## Review Checklist
+
+### 1. CLI
+
+- [ ] `assay evidence verify --eval <PATH> [BUNDLE]` — eval required, bundle positional (or `-` for stdin; not allowed with `--eval`)
+- [ ] `--pack cicd-starter[,eu-ai-act-baseline]` — comma-delimited pack refs
+- [ ] `--strict` — fail when packs unverifiable (no `--pack` or pack not resolvable)
+- [ ] `--json` — machine-readable output
+- [ ] `-q, --quiet` — exit code only
+- [ ] Help text references ADR-025 E2 Phase 3
+
+### 2. Verification Logic
+
+- [ ] **Schema:** `schema_version == "evaluation-v1"` else fail
+- [ ] **evaluation_id:** must be valid UUID
+- [ ] **created_at:** must be RFC3339
+- [ ] **Digest format:** `sha256:<64 hex>` for `bundle_digest`, `manifest_digest`, `results_digest`; fail on invalid
+- [ ] **Bundle binding:** `compute_bundle_digest(manifest)` == `evaluation.inputs.bundle_digest`
+- [ ] **Manifest binding:** `compute_manifest_digest(manifest)` == `evaluation.inputs.manifest_digest`
+- [ ] **Results digest:** if `report_inline` present → recompute JCS digest over report → match `outputs.results_digest`
+- [ ] **Results digest (no inline):** warn "not verifiable"; `--strict` does not fail on this (only on packs)
+- [ ] **Pack digests:** when `--pack` given, resolve packs, compare `packs_applied[].digest`; mismatch → fail
+- [ ] **Pack unverifiable:** pack in eval not in resolved set → warn; `--strict` → fail
+- [ ] **Pack not resolved:** no `--pack` but eval has `packs_applied` → unverifiable count; `--strict` → fail with "pass --pack to resolve"
+
+### 3. Exit Codes
+
+- [ ] **0** — all checks pass (warnings OK in non-strict)
+- [ ] **1** — verification failed (digest mismatch, schema error, pack mismatch)
+- [ ] **2** — infra/config (missing file, invalid JSON, bundle verify failed, pack resolution error)
+
+### 4. Output UX
+
+- [ ] Human: `✅ Evaluation verified` + bundle_digest, manifest_digest, results_digest status, packs summary
+- [ ] Human failure: `❌ Evaluation verification failed` + exact error(s)
+- [ ] JSON: `ok`, `bundle`, `results`, `packs`, `warnings` per spec
+
+### 5. Inline Report (results_digest)
+
+- [ ] `build_evaluation_from_lint` emits `report_inline: ReportInline { schema_version, report }` with canonical lint report
+- [ ] `canonical_report_json()` matches structure used for digest
+- [ ] `compute_results_digest_from_inline()` uses JCS over report
+- [ ] Verify: `report_inline` present → recompute and compare; absent → mark unverifiable
+
+### 6. Tests
+
+- [ ] `test_verify_eval_roundtrip` — lint → build eval → verify → ok
+- [ ] `test_verify_evaluation_ok` — unit roundtrip
+- [ ] `test_verify_evaluation_bundle_digest_mismatch` — wrong bundle_digest → fail
+- [ ] Manual: bundle_digest mutation → exit 1
+- [ ] Manual: manifest_digest mutation → exit 1
+- [ ] Manual: report payload mutation → results_digest mismatch → exit 1
+- [ ] Manual: pack digest mutation + `--pack` → exit 1
+- [ ] Manual: `--strict` without `--pack` (eval has packs) → exit 1
+
+### 7. Integration
+
+- [ ] Bundle must be verified first (`verify_bundle`); manifest from `VerifyResult`
+- [ ] Pack resolution via `load_packs()`; digest from `LoadedPack.digest`
+- [ ] No bundle mutation by lint/verify (sidecar is separate file)
+
+### 8. Documentation / ADR
+
+- [ ] ADR-025-E2: "verify --eval" checkbox/merge gate updated
+- [ ] ADR mentions `report_inline` for portable results_digest verification
+
+---
+
+## Manual Verification Commands
+
+```bash
+# Happy path
+assay evidence lint tests/fixtures/evidence/test-bundle.tar.gz --emit-eval /tmp/eval.json
+assay evidence verify --eval /tmp/eval.json tests/fixtures/evidence/test-bundle.tar.gz
+# Expected: exit 0
+
+# With pack digest verification
+assay evidence verify --eval /tmp/eval.json tests/fixtures/evidence/test-bundle.tar.gz --pack cicd-starter
+# Expected: exit 0, packs: 1 ok
+
+# Strict without --pack (eval has packs)
+assay evidence verify --eval /tmp/eval.json tests/fixtures/evidence/test-bundle.tar.gz --strict
+# Expected: exit 1, "--strict: 1 pack(s) unverifiable"
+
+# Mutate bundle_digest in eval → exit 1
+# Mutate manifest_digest in eval → exit 1
+# Mutate report payload (e.g. "total": 1 → 99) → exit 1
+# Mutate packs_applied digest + --pack cicd-starter → exit 1
+```
+
+---
+
+## Acceptance Criteria (from spec)
+
+| # | Criterium | Status |
+|---|-----------|--------|
+| 1 | `verify --eval eval.json bundle.tar.gz` exit 0 on valid pair | ✅ |
+| 2 | Mutate eval.bundle_digest → exit 1, clear message | ✅ |
+| 3 | Mutate eval.manifest_digest → exit 1 | ✅ |
+| 4 | Mutate inline report → results_digest mismatch → exit 1 | ✅ |
+| 5 | Pack digest mismatch → exit 1; unverifiable + strict → exit 1 | ✅ |
+
+---
+
+## Known Gaps / Follow-ups
+
+- **ADR-025-E2 merge gate:** checkbox "Verification: assay evidence verify --eval..." should be marked done
+- **Soak integration:** `assay sim soak --emit-eval` will reuse same pattern; verify --eval will support soak sidecar later
+- **Exit code 2:** Infra errors (file not found, invalid JSON) currently bubble via `anyhow`; CLI returns 1 on `Result::Err`. Consider explicit mapping for 2.
+- **JSON output:** `results_digest_verifiable` field present; consumers can distinguish "verified" vs "not verifiable (no report_inline)"


### PR DESCRIPTION
## Summary

Implements `assay evidence verify --eval` (ADR-025 E2 Phase 3) for tamper-evident evaluation sidecar verification. Enables CI/audit-ready proofs that (a) the eval belongs to this bundle and (b) pack inputs were not swapped.

## Changes

- **assay-evidence**: `evaluation` module
  - `Evaluation` schema (evaluation-v1), `ReportInline`, `verify_evaluation()`
  - Digest checks: bundle_digest, manifest_digest, results_digest (JCS over inline report)
  - Pack digest verification when `--pack` provided
  - `LintSummary`: add `Deserialize`, `PartialEq` for evaluation schema

- **assay-cli**: `assay evidence verify --eval eval.json bundle.tar.gz`
  - Flags: `--pack`, `--strict`, `--json`, `--quiet`
  - Output: human or machine-readable JSON

- **docs**: `REVIEW-PACK-verify-eval.md` for PR review

## Usage

```bash
assay evidence verify --eval eval.json bundle.tar.gz
assay evidence verify --eval eval.json bundle.tar.gz --pack cicd-starter
assay evidence verify --eval eval.json bundle.tar.gz --strict --pack cicd-starter
```

## Dependencies

- Requires lint `--emit-eval` to produce evaluation sidecars (separate PR or follow-up)
- Base: `feat/e2-writer-split-facade` (E2 writer split)

Made with [Cursor](https://cursor.com)