### PR TITLE
docs(adr025): close I3 Step4 rollout with runbook + reviewer gate (Step4C)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,6 +7,7 @@
 > Split refactor program closed loop through Wave7C Step3 on `main` (see [plan](architecture/PLAN-split-refactor-2026q1.md), [report](architecture/REPORT-split-refactor-2026q1.md), [program review pack](contributing/SPLIT-REVIEW-PACK-2026q1-program.md)).
 > Next: [Evidence-as-a-Product (ADR-025)](architecture/ADR-025-Evidence-as-a-Product.md) - Pivot from Sim Hardening to Audit Kit & Soak. Structural items in [RFC-004](architecture/RFC-004-open-items-convergence-q1-2026.md).
 > ADR-025 I2 Step4 status (2026-02-20): release-lane closure evidence integration merged on `main` (default `attach`), `enforce` remains opt-in.
+> ADR-025 I3 Step4 status (2026-02-21): release-lane OTel bridge evidence integration merged on `main` (default `attach`, `enforce` is contract-only under policy v1).
 
 **Strategic Focus:** Agent Runtime Evidence & Control Plane.
 **Core Value:** Verifiable Evidence (Open Standard) + Governance Platform.

--- a/docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
+++ b/docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
@@ -84,3 +84,11 @@ Reserved for later (no implementation in Step1):
 - Plan + schema define the bridge artifact contract and determinism constraints
 - Mapping contract is explicit, testable, and has clear non-goals
 - Reviewer gate enforces allowlist-only and workflow-ban
+
+## Status sync (2026-02-21)
+- Step1: contract + schema freeze complete on `main`
+- Step2: script-first OTel bridge generator + deterministic fixtures/tests complete on `main`
+- Step3: informational nightly OTel bridge workflow + artifact contract complete on `main`
+- Step4A: release integration contract/policy freeze complete on `main`
+- Step4B: release-lane OTel evidence attach wiring complete on `main` (default `attach`, enforce `contract_only`)
+- Step4C: runbook + review artifacts + closure gate (this slice)

--- a/docs/contributing/SPLIT-CHECKLIST-adr025-i3-step4-c-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-i3-step4-c-closure.md
@@ -1,0 +1,29 @@
+# SPLIT CHECKLIST — ADR-025 I3 Step4C (closure slice)
+
+## Scope (hard)
+- [ ] Only Step4C allowlist files changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No runtime behavior changes (docs + reviewer gate only)
+
+## Contracts (must match current main)
+- [ ] Policy exists: `schemas/otel_release_policy_v1.json`
+- [ ] Release script exists: `scripts/ci/adr025-otel-release.sh`
+- [ ] Step4B reviewer gate exists: `scripts/ci/review-adr025-i3-step4-b.sh`
+- [ ] Release wiring references OTel release script in `.github/workflows/release.yml`
+
+## Mode contract
+- [ ] Modes documented: `off|attach|warn|enforce`
+- [ ] Default documented: `attach`
+- [ ] Enforce semantics documented as `contract_only`
+- [ ] Exit contract documented: `0/1/2` with meanings
+
+## Runbook completeness
+- [ ] Missing artifact flow
+- [ ] Schema/contract mismatch flow
+- [ ] Policy-fail reserved semantics clarified
+- [ ] Break-glass override rules + audit trail
+
+## Reviewer gates
+- [ ] `scripts/ci/review-adr025-i3-step4-c.sh` exists
+- [ ] Gate enforces allowlist-only + workflow-ban
+- [ ] Gate verifies invariants on policy/script/release wiring

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step4-c-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step4-c-closure.md
@@ -1,0 +1,34 @@
+# Review Pack — ADR-025 I3 Step4C (closure)
+
+## Intent
+Close ADR-025 I3 Step4 by:
+- adding operational runbook for OTel release integration
+- capturing Step4A/4B contracts as reviewer checklist
+- syncing PLAN/ROADMAP status with current main
+- adding a strict Step4C reviewer gate
+
+## Non-goals
+- no workflow edits
+- no runtime behavior changes in OTel release integration
+- no PR-lane required-check changes
+
+## Scope (allowlist)
+- docs/ops/ADR-025-I3-OTEL-RELEASE-RUNBOOK.md
+- docs/contributing/SPLIT-CHECKLIST-adr025-i3-step4-c-closure.md
+- docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step4-c-closure.md
+- docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
+- docs/ROADMAP.md
+- scripts/ci/review-adr025-i3-step4-c.sh
+
+## Verification
+- `BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step4-c.sh`
+- `bash scripts/ci/review-adr025-i3-step4-a.sh`
+- `bash scripts/ci/review-adr025-i3-step4-b.sh`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+
+## Reviewer 60s scan
+1) confirm no workflow files changed
+2) run Step4C reviewer gate script
+3) skim runbook for mode/exit/break-glass correctness
+4) confirm PLAN/ROADMAP status lines match Step4 reality

--- a/docs/ops/ADR-025-I3-OTEL-RELEASE-RUNBOOK.md
+++ b/docs/ops/ADR-025-I3-OTEL-RELEASE-RUNBOOK.md
@@ -1,0 +1,108 @@
+# ADR-025 I3 — OTel Release Integration Runbook
+
+## Purpose
+Operational guidance for ADR-025 I3 OTel bridge integration in the **release lane only**.
+PR lanes remain unchanged.
+
+## What exists
+- Nightly OTel bridge workflow (informational): `.github/workflows/adr025-nightly-otel-bridge.yml`
+  - artifact: `adr025-otel-bridge-report`
+  - files: `otel_bridge_report_v1.json`, `otel_bridge_report_v1.md` (retention 14 days)
+- Release integration (Step4B):
+  - script: `scripts/ci/adr025-otel-release.sh`
+  - policy: `schemas/otel_release_policy_v1.json`
+  - wired in: `.github/workflows/release.yml` (before provenance/release publish)
+
+## Gate modes
+Configured via release workflow variable:
+- `off`     : skip OTel download/evaluation
+- `attach`  : download + attach OTel evidence; **non-blocking**
+- `warn`    : like attach, but emits explicit WARN on measurement issues; **non-blocking**
+- `enforce` : fail-closed on **contract validation** failures
+
+Default mode for I3 Step4 is **attach**.
+
+## Enforce semantics (contract-only)
+Policy v1 freezes enforce behavior as contract-only:
+- `enforce_semantics.mode = "contract_only"`
+- `policy_rules_enabled = false`
+
+Implication:
+- exit `1` (policy fail) is reserved for future explicit rules.
+- current enforce behavior primarily returns exit `2` on contract/measurement failures.
+
+## Contract validation baseline
+The helper validates:
+- JSON parse success
+- `schema_version == "otel_bridge_report_v1"`
+- required top-level contract (`source.kind`, `summary`, `traces`)
+- lowercase hex IDs (`trace_id`, `span_id`, optional `parent_span_id`, link IDs)
+- unix-nano fields are digit-strings where required
+- attribute/event/link container shapes
+
+## Exit contract
+From `scripts/ci/adr025-otel-release.sh`:
+- `0`: pass/attach/off (or non-blocking continuation in attach/warn)
+- `1`: policy fail (reserved until explicit policy rules exist)
+- `2`: measurement/contract fail (missing artifact/json, parse errors, schema mismatch)
+
+## Decision audit log
+The script emits one machine-parseable JSON decision line per run:
+- `event = "adr025.otel_release_decision"`
+- includes `mode`, `decision`, `exit_code`, plus `policy_path`, `report_path`, `run_id`
+- `score`/`threshold` are currently `null` for OTel release decisions
+
+## Common incidents & response
+
+### A) Missing artifact / missing `otel_bridge_report_v1.json`
+Symptoms:
+- log includes `missing otel_bridge_report_v1.json in downloaded artifact`
+- behavior:
+  - `attach`: continue, non-blocking
+  - `warn`: continue with warning
+  - `enforce`: exit `2` (blocks release)
+
+Actions:
+1) Check latest run of `adr025-nightly-otel-bridge.yml`.
+2) Confirm artifact name is exactly `adr025-otel-bridge-report`.
+3) Re-run nightly workflow via `workflow_dispatch` if needed.
+
+### B) Schema/contract mismatch
+Symptoms:
+- `unexpected otel schema_version` / invalid ID or unix-nano type logs
+- behavior:
+  - `attach`/`warn`: non-blocking
+  - `enforce`: exit `2`
+
+Actions:
+1) Verify report producer: `scripts/ci/adr025-otel-bridge.sh`.
+2) Verify policy file: `schemas/otel_release_policy_v1.json`.
+3) If contract change is intentional, land a new freeze slice first.
+
+### C) Unexpected policy-fail path
+Symptoms:
+- enforce returns exit `1`
+
+Interpretation:
+- with policy v1 (`policy_rules_enabled=false`), this should be rare and signals policy semantics drift.
+
+Actions:
+1) Inspect current policy JSON in repo.
+2) Confirm release workflow references policy v1 path.
+3) Revert unintended policy semantic change via freeze PR.
+
+## Break-glass / override
+Use only for time-critical release-owner decisions:
+- set `ASSAY_OTEL_GATE` to `off` or `attach` explicitly in release context
+- keep override auditable through workflow logs/inputs
+- never introduce silent bypass in script/workflow code
+
+After incident:
+1) restore default `attach`
+2) file follow-up with root cause and contract decision
+
+## Verification commands (local)
+- `bash scripts/ci/test-adr025-otel-release.sh`
+- `bash scripts/ci/review-adr025-i3-step4-a.sh`
+- `bash scripts/ci/review-adr025-i3-step4-b.sh`
+- `bash scripts/ci/review-adr025-i3-step4-c.sh`

--- a/scripts/ci/review-adr025-i3-step4-c.sh
+++ b/scripts/ci/review-adr025-i3-step4-c.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/ADR-025-I3-OTEL-RELEASE-RUNBOOK.md"
+  "docs/contributing/SPLIT-CHECKLIST-adr025-i3-step4-c-closure.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step4-c-closure.md"
+  "docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md"
+  "docs/ROADMAP.md"
+  "scripts/ci/review-adr025-i3-step4-c.sh"
+)
+
+echo "[review] diff allowlist"
+changed="$(git diff --name-only "$BASE_REF"...HEAD)"
+
+allowlisted_untracked=""
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    if [[ -n "$allowlisted_untracked" ]]; then
+      allowlisted_untracked+=$'\n'
+    fi
+    allowlisted_untracked+="$f"
+    continue
+  fi
+
+  for a in "${ALLOWLIST[@]}"; do
+    if [[ "$f" == "$a" ]]; then
+      if [[ -n "$allowlisted_untracked" ]]; then
+        allowlisted_untracked+=$'\n'
+      fi
+      allowlisted_untracked+="$f"
+      break
+    fi
+  done
+done < <(git ls-files --others --exclude-standard)
+
+if [[ -n "$allowlisted_untracked" ]]; then
+  if [[ -n "$changed" ]]; then
+    changed="$(printf "%s\n%s\n" "$changed" "$allowlisted_untracked")"
+  else
+    changed="$allowlisted_untracked"
+  fi
+fi
+
+if [[ -z "$changed" ]]; then
+  echo "FAIL: no changes detected vs $BASE_REF"
+  exit 1
+fi
+
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Step4C must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in I3 Step4C: $f"
+    exit 1
+  fi
+done <<< "$changed"
+
+echo "[review] invariants on main assets"
+test -f schemas/otel_release_policy_v1.json || { echo "FAIL: missing otel_release_policy_v1.json"; exit 1; }
+test -f scripts/ci/adr025-otel-release.sh || { echo "FAIL: missing adr025-otel-release.sh"; exit 1; }
+test -f scripts/ci/review-adr025-i3-step4-b.sh || { echo "FAIL: missing review-adr025-i3-step4-b.sh"; exit 1; }
+test -f .github/workflows/release.yml || { echo "FAIL: missing release.yml"; exit 1; }
+test -f .github/workflows/adr025-nightly-otel-bridge.yml || { echo "FAIL: missing adr025-nightly-otel-bridge.yml"; exit 1; }
+
+rg -n "adr025-otel-release\.sh" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release.yml must reference adr025-otel-release.sh"
+  exit 1
+}
+
+rg -n "schemas/otel_release_policy_v1\.json" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release.yml must reference otel_release_policy_v1.json"
+  exit 1
+}
+
+rg -n "ASSAY_OTEL_GATE" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release.yml must keep ASSAY_OTEL_GATE mode wiring"
+  exit 1
+}
+
+rg -n "MODE:.*attach" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release.yml must keep default attach mode expression"
+  exit 1
+}
+
+rg -n "name:\s*adr025-otel-bridge-release-evidence" .github/workflows/release.yml >/dev/null || {
+  echo "FAIL: release.yml must upload adr025-otel-bridge-release-evidence"
+  exit 1
+}
+
+rg -n "name:\s*adr025-otel-bridge-report" .github/workflows/adr025-nightly-otel-bridge.yml >/dev/null || {
+  echo "FAIL: nightly workflow must keep artifact name adr025-otel-bridge-report"
+  exit 1
+}
+
+rg -n "retention-days:\s*14" .github/workflows/adr025-nightly-otel-bridge.yml >/dev/null || {
+  echo "FAIL: nightly workflow must keep retention-days: 14"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Closes ADR-025 I3 Step4 by adding an ops runbook, closure review artifacts, and a strict Step4C reviewer gate. Syncs PLAN/ROADMAP to reflect Step4 status on main.

## Scope
- docs/ops/ADR-025-I3-OTEL-RELEASE-RUNBOOK.md
- docs/contributing/SPLIT-CHECKLIST-adr025-i3-step4-c-closure.md
- docs/contributing/SPLIT-REVIEW-PACK-adr025-i3-step4-c-closure.md
- docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
- docs/ROADMAP.md
- scripts/ci/review-adr025-i3-step4-c.sh

## Safety
- docs + reviewer gate only; no workflow edits in this slice
- allowlist-only diff enforced by Step4C reviewer gate
- invariant checks confirm Step4A/4B policy/script/wiring contracts exist on main

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-i3-step4-c.sh
- bash scripts/ci/review-adr025-i3-step4-a.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
