### PR TITLE
ci(adr025): add SHA-pinned nightly soak workflow + reviewer gate (Step3 C1)

### DIFF
--- a/.github/workflows/adr025-nightly-soak.yml
+++ b/.github/workflows/adr025-nightly-soak.yml
@@ -1,0 +1,60 @@
+name: ADR-025 Nightly Soak (informational)
+
+on:
+  schedule:
+    # Nightly at 02:17 UTC
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: adr025-nightly-soak
+  cancel-in-progress: false
+
+# Minimal permissions:
+# - contents:read for checkout
+# - actions:write for artifact upload
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  soak:
+    name: sim soak (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # Informational lane: never blocks anything
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build (assay-cli)
+        run: cargo build -p assay-cli
+
+      - name: Run soak (informational)
+        env:
+          # Gate mode placeholder (kept off for Step3 C1)
+          ASSAY_SOAK_GATE: "off"
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          cargo run -p assay-cli -- sim soak \
+            --target nightly \
+            --report artifacts/soak_report.json \
+            --seed 1 \
+            --iterations 50 \
+            --time-budget 60
+
+      - name: Upload soak report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: adr025-soak-report
+          path: artifacts/soak_report.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/adr025-nightly-soak.yml
+++ b/.github/workflows/adr025-nightly-soak.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
 
       - name: Build (assay-cli)
         run: cargo build -p assay-cli
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload soak report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: adr025-soak-report
           path: artifacts/soak_report.json

--- a/scripts/ci/review-adr025-i1-step3-c1.sh
+++ b/scripts/ci/review-adr025-i1-step3-c1.sh
@@ -30,4 +30,14 @@ rg -n "^permissions:" "$WF" >/dev/null || { echo "FAIL: missing permissions bloc
 rg -n "contents:\s*read" "$WF" >/dev/null || { echo "FAIL: missing contents: read"; exit 1; }
 rg -n "actions:\s*write" "$WF" >/dev/null || { echo "FAIL: missing actions: write (needed for artifacts)"; exit 1; }
 
+echo "[review] ensure actions are pinned to commit SHAs"
+if rg -n 'uses:\s+\S+@(v[0-9]+|stable|main|master|nightly)\b' "$WF" >/dev/null; then
+  echo "FAIL: actions must be pinned to a commit SHA (no @vN/@stable/@main/@master/@nightly)"
+  exit 1
+fi
+rg -n 'uses:\s+\S+@[0-9a-f]{40}\b' "$WF" >/dev/null || {
+  echo "FAIL: workflow must contain SHA-pinned actions"
+  exit 1
+}
+
 echo "[review] done"

--- a/scripts/ci/review-adr025-i1-step3-c1.sh
+++ b/scripts/ci/review-adr025-i1-step3-c1.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+WF=".github/workflows/adr025-nightly-soak.yml"
+
+echo "[review] checking $WF exists"
+test -f "$WF"
+
+echo "[review] ensure no pull_request trigger"
+if rg -n "pull_request" "$WF" >/dev/null; then
+  echo "FAIL: workflow must not include pull_request trigger"
+  exit 1
+fi
+
+echo "[review] ensure schedule + workflow_dispatch exist"
+rg -n "schedule:" "$WF" >/dev/null || { echo "FAIL: missing schedule trigger"; exit 1; }
+rg -n "workflow_dispatch:" "$WF" >/dev/null || { echo "FAIL: missing workflow_dispatch trigger"; exit 1; }
+
+echo "[review] ensure continue-on-error true (informational lane)"
+rg -n "continue-on-error:\s*true" "$WF" >/dev/null || {
+  echo "FAIL: soak job must be continue-on-error: true"
+  exit 1
+}
+
+echo "[review] ensure minimal permissions are explicitly set"
+rg -n "^permissions:" "$WF" >/dev/null || { echo "FAIL: missing permissions block"; exit 1; }
+rg -n "contents:\s*read" "$WF" >/dev/null || { echo "FAIL: missing contents: read"; exit 1; }
+rg -n "actions:\s*write" "$WF" >/dev/null || { echo "FAIL: missing actions: write (needed for artifacts)"; exit 1; }
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Adds ADR-025 Step3 C1: an informational nightly soak lane (schedule + workflow_dispatch only) that runs `assay sim soak` and uploads the soak report as an artifact.

## Safety / Guardrails
- No `pull_request` trigger
- `continue-on-error: true` (informational only)
- Explicit minimal permissions
- Actions are SHA-pinned (per repo policy)
- No required-check / branch-protection changes

## Files
- .github/workflows/adr025-nightly-soak.yml
- scripts/ci/review-adr025-i1-step3-c1.sh

## Verification
- scripts/ci/review-adr025-i1-step3-c1.sh
- pre-commit/pre-push hooks (workflow lint, shellcheck, fmt, clippy, linux compile gate)
