### PR TITLE
feat(policy): enforce MCP rules by tool classes (B1)

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -76,6 +76,18 @@ pub struct DecisionEvent {
 pub struct DecisionData {
     /// Tool name
     pub tool: String,
+    /// Tool classes observed at decision time (sorted)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_classes: Vec<String>,
+    /// Tool classes that matched the policy decision (sorted)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub matched_tool_classes: Vec<String>,
+    /// Match basis for policy evaluation: name, class, or name+class
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_basis: Option<String>,
+    /// Rule or policy field that matched
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_rule: Option<String>,
     /// Decision outcome
     pub decision: Decision,
     /// Machine-parseable reason code (MUST)
@@ -125,6 +137,10 @@ impl DecisionEvent {
             time: chrono::Utc::now().to_rfc3339(),
             data: DecisionData {
                 tool,
+                tool_classes: Vec::new(),
+                matched_tool_classes: Vec::new(),
+                match_basis: None,
+                matched_rule: None,
                 decision: Decision::Error, // Default to error, will be set
                 reason_code: reason_codes::S_INTERNAL_ERROR.to_string(),
                 reason: Some("Decision not finalized (guard dropped without emit)".to_string()),
@@ -202,6 +218,21 @@ impl DecisionEvent {
     pub fn with_latencies(mut self, authz_ms: Option<u64>, store_ms: Option<u64>) -> Self {
         self.data.authz_latency_ms = authz_ms;
         self.data.store_latency_ms = store_ms;
+        self
+    }
+
+    /// Set tool match metadata.
+    pub fn with_tool_match(
+        mut self,
+        tool_classes: Vec<String>,
+        matched_tool_classes: Vec<String>,
+        match_basis: Option<String>,
+        matched_rule: Option<String>,
+    ) -> Self {
+        self.data.tool_classes = tool_classes;
+        self.data.matched_tool_classes = matched_tool_classes;
+        self.data.match_basis = match_basis;
+        self.data.matched_rule = matched_rule;
         self
     }
 }
@@ -320,6 +351,22 @@ impl DecisionEmitterGuard {
         if let Some(ref mut event) = self.event {
             event.data.authz_latency_ms = authz_ms;
             event.data.store_latency_ms = store_ms;
+        }
+    }
+
+    /// Set tool match metadata for the event.
+    pub fn set_tool_match(
+        &mut self,
+        tool_classes: Vec<String>,
+        matched_tool_classes: Vec<String>,
+        match_basis: Option<String>,
+        matched_rule: Option<String>,
+    ) {
+        if let Some(ref mut event) = self.event {
+            event.data.tool_classes = tool_classes;
+            event.data.matched_tool_classes = matched_tool_classes;
+            event.data.match_basis = match_basis;
+            event.data.matched_rule = matched_rule;
         }
     }
 

--- a/crates/assay-core/src/mcp/mod.rs
+++ b/crates/assay-core/src/mcp/mod.rs
@@ -11,12 +11,16 @@ pub mod proxy;
 pub mod runtime_features;
 pub mod signing;
 pub mod tool_call_handler;
+pub mod tool_match;
+pub mod tool_taxonomy;
 pub mod trust_policy;
 pub mod types;
 
 pub use mapper_v2::*;
 pub use parser::*;
 pub use signing::{sign_tool, verify_tool, ToolSignature, VerifyError, VerifyResult};
+pub use tool_match::{MatchBasis, MatchResult, ToolContext, ToolRuleSelector};
+pub use tool_taxonomy::ToolTaxonomy;
 pub use trust_policy::TrustPolicy;
 pub use types::*;
 

--- a/crates/assay-core/src/mcp/policy.rs
+++ b/crates/assay-core/src/mcp/policy.rs
@@ -2,9 +2,11 @@ use super::identity::ToolIdentity;
 use super::jsonrpc::{
     ContentItem, JsonRpcRequest, JsonRpcResponse, ToolCallResult, ToolResultBody,
 };
+use super::tool_match::MatchBasis;
+use super::tool_taxonomy::ToolTaxonomy;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, OnceLock};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -44,6 +46,9 @@ pub struct McpPolicy {
     /// Cryptographic pins for tool integrity (Phase 9)
     #[serde(default)]
     pub tool_pins: HashMap<String, ToolIdentity>,
+
+    #[serde(default, flatten)]
+    pub tool_taxonomy: ToolTaxonomy,
 
     // Phase 4: Runtime Features
     #[serde(default)]
@@ -102,6 +107,24 @@ pub struct GlobalLimits {
 pub struct ToolPolicy {
     pub allow: Option<Vec<String>>,
     pub deny: Option<Vec<String>>,
+    #[serde(default)]
+    pub allow_classes: Option<Vec<String>>,
+    #[serde(default)]
+    pub deny_classes: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PolicyMatchMetadata {
+    pub tool_classes: Vec<String>,
+    pub matched_tool_classes: Vec<String>,
+    pub match_basis: MatchBasis,
+    pub matched_rule: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PolicyEvaluation {
+    pub decision: PolicyDecision,
+    pub metadata: PolicyMatchMetadata,
 }
 
 // Canonical Rule Shape (Legacy V1)
@@ -360,23 +383,44 @@ impl McpPolicy {
         state: &mut PolicyState,
         runtime_identity: Option<&ToolIdentity>,
     ) -> PolicyDecision {
+        self.evaluate_with_metadata(tool_name, args, state, runtime_identity)
+            .decision
+    }
+
+    pub fn evaluate_with_metadata(
+        &self,
+        tool_name: &str,
+        args: &Value,
+        state: &mut PolicyState,
+        runtime_identity: Option<&ToolIdentity>,
+    ) -> PolicyEvaluation {
+        let tool_classes = self.tool_taxonomy.classes_for(tool_name);
+        let tool_classes_vec: Vec<String> = tool_classes.iter().cloned().collect();
+        let mut metadata = PolicyMatchMetadata {
+            tool_classes: tool_classes_vec,
+            ..PolicyMatchMetadata::default()
+        };
+
         // 0. Tool Integrity Check (Phase 9)
         if let Some(pinned) = self.tool_pins.get(tool_name) {
             if let Some(runtime) = runtime_identity {
                 if pinned != runtime {
-                    return PolicyDecision::Deny {
-                        tool: tool_name.to_string(),
-                        code: "E_TOOL_DRIFT".to_string(),
-                        reason: format!(
-                            "Tool integrity failure: identity drifted from pinned version. (Runtime: {}, Pinned: {})",
-                            runtime.fingerprint(),
-                            pinned.fingerprint()
-                        ),
-                        contract: self.format_deny_contract(
-                            tool_name,
-                            "E_TOOL_DRIFT",
-                            "Tool metadata or schema has changed without policy update (SOTA Moat)",
-                        ),
+                    return PolicyEvaluation {
+                        decision: PolicyDecision::Deny {
+                            tool: tool_name.to_string(),
+                            code: "E_TOOL_DRIFT".to_string(),
+                            reason: format!(
+                                "Tool integrity failure: identity drifted from pinned version. (Runtime: {}, Pinned: {})",
+                                runtime.fingerprint(),
+                                pinned.fingerprint()
+                            ),
+                            contract: self.format_deny_contract(
+                                tool_name,
+                                "E_TOOL_DRIFT",
+                                "Tool metadata or schema has changed without policy update (SOTA Moat)",
+                            ),
+                        },
+                        metadata,
                     };
                 }
             }
@@ -384,35 +428,69 @@ impl McpPolicy {
 
         // 1. Rate limits
         if let Some(decision) = self.check_rate_limits(state) {
-            return decision;
+            return PolicyEvaluation { decision, metadata };
         }
 
-        // 2. Deny list
-        if self.is_denied(tool_name) {
-            return PolicyDecision::Deny {
-                tool: tool_name.to_string(),
-                code: "E_TOOL_DENIED".to_string(),
-                reason: "Tool is explicitly denylisted".to_string(),
-                contract: self.format_deny_contract(
-                    tool_name,
-                    "E_TOOL_DENIED",
-                    "Tool is denylisted",
-                ),
+        let deny_name_match = self.is_denied(tool_name);
+        let deny_class_matches = self.matched_deny_classes(&tool_classes);
+        if deny_name_match || !deny_class_matches.is_empty() {
+            metadata.matched_tool_classes = deny_class_matches.clone();
+            metadata.match_basis =
+                Self::classify_match_basis(deny_name_match, !deny_class_matches.is_empty());
+            metadata.matched_rule = Some(Self::matched_rule_name(
+                "tools.deny",
+                "tools.deny_classes",
+                &metadata,
+            ));
+
+            let deny_reason = if deny_name_match && !deny_class_matches.is_empty() {
+                "Tool is explicitly denylisted by name and class"
+            } else if deny_name_match {
+                "Tool is explicitly denylisted by name"
+            } else {
+                "Tool is explicitly denylisted by class"
+            };
+
+            return PolicyEvaluation {
+                decision: PolicyDecision::Deny {
+                    tool: tool_name.to_string(),
+                    code: "E_TOOL_DENIED".to_string(),
+                    reason: deny_reason.to_string(),
+                    contract: self.format_deny_contract(tool_name, "E_TOOL_DENIED", deny_reason),
+                },
+                metadata,
             };
         }
 
-        // 3. Allow list
-        if self.has_allowlist() && !self.is_allowed(tool_name) {
-            return PolicyDecision::Deny {
-                tool: tool_name.to_string(),
-                code: "E_TOOL_NOT_ALLOWED".to_string(),
-                reason: "Tool is not in the allowlist".to_string(),
-                contract: self.format_deny_contract(
-                    tool_name,
-                    "E_TOOL_NOT_ALLOWED",
-                    "Tool is not in allowlist",
-                ),
+        let allow_name_match = self.is_allowed(tool_name);
+        let allow_class_matches = self.matched_allow_classes(&tool_classes);
+        if self.has_allowlist() && !allow_name_match && allow_class_matches.is_empty() {
+            return PolicyEvaluation {
+                decision: PolicyDecision::Deny {
+                    tool: tool_name.to_string(),
+                    code: "E_TOOL_NOT_ALLOWED".to_string(),
+                    reason: "Tool is not in the allowlist".to_string(),
+                    contract: self.format_deny_contract(
+                        tool_name,
+                        "E_TOOL_NOT_ALLOWED",
+                        "Tool is not in allowlist",
+                    ),
+                },
+                metadata,
             };
+        }
+
+        if allow_name_match || !allow_class_matches.is_empty() {
+            metadata.matched_tool_classes = allow_class_matches;
+            metadata.match_basis = Self::classify_match_basis(
+                allow_name_match,
+                !metadata.matched_tool_classes.is_empty(),
+            );
+            metadata.matched_rule = Some(Self::matched_rule_name(
+                "tools.allow",
+                "tools.allow_classes",
+                &metadata,
+            ));
         }
 
         // 4. Schema Validation
@@ -428,23 +506,29 @@ impl McpPolicy {
                         })
                     })
                     .collect();
-                return PolicyDecision::Deny {
-                    tool: tool_name.to_string(),
-                    code: "E_ARG_SCHEMA".to_string(),
-                    reason: "JSON Schema validation failed".to_string(),
-                    contract: json!({
-                        "status": "deny",
-                        "error_code": "E_ARG_SCHEMA",
-                        "tool": tool_name,
-                        "violations": violations,
-                    }),
+                return PolicyEvaluation {
+                    decision: PolicyDecision::Deny {
+                        tool: tool_name.to_string(),
+                        code: "E_ARG_SCHEMA".to_string(),
+                        reason: "JSON Schema validation failed".to_string(),
+                        contract: json!({
+                            "status": "deny",
+                            "error_code": "E_ARG_SCHEMA",
+                            "tool": tool_name,
+                            "violations": violations,
+                        }),
+                    },
+                    metadata,
                 };
             }
-            return PolicyDecision::Allow;
+            return PolicyEvaluation {
+                decision: PolicyDecision::Allow,
+                metadata,
+            };
         }
 
         // 5. Unconstrained Mode
-        match self.enforcement.unconstrained_tools {
+        let decision = match self.enforcement.unconstrained_tools {
             UnconstrainedMode::Deny => PolicyDecision::Deny {
                 tool: tool_name.to_string(),
                 code: "E_TOOL_UNCONSTRAINED".to_string(),
@@ -461,7 +545,9 @@ impl McpPolicy {
                 reason: "Tool allowed but has no schema".to_string(),
             },
             UnconstrainedMode::Allow => PolicyDecision::Allow,
-        }
+        };
+
+        PolicyEvaluation { decision, metadata }
     }
 
     // Helper methods (extracted from original code or refactored)
@@ -509,7 +595,7 @@ impl McpPolicy {
     }
 
     fn has_allowlist(&self) -> bool {
-        self.allow.is_some() || self.tools.allow.is_some()
+        self.allow.is_some() || self.tools.allow.is_some() || self.tools.allow_classes.is_some()
     }
 
     fn is_allowed(&self, tool_name: &str) -> bool {
@@ -529,6 +615,52 @@ impl McpPolicy {
             "tool": tool,
             "reason": reason
         })
+    }
+
+    fn matched_deny_classes(&self, tool_classes: &BTreeSet<String>) -> Vec<String> {
+        self.match_classes(tool_classes, self.tools.deny_classes.as_ref())
+    }
+
+    fn matched_allow_classes(&self, tool_classes: &BTreeSet<String>) -> Vec<String> {
+        self.match_classes(tool_classes, self.tools.allow_classes.as_ref())
+    }
+
+    fn match_classes(
+        &self,
+        tool_classes: &BTreeSet<String>,
+        configured: Option<&Vec<String>>,
+    ) -> Vec<String> {
+        let mut matched = BTreeSet::new();
+        if let Some(configured_classes) = configured {
+            for class_name in configured_classes {
+                if tool_classes.contains(class_name) {
+                    matched.insert(class_name.clone());
+                }
+            }
+        }
+        matched.into_iter().collect()
+    }
+
+    fn classify_match_basis(name_match: bool, class_match: bool) -> MatchBasis {
+        match (name_match, class_match) {
+            (true, true) => MatchBasis::NameAndClass,
+            (true, false) => MatchBasis::Name,
+            (false, true) => MatchBasis::Class,
+            (false, false) => MatchBasis::None,
+        }
+    }
+
+    fn matched_rule_name(
+        name_field: &str,
+        class_field: &str,
+        metadata: &PolicyMatchMetadata,
+    ) -> String {
+        match metadata.match_basis {
+            MatchBasis::NameAndClass => format!("{name_field}+{class_field}"),
+            MatchBasis::Name => name_field.to_string(),
+            MatchBasis::Class => class_field.to_string(),
+            MatchBasis::None => name_field.to_string(),
+        }
     }
 
     // Proxy-specific check method (Legacy compatibility wrapper)

--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -4,7 +4,9 @@ use super::decision::{
     NullDecisionEmitter,
 };
 use super::jsonrpc::JsonRpcRequest;
-use super::policy::{make_deny_response, McpPolicy, PolicyDecision, PolicyState};
+use super::policy::{
+    make_deny_response, McpPolicy, PolicyDecision, PolicyMatchMetadata, PolicyState,
+};
 use std::{
     collections::HashMap,
     io::{self, BufRead, BufReader, Write},
@@ -257,14 +259,16 @@ impl McpProxy {
                         let tool_name = req.tool_params().map(|p| p.name).unwrap_or_default();
                         let tool_call_id = Self::extract_tool_call_id(&req);
 
-                        match policy.evaluate(
+                        let policy_eval = policy.evaluate_with_metadata(
                             &tool_name,
                             &req.tool_params()
                                 .map(|p| p.arguments)
                                 .unwrap_or(serde_json::Value::Null),
                             &mut state,
                             runtime_id.as_ref(),
-                        ) {
+                        );
+
+                        match policy_eval.decision {
                             PolicyDecision::Allow => {
                                 Self::handle_allow(&req, &mut audit_log, config.verbose);
                                 // Emit decision event (I1: always emit)
@@ -278,6 +282,7 @@ impl McpProxy {
                                         reason_codes::P_POLICY_ALLOW,
                                         None,
                                         req.id.clone(),
+                                        &policy_eval.metadata,
                                     );
                                 }
                             }
@@ -309,6 +314,7 @@ impl McpProxy {
                                     &code,
                                     Some(reason),
                                     req.id.clone(),
+                                    &policy_eval.metadata,
                                 );
                                 // Then proceed as a normal allow
                                 Self::handle_allow(&req, &mut audit_log, false);
@@ -357,6 +363,7 @@ impl McpProxy {
                                     &reason_code,
                                     Some(reason),
                                     req.id.clone(),
+                                    &policy_eval.metadata,
                                 );
 
                                 if config.dry_run {
@@ -487,6 +494,7 @@ impl McpProxy {
         reason_code: &str,
         reason: Option<String>,
         request_id: Option<serde_json::Value>,
+        metadata: &PolicyMatchMetadata,
     ) {
         let mut event = DecisionEvent::new(
             source.to_string(),
@@ -497,6 +505,10 @@ impl McpProxy {
         event.data.reason_code = reason_code.to_string();
         event.data.reason = reason;
         event.data.request_id = request_id;
+        event.data.tool_classes = metadata.tool_classes.clone();
+        event.data.matched_tool_classes = metadata.matched_tool_classes.clone();
+        event.data.match_basis = metadata.match_basis.as_str().map(ToString::to_string);
+        event.data.matched_rule = metadata.matched_rule.clone();
         emitter.emit(&event);
     }
 }

--- a/crates/assay-core/src/mcp/tool_call_handler.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler.rs
@@ -152,11 +152,28 @@ impl ToolCallHandler {
         let start = Instant::now();
 
         // Step 1: Policy evaluation
-        let policy_decision =
-            self.policy
-                .evaluate(&tool_name, &params.arguments, state, runtime_identity);
+        let policy_eval = self.policy.evaluate_with_metadata(
+            &tool_name,
+            &params.arguments,
+            state,
+            runtime_identity,
+        );
+        let tool_classes = policy_eval.metadata.tool_classes.clone();
+        let matched_tool_classes = policy_eval.metadata.matched_tool_classes.clone();
+        let match_basis = policy_eval
+            .metadata
+            .match_basis
+            .as_str()
+            .map(ToString::to_string);
+        let matched_rule = policy_eval.metadata.matched_rule.clone();
+        guard.set_tool_match(
+            policy_eval.metadata.tool_classes.clone(),
+            policy_eval.metadata.matched_tool_classes.clone(),
+            match_basis.clone(),
+            matched_rule.clone(),
+        );
 
-        match policy_decision {
+        match policy_eval.decision {
             PolicyDecision::Deny {
                 tool: _,
                 code,
@@ -174,7 +191,13 @@ impl ToolCallHandler {
                         tool_call_id,
                         tool_name,
                     )
-                    .deny(&reason_code, Some(reason)),
+                    .deny(&reason_code, Some(reason))
+                    .with_tool_match(
+                        tool_classes.clone(),
+                        matched_tool_classes.clone(),
+                        match_basis.clone(),
+                        matched_rule.clone(),
+                    ),
                 };
             }
             PolicyDecision::AllowWithWarning { .. } | PolicyDecision::Allow => {
@@ -201,6 +224,12 @@ impl ToolCallHandler {
                 .deny(
                     reason_codes::P_MANDATE_REQUIRED,
                     Some("Commit tool requires mandate authorization".to_string()),
+                )
+                .with_tool_match(
+                    tool_classes.clone(),
+                    matched_tool_classes.clone(),
+                    match_basis.clone(),
+                    matched_rule.clone(),
                 ),
             };
         }
@@ -250,7 +279,13 @@ impl ToolCallHandler {
                             tool_call_id,
                             tool_name,
                         )
-                        .allow(reason_codes::P_MANDATE_VALID),
+                        .allow(reason_codes::P_MANDATE_VALID)
+                        .with_tool_match(
+                            tool_classes.clone(),
+                            matched_tool_classes.clone(),
+                            match_basis.clone(),
+                            matched_rule.clone(),
+                        ),
                     };
                 }
                 Err(e) => {
@@ -259,12 +294,19 @@ impl ToolCallHandler {
                     guard.emit_deny(&reason_code, Some(reason.clone()));
 
                     return HandleResult::Deny {
-                        reason_code,
-                        reason,
+                        reason_code: reason_code.clone(),
+                        reason: reason.clone(),
                         decision_event: DecisionEvent::new(
                             self.config.event_source.clone(),
                             tool_call_id,
                             tool_name,
+                        )
+                        .deny(&reason_code, Some(reason))
+                        .with_tool_match(
+                            tool_classes.clone(),
+                            matched_tool_classes.clone(),
+                            match_basis.clone(),
+                            matched_rule.clone(),
                         ),
                     };
                 }
@@ -283,7 +325,13 @@ impl ToolCallHandler {
                 tool_call_id,
                 tool_name,
             )
-            .allow(reason_codes::P_POLICY_ALLOW),
+            .allow(reason_codes::P_POLICY_ALLOW)
+            .with_tool_match(
+                tool_classes,
+                matched_tool_classes,
+                match_basis,
+                matched_rule,
+            ),
         }
     }
 
@@ -489,6 +537,7 @@ mod tests {
             tools: super::super::policy::ToolPolicy {
                 allow: None,
                 deny: Some(vec!["dangerous_*".to_string()]),
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/crates/assay-core/src/mcp/tool_match.rs
+++ b/crates/assay-core/src/mcp/tool_match.rs
@@ -1,0 +1,159 @@
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone)]
+pub enum ToolContext<'a> {
+    Borrowed {
+        tool_name: &'a str,
+        tool_classes: &'a BTreeSet<String>,
+    },
+    Owned {
+        tool_name: &'a str,
+        tool_classes: BTreeSet<String>,
+    },
+}
+
+impl<'a> ToolContext<'a> {
+    pub fn tool_name(&self) -> &str {
+        match self {
+            Self::Borrowed { tool_name, .. } | Self::Owned { tool_name, .. } => tool_name,
+        }
+    }
+
+    pub fn tool_classes(&self) -> &BTreeSet<String> {
+        match self {
+            Self::Borrowed { tool_classes, .. } => tool_classes,
+            Self::Owned { tool_classes, .. } => tool_classes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum MatchBasis {
+    #[default]
+    None,
+    Name,
+    Class,
+    NameAndClass,
+}
+
+impl MatchBasis {
+    pub fn as_str(&self) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            Self::Name => Some("name"),
+            Self::Class => Some("class"),
+            Self::NameAndClass => Some("name+class"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchResult {
+    pub matched: bool,
+    pub matched_classes: Vec<String>,
+    pub basis: MatchBasis,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolRuleSelector {
+    pub name: Option<String>,
+    pub class: Option<String>,
+}
+
+impl ToolRuleSelector {
+    pub fn new(name: Option<String>, class: Option<String>) -> Self {
+        Self { name, class }
+    }
+
+    pub fn matches(&self, ctx: &ToolContext<'_>) -> MatchResult {
+        let name_ok = match &self.name {
+            Some(name) => ctx.tool_name() == name,
+            None => true,
+        };
+
+        let mut matched_classes = Vec::new();
+        let class_ok = match &self.class {
+            Some(class_name) => {
+                let ok = ctx.tool_classes().contains(class_name);
+                if ok {
+                    matched_classes.push(class_name.clone());
+                }
+                ok
+            }
+            None => true,
+        };
+
+        let basis = match (&self.name, &self.class) {
+            (Some(_), Some(_)) => MatchBasis::NameAndClass,
+            (Some(_), None) => MatchBasis::Name,
+            (None, Some(_)) => MatchBasis::Class,
+            (None, None) => MatchBasis::None,
+        };
+
+        MatchResult {
+            matched: name_ok && class_ok,
+            matched_classes,
+            basis,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn match_by_name_only() {
+        let ctx = ToolContext::Owned {
+            tool_name: "web_search",
+            tool_classes: BTreeSet::new(),
+        };
+        let selector = ToolRuleSelector::new(Some("web_search".to_string()), None);
+        let result = selector.matches(&ctx);
+        assert!(result.matched);
+        assert_eq!(result.basis, MatchBasis::Name);
+        assert!(result.matched_classes.is_empty());
+    }
+
+    #[test]
+    fn match_by_class_only() {
+        let ctx = ToolContext::Owned {
+            tool_name: "web_search_alt",
+            tool_classes: BTreeSet::from(["sink:network".to_string()]),
+        };
+        let selector = ToolRuleSelector::new(None, Some("sink:network".to_string()));
+        let result = selector.matches(&ctx);
+        assert!(result.matched);
+        assert_eq!(result.basis, MatchBasis::Class);
+        assert_eq!(result.matched_classes, vec!["sink:network".to_string()]);
+    }
+
+    #[test]
+    fn name_and_class_requires_both() {
+        let ctx = ToolContext::Owned {
+            tool_name: "web_search",
+            tool_classes: BTreeSet::from(["sink:network".to_string()]),
+        };
+        let selector = ToolRuleSelector::new(
+            Some("web_search".to_string()),
+            Some("sink:network".to_string()),
+        );
+        let result = selector.matches(&ctx);
+        assert!(result.matched);
+        assert_eq!(result.basis, MatchBasis::NameAndClass);
+    }
+
+    #[test]
+    fn missing_class_fails_and_selector() {
+        let ctx = ToolContext::Owned {
+            tool_name: "web_search",
+            tool_classes: BTreeSet::new(),
+        };
+        let selector = ToolRuleSelector::new(
+            Some("web_search".to_string()),
+            Some("sink:network".to_string()),
+        );
+        let result = selector.matches(&ctx);
+        assert!(!result.matched);
+    }
+}

--- a/crates/assay-core/src/mcp/tool_taxonomy.rs
+++ b/crates/assay-core/src/mcp/tool_taxonomy.rs
@@ -1,0 +1,25 @@
+use super::tool_match::ToolContext;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolTaxonomy {
+    #[serde(default)]
+    pub tool_classes: HashMap<String, BTreeSet<String>>,
+}
+
+impl ToolTaxonomy {
+    pub fn classes_for(&self, tool_name: &str) -> BTreeSet<String> {
+        self.tool_classes
+            .get(tool_name)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn context<'a>(&'a self, tool_name: &'a str) -> ToolContext<'a> {
+        ToolContext::Owned {
+            tool_name,
+            tool_classes: self.classes_for(tool_name),
+        }
+    }
+}

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -89,6 +89,7 @@ fn test_policy_deny_emits_once() {
     policy.tools = ToolPolicy {
         allow: None,
         deny: Some(vec!["blocked_*".to_string()]),
+        ..Default::default()
     };
     let handler = ToolCallHandler::new(
         policy,

--- a/crates/assay-core/tests/tool_taxonomy_policy_match.rs
+++ b/crates/assay-core/tests/tool_taxonomy_policy_match.rs
@@ -1,0 +1,127 @@
+use assay_core::mcp::decision::{Decision, NullDecisionEmitter};
+use assay_core::mcp::jsonrpc::JsonRpcRequest;
+use assay_core::mcp::policy::{McpPolicy, PolicyDecision, PolicyState};
+use assay_core::mcp::tool_call_handler::{HandleResult, ToolCallHandler, ToolCallHandlerConfig};
+use assay_core::mcp::{ToolRuleSelector, ToolTaxonomy};
+use serde_json::json;
+use std::collections::{BTreeSet, HashMap};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn taxonomy_fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/ci/fixtures/tool_taxonomy/policy_tool_class_block_network.yaml")
+}
+
+fn tool_call_request(tool: &str) -> JsonRpcRequest {
+    JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        method: "tools/call".to_string(),
+        params: json!({
+            "name": tool,
+            "arguments": {}
+        }),
+        id: Some(json!(1)),
+    }
+}
+
+#[test]
+fn tool_taxonomy_policy_match_alt_sink_matches_shared_class() {
+    let mut tool_classes: HashMap<String, BTreeSet<String>> = HashMap::new();
+    tool_classes.insert(
+        "web_search".to_string(),
+        BTreeSet::from(["sink:network".to_string()]),
+    );
+    tool_classes.insert(
+        "web_search_alt".to_string(),
+        BTreeSet::from(["sink:network".to_string()]),
+    );
+
+    let taxonomy = ToolTaxonomy { tool_classes };
+    let selector = ToolRuleSelector::new(None, Some("sink:network".to_string()));
+
+    let alt_ctx = taxonomy.context("web_search_alt");
+    let alt_match = selector.matches(&alt_ctx);
+    assert!(alt_match.matched);
+    assert_eq!(alt_match.matched_classes, vec!["sink:network".to_string()]);
+
+    let primary_ctx = taxonomy.context("web_search");
+    assert!(selector.matches(&primary_ctx).matched);
+}
+
+#[test]
+fn tool_taxonomy_policy_match_class_is_exact_string() {
+    let taxonomy = ToolTaxonomy::default();
+    let selector = ToolRuleSelector::new(None, Some("sink:network".to_string()));
+    let ctx = taxonomy.context("web_search_alt");
+    assert!(!selector.matches(&ctx).matched);
+}
+
+#[test]
+fn tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class() {
+    let policy = McpPolicy::from_file(&taxonomy_fixture_path()).expect("fixture policy");
+    let mut state = PolicyState::default();
+
+    let evaluation = policy.evaluate_with_metadata("web_search_alt", &json!({}), &mut state, None);
+
+    match evaluation.decision {
+        PolicyDecision::Deny { code, .. } => assert_eq!(code, "E_TOOL_DENIED"),
+        other => panic!("expected class-based deny, got {:?}", other),
+    }
+
+    assert_eq!(
+        evaluation.metadata.tool_classes,
+        vec!["sink:network".to_string()]
+    );
+    assert_eq!(
+        evaluation.metadata.matched_tool_classes,
+        vec!["sink:network".to_string()]
+    );
+    assert_eq!(evaluation.metadata.match_basis.as_str(), Some("class"));
+    assert_eq!(
+        evaluation.metadata.matched_rule.as_deref(),
+        Some("tools.deny_classes")
+    );
+}
+
+#[test]
+fn tool_taxonomy_policy_match_handler_decision_event_records_classes() {
+    let policy = McpPolicy::from_file(&taxonomy_fixture_path()).expect("fixture policy");
+    let handler = ToolCallHandler::new(
+        policy,
+        None,
+        Arc::new(NullDecisionEmitter),
+        ToolCallHandlerConfig {
+            event_source: "assay://tool-taxonomy-b1".to_string(),
+            ..ToolCallHandlerConfig::default()
+        },
+    );
+
+    let result = handler.handle_tool_call(
+        &tool_call_request("web_search_alt"),
+        &mut PolicyState::default(),
+        None,
+        None,
+        None,
+    );
+
+    match result {
+        HandleResult::Deny { decision_event, .. } => {
+            assert_eq!(decision_event.data.decision, Decision::Deny);
+            assert_eq!(
+                decision_event.data.tool_classes,
+                vec!["sink:network".to_string()]
+            );
+            assert_eq!(
+                decision_event.data.matched_tool_classes,
+                vec!["sink:network".to_string()]
+            );
+            assert_eq!(decision_event.data.match_basis.as_deref(), Some("class"));
+            assert_eq!(
+                decision_event.data.matched_rule.as_deref(),
+                Some("tools.deny_classes")
+            );
+        }
+        other => panic!("expected deny result, got {:?}", other),
+    }
+}

--- a/scripts/ci/fixtures/tool_taxonomy/policy_tool_class_block_network.yaml
+++ b/scripts/ci/fixtures/tool_taxonomy/policy_tool_class_block_network.yaml
@@ -1,0 +1,18 @@
+version: "2.0"
+name: "tool-taxonomy-b1"
+
+tool_classes:
+  read_document:
+    - "source:local"
+    - "source:sensitive"
+  web_search:
+    - "sink:network"
+  web_search_alt:
+    - "sink:network"
+
+tools:
+  deny_classes:
+    - "sink:network"
+
+enforcement:
+  unconstrained_tools: allow

--- a/scripts/ci/review-tool-taxonomy-b1.sh
+++ b/scripts/ci/review-tool-taxonomy-b1.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOW_PREFIXES=(
+  "crates/assay-core/src/mcp/"
+  "crates/assay-core/tests/tool_taxonomy_"
+  "scripts/ci/fixtures/tool_taxonomy/"
+  "scripts/ci/review-tool-taxonomy-b1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  [[ "$f" == .github/workflows/* ]] && { echo "FAIL: no workflows"; exit 1; }
+
+  ok="false"
+  for p in "${ALLOW_PREFIXES[@]}"; do
+    if [[ "$p" == */ ]]; then
+      [[ "$f" == "$p"* ]] && ok="true"
+    else
+      [[ "$f" == "$p"* ]] && ok="true"
+    fi
+    [[ "$ok" == "true" ]] && break
+  done
+
+  [[ "$ok" != "true" ]] && { echo "FAIL: file not allowed: $f"; exit 1; }
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n 'struct ToolTaxonomy' crates/assay-core/src/mcp/tool_taxonomy.rs >/dev/null || {
+  echo "FAIL: ToolTaxonomy missing"
+  exit 1
+}
+rg -n 'ToolRuleSelector' crates/assay-core/src/mcp/tool_match.rs >/dev/null || {
+  echo "FAIL: ToolRuleSelector missing"
+  exit 1
+}
+rg -n 'tool_taxonomy_policy_match_handler_decision_event_records_classes' crates/assay-core/tests/tool_taxonomy_policy_match.rs >/dev/null || {
+  echo "FAIL: handler decision-event test missing"
+  exit 1
+}
+
+cargo test -p assay-core tool_taxonomy_policy_match
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -- -D warnings
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Implements Tool Taxonomy v1 enforcement for the existing MCP policy evaluator.

This B1 slice adds:
- class-based matching for MCP `allow` / `deny` enforcement
- top-level `tool_classes` taxonomy parsing
- decision event fields for `tool_classes`, `matched_tool_classes`, `match_basis`, and `matched_rule`
- regression coverage for tool-hopping via shared sink classes
- allowlist-only reviewer gate

Important scope boundary:
- this extends the existing MCP allow/deny evaluator
- it does **not** introduce a new class-aware sequence DSL in product MCP policy
- no workflow changes

## Scope
- `crates/assay-core/src/mcp/decision.rs`
- `crates/assay-core/src/mcp/mod.rs`
- `crates/assay-core/src/mcp/policy.rs`
- `crates/assay-core/src/mcp/proxy.rs`
- `crates/assay-core/src/mcp/tool_call_handler.rs`
- `crates/assay-core/src/mcp/tool_match.rs`
- `crates/assay-core/src/mcp/tool_taxonomy.rs`
- `crates/assay-core/tests/decision_emit_invariant.rs`
- `crates/assay-core/tests/tool_taxonomy_policy_match.rs`
- `scripts/ci/fixtures/tool_taxonomy/policy_tool_class_block_network.yaml`
- `scripts/ci/review-tool-taxonomy-b1.sh`

## Safety
- deterministic matching only
- no LLM/probabilistic classification
- no workflows / required-check changes
- backward-compatible name-based policies remain supported

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-tool-taxonomy-b1.sh`
- `cargo test -p assay-core tool_taxonomy_policy_match`
- `cargo fmt --check`
- `cargo clippy -p assay-core -p assay-cli -- -D warnings`
