### PR TITLE
docs(split): freeze wave16 tool_call_handler with targeted gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-tool-call-handler-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-tool-call-handler-step1.md
@@ -1,0 +1,26 @@
+# Tool Call Handler Step1 Checklist (Freeze)
+
+Scope lock:
+- `docs/contributing/SPLIT-PLAN-wave16-tool-call-handler.md`
+- `docs/contributing/SPLIT-CHECKLIST-tool-call-handler-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-tool-call-handler-step1.md`
+- `scripts/ci/review-tool-call-handler-step1.sh`
+- no code edits under `crates/assay-core/src/mcp/**`
+- no workflow edits
+
+## Gate expectations
+
+- allowlist-only diff vs `BASE_REF` (default `origin/main`)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in `crates/assay-core/src/mcp/**`
+- hard fail untracked files in `crates/assay-core/src/mcp/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- targeted tests:
+  - `tool_taxonomy_policy_match_handler_decision_event_records_classes`
+  - `test_event_contains_required_fields`
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-tool-call-handler-step1.sh` passes
+- Step1 diff contains only the 4 allowlisted files

--- a/docs/contributing/SPLIT-PLAN-wave16-tool-call-handler.md
+++ b/docs/contributing/SPLIT-PLAN-wave16-tool-call-handler.md
@@ -1,0 +1,58 @@
+# Wave16 Plan — `mcp/tool_call_handler.rs` Split
+
+## Goal
+
+Split `crates/assay-core/src/mcp/tool_call_handler.rs` into bounded modules with zero behavior change and stable public API.
+
+## Step1 (freeze)
+
+Branch: `codex/wave16-tool-call-handler-step1-freeze` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave16-tool-call-handler.md`
+- `docs/contributing/SPLIT-CHECKLIST-tool-call-handler-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-tool-call-handler-step1.md`
+- `scripts/ci/review-tool-call-handler-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-core/src/mcp/**`
+- no workflow edits
+
+Step1 gate:
+- allowlist-only diff (the 4 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail on tracked changes in `crates/assay-core/src/mcp/**`
+- hard fail on untracked files in `crates/assay-core/src/mcp/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- targeted tests:
+  - `cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact`
+  - `cargo test -p assay-core test_event_contains_required_fields -- --exact`
+
+## Step2 (mechanical split preview)
+
+Target layout (preview):
+- `crates/assay-core/src/mcp/tool_call_handler/mod.rs` (facade + public API)
+- `crates/assay-core/src/mcp/tool_call_handler/emit.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/types.rs`
+- optional tests module relocation if inline tests exist
+
+Step2 principles:
+- 1:1 body moves
+- stable public surface (`ToolCallHandler`, `ToolCallHandlerConfig`, `HandleResult`)
+- no behavior changes in decision events / required field emission
+
+## Step3 (closure)
+
+Docs+gate-only closure slice that re-runs Step2 invariants and keeps allowlist strict.
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once chain is clean.

--- a/docs/contributing/SPLIT-REVIEW-PACK-tool-call-handler-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-tool-call-handler-step1.md
@@ -1,0 +1,40 @@
+# Tool Call Handler Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze Wave16 scope for `crates/assay-core/src/mcp/tool_call_handler.rs` before any mechanical moves.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave16-tool-call-handler.md`
+- `docs/contributing/SPLIT-CHECKLIST-tool-call-handler-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-tool-call-handler-step1.md`
+- `scripts/ci/review-tool-call-handler-step1.sh`
+
+## Non-goals
+
+- no changes under `crates/assay-core/src/mcp/**`
+- no workflow changes
+- no behavior or API changes
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-tool-call-handler-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm diff is only the 4 Step1 files.
+2. Confirm workflow-ban and mcp subtree bans exist in the script.
+3. Confirm targeted tests are pinned with `--exact`.
+4. Run reviewer script and expect PASS.

--- a/scripts/ci/review-tool-call-handler-step1.sh
+++ b/scripts/ci/review-tool-call-handler-step1.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave16-tool-call-handler.md"
+  "docs/contributing/SPLIT-CHECKLIST-tool-call-handler-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-tool-call-handler-step1.md"
+  "scripts/ci/review-tool-call-handler-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban, mcp ban)"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave16 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave16 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^crates/assay-core/src/mcp/' >/dev/null; then
+  echo "FAIL: Wave16 Step1 must not change crates/assay-core/src/mcp/**"
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- 'crates/assay-core/src/mcp/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under crates/assay-core/src/mcp/** are not allowed in Wave16 Step1"
+  git ls-files --others --exclude-standard -- 'crates/assay-core/src/mcp/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+echo "[review] gates"
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave16 Step1 freeze plan/checklist/review pack for `mcp/tool_call_handler`
- add `review-tool-call-handler-step1.sh` with strict allowlist + workflow ban + mcp subtree lock
- pin deterministic targeted tests for decision-event contract regression surface

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-tool-call-handler-step1.sh`

## Scope
- docs + gate script only
- no edits under `crates/assay-core/src/mcp/**`
