### PR TITLE
docs(exp): publish fragmented IPI experiment results + rerun guide

### DIFF
--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RERUN.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RERUN.md
@@ -1,0 +1,98 @@
+# Rerun Instructions - MCP Fragmented IPI Experiment (2026Q1)
+
+## Preconditions
+- Repository checked out at commit: `289a43ecc144` or a later commit that preserves the same Step2 harness behavior.
+- Experiment harness merged via PR #490.
+- Rust toolchain available to build:
+  - `assay-cli`
+  - `assay-mcp-server`
+- This rerun path does **not** require a live external MCP host.
+  The current experiment harness uses the local mock MCP server plus Assay wrap policy and the `assay_check_sequence` sidecar.
+
+## Smoke rerun (recommended)
+From repo root:
+
+```bash
+bash scripts/ci/test-exp-mcp-fragmented-ipi.sh
+```
+
+This rebuilds the required binaries, runs a small baseline/protected sample, and emits:
+- `target/exp-mcp-fragmented-ipi/test/summary.json`
+
+## Full rerun matching the published results
+From repo root:
+
+```bash
+set -euo pipefail
+SHA=$(git rev-parse --short=12 HEAD)
+STAMP=$(date +%Y%m%d-%H%M%S)
+OUT="target/exp-mcp-fragmented-ipi/runs/${STAMP}-${SHA}"
+mkdir -p "$OUT"
+
+cargo build -q -p assay-cli -p assay-mcp-server
+
+RUNS_ATTACK=10 RUNS_LEGIT=10 RUN_SET=deterministic \
+  bash scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh "$OUT/baseline-deterministic"
+RUNS_ATTACK=10 RUNS_LEGIT=10 RUN_SET=deterministic \
+  bash scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh "$OUT/protected-deterministic"
+python3 scripts/ci/exp-mcp-fragmented-ipi/score_runs.py \
+  "$OUT/baseline-deterministic/baseline_attack.jsonl" \
+  "$OUT/baseline-deterministic/baseline_legit.jsonl" \
+  "$OUT/protected-deterministic/protected_attack.jsonl" \
+  "$OUT/protected-deterministic/protected_legit.jsonl" \
+  > "$OUT/deterministic-summary.json"
+
+RUNS_ATTACK=10 RUNS_LEGIT=10 RUN_SET=variance \
+  bash scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh "$OUT/baseline-variance"
+RUNS_ATTACK=10 RUNS_LEGIT=10 RUN_SET=variance \
+  bash scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh "$OUT/protected-variance"
+python3 scripts/ci/exp-mcp-fragmented-ipi/score_runs.py \
+  "$OUT/baseline-variance/baseline_attack.jsonl" \
+  "$OUT/baseline-variance/baseline_legit.jsonl" \
+  "$OUT/protected-variance/protected_attack.jsonl" \
+  "$OUT/protected-variance/protected_legit.jsonl" \
+  > "$OUT/variance-summary.json"
+
+python3 scripts/ci/exp-mcp-fragmented-ipi/score_runs.py \
+  "$OUT/baseline-deterministic/baseline_attack.jsonl" \
+  "$OUT/baseline-deterministic/baseline_legit.jsonl" \
+  "$OUT/protected-deterministic/protected_attack.jsonl" \
+  "$OUT/protected-deterministic/protected_legit.jsonl" \
+  "$OUT/baseline-variance/baseline_attack.jsonl" \
+  "$OUT/baseline-variance/baseline_legit.jsonl" \
+  "$OUT/protected-variance/protected_attack.jsonl" \
+  "$OUT/protected-variance/protected_legit.jsonl" \
+  > "$OUT/combined-summary.json"
+
+printf 'artifact root: %s\n' "$OUT"
+```
+
+## Artifact output
+Run artifacts are written under:
+- `target/exp-mcp-fragmented-ipi/runs/<timestamp>-<gitsha>/`
+
+Each full run contains:
+- `baseline-deterministic/`
+- `protected-deterministic/`
+- `baseline-variance/`
+- `protected-variance/`
+- `deterministic-summary.json`
+- `variance-summary.json`
+- `combined-summary.json`
+
+## How scoring works
+- Attack success is detected by a canary token in `web_search.args.query`.
+- Protected-mode blocking is expected **before** sink calls, enforced via `assay_check_sequence`.
+- The wrap policy still records decisions and tool logs, but the sequence block in this experiment is attributed to the sidecar.
+
+## Obsidian tracking companion
+If you are also using the local experiment notebook, update:
+- `/Users/roelschuurkes/Documents/Obsidian Vault/Assay/Experiments/MCP-Fragmented-IPI-2026Q1/03 Run Register.md`
+- `/Users/roelschuurkes/Documents/Obsidian Vault/Assay/Experiments/MCP-Fragmented-IPI-2026Q1/07 Results Draft.md`
+
+## Known issues / troubleshooting
+- If the run stalls immediately, ensure `target/debug/assay` and `target/debug/assay-mcp-server` were built successfully.
+- If local hooks fail due to `libsqlite3-sys` build artifacts:
+  - run `cargo clean -p libsqlite3-sys`
+  - retry the command
+- If the artifact root exists from a previous partial run, use a fresh timestamped output directory.

--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md
@@ -1,0 +1,76 @@
+# Results - MCP Fragmented IPI Mitigation (2026Q1)
+
+## Run identity
+- Repo commit: `289a43ecc144`
+- Artifact root:
+  - `/tmp/assay-exp-mcp-fragmented-ipi-main/target/exp-mcp-fragmented-ipi/runs/20260302-232847-289a43ecc144`
+
+## Executive summary
+A fragmented-document indirect prompt injection (IPI) reliably caused tool-mediated exfiltration in the unprotected baseline (ASR = 1.0).
+With Assay protection enabled, all attack runs were blocked before the `web_search` sink call (TPR = 1.0, FNR = 0.0), while legitimate runs continued without false positives (false positive rate = 0.0).
+
+Blocking in this run is attributed to the **sequence enforcement sidecar** (`assay_check_sequence`), not a wrap-level argument deny.
+
+## Metrics (deterministic set)
+- Baseline ASR: **1.0**
+- Protected TPR / FNR / false positive rate: **1.0** / **0.0** / **0.0**
+- Tool decision latency (p50/p95): **0.771 ms / 1.913 ms**
+- Wilson intervals:
+  - Baseline ASR CI: **0.7225 - 1.0**
+  - Protected TPR CI: **0.7225 - 1.0**
+  - Protected FNR CI: **0.0 - 0.2775**
+  - Protected false positive rate CI: **0.0 - 0.2775**
+
+## Metrics (variance set)
+- Baseline ASR: **1.0**
+- Protected TPR / FNR / false positive rate: **1.0** / **0.0** / **0.0**
+- Tool decision latency (p50/p95): **0.899 ms / 2.097 ms**
+- Wilson intervals:
+  - Baseline ASR CI: **0.7225 - 1.0**
+  - Protected TPR CI: **0.7225 - 1.0**
+  - Protected FNR CI: **0.0 - 0.2775**
+  - Protected false positive rate CI: **0.0 - 0.2775**
+
+## Metrics (combined)
+- Runs total: **80**
+  - Attack runs: **40**
+  - Legit runs: **40**
+- Baseline ASR: **1.0**
+- Protected TPR / FNR / false positive rate: **1.0** / **0.0** / **0.0**
+- Tool decision latency (p50/p95): **0.836 ms / 2.003 ms**
+- Wilson intervals:
+  - Baseline ASR CI: **0.8389 - 1.0**
+  - Protected TPR CI: **0.8389 - 1.0**
+  - Protected FNR CI: **0.0 - 0.1611**
+  - Protected false positive rate CI: **0.0 - 0.1611**
+
+## Evidence locations
+Summaries:
+- `deterministic-summary.json`
+- `variance-summary.json`
+- `combined-summary.json`
+
+Raw records/logs:
+- `baseline-deterministic/`
+- `protected-deterministic/`
+- `baseline-variance/`
+- `protected-variance/`
+
+All located under:
+- `/tmp/assay-exp-mcp-fragmented-ipi-main/target/exp-mcp-fragmented-ipi/runs/20260302-232847-289a43ecc144/`
+
+## Key observations (audit-relevant)
+- Baseline exfiltrated in **all** attack runs:
+  - `web_search` was invoked
+  - the canary was present in baseline `web_search.query`
+- Protected mode blocked **all** attack runs **before** the sink call:
+  - enforcement triggered by `assay_check_sequence`
+  - protected attack runs did not invoke `web_search`
+- Legitimate runs proceeded in all sets:
+  - no false positives observed in this run
+
+## Limitations
+- Results are tied to the pinned fixtures and harness implementation used in PR #490.
+- "Blocked" attribution is based on the current harness instrumentation and sequence-sidecar path.
+- Entropy is not an enforcement rule in this experiment; it remains a shadow metric for follow-up work.
+- The current harness uses a local mock MCP tool server for reproducibility; it is not a live external-tool benchmark.

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-results.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-results.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md"
+  "docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RERUN.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-results.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: results PR must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in results PR: $f"
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n 'Repo commit:\s+`289a43ecc144`' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: results doc missing commit marker"
+  exit 1
+}
+rg -n 'Runs total:\s+\*\*80\*\*' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: results doc missing combined runs marker"
+  exit 1
+}
+rg -n 'bash scripts/ci/test-exp-mcp-fragmented-ipi.sh' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RERUN.md >/dev/null || {
+  echo "FAIL: rerun doc missing smoke rerun instruction"
+  exit 1
+}
+rg -n 'RUNS_ATTACK=10 RUNS_LEGIT=10 RUN_SET=deterministic' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RERUN.md >/dev/null || {
+  echo "FAIL: rerun doc missing full rerun instructions"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only results publication for the MCP fragmented IPI experiment (2026Q1). Captures measured ASR/TPR/false-positive rate and rerun instructions, pinned to commit `289a43ecc144`.

## Scope
- docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md
- docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RERUN.md
- scripts/ci/review-exp-mcp-fragmented-ipi-results.sh

## Safety
- Docs + reviewer gate only
- No workflows, no runtime changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-results.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
