### PR TITLE
docs(c1-c): close wave c1 with final layout and gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave-c1-c-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave-c1-c-closure.md
@@ -1,0 +1,29 @@
+# SPLIT CHECKLIST - Wave C1 C (Closure)
+
+## Scope Lock
+
+- [ ] Closure is docs + closure gate only.
+- [ ] No `.github/workflows/*` changes.
+- [ ] No production code edits in closure step.
+
+## Final Layout Validation
+
+- [ ] CLI args surface finalized:
+  - `crates/assay-cli/src/cli/args/mod.rs` (facade)
+  - thematic modules for args categories (`coverage`, `evidence`, `import`, `mcp`, `replay`, `runtime`, `sim`)
+- [ ] Replay command surface finalized:
+  - `crates/assay-cli/src/cli/commands/replay/mod.rs` (facade)
+  - `flow`, `run_args`, `failure`, `manifest`, `fs_ops`, `provenance`, `tests`
+- [ ] Env filter surface finalized:
+  - `crates/assay-cli/src/env_filter/mod.rs` (facade)
+  - `engine`, `matcher`, `patterns`, `tests`
+
+## Reviewer Gate
+
+- [ ] `scripts/ci/review-wave-c1-c-closure.sh` exists.
+- [ ] Gate enforces allowlist-only + workflow-ban.
+- [ ] Gate executes:
+  - `cargo fmt --check`
+  - `cargo clippy -p assay-cli --all-targets -- -D warnings`
+  - `cargo test -p assay-cli`
+- [ ] Gate asserts old monolith files are absent and key facades remain thin.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave-c1-final.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave-c1-final.md
@@ -1,0 +1,38 @@
+# SPLIT MOVE MAP - Wave C1 Final Layout
+
+## CLI Args (`crates/assay-cli/src/cli/args`)
+
+- Facade: `mod.rs` (`Cli`, `Command`, `ToolArgs` + module wiring/re-exports)
+- Add new command args near domain modules:
+  - replay flow args -> `replay.rs`
+  - setup/discovery/mcp wrapper args -> `mcp.rs`
+  - run/watch/calibrate/fix/sandbox args -> `runtime.rs`
+  - import/init/migrate/demo args -> `import.rs`
+  - coverage flags -> `coverage.rs`
+  - evidence command shell -> `evidence.rs`
+  - sim args -> `sim.rs`
+
+## Replay Command (`crates/assay-cli/src/cli/commands/replay`)
+
+- Facade: `mod.rs` (`pub use flow::run`)
+- Command orchestration: `flow.rs`
+- RunArg construction: `run_args.rs`
+- Failure/exit writing: `failure.rs`
+- Manifest/path resolution: `manifest.rs`
+- FS/workspace/seed overrides: `fs_ops.rs`
+- Provenance output annotation: `provenance.rs`
+- Unit tests: `tests.rs`
+
+## Env Filter (`crates/assay-cli/src/env_filter`)
+
+- Facade: `mod.rs` (public re-exports)
+- Filter engine and mode semantics: `engine.rs`
+- Glob matcher: `matcher.rs`
+- Pattern catalogs: `patterns.rs`
+- Unit tests: `tests.rs`
+
+## Reviewer Orientation (60s)
+
+1. Find feature area in this map.
+2. Confirm facade stayed thin.
+3. Inspect only the owning module for behavior changes.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave-c1-c-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave-c1-c-closure.md
@@ -1,0 +1,37 @@
+# Wave C1 Closure Review Pack
+
+## Intent
+
+Close Wave C1 with a final module map and closure gate that verifies the split landed cleanly and reviewably.
+
+## Scope
+
+- `docs/contributing/SPLIT-CHECKLIST-wave-c1-c-closure.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave-c1-final.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave-c1-c-closure.md`
+- `scripts/ci/review-wave-c1-c-closure.sh`
+
+## Non-goals
+
+- No production code changes.
+- No workflow changes.
+
+## Validation Command
+
+```bash
+BASE_REF=<c1-b3-commit> bash scripts/ci/review-wave-c1-c-closure.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-cli --all-targets -- -D warnings
+cargo test -p assay-cli
+```
+
+## Reviewer 60s Scan
+
+1. Confirm closure diff is docs/scripts only.
+2. Confirm final layout map is concrete and actionable.
+3. Run closure script and confirm PASS.

--- a/scripts/ci/review-wave-c1-c-closure.sh
+++ b/scripts/ci/review-wave-c1-c-closure.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+rg_bin="$(command -v rg)"
+
+echo "== Wave C1 Closure quality checks =="
+cargo fmt --check
+cargo clippy -p assay-cli --all-targets -- -D warnings
+cargo test -p assay-cli
+
+echo "== Wave C1 Closure final-layout checks =="
+required_files=(
+  "crates/assay-cli/src/cli/args/mod.rs"
+  "crates/assay-cli/src/cli/commands/replay/mod.rs"
+  "crates/assay-cli/src/env_filter/mod.rs"
+)
+for file in "${required_files[@]}"; do
+  if [ ! -f "${file}" ]; then
+    echo "missing required final-layout file: ${file}"
+    exit 1
+  fi
+done
+
+if [ -f "crates/assay-cli/src/cli/commands/replay.rs" ]; then
+  echo "legacy replay.rs should not exist after split"
+  exit 1
+fi
+if [ -f "crates/assay-cli/src/env_filter.rs" ]; then
+  echo "legacy env_filter.rs should not exist after split"
+  exit 1
+fi
+
+args_lines="$(wc -l < crates/assay-cli/src/cli/args/mod.rs | tr -d ' ')"
+replay_lines="$(wc -l < crates/assay-cli/src/cli/commands/replay/mod.rs | tr -d ' ')"
+env_lines="$(wc -l < crates/assay-cli/src/env_filter/mod.rs | tr -d ' ')"
+echo "facade lines: args=${args_lines} replay=${replay_lines} env_filter=${env_lines}"
+
+if [ "${args_lines}" -gt 180 ] || [ "${replay_lines}" -gt 40 ] || [ "${env_lines}" -gt 40 ]; then
+  echo "one or more facades exceeded thinness threshold"
+  exit 1
+fi
+
+echo "== Wave C1 Closure diff allowlist =="
+leaks="$({ git diff --name-only "${base_ref}...HEAD" | \
+  "${rg_bin}" -v '^docs/contributing/SPLIT-CHECKLIST-wave-c1-c-closure.md$|^docs/contributing/SPLIT-MOVE-MAP-wave-c1-final.md$|^docs/contributing/SPLIT-REVIEW-PACK-wave-c1-c-closure.md$|^scripts/ci/review-wave-c1-c-closure.sh$' || true; })"
+if [ -n "${leaks}" ]; then
+  echo "non-allowlisted files detected:"
+  echo "${leaks}"
+  exit 1
+fi
+
+if git diff --name-only "${base_ref}...HEAD" | "${rg_bin}" '^\.github/workflows/'; then
+  echo "workflow changes are forbidden in Wave C1 Closure"
+  exit 1
+fi
+
+echo "Wave C1 Closure reviewer script: PASS"


### PR DESCRIPTION
## Summary
- add Wave C1 closure artifacts: final layout map + closure checklist + closure review pack
- add closure reviewer gate to verify final split structure and keep closure diff docs/scripts-only
- no production code changes

## Scope
- `docs/contributing/SPLIT-CHECKLIST-wave-c1-c-closure.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave-c1-final.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave-c1-c-closure.md`
- `scripts/ci/review-wave-c1-c-closure.sh`

## Validation
- `BASE_REF=82a4d7c1 bash scripts/ci/review-wave-c1-c-closure.sh`
