### PR TITLE
ci(release): pin attest-build-provenance action by sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
           retention-days: 14
 
       - name: Generate build provenance attestations
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: release/*
 


### PR DESCRIPTION
## Summary
Fixes failed Release workflow for `v3.0.0` by pinning the only unpinned action.

## Root cause
`Create Release` failed with org policy:
- `actions/attest-build-provenance@v2` is not full-length SHA pinned.

## Change
- Pin `actions/attest-build-provenance` to commit SHA:
  - `e8998f949152b193b063cb0ec769d69d929409be` (`v2`)

## Scope
- `.github/workflows/release.yml` only

## Safety
- No behavior change besides policy-compliant action pinning
- No release logic/content changes
