### PR TITLE
ci(adr025): relax C3 gate fragility with local-action + permission allowlist (C3.2)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-adr025-step3-c3-rollout.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-step3-c3-rollout.md
@@ -5,7 +5,7 @@
 - [ ] No required-check / branch-protection behavior changed
 - [ ] All actions in ADR-025 workflows are SHA-pinned
 - [ ] Nightly lanes remain informational (`continue-on-error: true` at job level)
-- [ ] Permissions are minimal and explicit (exactly `contents: read`, `actions: write`; no `id-token: write`)
+- [ ] Permissions are explicit and constrained (`contents: read`, `actions: write` required; allowlisted extras only; no `id-token: write`)
 
 ## Nightly Soak (C1)
 - [ ] Workflow exists: `.github/workflows/adr025-nightly-soak.yml`

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-step3-c3-rollout.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-step3-c3-rollout.md
@@ -18,7 +18,7 @@ Close the Step3 loop by freezing rollout contracts:
 - Only `schedule` and `workflow_dispatch` are allowed under `on:`.
 
 ### Permissions policy
-- Explicit minimal permissions only: `contents: read` + `actions: write`.
+- Explicit constrained permissions: `contents: read` + `actions: write` required, with allowlisted optional keys only.
 - No `id-token: write` outside explicit release/provenance flows.
 
 ### Supply-chain policy


### PR DESCRIPTION
## Summary
ADR-025 Step3 C3.2 follow-up: reduce gate fragility while preserving hard security posture.

## Why
C3.1 was intentionally strict, but two rules were too brittle for future safe evolution:
- SHA check should allow local actions (`uses: ./.github/actions/...`)
- Permissions policy should use an allowlist model instead of exact-key lock

## Changes
- `check_sha_pins_strict` now:
  - allows local actions (`./...`)
  - requires remote actions to be pinned to 40-hex SHA
- `check_permissions_minimal` now:
  - still requires `contents: read` and `actions: write`
  - forbids `id-token: write` and `*-all`
  - allows controlled optional keys (`pull-requests`, `security-events`) with constrained values
- Synced checklist/review-pack wording with this constrained-allowlist policy

## Scope
- `scripts/ci/review-adr025-i1-step3-c3.sh`
- `docs/contributing/SPLIT-CHECKLIST-adr025-step3-c3-rollout.md`
- `docs/contributing/SPLIT-REVIEW-PACK-adr025-step3-c3-rollout.md`

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-adr025-i1-step3-c3.sh`
- pre-commit hooks pass

## Safety
- docs/scripts only
- no runtime workflow behavior changes
- no required-check/branch protection changes
