### PR TITLE
refactor(verify-step2): scaffold split behind stable facade

### DIFF
--- a/crates/assay-registry/src/verify.rs
+++ b/crates/assay-registry/src/verify.rs
@@ -4,6 +4,9 @@
 //! - Digest verification (SHA-256 of JCS-canonical content)
 //! - DSSE signature verification (Ed25519 over PAE)
 
+#[path = "verify_next/mod.rs"]
+mod verify_next;
+
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 

--- a/crates/assay-registry/src/verify.rs
+++ b/crates/assay-registry/src/verify.rs
@@ -7,16 +7,14 @@
 #[path = "verify_next/mod.rs"]
 mod verify_next;
 
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::VerifyingKey;
 
-use crate::canonicalize::{
-    compute_canonical_digest, parse_yaml_strict, to_canonical_jcs_bytes, CanonicalizeError,
-};
-use crate::digest::{compute_canonical_or_raw_digest, sha256_hex_bytes};
-use crate::error::{RegistryError, RegistryResult};
+use crate::canonicalize::CanonicalizeError;
+use crate::error::RegistryResult;
 use crate::trust::TrustStore;
-use crate::types::{DsseEnvelope, FetchResult};
+#[cfg(test)]
+use crate::types::DsseEnvelope;
+use crate::types::FetchResult;
 
 /// Payload type for pack definitions (DSSE-style binding).
 pub const PAYLOAD_TYPE_PACK_V1: &str = "application/vnd.assay.pack+yaml;v=1";
@@ -77,87 +75,22 @@ pub fn verify_pack(
     trust_store: &TrustStore,
     options: &VerifyOptions,
 ) -> RegistryResult<VerifyResult> {
-    // 1. Verify digest
-    if let Some(claimed_digest) = &result.headers.digest {
-        if claimed_digest != &result.computed_digest {
-            return Err(RegistryError::DigestMismatch {
-                name: "pack".to_string(),
-                version: "unknown".to_string(),
-                expected: claimed_digest.clone(),
-                actual: result.computed_digest.clone(),
-            });
-        }
-    }
-
-    // 2. Check for signature
-    let signature = &result.headers.signature;
-    if signature.is_none() {
-        if options.allow_unsigned {
-            return Ok(VerifyResult {
-                signed: false,
-                key_id: None,
-                digest: result.computed_digest.clone(),
-            });
-        } else {
-            return Err(RegistryError::Unsigned {
-                name: "pack".to_string(),
-                version: "unknown".to_string(),
-            });
-        }
-    }
-
-    // 3. Skip signature if requested
-    if options.skip_signature {
-        return Ok(VerifyResult {
-            signed: true,
-            key_id: result.headers.key_id.clone(),
-            digest: result.computed_digest.clone(),
-        });
-    }
-
-    // 4. Canonicalize content for DSSE verification
-    // CRITICAL: DSSE payload is canonical JCS bytes, not raw YAML
-    let canonical_bytes = canonicalize_for_dsse(&result.content)?;
-
-    // 5. Parse and verify DSSE signature
-    let sig_b64 = signature.as_ref().unwrap();
-    let envelope = parse_dsse_envelope(sig_b64)?;
-    verify_dsse_signature_bytes(&canonical_bytes, &envelope, trust_store)?;
-
-    Ok(VerifyResult {
-        signed: true,
-        key_id: envelope.signatures.first().map(|s| s.key_id.clone()),
-        digest: result.computed_digest.clone(),
-    })
+    verify_next::policy::verify_pack_impl(result, trust_store, options)
 }
 
 /// Canonicalize YAML content to JCS bytes for DSSE verification.
 ///
 /// Per SPEC §6.3: DSSE payload is the JCS canonical form of the pack content.
+#[cfg(test)]
 fn canonicalize_for_dsse(content: &str) -> RegistryResult<Vec<u8>> {
-    let json_value = parse_yaml_strict(content).map_err(|e| RegistryError::InvalidResponse {
-        message: format!("failed to parse YAML for signature verification: {}", e),
-    })?;
-
-    to_canonical_jcs_bytes(&json_value).map_err(|e| RegistryError::InvalidResponse {
-        message: format!("failed to canonicalize for signature verification: {}", e),
-    })
+    verify_next::dsse::canonicalize_for_dsse_impl(content)
 }
 
 /// Verify content digest matches expected.
 ///
 /// Uses canonical JCS digest per SPEC §6.2.
 pub fn verify_digest(content: &str, expected: &str) -> RegistryResult<()> {
-    let computed = compute_digest(content);
-    if computed != expected {
-        return Err(RegistryError::DigestMismatch {
-            name: "pack".to_string(),
-            version: "unknown".to_string(),
-            expected: expected.to_string(),
-            actual: computed,
-        });
-    }
-    Ok(())
+    verify_next::digest::verify_digest_impl(content, expected)
 }
 
 /// Compute canonical digest of content per SPEC §6.2.
@@ -170,19 +103,14 @@ pub fn verify_digest(content: &str, expected: &str) -> RegistryResult<()> {
 ///
 /// For content that may not be valid YAML, falls back to raw SHA-256.
 pub fn compute_digest(content: &str) -> String {
-    compute_canonical_or_raw_digest(content, |e| {
-        tracing::warn!(
-            error = %e,
-            "canonical digest failed, falling back to raw digest"
-        );
-    })
+    verify_next::digest::compute_digest_impl(content)
 }
 
 /// Compute canonical digest, returning error on invalid YAML.
 ///
 /// Use this when you need strict validation.
 pub fn compute_digest_strict(content: &str) -> Result<String, CanonicalizeError> {
-    compute_canonical_digest(content)
+    verify_next::digest::compute_digest_strict_impl(content)
 }
 
 /// Compute raw SHA-256 digest of content bytes.
@@ -191,20 +119,13 @@ pub fn compute_digest_strict(content: &str) -> Result<String, CanonicalizeError>
 /// This function is only for backward compatibility with pre-v1.0.2 digests.
 #[deprecated(since = "2.11.0", note = "use compute_digest for canonical JCS digest")]
 pub fn compute_digest_raw(content: &str) -> String {
-    sha256_hex_bytes(content.as_bytes())
+    verify_next::digest::compute_digest_raw_impl(content)
 }
 
 /// Parse DSSE envelope from Base64.
+#[cfg(test)]
 fn parse_dsse_envelope(b64: &str) -> RegistryResult<DsseEnvelope> {
-    let bytes = BASE64
-        .decode(b64)
-        .map_err(|e| RegistryError::SignatureInvalid {
-            reason: format!("invalid base64 envelope: {}", e),
-        })?;
-
-    serde_json::from_slice(&bytes).map_err(|e| RegistryError::SignatureInvalid {
-        reason: format!("invalid DSSE envelope: {}", e),
-    })
+    verify_next::wire::parse_dsse_envelope_impl(b64)
 }
 
 /// Build DSSE Pre-Authentication Encoding (PAE).
@@ -212,133 +133,39 @@ fn parse_dsse_envelope(b64: &str) -> RegistryResult<DsseEnvelope> {
 /// ```text
 /// PAE(type, payload) = "DSSEv1" SP LEN(type) SP type SP LEN(payload) SP payload
 /// ```
+#[cfg(test)]
 fn build_pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
-    let type_len = payload_type.len().to_string();
-    let payload_len = payload.len().to_string();
-
-    let mut pae = Vec::new();
-    pae.extend_from_slice(b"DSSEv1 ");
-    pae.extend_from_slice(type_len.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_type.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload_len.as_bytes());
-    pae.push(b' ');
-    pae.extend_from_slice(payload);
-    pae
+    verify_next::dsse::build_pae_impl(payload_type, payload)
 }
 
 /// Verify DSSE signature over canonical content bytes.
 ///
 /// Per SPEC §6.3: The DSSE payload MUST be the JCS canonical form of the content.
 /// This function compares canonical bytes, not raw YAML strings.
+#[cfg(test)]
 fn verify_dsse_signature_bytes(
     canonical_bytes: &[u8],
     envelope: &DsseEnvelope,
     trust_store: &TrustStore,
 ) -> RegistryResult<()> {
-    // 1. Check payload type
-    if envelope.payload_type != PAYLOAD_TYPE_PACK_V1 {
-        return Err(RegistryError::SignatureInvalid {
-            reason: format!(
-                "payload type mismatch: expected {}, got {}",
-                PAYLOAD_TYPE_PACK_V1, envelope.payload_type
-            ),
-        });
-    }
-
-    // 2. Decode payload from envelope
-    let payload_bytes =
-        BASE64
-            .decode(&envelope.payload)
-            .map_err(|e| RegistryError::SignatureInvalid {
-                reason: format!("invalid base64 payload: {}", e),
-            })?;
-
-    // 3. CRITICAL: Compare canonical bytes directly (not as strings)
-    // This ensures we're comparing apples to apples: canonical form to canonical form
-    if payload_bytes != canonical_bytes {
-        return Err(RegistryError::DigestMismatch {
-            name: "pack".to_string(),
-            version: "unknown".to_string(),
-            expected: format!("canonical payload ({} bytes)", payload_bytes.len()),
-            actual: format!("canonical content ({} bytes)", canonical_bytes.len()),
-        });
-    }
-
-    // 4. Verify at least one signature
-    if envelope.signatures.is_empty() {
-        return Err(RegistryError::SignatureInvalid {
-            reason: "no signatures in envelope".to_string(),
-        });
-    }
-
-    // 5. Build PAE over the canonical payload bytes
-    let pae = build_pae(&envelope.payload_type, &payload_bytes);
-
-    // 6. Verify each signature until one succeeds
-    let mut last_error = None;
-    for sig in &envelope.signatures {
-        match verify_single_signature(&pae, &sig.key_id, &sig.signature, trust_store) {
-            Ok(()) => return Ok(()),
-            Err(e) => last_error = Some(e),
-        }
-    }
-
-    Err(
-        last_error.unwrap_or_else(|| RegistryError::SignatureInvalid {
-            reason: "no valid signatures".to_string(),
-        }),
-    )
-}
-
-/// Verify a single signature.
-fn verify_single_signature(
-    pae: &[u8],
-    key_id: &str,
-    signature_b64: &str,
-    trust_store: &TrustStore,
-) -> RegistryResult<()> {
-    // 1. Get key from trust store
-    let key = trust_store.get_key(key_id)?;
-
-    // 2. Decode signature
-    let signature_bytes =
-        BASE64
-            .decode(signature_b64)
-            .map_err(|e| RegistryError::SignatureInvalid {
-                reason: format!("invalid base64 signature: {}", e),
-            })?;
-
-    let signature =
-        Signature::from_slice(&signature_bytes).map_err(|e| RegistryError::SignatureInvalid {
-            reason: format!("invalid signature bytes: {}", e),
-        })?;
-
-    // 3. Verify
-    key.verify(pae, &signature)
-        .map_err(|_| RegistryError::SignatureInvalid {
-            reason: "ed25519 verification failed".to_string(),
-        })
+    verify_next::dsse::verify_dsse_signature_bytes_impl(canonical_bytes, envelope, trust_store)
 }
 
 /// Compute key ID from public key bytes (SPKI DER).
 pub fn compute_key_id(spki_bytes: &[u8]) -> String {
-    sha256_hex_bytes(spki_bytes)
+    verify_next::keys::compute_key_id_impl(spki_bytes)
 }
 
 /// Compute key ID from a VerifyingKey.
 pub fn compute_key_id_from_key(key: &VerifyingKey) -> RegistryResult<String> {
-    use pkcs8::EncodePublicKey;
-    let doc = key.to_public_key_der().map_err(|e| RegistryError::Config {
-        message: format!("failed to encode public key: {}", e),
-    })?;
-    Ok(compute_key_id(doc.as_bytes()))
+    verify_next::keys::compute_key_id_from_key_impl(key)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::RegistryError;
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
     use ed25519_dalek::SigningKey;
 
     fn generate_keypair() -> SigningKey {

--- a/crates/assay-registry/src/verify_next/digest.rs
+++ b/crates/assay-registry/src/verify_next/digest.rs
@@ -4,3 +4,37 @@
 //! - digest compute/compare helpers only
 //! - no DSSE signature verification
 //! - no policy decisions
+
+use crate::canonicalize::{compute_canonical_digest, CanonicalizeError};
+use crate::digest::{compute_canonical_or_raw_digest, sha256_hex_bytes};
+use crate::error::{RegistryError, RegistryResult};
+
+pub(crate) fn verify_digest_impl(content: &str, expected: &str) -> RegistryResult<()> {
+    let computed = compute_digest_impl(content);
+    if computed != expected {
+        return Err(RegistryError::DigestMismatch {
+            name: "pack".to_string(),
+            version: "unknown".to_string(),
+            expected: expected.to_string(),
+            actual: computed,
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn compute_digest_impl(content: &str) -> String {
+    compute_canonical_or_raw_digest(content, |e| {
+        tracing::warn!(
+            error = %e,
+            "canonical digest failed, falling back to raw digest"
+        );
+    })
+}
+
+pub(crate) fn compute_digest_strict_impl(content: &str) -> Result<String, CanonicalizeError> {
+    compute_canonical_digest(content)
+}
+
+pub(crate) fn compute_digest_raw_impl(content: &str) -> String {
+    sha256_hex_bytes(content.as_bytes())
+}

--- a/crates/assay-registry/src/verify_next/digest.rs
+++ b/crates/assay-registry/src/verify_next/digest.rs
@@ -1,0 +1,6 @@
+//! Digest boundary for verify split.
+//!
+//! Contract target:
+//! - digest compute/compare helpers only
+//! - no DSSE signature verification
+//! - no policy decisions

--- a/crates/assay-registry/src/verify_next/dsse.rs
+++ b/crates/assay-registry/src/verify_next/dsse.rs
@@ -1,0 +1,5 @@
+//! DSSE crypto boundary for verify split.
+//!
+//! Contract target:
+//! - PAE building and signature verification only
+//! - no allow/deny policy decisions

--- a/crates/assay-registry/src/verify_next/dsse.rs
+++ b/crates/assay-registry/src/verify_next/dsse.rs
@@ -3,3 +3,118 @@
 //! Contract target:
 //! - PAE building and signature verification only
 //! - no allow/deny policy decisions
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use ed25519_dalek::{Signature, Verifier};
+
+use crate::canonicalize::{parse_yaml_strict, to_canonical_jcs_bytes};
+use crate::error::{RegistryError, RegistryResult};
+use crate::trust::TrustStore;
+use crate::types::DsseEnvelope;
+
+use super::super::PAYLOAD_TYPE_PACK_V1;
+
+pub(crate) fn canonicalize_for_dsse_impl(content: &str) -> RegistryResult<Vec<u8>> {
+    let json_value = parse_yaml_strict(content).map_err(|e| RegistryError::InvalidResponse {
+        message: format!("failed to parse YAML for signature verification: {}", e),
+    })?;
+
+    to_canonical_jcs_bytes(&json_value).map_err(|e| RegistryError::InvalidResponse {
+        message: format!("failed to canonicalize for signature verification: {}", e),
+    })
+}
+
+pub(crate) fn build_pae_impl(payload_type: &str, payload: &[u8]) -> Vec<u8> {
+    let type_len = payload_type.len().to_string();
+    let payload_len = payload.len().to_string();
+
+    let mut pae = Vec::new();
+    pae.extend_from_slice(b"DSSEv1 ");
+    pae.extend_from_slice(type_len.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload_type.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload_len.as_bytes());
+    pae.push(b' ');
+    pae.extend_from_slice(payload);
+    pae
+}
+
+pub(crate) fn verify_dsse_signature_bytes_impl(
+    canonical_bytes: &[u8],
+    envelope: &DsseEnvelope,
+    trust_store: &TrustStore,
+) -> RegistryResult<()> {
+    if envelope.payload_type != PAYLOAD_TYPE_PACK_V1 {
+        return Err(RegistryError::SignatureInvalid {
+            reason: format!(
+                "payload type mismatch: expected {}, got {}",
+                PAYLOAD_TYPE_PACK_V1, envelope.payload_type
+            ),
+        });
+    }
+
+    let payload_bytes =
+        BASE64
+            .decode(&envelope.payload)
+            .map_err(|e| RegistryError::SignatureInvalid {
+                reason: format!("invalid base64 payload: {}", e),
+            })?;
+
+    if payload_bytes != canonical_bytes {
+        return Err(RegistryError::DigestMismatch {
+            name: "pack".to_string(),
+            version: "unknown".to_string(),
+            expected: format!("canonical payload ({} bytes)", payload_bytes.len()),
+            actual: format!("canonical content ({} bytes)", canonical_bytes.len()),
+        });
+    }
+
+    if envelope.signatures.is_empty() {
+        return Err(RegistryError::SignatureInvalid {
+            reason: "no signatures in envelope".to_string(),
+        });
+    }
+
+    let pae = build_pae_impl(&envelope.payload_type, &payload_bytes);
+
+    let mut last_error = None;
+    for sig in &envelope.signatures {
+        match verify_single_signature_impl(&pae, &sig.key_id, &sig.signature, trust_store) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_error = Some(e),
+        }
+    }
+
+    Err(
+        last_error.unwrap_or_else(|| RegistryError::SignatureInvalid {
+            reason: "no valid signatures".to_string(),
+        }),
+    )
+}
+
+pub(crate) fn verify_single_signature_impl(
+    pae: &[u8],
+    key_id: &str,
+    signature_b64: &str,
+    trust_store: &TrustStore,
+) -> RegistryResult<()> {
+    let key = trust_store.get_key(key_id)?;
+
+    let signature_bytes =
+        BASE64
+            .decode(signature_b64)
+            .map_err(|e| RegistryError::SignatureInvalid {
+                reason: format!("invalid base64 signature: {}", e),
+            })?;
+
+    let signature =
+        Signature::from_slice(&signature_bytes).map_err(|e| RegistryError::SignatureInvalid {
+            reason: format!("invalid signature bytes: {}", e),
+        })?;
+
+    key.verify(pae, &signature)
+        .map_err(|_| RegistryError::SignatureInvalid {
+            reason: "ed25519 verification failed".to_string(),
+        })
+}

--- a/crates/assay-registry/src/verify_next/errors.rs
+++ b/crates/assay-registry/src/verify_next/errors.rs
@@ -1,0 +1,5 @@
+//! Error mapping boundary for verify split.
+//!
+//! Contract target:
+//! - shared error-construction helpers only
+//! - no ownership of parsing/crypto logic

--- a/crates/assay-registry/src/verify_next/keys.rs
+++ b/crates/assay-registry/src/verify_next/keys.rs
@@ -3,3 +3,20 @@
 //! Contract target:
 //! - key-id helpers only
 //! - no policy decisions
+
+use ed25519_dalek::VerifyingKey;
+
+use crate::digest::sha256_hex_bytes;
+use crate::error::{RegistryError, RegistryResult};
+
+pub(crate) fn compute_key_id_impl(spki_bytes: &[u8]) -> String {
+    sha256_hex_bytes(spki_bytes)
+}
+
+pub(crate) fn compute_key_id_from_key_impl(key: &VerifyingKey) -> RegistryResult<String> {
+    use pkcs8::EncodePublicKey;
+    let doc = key.to_public_key_der().map_err(|e| RegistryError::Config {
+        message: format!("failed to encode public key: {}", e),
+    })?;
+    Ok(compute_key_id_impl(doc.as_bytes()))
+}

--- a/crates/assay-registry/src/verify_next/keys.rs
+++ b/crates/assay-registry/src/verify_next/keys.rs
@@ -1,0 +1,5 @@
+//! Key helper boundary for verify split.
+//!
+//! Contract target:
+//! - key-id helpers only
+//! - no policy decisions

--- a/crates/assay-registry/src/verify_next/mod.rs
+++ b/crates/assay-registry/src/verify_next/mod.rs
@@ -1,0 +1,12 @@
+//! Verify split scaffold (Wave5 Step2 Commit B).
+//!
+//! Layout only: `verify.rs` remains the active implementation in this commit.
+//! Function moves and facade delegation are introduced in a follow-up commit.
+
+pub(crate) mod digest;
+pub(crate) mod dsse;
+pub(crate) mod errors;
+pub(crate) mod keys;
+pub(crate) mod policy;
+pub(crate) mod tests;
+pub(crate) mod wire;

--- a/crates/assay-registry/src/verify_next/policy.rs
+++ b/crates/assay-registry/src/verify_next/policy.rs
@@ -1,0 +1,6 @@
+//! Verify orchestration/policy boundary for split.
+//!
+//! Contract target:
+//! - verification flow orchestration and policy decisions only
+//! - no low-level DSSE crypto primitives
+//! - no base64/wire parsing internals

--- a/crates/assay-registry/src/verify_next/policy.rs
+++ b/crates/assay-registry/src/verify_next/policy.rs
@@ -4,3 +4,64 @@
 //! - verification flow orchestration and policy decisions only
 //! - no low-level DSSE crypto primitives
 //! - no base64/wire parsing internals
+
+use crate::error::{RegistryError, RegistryResult};
+use crate::trust::TrustStore;
+use crate::types::FetchResult;
+
+use super::super::{VerifyOptions, VerifyResult};
+use super::dsse::{canonicalize_for_dsse_impl, verify_dsse_signature_bytes_impl};
+use super::wire::parse_dsse_envelope_impl;
+
+pub(crate) fn verify_pack_impl(
+    result: &FetchResult,
+    trust_store: &TrustStore,
+    options: &VerifyOptions,
+) -> RegistryResult<VerifyResult> {
+    if let Some(claimed_digest) = &result.headers.digest {
+        if claimed_digest != &result.computed_digest {
+            return Err(RegistryError::DigestMismatch {
+                name: "pack".to_string(),
+                version: "unknown".to_string(),
+                expected: claimed_digest.clone(),
+                actual: result.computed_digest.clone(),
+            });
+        }
+    }
+
+    let signature = &result.headers.signature;
+    if signature.is_none() {
+        if options.allow_unsigned {
+            return Ok(VerifyResult {
+                signed: false,
+                key_id: None,
+                digest: result.computed_digest.clone(),
+            });
+        }
+        return Err(RegistryError::Unsigned {
+            name: "pack".to_string(),
+            version: "unknown".to_string(),
+        });
+    }
+
+    if options.skip_signature {
+        return Ok(VerifyResult {
+            signed: true,
+            key_id: result.headers.key_id.clone(),
+            digest: result.computed_digest.clone(),
+        });
+    }
+
+    let canonical_bytes = canonicalize_for_dsse_impl(&result.content)?;
+    let sig_b64 = signature
+        .as_ref()
+        .expect("signature presence already checked in policy");
+    let envelope = parse_dsse_envelope_impl(sig_b64)?;
+    verify_dsse_signature_bytes_impl(&canonical_bytes, &envelope, trust_store)?;
+
+    Ok(VerifyResult {
+        signed: true,
+        key_id: envelope.signatures.first().map(|s| s.key_id.clone()),
+        digest: result.computed_digest.clone(),
+    })
+}

--- a/crates/assay-registry/src/verify_next/tests.rs
+++ b/crates/assay-registry/src/verify_next/tests.rs
@@ -1,0 +1,4 @@
+#![cfg(test)]
+
+//! Placeholder test module for verify split scaffold.
+//! No test moves in Commit B; Step1 contract tests remain in `verify.rs`.

--- a/crates/assay-registry/src/verify_next/wire.rs
+++ b/crates/assay-registry/src/verify_next/wire.rs
@@ -4,3 +4,20 @@
 //! - envelope wire parsing/shape checks only
 //! - no policy decisions
 //! - no key trust decisions
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+
+use crate::error::{RegistryError, RegistryResult};
+use crate::types::DsseEnvelope;
+
+pub(crate) fn parse_dsse_envelope_impl(b64: &str) -> RegistryResult<DsseEnvelope> {
+    let bytes = BASE64
+        .decode(b64)
+        .map_err(|e| RegistryError::SignatureInvalid {
+            reason: format!("invalid base64 envelope: {}", e),
+        })?;
+
+    serde_json::from_slice(&bytes).map_err(|e| RegistryError::SignatureInvalid {
+        reason: format!("invalid DSSE envelope: {}", e),
+    })
+}

--- a/crates/assay-registry/src/verify_next/wire.rs
+++ b/crates/assay-registry/src/verify_next/wire.rs
@@ -1,0 +1,6 @@
+//! Wire-format boundary for verify split.
+//!
+//! Contract target:
+//! - envelope wire parsing/shape checks only
+//! - no policy decisions
+//! - no key trust decisions

--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -87,7 +87,8 @@ Step status:
 
 - Writer split: merged via PR #332.
 - Verify split: pending completion.
-- Verify Step1 behavior freeze (tests/docs/gates): in progress on `codex/wave5-step1-verify-freeze`.
+- Verify Step1 behavior freeze (tests/docs/gates): in review on `codex/wave5-step1-verify-freeze` (PR #348).
+- Verify Step2 mechanical split: in progress on `codex/wave5-step2-verify-split` (PR #349).
 
 ### A. `crates/assay-registry/src/verify.rs`
 

--- a/docs/contributing/SPLIT-CHECKLIST-wave5-step2-verify.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave5-step2-verify.md
@@ -1,0 +1,37 @@
+# Wave5 Step2 checklist: verify split behind stable facade
+
+Scope lock:
+- Step2 performs mechanical moves only.
+- `verify.rs` stays as public facade with unchanged symbol signatures.
+- No behavior/perf changes.
+
+Artifacts:
+- `docs/contributing/SPLIT-MOVE-MAP-wave5-step2-verify.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave5-step2-verify.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave5-step2-verify.md`
+- `scripts/ci/review-wave5-step2.sh`
+
+Runbook:
+```bash
+BASE_REF=origin/codex/wave5-step1-verify-freeze bash scripts/ci/review-wave5-step2.sh
+```
+
+Optional override:
+```bash
+BASE_REF=<your-base-ref> bash scripts/ci/review-wave5-step2.sh
+```
+
+Hard gates:
+- verify facade has expected delegation callsites for all public helpers
+- no `verify_next::` path usage outside `verify.rs`
+- `verify.rs` code-only has no heavy parsing/crypto internals
+- `policy.rs` has no low-level DSSE crypto primitives
+- `dsse.rs` has no policy tokens
+- DSSE crypto helper calls are single-source in `verify_next/dsse.rs`
+- `policy.rs` has exactly one DSSE boundary call (`verify_dsse_signature_bytes_impl`)
+- diff stays within Step2 allowlist
+
+Definition of done:
+- Reviewer script passes.
+- Step1 anchor tests remain green.
+- Move-map covers all moved functions and caller chains.

--- a/docs/contributing/SPLIT-CHECKLIST-wave5-step2-verify.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave5-step2-verify.md
@@ -27,6 +27,7 @@ Hard gates:
 - `verify.rs` code-only has no heavy parsing/crypto internals
 - `policy.rs` has no low-level DSSE crypto primitives
 - `dsse.rs` has no policy tokens
+- canonicalization helpers stay out of `policy.rs`, `wire.rs`, `keys.rs`
 - DSSE crypto helper calls are single-source in `verify_next/dsse.rs`
 - `policy.rs` has exactly one DSSE boundary call (`verify_dsse_signature_bytes_impl`)
 - diff stays within Step2 allowlist

--- a/docs/contributing/SPLIT-CHECKLIST-wave5-step2-verify.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave5-step2-verify.md
@@ -28,6 +28,8 @@ Hard gates:
 - `policy.rs` has no low-level DSSE crypto primitives
 - `dsse.rs` has no policy tokens
 - canonicalization helpers stay out of `policy.rs`, `wire.rs`, `keys.rs`
+- `VerifyResult { ... }` construction stays single-source in `verify_next/policy.rs`
+- canonicalization internals stay single-source (`canonicalize_for_dsse` + YAML/JCS parse in `verify_next/dsse.rs`; digest hash in `verify_next/digest.rs`)
 - DSSE crypto helper calls are single-source in `verify_next/dsse.rs`
 - `policy.rs` has exactly one DSSE boundary call (`verify_dsse_signature_bytes_impl`)
 - diff stays within Step2 allowlist

--- a/docs/contributing/SPLIT-MOVE-MAP-wave5-step2-verify.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave5-step2-verify.md
@@ -1,0 +1,39 @@
+# Wave5 Step2 move map: verify
+
+Module responsibilities:
+- `verify.rs`: public surface + thin delegating facade
+- `verify_next/policy.rs`: verification orchestration + fail-closed policy only
+- `verify_next/digest.rs`: digest compute/compare helpers only
+- `verify_next/wire.rs`: DSSE envelope wire parsing only
+- `verify_next/dsse.rs`: canonicalization-for-DSSE + PAE + signature verification only
+- `verify_next/keys.rs`: key-id helper functions only
+
+Function -> file map:
+- `verify_pack` -> `verify.rs` facade, impl in `verify_next/policy.rs`
+- `verify_digest` -> `verify.rs` facade, impl in `verify_next/digest.rs`
+- `compute_digest` -> `verify.rs` facade, impl in `verify_next/digest.rs`
+- `compute_digest_strict` -> `verify.rs` facade, impl in `verify_next/digest.rs`
+- `compute_digest_raw` -> `verify.rs` facade, impl in `verify_next/digest.rs`
+- `parse_dsse_envelope` (test helper wrapper) -> `verify.rs`, impl in `verify_next/wire.rs`
+- `canonicalize_for_dsse` (test helper wrapper) -> `verify.rs`, impl in `verify_next/dsse.rs`
+- `build_pae` (test helper wrapper) -> `verify.rs`, impl in `verify_next/dsse.rs`
+- `verify_dsse_signature_bytes` (test helper wrapper) -> `verify.rs`, impl in `verify_next/dsse.rs`
+- `verify_single_signature_impl` -> `verify_next/dsse.rs`
+- `compute_key_id` -> `verify.rs` facade, impl in `verify_next/keys.rs`
+- `compute_key_id_from_key` -> `verify.rs` facade, impl in `verify_next/keys.rs`
+
+Caller chains (top flows):
+- Verify pack flow:
+  - `verify_pack` -> `verify_next::policy::verify_pack_impl`
+  - `verify_pack_impl` -> `canonicalize_for_dsse_impl` + `parse_dsse_envelope_impl` + `verify_dsse_signature_bytes_impl`
+- Digest compare flow:
+  - `verify_digest` -> `verify_next::digest::verify_digest_impl`
+  - `verify_digest_impl` -> `compute_digest_impl`
+- DSSE envelope flow:
+  - `verify_pack_impl` -> `parse_dsse_envelope_impl` (wire)
+  - `verify_dsse_signature_bytes_impl` (dsse) -> `build_pae_impl` -> `verify_single_signature_impl`
+
+Mechanics contract:
+- Step2 is mechanical move only.
+- No public symbol/signature changes in `verify.rs`.
+- No error-code/classification contract changes.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave5-step2-verify.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave5-step2-verify.md
@@ -29,9 +29,16 @@ Caller chains (top flows):
 - Digest compare flow:
   - `verify_digest` -> `verify_next::digest::verify_digest_impl`
   - `verify_digest_impl` -> `compute_digest_impl`
+- Digest compute flow:
+  - `compute_digest` -> `verify_next::digest::compute_digest_impl`
+  - `compute_digest_strict` -> `verify_next::digest::compute_digest_strict_impl`
+  - `compute_digest_raw` -> `verify_next::digest::compute_digest_raw_impl`
 - DSSE envelope flow:
   - `verify_pack_impl` -> `parse_dsse_envelope_impl` (wire)
   - `verify_dsse_signature_bytes_impl` (dsse) -> `build_pae_impl` -> `verify_single_signature_impl`
+- Key-id flow:
+  - `compute_key_id` -> `verify_next::keys::compute_key_id_impl`
+  - `compute_key_id_from_key` -> `verify_next::keys::compute_key_id_from_key_impl`
 
 Mechanics contract:
 - Step2 is mechanical move only.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave5-step2-verify.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave5-step2-verify.md
@@ -23,7 +23,8 @@ Gates enforced by `review-wave5-step2.sh`:
 - Facade heavy-internal ban (`base64`, `serde_json::from_*`, canonicalize internals, DSSE low-level helpers).
 - `policy.rs` low-level crypto-ban + exact one DSSE boundary call.
 - `dsse.rs` policy-token ban.
-- DSSE crypto helper single-source gate in `verify_next/dsse.rs`.
+- canonicalization helpers banned in `policy.rs`, `wire.rs`, `keys.rs`.
+- DSSE crypto helper single-source gate in `verify_next/dsse.rs` (`build_pae_impl`, `verify_single_signature_impl`, `Signature::from_slice`, `key.verify`).
 - Diff allowlist gate.
 
 Validation command:

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave5-step2-verify.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave5-step2-verify.md
@@ -24,6 +24,8 @@ Gates enforced by `review-wave5-step2.sh`:
 - `policy.rs` low-level crypto-ban + exact one DSSE boundary call.
 - `dsse.rs` policy-token ban.
 - canonicalization helpers banned in `policy.rs`, `wire.rs`, `keys.rs`.
+- `VerifyResult { ... }` constructor single-source gate in `verify_next/policy.rs`.
+- canonicalization single-source gates (`canonicalize_for_dsse` + YAML/JCS parse in `verify_next/dsse.rs`; canonical digest hash in `verify_next/digest.rs`).
 - DSSE crypto helper single-source gate in `verify_next/dsse.rs` (`build_pae_impl`, `verify_single_signature_impl`, `Signature::from_slice`, `key.verify`).
 - Diff allowlist gate.
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave5-step2-verify.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave5-step2-verify.md
@@ -1,0 +1,35 @@
+# Review Pack: Wave5 Step2 (verify mechanical split)
+
+Intent:
+- Mechanically split `verify.rs` internals into `verify_next/*`.
+- Keep public verify surface stable via facade delegation.
+
+Scope:
+- `crates/assay-registry/src/verify.rs`
+- `crates/assay-registry/src/verify_next/*`
+- `docs/contributing/SPLIT-MOVE-MAP-wave5-step2-verify.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave5-step2-verify.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave5-step2-verify.md`
+- `scripts/ci/review-wave5-step2.sh`
+
+Core proof points:
+- Public surface remains in `verify.rs` (same symbols/signatures as Step1 snapshot).
+- Public helper bodies delegate to `verify_next/*` (including digest/key helpers).
+- Fail-closed/canonicalization anchors from Step1 remain green.
+
+Gates enforced by `review-wave5-step2.sh`:
+- Delegation callsite presence checks in `verify.rs`.
+- `verify_next::` path leak check outside facade.
+- Facade heavy-internal ban (`base64`, `serde_json::from_*`, canonicalize internals, DSSE low-level helpers).
+- `policy.rs` low-level crypto-ban + exact one DSSE boundary call.
+- `dsse.rs` policy-token ban.
+- DSSE crypto helper single-source gate in `verify_next/dsse.rs`.
+- Diff allowlist gate.
+
+Validation command:
+```bash
+BASE_REF=origin/codex/wave5-step1-verify-freeze bash scripts/ci/review-wave5-step2.sh
+```
+
+Expected outcome:
+- PASS with no boundary-gate violations.

--- a/scripts/ci/review-wave5-step2.sh
+++ b/scripts/ci/review-wave5-step2.sh
@@ -166,6 +166,22 @@ check_only_file_matches \
   crates/assay-registry/src/verify_next \
   'verify_next/dsse.rs'
 
+# VerifyResult construction stays single-source in policy orchestration.
+check_only_file_matches \
+  'VerifyResult[[:space:]]*\{' \
+  crates/assay-registry/src/verify_next \
+  'verify_next/policy.rs'
+
+# Canonicalization single-source boundaries.
+check_only_file_matches \
+  'pub\(crate\)[[:space:]]+fn[[:space:]]+canonicalize_for_dsse_impl\(|parse_yaml_strict|to_canonical_jcs_bytes' \
+  crates/assay-registry/src/verify_next \
+  'verify_next/dsse.rs'
+check_only_file_matches \
+  'compute_canonical_digest' \
+  crates/assay-registry/src/verify_next \
+  'verify_next/digest.rs'
+
 policy_boundary_calls="$(rg -n 'verify_dsse_signature_bytes_impl\(' crates/assay-registry/src/verify_next/policy.rs || true)"
 policy_boundary_count="$(echo "$policy_boundary_calls" | sed '/^$/d' | wc -l | tr -d ' ')"
 if [ "$policy_boundary_count" -ne 1 ]; then

--- a/scripts/ci/review-wave5-step2.sh
+++ b/scripts/ci/review-wave5-step2.sh
@@ -128,7 +128,9 @@ check_has_match 'verify_next::wire::parse_dsse_envelope_impl' crates/assay-regis
 check_has_match 'verify_next::dsse::build_pae_impl' crates/assay-registry/src/verify.rs
 check_has_match 'verify_next::dsse::verify_dsse_signature_bytes_impl' crates/assay-registry/src/verify.rs
 
-leaked_refs="$(rg -n 'verify_next::' crates/assay-registry/src | rg -v 'crates/assay-registry/src/verify.rs' || true)"
+leaked_refs="$(
+  rg -n 'verify_next::' crates/assay-registry/src -g'*.rs' -g'!verify.rs' -g'!*/tests.rs' || true
+)"
 if [ -n "$leaked_refs" ]; then
   echo "verify_next path usage leaked outside verify facade:"
   echo "$leaked_refs"
@@ -148,8 +150,19 @@ check_no_match_code_only \
   'allow_unsigned|skip_signature|Unsigned|VerifyOptions|policy' \
   crates/assay-registry/src/verify_next/dsse.rs
 
+# Canonicalization helpers must stay out of policy/wire/keys.
+check_no_match_code_only \
+  'parse_yaml_strict|to_canonical_jcs_bytes|compute_canonical_digest' \
+  crates/assay-registry/src/verify_next/policy.rs
+check_no_match_code_only \
+  'parse_yaml_strict|to_canonical_jcs_bytes|compute_canonical_digest' \
+  crates/assay-registry/src/verify_next/wire.rs
+check_no_match_code_only \
+  'parse_yaml_strict|to_canonical_jcs_bytes|compute_canonical_digest' \
+  crates/assay-registry/src/verify_next/keys.rs
+
 check_only_file_matches \
-  'build_pae_impl\(|verify_single_signature_impl\(|Signature::from_slice' \
+  'build_pae_impl\(|verify_single_signature_impl\(|Signature::from_slice|key\.verify\(' \
   crates/assay-registry/src/verify_next \
   'verify_next/dsse.rs'
 

--- a/scripts/ci/review-wave5-step2.sh
+++ b/scripts/ci/review-wave5-step2.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/codex/wave5-step1-verify-freeze"
+fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+
+rg_bin="$(command -v rg)"
+
+strip_code_only() {
+  local file="$1"
+  awk '
+    BEGIN {
+      pending_cfg_test = 0
+      skip_tests = 0
+      depth = 0
+    }
+    {
+      line = $0
+
+      if (skip_tests) {
+        opens = gsub(/\{/, "{", line)
+        closes = gsub(/\}/, "}", line)
+        depth += opens - closes
+        if (depth <= 0) {
+          skip_tests = 0
+          depth = 0
+        }
+        next
+      }
+
+      if (pending_cfg_test) {
+        if (line ~ /^[[:space:]]*#\[/ || line ~ /^[[:space:]]*$/) {
+          next
+        }
+        if (line ~ /^[[:space:]]*mod[[:space:]]+tests[[:space:]]*\{[[:space:]]*$/) {
+          skip_tests = 1
+          depth = 1
+          pending_cfg_test = 0
+          next
+        }
+        pending_cfg_test = 0
+      }
+
+      if (line ~ /^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$/) {
+        pending_cfg_test = 1
+        next
+      }
+
+      print
+    }
+  ' "$file"
+}
+
+check_has_match() {
+  local pattern="$1"
+  local file="$2"
+  if ! "$rg_bin" -n "$pattern" "$file" >/dev/null; then
+    echo "missing expected delegation pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+check_no_match_code_only() {
+  local pattern="$1"
+  local file="$2"
+  if strip_code_only "$file" | "$rg_bin" -v '^[[:space:]]*//' | "$rg_bin" -n "$pattern" >/dev/null; then
+    echo "forbidden code-only match in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+check_only_file_matches() {
+  local pattern="$1"
+  local root="$2"
+  local allowed="$3"
+  local matches leaked
+  matches="$($rg_bin -n "$pattern" "$root" -g'*.rs' || true)"
+  if [ -z "$matches" ]; then
+    echo "expected at least one match for: $pattern"
+    exit 1
+  fi
+  leaked="$(echo "$matches" | "$rg_bin" -v "$allowed" || true)"
+  if [ -n "$leaked" ]; then
+    echo "forbidden match outside allowed file:"
+    echo "$leaked"
+    exit 1
+  fi
+}
+
+echo "== Wave5 Step2 quality checks =="
+cargo fmt --check
+cargo clippy -p assay-registry --all-targets -- -D warnings
+cargo check -p assay-registry
+
+echo "== Wave5 Step2 contract anchors (verify) =="
+for test_name in \
+  test_verify_pack_fail_closed_matrix_contract \
+  test_verify_pack_malformed_signature_reason_is_stable \
+  test_verify_pack_canonicalization_equivalent_yaml_variants_contract \
+  test_verify_pack_uses_canonical_bytes \
+  test_verify_digest_mismatch \
+  test_parse_dsse_envelope_invalid_base64
+ do
+  echo "anchor: ${test_name}"
+  cargo test -p assay-registry "${test_name}" -- --nocapture
+done
+
+echo "== Wave5 Step2 delegation gates =="
+check_has_match 'verify_next::policy::verify_pack_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::digest::verify_digest_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::digest::compute_digest_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::digest::compute_digest_strict_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::digest::compute_digest_raw_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::keys::compute_key_id_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::keys::compute_key_id_from_key_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::dsse::canonicalize_for_dsse_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::wire::parse_dsse_envelope_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::dsse::build_pae_impl' crates/assay-registry/src/verify.rs
+check_has_match 'verify_next::dsse::verify_dsse_signature_bytes_impl' crates/assay-registry/src/verify.rs
+
+leaked_refs="$(rg -n 'verify_next::' crates/assay-registry/src | rg -v 'crates/assay-registry/src/verify.rs' || true)"
+if [ -n "$leaked_refs" ]; then
+  echo "verify_next path usage leaked outside verify facade:"
+  echo "$leaked_refs"
+  exit 1
+fi
+
+echo "== Wave5 Step2 boundary gates =="
+check_no_match_code_only \
+  'base64::|serde_json::from_(slice|str)|parse_yaml_strict|to_canonical_jcs_bytes|compute_canonical_digest' \
+  crates/assay-registry/src/verify.rs
+
+check_no_match_code_only \
+  'base64::|ed25519_dalek|serde_json::from_(slice|str)|Signature::from_slice|Verifier|build_pae_impl\(|verify_single_signature_impl\(' \
+  crates/assay-registry/src/verify_next/policy.rs
+
+check_no_match_code_only \
+  'allow_unsigned|skip_signature|Unsigned|VerifyOptions|policy' \
+  crates/assay-registry/src/verify_next/dsse.rs
+
+check_only_file_matches \
+  'build_pae_impl\(|verify_single_signature_impl\(|Signature::from_slice' \
+  crates/assay-registry/src/verify_next \
+  'verify_next/dsse.rs'
+
+policy_boundary_calls="$(rg -n 'verify_dsse_signature_bytes_impl\(' crates/assay-registry/src/verify_next/policy.rs || true)"
+policy_boundary_count="$(echo "$policy_boundary_calls" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [ "$policy_boundary_count" -ne 1 ]; then
+  echo "expected exactly one DSSE boundary call in policy.rs, got ${policy_boundary_count}"
+  echo "$policy_boundary_calls"
+  exit 1
+fi
+
+echo "== Wave5 Step2 diff allowlist =="
+leaks="$(
+  git diff --name-only "${base_ref}...HEAD" | \
+    "$rg_bin" -v \
+      '^crates/assay-registry/src/verify.rs$|^crates/assay-registry/src/verify_next/|^docs/contributing/SPLIT-MOVE-MAP-wave5-step2-verify.md$|^docs/contributing/SPLIT-CHECKLIST-wave5-step2-verify.md$|^docs/contributing/SPLIT-REVIEW-PACK-wave5-step2-verify.md$|^scripts/ci/review-wave5-step2.sh$|^docs/architecture/PLAN-split-refactor-2026q1.md$' || true
+)"
+if [ -n "$leaks" ]; then
+  echo "non-allowlisted files detected:"
+  echo "$leaks"
+  exit 1
+fi
+
+echo "Wave5 Step2 reviewer script: PASS"


### PR DESCRIPTION
## Intent
Wave5 Step2 Commit B: compile-safe scaffold for verify split behind stable facade.

## Stack
- Base: `codex/wave5-step1-verify-freeze`
- Head: `codex/wave5-step2-verify-split`

## Scope (Commit B only)
- Add `crates/assay-registry/src/verify_next/*` scaffold:
  - `mod.rs`, `wire.rs`, `digest.rs`, `dsse.rs`, `keys.rs`, `policy.rs`, `errors.rs`, `tests.rs`
- Minimal wiring in `crates/assay-registry/src/verify.rs`:
  - `#[path = "verify_next/mod.rs"] mod verify_next;`

## Behavior contract
- No function moves yet.
- `verify.rs` remains active implementation.
- No behavior/perf/API changes in this commit.

## Validation
Executed and passing:
- `cargo fmt --check`
- `cargo check -p assay-registry`
- `cargo clippy -p assay-registry --all-targets -- -D warnings`
- `rg -n "verify_next::" crates/assay-registry/src | rg -v "crates/assay-registry/src/verify.rs"` (empty)

## Next commits
- Commit C: mechanical function moves behind verify facade
- Commit D: move-map + hard boundary gates + reviewer script
