### PR TITLE
refactor(registry): centralize REGISTRY_USER_AGENT constant

### DIFF
--- a/crates/assay-registry/src/client/mod.rs
+++ b/crates/assay-registry/src/client/mod.rs
@@ -20,7 +20,7 @@ mod http;
 use helpers::compute_digest;
 use http::{HttpBackend, PackOutcome, SignatureOutcome};
 
-const USER_AGENT_VALUE: &str = concat!("assay-registry/", env!("CARGO_PKG_VERSION"));
+use crate::REGISTRY_USER_AGENT;
 
 /// Registry client for fetching packs.
 #[derive(Debug, Clone)]
@@ -44,7 +44,7 @@ impl RegistryClient {
         token_provider: TokenProvider,
     ) -> RegistryResult<Self> {
         let mut default_headers = HeaderMap::new();
-        default_headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
+        default_headers.insert(USER_AGENT, HeaderValue::from_static(REGISTRY_USER_AGENT));
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))

--- a/crates/assay-registry/src/lib.rs
+++ b/crates/assay-registry/src/lib.rs
@@ -58,6 +58,9 @@ pub mod trust;
 pub mod types;
 pub mod verify;
 
+/// User-Agent string sent by the registry client. Single source for client and tests.
+pub const REGISTRY_USER_AGENT: &str = concat!("assay-registry/", env!("CARGO_PKG_VERSION"));
+
 // Re-export main types
 pub use auth::TokenProvider;
 pub use cache::{CacheEntry, CacheMeta, PackCache};

--- a/crates/assay-registry/tests/registry_client.rs
+++ b/crates/assay-registry/tests/registry_client.rs
@@ -5,7 +5,9 @@
 
 use std::time::Duration;
 
-use assay_registry::{compute_digest, RegistryClient, RegistryConfig, RegistryError};
+use assay_registry::{
+    compute_digest, RegistryClient, RegistryConfig, RegistryError, REGISTRY_USER_AGENT,
+};
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -14,10 +16,6 @@ async fn create_test_client(mock_server: &MockServer) -> RegistryClient {
         .with_url(mock_server.uri())
         .with_token("test-token");
     RegistryClient::new(config).expect("failed to create client")
-}
-
-fn user_agent_value() -> String {
-    format!("assay-registry/{}", env!("CARGO_PKG_VERSION"))
 }
 
 #[tokio::test]
@@ -335,7 +333,7 @@ async fn test_user_agent_header() {
 
     Mock::given(method("GET"))
         .and(path("/packs/test/1.0.0"))
-        .and(header("user-agent", user_agent_value()))
+        .and(header("user-agent", REGISTRY_USER_AGENT))
         .respond_with(ResponseTemplate::new(200).set_body_string("content"))
         .expect(1)
         .mount(&mock_server)


### PR DESCRIPTION
## Description

Export `REGISTRY_USER_AGENT` from `lib.rs` as single source of truth. Use in client and integration tests to prevent drift.

## Type of Change
- [x] Refactor

## Verification
- [x] `cargo check` passes
- [x] `cargo test` passes (registry integration tests)

## Checklist
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (N/A – reuses existing tests)

Made with [Cursor](https://cursor.com)