### PR TITLE
docs(adr025): freeze I2 closure contract + schema v1 (I2 Step1)

### DIFF
--- a/docs/architecture/PLAN-ADR-025-I2-audit-kit-closure-2026q2.md
+++ b/docs/architecture/PLAN-ADR-025-I2-audit-kit-closure-2026q2.md
@@ -1,0 +1,69 @@
+# PLAN — ADR-025 I2 Audit Kit & Closure (2026q2)
+
+## Intent
+Iteration 2 operationalizes "Audit Kit & Closure" as evidence:
+- Manifest extensions (packs applied + mapping/provenance)
+- Completeness (required vs captured, signal gaps)
+- Closure Score (hermetic readiness score 0.0–1.0)
+
+Out of scope for I2:
+- OTel bridge (deferred to I3)
+
+## Inputs (frozen for Step1)
+### Required
+- Soak report v1 (from `assay sim soak`) — JSON
+- Nightly readiness v1 (from Step3 C2) — `nightly_readiness.json`
+- Evidence manifest / bundle metadata (Audit Kit surface)
+  - `x-assay.packs_applied` (pack ids + versions)
+  - mappings/provenance references (what mappings were applied and from where)
+
+### Optional
+- Additional evidence bundle metadata (attestations), if present
+
+## Outputs (frozen for Step1)
+- `closure_report_v1` JSON (schema: `schemas/closure_report_v1.schema.json`)
+- `closure_report_v1` markdown summary (human readable)
+
+## Closure score (v1)
+Score range: 0.0–1.0 (deterministic)
+
+Dimensions (initial):
+1) Completeness score (required vs captured signals)
+2) Provenance score (mappings/packs provenance present + consistent)
+3) Consistency score (inputs mutually consistent: versions/classifier/policy)
+4) Readiness score (derived from nightly readiness vs policy thresholds)
+
+Weighting (v1):
+- completeness: 0.40
+- provenance: 0.20
+- consistency: 0.20
+- readiness: 0.20
+
+## Completeness model (v1)
+- required_signals[]: list of required signals (by id)
+- captured_signals[]: list of captured signals (by id)
+- gaps[]: required - captured
+- completeness_ratio = captured_required / required_total
+
+## Manifest extensions (v1)
+Additions to manifest (conceptual contract):
+- `x-assay.packs_applied[]`:
+  - id, version, digest (optional), source (registry/local)
+- `x-assay.mappings_applied[]`:
+  - id, version, digest (optional), provenance_ref (optional)
+- `x-assay.provenance`:
+  - tool_version, policy_version, classifier_version (when relevant)
+
+## Exit code contract (closure evaluation)
+- 0: pass (meets closure policy / score threshold)
+- 1: policy/closure fail (score below threshold, or hard violations)
+- 2: measurement/contract fail (missing inputs, invalid schema, parse errors)
+
+## Step2 implementation plan (preview)
+- Implement closure evaluator (script first, CLI later)
+- Deterministic scoring with fixtures
+- Validate outputs against schema
+
+## Step3 rollout plan (preview)
+- Informational nightly closure artifact lane (no PR required-check impact)
+- Release/promote may attach closure artifact as evidence (non-blocking unless explicitly enabled later)

--- a/schemas/closure_report_v1.schema.json
+++ b/schemas/closure_report_v1.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.dev/schemas/closure_report_v1.schema.json",
+  "title": "Assay ADR-025 Closure Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_version",
+    "assay_version",
+    "inputs",
+    "policy",
+    "dimensions",
+    "summary",
+    "score"
+  ],
+  "properties": {
+    "schema_version": { "const": "closure_report_v1" },
+    "report_version": { "type": "string", "minLength": 1 },
+    "assay_version": { "type": "string", "minLength": 1 },
+
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["soak_report", "readiness"],
+      "properties": {
+        "soak_report": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["schema_version"],
+          "properties": {
+            "schema_version": { "type": "string" },
+            "digest": { "type": "string" },
+            "path": { "type": "string" }
+          }
+        },
+        "readiness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["schema_version", "classifier_version"],
+          "properties": {
+            "schema_version": { "type": "string" },
+            "classifier_version": { "type": "string" },
+            "digest": { "type": "string" },
+            "path": { "type": "string" }
+          }
+        },
+        "manifest": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "digest": { "type": "string" },
+            "path": { "type": "string" }
+          }
+        }
+      }
+    },
+
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_version", "score_threshold"],
+      "properties": {
+        "policy_version": { "type": "string" },
+        "score_threshold": { "type": "number", "minimum": 0.0, "maximum": 1.0 }
+      }
+    },
+
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["completeness", "provenance", "consistency", "readiness"],
+      "properties": {
+        "completeness": { "$ref": "#/$defs/dimension" },
+        "provenance": { "$ref": "#/$defs/dimension" },
+        "consistency": { "$ref": "#/$defs/dimension" },
+        "readiness": { "$ref": "#/$defs/dimension" }
+      }
+    },
+
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required_signals", "captured_signals", "gaps"],
+      "properties": {
+        "required_signals": { "type": "array", "items": { "type": "string" } },
+        "captured_signals": { "type": "array", "items": { "type": "string" } },
+        "gaps": { "type": "array", "items": { "type": "string" } },
+        "notes": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+
+    "violations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/violation" }
+    },
+
+    "score": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    }
+  },
+
+  "$defs": {
+    "dimension": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "weight", "signals"],
+      "properties": {
+        "score": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+        "weight": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+        "signals": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/signal" }
+        }
+      }
+    },
+    "signal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "status": { "type": "string", "enum": ["present", "missing", "mismatch", "unknown"] },
+        "detail": { "type": "string" }
+      }
+    },
+    "violation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "severity": { "type": "string", "enum": ["info", "warn", "error"] }
+      }
+    }
+  }
+}

--- a/scripts/ci/review-adr025-i2-step1.sh
+++ b/scripts/ci/review-adr025-i2-step1.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[review] BASE_REF=$BASE_REF"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/PLAN-ADR-025-I2-audit-kit-closure-2026q2.md"
+  "schemas/closure_report_v1.schema.json"
+  "scripts/ci/review-adr025-i2-step1.sh"
+)
+
+echo "[review] diff allowlist"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: I2 Step1 must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in I2 Step1: $f"
+    exit 1
+  fi
+done
+
+echo "[review] JSON parses"
+python3 - <<'PY'
+import json
+json.load(open("schemas/closure_report_v1.schema.json","r",encoding="utf-8"))
+print("schema json: ok")
+PY
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
ADR-025 I2 Step1 freezes the closure contract: plan + `closure_report_v1` schema + reviewer gate.

## Scope
- `docs/architecture/PLAN-ADR-025-I2-audit-kit-closure-2026q2.md`
- `schemas/closure_report_v1.schema.json`
- `scripts/ci/review-adr025-i2-step1.sh`

## Safety
- Reviewer gate enforces allowlist-only
- No workflow changes in this slice

## Verification
- `bash scripts/ci/review-adr025-i2-step1.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
- `cargo test -p assay-cli`
