### PR TITLE
docs(adr026): freeze canonicalization and hash boundary (Stab E3A)

### DIFF
--- a/docs/architecture/ADR-026-CANONICALIZATION-HASH-BOUNDARY.md
+++ b/docs/architecture/ADR-026-CANONICALIZATION-HASH-BOUNDARY.md
@@ -1,0 +1,67 @@
+# ADR-026 Canonicalization and Hash Boundary (E3A)
+
+## Intent
+Freeze a single canonicalization and hashing contract for ADR-026 adapter outputs.
+
+The goal is to make adapter-emitted evidence reproducible across runs and robust
+against semantically irrelevant JSON key-order differences, while preserving a
+separate raw-payload forensic boundary.
+
+## Scope
+In-scope:
+- canonical JSON rules for adapter-emitted payload digests
+- explicit hash boundary for canonical event payloads
+- explicit hash boundary for preserved raw payload bytes
+- determinism requirements for key-order independence tests
+
+Out-of-scope:
+- runtime implementation of the shared canonicalization utility (E3B)
+- workflow changes
+- changes to adapter mapping semantics
+- changes to raw payload persistence policy frozen in E2A/E2B
+
+## Canonical event payload contract (v1)
+Adapter payload digests must be computed over canonical JSON bytes, not over
+implementation-defined serializer output.
+
+Canonical JSON rules (v1):
+- object keys sorted lexicographically
+- nested objects normalized recursively
+- arrays preserve semantic order by default
+- arrays may be normalized only when the adapter contract defines them as
+  order-insensitive sets
+- strings and booleans are emitted unchanged
+- integers must preserve numeric value without stringifying unless the adapter
+  contract already freezes string encoding for that field
+
+## Raw payload hash boundary
+`raw_payload_ref.sha256` is computed over the exact raw payload bytes supplied to
+the adapter host boundary.
+
+Normative implications:
+- semantically equivalent JSON inputs with different key ordering may share the
+  same canonical event payload digest
+- those same inputs may have different `raw_payload_ref.sha256` values because
+  the raw-byte forensic boundary is intentionally stricter
+
+## Determinism requirements
+Each adapter conformance suite must include:
+- at least one test proving semantically equivalent payloads with different JSON
+  key ordering produce the same canonical event payload digest
+- at least one test proving exact raw payload bytes remain distinguishable via
+  `raw_payload_ref.sha256`
+- no duplicate ad hoc digest helpers once the shared canonicalization utility is
+  introduced
+
+## Shared utility contract
+E3B must introduce a shared canonicalization helper in the adapter layer so ACP
+and A2A do not diverge in hashing semantics.
+
+Minimum shared surface:
+- `canonical_json_bytes(value) -> Vec<u8>`
+- `digest_canonical_json(value) -> sha256 hex`
+
+## Non-goals
+- no change to adapter lossiness semantics
+- no change to AttachmentWriter media-type or size-cap policy
+- no crates.io publication changes

--- a/scripts/ci/review-adr026-stab-e3-a.sh
+++ b/scripts/ci/review-adr026-stab-e3-a.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-stab-e2-b-host-writer}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-026-CANONICALIZATION-HASH-BOUNDARY.md"
+  "scripts/ci/review-adr026-stab-e3-a.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: E3A must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in E3A: $f"
+    exit 1
+  fi
+done
+
+echo "[review] contract markers"
+DOC="docs/architecture/ADR-026-CANONICALIZATION-HASH-BOUNDARY.md"
+rg -n '^# ADR-026 Canonicalization and Hash Boundary \(E3A\)$' "$DOC" >/dev/null || {
+  echo "FAIL: missing E3A title"
+  exit 1
+}
+rg -n '^## Canonical event payload contract \(v1\)$' "$DOC" >/dev/null || {
+  echo "FAIL: missing canonical payload contract"
+  exit 1
+}
+rg -n '^## Raw payload hash boundary$' "$DOC" >/dev/null || {
+  echo "FAIL: missing raw payload boundary"
+  exit 1
+}
+rg -n 'same canonical event payload digest' "$DOC" >/dev/null || {
+  echo "FAIL: missing key-order independence rule"
+  exit 1
+}
+rg -n 'exact raw payload bytes remain distinguishable' "$DOC" >/dev/null || {
+  echo "FAIL: missing raw-byte distinguishability rule"
+  exit 1
+}
+rg -n 'canonical_json_bytes' "$DOC" >/dev/null || {
+  echo "FAIL: missing shared utility contract"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Freezes ADR-026 E3A: canonical JSON and hash-boundary rules for adapter-emitted payload digests, plus a strict reviewer gate. No runtime changes in this slice.

## Scope
- docs/architecture/ADR-026-CANONICALIZATION-HASH-BOUNDARY.md
- scripts/ci/review-adr026-stab-e3-a.sh

## Safety
- Docs + reviewer gate only
- No workflow changes
- Stacked on ADR-026 E2B branch to keep the diff pure

## Verification
- BASE_REF=origin/codex/adr026-stab-e2-b-host-writer bash scripts/ci/review-adr026-stab-e3-a.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
