### PR TITLE
docs(ops): close Coverage v1.1 line with runbook + reviewer gate (C-slice)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-coverage-v1-1-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-coverage-v1-1-closure.md
@@ -1,0 +1,21 @@
+# SPLIT CHECKLIST — Coverage v1.1 Closure (C-slice)
+
+## Scope discipline
+- [ ] Only docs + reviewer gate changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No Rust code changes
+- [ ] No schema / ADR changes
+
+## Runbook correctness
+- [ ] Documents `--out-md`
+- [ ] Documents `--routes-top`
+- [ ] States JSON (`coverage_report_v1`) is canonical
+- [ ] States markdown is derived output
+- [ ] Documents declared-tools-file semantics (1 per line, comments, union)
+- [ ] Documents exit codes (0/2/3) for generator mode
+- [ ] Bounded non-goals present (no workflows, no MCP wrap change, no schema bump)
+
+## Reviewer gate
+- [ ] Allowlist-only
+- [ ] Workflow-ban
+- [ ] Marker checks for critical content

--- a/docs/contributing/SPLIT-REVIEW-PACK-coverage-v1-1-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-coverage-v1-1-closure.md
@@ -1,0 +1,32 @@
+# SPLIT REVIEW PACK — Coverage v1.1 Closure (C-slice)
+
+## Intent
+Close the Coverage v1.1 DX line with operational docs and a reviewer gate.
+
+## Scope
+Docs + gate only:
+- `docs/ops/COVERAGE-V1-1-RUNBOOK.md`
+- `docs/contributing/SPLIT-CHECKLIST-coverage-v1-1-closure.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-coverage-v1-1-closure.md`
+- `scripts/ci/review-coverage-v1-1-c-closure.sh`
+
+## Safety
+- No runtime changes
+- No workflows
+- No schema/ADR changes
+
+## Reviewer quick-check (60s)
+1) Confirm the runbook includes:
+- `--out-md`
+- `--routes-top`
+- canonical JSON vs derived markdown
+- exit codes 0/2/3
+2) Run the reviewer gate:
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-coverage-v1-1-c-closure.sh
+```
+
+Expected outcome:
+- Gate passes
+- New dev can run Coverage v1.1 without reading code

--- a/docs/ops/COVERAGE-V1-1-RUNBOOK.md
+++ b/docs/ops/COVERAGE-V1-1-RUNBOOK.md
@@ -1,0 +1,67 @@
+# Coverage v1.1 Runbook
+
+## Intent
+Operational guidance for Coverage v1.1 DX polish:
+- `--out-md` writes a markdown report alongside canonical JSON output
+- `--routes-top` controls how many routes appear in markdown (JSON remains complete)
+
+This is a CLI/DX feature only:
+- no schema changes (`coverage_report_v1` remains canonical)
+- no workflow changes
+- no MCP wrap behavior changes
+
+## Canonical artifact
+The canonical machine-readable output remains:
+- `coverage_report_v1` JSON (schema-validated)
+
+Markdown is derived output for humans and PR review.
+
+## Quickstart
+
+### Generate JSON + Markdown
+```bash
+assay coverage \
+  --input artifacts/decision.jsonl \
+  --out artifacts/coverage_report_v1.json \
+  --out-md artifacts/coverage_report_v1.md \
+  --declared-tools-file declared_tools.txt \
+  --routes-top 10
+```
+
+## Declared tools file format
+- one tool name per line
+- blank lines ignored
+- lines starting with `#` are comments
+- file entries union with any `--declared-tool` flags
+
+Example:
+
+```text
+# allowed tools
+read_document
+web_search
+```
+
+## Route summary behavior
+- `--routes-top N` affects markdown only
+- JSON output remains complete (no truncation)
+- `--routes-top 0` hides the route table in markdown
+
+## Exit codes (generator mode)
+- `0`: success
+- `2`: measurement/contract issues (invalid jsonl, missing required fields, schema validation failure)
+- `3`: infra issues (failed to write json or markdown output)
+
+## Troubleshooting
+
+Markdown not written:
+- confirm `--out-md` points to a writable location
+- check stderr for `Infra error: failed to write ...`
+
+Unexpected exit 2:
+- input jsonl is malformed or missing required fields (`tool` or `tool_name`)
+- schema validation failed (file a bug with repro)
+
+## References
+- ADR-031 Coverage v1.1 DX Polish
+- Schema: `schemas/coverage_report_v1.schema.json`

--- a/scripts/ci/review-coverage-v1-1-c-closure.sh
+++ b/scripts/ci/review-coverage-v1-1-c-closure.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/COVERAGE-V1-1-RUNBOOK.md"
+  "docs/contributing/SPLIT-CHECKLIST-coverage-v1-1-closure.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-coverage-v1-1-closure.md"
+  "scripts/ci/review-coverage-v1-1-c-closure.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: coverage v1.1 closure must not touch workflows ($f)"
+    exit 1
+  fi
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in coverage v1.1 closure: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+rg -n '^# Coverage v1\.1 Runbook$' docs/ops/COVERAGE-V1-1-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook title missing"
+  exit 1
+}
+rg -n -- '--out-md' docs/ops/COVERAGE-V1-1-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing --out-md"
+  exit 1
+}
+rg -n -- '--routes-top' docs/ops/COVERAGE-V1-1-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing --routes-top"
+  exit 1
+}
+rg -n 'coverage_report_v1' docs/ops/COVERAGE-V1-1-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing coverage_report_v1 reference"
+  exit 1
+}
+rg -n 'Exit codes.*0.*2.*3|0.*success|2.*measurement|3.*infra' docs/ops/COVERAGE-V1-1-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing exit code contract (0/2/3)"
+  exit 1
+}
+rg -n 'declared-tools-file|declared tools file' docs/ops/COVERAGE-V1-1-RUNBOOK.md >/dev/null || {
+  echo "FAIL: runbook missing declared-tools-file guidance"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Summary
Docs-only C-slice closure for Coverage v1.1 DX polish.
Adds runbook, split checklist/review pack, and reviewer gate.

## Scope
- docs/ops/COVERAGE-V1-1-RUNBOOK.md
- docs/contributing/SPLIT-CHECKLIST-coverage-v1-1-closure.md
- docs/contributing/SPLIT-REVIEW-PACK-coverage-v1-1-closure.md
- scripts/ci/review-coverage-v1-1-c-closure.sh

## Safety
- No runtime changes
- No workflow changes
- No schema/ADR changes

## Verification
- BASE_REF=origin/main bash scripts/ci/review-coverage-v1-1-c-closure.sh
- cargo fmt --check
- cargo clippy -p assay-cli -- -D warnings
