### PR TITLE
feat(cli): B4 DX polish for coverage format/file input + wrap export logging

### DIFF
--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -395,6 +395,10 @@ pub struct CoverageArgs {
     #[arg(long = "declared-tool")]
     pub declared_tools: Vec<String>,
 
+    /// File with one declared tool per line (empty lines and # comments ignored).
+    #[arg(long = "declared-tools-file")]
+    pub declared_tools_file: Option<std::path::PathBuf>,
+
     #[arg(long, default_value = "eval.yaml")]
     pub config: std::path::PathBuf,
 
@@ -413,8 +417,12 @@ pub struct CoverageArgs {
     #[arg(long)]
     pub export_baseline: Option<PathBuf>,
 
+    /// Output format.
+    /// - `--format md|json` for `--input` mode
+    /// - `--input` mode: json|md (text aliases to json; markdown/github alias to md)
+    /// - legacy mode: text|json|markdown|github
     #[arg(long, default_value = "text")]
-    pub format: String, // text|json|markdown|github
+    pub format: String,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/crates/assay-cli/src/cli/commands/coverage.rs
+++ b/crates/assay-cli/src/cli/commands/coverage.rs
@@ -1,16 +1,41 @@
 use crate::cli::args::CoverageArgs;
 use crate::exit_codes;
 use anyhow::{Context, Result};
+use std::collections::BTreeSet;
 use std::path::Path;
 
+mod format_md;
 mod report;
 mod schema;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoverageOutputFormat {
+    Json,
+    Markdown,
+}
 
 pub(crate) async fn write_generated_coverage_report(
     input: &Path,
     out: &Path,
     declared_tools: &[String],
     source: &str,
+) -> Result<i32> {
+    write_generated_coverage_report_with_format(
+        input,
+        out,
+        declared_tools,
+        source,
+        CoverageOutputFormat::Json,
+    )
+    .await
+}
+
+pub(crate) async fn write_generated_coverage_report_with_format(
+    input: &Path,
+    out: &Path,
+    declared_tools: &[String],
+    source: &str,
+    format: CoverageOutputFormat,
 ) -> Result<i32> {
     use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_INFRA_ERROR};
 
@@ -40,8 +65,20 @@ pub(crate) async fn write_generated_coverage_report(
         }
     }
 
-    let payload = serde_json::to_vec_pretty(&report_value)
-        .expect("coverage report serialization should be infallible");
+    let payload = match format {
+        CoverageOutputFormat::Json => serde_json::to_vec_pretty(&report_value)
+            .expect("coverage report serialization should be infallible"),
+        CoverageOutputFormat::Markdown => {
+            match format_md::render_coverage_markdown(&report_value) {
+                Ok(markdown) => markdown.into_bytes(),
+                Err(e) => {
+                    eprintln!("Measurement error: failed to render markdown output: {e}");
+                    return Ok(EXIT_CONFIG_ERROR);
+                }
+            }
+        }
+    };
+
     if let Err(e) = tokio::fs::write(out, payload).await {
         eprintln!(
             "Infra error: failed to write coverage report to {}: {e}",
@@ -50,11 +87,8 @@ pub(crate) async fn write_generated_coverage_report(
         return Ok(EXIT_INFRA_ERROR);
     }
 
-    eprintln!(
-        "Generated coverage_report_v1 from {} -> {}",
-        input.display(),
-        out.display()
-    );
+    let _ = input; // kept for call-site parity and future diagnostics.
+    eprintln!("Wrote coverage_report_v1 to {}", out.display());
 
     Ok(exit_codes::EXIT_SUCCESS)
 }
@@ -92,7 +126,69 @@ async fn cmd_coverage_generate(args: &CoverageArgs) -> Result<i32> {
         }
     };
 
-    write_generated_coverage_report(input, out, &args.declared_tools, "jsonl").await
+    let declared_tools = match load_declared_tools(args).await {
+        Ok(v) => v,
+        Err(code) => return Ok(code),
+    };
+
+    let output_format = match parse_generate_output_format(&args.format) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Measurement error: {e}");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+
+    write_generated_coverage_report_with_format(input, out, &declared_tools, "jsonl", output_format)
+        .await
+}
+
+async fn load_declared_tools(args: &CoverageArgs) -> std::result::Result<Vec<String>, i32> {
+    use crate::exit_codes::EXIT_CONFIG_ERROR;
+
+    let mut declared = BTreeSet::new();
+
+    for raw in &args.declared_tools {
+        let tool = raw.trim();
+        if tool.is_empty() {
+            eprintln!("Measurement error: --declared-tool must not be empty");
+            return Err(EXIT_CONFIG_ERROR);
+        }
+        declared.insert(tool.to_string());
+    }
+
+    if let Some(path) = args.declared_tools_file.as_ref() {
+        let content = match tokio::fs::read_to_string(path).await {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "Measurement error: failed to read --declared-tools-file {}: {e}",
+                    path.display()
+                );
+                return Err(EXIT_CONFIG_ERROR);
+            }
+        };
+
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            declared.insert(line.to_string());
+        }
+    }
+
+    Ok(declared.into_iter().collect())
+}
+
+fn parse_generate_output_format(raw: &str) -> std::result::Result<CoverageOutputFormat, String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "json" | "text" => Ok(CoverageOutputFormat::Json),
+        "md" | "markdown" | "github" => Ok(CoverageOutputFormat::Markdown),
+        other => Err(format!(
+            "--format must be one of: json|md for --input mode (got '{other}')"
+        )),
+    }
 }
 
 async fn cmd_coverage_legacy(args: CoverageArgs) -> Result<i32> {

--- a/crates/assay-cli/src/cli/commands/coverage/format_md.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/format_md.rs
@@ -1,0 +1,100 @@
+use serde_json::Value;
+
+const MAX_ROUTES: usize = 10;
+
+fn as_string_array(value: Option<&Value>) -> Vec<String> {
+    match value {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToOwned::to_owned)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+pub(crate) fn render_coverage_markdown(report: &Value) -> Result<String, String> {
+    let schema_version = report
+        .get("schema_version")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "missing schema_version".to_string())?;
+    let report_version = report
+        .get("report_version")
+        .and_then(Value::as_str)
+        .unwrap_or("1");
+    let source = report
+        .pointer("/run/source")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+
+    let tools_seen = as_string_array(report.pointer("/tools/tools_seen"));
+    let tools_declared = as_string_array(report.pointer("/tools/tools_declared"));
+    let tools_unknown = as_string_array(report.pointer("/tools/tools_unknown"));
+    let taxonomy_missing = as_string_array(report.pointer("/taxonomy/tool_classes_missing"));
+
+    let mut routes: Vec<(String, String, u64)> = match report.pointer("/routes/routes_seen") {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|item| {
+                let from = item.get("from")?.as_str()?.to_string();
+                let to = item.get("to")?.as_str()?.to_string();
+                let count = item.get("count")?.as_u64()?;
+                Some((from, to, count))
+            })
+            .collect(),
+        _ => Vec::new(),
+    };
+
+    routes.sort_by(|a, b| {
+        b.2.cmp(&a.2)
+            .then_with(|| a.0.cmp(&b.0))
+            .then_with(|| a.1.cmp(&b.1))
+    });
+
+    let mut out = String::new();
+    out.push_str("# Coverage Report\n\n");
+    out.push_str(&format!("- Schema: `{}`\n", schema_version));
+    out.push_str(&format!("- Report version: `{}`\n", report_version));
+    out.push_str(&format!("- Source: `{}`\n\n", source));
+
+    out.push_str("## Tools\n\n");
+    out.push_str("| Metric | Value |\n");
+    out.push_str("| --- | ---: |\n");
+    out.push_str(&format!("| tools_seen | {} |\n", tools_seen.len()));
+    out.push_str(&format!("| tools_declared | {} |\n", tools_declared.len()));
+    out.push_str(&format!("| tools_unknown | {} |\n\n", tools_unknown.len()));
+
+    out.push_str("## Unknown Tools\n\n");
+    if tools_unknown.is_empty() {
+        out.push_str("- _none_\n\n");
+    } else {
+        for tool in &tools_unknown {
+            out.push_str(&format!("- `{}`\n", tool));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## Taxonomy Missing\n\n");
+    if taxonomy_missing.is_empty() {
+        out.push_str("- _none_\n\n");
+    } else {
+        for tool in &taxonomy_missing {
+            out.push_str(&format!("- `{}`\n", tool));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## Top Routes\n\n");
+    out.push_str("| From | To | Count |\n");
+    out.push_str("| --- | --- | ---: |\n");
+    for (from, to, count) in routes.into_iter().take(MAX_ROUTES) {
+        out.push_str(&format!("| `{}` | `{}` | {} |\n", from, to, count));
+    }
+    out.push('\n');
+
+    out.push_str("## Notes\n\n");
+    out.push_str("- Routes are adjacent tool-call edges in observed order (v1).\n");
+    out.push_str("- This markdown is a presentation of `coverage_report_v1`; enforcement behavior is unchanged.\n");
+
+    Ok(out)
+}

--- a/crates/assay-cli/src/cli/commands/session_state_window.rs
+++ b/crates/assay-cli/src/cli/commands/session_state_window.rs
@@ -157,7 +157,7 @@ pub(crate) async fn write_state_window_out(
         return Ok(EXIT_INFRA_ERROR);
     }
 
-    eprintln!("Generated session_state_window_v1 -> {}", out.display());
+    eprintln!("Wrote session_state_window_v1 to {}", out.display());
 
     Ok(EXIT_SUCCESS)
 }

--- a/crates/assay-cli/tests/coverage_declared_tools_file.rs
+++ b/crates/assay-cli/tests/coverage_declared_tools_file.rs
@@ -1,0 +1,44 @@
+#![allow(deprecated)]
+
+use assert_cmd::Command;
+use serde_json::Value;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/ci/fixtures/coverage")
+        .join(name)
+}
+
+#[test]
+fn coverage_declared_tools_file_union_with_flags() {
+    let dir = tempdir().unwrap();
+    let out = dir.path().join("coverage.json");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["coverage", "--input"])
+        .arg(fixture_path("input_basic.jsonl"))
+        .args(["--out"])
+        .arg(&out)
+        .args(["--declared-tools-file"])
+        .arg(fixture_path("declared_tools_basic.txt"))
+        .args(["--declared-tool", "web_search_alt"])
+        .assert()
+        .success();
+
+    let report: Value = serde_json::from_str(
+        &std::fs::read_to_string(&out).expect("coverage json should be written"),
+    )
+    .expect("coverage report must be valid JSON");
+
+    assert_eq!(
+        report["tools"]["tools_declared"],
+        serde_json::json!(["read_document", "web_search", "web_search_alt"])
+    );
+    assert_eq!(
+        report["tools"]["tools_unknown"],
+        serde_json::json!(["unknown_tool_x"])
+    );
+}

--- a/crates/assay-cli/tests/coverage_format_md.rs
+++ b/crates/assay-cli/tests/coverage_format_md.rs
@@ -1,0 +1,42 @@
+#![allow(deprecated)]
+
+use assert_cmd::Command;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/ci/fixtures/coverage")
+        .join(name)
+}
+
+#[test]
+fn coverage_format_md_generates_summary() {
+    let dir = tempdir().unwrap();
+    let out = dir.path().join("coverage.md");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["coverage", "--input"])
+        .arg(fixture_path("input_basic.jsonl"))
+        .args(["--out"])
+        .arg(&out)
+        .args([
+            "--declared-tool",
+            "read_document",
+            "--declared-tool",
+            "web_search",
+            "--declared-tool",
+            "web_search_alt",
+            "--format",
+            "md",
+        ])
+        .assert()
+        .success();
+
+    let markdown = std::fs::read_to_string(&out).expect("markdown output should be written");
+    assert!(markdown.contains("# Coverage Report"));
+    assert!(markdown.contains("tools_unknown"));
+    assert!(markdown.contains("`unknown_tool_x`"));
+    assert!(markdown.contains("| `read_document` | `web_search_alt` | 1 |"));
+}

--- a/scripts/ci/fixtures/coverage/declared_tools_basic.txt
+++ b/scripts/ci/fixtures/coverage/declared_tools_basic.txt
@@ -1,0 +1,5 @@
+# tools declared for coverage
+read_document
+web_search
+
+# comment + blank lines should be ignored

--- a/scripts/ci/review-b4b-dx-impl.sh
+++ b/scripts/ci/review-b4b-dx-impl.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-cli/src/cli/args/mod.rs"
+  "crates/assay-cli/src/cli/commands/coverage.rs"
+  "crates/assay-cli/src/cli/commands/coverage/report.rs"
+  "crates/assay-cli/src/cli/commands/coverage/format_md.rs"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-cli/tests/coverage_format_md.rs"
+  "crates/assay-cli/tests/coverage_declared_tools_file.rs"
+  "scripts/ci/fixtures/coverage/declared_tools_basic.txt"
+  "scripts/ci/review-b4b-dx-impl.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: B4B must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in B4B: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n 'declared_tools_file|declared-tools-file' crates/assay-cli/src/cli/args/mod.rs >/dev/null || {
+  echo "FAIL: missing --declared-tools-file flag in args"
+  exit 1
+}
+rg -n 'format.*md|--format.*md' crates/assay-cli/src/cli/args/mod.rs >/dev/null || {
+  echo "FAIL: missing --format md wiring in args"
+  exit 1
+}
+test -f crates/assay-cli/src/cli/commands/coverage/format_md.rs || {
+  echo "FAIL: missing format_md.rs implementation"
+  exit 1
+}
+rg -n 'render_coverage_markdown|format_md' crates/assay-cli/src/cli/commands/coverage/format_md.rs >/dev/null || {
+  echo "FAIL: format_md.rs missing render function markers"
+  exit 1
+}
+
+# Keep exit priority invariant: wrapped > coverage > state-window
+rg -n 'wrapped.*exit|wrapped_code' crates/assay-cli/src/cli/commands/mcp.rs >/dev/null || {
+  echo "FAIL: mcp wrap exit priority markers missing"
+  exit 1
+}
+
+# Tests present
+rg -n 'coverage_format_md' crates/assay-cli/tests/coverage_format_md.rs >/dev/null || {
+  echo "FAIL: missing coverage_format_md test"
+  exit 1
+}
+rg -n 'coverage_declared_tools_file' crates/assay-cli/tests/coverage_declared_tools_file.rs >/dev/null || {
+  echo "FAIL: missing declared-tools-file test"
+  exit 1
+}
+
+echo "[review] run targeted tests + fmt + clippy"
+cargo test -p assay-cli coverage_format_md
+cargo test -p assay-cli coverage_declared_tools_file
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Implement DX polish:
- `assay coverage --format md`
- `assay coverage --declared-tools-file`
- consistent `--coverage-out` / `--state-window-out` logging

## Scope
- assay-cli args + coverage + wrap export logging helper
- tests + fixture
- reviewer gate

## Safety
- No workflows
- No schema changes
- Exit priority unchanged: wrapped > coverage > state-window

## Verification
- BASE_REF=origin/main bash scripts/ci/review-b4b-dx-impl.sh
- cargo test -p assay-cli coverage_format_md
- cargo test -p assay-cli coverage_declared_tools_file
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
