### PR TITLE
docs(adr025): accept ADR-025 status on main

### DIFF
--- a/docs/architecture/ADR-025-Evidence-as-a-Product.md
+++ b/docs/architecture/ADR-025-Evidence-as-a-Product.md
@@ -1,7 +1,7 @@
 # ADR-025: Evidence-as-a-Product — Reliability Surfaces, Completeness/Closure, and Portable Verifiability
 
 ## Status
-Proposed (Feb 2026; rollout slices I1/I2/I3 implemented on `main`)
+Accepted (March 2026; I1/I2/I3 rollout slices implemented and closed-loop on `main`)
 
 ## Status Sync (2026-02-26)
 - I1 closed-loop on `main`: soak/reliability surface + readiness + release-lane enforcement.

--- a/docs/architecture/adrs.md
+++ b/docs/architecture/adrs.md
@@ -25,7 +25,7 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | [ADR-022](./ADR-022-SOC2-Baseline-Pack.md) | SOC2 Baseline Pack (AICPA Trust Service Criteria) | **Accepted** | **P2** |
 | [ADR-023](./ADR-023-CICD-Starter-Pack.md) | CICD Starter Pack (Adoption Floor) | **Accepted** | **P1** |
 | [ADR-024](./ADR-024-Sim-Engine-Hardening.md) | Sim Engine Hardening (Limits + Time Budget) | Proposed | **P2** |
-| [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Evidence-as-a-Product | Proposed | **P1/P2** |
+| [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Evidence-as-a-Product | Accepted | **P1/P2** |
 | [ADR-026](./ADR-026-Protocol-Adapters.md) | Protocol Adapters | **Accepted** | **P1** |
 | [ADR-020](./ADR-020-Dependency-Governance.md) | Dependency Governance | Accepted | - |
 
@@ -41,7 +41,7 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | **P1** | [ADR-023](./ADR-023-CICD-Starter-Pack.md) | Accepted | OSS starter adoption floor (implemented) |
 | **P2** | [ADR-021](./ADR-021-Local-Pack-Discovery.md) | Accepted | Local pack discovery + safe resolution order (implemented) |
 | **P2** | [ADR-022](./ADR-022-SOC2-Baseline-Pack.md) | Accepted | SOC2 baseline OSS pack (implemented) |
-| **P1/P2** | [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Proposed | I1/I2/I3 slices merged on `main`; ADR status pending formal accept |
+| **P1/P2** | [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Accepted | I1/I2/I3 slices merged on `main`; formal accept complete |
 | **P1** | [ADR-026](./ADR-026-Protocol-Adapters.md) | Accepted | ACP + A2A + UCP adapter slices and E0-E4 stabilization are merged on `main` |
 | **P2** | [ADR-013](./ADR-013-EU-AI-Act-Pack.md) | Proposed | Article 12 mapping, `--pack` flag |
 | **P3** | [ADR-012](./ADR-012-Transparency-Log.md) | Proposed | Builds on ADR-011 |

--- a/scripts/ci/review-adr025-status-sync.sh
+++ b/scripts/ci/review-adr025-status-sync.sh
@@ -8,11 +8,8 @@ cd "$ROOT"
 git rev-parse --verify "$BASE_REF" >/dev/null
 
 ALLOWLIST=(
-  "docs/architecture/ADR-025-I2-CLOSURE-RELEASE-INTEGRATION.md"
-  "docs/architecture/ADR-025-I3-OTEL-RELEASE-INTEGRATION.md"
-  "docs/architecture/ADR-025-I2-STABILIZATION-POLICY.md"
-  "docs/architecture/ADR-025-I3-STABILIZATION-POLICY.md"
-  "docs/ROADMAP.md"
+  "docs/architecture/ADR-025-Evidence-as-a-Product.md"
+  "docs/architecture/adrs.md"
   "scripts/ci/review-adr025-status-sync.sh"
 )
 
@@ -36,15 +33,23 @@ git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
   fi
 done
 
-echo "[review] status markers present"
-rg -n "Status Sync \(2026-02-25\)" docs/architecture/ADR-025-I2-CLOSURE-RELEASE-INTEGRATION.md >/dev/null || { echo "FAIL: missing I2 Step4 status sync"; exit 1; }
-rg -n "Status Sync \(2026-02-25\)" docs/architecture/ADR-025-I3-OTEL-RELEASE-INTEGRATION.md >/dev/null || { echo "FAIL: missing I3 Step4 status sync"; exit 1; }
-rg -n "Status Sync \(2026-02-25\)" docs/architecture/ADR-025-I2-STABILIZATION-POLICY.md >/dev/null || { echo "FAIL: missing I2 stabilization status sync"; exit 1; }
-rg -n "Status Sync \(2026-02-25\)" docs/architecture/ADR-025-I3-STABILIZATION-POLICY.md >/dev/null || { echo "FAIL: missing I3 stabilization status sync"; exit 1; }
+echo "[review] status markers"
+rg -n '^Accepted \(March 2026; I1/I2/I3 rollout slices implemented and closed-loop on `main`\)$' \
+  docs/architecture/ADR-025-Evidence-as-a-Product.md >/dev/null || {
+  echo "FAIL: ADR-025 accepted status missing"
+  exit 1
+}
 
-echo "[review] roadmap statuses updated"
-rg -n "Audit Kit \(Manifest/Provenance\) \(ADR-025\).*Complete" docs/ROADMAP.md >/dev/null || { echo "FAIL: roadmap audit kit row not updated"; exit 1; }
-rg -n "Soak Testing & Pass\^k \(ADR-025\).*Complete" docs/ROADMAP.md >/dev/null || { echo "FAIL: roadmap soak row not updated"; exit 1; }
-rg -n "Closure Score & Completeness \(ADR-025\).*Complete" docs/ROADMAP.md >/dev/null || { echo "FAIL: roadmap closure row not updated"; exit 1; }
+rg -n '\| \[ADR-025\]\(\./ADR-025-Evidence-as-a-Product.md\) \| Evidence-as-a-Product \| Accepted \| \*\*P1/P2\*\* \|' \
+  docs/architecture/adrs.md >/dev/null || {
+  echo "FAIL: adrs index missing accepted ADR-025 row"
+  exit 1
+}
+
+rg -n 'ADR-025.*Accepted.*I1/I2/I3 slices merged on `main`; formal accept complete' \
+  docs/architecture/adrs.md >/dev/null || {
+  echo "FAIL: priorities table missing ADR-025 accepted note"
+  exit 1
+}
 
 echo "[review] done"


### PR DESCRIPTION
## Summary
Marks ADR-025 as accepted now that the I1/I2/I3 rollout slices are implemented and closed-loop on `main`.

## Scope
- docs/architecture/ADR-025-Evidence-as-a-Product.md
- docs/architecture/adrs.md
- scripts/ci/review-adr025-status-sync.sh

## Safety
- Docs + reviewer gate only
- No workflow changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr025-status-sync.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
