### PR TITLE
docs(exp): freeze ablation live-enable contract

### DIFF
--- a/docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-LIVE-CONTRACT.md
+++ b/docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-LIVE-CONTRACT.md
@@ -1,0 +1,88 @@
+# Live Execution Contract - MCP Fragmented IPI Ablation (StepA Freeze)
+
+## Intent
+Freeze the behavioral and configuration contract for adding live execution support to the fragmented IPI ablation harness.
+
+This contract is tied to current codebase reality:
+- sequence/state enforcement exists
+- live ablation is not yet wired
+- the goal is truthful mechanism attribution, not broader feature expansion
+
+This document freezes behavior, not exact shell syntax.
+
+## Live mode switch (frozen)
+- `RUN_LIVE=0`: offline/mock execution path
+- `RUN_LIVE=1`: live execution path using a real MCP host command
+
+The harness must reject `RUN_LIVE=1` when `MCP_HOST_CMD` is unset.
+
+## Environment requirements (frozen)
+Required for live mode:
+- `MCP_HOST_CMD`
+
+Optional for live mode:
+- `MCP_HOST_ARGS`
+- `ASSAY_CMD` (default: `assay`)
+
+## Variant semantics (frozen)
+### Variant A - wrap_only
+Enabled:
+- wrap policy enforcement
+
+Disabled:
+- sequence sidecar
+
+Required live evidence:
+- `SIDECAR=disabled`
+- selected policy resolves to the wrap-only policy fixture
+
+### Variant B - sequence_only
+Enabled:
+- sequence sidecar
+
+Disabled for exfil blocking:
+- wrap-level deny rules intended to block the sink call
+
+Required live evidence:
+- `SIDECAR=enabled`
+- selected policy resolves to the sequence-only policy fixture
+- enforcement attribution must remain available before the sink call
+
+### Variant C - combined
+Enabled:
+- wrap policy enforcement
+- sequence sidecar
+
+Required live evidence:
+- `SIDECAR=enabled`
+- selected policy resolves to the combined policy fixture
+
+## Logging contract (frozen)
+Every protected live run must emit auditable markers for:
+- ablation mode
+- sidecar enabled/disabled state
+- selected Assay policy
+- selected MCP host command
+
+These markers must be present in protected run logs even if a run terminates early.
+
+## Security contract (frozen)
+The live-enable implementation must not:
+- hardcode absolute user paths in repo-tracked scripts
+- automatically execute live runs in CI
+- log raw sensitive document bodies into repo artifacts
+- weaken the current canary-based scoring contract
+
+## Evidence requirements
+Per mode, live runs must still preserve:
+- baseline/protected logs
+- per-mode `summary.json`
+- aggregate `ablation-summary.json`
+- enough log markers to attribute whether blocking came from wrap-only behavior, sequence enforcement, or both
+
+## Acceptance criteria (StepA)
+- live/offline mode semantics are unambiguous
+- live mode requires `MCP_HOST_CMD`
+- variant semantics remain identical to Step1/Step2
+- logging invariants and security constraints are explicit
+- no runtime/workflow changes are part of this slice

--- a/docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-LIVE-ENABLE-2026q1.md
+++ b/docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-LIVE-ENABLE-2026q1.md
@@ -1,0 +1,69 @@
+# PLAN - Ablation Live Enable: MCP Fragmented IPI Mitigation (2026Q1)
+
+## Intent
+Enable truthful live execution for the fragmented IPI ablation harness so causal attribution can be measured against a real MCP host path rather than only the current local mock harness.
+
+This is a docs-only freeze slice (StepA). No runtime or workflow changes.
+
+## Context (current state)
+- The current ablation harness supports local mock execution only.
+- `RUN_LIVE=1` is not yet supported in `scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh`.
+- Mock ablation results are useful for wiring and contract verification, but they are not sufficient for live mechanism attribution.
+
+## Live-enable scope (frozen)
+The next implementation slice must add `RUN_LIVE=1` support to:
+- `scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh`
+- `scripts/ci/exp-mcp-fragmented-ipi/ablation/run_variant.sh`
+- the existing baseline/protected ablation runners they invoke
+
+Live mode must remain opt-in:
+- `RUN_LIVE=0` stays the CI-safe default
+- `RUN_LIVE=1` is local/manual only
+
+## Required environment contract (frozen)
+For `RUN_LIVE=1`:
+- `MCP_HOST_CMD` is required
+- `MCP_HOST_ARGS` is optional
+- `ASSAY_CMD` defaults to `assay` if not set explicitly
+
+For `RUN_LIVE=0`:
+- no live MCP host is required
+- the current mock/offline path remains valid and required in CI
+
+## Mode semantics (unchanged)
+Live-enable must preserve the current ablation semantics exactly:
+- `wrap_only`: sequence sidecar disabled
+- `sequence_only`: sequence sidecar enabled and wrap policy kept permissive for exfil-blocking rules
+- `combined`: sequence sidecar enabled and blocking wrap policy enabled
+
+## Logging invariants (frozen)
+Every protected live run must log the following markers explicitly:
+- `ABLATION_MODE=<mode>`
+- `SIDECAR=enabled|disabled`
+- `ASSAY_POLICY=<path-or-name>`
+- `MCP_HOST_CMD=<command>`
+
+These markers exist for auditability and post-run mechanism attribution.
+
+## Safety constraints
+The live-enable slice must preserve the existing safety boundaries:
+- no absolute user-specific paths hardcoded in repo scripts or docs
+- no workflow changes
+- no auto-running live mode in CI
+- no prompt/body logging of sensitive document contents in repo artifacts
+- only canary signal, rule id, and minimal redacted argument summaries should be logged for security evidence
+
+## Non-goals
+- No new sink classes beyond the current `web_search` sink
+- No taint/label propagation claims
+- No entropy enforcement
+- No changes to experiment scoring semantics
+- No policy auto-synthesis or semantic clustering claims
+
+## Acceptance criteria (StepA)
+- `RUN_LIVE=1` support target files are explicitly frozen
+- required environment variables are frozen
+- mode semantics remain unchanged
+- logging invariants are explicit and auditable
+- docs explicitly state that live mode is local/manual, not CI-enforced
+- no runtime/workflow changes in this slice

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-a.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-a.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+DOC_PLAN="docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-LIVE-ENABLE-2026q1.md"
+DOC_CONTRACT="docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-LIVE-CONTRACT.md"
+
+ALLOWLIST=(
+  "$DOC_PLAN"
+  "$DOC_CONTRACT"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-a.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ablation live StepA must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ablation live StepA: $f"
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+for doc in "$DOC_PLAN" "$DOC_CONTRACT"; do
+  test -f "$doc" || { echo "FAIL: missing $doc"; exit 1; }
+done
+
+rg -n 'RUN_LIVE=1|RUN_LIVE=0' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must freeze live/offline mode semantics"
+  exit 1
+}
+rg -n 'MCP_HOST_CMD|MCP_HOST_ARGS|ASSAY_CMD' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must mention live env contract"
+  exit 1
+}
+rg -n 'wrap_only|sequence_only|combined|Variant A|Variant B|Variant C' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must mention all ablation variants"
+  exit 1
+}
+rg -n 'ABLATION_MODE=|SIDECAR=enabled\|disabled|ASSAY_POLICY=|MCP_HOST_CMD=' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must freeze logging invariants"
+  exit 1
+}
+rg -n 'No taint|no taint|No taint/label propagation|no taint/label propagation' "$DOC_PLAN" >/dev/null || {
+  echo "FAIL: plan must state no taint claims"
+  exit 1
+}
+rg -n 'no absolute user-specific paths hardcoded|no absolute user paths hardcoded' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must freeze no-hardcoded-user-paths constraint"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only StepA freeze for enabling truthful live execution in the MCP fragmented IPI ablation harness.

This freezes:
- `RUN_LIVE=1` support targets
- required live env vars (`MCP_HOST_CMD`, optional `MCP_HOST_ARGS`, optional `ASSAY_CMD`)
- unchanged mode semantics (`wrap_only`, `sequence_only`, `combined`)
- logging invariants for auditability (`ABLATION_MODE`, `SIDECAR`, `ASSAY_POLICY`, `MCP_HOST_CMD`)
- safety constraints (no workflows, no hardcoded user paths, no live-in-CI)

## Scope
- `docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-LIVE-ENABLE-2026q1.md`
- `docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-LIVE-CONTRACT.md`
- `scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-a.sh`

## Safety
- docs + reviewer gate only
- no workflows
- no runtime changes

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-a.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
