### PR TITLE
feat(coverage): generate coverage_report_v1 from JSONL inputs (B3.1)

### DIFF
--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -383,6 +383,18 @@ pub struct MigrateArgs {
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct CoverageArgs {
+    /// Path to JSONL tool/decision events for coverage_report_v1 generation.
+    #[arg(long)]
+    pub input: Option<std::path::PathBuf>,
+
+    /// Output path for coverage_report_v1 JSON.
+    #[arg(long)]
+    pub out: Option<std::path::PathBuf>,
+
+    /// Tools declared by policy/config (repeatable).
+    #[arg(long = "declared-tool")]
+    pub declared_tools: Vec<String>,
+
     #[arg(long, default_value = "eval.yaml")]
     pub config: std::path::PathBuf,
 
@@ -390,7 +402,7 @@ pub struct CoverageArgs {
     pub policy: Option<PathBuf>,
 
     #[arg(long, alias = "traces")]
-    pub trace_file: std::path::PathBuf,
+    pub trace_file: Option<std::path::PathBuf>,
 
     #[arg(long, default_value_t = 0.0)]
     pub min_coverage: f64,

--- a/crates/assay-cli/src/cli/commands/coverage.rs
+++ b/crates/assay-cli/src/cli/commands/coverage.rs
@@ -2,7 +2,97 @@ use crate::cli::args::CoverageArgs;
 use crate::exit_codes;
 use anyhow::{Context, Result};
 
+mod report;
+mod schema;
+
 pub async fn cmd_coverage(args: CoverageArgs) -> Result<i32> {
+    if args.input.is_some() {
+        return cmd_coverage_generate(&args).await;
+    }
+
+    cmd_coverage_legacy(args).await
+}
+
+async fn cmd_coverage_generate(args: &CoverageArgs) -> Result<i32> {
+    use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_INFRA_ERROR};
+
+    if args.declared_tools.iter().any(|t| t.trim().is_empty()) {
+        eprintln!("Measurement error: --declared-tool must not be empty");
+        return Ok(EXIT_CONFIG_ERROR);
+    }
+
+    if args.trace_file.is_some() {
+        eprintln!("Measurement error: --input and --trace-file/--traces cannot be used together");
+        return Ok(EXIT_CONFIG_ERROR);
+    }
+
+    let input = args
+        .input
+        .as_ref()
+        .expect("input mode already checked to be present");
+    let out = match args.out.as_ref() {
+        Some(out) => out,
+        None => {
+            eprintln!("Measurement error: --out is required when --input is used");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+
+    let report_value = match report::build_coverage_report(args).await {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Measurement error: {e}");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+
+    if let Err(e) = schema::validate_coverage_report_v1(&report_value) {
+        eprintln!("Measurement error: coverage report schema validation failed: {e}");
+        return Ok(EXIT_CONFIG_ERROR);
+    }
+
+    let Some(parent) = out.parent() else {
+        eprintln!("Infra error: invalid output path {}", out.display());
+        return Ok(EXIT_INFRA_ERROR);
+    };
+
+    if !parent.as_os_str().is_empty() {
+        if let Err(e) = tokio::fs::create_dir_all(parent).await {
+            eprintln!("Infra error: failed to prepare {}: {e}", parent.display());
+            return Ok(EXIT_INFRA_ERROR);
+        }
+    }
+
+    let payload = serde_json::to_vec_pretty(&report_value)
+        .expect("coverage report serialization should be infallible");
+    if let Err(e) = tokio::fs::write(out, payload).await {
+        eprintln!(
+            "Infra error: failed to write coverage report to {}: {e}",
+            out.display()
+        );
+        return Ok(EXIT_INFRA_ERROR);
+    }
+
+    eprintln!(
+        "Generated coverage_report_v1 from {} -> {}",
+        input.display(),
+        out.display()
+    );
+
+    Ok(exit_codes::EXIT_SUCCESS)
+}
+
+async fn cmd_coverage_legacy(args: CoverageArgs) -> Result<i32> {
+    let trace_file = match args.trace_file.as_ref() {
+        Some(path) => path,
+        None => {
+            eprintln!(
+                "Measurement error: --trace-file/--traces is required when --input is not used"
+            );
+            return Ok(exit_codes::EXIT_CONFIG_ERROR);
+        }
+    };
+
     // 1. Determine Policy & Context
     let (policy_path, suite_name, config_fingerprint) = if let Some(p) = args.policy {
         // Explicit Policy Mode
@@ -90,7 +180,7 @@ pub async fn cmd_coverage(args: CoverageArgs) -> Result<i32> {
     };
 
     // 3. Load Traces
-    let file_content: String = tokio::fs::read_to_string(&args.trace_file)
+    let file_content: String = tokio::fs::read_to_string(trace_file)
         .await
         .context("failed to read trace file")?;
 

--- a/crates/assay-cli/src/cli/commands/coverage/report.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/report.rs
@@ -1,0 +1,216 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{anyhow, Result};
+use chrono::{SecondsFormat, Utc};
+use serde_json::{json, Value};
+
+use crate::cli::args::CoverageArgs;
+
+fn extract_tool_name(v: &Value) -> Result<String, String> {
+    if let Some(s) = v.get("tool").and_then(|x| x.as_str()) {
+        let t = s.trim();
+        if !t.is_empty() {
+            return Ok(t.to_string());
+        }
+        return Err("field 'tool' must be non-empty string".to_string());
+    }
+
+    if let Some(s) = v.get("tool_name").and_then(|x| x.as_str()) {
+        let t = s.trim();
+        if !t.is_empty() {
+            return Ok(t.to_string());
+        }
+        return Err("field 'tool_name' must be non-empty string".to_string());
+    }
+
+    Err("missing required field: 'tool' or 'tool_name'".to_string())
+}
+
+fn extract_tool_classes(v: &Value) -> BTreeSet<String> {
+    match v.get("tool_classes") {
+        Some(Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|x| x.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToOwned::to_owned)
+            .collect(),
+        _ => BTreeSet::new(),
+    }
+}
+
+fn build_findings(tools_unknown: &[String], tools_missing_taxonomy: &[String]) -> Vec<Value> {
+    let mut findings = Vec::new();
+
+    for tool in tools_unknown {
+        findings.push(json!({
+            "kind": "unknown_tool",
+            "severity": "note",
+            "message": format!("tool '{}' was seen but not declared", tool),
+            "tool": tool,
+            "count": 1
+        }));
+    }
+
+    for tool in tools_missing_taxonomy {
+        findings.push(json!({
+            "kind": "missing_taxonomy",
+            "severity": "note",
+            "message": format!("tool '{}' was seen but has no taxonomy entry", tool),
+            "tool": tool,
+            "count": 1
+        }));
+    }
+
+    findings.sort_by(|a, b| {
+        let ak = (
+            a.get("severity")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            a.get("kind").and_then(Value::as_str).unwrap_or_default(),
+            a.get("message").and_then(Value::as_str).unwrap_or_default(),
+            a.get("tool").and_then(Value::as_str).unwrap_or_default(),
+            a.get("tool_class")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            a.get("count").and_then(Value::as_i64).unwrap_or_default(),
+        );
+        let bk = (
+            b.get("severity")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            b.get("kind").and_then(Value::as_str).unwrap_or_default(),
+            b.get("message").and_then(Value::as_str).unwrap_or_default(),
+            b.get("tool").and_then(Value::as_str).unwrap_or_default(),
+            b.get("tool_class")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            b.get("count").and_then(Value::as_i64).unwrap_or_default(),
+        );
+        ak.cmp(&bk)
+    });
+
+    findings
+}
+
+pub async fn build_coverage_report(args: &CoverageArgs) -> Result<Value> {
+    let input = args
+        .input
+        .as_ref()
+        .ok_or_else(|| anyhow!("--input is required in coverage generator mode"))?;
+
+    let file_content = tokio::fs::read_to_string(input)
+        .await
+        .map_err(|e| anyhow!("failed to read input file {}: {e}", input.display()))?;
+
+    let declared_tools: BTreeSet<String> = args
+        .declared_tools
+        .iter()
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+
+    let mut tools_in_order = Vec::new();
+    let mut classes_by_tool: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+    for (lineno, line) in file_content.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let value: Value = serde_json::from_str(line)
+            .map_err(|e| anyhow!("invalid json at line {}: {}", lineno + 1, e))?;
+
+        let tool = extract_tool_name(&value)
+            .map_err(|e| anyhow!("measurement error at line {}: {}", lineno + 1, e))?;
+        let classes = extract_tool_classes(&value);
+
+        tools_in_order.push(tool.clone());
+        classes_by_tool.entry(tool).or_default().extend(classes);
+    }
+
+    let tools_seen: BTreeSet<String> = tools_in_order.iter().cloned().collect();
+    let tools_unknown: BTreeSet<String> = tools_seen.difference(&declared_tools).cloned().collect();
+
+    let mut tool_classes_seen = BTreeSet::new();
+    let mut tool_classes_missing = BTreeSet::new();
+    for tool in &tools_seen {
+        let classes = classes_by_tool.get(tool).cloned().unwrap_or_default();
+        if classes.is_empty() {
+            tool_classes_missing.insert(tool.clone());
+        } else {
+            tool_classes_seen.extend(classes);
+        }
+    }
+
+    let mut route_counts: BTreeMap<(String, String), u64> = BTreeMap::new();
+    for pair in tools_in_order.windows(2) {
+        let key = (pair[0].clone(), pair[1].clone());
+        *route_counts.entry(key).or_insert(0) += 1;
+    }
+
+    let routes_seen: Vec<Value> = route_counts
+        .into_iter()
+        .map(|((from, to), count)| {
+            json!({
+                "from": from,
+                "to": to,
+                "count": count
+            })
+        })
+        .collect();
+
+    let tools_unknown_vec: Vec<String> = tools_unknown.into_iter().collect();
+    let tool_classes_missing_vec: Vec<String> = tool_classes_missing.into_iter().collect();
+    let findings = build_findings(&tools_unknown_vec, &tool_classes_missing_vec);
+
+    Ok(json!({
+        "schema_version": "coverage_report_v1",
+        "report_version": "1",
+        "run": {
+            "assay_version": env!("CARGO_PKG_VERSION"),
+            "generated_at": Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            "source": "jsonl"
+        },
+        "tools": {
+            "tools_seen": tools_seen.into_iter().collect::<Vec<_>>(),
+            "tools_declared": declared_tools.into_iter().collect::<Vec<_>>(),
+            "tools_unknown": tools_unknown_vec
+        },
+        "taxonomy": {
+            "tool_classes_seen": tool_classes_seen.into_iter().collect::<Vec<_>>(),
+            "tool_classes_missing": tool_classes_missing_vec
+        },
+        "routes": {
+            "routes_seen": routes_seen
+        },
+        "findings": findings
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extract_tool_prefers_tool_over_tool_name() {
+        let value = json!({
+            "tool": "web_search",
+            "tool_name": "web_search_alt"
+        });
+        let tool = extract_tool_name(&value).expect("tool should parse");
+        assert_eq!(tool, "web_search");
+    }
+
+    #[test]
+    fn extract_tool_name_rejects_missing_fields() {
+        let value = json!({
+            "decision": "deny"
+        });
+        let err = extract_tool_name(&value).expect_err("missing tool fields should fail");
+        assert!(err.contains("missing required field"));
+    }
+}

--- a/crates/assay-cli/src/cli/commands/coverage/schema.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/schema.rs
@@ -1,0 +1,71 @@
+#![allow(dead_code)]
+
+use std::sync::OnceLock;
+
+use anyhow::{anyhow, Result};
+use jsonschema::Draft;
+use serde_json::Value;
+
+const COVERAGE_REPORT_V1_SCHEMA_JSON: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../schemas/coverage_report_v1.schema.json"
+));
+
+static VALIDATOR: OnceLock<jsonschema::Validator> = OnceLock::new();
+static VALIDATOR_RESULT: OnceLock<Result<jsonschema::Validator, String>> = OnceLock::new();
+
+fn compiled_validator() -> Result<&'static jsonschema::Validator> {
+    let init = VALIDATOR_RESULT
+        .get_or_init(|| {
+            let schema: Value =
+                serde_json::from_str(COVERAGE_REPORT_V1_SCHEMA_JSON).map_err(|e| {
+                    format!("failed to parse embedded coverage_report_v1 schema JSON: {e}")
+                })?;
+
+            jsonschema::options()
+                .with_draft(Draft::Draft202012)
+                .build(&schema)
+                .map_err(|e| format!("failed to compile coverage_report_v1 schema: {e}"))
+        })
+        .as_ref()
+        .map_err(|e| anyhow!("{e}"))?;
+
+    Ok(VALIDATOR.get_or_init(|| init.clone()))
+}
+
+pub fn validate_coverage_report_v1(instance: &Value) -> Result<()> {
+    let validator = compiled_validator()?;
+    if validator.is_valid(instance) {
+        return Ok(());
+    }
+
+    const MAX_ERRORS: usize = 10;
+    let mut lines = Vec::new();
+    for (i, e) in validator.iter_errors(instance).take(MAX_ERRORS).enumerate() {
+        lines.push(format!("{:02}: {}", i + 1, e));
+    }
+
+    let mut msg = String::from("coverage_report_v1 schema validation failed");
+    if !lines.is_empty() {
+        msg.push_str(":\n");
+        msg.push_str(&lines.join("\n"));
+    }
+    Err(anyhow!(msg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn schema_compiles() {
+        let _ = compiled_validator().expect("schema should compile");
+    }
+
+    #[test]
+    fn empty_object_is_invalid() {
+        let v = json!({});
+        assert!(validate_coverage_report_v1(&v).is_err());
+    }
+}

--- a/crates/assay-cli/tests/coverage_contract.rs
+++ b/crates/assay-cli/tests/coverage_contract.rs
@@ -1,0 +1,107 @@
+#![allow(deprecated)]
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use serde_json::Value;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+fn read_json(path: &std::path::Path) -> Value {
+    let content = std::fs::read_to_string(path).expect("coverage report should exist");
+    serde_json::from_str(&content).expect("coverage report must be valid JSON")
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/ci/fixtures/coverage")
+        .join(name)
+}
+
+#[test]
+fn coverage_contract_generates_valid_report_from_basic_jsonl() {
+    let dir = tempdir().unwrap();
+    let out = dir.path().join("coverage.json");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["coverage", "--input"])
+        .arg(fixture_path("input_basic.jsonl"))
+        .args(["--out"])
+        .arg(&out)
+        .args([
+            "--declared-tool",
+            "read_document",
+            "--declared-tool",
+            "web_search",
+            "--declared-tool",
+            "web_search_alt",
+        ])
+        .assert()
+        .success();
+
+    let report = read_json(&out);
+    assert_eq!(report["schema_version"], "coverage_report_v1");
+    assert_eq!(
+        report["tools"]["tools_unknown"],
+        serde_json::json!(["unknown_tool_x"])
+    );
+    assert_eq!(
+        report["taxonomy"]["tool_classes_missing"],
+        serde_json::json!(["unknown_tool_x"])
+    );
+    assert_eq!(
+        report["routes"]["routes_seen"],
+        serde_json::json!([
+            {"count": 1, "from": "read_document", "to": "web_search_alt"},
+            {"count": 1, "from": "web_search", "to": "unknown_tool_x"},
+            {"count": 1, "from": "web_search_alt", "to": "web_search"}
+        ])
+    );
+}
+
+#[test]
+fn coverage_contract_accepts_tool_name_fallback_jsonl() {
+    let dir = tempdir().unwrap();
+    let out = dir.path().join("coverage.json");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["coverage", "--input"])
+        .arg(fixture_path("input_tool_name_fallback.jsonl"))
+        .args(["--out"])
+        .arg(&out)
+        .args([
+            "--declared-tool",
+            "read_document",
+            "--declared-tool",
+            "web_search",
+            "--declared-tool",
+            "web_search_alt",
+        ])
+        .assert()
+        .success();
+
+    let report = read_json(&out);
+    assert_eq!(report["schema_version"], "coverage_report_v1");
+    assert_eq!(
+        report["tools"]["tools_seen"],
+        serde_json::json!(["read_document", "web_search", "web_search_alt"])
+    );
+}
+
+#[test]
+fn coverage_contract_fails_when_tool_fields_missing() {
+    let dir = tempdir().unwrap();
+    let out = dir.path().join("coverage.json");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["coverage", "--input"])
+        .arg(fixture_path("input_missing_tool_fields.jsonl"))
+        .args(["--out"])
+        .arg(&out)
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(contains("missing required field: 'tool' or 'tool_name'"));
+}

--- a/scripts/ci/fixtures/coverage/README.md
+++ b/scripts/ci/fixtures/coverage/README.md
@@ -1,0 +1,5 @@
+# Coverage fixtures
+
+- `input_basic.jsonl`: basic positive fixture with declared tools, routes, and one unknown tool.
+- `input_tool_name_fallback.jsonl`: positive fixture for `tool_name` fallback parsing.
+- `input_missing_tool_fields.jsonl`: negative fixture for missing or empty `tool` / `tool_name` contract failures.

--- a/scripts/ci/fixtures/coverage/input_basic.jsonl
+++ b/scripts/ci/fixtures/coverage/input_basic.jsonl
@@ -1,0 +1,4 @@
+{"tool":"read_document","tool_classes":["source:local","source:sensitive"]}
+{"tool":"web_search_alt","tool_classes":["sink:network"]}
+{"tool":"web_search","tool_classes":["sink:network"]}
+{"tool":"unknown_tool_x"}

--- a/scripts/ci/fixtures/coverage/input_missing_tool_fields.jsonl
+++ b/scripts/ci/fixtures/coverage/input_missing_tool_fields.jsonl
@@ -1,0 +1,4 @@
+{"decision":"deny","ts":"2026-03-04T12:00:00Z"}
+{"tool_classes":["sink:network"]}
+{"tool":""}
+{"tool_name":"   "}

--- a/scripts/ci/fixtures/coverage/input_tool_name_fallback.jsonl
+++ b/scripts/ci/fixtures/coverage/input_tool_name_fallback.jsonl
@@ -1,0 +1,3 @@
+{"tool_name":"read_document","tool_classes":["source:local","source:sensitive"]}
+{"tool_name":"web_search_alt","tool_classes":["sink:network"]}
+{"tool_name":"web_search","tool_classes":["sink:network"]}

--- a/scripts/ci/review-coverage-b3-1.sh
+++ b/scripts/ci/review-coverage-b3-1.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOW_PREFIXES=(
+  "crates/assay-cli/src/cli/commands/coverage.rs"
+  "crates/assay-cli/src/cli/commands/coverage/"
+  "crates/assay-cli/src/cli/args/mod.rs"
+  "crates/assay-cli/tests/coverage_contract.rs"
+  "scripts/ci/fixtures/coverage/"
+  "scripts/ci/review-coverage-b3-1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  [[ "$f" == .github/workflows/* ]] && { echo "FAIL: no workflows"; exit 1; }
+
+  ok="false"
+  for p in "${ALLOW_PREFIXES[@]}"; do
+    if [[ "$p" == */ ]]; then
+      [[ "$f" == "$p"* ]] && ok="true"
+    else
+      [[ "$f" == "$p" ]] && ok="true"
+    fi
+    [[ "$ok" == "true" ]] && break
+  done
+
+  [[ "$ok" != "true" ]] && { echo "FAIL: file not allowed: $f"; exit 1; }
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+test -f crates/assay-cli/src/cli/commands/coverage/report.rs || {
+  echo "FAIL: coverage report builder missing"
+  exit 1
+}
+test -f crates/assay-cli/src/cli/commands/coverage/schema.rs || {
+  echo "FAIL: coverage schema validator missing"
+  exit 1
+}
+test -f scripts/ci/fixtures/coverage/input_tool_name_fallback.jsonl || {
+  echo "FAIL: fallback fixture missing"
+  exit 1
+}
+test -f scripts/ci/fixtures/coverage/input_missing_tool_fields.jsonl || {
+  echo "FAIL: negative fixture missing"
+  exit 1
+}
+rg -n "missing required field: 'tool' or 'tool_name'" crates/assay-cli/tests/coverage_contract.rs >/dev/null || {
+  echo "FAIL: negative coverage contract test missing"
+  exit 1
+}
+
+cargo test -p assay-cli coverage_contract
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Implements `assay coverage` to generate deterministic `coverage_report_v1` from JSONL tool/decision events, with schema validation and audit-friendly ordering.

## Scope
- assay-cli coverage command (+ report builder + schema validator)
- fixtures + contract tests
- reviewer gate

## Safety
- No workflow changes
- Informational-only generator (no enforcement)
- Deterministic output (sorted lists + stable edges)
- Legacy coverage path preserved when `--input` is not used

## Verification
- BASE_REF=origin/main bash scripts/ci/review-coverage-b3-1.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
- cargo test -p assay-cli coverage_contract
- cargo test -p assay-cli --test coverage_threshold
