### PR TITLE
docs(adr026): freeze parser hardening boundary + reviewer gate (Stab E4A)

### DIFF
--- a/docs/architecture/ADR-026-PARSER-HARDENING-BOUNDARY.md
+++ b/docs/architecture/ADR-026-PARSER-HARDENING-BOUNDARY.md
@@ -1,0 +1,73 @@
+# ADR-026 Parser Hardening Boundary (E4A)
+
+## Intent
+Freeze the parser-hardening boundary for ADR-026 protocol adapters before adding
+property tests or deeper runtime guards.
+
+The goal is to treat ACP and A2A inputs as attack surface, not only as trusted
+fixtures, while keeping the blast radius limited to adapter parsing and
+conformance behavior.
+
+## Scope
+In-scope:
+- parser threat model for ACP and A2A adapters
+- hard caps policy for payload bytes, JSON depth, and array length
+- strict vs lenient rules for malformed inputs and parser guardrails
+- test requirements for property-based hardening in E4B
+
+Out-of-scope:
+- workflow changes
+- crates.io publication changes
+- changes to adapter mapping semantics outside parser guardrails
+- adapter registry / Wasm plugin work
+
+## Threat model
+Adapters must assume upstream inputs may be adversarial.
+
+Minimum adversarial cases to harden against:
+- deeply nested JSON intended to exhaust recursion or stack depth
+- very large arrays intended to amplify parse or normalization cost
+- oversized payload bytes intended to exhaust memory or storage policy
+- malformed JSON and invalid UTF-8 byte sequences
+- unrecognized fields or enum-like values used to trigger lossy fallback paths
+
+## Hard caps contract (v1)
+The following caps are frozen for implementation in E4B:
+- `max_payload_bytes`: enforced before deep parsing begins
+- `max_json_depth`: enforced while traversing decoded JSON values
+- `max_array_length`: enforced for any adapter-consumed array
+
+Contract requirements:
+- cap violations are measurement/contract failures
+- malformed JSON is a measurement/contract failure in all modes
+- invalid UTF-8 input is a measurement/contract failure in all modes
+- lenient mode may preserve semantically lossy inputs, but must not bypass
+  structural parser failures or cap violations
+- no silent truncation of arrays, objects, or bytes is allowed
+
+## Enforcement locations
+E4B must make enforcement locations explicit:
+- payload byte caps at adapter ingress before deep parsing
+- JSON depth and array length caps inside shared or adapter-local parse helpers
+- conformance tests proving the caps are active for ACP and A2A
+
+## Property test requirements (E4B)
+Minimum hardening evidence required in E4B:
+- at least one property/proptest per adapter exercising randomized unknown-field
+  placement or object key ordering
+- at least one cap test for deep nesting
+- at least one cap test for large arrays
+- at least one malformed byte/invalid UTF-8 test path
+
+## Strict vs lenient boundary
+Lenient mode remains valid only for semantic translation loss.
+
+Lenient mode must not:
+- accept malformed JSON
+- accept invalid UTF-8 input
+- accept cap violations for payload bytes, depth, or array length
+
+## Non-goals
+- no change to canonical event digest rules frozen in E3A/E3B
+- no change to AttachmentWriter host policy frozen in E2A/E2B
+- no change to release-lane behavior

--- a/scripts/ci/review-adr026-stab-e4-a.sh
+++ b/scripts/ci/review-adr026-stab-e4-a.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-026-PARSER-HARDENING-BOUNDARY.md"
+  "scripts/ci/review-adr026-stab-e4-a.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: E4A must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in E4A: $f"
+    exit 1
+  fi
+done
+
+DOC="docs/architecture/ADR-026-PARSER-HARDENING-BOUNDARY.md"
+
+echo "[review] parser hardening markers"
+rg -n "deeply nested JSON|deep nesting" "$DOC" >/dev/null || {
+  echo "FAIL: threat model must mention deep nesting"
+  exit 1
+}
+rg -n "large arrays|array length" "$DOC" >/dev/null || {
+  echo "FAIL: threat model must mention large arrays"
+  exit 1
+}
+rg -n "invalid UTF-8" "$DOC" >/dev/null || {
+  echo "FAIL: threat model must mention invalid UTF-8"
+  exit 1
+}
+rg -n "max_payload_bytes|max_json_depth|max_array_length" "$DOC" >/dev/null || {
+  echo "FAIL: hard caps contract missing"
+  exit 1
+}
+rg -n "measurement/contract failure|measurement/contract failures" "$DOC" >/dev/null || {
+  echo "FAIL: measurement failure contract missing"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Freezes the ADR-026 parser-hardening boundary before runtime/property-test work. This slice captures the adapter threat model, hard caps contract, and strict-vs-lenient parser rules, plus a strict reviewer gate.

## Scope
- `docs/architecture/ADR-026-PARSER-HARDENING-BOUNDARY.md`
- `scripts/ci/review-adr026-stab-e4-a.sh`

## Safety
- Open-core only
- Docs + reviewer gate only
- No workflow changes
- No runtime behavior changes

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-adr026-stab-e4-a.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
