### PR TITLE
docs(split/wave8b-step1): freeze ucp split scope and gates

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave8b-step1-ucp.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave8b-step1-ucp.md
@@ -1,0 +1,28 @@
+# SPLIT CHECKLIST - Wave8B Step1 (UCP Freeze)
+
+## Scope
+
+- [ ] Step1 is docs + reviewer gate only
+- [ ] No `.github/workflows/*` changes
+- [ ] No production code changes in `crates/assay-adapter-ucp/src/lib.rs`
+
+## Inventory Baseline
+
+- [ ] Hotspot confirmed: `crates/assay-adapter-ucp/src/lib.rs` (981 LOC on `origin/main`)
+- [ ] Function zones inventoried (convert / parse / version / fields / mapping / payload / tests)
+- [ ] Step2 target module map frozen in review pack
+
+## Behavior Freeze
+
+- [ ] Public surface remains unchanged (`UcpAdapter`, `ProtocolAdapter` impl)
+- [ ] Event type strings unchanged
+- [ ] Strict/lenient contract unchanged
+- [ ] Error kind contract unchanged
+
+## Reviewer Gate
+
+- [ ] `scripts/ci/review-wave8b-step1.sh` exists
+- [ ] Gate enforces allowlist-only + workflow-ban
+- [ ] Gate executes fmt + clippy + targeted UCP tests
+- [ ] Gate enforces no-increase drift counters
+- [ ] Gate fails when `crates/assay-adapter-ucp/src/lib.rs` changes in Step1

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave8b-step1-ucp.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave8b-step1-ucp.md
@@ -1,0 +1,36 @@
+# Wave8B Step1 Review Pack - UCP Freeze
+
+## Intent
+
+Freeze UCP adapter behavior and lock reviewer gates before the Wave8B mechanical split.
+
+## Scope
+
+- `docs/contributing/SPLIT-CHECKLIST-wave8b-step1-ucp.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave8b-step1-ucp.md`
+- `scripts/ci/review-wave8b-step1.sh`
+
+## Non-goals
+
+- No mechanical code movement yet
+- No API or behavior changes
+- No workflow changes
+
+## Step2 planned split map (frozen)
+
+`crates/assay-adapter-ucp/src/lib.rs` ->
+
+- `adapter_impl/convert.rs`
+- `adapter_impl/parse.rs`
+- `adapter_impl/version.rs`
+- `adapter_impl/fields.rs`
+- `adapter_impl/mapping.rs`
+- `adapter_impl/payload.rs`
+- `adapter_impl/tests.rs`
+- thin facade remains in `lib.rs`
+
+## Validation Command
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave8b-step1.sh
+```

--- a/scripts/ci/review-wave8b-step1.sh
+++ b/scripts/ci/review-wave8b-step1.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+file="crates/assay-adapter-ucp/src/lib.rs"
+rg_bin="$(command -v rg)"
+
+check_no_increase() {
+  local pattern="$1"
+  local label="$2"
+  local before after
+  before="$({ git show "${base_ref}:${file}" | "$rg_bin" -n "$pattern" || true; } | wc -l | tr -d ' ')"
+  after="$({ "$rg_bin" -n "$pattern" "$file" || true; } | wc -l | tr -d ' ')"
+  echo "${label}: before=${before} after=${after}"
+  if [ "${after}" -gt "${before}" ]; then
+    echo "drift gate failed: ${label} increased"
+    exit 1
+  fi
+}
+
+echo "== Wave8B Step1 quality checks =="
+cargo fmt --check
+cargo clippy -p assay-adapter-ucp -p assay-adapter-api --all-targets -- -D warnings
+cargo test -p assay-adapter-ucp
+bash scripts/ci/test-adapter-ucp.sh
+
+echo "== Wave8B Step1 contract anchors =="
+for test_name in \
+  tests::protocol_metadata_uses_frozen_release_tag \
+  tests::strict_order_fixture_maps_expected_event \
+  tests::strict_missing_order_id_fails_with_measurement_error \
+  tests::lenient_missing_order_id_substitutes_unknown_order \
+  tests::excessive_json_depth_fails_measurement_contract
+
+do
+  echo "anchor: ${test_name}"
+  cargo test -p assay-adapter-ucp "${test_name}" -- --exact
+done
+
+echo "== Wave8B Step1 no-production-change gate =="
+if ! git diff --quiet "${base_ref}...HEAD" -- "${file}"; then
+  echo "${file} changed in Step1; only docs/reviewer artifacts are allowed"
+  git diff -- "${file}" | sed -n '1,160p'
+  exit 1
+fi
+
+echo "== Wave8B Step1 drift gates =="
+check_no_increase 'unwrap\(|expect\(' 'unwrap/expect'
+check_no_increase '\bunsafe\b' 'unsafe'
+check_no_increase 'println!\(|eprintln!\(|print!\(|dbg!\(' 'print/debug'
+check_no_increase 'panic!\(|todo!\(|unimplemented!\(' 'panic/todo/unimplemented'
+
+echo "== Wave8B Step1 diff allowlist =="
+leaks="$(
+  git diff --name-only "${base_ref}...HEAD" | \
+    "$rg_bin" -v '^crates/assay-adapter-a2a/src/lib.rs$|^crates/assay-adapter-a2a/src/adapter_impl/|^docs/contributing/SPLIT-CHECKLIST-wave8a-step1-a2a.md$|^docs/contributing/SPLIT-REVIEW-PACK-wave8a-step1-a2a.md$|^scripts/ci/review-wave8a-step1.sh$|^docs/contributing/SPLIT-MOVE-MAP-wave8a-step2-a2a.md$|^docs/contributing/SPLIT-CHECKLIST-wave8a-step2-a2a.md$|^docs/contributing/SPLIT-REVIEW-PACK-wave8a-step2-a2a.md$|^scripts/ci/review-wave8a-step2.sh$|^docs/contributing/SPLIT-CHECKLIST-wave8a-step3-a2a.md$|^docs/contributing/SPLIT-REVIEW-PACK-wave8a-step3-a2a.md$|^scripts/ci/review-wave8a-step3.sh$|^docs/contributing/SPLIT-CHECKLIST-wave8b-step1-ucp.md$|^docs/contributing/SPLIT-REVIEW-PACK-wave8b-step1-ucp.md$|^scripts/ci/review-wave8b-step1.sh$' || true
+)"
+if [ -n "${leaks}" ]; then
+  echo "non-allowlisted files detected:"
+  echo "${leaks}"
+  exit 1
+fi
+
+if git diff --name-only "${base_ref}...HEAD" | "$rg_bin" '^\.github/workflows/'; then
+  echo "workflow changes are forbidden in Wave8B Step1"
+  exit 1
+fi
+
+echo "Wave8B Step1 reviewer script: PASS"


### PR DESCRIPTION
## Summary
- Freeze Wave8B Step1 for `assay-adapter-ucp`.
- Add checklist + review pack + hard reviewer gate.
- No production code movement yet.

## Scope
- docs/contributing/SPLIT-CHECKLIST-wave8b-step1-ucp.md
- docs/contributing/SPLIT-REVIEW-PACK-wave8b-step1-ucp.md
- scripts/ci/review-wave8b-step1.sh

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave8b-step1.sh`
