### PR TITLE
docs(adr026): close parser hardening rollout with checklist and review pack (Stab E4C)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-adr026-stab-e4.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr026-stab-e4.md
@@ -1,0 +1,26 @@
+# SPLIT CHECKLIST - ADR-026 Stabilization E4 (closure)
+
+## Scope
+- [ ] Only E4 closure docs and reviewer gate changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No adapter runtime behavior changes in this slice
+
+## Hardening chain present
+- [ ] E0 adapter metadata contract is present in docs and code
+- [ ] E1 ACP lossiness preservation is implemented and gated
+- [ ] E2 host `AttachmentWriter` boundary is implemented and gated
+- [ ] E3 canonical payload digest contract is implemented and gated
+- [ ] E4 parser caps and property tests are implemented and gated
+
+## Parser hardening invariants
+- [ ] `max_payload_bytes` remains enforced at adapter ingress
+- [ ] `max_json_depth` is enforced for ACP and A2A payloads
+- [ ] `max_array_length` is enforced for ACP and A2A payloads
+- [ ] Invalid UTF-8 and malformed JSON fail with measurement errors in all modes
+- [ ] Lenient mode does not bypass parser/cap failures
+- [ ] Property/proptest coverage exists for ACP and A2A unknown-field lossiness accounting
+
+## Reviewer gate
+- [ ] `scripts/ci/review-adr026-stab-e4-c.sh` exists
+- [ ] Gate enforces allowlist-only + workflow-ban
+- [ ] Gate re-runs the E4B implementation gate against `origin/main`

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr026-stab-e4.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr026-stab-e4.md
@@ -1,0 +1,34 @@
+# Review Pack - ADR-026 Stabilization E4 (closure)
+
+## Intent
+Close the ADR-026 hardening loop for parser robustness by adding closure review artifacts for the E4 parser-hardening boundary and implementation.
+
+## Scope
+- docs/contributing/SPLIT-CHECKLIST-adr026-stab-e4.md
+- docs/contributing/SPLIT-REVIEW-PACK-adr026-stab-e4.md
+- scripts/ci/review-adr026-stab-e4-c.sh
+
+## Non-goals
+- No workflow changes
+- No new adapter mapping semantics
+- No release-lane integration changes
+- No Wasm/plugin registry work
+
+## What should already exist
+- `docs/architecture/ADR-026-PARSER-HARDENING-BOUNDARY.md`
+- `crates/assay-adapter-api/src/shape.rs`
+- `scripts/ci/review-adr026-stab-e4-b.sh`
+- ACP/A2A parser-cap tests and property tests in their crate test suites
+
+## Verification
+- `BASE_REF=origin/codex/adr026-stab-e4-b-parser-hardening BASE_REF_IMPL=origin/main bash scripts/ci/review-adr026-stab-e4-c.sh`
+- `BASE_REF=origin/main bash scripts/ci/review-adr026-stab-e4-b.sh`
+- `cargo test -p assay-adapter-api -p assay-adapter-acp -p assay-adapter-a2a`
+- `cargo fmt --check`
+- `cargo clippy -p assay-adapter-api -p assay-adapter-acp -p assay-adapter-a2a -- -D warnings`
+
+## Reviewer 60s scan
+1. Confirm this PR is docs + gate only.
+2. Confirm no `.github/workflows/*` changes.
+3. Run the E4C reviewer gate.
+4. Confirm the E4B implementation gate still passes against `origin/main`.

--- a/scripts/ci/review-adr026-stab-e4-c.sh
+++ b/scripts/ci/review-adr026-stab-e4-c.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-stab-e4-b-parser-hardening}"
+BASE_REF_IMPL="${BASE_REF_IMPL:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+git rev-parse --verify "$BASE_REF_IMPL" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-adr026-stab-e4.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr026-stab-e4.md"
+  "scripts/ci/review-adr026-stab-e4-c.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: E4C must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in E4C: $f"
+    exit 1
+  fi
+done
+
+echo "[review] closure artifacts mention parser hardening"
+rg -n 'max_json_depth|max_array_length|Invalid UTF-8|Lenient mode does not bypass' docs/contributing/SPLIT-CHECKLIST-adr026-stab-e4.md >/dev/null || {
+  echo "FAIL: E4 checklist is missing parser hardening invariants"
+  exit 1
+}
+rg -n 'review-adr026-stab-e4-b.sh|shape.rs|ADR-026-PARSER-HARDENING-BOUNDARY.md' docs/contributing/SPLIT-REVIEW-PACK-adr026-stab-e4.md >/dev/null || {
+  echo "FAIL: E4 review pack is missing core references"
+  exit 1
+}
+
+echo "[review] re-run E4B implementation gate vs $BASE_REF_IMPL"
+BASE_REF="$BASE_REF_IMPL" bash scripts/ci/review-adr026-stab-e4-b.sh
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Closes ADR-026 parser hardening with closure artifacts for E4: checklist, review pack, and a final reviewer gate that re-runs the E4B implementation gate against `origin/main`.

## Scope
- docs/contributing/SPLIT-CHECKLIST-adr026-stab-e4.md
- docs/contributing/SPLIT-REVIEW-PACK-adr026-stab-e4.md
- scripts/ci/review-adr026-stab-e4-c.sh

## Safety
- Docs + reviewer gate only
- No workflow changes
- No adapter runtime behavior changes
- Allowlist-only reviewer gate

## Verification
- BASE_REF=origin/codex/adr026-stab-e4-b-parser-hardening BASE_REF_IMPL=origin/main bash scripts/ci/review-adr026-stab-e4-c.sh
- BASE_REF=origin/main bash scripts/ci/review-adr026-stab-e4-b.sh
- cargo fmt --check
- cargo clippy -p assay-adapter-api -p assay-adapter-acp -p assay-adapter-a2a -- -D warnings
