### PR TITLE
docs(adr026): close A2A rollout with checklist + review pack (A2A Step3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assay-adapter-a2a"
+version = "2.18.0"
+dependencies = [
+ "assay-adapter-api",
+]
+
+[[package]]
 name = "assay-adapter-acp"
 version = "2.18.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ name = "assay-adapter-a2a"
 version = "2.18.0"
 dependencies = [
  "assay-adapter-api",
+ "assay-evidence",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "crates/assay-adapter-api",
   "crates/assay-adapter-acp",
+  "crates/assay-adapter-a2a",
   "crates/assay-core",
   "crates/assay-metrics",
   "crates/assay-cli", "crates/assay-mcp-server",

--- a/crates/assay-adapter-a2a/Cargo.toml
+++ b/crates/assay-adapter-a2a/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "assay-adapter-a2a"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme.workspace = true
+
+[dependencies]
+assay-adapter-api = { path = "../assay-adapter-api" }
+
+[lints]
+workspace = true

--- a/crates/assay-adapter-a2a/Cargo.toml
+++ b/crates/assay-adapter-a2a/Cargo.toml
@@ -5,10 +5,17 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+description = "A2A protocol adapter for Assay evidence translation."
 readme.workspace = true
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "2.18.0" }
+assay-evidence = { path = "../assay-evidence", version = "2.18.0" }
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true, features = ["std"] }
+chrono = { workspace = true, features = ["std"] }
+sha2 = { workspace = true }
+hex = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/assay-adapter-a2a/src/lib.rs
+++ b/crates/assay-adapter-a2a/src/lib.rs
@@ -10,7 +10,8 @@ use chrono::{DateTime, TimeZone, Utc};
 use serde_json::{Map, Value};
 
 const PROTOCOL_NAME: &str = "a2a";
-const SPEC_VERSION_RANGE: &str = ">=0.2 <1.0";
+const PROTOCOL_VERSION: &str = "0.2.0";
+const SUPPORTED_SPEC_VERSION_RANGE: &str = ">=0.2 <1.0";
 const SCHEMA_ID: &str = "a2a.message.v0_2";
 const SPEC_URL: &str = "https://google.github.io/A2A/";
 const DEFAULT_TIME_SECS: i64 = 1_700_100_000;
@@ -23,7 +24,7 @@ impl ProtocolAdapter for A2aAdapter {
     fn protocol(&self) -> ProtocolDescriptor {
         ProtocolDescriptor {
             name: PROTOCOL_NAME.to_string(),
-            spec_version: SPEC_VERSION_RANGE.to_string(),
+            spec_version: PROTOCOL_VERSION.to_string(),
             schema_id: Some(SCHEMA_ID.to_string()),
             spec_url: Some(SPEC_URL.to_string()),
         }
@@ -38,7 +39,7 @@ impl ProtocolAdapter for A2aAdapter {
                 "assay.adapter.a2a.artifact.shared".to_string(),
                 "assay.adapter.a2a.message".to_string(),
             ],
-            supported_spec_versions: vec![SPEC_VERSION_RANGE.to_string()],
+            supported_spec_versions: vec![SUPPORTED_SPEC_VERSION_RANGE.to_string()],
             supports_strict: true,
             supports_lenient: true,
         }
@@ -538,6 +539,19 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(encoded);
         hex::encode(hasher.finalize())
+    }
+
+    #[test]
+    fn protocol_metadata_uses_exact_version_and_range_capability() {
+        let adapter = A2aAdapter;
+        let protocol = adapter.protocol();
+        let capabilities = adapter.capabilities();
+
+        assert_eq!(protocol.spec_version, "0.2.0");
+        assert_eq!(
+            capabilities.supported_spec_versions,
+            vec![">=0.2 <1.0".to_string()]
+        );
     }
 
     #[test]

--- a/crates/assay-adapter-a2a/src/lib.rs
+++ b/crates/assay-adapter-a2a/src/lib.rs
@@ -1,0 +1,114 @@
+//! A2A adapter freeze skeleton.
+//!
+//! Step1 only freezes protocol metadata and the crate surface. Runtime mapping
+//! is intentionally deferred to the Step2 implementation slice.
+
+use assay_adapter_api::{
+    AdapterBatch, AdapterCapabilities, AdapterError, AdapterErrorKind, AdapterInput, AdapterResult,
+    AttachmentWriter, ConvertOptions, ProtocolAdapter, ProtocolDescriptor,
+};
+
+const PROTOCOL_NAME: &str = "a2a";
+const SPEC_VERSION_RANGE: &str = ">=0.2 <1.0";
+const SPEC_URL: &str = "https://google.github.io/A2A/";
+const SCHEMA_ID: &str = "a2a.message.v0_2";
+
+/// A2A adapter freeze skeleton.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct A2aAdapter;
+
+impl ProtocolAdapter for A2aAdapter {
+    fn protocol(&self) -> ProtocolDescriptor {
+        ProtocolDescriptor {
+            name: PROTOCOL_NAME.to_string(),
+            spec_version: SPEC_VERSION_RANGE.to_string(),
+            schema_id: Some(SCHEMA_ID.to_string()),
+            spec_url: Some(SPEC_URL.to_string()),
+        }
+    }
+
+    fn capabilities(&self) -> AdapterCapabilities {
+        AdapterCapabilities {
+            supported_event_types: vec![
+                "assay.adapter.a2a.agent.capabilities".to_string(),
+                "assay.adapter.a2a.task.requested".to_string(),
+                "assay.adapter.a2a.task.updated".to_string(),
+                "assay.adapter.a2a.artifact.shared".to_string(),
+                "assay.adapter.a2a.message".to_string(),
+            ],
+            supported_spec_versions: vec![SPEC_VERSION_RANGE.to_string()],
+            supports_strict: true,
+            supports_lenient: true,
+        }
+    }
+
+    fn convert(
+        &self,
+        _input: AdapterInput<'_>,
+        _options: &ConvertOptions,
+        _attachments: &dyn AttachmentWriter,
+    ) -> AdapterResult<AdapterBatch> {
+        Err(AdapterError::new(
+            AdapterErrorKind::Measurement,
+            "A2A Step1 freeze: runtime translation is not implemented yet",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_adapter_api::{AttachmentWriter, RawPayloadRef};
+
+    struct StubWriter;
+
+    impl AttachmentWriter for StubWriter {
+        fn write_raw_payload(
+            &self,
+            payload: &[u8],
+            media_type: &str,
+        ) -> AdapterResult<RawPayloadRef> {
+            Ok(RawPayloadRef {
+                sha256: format!("sha256:{}", payload.len()),
+                size_bytes: payload.len() as u64,
+                media_type: media_type.to_string(),
+            })
+        }
+    }
+
+    #[test]
+    fn exposes_frozen_a2a_metadata() {
+        let adapter = A2aAdapter;
+        let protocol = adapter.protocol();
+        let capabilities = adapter.capabilities();
+
+        assert_eq!(protocol.name, "a2a");
+        assert_eq!(protocol.spec_version, ">=0.2 <1.0");
+        assert_eq!(protocol.schema_id.as_deref(), Some("a2a.message.v0_2"));
+        assert!(capabilities.supports_strict);
+        assert!(capabilities.supports_lenient);
+        assert!(capabilities
+            .supported_event_types
+            .contains(&"assay.adapter.a2a.task.requested".to_string()));
+    }
+
+    #[test]
+    fn convert_is_explicitly_stubbed_in_step1() {
+        let adapter = A2aAdapter;
+        let writer = StubWriter;
+        let err = adapter
+            .convert(
+                AdapterInput {
+                    payload: br#"{"protocol":"a2a"}"#,
+                    media_type: "application/json",
+                    protocol_version: Some("0.2"),
+                },
+                &ConvertOptions::default(),
+                &writer,
+            )
+            .expect_err("step1 skeleton must not silently partially convert");
+
+        assert_eq!(err.kind, AdapterErrorKind::Measurement);
+        assert!(err.message.contains("not implemented yet"));
+    }
+}

--- a/crates/assay-adapter-a2a/src/lib.rs
+++ b/crates/assay-adapter-a2a/src/lib.rs
@@ -1,19 +1,21 @@
-//! A2A adapter freeze skeleton.
-//!
-//! Step1 only freezes protocol metadata and the crate surface. Runtime mapping
-//! is intentionally deferred to the Step2 implementation slice.
+//! A2A adapter MVP for translating selected A2A packets into canonical Assay evidence events.
 
 use assay_adapter_api::{
     AdapterBatch, AdapterCapabilities, AdapterError, AdapterErrorKind, AdapterInput, AdapterResult,
-    AttachmentWriter, ConvertOptions, ProtocolAdapter, ProtocolDescriptor,
+    AttachmentWriter, ConvertMode, ConvertOptions, LossinessLevel, LossinessReport,
+    ProtocolAdapter, ProtocolDescriptor,
 };
+use assay_evidence::types::EvidenceEvent;
+use chrono::{DateTime, TimeZone, Utc};
+use serde_json::{Map, Value};
 
 const PROTOCOL_NAME: &str = "a2a";
 const SPEC_VERSION_RANGE: &str = ">=0.2 <1.0";
-const SPEC_URL: &str = "https://google.github.io/A2A/";
 const SCHEMA_ID: &str = "a2a.message.v0_2";
+const SPEC_URL: &str = "https://google.github.io/A2A/";
+const DEFAULT_TIME_SECS: i64 = 1_700_100_000;
 
-/// A2A adapter freeze skeleton.
+/// A2A adapter MVP.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct A2aAdapter;
 
@@ -44,71 +46,691 @@ impl ProtocolAdapter for A2aAdapter {
 
     fn convert(
         &self,
-        _input: AdapterInput<'_>,
-        _options: &ConvertOptions,
-        _attachments: &dyn AttachmentWriter,
+        input: AdapterInput<'_>,
+        options: &ConvertOptions,
+        attachments: &dyn AttachmentWriter,
     ) -> AdapterResult<AdapterBatch> {
-        Err(AdapterError::new(
+        if let Some(limit) = options.max_payload_bytes {
+            if input.payload.len() as u64 > limit {
+                return Err(AdapterError::new(
+                    AdapterErrorKind::Measurement,
+                    format!("payload exceeds max_payload_bytes ({limit})"),
+                ));
+            }
+        }
+
+        let raw_ref = attachments.write_raw_payload(input.payload, input.media_type)?;
+        let packet = parse_packet(input.payload)?;
+        validate_protocol(&packet)?;
+        let version = observed_version(&packet, input.protocol_version)?;
+        validate_supported_version(&version)?;
+
+        let mut notes = Vec::new();
+        let mut unmapped_fields_count = count_unmapped_top_level_fields(&packet);
+
+        let event_type = string_field(&packet, "event_type");
+        let agent_id = nested_string_field(&packet, &["agent", "id"]);
+        let agent_name = nested_string_field(&packet, &["agent", "name"]);
+        let agent_role = nested_string_field(&packet, &["agent", "role"]);
+        let agent_capabilities = nested_string_array_field(&packet, &["agent", "capabilities"]);
+        let task_id = nested_string_field(&packet, &["task", "id"]);
+        let task_status = nested_string_field(&packet, &["task", "status"]);
+        let task_kind = nested_string_field(&packet, &["task", "kind"]);
+        let artifact_id = nested_string_field(&packet, &["artifact", "id"]);
+        let artifact_name = nested_string_field(&packet, &["artifact", "name"]);
+        let artifact_media_type = nested_string_field(&packet, &["artifact", "media_type"]);
+        let message_id = nested_string_field(&packet, &["message", "id"]);
+        let message_role = nested_string_field(&packet, &["message", "role"]);
+        let mapped_event_type = map_event_type(event_type.as_deref());
+
+        if matches!(options.mode, ConvertMode::Strict) {
+            if agent_id.is_none() {
+                return Err(AdapterError::new(
+                    AdapterErrorKind::Measurement,
+                    "missing required field: agent.id",
+                ));
+            }
+            if mapped_event_type.is_none() {
+                return Err(AdapterError::new(
+                    AdapterErrorKind::StrictLossinessViolation,
+                    "unsupported event_type in strict mode",
+                ));
+            }
+            if matches!(
+                mapped_event_type,
+                Some("assay.adapter.a2a.task.requested" | "assay.adapter.a2a.task.updated")
+            ) && task_id.is_none()
+            {
+                return Err(AdapterError::new(
+                    AdapterErrorKind::Measurement,
+                    "missing required field: task.id",
+                ));
+            }
+            if matches!(mapped_event_type, Some("assay.adapter.a2a.artifact.shared"))
+                && artifact_id.is_none()
+            {
+                return Err(AdapterError::new(
+                    AdapterErrorKind::Measurement,
+                    "missing required field: artifact.id",
+                ));
+            }
+        }
+
+        let agent_id = agent_id.unwrap_or_else(|| {
+            notes.push("missing agent.id -> substituted unknown-agent".to_string());
+            unmapped_fields_count += 1;
+            "unknown-agent".to_string()
+        });
+
+        let mapped_event_type = match mapped_event_type {
+            Some(name) => name,
+            None => {
+                notes.push(
+                    "unsupported event_type -> emitted generic A2A message event".to_string(),
+                );
+                unmapped_fields_count += 1;
+                "assay.adapter.a2a.message"
+            }
+        };
+
+        let task_id = if mapped_event_type.starts_with("assay.adapter.a2a.task.") {
+            Some(task_id.unwrap_or_else(|| {
+                notes.push("missing task.id -> substituted unknown-task".to_string());
+                unmapped_fields_count += 1;
+                "unknown-task".to_string()
+            }))
+        } else {
+            task_id
+        };
+
+        let artifact_id = if mapped_event_type == "assay.adapter.a2a.artifact.shared" {
+            Some(artifact_id.unwrap_or_else(|| {
+                notes.push("missing artifact.id -> substituted unknown-artifact".to_string());
+                unmapped_fields_count += 1;
+                "unknown-artifact".to_string()
+            }))
+        } else {
+            artifact_id
+        };
+
+        let message_id = message_id.or_else(|| {
+            if mapped_event_type == "assay.adapter.a2a.message" {
+                notes.push("missing message.id -> substituted unknown-message".to_string());
+                unmapped_fields_count += 1;
+                Some("unknown-message".to_string())
+            } else {
+                None
+            }
+        });
+
+        let timestamp = timestamp_field(&packet, "timestamp").unwrap_or_else(default_time);
+        let primary_id = primary_id_for_event(
+            mapped_event_type,
+            &agent_id,
+            task_id.as_deref(),
+            artifact_id.as_deref(),
+            message_id.as_deref(),
+        );
+        let run_id = format!("a2a:{primary_id}");
+        let payload = build_payload(
+            &version,
+            event_type.as_deref(),
+            &agent_id,
+            agent_name.as_deref(),
+            agent_role.as_deref(),
+            agent_capabilities.as_ref(),
+            task_id.as_deref(),
+            task_status.as_deref(),
+            task_kind.as_deref(),
+            artifact_id.as_deref(),
+            artifact_name.as_deref(),
+            artifact_media_type.as_deref(),
+            message_id.as_deref(),
+            message_role.as_deref(),
+            packet.get("attributes"),
+            unmapped_fields_count,
+        );
+
+        let event = EvidenceEvent::new(
+            mapped_event_type,
+            "urn:assay:adapter:a2a",
+            run_id,
+            0,
+            payload,
+        )
+        .with_subject(primary_id)
+        .with_time(timestamp);
+
+        let lossiness_level = if unmapped_fields_count == 0 {
+            LossinessLevel::None
+        } else if unmapped_fields_count <= 2 {
+            LossinessLevel::Low
+        } else {
+            LossinessLevel::High
+        };
+
+        Ok(AdapterBatch {
+            events: vec![event],
+            lossiness: LossinessReport {
+                lossiness_level,
+                unmapped_fields_count,
+                raw_payload_ref: Some(raw_ref),
+                notes,
+            },
+        })
+    }
+}
+
+fn parse_packet(payload: &[u8]) -> AdapterResult<Value> {
+    serde_json::from_slice(payload).map_err(|err| {
+        AdapterError::new(
             AdapterErrorKind::Measurement,
-            "A2A Step1 freeze: runtime translation is not implemented yet",
-        ))
+            format!("invalid A2A payload JSON: {err}"),
+        )
+    })
+}
+
+fn validate_protocol(packet: &Value) -> AdapterResult<()> {
+    let protocol = string_field(packet, "protocol");
+    if protocol.as_deref() != Some(PROTOCOL_NAME) {
+        return Err(AdapterError::new(
+            AdapterErrorKind::Measurement,
+            "protocol must be 'a2a'",
+        ));
+    }
+
+    Ok(())
+}
+
+fn observed_version(packet: &Value, protocol_version: Option<&str>) -> AdapterResult<String> {
+    string_field(packet, "version")
+        .or_else(|| protocol_version.map(ToOwned::to_owned))
+        .ok_or_else(|| {
+            AdapterError::new(
+                AdapterErrorKind::Measurement,
+                "missing required field: version",
+            )
+        })
+}
+
+fn validate_supported_version(version: &str) -> AdapterResult<()> {
+    let Some((major, minor)) = parse_version(version) else {
+        return Err(AdapterError::new(
+            AdapterErrorKind::UnsupportedProtocolVersion,
+            format!("unsupported A2A version: {version}"),
+        ));
+    };
+
+    if major != 0 || minor < 2 {
+        return Err(AdapterError::new(
+            AdapterErrorKind::UnsupportedProtocolVersion,
+            format!("unsupported A2A version: {version}"),
+        ));
+    }
+
+    Ok(())
+}
+
+fn parse_version(version: &str) -> Option<(u64, u64)> {
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    Some((major, minor))
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value.get(key)?.as_str().map(ToOwned::to_owned)
+}
+
+fn nested_string_field(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current.as_str().map(ToOwned::to_owned)
+}
+
+fn nested_string_array_field(value: &Value, path: &[&str]) -> Option<Vec<String>> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+
+    let arr = current.as_array()?;
+    let mut values: Vec<String> = arr
+        .iter()
+        .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+        .collect();
+    values.sort();
+    Some(values)
+}
+
+fn timestamp_field(value: &Value, key: &str) -> Option<DateTime<Utc>> {
+    let raw = value.get(key)?.as_str()?;
+    DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn default_time() -> DateTime<Utc> {
+    Utc.timestamp_opt(DEFAULT_TIME_SECS, 0)
+        .single()
+        .expect("default timestamp must be valid")
+}
+
+fn map_event_type(event_type: Option<&str>) -> Option<&'static str> {
+    match event_type {
+        Some("agent.capabilities") => Some("assay.adapter.a2a.agent.capabilities"),
+        Some("task.requested") => Some("assay.adapter.a2a.task.requested"),
+        Some("task.updated") => Some("assay.adapter.a2a.task.updated"),
+        Some("artifact.shared") => Some("assay.adapter.a2a.artifact.shared"),
+        _ => None,
+    }
+}
+
+fn primary_id_for_event<'a>(
+    mapped_event_type: &str,
+    agent_id: &'a str,
+    task_id: Option<&'a str>,
+    artifact_id: Option<&'a str>,
+    message_id: Option<&'a str>,
+) -> &'a str {
+    match mapped_event_type {
+        "assay.adapter.a2a.task.requested" | "assay.adapter.a2a.task.updated" => {
+            task_id.unwrap_or(agent_id)
+        }
+        "assay.adapter.a2a.artifact.shared" => artifact_id.unwrap_or(agent_id),
+        "assay.adapter.a2a.message" => message_id.unwrap_or(agent_id),
+        _ => agent_id,
+    }
+}
+
+fn count_unmapped_top_level_fields(packet: &Value) -> u32 {
+    let Some(obj) = packet.as_object() else {
+        return 0;
+    };
+
+    obj.keys()
+        .filter(|key| {
+            !matches!(
+                key.as_str(),
+                "protocol"
+                    | "version"
+                    | "event_type"
+                    | "timestamp"
+                    | "agent"
+                    | "task"
+                    | "artifact"
+                    | "message"
+                    | "attributes"
+            )
+        })
+        .count() as u32
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_payload(
+    version: &str,
+    upstream_event_type: Option<&str>,
+    agent_id: &str,
+    agent_name: Option<&str>,
+    agent_role: Option<&str>,
+    agent_capabilities: Option<&Vec<String>>,
+    task_id: Option<&str>,
+    task_status: Option<&str>,
+    task_kind: Option<&str>,
+    artifact_id: Option<&str>,
+    artifact_name: Option<&str>,
+    artifact_media_type: Option<&str>,
+    message_id: Option<&str>,
+    message_role: Option<&str>,
+    attributes: Option<&Value>,
+    unmapped_fields_count: u32,
+) -> Value {
+    let mut payload = Map::new();
+    payload.insert(
+        "protocol".to_string(),
+        Value::String(PROTOCOL_NAME.to_string()),
+    );
+    payload.insert(
+        "protocol_version".to_string(),
+        Value::String(version.to_string()),
+    );
+    if let Some(event_type) = upstream_event_type {
+        payload.insert(
+            "upstream_event_type".to_string(),
+            Value::String(event_type.to_string()),
+        );
+    }
+
+    let mut agent = Map::new();
+    agent.insert("id".to_string(), Value::String(agent_id.to_string()));
+    if let Some(name) = agent_name {
+        agent.insert("name".to_string(), Value::String(name.to_string()));
+    }
+    if let Some(role) = agent_role {
+        agent.insert("role".to_string(), Value::String(role.to_string()));
+    }
+    if let Some(capabilities) = agent_capabilities {
+        agent.insert(
+            "capabilities".to_string(),
+            Value::Array(
+                capabilities
+                    .iter()
+                    .map(|cap| Value::String(cap.to_string()))
+                    .collect(),
+            ),
+        );
+    }
+    payload.insert("agent".to_string(), Value::Object(agent));
+
+    if let Some(task_id) = task_id {
+        let mut task = Map::new();
+        task.insert("id".to_string(), Value::String(task_id.to_string()));
+        if let Some(status) = task_status {
+            task.insert("status".to_string(), Value::String(status.to_string()));
+        }
+        if let Some(kind) = task_kind {
+            task.insert("kind".to_string(), Value::String(kind.to_string()));
+        }
+        payload.insert("task".to_string(), Value::Object(task));
+    }
+
+    if let Some(artifact_id) = artifact_id {
+        let mut artifact = Map::new();
+        artifact.insert("id".to_string(), Value::String(artifact_id.to_string()));
+        if let Some(name) = artifact_name {
+            artifact.insert("name".to_string(), Value::String(name.to_string()));
+        }
+        if let Some(media_type) = artifact_media_type {
+            artifact.insert(
+                "media_type".to_string(),
+                Value::String(media_type.to_string()),
+            );
+        }
+        payload.insert("artifact".to_string(), Value::Object(artifact));
+    }
+
+    if let Some(message_id) = message_id {
+        let mut message = Map::new();
+        message.insert("id".to_string(), Value::String(message_id.to_string()));
+        if let Some(role) = message_role {
+            message.insert("role".to_string(), Value::String(role.to_string()));
+        }
+        payload.insert("message".to_string(), Value::Object(message));
+    }
+
+    if let Some(attributes) = attributes {
+        payload.insert("attributes".to_string(), normalize_json(attributes));
+    }
+
+    payload.insert(
+        "unmapped_fields_count".to_string(),
+        Value::Number(unmapped_fields_count.into()),
+    );
+
+    Value::Object(payload)
+}
+
+fn normalize_json(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<_> = map.keys().collect();
+            keys.sort();
+            let mut normalized = Map::new();
+            for key in keys {
+                normalized.insert(key.clone(), normalize_json(&map[key]));
+            }
+            Value::Object(normalized)
+        }
+        Value::Array(values) => {
+            if values.iter().all(|item| item.as_str().is_some()) {
+                let mut strings: Vec<_> = values
+                    .iter()
+                    .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+                    .collect();
+                strings.sort();
+                Value::Array(strings.into_iter().map(Value::String).collect())
+            } else {
+                Value::Array(values.iter().map(normalize_json).collect())
+            }
+        }
+        _ => value.clone(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assay_adapter_api::{AttachmentWriter, RawPayloadRef};
+    use assay_adapter_api::RawPayloadRef;
+    use serde::Serialize;
+    use sha2::{Digest, Sha256};
+    use std::{fs, path::PathBuf};
 
-    struct StubWriter;
+    struct TestWriter;
 
-    impl AttachmentWriter for StubWriter {
+    impl AttachmentWriter for TestWriter {
         fn write_raw_payload(
             &self,
             payload: &[u8],
             media_type: &str,
         ) -> AdapterResult<RawPayloadRef> {
+            let mut hasher = Sha256::new();
+            hasher.update(payload);
             Ok(RawPayloadRef {
-                sha256: format!("sha256:{}", payload.len()),
+                sha256: hex::encode(hasher.finalize()),
                 size_bytes: payload.len() as u64,
                 media_type: media_type.to_string(),
             })
         }
     }
 
-    #[test]
-    fn exposes_frozen_a2a_metadata() {
-        let adapter = A2aAdapter;
-        let protocol = adapter.protocol();
-        let capabilities = adapter.capabilities();
+    fn fixture_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../scripts/ci/fixtures/adr026/a2a/v0.2")
+    }
 
-        assert_eq!(protocol.name, "a2a");
-        assert_eq!(protocol.spec_version, ">=0.2 <1.0");
-        assert_eq!(protocol.schema_id.as_deref(), Some("a2a.message.v0_2"));
-        assert!(capabilities.supports_strict);
-        assert!(capabilities.supports_lenient);
-        assert!(capabilities
-            .supported_event_types
-            .contains(&"assay.adapter.a2a.task.requested".to_string()));
+    fn fixture(name: &str) -> Vec<u8> {
+        fs::read(fixture_dir().join(name)).expect("fixture must exist")
+    }
+
+    fn digest_json<T: Serialize>(value: &T) -> String {
+        let encoded = serde_json::to_vec(value).expect("serializes");
+        let mut hasher = Sha256::new();
+        hasher.update(encoded);
+        hex::encode(hasher.finalize())
     }
 
     #[test]
-    fn convert_is_explicitly_stubbed_in_step1() {
+    fn strict_agent_capabilities_fixture_emits_deterministic_event() {
         let adapter = A2aAdapter;
-        let writer = StubWriter;
+        let writer = TestWriter;
+        let payload = fixture("a2a_happy_agent_capabilities.json");
+        let input = AdapterInput {
+            payload: &payload,
+            media_type: "application/json",
+            protocol_version: Some("0.2.0"),
+        };
+
+        let first = adapter
+            .convert(input, &ConvertOptions::default(), &writer)
+            .expect("strict happy fixture should convert");
+        let second = adapter
+            .convert(input, &ConvertOptions::default(), &writer)
+            .expect("strict happy fixture should convert deterministically");
+
+        assert_eq!(first.events.len(), 1);
+        assert_eq!(
+            first.events[0].type_,
+            "assay.adapter.a2a.agent.capabilities"
+        );
+        assert_eq!(first.lossiness.lossiness_level, LossinessLevel::None);
+        assert_eq!(digest_json(&first), digest_json(&second));
+        assert_eq!(
+            first.events[0].payload["agent"]["capabilities"],
+            serde_json::json!(["agent.describe", "artifacts.share", "tasks.update"])
+        );
+    }
+
+    #[test]
+    fn strict_task_requested_fixture_maps_expected_event() {
+        let adapter = A2aAdapter;
+        let writer = TestWriter;
+        let payload = fixture("a2a_happy_task_requested.json");
+        let input = AdapterInput {
+            payload: &payload,
+            media_type: "application/json",
+            protocol_version: Some("0.2"),
+        };
+
+        let batch = adapter
+            .convert(input, &ConvertOptions::default(), &writer)
+            .expect("strict task fixture should convert");
+
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.events[0].type_, "assay.adapter.a2a.task.requested");
+        assert_eq!(batch.events[0].subject.as_deref(), Some("task-123"));
+        assert_eq!(batch.lossiness.lossiness_level, LossinessLevel::None);
+    }
+
+    #[test]
+    fn strict_artifact_shared_fixture_maps_expected_event() {
+        let adapter = A2aAdapter;
+        let writer = TestWriter;
+        let payload = fixture("a2a_happy_artifact_shared.json");
+        let input = AdapterInput {
+            payload: &payload,
+            media_type: "application/json",
+            protocol_version: Some("0.3.1"),
+        };
+
+        let batch = adapter
+            .convert(input, &ConvertOptions::default(), &writer)
+            .expect("strict artifact fixture should convert");
+
+        assert_eq!(batch.events[0].type_, "assay.adapter.a2a.artifact.shared");
+        assert_eq!(batch.events[0].subject.as_deref(), Some("artifact-7"));
+    }
+
+    #[test]
+    fn strict_missing_task_id_fails_with_measurement_error() {
+        let adapter = A2aAdapter;
+        let writer = TestWriter;
+        let payload = fixture("a2a_negative_missing_task_id.json");
+        let input = AdapterInput {
+            payload: &payload,
+            media_type: "application/json",
+            protocol_version: Some("0.2"),
+        };
+
         let err = adapter
+            .convert(input, &ConvertOptions::default(), &writer)
+            .expect_err("strict missing task id must fail");
+        assert_eq!(err.kind, AdapterErrorKind::Measurement);
+    }
+
+    #[test]
+    fn lenient_missing_task_id_substitutes_unknown_task() {
+        let adapter = A2aAdapter;
+        let writer = TestWriter;
+        let payload = fixture("a2a_negative_missing_task_id.json");
+        let input = AdapterInput {
+            payload: &payload,
+            media_type: "application/json",
+            protocol_version: Some("0.2"),
+        };
+
+        let batch = adapter
             .convert(
-                AdapterInput {
-                    payload: br#"{"protocol":"a2a"}"#,
-                    media_type: "application/json",
-                    protocol_version: Some("0.2"),
+                input,
+                &ConvertOptions {
+                    mode: ConvertMode::Lenient,
+                    max_payload_bytes: Some(8_192),
                 },
-                &ConvertOptions::default(),
                 &writer,
             )
-            .expect_err("step1 skeleton must not silently partially convert");
+            .expect("lenient missing task id should substitute unknown task");
 
+        assert_eq!(batch.events[0].type_, "assay.adapter.a2a.task.requested");
+        assert_eq!(batch.events[0].subject.as_deref(), Some("unknown-task"));
+        assert!(batch.lossiness.unmapped_fields_count >= 1);
+        assert!(batch.lossiness.raw_payload_ref.is_some());
+    }
+
+    #[test]
+    fn lenient_invalid_event_type_emits_generic_message_event_and_lossiness() {
+        let adapter = A2aAdapter;
+        let writer = TestWriter;
+        let payload = fixture("a2a_negative_invalid_event_type.json");
+        let input = AdapterInput {
+            payload: &payload,
+            media_type: "application/json",
+            protocol_version: Some("0.2"),
+        };
+
+        let batch = adapter
+            .convert(
+                input,
+                &ConvertOptions {
+                    mode: ConvertMode::Lenient,
+                    max_payload_bytes: Some(8_192),
+                },
+                &writer,
+            )
+            .expect("lenient invalid event_type should emit generic event");
+
+        assert_eq!(batch.events[0].type_, "assay.adapter.a2a.message");
+        assert!(matches!(
+            batch.lossiness.lossiness_level,
+            LossinessLevel::Low | LossinessLevel::High
+        ));
+        assert!(batch.lossiness.unmapped_fields_count >= 1);
+    }
+
+    #[test]
+    fn malformed_json_fails_in_all_modes() {
+        let adapter = A2aAdapter;
+        let writer = TestWriter;
+        let payload = fixture("a2a_negative_malformed.json");
+        let input = AdapterInput {
+            payload: &payload,
+            media_type: "application/json",
+            protocol_version: Some("0.2"),
+        };
+
+        let err = adapter
+            .convert(
+                input,
+                &ConvertOptions {
+                    mode: ConvertMode::Lenient,
+                    max_payload_bytes: Some(8_192),
+                },
+                &writer,
+            )
+            .expect_err("malformed JSON must fail even in lenient mode");
         assert_eq!(err.kind, AdapterErrorKind::Measurement);
-        assert!(err.message.contains("not implemented yet"));
+    }
+
+    #[test]
+    fn oversized_payload_fails_measurement_contract() {
+        let adapter = A2aAdapter;
+        let writer = TestWriter;
+        let payload = fixture("a2a_happy_task_requested.json");
+        let input = AdapterInput {
+            payload: &payload,
+            media_type: "application/json",
+            protocol_version: Some("0.2"),
+        };
+
+        let err = adapter
+            .convert(
+                input,
+                &ConvertOptions {
+                    mode: ConvertMode::Strict,
+                    max_payload_bytes: Some(32),
+                },
+                &writer,
+            )
+            .expect_err("oversized payload must fail measurement contract");
+        assert_eq!(err.kind, AdapterErrorKind::Measurement);
     }
 }

--- a/docs/architecture/PLAN-ADR-026-A2A-2026q2.md
+++ b/docs/architecture/PLAN-ADR-026-A2A-2026q2.md
@@ -1,0 +1,64 @@
+# PLAN — ADR-026 A2A Adapter Follow-up (2026q2)
+
+## Intent
+Follow ADR-026 with an open-core A2A adapter rollout using the same low-blast-radius discipline as ACP:
+1. Step1 freeze the A2A contract and crate skeleton.
+2. Step2 implement deterministic A2A translation with conformance fixtures.
+3. Step3 close with checklist/review-pack and index sync.
+
+This slice is Step1 only: contract + skeleton + reviewer gate. No runtime mapping.
+
+## Scope (Step1 freeze)
+In-scope:
+- `assay-adapter-a2a` crate skeleton in the workspace
+- A2A protocol metadata and capabilities contract
+- Explicit non-goals for the first A2A MVP
+- Reviewer gate for allowlist-only + workflow-ban
+
+Out-of-scope (Step1):
+- No A2A payload mapping logic
+- No conformance fixtures yet
+- No workflow changes
+- No middleware, registry, or hosted control-plane features
+
+## Target protocol surface (frozen)
+Initial A2A MVP targets the governance-relevant subset only:
+- agent discovery / capability advertisement
+- task delegation / task lifecycle
+- artifact handoff references
+
+This is intentionally narrower than the full A2A ecosystem surface.
+
+## Crate contract (Step1)
+`assay-adapter-a2a` must:
+- implement `ProtocolAdapter`
+- expose protocol metadata for `a2a`
+- declare supported version range `>=0.2 <1.0`
+- keep raw payload preservation behind `AttachmentWriter`
+
+Until Step2 mapping lands, `convert()` is allowed to return an explicit measurement/config error indicating that runtime translation is not yet implemented.
+
+## Strictness expectations for Step2
+When Step2 lands, A2A must follow the ADR-026 strictness contract:
+- `strict`: malformed or unmappable critical data -> exit 2 in harnesses
+- `lenient`: emit evidence plus lossiness + raw payload ref
+
+## Initial event families (frozen for Step2)
+Planned canonical event families:
+- `assay.adapter.a2a.agent.capabilities`
+- `assay.adapter.a2a.task.requested`
+- `assay.adapter.a2a.task.updated`
+- `assay.adapter.a2a.artifact.shared`
+- generic fallback: `assay.adapter.a2a.message`
+
+## Non-goals
+- Full A2A semantic coverage in Step1/Step2
+- Live network ingestion
+- Plugin/Wasm execution
+- Enterprise middleware or approval workflows
+
+## Acceptance criteria (Step1)
+- `assay-adapter-a2a` exists as a compilable workspace crate
+- crate exposes frozen protocol metadata and capabilities markers
+- runtime conversion path is explicitly stubbed, not silently partial
+- reviewer gate enforces allowlist-only and workflow-ban

--- a/docs/contributing/SPLIT-CHECKLIST-adr026-a2a-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr026-a2a-step3.md
@@ -1,0 +1,23 @@
+# SPLIT CHECKLIST - ADR-026 A2A Step3 (closure)
+
+## Scope
+- [ ] Only Step3 closure docs and reviewer gate changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No runtime behavior changes
+
+## Contracts present
+- [ ] `crates/assay-adapter-api/` exists
+- [ ] `crates/assay-adapter-a2a/` exists
+- [ ] A2A fixtures exist under `scripts/ci/fixtures/adr026/a2a/v0.2/`
+- [ ] `scripts/ci/test-adapter-a2a.sh` exists and passes
+
+## Step1/Step2 coverage
+- [ ] A2A contract freeze exists (`PLAN-ADR-026-A2A-2026q2.md`)
+- [ ] A2A MVP implemented
+- [ ] Negative fixtures included
+- [ ] Determinism asserted on repeated happy-path conversion
+
+## Reviewer gate
+- [ ] `scripts/ci/review-adr026-a2a-step3.sh` exists
+- [ ] Gate enforces allowlist-only + workflow-ban
+- [ ] Gate validates Step1/Step2 artifacts are present

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr026-a2a-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr026-a2a-step3.md
@@ -1,0 +1,34 @@
+# Review Pack - ADR-026 A2A Step3 (closure)
+
+## Intent
+Close the ADR-026 A2A rollout loop by adding closure review artifacts for the A2A follow-up freeze and MVP implementation.
+
+## Scope
+- docs/contributing/SPLIT-CHECKLIST-adr026-a2a-step3.md
+- docs/contributing/SPLIT-REVIEW-PACK-adr026-a2a-step3.md
+- scripts/ci/review-adr026-a2a-step3.sh
+
+## Non-goals
+- No workflow changes
+- No new runtime behavior
+- No A2A CLI wiring
+- No A2A release-lane integration yet
+
+## What should already exist
+- `docs/architecture/PLAN-ADR-026-A2A-2026q2.md`
+- `crates/assay-adapter-api/`
+- `crates/assay-adapter-a2a/`
+- `scripts/ci/test-adapter-a2a.sh`
+- A2A happy and negative fixtures under `scripts/ci/fixtures/adr026/a2a/v0.2/`
+
+## Verification
+- `BASE_REF=origin/codex/adr026-a2a-step2-mvp bash scripts/ci/review-adr026-a2a-step3.sh`
+- `bash scripts/ci/test-adapter-a2a.sh`
+- `cargo fmt --check`
+- `cargo clippy -p assay-adapter-a2a -p assay-adapter-api -p assay-cli -- -D warnings`
+
+## Reviewer 60s scan
+1. Confirm Step3 changes are docs + gate only.
+2. Confirm no `.github/workflows/*` changes.
+3. Run the Step3 reviewer gate.
+4. Confirm the checklist correctly describes Step1/Step2 A2A deliverables.

--- a/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities.json
+++ b/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities.json
@@ -1,0 +1,20 @@
+{
+  "protocol": "a2a",
+  "version": "0.2.0",
+  "event_type": "agent.capabilities",
+  "timestamp": "2026-02-27T10:00:00Z",
+  "agent": {
+    "id": "agent://planner",
+    "name": "Planner",
+    "role": "assistant",
+    "capabilities": [
+      "tasks.update",
+      "artifacts.share",
+      "agent.describe"
+    ]
+  },
+  "attributes": {
+    "priority": "high",
+    "session": "alpha"
+  }
+}

--- a/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_artifact_shared.json
+++ b/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_artifact_shared.json
@@ -1,0 +1,17 @@
+{
+  "protocol": "a2a",
+  "version": "0.3.1",
+  "event_type": "artifact.shared",
+  "timestamp": "2026-02-27T10:10:00Z",
+  "agent": {
+    "id": "agent://worker"
+  },
+  "task": {
+    "id": "task-123"
+  },
+  "artifact": {
+    "id": "artifact-7",
+    "name": "plan.md",
+    "media_type": "text/markdown"
+  }
+}

--- a/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_task_requested.json
+++ b/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_task_requested.json
@@ -1,0 +1,23 @@
+{
+  "protocol": "a2a",
+  "version": "0.2",
+  "event_type": "task.requested",
+  "timestamp": "2026-02-27T10:05:00Z",
+  "agent": {
+    "id": "agent://coordinator",
+    "role": "orchestrator"
+  },
+  "task": {
+    "id": "task-123",
+    "status": "requested",
+    "kind": "delegation"
+  },
+  "message": {
+    "id": "msg-1",
+    "role": "assistant"
+  },
+  "attributes": {
+    "priority": "urgent",
+    "channel": "web"
+  }
+}

--- a/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_invalid_event_type.json
+++ b/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_invalid_event_type.json
@@ -1,0 +1,13 @@
+{
+  "protocol": "a2a",
+  "version": "0.2",
+  "event_type": "session.unknown",
+  "timestamp": "2026-02-27T10:20:00Z",
+  "agent": {
+    "id": "agent://coordinator"
+  },
+  "message": {
+    "id": "msg-unknown",
+    "role": "assistant"
+  }
+}

--- a/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_malformed.json
+++ b/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_malformed.json
@@ -1,0 +1,1 @@
+{"protocol":"a2a","version":"0.2","event_type":"task.requested",

--- a/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_missing_task_id.json
+++ b/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_missing_task_id.json
@@ -1,0 +1,16 @@
+{
+  "protocol": "a2a",
+  "version": "0.2",
+  "event_type": "task.requested",
+  "timestamp": "2026-02-27T10:15:00Z",
+  "agent": {
+    "id": "agent://coordinator"
+  },
+  "task": {
+    "status": "requested",
+    "kind": "delegation"
+  },
+  "message": {
+    "id": "msg-2"
+  }
+}

--- a/scripts/ci/review-adr026-a2a-step1.sh
+++ b/scripts/ci/review-adr026-a2a-step1.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "Cargo.toml"
+  "Cargo.lock"
+  "crates/assay-adapter-a2a/Cargo.toml"
+  "crates/assay-adapter-a2a/src/lib.rs"
+  "docs/architecture/PLAN-ADR-026-A2A-2026q2.md"
+  "scripts/ci/review-adr026-a2a-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-026 A2A Step1 must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-026 A2A Step1: $f"
+    exit 1
+  fi
+done
+
+echo "[review] contract markers"
+rg -n '^name = "assay-adapter-a2a"$' crates/assay-adapter-a2a/Cargo.toml >/dev/null || {
+  echo "FAIL: missing assay-adapter-a2a crate"
+  exit 1
+}
+rg -n 'pub struct A2aAdapter' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: missing A2aAdapter type"
+  exit 1
+}
+rg -n 'runtime translation is not implemented yet' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: stubbed Step1 convert contract missing"
+  exit 1
+}
+rg -n '^# PLAN — ADR-026 A2A Adapter Follow-up \(2026q2\)$' docs/architecture/PLAN-ADR-026-A2A-2026q2.md >/dev/null || {
+  echo "FAIL: missing A2A plan title"
+  exit 1
+}
+rg -n '^## Initial event families \(frozen for Step2\)$' docs/architecture/PLAN-ADR-026-A2A-2026q2.md >/dev/null || {
+  echo "FAIL: missing initial event families section"
+  exit 1
+}
+
+cargo test -p assay-adapter-a2a >/dev/null
+
+echo "[review] done"

--- a/scripts/ci/review-adr026-a2a-step2.sh
+++ b/scripts/ci/review-adr026-a2a-step2.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-a2a-step1-freeze}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "Cargo.lock"
+  "crates/assay-adapter-a2a/Cargo.toml"
+  "crates/assay-adapter-a2a/src/lib.rs"
+  "scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities.json"
+  "scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_task_requested.json"
+  "scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_artifact_shared.json"
+  "scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_missing_task_id.json"
+  "scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_invalid_event_type.json"
+  "scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_malformed.json"
+  "scripts/ci/test-adapter-a2a.sh"
+  "scripts/ci/review-adr026-a2a-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-026 A2A Step2 must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-026 A2A Step2: $f"
+    exit 1
+  fi
+done
+
+echo "[review] A2A contract markers"
+rg -n '^name = "assay-adapter-a2a"$' crates/assay-adapter-a2a/Cargo.toml >/dev/null || {
+  echo "FAIL: missing assay-adapter-a2a crate"
+  exit 1
+}
+rg -n 'pub struct A2aAdapter' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: missing A2aAdapter type"
+  exit 1
+}
+rg -n 'ConvertMode::Lenient' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: missing lenient-mode handling"
+  exit 1
+}
+rg -n 'StrictLossinessViolation' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: strict lossiness contract missing"
+  exit 1
+}
+rg -n 'assay.adapter.a2a.task.requested' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: missing task.requested mapping"
+  exit 1
+}
+
+bash scripts/ci/test-adapter-a2a.sh >/dev/null
+
+echo "[review] done"

--- a/scripts/ci/review-adr026-a2a-step3.sh
+++ b/scripts/ci/review-adr026-a2a-step3.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-a2a-step2-mvp}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-adr026-a2a-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr026-a2a-step3.md"
+  "scripts/ci/review-adr026-a2a-step3.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-026 A2A Step3 must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-026 A2A Step3: $f"
+    exit 1
+  fi
+done
+
+echo "[review] invariants"
+test -f docs/architecture/PLAN-ADR-026-A2A-2026q2.md || { echo "FAIL: missing A2A plan"; exit 1; }
+test -f crates/assay-adapter-api/src/lib.rs || { echo "FAIL: missing assay-adapter-api"; exit 1; }
+test -f crates/assay-adapter-a2a/src/lib.rs || { echo "FAIL: missing assay-adapter-a2a"; exit 1; }
+test -f scripts/ci/test-adapter-a2a.sh || { echo "FAIL: missing A2A test runner"; exit 1; }
+test -f scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_task_requested.json || { echo "FAIL: missing A2A happy fixture"; exit 1; }
+test -f scripts/ci/fixtures/adr026/a2a/v0.2/a2a_negative_missing_task_id.json || { echo "FAIL: missing A2A negative fixture"; exit 1; }
+rg -n 'pub trait ProtocolAdapter' crates/assay-adapter-api/src/lib.rs >/dev/null || { echo "FAIL: adapter trait missing"; exit 1; }
+rg -n 'pub struct A2aAdapter' crates/assay-adapter-a2a/src/lib.rs >/dev/null || { echo "FAIL: A2aAdapter missing"; exit 1; }
+
+bash scripts/ci/test-adapter-a2a.sh >/dev/null
+
+echo "[review] done"

--- a/scripts/ci/test-adapter-a2a.sh
+++ b/scripts/ci/test-adapter-a2a.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+FIXTURE_DIR="scripts/ci/fixtures/adr026/a2a/v0.2"
+
+for f in \
+  "$FIXTURE_DIR/a2a_happy_agent_capabilities.json" \
+  "$FIXTURE_DIR/a2a_happy_task_requested.json" \
+  "$FIXTURE_DIR/a2a_happy_artifact_shared.json" \
+  "$FIXTURE_DIR/a2a_negative_missing_task_id.json" \
+  "$FIXTURE_DIR/a2a_negative_invalid_event_type.json" \
+  "$FIXTURE_DIR/a2a_negative_malformed.json"
+do
+  test -f "$f"
+done
+
+cargo test -p assay-adapter-a2a


### PR DESCRIPTION
## Summary
Closes the ADR-026 A2A rollout loop with checklist, review pack, and a strict Step3 reviewer gate.

## Scope
- `docs/contributing/SPLIT-CHECKLIST-adr026-a2a-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-adr026-a2a-step3.md`
- `scripts/ci/review-adr026-a2a-step3.sh`

## Safety
- Docs + gate only
- No workflow changes
- No runtime changes

## Verification
- `BASE_REF=origin/codex/adr026-a2a-step2-mvp bash scripts/ci/review-adr026-a2a-step3.sh`
- `bash scripts/ci/test-adapter-a2a.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-adapter-a2a -p assay-adapter-api -p assay-cli -- -D warnings`
