### PR TITLE
docs(adr026): freeze adapter metadata contract (E0A)

### DIFF
--- a/docs/architecture/ADR-026-ADAPTER-METADATA-CONTRACT.md
+++ b/docs/architecture/ADR-026-ADAPTER-METADATA-CONTRACT.md
@@ -1,0 +1,25 @@
+# ADR-026 Adapter Metadata Contract (E0)
+
+## Intent
+Ensure every adapter-emitted EvidenceEvent is traceable to:
+- adapter implementation identity (`adapter_id`)
+- adapter build/version (`adapter_version`)
+
+This enables audit reproducibility and regression triage across protocol/version churn.
+
+## Required fields (v1)
+- `adapter_id`: stable identifier, e.g. `assay-adapter-acp`
+- `adapter_version`: semver string (crate version)
+- `protocol_name`: e.g. `acp`
+- `protocol_version`: spec version string or range carried by the adapter output
+
+## Placement
+Metadata must be present in the adapter output envelope such that:
+- it is carried into `EvidenceEvent` payload or extensions
+- it is available even in lenient fallback events
+- it survives raw-payload preservation / lossiness reporting paths
+
+## Non-goals
+- No behavior changes to mapping semantics
+- No workflow changes
+- No release-line publication changes

--- a/scripts/ci/review-adr026-stab-e0-a.sh
+++ b/scripts/ci/review-adr026-stab-e0-a.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-stab-e1-acp-lossiness}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-026-ADAPTER-METADATA-CONTRACT.md"
+  "scripts/ci/review-adr026-stab-e0-a.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: E0A must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in E0A: $f"
+    exit 1
+  fi
+done
+
+echo "[review] contract markers"
+rg -n '^# ADR-026 Adapter Metadata Contract \(E0\)$' docs/architecture/ADR-026-ADAPTER-METADATA-CONTRACT.md >/dev/null || {
+  echo "FAIL: missing E0 contract title"
+  exit 1
+}
+rg -n '`adapter_id`' docs/architecture/ADR-026-ADAPTER-METADATA-CONTRACT.md >/dev/null || {
+  echo "FAIL: adapter_id requirement missing"
+  exit 1
+}
+rg -n '`adapter_version`' docs/architecture/ADR-026-ADAPTER-METADATA-CONTRACT.md >/dev/null || {
+  echo "FAIL: adapter_version requirement missing"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Freeze slice for ADR-026 adapter metadata requirements. This documents the required `adapter_id` / `adapter_version` contract and adds a strict reviewer gate. No runtime or workflow changes.

## Scope
- `docs/architecture/ADR-026-ADAPTER-METADATA-CONTRACT.md`
- `scripts/ci/review-adr026-stab-e0-a.sh`

## Safety
- Docs + reviewer gate only
- No workflow changes
- Stacked on ADR-026 Stab E1

## Verification
- `BASE_REF=origin/codex/adr026-stab-e1-acp-lossiness bash scripts/ci/review-adr026-stab-e0-a.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
