### PR TITLE
docs(policy): freeze Coverage v1.1 DX polish contract (A-slice)

### DIFF
--- a/docs/architecture/ADR-031-Coverage-v1.1-DX-Polish.md
+++ b/docs/architecture/ADR-031-Coverage-v1.1-DX-Polish.md
@@ -1,0 +1,52 @@
+# ADR-031: Coverage v1.1 DX Polish
+
+## Status
+Proposed (March 2026)
+
+## Context
+Coverage v1 is schema-stable and already supports:
+- JSON report generation via `assay coverage --input ... --out ...`
+- optional markdown viewing via `--format md` (v1.0 DX)
+
+Teams want a more PR-friendly dual artifact pattern:
+- canonical JSON for machines
+- stable markdown written to a file for reviewers and PR attachments
+
+We also want deterministic reviewer signal on route summaries without truncating the canonical JSON.
+
+## Decision
+We introduce Coverage v1.1 DX polish (no schema bump):
+1) `--out-md <path>`: write a markdown report alongside the canonical JSON report.
+2) `--routes-top <N>`: control how many top routes appear in markdown (JSON remains complete).
+
+This is a CLI/DX-only change:
+- no workflow changes
+- no coverage schema changes
+- no MCP wrap behavior changes
+
+## Contract
+### Flags
+- `assay coverage --input <jsonl> --out <coverage.json> [--out-md <coverage.md>] [--routes-top <N>]`
+- `--routes-top` default: `10`
+
+### Output
+- JSON output remains `coverage_report_v1` and is the canonical artifact.
+- Markdown is derived output and may change formatting without schema bump.
+
+### Exit codes (generator mode)
+- `0` success
+- `2` measurement/contract (invalid input, schema validation failure)
+- `3` infra (write failure for json or md)
+
+## Non-goals
+- no schema bump (`coverage_report_v1` unchanged)
+- no nightly/workflow wiring
+- no MCP wrap changes in this v1.1 line
+
+## Consequences
+Positive:
+- reviewers get stable file artifacts without losing machine-readable JSON
+- route-summary tuning without truncating canonical evidence
+
+Negative:
+- another output path to maintain (mitigated by strict tests in B-slice)

--- a/scripts/ci/review-coverage-v1-1-a-freeze.sh
+++ b/scripts/ci/review-coverage-v1-1-a-freeze.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/architecture/ADR-031-Coverage-v1.1-DX-Polish.md"
+  "scripts/ci/review-coverage-v1-1-a-freeze.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  [[ "$f" == .github/workflows/* ]] && { echo "FAIL: no workflows ($f)"; exit 1; }
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do [[ "$f" == "$a" ]] && ok="true" && break; done
+  [[ "$ok" != "true" ]] && { echo "FAIL: file not allowed in coverage v1.1 A-slice: $f"; exit 1; }
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n '^# ADR-031: Coverage v1.1 DX Polish$' docs/architecture/ADR-031-Coverage-v1.1-DX-Polish.md >/dev/null || {
+  echo "FAIL: ADR title missing"
+  exit 1
+}
+rg -n -- '--out-md' docs/architecture/ADR-031-Coverage-v1.1-DX-Polish.md >/dev/null || {
+  echo "FAIL: missing --out-md contract"
+  exit 1
+}
+rg -n -- '--routes-top' docs/architecture/ADR-031-Coverage-v1.1-DX-Polish.md >/dev/null || {
+  echo "FAIL: missing --routes-top contract"
+  exit 1
+}
+rg -n 'coverage_report_v1' docs/architecture/ADR-031-Coverage-v1.1-DX-Polish.md >/dev/null || {
+  echo "FAIL: missing schema reference coverage_report_v1"
+  exit 1
+}
+rg -n 'no schema bump' docs/architecture/ADR-031-Coverage-v1.1-DX-Polish.md >/dev/null || {
+  echo "FAIL: missing non-goal (no schema bump)"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Freeze contract for Coverage v1.1 DX polish:
- `assay coverage --out-md`
- `assay coverage --routes-top`
- output/exit semantics and non-goals

## Scope
- docs/architecture/ADR-031-Coverage-v1.1-DX-Polish.md
- scripts/ci/review-coverage-v1-1-a-freeze.sh

## Safety
- Docs + gate only
- No workflows
- No code/schema/test changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-coverage-v1-1-a-freeze.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
