### PR TITLE
ci(adr025): add I2 nightly closure rollout lane + reviewer gate (Step3)

### DIFF
--- a/.github/workflows/adr025-nightly-closure.yml
+++ b/.github/workflows/adr025-nightly-closure.yml
@@ -1,0 +1,86 @@
+name: ADR-025 Nightly Closure (informational)
+
+on:
+  schedule:
+    - cron: "41 2 * * *"
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: "Readiness runs to consider (informational only)"
+        required: false
+        default: "20"
+
+concurrency:
+  group: adr025-nightly-closure
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  closure:
+    name: closure evaluate (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - name: Prepare inputs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUNS: ${{ inputs.runs || '20' }}
+        run: |
+          set -euo pipefail
+          mkdir -p inputs artifacts
+
+          # 1) Produce a fresh soak report (self-contained informational lane)
+          cargo build -p assay-cli
+          cargo run -p assay-cli -- sim soak \
+            --target nightly \
+            --report inputs/soak_report.json \
+            --seed 1 \
+            --iterations 50 \
+            --time-budget 60
+
+          # 2) Download latest readiness artifact from I1 Step3 C2 lane
+          rid="$(gh run list --workflow "adr025-nightly-readiness.yml" --limit "${RUNS}" --json databaseId --jq '.[0].databaseId')"
+          echo "Using readiness run id: ${rid}"
+          gh run download "${rid}" -n "adr025-nightly-readiness" -D inputs
+
+          if [[ ! -f inputs/nightly_readiness.json ]]; then
+            candidate="$(find inputs -name nightly_readiness.json -print -quit)"
+            if [[ -n "${candidate}" ]]; then
+              cp "${candidate}" inputs/nightly_readiness.json
+            fi
+          fi
+          test -f inputs/nightly_readiness.json
+
+          # 3) Manifest input: v1 informational fixture
+          cp scripts/ci/fixtures/adr025-i2/manifest_good.json inputs/manifest.json
+
+      - name: Evaluate closure
+        run: |
+          set -euo pipefail
+          bash scripts/ci/adr025-closure-evaluate.sh \
+            --soak inputs/soak_report.json \
+            --readiness inputs/nightly_readiness.json \
+            --manifest inputs/manifest.json \
+            --policy schemas/closure_policy_v1.json \
+            --out-json artifacts/closure_report_v1.json \
+            --out-md artifacts/closure_report_v1.md
+
+      - name: Upload closure artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: adr025-closure-report
+          path: artifacts/*
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/contributing/SPLIT-CHECKLIST-adr025-i2-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-i2-step3.md
@@ -1,0 +1,22 @@
+# ADR-025 I2 Step3 Checklist (closure rollout informational)
+
+## Scope
+- [ ] Workflow exists: `.github/workflows/adr025-nightly-closure.yml`
+- [ ] Reviewer gate exists: `scripts/ci/review-adr025-i2-step3.sh`
+- [ ] Review pack exists: `docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step3.md`
+
+## Trigger/permissions contracts
+- [ ] Triggers are `schedule` + `workflow_dispatch` only
+- [ ] No `pull_request`/`pull_request_target`
+- [ ] Job-level `continue-on-error: true`
+- [ ] Actions are SHA-pinned
+- [ ] Minimal permissions (`contents: read`, `actions: write`)
+
+## Artifact contract
+- [ ] Upload artifact `adr025-closure-report`
+- [ ] Contains `closure_report_v1.json` and `closure_report_v1.md`
+- [ ] Retention is 14 days
+
+## Safety
+- [ ] Informational-only lane (no PR required-check impact)
+- [ ] No changes outside Step3 allowlist

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step3.md
@@ -1,0 +1,28 @@
+# ADR-025 I2 Step3 Review Pack (closure rollout informational)
+
+## Summary
+Adds an informational nightly closure lane that evaluates closure from:
+- fresh soak report (`assay sim soak`)
+- latest nightly readiness artifact (`adr025-nightly-readiness`)
+- I2 manifest fixture (`scripts/ci/fixtures/adr025-i2/manifest_good.json`)
+- closure policy (`schemas/closure_policy_v1.json`)
+
+Outputs are uploaded as artifact `adr025-closure-report`.
+
+## Safety contracts
+- Schedule + dispatch only (no PR triggers)
+- Job-level `continue-on-error: true`
+- SHA-pinned actions only
+- Minimal permissions only
+- No required-check / branch-protection changes
+
+## Verification
+- `BASE_REF=origin/main bash scripts/ci/review-adr025-i2-step3.sh`
+- Workflow contains evaluator invocation: `scripts/ci/adr025-closure-evaluate.sh`
+- Artifact contract:
+  - `closure_report_v1.json`
+  - `closure_report_v1.md`
+
+## Notes
+- This is informational-only rollout (I2 Step3).
+- Enforcement decisions remain outside this slice.

--- a/scripts/ci/review-adr025-i2-step3.sh
+++ b/scripts/ci/review-adr025-i2-step3.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+base_ref="${BASE_REF:-origin/main}"
+wf=".github/workflows/adr025-nightly-closure.yml"
+
+allowlist=(
+  ".github/workflows/adr025-nightly-closure.yml"
+  "scripts/ci/review-adr025-i2-step3.sh"
+  "docs/contributing/SPLIT-CHECKLIST-adr025-i2-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step3.md"
+)
+
+has_allowlisted_file() {
+  local f="$1"
+  for allowed in "${allowlist[@]}"; do
+    if [[ "$f" == "$allowed" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+check_diff_allowlist() {
+  echo "[review] diff allowlist vs ${base_ref}"
+
+  git rev-parse --verify "$base_ref" >/dev/null 2>&1 || {
+    echo "FAIL: base ref '$base_ref' not found (run: git fetch origin)"
+    exit 1
+  }
+
+  local changed
+  changed="$(git diff --name-only "${base_ref}...HEAD")"
+
+  if [[ -z "$changed" ]]; then
+    echo "FAIL: no changes detected vs ${base_ref}"
+    exit 1
+  fi
+
+  local leaked=0
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    if ! has_allowlisted_file "$f"; then
+      echo "FAIL: non-allowlisted file changed: $f"
+      leaked=1
+    fi
+  done <<< "$changed"
+
+  if [[ "$leaked" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+extract_top_level_event_keys() {
+  local file="$1"
+  awk '
+    BEGIN {in_on=0}
+    /^on:[[:space:]]*$/ {in_on=1; next}
+    in_on && /^[^[:space:]]/ {in_on=0}
+    in_on && /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/ {
+      key=$1
+      sub(":", "", key)
+      print key
+    }
+  ' "$file"
+}
+
+check_sched_dispatch_only() {
+  rg -n "^on:[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing top-level on: block"; exit 1; }
+  rg -n "^  schedule:[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing schedule trigger"; exit 1; }
+  rg -n "^  workflow_dispatch:[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing workflow_dispatch trigger"; exit 1; }
+
+  while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    if [[ "$key" != "schedule" && "$key" != "workflow_dispatch" ]]; then
+      echo "FAIL: non-allowed trigger under on:: $key"
+      exit 1
+    fi
+  done < <(extract_top_level_event_keys "$wf")
+}
+
+check_no_pr_trigger() {
+  if rg -n "pull_request|pull_request_target" "$wf" >/dev/null; then
+    echo "FAIL: workflow must not include pull_request/pull_request_target"
+    exit 1
+  fi
+}
+
+check_informational_job_level() {
+  if ! rg -n "^    continue-on-error:[[:space:]]*true[[:space:]]*$" "$wf" >/dev/null; then
+    echo "FAIL: missing job-level continue-on-error: true"
+    exit 1
+  fi
+
+  if rg -n "^[[:space:]]{6,}continue-on-error:[[:space:]]*true[[:space:]]*$" "$wf" >/dev/null; then
+    echo "FAIL: step-level continue-on-error found; require job-level only"
+    exit 1
+  fi
+}
+
+check_sha_pins_strict() {
+  local bad=0
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    local token
+    token="$(sed -E 's/^[[:space:]]*uses:[[:space:]]+([^[:space:]#]+).*/\1/' <<< "$line")"
+
+    if [[ "$token" =~ ^\./ ]]; then
+      continue
+    fi
+
+    if [[ ! "$token" =~ ^[^@]+@[0-9a-f]{40}$ ]]; then
+      echo "FAIL: non-SHA remote uses ref: $line"
+      bad=1
+    fi
+  done < <(rg "^[[:space:]]*uses:[[:space:]]+[^[:space:]#]+" "$wf" || true)
+
+  if [[ "$bad" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+check_permissions_minimal() {
+  rg -n "^permissions:[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing permissions block"; exit 1; }
+  rg -n "^  contents:[[:space:]]*read[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing contents: read"; exit 1; }
+  rg -n "^  actions:[[:space:]]*write[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing actions: write"; exit 1; }
+
+  if rg -n "id-token:[[:space:]]*write" "$wf" >/dev/null; then
+    echo "FAIL: must not request id-token: write"
+    exit 1
+  fi
+
+  if rg -n "permissions:[[:space:]]*(write-all|read-all)" "$wf" >/dev/null; then
+    echo "FAIL: broad permissions (*-all) are not allowed"
+    exit 1
+  fi
+}
+
+check_artifact_contract() {
+  rg -n "name:[[:space:]]*adr025-closure-report" "$wf" >/dev/null || { echo "FAIL: closure artifact name mismatch"; exit 1; }
+  rg -n "retention-days:[[:space:]]*14" "$wf" >/dev/null || { echo "FAIL: closure artifact retention mismatch"; exit 1; }
+  rg -n "adr025-closure-evaluate\.sh" "$wf" >/dev/null || { echo "FAIL: closure evaluator invocation missing"; exit 1; }
+}
+
+test -f "$wf" || { echo "FAIL: missing $wf"; exit 1; }
+
+check_diff_allowlist
+check_no_pr_trigger
+check_sched_dispatch_only
+check_informational_job_level
+check_sha_pins_strict
+check_permissions_minimal
+check_artifact_contract
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
ADR-025 I2 Step3 adds an informational nightly closure lane.

It runs closure evaluation from:
- fresh soak report (`assay sim soak`)
- latest readiness artifact (`adr025-nightly-readiness`)
- I2 manifest fixture
- closure policy (`schemas/closure_policy_v1.json`)

and uploads closure artifacts.

## Scope
- `.github/workflows/adr025-nightly-closure.yml`
- `scripts/ci/review-adr025-i2-step3.sh`
- `docs/contributing/SPLIT-CHECKLIST-adr025-i2-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step3.md`

## Safety contracts
- `schedule` + `workflow_dispatch` only
- no `pull_request` / `pull_request_target`
- job-level `continue-on-error: true`
- SHA-pinned actions
- minimal permissions (`contents: read`, `actions: write`)
- no required-check / branch-protection changes

## Artifact contract
- Artifact name: `adr025-closure-report`
- Files:
  - `closure_report_v1.json`
  - `closure_report_v1.md`
- Retention: 14 days

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-adr025-i2-step3.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
