### PR TITLE
docs(split): freeze wave15 mcp policy with targeted reviewer gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-mcp-policy-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-mcp-policy-step1.md
@@ -1,0 +1,35 @@
+# MCP Policy Step1 Checklist (Freeze)
+
+Scope lock:
+- docs + reviewer gate script only
+- no workflow changes
+- no edits under `crates/assay-core/src/mcp/**`
+
+## Required outputs
+
+- `docs/contributing/SPLIT-PLAN-wave15-mcp-policy.md`
+- `docs/contributing/SPLIT-CHECKLIST-mcp-policy-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-mcp-policy-step1.md`
+- `scripts/ci/review-mcp-policy-step1.sh`
+
+## Freeze requirements
+
+- Step2 module target layout documented
+- Step4 promote flow documented
+- no tracked changes in `crates/assay-core/src/mcp/**`
+- no untracked files in `crates/assay-core/src/mcp/**`
+
+## Gate requirements
+
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- `cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact`
+- `cargo test -p assay-core test_event_contains_required_fields -- --exact`
+- `cargo test -p assay-core test_mixed_tools_config -- --exact`
+- allowlist-only diff
+- workflow-ban
+
+## Definition of done
+
+- reviewer script passes with `BASE_REF=origin/main`
+- Step1 diff is limited to the four freeze files

--- a/docs/contributing/SPLIT-PLAN-wave15-mcp-policy.md
+++ b/docs/contributing/SPLIT-PLAN-wave15-mcp-policy.md
@@ -1,0 +1,55 @@
+# Wave15 Plan - `mcp/policy.rs` Split
+
+## Intent
+
+Split `crates/assay-core/src/mcp/policy.rs` into bounded modules while preserving behavior and public policy contract.
+
+## Scope
+
+- Step1 freeze: docs + reviewer gate script only
+- Step2 mechanical: move-only split under `crates/assay-core/src/mcp/policy/**`
+- Step3 closure: docs + reviewer gate script only
+- Step4 promote: single final promote PR (`main <- step3`)
+
+## Public contract freeze
+
+- `McpPolicy` behavior remains unchanged
+- taxonomy/class matching behavior remains unchanged
+- decision emission invariants remain unchanged
+- legacy normalization/migration behavior remains unchanged
+
+## Step1 targeted checks (locked)
+
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- `cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact`
+- `cargo test -p assay-core test_event_contains_required_fields -- --exact`
+- `cargo test -p assay-core test_mixed_tools_config -- --exact`
+
+## Mechanical target layout (Step2)
+
+- `crates/assay-core/src/mcp/policy/mod.rs` (facade + public surface)
+- `crates/assay-core/src/mcp/policy/engine.rs` (evaluation path)
+- `crates/assay-core/src/mcp/policy/schema.rs` (schema/validation helpers)
+- `crates/assay-core/src/mcp/policy/normalize.rs` (legacy shape normalization)
+- `crates/assay-core/src/mcp/policy/state.rs` (state helpers)
+- `crates/assay-core/src/mcp/policy/tests/mod.rs` (moved tests)
+
+## Step2 invariants to enforce
+
+- `mod.rs` remains thin and keeps public surface stable
+- no policy-engine logic left in facade
+- wrappers map 1:1 to internal implementation entrypoints
+- no inline tests in facade
+- no workflow changes
+
+## Promote discipline
+
+1. PR1: Step1 `main <- step1`
+2. PR2: Step2 `step1 <- step2`
+3. PR3: Step3 `step2 <- step3`
+4. Before final promote: merge `origin/main` into step3 branch and rerun Step3 gate
+5. Final promote PR: `main <- step3`
+
+Only enable auto-merge when `mergeStateStatus=CLEAN`.
+For flaky infra failures: rerun failed checks only.

--- a/docs/contributing/SPLIT-REVIEW-PACK-mcp-policy-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-mcp-policy-step1.md
@@ -1,0 +1,41 @@
+# MCP Policy Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze Wave15 scope for `mcp/policy.rs` split before any code movement.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave15-mcp-policy.md`
+- `docs/contributing/SPLIT-CHECKLIST-mcp-policy-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-mcp-policy-step1.md`
+- `scripts/ci/review-mcp-policy-step1.sh`
+
+## Non-goals
+
+- no edits in `crates/assay-core/src/mcp/**`
+- no behavior changes
+- no workflow changes
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-mcp-policy-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core test_mixed_tools_config -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm only Step1 docs/script changed.
+2. Confirm no `crates/assay-core/src/mcp/**` tracked/untracked changes.
+3. Confirm Step2 and Step4 process is explicit.
+4. Run reviewer script and expect PASS.

--- a/scripts/ci/review-mcp-policy-step1.sh
+++ b/scripts/ci/review-mcp-policy-step1.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-${1:-}}"
+if [ -z "${base_ref}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [ -z "${base_ref}" ]; then
+  base_ref="origin/main"
+fi
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}"
+  exit 1
+fi
+
+echo "BASE_REF=${base_ref} sha=$(git rev-parse "${base_ref}")"
+echo "HEAD sha=$(git rev-parse HEAD)"
+
+rg_bin="$(command -v rg)"
+
+echo '== MCP Policy Step1 quality checks =='
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core test_mixed_tools_config -- --exact
+
+echo '== MCP Policy Step1 freeze checks =='
+if git diff --name-only "${base_ref}...HEAD" | "${rg_bin}" '^crates/assay-core/src/mcp/'; then
+  echo 'tracked changes under crates/assay-core/src/mcp/** are forbidden in Step1'
+  exit 1
+fi
+if git status --porcelain -- crates/assay-core/src/mcp | "${rg_bin}" '^\?\?'; then
+  echo 'untracked files under crates/assay-core/src/mcp/** are forbidden in Step1'
+  exit 1
+fi
+
+echo '== MCP Policy Step1 diff allowlist =='
+leaks="$({ git diff --name-only "${base_ref}...HEAD" | \
+  "${rg_bin}" -v '^docs/contributing/SPLIT-PLAN-wave15-mcp-policy.md$|^docs/contributing/SPLIT-CHECKLIST-mcp-policy-step1.md$|^docs/contributing/SPLIT-REVIEW-PACK-mcp-policy-step1.md$|^scripts/ci/review-mcp-policy-step1.sh$' || true; })"
+if [ -n "${leaks}" ]; then
+  echo 'non-allowlisted files detected:'
+  echo "${leaks}"
+  exit 1
+fi
+
+if git diff --name-only "${base_ref}...HEAD" | "${rg_bin}" '^\.github/workflows/'; then
+  echo 'workflow changes are forbidden in mcp-policy Step1'
+  exit 1
+fi
+
+echo 'MCP Policy Step1 reviewer script: PASS'


### PR DESCRIPTION
## Summary
- add Wave15 Step1 freeze artifacts for `crates/assay-core/src/mcp/policy.rs`
- add `scripts/ci/review-mcp-policy-step1.sh` with allowlist/workflow-ban/mcp-scope lock
- pin deterministic targeted tests for taxonomy + decision emission + policy normalization path

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-mcp-policy-step1.sh`

## Scope
- docs + gate script only
- no edits under `crates/assay-core/src/mcp/**`
