### PR TITLE
docs(policy): freeze session/state window contract for MCP governance (A2)

### DIFF
--- a/docs/architecture/ADR-029-Session-State-Window.md
+++ b/docs/architecture/ADR-029-Session-State-Window.md
@@ -1,0 +1,95 @@
+# ADR-029: Session & State Window Contract (MCP Governance)
+
+## Status
+Proposed (March 2026)
+
+## Context
+Assay enforces deterministic governance for MCP tool routes. Several experiment lines demonstrated that stateful invariants (sequence/state) generalize beyond lexical checks, including tool-hopping and cross-session delayed sink attempts.
+
+To keep the product surface audit-grade, we need a frozen contract for:
+- how we identify a "session"
+- how we define a "state window" across sessions
+- what we store (privacy/retention defaults)
+- how we produce deterministic snapshot identifiers
+
+This ADR freezes the contract only. It does not add storage backends, enforcement modes, or workflows.
+
+## Decision
+Introduce `session_state_window_v1` as an informational contract describing:
+1) **Session key**: stable identifiers that partition MCP activity into sessions.
+2) **State window**: a bounded time/run window where prior actions remain relevant.
+3) **Privacy/retention defaults**: no raw bodies, no prompt/tool argument storage by default.
+4) **Deterministic snapshot id**: content-addressed state identifiers derived from a canonical snapshot payload.
+
+### 1) Session key contract (frozen)
+A session is identified by the tuple:
+
+- `event_source` (string) — normalized origin, e.g. `assay://…`
+- `server_id` (string) — MCP server label / wrapped target identity
+- `session_id` (string) — generated per run, unique within `(event_source, server_id)`
+
+Notes:
+- `session_id` MUST be opaque (no embedded PII, no timestamps required).
+- `session_id` MUST be stable for the duration of a wrapped MCP process.
+- Any cross-session state references MUST use `state_snapshot_id` (not raw content).
+
+### 2) State window contract (frozen)
+A state window is a bounded relevance horizon used by governance logic:
+
+- `window_kind`: `session` | `cross_session_decay`
+- For `session`: relevance lasts only within the session.
+- For `cross_session_decay`: relevance spans subsequent sessions, bounded by:
+  - `decay_runs` (integer >= 1): number of subsequent sessions where the window remains active.
+
+No other decay semantics (time-based TTL, hybrid windows) are defined in v1.
+
+### 3) Privacy/retention defaults (frozen)
+Default data handling rules:
+- Raw tool arguments, raw document bodies, raw prompts are **not** stored in state snapshots.
+- State snapshots contain only:
+  - tool names
+  - tool classes (if known)
+  - decision codes/reasons
+  - hashes/refs (content-addressed ids), never the raw payload
+
+Optional attachments MAY exist in the broader system, but are explicitly out of scope for this ADR.
+
+### 4) Deterministic snapshot id (frozen)
+`state_snapshot_id` is content-addressed:
+
+- `snapshot_canonical_json` is produced using canonical JSON (key-order independent).
+- `state_snapshot_id = "sha256:" + hex(sha256(snapshot_canonical_json_bytes))`
+
+This ADR freezes:
+- snapshot id MUST be derived from the canonical snapshot payload
+- snapshot id MUST be stable across runs when snapshot content is equal
+- snapshot id MUST NOT depend on local paths, timestamps, hostnames, or random values.
+
+## Schema
+A JSON schema `session_state_window_v1` defines the report/snapshot envelope for:
+- session key fields
+- state window parameters
+- snapshot id + canonicalization fields
+- privacy assertions (what is intentionally not present)
+
+## Consequences
+### Positive
+- Makes session/state semantics explicit and auditable.
+- Enables deterministic replay and cross-session experiments without implying storage/enforcement.
+- Provides a stable interface for future runtime implementations.
+
+### Negative
+- Some future use cases may need time-based TTL or richer provenance.
+- v1 intentionally does not define backend storage or enforcement integration.
+
+## Out of scope (explicit)
+- Any runtime/backend implementation
+- Any new policy DSL
+- Any workflow / CI gating changes
+- Any taint tracking or dataflow labeling
+- Any persistence format beyond this informational contract
+
+## Acceptance criteria (for this A-slice)
+- ADR exists and is marked Proposed.
+- `session_state_window_v1` schema exists.
+- Reviewer gate enforces allowlist-only scope + workflow-ban and validates schema parses.

--- a/schemas/session_state_window_v1.schema.json
+++ b/schemas/session_state_window_v1.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.dev/schemas/session_state_window_v1.schema.json",
+  "title": "Assay Session/State Window Contract v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_version",
+    "session",
+    "window",
+    "snapshot",
+    "privacy"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "session_state_window_v1"
+    },
+    "report_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["event_source", "server_id", "session_id"],
+      "properties": {
+        "event_source": { "type": "string", "minLength": 1 },
+        "server_id": { "type": "string", "minLength": 1 },
+        "session_id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["window_kind"],
+      "properties": {
+        "window_kind": {
+          "type": "string",
+          "enum": ["session", "cross_session_decay"]
+        },
+        "decay_runs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Only used when window_kind=cross_session_decay"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "window_kind": { "const": "cross_session_decay" } },
+            "required": ["window_kind"]
+          },
+          "then": { "required": ["decay_runs"] }
+        },
+        {
+          "if": {
+            "properties": { "window_kind": { "const": "session" } },
+            "required": ["window_kind"]
+          },
+          "then": {
+            "not": { "required": ["decay_runs"] }
+          }
+        }
+      ]
+    },
+    "snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state_snapshot_id", "canonicalization"],
+      "properties": {
+        "state_snapshot_id": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "canonicalization": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["method"],
+          "properties": {
+            "method": {
+              "type": "string",
+              "enum": ["canonical_json_sha256"]
+            }
+          }
+        },
+        "contents_ref": {
+          "type": "string",
+          "description": "Optional reference to a stored snapshot payload; not required in v1."
+        }
+      }
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stores_raw_tool_args",
+        "stores_raw_prompt_bodies",
+        "stores_raw_document_bodies"
+      ],
+      "properties": {
+        "stores_raw_tool_args": { "type": "boolean" },
+        "stores_raw_prompt_bodies": { "type": "boolean" },
+        "stores_raw_document_bodies": { "type": "boolean" },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/scripts/ci/review-session-state-a2.sh
+++ b/scripts/ci/review-session-state-a2.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-029-Session-State-Window.md"
+  "schemas/session_state_window_v1.schema.json"
+  "scripts/ci/review-session-state-a2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: A2 freeze must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in A2 freeze: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n '^# ADR-029: Session & State Window Contract' docs/architecture/ADR-029-Session-State-Window.md >/dev/null || {
+  echo "FAIL: ADR title missing"
+  exit 1
+}
+python3 - <<'PY'
+import json
+from pathlib import Path
+p = Path("schemas/session_state_window_v1.schema.json")
+obj = json.loads(p.read_text(encoding="utf-8"))
+assert obj["properties"]["schema_version"]["const"] == "session_state_window_v1"
+assert "session" in obj["properties"]
+assert "window" in obj["properties"]
+assert "snapshot" in obj["properties"]
+assert "privacy" in obj["properties"]
+print("ok")
+PY
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only A2 freeze for `session_state_window_v1`: session key contract, cross-session decay window contract, privacy/retention defaults, and deterministic snapshot id rules.

## Scope
- docs/architecture/ADR-029-Session-State-Window.md
- schemas/session_state_window_v1.schema.json
- scripts/ci/review-session-state-a2.sh

## Safety
- Docs + schema + reviewer gate only
- No workflows / runtime changes

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-session-state-a2.sh`
- `python3 -m json.tool schemas/session_state_window_v1.schema.json >/dev/null`
- `cargo fmt --check`
- `cargo clippy -p assay-cli -- -D warnings`
