### PR TITLE
docs: add bounded agent security positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Runs offline. No telemetry. No vendor lock-in.
 
 Assay validates AI agent behavior against policies. Record traces, generate policies, run deterministic CI gates, produce evidence bundles for audit. Works with any MCP-compatible agent.
 
+**Why Assay wins in 2026 agent security:** Assay's strongest wedge is deterministic governance on the tool-call path. The MCP fragmented-IPI experiment line shows that stateful sequence policies remain effective across payload fragmentation and tool-hopping, where wrap-only lexical checks fail. Assay does not claim to solve semantic hijacking in general or to block raw outbound network bytes by itself; it governs sink-call routes with auditable policy decisions and single-digit millisecond overhead. See `/Users/roelschuurkes/assay/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md`, `/Users/roelschuurkes/assay/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-WRAP-BYPASS-2026Q1-RESULTS.md`, and `/Users/roelschuurkes/assay/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SECOND-SINK-2026Q1-RESULTS.md`.
+
 > **Open Core:** Engine + baseline packs are MIT/Apache-2.0.
 > Compliance packs (EU AI Act, SOC2) are commercial.
 > See [ADR-016](docs/architecture/ADR-016-Pack-Taxonomy.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,6 +47,8 @@ The agentic commerce/interop space is fragmenting (Jan 2026):
 
 All these protocols converge on "tool calls + state transitions" — exactly what Assay captures as trace-linked evidence.
 
+**2026 runtime-governance positioning:** Recent fragmented-IPI experiments on `main` sharpen this moat. Assay's value is not "better regex"; it is deterministic governance on the tool bus. Wrap-only lexical enforcement is useful but brittle against multi-step leakage and tool-hopping. Sequence/state policies stay robust because they govern behavioral routes across sink labels and payload variants. The bounded claim remains important: these experiments demonstrate sink-call exfiltration control with audit-grade evidence and low decision overhead, not a universal solution to semantic hijacking or raw network egress.
+
 ### Why This Matters
 
 1. **Tool Signing** becomes critical: "tool substitution" and "merchant tool spoofing" are real commerce risks

--- a/scripts/ci/review-docs-positioning-agent-security.sh
+++ b/scripts/ci/review-docs-positioning-agent-security.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "README.md"
+  "docs/ROADMAP.md"
+  "scripts/ci/review-docs-positioning-agent-security.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+git diff --name-only "$BASE_REF"...HEAD | while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  [[ "$f" == .github/workflows/* ]] && { echo "FAIL: no workflows"; exit 1; }
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  [[ "$ok" != "true" ]] && { echo "FAIL: file not allowed: $f"; exit 1; }
+done
+
+rg -n "deterministic governance on the tool-call path|stateful sequence policies|tool-hopping" README.md >/dev/null || {
+  echo "FAIL: README missing positioning markers"
+  exit 1
+}
+rg -n "deterministic governance on the tool bus|multi-step leakage|tool-hopping|bounded claim" docs/ROADMAP.md >/dev/null || {
+  echo "FAIL: ROADMAP missing positioning markers"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Adds a bounded positioning paragraph for Assay's 2026 agent-security story.

This captures the current experimental evidence without overclaiming:
- deterministic governance on the tool-call path
- sequence/state policies as the real generalization wedge
- explicit bounds against claiming universal semantic-hijacking or raw network-egress control

## Scope
- `README.md`
- `docs/ROADMAP.md`
- `scripts/ci/review-docs-positioning-agent-security.sh`

## Safety
- docs + reviewer gate only
- no workflows
- no runtime changes

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-docs-positioning-agent-security.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
