### PR TITLE
docs(ci/wave4): default review BASE_REF to origin/main

### DIFF
--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -304,6 +304,15 @@ Step status:
 - Step 3 (`explain.rs` mechanical split behind stable facade): merged via PR #344.
 - Promotion to `main` (Wave4 closure): merged via PR #345.
 
+### Wave 4 outcome (merged on `main`)
+
+- PR chain: `#339` -> `#340` -> `#343` -> `#344` -> `#345`.
+- Facade hotspots reduced from 2764 LOC to 1252 LOC (~54.7% reduction).
+- `explain.rs` reduced from 1057 LOC to 11 LOC (thin facade).
+- Boundaries are enforced by reviewer scripts:
+  - `scripts/ci/review-wave4-step2.sh`
+  - `scripts/ci/review-wave4-step3.sh`
+
 ### Objectives
 
 - Improve maintainability without churn in public UX.

--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -300,8 +300,9 @@ Step status:
 
 - Step 1 (`lockfile.rs` + `cache.rs` behavior freeze/inventory/gates): merged via PR #339.
 - Step 2 (`lockfile.rs` + `cache.rs` mechanical split): merged via PR #340.
-- Step 2.x (`cache.rs` facade thinness follow-up for read/evict/list/get_metadata): in progress on `codex/wave4-step2x-cache-thinness`.
-- Step 3 (`explain.rs` mechanical split behind stable facade): in progress on `codex/wave4-step3-explain-split`.
+- Step 2.x (`cache.rs` facade thinness follow-up for read/evict/list/get_metadata): merged via PR #343.
+- Step 3 (`explain.rs` mechanical split behind stable facade): merged via PR #344.
+- Promotion to `main` (Wave4 closure): merged via PR #345.
 
 ### Objectives
 

--- a/docs/contributing/SPLIT-CHECKLIST-cache-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-cache-step1.md
@@ -27,7 +27,12 @@ Drift gates (best-effort code-only):
 
 Runbook:
 ```bash
-BASE_REF=origin/codex/wave3-step1-behavior-freeze-v2 bash scripts/ci/review-wave4-step1.sh
+BASE_REF=origin/main bash scripts/ci/review-wave4-step1.sh
+```
+
+Optional (stacked/local override):
+```bash
+BASE_REF=<your-base-ref> bash scripts/ci/review-wave4-step1.sh
 ```
 
 Definition of done:

--- a/docs/contributing/SPLIT-CHECKLIST-lockfile-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-lockfile-step1.md
@@ -26,7 +26,12 @@ Drift gates (best-effort code-only):
 
 Runbook:
 ```bash
-BASE_REF=origin/codex/wave3-step1-behavior-freeze-v2 bash scripts/ci/review-wave4-step1.sh
+BASE_REF=origin/main bash scripts/ci/review-wave4-step1.sh
+```
+
+Optional (stacked/local override):
+```bash
+BASE_REF=<your-base-ref> bash scripts/ci/review-wave4-step1.sh
 ```
 
 Definition of done:

--- a/docs/contributing/SPLIT-CHECKLIST-wave4-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave4-step2.md
@@ -20,7 +20,7 @@ Critical boundaries:
 
 Reviewer command:
 ```bash
-BASE_REF=origin/codex/wave3-step1-behavior-freeze-v2 bash scripts/ci/review-wave4-step2.sh
+BASE_REF=origin/main bash scripts/ci/review-wave4-step2.sh
 ```
 
 Definition of done:

--- a/docs/contributing/SPLIT-CHECKLIST-wave4-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave4-step3.md
@@ -18,7 +18,7 @@ Critical boundaries:
 
 Reviewer command:
 ```bash
-BASE_REF=origin/codex/wave4-step2x-cache-thinness bash scripts/ci/review-wave4-step3.sh
+BASE_REF=origin/main bash scripts/ci/review-wave4-step3.sh
 ```
 
 Definition of done:

--- a/docs/contributing/SPLIT-INVENTORY-wave4-step1.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave4-step1.md
@@ -6,7 +6,7 @@ Scope:
 
 Snapshot:
 - HEAD: `91dffdbb`
-- Base for Step1 drift checks: `origin/codex/wave3-step1-behavior-freeze-v2`
+- Base for Step1 drift checks: `origin/main`
 
 LOC:
 - `crates/assay-registry/src/lockfile.rs`: `863`

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave4-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave4-step1.md
@@ -21,7 +21,7 @@ Policy knobs:
 
 Verification command:
 ```bash
-BASE_REF=origin/codex/wave3-step1-behavior-freeze-v2 bash scripts/ci/review-wave4-step1.sh
+BASE_REF=origin/main bash scripts/ci/review-wave4-step1.sh
 ```
 
 Executed commands and outcomes:

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md
@@ -16,7 +16,7 @@ Scope:
 
 Verification command:
 ```bash
-BASE_REF=origin/codex/wave3-step1-behavior-freeze-v2 bash scripts/ci/review-wave4-step2.sh
+BASE_REF=origin/main bash scripts/ci/review-wave4-step2.sh
 ```
 
 Executed and passing:

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave4-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave4-step3.md
@@ -12,7 +12,7 @@ Scope:
 
 Verification command:
 ```bash
-BASE_REF=origin/codex/wave4-step2x-cache-thinness bash scripts/ci/review-wave4-step3.sh
+BASE_REF=origin/main bash scripts/ci/review-wave4-step3.sh
 ```
 
 Executed and passing:

--- a/scripts/ci/review-wave2-step1.sh
+++ b/scripts/ci/review-wave2-step1.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-base_ref="${1:-origin/main}"
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+
 rg_bin="$(command -v rg)"
 
 count_in_ref() {

--- a/scripts/ci/review-wave2-step2.sh
+++ b/scripts/ci/review-wave2-step2.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-base_ref="${1:-origin/codex/wave2-step1-behavior-freeze}"
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+
 rg_bin="$(command -v rg)"
 
 check_no_match() {

--- a/scripts/ci/review-wave3-step1.sh
+++ b/scripts/ci/review-wave3-step1.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-base_ref="${BASE_REF:-${1:-origin/codex/wave2-step2-runtime-split}}"
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+
 rg_bin="$(command -v rg)"
 
 strip_code_only() {

--- a/scripts/ci/review-wave3-step2.sh
+++ b/scripts/ci/review-wave3-step2.sh
@@ -6,8 +6,13 @@ if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
   base_ref="origin/${GITHUB_BASE_REF}"
 fi
 if [ -z "${base_ref}" ]; then
-  base_ref="origin/codex/wave3-step1-behavior-freeze-v2"
+  base_ref="origin/main"
 fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
 
 rg_bin="$(command -v rg)"
 tmp_dir="$(mktemp -d)"

--- a/scripts/ci/review-wave4-step1.sh
+++ b/scripts/ci/review-wave4-step1.sh
@@ -6,7 +6,7 @@ if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
   base_ref="origin/${GITHUB_BASE_REF}"
 fi
 if [ -z "${base_ref}" ]; then
-  base_ref="origin/codex/wave3-step1-behavior-freeze-v2"
+  base_ref="origin/main"
 fi
 
 rg_bin="$(command -v rg)"

--- a/scripts/ci/review-wave4-step1.sh
+++ b/scripts/ci/review-wave4-step1.sh
@@ -8,6 +8,11 @@ fi
 if [ -z "${base_ref}" ]; then
   base_ref="origin/main"
 fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
 
 rg_bin="$(command -v rg)"
 

--- a/scripts/ci/review-wave4-step2.sh
+++ b/scripts/ci/review-wave4-step2.sh
@@ -6,7 +6,7 @@ if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
   base_ref="origin/${GITHUB_BASE_REF}"
 fi
 if [ -z "${base_ref}" ]; then
-  base_ref="origin/codex/wave3-step1-behavior-freeze-v2"
+  base_ref="origin/main"
 fi
 
 rg_bin="$(command -v rg)"

--- a/scripts/ci/review-wave4-step2.sh
+++ b/scripts/ci/review-wave4-step2.sh
@@ -99,6 +99,17 @@ fi
 check_no_match_code_only 'tokio::fs|tracing::info|fs::read_to_string|fs::write' crates/assay-registry/src/lockfile.rs
 # Cache facade should delegate all moved read/write/evict logic into cache_next.
 check_no_match_code_only 'tokio::fs|serde_json::|compute_digest|tracing::(debug|warn|info|error)|fs::read_to_string|fs::write|create_dir_all|remove_dir_all|read_dir' crates/assay-registry/src/cache.rs
+# smoke alarms for accidental facade growth.
+lockfile_loc="$(wc -l < crates/assay-registry/src/lockfile.rs | tr -d ' ')"
+cache_loc="$(wc -l < crates/assay-registry/src/cache.rs | tr -d ' ')"
+if [ "${lockfile_loc}" -gt 700 ]; then
+  echo "lockfile.rs facade exceeded 700 LOC (${lockfile_loc})"
+  exit 1
+fi
+if [ "${cache_loc}" -gt 650 ]; then
+  echo "cache.rs facade exceeded 650 LOC (${cache_loc})"
+  exit 1
+fi
 
 echo "== Wave4 Step2 single-source gates =="
 check_no_match_in_dir_excluding 'fs::rename\(' crates/assay-registry/src/cache_next io.rs

--- a/scripts/ci/review-wave4-step2.sh
+++ b/scripts/ci/review-wave4-step2.sh
@@ -8,6 +8,11 @@ fi
 if [ -z "${base_ref}" ]; then
   base_ref="origin/main"
 fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
 
 rg_bin="$(command -v rg)"
 

--- a/scripts/ci/review-wave4-step3.sh
+++ b/scripts/ci/review-wave4-step3.sh
@@ -34,6 +34,17 @@ if "$rg_bin" -n 'SequenceRule|check_end_of_trace|to_terminal\(|to_markdown\(|to_
   echo "explain.rs facade contains implementation logic"
   exit 1
 fi
+# explain facade must not own heavy deps.
+if "$rg_bin" -n 'serde_json::|tokio::fs|std::fs|reqwest|regex|globset|pulldown_cmark' crates/assay-core/src/explain.rs; then
+  echo "explain.rs facade contains heavy imports/deps"
+  exit 1
+fi
+# smoke alarm for accidental facade growth.
+explain_loc="$(wc -l < crates/assay-core/src/explain.rs | tr -d ' ')"
+if [ "${explain_loc}" -gt 50 ]; then
+  echo "explain.rs facade exceeded 50 LOC (${explain_loc})"
+  exit 1
+fi
 
 # render methods should only live in render.rs.
 render_outside="$($rg_bin -n 'fn to_terminal\(|fn to_markdown\(|fn to_html\(' crates/assay-core/src/explain_next -g'*.rs' -g'!render.rs' || true)"

--- a/scripts/ci/review-wave4-step3.sh
+++ b/scripts/ci/review-wave4-step3.sh
@@ -8,6 +8,11 @@ fi
 if [ -z "${base_ref}" ]; then
   base_ref="origin/main"
 fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
 
 rg_bin="$(command -v rg)"
 

--- a/scripts/ci/review-wave4-step3.sh
+++ b/scripts/ci/review-wave4-step3.sh
@@ -6,7 +6,7 @@ if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
   base_ref="origin/${GITHUB_BASE_REF}"
 fi
 if [ -z "${base_ref}" ]; then
-  base_ref="origin/codex/wave4-step2x-cache-thinness"
+  base_ref="origin/main"
 fi
 
 rg_bin="$(command -v rg)"


### PR DESCRIPTION
## Intent
Housekeeping for Wave4 reviewer scripts/docs: default `BASE_REF` to `origin/main` while keeping overrides.

## Scope
- `scripts/ci/review-wave4-step{1,2,3}.sh`
- `docs/contributing/SPLIT-INVENTORY-wave4-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave4-step1.md`
- `docs/contributing/SPLIT-CHECKLIST-wave4-step2.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave4-step2.md`
- `docs/contributing/SPLIT-CHECKLIST-wave4-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave4-step3.md`

## Why
Wave4 is now landed on `main`; defaults should reflect mainline validation instead of old stacked branch refs.

## Validation
- `bash -n scripts/ci/review-wave4-step1.sh scripts/ci/review-wave4-step2.sh scripts/ci/review-wave4-step3.sh`
