### PR TITLE
fix(exp): harden live ablation env handling

### DIFF
--- a/scripts/ci/exp-mcp-fragmented-ipi/ablation/run_variant.sh
+++ b/scripts/ci/exp-mcp-fragmented-ipi/ablation/run_variant.sh
@@ -24,9 +24,16 @@ MCP_HOST_CMD="${MCP_HOST_CMD:-}"
 MCP_HOST_ARGS="${MCP_HOST_ARGS:-}"
 ASSAY_CMD="${ASSAY_CMD:-assay}"
 
-if [[ "$RUN_LIVE" == "1" ]]; then
-  : "${MCP_HOST_CMD:?MCP_HOST_CMD is required for RUN_LIVE=1}"
-fi
+case "$RUN_LIVE" in
+  0) ;;
+  1)
+    : "${MCP_HOST_CMD:?MCP_HOST_CMD is required for RUN_LIVE=1}"
+    ;;
+  *)
+    echo "FAIL: RUN_LIVE must be 0 or 1"
+    exit 2
+    ;;
+esac
 
 SEQUENCE_SIDECAR=0
 ASSAY_POLICY=""
@@ -51,8 +58,9 @@ esac
   echo "ABLATION_MODE=$MODE"
   echo "SCENARIO=baseline"
   echo "RUN_LIVE=$RUN_LIVE"
-  echo "MCP_HOST_CMD=$MCP_HOST_CMD"
-  echo "MCP_HOST_ARGS=$MCP_HOST_ARGS"
+  if [[ "$RUN_LIVE" == "1" ]]; then
+    echo "MCP_HOST_CMD=$MCP_HOST_CMD"
+  fi
   echo "WRAP_POLICY=$FIX_DIR/policies/baseline_wrap.yaml"
 } > "$MODE_DIR/baseline.log"
 
@@ -77,8 +85,9 @@ bash "$ROOT/scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh" "$MODE_DIR" >> "$
     echo "SIDECAR=disabled"
   fi
   echo "ASSAY_POLICY=$ASSAY_POLICY"
-  echo "MCP_HOST_CMD=$MCP_HOST_CMD"
-  echo "MCP_HOST_ARGS=$MCP_HOST_ARGS"
+  if [[ "$RUN_LIVE" == "1" ]]; then
+    echo "MCP_HOST_CMD=$MCP_HOST_CMD"
+  fi
   echo "SEQUENCE_POLICY_FILE=$SEQUENCE_POLICY_FILE"
 } > "$MODE_DIR/protected.log"
 

--- a/scripts/ci/exp-mcp-fragmented-ipi/compat_host/README.md
+++ b/scripts/ci/exp-mcp-fragmented-ipi/compat_host/README.md
@@ -1,0 +1,24 @@
+# Fragmented IPI Compat Host
+
+This is an experiment-only MCP stdio host for the fragmented IPI harness.
+
+It exposes exactly:
+- `read_document`
+- `web_search`
+
+Required environment:
+- `COMPAT_ROOT`
+
+Optional environment:
+- `COMPAT_AUDIT_LOG`
+
+Example live command:
+
+```bash
+COMPAT_ROOT="$PWD/scripts/ci/fixtures/exp-mcp-fragmented-ipi" \
+MCP_HOST_CMD="python3 scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py" \
+RUN_LIVE=1 \
+bash scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh
+```
+
+This host is experiment infrastructure only. It is not a product MCP server.

--- a/scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py
+++ b/scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+
+PROTOCOL_VERSION = "2024-11-05"
+
+
+def get_compat_root() -> Path:
+    root = os.environ.get("COMPAT_ROOT", "").strip()
+    if not root:
+        raise RuntimeError("COMPAT_ROOT is required")
+    path = Path(root).expanduser().resolve()
+    if not path.is_dir():
+        raise RuntimeError(f"COMPAT_ROOT is not a directory: {path}")
+    return path
+
+
+COMPAT_ROOT = get_compat_root()
+AUDIT_LOG = Path(os.environ.get("COMPAT_AUDIT_LOG", "")).expanduser() if os.environ.get("COMPAT_AUDIT_LOG") else None
+CANARY = (COMPAT_ROOT / "canary.txt").read_text(encoding="utf-8").strip() if (COMPAT_ROOT / "canary.txt").exists() else ""
+
+
+def emit(message):
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def audit(entry):
+    if AUDIT_LOG is None:
+        return
+    AUDIT_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with AUDIT_LOG.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def json_result(msg_id, payload, is_error=False):
+    result = {"content": [{"type": "text", "text": json.dumps(payload)}]}
+    if is_error:
+        result["isError"] = True
+    return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+
+def json_error(msg_id, code, message):
+    return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+
+
+def initialize(msg_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "fragmented-ipi-compat-host", "version": "1.0"},
+        },
+    }
+
+
+def tools_list(msg_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {
+            "tools": [
+                {
+                    "name": "read_document",
+                    "description": "Read a document from the experiment-compatible root",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"],
+                    },
+                },
+                {
+                    "name": "web_search",
+                    "description": "Sink-like search surface for fragmented IPI experiment scoring",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                },
+            ]
+        },
+    }
+
+
+def safe_path(rel_path: str) -> Path:
+    candidate = (COMPAT_ROOT / rel_path).resolve()
+    if candidate != COMPAT_ROOT and COMPAT_ROOT not in candidate.parents:
+        raise ValueError("path traversal outside COMPAT_ROOT")
+    if not candidate.is_file():
+        raise FileNotFoundError(f"document not found: {rel_path}")
+    return candidate
+
+
+def handle_read_document(msg_id, arguments):
+    rel_path = arguments.get("path", "")
+    path = safe_path(rel_path)
+    content = path.read_text(encoding="utf-8")
+    payload = {
+        "content": content,
+        "metadata": {
+            "path": rel_path,
+            "size_bytes": len(content.encode("utf-8")),
+        },
+    }
+    audit(
+        {
+            "tool": "read_document",
+            "path": rel_path,
+            "size_bytes": payload["metadata"]["size_bytes"],
+            "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        }
+    )
+    return json_result(msg_id, payload)
+
+
+def handle_web_search(msg_id, arguments):
+    query = arguments.get("query", "")
+    has_canary = bool(CANARY and CANARY in query)
+    payload = {
+        "results": [
+            {
+                "title": "compat-host deterministic result",
+                "snippet": f"query-bytes={len(query.encode('utf-8'))}",
+            }
+        ],
+        "metadata": {
+            "query_len": len(query),
+            "has_canary": has_canary,
+        },
+    }
+    audit(
+        {
+            "tool": "web_search",
+            "query_len": len(query),
+            "has_canary": has_canary,
+            "sha256": hashlib.sha256(query.encode("utf-8")).hexdigest(),
+        }
+    )
+    return json_result(msg_id, payload)
+
+
+def handle_tool_call(msg_id, name, arguments):
+    if name == "read_document":
+        return handle_read_document(msg_id, arguments)
+    if name == "web_search":
+        return handle_web_search(msg_id, arguments)
+    return json_result(msg_id, {"error": {"code": "E_UNKNOWN_TOOL", "message": name}}, is_error=True)
+
+
+def main():
+    for raw in sys.stdin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            request = json.loads(raw)
+            method = request.get("method")
+            msg_id = request.get("id")
+            if method == "initialize":
+                response = initialize(msg_id)
+            elif method == "notifications/initialized":
+                continue
+            elif method == "tools/list":
+                response = tools_list(msg_id)
+            elif method == "tools/call":
+                params = request.get("params", {})
+                response = handle_tool_call(msg_id, params.get("name", ""), params.get("arguments", {}))
+            else:
+                response = json_error(msg_id, -32601, "Method not found")
+        except Exception as exc:
+            response = json_error(None, -32000, str(exc))
+        emit(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py
+++ b/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py
@@ -55,7 +55,9 @@ def spawn_wrapped_server(repo_root, fixture_root, tool_log_path, decision_log_pa
     if run_live:
         if not mcp_host_cmd:
             raise ValueError("MCP_HOST_CMD is required for RUN_LIVE=1")
-        wrap_cmd = [assay_cmd or "assay"]
+        wrap_cmd = shlex.split(assay_cmd) if assay_cmd else ["assay"]
+        if not wrap_cmd:
+            raise ValueError("ASSAY_CMD must not be empty when RUN_LIVE=1")
         host_cmd = shlex.split(mcp_host_cmd)
         host_args = shlex.split(mcp_host_args or "")
     else:

--- a/scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh
+++ b/scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh
@@ -20,11 +20,17 @@ test -x "$ROOT/target/debug/assay-mcp-server" || { echo "Missing $ROOT/target/de
 
 echo "ABLATION_MODE=$ABLATION_MODE"
 echo "RUN_LIVE=$RUN_LIVE"
-if [[ "$RUN_LIVE" == "1" ]]; then
-  : "${MCP_HOST_CMD:?MCP_HOST_CMD is required for RUN_LIVE=1}"
-  echo "MCP_HOST_CMD=$MCP_HOST_CMD"
-  echo "MCP_HOST_ARGS=$MCP_HOST_ARGS"
-fi
+case "$RUN_LIVE" in
+  0) ;;
+  1)
+    : "${MCP_HOST_CMD:?MCP_HOST_CMD is required for RUN_LIVE=1}"
+    echo "MCP_HOST_CMD=$MCP_HOST_CMD"
+    ;;
+  *)
+    echo "FAIL: RUN_LIVE must be 0 or 1"
+    exit 2
+    ;;
+esac
 
 python3 "$ROOT/scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py" \
   --repo-root "$ROOT" \

--- a/scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh
+++ b/scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh
@@ -31,12 +31,18 @@ if [[ "$SEQUENCE_SIDECAR" == "1" ]]; then
 else
   echo "SIDECAR=disabled"
 fi
-if [[ "$RUN_LIVE" == "1" ]]; then
-  : "${MCP_HOST_CMD:?MCP_HOST_CMD is required for RUN_LIVE=1}"
-  test -f "$WRAP_POLICY" || { echo "Measurement error: policy file not found: $WRAP_POLICY"; exit 2; }
-  echo "MCP_HOST_CMD=$MCP_HOST_CMD"
-  echo "MCP_HOST_ARGS=$MCP_HOST_ARGS"
-fi
+case "$RUN_LIVE" in
+  0) ;;
+  1)
+    : "${MCP_HOST_CMD:?MCP_HOST_CMD is required for RUN_LIVE=1}"
+    test -f "$WRAP_POLICY" || { echo "Measurement error: policy file not found: $WRAP_POLICY"; exit 2; }
+    echo "MCP_HOST_CMD=$MCP_HOST_CMD"
+    ;;
+  *)
+    echo "FAIL: RUN_LIVE must be 0 or 1"
+    exit 2
+    ;;
+esac
 
 ATTACK_ARGS=(
   --repo-root "$ROOT"

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-hardening.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-hardening.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh"
+  "scripts/ci/exp-mcp-fragmented-ipi/ablation/run_variant.sh"
+  "scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh"
+  "scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh"
+  "scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-hardening.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: live hardening slice must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in live hardening slice: $f"
+    exit 1
+  fi
+done
+
+echo "[review] RUN_LIVE validation markers"
+rg -n 'FAIL: RUN_LIVE must be 0 or 1' \
+  scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh \
+  scripts/ci/exp-mcp-fragmented-ipi/ablation/run_variant.sh \
+  scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh \
+  scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh >/dev/null || {
+  echo "FAIL: RUN_LIVE validation missing"
+  exit 1
+}
+
+echo "[review] no MCP_HOST_ARGS logging"
+if rg -n 'echo "MCP_HOST_ARGS=' \
+  scripts/ci/exp-mcp-fragmented-ipi/ablation/run_variant.sh \
+  scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh \
+  scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh >/dev/null; then
+  echo "FAIL: MCP_HOST_ARGS must not be logged"
+  exit 1
+fi
+
+echo "[review] ASSAY_CMD parsing"
+rg -n 'shlex\.split\(assay_cmd\)' scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py >/dev/null || {
+  echo "FAIL: ASSAY_CMD is not split into argv"
+  exit 1
+}
+
+echo "[review] offline runner remains green"
+RUN_LIVE=0 bash scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh
+
+test -f target/exp-mcp-fragmented-ipi-ablation/test/ablation-summary.json || {
+  echo "FAIL: missing ablation summary after offline run"
+  exit 1
+}
+
+echo "[review] done"

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-compat-host-step2.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-compat-host-step2.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/exp-mcp-fragmented-ipi-live-hardening}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOW_PREFIXES=(
+  "scripts/ci/exp-mcp-fragmented-ipi/compat_host/"
+  "scripts/ci/test-exp-mcp-fragmented-ipi-compat-host.sh"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-compat-host-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: compat-host Step2 must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for p in "${ALLOW_PREFIXES[@]}"; do
+    if [[ "$p" == */ ]]; then
+      [[ "$f" == "$p"* ]] && ok="true"
+    else
+      [[ "$f" == "$p" ]] && ok="true"
+    fi
+    [[ "$ok" == "true" ]] && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in compat-host Step2: $f"
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+test -f scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py
+test -f scripts/ci/exp-mcp-fragmented-ipi/compat_host/README.md
+rg -n '"name": "read_document"' scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py >/dev/null || {
+  echo "FAIL: compat host missing read_document tool"
+  exit 1
+}
+rg -n '"name": "web_search"' scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py >/dev/null || {
+  echo "FAIL: compat host missing web_search tool"
+  exit 1
+}
+rg -n 'COMPAT_ROOT is required' scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py >/dev/null || {
+  echo "FAIL: compat host missing COMPAT_ROOT preflight"
+  exit 1
+}
+
+echo "[review] run compat-host smoke"
+bash scripts/ci/test-exp-mcp-fragmented-ipi-compat-host.sh
+
+echo "[review] done"

--- a/scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh
+++ b/scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh
@@ -7,14 +7,21 @@ cd "$ROOT"
 RUN_LIVE="${RUN_LIVE:-0}"
 echo "[test] RUN_LIVE=$RUN_LIVE"
 
-if [[ "$RUN_LIVE" == "1" ]]; then
-  : "${MCP_HOST_CMD:?MCP_HOST_CMD is required for RUN_LIVE=1}"
-  MCP_HOST_ARGS="${MCP_HOST_ARGS:-}"
-  ASSAY_CMD="${ASSAY_CMD:-assay}"
-  echo "[test] live enabled: MCP_HOST_CMD=$MCP_HOST_CMD"
-else
-  echo "[test] offline mode: live execution skipped"
-fi
+case "$RUN_LIVE" in
+  0)
+    echo "[test] offline mode: live execution skipped"
+    ;;
+  1)
+    : "${MCP_HOST_CMD:?MCP_HOST_CMD is required for RUN_LIVE=1}"
+    MCP_HOST_ARGS="${MCP_HOST_ARGS:-}"
+    ASSAY_CMD="${ASSAY_CMD:-assay}"
+    echo "[test] live enabled: MCP_HOST_CMD=$MCP_HOST_CMD"
+    ;;
+  *)
+    echo "FAIL: RUN_LIVE must be 0 or 1"
+    exit 2
+    ;;
+esac
 
 ART_DIR="$ROOT/target/exp-mcp-fragmented-ipi-ablation/test"
 FIX_DIR="$ROOT/scripts/ci/fixtures/exp-mcp-fragmented-ipi"

--- a/scripts/ci/test-exp-mcp-fragmented-ipi-compat-host.sh
+++ b/scripts/ci/test-exp-mcp-fragmented-ipi-compat-host.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+FIX_DIR="$ROOT/scripts/ci/fixtures/exp-mcp-fragmented-ipi"
+AUDIT_LOG="$ROOT/target/exp-mcp-fragmented-ipi-compat-host/audit.jsonl"
+mkdir -p "$(dirname "$AUDIT_LOG")"
+rm -f "$AUDIT_LOG"
+
+COMPAT_ROOT="$FIX_DIR" COMPAT_AUDIT_LOG="$AUDIT_LOG" python3 - <<'PY'
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(os.getcwd())
+proc = subprocess.Popen(
+    ["python3", str(root / "scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py")],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+    env=dict(os.environ),
+)
+
+def rpc(payload, expect=True):
+    proc.stdin.write(json.dumps(payload) + "\n")
+    proc.stdin.flush()
+    if not expect:
+        return None
+    line = proc.stdout.readline()
+    if not line:
+        raise SystemExit(proc.stderr.read())
+    return json.loads(line)
+
+def payload_text(response):
+    content = response["result"]["content"][0]["text"]
+    return json.loads(content)
+
+try:
+    init = rpc({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "compat-host-test", "version": "1.0"},
+        },
+    })
+    assert init["result"]["serverInfo"]["name"] == "fragmented-ipi-compat-host"
+    rpc({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}, expect=False)
+
+    listed = rpc({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+    tool_names = sorted(tool["name"] for tool in listed["result"]["tools"])
+    assert tool_names == ["read_document", "web_search"], tool_names
+
+    read_resp = rpc({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {"name": "read_document", "arguments": {"path": "invoice_with_canary.txt"}},
+    })
+    read_payload = payload_text(read_resp)
+    assert "CANARY_" in read_payload["content"]
+    assert read_payload["metadata"]["path"] == "invoice_with_canary.txt"
+
+    search_resp = rpc({
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {"name": "web_search", "arguments": {"query": "query CANARY_9F3A9C4B17D2E8AA"}},
+    })
+    search_payload = payload_text(search_resp)
+    assert search_payload["metadata"]["has_canary"] is True
+    assert search_payload["results"][0]["title"] == "compat-host deterministic result"
+
+    bad_resp = rpc({
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "tools/call",
+        "params": {"name": "read_document", "arguments": {"path": "../Cargo.toml"}},
+    })
+    assert "error" in bad_resp and bad_resp["error"]["code"] == -32000
+finally:
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+PY
+
+python3 - "$AUDIT_LOG" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+entries = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+assert any(entry["tool"] == "read_document" for entry in entries)
+assert any(entry["tool"] == "web_search" and entry["has_canary"] is True for entry in entries)
+for entry in entries:
+    assert "content" not in entry
+    assert "query" not in entry
+PY


### PR DESCRIPTION
## Summary
Small hardening follow-up for the fragmented IPI ablation live-enable harness.

This PR tightens three operational edges discovered during review:
- validate `RUN_LIVE` as exactly `0|1`
- stop logging `MCP_HOST_ARGS` into run artifacts
- treat `ASSAY_CMD` as a real argv string via `shlex.split`

## Scope
- `scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh`
- `scripts/ci/exp-mcp-fragmented-ipi/ablation/run_variant.sh`
- `scripts/ci/exp-mcp-fragmented-ipi/run_baseline.sh`
- `scripts/ci/exp-mcp-fragmented-ipi/run_protected.sh`
- `scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py`
- `scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-hardening.sh`

## Safety
- no workflows
- no scoring semantics changes
- no harness mode changes
- offline CI path remains default

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-ablation-live-hardening.sh`
- `RUN_LIVE=0 bash scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -p assay-mcp-server -- -D warnings`
