### PR TITLE
docs(ops): close B4 DX line with runbook + reviewer gate (C-slice)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-b4-dx-polish-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-b4-dx-polish-closure.md
@@ -1,0 +1,20 @@
+# SPLIT CHECKLIST — B4 DX Polish Closure (C-slice)
+
+## Scope discipline
+- [ ] Only docs + reviewer gate changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No Rust code changes
+- [ ] No schema/ADR changes
+
+## Runbook completeness
+- [ ] Documents `assay coverage --format md`
+- [ ] Documents `assay coverage --declared-tools-file`
+- [ ] Documents `assay mcp wrap --coverage-out`
+- [ ] Documents `assay mcp wrap --state-window-out`
+- [ ] Documents invariant `wrapped > coverage > state-window`
+- [ ] Includes bounded non-goals
+
+## Gate
+- [ ] Reviewer gate allowlist-only
+- [ ] Reviewer gate workflow-ban
+- [ ] Marker checks pass

--- a/docs/contributing/SPLIT-REVIEW-PACK-b4-dx-polish-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-b4-dx-polish-closure.md
@@ -1,0 +1,32 @@
+# SPLIT REVIEW PACK — B4 DX Polish Closure (C-slice)
+
+## Intent
+Close B4 with docs-only operational guidance and a strict reviewer gate.
+
+## Scope
+- `/Users/roelschuurkes/assay/docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md`
+- `/Users/roelschuurkes/assay/docs/contributing/SPLIT-CHECKLIST-b4-dx-polish-closure.md`
+- `/Users/roelschuurkes/assay/docs/contributing/SPLIT-REVIEW-PACK-b4-dx-polish-closure.md`
+- `/Users/roelschuurkes/assay/scripts/ci/review-b4c-dx-closure.sh`
+
+## Safety
+- Docs + gate only
+- No workflows
+- No runtime/schema changes
+
+## Reviewer Quick Check
+1. Confirm runbook contains:
+- `assay coverage --format md`
+- `--declared-tools-file`
+- `assay mcp wrap --coverage-out`
+- `assay mcp wrap --state-window-out`
+- `wrapped > coverage > state-window`
+
+2. Run:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-b4c-dx-closure.sh
+```
+
+Expected:
+- Gate passes
+- Docs are sufficient for new contributors to use B4 DX outputs consistently.

--- a/docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md
+++ b/docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md
@@ -1,0 +1,78 @@
+# Coverage and Wrap DX Runbook (B4)
+
+## Intent
+Operational guidance for B4 DX polish on main:
+- `assay coverage --format md`
+- `assay coverage --declared-tools-file <path>`
+- consistent wrap export logging for `--coverage-out` and `--state-window-out`
+
+This runbook is documentation-only and does not change enforcement behavior.
+
+## What Shipped
+- Coverage input mode accepts declared tools from:
+  - repeated `--declared-tool`
+  - `--declared-tools-file` (one tool per line, `#` comments ignored)
+- Coverage output format in input mode supports markdown summary via `--format md`.
+- Wrap export logging now uses one consistent line per successful write:
+  - `Wrote coverage_report_v1 to <path>`
+  - `Wrote session_state_window_v1 to <path>`
+
+## Quickstart
+
+### Coverage JSON output
+```bash
+assay coverage \
+  --input traces.ndjson \
+  --out artifacts/coverage_report_v1.json \
+  --declared-tool read_document \
+  --declared-tool web_search
+```
+
+### Coverage markdown output
+```bash
+assay coverage \
+  --input traces.ndjson \
+  --out artifacts/coverage_report_v1.md \
+  --declared-tools-file scripts/ci/fixtures/coverage/declared_tools_basic.txt \
+  --format md
+```
+
+### Wrap with both exports
+```bash
+assay mcp wrap \
+  --policy assay.yaml \
+  --event-source assay://local/demo \
+  --coverage-out artifacts/coverage_report_v1.json \
+  --state-window-out artifacts/session_state_window_v1.json \
+  -- <mcp-host-cmd> <args...>
+```
+
+Direct examples for reviewers:
+- `assay mcp wrap --coverage-out artifacts/coverage_report_v1.json -- <mcp-host-cmd> <args...>`
+- `assay mcp wrap --state-window-out artifacts/session_state_window_v1.json -- <mcp-host-cmd> <args...>`
+
+## Exit Priority Invariant
+Wrapped process exit remains authoritative.
+
+The invariant is unchanged and must remain:
+- `wrapped > coverage > state-window`
+
+Meaning:
+- If wrapped fails, its exit code is returned.
+- If wrapped succeeds but coverage generation fails, coverage exit is returned.
+- If wrapped and coverage succeed but state window export fails, state-window exit is returned.
+
+## Error Mapping
+- input/contract parsing failures: exit `2`
+- output/write failures: exit `3`
+
+## Bounded Non-Goals
+- No policy DSL changes.
+- No schema changes (`coverage_report_v1`, `session_state_window_v1` unchanged).
+- No workflow/required-check changes.
+- No runtime enforcement behavior changes.
+
+## References
+- ADR-030 Coverage + Wrap DX Polish
+- `/Users/roelschuurkes/assay/schemas/coverage_report_v1.schema.json`
+- `/Users/roelschuurkes/assay/schemas/session_state_window_v1.schema.json`

--- a/scripts/ci/review-b4c-dx-closure.sh
+++ b/scripts/ci/review-b4c-dx-closure.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md"
+  "docs/contributing/SPLIT-CHECKLIST-b4-dx-polish-closure.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-b4-dx-polish-closure.md"
+  "scripts/ci/review-b4c-dx-closure.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: B4C closure must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in B4C closure: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n 'Coverage.*Wrap.*DX.*Runbook|COVERAGE-AND-WRAP-DX-RUNBOOK' docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook title marker missing"
+  exit 1
+}
+rg -n 'assay coverage.*--format md|--format md' docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing --format md usage"
+  exit 1
+}
+rg -n -- '--declared-tools-file' docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing --declared-tools-file usage"
+  exit 1
+}
+rg -n 'assay mcp wrap.*--coverage-out' docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing wrap --coverage-out usage"
+  exit 1
+}
+rg -n 'assay mcp wrap.*--state-window-out' docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing wrap --state-window-out usage"
+  exit 1
+}
+rg -n 'wrapped > coverage > state-window|wrapped.*authoritative' docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing exit priority invariant"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Close B4 DX line with runbook + checklist/review-pack + reviewer gate.

## Scope
- docs/ops/COVERAGE-AND-WRAP-DX-RUNBOOK.md
- docs/contributing/SPLIT-CHECKLIST-b4-dx-polish-closure.md
- docs/contributing/SPLIT-REVIEW-PACK-b4-dx-polish-closure.md
- scripts/ci/review-b4c-dx-closure.sh

## Safety
- Docs + gate only
- No workflows
- No runtime/schema changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-b4c-dx-closure.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
