### PR TITLE
docs(adr024): sync superseded status in ADR index

### DIFF
--- a/docs/architecture/adrs.md
+++ b/docs/architecture/adrs.md
@@ -24,7 +24,7 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | [ADR-021](./ADR-021-Local-Pack-Discovery.md) | Local Pack Discovery and Pack Resolution Order | **Accepted** | **P2** |
 | [ADR-022](./ADR-022-SOC2-Baseline-Pack.md) | SOC2 Baseline Pack (AICPA Trust Service Criteria) | **Accepted** | **P2** |
 | [ADR-023](./ADR-023-CICD-Starter-Pack.md) | CICD Starter Pack (Adoption Floor) | **Accepted** | **P1** |
-| [ADR-024](./ADR-024-Sim-Engine-Hardening.md) | Sim Engine Hardening (Limits + Time Budget) | Proposed | **P2** |
+| [ADR-024](./ADR-024-Sim-Engine-Hardening.md) | Sim Engine Hardening (Limits + Time Budget) | Superseded | **P2** |
 | [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Evidence-as-a-Product | Accepted | **P1/P2** |
 | [ADR-026](./ADR-026-Protocol-Adapters.md) | Protocol Adapters | **Accepted** | **P1** |
 | [ADR-020](./ADR-020-Dependency-Governance.md) | Dependency Governance | Accepted | - |

--- a/scripts/ci/review-adr024-status-sync.sh
+++ b/scripts/ci/review-adr024-status-sync.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/adrs.md"
+  "scripts/ci/review-adr024-status-sync.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-024 status sync must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-024 status sync: $f"
+    exit 1
+  fi
+done
+
+echo "[review] status markers"
+rg -n '^Superseded \(February 2026, by ADR-025 Reliability Surface / I1 soak rollout\)$' \
+  docs/architecture/ADR-024-Sim-Engine-Hardening.md >/dev/null || {
+  echo "FAIL: ADR-024 source ADR is not marked superseded"
+  exit 1
+}
+
+rg -n '\| \[ADR-024\]\(\./ADR-024-Sim-Engine-Hardening.md\) \| Sim Engine Hardening \(Limits \+ Time Budget\) \| Superseded \| \*\*P2\*\* \|' \
+  docs/architecture/adrs.md >/dev/null || {
+  echo "FAIL: ADR-024 adrs row not marked superseded"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Syncs the ADR index with the current ADR-024 state. The ADR itself is already marked superseded by ADR-025; this PR updates `adrs.md` to match and adds a narrow reviewer gate.

## Scope
- docs/architecture/adrs.md
- scripts/ci/review-adr024-status-sync.sh

## Safety
- Docs + reviewer gate only
- No workflow changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr024-status-sync.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
