### PR TITLE
docs(adr025): freeze I3 OTel bridge contract + schema v1 (I3 Step1)

### DIFF
--- a/docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
+++ b/docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
@@ -1,0 +1,82 @@
+# PLAN — ADR-025 I3 OTel Bridge (2026q2)
+
+## Intent
+Iteration 3 introduces an OpenTelemetry bridge as an interoperability layer:
+1) **OTel export/import contract** (GenAI semantic conventions + deterministic envelope).
+2) **Mapping contract OTel -> Assay evidence** (how OTel data becomes verifiable evidence artifacts).
+
+Step1 is a freeze slice: contracts only (docs + schema + reviewer gate). No runtime.
+
+## Scope (Step1 freeze)
+In-scope:
+- Documented export/import envelope and determinism constraints
+- `otel_bridge_report_v1` schema (strict contract for bridge artifacts)
+- Mapping contract section (OTel -> Assay evidence), with explicit non-goals
+
+Out-of-scope (Step1):
+- No ingestion/export code changes
+- No workflow changes
+- No OTel SDK wiring
+- No “live” span/event capture
+- No dashboard/observability product work
+
+## Part A — OTel export/import contract (frozen)
+
+### Inputs
+- OTel traces/spans representing AI-agent execution
+- OTel attributes aligned with GenAI semantic conventions (where present)
+
+### Export format (bridge artifact)
+- Primary output: `otel_bridge_report_v1.json` (schema in `schemas/otel_bridge_report_v1.schema.json`)
+- Optional: raw OTel export payload(s) referenced by digest/path (not embedded by default)
+
+### Envelope requirements (determinism)
+- Stable ordering:
+  - spans ordered by `(trace_id, span_id)` lexicographically
+  - attributes and events sorted deterministically
+- Numeric safety:
+  - large integers that may exceed JS safe-int must be represented as strings in bridge report (explicit list in schema)
+- Redaction:
+  - bridge report can include a redaction summary, but must never require secrets to validate
+- Time:
+  - timestamps preserved if present; additional derived fields must be deterministic
+
+### Compatibility guarantees
+- Bridge report is valid without proprietary vendor fields.
+- Unknown OTel attributes are preserved under a namespaced extension object, but bridge schema remains strict for core fields.
+
+## Part B — Mapping contract: OTel -> Assay evidence (frozen)
+
+### Goal
+Define a deterministic mapping from OTel bridge report to Assay evidence primitives:
+- Evidence events (CloudEvents-like) representing agent/tool calls
+- Manifest extensions to track what was captured/mapped
+
+### Mapping outputs (conceptual)
+- Evidence manifest extensions:
+  - `x-assay.otel_bridge`:
+    - `schema_version`, `classifier_version` (if applicable)
+    - `source`: "otel"
+    - `trace_count`, `span_count`
+    - `mappings_applied[]` (ids/versions/digests)
+  - `x-assay.signal_gaps[]` (required vs captured, if applicable)
+- Evidence events derived deterministically from spans:
+  - tool invocation events
+  - model request/response events
+  - policy decision events (where present)
+
+### Non-goals (Step1)
+- No full OpenTelemetry semantic coverage beyond GenAI + minimal trace context
+- No runtime enforcement based on OTel in I3 Step1
+- No changes to existing evidence bundle formats
+
+## Exit contracts (future Step2)
+Reserved for later (no implementation in Step1):
+- 0: bridge pass
+- 1: mapping/policy fail
+- 2: measurement/contract fail
+
+## Acceptance criteria (Step1)
+- Plan + schema define the bridge artifact contract and determinism constraints
+- Mapping contract is explicit, testable, and has clear non-goals
+- Reviewer gate enforces allowlist-only and workflow-ban

--- a/schemas/otel_bridge_report_v1.schema.json
+++ b/schemas/otel_bridge_report_v1.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.dev/schemas/otel_bridge_report_v1.schema.json",
+  "title": "Assay OTel Bridge Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_version",
+    "assay_version",
+    "source",
+    "summary",
+    "traces"
+  ],
+  "properties": {
+    "schema_version": { "const": "otel_bridge_report_v1" },
+    "report_version": { "type": "string", "minLength": 1 },
+    "assay_version": { "type": "string", "minLength": 1 },
+
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "const": "otel" },
+        "exporter": { "type": "string" },
+        "collector": { "type": "string" }
+      }
+    },
+
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_count", "span_count"],
+      "properties": {
+        "trace_count": { "type": "integer", "minimum": 0 },
+        "span_count": { "type": "integer", "minimum": 0 },
+        "redaction": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["applied"],
+          "properties": {
+            "applied": { "type": "boolean" },
+            "rules": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+      }
+    },
+
+    "traces": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/trace" }
+    },
+
+    "extensions": {
+      "type": "object",
+      "description": "Namespace for vendor- or environment-specific fields not required for validation.",
+      "additionalProperties": true
+    }
+  },
+
+  "$defs": {
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id", "spans"],
+      "properties": {
+        "trace_id": { "$ref": "#/$defs/hex_id" },
+        "spans": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/span" }
+        }
+      }
+    },
+
+    "span": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["span_id", "name", "kind", "start_time_unix_nano", "end_time_unix_nano", "attributes"],
+      "properties": {
+        "span_id": { "$ref": "#/$defs/hex_span_id" },
+        "parent_span_id": { "$ref": "#/$defs/hex_span_id" },
+        "name": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "enum": ["INTERNAL", "SERVER", "CLIENT", "PRODUCER", "CONSUMER"] },
+
+        "start_time_unix_nano": {
+          "description": "May exceed JS safe-int; encoded as string.",
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "end_time_unix_nano": {
+          "description": "May exceed JS safe-int; encoded as string.",
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+
+        "attributes": {
+          "type": "array",
+          "description": "Deterministically sorted list of key/value attributes.",
+          "items": { "$ref": "#/$defs/kv" }
+        },
+
+        "events": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/event" }
+        },
+
+        "links": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/link" }
+        },
+
+        "status": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["code"],
+          "properties": {
+            "code": { "type": "string", "enum": ["UNSET", "OK", "ERROR"] },
+            "message": { "type": "string" }
+          }
+        }
+      }
+    },
+
+    "kv": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "value"],
+      "properties": {
+        "key": { "type": "string", "minLength": 1 },
+        "value": { "$ref": "#/$defs/any_value" }
+      }
+    },
+
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "time_unix_nano", "attributes"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "time_unix_nano": { "type": "string", "pattern": "^[0-9]+$" },
+        "attributes": { "type": "array", "items": { "$ref": "#/$defs/kv" } }
+      }
+    },
+
+    "link": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id", "span_id"],
+      "properties": {
+        "trace_id": { "$ref": "#/$defs/hex_id" },
+        "span_id": { "$ref": "#/$defs/hex_span_id" },
+        "attributes": { "type": "array", "items": { "$ref": "#/$defs/kv" } }
+      }
+    },
+
+    "any_value": {
+      "description": "OTel AnyValue-like; restricted to JSON-friendly subset for bridge report.",
+      "oneOf": [
+        { "type": "string" },
+        { "type": "number" },
+        { "type": "boolean" },
+        { "type": "null" },
+        { "type": "array", "items": { "$ref": "#/$defs/any_value" } },
+        { "type": "object", "additionalProperties": { "$ref": "#/$defs/any_value" } }
+      ]
+    },
+
+    "hex_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{32}$"
+    },
+    "hex_span_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{16}$"
+    }
+  }
+}

--- a/scripts/ci/review-adr025-i3-step1.sh
+++ b/scripts/ci/review-adr025-i3-step1.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md"
+  "schemas/otel_bridge_report_v1.schema.json"
+  "scripts/ci/review-adr025-i3-step1.sh"
+)
+
+echo "[review] allowlist + workflow-ban"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: I3 Step1 must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in I3 Step1: $f"
+    exit 1
+  fi
+done
+
+echo "[review] schema JSON parses"
+python3 - <<'PY'
+import json
+json.load(open("schemas/otel_bridge_report_v1.schema.json","r",encoding="utf-8"))
+print("otel_bridge_report_v1 schema: ok")
+PY
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
ADR-025 I3 Step1 freezes the OTel bridge export/import contract and the mapping contract (docs only), plus a strict reviewer gate.

## Scope
- docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
- schemas/otel_bridge_report_v1.schema.json
- scripts/ci/review-adr025-i3-step1.sh

## Safety
- Allowlist-only diff
- Workflow-ban enforced

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step1.sh
- cargo fmt/clippy/test (assay-cli)
