### PR TITLE
refactor(verify-step2): mechanical split behind stable verify facade

### DIFF
--- a/crates/assay-registry/src/verify_next/digest.rs
+++ b/crates/assay-registry/src/verify_next/digest.rs
@@ -1,0 +1,6 @@
+//! Digest parsing/compare boundary for Step-2 split.
+//!
+//! Contract target:
+//! - digest-only helpers
+//! - no DSSE verification
+//! - no policy decisions

--- a/crates/assay-registry/src/verify_next/digest.rs
+++ b/crates/assay-registry/src/verify_next/digest.rs
@@ -4,3 +4,35 @@
 //! - digest-only helpers
 //! - no DSSE verification
 //! - no policy decisions
+
+use crate::canonicalize::{compute_canonical_digest, CanonicalizeError};
+use crate::digest::{compute_canonical_or_raw_digest, sha256_hex_bytes};
+use crate::error::RegistryResult;
+
+use super::errors_next;
+
+pub(super) fn verify_digest_impl(content: &str, expected: &str) -> RegistryResult<()> {
+    let computed = compute_digest_impl(content);
+    if computed != expected {
+        return Err(errors_next::digest_mismatch(expected, computed));
+    }
+    Ok(())
+}
+
+pub(super) fn compute_digest_impl(content: &str) -> String {
+    compute_canonical_or_raw_digest(content, |e| {
+        tracing::warn!(
+            error = %e,
+            "canonical digest failed, falling back to raw digest"
+        );
+    })
+}
+
+pub(super) fn compute_digest_strict_impl(content: &str) -> Result<String, CanonicalizeError> {
+    compute_canonical_digest(content)
+}
+
+#[allow(deprecated)]
+pub(super) fn compute_digest_raw_impl(content: &str) -> String {
+    sha256_hex_bytes(content.as_bytes())
+}

--- a/crates/assay-registry/src/verify_next/dsse.rs
+++ b/crates/assay-registry/src/verify_next/dsse.rs
@@ -1,0 +1,5 @@
+//! DSSE verification boundary for Step-2 split.
+//!
+//! Contract target:
+//! - envelope parse and signature verification
+//! - no allow/skip/unsigned policy decisions

--- a/crates/assay-registry/src/verify_next/dsse.rs
+++ b/crates/assay-registry/src/verify_next/dsse.rs
@@ -3,3 +3,91 @@
 //! Contract target:
 //! - envelope parse and signature verification
 //! - no allow/skip/unsigned policy decisions
+//!
+//! Forbidden responsibilities:
+//! - deciding unsigned-allow policy
+//! - handling skip-signature policy
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use ed25519_dalek::{Signature, Verifier};
+
+use crate::error::RegistryResult;
+use crate::trust::TrustStore;
+use crate::types::DsseEnvelope;
+
+use super::errors_next;
+use super::PAYLOAD_TYPE_PACK_V1;
+
+pub(super) fn build_pae_impl(payload_type: &str, payload: &[u8]) -> Vec<u8> {
+    let type_len = payload_type.len().to_string();
+    let payload_len = payload.len().to_string();
+
+    let mut pae = Vec::new();
+    pae.extend_from_slice(b"DSSEv1 ");
+    pae.extend_from_slice(type_len.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload_type.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload_len.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload);
+    pae
+}
+
+pub(super) fn verify_dsse_signature_bytes_impl(
+    canonical_bytes: &[u8],
+    envelope: &DsseEnvelope,
+    trust_store: &TrustStore,
+) -> RegistryResult<()> {
+    if envelope.payload_type != PAYLOAD_TYPE_PACK_V1 {
+        return Err(errors_next::signature_invalid(format!(
+            "payload type mismatch: expected {}, got {}",
+            PAYLOAD_TYPE_PACK_V1, envelope.payload_type
+        )));
+    }
+
+    let payload_bytes = BASE64
+        .decode(&envelope.payload)
+        .map_err(|e| errors_next::signature_invalid(format!("invalid base64 payload: {}", e)))?;
+
+    if payload_bytes != canonical_bytes {
+        return Err(errors_next::digest_mismatch(
+            format!("canonical payload ({} bytes)", payload_bytes.len()),
+            format!("canonical content ({} bytes)", canonical_bytes.len()),
+        ));
+    }
+
+    if envelope.signatures.is_empty() {
+        return Err(errors_next::signature_invalid("no signatures in envelope"));
+    }
+
+    let pae = build_pae_impl(&envelope.payload_type, &payload_bytes);
+    let mut last_error = None;
+    for sig in &envelope.signatures {
+        match verify_single_signature_impl(&pae, &sig.key_id, &sig.signature, trust_store) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_error = Some(e),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| errors_next::signature_invalid("no valid signatures")))
+}
+
+pub(super) fn verify_single_signature_impl(
+    pae: &[u8],
+    key_id: &str,
+    signature_b64: &str,
+    trust_store: &TrustStore,
+) -> RegistryResult<()> {
+    let key = trust_store.get_key(key_id)?;
+
+    let signature_bytes = BASE64
+        .decode(signature_b64)
+        .map_err(|e| errors_next::signature_invalid(format!("invalid base64 signature: {}", e)))?;
+
+    let signature = Signature::from_slice(&signature_bytes)
+        .map_err(|e| errors_next::signature_invalid(format!("invalid signature bytes: {}", e)))?;
+
+    key.verify(pae, &signature)
+        .map_err(|_| errors_next::signature_invalid("ed25519 verification failed"))
+}

--- a/crates/assay-registry/src/verify_next/dsse.rs
+++ b/crates/assay-registry/src/verify_next/dsse.rs
@@ -1,7 +1,7 @@
 //! DSSE verification boundary for Step-2 split.
 //!
 //! Contract target:
-//! - envelope parse and signature verification
+//! - payload decode, PAE building, and signature verification
 //! - no allow/skip/unsigned policy decisions
 //!
 //! Forbidden responsibilities:

--- a/crates/assay-registry/src/verify_next/errors.rs
+++ b/crates/assay-registry/src/verify_next/errors.rs
@@ -3,3 +3,36 @@
 //! Contract target:
 //! - typed error constructors/mapping helpers
 //! - deterministic error classification
+
+use crate::error::RegistryError;
+
+pub(super) fn digest_mismatch(
+    expected: impl Into<String>,
+    actual: impl Into<String>,
+) -> RegistryError {
+    RegistryError::DigestMismatch {
+        name: "pack".to_string(),
+        version: "unknown".to_string(),
+        expected: expected.into(),
+        actual: actual.into(),
+    }
+}
+
+pub(super) fn unsigned_pack() -> RegistryError {
+    RegistryError::Unsigned {
+        name: "pack".to_string(),
+        version: "unknown".to_string(),
+    }
+}
+
+pub(super) fn invalid_response(message: impl Into<String>) -> RegistryError {
+    RegistryError::InvalidResponse {
+        message: message.into(),
+    }
+}
+
+pub(super) fn signature_invalid(reason: impl Into<String>) -> RegistryError {
+    RegistryError::SignatureInvalid {
+        reason: reason.into(),
+    }
+}

--- a/crates/assay-registry/src/verify_next/errors.rs
+++ b/crates/assay-registry/src/verify_next/errors.rs
@@ -1,0 +1,5 @@
+//! Error mapping boundary for Step-2 split.
+//!
+//! Contract target:
+//! - typed error constructors/mapping helpers
+//! - deterministic error classification

--- a/crates/assay-registry/src/verify_next/keys.rs
+++ b/crates/assay-registry/src/verify_next/keys.rs
@@ -3,3 +3,21 @@
 //! Contract target:
 //! - key-id derivation and key lookup helpers
 //! - no allow/skip/unsigned policy decisions
+
+use ed25519_dalek::VerifyingKey;
+
+use crate::digest::sha256_hex_bytes;
+use crate::error::{RegistryError, RegistryResult};
+
+pub(super) fn compute_key_id_impl(spki_bytes: &[u8]) -> String {
+    sha256_hex_bytes(spki_bytes)
+}
+
+pub(super) fn compute_key_id_from_key_impl(key: &VerifyingKey) -> RegistryResult<String> {
+    use pkcs8::EncodePublicKey;
+
+    let doc = key.to_public_key_der().map_err(|e| RegistryError::Config {
+        message: format!("failed to encode public key: {}", e),
+    })?;
+    Ok(compute_key_id_impl(doc.as_bytes()))
+}

--- a/crates/assay-registry/src/verify_next/keys.rs
+++ b/crates/assay-registry/src/verify_next/keys.rs
@@ -1,0 +1,5 @@
+//! Key-id and trust-key boundary for Step-2 split.
+//!
+//! Contract target:
+//! - key-id derivation and key lookup helpers
+//! - no allow/skip/unsigned policy decisions

--- a/crates/assay-registry/src/verify_next/mod.rs
+++ b/crates/assay-registry/src/verify_next/mod.rs
@@ -1,0 +1,14 @@
+//! Step-2 scaffold for verify module split.
+//!
+//! Commit A keeps `src/verify.rs` as the active implementation to guarantee
+//! zero behavior change while the new module layout is prepared.
+//!
+//! This module is not wired into `lib.rs` yet.
+
+pub(crate) mod digest;
+pub(crate) mod dsse;
+pub(crate) mod errors;
+pub(crate) mod keys;
+pub(crate) mod policy;
+pub(crate) mod tests;
+pub(crate) mod wire;

--- a/crates/assay-registry/src/verify_next/mod.rs
+++ b/crates/assay-registry/src/verify_next/mod.rs
@@ -1,9 +1,9 @@
 //! Step-2 scaffold for verify module split.
 //!
-//! Commit A keeps `src/verify.rs` as the active implementation to guarantee
-//! zero behavior change while the new module layout is prepared.
+//! `src/verify.rs` remains the public facade and delegates into `verify_next/*`
+//! so symbol paths/signatures stay stable during the split rollout.
 //!
-//! This module is not wired into `lib.rs` yet.
+//! This module is intentionally not exposed via `lib.rs` as `pub mod verify_next`.
 //!
 //! Forbidden knowledge for this facade:
 //! - no direct crypto implementation details

--- a/crates/assay-registry/src/verify_next/mod.rs
+++ b/crates/assay-registry/src/verify_next/mod.rs
@@ -4,6 +4,11 @@
 //! zero behavior change while the new module layout is prepared.
 //!
 //! This module is not wired into `lib.rs` yet.
+//!
+//! Forbidden knowledge for this facade:
+//! - no direct crypto implementation details
+//! - no DSSE parsing/verification internals
+//! - no policy branch logic beyond orchestration
 
 pub(crate) mod digest;
 pub(crate) mod dsse;

--- a/crates/assay-registry/src/verify_next/policy.rs
+++ b/crates/assay-registry/src/verify_next/policy.rs
@@ -1,0 +1,7 @@
+//! Verification policy boundary for Step-2 split.
+//!
+//! Contract target:
+//! - allow/skip/unsigned decisions
+//! - fail-closed decision mapping
+//! - no crypto/base64/DSSE parsing logic
+//! - no IO/network access

--- a/crates/assay-registry/src/verify_next/policy.rs
+++ b/crates/assay-registry/src/verify_next/policy.rs
@@ -54,9 +54,11 @@ pub(super) fn verify_pack_impl(
     }
 
     let canonical_bytes = wire_next::canonicalize_for_dsse_impl(&result.content)?;
-    let sig_b64 = signature
-        .as_ref()
-        .expect("signature presence already checked in policy");
+    let Some(sig_b64) = signature.as_ref() else {
+        // Defensive fallback: keep fail-closed behavior if a future edit
+        // breaks the earlier invariant check.
+        return Err(errors_next::unsigned_pack());
+    };
     let envelope = wire_next::parse_dsse_envelope_impl(sig_b64)?;
     dsse_next::verify_dsse_signature_bytes_impl(&canonical_bytes, &envelope, trust_store)?;
 

--- a/crates/assay-registry/src/verify_next/policy.rs
+++ b/crates/assay-registry/src/verify_next/policy.rs
@@ -5,3 +5,64 @@
 //! - fail-closed decision mapping
 //! - no crypto/base64/DSSE parsing logic
 //! - no IO/network access
+//!
+//! Forbidden imports (enforced via future grep-gates):
+//! - base64::, ed25519_*, sha2::, serde_json::from_slice
+//! - reqwest, tokio::fs, std::fs, std::net
+
+use crate::error::RegistryResult;
+use crate::trust::TrustStore;
+use crate::types::FetchResult;
+
+use super::dsse_next;
+use super::errors_next;
+use super::wire_next;
+use super::{VerifyOptions, VerifyResult};
+
+pub(super) fn verify_pack_impl(
+    result: &FetchResult,
+    trust_store: &TrustStore,
+    options: &VerifyOptions,
+) -> RegistryResult<VerifyResult> {
+    if let Some(claimed_digest) = &result.headers.digest {
+        if claimed_digest != &result.computed_digest {
+            return Err(errors_next::digest_mismatch(
+                claimed_digest.clone(),
+                result.computed_digest.clone(),
+            ));
+        }
+    }
+
+    let signature = &result.headers.signature;
+    if signature.is_none() {
+        if options.allow_unsigned {
+            return Ok(VerifyResult {
+                signed: false,
+                key_id: None,
+                digest: result.computed_digest.clone(),
+            });
+        }
+        return Err(errors_next::unsigned_pack());
+    }
+
+    if options.skip_signature {
+        return Ok(VerifyResult {
+            signed: true,
+            key_id: result.headers.key_id.clone(),
+            digest: result.computed_digest.clone(),
+        });
+    }
+
+    let canonical_bytes = wire_next::canonicalize_for_dsse_impl(&result.content)?;
+    let sig_b64 = signature
+        .as_ref()
+        .expect("signature presence already checked in policy");
+    let envelope = wire_next::parse_dsse_envelope_impl(sig_b64)?;
+    dsse_next::verify_dsse_signature_bytes_impl(&canonical_bytes, &envelope, trust_store)?;
+
+    Ok(VerifyResult {
+        signed: true,
+        key_id: envelope.signatures.first().map(|s| s.key_id.clone()),
+        digest: result.computed_digest.clone(),
+    })
+}

--- a/crates/assay-registry/src/verify_next/tests.rs
+++ b/crates/assay-registry/src/verify_next/tests.rs
@@ -2,3 +2,13 @@
 //!
 //! Commit A keeps tests in `src/verify.rs` active.
 //! This module is reserved for Step-2 relocation in Commit B/C.
+
+#![cfg(test)]
+
+mod contract {
+    // Reserved for behavior-freeze contract tests moved from verify.rs.
+}
+
+mod vectors {
+    // Reserved for DSSE/digest vector tests moved from verify.rs.
+}

--- a/crates/assay-registry/src/verify_next/tests.rs
+++ b/crates/assay-registry/src/verify_next/tests.rs
@@ -1,0 +1,4 @@
+//! Test module boundary for Step-2 split.
+//!
+//! Commit A keeps tests in `src/verify.rs` active.
+//! This module is reserved for Step-2 relocation in Commit B/C.

--- a/crates/assay-registry/src/verify_next/wire.rs
+++ b/crates/assay-registry/src/verify_next/wire.rs
@@ -1,0 +1,6 @@
+//! Wire-level parsing boundary for Step-2 split.
+//!
+//! Contract target:
+//! - parsing and shape checks only
+//! - no policy decisions
+//! - no cryptographic verification

--- a/crates/assay-registry/src/verify_next/wire.rs
+++ b/crates/assay-registry/src/verify_next/wire.rs
@@ -4,3 +4,36 @@
 //! - parsing and shape checks only
 //! - no policy decisions
 //! - no cryptographic verification
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+
+use crate::canonicalize::{parse_yaml_strict, to_canonical_jcs_bytes};
+use crate::error::RegistryResult;
+use crate::types::DsseEnvelope;
+
+use super::errors_next;
+
+pub(super) fn canonicalize_for_dsse_impl(content: &str) -> RegistryResult<Vec<u8>> {
+    let json_value = parse_yaml_strict(content).map_err(|e| {
+        errors_next::invalid_response(format!(
+            "failed to parse YAML for signature verification: {}",
+            e
+        ))
+    })?;
+
+    to_canonical_jcs_bytes(&json_value).map_err(|e| {
+        errors_next::invalid_response(format!(
+            "failed to canonicalize for signature verification: {}",
+            e
+        ))
+    })
+}
+
+pub(super) fn parse_dsse_envelope_impl(b64: &str) -> RegistryResult<DsseEnvelope> {
+    let bytes = BASE64
+        .decode(b64)
+        .map_err(|e| errors_next::signature_invalid(format!("invalid base64 envelope: {}", e)))?;
+
+    serde_json::from_slice(&bytes)
+        .map_err(|e| errors_next::signature_invalid(format!("invalid DSSE envelope: {}", e)))
+}

--- a/docs/contributing/SPLIT-CHECKLIST-verify-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-verify-step2.md
@@ -22,7 +22,7 @@ cargo test -p assay-registry test_verify_pack_malformed_signature_reason_is_stab
 ### 1) policy.rs has no direct crypto/parsing/IO internals
 
 ```bash
-rg -n "base64::|ed25519|sha2::|serde_json::from_slice|reqwest|tokio::fs|std::fs|std::net" crates/assay-registry/src/verify_next/policy.rs | rg -v '^\d+:\s*//!'
+rg -n "base64::|ed25519|sha2::|serde_json::from_slice|reqwest|tokio::fs|std::fs|std::net" crates/assay-registry/src/verify_next/policy.rs | rg -v '^\d+:\s*//!' | rg -v '^\d+:\s*//'
 # Expect: empty output
 ```
 
@@ -36,14 +36,14 @@ rg -n "build_pae_impl|verify_single_signature_impl|Signature::|Verifier::|to_pub
 ### 3) policy.rs has exactly one DSSE boundary call site
 
 ```bash
-rg -n "dsse_next::" crates/assay-registry/src/verify_next/policy.rs | rg -v '^\d+:\s*//!'
+rg -n "dsse_next::verify_dsse_signature_bytes_impl\(" crates/assay-registry/src/verify_next/policy.rs | rg -v '^\d+:\s*//!' | rg -v '^\d+:\s*//'
 # Expect: one match to dsse_next::verify_dsse_signature_bytes_impl(...)
 ```
 
 ### 4) dsse.rs contains no policy tokens
 
 ```bash
-rg -n "allow_unsigned|skip_signature|unsigned" crates/assay-registry/src/verify_next/dsse.rs | rg -v '^\d+:\s*//!'
+rg -n "allow_unsigned|skip_signature|unsigned" crates/assay-registry/src/verify_next/dsse.rs | rg -v '^\d+:\s*//!' | rg -v '^\d+:\s*//'
 # Expect: empty output
 ```
 

--- a/docs/contributing/SPLIT-CHECKLIST-verify-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-verify-step2.md
@@ -1,0 +1,65 @@
+# Verify split (Step 2) — checklist & grep-gates
+
+Status: Wave 1 / Step 2 (mechanical move behind stable facade)
+
+## Scope lock
+
+- `src/verify.rs` remains the public facade.
+- Public symbols/paths remain unchanged.
+- `verify_next/*` hosts moved implementation only.
+- No perf work and no API redesign in this step.
+
+## Reviewer script (copy/paste)
+
+```bash
+cargo check -p assay-registry
+cargo test -p assay-registry test_verify_pack_fail_closed_matrix_contract -- --nocapture
+cargo test -p assay-registry test_verify_pack_malformed_signature_reason_is_stable -- --nocapture
+```
+
+## Boundary grep-gates (copy/paste)
+
+### 1) policy.rs has no direct crypto/parsing/IO internals
+
+```bash
+rg -n "base64::|ed25519|sha2::|serde_json::from_slice|reqwest|tokio::fs|std::fs|std::net" crates/assay-registry/src/verify_next/policy.rs | rg -v '^\d+:\s*//!'
+# Expect: empty output
+```
+
+### 2) policy.rs does not call low-level DSSE crypto helpers
+
+```bash
+rg -n "build_pae_impl|verify_single_signature_impl|Signature::|Verifier::|to_public_key_der" crates/assay-registry/src/verify_next/policy.rs | rg -v '^\d+:\s*//!'
+# Expect: empty output
+```
+
+### 3) policy.rs has exactly one DSSE boundary call site
+
+```bash
+rg -n "dsse_next::" crates/assay-registry/src/verify_next/policy.rs | rg -v '^\d+:\s*//!'
+# Expect: one match to dsse_next::verify_dsse_signature_bytes_impl(...)
+```
+
+### 4) dsse.rs contains no policy tokens
+
+```bash
+rg -n "allow_unsigned|skip_signature|unsigned" crates/assay-registry/src/verify_next/dsse.rs | rg -v '^\d+:\s*//!'
+# Expect: empty output
+```
+
+### 5) facade path stays stable
+
+```bash
+rg -n "pub mod verify;" crates/assay-registry/src/lib.rs
+# Expect: exactly one match
+```
+
+## Move-map reference
+
+See `docs/contributing/SPLIT-MOVE-MAP-verify-step2.md` for function-to-file mapping.
+
+## Known sandbox limitation
+
+In this sandbox, `registry_client` integration tests that spawn wiremock can fail with
+`Operation not permitted` (port bind). This does not affect Step-2 verify split
+correctness. Use GitHub CI for full integration-suite confirmation.

--- a/docs/contributing/SPLIT-MOVE-MAP-verify-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-verify-step2.md
@@ -1,0 +1,32 @@
+# Verify Step 2 Move Map (Commit B)
+
+Status: mechanical function move with facade signatures unchanged.
+
+## Public API (path/signature unchanged in `src/verify.rs`)
+
+- `pub fn verify_pack(...)` -> facade in `src/verify.rs`, impl in `src/verify_next/policy.rs`
+- `pub fn verify_digest(...)` -> facade in `src/verify.rs`, impl in `src/verify_next/digest.rs`
+- `pub fn compute_digest(...)` -> facade in `src/verify.rs`, impl in `src/verify_next/digest.rs`
+- `pub fn compute_digest_strict(...)` -> facade in `src/verify.rs`, impl in `src/verify_next/digest.rs`
+- `pub fn compute_digest_raw(...)` -> facade in `src/verify.rs`, impl in `src/verify_next/digest.rs`
+- `pub fn compute_key_id(...)` -> facade in `src/verify.rs`, impl in `src/verify_next/keys.rs`
+- `pub fn compute_key_id_from_key(...)` -> facade in `src/verify.rs`, impl in `src/verify_next/keys.rs`
+
+## Internal helpers moved
+
+- `canonicalize_for_dsse` -> `src/verify_next/wire.rs` (`canonicalize_for_dsse_impl`)
+- `parse_dsse_envelope` -> `src/verify_next/wire.rs` (`parse_dsse_envelope_impl`)
+- `build_pae` -> `src/verify_next/dsse.rs` (`build_pae_impl`)
+- `verify_dsse_signature_bytes` -> `src/verify_next/dsse.rs` (`verify_dsse_signature_bytes_impl`)
+- `verify_single_signature` -> `src/verify_next/dsse.rs` (`verify_single_signature_impl`)
+
+## Error construction moved
+
+- common error constructors are centralized in `src/verify_next/errors.rs`
+
+## Boundary intent
+
+- `policy.rs`: allow/skip/unsigned decision logic only
+- `dsse.rs`: crypto verify only (no policy decisions)
+- `wire.rs`: parsing and shape validation only
+- `digest.rs`: digest-only logic


### PR DESCRIPTION
## Summary
Wave 1 Step 2: mechanical verify split behind a stable facade.

This PR keeps `src/verify.rs` as the public facade (symbol paths/signatures unchanged) and moves implementation logic into `src/verify_next/*` modules.

## Base/stack
- Base: `codex/wave1-step1-behavior-freeze`
- Head: `codex/wave1-step2-verify-split`

## Commit slices
- `acb4bc7e` — compile-safe scaffold (`verify_next/*`) with no behavior changes
- `82cb98ea` — mechanical function moves to `verify_next/*` with facade wrappers in `verify.rs`

## Function -> file move map
See: `docs/contributing/SPLIT-MOVE-MAP-verify-step2.md`

Highlights:
- `verify_pack` facade unchanged, impl moved to `verify_next/policy.rs`
- digest functions moved to `verify_next/digest.rs`
- DSSE verify helpers moved to `verify_next/dsse.rs`
- parse/shape helpers moved to `verify_next/wire.rs`
- key-id helpers moved to `verify_next/keys.rs`
- error constructors centralized in `verify_next/errors.rs`

## Contract safety
- Public symbol paths remain unchanged (`crate::verify::*`).
- Step-1 behavior-freeze tests remain in place and unchanged in assertions.

## Boundary checks (code-only grep)
```bash
# policy has no crypto/base64/io-network code
rg -n "base64::|ed25519|sha2::|serde_json::from_slice|reqwest|tokio::fs|std::fs|std::net" crates/assay-registry/src/verify_next/policy.rs | rg -v '^\\d+:\\s*//!'
# expect: no output

# dsse has no policy decision tokens
rg -n "allow_unsigned|skip_signature|unsigned" crates/assay-registry/src/verify_next/dsse.rs | rg -v '^\\d+:\\s*//!'
# expect: no output
```

## Validation
Executed and passing:
```bash
cargo check -p assay-registry
cargo test -p assay-registry test_verify_pack_fail_closed_matrix_contract -- --nocapture
cargo test -p assay-registry test_verify_pack_malformed_signature_reason_is_stable -- --nocapture
```

Note: full `cargo test -p assay-registry` includes `registry_client` integration tests that require local mock-server port binding; those fail in this sandbox (`Operation not permitted`) but are unrelated to verify split semantics.

## Risk
Medium-low: internal refactor only, facade + contract tests preserved.
