### PR TITLE
chore(release): sync workspace to v2.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-cli"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "aya",
  "chrono",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "assay-core",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "2.17.0"
+version = "2.18.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
## Summary
Sync `main` to release workspace version `v2.18.0`.

This PR cherry-picks the existing release commit and only updates:
- `Cargo.toml` workspace version
- `Cargo.lock` crate version entries

## Scope
- no code changes
- no behavior changes
- version metadata sync only
