### PR TITLE
ci(adr025): harden closure release attach script + deterministic tests (Stab B)

### DIFF
--- a/scripts/ci/fixtures/adr025-i2/closure_report_fail.json
+++ b/scripts/ci/fixtures/adr025-i2/closure_report_fail.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "closure_report_v1",
+  "score": 0.10,
+  "inputs": {
+    "readiness": {
+      "classifier_version": "1"
+    }
+  },
+  "violations": []
+}

--- a/scripts/ci/fixtures/adr025-i2/closure_report_pass.json
+++ b/scripts/ci/fixtures/adr025-i2/closure_report_pass.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "closure_report_v1",
+  "score": 0.95,
+  "inputs": {
+    "readiness": {
+      "classifier_version": "1"
+    }
+  },
+  "violations": []
+}

--- a/scripts/ci/fixtures/adr025-i2/closure_report_schema_mismatch.json
+++ b/scripts/ci/fixtures/adr025-i2/closure_report_schema_mismatch.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "closure_report_v0",
+  "score": 0.95,
+  "inputs": {
+    "readiness": {
+      "classifier_version": "1"
+    }
+  },
+  "violations": []
+}

--- a/scripts/ci/fixtures/adr025-i2/closure_report_violations_null.json
+++ b/scripts/ci/fixtures/adr025-i2/closure_report_violations_null.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "closure_report_v1",
+  "score": 0.95,
+  "inputs": {
+    "readiness": {
+      "classifier_version": "1"
+    }
+  },
+  "violations": null
+}

--- a/scripts/ci/fixtures/adr025-i2/closure_report_violations_wrong_type.json
+++ b/scripts/ci/fixtures/adr025-i2/closure_report_violations_wrong_type.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "closure_report_v1",
+  "score": 0.95,
+  "inputs": {
+    "readiness": {
+      "classifier_version": "1"
+    }
+  },
+  "violations": "oops"
+}

--- a/scripts/ci/review-adr025-i2-stab-b.sh
+++ b/scripts/ci/review-adr025-i2-stab-b.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOW_PREFIXES=(
+  "scripts/ci/adr025-closure-release.sh"
+  "scripts/ci/test-adr025-closure-release.sh"
+  "scripts/ci/fixtures/adr025-i2/"
+  "scripts/ci/review-adr025-i2-stab-b.sh"
+)
+
+echo "[review] allowlist + workflow-ban"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: stabilization StepB must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for p in "${ALLOW_PREFIXES[@]}"; do
+    if [[ "$p" == */ ]]; then
+      [[ "$f" == "$p"* ]] && ok="true"
+    else
+      [[ "$f" == "$p" ]] && ok="true"
+    fi
+    [[ "$ok" == "true" ]] && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in stabilization StepB: $f"
+    exit 1
+  fi
+done
+
+echo "[review] run closure release tests"
+bash scripts/ci/test-adr025-closure-release.sh
+
+echo "[review] done"

--- a/scripts/ci/test-adr025-closure-release.sh
+++ b/scripts/ci/test-adr025-closure-release.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+POLICY="schemas/closure_release_policy_v1.json"
+
+run_case() {
+  local mode="$1"
+  local json="$2"
+  local expect="$3"
+
+  set +e
+  ASSAY_CLOSURE_RELEASE_TEST_MODE=1 \
+  MODE="$mode" \
+  POLICY="$POLICY" \
+  ASSAY_CLOSURE_RELEASE_LOCAL_JSON="$json" \
+  bash scripts/ci/adr025-closure-release.sh
+  code=$?
+  set -e
+
+  if [[ "$code" -ne "$expect" ]]; then
+    echo "FAIL: mode=$mode json=$json expected=$expect got=$code"
+    exit 1
+  fi
+  echo "ok: mode=$mode expected=$expect"
+}
+
+run_missing_case() {
+  local mode="$1"
+  local expect="$2"
+
+  set +e
+  ASSAY_CLOSURE_RELEASE_TEST_MODE=1 \
+  MODE="$mode" \
+  POLICY="$POLICY" \
+  ASSAY_CLOSURE_RELEASE_SIMULATE_MISSING_ARTIFACT=1 \
+  bash scripts/ci/adr025-closure-release.sh
+  code=$?
+  set -e
+
+  if [[ "$code" -ne "$expect" ]]; then
+    echo "FAIL: missing-artifact mode=$mode expected=$expect got=$code"
+    exit 1
+  fi
+  echo "ok: missing-artifact mode=$mode expected=$expect"
+}
+
+echo "[test] attach mode never blocks (0) on policy fail"
+run_case "attach" "scripts/ci/fixtures/adr025-i2/closure_report_fail.json" 0
+
+echo "[test] warn mode never blocks (0) on policy fail"
+run_case "warn" "scripts/ci/fixtures/adr025-i2/closure_report_fail.json" 0
+
+echo "[test] enforce blocks on low score (1)"
+run_case "enforce" "scripts/ci/fixtures/adr025-i2/closure_report_fail.json" 1
+
+echo "[test] enforce passes on high score (0)"
+run_case "enforce" "scripts/ci/fixtures/adr025-i2/closure_report_pass.json" 0
+
+echo "[test] schema mismatch is measurement fail (2) in enforce"
+run_case "enforce" "scripts/ci/fixtures/adr025-i2/closure_report_schema_mismatch.json" 2
+
+echo "[test] violations null treated as empty (enforce pass)"
+run_case "enforce" "scripts/ci/fixtures/adr025-i2/closure_report_violations_null.json" 0
+
+echo "[test] violations wrong type is measurement fail (2) in enforce"
+run_case "enforce" "scripts/ci/fixtures/adr025-i2/closure_report_violations_wrong_type.json" 2
+
+echo "[test] missing artifact semantics by mode"
+run_missing_case "attach" 0
+run_missing_case "warn" 0
+run_missing_case "enforce" 2
+
+echo "[test] done"


### PR DESCRIPTION
## Summary
Stabilization PR-B hardens `adr025-closure-release.sh` diagnostics and contract parsing, and adds deterministic tests/fixtures.

## Scope
- scripts/ci/adr025-closure-release.sh
- scripts/ci/test-adr025-closure-release.sh
- scripts/ci/fixtures/adr025-i2/*
- scripts/ci/review-adr025-i2-stab-b.sh

## Safety
- No `.github/workflows/*` changes
- Attach/Warn remain non-blocking modes
- Enforce keeps fail-closed semantics

## Verification
- bash scripts/ci/test-adr025-closure-release.sh
- BASE_REF=origin/main bash scripts/ci/review-adr025-i2-stab-b.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
