### PR TITLE
feat(adr026): canonicalize event digests and enforce key-order independence (Stab E3B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,8 +148,10 @@ name = "assay-adapter-api"
 version = "2.18.0"
 dependencies = [
  "assay-evidence",
+ "hex",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
 ]
 

--- a/crates/assay-adapter-a2a/src/lib.rs
+++ b/crates/assay-adapter-a2a/src/lib.rs
@@ -528,9 +528,8 @@ fn normalize_json(value: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assay_adapter_api::RawPayloadRef;
-    use serde::Serialize;
-    use sha2::{Digest, Sha256};
+    use assay_adapter_api::{digest_canonical_json, RawPayloadRef};
+    use sha2::Digest;
     use std::{fs, path::PathBuf};
 
     struct TestWriter;
@@ -541,10 +540,8 @@ mod tests {
             payload: &[u8],
             media_type: &str,
         ) -> AdapterResult<RawPayloadRef> {
-            let mut hasher = Sha256::new();
-            hasher.update(payload);
             Ok(RawPayloadRef {
-                sha256: hex::encode(hasher.finalize()),
+                sha256: hex::encode(sha2::Sha256::digest(payload)),
                 size_bytes: payload.len() as u64,
                 media_type: media_type.to_string(),
             })
@@ -557,13 +554,6 @@ mod tests {
 
     fn fixture(name: &str) -> Vec<u8> {
         fs::read(fixture_dir().join(name)).expect("fixture must exist")
-    }
-
-    fn digest_json<T: Serialize>(value: &T) -> String {
-        let encoded = serde_json::to_vec(value).expect("serializes");
-        let mut hasher = Sha256::new();
-        hasher.update(encoded);
-        hex::encode(hasher.finalize())
     }
 
     #[test]
@@ -606,10 +596,77 @@ mod tests {
             "assay.adapter.a2a.agent.capabilities"
         );
         assert_eq!(first.lossiness.lossiness_level, LossinessLevel::None);
-        assert_eq!(digest_json(&first), digest_json(&second));
+        assert_eq!(
+            digest_canonical_json(&first),
+            digest_canonical_json(&second)
+        );
         assert_eq!(
             first.events[0].payload["agent"]["capabilities"],
             serde_json::json!(["agent.describe", "artifacts.share", "tasks.update"])
+        );
+    }
+
+    #[test]
+    fn strict_key_order_independent_event_digest_keeps_raw_hash_bytes_exact() {
+        let adapter = A2aAdapter;
+        let writer = TestWriter;
+        let payload_a = br#"{
+          "protocol":"a2a",
+          "version":"0.2.0",
+          "event_type":"task.requested",
+          "timestamp":"2026-02-27T11:05:00Z",
+          "agent":{"id":"agent-7","name":"Agent Seven","role":"planner","capabilities":["tasks.update","agent.describe"]},
+          "task":{"id":"task-xyz","status":"queued","kind":"analysis"},
+          "attributes":{"priority":"high","tenant":"acme"}
+        }"#;
+        let payload_b = br#"{
+          "version":"0.2.0",
+          "protocol":"a2a",
+          "timestamp":"2026-02-27T11:05:00Z",
+          "event_type":"task.requested",
+          "task":{"kind":"analysis","status":"queued","id":"task-xyz"},
+          "agent":{"role":"planner","name":"Agent Seven","id":"agent-7","capabilities":["agent.describe","tasks.update"]},
+          "attributes":{"tenant":"acme","priority":"high"}
+        }"#;
+
+        let first = adapter
+            .convert(
+                AdapterInput {
+                    payload: payload_a,
+                    media_type: "application/json",
+                    protocol_version: Some("0.2.0"),
+                },
+                &ConvertOptions::default(),
+                &writer,
+            )
+            .expect("first payload should convert");
+        let second = adapter
+            .convert(
+                AdapterInput {
+                    payload: payload_b,
+                    media_type: "application/json",
+                    protocol_version: Some("0.2.0"),
+                },
+                &ConvertOptions::default(),
+                &writer,
+            )
+            .expect("second payload should convert");
+
+        assert_eq!(
+            digest_canonical_json(&first.events[0].payload),
+            digest_canonical_json(&second.events[0].payload)
+        );
+        assert_ne!(
+            first
+                .lossiness
+                .raw_payload_ref
+                .as_ref()
+                .map(|raw| raw.sha256.clone()),
+            second
+                .lossiness
+                .raw_payload_ref
+                .as_ref()
+                .map(|raw| raw.sha256.clone())
         );
     }
 

--- a/crates/assay-adapter-acp/src/lib.rs
+++ b/crates/assay-adapter-acp/src/lib.rs
@@ -334,9 +334,10 @@ fn normalize_json(value: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assay_adapter_api::{AttachmentWriter, ConvertMode, ConvertOptions, RawPayloadRef};
-    use serde::Serialize;
-    use sha2::{Digest, Sha256};
+    use assay_adapter_api::{
+        digest_canonical_json, AttachmentWriter, ConvertMode, ConvertOptions, RawPayloadRef,
+    };
+    use sha2::Digest;
     use std::fs;
     use std::path::PathBuf;
 
@@ -348,10 +349,8 @@ mod tests {
             payload: &[u8],
             media_type: &str,
         ) -> AdapterResult<RawPayloadRef> {
-            let mut hasher = Sha256::new();
-            hasher.update(payload);
             Ok(RawPayloadRef {
-                sha256: hex::encode(hasher.finalize()),
+                sha256: hex::encode(sha2::Sha256::digest(payload)),
                 size_bytes: payload.len() as u64,
                 media_type: media_type.to_string(),
             })
@@ -365,13 +364,6 @@ mod tests {
 
     fn fixture(name: &str) -> Vec<u8> {
         fs::read(fixture_dir().join(name)).expect("fixture must exist")
-    }
-
-    fn digest_json<T: Serialize>(value: &T) -> String {
-        let encoded = serde_json::to_vec(value).expect("serializes");
-        let mut hasher = Sha256::new();
-        hasher.update(encoded);
-        hex::encode(hasher.finalize())
     }
 
     #[test]
@@ -394,7 +386,10 @@ mod tests {
 
         assert_eq!(first.events.len(), 1);
         assert_eq!(first.lossiness.lossiness_level, LossinessLevel::None);
-        assert_eq!(digest_json(&first), digest_json(&second));
+        assert_eq!(
+            digest_canonical_json(&first),
+            digest_canonical_json(&second)
+        );
         assert_eq!(first.events[0].type_, "assay.adapter.acp.intent.created");
         assert_eq!(
             first.events[0].payload["adapter_id"],
@@ -488,8 +483,8 @@ mod tests {
             .expect("second payload should convert");
 
         assert_eq!(
-            digest_json(&first.events[0].payload),
-            digest_json(&second.events[0].payload)
+            digest_canonical_json(&first.events[0].payload),
+            digest_canonical_json(&second.events[0].payload)
         );
         assert_ne!(
             first

--- a/crates/assay-adapter-api/Cargo.toml
+++ b/crates/assay-adapter-api/Cargo.toml
@@ -13,6 +13,8 @@ assay-evidence = { path = "../assay-evidence", version = "2.18.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/assay-adapter-api/src/canonical.rs
+++ b/crates/assay-adapter-api/src/canonical.rs
@@ -1,0 +1,104 @@
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// Serialize a JSON value into deterministic canonical bytes.
+#[must_use]
+pub fn canonical_json_bytes(value: &Value) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_canonical(value, &mut out);
+    out
+}
+
+/// Serialize any serde value into canonical JSON bytes.
+#[must_use]
+pub fn canonical_bytes<T: Serialize>(value: &T) -> Vec<u8> {
+    let value = serde_json::to_value(value).expect("value must serialize to JSON");
+    canonical_json_bytes(&value)
+}
+
+/// Compute a SHA-256 digest over canonical JSON bytes.
+#[must_use]
+pub fn digest_canonical_json<T: Serialize>(value: &T) -> String {
+    let bytes = canonical_bytes(value);
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn write_canonical(value: &Value, out: &mut Vec<u8>) {
+    match value {
+        Value::Null => out.extend_from_slice(b"null"),
+        Value::Bool(boolean) => out.extend_from_slice(if *boolean { b"true" } else { b"false" }),
+        Value::Number(number) => out.extend_from_slice(number.to_string().as_bytes()),
+        Value::String(string) => out.extend_from_slice(
+            serde_json::to_string(string)
+                .expect("string escaping must succeed")
+                .as_bytes(),
+        ),
+        Value::Array(array) => {
+            out.push(b'[');
+            for (index, item) in array.iter().enumerate() {
+                if index > 0 {
+                    out.push(b',');
+                }
+                write_canonical(item, out);
+            }
+            out.push(b']');
+        }
+        Value::Object(object) => {
+            out.push(b'{');
+            let mut keys: Vec<_> = object.keys().collect();
+            keys.sort();
+            for (index, key) in keys.iter().enumerate() {
+                if index > 0 {
+                    out.push(b',');
+                }
+                out.extend_from_slice(
+                    serde_json::to_string(key)
+                        .expect("key escaping must succeed")
+                        .as_bytes(),
+                );
+                out.push(b':');
+                write_canonical(&object[*key], out);
+            }
+            out.push(b'}');
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn canonical_object_key_order_independent() {
+        let first = json!({"b": 1, "a": 2});
+        let second = json!({"a": 2, "b": 1});
+
+        assert_eq!(canonical_json_bytes(&first), canonical_json_bytes(&second));
+        assert_eq!(
+            digest_canonical_json(&first),
+            digest_canonical_json(&second)
+        );
+    }
+
+    #[test]
+    fn canonical_nested_object_key_order_independent() {
+        let first = json!({
+            "outer": {"z": true, "a": [3, {"b": 2, "a": 1}]},
+            "name": "adapter"
+        });
+        let second = json!({
+            "name": "adapter",
+            "outer": {"a": [3, {"a": 1, "b": 2}], "z": true}
+        });
+
+        assert_eq!(canonical_json_bytes(&first), canonical_json_bytes(&second));
+        assert_eq!(
+            digest_canonical_json(&first),
+            digest_canonical_json(&second)
+        );
+    }
+}

--- a/crates/assay-adapter-api/src/lib.rs
+++ b/crates/assay-adapter-api/src/lib.rs
@@ -1,9 +1,13 @@
 //! Stable contracts for protocol adapters that translate external protocol payloads
 //! into canonical Assay evidence events.
 
+mod canonical;
+
 use assay_evidence::types::EvidenceEvent;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+pub use canonical::{canonical_bytes, canonical_json_bytes, digest_canonical_json};
 
 /// Result type for adapter operations.
 pub type AdapterResult<T> = Result<T, AdapterError>;

--- a/scripts/ci/review-adr026-stab-e3-b.sh
+++ b/scripts/ci/review-adr026-stab-e3-b.sh
@@ -8,6 +8,7 @@ cd "$ROOT"
 git rev-parse --verify "$BASE_REF" >/dev/null
 
 ALLOWLIST=(
+  "Cargo.lock"
   "crates/assay-adapter-api/Cargo.toml"
   "crates/assay-adapter-api/src/canonical.rs"
   "crates/assay-adapter-api/src/lib.rs"

--- a/scripts/ci/review-adr026-stab-e3-b.sh
+++ b/scripts/ci/review-adr026-stab-e3-b.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-stab-e2-b-host-writer}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-adapter-api/Cargo.toml"
+  "crates/assay-adapter-api/src/canonical.rs"
+  "crates/assay-adapter-api/src/lib.rs"
+  "crates/assay-adapter-acp/src/lib.rs"
+  "crates/assay-adapter-a2a/src/lib.rs"
+  "scripts/ci/review-adr026-stab-e3-b.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: E3B must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in E3B: $f"
+    exit 1
+  fi
+done
+
+echo "[review] canonicalization markers"
+rg -n 'pub fn canonical_json_bytes' crates/assay-adapter-api/src/canonical.rs >/dev/null || {
+  echo "FAIL: canonical_json_bytes missing"
+  exit 1
+}
+rg -n 'pub fn digest_canonical_json' crates/assay-adapter-api/src/canonical.rs >/dev/null || {
+  echo "FAIL: digest_canonical_json missing"
+  exit 1
+}
+rg -n 'digest_canonical_json' crates/assay-adapter-acp/src/lib.rs >/dev/null || {
+  echo "FAIL: ACP canonical digest adoption missing"
+  exit 1
+}
+rg -n 'digest_canonical_json' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: A2A canonical digest adoption missing"
+  exit 1
+}
+rg -n 'raw_payload_ref' crates/assay-adapter-acp/src/lib.rs >/dev/null || {
+  echo "FAIL: ACP raw payload boundary coverage missing"
+  exit 1
+}
+rg -n 'raw_payload_ref' crates/assay-adapter-a2a/src/lib.rs >/dev/null || {
+  echo "FAIL: A2A raw payload boundary coverage missing"
+  exit 1
+}
+
+cargo test -p assay-adapter-api -p assay-adapter-acp -p assay-adapter-a2a >/dev/null
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Promotes ADR-026 E3B onto `main` after the stacked branch had already absorbed E2B/E3A. This PR contains only the canonical JSON digest implementation, adapter digest migration, key-order independence tests, and the E3B reviewer gate.

## Scope
- `Cargo.lock`
- `crates/assay-adapter-api/Cargo.toml`
- `crates/assay-adapter-api/src/canonical.rs`
- `crates/assay-adapter-api/src/lib.rs`
- `crates/assay-adapter-acp/src/lib.rs`
- `crates/assay-adapter-a2a/src/lib.rs`
- `scripts/ci/review-adr026-stab-e3-b.sh`

## Safety
- Open-core only
- No workflow changes
- Event digests use canonical JSON
- Raw payload hashes remain bytes-exact by design
- Allowlist-only reviewer gate

## Verification
- `cargo test -p assay-adapter-api -p assay-adapter-acp -p assay-adapter-a2a`
- `BASE_REF=origin/main bash scripts/ci/review-adr026-stab-e3-b.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-adapter-api -p assay-adapter-acp -p assay-adapter-a2a -- -D warnings`
