### PR TITLE
docs(split): freeze wave17 replay-bundle with step1 gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-replay-bundle-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-replay-bundle-step1.md
@@ -1,0 +1,27 @@
+# Replay Bundle Step1 Checklist (Freeze)
+
+Scope lock:
+- `docs/contributing/SPLIT-PLAN-wave17-replay-bundle.md`
+- `docs/contributing/SPLIT-CHECKLIST-replay-bundle-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-replay-bundle-step1.md`
+- `scripts/ci/review-replay-bundle-step1.sh`
+- no code edits under `crates/assay-core/src/replay/**`
+- no workflow edits
+
+## Gate expectations
+
+- allowlist-only diff vs `BASE_REF` (default `origin/main`)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in `crates/assay-core/src/replay/**`
+- hard fail untracked files in `crates/assay-core/src/replay/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- targeted exact tests:
+  - `replay::bundle::tests::write_bundle_minimal_roundtrip`
+  - `replay::bundle::tests::bundle_digest_equals_sha256_of_written_bytes`
+  - `replay::verify::tests::verify_clean_bundle_passes`
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-replay-bundle-step1.sh` passes
+- Step1 diff contains only the 4 allowlisted files

--- a/docs/contributing/SPLIT-PLAN-wave17-replay-bundle.md
+++ b/docs/contributing/SPLIT-PLAN-wave17-replay-bundle.md
@@ -1,0 +1,61 @@
+# Wave17 Plan — `replay/bundle.rs` Split
+
+## Goal
+
+Split `crates/assay-core/src/replay/bundle.rs` into bounded modules with zero behavior change and stable public API/contracts.
+
+## Step1 (freeze)
+
+Branch: `codex/wave17-replay-bundle-step1-freeze` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave17-replay-bundle.md`
+- `docs/contributing/SPLIT-CHECKLIST-replay-bundle-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-replay-bundle-step1.md`
+- `scripts/ci/review-replay-bundle-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-core/src/replay/**`
+- no workflow edits
+
+Step1 gate:
+- allowlist-only diff (the 4 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in `crates/assay-core/src/replay/**`
+- hard fail untracked files in `crates/assay-core/src/replay/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- targeted exact tests:
+  - `cargo test -p assay-core --lib replay::bundle::tests::write_bundle_minimal_roundtrip -- --exact`
+  - `cargo test -p assay-core --lib replay::bundle::tests::bundle_digest_equals_sha256_of_written_bytes -- --exact`
+  - `cargo test -p assay-core --lib replay::verify::tests::verify_clean_bundle_passes -- --exact`
+
+## Step2 (mechanical split preview)
+
+Target layout (preview):
+- `crates/assay-core/src/replay/bundle/mod.rs` (facade + public API)
+- `crates/assay-core/src/replay/bundle/manifest.rs`
+- `crates/assay-core/src/replay/bundle/verify.rs`
+- `crates/assay-core/src/replay/bundle/io.rs`
+- `crates/assay-core/src/replay/bundle/paths.rs`
+- `crates/assay-core/src/replay/bundle/tests.rs` (or `tests/mod.rs`)
+
+Step2 principles:
+- 1:1 body moves
+- stable public surface and manifest shape
+- no hash/content-address semantic drift
+- no behavior changes in verify/error categorization
+
+## Step3 (closure)
+
+Docs+gate-only closure slice that re-runs Step2 invariants and keeps allowlist strict.
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once chain is clean.

--- a/docs/contributing/SPLIT-REVIEW-PACK-replay-bundle-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-replay-bundle-step1.md
@@ -1,0 +1,41 @@
+# Replay Bundle Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze Wave17 scope for `crates/assay-core/src/replay/bundle.rs` before any mechanical moves.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave17-replay-bundle.md`
+- `docs/contributing/SPLIT-CHECKLIST-replay-bundle-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-replay-bundle-step1.md`
+- `scripts/ci/review-replay-bundle-step1.sh`
+
+## Non-goals
+
+- no changes under `crates/assay-core/src/replay/**`
+- no workflow changes
+- no behavior or API changes
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-replay-bundle-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib replay::bundle::tests::write_bundle_minimal_roundtrip -- --exact
+cargo test -p assay-core --lib replay::bundle::tests::bundle_digest_equals_sha256_of_written_bytes -- --exact
+cargo test -p assay-core --lib replay::verify::tests::verify_clean_bundle_passes -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm diff is only the 4 Step1 files.
+2. Confirm workflow-ban and replay subtree bans exist in the script.
+3. Confirm targeted tests are pinned with `--exact`.
+4. Run reviewer script and expect PASS.

--- a/scripts/ci/review-replay-bundle-step1.sh
+++ b/scripts/ci/review-replay-bundle-step1.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave17-replay-bundle.md"
+  "docs/contributing/SPLIT-CHECKLIST-replay-bundle-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-replay-bundle-step1.md"
+  "scripts/ci/review-replay-bundle-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban, replay ban)"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave17 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave17 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^crates/assay-core/src/replay/' >/dev/null; then
+  echo "FAIL: Wave17 Step1 must not change crates/assay-core/src/replay/**"
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- 'crates/assay-core/src/replay/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under crates/assay-core/src/replay/** are not allowed in Wave17 Step1"
+  git ls-files --others --exclude-standard -- 'crates/assay-core/src/replay/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+
+cargo test -p assay-core --lib replay::bundle::tests::write_bundle_minimal_roundtrip -- --exact
+cargo test -p assay-core --lib replay::bundle::tests::bundle_digest_equals_sha256_of_written_bytes -- --exact
+cargo test -p assay-core --lib replay::verify::tests::verify_clean_bundle_passes -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave17 Step1 freeze artifacts for `crates/assay-core/src/replay/bundle.rs`
- pin deterministic replay/bundle exact tests in the Step1 reviewer gate
- lock Step1 scope to docs+gate only (no replay code changes)

## Scope
- `docs/contributing/SPLIT-PLAN-wave17-replay-bundle.md`
- `docs/contributing/SPLIT-CHECKLIST-replay-bundle-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-replay-bundle-step1.md`
- `scripts/ci/review-replay-bundle-step1.sh`

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-replay-bundle-step1.sh`
- includes:
  - `cargo fmt --check`
  - `cargo clippy -p assay-core --all-targets -- -D warnings`
  - `cargo test -p assay-core --lib replay::bundle::tests::write_bundle_minimal_roundtrip -- --exact`
  - `cargo test -p assay-core --lib replay::bundle::tests::bundle_digest_equals_sha256_of_written_bytes -- --exact`
  - `cargo test -p assay-core --lib replay::verify::tests::verify_clean_bundle_passes -- --exact`
