### PR TITLE
docs(adr025): freeze I3 OTel release integration contract + policy v1 (I3 Step4A)

### DIFF
--- a/docs/architecture/ADR-025-I3-OTEL-RELEASE-INTEGRATION.md
+++ b/docs/architecture/ADR-025-I3-OTEL-RELEASE-INTEGRATION.md
@@ -1,0 +1,54 @@
+# ADR-025 I3 — OTel Bridge Release Integration (v1)
+
+## Intent
+Attach OTel bridge evidence to the **release lane only**, with minimal risk:
+- Default mode is **attach** (non-blocking)
+- Enforcement (if enabled) is **contract validation first**
+- PR lanes remain unchanged (no required-check impact)
+
+## Scope
+In-scope (Step4A):
+- Contract + policy freeze (docs + policy JSON + reviewer gate)
+- No workflow changes
+- No runtime script changes
+
+Out-of-scope (Step4A):
+- Release workflow wiring (Step4B)
+- Any enforcement expansion beyond contract validation
+- OTel SDK wiring / live capture
+
+## Inputs
+Nightly OTel bridge artifact (from I3 Step3):
+- workflow: `.github/workflows/adr025-nightly-otel-bridge.yml`
+- artifact name: `adr025-otel-bridge-report`
+- files:
+  - `otel_bridge_report_v1.json`
+  - `otel_bridge_report_v1.md`
+- retention: 14 days
+
+## Mode contract (for Step4B)
+- `off`     : skip download/attach
+- `attach`  : download + attach evidence; non-blocking (default)
+- `warn`    : like attach, but emits explicit warning on missing/invalid artifact; non-blocking
+- `enforce` : fail-closed **on contract validation** (exit 2).
+  Exit 1 is reserved for future explicit policy rules that are evaluable from the bridge report.
+
+Default: `attach`
+
+## Validation contract (enforce mode baseline)
+Contract validation checks (v1):
+- JSON parses
+- `schema_version == "otel_bridge_report_v1"`
+- trace/span ids are lowercase hex and correct length (as per schema)
+- unix_nano fields are digit-strings where present
+- required top-level fields exist (`source`, `summary`, `traces`)
+
+## Exit contract (for Step4B helper script)
+- 0: pass/attach/off
+- 1: policy fail (reserved; only when explicit policy rules are introduced)
+- 2: measurement/contract fail (missing artifact/json, parse errors, schema mismatch)
+
+## Non-goals
+- No PR required-check changes
+- No workflow trigger changes in Step4A
+- No score-based enforcement (bridge report is not a scoring artifact)

--- a/schemas/otel_release_policy_v1.json
+++ b/schemas/otel_release_policy_v1.json
@@ -1,0 +1,22 @@
+{
+  "policy_version": "otel_release_policy_v1",
+  "default_mode": "attach",
+  "artifact": {
+    "workflow": "adr025-nightly-otel-bridge.yml",
+    "name": "adr025-otel-bridge-report",
+    "files": [
+      "otel_bridge_report_v1.json",
+      "otel_bridge_report_v1.md"
+    ],
+    "retention_days": 14
+  },
+  "enforce_semantics": {
+    "mode": "contract_only",
+    "policy_rules_enabled": false
+  },
+  "exit_contract": {
+    "pass": 0,
+    "policy_fail": 1,
+    "measurement_fail": 2
+  }
+}

--- a/scripts/ci/review-adr025-i3-step4-a.sh
+++ b/scripts/ci/review-adr025-i3-step4-a.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-025-I3-OTEL-RELEASE-INTEGRATION.md"
+  "schemas/otel_release_policy_v1.json"
+  "scripts/ci/review-adr025-i3-step4-a.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: I3 Step4A must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in I3 Step4A: $f"
+    exit 1
+  fi
+done
+
+echo "[review] policy JSON parses"
+python3 - <<'PY'
+import json
+json.load(open("schemas/otel_release_policy_v1.json", "r", encoding="utf-8"))
+print("otel_release_policy_v1.json: ok")
+PY
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
I3 Step4A freezes the release integration contract for OTel bridge evidence (docs + policy + reviewer gate). No workflow/runtime changes.

## Scope
- docs/architecture/ADR-025-I3-OTEL-RELEASE-INTEGRATION.md
- schemas/otel_release_policy_v1.json
- scripts/ci/review-adr025-i3-step4-a.sh

## Safety
- Allowlist-only diff
- Workflow-ban enforced

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step4-a.sh
- cargo fmt/clippy (assay-cli)
