### PR TITLE
ci(adr025): implement I3 OTel bridge report generator + deterministic tests (I3 Step2)

### DIFF
--- a/scripts/ci/adr025-otel-bridge.sh
+++ b/scripts/ci/adr025-otel-bridge.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IN=""
+OUT_JSON=""
+OUT_MD=""
+ASSAY_VERSION="${ASSAY_VERSION:-0.0.0-script}"
+
+usage() {
+  echo "Usage: $0 --in <otel_input.json> --out-json <otel_bridge_report_v1.json> --out-md <otel_bridge_report_v1.md> [--assay-version <v>]"
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --in)
+      IN="$2"
+      shift 2
+      ;;
+    --out-json)
+      OUT_JSON="$2"
+      shift 2
+      ;;
+    --out-md)
+      OUT_MD="$2"
+      shift 2
+      ;;
+    --assay-version)
+      ASSAY_VERSION="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      usage
+      ;;
+  esac
+done
+
+[[ -z "$IN" || -z "$OUT_JSON" || -z "$OUT_MD" ]] && usage
+[[ -f "$IN" ]] || {
+  echo "Measurement error: missing input file: $IN"
+  exit 2
+}
+
+python3 - <<'PY' "$IN" "$OUT_JSON" "$OUT_MD" "$ASSAY_VERSION"
+import json
+import sys
+from typing import Any, Dict, List
+
+in_path, out_json, out_md, assay_version = sys.argv[1:]
+
+
+def die(msg: str):
+    print(f"Measurement error: {msg}")
+    raise SystemExit(2)
+
+
+def to_str_int(x: Any) -> str:
+    if isinstance(x, int):
+        return str(x)
+    if isinstance(x, str) and x.isdigit():
+        return x
+    die(f"expected unix_nano int or digit-string, got {x!r}")
+
+
+def norm_hex(x: Any, n: int, label: str) -> str:
+    if not isinstance(x, str):
+        die(f"{label} must be string")
+    y = x.strip().lower()
+    if len(y) != n or any(c not in "0123456789abcdef" for c in y):
+        die(f"{label} must be lowercase hex len={n}, got {x!r}")
+    return y
+
+
+def kv_list(obj: Any) -> List[Dict[str, Any]]:
+    if obj is None:
+        return []
+    if isinstance(obj, list):
+        out = []
+        for it in obj:
+            if not isinstance(it, dict) or "key" not in it or "value" not in it:
+                die("attributes list items must be {key,value}")
+            out.append({"key": str(it["key"]), "value": it["value"]})
+        out.sort(key=lambda x: x["key"])
+        return out
+    if isinstance(obj, dict):
+        out = [{"key": str(k), "value": v} for k, v in obj.items()]
+        out.sort(key=lambda x: x["key"])
+        return out
+    die("attributes must be object or array")
+
+
+def event_list(obj: Any) -> List[Dict[str, Any]]:
+    if obj is None:
+        return []
+    if not isinstance(obj, list):
+        die("events must be array")
+    out = []
+    for e in obj:
+        if not isinstance(e, dict):
+            die("event must be object")
+        name = e.get("name")
+        t = e.get("time_unix_nano")
+        attrs = kv_list(e.get("attributes", {}))
+        if not isinstance(name, str) or not name:
+            die("event.name required")
+        out.append({"name": name, "time_unix_nano": to_str_int(t), "attributes": attrs})
+    out.sort(key=lambda x: (x["time_unix_nano"], x["name"]))
+    return out
+
+
+def link_list(obj: Any) -> List[Dict[str, Any]]:
+    if obj is None:
+        return []
+    if not isinstance(obj, list):
+        die("links must be array")
+    out = []
+    for l in obj:
+        if not isinstance(l, dict):
+            die("link must be object")
+        tid = norm_hex(l.get("trace_id"), 32, "link.trace_id")
+        sid = norm_hex(l.get("span_id"), 16, "link.span_id")
+        attrs = kv_list(l.get("attributes", {}))
+        out.append({"trace_id": tid, "span_id": sid, "attributes": attrs})
+    out.sort(key=lambda x: (x["trace_id"], x["span_id"]))
+    return out
+
+
+data = json.load(open(in_path, "r", encoding="utf-8"))
+traces_in = data.get("traces")
+if not isinstance(traces_in, list):
+    die("top-level traces must be array")
+
+traces_out = []
+span_count = 0
+
+for t in traces_in:
+    if not isinstance(t, dict):
+        die("trace must be object")
+    trace_id = norm_hex(t.get("trace_id"), 32, "trace_id")
+    spans_in = t.get("spans")
+    if not isinstance(spans_in, list):
+        die("trace.spans must be array")
+
+    spans_out = []
+    for s in spans_in:
+        if not isinstance(s, dict):
+            die("span must be object")
+        span_id = norm_hex(s.get("span_id"), 16, "span_id")
+        parent = s.get("parent_span_id")
+        parent_id = norm_hex(parent, 16, "parent_span_id") if parent is not None else None
+
+        name = s.get("name")
+        kind = s.get("kind")
+        if not isinstance(name, str) or not name:
+            die("span.name required")
+        if kind not in ("INTERNAL", "SERVER", "CLIENT", "PRODUCER", "CONSUMER"):
+            die(f"span.kind invalid: {kind!r}")
+
+        st = to_str_int(s.get("start_time_unix_nano"))
+        et = to_str_int(s.get("end_time_unix_nano"))
+
+        attrs = kv_list(s.get("attributes", {}))
+        events = event_list(s.get("events", []))
+        links = link_list(s.get("links", []))
+
+        span_obj = {
+            "span_id": span_id,
+            "name": name,
+            "kind": kind,
+            "start_time_unix_nano": st,
+            "end_time_unix_nano": et,
+            "attributes": attrs,
+        }
+        if parent_id:
+            span_obj["parent_span_id"] = parent_id
+        if events:
+            span_obj["events"] = events
+        if links:
+            span_obj["links"] = links
+
+        spans_out.append(span_obj)
+        span_count += 1
+
+    spans_out.sort(key=lambda x: (trace_id, x["span_id"]))
+    traces_out.append({"trace_id": trace_id, "spans": spans_out})
+
+traces_out.sort(key=lambda x: x["trace_id"])
+
+report = {
+    "schema_version": "otel_bridge_report_v1",
+    "report_version": "1",
+    "assay_version": assay_version,
+    "source": {"kind": "otel"},
+    "summary": {"trace_count": len(traces_out), "span_count": span_count},
+    "traces": traces_out,
+    "extensions": {
+        "non_attribute_metadata": {
+            "resource": data.get("resource", None)
+        }
+    },
+}
+
+with open(out_json, "w", encoding="utf-8") as f:
+    json.dump(report, f, indent=2, sort_keys=True)
+
+md = []
+md.append("# ADR-025 OTel Bridge Report (v1)")
+md.append("")
+md.append(f"- trace_count: **{report['summary']['trace_count']}**")
+md.append(f"- span_count: **{report['summary']['span_count']}**")
+md.append("")
+md.append("## Notes")
+md.append("- Unknown OTel attributes are preserved in `attributes[]` entries.")
+md.append("- `extensions` is reserved for non-attribute metadata (e.g., resource).")
+with open(out_md, "w", encoding="utf-8") as f:
+    f.write("\n".join(md) + "\n")
+
+raise SystemExit(0)
+PY

--- a/scripts/ci/fixtures/adr025-i3/otel_input_minimal.json
+++ b/scripts/ci/fixtures/adr025-i3/otel_input_minimal.json
@@ -1,0 +1,30 @@
+{
+  "resource": { "attributes": { "service.name": "demo" } },
+  "traces": [
+    {
+      "trace_id": "0123456789abcdef0123456789abcdef",
+      "spans": [
+        {
+          "span_id": "0011223344556677",
+          "name": "agent.run",
+          "kind": "INTERNAL",
+          "start_time_unix_nano": 1700000000000000000,
+          "end_time_unix_nano": 1700000000100000000,
+          "attributes": {
+            "gen_ai.provider.name": "openai",
+            "gen_ai.operation.name": "chat",
+            "custom.foo": "bar"
+          },
+          "events": [
+            {
+              "name": "gen_ai.prompt",
+              "time_unix_nano": 1700000000000000001,
+              "attributes": { "content": "hello" }
+            }
+          ],
+          "links": []
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ci/fixtures/adr025-i3/otel_input_missing_required.json
+++ b/scripts/ci/fixtures/adr025-i3/otel_input_missing_required.json
@@ -1,0 +1,14 @@
+{
+  "traces": [
+    {
+      "trace_id": "0123456789abcdef0123456789abcdef",
+      "spans": [
+        {
+          "name": "missing span_id + times",
+          "kind": "INTERNAL",
+          "attributes": {}
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ci/fixtures/adr025-i3/otel_input_uppercase_ids.json
+++ b/scripts/ci/fixtures/adr025-i3/otel_input_uppercase_ids.json
@@ -1,0 +1,19 @@
+{
+  "traces": [
+    {
+      "trace_id": "0123456789ABCDEF0123456789ABCDEF",
+      "spans": [
+        {
+          "span_id": "0011223344556677",
+          "name": "agent.run",
+          "kind": "INTERNAL",
+          "start_time_unix_nano": "1700000000000000000",
+          "end_time_unix_nano": "1700000000100000000",
+          "attributes": { "k": "v" },
+          "events": [],
+          "links": []
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/ci/review-adr025-i3-step2.sh
+++ b/scripts/ci/review-adr025-i3-step2.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOW_PREFIXES=(
+  "scripts/ci/adr025-otel-bridge.sh"
+  "scripts/ci/test-adr025-otel-bridge.sh"
+  "scripts/ci/fixtures/adr025-i3/"
+  "scripts/ci/review-adr025-i3-step2.sh"
+)
+
+echo "[review] allowlist + workflow-ban"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: I3 Step2 must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for p in "${ALLOW_PREFIXES[@]}"; do
+    if [[ "$p" == */ ]]; then
+      [[ "$f" == "$p"* ]] && ok="true"
+    else
+      [[ "$f" == "$p" ]] && ok="true"
+    fi
+    [[ "$ok" == "true" ]] && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in I3 Step2: $f"
+    exit 1
+  fi
+done
+
+echo "[review] run otel bridge tests"
+bash scripts/ci/test-adr025-otel-bridge.sh
+
+echo "[review] done"

--- a/scripts/ci/test-adr025-otel-bridge.sh
+++ b/scripts/ci/test-adr025-otel-bridge.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+OUTDIR="$(mktemp -d)"
+trap 'rm -rf "$OUTDIR"' EXIT
+
+run_ok() {
+  local infile="$1"
+  local outjson="$2"
+  local outmd="$3"
+
+  bash scripts/ci/adr025-otel-bridge.sh \
+    --in "$infile" \
+    --out-json "$outjson" \
+    --out-md "$outmd"
+
+  test -f "$outjson"
+  test -f "$outmd"
+  python3 - <<'PY' "$outjson"
+import json
+import sys
+
+d = json.load(open(sys.argv[1], "r", encoding="utf-8"))
+assert d["schema_version"] == "otel_bridge_report_v1"
+assert "traces" in d and isinstance(d["traces"], list)
+PY
+}
+
+echo "[test] pass minimal"
+run_ok "scripts/ci/fixtures/adr025-i3/otel_input_minimal.json" "$OUTDIR/r1.json" "$OUTDIR/r1.md"
+
+echo "[test] uppercase ids normalize"
+run_ok "scripts/ci/fixtures/adr025-i3/otel_input_uppercase_ids.json" "$OUTDIR/r2.json" "$OUTDIR/r2.md"
+python3 - <<'PY' "$OUTDIR/r2.json"
+import json
+import sys
+
+d = json.load(open(sys.argv[1], "r", encoding="utf-8"))
+tid = d["traces"][0]["trace_id"]
+assert tid == tid.lower()
+PY
+
+echo "[test] missing required => exit 2"
+set +e
+bash scripts/ci/adr025-otel-bridge.sh \
+  --in "scripts/ci/fixtures/adr025-i3/otel_input_missing_required.json" \
+  --out-json "$OUTDIR/r3.json" \
+  --out-md "$OUTDIR/r3.md"
+code=$?
+set -e
+test "$code" -eq 2
+
+echo "[test] done"


### PR DESCRIPTION
## Summary
Implements a script-first ADR-025 I3 Step2 OTel bridge generator and deterministic test/gate coverage.

## Scope
- scripts/ci/adr025-otel-bridge.sh
- scripts/ci/test-adr025-otel-bridge.sh
- scripts/ci/fixtures/adr025-i3/*
- scripts/ci/review-adr025-i3-step2.sh

## Determinism + Contract
- Lowercase trace/span ID normalization
- Deterministic sorting for traces/spans/attributes/events/links
- unix_nano fields emitted as strings
- Unknown attrs preserved in `attributes[]`
- Exit 2 on measurement/contract errors

## Safety
- No `.github/workflows/*` changes
- Reviewer gate enforces allowlist-only + workflow-ban

## Verification
- bash scripts/ci/test-adr025-otel-bridge.sh
- BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step2.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
- cargo test -p assay-cli
