### PR TITLE
docs(adr026): close UCP rollout with checklist + review pack (UCP Step3)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-adr026-ucp-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-adr026-ucp-step3.md
@@ -1,0 +1,24 @@
+# SPLIT CHECKLIST - ADR-026 UCP Step3 (closure)
+
+## Scope
+- [ ] Only Step3 closure docs and reviewer gate changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No runtime behavior changes
+
+## Contracts present
+- [ ] `crates/assay-adapter-api/` exists
+- [ ] `crates/assay-adapter-ucp/` exists
+- [ ] UCP fixtures exist under `scripts/ci/fixtures/adr026/ucp/v2026-01-23/`
+- [ ] `scripts/ci/test-adapter-ucp.sh` exists and passes
+
+## Step1/Step2 coverage
+- [ ] UCP contract freeze exists (`PLAN-ADR-026-UCP-2026q2.md`)
+- [ ] UCP MVP implemented for the frozen event families
+- [ ] Negative fixtures included
+- [ ] Determinism asserted on repeated happy-path conversion and key-order independence
+- [ ] Parser caps enforced for payload size, JSON depth, and array length
+
+## Reviewer gate
+- [ ] `scripts/ci/review-adr026-ucp-step3.sh` exists
+- [ ] Gate enforces allowlist-only + workflow-ban
+- [ ] Gate validates Step1/Step2 artifacts are present

--- a/docs/contributing/SPLIT-REVIEW-PACK-adr026-ucp-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-adr026-ucp-step3.md
@@ -1,0 +1,34 @@
+# Review Pack - ADR-026 UCP Step3 (closure)
+
+## Intent
+Close the ADR-026 UCP rollout loop by adding closure review artifacts for the UCP contract freeze and MVP implementation.
+
+## Scope
+- docs/contributing/SPLIT-CHECKLIST-adr026-ucp-step3.md
+- docs/contributing/SPLIT-REVIEW-PACK-adr026-ucp-step3.md
+- scripts/ci/review-adr026-ucp-step3.sh
+
+## Non-goals
+- No workflow changes
+- No new runtime behavior
+- No UCP CLI wiring
+- No UCP release-lane integration yet
+
+## What should already exist
+- `docs/architecture/PLAN-ADR-026-UCP-2026q2.md`
+- `crates/assay-adapter-api/`
+- `crates/assay-adapter-ucp/`
+- `scripts/ci/test-adapter-ucp.sh`
+- UCP happy and negative fixtures under `scripts/ci/fixtures/adr026/ucp/v2026-01-23/`
+
+## Verification
+- `BASE_REF=origin/codex/adr026-ucp-step2-mvp-v2 bash scripts/ci/review-adr026-ucp-step3.sh`
+- `bash scripts/ci/test-adapter-ucp.sh`
+- `cargo fmt --check`
+- `cargo clippy -p assay-adapter-ucp -p assay-adapter-api -p assay-cli -- -D warnings`
+
+## Reviewer 60s scan
+1. Confirm Step3 changes are docs + gate only.
+2. Confirm no `.github/workflows/*` changes.
+3. Run the Step3 reviewer gate.
+4. Confirm the checklist correctly describes Step1/Step2 UCP deliverables.

--- a/scripts/ci/review-adr026-ucp-step3.sh
+++ b/scripts/ci/review-adr026-ucp-step3.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/adr026-ucp-step2-mvp-v2}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-adr026-ucp-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-adr026-ucp-step3.md"
+  "scripts/ci/review-adr026-ucp-step3.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-026 UCP Step3 must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-026 UCP Step3: $f"
+    exit 1
+  fi
+done
+
+echo "[review] invariants"
+test -f docs/architecture/PLAN-ADR-026-UCP-2026q2.md || { echo "FAIL: missing UCP plan"; exit 1; }
+test -f crates/assay-adapter-api/src/lib.rs || { echo "FAIL: missing assay-adapter-api"; exit 1; }
+test -f crates/assay-adapter-ucp/src/lib.rs || { echo "FAIL: missing assay-adapter-ucp"; exit 1; }
+test -f scripts/ci/test-adapter-ucp.sh || { echo "FAIL: missing UCP test runner"; exit 1; }
+test -f scripts/ci/fixtures/adr026/ucp/v2026-01-23/ucp_happy_order_requested.json || { echo "FAIL: missing UCP happy fixture"; exit 1; }
+test -f scripts/ci/fixtures/adr026/ucp/v2026-01-23/ucp_negative_missing_order_id.json || { echo "FAIL: missing UCP negative fixture"; exit 1; }
+rg -n 'pub trait ProtocolAdapter' crates/assay-adapter-api/src/lib.rs >/dev/null || { echo "FAIL: adapter trait missing"; exit 1; }
+rg -n 'pub struct UcpAdapter' crates/assay-adapter-ucp/src/lib.rs >/dev/null || { echo "FAIL: UcpAdapter missing"; exit 1; }
+rg -n 'assay.adapter.ucp.order.requested' crates/assay-adapter-ucp/src/lib.rs >/dev/null || { echo "FAIL: UCP order mapping missing"; exit 1; }
+rg -n 'max_json_depth|max_array_length|max_payload_bytes' crates/assay-adapter-ucp/src/lib.rs >/dev/null || { echo "FAIL: parser caps markers missing"; exit 1; }
+
+bash scripts/ci/test-adapter-ucp.sh >/dev/null
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Closes the ADR-026 UCP rollout loop with Step3 closure artifacts: checklist, review pack, and a strict stacked reviewer gate.

## Scope
- docs/contributing/SPLIT-CHECKLIST-adr026-ucp-step3.md
- docs/contributing/SPLIT-REVIEW-PACK-adr026-ucp-step3.md
- scripts/ci/review-adr026-ucp-step3.sh

## Safety
- Docs + reviewer gate only
- No workflow changes
- No runtime changes

## Verification
- BASE_REF=origin/codex/adr026-ucp-step2-mvp-v2 bash scripts/ci/review-adr026-ucp-step3.sh
- cargo fmt --check
- cargo clippy -p assay-adapter-ucp -p assay-adapter-api -p assay-cli -- -D warnings
