### PR TITLE
docs(adr011-012): sync signing boundary to open-core policy

### DIFF
--- a/docs/architecture/ADR-011-Tool-Signing.md
+++ b/docs/architecture/ADR-011-Tool-Signing.md
@@ -86,10 +86,10 @@ We will implement **Sigstore-based keyless signing** as an enterprise extension 
 ### Signing Flow (CLI)
 
 ```bash
-# Keyless signing (recommended)
+# Keyless signing (enterprise advanced signing)
 assay tool sign --keyless tool-definition.json
 
-# Key-based signing (enterprise)
+# Local-key signing (open-core)
 assay tool sign --key private.pem tool-definition.json
 
 # Verify a signed tool
@@ -98,7 +98,7 @@ assay tool verify tool-definition.json
 # Verify with explicit trust requirements
 assay tool verify tool-definition.json --require-producer-trust policy.yaml
 
-# Verify and require Rekor transparency proof
+# Verify and require Rekor transparency proof (enterprise advanced signing)
 assay tool verify tool-definition.json --rekor-required
 ```
 
@@ -123,7 +123,7 @@ trust_anchors:
   - issuer: "https://accounts.google.com"
     subject: "*@mycompany.com"
 
-require_transparency: true
+require_transparency: true  # enterprise advanced signing
 allow_unsigned: false
 ```
 
@@ -377,7 +377,7 @@ This enables interoperability with other MCP security tools.
 
 ## Implementation Plan
 
-### Phase 1: Signing CLI (Week 1)
+### Phase 1: Enterprise Signing CLI (Week 1)
 - [ ] `assay tool sign --keyless` command
 - [ ] Fulcio integration for certificate issuance
 - [ ] Rekor integration for transparency logging
@@ -411,10 +411,10 @@ This enables interoperability with other MCP security tools.
 ## Consequences
 
 ### Positive
-- Provenance for all tool definitions
-- No key management for developers (keyless)
-- Transparency via public Rekor log
-- Interoperable with Sigstore ecosystem
+- Provenance for enterprise-managed tool definitions
+- No key management for enterprise developers using keyless mode
+- Transparency via Rekor for the enterprise advanced-signing extension
+- Interoperable with Sigstore ecosystem when that extension is enabled
 
 ### Negative
 - External dependency (Sigstore infrastructure)

--- a/docs/architecture/ADR-012-Transparency-Log.md
+++ b/docs/architecture/ADR-012-Transparency-Log.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Proposed (January 2026)
+Proposed (January 2026; boundary sync February 2026)
+
+Open-core boundary note (current `main`):
+- Open-core delivered signing/verification stops at local-key `x-assay-sig` flows.
+- Rekor/Fulcio integration remains part of the enterprise advanced-signing surface.
 
 ## Context
 
@@ -17,7 +21,7 @@ This ADR details the Rekor integration for verification and monitoring.
 
 ## Decision
 
-We will integrate with **public Rekor** (rekor.sigstore.dev) for open source, with optional private instance support for enterprise.
+We will integrate with Rekor as part of the **enterprise advanced-signing** extension described in [ADR-011](./ADR-011-Tool-Signing.md). Open-core verification does not require or query Rekor. Enterprise deployments may use the public Rekor service or a private instance depending policy and operating model.
 
 ### Verification Flow
 
@@ -315,7 +319,7 @@ impl RekorCache {
 - Operational burden
 - No cross-organization trust
 
-**Decision:** Public Rekor for open source, private option for enterprise.
+**Decision:** Rekor remains enterprise-only; enterprise deployments may choose public Rekor or a private instance.
 
 ### 3. Alternative Transparency Logs
 
@@ -329,7 +333,7 @@ impl RekorCache {
 ### CLI Flags
 
 ```bash
-# Require Rekor transparency proof for verification
+# Require Rekor transparency proof for verification (enterprise advanced signing)
 assay tool verify tool.json --rekor-required
 
 # Verify evidence bundle with Rekor check
@@ -345,7 +349,7 @@ assay evidence verify bundle.tar.gz --offline
 ```yaml
 # assay.yaml
 tool_verification:
-  require_transparency: true  # Equivalent to --rekor-required
+  require_transparency: true  # Enterprise advanced signing; equivalent to --rekor-required
 
 evidence_verification:
   require_transparency: true
@@ -353,7 +357,7 @@ evidence_verification:
 
 ## Implementation Plan
 
-### Phase 1: Basic Verification (Week 1)
+### Phase 1: Enterprise Verification (Week 1)
 - [ ] Rekor API client
 - [ ] Entry fetching
 - [ ] Inclusion proof verification
@@ -385,9 +389,9 @@ evidence_verification:
 ## Consequences
 
 ### Positive
-- Cryptographic proof of signing time
-- Detection of compromised identities
-- Append-only audit trail
+- Cryptographic proof of signing time for the enterprise signing surface
+- Detection of compromised enterprise identities
+- Append-only audit trail when the enterprise extension is enabled
 - No trust in single entity (distributed witnesses)
 
 ### Negative

--- a/scripts/ci/review-adr011-012-boundary-sync.sh
+++ b/scripts/ci/review-adr011-012-boundary-sync.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-011-Tool-Signing.md"
+  "docs/architecture/ADR-012-Transparency-Log.md"
+  "scripts/ci/review-adr011-012-boundary-sync.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: boundary sync must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-011/012 boundary sync: $f"
+    exit 1
+  fi
+done
+
+ADR11="docs/architecture/ADR-011-Tool-Signing.md"
+ADR12="docs/architecture/ADR-012-Transparency-Log.md"
+
+echo "[review] boundary alignment"
+rg -n "Enterprise pending: Sigstore keyless \+ transparency-log verification" "$ADR11" >/dev/null || {
+  echo "FAIL: ADR-011 missing enterprise boundary note"
+  exit 1
+}
+rg -n "enterprise extension" "$ADR11" >/dev/null || {
+  echo "FAIL: ADR-011 missing enterprise extension wording"
+  exit 1
+}
+rg -n "Rekor/Fulcio integration remains part of the enterprise advanced-signing surface" "$ADR12" >/dev/null || {
+  echo "FAIL: ADR-012 missing enterprise boundary note"
+  exit 1
+}
+if rg -n "public Rekor.*open source" "$ADR12" >/dev/null; then
+  echo "FAIL: ADR-012 still claims public Rekor for open source"
+  exit 1
+fi
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Syncs ADR-011 and ADR-012 to the current open-core boundary: local-key `x-assay-sig` remains OSS, while Sigstore keyless and Rekor transparency verification remain enterprise advanced-signing features.

## Scope
- `docs/architecture/ADR-011-Tool-Signing.md`
- `docs/architecture/ADR-012-Transparency-Log.md`
- `scripts/ci/review-adr011-012-boundary-sync.sh`

## Safety
- Docs + reviewer gate only
- No workflow changes
- No runtime changes

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-adr011-012-boundary-sync.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
