### PR TITLE
chore(release): prepare v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [v2.19.0] - 2026-03-05
+## [v3.0.0] - 2026-03-05
+
+### Breaking API Changes
+
+- `assay_core::mcp::policy::ToolPolicy` adds `allow_classes` and `deny_classes`.
+- `assay_core::mcp::decision::DecisionData` adds `tool_classes`, `matched_tool_classes`, `match_basis`, and `matched_rule`.
+- External struct-literal construction against these types now requires populating the new fields.
 
 ### DX and Runtime
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "aya",
  "chrono",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assay-core",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "2.19.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "2.19.0"
+version = "3.0.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -69,15 +69,15 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "2.19.0" }
-assay-common = { path = "crates/assay-common", version = "2.19.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "2.19.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "2.19.0" }
-assay-policy = { path = "crates/assay-policy", version = "2.19.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "2.19.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "2.19.0" }
-assay-sim = { path = "crates/assay-sim", version = "2.19.0" }
-assay-registry = { path = "crates/assay-registry", version = "2.19.0" }
+assay-core = { path = "crates/assay-core", version = "3.0.0" }
+assay-common = { path = "crates/assay-common", version = "3.0.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.0.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.0.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.0.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.0.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.0.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.0.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.0.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/crates/assay-adapter-a2a/Cargo.toml
+++ b/crates/assay-adapter-a2a/Cargo.toml
@@ -9,8 +9,8 @@ description = "A2A protocol adapter for Assay evidence translation."
 readme.workspace = true
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "2.19.0" }
-assay-evidence = { path = "../assay-evidence", version = "2.19.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "3.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std"] }

--- a/crates/assay-adapter-acp/Cargo.toml
+++ b/crates/assay-adapter-acp/Cargo.toml
@@ -9,8 +9,8 @@ description = "ACP protocol adapter for Assay evidence translation."
 readme.workspace = true
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "2.19.0" }
-assay-evidence = { path = "../assay-evidence", version = "2.19.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "3.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std"] }

--- a/crates/assay-adapter-api/Cargo.toml
+++ b/crates/assay-adapter-api/Cargo.toml
@@ -9,7 +9,7 @@ description = "Protocol adapter API contracts for Assay evidence translation."
 readme.workspace = true
 
 [dependencies]
-assay-evidence = { path = "../assay-evidence", version = "2.19.0" }
+assay-evidence = { path = "../assay-evidence", version = "3.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }

--- a/crates/assay-adapter-ucp/Cargo.toml
+++ b/crates/assay-adapter-ucp/Cargo.toml
@@ -9,8 +9,8 @@ description = "UCP protocol adapter for Assay evidence translation."
 readme.workspace = true
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "2.19.0" }
-assay-evidence = { path = "../assay-evidence", version = "2.19.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
+assay-evidence = { path = "../assay-evidence", version = "3.0.0" }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std"] }

--- a/crates/assay-core/Cargo.toml
+++ b/crates/assay-core/Cargo.toml
@@ -20,7 +20,7 @@ kill-switch-capture = ["kill-switch", "dep:procfs"]
 runtime-monitor = []
 
 [dependencies]
-assay-adapter-api = { path = "../assay-adapter-api", version = "2.19.0" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
 assay-common = { workspace = true, features = ["std"] }
 anyhow.workspace = true
 async-trait.workspace = true

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -1,13 +1,31 @@
-# Assay v2.19.0 Release Runbook
+# Assay v3.0.0 Release Runbook
 
 **Target date**: 2026-03-05
-**Release type**: additive feature release (non-breaking)
+**Release type**: major feature release (breaking)
 
 ## Scope
 
-- Workspace/package version bump to `2.19.0`
-- Changelog section for `v2.19.0`
+- Workspace/package version bump to `3.0.0`
+- Changelog section for `v3.0.0`
 - Publish Rust crates and Python package (`assay-it`) on the same release line
+
+## Breaking API Notes (assay-core)
+
+This release introduces intentional public API breakage in MCP policy/decision model structs.
+
+- `assay_core::mcp::policy::ToolPolicy` adds:
+  - `allow_classes: Option<Vec<String>>`
+  - `deny_classes: Option<Vec<String>>`
+- `assay_core::mcp::decision::DecisionData` adds:
+  - `tool_classes: Vec<String>`
+  - `matched_tool_classes: Vec<String>`
+  - `match_basis: Option<String>`
+  - `matched_rule: Option<String>`
+
+Semver implication:
+
+- External code constructing these structs via struct literals must add the new fields.
+- This is why the release line is `v3.0.0` instead of `v2.19.0`.
 
 ## Preflight
 
@@ -105,11 +123,11 @@ python3 -m pip index versions assay-it | head -n 20
 ## Tag + GitHub Release
 
 ```bash
-git tag -a v2.19.0 -m "Assay v2.19.0"
-git push origin v2.19.0
+git tag -a v3.0.0 -m "Assay v3.0.0"
+git push origin v3.0.0
 ```
 
-Create GitHub release notes from `CHANGELOG.md` `v2.19.0` section.
+Create GitHub release notes from `CHANGELOG.md` `v3.0.0` section.
 
 ## GitHub Action Marketplace v2 Check
 
@@ -130,5 +148,5 @@ If any mandatory gate fails:
 If partial publish occurred:
 
 - do not retag
-- cut `v2.19.1` with forward fix
+- cut `v3.0.1` with forward fix
 - document partial state in release notes


### PR DESCRIPTION
## Summary
Semver-correct release recovery: prepare `v3.0.0` (major) instead of `v2.19.0`.

## Why major
`assay-core` added public fields on externally constructible structs, which is semver-breaking for minor lines:
- `ToolPolicy.allow_classes`
- `ToolPolicy.deny_classes`
- `DecisionData.tool_classes`
- `DecisionData.matched_tool_classes`
- `DecisionData.match_basis`
- `DecisionData.matched_rule`

## Scope
- bump workspace/crate line from `2.19.0` to `3.0.0`
- convert release runbook and changelog section to `v3.0.0`
- keep semver baseline policy unchanged (no gate suppression)

## Distribution note
Adapter crates remain workspace-internal per ADR-026 distribution policy; this change does not expand publish scope.

## Verification
- `cargo fmt --check`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets -- -D warnings`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --workspace`
- `cargo run -p assay-cli -- coverage --input scripts/ci/fixtures/coverage/input_basic.jsonl --out /tmp/release-smoke-coverage.json --out-md /tmp/release-smoke-coverage.md --routes-top 5 --declared-tool read_document --declared-tool web_search --declared-tool web_search_alt`
- `cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report`
