### PR TITLE
docs(exp): promote hermetic ablation rerun provenance

### DIFF
--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md
@@ -1,7 +1,7 @@
 # Rerun — MCP Fragmented IPI Ablation (2026Q1)
 
 ## Preconditions
-- Repository checked out at commit `dd6c0c9952a3` or later with equivalent experiment files
+- Repository checked out at commit `33208d4b4ddb` or an equivalent later commit
 - Compat-host present at:
   - `scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py`
 - Live ablation harness present from:
@@ -10,6 +10,12 @@
   - PR `#510`
   - PR `#511`
   - PR `#513`
+
+## Reference paper-grade artifact
+- run root:
+  - `/tmp/assay-exp-hermetic-rerun/target/exp-mcp-fragmented-ipi-ablation/runs/hermetic-20260303-110905-33208d4b4ddb`
+- build metadata:
+  - `/tmp/assay-exp-hermetic-rerun/target/exp-mcp-fragmented-ipi-ablation/runs/hermetic-20260303-110905-33208d4b4ddb/build-info.json`
 
 ## One-command live pilot
 From repo root:
@@ -22,15 +28,36 @@ ASSAY_CMD="$PWD/target/debug/assay" \
 bash scripts/ci/test-exp-mcp-fragmented-ipi-ablation.sh
 ```
 
-## Extended live run matching the published batch
+## Extended live run matching the paper-grade batch
 From repo root:
 
 ```bash
-RUN_ID="$(date -u +%Y%m%d-%H%M%S)-$(git rev-parse --short=12 HEAD)"
+RUN_ID="hermetic-$(date -u +%Y%m%d-%H%M%S)-$(git rev-parse --short=12 HEAD)"
 ART_ROOT="target/exp-mcp-fragmented-ipi-ablation/runs/$RUN_ID"
 FIX_DIR="scripts/ci/fixtures/exp-mcp-fragmented-ipi"
 HOST_CMD="python3 $PWD/scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py"
 ASSAY_BIN="$PWD/target/debug/assay"
+LOCK_HASH="$(shasum -a 256 Cargo.lock | awk '{print $1}')"
+
+mkdir -p "$ART_ROOT"
+
+python3 - <<'PY' "$ART_ROOT/build-info.json" "$(git rev-parse --short=12 HEAD)" "$LOCK_HASH"
+import json, pathlib, platform, subprocess, sys
+out = pathlib.Path(sys.argv[1])
+git_sha = sys.argv[2]
+lock_hash = sys.argv[3]
+def run(cmd):
+    return subprocess.check_output(cmd, text=True).strip()
+out.write_text(json.dumps({
+    'schema_version': 'exp_mcp_fragmented_ipi_build_info_v1',
+    'git_sha': git_sha,
+    'rustc_version': run(['rustc','--version']),
+    'cargo_version': run(['cargo','--version']),
+    'cargo_lock_sha256': lock_hash,
+    'platform': platform.platform(),
+    'machine': platform.machine(),
+}, indent=2, sort_keys=True))
+PY
 
 for SET in deterministic variance; do
   SET_ROOT="$ART_ROOT/$SET"
@@ -74,7 +101,6 @@ Also confirm in each per-mode `summary.json`:
 - `protected_sequence_policy_files`
 
 ## Rebuild-grade rerun checklist
-Use this checklist before treating a rerun as the final publication artifact:
 1. Build `target/debug/assay` and `target/debug/assay-mcp-server` from the same checkout used for scripts.
 2. Record `git rev-parse HEAD`.
 3. Record `rustc --version`.
@@ -86,14 +112,11 @@ Use this checklist before treating a rerun as the final publication artifact:
 9. Confirm protected logs contain the correct `SIDECAR` and `ASSAY_POLICY` markers per mode.
 10. Confirm `combined-summary.json` is generated from the final rerun root, not copied from earlier pilot runs.
 
-## Published run caveat
-The currently published live ablation run used:
-- scripts/tree from `dd6c0c9952a3`
-- binaries copied from `f4364a09a09b`
-
-That is acceptable as strong experiment evidence, but it is not the cleanest single-source provenance run.
+## Note on offline build provenance
+The reference rerun was built from local Cargo cache and produced a provenance-clean scripts/binaries artifact.
+The current `build-info.json` does not explicitly include `CARGO_NET_OFFLINE=true`; if that matters for a future artifact line, extend the metadata capture step to include an allowlisted env snapshot.
 
 ## Troubleshooting
-- If local builds fail because Cargo cannot download crates, fix the Cargo cache or use a network-enabled environment, then rerun from a clean checkout.
+- If local builds fail because Cargo cannot download crates, prime the Cargo cache first or use a network-enabled environment, then rerun from a clean checkout.
 - If the compat host fails immediately, verify `COMPAT_ROOT` is set and points to the fixture directory containing `canary.txt`.
 - If `RUN_LIVE=1` fails preflight, verify `MCP_HOST_CMD` and `ASSAY_CMD` are non-empty.

--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md
@@ -1,24 +1,29 @@
 # Results — MCP Fragmented IPI Ablation (2026Q1)
 
 ## Run identity
-- Scripts/tree commit: `dd6c0c9952a3`
+- Paper-grade rerun commit: `33208d4b4ddb`
 - Artifact root:
-  - `/tmp/assay-exp-live-batch/target/exp-mcp-fragmented-ipi-ablation/runs/20260303-103425-dd6c0c9952a3`
-- Date/time (UTC): `2026-03-03T10:34:25Z`
+  - `/tmp/assay-exp-hermetic-rerun/target/exp-mcp-fragmented-ipi-ablation/runs/hermetic-20260303-110905-33208d4b4ddb`
+- Date/time (UTC): `2026-03-03T11:09:05Z`
 - Sink surface: compat host (`read_document` + sink-like `web_search`)
 - MCP server mode: local compat-host over stdio JSON-RPC
+- Build metadata:
+  - `/tmp/assay-exp-hermetic-rerun/target/exp-mcp-fragmented-ipi-ablation/runs/hermetic-20260303-110905-33208d4b4ddb/build-info.json`
 
-## Binary provenance caveat
-This run used the current `main` scripts and fixtures from commit `dd6c0c9952a3`, but the local Rust binaries were copied from:
-- `/private/tmp/assay-exp-mcp-fragmented-ipi-live-hardening`
-- binary provenance commit: `f4364a09a09b`
+## Paper-grade rerun provenance
+This rerun is the reference artifact for the current experiment line.
 
-Reason:
-- rebuilding current `main` in the clean worktree was blocked by network-restricted crate download for `tempfile 3.26.0`
+- scripts/tree SHA: `33208d4b4ddb`
+- binaries build SHA: `33208d4b4ddb`
+- `rustc`: `1.92.0`
+- `cargo`: `1.92.0`
+- `Cargo.lock` sha256:
+  - `deee7ee9afa88a616118fd70dc92d269ddc6acc1a0fcd8b6ec3b3a170eadd69e`
 
 Interpretation impact:
-- this is strong live experiment evidence
-- it is **not yet** the final single-source, rebuild-at-HEAD publication artifact
+- the earlier live batch established the mechanism and run shape
+- this rerun removes the scripts/binaries provenance mismatch
+- this is now the paper-grade artifact for the compat-host experiment setup
 
 ## Purpose
 This ablation isolates causal mechanism for preventing tool-mediated exfiltration in the fragmented IPI scenario by comparing:
@@ -53,46 +58,48 @@ Not as:
   - baseline attack runs: `20`
   - protected attack runs: `20`
   - protected legit runs: `20`
+- Across the full batch:
+  - `240` recorded condition instances
 
 ## Results (combined across both sets)
-| Mode | Baseline ASR | Protected TPR | Protected FNR | Protected false positive rate | Decision latency p50 (ms) | Decision latency p95 (ms) | blocked_by_wrap | blocked_by_sequence |
-|------|--------------|---------------|---------------|---------------|----------------------------|----------------------------|-----------------|---------------------|
-| `wrap_only` | `1.0` | `1.0` | `0.0` | `0.0` | `0.671` | `1.955` | `20` | `0` |
-| `sequence_only` | `1.0` | `1.0` | `0.0` | `0.0` | `0.738` | `2.303` | `0` | `20` |
-| `combined` | `1.0` | `1.0` | `0.0` | `0.0` | `0.731` | `2.085` | `0` | `20` |
+| Mode | Baseline ASR | Protected TPR | Protected FNR | Protected false positive rate | Decision latency p50 (ms) | Decision latency p95 (ms) | blocked_by_wrap | blocked_by_sequence | Primary blocker |
+|------|--------------|---------------|---------------|-------------------------------|----------------------------|----------------------------|-----------------|---------------------|-----------------|
+| `wrap_only` | `1.0` | `1.0` | `0.0` | `0.0` | `0.669` | `3.447` | `20` | `0` | wrap policy |
+| `sequence_only` | `1.0` | `1.0` | `0.0` | `0.0` | `0.737` | `3.213` | `0` | `20` | sequence constraint |
+| `combined` | `1.0` | `1.0` | `0.0` | `0.0` | `0.877` | `3.490` | `0` | `20` | sequence early exit |
 
 ## Deterministic set
 - `wrap_only`
   - baseline ASR: `1.0`
   - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
-  - latency p50/p95: `0.626 / 1.950 ms`
+  - latency p50/p95: `0.615 / 3.447 ms`
   - attribution: `blocked_by_wrap=10`, `blocked_by_sequence=0`
 - `sequence_only`
   - baseline ASR: `1.0`
   - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
-  - latency p50/p95: `0.747 / 1.839 ms`
+  - latency p50/p95: `0.683 / 2.446 ms`
   - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
 - `combined`
   - baseline ASR: `1.0`
   - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
-  - latency p50/p95: `0.775 / 2.063 ms`
+  - latency p50/p95: `0.990 / 3.291 ms`
   - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
 
 ## Variance set
 - `wrap_only`
   - baseline ASR: `1.0`
   - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
-  - latency p50/p95: `0.717 / 1.955 ms`
+  - latency p50/p95: `0.723 / 2.383 ms`
   - attribution: `blocked_by_wrap=10`, `blocked_by_sequence=0`
 - `sequence_only`
   - baseline ASR: `1.0`
   - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
-  - latency p50/p95: `0.729 / 2.303 ms`
+  - latency p50/p95: `0.791 / 3.213 ms`
   - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
 - `combined`
   - baseline ASR: `1.0`
   - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
-  - latency p50/p95: `0.687 / 2.085 ms`
+  - latency p50/p95: `0.764 / 3.490 ms`
   - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
 
 ## Mechanism attribution
@@ -111,6 +118,9 @@ Audit markers in protected logs confirm the mode split:
   - `ASSAY_POLICY=...ablation_combined.yaml`
   - observed blocking source in this run: `assay_check_sequence`
 
+`combined` should be read as **first decisive block observed**, not “both layers triggered equally”.
+That is why `blocked_by_wrap=0` in `combined`: the sequence layer short-circuits first in this scenario.
+
 This is the core ablation result:
 - `wrap_only` blocks via wrap, not sequence
 - `sequence_only` blocks via sequence, not wrap
@@ -119,25 +129,51 @@ This is the core ablation result:
 ## Interpretation
 ### What this run supports
 - Baseline vulnerability remains structural in this compat-host scenario: baseline ASR stayed `1.0` in every mode and set.
+- Across `240` recorded condition instances in this batch, mitigation was consistent.
 - Both mitigation mechanisms are individually sufficient for this scenario:
   - wrap-only is sufficient
   - sequence-only is sufficient
-- Combined enforcement does not improve ASR/TPR/FPR in this exact scenario because sequence already short-circuits the sink path.
-- Overhead remains proxy-grade, with p95 between `1.955 ms` and `2.303 ms`.
+- Combined enforcement does not improve ASR/TPR/false positive rate in this exact scenario because sequence already short-circuits the sink path.
+- Overhead remains low: single-digit millisecond tool decision latency, negligible relative to typical LLM inference and tool execution latency.
+
+### Why sequence still matters
+This scenario now shows that wrap-only is sufficient for the current attack shape, but that does **not** make the sequence layer redundant in general.
+
+Wrap rules block a specific exfiltration method visible in tool arguments.
+Sequence rules block the structural exfiltration intent: a sink call following a sensitive read.
+
+That distinction matters for future scenarios where:
+- the sink query no longer matches obvious lexical patterns
+- the exfiltration is split across multiple benign-looking tool calls
+- the sink surface changes while the forbidden state transition stays the same
 
 ### What this run does **not** support
 - No claim of outbound internet exfiltration prevention.
 - No claim of general sink coverage beyond the sink-like `web_search` compat surface.
 - No claim of generalization to arbitrary third-party MCP servers without adaptation.
-- No claim of single-source provenance for final publication, because the binaries were not rebuilt from the exact same commit as the scripts.
+- No claim that the current scenario proves sequence is strictly necessary against every attack shape.
+
+## Limitations
+1. **Sink fidelity**
+   - the compat host is a sink-like MCP surface, not a real TCP/HTTP sink
+2. **Scenario ceiling effect**
+   - the current attack is strong enough to reliably fool the agent, but still easy enough for wrap-only to block
+3. **Environment-specific latency**
+   - p95 latency reflects tool-decision overhead on an M1 Pro/macOS environment and should not be read as end-to-end model latency
+4. **Offline-build metadata capture**
+   - the build was performed from local cache, but `build-info.json` did not record `CARGO_NET_OFFLINE=true` because that env was not propagated into the metadata-writing step
 
 ## Evidence locations
+Reference artifact:
+- `/tmp/assay-exp-hermetic-rerun/target/exp-mcp-fragmented-ipi-ablation/runs/hermetic-20260303-110905-33208d4b4ddb/`
+
 Per set:
 - `deterministic/ablation-summary.json`
 - `variance/ablation-summary.json`
 
 Combined:
 - `combined-summary.json`
+- `build-info.json`
 
 Per mode, per set:
 - `<set>/<mode>/baseline.log`
@@ -145,10 +181,7 @@ Per mode, per set:
 - `<set>/<mode>/summary.json`
 - `<set>/<mode>/compat-audit.jsonl`
 
-All under:
-- `/tmp/assay-exp-live-batch/target/exp-mcp-fragmented-ipi-ablation/runs/20260303-103425-dd6c0c9952a3/`
-
 ## Recommended follow-up
-1. Rebuild and rerun at a single commit SHA so scripts/tree and binaries share identical provenance.
-2. Keep the compat-host live run as the reference for mechanism attribution.
-3. If we want stronger separation between wrap-only and sequence-only efficacy, weaken the wrap-only fixture or change the sink scenario so wrap-only no longer trivially matches.
+1. Keep the hermetic rerun artifact as the current paper-grade baseline for the compat-host setup.
+2. Add a harder wrap-bypass variant so `sequence_only` necessity can be isolated more sharply.
+3. Consider a higher-fidelity sink in a later experiment line if we want stronger network-surface claims.

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-ablation-results.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-ablation-results.sh
@@ -30,10 +30,11 @@ git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
 done
 
 echo "[review] marker checks"
-rg -n 'Scripts/tree commit: `dd6c0c9952a3`' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing scripts/tree commit marker"; exit 1; }
-rg -n 'binary provenance commit: `f4364a09a09b`' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing binary provenance marker"; exit 1; }
+rg -n 'Paper-grade rerun commit: `33208d4b4ddb`' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing paper-grade commit marker"; exit 1; }
+rg -n 'Cargo.lock` sha256|deee7ee9afa88a616118fd70dc92d269ddc6acc1a0fcd8b6ec3b3a170eadd69e' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing Cargo.lock provenance marker"; exit 1; }
+rg -n 'first decisive block observed' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing combined first-block interpretation"; exit 1; }
 rg -n 'tool-mediated sink-call exfiltration control' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing bounded claim wording"; exit 1; }
-rg -n 'blocked_by_wrap|blocked_by_sequence' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing mechanism attribution markers"; exit 1; }
+rg -n 'build-info.json' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md >/dev/null || { echo "FAIL: missing build-info reference"; exit 1; }
 rg -n 'Rebuild-grade rerun checklist' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md >/dev/null || { echo "FAIL: missing rebuild-grade rerun checklist"; exit 1; }
 rg -n 'RUN_LIVE=1' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md >/dev/null || { echo "FAIL: missing live rerun instruction"; exit 1; }
 


### PR DESCRIPTION
## Summary
Promotes the hermetic rebuild rerun to the primary MCP fragmented IPI ablation artifact.

This docs-only update:
- replaces the earlier binaries-mismatch caveat with the provenance-clean rerun
- updates the ablation table to the paper-grade artifact root
- records build metadata (`rustc`, `cargo`, `Cargo.lock` hash, commit SHA)
- keeps claim boundaries explicit (`sink-like` compat-host surface)

## Scope
- docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RESULTS.md
- docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-ABLATION-2026Q1-RERUN.md
- scripts/ci/review-exp-mcp-fragmented-ipi-ablation-results.sh

## Safety
- docs + reviewer gate only
- no workflows
- no runtime changes

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-ablation-results.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
