### PR TITLE
docs(ops): close MCP session/state export line with runbook + reviewer gate (C-slice)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-mcp-session-state-window-export-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-mcp-session-state-window-export-closure.md
@@ -1,0 +1,24 @@
+# SPLIT CHECKLIST — MCP Session/State Window Export Closure (C-slice)
+
+## Scope discipline
+- [ ] Only docs + reviewer gate changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No Rust code changes
+- [ ] No schema/ADR changes
+
+## Runbook completeness
+- [ ] Documents `assay mcp wrap --state-window-out`
+- [ ] Documents exit priority: wrapped > coverage > state-window
+- [ ] States deterministic snapshot id mechanism
+- [ ] States privacy defaults (`stores_raw_* = false`)
+- [ ] Bounded non-goals present (no backend, no enforcement, no cross-session decay)
+
+## Consistency checks
+- [ ] References ADR-029
+- [ ] References `session_state_window_v1` schema name correctly
+- [ ] Mentions `window_kind: session` for current export
+
+## Gate
+- [ ] Reviewer gate allowlist-only
+- [ ] Reviewer gate bans workflows
+- [ ] Marker checks pass

--- a/docs/contributing/SPLIT-REVIEW-PACK-mcp-session-state-window-export-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-mcp-session-state-window-export-closure.md
@@ -1,0 +1,30 @@
+# SPLIT REVIEW PACK — MCP Session/State Window Export Closure (C-slice)
+
+## Intent
+Close the session/state export line with operational documentation and a reviewer gate.
+
+## Scope
+Docs + reviewer script only:
+- `docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md`
+- `docs/contributing/SPLIT-CHECKLIST-mcp-session-state-window-export-closure.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-mcp-session-state-window-export-closure.md`
+- `scripts/ci/review-mcp-session-state-window-export-closure.sh`
+
+## Safety contracts
+- No runtime changes
+- No workflow changes
+- No schema/ADR changes
+
+## Reviewer quick-check (60s)
+1. Confirm runbook includes:
+- `assay mcp wrap --state-window-out`
+- deterministic snapshot id and privacy defaults
+- bounded non-goals
+2. Run the reviewer gate:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-mcp-session-state-window-export-closure.sh
+```
+
+## Expected outcome
+- Gate passes.
+- Documentation is sufficient for a new developer to use the export correctly.

--- a/docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md
+++ b/docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md
@@ -1,0 +1,77 @@
+# MCP Session/State Window Export Runbook (v1)
+
+## Intent
+Operational guide for the informational `session_state_window_v1` export from MCP wrap:
+
+- CLI surface: `assay mcp wrap --state-window-out <path>`
+- Contract: ADR-029 + `schemas/session_state_window_v1.schema.json`
+- Guarantees:
+  - schema-validated output
+  - deterministic snapshot ids (canonical JSON -> sha256)
+  - no backend / no enforcement (informational only)
+  - wrapped process exit remains authoritative
+
+## What shipped on `main`
+- `assay mcp wrap --state-window-out <path>` writes a `session_state_window_v1` JSON file after the wrapped session completes.
+- The report includes:
+  - `session` tuple (`event_source`, `server_id`, `session_id`)
+  - `window` (`window_kind: "session"` in v1 export)
+  - `snapshot.state_snapshot_id` (deterministic content-addressed id)
+  - `privacy` defaults (`stores_raw_* = false`)
+- Output is validated against the embedded schema before writing.
+
+## Quickstart
+```bash
+assay mcp wrap \
+  --policy policy.yaml \
+  --event-source assay://local/demo \
+  --state-window-out artifacts/session_state_window_v1.json \
+  -- <mcp-host-cmd> <args...>
+```
+
+## Exit semantics
+- Wrapped command exit code is always authoritative:
+  - if the wrapped command fails, its exit code is returned
+- If wrapped succeeds:
+  - coverage-out (if enabled) may still fail the overall run
+  - state-window-out failures return:
+    - `2` for measurement/contract issues (rare)
+    - `3` for infra write issues
+- Current priority is: wrapped > coverage > state-window.
+
+## Interpretation
+
+### What this report is good for
+- Auditable session identity for MCP governance workflows.
+- Stable, content-addressed snapshot ids for later linking/correlation.
+- A minimal session-scope state window boundary for experiments and future features.
+
+### What this does NOT claim (bounded)
+- No cross-session decay logic is implemented by this export.
+- No backend persistence is defined.
+- No enforcement behavior is introduced.
+- No taint tracking or semantic flow labeling.
+
+## Privacy defaults
+The export is intentionally safe-by-default:
+- `stores_raw_tool_args = false`
+- `stores_raw_prompt_bodies = false`
+- `stores_raw_document_bodies = false`
+
+Only identifiers and stable metadata are included.
+
+## Troubleshooting
+
+### Output file missing
+- Ensure `--state-window-out` is set and points to a writable location.
+- Check wrapped process exit code: failures may stop later exports depending on exit priority.
+
+### Schema validation failure
+- Indicates a bug/regression. Capture:
+  - `assay --version`
+  - the command line used
+  - stderr output
+
+## References
+- ADR-029 Session & State Window Contract
+- Schema: `schemas/session_state_window_v1.schema.json`

--- a/scripts/ci/review-mcp-session-state-window-export-closure.sh
+++ b/scripts/ci/review-mcp-session-state-window-export-closure.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md"
+  "docs/contributing/SPLIT-CHECKLIST-mcp-session-state-window-export-closure.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-mcp-session-state-window-export-closure.md"
+  "scripts/ci/review-mcp-session-state-window-export-closure.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: closure slice must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in closure slice: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n 'MCP Session/State Window Export Runbook \(v1\)' docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook title missing"
+  exit 1
+}
+rg -n 'assay mcp wrap.*--state-window-out' docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md >/dev/null || {
+  echo "FAIL: state-window-out usage missing"
+  exit 1
+}
+rg -n 'wrapped.*exit.*authoritative|exit.*priority|wrapped > coverage > state-window' docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md >/dev/null || {
+  echo "FAIL: exit priority/authoritative note missing"
+  exit 1
+}
+rg -n 'deterministic|canonical JSON|sha256' docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md >/dev/null || {
+  echo "FAIL: deterministic snapshot id explanation missing"
+  exit 1
+}
+rg -n 'stores_raw_tool_args.*false' docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md >/dev/null || {
+  echo "FAIL: privacy defaults missing"
+  exit 1
+}
+rg -n 'ADR-029' docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md >/dev/null || {
+  echo "FAIL: ADR reference missing"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only C-slice closure for the MCP session/state window export line.

## Scope
- /Users/roelschuurkes/assay/docs/ops/MCP-SESSION-STATE-WINDOW-EXPORT-RUNBOOK.md
- /Users/roelschuurkes/assay/docs/contributing/SPLIT-CHECKLIST-mcp-session-state-window-export-closure.md
- /Users/roelschuurkes/assay/docs/contributing/SPLIT-REVIEW-PACK-mcp-session-state-window-export-closure.md
- /Users/roelschuurkes/assay/scripts/ci/review-mcp-session-state-window-export-closure.sh

## Safety
- Docs + reviewer gate only
- No workflows
- No runtime/schema/ADR changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-mcp-session-state-window-export-closure.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings