### PR TITLE
docs(split): close wave11 registry_client split with step3 gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-registry-client-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-registry-client-step3.md
@@ -1,0 +1,52 @@
+# Registry Client Step3 Checklist (Closure)
+
+Scope lock:
+- closure/docs/gates only
+- no workflow changes
+- no behavior changes
+
+## Goal
+
+Close Wave11 `registry_client` split with strict closure guards:
+- keep `registry_client.rs` as a thin facade
+- keep module wiring explicit in `registry_client/mod.rs`
+- keep test inventory parity fixed at 26
+- enforce allowlist-only diff scope
+
+## Final layout invariants
+
+- `crates/assay-registry/tests/registry_client.rs` stays facade-only:
+  - `#[path = "registry_client/mod.rs"]`
+  - `mod registry_client;`
+- `crates/assay-registry/tests/registry_client/mod.rs` explicitly declares:
+  - `mod support;`
+  - `mod scenarios_pack_fetch;`
+  - `mod scenarios_meta_keys;`
+  - `mod scenarios_auth_headers;`
+  - `mod scenarios_signature;`
+  - `mod scenarios_cache_digest;`
+  - `mod scenarios_retry;`
+- `crates/assay-registry/tests/registry_client/support.rs` retains shared `create_test_client` helper
+- scenario test inventory remains exactly `26`
+
+## Required checks
+
+- `cargo fmt --check`
+- `cargo clippy -p assay-registry --tests -- -D warnings`
+- `cargo test -p assay-registry --tests`
+- `BASE_REF=origin/main bash scripts/ci/review-registry-client-step3.sh`
+
+## Diff allowlist (Step3)
+
+- `crates/assay-registry/tests/registry_client.rs`
+- `crates/assay-registry/tests/registry_client/*.rs`
+- `docs/contributing/SPLIT-CHECKLIST-registry-client-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-registry-client-step3.md`
+- `scripts/ci/review-registry-client-step3.sh`
+
+## Acceptatiecriteria
+
+- closure script passes end-to-end
+- no workflow edits
+- no test inventory drift (`26`)
+- no hidden logic reintroduced in `registry_client.rs`

--- a/docs/contributing/SPLIT-REVIEW-PACK-registry-client-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-registry-client-step3.md
@@ -1,0 +1,45 @@
+# Registry Client Step3 Review Pack (Closure)
+
+## Intent
+
+Close Wave11 `registry_client` split with a strict closure gate and no behavior churn.
+
+## Scope
+
+- `docs/contributing/SPLIT-CHECKLIST-registry-client-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-registry-client-step3.md`
+- `scripts/ci/review-registry-client-step3.sh`
+
+## Final shape snapshot
+
+| File | LOC |
+| --- | ---: |
+| `crates/assay-registry/tests/registry_client.rs` | 2 |
+| `crates/assay-registry/tests/registry_client/mod.rs` | 20 |
+| `crates/assay-registry/tests/registry_client/support.rs` | 8 |
+| `crates/assay-registry/tests/registry_client/scenarios_*.rs` | 733 |
+| `registry_client` test inventory | 26 |
+
+## Non-goals
+
+- no production code changes
+- no test behavior changes
+- no workflow changes
+
+## Validation command
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-registry-client-step3.sh
+```
+
+## Reviewer 60s scan
+
+1. Confirm Step3 diff is docs + reviewer script only.
+2. Confirm `registry_client.rs` is still facade-only (no inline tests/functions).
+3. Confirm `registry_client/mod.rs` still has explicit scenario module wiring.
+4. Confirm test inventory remains exactly `26`.
+5. Run reviewer script and confirm PASS.
+
+## Wiremock note
+
+Wiremock tests require local port binding; CI handles this. Local runs may need an unsandboxed environment.

--- a/scripts/ci/review-registry-client-step3.sh
+++ b/scripts/ci/review-registry-client-step3.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+rg_bin="$(command -v rg)"
+facade_file="crates/assay-registry/tests/registry_client.rs"
+module_root="crates/assay-registry/tests/registry_client"
+mod_file="${module_root}/mod.rs"
+support_file="${module_root}/support.rs"
+
+check_has_match() {
+  local pattern="$1"
+  local file="$2"
+  if ! "${rg_bin}" -n "${pattern}" "${file}" >/dev/null; then
+    echo "missing expected pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+check_no_match() {
+  local pattern="$1"
+  local file="$2"
+  if "${rg_bin}" -n "${pattern}" "${file}" >/dev/null; then
+    echo "forbidden pattern in ${file}: ${pattern}"
+    exit 1
+  fi
+}
+
+echo "== Registry Client Step3 quality checks =="
+cargo fmt --check
+cargo clippy -p assay-registry --tests -- -D warnings
+cargo test -p assay-registry --tests
+
+echo "== Registry Client Step3 closure invariants =="
+facade_loc="$(wc -l < "${facade_file}" | tr -d ' ')"
+if [ "${facade_loc}" -gt 5 ]; then
+  echo "facade grew beyond closure target: ${facade_loc} > 5"
+  exit 1
+fi
+
+check_has_match '^\#\[path = "registry_client/mod.rs"\]$' "${facade_file}"
+check_has_match '^mod registry_client;$' "${facade_file}"
+check_no_match '^\#\[tokio::test\]' "${facade_file}"
+check_no_match '^async fn test_' "${facade_file}"
+check_no_match '^fn test_' "${facade_file}"
+
+check_has_match '^mod scenarios_pack_fetch;$' "${mod_file}"
+check_has_match '^mod scenarios_meta_keys;$' "${mod_file}"
+check_has_match '^mod scenarios_auth_headers;$' "${mod_file}"
+check_has_match '^mod scenarios_signature;$' "${mod_file}"
+check_has_match '^mod scenarios_cache_digest;$' "${mod_file}"
+check_has_match '^mod scenarios_retry;$' "${mod_file}"
+check_has_match '^mod support;$' "${mod_file}"
+check_no_match '^async fn test_' "${mod_file}"
+check_no_match '^fn test_' "${mod_file}"
+
+check_has_match '^pub\(super\) async fn create_test_client' "${support_file}"
+check_no_match '^async fn test_' "${support_file}"
+
+test_count="$("${rg_bin}" -n '^async fn test_' "${module_root}"/scenarios_*.rs | wc -l | tr -d ' ')"
+echo "test inventory count: ${test_count}"
+if [ "${test_count}" -ne 26 ]; then
+  echo "test inventory drift: expected 26, got ${test_count}"
+  exit 1
+fi
+
+echo "== Registry Client Step3 diff allowlist =="
+leaks="$({ git diff --name-only "${base_ref}...HEAD" | \
+  "${rg_bin}" -v '^crates/assay-registry/tests/registry_client.rs$|^crates/assay-registry/tests/registry_client/[^/]+\.rs$|^docs/contributing/SPLIT-CHECKLIST-registry-client-step3.md$|^docs/contributing/SPLIT-REVIEW-PACK-registry-client-step3.md$|^scripts/ci/review-registry-client-step3.sh$' || true; })"
+if [ -n "${leaks}" ]; then
+  echo "non-allowlisted files detected:"
+  echo "${leaks}"
+  exit 1
+fi
+
+if git diff --name-only "${base_ref}...HEAD" | "${rg_bin}" '^\.github/workflows/'; then
+  echo "workflow changes are forbidden in registry-client Step3"
+  exit 1
+fi
+
+echo "Registry Client Step3 reviewer script: PASS"


### PR DESCRIPTION
## Summary
- add Wave11 Step3 closure artifacts for `registry_client` split
- add hard closure gate script with facade-thinness, explicit module wiring, fixed test inventory (`26`), allowlist, and workflow-ban checks
- keep Step3 diff to docs + reviewer script only (no code movement)

## Scope
- `docs/contributing/SPLIT-CHECKLIST-registry-client-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-registry-client-step3.md`
- `scripts/ci/review-registry-client-step3.sh`

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-registry-client-step3.sh`

Gate covers:
- `cargo fmt --check`
- `cargo clippy -p assay-registry --tests -- -D warnings`
- `cargo test -p assay-registry --tests`
- facade invariants (`registry_client.rs` remains path+mod only)
- explicit module declarations in `registry_client/mod.rs`
- fixed test inventory (`26`)
- diff allowlist + workflow-ban

## Notes
- wiremock tests require local port bind; CI handles this; local runs may require unsandboxed execution.
