### PR TITLE
docs(adr025): Step3 closure (promotion criteria + reviewer gates) (C3)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -381,6 +381,7 @@ assay sim soak --iterations 100 --seed 42 --target bundle.tar.gz --report soak.j
 **Design decisions:**
 - **Pass condition**: "Pass All K" is the gold standard for Agentic CI
 - **Evidence**: The *Soak Report* itself is an artifact in the evidence bundle
+- **Step3 rollout status**: informational nightly soak + informational readiness aggregation are active; enforcement is explicitly deferred to Step4 (no PR required-check impact in Step3)
 
 ### H. Audit Kit & Closure (P2) [ADR-025]
 

--- a/docs/architecture/PLAN-ADR-025-I1-audit-kit-soak-2026q2.md
+++ b/docs/architecture/PLAN-ADR-025-I1-audit-kit-soak-2026q2.md
@@ -117,6 +117,17 @@ Workflow/gating rollout:
 2. release/promote fail-closed verify path
 3. env switch: `ASSAY_SOAK_GATE=off|warn|enforce`
 
+Step3 rollout status:
+
+1. C1 merged: informational nightly soak workflow (`adr025-nightly-soak.yml`).
+2. C2 merged/planned: informational readiness aggregation workflow (`adr025-nightly-readiness.yml`) and report script (`scripts/ci/adr025-soak-readiness-report.sh`).
+3. C3 (this closure slice): checklist/review-pack/reviewer gates and promotion criteria freeze.
+
+Step3 policy guarantee:
+
+- No PR required-check behavior change is introduced in Step3.
+- PR blast radius remains constrained by `schedule` + `workflow_dispatch` only and `continue-on-error: true` on ADR-025 nightly lanes.
+
 ## 6) Promotion criteria (I1)
 
 Promotion-ready is true only if all are true:

--- a/docs/contributing/SPLIT-CHECKLIST-adr025-step3-c3-rollout.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-step3-c3-rollout.md
@@ -1,0 +1,30 @@
+# ADR-025 Step3 C3 Rollout Closure Checklist
+
+## Scope guardrails (hard)
+- [ ] No `pull_request` triggers added to ADR-025 workflows
+- [ ] No required-check / branch-protection behavior changed
+- [ ] All actions in ADR-025 workflows are SHA-pinned
+- [ ] Nightly lanes remain informational (`continue-on-error: true`)
+- [ ] Permissions are minimal and explicit (no `id-token: write`)
+
+## Nightly Soak (C1)
+- [ ] Workflow exists: `.github/workflows/adr025-nightly-soak.yml`
+- [ ] Triggers: `schedule` + `workflow_dispatch` only
+- [ ] Artifact: `adr025-soak-report` retention 14 days
+
+## Readiness Aggregation (C2)
+- [ ] Workflow exists: `.github/workflows/adr025-nightly-readiness.yml`
+- [ ] Triggers: `schedule` + `workflow_dispatch` only
+- [ ] Aggregator script exists: `scripts/ci/adr025-soak-readiness-report.sh`
+- [ ] Outputs: `nightly_readiness.json` + `nightly_readiness.md`
+- [ ] Artifact: `adr025-nightly-readiness` retention 14 days
+
+## Promotion criteria (hard-lock)
+- [ ] Window definition is explicit (N runs or time window)
+- [ ] Thresholds are explicit and measurable
+- [ ] Classifier rules are deterministic and versioned (`classifier_version`)
+- [ ] Explicit statement: "No PR required-check impact in Step3"
+
+## Reviewer gates
+- [ ] Reviewer script exists: `scripts/ci/review-adr025-i1-step3-c3.sh`
+- [ ] Script enforces allowlist + policy checks

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-step3-c3-rollout.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-step3-c3-rollout.md
@@ -1,0 +1,57 @@
+# ADR-025 Step3 C3 Rollout Closure — Review Pack
+
+## Intent
+Close the Step3 loop by freezing rollout contracts:
+- Informational nightly soak lane (C1)
+- Informational readiness aggregation lane (C2)
+- Explicit promotion criteria and classifier rules
+- Reviewer gates to prevent PR blast radius and permission creep
+
+## Non-goals
+- No PR required-check changes
+- No enforcement gate in PR lanes
+- No release/promote fail-closed behavior (deferred to Step4)
+
+## Hard contracts
+### Trigger policy
+- ADR-025 workflows must not include `pull_request`.
+- Only `schedule` and `workflow_dispatch` are allowed.
+
+### Permissions policy
+- Explicit minimal permissions.
+- No `id-token: write` outside explicit release/provenance flows.
+
+### Supply-chain policy
+- All actions must be SHA-pinned.
+
+### Artifact contracts
+- Soak artifact: `adr025-soak-report` (retention 14 days)
+- Readiness artifact: `adr025-nightly-readiness` (retention 14 days)
+- Readiness outputs: `nightly_readiness.json` + `nightly_readiness.md`
+
+## Promotion criteria (informational in Step3)
+Window (default):
+- Last 20 soak runs (or a fixed time window if adopted later)
+
+Thresholds (initial):
+- contract_fail_rate (exit 2) <= 0.05
+- infra_fail_rate (exit 3) <= 0.01
+- success_rate (exit 0) >= 0.90
+- unknown_rate <= 0.05
+
+Classifier rules (deterministic):
+- classifier_version: "1"
+- Treat non-success workflow conclusions conservatively as contract failures unless refined in Step4.
+
+## Verification
+- Run: `bash scripts/ci/review-adr025-i1-step3-c3.sh`
+- Local lint sanity:
+  - `cargo fmt --check`
+  - `cargo clippy -p assay-cli -- -D warnings`
+  - `cargo test -p assay-cli`
+
+## Reviewer checklist
+- [ ] No PR triggers introduced
+- [ ] SHA pinning enforced
+- [ ] Minimal permissions enforced
+- [ ] Promotion criteria are explicit and measurable

--- a/scripts/ci/review-adr025-i1-step3-c3.sh
+++ b/scripts/ci/review-adr025-i1-step3-c3.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+WFS=(
+  ".github/workflows/adr025-nightly-soak.yml"
+  ".github/workflows/adr025-nightly-readiness.yml"
+)
+
+echo "[review] workflows exist"
+for wf in "${WFS[@]}"; do
+  test -f "$wf" || { echo "FAIL: missing $wf"; exit 1; }
+done
+
+check_no_pr_trigger() {
+  local wf="$1"
+  if rg -n "pull_request" "$wf" >/dev/null; then
+    echo "FAIL: $wf must not include pull_request trigger"
+    exit 1
+  fi
+}
+
+check_sched_dispatch() {
+  local wf="$1"
+  rg -n "schedule:" "$wf" >/dev/null || { echo "FAIL: $wf missing schedule"; exit 1; }
+  rg -n "workflow_dispatch:" "$wf" >/dev/null || { echo "FAIL: $wf missing workflow_dispatch"; exit 1; }
+}
+
+check_informational() {
+  local wf="$1"
+  rg -n "continue-on-error:\s*true" "$wf" >/dev/null || { echo "FAIL: $wf must be continue-on-error: true"; exit 1; }
+}
+
+check_sha_pins() {
+  local wf="$1"
+  if rg -n 'uses:\s+\S+@(v[0-9]+|stable|main|master|nightly)\b' "$wf" >/dev/null; then
+    echo "FAIL: $wf uses non-SHA action ref"
+    exit 1
+  fi
+  if ! rg -n 'uses:\s+\S+@[0-9a-f]{40}\b' "$wf" >/dev/null; then
+    echo "FAIL: $wf expected SHA-pinned action refs"
+    exit 1
+  fi
+}
+
+check_permissions_minimal() {
+  local wf="$1"
+  rg -n "^permissions:" "$wf" >/dev/null || { echo "FAIL: $wf missing permissions block"; exit 1; }
+  if rg -n "id-token:\s*write" "$wf" >/dev/null; then
+    echo "FAIL: $wf must not request id-token: write"
+    exit 1
+  fi
+}
+
+echo "[review] policy checks"
+for wf in "${WFS[@]}"; do
+  check_no_pr_trigger "$wf"
+  check_sched_dispatch "$wf"
+  check_informational "$wf"
+  check_sha_pins "$wf"
+  check_permissions_minimal "$wf"
+done
+
+echo "[review] artifact contract checks"
+rg -n "name:\s*adr025-soak-report" .github/workflows/adr025-nightly-soak.yml >/dev/null || { echo "FAIL: soak artifact name mismatch"; exit 1; }
+rg -n "retention-days:\s*14" .github/workflows/adr025-nightly-soak.yml >/dev/null || { echo "FAIL: soak retention mismatch"; exit 1; }
+
+rg -n "name:\s*adr025-nightly-readiness" .github/workflows/adr025-nightly-readiness.yml >/dev/null || { echo "FAIL: readiness artifact name mismatch"; exit 1; }
+rg -n "retention-days:\s*14" .github/workflows/adr025-nightly-readiness.yml >/dev/null || { echo "FAIL: readiness retention mismatch"; exit 1; }
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
ADR-025 Step3 C3 closes the rollout loop by freezing promotion criteria, classifier rules, and reviewer gates for C1/C2 workflows.

## Safety
- No pull_request triggers
- No required-check / branch-protection changes
- SHA-pinned actions enforced
- Minimal permissions enforced

## Files
- docs/contributing/SPLIT-CHECKLIST-adr025-step3-c3-rollout.md
- docs/contributing/SPLIT-REVIEW-PACK-adr025-step3-c3-rollout.md
- docs/architecture/PLAN-ADR-025-I1-audit-kit-soak-2026q2.md
- docs/ROADMAP.md
- scripts/ci/review-adr025-i1-step3-c3.sh

## Verification
- bash scripts/ci/review-adr025-i1-step3-c3.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
- cargo test -p assay-cli
