### PR TITLE
ci(adr025): add informational nightly OTel bridge workflow + reviewer gate (I3 Step3)

### DIFF
--- a/.github/workflows/adr025-nightly-otel-bridge.yml
+++ b/.github/workflows/adr025-nightly-otel-bridge.yml
@@ -1,0 +1,47 @@
+name: ADR-025 Nightly OTel Bridge (informational)
+
+on:
+  schedule:
+    - cron: "53 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: adr025-nightly-otel-bridge
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  otel_bridge:
+    name: otel bridge (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Prepare artifacts dir
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+
+      - name: Generate OTel bridge report (fixture)
+        run: |
+          set -euo pipefail
+          bash scripts/ci/adr025-otel-bridge.sh \
+            --in scripts/ci/fixtures/adr025-i3/otel_input_minimal.json \
+            --out-json artifacts/otel_bridge_report_v1.json \
+            --out-md artifacts/otel_bridge_report_v1.md
+
+      - name: Upload OTel bridge artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: adr025-otel-bridge-report
+          path: artifacts/*
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/contributing/SPLIT-CHECKLIST-adr025-i3-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-i3-step3.md
@@ -1,0 +1,22 @@
+# ADR-025 I3 Step3 Checklist (OTel bridge rollout informational)
+
+## Scope
+- [ ] Workflow exists: `.github/workflows/adr025-nightly-otel-bridge.yml`
+- [ ] Reviewer gate exists: `scripts/ci/review-adr025-i3-step3.sh`
+- [ ] Review pack exists: `docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md`
+
+## Trigger/permissions contracts
+- [ ] Triggers are `schedule` + `workflow_dispatch` only
+- [ ] No `pull_request`/`pull_request_target`
+- [ ] Job-level `continue-on-error: true`
+- [ ] Actions are SHA-pinned
+- [ ] Minimal permissions (`contents: read`, `actions: write`)
+
+## Artifact contract
+- [ ] Upload artifact `adr025-otel-bridge-report`
+- [ ] Contains `otel_bridge_report_v1.json` and `otel_bridge_report_v1.md`
+- [ ] Retention is 14 days
+
+## Safety
+- [ ] Informational-only lane (no PR required-check impact)
+- [ ] No changes outside Step3 allowlist

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md
@@ -1,0 +1,25 @@
+# ADR-025 I3 Step3 Review Pack (OTel bridge rollout informational)
+
+## Summary
+Adds an informational nightly OTel bridge lane that generates `otel_bridge_report_v1` from deterministic fixture input:
+- generator: `scripts/ci/adr025-otel-bridge.sh`
+- input fixture: `scripts/ci/fixtures/adr025-i3/otel_input_minimal.json`
+- output artifact: `adr025-otel-bridge-report`
+
+## Safety contracts
+- Schedule + dispatch only (no PR triggers)
+- Job-level `continue-on-error: true`
+- SHA-pinned actions only
+- Minimal permissions only
+- No required-check / branch-protection changes
+
+## Verification
+- `BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step3.sh`
+- Workflow contains generator invocation: `scripts/ci/adr025-otel-bridge.sh`
+- Artifact contract:
+  - `otel_bridge_report_v1.json`
+  - `otel_bridge_report_v1.md`
+
+## Notes
+- This is informational-only rollout (I3 Step3).
+- Enforcement decisions remain outside this slice.

--- a/scripts/ci/review-adr025-i3-step3.sh
+++ b/scripts/ci/review-adr025-i3-step3.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+base_ref="${BASE_REF:-origin/main}"
+wf=".github/workflows/adr025-nightly-otel-bridge.yml"
+
+allowlist=(
+  ".github/workflows/adr025-nightly-otel-bridge.yml"
+  "scripts/ci/review-adr025-i3-step3.sh"
+  "docs/contributing/SPLIT-CHECKLIST-adr025-i3-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md"
+)
+
+has_allowlisted_file() {
+  local f="$1"
+  for allowed in "${allowlist[@]}"; do
+    if [[ "$f" == "$allowed" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+check_diff_allowlist() {
+  echo "[review] diff allowlist vs ${base_ref}"
+
+  git rev-parse --verify "$base_ref" >/dev/null 2>&1 || {
+    echo "FAIL: base ref '$base_ref' not found (run: git fetch origin)"
+    exit 1
+  }
+
+  local changed
+  changed="$(git diff --name-only "${base_ref}...HEAD")"
+
+  if [[ -z "$changed" ]]; then
+    echo "FAIL: no changes detected vs ${base_ref}"
+    exit 1
+  fi
+
+  local leaked=0
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    if ! has_allowlisted_file "$f"; then
+      echo "FAIL: non-allowlisted file changed: $f"
+      leaked=1
+    fi
+  done <<< "$changed"
+
+  if [[ "$leaked" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+extract_top_level_event_keys() {
+  local file="$1"
+  awk '
+    BEGIN {in_on=0}
+    /^on:[[:space:]]*$/ {in_on=1; next}
+    in_on && /^[^[:space:]]/ {in_on=0}
+    in_on && /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/ {
+      key=$1
+      sub(":", "", key)
+      print key
+    }
+  ' "$file"
+}
+
+check_sched_dispatch_only() {
+  rg -n "^on:[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing top-level on: block"; exit 1; }
+  rg -n "^  schedule:[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing schedule trigger"; exit 1; }
+  rg -n "^  workflow_dispatch:[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing workflow_dispatch trigger"; exit 1; }
+
+  while IFS= read -r key; do
+    [[ -z "$key" ]] && continue
+    if [[ "$key" != "schedule" && "$key" != "workflow_dispatch" ]]; then
+      echo "FAIL: non-allowed trigger under on:: $key"
+      exit 1
+    fi
+  done < <(extract_top_level_event_keys "$wf")
+}
+
+check_no_pr_trigger() {
+  if rg -n "pull_request|pull_request_target" "$wf" >/dev/null; then
+    echo "FAIL: workflow must not include pull_request/pull_request_target"
+    exit 1
+  fi
+}
+
+check_informational_job_level() {
+  if ! rg -n "^    continue-on-error:[[:space:]]*true[[:space:]]*$" "$wf" >/dev/null; then
+    echo "FAIL: missing job-level continue-on-error: true"
+    exit 1
+  fi
+
+  if rg -n "^[[:space:]]{6,}continue-on-error:[[:space:]]*true[[:space:]]*$" "$wf" >/dev/null; then
+    echo "FAIL: step-level continue-on-error found; require job-level only"
+    exit 1
+  fi
+}
+
+check_sha_pins_strict() {
+  local bad=0
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    local token
+    token="$(sed -E 's/^[[:space:]]*uses:[[:space:]]+([^[:space:]#]+).*/\1/' <<< "$line")"
+
+    if [[ "$token" =~ ^\./ ]]; then
+      continue
+    fi
+
+    if [[ ! "$token" =~ ^[^@]+@[0-9a-f]{40}$ ]]; then
+      echo "FAIL: non-SHA remote uses ref: $line"
+      bad=1
+    fi
+  done < <(rg "^[[:space:]]*uses:[[:space:]]+[^[:space:]#]+" "$wf" || true)
+
+  if [[ "$bad" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+check_permissions_minimal() {
+  rg -n "^permissions:[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing permissions block"; exit 1; }
+  rg -n "^  contents:[[:space:]]*read[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing contents: read"; exit 1; }
+  rg -n "^  actions:[[:space:]]*write[[:space:]]*$" "$wf" >/dev/null || { echo "FAIL: missing actions: write"; exit 1; }
+
+  if rg -n "id-token:[[:space:]]*write" "$wf" >/dev/null; then
+    echo "FAIL: must not request id-token: write"
+    exit 1
+  fi
+
+  if rg -n "permissions:[[:space:]]*(write-all|read-all)" "$wf" >/dev/null; then
+    echo "FAIL: broad permissions (*-all) are not allowed"
+    exit 1
+  fi
+}
+
+check_artifact_contract() {
+  rg -n "name:[[:space:]]*adr025-otel-bridge-report" "$wf" >/dev/null || { echo "FAIL: artifact name mismatch"; exit 1; }
+  rg -n "retention-days:[[:space:]]*14" "$wf" >/dev/null || { echo "FAIL: artifact retention mismatch"; exit 1; }
+  rg -n "adr025-otel-bridge\.sh" "$wf" >/dev/null || { echo "FAIL: otel bridge invocation missing"; exit 1; }
+}
+
+test -f "$wf" || { echo "FAIL: missing $wf"; exit 1; }
+
+check_diff_allowlist
+check_no_pr_trigger
+check_sched_dispatch_only
+check_informational_job_level
+check_sha_pins_strict
+check_permissions_minimal
+check_artifact_contract
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Adds ADR-025 I3 Step3 informational nightly OTel bridge rollout lane.

## Scope
- .github/workflows/adr025-nightly-otel-bridge.yml
- docs/contributing/SPLIT-CHECKLIST-adr025-i3-step3.md
- docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md
- scripts/ci/review-adr025-i3-step3.sh

## Safety
- schedule + workflow_dispatch only
- job-level continue-on-error: true
- SHA-pinned actions
- minimal permissions (contents: read, actions: write)
- no PR required-check impact

## Artifact contract
- name: adr025-otel-bridge-report
- files: otel_bridge_report_v1.json + otel_bridge_report_v1.md
- retention-days: 14

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step3.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
