### PR TITLE
docs(adr026): freeze UCP follow-up contract + crate skeleton (UCP Step1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "assay-adapter-ucp"
+version = "2.18.0"
+dependencies = [
+ "assay-adapter-api",
+]
+
+[[package]]
 name = "assay-cli"
 version = "2.18.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/assay-adapter-api",
   "crates/assay-adapter-acp",
   "crates/assay-adapter-a2a",
+  "crates/assay-adapter-ucp",
   "crates/assay-core",
   "crates/assay-metrics",
   "crates/assay-cli", "crates/assay-mcp-server",

--- a/crates/assay-adapter-ucp/Cargo.toml
+++ b/crates/assay-adapter-ucp/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "assay-adapter-ucp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "UCP protocol adapter for Assay evidence translation."
+readme.workspace = true
+
+[dependencies]
+assay-adapter-api = { path = "../assay-adapter-api", version = "2.18.0" }
+
+[lints]
+workspace = true

--- a/crates/assay-adapter-ucp/src/lib.rs
+++ b/crates/assay-adapter-ucp/src/lib.rs
@@ -1,0 +1,125 @@
+//! UCP adapter Step1 skeleton for freezing the protocol contract before runtime mapping lands.
+
+use assay_adapter_api::{
+    AdapterBatch, AdapterCapabilities, AdapterDescriptor, AdapterError, AdapterErrorKind,
+    AdapterInput, AdapterResult, AttachmentWriter, ConvertOptions, ProtocolAdapter,
+    ProtocolDescriptor,
+};
+
+const PROTOCOL_NAME: &str = "ucp";
+const PROTOCOL_VERSION: &str = "v2026-01-23";
+const SUPPORTED_RELEASE_LINE: &str = "v2026-01-23";
+const SCHEMA_ID: &str = "ucp.packet.v2026_01_23";
+const SPEC_URL: &str = "https://github.com/google-agentic-commerce/ucp";
+const ADAPTER_ID: &str = "assay-adapter-ucp";
+
+/// UCP adapter Step1 skeleton.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UcpAdapter;
+
+impl ProtocolAdapter for UcpAdapter {
+    fn adapter(&self) -> AdapterDescriptor {
+        AdapterDescriptor {
+            adapter_id: ADAPTER_ID,
+            adapter_version: env!("CARGO_PKG_VERSION"),
+        }
+    }
+
+    fn protocol(&self) -> ProtocolDescriptor {
+        ProtocolDescriptor {
+            name: PROTOCOL_NAME.to_string(),
+            spec_version: PROTOCOL_VERSION.to_string(),
+            schema_id: Some(SCHEMA_ID.to_string()),
+            spec_url: Some(SPEC_URL.to_string()),
+        }
+    }
+
+    fn capabilities(&self) -> AdapterCapabilities {
+        AdapterCapabilities {
+            supported_event_types: vec![
+                "assay.adapter.ucp.discovery.requested".to_string(),
+                "assay.adapter.ucp.order.requested".to_string(),
+                "assay.adapter.ucp.checkout.updated".to_string(),
+                "assay.adapter.ucp.fulfillment.updated".to_string(),
+                "assay.adapter.ucp.message".to_string(),
+            ],
+            supported_spec_versions: vec![SUPPORTED_RELEASE_LINE.to_string()],
+            supports_strict: true,
+            supports_lenient: true,
+        }
+    }
+
+    fn convert(
+        &self,
+        _input: AdapterInput<'_>,
+        _options: &ConvertOptions,
+        _attachments: &dyn AttachmentWriter,
+    ) -> AdapterResult<AdapterBatch> {
+        Err(AdapterError::new(
+            AdapterErrorKind::Measurement,
+            "runtime translation is not implemented yet for UCP Step1",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_adapter_api::{AttachmentWriter, ConvertMode, RawPayloadRef};
+
+    struct StubWriter;
+
+    impl AttachmentWriter for StubWriter {
+        fn write_raw_payload(
+            &self,
+            payload: &[u8],
+            media_type: &str,
+        ) -> AdapterResult<RawPayloadRef> {
+            Ok(RawPayloadRef {
+                sha256: format!("sha256:{}", payload.len()),
+                size_bytes: payload.len() as u64,
+                media_type: media_type.to_string(),
+            })
+        }
+    }
+
+    #[test]
+    fn protocol_metadata_uses_frozen_release_tag() {
+        let adapter = UcpAdapter;
+        assert_eq!(adapter.adapter().adapter_id, "assay-adapter-ucp");
+        assert!(!adapter.adapter().adapter_version.is_empty());
+        assert_eq!(adapter.protocol().name, "ucp");
+        assert_eq!(adapter.protocol().spec_version, "v2026-01-23");
+        assert_eq!(
+            adapter.capabilities().supported_spec_versions,
+            vec!["v2026-01-23"]
+        );
+    }
+
+    #[test]
+    fn convert_explicitly_stubs_runtime_translation() {
+        let adapter = UcpAdapter;
+        let writer = StubWriter;
+        let input = AdapterInput {
+            payload: br#"{}"#,
+            media_type: "application/json",
+            protocol_version: Some("v2026-01-23"),
+        };
+
+        let err = adapter
+            .convert(
+                input,
+                &ConvertOptions {
+                    mode: ConvertMode::Strict,
+                    ..ConvertOptions::default()
+                },
+                &writer,
+            )
+            .expect_err("step1 skeleton must not claim runtime support");
+
+        assert_eq!(err.kind, AdapterErrorKind::Measurement);
+        assert!(err
+            .message
+            .contains("runtime translation is not implemented yet"));
+    }
+}

--- a/docs/architecture/PLAN-ADR-026-UCP-2026q2.md
+++ b/docs/architecture/PLAN-ADR-026-UCP-2026q2.md
@@ -1,0 +1,71 @@
+# PLAN — ADR-026 UCP Adapter Follow-up (2026q2)
+
+## Intent
+Follow ADR-026 with an open-core UCP adapter rollout using the same low-blast-radius discipline as ACP and A2A:
+1. Step1 freeze the UCP contract and crate skeleton.
+2. Step2 implement deterministic UCP translation with conformance fixtures.
+3. Step3 close with checklist/review-pack and index sync.
+
+This slice is Step1 only: contract + skeleton + reviewer gate. No runtime mapping.
+
+## Scope (Step1 freeze)
+In-scope:
+- `assay-adapter-ucp` crate skeleton in the workspace
+- UCP protocol metadata and capabilities contract
+- Explicit non-goals for the first UCP MVP
+- Reviewer gate for allowlist-only + workflow-ban
+
+Out-of-scope (Step1):
+- No UCP payload mapping logic
+- No conformance fixtures yet
+- No workflow changes
+- No middleware, registry, or hosted control-plane features
+
+## Target protocol surface (frozen)
+Initial UCP MVP targets the governance-relevant subset only:
+- discovery / catalog selection intent
+- order and checkout lifecycle transitions
+- post-purchase / fulfillment state references
+
+This is intentionally narrower than the full UCP ecosystem surface.
+
+## Upstream version anchor (frozen)
+Step1 freezes against the current upstream release tag observed at implementation time:
+- upstream project: `google-agentic-commerce/ucp`
+- exact release tag: `v2026-01-23`
+
+Because UCP uses date-tagged releases rather than classic semver, Step1 freezes the exact release tag instead of inventing a synthetic version range.
+
+## Crate contract (Step1)
+`assay-adapter-ucp` must:
+- implement `ProtocolAdapter`
+- expose protocol metadata for `ucp`
+- declare support for the exact upstream release tag `v2026-01-23`
+- keep raw payload preservation behind `AttachmentWriter`
+
+Until Step2 mapping lands, `convert()` is allowed to return an explicit measurement/config error indicating that runtime translation is not yet implemented.
+
+## Strictness expectations for Step2
+When Step2 lands, UCP must follow the ADR-026 strictness contract:
+- `strict`: malformed or unmappable critical data -> exit 2 in harnesses
+- `lenient`: emit evidence plus lossiness + raw payload ref
+
+## Initial event families (frozen for Step2)
+Planned canonical event families:
+- `assay.adapter.ucp.discovery.requested`
+- `assay.adapter.ucp.order.requested`
+- `assay.adapter.ucp.checkout.updated`
+- `assay.adapter.ucp.fulfillment.updated`
+- generic fallback: `assay.adapter.ucp.message`
+
+## Non-goals
+- Full UCP semantic coverage in Step1/Step2
+- Live network ingestion
+- Plugin/Wasm execution
+- Enterprise middleware or approval workflows
+
+## Acceptance criteria (Step1)
+- `assay-adapter-ucp` exists as a compilable workspace crate
+- crate exposes frozen protocol metadata and capabilities markers
+- runtime conversion path is explicitly stubbed, not silently partial
+- reviewer gate enforces allowlist-only and workflow-ban

--- a/scripts/ci/review-adr026-ucp-step1.sh
+++ b/scripts/ci/review-adr026-ucp-step1.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "Cargo.toml"
+  "Cargo.lock"
+  "crates/assay-adapter-ucp/Cargo.toml"
+  "crates/assay-adapter-ucp/src/lib.rs"
+  "docs/architecture/PLAN-ADR-026-UCP-2026q2.md"
+  "scripts/ci/review-adr026-ucp-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-026 UCP Step1 must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-026 UCP Step1: $f"
+    exit 1
+  fi
+done
+
+echo "[review] contract markers"
+rg -n '^name = "assay-adapter-ucp"$' crates/assay-adapter-ucp/Cargo.toml >/dev/null || {
+  echo "FAIL: missing assay-adapter-ucp crate"
+  exit 1
+}
+rg -n 'pub struct UcpAdapter' crates/assay-adapter-ucp/src/lib.rs >/dev/null || {
+  echo "FAIL: missing UcpAdapter type"
+  exit 1
+}
+rg -n 'fn adapter\(&self\) -> AdapterDescriptor' crates/assay-adapter-ucp/src/lib.rs >/dev/null || {
+  echo "FAIL: missing adapter metadata contract"
+  exit 1
+}
+rg -n 'runtime translation is not implemented yet for UCP Step1' crates/assay-adapter-ucp/src/lib.rs >/dev/null || {
+  echo "FAIL: stubbed Step1 convert contract missing"
+  exit 1
+}
+rg -n '^# PLAN — ADR-026 UCP Adapter Follow-up \(2026q2\)$' docs/architecture/PLAN-ADR-026-UCP-2026q2.md >/dev/null || {
+  echo "FAIL: missing UCP plan title"
+  exit 1
+}
+rg -n '^## Initial event families \(frozen for Step2\)$' docs/architecture/PLAN-ADR-026-UCP-2026q2.md >/dev/null || {
+  echo "FAIL: missing initial event families section"
+  exit 1
+}
+rg -n '^## Upstream version anchor \(frozen\)$' docs/architecture/PLAN-ADR-026-UCP-2026q2.md >/dev/null || {
+  echo "FAIL: missing upstream version anchor section"
+  exit 1
+}
+
+cargo test -p assay-adapter-ucp >/dev/null
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Starts the ADR-026 UCP follow-up with a Step1 freeze slice: plan doc, compileable `assay-adapter-ucp` skeleton, and a strict reviewer gate. No runtime mapping is introduced yet.

## Scope
- Cargo.toml
- Cargo.lock
- crates/assay-adapter-ucp/*
- docs/architecture/PLAN-ADR-026-UCP-2026q2.md
- scripts/ci/review-adr026-ucp-step1.sh

## Safety
- Open-core only
- No workflow changes
- No live UCP mapping behavior in this slice

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr026-ucp-step1.sh
- cargo test -p assay-adapter-ucp
- cargo fmt --check
- cargo clippy -p assay-adapter-ucp -p assay-adapter-api -p assay-cli -- -D warnings
