### PR TITLE
docs(exp): freeze fragmented IPI compat-host contract

### DIFF
--- a/docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-COMPAT-HOST-CONTRACT.md
+++ b/docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-COMPAT-HOST-CONTRACT.md
@@ -1,0 +1,91 @@
+# Compat Host Contract - MCP Fragmented IPI Experiment (Step1 Freeze)
+
+## Intent
+Freeze the behavioral contract for an experiment-only MCP compat host that makes the existing fragmented IPI harness runnable against live stdio MCP traffic without changing the harness tool surface.
+
+This contract freezes behavior, not a particular implementation language.
+
+## Experiment boundary
+This compat host is:
+- experiment infrastructure
+- scoped to the fragmented IPI experiment
+- allowed to adapt backend tool names and payload shapes
+
+This compat host is not:
+- a new Assay product capability
+- a general-purpose MCP router
+- a claim that arbitrary external MCP servers are natively compatible with the harness
+
+## Required exposed tools (frozen)
+The compat host must expose exactly:
+- `read_document`
+- `web_search`
+
+No additional experiment-visible tools are required in this line.
+
+## `read_document` contract
+Input:
+- `path: string`
+
+Behavior:
+- resolves the requested document through a constrained backend read path
+- returns document content in the shape expected by the current experiment harness
+
+Default backend intent:
+- filesystem-like MCP source backend
+
+Safety requirements:
+- path resolution must stay within an explicitly allowed experiment root
+- path traversal outside the allowed root must fail deterministically
+
+## `web_search` contract
+Input:
+- `query: string`
+
+Behavior:
+- exposes a sink-like tool call that preserves query observability for canary-based scoring
+- returns result payloads sufficient for harness progress
+
+Default backend intent:
+- sink-like compat surface suitable for experiment scoring
+
+The contract does not require:
+- real internet search quality
+- vendor-specific browser integration
+
+It does require:
+- the query be available for deterministic attack-success scoring
+- the sink invocation remain visible to Assay wrap and sequence enforcement
+
+## Assay compatibility requirements
+The compat host must remain compatible with the current experiment line:
+- Assay wrap policy enforcement
+- `assay_check_sequence` sidecar
+- existing attack-success scoring via canary in `web_search.args.query`
+
+The compat host must preserve enough surface stability that:
+- baseline runs still measure sink invocation
+- protected runs still allow mechanism attribution
+
+## Logging and evidence constraints
+The compat host may emit experiment logs, but must not:
+- log raw sensitive document bodies into repo artifacts
+- weaken current audit markers or result semantics
+
+It should preserve enough metadata to support:
+- sink-call attribution
+- backend-mapping visibility
+- deterministic replay/debugging
+
+## Non-goals
+- no Obsidian dependency in this contract
+- no new sink categories beyond `web_search`
+- no taint-tracking claims
+- no replacement of current harness scoring logic
+
+## Acceptance criteria (Step1)
+- the compat host is explicitly frozen as experiment-only infrastructure
+- the `read_document` plus `web_search` surface is explicit
+- source and sink semantics are explicit enough to drive a minimal implementation
+- filesystem-style source scoping and sink observability are explicit
+- Obsidian is explicitly outside this slice

--- a/docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-COMPAT-HOST-2026q1.md
+++ b/docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-COMPAT-HOST-2026q1.md
@@ -1,0 +1,99 @@
+# PLAN - Experiment: MCP Compat Host for Fragmented IPI (2026Q1)
+
+## Intent
+Enable truthful live execution for the fragmented IPI experiment without changing the existing harness tool contract.
+
+The chosen approach is a thin, experiment-only MCP compat host that exposes exactly:
+- `read_document`
+- `web_search`
+
+This compat host exists to preserve the current experiment surface while allowing the harness to run over real stdio MCP traffic.
+
+This is a docs-only freeze slice (Step1). No runtime or workflow changes.
+
+## Why this approach
+The current experiment already demonstrates:
+- Assay wrap plus sequence enforcement can deterministically block tool-mediated exfiltration in the controlled harness
+
+What is not yet demonstrated is:
+- the same harness running unchanged against a real MCP host path without tool-surface mismatch
+
+The repo does not currently provide a drop-in live MCP server with the exact `read_document` plus `web_search` surface expected by the harness.
+
+Therefore, the smallest correct next step is:
+- keep the harness unchanged
+- add an experiment-only compat host
+- map the compat host onto external MCP-compatible backends where appropriate
+
+## Chosen backend strategy (frozen)
+Default target for the compat host:
+- source backend: filesystem-like MCP server surface for document reads
+- sink surface: `web_search` remains a sink-like tool exposed by the compat host for experiment scoring and observability
+
+This slice is explicitly not tied to:
+- Obsidian
+- vendor-specific browser/search products
+- product/runtime feature work in Assay core
+
+## Scope (Step1)
+In-scope:
+- freeze the compat-host role and boundaries
+- freeze the exact two-tool surface
+- freeze safety constraints and evidence requirements
+- freeze the distinction between experiment adapter code and product code
+
+Out-of-scope:
+- no runtime compat-host implementation yet
+- no workflow changes
+- no new sink classes beyond `web_search`
+- no claim that arbitrary external MCP servers are drop-in compatible
+- no changes to experiment scoring semantics
+
+## Compat-host role (frozen)
+The compat host must:
+- speak MCP over stdio
+- expose exactly `read_document` and `web_search`
+- preserve the existing harness expectations for arguments and result structure
+- remain small enough to audit as experiment infrastructure
+
+The compat host must not:
+- become a general Assay product feature
+- expand the experiment surface beyond the two required tools
+- silently change attack-success semantics
+
+## Tool contract (frozen)
+### `read_document`
+- input: `path: string`
+- output includes document content
+- intended source: external filesystem-like backend constrained to experiment fixtures or other explicitly allowed roots
+
+### `web_search`
+- input: `query: string`
+- output includes result payloads sufficient for the harness
+- semantic role: sink-like tool call for exfiltration scoring and observability
+
+The experiment does not require `web_search` to provide general internet retrieval quality.
+It does require:
+- a visible sink call
+- preserved query content for canary-based scoring
+- deterministic logging/evidence
+
+## Safety constraints (frozen)
+- no Obsidian dependency in this compat-host line
+- no hardcoded absolute user paths in repo-tracked scripts or docs
+- no raw sensitive body logging in repo artifacts
+- no workflow changes
+- no CI dependence on external network services
+
+## Evidence and audit requirements
+Live runs using the compat host must preserve:
+- tool call observability at the MCP boundary
+- enough metadata to attribute sink invocation and blocking
+- compatibility with the existing Assay wrap plus sequence-sidecar instrumentation
+
+## Acceptance criteria (Step1)
+- the docs freeze an experiment-only compat host, not a product feature
+- the exact two-tool surface is explicit
+- Obsidian is explicitly out of scope
+- backend strategy is explicit enough to guide implementation without overcommitting to vendor-specific tooling
+- no runtime/workflow changes are part of this slice

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-compat-host-step1.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-compat-host-step1.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+DOC_PLAN="docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-COMPAT-HOST-2026q1.md"
+DOC_CONTRACT="docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-COMPAT-HOST-CONTRACT.md"
+
+ALLOWLIST=(
+  "$DOC_PLAN"
+  "$DOC_CONTRACT"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-compat-host-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: compat-host Step1 must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in compat-host Step1: $f"
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+for doc in "$DOC_PLAN" "$DOC_CONTRACT"; do
+  test -f "$doc" || { echo "FAIL: missing $doc"; exit 1; }
+done
+
+rg -n 'experiment-only|experiment infrastructure' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must freeze experiment-only boundary"
+  exit 1
+}
+rg -n '`read_document`' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must mention read_document surface"
+  exit 1
+}
+rg -n '`web_search`' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must mention web_search surface"
+  exit 1
+}
+rg -n 'filesystem-like MCP|filesystem-like backend|filesystem-like MCP source backend' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must freeze filesystem-style source backend intent"
+  exit 1
+}
+rg -n 'Obsidian' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must explicitly mark Obsidian out of scope"
+  exit 1
+}
+rg -n 'not a new Assay product capability|not a general Assay product feature|not a product feature' "$DOC_PLAN" "$DOC_CONTRACT" >/dev/null || {
+  echo "FAIL: docs must forbid product-scope creep"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only Step1 freeze for an experiment-only MCP compat host that preserves the fragmented IPI harness surface while avoiding external tool-surface mismatch.

This slice freezes:
- experiment-only compat-host scope
- exact `read_document` + `web_search` surface
- filesystem-style source backend intent
- sink-like `web_search` semantics for scoring and observability
- explicit exclusion of Obsidian and product-scope creep

## Scope
- docs/architecture/PLAN-EXPERIMENT-MCP-FRAGMENTED-IPI-COMPAT-HOST-2026q1.md
- docs/architecture/EXPERIMENT-MCP-FRAGMENTED-IPI-COMPAT-HOST-CONTRACT.md
- scripts/ci/review-exp-mcp-fragmented-ipi-compat-host-step1.sh

## Safety
- Docs + reviewer gate only
- No workflows
- No runtime changes

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-compat-host-step1.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
