### PR TITLE
docs(adr026): sync accepted status and roadmap progress

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -414,10 +414,15 @@ Lightweight adapters that map protocol-specific events to Assay's `EvidenceEvent
 | `assay-adapter-ucp` | Universal Commerce Protocol | Google/Shopify commerce journeys |
 | `assay-adapter-a2a` | Agent2Agent | Agent discovery/tasks/messages |
 
-- [ ] **Adapter trait**: Common interface for protocol → EvidenceEvent mapping
-- [ ] **ACP adapter**: Tool calls, checkout events, payment intents (leverages v2.11.0 mandate support)
+- [x] **Adapter trait**: Common interface for protocol → EvidenceEvent mapping
+- [x] **ACP adapter**: Tool calls, checkout events, payment intents (leverages v2.11.0 mandate support)
 - [ ] **UCP adapter**: Discover/buy/post-purchase state transitions
-- [ ] **A2A adapter**: Agent capabilities, task delegation, artifacts
+- [x] **A2A adapter**: Agent capabilities, task delegation, artifacts
+
+Status on `main`:
+- `assay-adapter-api`, `assay-adapter-acp`, and `assay-adapter-a2a` are merged in open core.
+- ADR-026 stabilization through E4 is merged on `main` (metadata identity, lossiness preservation, host attachment policy, canonical digests, parser hardening).
+- `assay-adapter-ucp` remains the next protocol-adapter implementation gap in this roadmap section.
 
 **Why adapters:** The market is fragmenting (ACP vs UCP vs AP2 vs x402). Assay's value is protocol-agnostic governance, not protocol lock-in.
 

--- a/docs/architecture/ADR-026-Protocol-Adapters.md
+++ b/docs/architecture/ADR-026-Protocol-Adapters.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (February 2026)
+Accepted (February 2026; ACP + A2A adapter rollout and E0-E4 stabilization merged on `main`)
 
 ## Context
 
@@ -151,6 +151,19 @@ Rationale:
 - ADR includes explicit negative-fixture conformance requirements
 - ADR freezes ACP as MVP and A2A as follow-up
 - No workflow or runtime behavior changes are introduced in this slice
+
+## Implementation Status
+
+Current status on `main`:
+- `assay-adapter-api` exists as the shared adapter contract surface
+- `assay-adapter-acp` is implemented with strict/lenient conversion, fixtures, and conformance tests
+- `assay-adapter-a2a` is implemented with strict/lenient conversion, fixtures, and conformance tests
+- Stabilization through E4 is merged:
+  - E0: adapter identity metadata
+  - E1: ACP lossiness preservation
+  - E2: host-side `AttachmentWriter` policy
+  - E3: canonical event digests with bytes-exact raw payload hashes
+  - E4: parser caps and property-based hardening
 
 ## Consequences
 

--- a/docs/architecture/adrs.md
+++ b/docs/architecture/adrs.md
@@ -26,6 +26,7 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | [ADR-023](./ADR-023-CICD-Starter-Pack.md) | CICD Starter Pack (Adoption Floor) | **Accepted** | **P1** |
 | [ADR-024](./ADR-024-Sim-Engine-Hardening.md) | Sim Engine Hardening (Limits + Time Budget) | Proposed | **P2** |
 | [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Evidence-as-a-Product | Proposed | **P1/P2** |
+| [ADR-026](./ADR-026-Protocol-Adapters.md) | Protocol Adapters | **Accepted** | **P1** |
 | [ADR-020](./ADR-020-Dependency-Governance.md) | Dependency Governance | Accepted | - |
 
 ## Q2 2026 Priorities
@@ -41,6 +42,7 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | **P2** | [ADR-021](./ADR-021-Local-Pack-Discovery.md) | Accepted | Local pack discovery + safe resolution order (implemented) |
 | **P2** | [ADR-022](./ADR-022-SOC2-Baseline-Pack.md) | Accepted | SOC2 baseline OSS pack (implemented) |
 | **P1/P2** | [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Proposed | I1/I2/I3 slices merged on `main`; ADR status pending formal accept |
+| **P1** | [ADR-026](./ADR-026-Protocol-Adapters.md) | Accepted | ACP + A2A adapter slices and E0-E4 stabilization are merged on `main` |
 | **P2** | [ADR-013](./ADR-013-EU-AI-Act-Pack.md) | Proposed | Article 12 mapping, `--pack` flag |
 | **P3** | [ADR-012](./ADR-012-Transparency-Log.md) | Proposed | Builds on ADR-011 |
 | Deferred | [ADR-009](./ADR-009-WORM-Storage.md) | Deferred | Managed WORM → Q3+ if demand |

--- a/scripts/ci/review-adr026-status-sync.sh
+++ b/scripts/ci/review-adr026-status-sync.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/adrs.md"
+  "docs/ROADMAP.md"
+  "docs/architecture/ADR-026-Protocol-Adapters.md"
+  "scripts/ci/review-adr026-status-sync.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-026 status sync must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-026 status sync: $f"
+    exit 1
+  fi
+done
+
+echo "[review] ADR-026 status markers"
+rg -n 'ADR-026.*Accepted' docs/architecture/adrs.md >/dev/null || {
+  echo "FAIL: adrs index missing accepted ADR-026 status"
+  exit 1
+}
+rg -n '^\- \[x\] \*\*Adapter trait\*\*' docs/ROADMAP.md >/dev/null || {
+  echo "FAIL: roadmap missing completed adapter trait marker"
+  exit 1
+}
+rg -n '^\- \[x\] \*\*ACP adapter\*\*' docs/ROADMAP.md >/dev/null || {
+  echo "FAIL: roadmap missing completed ACP adapter marker"
+  exit 1
+}
+rg -n '^\- \[x\] \*\*A2A adapter\*\*' docs/ROADMAP.md >/dev/null || {
+  echo "FAIL: roadmap missing completed A2A adapter marker"
+  exit 1
+}
+rg -n '^Accepted .*E0-E4 stabilization' docs/architecture/ADR-026-Protocol-Adapters.md >/dev/null || {
+  echo "FAIL: ADR-026 status line missing accepted implementation status"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Syncs ADR-026 documentation to the implementation already on `main`: accepts the ADR formally, marks ACP/A2A adapter progress in the roadmap, and updates the architecture ADR index.

## Scope
- docs/architecture/adrs.md
- docs/ROADMAP.md
- docs/architecture/ADR-026-Protocol-Adapters.md
- scripts/ci/review-adr026-status-sync.sh

## Safety
- Docs + reviewer gate only
- No workflow changes
- No runtime changes
- Allowlist-only reviewer gate

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr026-status-sync.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
