### PR TITLE
docs(adr025): close P3 index consolidation with closure gate + status sync (P3 C)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,6 +8,7 @@
 > Next: [Evidence-as-a-Product (ADR-025)](architecture/ADR-025-Evidence-as-a-Product.md) - Pivot from Sim Hardening to Audit Kit & Soak. Structural items in [RFC-004](architecture/RFC-004-open-items-convergence-q1-2026.md).
 > ADR-025 I2 Step4 status (2026-02-20): release-lane closure evidence integration merged on `main` (default `attach`), `enforce` remains opt-in.
 > ADR-025 I3 Step4 status (2026-02-21): release-lane OTel bridge evidence integration merged on `main` (default `attach`, `enforce` is contract-only under policy v1).
+> ADR-025 P3 status (2026-02-24): index consolidation A/B/C complete on `main` (single entrypoint + reviewer gates).
 
 **Strategic Focus:** Agent Runtime Evidence & Control Plane.
 **Core Value:** Verifiable Evidence (Open Standard) + Governance Platform.

--- a/docs/architecture/ADR-025-INDEX.md
+++ b/docs/architecture/ADR-025-INDEX.md
@@ -7,6 +7,11 @@ Single entry point for ADR-025 deliverables across I1/I2/I3:
 - how to validate locally
 - what is informational vs release-lane evidence
 
+## Status sync (2026-02-24)
+- P3-A merged: index structure/contract freeze.
+- P3-B merged: index populated with canonical I1/I2/I3 links and artifact map.
+- P3-C closure: checklist/review-pack + reviewer gate finalize the consolidation loop.
+
 ## Quick Start (Where to look first)
 1. Product-level ADR:
    - `docs/architecture/ADR-025-Evidence-as-a-Product.md`

--- a/docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
+++ b/docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
@@ -91,4 +91,4 @@ Reserved for later (no implementation in Step1):
 - Step3: informational nightly OTel bridge workflow + artifact contract complete on `main`
 - Step4A: release integration contract/policy freeze complete on `main`
 - Step4B: release-lane OTel evidence attach wiring complete on `main` (default `attach`, enforce `contract_only`)
-- Step4C: runbook + review artifacts + closure gate (this slice)
+- Step4C: runbook + review artifacts + closure gate complete on `main`

--- a/docs/contributing/SPLIT-CHECKLIST-adr025-p3-index-c.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr025-p3-index-c.md
@@ -1,0 +1,20 @@
+# SPLIT CHECKLIST — ADR-025 P3 Index (PR-C closure)
+
+## Scope (hard)
+- [ ] Only P3-C allowlist files changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No runtime behavior changes (docs + reviewer gate only)
+
+## Index coverage contract
+- [ ] `docs/architecture/ADR-025-INDEX.md` still includes I1/I2/I3 sections
+- [ ] Index still links core nightly workflows and release wiring paths
+- [ ] Index still lists reviewer gates for I1/I2/I3 and stabilization slices
+
+## Status sync contract
+- [ ] `docs/ROADMAP.md` contains ADR-025 P3 consolidation status sync line
+- [ ] `docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md` Step4C status wording reflects merged reality on `main`
+
+## Reviewer gate
+- [ ] `scripts/ci/review-adr025-p3-index-c.sh` exists
+- [ ] Gate enforces allowlist-only + workflow-ban
+- [ ] Gate validates index invariants and P3 A/B gate presence

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr025-p3-index-c.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr025-p3-index-c.md
@@ -1,0 +1,33 @@
+# Review Pack — ADR-025 P3 Index (PR-C closure)
+
+## Intent
+Close ADR-025 P3 index consolidation by:
+- adding closure checklist/review-pack artifacts
+- adding a strict P3-C reviewer gate
+- syncing ROADMAP/PLAN wording to current merged ADR-025 state
+
+## Non-goals
+- no workflow edits
+- no runtime/script behavior changes outside reviewer gate
+- no PR required-check / branch-protection changes
+
+## Scope (allowlist)
+- docs/architecture/ADR-025-INDEX.md
+- docs/contributing/SPLIT-CHECKLIST-adr025-p3-index-c.md
+- docs/contributing/SPLIT-REVIEW-PACK-adr025-p3-index-c.md
+- docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
+- docs/ROADMAP.md
+- scripts/ci/review-adr025-p3-index-c.sh
+
+## Verification
+- `BASE_REF=origin/main bash scripts/ci/review-adr025-p3-index-c.sh`
+- `test -f scripts/ci/review-adr025-p3-index-a.sh`
+- `test -f scripts/ci/review-adr025-p3-index-b.sh`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+
+## Reviewer 60s scan
+1) confirm no workflow files changed
+2) run P3-C reviewer gate script
+3) skim index status sync + roadmap/plan status lines
+4) confirm index still links I1/I2/I3 core artifacts and gates

--- a/scripts/ci/review-adr025-p3-index-c.sh
+++ b/scripts/ci/review-adr025-p3-index-c.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-025-INDEX.md"
+  "docs/contributing/SPLIT-CHECKLIST-adr025-p3-index-c.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr025-p3-index-c.md"
+  "docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md"
+  "docs/ROADMAP.md"
+  "scripts/ci/review-adr025-p3-index-c.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+changed="$(git diff --name-only "$BASE_REF"...HEAD)"
+
+allowlisted_untracked=""
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    if [[ -n "$allowlisted_untracked" ]]; then
+      allowlisted_untracked+=$'\n'
+    fi
+    allowlisted_untracked+="$f"
+    continue
+  fi
+
+  for a in "${ALLOWLIST[@]}"; do
+    if [[ "$f" == "$a" ]]; then
+      if [[ -n "$allowlisted_untracked" ]]; then
+        allowlisted_untracked+=$'\n'
+      fi
+      allowlisted_untracked+="$f"
+      break
+    fi
+  done
+done < <(git ls-files --others --exclude-standard)
+
+if [[ -n "$allowlisted_untracked" ]]; then
+  if [[ -n "$changed" ]]; then
+    changed="$(printf "%s\n%s\n" "$changed" "$allowlisted_untracked")"
+  else
+    changed="$allowlisted_untracked"
+  fi
+fi
+
+if [[ -z "$changed" ]]; then
+  echo "FAIL: no changes detected vs $BASE_REF"
+  exit 1
+fi
+
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-025 P3 PR-C must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-025 P3 PR-C: $f"
+    exit 1
+  fi
+done <<< "$changed"
+
+echo "[review] invariants"
+test -f docs/architecture/ADR-025-INDEX.md || { echo "FAIL: missing ADR-025 index"; exit 1; }
+test -f scripts/ci/review-adr025-p3-index-a.sh || { echo "FAIL: missing P3 A reviewer gate"; exit 1; }
+test -f scripts/ci/review-adr025-p3-index-b.sh || { echo "FAIL: missing P3 B reviewer gate"; exit 1; }
+
+rg -n "### I1" docs/architecture/ADR-025-INDEX.md >/dev/null || { echo "FAIL: index missing I1 section"; exit 1; }
+rg -n "### I2" docs/architecture/ADR-025-INDEX.md >/dev/null || { echo "FAIL: index missing I2 section"; exit 1; }
+rg -n "### I3" docs/architecture/ADR-025-INDEX.md >/dev/null || { echo "FAIL: index missing I3 section"; exit 1; }
+
+rg -n "adr025-nightly-soak\.yml" docs/architecture/ADR-025-INDEX.md >/dev/null || { echo "FAIL: index missing soak workflow link"; exit 1; }
+rg -n "adr025-nightly-closure\.yml" docs/architecture/ADR-025-INDEX.md >/dev/null || { echo "FAIL: index missing closure workflow link"; exit 1; }
+rg -n "adr025-nightly-otel-bridge\.yml" docs/architecture/ADR-025-INDEX.md >/dev/null || { echo "FAIL: index missing OTel workflow link"; exit 1; }
+
+rg -n "ADR-025 P3 status" docs/ROADMAP.md >/dev/null || { echo "FAIL: ROADMAP missing ADR-025 P3 status sync"; exit 1; }
+rg -n "Step4C: .*complete on main|Step4C: .*complete on \`main\`" docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md >/dev/null || {
+  echo "FAIL: I3 plan status sync missing Step4C complete-on-main wording"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
P3 PR-C closes the ADR-025 index consolidation loop with closure checklist/review-pack artifacts, a strict reviewer gate, and small ROADMAP/PLAN status sync updates.

## Scope
- docs/architecture/ADR-025-INDEX.md
- docs/contributing/SPLIT-CHECKLIST-adr025-p3-index-c.md
- docs/contributing/SPLIT-REVIEW-PACK-adr025-p3-index-c.md
- docs/architecture/PLAN-ADR-025-I3-otel-bridge-2026q2.md
- docs/ROADMAP.md
- scripts/ci/review-adr025-p3-index-c.sh

## Safety
- Allowlist-only diff
- Workflow-ban enforced
- Docs + reviewer gate only (no runtime/workflow behavior changes)

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-p3-index-c.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
