### PR TITLE
docs(adr025): freeze I3 stabilization policy + reviewer gate (I3 Stab A)

### DIFF
--- a/docs/architecture/ADR-025-I3-STABILIZATION-POLICY.md
+++ b/docs/architecture/ADR-025-I3-STABILIZATION-POLICY.md
@@ -1,0 +1,55 @@
+# ADR-025 I3 Stabilization Policy (v1)
+
+## Intent
+Harden the I3 OTel bridge generator with minimal blast radius:
+- Add deterministic edge-case fixtures and tests
+- Clarify determinism invariants and failure modes
+- Keep workflows unchanged during stabilization slices
+
+## Scope (stabilization)
+In-scope:
+- `scripts/ci/adr025-otel-bridge.sh` (parsing/sorting/normalization hardening)
+- Additive fixtures under `scripts/ci/fixtures/adr025-i3/`
+- Deterministic tests in `scripts/ci/test-adr025-otel-bridge.sh`
+- Docs/checklist sync + stabilization reviewer gates
+
+Out-of-scope:
+- Any `.github/workflows/*` edits (stabilization does not touch Step3 lane)
+- Any Rust runtime changes
+- Any PR required-check changes
+- OTel SDK wiring / live capture
+
+## Contracts to preserve (must not change)
+### Exit contract (script)
+- 0: report generated successfully
+- 2: measurement/contract failure (invalid JSON, missing required fields, invalid IDs/timestamps)
+
+### Core contract (I3 Step1)
+- `schema_version == "otel_bridge_report_v1"`
+- `trace_id` and `span_id` normalized to lowercase hex (32/16)
+- Unknown OTel attrs remain in `attributes[]` (KV list)
+- `extensions` is only for non-attribute metadata (e.g., resource)
+
+### Determinism invariants (freeze)
+- Sorting:
+  - traces sorted by `trace_id`
+  - spans sorted by `span_id` (within trace)
+  - attributes sorted by `key`
+  - events sorted by `(time_unix_nano, name)`
+  - links sorted by `(trace_id, span_id)`
+- Time encoding:
+  - `*_time_unix_nano` encoded as digit-strings in output
+
+## Hardening goals (Stab B)
+Add fixtures/tests for edge cases:
+- Multiple traces/spans ordering
+- Attributes ordering stability
+- Events ordering stability
+- Links ordering stability
+- Mixed input types for unix_nano (int vs digit-string) => output always digit-string
+- Uppercase IDs normalization
+- Contract failures remain exit 2
+
+## Docs sync goals (Stab C)
+- Update I3 Step3 checklist/review-pack to mention deterministic edge-cases covered
+- Optional: add short ops note about interpreting bridge report ordering

--- a/scripts/ci/review-adr025-i3-stab-a.sh
+++ b/scripts/ci/review-adr025-i3-stab-a.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-025-I3-STABILIZATION-POLICY.md"
+  "scripts/ci/review-adr025-i3-stab-a.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: I3 stabilization Stab A must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in I3 stabilization Stab A: $f"
+    exit 1
+  fi
+done
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
I3 Stabilization Stab A freezes hardening contracts for the OTel bridge generator and adds a strict reviewer gate.

## Scope
- docs/architecture/ADR-025-I3-STABILIZATION-POLICY.md
- scripts/ci/review-adr025-i3-stab-a.sh

## Safety
- Allowlist-only diff
- Workflow-ban enforced

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-i3-stab-a.sh
- cargo fmt/clippy (assay-cli)
