### PR TITLE
docs(architecture): sync ADR index and roadmap after B4

### DIFF
--- a/docs/DX-ROADMAP.md
+++ b/docs/DX-ROADMAP.md
@@ -4,8 +4,9 @@
 > Code health (RFC-002) and generate decomposition (RFC-003) are complete.
 > Remaining structural items tracked in [RFC-004](architecture/RFC-004-open-items-convergence-q1-2026.md).
 > Split refactor closure status is tracked in [PLAN-split-refactor-2026q1](architecture/PLAN-split-refactor-2026q1.md) and [REPORT-split-refactor-2026q1](architecture/REPORT-split-refactor-2026q1.md).
+> **Status sync (2026-03-04):** B4 DX polish is closed-loop on `main` (freeze, implement, closure): `coverage --format md`, `--declared-tools-file`, consistent wrap export write logs, and runbook/gates.
 
-**Last updated:** 2026-02-17
+**Last updated:** 2026-03-04
 **Scope:** 6 features across 3 priority tiers + DX polish
 **EU AI Act phased dates:** 2025-02-02, 2025-08-02, 2026-08-02
 **Planning assumption:** no stop-clock; roadmap tracks current phased dates.
@@ -32,6 +33,7 @@
 | `watch` edge hardening (coarse mtime + parse fallback) | P1 | Partial (core on main; branch delta remains) | codex/p1-watch-edge-hardening |
 | P0/P1 DX integration to `main` | P0/P1 | Done | #191 |
 | Docs alignment + link guard | DX polish | Done | #184 |
+| B4 DX polish (coverage markdown/file input + wrap export log consistency + closure) | P2 | Done | #578, #580, #582 |
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,6 +10,7 @@
 > ADR-025 I3 Step4 status (2026-02-21): release-lane OTel bridge evidence integration merged on `main` (default `attach`, `enforce` is contract-only under policy v1).
 > ADR-025 P3 status (2026-02-24): index consolidation A/B/C complete on `main` (single entrypoint + reviewer gates).
 > Experiment evidence status (2026-03-04): the fragmented-IPI line is now closed-loop on `main` across baseline, ablation, wrap-bypass, second-sink, sink-failure, and full-window cross-session decay (`k+1..k+3`). This shifts 2026 product priority toward route-governance primitives: tool classes, replayable session/state contracts, and coverage/completeness.
+> Governance core status (2026-03-04): ADR-027/028/029/030 slices are merged on `main` (tool taxonomy + class matching, coverage contract/generator/wrap emission, session/state informational export, and DX polish closure).
 
 **Strategic Focus:** Agent Runtime Evidence & Control Plane.
 **Core Value:** Verifiable Evidence (Open Standard) + Governance Platform.

--- a/docs/architecture/adrs.md
+++ b/docs/architecture/adrs.md
@@ -27,6 +27,10 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | [ADR-024](./ADR-024-Sim-Engine-Hardening.md) | Sim Engine Hardening (Limits + Time Budget) | Superseded | **P2** |
 | [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Evidence-as-a-Product | Accepted | **P1/P2** |
 | [ADR-026](./ADR-026-Protocol-Adapters.md) | Protocol Adapters | **Accepted** | **P1** |
+| [ADR-027](./ADR-027-Tool-Taxonomy.md) | Tool Taxonomy and Class-Based Route Policies | Proposed | **P1** |
+| [ADR-028](./ADR-028-Coverage-Report.md) | Coverage Report (Tool & Route Completeness) | Proposed | **P1** |
+| [ADR-029](./ADR-029-Session-State-Window.md) | Session & State Window Contract (MCP Governance) | Proposed | **P1** |
+| [ADR-030](./ADR-030-Coverage-Wrap-DX-Polish.md) | Coverage + Wrap DX Polish | Proposed | **P2** |
 | [ADR-020](./ADR-020-Dependency-Governance.md) | Dependency Governance | Accepted | - |
 
 ## Q2 2026 Priorities
@@ -43,6 +47,10 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | **P2** | [ADR-022](./ADR-022-SOC2-Baseline-Pack.md) | Accepted | SOC2 baseline OSS pack (implemented) |
 | **P1/P2** | [ADR-025](./ADR-025-Evidence-as-a-Product.md) | Accepted | I1/I2/I3 slices merged on `main`; formal accept complete |
 | **P1** | [ADR-026](./ADR-026-Protocol-Adapters.md) | Accepted | ACP + A2A + UCP adapter slices and E0-E4 stabilization are merged on `main` |
+| **P1** | [ADR-027](./ADR-027-Tool-Taxonomy.md) | Proposed | A/B slices merged on `main` (taxonomy + class-aware tool matching); formal status update pending |
+| **P1** | [ADR-028](./ADR-028-Coverage-Report.md) | Proposed | A/B slices merged on `main` (coverage contract + generator + wrap emission); formal status update pending |
+| **P1** | [ADR-029](./ADR-029-Session-State-Window.md) | Proposed | A/B slices merged on `main` (session/state contract + informational export); formal status update pending |
+| **P2** | [ADR-030](./ADR-030-Coverage-Wrap-DX-Polish.md) | Proposed | A/B/C slices merged on `main` (coverage markdown/file input + closure docs); formal status update pending |
 | **P2** | [ADR-013](./ADR-013-EU-AI-Act-Pack.md) | Accepted | Article 12 mapping, `--pack` flag |
 | **P3** | [ADR-012](./ADR-012-Transparency-Log.md) | Proposed | Builds on ADR-011 |
 | Deferred | [ADR-009](./ADR-009-WORM-Storage.md) | Deferred | Managed WORM → Q3+ if demand |

--- a/scripts/ci/review-p3-adr-roadmap-consistency.sh
+++ b/scripts/ci/review-p3-adr-roadmap-consistency.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/adrs.md"
+  "docs/ROADMAP.md"
+  "docs/DX-ROADMAP.md"
+  "scripts/ci/review-p3-adr-roadmap-consistency.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: P3 consistency slice must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in P3 consistency slice: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n 'ADR-027|ADR-028|ADR-029|ADR-030' docs/architecture/adrs.md >/dev/null || {
+  echo "FAIL: ADR index missing ADR-027..030 entries"
+  exit 1
+}
+rg -n 'Governance core status \(2026-03-04\)' docs/ROADMAP.md >/dev/null || {
+  echo "FAIL: ROADMAP missing governance core status sync"
+  exit 1
+}
+rg -n 'Status sync \(2026-03-04\).*B4 DX polish' docs/DX-ROADMAP.md >/dev/null || {
+  echo "FAIL: DX roadmap missing B4 status sync"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only consistency sync after B4 close-out:
- add ADR-027..030 entries to ADR index and priority table
- add governance-core status sync to main roadmap
- add B4 status sync to DX roadmap
- add strict reviewer gate for this slice

## Scope
- docs/architecture/adrs.md
- docs/ROADMAP.md
- docs/DX-ROADMAP.md
- scripts/ci/review-p3-adr-roadmap-consistency.sh

## Safety
- Docs + gate only
- No workflows
- No runtime/schema/ADR-status behavior changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-p3-adr-roadmap-consistency.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
