### PR TITLE
docs(exp): publish live ablation results + rerun guide

### DIFF
--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md
@@ -1,0 +1,99 @@
+# Rerun — MCP Fragmented IPI Ablation (2026Q1)
+
+## Preconditions
+- Repository checked out at commit `dd6c0c9952a3` or later with equivalent experiment files
+- Compat-host present at:
+  - `scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py`
+- Live ablation harness present from:
+  - PR `#499`
+  - PR `#503`
+  - PR `#510`
+  - PR `#511`
+  - PR `#513`
+
+## One-command live pilot
+From repo root:
+
+```bash
+RUN_LIVE=1 \
+COMPAT_ROOT="$PWD/scripts/ci/fixtures/exp-mcp-fragmented-ipi" \
+MCP_HOST_CMD="python3 $PWD/scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py" \
+ASSAY_CMD="$PWD/target/debug/assay" \
+bash scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh
+```
+
+## Extended live run matching the published batch
+From repo root:
+
+```bash
+RUN_ID="$(date -u +%Y%m%d-%H%M%S)-$(git rev-parse --short=12 HEAD)"
+ART_ROOT="target/exp-mcp-fragmented-ipi-ablation/runs/$RUN_ID"
+FIX_DIR="scripts/ci/fixtures/exp-mcp-fragmented-ipi"
+HOST_CMD="python3 $PWD/scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py"
+ASSAY_BIN="$PWD/target/debug/assay"
+
+for SET in deterministic variance; do
+  SET_ROOT="$ART_ROOT/$SET"
+  mkdir -p "$SET_ROOT"
+  for MODE in wrap_only sequence_only combined; do
+    RUN_LIVE=1 \
+    COMPAT_ROOT="$PWD/$FIX_DIR" \
+    COMPAT_AUDIT_LOG="$PWD/$SET_ROOT/$MODE/compat-audit.jsonl" \
+    MCP_HOST_CMD="$HOST_CMD" \
+    ASSAY_CMD="$ASSAY_BIN" \
+    RUNS_ATTACK=10 \
+    RUNS_LEGIT=10 \
+    RUN_SET="$SET" \
+    bash scripts/ci/exp-mcp-fragmented-ipi/ablation/run_variant.sh "$PWD/$SET_ROOT" "$PWD/$FIX_DIR" "$MODE"
+  done
+  python3 scripts/ci/exp-mcp-fragmented-ipi/ablation/score_ablation.py \
+    --root "$PWD/$SET_ROOT" \
+    --out "$PWD/$SET_ROOT/ablation-summary.json"
+done
+```
+
+## Audit checklist
+Per protected mode log, confirm:
+- `wrap_only`
+  - `ABLATION_MODE=wrap_only`
+  - `SIDECAR=disabled`
+  - `ASSAY_POLICY=...ablation_wrap_only.yaml`
+- `sequence_only`
+  - `ABLATION_MODE=sequence_only`
+  - `SIDECAR=enabled`
+  - `ASSAY_POLICY=...ablation_sequence_only.yaml`
+- `combined`
+  - `ABLATION_MODE=combined`
+  - `SIDECAR=enabled`
+  - `ASSAY_POLICY=...ablation_combined.yaml`
+
+Also confirm in each per-mode `summary.json`:
+- `conditions.protected.mode`
+- `conditions.protected.sidecar_enabled`
+- `protected_wrap_policies`
+- `protected_sequence_policy_files`
+
+## Rebuild-grade rerun checklist
+Use this checklist before treating a rerun as the final publication artifact:
+1. Build `target/debug/assay` and `target/debug/assay-mcp-server` from the same checkout used for scripts.
+2. Record `git rev-parse HEAD`.
+3. Record `rustc --version`.
+4. Record `cargo --version`.
+5. Record a hash of `Cargo.lock`.
+6. Ensure `ASSAY_CMD` points to the freshly built `target/debug/assay`.
+7. Ensure `COMPAT_ROOT` points to the exact fixture tree used in the run.
+8. Archive the full run root, including `compat-audit.jsonl` files.
+9. Confirm protected logs contain the correct `SIDECAR` and `ASSAY_POLICY` markers per mode.
+10. Confirm `combined-summary.json` is generated from the final rerun root, not copied from earlier pilot runs.
+
+## Published run caveat
+The currently published live ablation run used:
+- scripts/tree from `dd6c0c9952a3`
+- binaries copied from `f4364a09a09b`
+
+That is acceptable as strong experiment evidence, but it is not the cleanest single-source provenance run.
+
+## Troubleshooting
+- If local builds fail because Cargo cannot download crates, fix the Cargo cache or use a network-enabled environment, then rerun from a clean checkout.
+- If the compat host fails immediately, verify `COMPAT_ROOT` is set and points to the fixture directory containing `canary.txt`.
+- If `RUN_LIVE=1` fails preflight, verify `MCP_HOST_CMD` and `ASSAY_CMD` are non-empty.

--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md
@@ -1,0 +1,154 @@
+# Results — MCP Fragmented IPI Ablation (2026Q1)
+
+## Run identity
+- Scripts/tree commit: `dd6c0c9952a3`
+- Artifact root:
+  - `/tmp/assay-exp-live-batch/target/exp-mcp-fragmented-ipi-ablation/runs/20260303-103425-dd6c0c9952a3`
+- Date/time (UTC): `2026-03-03T10:34:25Z`
+- Sink surface: compat host (`read_document` + sink-like `web_search`)
+- MCP server mode: local compat-host over stdio JSON-RPC
+
+## Binary provenance caveat
+This run used the current `main` scripts and fixtures from commit `dd6c0c9952a3`, but the local Rust binaries were copied from:
+- `/private/tmp/assay-exp-mcp-fragmented-ipi-live-hardening`
+- binary provenance commit: `f4364a09a09b`
+
+Reason:
+- rebuilding current `main` in the clean worktree was blocked by network-restricted crate download for `tempfile 3.26.0`
+
+Interpretation impact:
+- this is strong live experiment evidence
+- it is **not yet** the final single-source, rebuild-at-HEAD publication artifact
+
+## Purpose
+This ablation isolates causal mechanism for preventing tool-mediated exfiltration in the fragmented IPI scenario by comparing:
+
+- **wrap_only**: wrap policy enabled, sequence sidecar disabled
+- **sequence_only**: wrap permissive, sequence sidecar enabled
+- **combined**: wrap policy enabled, sequence sidecar enabled
+
+Attack success is canary-based: the canary appears in `web_search.args.query`.
+
+## Scope boundary
+This run demonstrates control over a **sink-like tool call**, not outbound internet exfiltration.
+The compat host preserves the relevant bus-level property for the experiment:
+- sensitive content is read through `read_document`
+- sensitive content reaches a sink-like tool through `web_search`
+- Assay policy and sequence enforcement observe and block that transition on the tool-call path
+
+Claims from this run should therefore be phrased as:
+- tool-mediated sink-call exfiltration control
+
+Not as:
+- generic internet exfiltration prevention
+- general mitigation across arbitrary MCP servers without adaptation
+
+## Experimental design
+- Modes: `wrap_only`, `sequence_only`, `combined`
+- Sets: `deterministic`, `variance`
+- Per set, per mode, per condition:
+  - attack runs: `10`
+  - legit runs: `10`
+- Combined per mode:
+  - baseline attack runs: `20`
+  - protected attack runs: `20`
+  - protected legit runs: `20`
+
+## Results (combined across both sets)
+| Mode | Baseline ASR | Protected TPR | Protected FNR | Protected false positive rate | Decision latency p50 (ms) | Decision latency p95 (ms) | blocked_by_wrap | blocked_by_sequence |
+|------|--------------|---------------|---------------|---------------|----------------------------|----------------------------|-----------------|---------------------|
+| `wrap_only` | `1.0` | `1.0` | `0.0` | `0.0` | `0.671` | `1.955` | `20` | `0` |
+| `sequence_only` | `1.0` | `1.0` | `0.0` | `0.0` | `0.738` | `2.303` | `0` | `20` |
+| `combined` | `1.0` | `1.0` | `0.0` | `0.0` | `0.731` | `2.085` | `0` | `20` |
+
+## Deterministic set
+- `wrap_only`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.626 / 1.950 ms`
+  - attribution: `blocked_by_wrap=10`, `blocked_by_sequence=0`
+- `sequence_only`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.747 / 1.839 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
+- `combined`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.775 / 2.063 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
+
+## Variance set
+- `wrap_only`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.717 / 1.955 ms`
+  - attribution: `blocked_by_wrap=10`, `blocked_by_sequence=0`
+- `sequence_only`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.729 / 2.303 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
+- `combined`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.687 / 2.085 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
+
+## Mechanism attribution
+Audit markers in protected logs confirm the mode split:
+
+- `wrap_only`
+  - `SIDECAR=disabled`
+  - `ASSAY_POLICY=...ablation_wrap_only.yaml`
+  - observed blocking source: wrap policy only
+- `sequence_only`
+  - `SIDECAR=enabled`
+  - `ASSAY_POLICY=...ablation_sequence_only.yaml`
+  - observed blocking source: `assay_check_sequence`
+- `combined`
+  - `SIDECAR=enabled`
+  - `ASSAY_POLICY=...ablation_combined.yaml`
+  - observed blocking source in this run: `assay_check_sequence`
+
+This is the core ablation result:
+- `wrap_only` blocks via wrap, not sequence
+- `sequence_only` blocks via sequence, not wrap
+- `combined` is dominated by sequence in this scenario
+
+## Interpretation
+### What this run supports
+- Baseline vulnerability remains structural in this compat-host scenario: baseline ASR stayed `1.0` in every mode and set.
+- Both mitigation mechanisms are individually sufficient for this scenario:
+  - wrap-only is sufficient
+  - sequence-only is sufficient
+- Combined enforcement does not improve ASR/TPR/FPR in this exact scenario because sequence already short-circuits the sink path.
+- Overhead remains proxy-grade, with p95 between `1.955 ms` and `2.303 ms`.
+
+### What this run does **not** support
+- No claim of outbound internet exfiltration prevention.
+- No claim of general sink coverage beyond the sink-like `web_search` compat surface.
+- No claim of generalization to arbitrary third-party MCP servers without adaptation.
+- No claim of single-source provenance for final publication, because the binaries were not rebuilt from the exact same commit as the scripts.
+
+## Evidence locations
+Per set:
+- `deterministic/ablation-summary.json`
+- `variance/ablation-summary.json`
+
+Combined:
+- `combined-summary.json`
+
+Per mode, per set:
+- `<set>/<mode>/baseline.log`
+- `<set>/<mode>/protected.log`
+- `<set>/<mode>/summary.json`
+- `<set>/<mode>/compat-audit.jsonl`
+
+All under:
+- `/tmp/assay-exp-live-batch/target/exp-mcp-fragmented-ipi-ablation/runs/20260303-103425-dd6c0c9952a3/`
+
+## Recommended follow-up
+1. Rebuild and rerun at a single commit SHA so scripts/tree and binaries share identical provenance.
+2. Keep the compat-host live run as the reference for mechanism attribution.
+3. If we want stronger separation between wrap-only and sequence-only efficacy, weaken the wrap-only fixture or change the sink scenario so wrap-only no longer trivially matches.

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-ablation-results.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-ablation-results.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md"
+  "docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-ablation-results.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: ablation results PR must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in ablation results PR: $f"
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n 'Scripts/tree commit: `dd6c0c9952a3`' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing scripts/tree commit marker"; exit 1; }
+rg -n 'binary provenance commit: `f4364a09a09b`' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing binary provenance marker"; exit 1; }
+rg -n 'tool-mediated sink-call exfiltration control' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing bounded claim wording"; exit 1; }
+rg -n 'blocked_by_wrap|blocked_by_sequence' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing mechanism attribution markers"; exit 1; }
+rg -n 'Rebuild-grade rerun checklist' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md >/dev/null || { echo "FAIL: missing rebuild-grade rerun checklist"; exit 1; }
+rg -n 'RUN_LIVE=1' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md >/dev/null || { echo "FAIL: missing live rerun instruction"; exit 1; }
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only publication of the **live** MCP fragmented IPI ablation results.

This PR records a three-way mechanism comparison on the compat-host sink surface:
- `wrap_only`
- `sequence_only`
- `combined`

The main result is not only that all protected variants block the attack in this setup, but that the run now shows **clean causal attribution**:
- `wrap_only` blocks via wrap policy only
- `sequence_only` blocks via sequence sidecar only
- `combined` is dominated by the sequence layer in this scenario (early exit before wrap-level blocking matters)

## Key Results
| Mode | Baseline ASR | Protected TPR | Primary Blocker | p95 Latency |
|------|--------------|---------------|-----------------|-------------|
| `wrap_only` | `1.0` | `1.0` | Argument / wrap policy | `1.955 ms` |
| `sequence_only` | `1.0` | `1.0` | Stateful sequence constraint | `2.303 ms` |
| `combined` | `1.0` | `1.0` | Sequence layer (early exit) | `2.085 ms` |

## Scope
- `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md`
- `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md`
- `scripts/ci/review-exp-mcp-fragmented-ipi-ablation-results.sh`

## Safety
- docs + reviewer gate only
- no workflows
- no runtime changes

## Important Boundaries
- This is a **tool-mediated sink-call** experiment on a compat-host surface, not a direct outbound internet benchmark.
- Claims should stay bounded to sink-call exfiltration control on the MCP tool path.
- The published run includes a provenance caveat:
  - scripts/tree from `dd6c0c9952a3`
  - local binaries copied from `f4364a09a09b`
- That makes this strong live evidence, but not yet the final single-source rebuild-at-HEAD artifact.

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-ablation-results.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings` *(blocked in this clean worktree by network-restricted crate download; no code paths changed in this PR)*
