### PR TITLE
feat(coverage): add --out-md and --routes-top (v1.1 DX polish)

### DIFF
--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -391,6 +391,10 @@ pub struct CoverageArgs {
     #[arg(long)]
     pub out: Option<std::path::PathBuf>,
 
+    /// Optional markdown output path for derived human-readable summary.
+    #[arg(long = "out-md")]
+    pub out_md: Option<std::path::PathBuf>,
+
     /// Tools declared by policy/config (repeatable).
     #[arg(long = "declared-tool")]
     pub declared_tools: Vec<String>,
@@ -423,6 +427,10 @@ pub struct CoverageArgs {
     /// - legacy mode: text|json|markdown|github
     #[arg(long, default_value = "text")]
     pub format: String,
+
+    /// Number of top routes to include in markdown output (default: 10).
+    #[arg(long = "routes-top", default_value_t = 10)]
+    pub routes_top: usize,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/crates/assay-cli/src/cli/commands/coverage.rs
+++ b/crates/assay-cli/src/cli/commands/coverage.rs
@@ -1,6 +1,7 @@
 use crate::cli::args::CoverageArgs;
 use crate::exit_codes;
 use anyhow::{Context, Result};
+use serde_json::Value;
 use std::collections::BTreeSet;
 use std::path::Path;
 
@@ -14,6 +15,8 @@ pub(crate) enum CoverageOutputFormat {
     Markdown,
 }
 
+const DEFAULT_ROUTES_TOP: usize = 10;
+
 pub(crate) async fn write_generated_coverage_report(
     input: &Path,
     out: &Path,
@@ -26,6 +29,7 @@ pub(crate) async fn write_generated_coverage_report(
         declared_tools,
         source,
         CoverageOutputFormat::Json,
+        DEFAULT_ROUTES_TOP,
     )
     .await
 }
@@ -36,22 +40,48 @@ pub(crate) async fn write_generated_coverage_report_with_format(
     declared_tools: &[String],
     source: &str,
     format: CoverageOutputFormat,
+    routes_top: usize,
 ) -> Result<i32> {
-    use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_INFRA_ERROR};
+    let report_value =
+        match build_and_validate_generated_coverage_report(input, declared_tools, source).await {
+            Ok(v) => v,
+            Err(code) => return Ok(code),
+        };
+
+    write_generated_coverage_payload(out, &report_value, format, routes_top).await
+}
+
+async fn build_and_validate_generated_coverage_report(
+    input: &Path,
+    declared_tools: &[String],
+    source: &str,
+) -> std::result::Result<Value, i32> {
+    use crate::exit_codes::EXIT_CONFIG_ERROR;
 
     let report_value =
         match report::build_coverage_report_from_input(input, declared_tools, source).await {
             Ok(v) => v,
             Err(e) => {
                 eprintln!("Measurement error: {e}");
-                return Ok(EXIT_CONFIG_ERROR);
+                return Err(EXIT_CONFIG_ERROR);
             }
         };
 
     if let Err(e) = schema::validate_coverage_report_v1(&report_value) {
         eprintln!("Measurement error: coverage report schema validation failed: {e}");
-        return Ok(EXIT_CONFIG_ERROR);
+        return Err(EXIT_CONFIG_ERROR);
     }
+
+    Ok(report_value)
+}
+
+async fn write_generated_coverage_payload(
+    out: &Path,
+    report_value: &Value,
+    format: CoverageOutputFormat,
+    routes_top: usize,
+) -> Result<i32> {
+    use crate::exit_codes::EXIT_INFRA_ERROR;
 
     let Some(parent) = out.parent() else {
         eprintln!("Infra error: invalid output path {}", out.display());
@@ -69,11 +99,11 @@ pub(crate) async fn write_generated_coverage_report_with_format(
         CoverageOutputFormat::Json => serde_json::to_vec_pretty(&report_value)
             .expect("coverage report serialization should be infallible"),
         CoverageOutputFormat::Markdown => {
-            match format_md::render_coverage_markdown(&report_value) {
+            match format_md::render_coverage_markdown(report_value, routes_top) {
                 Ok(markdown) => markdown.into_bytes(),
                 Err(e) => {
                     eprintln!("Measurement error: failed to render markdown output: {e}");
-                    return Ok(EXIT_CONFIG_ERROR);
+                    return Ok(exit_codes::EXIT_CONFIG_ERROR);
                 }
             }
         }
@@ -87,13 +117,22 @@ pub(crate) async fn write_generated_coverage_report_with_format(
         return Ok(EXIT_INFRA_ERROR);
     }
 
-    let _ = input; // kept for call-site parity and future diagnostics.
-    eprintln!("Wrote coverage_report_v1 to {}", out.display());
+    match format {
+        CoverageOutputFormat::Json => eprintln!("Wrote coverage_report_v1 to {}", out.display()),
+        CoverageOutputFormat::Markdown => {
+            eprintln!("Wrote coverage_report_v1 markdown to {}", out.display())
+        }
+    }
 
     Ok(exit_codes::EXIT_SUCCESS)
 }
 
 pub async fn cmd_coverage(args: CoverageArgs) -> Result<i32> {
+    if args.input.is_none() && args.out_md.is_some() {
+        eprintln!("Measurement error: --out-md is only supported with --input mode");
+        return Ok(exit_codes::EXIT_CONFIG_ERROR);
+    }
+
     if args.input.is_some() {
         return cmd_coverage_generate(&args).await;
     }
@@ -139,8 +178,39 @@ async fn cmd_coverage_generate(args: &CoverageArgs) -> Result<i32> {
         }
     };
 
-    write_generated_coverage_report_with_format(input, out, &declared_tools, "jsonl", output_format)
-        .await
+    let primary_format = if args.out_md.is_some() {
+        CoverageOutputFormat::Json
+    } else {
+        output_format
+    };
+
+    let status = write_generated_coverage_report_with_format(
+        input,
+        out,
+        &declared_tools,
+        "jsonl",
+        primary_format,
+        args.routes_top,
+    )
+    .await?;
+
+    if status != exit_codes::EXIT_SUCCESS {
+        return Ok(status);
+    }
+
+    if let Some(out_md) = args.out_md.as_ref() {
+        return write_generated_coverage_report_with_format(
+            input,
+            out_md,
+            &declared_tools,
+            "jsonl",
+            CoverageOutputFormat::Markdown,
+            args.routes_top,
+        )
+        .await;
+    }
+
+    Ok(status)
 }
 
 async fn load_declared_tools(args: &CoverageArgs) -> std::result::Result<Vec<String>, i32> {

--- a/crates/assay-cli/src/cli/commands/coverage/format_md.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/format_md.rs
@@ -1,7 +1,5 @@
 use serde_json::Value;
 
-const MAX_ROUTES: usize = 10;
-
 fn as_string_array(value: Option<&Value>) -> Vec<String> {
     match value {
         Some(Value::Array(items)) => items
@@ -13,7 +11,10 @@ fn as_string_array(value: Option<&Value>) -> Vec<String> {
     }
 }
 
-pub(crate) fn render_coverage_markdown(report: &Value) -> Result<String, String> {
+pub(crate) fn render_coverage_markdown(
+    report: &Value,
+    routes_top: usize,
+) -> Result<String, String> {
     let schema_version = report
         .get("schema_version")
         .and_then(Value::as_str)
@@ -85,12 +86,16 @@ pub(crate) fn render_coverage_markdown(report: &Value) -> Result<String, String>
     }
 
     out.push_str("## Top Routes\n\n");
-    out.push_str("| From | To | Count |\n");
-    out.push_str("| --- | --- | ---: |\n");
-    for (from, to, count) in routes.into_iter().take(MAX_ROUTES) {
-        out.push_str(&format!("| `{}` | `{}` | {} |\n", from, to, count));
+    if routes_top == 0 {
+        out.push_str("(routes hidden; --routes-top=0)\n\n");
+    } else {
+        out.push_str("| From | To | Count |\n");
+        out.push_str("| --- | --- | ---: |\n");
+        for (from, to, count) in routes.into_iter().take(routes_top) {
+            out.push_str(&format!("| `{}` | `{}` | {} |\n", from, to, count));
+        }
+        out.push('\n');
     }
-    out.push('\n');
 
     out.push_str("## Notes\n\n");
     out.push_str("- Routes are adjacent tool-call edges in observed order (v1).\n");

--- a/crates/assay-cli/tests/coverage_out_md.rs
+++ b/crates/assay-cli/tests/coverage_out_md.rs
@@ -1,0 +1,48 @@
+#![allow(deprecated)]
+
+use assert_cmd::Command;
+use serde_json::Value;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/ci/fixtures/coverage")
+        .join(name)
+}
+
+#[test]
+fn coverage_out_md_writes_json_and_markdown_artifacts() {
+    let dir = tempdir().unwrap();
+    let out_json = dir.path().join("coverage.json");
+    let out_md = dir.path().join("coverage.md");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["coverage", "--input"])
+        .arg(fixture_path("input_basic.jsonl"))
+        .args(["--out"])
+        .arg(&out_json)
+        .args(["--out-md"])
+        .arg(&out_md)
+        .args([
+            "--declared-tool",
+            "read_document",
+            "--declared-tool",
+            "web_search",
+            "--declared-tool",
+            "web_search_alt",
+            "--format",
+            "md",
+        ])
+        .assert()
+        .success();
+
+    let json_text = std::fs::read_to_string(&out_json).expect("json report should exist");
+    let report: Value = serde_json::from_str(&json_text).expect("json report must parse");
+    assert_eq!(report["schema_version"], "coverage_report_v1");
+
+    let markdown = std::fs::read_to_string(&out_md).expect("markdown report should exist");
+    assert!(markdown.contains("# Coverage Report"));
+    assert!(markdown.contains("## Top Routes"));
+}

--- a/crates/assay-cli/tests/coverage_routes_top.rs
+++ b/crates/assay-cli/tests/coverage_routes_top.rs
@@ -1,0 +1,46 @@
+#![allow(deprecated)]
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn coverage_routes_top_limits_markdown_route_rows() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("input.jsonl");
+    let out_json = dir.path().join("coverage.json");
+    let out_md = dir.path().join("coverage.md");
+
+    let input_jsonl = [
+        r#"{"tool":"A"}"#,
+        r#"{"tool":"B"}"#,
+        r#"{"tool":"A"}"#,
+        r#"{"tool":"B"}"#,
+        r#"{"tool":"A"}"#,
+        r#"{"tool":"B"}"#,
+        r#"{"tool":"A"}"#,
+        r#"{"tool":"B"}"#,
+        r#"{"tool":"A"}"#,
+        r#"{"tool":"B"}"#,
+        r#"{"tool":"C"}"#,
+        r#"{"tool":"D"}"#,
+    ]
+    .join("\n");
+    fs::write(&input, input_jsonl).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args(["coverage", "--input"])
+        .arg(&input)
+        .args(["--out"])
+        .arg(&out_json)
+        .args(["--out-md"])
+        .arg(&out_md)
+        .args(["--routes-top", "1"])
+        .assert()
+        .success();
+
+    let markdown = fs::read_to_string(out_md).expect("markdown should exist");
+    assert!(markdown.contains("| `A` | `B` | 5 |"));
+    assert!(!markdown.contains("| `B` | `A` | 4 |"));
+}

--- a/scripts/ci/review-coverage-v1-1-b-impl.sh
+++ b/scripts/ci/review-coverage-v1-1-b-impl.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-cli/src/cli/args/mod.rs"
+  "crates/assay-cli/src/cli/commands/coverage.rs"
+  "crates/assay-cli/src/cli/commands/coverage/format_md.rs"
+  "crates/assay-cli/tests/coverage_out_md.rs"
+  "crates/assay-cli/tests/coverage_routes_top.rs"
+  "scripts/ci/review-coverage-v1-1-b-impl.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: coverage v1.1 B-slice must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in coverage v1.1 B-slice: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n 'out_md|out-md' crates/assay-cli/src/cli/args/mod.rs >/dev/null || {
+  echo "FAIL: missing --out-md arg wiring"
+  exit 1
+}
+rg -n 'routes_top|routes-top' crates/assay-cli/src/cli/args/mod.rs >/dev/null || {
+  echo "FAIL: missing --routes-top arg wiring"
+  exit 1
+}
+rg -n 'render_coverage_markdown' crates/assay-cli/src/cli/commands/coverage/format_md.rs >/dev/null || {
+  echo "FAIL: markdown renderer entrypoint missing"
+  exit 1
+}
+rg -n 'routes_top' crates/assay-cli/src/cli/commands/coverage/format_md.rs >/dev/null || {
+  echo "FAIL: markdown renderer missing routes_top support"
+  exit 1
+}
+rg -n 'coverage_out_md_writes_json_and_markdown_artifacts' crates/assay-cli/tests/coverage_out_md.rs >/dev/null || {
+  echo "FAIL: missing coverage_out_md test"
+  exit 1
+}
+rg -n 'coverage_routes_top_limits_markdown_route_rows' crates/assay-cli/tests/coverage_routes_top.rs >/dev/null || {
+  echo "FAIL: missing coverage_routes_top test"
+  exit 1
+}
+
+echo "[review] run targeted tests + fmt + clippy"
+cargo test -p assay-cli coverage_out_md
+cargo test -p assay-cli coverage_routes_top
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Implements Coverage v1.1 DX polish in `assay coverage`:
- adds `--out-md <path>` to emit optional markdown alongside canonical JSON output
- adds `--routes-top <N>` to control top-route rows in markdown output
- keeps JSON `coverage_report_v1` as canonical machine artifact when `--out-md` is used

## Scope
- `crates/assay-cli/src/cli/args/mod.rs`
- `crates/assay-cli/src/cli/commands/coverage.rs`
- `crates/assay-cli/src/cli/commands/coverage/format_md.rs`
- `crates/assay-cli/tests/coverage_out_md.rs`
- `crates/assay-cli/tests/coverage_routes_top.rs`
- `scripts/ci/review-coverage-v1-1-b-impl.sh`

## Safety
- No workflow changes
- No schema changes
- No MCP wrap behavior changes

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-coverage-v1-1-b-impl.sh`
- `cargo test -p assay-cli coverage_format_md`
