### PR TITLE
feat(mcp): add informational --state-window-out export (B1)

### DIFF
--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -527,6 +527,10 @@ pub struct McpWrapArgs {
     #[arg(long, requires = "event_source")]
     pub coverage_out: Option<PathBuf>,
 
+    /// Write a session_state_window_v1 informational report after the wrapped MCP session completes.
+    #[arg(long, requires = "event_source")]
+    pub state_window_out: Option<PathBuf>,
+
     /// CloudEvents source URI (e.g. assay://org/app).
     /// Must be absolute URI with scheme://. Required when --audit-log or --decision-log is set.
     #[arg(long, value_name = "URI")]

--- a/crates/assay-cli/src/cli/commands/mcp.rs
+++ b/crates/assay-cli/src/cli/commands/mcp.rs
@@ -1,5 +1,6 @@
 use super::super::args::{McpArgs, McpSub, McpWrapArgs};
 use super::coverage;
+use super::session_state_window;
 use anyhow::{Context, Result};
 use assay_core::mcp::policy::McpPolicy;
 use assay_core::mcp::proxy::{McpProxy, ProxyConfig, ProxyConfigRaw};
@@ -152,6 +153,14 @@ fn unique_temp_path(stem: &str, extension: &str) -> PathBuf {
     ))
 }
 
+fn generate_session_id() -> String {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("mcpwrap-{}-{stamp}", std::process::id())
+}
+
 struct TempPathGuard {
     path: PathBuf,
 }
@@ -183,6 +192,7 @@ async fn cmd_wrap(args: McpWrapArgs) -> anyhow::Result<i32> {
 
     let cmd = &args.command[0];
     let cmd_args = &args.command[1..];
+    let session_id = generate_session_id();
 
     // Load Policy
     let policy = if args.policy.exists() {
@@ -228,6 +238,8 @@ async fn cmd_wrap(args: McpWrapArgs) -> anyhow::Result<i32> {
             .unwrap_or_else(|| "default-mcp-server".into()),
     };
     let config = ProxyConfig::try_from_raw(raw)?;
+    let state_window_event_source = config.event_source.clone();
+    let state_window_server_id = config.server_id.clone();
 
     if config.dry_run {
         eprintln!("[assay] DRY RUN MODE: No actions will be blocked.");
@@ -271,17 +283,43 @@ async fn cmd_wrap(args: McpWrapArgs) -> anyhow::Result<i32> {
         crate::exit_codes::EXIT_SUCCESS
     };
 
+    let state_status = if let Some(state_window_out) = args.state_window_out.as_ref() {
+        let event_source = state_window_event_source
+            .as_deref()
+            .context("state window export requires event_source")?;
+        session_state_window::write_state_window_out(
+            state_window_out,
+            event_source,
+            &state_window_server_id,
+            &session_id,
+        )
+        .await?
+    } else {
+        crate::exit_codes::EXIT_SUCCESS
+    };
+
     if wrapped_code != crate::exit_codes::EXIT_SUCCESS {
-        if coverage_status != crate::exit_codes::EXIT_SUCCESS {
+        if coverage_status != crate::exit_codes::EXIT_SUCCESS
+            || state_status != crate::exit_codes::EXIT_SUCCESS
+        {
             eprintln!(
-                "Coverage generation failed after wrapped command exited with code {}; preserving wrapped exit code",
+                "Coverage/state-window generation failed after wrapped command exited with code {}; preserving wrapped exit code",
                 wrapped_code
             );
         }
         return Ok(wrapped_code);
     }
 
-    Ok(coverage_status)
+    if coverage_status != crate::exit_codes::EXIT_SUCCESS {
+        if state_status != crate::exit_codes::EXIT_SUCCESS {
+            eprintln!(
+                "State window export failed after coverage generation failed; preserving coverage exit code"
+            );
+        }
+        return Ok(coverage_status);
+    }
+
+    Ok(state_status)
 }
 
 #[cfg(test)]

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -39,6 +39,7 @@ pub(crate) mod run;
 pub(crate) mod run_output;
 pub(crate) mod runner_builder;
 pub mod sandbox;
+pub(crate) mod session_state_window;
 pub mod setup;
 #[cfg(feature = "sim")]
 pub mod sim;

--- a/crates/assay-cli/src/cli/commands/session_state_window.rs
+++ b/crates/assay-cli/src/cli/commands/session_state_window.rs
@@ -1,0 +1,198 @@
+use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_INFRA_ERROR, EXIT_SUCCESS};
+use jsonschema::{Draft, Validator};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use std::sync::OnceLock;
+
+fn session_state_window_schema_json() -> &'static str {
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../schemas/session_state_window_v1.schema.json"
+    ))
+}
+
+fn session_state_window_validator() -> Result<&'static Validator, String> {
+    static COMPILED: OnceLock<Result<Validator, String>> = OnceLock::new();
+    static VALIDATOR: OnceLock<Validator> = OnceLock::new();
+
+    let compiled = COMPILED.get_or_init(|| {
+        let schema: Value = serde_json::from_str(session_state_window_schema_json())
+            .map_err(|e| format!("failed to parse embedded session_state_window schema: {e}"))?;
+
+        jsonschema::options()
+            .with_draft(Draft::Draft202012)
+            .build(&schema)
+            .map_err(|e| format!("failed to compile session_state_window schema: {e}"))
+    });
+
+    match compiled {
+        Ok(validator) => Ok(VALIDATOR.get_or_init(|| validator.clone())),
+        Err(err) => Err(err.clone()),
+    }
+}
+
+fn validate_session_state_window_v1(report: &Value) -> Result<(), String> {
+    let validator = session_state_window_validator()?;
+    let mut errs = validator.iter_errors(report);
+    let mut out = Vec::new();
+
+    for _ in 0..8 {
+        if let Some(err) = errs.next() {
+            out.push(format!("{err} at {}", err.instance_path()));
+        } else {
+            break;
+        }
+    }
+
+    if out.is_empty() {
+        Ok(())
+    } else {
+        Err(out.join("; "))
+    }
+}
+
+fn canonical_json_bytes(v: &Value) -> anyhow::Result<Vec<u8>> {
+    fn normalize(v: &Value) -> Value {
+        match v {
+            Value::Object(map) => {
+                let mut keys: Vec<_> = map.keys().cloned().collect();
+                keys.sort();
+                let mut out = serde_json::Map::new();
+                for key in keys {
+                    out.insert(key.clone(), normalize(&map[&key]));
+                }
+                Value::Object(out)
+            }
+            Value::Array(arr) => Value::Array(arr.iter().map(normalize).collect()),
+            _ => v.clone(),
+        }
+    }
+
+    Ok(serde_json::to_vec(&normalize(v))?)
+}
+
+fn digest_canonical_json(v: &Value) -> anyhow::Result<String> {
+    let mut hasher = Sha256::new();
+    hasher.update(canonical_json_bytes(v)?);
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+pub(crate) async fn write_state_window_out(
+    out: &Path,
+    event_source: &str,
+    server_id: &str,
+    session_id: &str,
+) -> anyhow::Result<i32> {
+    let privacy = json!({
+        "stores_raw_tool_args": false,
+        "stores_raw_prompt_bodies": false,
+        "stores_raw_document_bodies": false
+    });
+
+    let snapshot_payload = json!({
+        "session": {
+            "event_source": event_source,
+            "server_id": server_id,
+            "session_id": session_id
+        },
+        "window": {
+            "window_kind": "session"
+        },
+        "privacy": privacy
+    });
+
+    let state_snapshot_id = match digest_canonical_json(&snapshot_payload) {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!("Measurement error: failed to compute state snapshot id: {e}");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+
+    let report = json!({
+        "schema_version": "session_state_window_v1",
+        "report_version": "1",
+        "session": {
+            "event_source": event_source,
+            "server_id": server_id,
+            "session_id": session_id
+        },
+        "window": {
+            "window_kind": "session"
+        },
+        "snapshot": {
+            "state_snapshot_id": state_snapshot_id,
+            "canonicalization": {
+                "method": "canonical_json_sha256"
+            }
+        },
+        "privacy": privacy
+    });
+
+    if let Err(e) = validate_session_state_window_v1(&report) {
+        eprintln!("Measurement error: session state window schema validation failed: {e}");
+        return Ok(EXIT_CONFIG_ERROR);
+    }
+
+    let Some(parent) = out.parent() else {
+        eprintln!("Infra error: invalid output path {}", out.display());
+        return Ok(EXIT_INFRA_ERROR);
+    };
+
+    if !parent.as_os_str().is_empty() {
+        if let Err(e) = tokio::fs::create_dir_all(parent).await {
+            eprintln!("Infra error: failed to prepare {}: {e}", parent.display());
+            return Ok(EXIT_INFRA_ERROR);
+        }
+    }
+
+    let payload = serde_json::to_vec_pretty(&report)
+        .expect("session state window report serialization should be infallible");
+    if let Err(e) = tokio::fs::write(out, payload).await {
+        eprintln!(
+            "Infra error: failed to write state window report to {}: {e}",
+            out.display()
+        );
+        return Ok(EXIT_INFRA_ERROR);
+    }
+
+    eprintln!("Generated session_state_window_v1 -> {}", out.display());
+
+    Ok(EXIT_SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn state_window_writer_emits_schema_valid_session_report() {
+        let dir = tempdir().unwrap();
+        let out = dir.path().join("state.json");
+
+        let exit = write_state_window_out(
+            &out,
+            "assay://tests/session-state",
+            "default-mcp-server",
+            "mcpwrap-123",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(exit, EXIT_SUCCESS);
+
+        let report: Value = serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+        assert_eq!(report["schema_version"], "session_state_window_v1");
+        assert_eq!(report["window"]["window_kind"], "session");
+        assert_eq!(report["privacy"]["stores_raw_tool_args"], false);
+        assert_eq!(report["privacy"]["stores_raw_prompt_bodies"], false);
+        assert_eq!(report["privacy"]["stores_raw_document_bodies"], false);
+
+        let id = report["snapshot"]["state_snapshot_id"].as_str().unwrap();
+        let re = Regex::new(r"^sha256:[0-9a-f]{64}$").unwrap();
+        assert!(re.is_match(id));
+    }
+}

--- a/crates/assay-cli/tests/mcp_wrap_state_window_out.rs
+++ b/crates/assay-cli/tests/mcp_wrap_state_window_out.rs
@@ -1,0 +1,107 @@
+#![allow(deprecated)]
+
+use anyhow::Context;
+use assert_cmd::Command;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn exe_name(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+fn bin_path(bin: &str) -> anyhow::Result<PathBuf> {
+    let env_key_underscore = format!("CARGO_BIN_EXE_{}", bin.replace('-', "_"));
+    let env_key_hyphen = format!("CARGO_BIN_EXE_{bin}");
+
+    if let Ok(p) = std::env::var(&env_key_underscore).or_else(|_| std::env::var(&env_key_hyphen)) {
+        return Ok(PathBuf::from(p));
+    }
+
+    let target_dir = if let Ok(td) = std::env::var("CARGO_TARGET_DIR") {
+        PathBuf::from(td)
+    } else {
+        let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace_root = manifest
+            .parent()
+            .and_then(|p| p.parent())
+            .context("failed to resolve workspace root from CARGO_MANIFEST_DIR")?;
+        workspace_root.join("target")
+    };
+
+    Ok(target_dir.join("debug").join(exe_name(bin)))
+}
+
+fn read_json(path: &Path) -> Value {
+    let content = std::fs::read_to_string(path).expect("state window report should exist");
+    serde_json::from_str(&content).expect("state window report must be valid JSON")
+}
+
+#[test]
+fn mcp_wrap_state_window_out_writes_valid_v1_report() -> anyhow::Result<()> {
+    let assay = bin_path("assay")?;
+    assert!(assay.exists(), "missing binary: {}", assay.display());
+
+    let tmp = TempDir::new()?;
+    let policy_path = tmp.path().join("proxy-policy.yaml");
+    let out = tmp.path().join("state-window.json");
+
+    std::fs::write(
+        &policy_path,
+        r#"
+version: "2.0"
+name: "state-window-export"
+tools:
+  allow: ["*"]
+enforcement:
+  unconstrained_tools: allow
+"#,
+    )?;
+
+    Command::new(&assay)
+        .args([
+            "mcp",
+            "wrap",
+            "--policy",
+            policy_path.to_string_lossy().as_ref(),
+            "--event-source",
+            "assay://tests/state-window",
+            "--label",
+            "default-mcp-server",
+            "--state-window-out",
+        ])
+        .arg(&out)
+        .arg("--")
+        .arg(assay)
+        .arg("--help")
+        .assert()
+        .success();
+
+    let report = read_json(&out);
+    assert_eq!(report["schema_version"], "session_state_window_v1");
+    assert_eq!(report["report_version"], "1");
+    assert_eq!(
+        report["session"]["event_source"],
+        "assay://tests/state-window"
+    );
+    assert_eq!(report["session"]["server_id"], "default-mcp-server");
+    assert!(!report["session"]["session_id"]
+        .as_str()
+        .unwrap()
+        .trim()
+        .is_empty());
+    assert_eq!(report["window"]["window_kind"], "session");
+    assert_eq!(report["privacy"]["stores_raw_tool_args"], false);
+    assert_eq!(report["privacy"]["stores_raw_prompt_bodies"], false);
+    assert_eq!(report["privacy"]["stores_raw_document_bodies"], false);
+
+    let id = report["snapshot"]["state_snapshot_id"].as_str().unwrap();
+    assert!(id.starts_with("sha256:"));
+    assert_eq!(id.len(), "sha256:".len() + 64);
+
+    Ok(())
+}

--- a/scripts/ci/review-session-state-b1.sh
+++ b/scripts/ci/review-session-state-b1.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-cli/src/cli/args/mod.rs"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-cli/tests/mcp_wrap_state_window_out.rs"
+  "scripts/ci/review-session-state-b1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  [[ "$f" == .github/workflows/* ]] && { echo "FAIL: no workflows"; exit 1; }
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  [[ "$ok" != "true" ]] && { echo "FAIL: file not allowed: $f"; exit 1; }
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+rg -n 'state_window_out' crates/assay-cli/src/cli/args/mod.rs >/dev/null || {
+  echo "FAIL: missing --state-window-out"
+  exit 1
+}
+rg -n 'write_state_window_out' crates/assay-cli/src/cli/commands/mcp.rs >/dev/null || {
+  echo "FAIL: mcp wrap missing export hook"
+  exit 1
+}
+
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Add `assay mcp wrap --state-window-out <path>` as an informational `session_state_window_v1` export, without changing MCP enforcement or introducing any workflow changes.

## Scope
- crates/assay-cli/src/cli/args/mod.rs
- crates/assay-cli/src/cli/commands/mod.rs
- crates/assay-cli/src/cli/commands/mcp.rs
- crates/assay-cli/src/cli/commands/session_state_window.rs
- crates/assay-cli/tests/mcp_wrap_state_window_out.rs
- scripts/ci/review-session-state-b1.sh

## Safety
- no workflows
- no core proxy changes
- informational export only
- wrapped exit code remains authoritative over coverage/state export failures

## Verification
- BASE_REF=origin/main bash scripts/ci/review-session-state-b1.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
- cargo test -p assay-cli mcp_wrap_state_window_out
