### PR TITLE
docs/ci(wave6-step4): freeze nightly promotion policy criteria + reviewer gates

### DIFF
--- a/.github/workflows/wave6-nightly-safety.yml
+++ b/.github/workflows/wave6-nightly-safety.yml
@@ -95,14 +95,126 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
+      - name: "Generate nightly status artifact (Option A: API aggregator)"
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100"
+            jobs_json="$(curl -fsSL \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "${api_url}")"
+
+            run_attempt="${GITHUB_RUN_ATTEMPT:-1}"
+            generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+            jq -n \
+              --arg repo "${GITHUB_REPOSITORY}" \
+              --arg workflow_file "wave6-nightly-safety.yml" \
+              --argjson run_id "${GITHUB_RUN_ID}" \
+              --argjson run_attempt "${run_attempt}" \
+              --arg ref "${GITHUB_REF}" \
+              --arg sha "${GITHUB_SHA}" \
+              --arg event "${GITHUB_EVENT_NAME}" \
+              --arg generated_at "${generated_at}" \
+              --argjson payload "${jobs_json}" \
+              '
+              def classify($c; $attempt):
+                if ($c == "success") and ($attempt > 1) then "flake"
+                elif $c == "success" then "success"
+                elif ($c == "cancelled" or $c == "timed_out") then "infra"
+                elif $c == "failure" then "test"
+                else "infra"
+                end;
+
+              def duration_seconds($s; $e):
+                if (($s | type) == "string") and (($e | type) == "string") then
+                  ((($e | fromdateiso8601) - ($s | fromdateiso8601)) | floor)
+                else
+                  0
+                end;
+
+              def smoke_name($n):
+                ($n == "Nightly Miri (assay-registry smoke)")
+                or ($n == "Nightly property smoke (assay-cli)");
+
+              def normalize_job($j):
+                ($j.conclusion // "unknown") as $c
+                | {
+                    job_id: $j.id,
+                    name: $j.name,
+                    conclusion: $c,
+                    outcome: (if $c == "success" then "pass" else "fail" end),
+                    category: classify($c; $run_attempt),
+                    duration_seconds: duration_seconds($j.started_at; $j.completed_at),
+                    notes: []
+                  };
+
+              def workflow_category($jobs):
+                if ($jobs | map(select(.category == "test")) | length) > 0 then "test"
+                elif ($jobs | map(select(.category == "infra")) | length) > 0 then "infra"
+                elif ($jobs | map(select(.category == "flake")) | length) > 0 then "flake"
+                elif (($jobs | length) > 0) and (($jobs | map(select(.category == "success")) | length) == ($jobs | length)) then "success"
+                else "infra"
+                end;
+
+              def workflow_conclusion($category):
+                if ($category == "success") or ($category == "flake") then "success"
+                elif $category == "test" then "failure"
+                else "cancelled"
+                end;
+
+              (($payload.jobs // []) | map(select(smoke_name(.name))) | map(normalize_job(.))) as $jobs
+              | (workflow_category($jobs)) as $wf_category
+              | {
+                  schema_version: 1,
+                  classifier_version: 1,
+                  repo: $repo,
+                  workflow_file: $workflow_file,
+                  run_id: $run_id,
+                  run_attempt: $run_attempt,
+                  ref: $ref,
+                  sha: $sha,
+                  event: $event,
+                  generated_at_utc: $generated_at,
+                  workflow_conclusion: workflow_conclusion($wf_category),
+                  workflow_category: $wf_category,
+                  jobs: $jobs,
+                  summary: {
+                    total_jobs: ($jobs | length),
+                    success_jobs: ($jobs | map(select(.category == "success")) | length),
+                    flake_jobs: ($jobs | map(select(.category == "flake")) | length),
+                    infra_fail_jobs: ($jobs | map(select(.category == "infra")) | length),
+                    test_fail_jobs: ($jobs | map(select(.category == "test")) | length),
+                    workflow_duration_seconds: (($jobs | map(.duration_seconds) | add) // 0)
+                  }
+                }
+              ' > nightly_status.json
+          }
+
+      - name: Upload nightly status artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nightly-status
+          path: nightly_status.json
+          retention-days: 14
+
       - name: Publish summary
         shell: bash
         run: |
+          set -euo pipefail
           {
             echo "## Wave6 nightly safety summary"
             echo "- miri-registry-smoke: ${{ needs.miri-registry-smoke.result }}"
             echo "- proptest-cli-smoke: ${{ needs.proptest-cli-smoke.result }}"
+            echo "- run_attempt: ${GITHUB_RUN_ATTEMPT:-1}"
+            echo "- workflow_category: $(jq -r '.workflow_category' nightly_status.json)"
+            echo "- schema_version: $(jq -r '.schema_version' nightly_status.json)"
+            echo "- classifier_version: $(jq -r '.classifier_version' nightly_status.json)"
+            echo "- artifact: nightly-status (nightly_status.json)"
             echo "- Non-blocking lane (continue-on-error=true on smoke jobs)."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -368,6 +368,7 @@ Step status:
 - Step 1 (behavior freeze + inventory + drift gates): merged via PR #353.
 - Step 2 (attestation pair): merged via PR #355.
 - Step 3 (nightly safety lane): merged in stacked flow via PR #356 and promoted to `main` via PR #355.
+- Step 4 (nightly promotion policy freeze): in progress on `codex/wave6-step4-nightly-promotion-freeze`.
 
 Step 1 scope (freeze only):
 
@@ -386,6 +387,13 @@ Step 3 scope (implemented):
 
 - Add nightly fuzz/model lane for parser/crypto/concurrency hotspots (non-blocking first).
 - Introduce promotion policy for escalating nightly checks to required status when stable.
+
+Step 4 scope (in progress):
+
+- Freeze measurable promotion criteria (window, formulas, thresholds, category rules).
+- Add Step4 reviewer script with hard-fail allowlist and baseline invariants.
+- Keep workflow behavior unchanged in Commit A (policy/gates/docs only).
+- Policy guarantee: no required-check/branch-protection changes in Step4.
 
 Current baseline strengths:
 

--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -392,7 +392,7 @@ Step 4 scope (in progress):
 
 - Freeze measurable promotion criteria (window, formulas, thresholds, category rules).
 - Add Step4 reviewer script with hard-fail allowlist and baseline invariants.
-- Keep workflow behavior unchanged in Commit A (policy/gates/docs only).
+- Commit B: emit `nightly_status.json` (`schema_version` + `classifier_version`) from a single summary aggregator.
 - Policy guarantee: no required-check/branch-protection changes in Step4.
 
 Current baseline strengths:

--- a/docs/contributing/SPLIT-CHECKLIST-wave6-step4-nightly-promotion.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave6-step4-nightly-promotion.md
@@ -1,0 +1,59 @@
+# Wave6 Step4 checklist: nightly promotion policy
+
+Scope lock (Commit A):
+- docs + reviewer gates only
+- no workflow semantic changes
+- no required-check/branch-protection changes
+
+Artifacts:
+- `docs/contributing/SPLIT-INVENTORY-wave6-step4-nightly-promotion.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave6-step4-nightly-promotion.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave6-step4-nightly-promotion.md`
+- `scripts/ci/review-wave6-step4-ci.sh`
+- `docs/architecture/PLAN-split-refactor-2026q1.md`
+
+Runbook:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step4-ci.sh
+```
+
+Metric criteria (policy freeze for Step4):
+
+| Metric | Window | Threshold | How measured | Category rule |
+|---|---|---|---|---|
+| `scheduled_runs_count` | most recent 20 completed `schedule` runs on `main`; if more exist, use newest 20 | `>= 14` runs; if `< 14`, promotion-ready = false | GitHub Actions runs API (`workflow=wave6-nightly-safety.yml`, `event=schedule`) | n/a |
+| `window_span_days` | same selected runs | `>= 14` days; if `< 14`, promotion-ready = false | `newest.created_at - oldest.created_at` in selected window | n/a |
+| `smoke_success_rate_excl_infra` | same selected runs | `>= 95%` | `success_runs / (success_runs + test_fail_runs + flake_runs)` | `infra` excluded from denominator |
+| `infra_failure_rate` | same selected runs | `<= 10%` | `infra_fail_runs / total_runs` | `infra` includes cancelled/timed_out/runner unavailable/network transient |
+| `flake_rate` | same selected runs | `<= 5%` | `flake_runs / total_runs` | **Option 1 fixed**: flake only via `run_attempt > 1` (no cross-run SHA heuristic in Step4) |
+| `duration_median_minutes` | same selected runs | `<= 20` | median of `workflow_duration_seconds / 60` | n/a |
+| `duration_p95_minutes` | same selected runs | `<= 35` | p95 of `workflow_duration_seconds / 60` | n/a |
+| `recent_red_streak` | last 10 selected runs | `<= 1` consecutive red | run sequence check | red = `test` or `flake`; `infra` tracked separately |
+| `required_check_impact` | policy invariant | `0` required-check changes | repo policy: Step4 does not edit branch protection or required check config | n/a |
+
+Classification notes (Step4):
+- `success`: smoke command exits `0`.
+- `infra`: cancellation/timeout/runner/network/transient infra signature.
+- `test`: deterministic assertion/test failure.
+- `flake`: retry-attempt signal only (`run_attempt > 1`) with eventual success.
+
+Commit B requirement (schema freeze now, implementation later):
+- nightly workflow uploads `nightly_status.json` artifact.
+- schema must include:
+  - `schema_version` (integer)
+  - `classifier_version` (integer)
+  - `repo`, `workflow_file`, `run_id`, `run_attempt`, `sha`
+  - per-job `job_id`, `conclusion`, `outcome`, `category`, `duration_seconds`
+  - workflow-level `workflow_conclusion`, `workflow_category`, aggregate counters
+
+Hard gates (Commit A script):
+- nightly workflow still has `schedule` + `workflow_dispatch`.
+- smoke jobs remain `continue-on-error: true`.
+- permissions remain minimal (`permissions: {}` and no `id-token: write` in nightly lane).
+- baseline currently has no workflow `concurrency` or `timeout-minutes`; Commit A keeps this unchanged.
+- strict diff allowlist for Step4 Commit A files.
+
+Definition of done (Commit A):
+- reviewer script passes against `origin/main`.
+- policy criteria and formulas are frozen and audit-ready.
+- no workflow behavior changes landed in Commit A.

--- a/docs/contributing/SPLIT-INVENTORY-wave6-step4-nightly-promotion.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave6-step4-nightly-promotion.md
@@ -3,27 +3,32 @@
 Snapshot baseline (`origin/main` before Step4): `a8917d06`
 Working branch head: see `git rev-parse --short HEAD`
 
-Step4 Commit A scope:
-- docs + reviewer gates only
-- no workflow semantic changes
+Step4 Commit B scope:
+- nightly workflow instrumentation + docs/reviewer gates
 - no production crate code changes
+- no required-check/branch-protection changes
 
-Target files (Commit A):
+Target files (Step4):
+- `.github/workflows/wave6-nightly-safety.yml`
 - `docs/contributing/SPLIT-INVENTORY-wave6-step4-nightly-promotion.md`
 - `docs/contributing/SPLIT-CHECKLIST-wave6-step4-nightly-promotion.md`
 - `docs/contributing/SPLIT-REVIEW-PACK-wave6-step4-nightly-promotion.md`
 - `scripts/ci/review-wave6-step4-ci.sh`
 - `docs/architecture/PLAN-split-refactor-2026q1.md`
 
-Baseline anchor workflow (read-only in Commit A):
-- `.github/workflows/wave6-nightly-safety.yml`
+Instrumentation choice:
+- Option A: centralized API aggregator in `nightly-summary` job writes one `nightly_status.json`.
 
-Promotion policy source (Commit A contract):
+Promotion policy source:
 - use GitHub Actions runs API as the metric source of truth
 - compute over most recent completed `schedule` runs on `main`
 - no branch protection edits in Step4
 
-Non-goals (Commit A):
-- no nightly workflow edits
+Artifact contract:
+- name: `nightly-status`
+- file: `nightly_status.json`
+- retention: 14 days
+
+Non-goals:
 - no required-check changes
-- no artifact schema implementation yet (specified for Commit B)
+- no branch-protection edits

--- a/docs/contributing/SPLIT-INVENTORY-wave6-step4-nightly-promotion.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave6-step4-nightly-promotion.md
@@ -1,0 +1,29 @@
+# Wave6 Step4 inventory: nightly promotion policy freeze
+
+Snapshot baseline (`origin/main` before Step4): `a8917d06`
+Working branch head: see `git rev-parse --short HEAD`
+
+Step4 Commit A scope:
+- docs + reviewer gates only
+- no workflow semantic changes
+- no production crate code changes
+
+Target files (Commit A):
+- `docs/contributing/SPLIT-INVENTORY-wave6-step4-nightly-promotion.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave6-step4-nightly-promotion.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave6-step4-nightly-promotion.md`
+- `scripts/ci/review-wave6-step4-ci.sh`
+- `docs/architecture/PLAN-split-refactor-2026q1.md`
+
+Baseline anchor workflow (read-only in Commit A):
+- `.github/workflows/wave6-nightly-safety.yml`
+
+Promotion policy source (Commit A contract):
+- use GitHub Actions runs API as the metric source of truth
+- compute over most recent completed `schedule` runs on `main`
+- no branch protection edits in Step4
+
+Non-goals (Commit A):
+- no nightly workflow edits
+- no required-check changes
+- no artifact schema implementation yet (specified for Commit B)

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave6-step4-nightly-promotion.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave6-step4-nightly-promotion.md
@@ -1,11 +1,11 @@
 # Review Pack: Wave6 Step4 (nightly promotion policy)
 
 Intent:
-- freeze a measurable, source-verifiable promotion policy for the nightly safety lane.
+- implement Step4 metrics instrumentation behind a frozen promotion policy.
 
 Scope:
-- docs + reviewer script only (Commit A)
-- no workflow edits in this commit
+- `.github/workflows/wave6-nightly-safety.yml`
+- docs + reviewer script updates for Step4
 
 Reviewer command:
 ```bash
@@ -15,12 +15,31 @@ BASE_REF=origin/main bash scripts/ci/review-wave6-step4-ci.sh
 Expected result:
 - PASS with allowlisted diff only.
 
-Policy highlights:
+Policy highlights (frozen):
 - fixed window selection: newest 20 completed scheduled runs on `main`.
 - promotion-ready is auto-false when fewer than 14 runs or fewer than 14 days of span.
 - flake detection is deterministic in Step4: retry-attempt signal only (`run_attempt > 1`).
 - required-check impact is policy-locked: Step4 does not change required checks/branch protection.
 
-Commit B schema requirement (preview):
-- workflow emits `nightly_status.json` artifact with `schema_version` + `classifier_version`.
-- include raw and normalized outcomes (`conclusion` + `category`) and timing fields.
+Commit B implementation details:
+- Option A aggregator in `nightly-summary` job (GitHub Actions API).
+- One artifact per run:
+  - artifact: `nightly-status`
+  - file: `nightly_status.json`
+  - retention: 14 days
+- Schema includes:
+  - `schema_version`, `classifier_version`
+  - run metadata and workflow-level normalized fields
+  - per-job `job_id` + raw `conclusion` + normalized `category`
+- job permissions for aggregator: `actions: read`, `contents: read` only.
+- nightly workflow remains non-blocking (`continue-on-error: true` on smoke jobs).
+
+Conclusion-to-category mapping:
+
+| Raw conclusion | Category |
+|---|---|
+| `success` and `run_attempt == 1` | `success` |
+| `success` and `run_attempt > 1` | `flake` |
+| `failure` | `test` |
+| `cancelled` or `timed_out` | `infra` |
+| other values | `infra` |

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave6-step4-nightly-promotion.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave6-step4-nightly-promotion.md
@@ -1,0 +1,26 @@
+# Review Pack: Wave6 Step4 (nightly promotion policy)
+
+Intent:
+- freeze a measurable, source-verifiable promotion policy for the nightly safety lane.
+
+Scope:
+- docs + reviewer script only (Commit A)
+- no workflow edits in this commit
+
+Reviewer command:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave6-step4-ci.sh
+```
+
+Expected result:
+- PASS with allowlisted diff only.
+
+Policy highlights:
+- fixed window selection: newest 20 completed scheduled runs on `main`.
+- promotion-ready is auto-false when fewer than 14 runs or fewer than 14 days of span.
+- flake detection is deterministic in Step4: retry-attempt signal only (`run_attempt > 1`).
+- required-check impact is policy-locked: Step4 does not change required checks/branch protection.
+
+Commit B schema requirement (preview):
+- workflow emits `nightly_status.json` artifact with `schema_version` + `classifier_version`.
+- include raw and normalized outcomes (`conclusion` + `category`) and timing fields.

--- a/scripts/ci/review-wave6-step4-ci.sh
+++ b/scripts/ci/review-wave6-step4-ci.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+rg_bin="$(command -v rg)"
+wf_file=".github/workflows/wave6-nightly-safety.yml"
+
+check_has_match() {
+  local pattern="$1"
+  local file="$2"
+  if [ ! -f "$file" ]; then
+    echo "missing expected file: ${file}"
+    exit 1
+  fi
+  if ! "$rg_bin" -n -- "$pattern" "$file" >/dev/null; then
+    echo "missing expected pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+check_no_match() {
+  local pattern="$1"
+  local file="$2"
+  if [ ! -f "$file" ]; then
+    echo "missing expected file: ${file}"
+    exit 1
+  fi
+  if "$rg_bin" -n -- "$pattern" "$file" >/dev/null; then
+    echo "unexpected pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+echo "== Wave6 Step4 baseline policy checks =="
+check_has_match '^name:[[:space:]]+Wave6 Nightly Safety' "$wf_file"
+check_has_match '^on:' "$wf_file"
+check_has_match 'schedule:' "$wf_file"
+check_has_match 'workflow_dispatch:' "$wf_file"
+check_has_match 'miri-registry-smoke:' "$wf_file"
+check_has_match 'proptest-cli-smoke:' "$wf_file"
+check_has_match 'continue-on-error:[[:space:]]+true' "$wf_file"
+check_has_match '^permissions:[[:space:]]*\{\}' "$wf_file"
+check_no_match 'id-token:[[:space:]]+write' "$wf_file"
+
+echo "== Wave6 Step4 baseline shape (pre-Commit B) =="
+check_no_match '^concurrency:' "$wf_file"
+check_no_match 'timeout-minutes:' "$wf_file"
+
+echo "== Wave6 Step4 diff allowlist (Commit A) =="
+leaks="$($rg_bin -v \
+  '^docs/contributing/SPLIT-(INVENTORY|CHECKLIST|REVIEW-PACK)-wave6-step4-nightly-promotion\.md$|^scripts/ci/review-wave6-step4-ci\.sh$|^docs/architecture/PLAN-split-refactor-2026q1\.md$' \
+  < <(git diff --name-only "${base_ref}...HEAD") || true)"
+if [ -n "${leaks}" ]; then
+  echo "non-allowlisted files detected:"
+  echo "${leaks}"
+  exit 1
+fi
+
+echo "Wave6 Step4 reviewer script: PASS"


### PR DESCRIPTION
## Intent
Wave6 Step4 Commit A: freeze measurable nightly promotion policy and reviewer gates (docs + script only).

## Scope lock
- docs + reviewer gates only
- no workflow semantic changes
- no production crate code changes
- no required-check / branch-protection changes

## Artifacts
- `docs/contributing/SPLIT-INVENTORY-wave6-step4-nightly-promotion.md`
- `docs/contributing/SPLIT-CHECKLIST-wave6-step4-nightly-promotion.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave6-step4-nightly-promotion.md`
- `scripts/ci/review-wave6-step4-ci.sh`
- `docs/architecture/PLAN-split-refactor-2026q1.md`

## Policy freeze details
- Deterministic run window: newest 20 completed scheduled runs on `main`.
- Promotion-ready auto-false when run count `< 14` or span `< 14` days.
- Flake classification fixed for Step4: retry-attempt signal only (`run_attempt > 1`).
- Required-check impact is policy-locked: Step4 does not modify required checks.

## Commit B contract (preview)
- Workflow emits `nightly_status.json` artifact.
- Schema includes `schema_version`, `classifier_version`, raw `conclusion`, normalized `category`, and per-job timing metadata.

## Validation
```bash
BASE_REF=origin/main bash scripts/ci/review-wave6-step4-ci.sh
```

## Risk
Low (docs + reviewer script only).
