### PR TITLE
ci(wave6-step2): add release attestation producer+verify pair

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,8 @@ jobs:
     environment: release
     permissions:
       contents: write
+      attestations: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -226,6 +228,56 @@ jobs:
           mkdir -p release
           find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.sha256" \) -exec cp {} release/ \;
           ls -la release/
+
+      - name: Generate build provenance attestations
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/*
+
+      - name: Verify release attestations (fail closed)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/release.yml
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          assets=(release/*.tar.gz release/*.zip)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "No release archives found for attestation verification"
+            exit 1
+          fi
+
+          verify_with_retry() {
+            local file="$1"
+            local attempts=8
+            local sleep_seconds=4
+            local i
+
+            for i in $(seq 1 "${attempts}"); do
+              if gh attestation verify "$file" \
+                --repo "${REPO}" \
+                --signer-workflow "${SIGNER_WORKFLOW}" \
+                --cert-oidc-issuer "https://token.actions.githubusercontent.com"; then
+                echo "Attestation verified: ${file}"
+                return 0
+              fi
+
+              if [ "${i}" -lt "${attempts}" ]; then
+                echo "Attestation not available/valid yet for ${file} (attempt ${i}/${attempts}); retrying..."
+                sleep "${sleep_seconds}"
+              fi
+            done
+
+            echo "Attestation verification failed for ${file} after ${attempts} attempts"
+            return 1
+          }
+
+          for asset in "${assets[@]}"; do
+            verify_with_retry "${asset}"
+          done
 
       - name: Generate release notes
         id: notes

--- a/.github/workflows/wave6-nightly-safety.yml
+++ b/.github/workflows/wave6-nightly-safety.yml
@@ -1,0 +1,108 @@
+name: Wave6 Nightly Safety
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  miri-registry-smoke:
+    name: Nightly Miri (assay-registry smoke)
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: nightly
+          components: miri
+
+      - name: Install Linux deps
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev || {
+            sudo DEBIAN_FRONTEND=noninteractive apt-get update -y \
+              -o Acquire::Retries=10 \
+              -o Acquire::http::Timeout=60 \
+              -o Acquire::https::Timeout=60 \
+              -o Acquire::CompressionTypes::Order::=gz \
+              -o Acquire::ForceIPv4=true \
+              -o Acquire::Languages=none
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
+          }
+
+      - name: Swatinem/rust-cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+
+      - name: Miri smoke test (verify fail-closed anchor)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo miri setup
+          cargo miri test -p assay-registry test_verify_pack_fail_closed_matrix_contract -- --exact --nocapture
+
+  proptest-cli-smoke:
+    name: Nightly property smoke (assay-cli)
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - name: Install Linux deps
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev || {
+            sudo DEBIAN_FRONTEND=noninteractive apt-get update -y \
+              -o Acquire::Retries=10 \
+              -o Acquire::http::Timeout=60 \
+              -o Acquire::https::Timeout=60 \
+              -o Acquire::CompressionTypes::Order::=gz \
+              -o Acquire::ForceIPv4=true \
+              -o Acquire::Languages=none
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
+          }
+
+      - name: Swatinem/rust-cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+
+      - name: Proptest smoke anchor
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test -p assay-cli test_roundtrip_property -- --nocapture
+
+  nightly-summary:
+    name: Nightly safety summary
+    needs: [miri-registry-smoke, proptest-cli-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Publish summary
+        shell: bash
+        run: |
+          {
+            echo "## Wave6 nightly safety summary"
+            echo "- miri-registry-smoke: ${{ needs.miri-registry-smoke.result }}"
+            echo "- proptest-cli-smoke: ${{ needs.proptest-cli-smoke.result }}"
+            echo "- Non-blocking lane (continue-on-error=true on smoke jobs)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -365,8 +365,8 @@ Exit criteria (Wave 5):
 
 Step status:
 
-- Step 1 (behavior freeze + inventory + drift gates): in progress on `codex/wave6-step1-ci-hardening-freeze`.
-- Step 2 (attestation pair): planned.
+- Step 1 (behavior freeze + inventory + drift gates): merged via PR #353.
+- Step 2 (attestation pair): in progress on `codex/wave6-step2-attestation-pair`.
 - Step 3 (nightly fuzz/model lane): planned.
 
 Step 1 scope (freeze only):

--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -367,7 +367,7 @@ Step status:
 
 - Step 1 (behavior freeze + inventory + drift gates): merged via PR #353.
 - Step 2 (attestation pair): in progress on `codex/wave6-step2-attestation-pair`.
-- Step 3 (nightly fuzz/model lane): planned.
+- Step 3 (nightly fuzz/model lane): in progress on `codex/wave6-step3-nightly-safety`.
 
 Step 1 scope (freeze only):
 

--- a/docs/contributing/SPLIT-CHECKLIST-wave6-step2-ci-attestation.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave6-step2-ci-attestation.md
@@ -1,0 +1,28 @@
+# Wave6 Step2 checklist: attestation pair
+
+Scope lock:
+- release workflow attestation producer + verify pair only
+- docs/reviewer gates updates only
+- no crate code changes
+
+Artifacts:
+- `docs/contributing/SPLIT-INVENTORY-wave6-step2-ci-attestation.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave6-step2-ci-attestation.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave6-step2-ci-attestation.md`
+- `scripts/ci/review-wave6-step2-ci.sh`
+
+Runbook:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step2-ci.sh
+```
+
+Hard gates:
+- release job includes `attestations: write` and `id-token: write`.
+- producer present: `actions/attest-build-provenance@v2` with `subject-path: release/*`.
+- verifier present: `gh attestation verify` with signer workflow and OIDC issuer constraints.
+- fail-closed path present for missing release assets and verification failures.
+- strict diff allowlist.
+
+Definition of done:
+- reviewer script passes.
+- release workflow contains producer + verify pair.

--- a/docs/contributing/SPLIT-CHECKLIST-wave6-step3-nightly.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave6-step3-nightly.md
@@ -1,0 +1,29 @@
+# Wave6 Step3 checklist: nightly safety lane
+
+Scope lock:
+- add non-blocking nightly workflow only
+- docs + reviewer gates for Step3 only
+- no production crate code changes
+
+Artifacts:
+- `docs/contributing/SPLIT-INVENTORY-wave6-step3-nightly.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave6-step3-nightly.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave6-step3-nightly.md`
+- `scripts/ci/review-wave6-step3-ci.sh`
+- `.github/workflows/wave6-nightly-safety.yml`
+
+Runbook:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step3-ci.sh
+# stacked PRs: BASE_REF=origin/codex/wave6-step2-attestation-pair
+```
+
+Hard gates:
+- workflow has `schedule` + `workflow_dispatch`.
+- smoke jobs include `continue-on-error: true`.
+- miri and property smoke anchor commands present.
+- strict diff allowlist for Step3 files.
+
+Definition of done:
+- reviewer script passes.
+- nightly lane is non-blocking and does not change required PR checks.

--- a/docs/contributing/SPLIT-INVENTORY-wave6-step1-ci.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave6-step1-ci.md
@@ -1,6 +1,7 @@
 # Wave6 Step1 inventory: CI/CD hardening baseline
 
-Snapshot commit (this PR): `5a72f04b`
+Snapshot baseline (`origin/main` at time of Step1 freeze): `5a72f04b`
+PR head (Step1 change set): `40acafd4`
 
 Scope baseline (workflows):
 - `.github/workflows/split-wave0-gates.yml`

--- a/docs/contributing/SPLIT-INVENTORY-wave6-step2-ci-attestation.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave6-step2-ci-attestation.md
@@ -1,0 +1,25 @@
+# Wave6 Step2 inventory: attestation producer + verify pair
+
+Snapshot baseline (`origin/main` before Step2): `1a5af4dd`
+Working branch head: see `git rev-parse --short HEAD`
+
+Target files:
+- `.github/workflows/release.yml`
+- `scripts/ci/review-wave6-step2-ci.sh`
+- `docs/contributing/SPLIT-*wave6-step2-ci-attestation.md`
+- `docs/architecture/PLAN-split-refactor-2026q1.md`
+
+Step2 contract:
+- Add provenance attestation producer in release workflow.
+- Add attestation verification in release workflow with fail-closed behavior.
+- Keep Wave0 gates and existing release behavior otherwise unchanged.
+
+Planned producer/verify anchors:
+- `uses: actions/attest-build-provenance@v2`
+- `subject-path: release/*`
+- `gh attestation verify ... --repo ... --signer-workflow ... --cert-oidc-issuer ...`
+- fail-closed branch when no release archives are present.
+
+Non-goals in Step2:
+- no nightly fuzz/model lane changes (Wave6 Step3)
+- no unrelated workflow refactors

--- a/docs/contributing/SPLIT-INVENTORY-wave6-step3-nightly.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave6-step3-nightly.md
@@ -1,0 +1,24 @@
+# Wave6 Step3 inventory: nightly safety lane
+
+Snapshot baseline (`origin/main` before Step3): `3e479c88`
+Working branch head: see `git rev-parse --short HEAD`
+
+Target files:
+- `.github/workflows/wave6-nightly-safety.yml`
+- `scripts/ci/review-wave6-step3-ci.sh`
+- `docs/contributing/SPLIT-*wave6-step3-nightly.md`
+- `docs/architecture/PLAN-split-refactor-2026q1.md`
+
+Step3 contract:
+- add non-blocking nightly/model lane (schedule + manual trigger)
+- keep PR-required CI paths unchanged
+- keep Wave0/Step2 gates intact
+
+Nightly anchors (this step):
+- miri smoke: `cargo miri test -p assay-registry test_verify_pack_fail_closed_matrix_contract`
+- property smoke: `cargo test -p assay-cli test_roundtrip_property`
+- `continue-on-error: true` on smoke jobs
+
+Non-goals:
+- no required-status promotion in Step3
+- no Kani lane in this step

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave6-step2-ci-attestation.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave6-step2-ci-attestation.md
@@ -1,0 +1,23 @@
+# Review Pack: Wave6 Step2 (attestation pair)
+
+Intent:
+- implement fail-closed attestation pair in release flow.
+
+Scope:
+- `.github/workflows/release.yml`
+- docs + reviewer script for Step2
+
+Producer/verify model:
+- Producer: `actions/attest-build-provenance@v2` over `release/*`.
+- Verify: `gh attestation verify` per release archive with signer workflow and OIDC issuer checks.
+- Fail-closed behavior:
+  - no release archive => fail
+  - verification retry exhausted => fail
+
+Reviewer command:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step2-ci.sh
+```
+
+Expected result:
+- PASS with allowlisted diff only.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave6-step3-nightly.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave6-step3-nightly.md
@@ -1,0 +1,22 @@
+# Review Pack: Wave6 Step3 (nightly safety lane)
+
+Intent:
+- add a non-blocking nightly/model safety lane with concrete smoke anchors.
+
+Scope:
+- `.github/workflows/wave6-nightly-safety.yml`
+- docs/reviewer artifacts for Step3
+
+Nightly jobs:
+- `miri-registry-smoke` (continue-on-error)
+- `proptest-cli-smoke` (continue-on-error)
+- `nightly-summary` (always)
+
+Reviewer command:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step3-ci.sh
+# stacked PRs: BASE_REF=origin/codex/wave6-step2-attestation-pair
+```
+
+Expected result:
+- PASS with allowlisted diff only.

--- a/scripts/ci/review-wave6-step1-ci.sh
+++ b/scripts/ci/review-wave6-step1-ci.sh
@@ -36,6 +36,7 @@ echo "== Wave6 Step1 baseline anchor checks =="
 check_has_match 'attestation_conditional:' .github/workflows/action-tests.yml
 check_has_match 'name:[[:space:]]+Wave 0 feature matrix' .github/workflows/split-wave0-gates.yml
 check_has_match 'cargo nextest run -p assay-registry --all-features' .github/workflows/split-wave0-gates.yml
+check_has_match 'cargo hack' .github/workflows/split-wave0-gates.yml
 check_has_match 'cargo install --locked cargo-semver-checks' .github/workflows/split-wave0-gates.yml
 check_has_match '-D clippy::todo -D clippy::unimplemented' .github/workflows/split-wave0-gates.yml
 check_has_match 'id-token:[[:space:]]+write' .github/workflows/release.yml

--- a/scripts/ci/review-wave6-step1-ci.sh
+++ b/scripts/ci/review-wave6-step1-ci.sh
@@ -22,6 +22,10 @@ rg_bin="$(command -v rg)"
 check_has_match() {
   local pattern="$1"
   local file="$2"
+  if [ ! -f "$file" ]; then
+    echo "missing expected file: ${file}"
+    exit 1
+  fi
   if ! "$rg_bin" -n -- "$pattern" "$file" >/dev/null; then
     echo "missing expected pattern in ${file}: ${pattern}"
     exit 1

--- a/scripts/ci/review-wave6-step2-ci.sh
+++ b/scripts/ci/review-wave6-step2-ci.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+rg_bin="$(command -v rg)"
+release_file=".github/workflows/release.yml"
+
+check_has_match() {
+  local pattern="$1"
+  local file="$2"
+  if [ ! -f "$file" ]; then
+    echo "missing expected file: ${file}"
+    exit 1
+  fi
+  if ! "$rg_bin" -n -- "$pattern" "$file" >/dev/null; then
+    echo "missing expected pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+check_has_match_multiline() {
+  local pattern="$1"
+  local file="$2"
+  if [ ! -f "$file" ]; then
+    echo "missing expected file: ${file}"
+    exit 1
+  fi
+  if ! "$rg_bin" -nUP -- "$pattern" "$file" >/dev/null; then
+    echo "missing expected multiline pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+echo "== Wave6 Step2 attestation pair checks =="
+check_has_match_multiline 'release:\n(?:.|\n)*?permissions:\n(?:.|\n)*?contents:\s+write\n(?:.|\n)*?attestations:\s+write\n(?:.|\n)*?id-token:\s+write' "$release_file"
+check_has_match 'uses: actions/attest-build-provenance@v2' "$release_file"
+check_has_match 'subject-path: release/\*' "$release_file"
+check_has_match 'gh attestation verify "\$file"' "$release_file"
+check_has_match '--repo "\$\{REPO\}"' "$release_file"
+check_has_match '--signer-workflow "\$\{SIGNER_WORKFLOW\}"' "$release_file"
+check_has_match '--cert-oidc-issuer "https://token.actions.githubusercontent.com"' "$release_file"
+check_has_match 'No release archives found for attestation verification' "$release_file"
+check_has_match 'Attestation verification failed for \$\{file\} after \$\{attempts\} attempts' "$release_file"
+
+echo "== Wave6 Step2 diff allowlist =="
+leaks="$($rg_bin -v \
+  '^\.github/workflows/release\.yml$|^docs/contributing/SPLIT-(INVENTORY|CHECKLIST|REVIEW-PACK)-wave6-step2-ci-attestation\.md$|^scripts/ci/review-wave6-step2-ci\.sh$|^docs/architecture/PLAN-split-refactor-2026q1\.md$|^docs/contributing/SPLIT-INVENTORY-wave6-step1-ci\.md$|^scripts/ci/review-wave6-step1-ci\.sh$' \
+  < <(git diff --name-only "${base_ref}...HEAD") || true)"
+if [ -n "${leaks}" ]; then
+  echo "non-allowlisted files detected:"
+  echo "${leaks}"
+  exit 1
+fi
+
+echo "Wave6 Step2 reviewer script: PASS"

--- a/scripts/ci/review-wave6-step3-ci.sh
+++ b/scripts/ci/review-wave6-step3-ci.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+rg_bin="$(command -v rg)"
+wf_file=".github/workflows/wave6-nightly-safety.yml"
+
+check_has_match() {
+  local pattern="$1"
+  local file="$2"
+  if [ ! -f "$file" ]; then
+    echo "missing expected file: ${file}"
+    exit 1
+  fi
+  if ! "$rg_bin" -n -- "$pattern" "$file" >/dev/null; then
+    echo "missing expected pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+echo "== Wave6 Step3 nightly lane checks =="
+check_has_match '^name:[[:space:]]+Wave6 Nightly Safety' "$wf_file"
+check_has_match '^on:' "$wf_file"
+check_has_match 'schedule:' "$wf_file"
+check_has_match 'workflow_dispatch:' "$wf_file"
+check_has_match 'miri-registry-smoke:' "$wf_file"
+check_has_match 'proptest-cli-smoke:' "$wf_file"
+check_has_match 'continue-on-error:[[:space:]]+true' "$wf_file"
+check_has_match 'cargo miri test -p assay-registry test_verify_pack_fail_closed_matrix_contract' "$wf_file"
+check_has_match 'cargo test -p assay-cli test_roundtrip_property' "$wf_file"
+
+echo "== Wave6 Step3 diff allowlist =="
+leaks="$($rg_bin -v \
+  '^\.github/workflows/wave6-nightly-safety\.yml$|^docs/contributing/SPLIT-(INVENTORY|CHECKLIST|REVIEW-PACK)-wave6-step3-nightly\.md$|^scripts/ci/review-wave6-step3-ci\.sh$|^docs/architecture/PLAN-split-refactor-2026q1\.md$' \
+  < <(git diff --name-only "${base_ref}...HEAD") || true)"
+if [ -n "${leaks}" ]; then
+  echo "non-allowlisted files detected:"
+  echo "${leaks}"
+  exit 1
+fi
+
+echo "Wave6 Step3 reviewer script: PASS"


### PR DESCRIPTION
## Intent
Wave6 Step2: add release provenance attestation producer + fail-closed verification pair.

## Scope
- `.github/workflows/release.yml`
- Step2 docs/reviewer artifacts
- plan status update for Wave6 Step2
- small Step1 script/docs alignment (cargo-hack anchor + snapshot labeling)

## Commit slices
- `ede63dd0` docs(ci/wave6): clarify Step1 snapshot SHA labels and harden anchor helper
- `482384e4` ci(wave6-step1): align baseline anchors with cargo-hack check
- `e060254c` ci(wave6-step2): add release provenance attestation and fail-closed verification

## Step2 behavior
Producer:
- `actions/attest-build-provenance@v2` over `release/*`

Verifier (fail-closed):
- `gh attestation verify` per release archive (`*.tar.gz` / `*.zip`)
- enforces:
  - `--repo $REPO`
  - `--signer-workflow $SIGNER_WORKFLOW`
  - `--cert-oidc-issuer https://token.actions.githubusercontent.com`
- retries with bounded attempts, then hard-fails
- hard-fails if no release archives are found

## Reviewer artifacts
- `docs/contributing/SPLIT-INVENTORY-wave6-step2-ci-attestation.md`
- `docs/contributing/SPLIT-CHECKLIST-wave6-step2-ci-attestation.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave6-step2-ci-attestation.md`
- `scripts/ci/review-wave6-step2-ci.sh`

## Validation (executed)
- `BASE_REF=origin/main bash scripts/ci/review-wave6-step2-ci.sh` ✅

## Risk
Medium-low: workflow-only changes with explicit fail-closed checks.
