### PR TITLE
fix(ci): ensure cargo in PATH for eBPF self-hosted Install Dependencies step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Self-hosted runner: Rust in /opt/rust; cloud-init may symlink to /usr/local/bin
+          export PATH="/opt/rust/bin:/usr/local/bin:${HOME:-/home/github-runner}/.cargo/bin:${PATH}"
 
           # Switch Ubuntu Ports mirror with robust failover
           set +e


### PR DESCRIPTION
## Problem

eBPF monitor smoke (Linux - Self-Hosted) fails with:
```
cargo: command not found
Error: Process completed with exit code 127
```

The failure occurs in the "Install Dependencies" step when running `cargo install bpf-linker --locked`.

## Root cause

The self-hosted runner uses `--noprofile`, so the shell gets a minimal PATH. The job-level `env.PATH` may not propagate correctly to the step's subshell. The runner has Rust in `/opt/rust` and cloud-init symlinks cargo/rustc to `/usr/local/bin`, but neither was reliably in PATH when the step ran.

## Fix

Explicitly export PATH at the start of the Install Dependencies step:
```
export PATH="/opt/rust/bin:/usr/local/bin:${HOME:-/home/github-runner}/.cargo/bin:${PATH}"
```

Made with [Cursor](https://cursor.com)