### PR TITLE
ci(wave6-step3): add non-blocking nightly safety lane + reviewer gates

### DIFF
--- a/.github/workflows/wave6-nightly-safety.yml
+++ b/.github/workflows/wave6-nightly-safety.yml
@@ -1,0 +1,108 @@
+name: Wave6 Nightly Safety
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  miri-registry-smoke:
+    name: Nightly Miri (assay-registry smoke)
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: nightly
+          components: miri
+
+      - name: Install Linux deps
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev || {
+            sudo DEBIAN_FRONTEND=noninteractive apt-get update -y \
+              -o Acquire::Retries=10 \
+              -o Acquire::http::Timeout=60 \
+              -o Acquire::https::Timeout=60 \
+              -o Acquire::CompressionTypes::Order::=gz \
+              -o Acquire::ForceIPv4=true \
+              -o Acquire::Languages=none
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
+          }
+
+      - name: Swatinem/rust-cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+
+      - name: Miri smoke test (verify fail-closed anchor)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo miri setup
+          cargo miri test -p assay-registry test_verify_pack_fail_closed_matrix_contract -- --exact --nocapture
+
+  proptest-cli-smoke:
+    name: Nightly property smoke (assay-cli)
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - name: Install Linux deps
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev || {
+            sudo DEBIAN_FRONTEND=noninteractive apt-get update -y \
+              -o Acquire::Retries=10 \
+              -o Acquire::http::Timeout=60 \
+              -o Acquire::https::Timeout=60 \
+              -o Acquire::CompressionTypes::Order::=gz \
+              -o Acquire::ForceIPv4=true \
+              -o Acquire::Languages=none
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
+          }
+
+      - name: Swatinem/rust-cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+
+      - name: Proptest smoke anchor
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test -p assay-cli test_roundtrip_property -- --nocapture
+
+  nightly-summary:
+    name: Nightly safety summary
+    needs: [miri-registry-smoke, proptest-cli-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Publish summary
+        shell: bash
+        run: |
+          {
+            echo "## Wave6 nightly safety summary"
+            echo "- miri-registry-smoke: ${{ needs.miri-registry-smoke.result }}"
+            echo "- proptest-cli-smoke: ${{ needs.proptest-cli-smoke.result }}"
+            echo "- Non-blocking lane (continue-on-error=true on smoke jobs)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -367,7 +367,7 @@ Step status:
 
 - Step 1 (behavior freeze + inventory + drift gates): merged via PR #353.
 - Step 2 (attestation pair): in progress on `codex/wave6-step2-attestation-pair`.
-- Step 3 (nightly fuzz/model lane): planned.
+- Step 3 (nightly fuzz/model lane): in progress on `codex/wave6-step3-nightly-safety`.
 
 Step 1 scope (freeze only):
 

--- a/docs/contributing/SPLIT-CHECKLIST-wave6-step3-nightly.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave6-step3-nightly.md
@@ -1,0 +1,29 @@
+# Wave6 Step3 checklist: nightly safety lane
+
+Scope lock:
+- add non-blocking nightly workflow only
+- docs + reviewer gates for Step3 only
+- no production crate code changes
+
+Artifacts:
+- `docs/contributing/SPLIT-INVENTORY-wave6-step3-nightly.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave6-step3-nightly.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave6-step3-nightly.md`
+- `scripts/ci/review-wave6-step3-ci.sh`
+- `.github/workflows/wave6-nightly-safety.yml`
+
+Runbook:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step3-ci.sh
+# stacked PRs: BASE_REF=origin/codex/wave6-step2-attestation-pair
+```
+
+Hard gates:
+- workflow has `schedule` + `workflow_dispatch`.
+- smoke jobs include `continue-on-error: true`.
+- miri and property smoke anchor commands present.
+- strict diff allowlist for Step3 files.
+
+Definition of done:
+- reviewer script passes.
+- nightly lane is non-blocking and does not change required PR checks.

--- a/docs/contributing/SPLIT-INVENTORY-wave6-step3-nightly.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave6-step3-nightly.md
@@ -1,0 +1,24 @@
+# Wave6 Step3 inventory: nightly safety lane
+
+Snapshot baseline (`origin/main` before Step3): `3e479c88`
+Working branch head: see `git rev-parse --short HEAD`
+
+Target files:
+- `.github/workflows/wave6-nightly-safety.yml`
+- `scripts/ci/review-wave6-step3-ci.sh`
+- `docs/contributing/SPLIT-*wave6-step3-nightly.md`
+- `docs/architecture/PLAN-split-refactor-2026q1.md`
+
+Step3 contract:
+- add non-blocking nightly/model lane (schedule + manual trigger)
+- keep PR-required CI paths unchanged
+- keep Wave0/Step2 gates intact
+
+Nightly anchors (this step):
+- miri smoke: `cargo miri test -p assay-registry test_verify_pack_fail_closed_matrix_contract`
+- property smoke: `cargo test -p assay-cli test_roundtrip_property`
+- `continue-on-error: true` on smoke jobs
+
+Non-goals:
+- no required-status promotion in Step3
+- no Kani lane in this step

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave6-step3-nightly.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave6-step3-nightly.md
@@ -1,0 +1,22 @@
+# Review Pack: Wave6 Step3 (nightly safety lane)
+
+Intent:
+- add a non-blocking nightly/model safety lane with concrete smoke anchors.
+
+Scope:
+- `.github/workflows/wave6-nightly-safety.yml`
+- docs/reviewer artifacts for Step3
+
+Nightly jobs:
+- `miri-registry-smoke` (continue-on-error)
+- `proptest-cli-smoke` (continue-on-error)
+- `nightly-summary` (always)
+
+Reviewer command:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step3-ci.sh
+# stacked PRs: BASE_REF=origin/codex/wave6-step2-attestation-pair
+```
+
+Expected result:
+- PASS with allowlisted diff only.

--- a/scripts/ci/review-wave6-step3-ci.sh
+++ b/scripts/ci/review-wave6-step3-ci.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+rg_bin="$(command -v rg)"
+wf_file=".github/workflows/wave6-nightly-safety.yml"
+
+check_has_match() {
+  local pattern="$1"
+  local file="$2"
+  if [ ! -f "$file" ]; then
+    echo "missing expected file: ${file}"
+    exit 1
+  fi
+  if ! "$rg_bin" -n -- "$pattern" "$file" >/dev/null; then
+    echo "missing expected pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+echo "== Wave6 Step3 nightly lane checks =="
+check_has_match '^name:[[:space:]]+Wave6 Nightly Safety' "$wf_file"
+check_has_match '^on:' "$wf_file"
+check_has_match 'schedule:' "$wf_file"
+check_has_match 'workflow_dispatch:' "$wf_file"
+check_has_match 'miri-registry-smoke:' "$wf_file"
+check_has_match 'proptest-cli-smoke:' "$wf_file"
+check_has_match 'continue-on-error:[[:space:]]+true' "$wf_file"
+check_has_match 'cargo miri test -p assay-registry test_verify_pack_fail_closed_matrix_contract' "$wf_file"
+check_has_match 'cargo test -p assay-cli test_roundtrip_property' "$wf_file"
+
+echo "== Wave6 Step3 diff allowlist =="
+leaks="$($rg_bin -v \
+  '^\.github/workflows/wave6-nightly-safety\.yml$|^docs/contributing/SPLIT-(INVENTORY|CHECKLIST|REVIEW-PACK)-wave6-step3-nightly\.md$|^scripts/ci/review-wave6-step3-ci\.sh$|^docs/architecture/PLAN-split-refactor-2026q1\.md$' \
+  < <(git diff --name-only "${base_ref}...HEAD") || true)"
+if [ -n "${leaks}" ]; then
+  echo "non-allowlisted files detected:"
+  echo "${leaks}"
+  exit 1
+fi
+
+echo "Wave6 Step3 reviewer script: PASS"


### PR DESCRIPTION
## Intent
Wave6 Step3: add a non-blocking nightly safety lane (Miri + property smoke) with reviewer gates and docs artifacts.

## Scope
- `.github/workflows/wave6-nightly-safety.yml`
- `scripts/ci/review-wave6-step3-ci.sh`
- `docs/contributing/SPLIT-{INVENTORY,CHECKLIST,REVIEW-PACK}-wave6-step3-nightly.md`
- `docs/architecture/PLAN-split-refactor-2026q1.md`

## Contract
- No production crate code changes.
- Nightly lane remains non-blocking (`continue-on-error: true` on smoke jobs).
- Existing required PR CI remains unchanged.

## Anchors
- Miri smoke: `cargo miri test -p assay-registry test_verify_pack_fail_closed_matrix_contract -- --exact --nocapture`
- Property smoke: `cargo test -p assay-cli test_roundtrip_property -- --nocapture`

## Validation
- `BASE_REF=origin/codex/wave6-step2-attestation-pair bash scripts/ci/review-wave6-step3-ci.sh`

## Risk
Low (workflow + docs/scripts only).
