### PR TITLE
feat(coverage): emit coverage reports from mcp wrap decision logs (B3.2)

### DIFF
--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -522,6 +522,11 @@ pub struct McpWrapArgs {
     #[arg(long, requires = "event_source")]
     pub decision_log: Option<PathBuf>,
 
+    /// Generate a coverage_report_v1 from wrap decision events at session end.
+    /// Requires --event-source. If --decision-log is omitted, a temporary decision log is used.
+    #[arg(long, requires = "event_source")]
+    pub coverage_out: Option<PathBuf>,
+
     /// CloudEvents source URI (e.g. assay://org/app).
     /// Must be absolute URI with scheme://. Required when --audit-log or --decision-log is set.
     #[arg(long, value_name = "URI")]

--- a/crates/assay-cli/src/cli/commands/coverage.rs
+++ b/crates/assay-cli/src/cli/commands/coverage.rs
@@ -1,50 +1,27 @@
 use crate::cli::args::CoverageArgs;
 use crate::exit_codes;
 use anyhow::{Context, Result};
+use std::path::Path;
 
 mod report;
 mod schema;
 
-pub async fn cmd_coverage(args: CoverageArgs) -> Result<i32> {
-    if args.input.is_some() {
-        return cmd_coverage_generate(&args).await;
-    }
-
-    cmd_coverage_legacy(args).await
-}
-
-async fn cmd_coverage_generate(args: &CoverageArgs) -> Result<i32> {
+pub(crate) async fn write_generated_coverage_report(
+    input: &Path,
+    out: &Path,
+    declared_tools: &[String],
+    source: &str,
+) -> Result<i32> {
     use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_INFRA_ERROR};
 
-    if args.declared_tools.iter().any(|t| t.trim().is_empty()) {
-        eprintln!("Measurement error: --declared-tool must not be empty");
-        return Ok(EXIT_CONFIG_ERROR);
-    }
-
-    if args.trace_file.is_some() {
-        eprintln!("Measurement error: --input and --trace-file/--traces cannot be used together");
-        return Ok(EXIT_CONFIG_ERROR);
-    }
-
-    let input = args
-        .input
-        .as_ref()
-        .expect("input mode already checked to be present");
-    let out = match args.out.as_ref() {
-        Some(out) => out,
-        None => {
-            eprintln!("Measurement error: --out is required when --input is used");
-            return Ok(EXIT_CONFIG_ERROR);
-        }
-    };
-
-    let report_value = match report::build_coverage_report(args).await {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("Measurement error: {e}");
-            return Ok(EXIT_CONFIG_ERROR);
-        }
-    };
+    let report_value =
+        match report::build_coverage_report_from_input(input, declared_tools, source).await {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Measurement error: {e}");
+                return Ok(EXIT_CONFIG_ERROR);
+            }
+        };
 
     if let Err(e) = schema::validate_coverage_report_v1(&report_value) {
         eprintln!("Measurement error: coverage report schema validation failed: {e}");
@@ -80,6 +57,42 @@ async fn cmd_coverage_generate(args: &CoverageArgs) -> Result<i32> {
     );
 
     Ok(exit_codes::EXIT_SUCCESS)
+}
+
+pub async fn cmd_coverage(args: CoverageArgs) -> Result<i32> {
+    if args.input.is_some() {
+        return cmd_coverage_generate(&args).await;
+    }
+
+    cmd_coverage_legacy(args).await
+}
+
+async fn cmd_coverage_generate(args: &CoverageArgs) -> Result<i32> {
+    use crate::exit_codes::EXIT_CONFIG_ERROR;
+
+    if args.declared_tools.iter().any(|t| t.trim().is_empty()) {
+        eprintln!("Measurement error: --declared-tool must not be empty");
+        return Ok(EXIT_CONFIG_ERROR);
+    }
+
+    if args.trace_file.is_some() {
+        eprintln!("Measurement error: --input and --trace-file/--traces cannot be used together");
+        return Ok(EXIT_CONFIG_ERROR);
+    }
+
+    let input = args
+        .input
+        .as_ref()
+        .expect("input mode already checked to be present");
+    let out = match args.out.as_ref() {
+        Some(out) => out,
+        None => {
+            eprintln!("Measurement error: --out is required when --input is used");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+
+    write_generated_coverage_report(input, out, &args.declared_tools, "jsonl").await
 }
 
 async fn cmd_coverage_legacy(args: CoverageArgs) -> Result<i32> {

--- a/crates/assay-cli/src/cli/commands/coverage/report.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/report.rs
@@ -1,10 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 
 use anyhow::{anyhow, Result};
 use chrono::{SecondsFormat, Utc};
 use serde_json::{json, Value};
-
-use crate::cli::args::CoverageArgs;
 
 fn extract_tool_name(v: &Value) -> Result<String, String> {
     if let Some(s) = v.get("tool").and_then(|x| x.as_str()) {
@@ -93,18 +92,16 @@ fn build_findings(tools_unknown: &[String], tools_missing_taxonomy: &[String]) -
     findings
 }
 
-pub async fn build_coverage_report(args: &CoverageArgs) -> Result<Value> {
-    let input = args
-        .input
-        .as_ref()
-        .ok_or_else(|| anyhow!("--input is required in coverage generator mode"))?;
-
+pub async fn build_coverage_report_from_input(
+    input: &Path,
+    declared_tools_input: &[String],
+    source: &str,
+) -> Result<Value> {
     let file_content = tokio::fs::read_to_string(input)
         .await
         .map_err(|e| anyhow!("failed to read input file {}: {e}", input.display()))?;
 
-    let declared_tools: BTreeSet<String> = args
-        .declared_tools
+    let declared_tools: BTreeSet<String> = declared_tools_input
         .iter()
         .map(|t| t.trim())
         .filter(|t| !t.is_empty())
@@ -172,7 +169,7 @@ pub async fn build_coverage_report(args: &CoverageArgs) -> Result<Value> {
         "run": {
             "assay_version": env!("CARGO_PKG_VERSION"),
             "generated_at": Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
-            "source": "jsonl"
+            "source": source
         },
         "tools": {
             "tools_seen": tools_seen.into_iter().collect::<Vec<_>>(),
@@ -188,29 +185,4 @@ pub async fn build_coverage_report(args: &CoverageArgs) -> Result<Value> {
         },
         "findings": findings
     }))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn extract_tool_prefers_tool_over_tool_name() {
-        let value = json!({
-            "tool": "web_search",
-            "tool_name": "web_search_alt"
-        });
-        let tool = extract_tool_name(&value).expect("tool should parse");
-        assert_eq!(tool, "web_search");
-    }
-
-    #[test]
-    fn extract_tool_name_rejects_missing_fields() {
-        let value = json!({
-            "decision": "deny"
-        });
-        let err = extract_tool_name(&value).expect_err("missing tool fields should fail");
-        assert!(err.contains("missing required field"));
-    }
 }

--- a/crates/assay-cli/src/cli/commands/mcp.rs
+++ b/crates/assay-cli/src/cli/commands/mcp.rs
@@ -1,6 +1,12 @@
 use super::super::args::{McpArgs, McpSub, McpWrapArgs};
+use super::coverage;
+use anyhow::{Context, Result};
 use assay_core::mcp::policy::McpPolicy;
 use assay_core::mcp::proxy::{McpProxy, ProxyConfig, ProxyConfigRaw};
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub async fn run(args: McpArgs) -> anyhow::Result<i32> {
     match args.cmd {
@@ -9,6 +15,160 @@ pub async fn run(args: McpArgs) -> anyhow::Result<i32> {
             super::config_path::run(config_args);
             Ok(0)
         }
+    }
+}
+
+fn is_explicit_tool_name(pattern: &str) -> bool {
+    let trimmed = pattern.trim();
+    !trimmed.is_empty() && !trimmed.contains('*')
+}
+
+fn collect_declared_tools(policy: &McpPolicy) -> Vec<String> {
+    let mut declared = BTreeSet::new();
+
+    if let Some(allow) = &policy.tools.allow {
+        for tool in allow {
+            if is_explicit_tool_name(tool) {
+                declared.insert(tool.trim().to_string());
+            }
+        }
+    }
+
+    if let Some(deny) = &policy.tools.deny {
+        for tool in deny {
+            if is_explicit_tool_name(tool) {
+                declared.insert(tool.trim().to_string());
+            }
+        }
+    }
+
+    for tool in policy.schemas.keys() {
+        if tool != "$defs" && is_explicit_tool_name(tool) {
+            declared.insert(tool.trim().to_string());
+        }
+    }
+
+    for constraint in &policy.constraints {
+        if is_explicit_tool_name(&constraint.tool) {
+            declared.insert(constraint.tool.trim().to_string());
+        }
+    }
+
+    for tool in policy.tool_pins.keys() {
+        if is_explicit_tool_name(tool) {
+            declared.insert(tool.trim().to_string());
+        }
+    }
+
+    declared.into_iter().collect()
+}
+
+fn extract_tool_name_from_decision_event(v: &Value) -> Result<String> {
+    for (pointer, label) in [
+        (Some("/data/tool"), "data.tool"),
+        (Some("/data/tool_name"), "data.tool_name"),
+        (None, "tool"),
+        (None, "tool_name"),
+    ] {
+        let value = match pointer {
+            Some(path) => v.pointer(path),
+            None => v.get(label),
+        };
+        if let Some(s) = value.and_then(Value::as_str) {
+            let tool = s.trim();
+            if !tool.is_empty() {
+                return Ok(tool.to_string());
+            }
+            anyhow::bail!("field '{label}' must be non-empty string");
+        }
+    }
+
+    anyhow::bail!("missing required field: 'data.tool', 'data.tool_name', 'tool', or 'tool_name'")
+}
+
+fn extract_tool_classes_from_decision_event(v: &Value) -> BTreeSet<String> {
+    match v.pointer("/data/tool_classes") {
+        Some(Value::Array(arr)) => arr
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToOwned::to_owned)
+            .collect(),
+        _ => BTreeSet::new(),
+    }
+}
+
+async fn normalize_decision_jsonl_to_coverage_jsonl(input: &Path, output: &Path) -> Result<()> {
+    let content = tokio::fs::read_to_string(input)
+        .await
+        .with_context(|| format!("failed to read decision log {}", input.display()))?;
+
+    let mut lines = Vec::new();
+    for (lineno, raw) in content.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let value: Value = serde_json::from_str(line)
+            .with_context(|| format!("invalid json at line {}", lineno + 1))?;
+        let tool = extract_tool_name_from_decision_event(&value)
+            .with_context(|| format!("measurement error at line {}", lineno + 1))?;
+        let tool_classes = extract_tool_classes_from_decision_event(&value)
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        lines.push(serde_json::to_string(&json!({
+            "tool": tool,
+            "tool_classes": tool_classes,
+        }))?);
+    }
+
+    let mut normalized = lines.join("\n");
+    if !normalized.is_empty() {
+        normalized.push('\n');
+    }
+
+    tokio::fs::write(output, normalized)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to write normalized coverage input {}",
+                output.display()
+            )
+        })?;
+    Ok(())
+}
+
+fn unique_temp_path(stem: &str, extension: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "assay-{stem}-{}-{stamp}.{extension}",
+        std::process::id()
+    ))
+}
+
+struct TempPathGuard {
+    path: PathBuf,
+}
+
+impl TempPathGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempPathGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
     }
 }
 
@@ -35,14 +195,37 @@ async fn cmd_wrap(args: McpWrapArgs) -> anyhow::Result<i32> {
         );
     };
 
+    let declared_tools = if args.coverage_out.is_some() {
+        collect_declared_tools(&policy)
+    } else {
+        Vec::new()
+    };
+
+    let temp_decision_log = if args.coverage_out.is_some() && args.decision_log.is_none() {
+        Some(TempPathGuard::new(unique_temp_path(
+            "wrap-decision-log",
+            "ndjson",
+        )))
+    } else {
+        None
+    };
+    let effective_decision_log = args.decision_log.clone().or_else(|| {
+        temp_decision_log
+            .as_ref()
+            .map(|guard| guard.path().to_path_buf())
+    });
+
     // Build and validate config (fail-fast on invalid event_source)
     let raw = ProxyConfigRaw {
         dry_run: args.dry_run,
         verbose: args.verbose,
-        audit_log_path: args.audit_log,
-        decision_log_path: args.decision_log,
-        event_source: args.event_source,
-        server_id: args.label.unwrap_or_else(|| "default-mcp-server".into()),
+        audit_log_path: args.audit_log.clone(),
+        decision_log_path: effective_decision_log.clone(),
+        event_source: args.event_source.clone(),
+        server_id: args
+            .label
+            .clone()
+            .unwrap_or_else(|| "default-mcp-server".into()),
     };
     let config = ProxyConfig::try_from_raw(raw)?;
 
@@ -56,7 +239,200 @@ async fn cmd_wrap(args: McpWrapArgs) -> anyhow::Result<i32> {
     let proxy = McpProxy::spawn(cmd, cmd_args, policy, config)?;
 
     // Run (blocking for now, as it manages threads)
-    let code = tokio::task::spawn_blocking(move || proxy.run()).await??;
+    let wrapped_code = tokio::task::spawn_blocking(move || proxy.run()).await??;
 
-    Ok(code)
+    let coverage_status = if let Some(coverage_out) = args.coverage_out.as_ref() {
+        let normalized_log = TempPathGuard::new(unique_temp_path("wrap-coverage-input", "jsonl"));
+        let decision_log_path = effective_decision_log
+            .as_ref()
+            .context("coverage generation requires a decision log path")?;
+
+        match normalize_decision_jsonl_to_coverage_jsonl(decision_log_path, normalized_log.path())
+            .await
+        {
+            Ok(()) => {
+                coverage::write_generated_coverage_report(
+                    normalized_log.path(),
+                    coverage_out,
+                    &declared_tools,
+                    "decision_jsonl",
+                )
+                .await?
+            }
+            Err(e) => {
+                eprintln!(
+                    "Measurement error: failed to normalize decision log {}: {e}",
+                    decision_log_path.display()
+                );
+                crate::exit_codes::EXIT_CONFIG_ERROR
+            }
+        }
+    } else {
+        crate::exit_codes::EXIT_SUCCESS
+    };
+
+    if wrapped_code != crate::exit_codes::EXIT_SUCCESS {
+        if coverage_status != crate::exit_codes::EXIT_SUCCESS {
+            eprintln!(
+                "Coverage generation failed after wrapped command exited with code {}; preserving wrapped exit code",
+                wrapped_code
+            );
+        }
+        return Ok(wrapped_code);
+    }
+
+    Ok(coverage_status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn fixture_path(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../scripts/ci/fixtures/coverage")
+            .join(name)
+    }
+
+    #[tokio::test]
+    async fn mcp_wrap_coverage_normalizer_extracts_nested_tool_and_classes() {
+        let dir = tempdir().unwrap();
+        let out = dir.path().join("normalized.jsonl");
+
+        normalize_decision_jsonl_to_coverage_jsonl(
+            &fixture_path("decision_event_basic.jsonl"),
+            &out,
+        )
+        .await
+        .expect("normalization should succeed");
+
+        let content = std::fs::read_to_string(&out).unwrap();
+        let line = content.lines().next().unwrap();
+        let value: Value = serde_json::from_str(line).unwrap();
+        assert_eq!(value["tool"], "assay_policy_decide");
+        assert_eq!(value["tool_classes"], json!(["sink:network"]));
+    }
+
+    #[tokio::test]
+    async fn mcp_wrap_coverage_normalizer_accepts_data_tool_name_fallback() {
+        let dir = tempdir().unwrap();
+        let input = dir.path().join("decision.jsonl");
+        let out = dir.path().join("normalized.jsonl");
+        std::fs::write(
+            &input,
+            r#"{"data":{"tool_name":"web_search_alt"}}
+"#,
+        )
+        .unwrap();
+
+        normalize_decision_jsonl_to_coverage_jsonl(&input, &out)
+            .await
+            .expect("data.tool_name fallback should succeed");
+
+        let content = std::fs::read_to_string(&out).unwrap();
+        let line = content.lines().next().unwrap();
+        let value: Value = serde_json::from_str(line).unwrap();
+        assert_eq!(value["tool"], "web_search_alt");
+    }
+
+    #[tokio::test]
+    async fn mcp_wrap_coverage_normalizer_accepts_top_level_tool_name_fallback() {
+        let dir = tempdir().unwrap();
+        let input = dir.path().join("decision.jsonl");
+        let out = dir.path().join("normalized.jsonl");
+        std::fs::write(
+            &input,
+            r#"{"tool_name":"web_search"}
+"#,
+        )
+        .unwrap();
+
+        normalize_decision_jsonl_to_coverage_jsonl(&input, &out)
+            .await
+            .expect("top-level tool_name fallback should succeed");
+
+        let content = std::fs::read_to_string(&out).unwrap();
+        let line = content.lines().next().unwrap();
+        let value: Value = serde_json::from_str(line).unwrap();
+        assert_eq!(value["tool"], "web_search");
+        assert_eq!(value["tool_classes"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn mcp_wrap_coverage_normalizer_rejects_missing_tool_fields() {
+        let dir = tempdir().unwrap();
+        let input = dir.path().join("decision.jsonl");
+        let out = dir.path().join("normalized.jsonl");
+        std::fs::write(
+            &input,
+            r#"{"decision":"deny"}
+"#,
+        )
+        .unwrap();
+
+        let err = normalize_decision_jsonl_to_coverage_jsonl(&input, &out)
+            .await
+            .expect_err("missing tool fields must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("missing required field"));
+    }
+
+    #[tokio::test]
+    async fn mcp_wrap_coverage_normalizer_and_report_writer_emit_v1_report() {
+        let dir = tempdir().unwrap();
+        let normalized = dir.path().join("normalized.jsonl");
+        let coverage_out = dir.path().join("coverage.json");
+
+        normalize_decision_jsonl_to_coverage_jsonl(
+            &fixture_path("decision_event_basic.jsonl"),
+            &normalized,
+        )
+        .await
+        .expect("normalization should succeed");
+
+        let exit = coverage::write_generated_coverage_report(
+            &normalized,
+            &coverage_out,
+            &["assay_policy_decide".to_string()],
+            "decision_jsonl",
+        )
+        .await
+        .expect("coverage generation should complete");
+        assert_eq!(exit, crate::exit_codes::EXIT_SUCCESS);
+
+        let report: Value =
+            serde_json::from_str(&std::fs::read_to_string(&coverage_out).unwrap()).unwrap();
+        assert_eq!(report["schema_version"], "coverage_report_v1");
+        assert_eq!(report["run"]["source"], "decision_jsonl");
+        assert_eq!(
+            report["tools"]["tools_seen"],
+            json!(["assay_policy_decide"])
+        );
+        assert_eq!(
+            report["taxonomy"]["tool_classes_seen"],
+            json!(["sink:network"])
+        );
+    }
+
+    #[test]
+    fn mcp_wrap_coverage_collect_declared_tools_ignores_wildcards() {
+        let mut policy = McpPolicy::default();
+        policy.tools.allow = Some(vec!["assay_policy_decide".into(), "*".into()]);
+        policy.tools.deny = Some(vec!["assay_check_args".into(), "exec*".into()]);
+        policy.schemas.insert("$defs".into(), json!({}));
+        policy
+            .schemas
+            .insert("assay_check_sequence".into(), json!({"type": "object"}));
+
+        let declared = collect_declared_tools(&policy);
+        assert_eq!(
+            declared,
+            vec![
+                "assay_check_args".to_string(),
+                "assay_check_sequence".to_string(),
+                "assay_policy_decide".to_string(),
+            ]
+        );
+    }
 }

--- a/crates/assay-cli/tests/mcp_wrap_coverage.rs
+++ b/crates/assay-cli/tests/mcp_wrap_coverage.rs
@@ -1,0 +1,46 @@
+#![allow(deprecated)]
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn read_json(path: &std::path::Path) -> Value {
+    let content = std::fs::read_to_string(path).expect("coverage report should exist");
+    serde_json::from_str(&content).expect("coverage report must be valid JSON")
+}
+
+#[test]
+fn mcp_wrap_coverage_cli_smoke_writes_report() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("normalized-wrap.jsonl");
+    let out = dir.path().join("coverage.json");
+
+    std::fs::write(
+        &input,
+        r#"{"tool":"assay_policy_decide","tool_classes":["sink:network"]}
+"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["coverage", "--input"])
+        .arg(&input)
+        .args(["--out"])
+        .arg(&out)
+        .args(["--declared-tool", "assay_policy_decide"])
+        .assert()
+        .success();
+
+    let report = read_json(&out);
+    assert_eq!(report["schema_version"], "coverage_report_v1");
+    assert_eq!(report["run"]["source"], "jsonl");
+    assert_eq!(
+        report["tools"]["tools_seen"],
+        serde_json::json!(["assay_policy_decide"])
+    );
+    assert_eq!(
+        report["taxonomy"]["tool_classes_seen"],
+        serde_json::json!(["sink:network"])
+    );
+}

--- a/scripts/ci/fixtures/coverage/README.md
+++ b/scripts/ci/fixtures/coverage/README.md
@@ -3,3 +3,4 @@
 - `input_basic.jsonl`: basic positive fixture with declared tools, routes, and one unknown tool.
 - `input_tool_name_fallback.jsonl`: positive fixture for `tool_name` fallback parsing.
 - `input_missing_tool_fields.jsonl`: negative fixture for missing or empty `tool` / `tool_name` contract failures.
+- `decision_event_basic.jsonl`: decision-event fixture for B3.2 wrap-path normalization from nested `data.tool` and `data.tool_classes`.

--- a/scripts/ci/fixtures/coverage/decision_event_basic.jsonl
+++ b/scripts/ci/fixtures/coverage/decision_event_basic.jsonl
@@ -1,0 +1,1 @@
+{"specversion":"1.0","id":"evt-1","type":"assay.tool.decision","source":"assay://tests/basic","time":"2026-03-04T14:00:00Z","data":{"tool":"assay_policy_decide","tool_classes":["sink:network"],"decision":"allow","reason_code":"P_POLICY_ALLOW","tool_call_id":"tc-1"}}

--- a/scripts/ci/review-coverage-b3-2.sh
+++ b/scripts/ci/review-coverage-b3-2.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-cli/src/cli/args/mod.rs"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage.rs"
+  "crates/assay-cli/src/cli/commands/coverage/report.rs"
+  "crates/assay-cli/tests/mcp_wrap_coverage.rs"
+  "scripts/ci/fixtures/coverage/decision_event_basic.jsonl"
+  "scripts/ci/fixtures/coverage/README.md"
+  "scripts/ci/review-coverage-b3-2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  [[ "$f" == .github/workflows/* ]] && { echo "FAIL: no workflows"; exit 1; }
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  [[ "$ok" != "true" ]] && { echo "FAIL: file not allowed: $f"; exit 1; }
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n 'coverage_out' crates/assay-cli/src/cli/args/mod.rs >/dev/null || {
+  echo "FAIL: McpWrapArgs missing coverage_out"
+  exit 1
+}
+rg -n 'normalize_decision_jsonl_to_coverage_jsonl|collect_declared_tools' crates/assay-cli/src/cli/commands/mcp.rs >/dev/null || {
+  echo "FAIL: mcp wrap missing coverage helpers"
+  exit 1
+}
+rg -n 'mcp_wrap_coverage_normalizer_and_report_writer_emit_v1_report' crates/assay-cli/src/cli/commands/mcp.rs >/dev/null || {
+  echo "FAIL: wrap coverage writer test missing"
+  exit 1
+}
+
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli coverage_contract
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Implements B3.2 coverage emission for `assay mcp wrap` by normalizing decision JSONL into the existing `coverage_report_v1` builder.

## Scope
- additive `--coverage-out` on `assay mcp wrap`
- wrap-path-only decision JSONL normalization (`data.tool` / `data.tool_name` / `tool` / `tool_name`)
- declared tools derived conservatively from explicit policy tool names only
- temp decision-log handling when `--coverage-out` is set without `--decision-log`
- stable tests + reviewer gate

## Safety
- no workflows
- no assay-core runtime changes
- no broad inference; only narrow keypath normalization for wrap decision events
- wrapped process exit code is preserved; coverage generation errors do not mask wrapped failures

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-coverage-b3-2.sh`
- `cargo test -p assay-cli coverage_contract`
- `cargo test -p assay-cli mcp_wrap_coverage`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
