### PR TITLE
docs(exp): publish wrap-bypass live results + rerun guide

### DIFF
--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RERUN.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RERUN.md
@@ -1,0 +1,107 @@
+# Rerun - MCP Fragmented IPI Wrap-bypass Variant (2026Q1)
+
+## Preconditions
+- Repository includes the wrap-bypass Step2 harness from PR `#526`.
+- Build environment has the required Rust toolchain:
+  - `rustc 1.92.0`
+  - `cargo 1.92.0`
+- Compat host is available in-repo:
+  - `scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py`
+- Fixture root:
+  - `scripts/ci/fixtures/exp-mcp-fragmented-ipi`
+
+## Smoke rerun
+From repo root:
+
+```bash
+EXPERIMENT_VARIANT=wrap_bypass \
+RUN_LIVE=1 \
+COMPAT_ROOT="$PWD/scripts/ci/fixtures/exp-mcp-fragmented-ipi" \
+MCP_HOST_CMD="python3 $PWD/scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py" \
+ASSAY_CMD="$PWD/target/debug/assay" \
+bash scripts/ci/test-exp-mcp-fragmented-ipi-wrap-bypass.sh
+```
+
+This is a small smoke run. It is useful for configuration validation, not as the paper-grade batch.
+
+## Full matrix rerun
+From repo root:
+
+```bash
+set -euo pipefail
+ROOT="$PWD"
+FIX_DIR="$ROOT/scripts/ci/fixtures/exp-mcp-fragmented-ipi"
+SHA="$(git rev-parse --short=12 HEAD)"
+STAMP="$(date -u +%Y%m%d-%H%M%S)"
+RUN_ROOT="$ROOT/target/exp-mcp-fragmented-ipi-wrap-bypass/runs/live-main-$STAMP-$SHA"
+mkdir -p "$RUN_ROOT/deterministic" "$RUN_ROOT/variance"
+
+CARGO_NET_OFFLINE=true cargo build -q -p assay-cli -p assay-mcp-server
+
+for set_name in deterministic variance; do
+  case "$set_name" in
+    deterministic) RUN_SET=deterministic ;;
+    variance) RUN_SET=variance ;;
+  esac
+  for mode in wrap_only sequence_only combined; do
+    EXPERIMENT_VARIANT=wrap_bypass \
+    RUN_LIVE=1 \
+    COMPAT_ROOT="$FIX_DIR" \
+    COMPAT_AUDIT_LOG="$RUN_ROOT/compat-audit.jsonl" \
+    MCP_HOST_CMD="python3 $ROOT/scripts/ci/exp-mcp-fragmented-ipi/compat_host/compat_host.py" \
+    ASSAY_CMD="$ROOT/target/debug/assay" \
+    RUNS_ATTACK=10 RUNS_LEGIT=10 RUN_SET="$RUN_SET" \
+      bash "$ROOT/scripts/ci/exp-mcp-fragmented-ipi/ablation/run_variant.sh" "$RUN_ROOT/$set_name" "$FIX_DIR" "$mode"
+
+    python3 "$ROOT/scripts/ci/exp-mcp-fragmented-ipi/score_wrap_bypass.py" \
+      "$RUN_ROOT/$set_name/$mode/baseline_attack.jsonl" \
+      "$RUN_ROOT/$set_name/$mode/baseline_legit.jsonl" \
+      "$RUN_ROOT/$set_name/$mode/protected_attack.jsonl" \
+      "$RUN_ROOT/$set_name/$mode/protected_legit.jsonl" \
+      --expected "$FIX_DIR/wrap_bypass/expected_fragments.json" \
+      --out "$RUN_ROOT/$set_name/$mode/wrap-bypass-summary.json"
+  done
+done
+```
+
+## Paper-grade reference rerun
+The reference artifact used in the current results doc is:
+- `/tmp/assay-exp-wrap-bypass-live-main/target/exp-mcp-fragmented-ipi-wrap-bypass/runs/live-main-20260303-122018-8bf0d17ffb1d`
+
+Reference provenance file:
+- `/tmp/assay-exp-wrap-bypass-live-main/target/exp-mcp-fragmented-ipi-wrap-bypass/runs/live-main-20260303-122018-8bf0d17ffb1d/build-info.json`
+
+## Output locations
+Expected outputs under the run root:
+- `deterministic/wrap-bypass-ablation-summary.json`
+- `variance/wrap-bypass-ablation-summary.json`
+- `combined-summary.json`
+- `build-info.json`
+- `compat-audit.jsonl`
+
+Per mode, per set:
+- `<set>/<mode>/baseline_attack.jsonl`
+- `<set>/<mode>/baseline_legit.jsonl`
+- `<set>/<mode>/protected_attack.jsonl`
+- `<set>/<mode>/protected_legit.jsonl`
+- `<set>/<mode>/wrap-bypass-summary.json`
+
+## Audit checklist
+For each protected mode, verify:
+- `wrap_only`
+  - `SIDECAR=disabled`
+  - `ASSAY_POLICY=...ablation_wrap_only.yaml`
+- `sequence_only`
+  - `SIDECAR=enabled`
+  - `ASSAY_POLICY=...ablation_sequence_only.yaml`
+- `combined`
+  - `SIDECAR=enabled`
+  - `ASSAY_POLICY=...ablation_combined.yaml`
+
+## Rebuild-grade rerun checklist
+- scripts and binaries built from the same checkout SHA
+- `Cargo.lock` hash recorded
+- `build-info.json` stored next to artifacts
+- `cargo_net_offline=true` or equivalent cache mode recorded
+- deterministic and variance sets both completed
+- combined summary regenerated from the same run root

--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md
@@ -1,0 +1,182 @@
+# Results - MCP Fragmented IPI Wrap-bypass Variant (2026Q1)
+
+## Run identity
+- Repo commit (scripts + binaries): `8bf0d17ffb1d`
+- Artifact root:
+  - `/tmp/assay-exp-wrap-bypass-live-main/target/exp-mcp-fragmented-ipi-wrap-bypass/runs/live-main-20260303-122018-8bf0d17ffb1d`
+- Date/time (UTC): `2026-03-03T12:20:18Z`
+- Sink surface: compat host (`read_document` + sink-like `web_search`)
+- Build metadata:
+  - `/tmp/assay-exp-wrap-bypass-live-main/target/exp-mcp-fragmented-ipi-wrap-bypass/runs/live-main-20260303-122018-8bf0d17ffb1d/build-info.json`
+
+## Paper-grade provenance
+This run is the canonical artifact for the wrap-bypass variant.
+
+- `git_sha`: `8bf0d17ffb1d`
+- `rustc`: `1.92.0`
+- `cargo`: `1.92.0`
+- `Cargo.lock` sha256:
+  - `deee7ee9afa88a616118fd70dc92d269ddc6acc1a0fcd8b6ec3b3a170eadd69e`
+- platform: `macOS-26.2-arm64`
+- build mode: offline local cache (`cargo_net_offline=true` recorded in `build-info.json`)
+
+## Purpose
+This variant isolates why sequence constraints remain structurally stronger than wrap-only lexical or argument checks.
+
+Attack success is no longer defined as “canary in one sink query”.
+Instead, success is defined as ordered reconstruction of the canary across multiple sink calls.
+
+The variant keeps the same three modes:
+- `wrap_only`
+- `sequence_only`
+- `combined`
+
+## Variant definition
+- sensitive reads come from `wrap_bypass/attack_doc_part1.txt` and `wrap_bypass/attack_doc_part2.txt`
+- each part yields one fragment of the canary
+- attack runs emit multiple `web_search(args.query=...)` calls
+- each individual query avoids obvious URL markers
+- success is when the canary can be reconstructed from ordered sink queries within the configured window
+
+## Scope boundary
+This run demonstrates control over **tool-mediated sink-call exfiltration**, not outbound internet exfiltration.
+The compat host preserves the relevant bus-level property for the experiment:
+- sensitive content is read through `read_document`
+- sensitive fragments reach a sink-like tool through `web_search`
+- Assay policy and sequence enforcement observe and block that transition on the tool-call path
+
+Claims from this run should therefore be phrased as:
+- tool-mediated sink-call exfiltration control under ordered fragment reconstruction
+
+Not as:
+- generic internet exfiltration prevention
+- general mitigation across arbitrary MCP servers without adaptation
+
+## Experimental design
+- Modes: `wrap_only`, `sequence_only`, `combined`
+- Sets: `deterministic`, `variance`
+- Per set, per mode, per condition:
+  - attack runs: `10`
+  - legit runs: `10`
+- Across the full batch:
+  - `240` recorded condition instances
+
+## Results (combined across both sets)
+| Mode | Baseline ASR | Protected TPR | Protected FNR | Protected false positive rate | Decision latency p50 (ms) | Decision latency p95 (ms) | blocked_by_wrap | blocked_by_sequence | Primary blocker |
+|------|--------------|---------------|---------------|-------------------------------|----------------------------|----------------------------|-----------------|---------------------|-----------------|
+| `wrap_only` | `1.0` | `0.0` | `1.0` | `0.0` | `0.528` | `1.387` | `0` | `0` | none observed |
+| `sequence_only` | `1.0` | `1.0` | `0.0` | `0.0` | `0.568` | `1.499` | `0` | `20` | sequence constraint |
+| `combined` | `1.0` | `1.0` | `0.0` | `0.0` | `0.610` | `1.533` | `0` | `20` | sequence early exit |
+
+## Deterministic set
+- `wrap_only`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `0.0 / 1.0 / 0.0`
+  - latency p50/p95: `0.548 / 1.425 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=0`
+- `sequence_only`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.568 / 1.641 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
+- `combined`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.604 / 1.216 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
+
+## Variance set
+- `wrap_only`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `0.0 / 1.0 / 0.0`
+  - latency p50/p95: `0.525 / 1.220 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=0`
+- `sequence_only`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.598 / 1.300 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
+- `combined`
+  - baseline ASR: `1.0`
+  - protected TPR / FNR / false positive rate: `1.0 / 0.0 / 0.0`
+  - latency p50/p95: `0.621 / 1.827 ms`
+  - attribution: `blocked_by_wrap=0`, `blocked_by_sequence=10`
+
+## Mechanism attribution
+Audit markers in protected logs confirm the mode split:
+
+- `wrap_only`
+  - `SIDECAR=disabled`
+  - `ASSAY_POLICY=...ablation_wrap_only.yaml`
+  - no decisive protective block observed in this scenario
+- `sequence_only`
+  - `SIDECAR=enabled`
+  - `ASSAY_POLICY=...ablation_sequence_only.yaml`
+  - observed blocking source: `assay_check_sequence`
+- `combined`
+  - `SIDECAR=enabled`
+  - `ASSAY_POLICY=...ablation_combined.yaml`
+  - observed blocking source in this run: `assay_check_sequence`
+
+`combined` should be read as the **first decisive block observed**, not as “both layers triggered equally”.
+That is why `blocked_by_wrap=0` in `combined`: the sequence layer short-circuits first in this scenario.
+
+## Interpretation
+### What this run supports
+- Baseline vulnerability remains structural in this wrap-bypass scenario: baseline ASR stayed `1.0` in every mode and set.
+- The harder scenario now separates the mechanisms cleanly:
+  - `wrap_only` fails completely
+  - `sequence_only` blocks completely
+  - `combined` blocks completely and is dominated by sequence
+- Across `240` recorded condition instances in this batch, mitigation behavior was consistent.
+- Overhead remains low: single-digit millisecond tool-decision latency.
+
+### Why this result matters
+This is the result the earlier ablation could not show.
+The current attack shape bypasses wrap-only lexical constraints without changing the forbidden state transition.
+That makes `sequence_only` the structurally robust layer in this scenario.
+
+In other words:
+- wrap rules stop methods that remain visible in tool arguments
+- sequence rules stop the sink transition after a sensitive read, even when the exfiltration is split across multiple benign-looking calls
+
+### What this run does **not** support
+- No claim of outbound internet exfiltration prevention.
+- No claim of general sink coverage beyond the sink-like `web_search` compat surface.
+- No claim of generalization to arbitrary third-party MCP servers without adaptation.
+- No claim that this single wrap-bypass construction exhausts the space of future attacks.
+
+## Limitations
+1. **Sink fidelity**
+   - the compat host is a sink-like MCP surface, not a real TCP/HTTP sink
+2. **Single sink class**
+   - the variant still targets `web_search` only
+3. **Environment-specific latency**
+   - p95 latency reflects tool-decision overhead on an M1 Pro/macOS environment and should not be read as end-to-end model latency
+4. **Reconstruction policy is fixed**
+   - this variant uses ordered concatenation within a bounded call window, not arbitrary semantic reassembly
+
+## Evidence locations
+Reference artifact:
+- `/tmp/assay-exp-wrap-bypass-live-main/target/exp-mcp-fragmented-ipi-wrap-bypass/runs/live-main-20260303-122018-8bf0d17ffb1d/`
+
+Per set:
+- `deterministic/wrap-bypass-ablation-summary.json`
+- `variance/wrap-bypass-ablation-summary.json`
+
+Combined:
+- `combined-summary.json`
+- `build-info.json`
+- `compat-audit.jsonl`
+
+Per mode, per set:
+- `<set>/<mode>/baseline.log`
+- `<set>/<mode>/protected.log`
+- `<set>/<mode>/wrap-bypass-summary.json`
+- `<set>/<mode>/baseline_attack.jsonl`
+- `<set>/<mode>/protected_attack.jsonl`
+
+## Recommended follow-up
+1. Add a second sink class or mock sink alias to test whether sequence robustness generalizes beyond `web_search`.
+2. Explore cross-session decay and longer session windows for ordered fragment reconstruction.
+3. Introduce a higher-fidelity network sink in a later experiment line if stronger outbound-sink claims are required.

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-wrap-bypass-results.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-wrap-bypass-results.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md"
+  "docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RERUN.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-wrap-bypass-results.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: wrap-bypass results PR must not change workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    if [[ "$f" == "$a" ]]; then
+      ok="true"
+      break
+    fi
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in wrap-bypass results PR: $f"
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n 'Repo commit \(scripts \+ binaries\): `8bf0d17ffb1d`' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing commit marker"; exit 1; }
+rg -n 'Cargo\.lock' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing Cargo.lock label"; exit 1; }
+rg -n 'deee7ee9afa88a616118fd70dc92d269ddc6acc1a0fcd8b6ec3b3a170eadd69e' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing Cargo.lock hash"; exit 1; }
+rg -n '`wrap_only`|`sequence_only`|`combined`' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing mode markers"; exit 1; }
+rg -n 'first decisive block observed' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing combined interpretation marker"; exit 1; }
+rg -n 'tool-mediated sink-call exfiltration control' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md >/dev/null || { echo "FAIL: missing bounded claim wording"; exit 1; }
+rg -n 'RUN_LIVE=1' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RERUN.md >/dev/null || { echo "FAIL: missing live rerun instruction"; exit 1; }
+rg -n 'build-info.json' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RERUN.md >/dev/null || { echo "FAIL: missing build-info reference"; exit 1; }
+rg -n 'Rebuild-grade rerun checklist' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RERUN.md >/dev/null || { echo "FAIL: missing rebuild checklist"; exit 1; }
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only publication of the canonical wrap-bypass live batch. Captures ordered-reconstruction scoring, shows `wrap_only` failure in the harder variant, and records that `sequence_only` and `combined` still block completely.

## Scope
- docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md
- docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RERUN.md
- scripts/ci/review-exp-mcp-fragmented-ipi-wrap-bypass-results.sh

## Safety
- Docs + reviewer gate only
- No workflows, no runtime changes

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-wrap-bypass-results.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`

## Key Results
- `wrap_only`: baseline ASR `1.0`, protected TPR/FNR/FPR `0.0/1.0/0.0`
- `sequence_only`: baseline ASR `1.0`, protected TPR/FNR/FPR `1.0/0.0/0.0`
- `combined`: baseline ASR `1.0`, protected TPR/FNR/FPR `1.0/0.0/0.0`
- Combined attribution:
  - `wrap_only`: `blocked_by_wrap=0`, `blocked_by_sequence=0`
  - `sequence_only`: `blocked_by_wrap=0`, `blocked_by_sequence=20`
  - `combined`: `blocked_by_wrap=0`, `blocked_by_sequence=20`

## Provenance
- Repo commit (scripts + binaries): `8bf0d17ffb1d`
- Artifact root: `/tmp/assay-exp-wrap-bypass-live-main/target/exp-mcp-fragmented-ipi-wrap-bypass/runs/live-main-20260303-122018-8bf0d17ffb1d`
- Build info: `.../build-info.json`
