### PR TITLE
docs(ops): close MCP taxonomy + coverage line with runbook + reviewer gate (C-slice)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-mcp-tool-taxonomy-coverage-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-mcp-tool-taxonomy-coverage-closure.md
@@ -1,0 +1,28 @@
+# SPLIT CHECKLIST — MCP Tool Taxonomy + Coverage Closure (C-slice)
+
+## Scope discipline
+- [ ] Only docs + reviewer gate changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No Rust code changes
+- [ ] No schema changes
+
+## Runbook completeness
+- [ ] Explains taxonomy + allow/deny classes
+- [ ] Explains offline `assay coverage` usage
+- [ ] Explains `assay mcp wrap --coverage-out` usage
+- [ ] Lists bounded non-goals (no session inference, no taint tracking)
+- [ ] Troubleshooting section present
+
+## Consistency checks (manual spot-check)
+- [ ] Mentions ADR-028 / ADR-029 correctly
+- [ ] Uses correct schema names:
+  - [ ] `coverage_report_v1`
+  - [ ] `session_state_window_v1`
+- [ ] Uses correct CLI flags:
+  - [ ] `assay coverage --input/--out/--declared-tool`
+  - [ ] `assay mcp wrap --coverage-out`
+
+## Gate
+- [ ] Reviewer gate enforces allowlist-only
+- [ ] Reviewer gate bans workflows
+- [ ] Reviewer gate marker checks pass

--- a/docs/contributing/SPLIT-REVIEW-PACK-mcp-tool-taxonomy-coverage-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-mcp-tool-taxonomy-coverage-closure.md
@@ -1,0 +1,33 @@
+# SPLIT REVIEW PACK — MCP Tool Taxonomy + Coverage Closure (C-slice)
+
+## Intent
+Close the MCP governance spine line with operational documentation and a reviewer gate:
+- tool taxonomy + class-aware allow/deny
+- coverage report generation + wrap emission
+- bounded claims and non-goals
+
+## Scope
+Docs + reviewer script only:
+- `docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md`
+- `docs/contributing/SPLIT-CHECKLIST-mcp-tool-taxonomy-coverage-closure.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-mcp-tool-taxonomy-coverage-closure.md`
+- `scripts/ci/review-mcp-tool-taxonomy-coverage-closure.sh`
+
+## Safety contracts
+- No runtime changes
+- No workflow changes
+- No schema changes
+
+## Reviewer quick-check (60s)
+1. Open the runbook and ensure it includes:
+   - `assay coverage --input` and `assay mcp wrap --coverage-out`
+   - bounded non-goals
+2. Run reviewer gate:
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-mcp-tool-taxonomy-coverage-closure.sh
+```
+
+## Expected outcome
+- Gate passes
+- Documentation is sufficient for a new developer to use taxonomy + coverage without reading code

--- a/docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md
+++ b/docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md
@@ -1,0 +1,98 @@
+# MCP Tool Taxonomy + Coverage Runbook (v1)
+
+## Intent
+Operational guide for the MCP governance spine:
+- tool taxonomy (classes)
+- class-aware allow/deny evaluation
+- coverage report generation (offline)
+- coverage emission from `assay mcp wrap` (runtime)
+- session/state window contract reference (ADR-029)
+
+This runbook is informational and does not change enforcement behavior.
+
+## What shipped on `main`
+### Policy surface
+- `tool_classes`: a taxonomy map of tool -> classes
+- `tools.allow_classes` / `tools.deny_classes`: class-based matching in allow/deny evaluation
+- decision events include deterministic `matched_tool_classes`
+
+### Coverage surface
+- `assay coverage --input <jsonl> --out <path> [--declared-tool ...]`
+  - input accepts `tool` (preferred) or `tool_name` (fallback)
+- `assay mcp wrap --coverage-out <path> ...`
+  - emits `coverage_report_v1` based on decision log normalization
+  - no core proxy changes required
+
+### Contracts
+- `schemas/coverage_report_v1.schema.json` (ADR-028)
+- `schemas/session_state_window_v1.schema.json` (ADR-029, freeze only)
+
+## Quickstart: classify tools (taxonomy)
+1. Define classes per tool in policy.
+   Prefer stable class strings such as:
+   - `sink:network`
+   - `source:local`
+   - `source:sensitive`
+   - `exec:system`
+   - `store:disk`
+2. Use allow/deny by class.
+   - block all network sinks:
+     - `tools.deny_classes: ["sink:network"]`
+   - allow only local sources:
+     - `tools.allow_classes: ["source:local"]`
+
+## Quickstart: generate coverage offline
+Given a JSONL file of tool events:
+
+```bash
+assay coverage \
+  --input traces.ndjson \
+  --out artifacts/coverage_report_v1.json \
+  --declared-tool read_document \
+  --declared-tool web_search
+```
+
+Interpretation:
+- `tools.tools_unknown`: observed tools not declared by policy/config
+- `taxonomy.tool_classes_missing`: observed tools with no taxonomy entry (blind spots)
+- `routes.routes_seen`: adjacent tool-call edges (v1 is order-based, no session inference)
+
+## Quickstart: emit coverage from an MCP wrapped session
+
+```bash
+assay mcp wrap \
+  --policy policy.yaml \
+  --event-source assay://local/demo \
+  --coverage-out artifacts/coverage_report_v1.json \
+  -- <mcp-host-cmd> <args...>
+```
+
+Notes:
+- If no `--decision-log` is provided, a temp decision log is created and cleaned up.
+- Coverage generation failures return exit code `2` (measurement/contract) but do not mask wrapped process failures.
+
+## Operational interpretation guidelines
+### Completeness questions this answers
+- Did we see any tools that our policy did not explicitly declare?
+- Are we missing taxonomy for tools that occurred in production traces?
+- What tool-to-tool adjacency edges are actually exercised?
+
+### What this does NOT claim
+- No session/state inference in coverage v1 routes.
+- No taint tracking or semantic flow labeling.
+- No enforcement changes from coverage emission.
+
+## Troubleshooting
+### Coverage-out exists but is empty or missing fields
+- Ensure decision events contain `data.tool` or top-level `tool|tool_name`.
+- Ensure the wrapped command produced at least one decision event.
+
+### Coverage generation fails (exit 2)
+- Most common: decision log line missing tool identity (`tool`/`tool_name`).
+- Verify input JSONL is line-delimited valid JSON.
+
+## References
+- ADR-028 Coverage Report
+- ADR-029 Session/State Window Contract (freeze)
+- Coverage schema: `schemas/coverage_report_v1.schema.json`
+- Session/state schema: `schemas/session_state_window_v1.schema.json`

--- a/scripts/ci/review-mcp-tool-taxonomy-coverage-closure.sh
+++ b/scripts/ci/review-mcp-tool-taxonomy-coverage-closure.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md"
+  "docs/contributing/SPLIT-CHECKLIST-mcp-tool-taxonomy-coverage-closure.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-mcp-tool-taxonomy-coverage-closure.md"
+  "scripts/ci/review-mcp-tool-taxonomy-coverage-closure.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: closure slice must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in closure slice: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n 'MCP Tool Taxonomy \+ Coverage Runbook \(v1\)' docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook title missing"
+  exit 1
+}
+rg -n 'assay mcp wrap.*--coverage-out' docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md >/dev/null || {
+  echo "FAIL: wrap coverage-out usage missing"
+  exit 1
+}
+rg -n 'assay coverage.*--input' docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md >/dev/null || {
+  echo "FAIL: coverage offline usage missing"
+  exit 1
+}
+rg -n 'ADR-028|ADR-029' docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md >/dev/null || {
+  echo "FAIL: ADR references missing"
+  exit 1
+}
+rg -n 'No session/state inference in coverage v1 routes' docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md >/dev/null || {
+  echo "FAIL: bounded non-goal missing"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Close the MCP governance spine line with operational documentation and a reviewer gate for taxonomy + coverage.

## Scope
- docs/ops/MCP-TOOL-TAXONOMY-AND-COVERAGE-RUNBOOK.md
- docs/contributing/SPLIT-CHECKLIST-mcp-tool-taxonomy-coverage-closure.md
- docs/contributing/SPLIT-REVIEW-PACK-mcp-tool-taxonomy-coverage-closure.md
- scripts/ci/review-mcp-tool-taxonomy-coverage-closure.sh

## Safety
- docs + reviewer gate only
- no workflows
- no runtime changes
- no schema changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-mcp-tool-taxonomy-coverage-closure.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
