### PR TITLE
docs(ci/wave7c-step1): freeze judge/json_strict contracts before split

### DIFF
--- a/docs/architecture/PLAN-split-refactor-2026q1.md
+++ b/docs/architecture/PLAN-split-refactor-2026q1.md
@@ -414,6 +414,24 @@ Program additions tracked in Wave 6:
 3. Nightly fuzz/model lane for parser/crypto/concurrency hotspots (non-blocking first, then required for touched paths).
 4. Fast test execution path with `cargo-nextest` for broader matrix coverage time budget.
 
+## Wave 7: Runtime/domain continuation
+
+Step status:
+
+- Wave7A Step3 (authorizer closure): merged via PR #363.
+- Wave7B Step1 (loader/store freeze): merged via PR #364.
+- Wave7B Step2 (loader/store mechanical split): merged via PR #366.
+- Wave7B Step3 (loader/store closure): merged via PR #368.
+- Wave7C Step1 (judge + json_strict freeze): in progress on `codex/wave7c-step1-judge-json-strict-freeze`.
+
+Wave7C Step1 scope (freeze only):
+
+- Freeze anchors and reviewer gates for:
+  - `crates/assay-core/src/judge/mod.rs`
+  - `crates/assay-evidence/src/json_strict/mod.rs`
+- tests/docs/gates only.
+- no mechanical moves and no behavior/perf/API change in Step1.
+
 ## 5) Definition of Done per split PR
 
 Each split PR must include:

--- a/docs/contributing/SPLIT-CHECKLIST-wave7c-step1-judge-json-strict.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave7c-step1-judge-json-strict.md
@@ -1,0 +1,36 @@
+# Wave7C Step1 Checklist: judge + json_strict freeze
+
+Scope lock:
+- docs + reviewer gates + tests only.
+- no production-path code edits in:
+  - `/Users/roelschuurkes/assay/crates/assay-core/src/judge/mod.rs`
+  - `/Users/roelschuurkes/assay/crates/assay-evidence/src/json_strict/mod.rs`
+
+Freeze anchors:
+- Judge:
+  - `judge::tests::contract_two_of_three_majority`
+  - `judge::tests::contract_sprt_early_stop`
+  - `judge::tests::contract_abstain_mapping`
+  - `judge::tests::contract_determinism_parallel_replay`
+- JSON strict:
+  - `json_strict::tests::test_rejects_top_level_duplicate`
+  - `json_strict::tests::test_rejects_unicode_escape_duplicate`
+  - `json_strict::tests::test_signature_duplicate_key_attack`
+  - `json_strict::tests::test_dos_nesting_depth_limit`
+  - `json_strict::tests::test_string_length_over_limit_rejected`
+
+Hard gates (review-wave7c-step1.sh):
+- BASE_REF guard + printed base/head SHA.
+- fmt/clippy/check for `assay-core` + `assay-evidence`.
+- no-production-change (code-only strip, excluding `#[cfg(test)] mod tests` blocks).
+- file-local public-surface freeze.
+- no-increase drift counters:
+  - `unwrap/expect`, `unsafe`, print/debug/log macros,
+  - `panic/todo/unimplemented`,
+  - IO/process/network patterns.
+- strict diff allowlist.
+
+Definition of done:
+- `BASE_REF=origin/main bash scripts/ci/review-wave7c-step1.sh` passes.
+- only allowlisted files changed.
+- Step1 remains behavior/perf neutral.

--- a/docs/contributing/SPLIT-INVENTORY-wave7c-step1-judge-json-strict.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave7c-step1-judge-json-strict.md
@@ -1,0 +1,22 @@
+# Wave7C Step1 Inventory: judge + json_strict freeze
+
+Intent:
+- Behavior freeze and reviewer-gate baseline before any mechanical split for:
+  - `/Users/roelschuurkes/assay/crates/assay-core/src/judge/mod.rs`
+  - `/Users/roelschuurkes/assay/crates/assay-evidence/src/json_strict/mod.rs`
+
+Snapshot:
+- Baseline commit (origin/main at authoring): `f42c20db`
+
+LOC snapshot:
+- `/Users/roelschuurkes/assay/crates/assay-core/src/judge/mod.rs`: `712`
+- `/Users/roelschuurkes/assay/crates/assay-evidence/src/json_strict/mod.rs`: `759`
+
+Hotspot rationale:
+- `judge/mod.rs`: mixed orchestration + prompt/build + reliability loop + cache/meta wiring in one file.
+- `json_strict/mod.rs`: strict parser state-machine + tests in same module; strong security boundary with duplicate-key rejection.
+
+Wave7C Step1 scope lock:
+- tests + docs + reviewer gates only.
+- no mechanical move.
+- no behavior/perf/API changes.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave7c-step1-judge-json-strict.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave7c-step1-judge-json-strict.md
@@ -1,0 +1,42 @@
+# Wave7C Step1 review pack: judge + json_strict freeze
+
+Intent:
+- Freeze behavior/contracts and reviewer gates before Wave7C mechanical split.
+- Preserve public surface and production-path semantics for:
+  - `/Users/roelschuurkes/assay/crates/assay-core/src/judge/mod.rs`
+  - `/Users/roelschuurkes/assay/crates/assay-evidence/src/json_strict/mod.rs`
+
+Executed validation:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave7c-step1.sh
+```
+
+This executes:
+```bash
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo check -p assay-core -p assay-evidence
+```
+
+Anchor tests executed:
+- Judge:
+  - `judge::tests::contract_two_of_three_majority`
+  - `judge::tests::contract_sprt_early_stop`
+  - `judge::tests::contract_abstain_mapping`
+  - `judge::tests::contract_determinism_parallel_replay`
+- JSON strict:
+  - `json_strict::tests::test_rejects_top_level_duplicate`
+  - `json_strict::tests::test_rejects_unicode_escape_duplicate`
+  - `json_strict::tests::test_signature_duplicate_key_attack`
+  - `json_strict::tests::test_dos_nesting_depth_limit`
+  - `json_strict::tests::test_string_length_over_limit_rejected`
+
+Proof points:
+- no-production-change gate compares code-only (test blocks stripped) vs `BASE_REF`.
+- public-surface freeze gate compares file-local `pub` symbols vs `BASE_REF`.
+- drift counters are no-increase only (best-effort code-only).
+- strict allowlist prevents scope creep.
+
+Risk:
+- Low. Step1 artifacts/gates only; no mechanical movement yet.

--- a/docs/contributing/SPLIT-SYMBOLS-wave7c-step1-judge-json-strict.md
+++ b/docs/contributing/SPLIT-SYMBOLS-wave7c-step1-judge-json-strict.md
@@ -1,0 +1,21 @@
+# Wave7C Step1 Symbols: judge + json_strict
+
+Source command:
+```bash
+rg -n '^\s*pub\s+(const|struct|enum|type|trait|fn)\b' \
+  crates/assay-core/src/judge/mod.rs \
+  crates/assay-evidence/src/json_strict/mod.rs
+```
+
+Output snapshot:
+```text
+crates/assay-core/src/judge/mod.rs:9:pub struct JudgeRuntimeConfig {
+crates/assay-core/src/judge/mod.rs:27:pub struct JudgeService {
+crates/assay-core/src/judge/mod.rs:35:    pub fn new(
+crates/assay-evidence/src/json_strict/mod.rs:73:pub fn from_str_strict<T: DeserializeOwned>(s: &str) -> Result<T, StrictJsonError> {
+crates/assay-evidence/src/json_strict/mod.rs:83:pub fn validate_json_strict(s: &str) -> Result<(), StrictJsonError> {
+```
+
+Notes:
+- This freeze is file-local public-surface parity for the two hotspots.
+- No crate-level API redesign is in scope for Step1.

--- a/scripts/ci/review-wave7c-step1.sh
+++ b/scripts/ci/review-wave7c-step1.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+rg_bin="$(command -v rg)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+strip_code_only() {
+  local file="$1"
+  awk '
+    BEGIN {
+      pending_cfg_test = 0
+      skip_tests = 0
+      depth = 0
+    }
+    {
+      line = $0
+
+      if (skip_tests) {
+        opens = gsub(/\{/, "{", line)
+        closes = gsub(/\}/, "}", line)
+        depth += opens - closes
+        if (depth <= 0) {
+          skip_tests = 0
+          depth = 0
+        }
+        next
+      }
+
+      if (pending_cfg_test) {
+        if (line ~ /^[[:space:]]*#\[/ || line ~ /^[[:space:]]*$/) {
+          next
+        }
+        if (line ~ /^[[:space:]]*mod[[:space:]]+tests[[:space:]]*;[[:space:]]*$/) {
+          pending_cfg_test = 0
+          next
+        }
+        if (line ~ /^[[:space:]]*mod[[:space:]]+tests[[:space:]]*\{[[:space:]]*$/) {
+          skip_tests = 1
+          depth = 1
+          pending_cfg_test = 0
+          next
+        }
+        pending_cfg_test = 0
+      }
+
+      if (line ~ /^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$/) {
+        pending_cfg_test = 1
+        next
+      }
+
+      print
+    }
+  ' "$file"
+}
+
+count_in_ref() {
+  local ref="$1"
+  local file="$2"
+  local pattern="$3"
+  git show "${ref}:${file}" | strip_code_only /dev/stdin | "$rg_bin" -v '^[[:space:]]*//' | "$rg_bin" -n "$pattern" || true
+}
+
+count_in_worktree() {
+  local file="$1"
+  local pattern="$2"
+  strip_code_only "$file" | "$rg_bin" -v '^[[:space:]]*//' | "$rg_bin" -n "$pattern" || true
+}
+
+check_no_increase() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  local before after
+  before="$(count_in_ref "$base_ref" "$file" "$pattern" | wc -l | tr -d ' ')"
+  after="$(count_in_worktree "$file" "$pattern" | wc -l | tr -d ' ')"
+  echo "$label: before=$before after=$after"
+  if [ "$after" -gt "$before" ]; then
+    echo "drift gate failed: $label increased"
+    exit 1
+  fi
+}
+
+echo "== Wave7C Step1 quality checks =="
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo check -p assay-core -p assay-evidence
+
+echo "== Wave7C Step1 contract anchors (judge) =="
+for test_name in \
+  judge::tests::contract_two_of_three_majority \
+  judge::tests::contract_sprt_early_stop \
+  judge::tests::contract_abstain_mapping \
+  judge::tests::contract_determinism_parallel_replay
+do
+  echo "anchor: ${test_name}"
+  cargo test -p assay-core --lib "${test_name}" -- --exact
+done
+
+echo "== Wave7C Step1 contract anchors (json_strict) =="
+for test_name in \
+  json_strict::tests::test_rejects_top_level_duplicate \
+  json_strict::tests::test_rejects_unicode_escape_duplicate \
+  json_strict::tests::test_signature_duplicate_key_attack \
+  json_strict::tests::test_dos_nesting_depth_limit \
+  json_strict::tests::test_string_length_over_limit_rejected
+do
+  echo "anchor: ${test_name}"
+  cargo test -p assay-evidence --lib "${test_name}" -- --exact
+done
+
+echo "== Wave7C Step1 no-production-change gates =="
+hotspot_paths=(
+  "crates/assay-core/src/judge/mod.rs"
+  "crates/assay-evidence/src/json_strict/mod.rs"
+)
+for hotspot in "${hotspot_paths[@]}"; do
+  git show "${base_ref}:${hotspot}" | strip_code_only /dev/stdin > "${tmp_dir}/base_code.rs"
+  strip_code_only "${hotspot}" > "${tmp_dir}/head_code.rs"
+  if ! cmp -s "${tmp_dir}/base_code.rs" "${tmp_dir}/head_code.rs"; then
+    echo "${hotspot} production code changed in Step1; only #[cfg(test)] changes are allowed"
+    diff -u "${tmp_dir}/base_code.rs" "${tmp_dir}/head_code.rs" | sed -n '1,120p'
+    exit 1
+  fi
+done
+
+echo "== Wave7C Step1 public-surface freeze gates =="
+for hotspot in "${hotspot_paths[@]}"; do
+  git show "${base_ref}:${hotspot}" | "$rg_bin" -n '^\s*pub\s+(const|struct|enum|type|trait|fn)\b' > "${tmp_dir}/pub_base.txt"
+  "$rg_bin" -n '^\s*pub\s+(const|struct|enum|type|trait|fn)\b' "${hotspot}" > "${tmp_dir}/pub_head.txt"
+  if ! cmp -s "${tmp_dir}/pub_base.txt" "${tmp_dir}/pub_head.txt"; then
+    echo "${hotspot} public surface drift detected"
+    diff -u "${tmp_dir}/pub_base.txt" "${tmp_dir}/pub_head.txt"
+    exit 1
+  fi
+done
+
+echo "== Wave7C Step1 drift gates =="
+for hotspot in "${hotspot_paths[@]}"; do
+  check_no_increase "${hotspot}" 'unwrap\(|expect\(' "${hotspot} unwrap/expect (best-effort code-only)"
+  check_no_increase "${hotspot}" '\bunsafe\b' "${hotspot} unsafe"
+  check_no_increase "${hotspot}" 'println!\(|eprintln!\(|print!\(|dbg!\(|tracing::(debug|trace)!' "${hotspot} print/debug/log (best-effort code-only)"
+  check_no_increase "${hotspot}" 'panic!\(|todo!\(|unimplemented!\(' "${hotspot} panic/todo/unimplemented (best-effort code-only)"
+  check_no_increase "${hotspot}" 'tokio::fs|std::fs|OpenOptions|rename\(|create_dir_all|tempfile' "${hotspot} IO footprint (best-effort code-only)"
+  check_no_increase "${hotspot}" 'Command::new|std::process|tokio::process|reqwest|hyper' "${hotspot} process/network (best-effort code-only)"
+done
+
+echo "== Wave7C Step1 diff allowlist =="
+leaks="$(
+  git diff --name-only "${base_ref}...HEAD" | \
+    "$rg_bin" -v \
+      '^crates/assay-core/src/judge/mod.rs$|^crates/assay-evidence/src/json_strict/mod.rs$|^docs/contributing/SPLIT-INVENTORY-wave7c-step1-judge-json-strict.md$|^docs/contributing/SPLIT-SYMBOLS-wave7c-step1-judge-json-strict.md$|^docs/contributing/SPLIT-CHECKLIST-wave7c-step1-judge-json-strict.md$|^docs/contributing/SPLIT-REVIEW-PACK-wave7c-step1-judge-json-strict.md$|^scripts/ci/review-wave7c-step1.sh$|^docs/architecture/PLAN-split-refactor-2026q1.md$' || true
+)"
+if [ -n "$leaks" ]; then
+  echo "non-allowlisted files detected:"
+  echo "$leaks"
+  exit 1
+fi
+
+echo "Wave7C Step1 reviewer script: PASS"


### PR DESCRIPTION
Intent
Wave7C Step1 behavior freeze/inventory for `judge/mod.rs` and `json_strict/mod.rs` before mechanical split.

Scope lock
- tests + docs + gates only
- no mechanical split yet
- no behavior/perf/API changes

Artifacts
- docs/contributing/SPLIT-INVENTORY-wave7c-step1-judge-json-strict.md
- docs/contributing/SPLIT-SYMBOLS-wave7c-step1-judge-json-strict.md
- docs/contributing/SPLIT-CHECKLIST-wave7c-step1-judge-json-strict.md
- docs/contributing/SPLIT-REVIEW-PACK-wave7c-step1-judge-json-strict.md
- scripts/ci/review-wave7c-step1.sh
- docs/architecture/PLAN-split-refactor-2026q1.md (Wave7 status update)

Freeze anchors
- Judge:
  - judge::tests::contract_two_of_three_majority
  - judge::tests::contract_sprt_early_stop
  - judge::tests::contract_abstain_mapping
  - judge::tests::contract_determinism_parallel_replay
- JSON strict:
  - json_strict::tests::test_rejects_top_level_duplicate
  - json_strict::tests::test_rejects_unicode_escape_duplicate
  - json_strict::tests::test_signature_duplicate_key_attack
  - json_strict::tests::test_dos_nesting_depth_limit
  - json_strict::tests::test_string_length_over_limit_rejected

Validation
Executed and passing:
- BASE_REF=origin/main bash scripts/ci/review-wave7c-step1.sh

Risk
Low. Step1 freeze only; no production-path logic movement.
