### PR TITLE
docs(policy): freeze B4 DX contract for coverage + wrap

### DIFF
--- a/docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md
+++ b/docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md
@@ -1,0 +1,52 @@
+# ADR-030: Coverage + Wrap DX Polish
+
+## Status
+Proposed (March 2026)
+
+## Context
+The current MCP governance spine is complete and working on `main`:
+- tool taxonomy and class-aware matching
+- coverage report contract + generator + wrap emission
+- session/state window contract + informational wrap export
+
+B4 focuses on CLI/DX polish only. We need a small, low-risk contract for usability improvements without changing policy semantics or runtime enforcement.
+
+## Decision
+Introduce a DX-only polish scope for coverage and wrap exports:
+
+1. `assay coverage` adds format selection:
+- `--format json|md`
+- `md` provides a human-readable summary for PR/review workflows.
+
+2. `assay coverage` adds declared tools file input:
+- `--declared-tools-file <path>`
+- File is one tool per line.
+- Empty lines and comment lines (`# ...`) are ignored.
+- Values are unioned with repeated `--declared-tool` flags.
+
+3. `assay mcp wrap` export logging is consistent:
+- `--coverage-out` writes one stderr line in a stable style.
+- `--state-window-out` writes one stderr line in the same style.
+
+## Constraints (frozen)
+- No schema changes (`coverage_report_v1` and `session_state_window_v1` stay unchanged).
+- No workflow or required-check changes.
+- No behavior changes to enforcement paths.
+- Exit precedence remains unchanged: `wrapped > coverage > state-window`.
+
+## Error Handling (frozen)
+- Input/contract parsing failures return exit code `2`.
+- Output write failures return exit code `3`.
+- Wrapped process exit remains authoritative.
+
+## Out of Scope
+- Any policy DSL changes.
+- Any state backend implementation.
+- Any taint/semantic dataflow features.
+- Any runtime behavior changes beyond DX output formatting and file-input ergonomics.
+
+## Acceptance Criteria (B4A)
+- ADR-030 documents `--format md` and `--declared-tools-file`.
+- ADR-030 documents both `--coverage-out` and `--state-window-out` logging consistency.
+- ADR-030 documents exit-precedence invariants.
+- Reviewer gate enforces docs-only scope + workflow ban.

--- a/scripts/ci/review-b4a-dx-freeze.sh
+++ b/scripts/ci/review-b4a-dx-freeze.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md"
+  "scripts/ci/review-b4a-dx-freeze.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: B4A freeze must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in B4A freeze: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n '^# ADR-030: Coverage \+ Wrap DX Polish' docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md >/dev/null || {
+  echo "FAIL: ADR-030 title missing"
+  exit 1
+}
+rg -n 'assay coverage.*--format (md\|json)|--format md' docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md >/dev/null || {
+  echo "FAIL: ADR-030 missing --format md contract"
+  exit 1
+}
+rg -n -- '--declared-tools-file' docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md >/dev/null || {
+  echo "FAIL: ADR-030 missing --declared-tools-file contract"
+  exit 1
+}
+rg -n -- '--coverage-out' docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md >/dev/null || {
+  echo "FAIL: ADR-030 missing wrap export mention (--coverage-out)"
+  exit 1
+}
+rg -n -- '--state-window-out' docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md >/dev/null || {
+  echo "FAIL: ADR-030 missing wrap export mention (--state-window-out)"
+  exit 1
+}
+rg -n 'wrapped.*exit.*authoritative|wrapped > coverage > state-window' docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md >/dev/null || {
+  echo "FAIL: ADR-030 missing exit priority constraint"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Freeze DX contract for coverage + wrap exports:
- `assay coverage --format md`
- `assay coverage --declared-tools-file`
- consistent wrap export logging
- no behavior change; wrapped exit remains authoritative

## Scope
- docs/architecture/ADR-030-Coverage-Wrap-DX-Polish.md
- scripts/ci/review-b4a-dx-freeze.sh

## Safety
- Docs + gate only
- No workflows, no runtime changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-b4a-dx-freeze.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
