### PR TITLE
docs(exp): close fragmented IPI experiment rollout (Step3)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-step3.md
@@ -1,0 +1,23 @@
+# SPLIT CHECKLIST - Experiment MCP Fragmented IPI Step3 (closure)
+
+## Scope
+- [ ] Only Step3 closure docs and reviewer gate changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No runtime product behavior changes
+
+## Step1 freeze present
+- [ ] `docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-2026q1.md` exists
+- [ ] `docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-POLICY-CONTRACT.md` exists
+- [ ] Step1 reviewer gate exists
+
+## Step2 harness present
+- [ ] Fragmented IPI fixtures exist under `scripts/ci/fixtures/exp-mcp-fragmented-ipi/`
+- [ ] Baseline and protected policy fixtures exist
+- [ ] `scripts/ci/test-exp-mcp-fragmented-ipi.sh` exists and passes
+- [ ] `scripts/ci/exp-mcp-fragmented-ipi/score_runs.py` emits deterministic canary metrics
+- [ ] Protected mode uses wrap policy plus `assay_check_sequence` sidecar
+
+## Reviewer gate
+- [ ] `scripts/ci/review-exp-mcp-fragmented-ipi-step3.sh` exists
+- [ ] Gate enforces allowlist-only + workflow-ban
+- [ ] Gate validates Step1/Step2 artifacts are present

--- a/docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-step3.md
@@ -1,0 +1,36 @@
+# Review Pack - Experiment MCP Fragmented IPI Step3 (closure)
+
+## Intent
+Close the fragmented IPI experiment loop by adding closure review artifacts for the Step1 freeze and Step2 harness implementation.
+
+## Scope
+- docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-step3.md
+- docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-step3.md
+- scripts/ci/review-exp-mcp-fragmented-ipi-step3.sh
+
+## Non-goals
+- No workflow changes
+- No runtime product changes
+- No new policy primitives
+- No experiment result interpretation beyond what the existing Step2 scorer emits
+
+## What should already exist
+- `docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-2026q1.md`
+- `docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-POLICY-CONTRACT.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-step1.sh`
+- `scripts/ci/fixtures/exp-mcp-fragmented-ipi/`
+- `scripts/ci/exp-mcp-fragmented-ipi/`
+- `scripts/ci/test-exp-mcp-fragmented-ipi.sh`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-step2.sh`
+
+## Verification
+- `BASE_REF=origin/codex/exp-mcp-fragmented-ipi-step2-harness bash scripts/ci/review-exp-mcp-fragmented-ipi-step3.sh`
+- `bash scripts/ci/test-exp-mcp-fragmented-ipi.sh`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -p assay-mcp-server -- -D warnings`
+
+## Reviewer 60s scan
+1. Confirm Step3 changes are docs + gate only.
+2. Confirm no `.github/workflows/*` changes.
+3. Run the Step3 reviewer gate.
+4. Confirm the checklist matches the actual Step1/Step2 experiment artifacts and the current sequence-sidecar design.

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-step3.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-step3.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/exp-mcp-fragmented-ipi-step2-harness}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-step3.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-step3.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Experiment Step3 must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in experiment Step3: $f"
+    exit 1
+  fi
+done
+
+echo "[review] invariants"
+test -f docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-2026q1.md || { echo "FAIL: missing Step1 plan"; exit 1; }
+test -f docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-POLICY-CONTRACT.md || { echo "FAIL: missing Step1 policy contract"; exit 1; }
+test -f scripts/ci/review-exp-mcp-fragmented-ipi-step1.sh || { echo "FAIL: missing Step1 reviewer gate"; exit 1; }
+test -f scripts/ci/fixtures/exp-mcp-fragmented-ipi/invoice_with_canary.txt || { echo "FAIL: missing invoice canary fixture"; exit 1; }
+test -f scripts/ci/fixtures/exp-mcp-fragmented-ipi/policies/fragmented_sequence.yaml || { echo "FAIL: missing sequence policy fixture"; exit 1; }
+test -f scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py || { echo "FAIL: missing Step2 driver"; exit 1; }
+test -f scripts/ci/exp-mcp-fragmented-ipi/score_runs.py || { echo "FAIL: missing Step2 scorer"; exit 1; }
+test -f scripts/ci/test-exp-mcp-fragmented-ipi.sh || { echo "FAIL: missing Step2 test runner"; exit 1; }
+rg -n 'assay_check_sequence|blocked_by_sequence' scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py >/dev/null || { echo "FAIL: driver missing sequence-sidecar markers"; exit 1; }
+rg -n 'baseline_asr|protected_tpr|protected_false_positive_rate' scripts/ci/exp-mcp-fragmented-ipi/score_runs.py >/dev/null || { echo "FAIL: scorer missing security metrics"; exit 1; }
+
+bash scripts/ci/test-exp-mcp-fragmented-ipi.sh >/dev/null
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Adds Step3 closure artifacts for the fragmented IPI experiment: checklist, review pack, and a narrow reviewer gate that verifies the Step1 freeze and Step2 harness deliverables.

## Scope
- docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-step3.md
- docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-step3.md
- scripts/ci/review-exp-mcp-fragmented-ipi-step3.sh

## Safety
- Docs + reviewer gate only
- No workflow changes
- No runtime product changes

## Verification
- BASE_REF=origin/codex/exp-mcp-fragmented-ipi-step2-harness bash scripts/ci/review-exp-mcp-fragmented-ipi-step3.sh
- bash scripts/ci/test-exp-mcp-fragmented-ipi.sh
- cargo fmt --check
- cargo clippy -p assay-cli -p assay-mcp-server -- -D warnings
