### PR TITLE
docs(adr025): close I2 Step4 rollout with runbook + reviewer gate (Step4C)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,6 +6,7 @@
 > **Starter packs (ADR-023)** merged PR #289 — cicd-starter default pack, assayrunid fix, vendored drift CI, --explain UX.
 > Split refactor program closed loop through Wave7C Step3 on `main` (see [plan](architecture/PLAN-split-refactor-2026q1.md), [report](architecture/REPORT-split-refactor-2026q1.md), [program review pack](contributing/SPLIT-REVIEW-PACK-2026q1-program.md)).
 > Next: [Evidence-as-a-Product (ADR-025)](architecture/ADR-025-Evidence-as-a-Product.md) - Pivot from Sim Hardening to Audit Kit & Soak. Structural items in [RFC-004](architecture/RFC-004-open-items-convergence-q1-2026.md).
+> ADR-025 I2 Step4 status (2026-02-20): release-lane closure evidence integration merged on `main` (default `attach`), `enforce` remains opt-in.
 
 **Strategic Focus:** Agent Runtime Evidence & Control Plane.
 **Core Value:** Verifiable Evidence (Open Standard) + Governance Platform.

--- a/docs/architecture/PLAN-ADR-025-I2-audit-kit-closure-2026q2.md
+++ b/docs/architecture/PLAN-ADR-025-I2-audit-kit-closure-2026q2.md
@@ -67,3 +67,8 @@ Additions to manifest (conceptual contract):
 ## Step3 rollout plan (preview)
 - Informational nightly closure artifact lane (no PR required-check impact)
 - Release/promote may attach closure artifact as evidence (non-blocking unless explicitly enabled later)
+
+## Step4 status (2026-02-20)
+- Step4A merged on `main`: release integration contract freeze (`off|attach|warn|enforce`, default `attach`).
+- Step4B merged on `main`: release-lane closure attach wiring via `scripts/ci/adr025-closure-release.sh`.
+- Step4C closes the rollout loop: runbook, reviewer closure artifacts, and Step4C allowlist/invariant gate.

--- a/docs/contributing/SPLIT-CHECKLIST-adr025-i2-step4-c-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-i2-step4-c-closure.md
@@ -1,0 +1,28 @@
+# SPLIT CHECKLIST — ADR-025 I2 Step4C (closure slice)
+
+## Scope (hard)
+- [ ] Only Step4C allowlist files changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No runtime behavior changes (docs + reviewer gate only)
+
+## Contracts (must match current main)
+- [ ] Policy exists: `schemas/closure_release_policy_v1.json`
+- [ ] Release script exists: `scripts/ci/adr025-closure-release.sh`
+- [ ] Step4B reviewer gate exists: `scripts/ci/review-adr025-i2-step4-b.sh`
+- [ ] Release wiring references release script in `.github/workflows/release.yml`
+
+## Mode contract
+- [ ] Modes documented: `off|attach|warn|enforce`
+- [ ] Default documented: `attach`
+- [ ] Exit contract documented: `0/1/2` with meanings
+
+## Runbook completeness
+- [ ] Missing artifact flow
+- [ ] Classifier/schema mismatch flow
+- [ ] Score below threshold flow
+- [ ] Break-glass override rules + audit trail
+
+## Reviewer gates
+- [ ] `scripts/ci/review-adr025-i2-step4-c.sh` exists
+- [ ] Gate enforces allowlist-only + workflow-ban
+- [ ] Gate verifies invariants on main assets (policy/script/release wiring)

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step4-c-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step4-c-closure.md
@@ -1,0 +1,34 @@
+# Review Pack — ADR-025 I2 Step4C (closure)
+
+## Intent
+Close ADR-025 I2 Step4 by:
+- Adding operational runbook for closure release integration
+- Capturing Step4A/4B contracts as reviewer checklist
+- Syncing PLAN/ROADMAP with what is on `main`
+- Adding a strict reviewer gate for this closure slice
+
+## Non-goals
+- No workflow edits
+- No changes to closure generation or release runtime behavior
+- No PR-lane required-check changes
+
+## Scope (allowlist)
+- docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md
+- docs/contributing/SPLIT-CHECKLIST-adr025-i2-step4-c-closure.md
+- docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step4-c-closure.md
+- docs/architecture/PLAN-ADR-025-I2-audit-kit-closure-2026q2.md
+- docs/ROADMAP.md
+- scripts/ci/review-adr025-i2-step4-c.sh
+
+## Verification
+- `BASE_REF=origin/main bash scripts/ci/review-adr025-i2-step4-c.sh`
+- `bash scripts/ci/review-adr025-i2-step4-a.sh`
+- `bash scripts/ci/review-adr025-i2-step4-b.sh`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+
+## Reviewer 60s scan
+1) Confirm no workflow files changed
+2) Run Step4C reviewer gate script
+3) Skim runbook for mode/exit/break-glass correctness
+4) Confirm PLAN/ROADMAP status lines match Step4 reality

--- a/docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md
+++ b/docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md
@@ -1,0 +1,84 @@
+# ADR-025 I2 — Closure Release Runbook
+
+## Purpose
+Operational guidance for the ADR-025 I2 closure artifact integration in the **release lane only**.
+PR lanes are intentionally unchanged.
+
+## What exists
+- Nightly closure artifact workflow (informational): `.github/workflows/adr025-nightly-closure.yml`
+  - artifact: `adr025-closure-report`
+  - files: `closure_report_v1.json`, `closure_report_v1.md` (retention 14 days)
+- Release integration (Step4B):
+  - script: `scripts/ci/adr025-closure-release.sh`
+  - policy: `schemas/closure_release_policy_v1.json`
+  - wired in: `.github/workflows/release.yml` (before publish/attestations)
+
+## Gate modes
+Configured via env/input (release workflow):
+- `off`     : skip closure download/eval
+- `attach`  : download + attach closure artifacts; **non-blocking**
+- `warn`    : like attach, but prints WARN on missing/invalid closure; **non-blocking**
+- `enforce` : fail-closed on policy/contract violations
+
+Default mode for I2 is **attach**.
+
+## Exit contract (release integration)
+The release step's decision is determined by `scripts/ci/adr025-closure-release.sh`:
+- `0` pass/attach (or off)
+- `1` policy/closure fail (only blocks in `enforce`)
+- `2` measurement/contract fail (missing artifact/json, parse errors, schema mismatch)
+
+## Common incidents & response
+
+### A) Missing closure artifact / missing closure_report_v1.json
+Symptoms:
+- Script prints "missing closure_report_v1.json in artifact"
+- Exit:
+  - `attach`: continues (non-blocking), artifacts may be absent
+  - `warn`: continues with WARN
+  - `enforce`: exit `2` (blocks release)
+
+Actions:
+1) Check nightly closure workflow health and latest run outcome.
+2) Confirm artifact name is `adr025-closure-report`.
+3) Re-run nightly closure via workflow_dispatch if needed.
+
+### B) Classifier mismatch / schema mismatch / invalid JSON
+Symptoms:
+- Script prints "unexpected closure schema_version" or parse errors.
+- Exit:
+  - `attach`/`warn`: non-blocking, logs decision
+  - `enforce`: exit `2` (blocks release)
+
+Actions:
+1) Verify `closure_report_v1.json` was produced by current `adr025-closure-evaluate.sh`.
+2) Verify policy file version aligns (`schemas/closure_release_policy_v1.json`).
+3) If mismatch is due to a planned contract change: update policy/contracts first (new freeze slice).
+
+### C) Score below threshold
+Symptoms:
+- In enforce mode: "closure score < threshold"
+- Exit:
+  - `enforce`: exit `1` (blocks release)
+  - `attach`/`warn`: logs score and proceeds
+
+Actions:
+1) Inspect `closure_report_v1.md` for gaps/violations.
+2) Address completeness/provenance gaps (inputs/manifest extensions).
+3) If threshold is too strict: change policy via a freeze PR (do not hotfix in release).
+
+## Break-glass / override
+Use break-glass only for time-critical releases with explicit release ownership.
+Rules:
+- Override must be explicit (set mode to `off` or `attach`) and auditable (workflow run inputs/logs).
+- Do not silently bypass enforcement in code.
+- After incident, revert to default **attach** and file a follow-up issue describing:
+  - root cause
+  - whether policy/inputs need adjustment
+  - whether to upgrade to `warn`/`enforce` later
+
+## Verification commands (local)
+- Reviewer gates:
+  - `bash scripts/ci/review-adr025-i2-step4-a.sh`
+  - `bash scripts/ci/review-adr025-i2-step4-b.sh`
+  - `bash scripts/ci/review-adr025-i2-step4-c.sh`

--- a/scripts/ci/review-adr025-i2-step4-c.sh
+++ b/scripts/ci/review-adr025-i2-step4-c.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md"
+  "docs/contributing/SPLIT-CHECKLIST-adr025-i2-step4-c-closure.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step4-c-closure.md"
+  "docs/architecture/PLAN-ADR-025-I2-audit-kit-closure-2026q2.md"
+  "docs/ROADMAP.md"
+  "scripts/ci/review-adr025-i2-step4-c.sh"
+)
+
+echo "[review] diff allowlist"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Step4C must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in I2 Step4C: $f"
+    exit 1
+  fi
+done
+
+echo "[review] invariants on main assets"
+test -f schemas/closure_release_policy_v1.json || { echo "FAIL: missing closure_release_policy_v1.json"; exit 1; }
+test -f scripts/ci/adr025-closure-release.sh || { echo "FAIL: missing adr025-closure-release.sh"; exit 1; }
+test -f scripts/ci/review-adr025-i2-step4-b.sh || { echo "FAIL: missing review-adr025-i2-step4-b.sh"; exit 1; }
+test -f .github/workflows/release.yml || { echo "FAIL: missing release.yml"; exit 1; }
+
+rg -n "adr025-closure-release\.sh" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release.yml must reference adr025-closure-release.sh"
+  exit 1
+}
+rg -n "closure_release_policy_v1\.json" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release.yml must reference closure_release_policy_v1.json"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Closes ADR-025 I2 Step4 by adding an ops runbook, closure review artifacts, and a strict Step4C reviewer gate. Syncs PLAN/ROADMAP to reflect Step4A/4B on main.

## Scope
Docs + reviewer gate only; no workflow/runtime behavior changes.

## Safety
- No `.github/workflows/*` changes (enforced)
- Allowlist-only diff
- Invariant checks confirm policy/script/release wiring exist on main

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-i2-step4-c.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
- cargo test -p assay-cli
