### PR TITLE
docs(adr025): close I3 stabilization loop with ops/docs sync + gate (I3 Stab C)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-adr025-i3-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-i3-step3.md
@@ -17,6 +17,13 @@
 - [ ] Contains `otel_bridge_report_v1.json` and `otel_bridge_report_v1.md`
 - [ ] Retention is 14 days
 
+## Stabilization coverage (I3 Stab B)
+- [ ] Multi-trace ordering covered by fixture tests
+- [ ] Multi-span ordering + parent ID lowercase normalization covered
+- [ ] Attribute/event/link sorting invariants covered
+- [ ] unix_nano int vs digit-string inputs normalize to digit-strings
+- [ ] Contract failures still map to exit code `2`
+
 ## Safety
 - [ ] Informational-only lane (no PR required-check impact)
 - [ ] No changes outside Step3 allowlist

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md
@@ -6,6 +6,10 @@ Adds an informational nightly OTel bridge lane that generates `otel_bridge_repor
 - input fixture: `scripts/ci/fixtures/adr025-i3/otel_input_minimal.json`
 - output artifact: `adr025-otel-bridge-report`
 
+Stabilization status:
+- I3 Stab A: hardening contract frozen
+- I3 Stab B: edge-case determinism fixtures + invariant assertions landed
+
 ## Safety contracts
 - Schedule + dispatch only (no PR triggers)
 - Job-level `continue-on-error: true`
@@ -15,6 +19,7 @@ Adds an informational nightly OTel bridge lane that generates `otel_bridge_repor
 
 ## Verification
 - `BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step3.sh`
+- `bash scripts/ci/test-adr025-otel-bridge.sh`
 - Workflow contains generator invocation: `scripts/ci/adr025-otel-bridge.sh`
 - Artifact contract:
   - `otel_bridge_report_v1.json`

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md
@@ -2,13 +2,13 @@
 
 ## Summary
 Adds an informational nightly OTel bridge lane that generates `otel_bridge_report_v1` from deterministic fixture input:
-- generator: `scripts/ci/adr025-otel-bridge.sh`
-- input fixture: `scripts/ci/fixtures/adr025-i3/otel_input_minimal.json`
-- output artifact: `adr025-otel-bridge-report`
+- Generator: `scripts/ci/adr025-otel-bridge.sh`
+- Input fixture: `scripts/ci/fixtures/adr025-i3/otel_input_minimal.json`
+- Output artifact: `adr025-otel-bridge-report` (retention: 14 days)
 
-Stabilization status:
-- I3 Stab A: hardening contract frozen
-- I3 Stab B: edge-case determinism fixtures + invariant assertions landed
+Stabilization status (on main):
+- I3 Stab A: hardening contract frozen (`scripts/ci/review-adr025-i3-stab-a.sh`)
+- I3 Stab B: determinism edge-case fixtures + invariant assertions (`scripts/ci/review-adr025-i3-stab-b.sh`)
 
 ## Safety contracts
 - Schedule + dispatch only (no PR triggers)
@@ -18,8 +18,8 @@ Stabilization status:
 - No required-check / branch-protection changes
 
 ## Verification
-- `BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step3.sh`
-- `bash scripts/ci/test-adr025-otel-bridge.sh`
+- Reviewer gate: `BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step3.sh`
+- Determinism tests: `bash scripts/ci/test-adr025-otel-bridge.sh`
 - Workflow contains generator invocation: `scripts/ci/adr025-otel-bridge.sh`
 - Artifact contract:
   - `otel_bridge_report_v1.json`

--- a/docs/ops/ADR-025-I3-OTEL-BRIDGE-RUNBOOK.md
+++ b/docs/ops/ADR-025-I3-OTEL-BRIDGE-RUNBOOK.md
@@ -1,0 +1,51 @@
+# ADR-025 I3 OTel Bridge Runbook
+
+## Purpose
+Operational guide for the ADR-025 I3 OTel bridge informational lane.
+This lane produces deterministic bridge artifacts for audit/debug and does not gate PR lanes.
+
+## What runs
+- Workflow: `.github/workflows/adr025-nightly-otel-bridge.yml`
+- Generator: `scripts/ci/adr025-otel-bridge.sh`
+- Input fixture (Step3): `scripts/ci/fixtures/adr025-i3/otel_input_minimal.json`
+- Uploaded artifact: `adr025-otel-bridge-report`
+  - `otel_bridge_report_v1.json`
+  - `otel_bridge_report_v1.md`
+
+## Determinism invariants
+- `trace_id` sorted lexicographically across traces.
+- `span_id` sorted lexicographically within each trace.
+- `attributes[]` sorted by key.
+- `events[]` sorted by `(time_unix_nano, name)`.
+- `links[]` sorted by `(trace_id, span_id)`.
+- `trace_id`/`span_id` persisted as lowercase hex.
+- `*_time_unix_nano` persisted as digit-strings.
+
+## Exit contract (generator)
+- `0`: bridge report generated.
+- `2`: measurement/contract failure (input shape, missing required fields, invalid IDs/timestamps).
+
+## Quick triage
+### Missing artifact output
+- Verify workflow run completed and upload step ran (`if: always()`).
+- Confirm artifact name is exactly `adr025-otel-bridge-report`.
+
+### Contract/shape failure
+Typical generator messages:
+- `Measurement error: top-level traces must be array`
+- `Measurement error: span_id must be string`
+- `Measurement error: expected unix_nano int or digit-string`
+
+Actions:
+1. Re-run local tests for deterministic fixtures.
+2. Validate input fixture shape.
+3. If contract change is intentional, update Step1 freeze docs/schema first.
+
+## Local verification
+- `bash scripts/ci/test-adr025-otel-bridge.sh`
+- `BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step3.sh`
+- `BASE_REF=origin/main bash scripts/ci/review-adr025-i3-stab-b.sh`
+
+## Notes
+- Unknown OTel attrs must remain under `attributes[]` entries in the report.
+- Top-level `extensions` is reserved for non-attribute metadata.

--- a/scripts/ci/review-adr025-i3-stab-c.sh
+++ b/scripts/ci/review-adr025-i3-stab-c.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-adr025-i3-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md"
+  "docs/ops/ADR-025-I3-OTEL-BRIDGE-RUNBOOK.md"
+  "scripts/ci/review-adr025-i3-stab-c.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: I3 Stab C must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    if [[ "$f" == "$a" ]]; then
+      ok="true"
+      break
+    fi
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in I3 Stab C: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] invariants"
+# Existing assets from I3 Step2/Step3/StabB must exist.
+test -f scripts/ci/adr025-otel-bridge.sh || { echo "FAIL: missing scripts/ci/adr025-otel-bridge.sh"; exit 1; }
+test -f scripts/ci/test-adr025-otel-bridge.sh || { echo "FAIL: missing scripts/ci/test-adr025-otel-bridge.sh"; exit 1; }
+test -f .github/workflows/adr025-nightly-otel-bridge.yml || { echo "FAIL: missing nightly otel workflow"; exit 1; }
+
+# Ensure StabB edge-case fixtures are still referenced by tests.
+rg -n "otel_input_multi_trace_unsorted\.json" scripts/ci/test-adr025-otel-bridge.sh >/dev/null || { echo "FAIL: missing multi-trace test reference"; exit 1; }
+rg -n "otel_input_multi_span_unsorted\.json" scripts/ci/test-adr025-otel-bridge.sh >/dev/null || { echo "FAIL: missing multi-span test reference"; exit 1; }
+rg -n "otel_input_events_unsorted\.json" scripts/ci/test-adr025-otel-bridge.sh >/dev/null || { echo "FAIL: missing events-order test reference"; exit 1; }
+rg -n "otel_input_links_unsorted\.json" scripts/ci/test-adr025-otel-bridge.sh >/dev/null || { echo "FAIL: missing links-order test reference"; exit 1; }
+
+# Ensure docs include stabilization coverage callouts.
+rg -n "Stabilization coverage \(I3 Stab B\)" docs/contributing/SPLIT-CHECKLIST-adr025-i3-step3.md >/dev/null || { echo "FAIL: checklist missing Stab B coverage section"; exit 1; }
+rg -n "I3 Stab B" docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md >/dev/null || { echo "FAIL: review pack missing Stab B status"; exit 1; }
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
I3 Stabilization Stab C closes the stabilization mini-slice by syncing rollout docs with Stab B determinism coverage, adding an I3 OTel bridge ops runbook, and adding a strict Stab C reviewer gate.

## Scope
- docs/contributing/SPLIT-CHECKLIST-adr025-i3-step3.md
- docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step3.md
- docs/ops/ADR-025-I3-OTEL-BRIDGE-RUNBOOK.md
- scripts/ci/review-adr025-i3-stab-c.sh

## Safety
- No `.github/workflows/*` changes
- Allowlist-only reviewer gate
- Workflow-ban enforced by gate

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-i3-stab-c.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
