### PR TITLE
refactor(wave4-step2): split lockfile/cache behind stable facades

### DIFF
--- a/crates/assay-registry/src/cache_next/errors.rs
+++ b/crates/assay-registry/src/cache_next/errors.rs
@@ -1,0 +1,5 @@
+//! Cache error mapping scaffold.
+//!
+//! Planned ownership (Step2+):
+//! - typed error constructors/mappers only
+//! - no IO side effects

--- a/crates/assay-registry/src/cache_next/integrity.rs
+++ b/crates/assay-registry/src/cache_next/integrity.rs
@@ -3,3 +3,18 @@
 //! Planned ownership (Step2+):
 //! - digest/signature verification helpers
 //! - corruption handling helpers
+
+use crate::error::{RegistryError, RegistryResult};
+use crate::types::DsseEnvelope;
+
+pub(crate) fn parse_signature_impl(b64: &str) -> RegistryResult<DsseEnvelope> {
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+
+    let bytes = BASE64.decode(b64).map_err(|e| RegistryError::Cache {
+        message: format!("invalid base64 signature: {}", e),
+    })?;
+
+    serde_json::from_slice(&bytes).map_err(|e| RegistryError::Cache {
+        message: format!("invalid DSSE envelope: {}", e),
+    })
+}

--- a/crates/assay-registry/src/cache_next/integrity.rs
+++ b/crates/assay-registry/src/cache_next/integrity.rs
@@ -1,0 +1,5 @@
+//! Integrity boundary scaffold for cache split.
+//!
+//! Planned ownership (Step2+):
+//! - digest/signature verification helpers
+//! - corruption handling helpers

--- a/crates/assay-registry/src/cache_next/io.rs
+++ b/crates/assay-registry/src/cache_next/io.rs
@@ -1,0 +1,5 @@
+//! IO boundary scaffold for cache split.
+//!
+//! Planned ownership (Step2+):
+//! - atomic write/rename helpers
+//! - filesystem interactions for cache content

--- a/crates/assay-registry/src/cache_next/io.rs
+++ b/crates/assay-registry/src/cache_next/io.rs
@@ -3,3 +3,37 @@
 //! Planned ownership (Step2+):
 //! - atomic write/rename helpers
 //! - filesystem interactions for cache content
+
+use std::path::{Path, PathBuf};
+
+use tokio::fs;
+
+use crate::error::{RegistryError, RegistryResult};
+
+pub(crate) fn default_cache_dir_impl() -> RegistryResult<PathBuf> {
+    let base = dirs::cache_dir()
+        .or_else(dirs::home_dir)
+        .ok_or_else(|| RegistryError::Cache {
+            message: "could not determine cache directory".to_string(),
+        })?;
+
+    Ok(base.join("assay").join("cache").join("packs"))
+}
+
+pub(crate) async fn write_atomic_impl(path: &Path, content: &str) -> RegistryResult<()> {
+    let temp_path = path.with_extension("tmp");
+
+    fs::write(&temp_path, content)
+        .await
+        .map_err(|e| RegistryError::Cache {
+            message: format!("failed to write temp file: {}", e),
+        })?;
+
+    fs::rename(&temp_path, path)
+        .await
+        .map_err(|e| RegistryError::Cache {
+            message: format!("failed to rename temp file: {}", e),
+        })?;
+
+    Ok(())
+}

--- a/crates/assay-registry/src/cache_next/keys.rs
+++ b/crates/assay-registry/src/cache_next/keys.rs
@@ -1,0 +1,4 @@
+//! Key/path derivation boundary scaffold for cache split.
+//!
+//! Planned ownership (Step2+):
+//! - cache key and path derivation helpers

--- a/crates/assay-registry/src/cache_next/keys.rs
+++ b/crates/assay-registry/src/cache_next/keys.rs
@@ -2,3 +2,9 @@
 //!
 //! Planned ownership (Step2+):
 //! - cache key and path derivation helpers
+
+use std::path::{Path, PathBuf};
+
+pub(crate) fn pack_dir_impl(cache_dir: &Path, name: &str, version: &str) -> PathBuf {
+    cache_dir.join(name).join(version)
+}

--- a/crates/assay-registry/src/cache_next/mod.rs
+++ b/crates/assay-registry/src/cache_next/mod.rs
@@ -10,4 +10,5 @@ pub(crate) mod integrity;
 pub(crate) mod io;
 pub(crate) mod keys;
 pub(crate) mod policy;
+pub(crate) mod put;
 pub(crate) mod tests;

--- a/crates/assay-registry/src/cache_next/mod.rs
+++ b/crates/assay-registry/src/cache_next/mod.rs
@@ -1,0 +1,13 @@
+//! Wave4 Step2 cache split scaffold.
+//!
+//! Commit A contract:
+//! - `cache.rs` remains the active facade.
+//! - No wiring to this module yet.
+//! - No behavior/perf changes in this commit.
+
+pub(crate) mod errors;
+pub(crate) mod integrity;
+pub(crate) mod io;
+pub(crate) mod keys;
+pub(crate) mod policy;
+pub(crate) mod tests;

--- a/crates/assay-registry/src/cache_next/policy.rs
+++ b/crates/assay-registry/src/cache_next/policy.rs
@@ -3,3 +3,32 @@
 //! Planned ownership (Step2+):
 //! - TTL/eviction policy helpers
 //! - no filesystem writes
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::types::PackHeaders;
+
+pub(crate) fn parse_cache_control_expiry_impl(
+    headers: &PackHeaders,
+    default_ttl_secs: i64,
+) -> DateTime<Utc> {
+    let now = Utc::now();
+    let default_ttl = Duration::seconds(default_ttl_secs);
+
+    let ttl = headers
+        .cache_control
+        .as_ref()
+        .and_then(|cc| {
+            cc.split(',')
+                .find(|part| part.trim().starts_with("max-age="))
+                .and_then(|part| {
+                    part.trim()
+                        .strip_prefix("max-age=")
+                        .and_then(|v| v.parse::<i64>().ok())
+                })
+        })
+        .map(Duration::seconds)
+        .unwrap_or(default_ttl);
+
+    now + ttl
+}

--- a/crates/assay-registry/src/cache_next/policy.rs
+++ b/crates/assay-registry/src/cache_next/policy.rs
@@ -1,0 +1,5 @@
+//! Cache policy boundary scaffold for cache split.
+//!
+//! Planned ownership (Step2+):
+//! - TTL/eviction policy helpers
+//! - no filesystem writes

--- a/crates/assay-registry/src/cache_next/put.rs
+++ b/crates/assay-registry/src/cache_next/put.rs
@@ -1,0 +1,63 @@
+//! Cache put-path boundary for Step2 split.
+
+use chrono::Utc;
+use tokio::fs;
+use tracing::debug;
+
+use crate::error::{RegistryError, RegistryResult};
+use crate::types::FetchResult;
+
+use super::super::{
+    parse_cache_control_expiry, parse_signature, write_atomic, CacheMeta, PackCache,
+};
+
+pub(crate) async fn put_impl(
+    cache: &PackCache,
+    name: &str,
+    version: &str,
+    result: &FetchResult,
+    registry_url: Option<&str>,
+) -> RegistryResult<()> {
+    let pack_dir = cache.pack_dir(name, version);
+
+    fs::create_dir_all(&pack_dir)
+        .await
+        .map_err(|e| RegistryError::Cache {
+            message: format!("failed to create cache directory: {}", e),
+        })?;
+
+    let expires_at = parse_cache_control_expiry(&result.headers);
+
+    let metadata = CacheMeta {
+        fetched_at: Utc::now(),
+        digest: result.computed_digest.clone(),
+        etag: result.headers.etag.clone(),
+        expires_at,
+        key_id: result.headers.key_id.clone(),
+        registry_url: registry_url.map(String::from),
+    };
+
+    let pack_path = pack_dir.join("pack.yaml");
+    let meta_path = pack_dir.join("metadata.json");
+
+    write_atomic(&pack_path, &result.content).await?;
+
+    let meta_json = serde_json::to_string_pretty(&metadata).map_err(|e| RegistryError::Cache {
+        message: format!("failed to serialize metadata: {}", e),
+    })?;
+    write_atomic(&meta_path, &meta_json).await?;
+
+    if let Some(sig_b64) = &result.headers.signature {
+        if let Ok(envelope) = parse_signature(sig_b64) {
+            let sig_path = pack_dir.join("signature.json");
+            let sig_json =
+                serde_json::to_string_pretty(&envelope).map_err(|e| RegistryError::Cache {
+                    message: format!("failed to serialize signature: {}", e),
+                })?;
+            write_atomic(&sig_path, &sig_json).await?;
+        }
+    }
+
+    debug!(name, version, "cached pack");
+    Ok(())
+}

--- a/crates/assay-registry/src/cache_next/tests.rs
+++ b/crates/assay-registry/src/cache_next/tests.rs
@@ -1,0 +1,4 @@
+//! Step2 placeholder.
+//!
+//! No tests are moved in Wave4 Step2 Commit A.
+//! Step1 freeze tests remain in existing lockfile/cache files.

--- a/crates/assay-registry/src/lockfile_next/digest.rs
+++ b/crates/assay-registry/src/lockfile_next/digest.rs
@@ -3,3 +3,131 @@
 //! Planned ownership (Step2+):
 //! - digest normalization and compare helpers
 //! - mismatch detection helpers
+
+use chrono::Utc;
+use tracing::{debug, info, warn};
+
+use crate::error::{RegistryError, RegistryResult};
+use crate::resolver::PackResolver;
+
+use super::super::{LockMismatch, LockSource, Lockfile, VerifyLockResult};
+
+pub(crate) async fn verify_lockfile_impl(
+    lockfile: &Lockfile,
+    resolver: &PackResolver,
+) -> RegistryResult<VerifyLockResult> {
+    let mut matched = Vec::new();
+    let mut mismatched = Vec::new();
+    let mut missing = Vec::new();
+
+    for locked in &lockfile.packs {
+        debug!(name = %locked.name, version = %locked.version, "verifying locked pack");
+
+        let reference = match locked.source {
+            LockSource::Bundled => locked.name.clone(),
+            LockSource::Registry => {
+                format!("{}@{}#{}", locked.name, locked.version, locked.digest)
+            }
+            LockSource::Byos => locked
+                .byos_url
+                .clone()
+                .unwrap_or_else(|| locked.name.clone()),
+            LockSource::Local => {
+                warn!(
+                    name = %locked.name,
+                    "cannot verify local pack - skipping"
+                );
+                continue;
+            }
+        };
+
+        match resolver.resolve(&reference).await {
+            Ok(resolved) => {
+                if resolved.digest == locked.digest {
+                    matched.push(locked.name.clone());
+                } else {
+                    mismatched.push(LockMismatch {
+                        name: locked.name.clone(),
+                        version: locked.version.clone(),
+                        expected: locked.digest.clone(),
+                        actual: resolved.digest,
+                    });
+                }
+            }
+            Err(e) => {
+                warn!(name = %locked.name, error = %e, "failed to resolve locked pack");
+                missing.push(locked.name.clone());
+            }
+        }
+    }
+
+    let all_match = mismatched.is_empty() && missing.is_empty();
+
+    Ok(VerifyLockResult {
+        all_match,
+        matched,
+        mismatched,
+        missing,
+        extra: Vec::new(),
+    })
+}
+
+pub(crate) async fn check_lockfile_impl(
+    lockfile: &Lockfile,
+    resolver: &PackResolver,
+) -> RegistryResult<Vec<LockMismatch>> {
+    let result = verify_lockfile_impl(lockfile, resolver).await?;
+
+    if !result.all_match {
+        return Err(RegistryError::Lockfile {
+            message: format!(
+                "lockfile verification failed: {} mismatched, {} missing",
+                result.mismatched.len(),
+                result.missing.len()
+            ),
+        });
+    }
+
+    Ok(result.mismatched)
+}
+
+pub(crate) async fn update_lockfile_impl(
+    lockfile: &mut Lockfile,
+    resolver: &PackResolver,
+) -> RegistryResult<Vec<String>> {
+    let mut updated = Vec::new();
+
+    for locked in &mut lockfile.packs {
+        if locked.source != LockSource::Registry {
+            continue;
+        }
+
+        debug!(name = %locked.name, version = %locked.version, "checking for updates");
+        let reference = format!("{}@{}", locked.name, locked.version);
+
+        match resolver.resolve(&reference).await {
+            Ok(resolved) => {
+                if resolved.digest != locked.digest {
+                    info!(
+                        name = %locked.name,
+                        old_digest = %locked.digest,
+                        new_digest = %resolved.digest,
+                        "updating locked digest"
+                    );
+
+                    locked.digest = resolved.digest;
+                    updated.push(locked.name.clone());
+                }
+            }
+            Err(e) => {
+                warn!(name = %locked.name, error = %e, "failed to update pack");
+            }
+        }
+    }
+
+    if !updated.is_empty() {
+        lockfile.generated_at = Utc::now();
+    }
+
+    Ok(updated)
+}

--- a/crates/assay-registry/src/lockfile_next/digest.rs
+++ b/crates/assay-registry/src/lockfile_next/digest.rs
@@ -1,0 +1,5 @@
+//! Digest and mismatch-check boundary scaffold for lockfile split.
+//!
+//! Planned ownership (Step2+):
+//! - digest normalization and compare helpers
+//! - mismatch detection helpers

--- a/crates/assay-registry/src/lockfile_next/errors.rs
+++ b/crates/assay-registry/src/lockfile_next/errors.rs
@@ -1,0 +1,5 @@
+//! Lockfile error mapping scaffold.
+//!
+//! Planned ownership (Step2+):
+//! - typed error constructors/mappers only
+//! - no parsing/IO side effects

--- a/crates/assay-registry/src/lockfile_next/format.rs
+++ b/crates/assay-registry/src/lockfile_next/format.rs
@@ -3,3 +3,22 @@
 //! Planned ownership (Step2+):
 //! - canonical output ordering
 //! - serialization helpers
+
+use chrono::Utc;
+
+use crate::error::{RegistryError, RegistryResult};
+
+use super::super::{LockedPack, Lockfile};
+
+pub(crate) fn to_yaml_impl(lockfile: &Lockfile) -> RegistryResult<String> {
+    serde_yaml::to_string(lockfile).map_err(|e| RegistryError::Lockfile {
+        message: format!("failed to serialize lockfile: {}", e),
+    })
+}
+
+pub(crate) fn add_pack_impl(lockfile: &mut Lockfile, pack: LockedPack) {
+    lockfile.packs.retain(|p| p.name != pack.name);
+    lockfile.packs.push(pack);
+    lockfile.packs.sort_by(|a, b| a.name.cmp(&b.name));
+    lockfile.generated_at = Utc::now();
+}

--- a/crates/assay-registry/src/lockfile_next/format.rs
+++ b/crates/assay-registry/src/lockfile_next/format.rs
@@ -1,0 +1,5 @@
+//! Formatting and stable-ordering boundary scaffold for lockfile split.
+//!
+//! Planned ownership (Step2+):
+//! - canonical output ordering
+//! - serialization helpers

--- a/crates/assay-registry/src/lockfile_next/io.rs
+++ b/crates/assay-registry/src/lockfile_next/io.rs
@@ -1,0 +1,42 @@
+//! Lockfile IO boundary for Step2 split.
+
+use std::path::Path;
+
+use tokio::fs;
+use tracing::info;
+
+use crate::error::{RegistryError, RegistryResult};
+
+use super::super::Lockfile;
+
+pub(crate) async fn load_impl(path: impl AsRef<Path>) -> RegistryResult<Lockfile> {
+    let path = path.as_ref();
+
+    if !path.exists() {
+        return Err(RegistryError::Lockfile {
+            message: format!("lockfile not found: {}", path.display()),
+        });
+    }
+
+    let content = fs::read_to_string(path)
+        .await
+        .map_err(|e| RegistryError::Lockfile {
+            message: format!("failed to read lockfile: {}", e),
+        })?;
+
+    Lockfile::parse(&content)
+}
+
+pub(crate) async fn save_impl(lockfile: &Lockfile, path: impl AsRef<Path>) -> RegistryResult<()> {
+    let path = path.as_ref();
+    let content = lockfile.to_yaml()?;
+
+    fs::write(path, content)
+        .await
+        .map_err(|e| RegistryError::Lockfile {
+            message: format!("failed to write lockfile: {}", e),
+        })?;
+
+    info!(path = %path.display(), "saved lockfile");
+    Ok(())
+}

--- a/crates/assay-registry/src/lockfile_next/mod.rs
+++ b/crates/assay-registry/src/lockfile_next/mod.rs
@@ -8,6 +8,7 @@
 pub(crate) mod digest;
 pub(crate) mod errors;
 pub(crate) mod format;
+pub(crate) mod io;
 pub(crate) mod parse;
 pub(crate) mod tests;
 pub(crate) mod types;

--- a/crates/assay-registry/src/lockfile_next/mod.rs
+++ b/crates/assay-registry/src/lockfile_next/mod.rs
@@ -1,0 +1,13 @@
+//! Wave4 Step2 lockfile split scaffold.
+//!
+//! Commit A contract:
+//! - `lockfile.rs` remains the active facade.
+//! - No wiring to this module yet.
+//! - No behavior/perf changes in this commit.
+
+pub(crate) mod digest;
+pub(crate) mod errors;
+pub(crate) mod format;
+pub(crate) mod parse;
+pub(crate) mod tests;
+pub(crate) mod types;

--- a/crates/assay-registry/src/lockfile_next/mod.rs
+++ b/crates/assay-registry/src/lockfile_next/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Commit A contract:
 //! - `lockfile.rs` remains the active facade.
-//! - No wiring to this module yet.
-//! - No behavior/perf changes in this commit.
+//! - Step2 routes implementation here with stable facade signatures.
+//! - No behavior/perf changes intended in Step2.
 
 pub(crate) mod digest;
 pub(crate) mod errors;
@@ -11,3 +11,81 @@ pub(crate) mod format;
 pub(crate) mod parse;
 pub(crate) mod tests;
 pub(crate) mod types;
+
+use tracing::{debug, warn};
+
+use crate::error::RegistryResult;
+use crate::reference::PackRef;
+use crate::resolver::{PackResolver, ResolveSource};
+
+use super::{LockSignature, LockSource, LockedPack, Lockfile};
+
+pub(crate) async fn generate_lockfile_impl(
+    references: &[String],
+    resolver: &PackResolver,
+) -> RegistryResult<Lockfile> {
+    let mut lockfile = Lockfile::new();
+
+    for reference in references {
+        debug!(reference, "locking pack");
+
+        let pack_ref = PackRef::parse(reference)?;
+        let resolved = resolver.resolve_ref(&pack_ref).await?;
+
+        let (name, version) = match &pack_ref {
+            PackRef::Bundled(name) => (name.clone(), "bundled".to_string()),
+            PackRef::Registry { name, version, .. } => (name.clone(), version.clone()),
+            PackRef::Byos(url) => {
+                let name = url
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or("unknown")
+                    .trim_end_matches(".yaml")
+                    .trim_end_matches(".yml")
+                    .to_string();
+                (name, "byos".to_string())
+            }
+            PackRef::Local(path) => {
+                let name = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                warn!(
+                    path = %path.display(),
+                    "locking local file - consider using registry or bundled packs instead"
+                );
+                (name, "local".to_string())
+            }
+        };
+
+        let (source, registry_url, byos_url) = match &resolved.source {
+            ResolveSource::Local(_) => (LockSource::Local, None, None),
+            ResolveSource::Bundled(_) => (LockSource::Bundled, None, None),
+            ResolveSource::Cache => (LockSource::Registry, None, None),
+            ResolveSource::Registry(url) => (LockSource::Registry, Some(url.clone()), None),
+            ResolveSource::Byos(url) => (LockSource::Byos, None, Some(url.clone())),
+        };
+
+        let signature = resolved.verification.as_ref().and_then(|v| {
+            v.key_id.as_ref().map(|key_id| LockSignature {
+                algorithm: "Ed25519".to_string(),
+                key_id: key_id.clone(),
+            })
+        });
+
+        let locked = LockedPack {
+            name,
+            version,
+            digest: resolved.digest,
+            source,
+            registry_url,
+            byos_url,
+            signature,
+        };
+
+        lockfile.add_pack(locked);
+    }
+
+    Ok(lockfile)
+}

--- a/crates/assay-registry/src/lockfile_next/parse.rs
+++ b/crates/assay-registry/src/lockfile_next/parse.rs
@@ -3,3 +3,25 @@
 //! Planned ownership (Step2+):
 //! - deserialize and version-shape validation
 //! - parse helpers used by lockfile facade
+
+use crate::error::{RegistryError, RegistryResult};
+
+use super::super::{Lockfile, LOCKFILE_VERSION};
+
+pub(crate) fn parse_lockfile_impl(content: &str) -> RegistryResult<Lockfile> {
+    let lockfile: Lockfile =
+        serde_yaml::from_str(content).map_err(|e| RegistryError::Lockfile {
+            message: format!("failed to parse lockfile: {}", e),
+        })?;
+
+    if lockfile.version > LOCKFILE_VERSION {
+        return Err(RegistryError::Lockfile {
+            message: format!(
+                "lockfile version {} is newer than supported version {}",
+                lockfile.version, LOCKFILE_VERSION
+            ),
+        });
+    }
+
+    Ok(lockfile)
+}

--- a/crates/assay-registry/src/lockfile_next/parse.rs
+++ b/crates/assay-registry/src/lockfile_next/parse.rs
@@ -1,0 +1,5 @@
+//! Parsing-only boundary scaffold for lockfile split.
+//!
+//! Planned ownership (Step2+):
+//! - deserialize and version-shape validation
+//! - parse helpers used by lockfile facade

--- a/crates/assay-registry/src/lockfile_next/tests.rs
+++ b/crates/assay-registry/src/lockfile_next/tests.rs
@@ -1,0 +1,4 @@
+//! Step2 placeholder.
+//!
+//! No tests are moved in Wave4 Step2 Commit A.
+//! Step1 freeze tests remain in existing lockfile/cache files.

--- a/crates/assay-registry/src/lockfile_next/types.rs
+++ b/crates/assay-registry/src/lockfile_next/types.rs
@@ -1,0 +1,5 @@
+//! Lockfile type ownership scaffold.
+//!
+//! Planned ownership (Step2+):
+//! - lockfile structs/enums currently defined in lockfile facade
+//! - re-export strategy remains facade-first

--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -298,8 +298,8 @@ Security improvements:
 
 Step status:
 
-- Step 1 (`lockfile.rs` + `cache.rs` behavior freeze/inventory/gates): in progress on `codex/wave4-step1-registry-freeze`.
-- Step 2 (`lockfile.rs` + `cache.rs` mechanical split): pending after Step 1 merge.
+- Step 1 (`lockfile.rs` + `cache.rs` behavior freeze/inventory/gates): merged via PR #339.
+- Step 2 (`lockfile.rs` + `cache.rs` mechanical split): in progress on `codex/wave4-step2-lockfile-cache-split`.
 - `explain.rs` follows as a separate slice to keep review size and blast radius small.
 
 ### Objectives

--- a/docs/contributing/SPLIT-CHECKLIST-wave4-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave4-step2.md
@@ -1,0 +1,28 @@
+# Wave4 Step2 checklist (lockfile/cache mechanical split)
+
+Scope lock:
+- Step2 is a mechanical split behind stable facades.
+- No behavior/perf changes intended.
+- Public module paths remain unchanged.
+
+Artifacts:
+- `docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave4-step2.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md`
+- `scripts/ci/review-wave4-step2.sh`
+
+Critical boundaries:
+- Stable ordering logic is single-source in `lockfile_next/format.rs`.
+- Atomic write/rename logic is single-source in `cache_next/io.rs`.
+- Facades delegate to `*_next` impl paths for moved logic.
+
+Reviewer command:
+```bash
+BASE_REF=origin/codex/wave3-step1-behavior-freeze-v2 bash scripts/ci/review-wave4-step2.sh
+```
+
+Definition of done:
+- fmt/clippy/check pass for `assay-registry`.
+- Lockfile/cache contract-anchor tests pass.
+- Delegation and single-source gates pass.
+- Diff allowlist contains only Step2 scope files.

--- a/docs/contributing/SPLIT-CHECKLIST-wave4-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave4-step2.md
@@ -15,6 +15,8 @@ Critical boundaries:
 - Stable ordering logic is single-source in `lockfile_next/format.rs`.
 - Atomic write/rename logic is single-source in `cache_next/io.rs`.
 - Facades delegate to `*_next` impl paths for moved logic.
+- Lockfile IO (`load`/`save`) delegates to `lockfile_next/io.rs`.
+- Cache write path (`put`) delegates to `cache_next/put.rs`.
 
 Reviewer command:
 ```bash

--- a/docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md
@@ -29,6 +29,9 @@ No public symbol path changes intended (`crate::lockfile::*`, `crate::cache::*` 
 - `parse_signature` -> `cache_next/integrity.rs::parse_signature_impl`
 - `write_atomic` -> `cache_next/io.rs::write_atomic_impl`
 
+`put_impl` now calls `policy::parse_cache_control_expiry_impl`,
+`integrity::parse_signature_impl`, and `io::write_atomic_impl` directly (no facade helper indirection).
+
 ## Drift-sensitive paths
 
 - Lockfile stable ordering remains in one path: `lockfile_next/format.rs::add_pack_impl`.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md
@@ -10,6 +10,8 @@ No public symbol path changes intended (`crate::lockfile::*`, `crate::cache::*` 
 
 ## Lockfile moves
 
+- `Lockfile::load` -> `lockfile_next/io.rs::load_impl`
+- `Lockfile::save` -> `lockfile_next/io.rs::save_impl`
 - `Lockfile::parse` -> `lockfile_next/parse.rs::parse_lockfile_impl`
 - `Lockfile::to_yaml` -> `lockfile_next/format.rs::to_yaml_impl`
 - `Lockfile::add_pack` -> `lockfile_next/format.rs::add_pack_impl`
@@ -21,6 +23,7 @@ No public symbol path changes intended (`crate::lockfile::*`, `crate::cache::*` 
 ## Cache moves
 
 - `PackCache::pack_dir` -> `cache_next/keys.rs::pack_dir_impl`
+- `PackCache::put` -> `cache_next/put.rs::put_impl`
 - `default_cache_dir` -> `cache_next/io.rs::default_cache_dir_impl`
 - `parse_cache_control_expiry` -> `cache_next/policy.rs::parse_cache_control_expiry_impl`
 - `parse_signature` -> `cache_next/integrity.rs::parse_signature_impl`

--- a/docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md
@@ -1,0 +1,32 @@
+# Wave4 Step2 move map (lockfile/cache mechanical split)
+
+Scope:
+- `crates/assay-registry/src/lockfile.rs`
+- `crates/assay-registry/src/cache.rs`
+- `crates/assay-registry/src/lockfile_next/*`
+- `crates/assay-registry/src/cache_next/*`
+
+No public symbol path changes intended (`crate::lockfile::*`, `crate::cache::*` remain stable).
+
+## Lockfile moves
+
+- `Lockfile::parse` -> `lockfile_next/parse.rs::parse_lockfile_impl`
+- `Lockfile::to_yaml` -> `lockfile_next/format.rs::to_yaml_impl`
+- `Lockfile::add_pack` -> `lockfile_next/format.rs::add_pack_impl`
+- `generate_lockfile` -> `lockfile_next/mod.rs::generate_lockfile_impl`
+- `verify_lockfile` -> `lockfile_next/digest.rs::verify_lockfile_impl`
+- `check_lockfile` -> `lockfile_next/digest.rs::check_lockfile_impl`
+- `update_lockfile` -> `lockfile_next/digest.rs::update_lockfile_impl`
+
+## Cache moves
+
+- `PackCache::pack_dir` -> `cache_next/keys.rs::pack_dir_impl`
+- `default_cache_dir` -> `cache_next/io.rs::default_cache_dir_impl`
+- `parse_cache_control_expiry` -> `cache_next/policy.rs::parse_cache_control_expiry_impl`
+- `parse_signature` -> `cache_next/integrity.rs::parse_signature_impl`
+- `write_atomic` -> `cache_next/io.rs::write_atomic_impl`
+
+## Drift-sensitive paths
+
+- Lockfile stable ordering remains in one path: `lockfile_next/format.rs::add_pack_impl`.
+- Atomic write/rename remains in one path: `cache_next/io.rs::write_atomic_impl`.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md
@@ -25,6 +25,9 @@ Executed and passing:
 - `cargo check -p assay-registry`
 - Lockfile/cache anchor subset tests
 - Delegation gates (facade -> `*_next` impl paths)
+- Facade-thinness tightening:
+  - `Lockfile::load/save` now delegate to `lockfile_next/io.rs`
+  - `PackCache::put` now delegates to `cache_next/put.rs`
 - Single-source gates:
   - ordering path only in `lockfile_next/format.rs`
   - atomic write/rename path only in `cache_next/io.rs`
@@ -34,3 +37,6 @@ No behavior/perf changes intended:
 - no output/error-string rewrites
 - no dependency/Cargo changes
 - no demo/ changes
+
+Atomic write note:
+- rename-based atomic write semantics are unchanged in Step2 (no fsync hardening added here).

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md
@@ -28,6 +28,7 @@ Executed and passing:
 - Facade-thinness tightening:
   - `Lockfile::load/save` now delegate to `lockfile_next/io.rs`
   - `PackCache::put` now delegates to `cache_next/put.rs`
+  - `put_impl` directly calls `cache_next::{policy,integrity,io}` helpers (no facade helper dependency)
 - Single-source gates:
   - ordering path only in `lockfile_next/format.rs`
   - atomic write/rename path only in `cache_next/io.rs`

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md
@@ -1,0 +1,36 @@
+# Review Pack: Wave4 Step2 (lockfile/cache mechanical split)
+
+Intent:
+- Mechanical split of lockfile/cache implementation behind stable facades.
+- Preserve behavior and public symbol paths.
+
+Scope:
+- `crates/assay-registry/src/lockfile.rs`
+- `crates/assay-registry/src/cache.rs`
+- `crates/assay-registry/src/lockfile_next/*`
+- `crates/assay-registry/src/cache_next/*`
+- `docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave4-step2.md`
+- `scripts/ci/review-wave4-step2.sh`
+- `docs/architecture/PLAN-split-refactor-2026q1.md`
+
+Verification command:
+```bash
+BASE_REF=origin/codex/wave3-step1-behavior-freeze-v2 bash scripts/ci/review-wave4-step2.sh
+```
+
+Executed and passing:
+- `cargo fmt --check`
+- `cargo clippy -p assay-registry --all-targets -- -D warnings`
+- `cargo check -p assay-registry`
+- Lockfile/cache anchor subset tests
+- Delegation gates (facade -> `*_next` impl paths)
+- Single-source gates:
+  - ordering path only in `lockfile_next/format.rs`
+  - atomic write/rename path only in `cache_next/io.rs`
+- Step2 diff allowlist
+
+No behavior/perf changes intended:
+- no output/error-string rewrites
+- no dependency/Cargo changes
+- no demo/ changes

--- a/scripts/ci/review-wave4-step2.sh
+++ b/scripts/ci/review-wave4-step2.sh
@@ -68,9 +68,13 @@ check_has_match 'lockfile_next::digest::update_lockfile_impl' crates/assay-regis
 check_has_match 'cache_next::put::put_impl' crates/assay-registry/src/cache.rs
 check_has_match 'cache_next::keys::pack_dir_impl' crates/assay-registry/src/cache.rs
 check_has_match 'cache_next::io::default_cache_dir_impl' crates/assay-registry/src/cache.rs
-check_has_match 'cache_next::policy::parse_cache_control_expiry_impl' crates/assay-registry/src/cache.rs
-check_has_match 'cache_next::integrity::parse_signature_impl' crates/assay-registry/src/cache.rs
-check_has_match 'cache_next::io::write_atomic_impl' crates/assay-registry/src/cache.rs
+check_has_match 'policy::parse_cache_control_expiry_impl' crates/assay-registry/src/cache_next/put.rs
+check_has_match 'integrity::parse_signature_impl' crates/assay-registry/src/cache_next/put.rs
+check_has_match 'io::write_atomic_impl' crates/assay-registry/src/cache_next/put.rs
+if "$rg_bin" -n 'super::super::(parse_cache_control_expiry|parse_signature|write_atomic)' crates/assay-registry/src/cache_next/put.rs; then
+  echo "cache put path still depends on facade helper wrappers"
+  exit 1
+fi
 
 # Lockfile facade should no longer own direct fs/logging paths for load/save.
 if "$rg_bin" -n 'tokio::fs|tracing::info|fs::read_to_string|fs::write' crates/assay-registry/src/lockfile.rs; then

--- a/scripts/ci/review-wave4-step2.sh
+++ b/scripts/ci/review-wave4-step2.sh
@@ -55,6 +55,8 @@ do
 done
 
 echo "== Wave4 Step2 delegation gates =="
+check_has_match 'lockfile_next::io::load_impl' crates/assay-registry/src/lockfile.rs
+check_has_match 'lockfile_next::io::save_impl' crates/assay-registry/src/lockfile.rs
 check_has_match 'lockfile_next::parse::parse_lockfile_impl' crates/assay-registry/src/lockfile.rs
 check_has_match 'lockfile_next::format::to_yaml_impl' crates/assay-registry/src/lockfile.rs
 check_has_match 'lockfile_next::format::add_pack_impl' crates/assay-registry/src/lockfile.rs
@@ -63,14 +65,22 @@ check_has_match 'lockfile_next::digest::verify_lockfile_impl' crates/assay-regis
 check_has_match 'lockfile_next::digest::check_lockfile_impl' crates/assay-registry/src/lockfile.rs
 check_has_match 'lockfile_next::digest::update_lockfile_impl' crates/assay-registry/src/lockfile.rs
 
+check_has_match 'cache_next::put::put_impl' crates/assay-registry/src/cache.rs
 check_has_match 'cache_next::keys::pack_dir_impl' crates/assay-registry/src/cache.rs
 check_has_match 'cache_next::io::default_cache_dir_impl' crates/assay-registry/src/cache.rs
 check_has_match 'cache_next::policy::parse_cache_control_expiry_impl' crates/assay-registry/src/cache.rs
 check_has_match 'cache_next::integrity::parse_signature_impl' crates/assay-registry/src/cache.rs
 check_has_match 'cache_next::io::write_atomic_impl' crates/assay-registry/src/cache.rs
 
+# Lockfile facade should no longer own direct fs/logging paths for load/save.
+if "$rg_bin" -n 'tokio::fs|tracing::info|fs::read_to_string|fs::write' crates/assay-registry/src/lockfile.rs; then
+  echo "lockfile facade still contains direct IO/logging ownership"
+  exit 1
+fi
+
 echo "== Wave4 Step2 single-source gates =="
 check_no_match_in_dir_excluding 'fs::rename\(' crates/assay-registry/src/cache_next io.rs
+check_no_match_in_dir_excluding 'create_dir_all\(' crates/assay-registry/src/cache_next put.rs
 check_no_match_in_dir_excluding 'max-age=' crates/assay-registry/src/cache_next policy.rs
 check_no_match_in_dir_excluding 'sort_by\(' crates/assay-registry/src/lockfile_next format.rs
 

--- a/scripts/ci/review-wave4-step2.sh
+++ b/scripts/ci/review-wave4-step2.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/codex/wave3-step1-behavior-freeze-v2"
+fi
+
+rg_bin="$(command -v rg)"
+
+check_has_match() {
+  local pattern="$1"
+  local file="$2"
+  if ! "$rg_bin" -n "$pattern" "$file" >/dev/null; then
+    echo "missing expected delegation pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+check_no_match_in_dir_excluding() {
+  local pattern="$1"
+  local root="$2"
+  local excluded_file="$3"
+  local matches
+  matches="$($rg_bin -n "$pattern" "$root" -g'*.rs' -g"!${excluded_file}" || true)"
+  if [ -n "$matches" ]; then
+    echo "forbidden matches outside ${excluded_file}:"
+    echo "$matches"
+    exit 1
+  fi
+}
+
+echo "== Wave4 Step2 quality checks =="
+echo "using base_ref=${base_ref}"
+cargo fmt --check
+cargo clippy -p assay-registry --all-targets -- -D warnings
+cargo check -p assay-registry
+
+echo "== Wave4 Step2 contract anchors =="
+for test_name in \
+  test_lockfile_v2_roundtrip \
+  test_lockfile_stable_ordering \
+  test_lockfile_digest_mismatch_detection \
+  test_lockfile_signature_fields \
+  test_cache_roundtrip \
+  test_cache_integrity_failure \
+  test_signature_json_corrupt_handling \
+  test_atomic_write_prevents_partial_cache
+do
+  echo "anchor: ${test_name}"
+  cargo test -p assay-registry "${test_name}" -- --nocapture
+done
+
+echo "== Wave4 Step2 delegation gates =="
+check_has_match 'lockfile_next::parse::parse_lockfile_impl' crates/assay-registry/src/lockfile.rs
+check_has_match 'lockfile_next::format::to_yaml_impl' crates/assay-registry/src/lockfile.rs
+check_has_match 'lockfile_next::format::add_pack_impl' crates/assay-registry/src/lockfile.rs
+check_has_match 'lockfile_next::generate_lockfile_impl' crates/assay-registry/src/lockfile.rs
+check_has_match 'lockfile_next::digest::verify_lockfile_impl' crates/assay-registry/src/lockfile.rs
+check_has_match 'lockfile_next::digest::check_lockfile_impl' crates/assay-registry/src/lockfile.rs
+check_has_match 'lockfile_next::digest::update_lockfile_impl' crates/assay-registry/src/lockfile.rs
+
+check_has_match 'cache_next::keys::pack_dir_impl' crates/assay-registry/src/cache.rs
+check_has_match 'cache_next::io::default_cache_dir_impl' crates/assay-registry/src/cache.rs
+check_has_match 'cache_next::policy::parse_cache_control_expiry_impl' crates/assay-registry/src/cache.rs
+check_has_match 'cache_next::integrity::parse_signature_impl' crates/assay-registry/src/cache.rs
+check_has_match 'cache_next::io::write_atomic_impl' crates/assay-registry/src/cache.rs
+
+echo "== Wave4 Step2 single-source gates =="
+check_no_match_in_dir_excluding 'fs::rename\(' crates/assay-registry/src/cache_next io.rs
+check_no_match_in_dir_excluding 'max-age=' crates/assay-registry/src/cache_next policy.rs
+check_no_match_in_dir_excluding 'sort_by\(' crates/assay-registry/src/lockfile_next format.rs
+
+echo "== Wave4 Step2 diff allowlist =="
+leaks="$(
+  git diff --name-only "${base_ref}...HEAD" | \
+    "$rg_bin" -v \
+      '^crates/assay-registry/src/lockfile.rs$|^crates/assay-registry/src/cache.rs$|^crates/assay-registry/src/lockfile_next/|^crates/assay-registry/src/cache_next/|^docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md$|^docs/contributing/SPLIT-CHECKLIST-wave4-step2.md$|^docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md$|^scripts/ci/review-wave4-step2.sh$|^docs/architecture/PLAN-split-refactor-2026q1.md$' || true
+)"
+if [ -n "$leaks" ]; then
+  echo "non-allowlisted files detected:"
+  echo "$leaks"
+  exit 1
+fi
+
+echo "Wave4 Step2 reviewer script: PASS"


### PR DESCRIPTION
## Intent
Wave 4 Step 2 mechanical split for registry hotspots behind stable facades:
- `crates/assay-registry/src/lockfile.rs`
- `crates/assay-registry/src/cache.rs`

No public symbol path changes intended.
No behavior/perf changes intended.

## Stack
- Base: `codex/wave3-step1-behavior-freeze-v2`
- Head: `codex/wave4-step2-lockfile-cache-split`
- Reviewer script base: `origin/codex/wave3-step1-behavior-freeze-v2`

## Commit slices
- `1e78f1b9` (A) scaffold: compile-safe `lockfile_next/*` + `cache_next/*`
- `96651dd5` (B) move: mechanical implementation moves behind stable facades
- `c466c672` (C) docs/gates: move-map + checklist + reviewer script + review pack

## Review artifacts
- `docs/contributing/SPLIT-MOVE-MAP-wave4-step2.md`
- `docs/contributing/SPLIT-CHECKLIST-wave4-step2.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md`
- `scripts/ci/review-wave4-step2.sh`

## Drift-sensitive proof points
- Lockfile stable ordering path is single-source in `lockfile_next/format.rs`.
- Cache atomic write/rename path is single-source in `cache_next/io.rs`.

## Validation (executed)
```bash
cargo fmt --check
cargo clippy -p assay-registry --all-targets -- -D warnings
cargo check -p assay-registry
BASE_REF=origin/codex/wave3-step1-behavior-freeze-v2 bash scripts/ci/review-wave4-step2.sh
```

Result: PASS.

## Plan update
`docs/architecture/PLAN-split-refactor-2026q1.md` updated:
- Wave4 Step1 merged via #339
- Wave4 Step2 in progress on this branch

## Risk
Medium-low. Internal refactor only; behavior anchors and hard gates included.


## Note (cache facade thinness)
Cache facade thinness is intentionally partial in Wave4 Step2. The `put` path is moved behind `cache_next::put` and uses `cache_next::{policy,io,integrity}` directly. Read/evict/list/clear paths remain in `cache.rs` and are planned for a follow-up Step2.x thinning PR to keep this PR mechanical and rollbackable.
