### PR TITLE
docs(policy): freeze coverage report contract for tool/route completeness (A3)

### DIFF
--- a/docs/architecture/ADR-028-Coverage-Report.md
+++ b/docs/architecture/ADR-028-Coverage-Report.md
@@ -1,0 +1,76 @@
+# ADR-028: Coverage Report (Tool & Route Completeness)
+
+## Status
+Proposed (March 2026)
+
+## Context
+Assay's governance model is deterministic policy-as-code + evidence. As tool surfaces grow (multiple sinks, alternates, protocol adapters), correctness alone is not enough: we need to detect blind spots.
+
+Without a completeness/coverage view, teams can mistakenly believe they are governed while:
+- tools are used that are not declared or classified
+- sink classes exist but are not governed
+- observed routes are not covered by policy intent
+
+This ADR freezes a minimal, deterministic coverage report contract to support auditability and unknown/untaxed surface detection.
+
+The report is informational by default (no required-check blast radius). Enforcement modes are out of scope for this ADR.
+
+## Decision
+Introduce Coverage Report v1:
+- A deterministic JSON report that summarizes:
+  1. tools observed in a run/session
+  2. tools declared in policy/config
+  3. tools unknown/undeclared
+  4. taxonomy coverage (classes present vs missing)
+  5. routes observed (source -> sink edges), in a bounded form
+
+Coverage Report v1 is designed to:
+- be stable/deterministic for diffing
+- support SARIF/JUnit rendering later (out of scope here)
+- support future mode switches (warn/enforce) without changing the schema (out of scope here)
+
+### Definitions (frozen)
+- tools_seen: tool names observed in evidence / intercepted calls during the report window.
+- tools_declared: tool names explicitly declared in policy/config.
+- tools_unknown: tools_seen minus tools_declared.
+- tool_classes_seen: union of classes for tools_seen that have taxonomy entries.
+- tool_classes_missing: tools_seen that have no taxonomy entry (empty class set).
+- routes_seen: observed edges between tool classes and/or tool names, recorded deterministically.
+
+### Severity Mapping (Informational, Frozen)
+Coverage report emits findings with a severity level:
+- unknown_tool:
+  - severity: warning if the tool is a sink class (when known) or the name suggests sink (out of scope for v1 heuristics)
+  - otherwise note
+- missing_taxonomy:
+  - severity: note (v1 informational only)
+- uncovered_sink_class:
+  - severity: warning if a sink class appears but no governance rule references that class (rule linking is out of scope for v1; placeholder field allowed)
+
+> Note: v1 does not define heuristic sink detection. It only reports raw facts plus a minimal severity mapping based on explicit taxonomy presence.
+
+## Consequences
+### Positive
+- Makes governance gaps visible and audit-friendly.
+- Enables reviewers to ask "what did you not cover?" in a deterministic way.
+- Directly complements Tool Taxonomy (ADR-027).
+
+### Negative
+- Requires clear definitions of the report window and observation source.
+- Can generate noise if teams have many tools without taxonomy.
+
+### Mitigations
+- Keep v1 informational and deterministic.
+- Provide explicit counters and lists so teams can prioritize remediation.
+- Add optional allowlists later (out of scope).
+
+## Out Of Scope (v1)
+- Workflow changes or required-check additions.
+- Automated enforcement based on coverage results.
+- Probabilistic classification of tools.
+- Full route semantics (taint tracking, dataflow labeling).
+- SARIF export details (separate ADR if needed).
+
+## Acceptance Criteria (For This Freeze Slice)
+- JSON schema exists for coverage_report_v1.
+- Reviewer gate enforces docs/schema-only scope and workflow-ban.

--- a/schemas/coverage_report_v1.schema.json
+++ b/schemas/coverage_report_v1.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.dev/schemas/coverage_report_v1.schema.json",
+  "title": "Assay Coverage Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "report_version", "run", "tools", "taxonomy", "routes", "findings"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "coverage_report_v1"
+    },
+    "report_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["assay_version", "generated_at"],
+      "properties": {
+        "assay_version": { "type": "string", "minLength": 1 },
+        "generated_at": { "type": "string", "minLength": 1 },
+        "source": {
+          "type": "string",
+          "description": "Observation source, e.g. mcp_proxy, trace_replay, bundle_replay."
+        }
+      }
+    },
+    "tools": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tools_seen", "tools_declared", "tools_unknown"],
+      "properties": {
+        "tools_seen": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "tools_declared": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "tools_unknown": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "taxonomy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tool_classes_seen", "tool_classes_missing"],
+      "properties": {
+        "tool_classes_seen": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "tool_classes_missing": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true,
+          "description": "Tools that were seen but have no taxonomy entry."
+        }
+      }
+    },
+    "routes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["routes_seen"],
+      "properties": {
+        "routes_seen": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["from", "to", "count"],
+            "properties": {
+              "from": { "type": "string", "minLength": 1 },
+              "to": { "type": "string", "minLength": 1 },
+              "count": { "type": "integer", "minimum": 1 }
+            }
+          }
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "severity", "message"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["unknown_tool", "missing_taxonomy", "uncovered_sink_class"]
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["note", "warning"]
+          },
+          "message": { "type": "string", "minLength": 1 },
+          "tool": { "type": "string" },
+          "tool_class": { "type": "string" },
+          "count": { "type": "integer", "minimum": 0 }
+        }
+      }
+    }
+  }
+}

--- a/scripts/ci/review-coverage-a3.sh
+++ b/scripts/ci/review-coverage-a3.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-028-Coverage-Report.md"
+  "schemas/coverage_report_v1.schema.json"
+  "scripts/ci/review-coverage-a3.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: coverage A3 must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in coverage A3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n '^# ADR-028: Coverage Report' docs/architecture/ADR-028-Coverage-Report.md >/dev/null || {
+  echo "FAIL: ADR title missing"
+  exit 1
+}
+rg -n 'tools_seen' docs/architecture/ADR-028-Coverage-Report.md >/dev/null || {
+  echo "FAIL: ADR missing tools_seen definition"
+  exit 1
+}
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = Path("schemas/coverage_report_v1.schema.json")
+obj = json.loads(p.read_text(encoding="utf-8"))
+assert obj["properties"]["schema_version"]["const"] == "coverage_report_v1"
+assert "tools" in obj["properties"]
+assert "taxonomy" in obj["properties"]
+assert "routes" in obj["properties"]
+assert "findings" in obj["properties"]
+print("ok")
+PY
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only A3 freeze for `coverage_report_v1`: deterministic tool/taxonomy/route completeness reporting for governance blind spots.

## Scope
- docs/architecture/ADR-028-Coverage-Report.md
- schemas/coverage_report_v1.schema.json
- scripts/ci/review-coverage-a3.sh

## Safety
- Docs + schema + reviewer gate only
- No workflows / required-check changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-coverage-a3.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
