### PR TITLE
docs(adr025): sync I2 stabilization ops docs + reviewer gate (Stab C)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-adr025-i2-step4-c-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-i2-step4-c-closure.md
@@ -20,6 +20,8 @@
 - [ ] Missing artifact flow
 - [ ] Classifier/schema mismatch flow
 - [ ] Score below threshold flow
+- [ ] Violations type contract is explicit (`null/missing` vs wrong type)
+- [ ] Test-mode env knobs are documented as test-only
 - [ ] Break-glass override rules + audit trail
 
 ## Reviewer gates

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step4-c-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step4-c-closure.md
@@ -4,6 +4,7 @@
 Close ADR-025 I2 Step4 by:
 - Adding operational runbook for closure release integration
 - Capturing Step4A/4B contracts as reviewer checklist
+- Syncing Stab B hardening semantics (debug output, violations type contract, test-mode notes)
 - Syncing PLAN/ROADMAP with what is on `main`
 - Adding a strict reviewer gate for this closure slice
 

--- a/scripts/ci/review-adr025-i2-stab-c.sh
+++ b/scripts/ci/review-adr025-i2-stab-c.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md"
+  "docs/contributing/SPLIT-CHECKLIST-adr025-i2-step4-c-closure.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step4-c-closure.md"
+  "scripts/ci/review-adr025-i2-stab-c.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: stabilization StepC must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    if [[ "$f" == "$a" ]]; then
+      ok="true"
+      break
+    fi
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in stabilization StepC: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] invariants"
+test -f scripts/ci/adr025-closure-release.sh || { echo "FAIL: missing scripts/ci/adr025-closure-release.sh"; exit 1; }
+test -f scripts/ci/test-adr025-closure-release.sh || { echo "FAIL: missing scripts/ci/test-adr025-closure-release.sh"; exit 1; }
+
+rg -n "ASSAY_CLOSURE_RELEASE_TEST_MODE" scripts/ci/adr025-closure-release.sh >/dev/null || {
+  echo "FAIL: missing ASSAY_CLOSURE_RELEASE_TEST_MODE in closure release script"
+  exit 1
+}
+rg -n "violations must be a list if present" scripts/ci/adr025-closure-release.sh >/dev/null || {
+  echo "FAIL: missing violations type contract check in closure release script"
+  exit 1
+}
+
+rg -n "Violations field wrong type" docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing violations wrong-type triage section"
+  exit 1
+}
+rg -n "Test-only knobs" docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing test-only knobs section"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Stabilization Step C syncs ADR-025 I2 operational docs with Stab B hardening behavior and adds a dedicated Stab C reviewer gate.

## Scope
- docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md
- docs/contributing/SPLIT-CHECKLIST-adr025-i2-step4-c-closure.md
- docs/contributing/SPLIT-REVIEW-PACK-adr025-i2-step4-c-closure.md
- scripts/ci/review-adr025-i2-stab-c.sh

## Safety
- No `.github/workflows/*` changes
- Reviewer gate enforces allowlist-only scope and workflow-ban
- Invariant checks cover closure release script + Stab B test presence

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-i2-stab-c.sh
- BASE_REF=origin/main bash scripts/ci/review-adr025-i2-step4-c.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
- cargo test -p assay-cli
