### PR TITLE
docs(adr025): populate ADR-025 index with links and artifact map (P3 B)

### DIFF
--- a/docs/architecture/ADR-025-INDEX.md
+++ b/docs/architecture/ADR-025-INDEX.md
@@ -1,51 +1,155 @@
-# ADR-025 Index (Contract)
+# ADR-025 Index
 
 ## Intent
-Provide a single, stable entry point for ADR-025 deliverables (I1/I2/I3), including:
-- Where to start (first reads)
-- Where artifacts live (schemas, scripts, workflows)
-- How to validate locally (reviewer gates + test runners)
-- What is informational vs release-lane evidence vs fail-closed
+Single entry point for ADR-025 deliverables across I1/I2/I3:
+- where to start reading
+- where schemas/scripts/workflows live
+- how to validate locally
+- what is informational vs release-lane evidence
 
-This document defines the **structure/contract** of the ADR-025 index.
-Content population happens in PR-B.
+## Quick Start (Where to look first)
+1. Product-level ADR:
+   - `docs/architecture/ADR-025-Evidence-as-a-Product.md`
+2. Iteration plans:
+   - `docs/architecture/PLAN-ADR-025-I1-audit-kit-soak-2026q2.md`
+   - `docs/architecture/PLAN-ADR-025-I2-audit-kit-closure-2026q2.md`
+   - `docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md`
+3. Release integration contracts:
+   - `docs/architecture/ADR-025-SOAK-ENFORCEMENT-POLICY.md`
+   - `docs/architecture/ADR-025-I2-CLOSURE-RELEASE-INTEGRATION.md`
+   - `docs/architecture/ADR-025-I3-OTEL-RELEASE-INTEGRATION.md`
+4. Ops runbooks:
+   - `docs/ops/ADR-025-SOAK-ENFORCEMENT-RUNBOOK.md`
+   - `docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md`
+   - `docs/ops/ADR-025-I3-OTEL-BRIDGE-RUNBOOK.md`
+   - `docs/ops/ADR-025-I3-OTEL-RELEASE-RUNBOOK.md`
 
-## Scope
-In-scope:
-- Document structure/sections and naming
-- Link targets and canonical paths (to be populated in PR-B)
-- Non-goals and update policy
+## Local Validation (Common)
+- `bash scripts/ci/test-adr025-soak-enforce.sh`
+- `bash scripts/ci/test-adr025-closure-evaluate.sh`
+- `bash scripts/ci/test-adr025-closure-release.sh`
+- `bash scripts/ci/test-adr025-otel-bridge.sh`
+- `bash scripts/ci/test-adr025-otel-release.sh`
 
-Out-of-scope:
-- Any runtime changes
-- Any workflow changes
-- Refactoring existing docs
+## Iterations Overview
 
-## Index structure (frozen)
-1. **Quick Start (Where to look first)**
-   - One-screen “start here” for new devs
-2. **Iterations Overview**
-   - I1: Soak + readiness + release enforcement
-   - I2: Closure (completeness/provenance) + release attach
-   - I3: OTel bridge + release attach
-3. **Artifacts Map**
-   - Schemas
-   - Scripts (generators, enforce/attach, tests)
-   - Workflows (informational lanes + release integration)
-4. **Reviewer Gates Map**
-   - Step-level reviewer scripts (A/B/C)
-   - Stabilization gates (where applicable)
-5. **Operational Runbooks**
-   - I2 closure release runbook
-   - I3 otel release runbook
-6. **Contracts**
-   - Artifact names + retention
-   - Mode contracts (off|attach|warn|enforce)
-   - Exit contracts (0/1/2; plus infra distinctions where used)
-7. **Maintenance policy**
-   - When to update the index
-   - What changes require a freeze PR
+### I1 - Soak + readiness + release enforcement
+Primary outputs:
+- informational soak/readiness lanes
+- fail-closed readiness enforcement in release lane
 
-## Maintenance policy (frozen)
-- The index is updated only via small PRs following A/B/C discipline.
-- PR-A defines structure; PR-B populates content; PR-C closes with checklist/review-pack + plan/roadmap sync.
+Key files:
+- schemas: `schemas/soak_readiness_policy_v1.json`
+- scripts:
+  - `scripts/ci/adr025-soak-readiness-report.sh`
+  - `scripts/ci/adr025-soak-enforce.sh`
+- workflows:
+  - `.github/workflows/adr025-nightly-soak.yml`
+  - `.github/workflows/adr025-nightly-readiness.yml`
+  - `.github/workflows/release.yml` (readiness enforcement step)
+
+### I2 - Closure (completeness/provenance) + release attach
+Primary outputs:
+- closure report generation + informational nightly closure lane
+- release-lane closure evidence attach/enforce modes
+
+Key files:
+- schemas:
+  - `schemas/closure_report_v1.schema.json`
+  - `schemas/closure_policy_v1.json`
+  - `schemas/closure_release_policy_v1.json`
+- scripts:
+  - `scripts/ci/adr025-closure-evaluate.sh`
+  - `scripts/ci/adr025-closure-release.sh`
+- workflows:
+  - `.github/workflows/adr025-nightly-closure.yml`
+  - `.github/workflows/release.yml` (closure integration step)
+
+### I3 - OTel bridge + release attach
+Primary outputs:
+- OTel bridge report generator + informational nightly OTel lane
+- release-lane OTel evidence attach/enforce modes
+
+Key files:
+- schemas:
+  - `schemas/otel_bridge_report_v1.schema.json`
+  - `schemas/otel_release_policy_v1.json`
+- scripts:
+  - `scripts/ci/adr025-otel-bridge.sh`
+  - `scripts/ci/adr025-otel-release.sh`
+- workflows:
+  - `.github/workflows/adr025-nightly-otel-bridge.yml`
+  - `.github/workflows/release.yml` (OTel integration step)
+
+## Artifacts Map
+
+| Iteration | Artifact | Produced By | Contract |
+|---|---|---|---|
+| I1 | `adr025-soak-report` | `.github/workflows/adr025-nightly-soak.yml` | soak report JSON + retention 14 days |
+| I1 | `adr025-nightly-readiness` | `.github/workflows/adr025-nightly-readiness.yml` | `nightly_readiness.json` + `nightly_readiness.md`, retention 14 days |
+| I2 | `adr025-closure-report` | `.github/workflows/adr025-nightly-closure.yml` | `closure_report_v1.json` + `closure_report_v1.md`, retention 14 days |
+| I2 | `adr025-closure-release-evidence` | `.github/workflows/release.yml` | closure evidence attached in release lane |
+| I3 | `adr025-otel-bridge-report` | `.github/workflows/adr025-nightly-otel-bridge.yml` | `otel_bridge_report_v1.json` + `otel_bridge_report_v1.md`, retention 14 days |
+| I3 | `adr025-otel-bridge-release-evidence` | `.github/workflows/release.yml` | OTel evidence attached in release lane |
+
+## Reviewer Gates Map
+
+### I1
+- `scripts/ci/review-adr025-i1-step1.sh`
+- `scripts/ci/review-adr025-i1-step3-c1.sh`
+- `scripts/ci/review-adr025-i1-step3-c2.sh`
+- `scripts/ci/review-adr025-i1-step3-c3.sh`
+- `scripts/ci/review-adr025-i1-step4-a.sh`
+- `scripts/ci/review-adr025-i1-step4-b.sh`
+- `scripts/ci/review-adr025-i1-step4-c.sh`
+
+### I2
+- `scripts/ci/review-adr025-i2-step1.sh`
+- `scripts/ci/review-adr025-i2-step2.sh`
+- `scripts/ci/review-adr025-i2-step3.sh`
+- `scripts/ci/review-adr025-i2-step4-a.sh`
+- `scripts/ci/review-adr025-i2-step4-b.sh`
+- `scripts/ci/review-adr025-i2-step4-c.sh`
+- stabilization:
+  - `scripts/ci/review-adr025-i2-stab-a.sh`
+  - `scripts/ci/review-adr025-i2-stab-b.sh`
+  - `scripts/ci/review-adr025-i2-stab-c.sh`
+  - `scripts/ci/review-adr025-i2-stab-d.sh`
+
+### I3
+- `scripts/ci/review-adr025-i3-step1.sh`
+- `scripts/ci/review-adr025-i3-step2.sh`
+- `scripts/ci/review-adr025-i3-step3.sh`
+- `scripts/ci/review-adr025-i3-step4-a.sh`
+- `scripts/ci/review-adr025-i3-step4-b.sh`
+- `scripts/ci/review-adr025-i3-step4-c.sh`
+- stabilization:
+  - `scripts/ci/review-adr025-i3-stab-a.sh`
+  - `scripts/ci/review-adr025-i3-stab-b.sh`
+  - `scripts/ci/review-adr025-i3-stab-c.sh`
+
+## Operational Runbooks
+- I1 soak enforcement: `docs/ops/ADR-025-SOAK-ENFORCEMENT-RUNBOOK.md`
+- I2 closure release integration: `docs/ops/ADR-025-I2-CLOSURE-RELEASE-RUNBOOK.md`
+- I3 OTel bridge informational lane: `docs/ops/ADR-025-I3-OTEL-BRIDGE-RUNBOOK.md`
+- I3 OTel release integration: `docs/ops/ADR-025-I3-OTEL-RELEASE-RUNBOOK.md`
+
+## Contracts (Current)
+
+### Modes
+- release integration modes are `off|attach|warn|enforce`
+- default for I2/I3 release integrations is `attach`
+
+### Exit codes
+- `0`: pass/attach/off
+- `1`: policy fail when explicit policy rules are enabled
+- `2`: measurement/contract failure (missing artifact/json, parse/schema mismatch)
+
+### Informational vs release-lane
+- nightly soak/readiness/closure/otel workflows are informational lanes
+- release workflow integrates fail-closed or non-blocking attach behavior per policy and mode
+
+## Maintenance policy
+- Keep updates in small A/B/C slices.
+- Use docs-only PRs for index refresh unless a linked contract actually changes.
+- If contracts change (artifact names, modes, exit semantics), update source ADR/policy first, then this index.

--- a/scripts/ci/review-adr025-p3-index-b.sh
+++ b/scripts/ci/review-adr025-p3-index-b.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-025-INDEX.md"
+  "scripts/ci/review-adr025-p3-index-b.sh"
+)
+
+changed="$(git diff --name-only "$BASE_REF"...HEAD)"
+
+allowlisted_untracked=""
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  for a in "${ALLOWLIST[@]}"; do
+    if [[ "$f" == "$a" ]]; then
+      if [[ -n "$allowlisted_untracked" ]]; then
+        allowlisted_untracked+=$'\n'
+      fi
+      allowlisted_untracked+="$f"
+      break
+    fi
+  done
+done < <(git ls-files --others --exclude-standard)
+
+if [[ -n "$allowlisted_untracked" ]]; then
+  if [[ -n "$changed" ]]; then
+    changed="$(printf "%s\n%s\n" "$changed" "$allowlisted_untracked")"
+  else
+    changed="$allowlisted_untracked"
+  fi
+fi
+
+if [[ -z "$changed" ]]; then
+  echo "FAIL: no changes detected vs $BASE_REF"
+  exit 1
+fi
+
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-025 P3 PR-B must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-025 P3 PR-B: $f"
+    exit 1
+  fi
+done
+
+rg -n "I1|Iteration 1" docs/architecture/ADR-025-INDEX.md >/dev/null || {
+  echo "FAIL: index missing I1 section"
+  exit 1
+}
+rg -n "I2|Iteration 2" docs/architecture/ADR-025-INDEX.md >/dev/null || {
+  echo "FAIL: index missing I2 section"
+  exit 1
+}
+rg -n "I3|Iteration 3" docs/architecture/ADR-025-INDEX.md >/dev/null || {
+  echo "FAIL: index missing I3 section"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
P3 PR-B populates the ADR-025 index with links to all I1/I2/I3 deliverables and a compact "where to look first" matrix.

## Scope
- docs/architecture/ADR-025-INDEX.md
- scripts/ci/review-adr025-p3-index-b.sh

## Safety
- Allowlist-only diff
- Workflow-ban enforced

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-p3-index-b.sh
- cargo fmt/clippy (assay-cli)
