### PR TITLE
feat(adr026): add adapter metadata identity to API and events (Stab E0B)

### DIFF
--- a/crates/assay-adapter-a2a/src/lib.rs
+++ b/crates/assay-adapter-a2a/src/lib.rs
@@ -1,9 +1,9 @@
 //! A2A adapter MVP for translating selected A2A packets into canonical Assay evidence events.
 
 use assay_adapter_api::{
-    AdapterBatch, AdapterCapabilities, AdapterError, AdapterErrorKind, AdapterInput, AdapterResult,
-    AttachmentWriter, ConvertMode, ConvertOptions, LossinessLevel, LossinessReport,
-    ProtocolAdapter, ProtocolDescriptor,
+    AdapterBatch, AdapterCapabilities, AdapterDescriptor, AdapterError, AdapterErrorKind,
+    AdapterInput, AdapterResult, AttachmentWriter, ConvertMode, ConvertOptions, LossinessLevel,
+    LossinessReport, ProtocolAdapter, ProtocolDescriptor,
 };
 use assay_evidence::types::EvidenceEvent;
 use chrono::{DateTime, TimeZone, Utc};
@@ -15,12 +15,20 @@ const SUPPORTED_SPEC_VERSION_RANGE: &str = ">=0.2 <1.0";
 const SCHEMA_ID: &str = "a2a.message.v0_2";
 const SPEC_URL: &str = "https://google.github.io/A2A/";
 const DEFAULT_TIME_SECS: i64 = 1_700_100_000;
+const ADAPTER_ID: &str = "assay-adapter-a2a";
 
 /// A2A adapter MVP.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct A2aAdapter;
 
 impl ProtocolAdapter for A2aAdapter {
+    fn adapter(&self) -> AdapterDescriptor {
+        AdapterDescriptor {
+            adapter_id: ADAPTER_ID,
+            adapter_version: env!("CARGO_PKG_VERSION"),
+        }
+    }
+
     fn protocol(&self) -> ProtocolDescriptor {
         ProtocolDescriptor {
             name: PROTOCOL_NAME.to_string(),
@@ -164,6 +172,7 @@ impl ProtocolAdapter for A2aAdapter {
             }
         });
 
+        let adapter = self.adapter();
         let timestamp = timestamp_field(&packet, "timestamp").unwrap_or_else(default_time);
         let primary_id = primary_id_for_event(
             mapped_event_type,
@@ -174,6 +183,8 @@ impl ProtocolAdapter for A2aAdapter {
         );
         let run_id = format!("a2a:{primary_id}");
         let payload = build_payload(
+            adapter.adapter_id,
+            adapter.adapter_version,
             &version,
             event_type.as_deref(),
             &agent_id,
@@ -371,6 +382,8 @@ fn count_unmapped_top_level_fields(packet: &Value) -> u32 {
 
 #[allow(clippy::too_many_arguments)]
 fn build_payload(
+    adapter_id: &str,
+    adapter_version: &str,
     version: &str,
     upstream_event_type: Option<&str>,
     agent_id: &str,
@@ -390,7 +403,19 @@ fn build_payload(
 ) -> Value {
     let mut payload = Map::new();
     payload.insert(
+        "adapter_id".to_string(),
+        Value::String(adapter_id.to_string()),
+    );
+    payload.insert(
+        "adapter_version".to_string(),
+        Value::String(adapter_version.to_string()),
+    );
+    payload.insert(
         "protocol".to_string(),
+        Value::String(PROTOCOL_NAME.to_string()),
+    );
+    payload.insert(
+        "protocol_name".to_string(),
         Value::String(PROTOCOL_NAME.to_string()),
     );
     payload.insert(
@@ -544,9 +569,12 @@ mod tests {
     #[test]
     fn protocol_metadata_uses_exact_version_and_range_capability() {
         let adapter = A2aAdapter;
+        let descriptor = adapter.adapter();
         let protocol = adapter.protocol();
         let capabilities = adapter.capabilities();
 
+        assert_eq!(descriptor.adapter_id, ADAPTER_ID);
+        assert!(!descriptor.adapter_version.is_empty());
         assert_eq!(protocol.spec_version, "0.2.0");
         assert_eq!(
             capabilities.supported_spec_versions,
@@ -604,6 +632,18 @@ mod tests {
         assert_eq!(batch.events[0].type_, "assay.adapter.a2a.task.requested");
         assert_eq!(batch.events[0].subject.as_deref(), Some("task-123"));
         assert_eq!(batch.lossiness.lossiness_level, LossinessLevel::None);
+        assert_eq!(
+            batch.events[0].payload["adapter_id"],
+            Value::String(ADAPTER_ID.to_string())
+        );
+        assert_eq!(
+            batch.events[0].payload["adapter_version"],
+            Value::String(env!("CARGO_PKG_VERSION").to_string())
+        );
+        assert_eq!(
+            batch.events[0].payload["protocol_name"],
+            Value::String(PROTOCOL_NAME.to_string())
+        );
     }
 
     #[test]
@@ -698,6 +738,14 @@ mod tests {
             LossinessLevel::Low | LossinessLevel::High
         ));
         assert!(batch.lossiness.unmapped_fields_count >= 1);
+        assert_eq!(
+            batch.events[0].payload["adapter_id"],
+            Value::String(ADAPTER_ID.to_string())
+        );
+        assert_eq!(
+            batch.events[0].payload["adapter_version"],
+            Value::String(env!("CARGO_PKG_VERSION").to_string())
+        );
     }
 
     #[test]

--- a/crates/assay-adapter-acp/src/lib.rs
+++ b/crates/assay-adapter-acp/src/lib.rs
@@ -1,9 +1,9 @@
 //! ACP adapter MVP for translating selected ACP packets into canonical Assay evidence events.
 
 use assay_adapter_api::{
-    AdapterBatch, AdapterCapabilities, AdapterError, AdapterErrorKind, AdapterInput, AdapterResult,
-    AttachmentWriter, ConvertMode, ConvertOptions, LossinessLevel, LossinessReport,
-    ProtocolAdapter, ProtocolDescriptor,
+    AdapterBatch, AdapterCapabilities, AdapterDescriptor, AdapterError, AdapterErrorKind,
+    AdapterInput, AdapterResult, AttachmentWriter, ConvertMode, ConvertOptions, LossinessLevel,
+    LossinessReport, ProtocolAdapter, ProtocolDescriptor,
 };
 use assay_evidence::types::EvidenceEvent;
 use chrono::{DateTime, TimeZone, Utc};
@@ -14,12 +14,20 @@ const SPEC_VERSION: &str = "2.11.0";
 const SCHEMA_ID: &str = "acp.packet.v2_11_0";
 const SPEC_URL: &str = "https://example.invalid/specs/acp/2.11.0";
 const DEFAULT_TIME_SECS: i64 = 1_700_000_000;
+const ADAPTER_ID: &str = "assay-adapter-acp";
 
 /// ACP adapter MVP.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct AcpAdapter;
 
 impl ProtocolAdapter for AcpAdapter {
+    fn adapter(&self) -> AdapterDescriptor {
+        AdapterDescriptor {
+            adapter_id: ADAPTER_ID,
+            adapter_version: env!("CARGO_PKG_VERSION"),
+        }
+    }
+
     fn protocol(&self) -> ProtocolDescriptor {
         ProtocolDescriptor {
             name: PROTOCOL_NAME.to_string(),
@@ -114,9 +122,12 @@ impl ProtocolAdapter for AcpAdapter {
             }
         };
 
+        let adapter = self.adapter();
         let timestamp = timestamp_field(&packet, "timestamp").unwrap_or_else(default_time);
         let run_id = format!("acp:{}", packet_id);
         let payload = build_payload(
+            adapter.adapter_id,
+            adapter.adapter_version,
             &packet_id,
             &actor_id,
             actor_role.as_deref(),
@@ -242,6 +253,8 @@ fn count_unmapped_top_level_fields(packet: &Value) -> u32 {
 
 #[allow(clippy::too_many_arguments)]
 fn build_payload(
+    adapter_id: &str,
+    adapter_version: &str,
     packet_id: &str,
     actor_id: &str,
     actor_role: Option<&str>,
@@ -253,7 +266,19 @@ fn build_payload(
 ) -> Value {
     let mut payload = Map::new();
     payload.insert(
+        "adapter_id".to_string(),
+        Value::String(adapter_id.to_string()),
+    );
+    payload.insert(
+        "adapter_version".to_string(),
+        Value::String(adapter_version.to_string()),
+    );
+    payload.insert(
         "protocol".to_string(),
+        Value::String(PROTOCOL_NAME.to_string()),
+    );
+    payload.insert(
+        "protocol_name".to_string(),
         Value::String(PROTOCOL_NAME.to_string()),
     );
     payload.insert(
@@ -371,6 +396,18 @@ mod tests {
         assert_eq!(first.lossiness.lossiness_level, LossinessLevel::None);
         assert_eq!(digest_json(&first), digest_json(&second));
         assert_eq!(first.events[0].type_, "assay.adapter.acp.intent.created");
+        assert_eq!(
+            first.events[0].payload["adapter_id"],
+            Value::String(ADAPTER_ID.to_string())
+        );
+        assert_eq!(
+            first.events[0].payload["adapter_version"],
+            Value::String(env!("CARGO_PKG_VERSION").to_string())
+        );
+        assert_eq!(
+            first.events[0].payload["protocol_name"],
+            Value::String(PROTOCOL_NAME.to_string())
+        );
         assert_eq!(
             first.events[0].payload["attributes"]["merchant_id"],
             Value::String("merchant-42".to_string())
@@ -515,6 +552,14 @@ mod tests {
         ));
         assert!(batch.lossiness.unmapped_fields_count >= 1);
         assert!(batch.lossiness.raw_payload_ref.is_some());
+        assert_eq!(
+            batch.events[0].payload["adapter_id"],
+            Value::String(ADAPTER_ID.to_string())
+        );
+        assert_eq!(
+            batch.events[0].payload["adapter_version"],
+            Value::String(env!("CARGO_PKG_VERSION").to_string())
+        );
     }
 
     #[test]

--- a/crates/assay-adapter-api/src/lib.rs
+++ b/crates/assay-adapter-api/src/lib.rs
@@ -21,6 +21,15 @@ pub struct ProtocolDescriptor {
     pub spec_url: Option<String>,
 }
 
+/// Stable adapter implementation metadata exposed by each adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdapterDescriptor {
+    /// Stable adapter crate or implementation identifier.
+    pub adapter_id: &'static str,
+    /// Adapter build/version string.
+    pub adapter_version: &'static str,
+}
+
 /// Capabilities exposed by the adapter for review and routing.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AdapterCapabilities {
@@ -154,6 +163,9 @@ pub trait AttachmentWriter {
 
 /// Stable contract implemented by protocol-specific adapters.
 pub trait ProtocolAdapter {
+    /// Return stable adapter implementation metadata.
+    fn adapter(&self) -> AdapterDescriptor;
+
     /// Return stable protocol metadata.
     fn protocol(&self) -> ProtocolDescriptor;
 
@@ -193,6 +205,13 @@ mod tests {
     struct StubAdapter;
 
     impl ProtocolAdapter for StubAdapter {
+        fn adapter(&self) -> AdapterDescriptor {
+            AdapterDescriptor {
+                adapter_id: "assay-adapter-acp",
+                adapter_version: env!("CARGO_PKG_VERSION"),
+            }
+        }
+
         fn protocol(&self) -> ProtocolDescriptor {
             ProtocolDescriptor {
                 name: "acp".to_string(),
@@ -285,5 +304,14 @@ mod tests {
             batch.lossiness.raw_payload_ref.expect("raw ref").size_bytes,
             19
         );
+    }
+
+    #[test]
+    fn adapter_descriptor_exposes_identity() {
+        let adapter = StubAdapter;
+        let descriptor = adapter.adapter();
+
+        assert_eq!(descriptor.adapter_id, "assay-adapter-acp");
+        assert!(!descriptor.adapter_version.is_empty());
     }
 }

--- a/docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md
+++ b/docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md
@@ -1,0 +1,51 @@
+# ADR-026 AttachmentWriter Host Boundary (E2A)
+
+## Intent
+Freeze the host-side policy boundary for raw payload preservation used by protocol adapters.
+
+The adapter contract remains minimal, but host implementations of `AttachmentWriter` must enforce a consistent safety policy before runtime rollout.
+
+## Scope
+In-scope:
+- host-enforced payload size caps
+- media-type allowlist / validation
+- explicit redaction boundary ownership
+- error taxonomy for attachment persistence failures
+
+Out-of-scope:
+- runtime implementation of the host writer (E2B)
+- workflow changes
+- release-lane integration changes
+
+## Host policy contract (v1)
+A production `AttachmentWriter` implementation must enforce:
+- a hard maximum payload size before persistence
+- media-type validation against an explicit allowlist or contract rule
+- no direct adapter-managed filesystem writes
+- no raw payload contents in logs
+
+## Redaction boundary
+Adapters do not perform redaction.
+
+Redaction, rejection, or secret-handling policy is owned by the host layer implementing `AttachmentWriter`.
+
+## Error taxonomy
+The host writer contract must distinguish at least:
+- measurement/contract failures
+  - oversize payload
+  - unsupported or invalid media type
+  - invalid persistence contract inputs
+- infrastructure failures
+  - storage write failure
+  - unavailable attachment backend
+
+## Required output shape
+Successful writes must produce a stable digest-backed reference containing:
+- `sha256`
+- `size_bytes`
+- `media_type`
+
+## Non-goals
+- no adapter mapping behavior changes in this freeze slice
+- no workflow changes
+- no crates.io publication changes

--- a/scripts/ci/review-adr026-stab-e0-b.sh
+++ b/scripts/ci/review-adr026-stab-e0-b.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-adapter-api/src/lib.rs"
+  "crates/assay-adapter-acp/src/lib.rs"
+  "crates/assay-adapter-a2a/src/lib.rs"
+  "scripts/ci/review-adr026-stab-e0-b.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: E0B must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in E0B: $f"
+    exit 1
+  fi
+done
+
+echo "[review] adapter metadata markers"
+rg -n 'pub struct AdapterDescriptor' crates/assay-adapter-api/src/lib.rs >/dev/null || {
+  echo "FAIL: AdapterDescriptor missing"
+  exit 1
+}
+rg -n 'fn adapter\(&self\) -> AdapterDescriptor' crates/assay-adapter-api/src/lib.rs >/dev/null || {
+  echo "FAIL: ProtocolAdapter::adapter contract missing"
+  exit 1
+}
+rg -n '"adapter_id"' crates/assay-adapter-acp/src/lib.rs >/dev/null || {
+  echo "FAIL: ACP adapter_id metadata missing"
+  exit 1
+}
+rg -n '"adapter_version"' crates/assay-adapter-acp/src/lib.rs >/dev/null || {
+  echo "FAIL: ACP adapter_version metadata missing"
+  exit 1
+}
+rg -n '"adapter_id"' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: A2A adapter_id metadata missing"
+  exit 1
+}
+rg -n '"adapter_version"' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: A2A adapter_version metadata missing"
+  exit 1
+}
+
+cargo test -p assay-adapter-api -p assay-adapter-acp -p assay-adapter-a2a >/dev/null
+
+echo "[review] done"

--- a/scripts/ci/review-adr026-stab-e2-a.sh
+++ b/scripts/ci/review-adr026-stab-e2-a.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-stab-e0-b-impl}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md"
+  "scripts/ci/review-adr026-stab-e2-a.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: E2A must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in E2A: $f"
+    exit 1
+  fi
+done
+
+echo "[review] contract markers"
+rg -n '^# ADR-026 AttachmentWriter Host Boundary \(E2A\)$' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing E2A title"
+  exit 1
+}
+rg -n 'hard maximum payload size' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing size-cap contract"
+  exit 1
+}
+rg -n 'media-type validation' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing media-type contract"
+  exit 1
+}
+rg -n '^## Redaction boundary$' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing redaction boundary section"
+  exit 1
+}
+rg -n '^## Error taxonomy$' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing error taxonomy section"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Implements the ADR-026 adapter metadata contract in code. The shared adapter API now exposes `AdapterDescriptor`, and ACP/A2A payloads now carry `adapter_id`, `adapter_version`, `protocol_name`, and `protocol_version` in both happy-path and lenient fallback events.

This branch also now carries the stacked E2A freeze docs for the `AttachmentWriter` host boundary.

## Scope
- `crates/assay-adapter-api/src/lib.rs`
- `crates/assay-adapter-acp/src/lib.rs`
- `crates/assay-adapter-a2a/src/lib.rs`
- `scripts/ci/review-adr026-stab-e0-b.sh`
- `docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md`
- `scripts/ci/review-adr026-stab-e2-a.sh`

## Safety
- Open-core only
- No workflow changes
- Allowlist-only reviewer gates

## Verification
- `cargo test -p assay-adapter-api -p assay-adapter-acp -p assay-adapter-a2a`
- `BASE_REF=origin/main bash scripts/ci/review-adr026-stab-e0-b.sh`
- `BASE_REF=origin/codex/adr026-stab-e0-b-impl bash scripts/ci/review-adr026-stab-e2-a.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-adapter-api -p assay-adapter-acp -p assay-adapter-a2a -p assay-cli -- -D warnings`
