### PR TITLE
docs(adr026): freeze A2A follow-up contract + crate skeleton (A2A Step1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assay-adapter-a2a"
+version = "2.18.0"
+dependencies = [
+ "assay-adapter-api",
+]
+
+[[package]]
 name = "assay-adapter-acp"
 version = "2.18.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "crates/assay-adapter-api",
   "crates/assay-adapter-acp",
+  "crates/assay-adapter-a2a",
   "crates/assay-core",
   "crates/assay-metrics",
   "crates/assay-cli", "crates/assay-mcp-server",

--- a/crates/assay-adapter-a2a/Cargo.toml
+++ b/crates/assay-adapter-a2a/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "assay-adapter-a2a"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme.workspace = true
+
+[dependencies]
+assay-adapter-api = { path = "../assay-adapter-api" }
+
+[lints]
+workspace = true

--- a/crates/assay-adapter-a2a/src/lib.rs
+++ b/crates/assay-adapter-a2a/src/lib.rs
@@ -1,0 +1,114 @@
+//! A2A adapter freeze skeleton.
+//!
+//! Step1 only freezes protocol metadata and the crate surface. Runtime mapping
+//! is intentionally deferred to the Step2 implementation slice.
+
+use assay_adapter_api::{
+    AdapterBatch, AdapterCapabilities, AdapterError, AdapterErrorKind, AdapterInput, AdapterResult,
+    AttachmentWriter, ConvertOptions, ProtocolAdapter, ProtocolDescriptor,
+};
+
+const PROTOCOL_NAME: &str = "a2a";
+const SPEC_VERSION_RANGE: &str = ">=0.2 <1.0";
+const SPEC_URL: &str = "https://google.github.io/A2A/";
+const SCHEMA_ID: &str = "a2a.message.v0_2";
+
+/// A2A adapter freeze skeleton.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct A2aAdapter;
+
+impl ProtocolAdapter for A2aAdapter {
+    fn protocol(&self) -> ProtocolDescriptor {
+        ProtocolDescriptor {
+            name: PROTOCOL_NAME.to_string(),
+            spec_version: SPEC_VERSION_RANGE.to_string(),
+            schema_id: Some(SCHEMA_ID.to_string()),
+            spec_url: Some(SPEC_URL.to_string()),
+        }
+    }
+
+    fn capabilities(&self) -> AdapterCapabilities {
+        AdapterCapabilities {
+            supported_event_types: vec![
+                "assay.adapter.a2a.agent.capabilities".to_string(),
+                "assay.adapter.a2a.task.requested".to_string(),
+                "assay.adapter.a2a.task.updated".to_string(),
+                "assay.adapter.a2a.artifact.shared".to_string(),
+                "assay.adapter.a2a.message".to_string(),
+            ],
+            supported_spec_versions: vec![SPEC_VERSION_RANGE.to_string()],
+            supports_strict: true,
+            supports_lenient: true,
+        }
+    }
+
+    fn convert(
+        &self,
+        _input: AdapterInput<'_>,
+        _options: &ConvertOptions,
+        _attachments: &dyn AttachmentWriter,
+    ) -> AdapterResult<AdapterBatch> {
+        Err(AdapterError::new(
+            AdapterErrorKind::Measurement,
+            "A2A Step1 freeze: runtime translation is not implemented yet",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_adapter_api::{AttachmentWriter, RawPayloadRef};
+
+    struct StubWriter;
+
+    impl AttachmentWriter for StubWriter {
+        fn write_raw_payload(
+            &self,
+            payload: &[u8],
+            media_type: &str,
+        ) -> AdapterResult<RawPayloadRef> {
+            Ok(RawPayloadRef {
+                sha256: format!("sha256:{}", payload.len()),
+                size_bytes: payload.len() as u64,
+                media_type: media_type.to_string(),
+            })
+        }
+    }
+
+    #[test]
+    fn exposes_frozen_a2a_metadata() {
+        let adapter = A2aAdapter;
+        let protocol = adapter.protocol();
+        let capabilities = adapter.capabilities();
+
+        assert_eq!(protocol.name, "a2a");
+        assert_eq!(protocol.spec_version, ">=0.2 <1.0");
+        assert_eq!(protocol.schema_id.as_deref(), Some("a2a.message.v0_2"));
+        assert!(capabilities.supports_strict);
+        assert!(capabilities.supports_lenient);
+        assert!(capabilities
+            .supported_event_types
+            .contains(&"assay.adapter.a2a.task.requested".to_string()));
+    }
+
+    #[test]
+    fn convert_is_explicitly_stubbed_in_step1() {
+        let adapter = A2aAdapter;
+        let writer = StubWriter;
+        let err = adapter
+            .convert(
+                AdapterInput {
+                    payload: br#"{"protocol":"a2a"}"#,
+                    media_type: "application/json",
+                    protocol_version: Some("0.2"),
+                },
+                &ConvertOptions::default(),
+                &writer,
+            )
+            .expect_err("step1 skeleton must not silently partially convert");
+
+        assert_eq!(err.kind, AdapterErrorKind::Measurement);
+        assert!(err.message.contains("not implemented yet"));
+    }
+}

--- a/docs/architecture/PLAN-ADR-026-A2A-2026q2.md
+++ b/docs/architecture/PLAN-ADR-026-A2A-2026q2.md
@@ -1,0 +1,64 @@
+# PLAN — ADR-026 A2A Adapter Follow-up (2026q2)
+
+## Intent
+Follow ADR-026 with an open-core A2A adapter rollout using the same low-blast-radius discipline as ACP:
+1. Step1 freeze the A2A contract and crate skeleton.
+2. Step2 implement deterministic A2A translation with conformance fixtures.
+3. Step3 close with checklist/review-pack and index sync.
+
+This slice is Step1 only: contract + skeleton + reviewer gate. No runtime mapping.
+
+## Scope (Step1 freeze)
+In-scope:
+- `assay-adapter-a2a` crate skeleton in the workspace
+- A2A protocol metadata and capabilities contract
+- Explicit non-goals for the first A2A MVP
+- Reviewer gate for allowlist-only + workflow-ban
+
+Out-of-scope (Step1):
+- No A2A payload mapping logic
+- No conformance fixtures yet
+- No workflow changes
+- No middleware, registry, or hosted control-plane features
+
+## Target protocol surface (frozen)
+Initial A2A MVP targets the governance-relevant subset only:
+- agent discovery / capability advertisement
+- task delegation / task lifecycle
+- artifact handoff references
+
+This is intentionally narrower than the full A2A ecosystem surface.
+
+## Crate contract (Step1)
+`assay-adapter-a2a` must:
+- implement `ProtocolAdapter`
+- expose protocol metadata for `a2a`
+- declare supported version range `>=0.2 <1.0`
+- keep raw payload preservation behind `AttachmentWriter`
+
+Until Step2 mapping lands, `convert()` is allowed to return an explicit measurement/config error indicating that runtime translation is not yet implemented.
+
+## Strictness expectations for Step2
+When Step2 lands, A2A must follow the ADR-026 strictness contract:
+- `strict`: malformed or unmappable critical data -> exit 2 in harnesses
+- `lenient`: emit evidence plus lossiness + raw payload ref
+
+## Initial event families (frozen for Step2)
+Planned canonical event families:
+- `assay.adapter.a2a.agent.capabilities`
+- `assay.adapter.a2a.task.requested`
+- `assay.adapter.a2a.task.updated`
+- `assay.adapter.a2a.artifact.shared`
+- generic fallback: `assay.adapter.a2a.message`
+
+## Non-goals
+- Full A2A semantic coverage in Step1/Step2
+- Live network ingestion
+- Plugin/Wasm execution
+- Enterprise middleware or approval workflows
+
+## Acceptance criteria (Step1)
+- `assay-adapter-a2a` exists as a compilable workspace crate
+- crate exposes frozen protocol metadata and capabilities markers
+- runtime conversion path is explicitly stubbed, not silently partial
+- reviewer gate enforces allowlist-only and workflow-ban

--- a/scripts/ci/review-adr026-a2a-step1.sh
+++ b/scripts/ci/review-adr026-a2a-step1.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "Cargo.toml"
+  "Cargo.lock"
+  "crates/assay-adapter-a2a/Cargo.toml"
+  "crates/assay-adapter-a2a/src/lib.rs"
+  "docs/architecture/PLAN-ADR-026-A2A-2026q2.md"
+  "scripts/ci/review-adr026-a2a-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-026 A2A Step1 must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-026 A2A Step1: $f"
+    exit 1
+  fi
+done
+
+echo "[review] contract markers"
+rg -n '^name = "assay-adapter-a2a"$' crates/assay-adapter-a2a/Cargo.toml >/dev/null || {
+  echo "FAIL: missing assay-adapter-a2a crate"
+  exit 1
+}
+rg -n 'pub struct A2aAdapter' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: missing A2aAdapter type"
+  exit 1
+}
+rg -n 'runtime translation is not implemented yet' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: stubbed Step1 convert contract missing"
+  exit 1
+}
+rg -n '^# PLAN — ADR-026 A2A Adapter Follow-up \(2026q2\)$' docs/architecture/PLAN-ADR-026-A2A-2026q2.md >/dev/null || {
+  echo "FAIL: missing A2A plan title"
+  exit 1
+}
+rg -n '^## Initial event families \(frozen for Step2\)$' docs/architecture/PLAN-ADR-026-A2A-2026q2.md >/dev/null || {
+  echo "FAIL: missing initial event families section"
+  exit 1
+}
+
+cargo test -p assay-adapter-a2a >/dev/null
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Starts the ADR-026 A2A follow-up with a Step1 freeze slice: plan doc, compileable `assay-adapter-a2a` skeleton, and a strict reviewer gate. No runtime mapping is introduced yet.

## Scope
- `Cargo.toml`
- `Cargo.lock`
- `crates/assay-adapter-a2a/*`
- `docs/architecture/PLAN-ADR-026-A2A-2026q2.md`
- `scripts/ci/review-adr026-a2a-step1.sh`

## Safety
- Open-core only
- No workflow changes
- No live A2A mapping behavior in this slice

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-adr026-a2a-step1.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-adapter-a2a -p assay-adapter-api -p assay-cli -- -D warnings`
