### PR TITLE
docs(adr025): Step4C closure (runbook + reviewer gates + roadmap sync)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -373,15 +373,16 @@ assay sim soak --iterations 100 --seed 42 --target bundle.tar.gz --report soak.j
 ```
 
 **Scope (Iteration 1):**
-- [ ] **CLI**: `assay sim soak` subcommand with `pass^k` semantics (pass_all, pass_rate)
-- [ ] **Report**: `soak-report-v1` strict JSON schema (decision_policy, violations_by_rule)
-- [ ] **Determinism**: Seeded execution for reproducible reliability
-- [ ] **Limits**: Time budget and resource limits (inherited from ADR-024 work)
+- [x] **CLI**: `assay sim soak` subcommand with `pass^k` semantics (pass_all, pass_rate)
+- [x] **Report**: `soak-report-v1` strict JSON schema (decision_policy, violations_by_rule)
+- [x] **Determinism**: Seeded execution for reproducible reliability
+- [x] **Limits**: Time budget and resource limits (inherited from ADR-024 work)
 
 **Design decisions:**
 - **Pass condition**: "Pass All K" is the gold standard for Agentic CI
 - **Evidence**: The *Soak Report* itself is an artifact in the evidence bundle
-- **Step3 rollout status**: informational nightly soak + informational readiness aggregation are active; enforcement is explicitly deferred to Step4 (no PR required-check impact in Step3)
+- **Step3 rollout status**: informational nightly soak + informational readiness aggregation are active; no PR required-check impact in Step3
+- **Step4 rollout status**: fail-closed enforcement is active in release lane only (policy v1 + readiness enforcement script); PR lanes remain unchanged
 
 ### H. Audit Kit & Closure (P2) [ADR-025]
 

--- a/docs/architecture/PLAN-ADR-025-I1-audit-kit-soak-2026q2.md
+++ b/docs/architecture/PLAN-ADR-025-I1-audit-kit-soak-2026q2.md
@@ -120,13 +120,19 @@ Workflow/gating rollout:
 Step3 rollout status:
 
 1. C1 merged: informational nightly soak workflow (`adr025-nightly-soak.yml`).
-2. C2 merged/planned: informational readiness aggregation workflow (`adr025-nightly-readiness.yml`) and report script (`scripts/ci/adr025-soak-readiness-report.sh`).
-3. C3 (this closure slice): checklist/review-pack/reviewer gates and promotion criteria freeze.
+2. C2 merged: informational readiness aggregation workflow (`adr025-nightly-readiness.yml`) and report script (`scripts/ci/adr025-soak-readiness-report.sh`).
+3. C3 merged: checklist/review-pack/reviewer gates and promotion criteria freeze.
 
 Step3 policy guarantee:
 
 - No PR required-check behavior change is introduced in Step3.
 - PR blast radius remains constrained by `schedule` + `workflow_dispatch` only and `continue-on-error: true` on ADR-025 nightly lanes.
+
+Step4 enforcement status:
+
+1. Step4A merged: enforcement policy v1 freeze (`docs/architecture/ADR-025-SOAK-ENFORCEMENT-POLICY.md`) and Step4A reviewer gate.
+2. Step4B merged: fail-closed readiness enforcement wired in release lane only (`.github/workflows/release.yml`) with script/tests/fixtures and Step4B reviewer gate.
+3. Step4C (this closure slice): runbook + closure checklist/review-pack + reviewer gate and plan/roadmap sync.
 
 ## 6) Promotion criteria (I1)
 

--- a/docs/contributing/SPLIT-CHECKLIST-adr025-step4-c-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-step4-c-closure.md
@@ -1,0 +1,22 @@
+# ADR-025 Step4C Closure Checklist
+
+## Scope guardrails
+- [ ] Docs/scripts only in this slice
+- [ ] No `.github/workflows/*` file changes
+- [ ] No PR required-check behavior changes
+
+## Step4 closure artifacts
+- [ ] Runbook exists: `docs/ops/ADR-025-SOAK-ENFORCEMENT-RUNBOOK.md`
+- [ ] Checklist exists: `docs/contributing/SPLIT-CHECKLIST-adr025-step4-c-closure.md`
+- [ ] Review pack exists: `docs/contributing/SPLIT-REVIEW-PACK-adr025-step4-c-closure.md`
+- [ ] Reviewer script exists: `scripts/ci/review-adr025-i1-step4-c.sh`
+
+## Invariant checks documented
+- [ ] Release workflow contains ADR-025 enforcement step
+- [ ] Enforcement references `schemas/soak_readiness_policy_v1.json`
+- [ ] Enforcement consumes `adr025-nightly-readiness` artifact
+- [ ] Exit contract 0/1/2 documented in runbook and plan
+
+## Planning/docs sync
+- [ ] Step4 status updated in PLAN
+- [ ] Step4 status updated in ROADMAP

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-step4-c-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-step4-c-closure.md
@@ -1,0 +1,27 @@
+# ADR-025 Step4C Closure — Review Pack
+
+## Intent
+Close ADR-025 Step4 with operational docs and reviewer gates after Step4B implementation.
+
+## Scope
+- Runbook for fail-closed release-lane enforcement
+- Closure checklist/review pack
+- Reviewer script for Step4C doc-slice policy
+- PLAN/ROADMAP status sync
+
+## Hard guarantees
+- No workflow edits in Step4C slice
+- No PR-lane trigger/check behavior changes
+- Release-lane enforcement remains the only fail-closed path
+
+## Verification commands
+- `BASE_REF=origin/main bash scripts/ci/review-adr025-i1-step4-c.sh`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+- `cargo test -p assay-cli`
+
+## Reviewer checklist
+- [ ] Allowlist-only Step4C diff
+- [ ] Runbook documents fail classes and operator actions
+- [ ] PLAN and ROADMAP reflect Step4 status accurately
+- [ ] Reviewer script checks Step4B invariants from repository state

--- a/docs/ops/ADR-025-SOAK-ENFORCEMENT-RUNBOOK.md
+++ b/docs/ops/ADR-025-SOAK-ENFORCEMENT-RUNBOOK.md
@@ -1,0 +1,57 @@
+# ADR-025 Soak Enforcement Runbook (Step4C)
+
+## Purpose
+Operate release-lane soak enforcement safely and reproducibly, without impacting PR lanes.
+
+## Scope
+- Applies to `.github/workflows/release.yml` only.
+- Does not change PR required checks.
+- Nightly readiness generation remains informational.
+
+## Enforcement flow
+1. Release job fetches latest successful `adr025-nightly-readiness` run on `main`.
+2. Downloads artifact `adr025-nightly-readiness`.
+3. Requires `input/readiness/nightly_readiness.json` to exist.
+4. Runs `scripts/ci/adr025-soak-enforce.sh` against:
+   - `schemas/soak_readiness_policy_v1.json`
+   - downloaded readiness JSON
+
+## Exit contract
+- `0`: pass (release can continue)
+- `1`: policy fail (threshold violation)
+- `2`: measurement/contract fail (missing artifact/json, parse error, classifier mismatch, insufficient window)
+
+## Fail-closed behavior
+Any non-zero result from enforcement blocks release publishing in release lane.
+
+## Policy invariants (v1)
+- classifier lock: readiness `classifier_version` must equal policy `classifier_version`.
+- minimum window: `window.runs_observed >= window.runs_observed_minimum`.
+- thresholds:
+  - success_rate >= 0.90
+  - contract_fail_rate <= 0.05
+  - infra_fail_rate <= 0.01
+  - unknown_rate <= 0.05
+
+## Operator triage
+When release blocks:
+1. Inspect release logs for enforcement step output.
+2. Identify failure class:
+   - policy fail (`exit 1`) -> readiness below thresholds
+   - measurement/contract fail (`exit 2`) -> artifact/schema/window/classifier issue
+3. Confirm latest readiness artifact exists and is valid.
+4. Re-run readiness workflow manually if needed (`workflow_dispatch`) and retry release.
+
+## Break-glass (controlled)
+- Allowed only by release owner.
+- Must be explicit, auditable, and temporary.
+- No silent bypass in PR lanes.
+- Any break-glass action requires:
+  - reason logged in release run notes/comment
+  - follow-up issue to restore normal enforcement if disabled
+
+## Evidence to capture in incidents
+- release workflow run URL
+- readiness workflow run URL used by enforcement
+- enforcement script output and exit code
+- policy version and classifier version values

--- a/scripts/ci/review-adr025-i1-step4-c.sh
+++ b/scripts/ci/review-adr025-i1-step4-c.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/PLAN-ADR-025-I1-audit-kit-soak-2026q2.md"
+  "docs/ROADMAP.md"
+  "docs/ops/ADR-025-SOAK-ENFORCEMENT-RUNBOOK.md"
+  "docs/contributing/SPLIT-CHECKLIST-adr025-step4-c-closure.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr025-step4-c-closure.md"
+  "scripts/ci/review-adr025-i1-step4-c.sh"
+)
+
+echo "[review] allowlist diff vs ${BASE_REF}"
+changed="$(git diff --name-only "$BASE_REF"...HEAD)"
+
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Step4C must not edit workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    if [[ "$f" == "$a" ]]; then
+      ok="true"
+      break
+    fi
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Step4C: $f"
+    exit 1
+  fi
+done <<< "$changed"
+
+echo "[review] Step4B invariant checks from repo state"
+
+test -f scripts/ci/adr025-soak-enforce.sh || { echo "FAIL: missing scripts/ci/adr025-soak-enforce.sh"; exit 1; }
+rg -n 'classifier_version' scripts/ci/adr025-soak-enforce.sh >/dev/null || { echo "FAIL: enforcement script missing classifier lock"; exit 1; }
+rg -n 'runs_observed_minimum' scripts/ci/adr025-soak-enforce.sh >/dev/null || { echo "FAIL: enforcement script missing minimum window logic"; exit 1; }
+
+rg -n 'ADR-025 enforce readiness \(fail-closed\)' .github/workflows/release.yml >/dev/null || { echo "FAIL: release.yml missing ADR-025 enforcement step"; exit 1; }
+rg -n 'adr025-nightly-readiness\.yml' .github/workflows/release.yml >/dev/null || { echo "FAIL: release.yml missing readiness workflow reference"; exit 1; }
+rg -n 'nightly_readiness\.json' .github/workflows/release.yml >/dev/null || { echo "FAIL: release.yml missing readiness artifact JSON check"; exit 1; }
+rg -n 'schemas/soak_readiness_policy_v1\.json' .github/workflows/release.yml >/dev/null || { echo "FAIL: release.yml missing policy reference"; exit 1; }
+
+if rg -n '^\s*pull_request' .github/workflows/release.yml >/dev/null; then
+  echo "FAIL: release workflow must not include pull_request trigger"
+  exit 1
+fi
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Step4C closes ADR-025 Step4 with operational documentation and closure reviewer gates.

## Included
- Runbook: `docs/ops/ADR-025-SOAK-ENFORCEMENT-RUNBOOK.md`
- Closure checklist/review-pack:
  - `docs/contributing/SPLIT-CHECKLIST-adr025-step4-c-closure.md`
  - `docs/contributing/SPLIT-REVIEW-PACK-adr025-step4-c-closure.md`
- Reviewer gate: `scripts/ci/review-adr025-i1-step4-c.sh`
- Plan/Roadmap sync:
  - `docs/architecture/PLAN-ADR-025-I1-audit-kit-soak-2026q2.md`
  - `docs/ROADMAP.md`

## Safety
- Docs/scripts only
- No workflow edits in this slice
- No PR required-check behavior changes

## Verification
- `BASE_REF=origin/codex/adr025-i1-step4-b-enforce-release bash scripts/ci/review-adr025-i1-step4-c.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
- `cargo test -p assay-cli`
