### PR TITLE
docs(adr013): sync accepted status in ADR index

### DIFF
--- a/docs/architecture/adrs.md
+++ b/docs/architecture/adrs.md
@@ -18,7 +18,7 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | [ADR-010](./ADR-010-Evidence-Store-API.md) | Evidence Store Ingest API | **Deferred** | Q3+ |
 | [ADR-011](./ADR-011-Tool-Signing.md) | MCP Tool Signing with Sigstore | Proposed | **P1** |
 | [ADR-012](./ADR-012-Transparency-Log.md) | Transparency Log Integration | Proposed | **P3** |
-| [ADR-013](./ADR-013-EU-AI-Act-Pack.md) | EU AI Act Compliance Pack | Proposed | **P2** |
+| [ADR-013](./ADR-013-EU-AI-Act-Pack.md) | EU AI Act Compliance Pack | Accepted | **P2** |
 | [ADR-014](./ADR-014-GitHub-Action-v2.md) | GitHub Action v2 Design | **Implemented** | ✅ |
 | [ADR-015](./ADR-015-BYOS-Storage-Strategy.md) | BYOS Storage Strategy | **Accepted** | **P1** |
 | [ADR-021](./ADR-021-Local-Pack-Discovery.md) | Local Pack Discovery and Pack Resolution Order | **Accepted** | **P2** |
@@ -43,7 +43,7 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | **P2** | [ADR-022](./ADR-022-SOC2-Baseline-Pack.md) | Accepted | SOC2 baseline OSS pack (implemented) |
 | **P1/P2** | [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Accepted | I1/I2/I3 slices merged on `main`; formal accept complete |
 | **P1** | [ADR-026](./ADR-026-Protocol-Adapters.md) | Accepted | ACP + A2A + UCP adapter slices and E0-E4 stabilization are merged on `main` |
-| **P2** | [ADR-013](./ADR-013-EU-AI-Act-Pack.md) | Proposed | Article 12 mapping, `--pack` flag |
+| **P2** | [ADR-013](./ADR-013-EU-AI-Act-Pack.md) | Accepted | Article 12 mapping, `--pack` flag |
 | **P3** | [ADR-012](./ADR-012-Transparency-Log.md) | Proposed | Builds on ADR-011 |
 | Deferred | [ADR-009](./ADR-009-WORM-Storage.md) | Deferred | Managed WORM → Q3+ if demand |
 | Deferred | [ADR-010](./ADR-010-Evidence-Store-API.md) | Deferred | Managed API → Q3+ if demand |

--- a/scripts/ci/review-adr013-status-sync.sh
+++ b/scripts/ci/review-adr013-status-sync.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/adrs.md"
+  "scripts/ci/review-adr013-status-sync.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ADR-013 status sync must not change workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ADR-013 status sync: $f"
+    exit 1
+  fi
+done
+
+echo "[review] status markers"
+rg -n '^Accepted \(January 2026\)$' docs/architecture/ADR-013-EU-AI-Act-Pack.md >/dev/null || {
+  echo "FAIL: ADR-013 source ADR is not accepted"
+  exit 1
+}
+
+rg -n '\| \[ADR-013\]\(\./ADR-013-EU-AI-Act-Pack.md\) \| EU AI Act Compliance Pack \| Accepted \| \*\*P2\*\* \|' docs/architecture/adrs.md >/dev/null || {
+  echo "FAIL: ADR-013 index row not marked accepted"
+  exit 1
+}
+
+rg -n '\| \*\*P2\*\* \| \[ADR-013\]\(\./ADR-013-EU-AI-Act-Pack.md\) \| Accepted \| Article 12 mapping, `--pack` flag \|' docs/architecture/adrs.md >/dev/null || {
+  echo "FAIL: ADR-013 priorities row not marked accepted"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Syncs the ADR index with the current ADR-013 state. The ADR itself is already accepted; this PR updates `adrs.md` to match and adds a narrow reviewer gate.

## Scope
- docs/architecture/adrs.md
- scripts/ci/review-adr013-status-sync.sh

## Safety
- Docs + reviewer gate only
- No workflow changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-adr013-status-sync.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
