### PR TITLE
docs(adr025): freeze P3 ADR-025 index contract + reviewer gate (P3 A)

### DIFF
--- a/docs/architecture/ADR-025-INDEX.md
+++ b/docs/architecture/ADR-025-INDEX.md
@@ -1,0 +1,51 @@
+# ADR-025 Index (Contract)
+
+## Intent
+Provide a single, stable entry point for ADR-025 deliverables (I1/I2/I3), including:
+- Where to start (first reads)
+- Where artifacts live (schemas, scripts, workflows)
+- How to validate locally (reviewer gates + test runners)
+- What is informational vs release-lane evidence vs fail-closed
+
+This document defines the **structure/contract** of the ADR-025 index.
+Content population happens in PR-B.
+
+## Scope
+In-scope:
+- Document structure/sections and naming
+- Link targets and canonical paths (to be populated in PR-B)
+- Non-goals and update policy
+
+Out-of-scope:
+- Any runtime changes
+- Any workflow changes
+- Refactoring existing docs
+
+## Index structure (frozen)
+1. **Quick Start (Where to look first)**
+   - One-screen “start here” for new devs
+2. **Iterations Overview**
+   - I1: Soak + readiness + release enforcement
+   - I2: Closure (completeness/provenance) + release attach
+   - I3: OTel bridge + release attach
+3. **Artifacts Map**
+   - Schemas
+   - Scripts (generators, enforce/attach, tests)
+   - Workflows (informational lanes + release integration)
+4. **Reviewer Gates Map**
+   - Step-level reviewer scripts (A/B/C)
+   - Stabilization gates (where applicable)
+5. **Operational Runbooks**
+   - I2 closure release runbook
+   - I3 otel release runbook
+6. **Contracts**
+   - Artifact names + retention
+   - Mode contracts (off|attach|warn|enforce)
+   - Exit contracts (0/1/2; plus infra distinctions where used)
+7. **Maintenance policy**
+   - When to update the index
+   - What changes require a freeze PR
+
+## Maintenance policy (frozen)
+- The index is updated only via small PRs following A/B/C discipline.
+- PR-A defines structure; PR-B populates content; PR-C closes with checklist/review-pack + plan/roadmap sync.

--- a/scripts/ci/review-adr025-p3-index-a.sh
+++ b/scripts/ci/review-adr025-p3-index-a.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-025-INDEX.md"
+  "scripts/ci/review-adr025-p3-index-a.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-025 P3 PR-A must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-025 P3 PR-A: $f"
+    exit 1
+  fi
+done
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
P3 PR-A freezes the structure/contract for a central ADR-025 index and adds a strict reviewer gate.

## Scope
- docs/architecture/ADR-025-INDEX.md
- scripts/ci/review-adr025-p3-index-a.sh

## Safety
- Allowlist-only diff
- Workflow-ban enforced

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-p3-index-a.sh
- cargo fmt/clippy (assay-cli)
