### PR TITLE
ci(adr025): wire I2 Step4B closure release integration (attach default)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,26 @@ jobs:
             --policy schemas/soak_readiness_policy_v1.json \
             --readiness input/readiness/nightly_readiness.json
 
+      - name: ADR-025 closure release integration
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: ${{ vars.ASSAY_CLOSURE_GATE || 'attach' }}
+          POLICY: schemas/closure_release_policy_v1.json
+          OUT_DIR: artifacts/adr025-closure
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/adr025-closure-release.sh
+
+      - name: Upload ADR-025 closure release evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: adr025-closure-release-evidence
+          path: artifacts/adr025-closure/*
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Generate build provenance attestations
         uses: actions/attest-build-provenance@v2
         with:

--- a/scripts/ci/adr025-closure-release.sh
+++ b/scripts/ci/adr025-closure-release.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${MODE:-attach}"
+POLICY="${POLICY:-schemas/closure_release_policy_v1.json}"
+OUT_DIR="${OUT_DIR:-artifacts/adr025-closure}"
+CLOSURE_JSON=""
+
+usage() {
+  echo "Usage: $0 [--mode off|attach|warn|enforce] [--policy <path>] [--out-dir <dir>] [--closure-json <path>]"
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --policy)
+      POLICY="$2"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --closure-json)
+      CLOSURE_JSON="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      usage
+      ;;
+  esac
+done
+
+case "$MODE" in
+  off|attach|warn|enforce) ;;
+  *)
+    echo "Config error: invalid mode '$MODE'"
+    exit 2
+    ;;
+esac
+
+mkdir -p "$OUT_DIR"
+
+warn_or_fail_measurement() {
+  local msg="$1"
+  if [[ "$MODE" == "warn" ]]; then
+    echo "WARN: ${msg} (mode=warn, continuing)"
+    return 0
+  fi
+  echo "Measurement error: ${msg}"
+  return 2
+}
+
+if [[ "$MODE" == "off" ]]; then
+  echo "ADR-025 closure: mode=off (skipping)"
+  exit 0
+fi
+
+if [[ ! -f "$POLICY" ]]; then
+  warn_or_fail_measurement "policy not found: $POLICY"
+  exit $?
+fi
+
+if [[ -z "$CLOSURE_JSON" ]]; then
+  : "${GH_TOKEN:?Missing GH_TOKEN}"
+
+  rid="$(gh run list --workflow "adr025-nightly-closure.yml" --branch main --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
+  if [[ -z "$rid" || "$rid" == "null" ]]; then
+    warn_or_fail_measurement "could not find successful adr025-nightly-closure run"
+    exit $?
+  fi
+
+  echo "ADR-025 closure: using run id: $rid"
+  gh run download "$rid" -n "adr025-closure-report" -D "$OUT_DIR" || true
+
+  found_json="$(find "$OUT_DIR" -name 'closure_report_v1.json' -print -quit)"
+  if [[ -z "$found_json" ]]; then
+    warn_or_fail_measurement "missing closure_report_v1.json in downloaded artifact"
+    exit $?
+  fi
+  CLOSURE_JSON="$found_json"
+fi
+
+if [[ ! -f "$CLOSURE_JSON" ]]; then
+  warn_or_fail_measurement "closure report JSON not found: $CLOSURE_JSON"
+  exit $?
+fi
+
+python3 - <<'PY' "$MODE" "$POLICY" "$CLOSURE_JSON"
+import json
+import sys
+
+mode, policy_path, report_path = sys.argv[1:]
+
+
+def die(code, msg):
+    print(msg)
+    raise SystemExit(code)
+
+
+try:
+    policy = json.load(open(policy_path, "r", encoding="utf-8"))
+except Exception as exc:
+    die(2, f"Measurement error: invalid policy json: {exc}")
+
+try:
+    report = json.load(open(report_path, "r", encoding="utf-8"))
+except Exception as exc:
+    die(2, f"Measurement error: invalid closure report json: {exc}")
+
+if report.get("schema_version") != "closure_report_v1":
+    die(2, f"Measurement error: unexpected closure schema_version: {report.get('schema_version')}")
+
+score = report.get("score")
+if not isinstance(score, (int, float)):
+    die(2, "Measurement error: closure report missing numeric score")
+score = float(score)
+
+threshold = policy.get("score_threshold")
+if threshold is None:
+    die(2, "Measurement error: policy missing score_threshold")
+try:
+    threshold = float(threshold)
+except ValueError:
+    die(2, f"Measurement error: invalid score_threshold in policy: {threshold}")
+
+classifier_expected = policy.get("classifier_version")
+readiness = ((report.get("inputs") or {}).get("readiness") or {})
+classifier_found = readiness.get("classifier_version")
+
+if classifier_expected is not None:
+    if classifier_found is None:
+        die(2, "Measurement error: closure report missing inputs.readiness.classifier_version")
+    if str(classifier_found) != str(classifier_expected):
+        die(1, f"Policy fail: classifier_version mismatch (report={classifier_found}, policy={classifier_expected})")
+
+violations = report.get("violations") or []
+hard_error = any(isinstance(v, dict) and v.get("severity") == "error" for v in violations)
+
+if mode == "enforce":
+    if hard_error:
+        die(1, "Policy fail: closure report contains error-severity violations")
+    if score < threshold:
+        die(1, f"Policy fail: closure score {score:.3f} < threshold {threshold:.3f}")
+    print(f"Pass: closure score {score:.3f} >= threshold {threshold:.3f}")
+    raise SystemExit(0)
+
+if mode == "attach":
+    if hard_error or score < threshold:
+        print(f"ADR-025 closure: mode=attach score={score:.3f} threshold={threshold:.3f} (non-blocking attach)")
+    else:
+        print(f"ADR-025 closure: mode=attach score={score:.3f} threshold={threshold:.3f}")
+    raise SystemExit(0)
+
+# warn mode
+if hard_error or score < threshold:
+    print(f"WARN: ADR-025 closure non-pass (mode=warn) score={score:.3f}, threshold={threshold:.3f}")
+else:
+    print(f"ADR-025 closure: mode=warn pass score={score:.3f}, threshold={threshold:.3f}")
+raise SystemExit(0)
+PY
+
+found_md="$(find "$OUT_DIR" -name 'closure_report_v1.md' -print -quit || true)"
+if [[ -z "$found_md" ]]; then
+  echo "NOTE: closure_report_v1.md missing (non-fatal)"
+fi
+
+echo "ADR-025 closure: ready in $OUT_DIR"
+exit 0

--- a/scripts/ci/fixtures/adr025-i2/closure_report_fail.json
+++ b/scripts/ci/fixtures/adr025-i2/closure_report_fail.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "closure_report_v1",
+  "score": 0.72,
+  "inputs": {
+    "readiness": {
+      "classifier_version": "1"
+    }
+  },
+  "violations": []
+}

--- a/scripts/ci/fixtures/adr025-i2/closure_report_hard_violation.json
+++ b/scripts/ci/fixtures/adr025-i2/closure_report_hard_violation.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "closure_report_v1",
+  "score": 0.93,
+  "inputs": {
+    "readiness": {
+      "classifier_version": "1"
+    }
+  },
+  "violations": [
+    {
+      "code": "CLSR-CONSISTENCY-MISMATCH",
+      "message": "classifier mismatch",
+      "severity": "error"
+    }
+  ]
+}

--- a/scripts/ci/fixtures/adr025-i2/closure_report_invalid.json
+++ b/scripts/ci/fixtures/adr025-i2/closure_report_invalid.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": "not-closure-v1",
+  "inputs": {}
+}

--- a/scripts/ci/fixtures/adr025-i2/closure_report_pass.json
+++ b/scripts/ci/fixtures/adr025-i2/closure_report_pass.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "closure_report_v1",
+  "score": 0.92,
+  "inputs": {
+    "readiness": {
+      "classifier_version": "1"
+    }
+  },
+  "violations": []
+}

--- a/scripts/ci/review-adr025-i2-step4-b.sh
+++ b/scripts/ci/review-adr025-i2-step4-b.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOW_PREFIXES=(
+  "scripts/ci/adr025-closure-release.sh"
+  "scripts/ci/test-adr025-closure-release.sh"
+  "scripts/ci/fixtures/adr025-i2/"
+  "scripts/ci/review-adr025-i2-step4-b.sh"
+  ".github/workflows/release.yml"
+)
+
+is_allowed() {
+  local f="$1"
+  for p in "${ALLOW_PREFIXES[@]}"; do
+    if [[ "$p" == */ ]]; then
+      [[ "$f" == "$p"* ]] && return 0
+    else
+      [[ "$f" == "$p" ]] && return 0
+    fi
+  done
+  return 1
+}
+
+changed="$(git diff --name-only "$BASE_REF"...HEAD)"
+untracked="$(git ls-files --others --exclude-standard)"
+
+if [[ -n "$untracked" ]]; then
+  if [[ -n "$changed" ]]; then
+    changed="$(printf "%s\n%s\n" "$changed" "$untracked")"
+  else
+    changed="$untracked"
+  fi
+fi
+
+if [[ -z "$changed" ]]; then
+  echo "FAIL: no changes detected vs $BASE_REF"
+  exit 1
+fi
+
+echo "[review] allowlist"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if ! is_allowed "$f"; then
+    echo "FAIL: file not allowed in I2 Step4B: $f"
+    exit 1
+  fi
+
+  if [[ "$f" == .github/workflows/* && "$f" != ".github/workflows/release.yml" ]]; then
+    echo "FAIL: Step4B must not touch non-release workflows ($f)"
+    exit 1
+  fi
+done <<< "$changed"
+
+echo "[review] release workflow trigger remains non-PR"
+if rg -n '^\s*pull_request|^\s*pull_request_target' .github/workflows/release.yml >/dev/null; then
+  echo "FAIL: release workflow must not include pull_request triggers"
+  exit 1
+fi
+
+echo "[review] closure release script wired in release.yml"
+rg -n "adr025-closure-release\.sh" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release workflow missing adr025-closure-release.sh step"
+  exit 1
+}
+
+rg -n "MODE:\s*\$\{\{\s*vars\.ASSAY_CLOSURE_GATE\s*\|\|\s*'attach'\s*\}\}" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release workflow missing default attach mode expression"
+  exit 1
+}
+
+rg -n "name:\s*adr025-closure-release-evidence" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release workflow missing closure release evidence artifact name"
+  exit 1
+}
+
+echo "[review] Step4B must not add id-token: write"
+if git diff -U0 "$BASE_REF"...HEAD -- .github/workflows/release.yml | rg -n '^\+\s*id-token:\s*write' >/dev/null; then
+  echo "FAIL: Step4B must not add id-token: write"
+  exit 1
+fi
+
+echo "[review] run script tests"
+bash scripts/ci/test-adr025-closure-release.sh
+
+echo "[review] done"

--- a/scripts/ci/test-adr025-closure-release.sh
+++ b/scripts/ci/test-adr025-closure-release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+OUTDIR="$(mktemp -d)"
+trap 'rm -rf "$OUTDIR"' EXIT
+
+POLICY="schemas/closure_release_policy_v1.json"
+PASS_JSON="scripts/ci/fixtures/adr025-i2/closure_report_pass.json"
+FAIL_JSON="scripts/ci/fixtures/adr025-i2/closure_report_fail.json"
+HARD_JSON="scripts/ci/fixtures/adr025-i2/closure_report_hard_violation.json"
+INVALID_JSON="scripts/ci/fixtures/adr025-i2/closure_report_invalid.json"
+
+echo "[test] mode=off -> 0"
+bash scripts/ci/adr025-closure-release.sh --mode off --policy "$POLICY" --out-dir "$OUTDIR"
+
+echo "[test] mode=attach pass -> 0"
+bash scripts/ci/adr025-closure-release.sh --mode attach --policy "$POLICY" --closure-json "$PASS_JSON" --out-dir "$OUTDIR"
+
+echo "[test] mode=attach fail-score -> still 0"
+bash scripts/ci/adr025-closure-release.sh --mode attach --policy "$POLICY" --closure-json "$FAIL_JSON" --out-dir "$OUTDIR"
+
+echo "[test] mode=enforce fail-score -> 1"
+set +e
+bash scripts/ci/adr025-closure-release.sh --mode enforce --policy "$POLICY" --closure-json "$FAIL_JSON" --out-dir "$OUTDIR"
+code=$?
+set -e
+test "$code" -eq 1
+
+echo "[test] mode=enforce hard-violation -> 1"
+set +e
+bash scripts/ci/adr025-closure-release.sh --mode enforce --policy "$POLICY" --closure-json "$HARD_JSON" --out-dir "$OUTDIR"
+code=$?
+set -e
+test "$code" -eq 1
+
+echo "[test] mode=enforce invalid-contract -> 2"
+set +e
+bash scripts/ci/adr025-closure-release.sh --mode enforce --policy "$POLICY" --closure-json "$INVALID_JSON" --out-dir "$OUTDIR"
+code=$?
+set -e
+test "$code" -eq 2
+
+echo "[test] mode=warn invalid-contract -> 0"
+bash scripts/ci/adr025-closure-release.sh --mode warn --policy "$POLICY" --closure-json "$INVALID_JSON" --out-dir "$OUTDIR"
+
+echo "[test] done"


### PR DESCRIPTION
## Summary
ADR-025 I2 Step4B wires closure release integration into `release.yml` with explicit mode contract:
- `off|attach|warn|enforce`
- default mode: `attach`

Release lane behavior:
- download latest `adr025-closure-report` from `adr025-nightly-closure.yml`
- evaluate via `scripts/ci/adr025-closure-release.sh`
- upload release evidence artifact `adr025-closure-release-evidence`

## Scope
- `scripts/ci/adr025-closure-release.sh`
- `scripts/ci/test-adr025-closure-release.sh`
- `scripts/ci/review-adr025-i2-step4-b.sh`
- `scripts/ci/fixtures/adr025-i2/closure_report_*.json`
- `.github/workflows/release.yml`

## Safety
- Release-only workflow wiring (no PR trigger changes)
- Default mode is non-blocking `attach`
- `warn` mode is non-blocking and converts failures to warnings
- `enforce` mode propagates policy/contract failures (`1/2`)
- No new `id-token: write` introduced

## Verification
- `bash scripts/ci/test-adr025-closure-release.sh`
- `BASE_REF=origin/codex/adr025-i2-step4-a-freeze bash scripts/ci/review-adr025-i2-step4-b.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`

## Notes
- This PR is stacked on Step4A (`#405`) and should merge after Step4A.
