### PR TITLE
docs(adr026): freeze AttachmentWriter host boundary (E2A)

### DIFF
--- a/docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md
+++ b/docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md
@@ -1,0 +1,51 @@
+# ADR-026 AttachmentWriter Host Boundary (E2A)
+
+## Intent
+Freeze the host-side policy boundary for raw payload preservation used by protocol adapters.
+
+The adapter contract remains minimal, but host implementations of `AttachmentWriter` must enforce a consistent safety policy before runtime rollout.
+
+## Scope
+In-scope:
+- host-enforced payload size caps
+- media-type allowlist / validation
+- explicit redaction boundary ownership
+- error taxonomy for attachment persistence failures
+
+Out-of-scope:
+- runtime implementation of the host writer (E2B)
+- workflow changes
+- release-lane integration changes
+
+## Host policy contract (v1)
+A production `AttachmentWriter` implementation must enforce:
+- a hard maximum payload size before persistence
+- media-type validation against an explicit allowlist or contract rule
+- no direct adapter-managed filesystem writes
+- no raw payload contents in logs
+
+## Redaction boundary
+Adapters do not perform redaction.
+
+Redaction, rejection, or secret-handling policy is owned by the host layer implementing `AttachmentWriter`.
+
+## Error taxonomy
+The host writer contract must distinguish at least:
+- measurement/contract failures
+  - oversize payload
+  - unsupported or invalid media type
+  - invalid persistence contract inputs
+- infrastructure failures
+  - storage write failure
+  - unavailable attachment backend
+
+## Required output shape
+Successful writes must produce a stable digest-backed reference containing:
+- `sha256`
+- `size_bytes`
+- `media_type`
+
+## Non-goals
+- no adapter mapping behavior changes in this freeze slice
+- no workflow changes
+- no crates.io publication changes

--- a/scripts/ci/review-adr026-stab-e2-a.sh
+++ b/scripts/ci/review-adr026-stab-e2-a.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-stab-e0-b-impl}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md"
+  "scripts/ci/review-adr026-stab-e2-a.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: E2A must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in E2A: $f"
+    exit 1
+  fi
+done
+
+echo "[review] contract markers"
+rg -n '^# ADR-026 AttachmentWriter Host Boundary \(E2A\)$' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing E2A title"
+  exit 1
+}
+rg -n 'hard maximum payload size' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing size-cap contract"
+  exit 1
+}
+rg -n 'media-type validation' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing media-type contract"
+  exit 1
+}
+rg -n '^## Redaction boundary$' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing redaction boundary section"
+  exit 1
+}
+rg -n '^## Error taxonomy$' docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md >/dev/null || {
+  echo "FAIL: missing error taxonomy section"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Freeze slice for the ADR-026 AttachmentWriter host boundary. This locks the host-side policy contract for size caps, media-type validation, redaction ownership, and error taxonomy before runtime implementation.

## Scope
- `docs/architecture/ADR-026-ATTACHMENT-WRITER-BOUNDARY.md`
- `scripts/ci/review-adr026-stab-e2-a.sh`

## Safety
- Docs + reviewer gate only
- No workflow changes
- Stacked on ADR-026 Stab E0B

## Verification
- `BASE_REF=origin/codex/adr026-stab-e0-b-impl bash scripts/ci/review-adr026-stab-e2-a.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
