### PR TITLE
docs(ci/wave6-step1): freeze CI hardening baseline and reviewer gates

### DIFF
--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -1,6 +1,6 @@
 # Plan: Refactor Hotspots (Q1-Q2 2026)
 
-> Status: Proposed
+> Status: In progress (Waves 1-5 merged; Wave 6 active)
 > Date: 2026-02-13
 > Scope: Largest handwritten Rust production files and related CI/CD gates
 > Constraint: No behavior drift in CLI/public contracts; incremental mergeable PRs
@@ -361,7 +361,33 @@ Exit criteria (Wave 5):
 - Step1 contract anchors remain green (via Step3 reviewer script).
 - Step3 boundary scripts remain green with no allowlist leakage.
 
-## 4) CI/CD improvements linked to this plan
+## Wave 6: CI/CD hardening closure
+
+Step status:
+
+- Step 1 (behavior freeze + inventory + drift gates): in progress on `codex/wave6-step1-ci-hardening-freeze`.
+- Step 2 (attestation pair): planned.
+- Step 3 (nightly fuzz/model lane): planned.
+
+Step 1 scope (freeze only):
+
+- Baseline inventory for existing CI/release guardrails.
+- Reviewer script with hard-fail allowlist and baseline anchor checks.
+- No workflow semantic changes in Step1.
+
+Step 2 scope (planned):
+
+- Artifact attestation as a required pair:
+  - produce provenance in release workflow (`attest-build-provenance`)
+  - verify attestation in CI/release validation; fail closed if missing/invalid
+- Keep existing Wave0 feature/semver/placeholder gates intact.
+
+Step 3 scope (planned):
+
+- Add nightly fuzz/model lane for parser/crypto/concurrency hotspots (non-blocking first).
+- Introduce promotion policy for escalating nightly checks to required status when stable.
+
+Current baseline strengths:
 
 Already strong today:
 
@@ -370,7 +396,7 @@ Already strong today:
 - `cargo-audit` + `cargo-deny`.
 - Criterion + Bencher lanes.
 
-Additions for this refactor program:
+Program additions tracked in Wave 6:
 
 1. Artifact attestation as a required pair:
    - produce provenance in release workflow (`attest-build-provenance`)

--- a/docs/contributing/SPLIT-CHECKLIST-wave6-step1-ci.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave6-step1-ci.md
@@ -1,0 +1,26 @@
+# Wave6 Step1 checklist: CI/CD hardening freeze
+
+Scope lock:
+- Step1 is docs + reviewer gates only.
+- No workflow semantics change in this step.
+- No production crate code changes in this step.
+
+Artifacts:
+- `docs/contributing/SPLIT-INVENTORY-wave6-step1-ci.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave6-step1-ci.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave6-step1-ci.md`
+- `scripts/ci/review-wave6-step1-ci.sh`
+
+Runbook:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step1-ci.sh
+```
+
+Hard gates (script-enforced):
+- BASE_REF resolve guard + effective SHA print.
+- Baseline workflow anchors still present (feature matrix/nextest/semver/clippy anti-placeholder, attestation conditional, id-token write).
+- Strict diff allowlist fail-fast for Step1 docs/script/plan scope.
+
+Definition of done:
+- reviewer script passes.
+- no workflow behavior changes in this PR.

--- a/docs/contributing/SPLIT-INVENTORY-wave6-step1-ci.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave6-step1-ci.md
@@ -1,0 +1,26 @@
+# Wave6 Step1 inventory: CI/CD hardening baseline
+
+Snapshot commit (this PR): `5a72f04b`
+
+Scope baseline (workflows):
+- `.github/workflows/split-wave0-gates.yml`
+- `.github/workflows/release.yml`
+- `.github/workflows/ci.yml`
+- `.github/workflows/action-tests.yml`
+
+Baseline anchors (present today):
+- `split-wave0-gates.yml` has Wave0 feature matrix and curated feature runs.
+- `split-wave0-gates.yml` uses `cargo-nextest` and `cargo-hack` on hotspot crates.
+- `split-wave0-gates.yml` runs semver checks via `cargo-semver-checks`.
+- `split-wave0-gates.yml` enforces anti-placeholder clippy (`todo` + `unimplemented`).
+- `action-tests.yml` includes `attestation_conditional` logic test.
+- `release.yml` declares `id-token: write` in release jobs.
+
+Known gaps tracked for Wave6 follow-up (not changed in Step1):
+- No explicit `attest-build-provenance` producer in release workflow.
+- No CI/release attestation verification gate that fails closed.
+- No dedicated nightly fuzz/model workflow lane (`miri`/fuzz/Kani) yet.
+
+Step1 contract:
+- docs + gates only.
+- no workflow semantic changes.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave6-step1-ci.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave6-step1-ci.md
@@ -1,0 +1,23 @@
+# Review Pack: Wave6 Step1 (CI/CD hardening freeze)
+
+Intent:
+- establish a reviewable CI/CD baseline before changing attestation/nightly lanes.
+
+Scope:
+- docs + reviewer script only.
+- no workflow semantic changes.
+
+Reviewer script:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step1-ci.sh
+```
+
+What the script proves:
+- current baseline anchors still exist in workflows.
+- Step1 diff stays inside an explicit allowlist.
+- BASE_REF resolution is explicit and logged.
+
+Follow-up target (Wave6 Step2+):
+- add attestation producer + verification pair (fail closed).
+- add nightly fuzz/model lane (non-blocking first).
+- keep existing Wave0 gates intact while introducing new checks.

--- a/scripts/ci/review-wave6-step1-ci.sh
+++ b/scripts/ci/review-wave6-step1-ci.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+rg_bin="$(command -v rg)"
+
+check_has_match() {
+  local pattern="$1"
+  local file="$2"
+  if ! "$rg_bin" -n -- "$pattern" "$file" >/dev/null; then
+    echo "missing expected pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+echo "== Wave6 Step1 baseline anchor checks =="
+check_has_match 'attestation_conditional:' .github/workflows/action-tests.yml
+check_has_match 'name:[[:space:]]+Wave 0 feature matrix' .github/workflows/split-wave0-gates.yml
+check_has_match 'cargo nextest run -p assay-registry --all-features' .github/workflows/split-wave0-gates.yml
+check_has_match 'cargo install --locked cargo-semver-checks' .github/workflows/split-wave0-gates.yml
+check_has_match '-D clippy::todo -D clippy::unimplemented' .github/workflows/split-wave0-gates.yml
+check_has_match 'id-token:[[:space:]]+write' .github/workflows/release.yml
+
+echo "== Wave6 Step1 diff allowlist =="
+leaks="$($rg_bin -v \
+  '^docs/contributing/SPLIT-(INVENTORY|CHECKLIST|REVIEW-PACK)-wave6-step1-ci\.md$|^scripts/ci/review-wave6-step1-ci\.sh$|^docs/architecture/PLAN-split-refactor-2026q1\.md$' \
+  < <(git diff --name-only "${base_ref}...HEAD") || true)"
+if [ -n "${leaks}" ]; then
+  echo "non-allowlisted files detected:"
+  echo "${leaks}"
+  exit 1
+fi
+
+echo "Wave6 Step1 reviewer script: PASS"


### PR DESCRIPTION
## Intent
Wave6 Step1 behavior freeze/inventory for CI/CD hardening workstream.

## Scope lock
- docs + reviewer gates only
- no workflow semantic changes
- no production crate code changes

## Artifacts
- `docs/contributing/SPLIT-INVENTORY-wave6-step1-ci.md`
- `docs/contributing/SPLIT-CHECKLIST-wave6-step1-ci.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave6-step1-ci.md`
- `scripts/ci/review-wave6-step1-ci.sh`
- `docs/architecture/PLAN-split-refactor-2026q1.md` (Wave6 section/status)

## Baseline anchors frozen
- Wave0 feature matrix + nextest/hack/semver gates in `split-wave0-gates.yml`
- anti-placeholder clippy gate (`todo` + `unimplemented`)
- attestation conditional logic test in `action-tests.yml`
- OIDC `id-token: write` present in `release.yml`

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave6-step1-ci.sh` ✅

## Risk
Low (docs/scripts only).
