### PR TITLE
docs(adr026): close adapter rollout with checklist + review pack (Step3)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-adr026-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr026-step3.md
@@ -1,0 +1,23 @@
+# SPLIT CHECKLIST - ADR-026 Step3 (closure)
+
+## Scope
+- [ ] Only Step3 closure docs and reviewer gate changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No runtime behavior changes
+
+## Contracts present
+- [ ] `crates/assay-adapter-api/` exists
+- [ ] `crates/assay-adapter-acp/` exists
+- [ ] ACP fixtures exist under `scripts/ci/fixtures/adr026/acp/v2.11.0/`
+- [ ] `scripts/ci/test-adapter-acp.sh` exists and passes
+
+## Step1/Step2 coverage
+- [ ] Adapter API contract frozen (`ProtocolAdapter`, `AttachmentWriter`, strict/lenient)
+- [ ] ACP MVP implemented
+- [ ] Negative fixtures included
+- [ ] Determinism asserted on repeated happy-path conversion
+
+## Reviewer gate
+- [ ] `scripts/ci/review-adr026-step3.sh` exists
+- [ ] Gate enforces allowlist-only + workflow-ban
+- [ ] Gate validates Step1/Step2 artifacts are present

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr026-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr026-step3.md
@@ -1,0 +1,33 @@
+# Review Pack - ADR-026 Step3 (closure)
+
+## Intent
+Close ADR-026 initial rollout loop by adding closure review artifacts for the adapter API freeze and ACP MVP implementation.
+
+## Scope
+- docs/contributing/SPLIT-CHECKLIST-adr026-step3.md
+- docs/contributing/SPLIT-REVIEW-PACK-adr026-step3.md
+- scripts/ci/review-adr026-step3.sh
+
+## Non-goals
+- No workflow changes
+- No new runtime behavior
+- No ACP CLI wiring
+- No A2A implementation yet
+
+## What should already exist
+- `crates/assay-adapter-api/`
+- `crates/assay-adapter-acp/`
+- `scripts/ci/test-adapter-acp.sh`
+- ACP happy and negative fixtures under `scripts/ci/fixtures/adr026/acp/v2.11.0/`
+
+## Verification
+- `BASE_REF=origin/codex/adr026-step2-acp-mvp bash scripts/ci/review-adr026-step3.sh`
+- `bash scripts/ci/test-adapter-acp.sh`
+- `cargo fmt --check`
+- `cargo clippy -p assay-adapter-acp -p assay-adapter-api -p assay-cli -- -D warnings`
+
+## Reviewer 60s scan
+1. Confirm Step3 changes are docs + gate only.
+2. Confirm no `.github/workflows/*` changes.
+3. Run the Step3 reviewer gate.
+4. Confirm the checklist correctly describes Step1/Step2 deliverables.

--- a/scripts/ci/review-adr026-step3.sh
+++ b/scripts/ci/review-adr026-step3.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-step2-acp-mvp}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-adr026-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr026-step3.md"
+  "scripts/ci/review-adr026-step3.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-026 Step3 must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-026 Step3: $f"
+    exit 1
+  fi
+done
+
+echo "[review] invariants"
+test -f crates/assay-adapter-api/src/lib.rs || { echo "FAIL: missing assay-adapter-api"; exit 1; }
+test -f crates/assay-adapter-acp/src/lib.rs || { echo "FAIL: missing assay-adapter-acp"; exit 1; }
+test -f scripts/ci/test-adapter-acp.sh || { echo "FAIL: missing ACP test runner"; exit 1; }
+test -f scripts/ci/fixtures/adr026/acp/v2.11.0/acp_happy_intent_created.json || { echo "FAIL: missing happy fixture"; exit 1; }
+test -f scripts/ci/fixtures/adr026/acp/v2.11.0/acp_negative_missing_packet_id.json || { echo "FAIL: missing negative fixture"; exit 1; }
+rg -n 'pub trait ProtocolAdapter' crates/assay-adapter-api/src/lib.rs >/dev/null || { echo "FAIL: adapter trait missing"; exit 1; }
+rg -n 'pub struct AcpAdapter' crates/assay-adapter-acp/src/lib.rs >/dev/null || { echo "FAIL: AcpAdapter missing"; exit 1; }
+
+bash scripts/ci/test-adapter-acp.sh >/dev/null
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Closes the initial ADR-026 rollout loop with review artifacts and a closure reviewer gate.

## Scope
- docs/contributing/SPLIT-CHECKLIST-adr026-step3.md
- docs/contributing/SPLIT-REVIEW-PACK-adr026-step3.md
- scripts/ci/review-adr026-step3.sh

## Safety
- Allowlist-only diff
- Workflow-ban enforced
- Docs + reviewer gate only

## Verification
- BASE_REF=origin/codex/adr026-step2-acp-mvp bash scripts/ci/review-adr026-step3.sh
- bash scripts/ci/test-adapter-acp.sh
- cargo fmt --check
- cargo clippy -p assay-adapter-acp -p assay-adapter-api -p assay-cli -- -D warnings
