### PR TITLE
docs(split): freeze wave18 mandate types with reviewer gates (step1)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-mandate-types-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-mandate-types-step1.md
@@ -1,0 +1,27 @@
+# Mandate Types Step1 Checklist (Freeze)
+
+Scope lock:
+- `docs/contributing/SPLIT-PLAN-wave18-mandate-types.md`
+- `docs/contributing/SPLIT-CHECKLIST-mandate-types-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-mandate-types-step1.md`
+- `scripts/ci/review-mandate-types-step1.sh`
+- no code edits under `crates/assay-evidence/src/mandate/**`
+- no workflow edits
+
+## Gate expectations
+
+- allowlist-only diff vs `BASE_REF` (default `origin/main`)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in `crates/assay-evidence/src/mandate/**`
+- hard fail untracked files in `crates/assay-evidence/src/mandate/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
+- targeted exact tests:
+  - `mandate::types::tests::test_mandate_kind_serialization`
+  - `mandate::types::tests::test_mandate_builder`
+  - `mandate::types::tests::test_operation_class_serialization`
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-mandate-types-step1.sh` passes
+- Step1 diff contains only the 4 allowlisted files

--- a/docs/contributing/SPLIT-PLAN-wave18-mandate-types.md
+++ b/docs/contributing/SPLIT-PLAN-wave18-mandate-types.md
@@ -1,0 +1,60 @@
+# Wave18 Plan — `mandate/types.rs` Split
+
+## Goal
+
+Split `crates/assay-evidence/src/mandate/types.rs` into bounded modules with zero behavior change and stable public API/contracts.
+
+## Step1 (freeze)
+
+Branch: `codex/wave18-mandate-types-step1-freeze` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave18-mandate-types.md`
+- `docs/contributing/SPLIT-CHECKLIST-mandate-types-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-mandate-types-step1.md`
+- `scripts/ci/review-mandate-types-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-evidence/src/mandate/**`
+- no workflow edits
+
+Step1 gate:
+- allowlist-only diff (the 4 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in `crates/assay-evidence/src/mandate/**`
+- hard fail untracked files in `crates/assay-evidence/src/mandate/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
+- targeted exact tests:
+  - `cargo test -p assay-evidence --lib mandate::types::tests::test_mandate_kind_serialization -- --exact`
+  - `cargo test -p assay-evidence --lib mandate::types::tests::test_mandate_builder -- --exact`
+  - `cargo test -p assay-evidence --lib mandate::types::tests::test_operation_class_serialization -- --exact`
+
+## Step2 (mechanical split preview)
+
+Target layout (preview):
+- `crates/assay-evidence/src/mandate/types/mod.rs` (facade + public API)
+- `crates/assay-evidence/src/mandate/types/core.rs`
+- `crates/assay-evidence/src/mandate/types/serde.rs`
+- `crates/assay-evidence/src/mandate/types/schema.rs`
+- `crates/assay-evidence/src/mandate/types/tests.rs` (or `tests/mod.rs`)
+
+Step2 principles:
+- 1:1 body moves
+- stable public type paths and serde surface
+- no schema/invariant behavior changes
+- no type or variant drift
+
+## Step3 (closure)
+
+Docs+gate-only closure slice that re-runs Step2 invariants and keeps allowlist strict.
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once chain is clean.

--- a/docs/contributing/SPLIT-REVIEW-PACK-mandate-types-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-mandate-types-step1.md
@@ -1,0 +1,41 @@
+# Mandate Types Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze Wave18 scope for `crates/assay-evidence/src/mandate/types.rs` before any mechanical moves.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave18-mandate-types.md`
+- `docs/contributing/SPLIT-CHECKLIST-mandate-types-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-mandate-types-step1.md`
+- `scripts/ci/review-mandate-types-step1.sh`
+
+## Non-goals
+
+- no changes under `crates/assay-evidence/src/mandate/**`
+- no workflow changes
+- no behavior or API changes
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-mandate-types-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo test -p assay-evidence --lib mandate::types::tests::test_mandate_kind_serialization -- --exact
+cargo test -p assay-evidence --lib mandate::types::tests::test_mandate_builder -- --exact
+cargo test -p assay-evidence --lib mandate::types::tests::test_operation_class_serialization -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm diff is only the 4 Step1 files.
+2. Confirm workflow-ban and mandate subtree bans exist in the script.
+3. Confirm targeted tests are pinned with `--exact`.
+4. Run reviewer script and expect PASS.

--- a/scripts/ci/review-mandate-types-step1.sh
+++ b/scripts/ci/review-mandate-types-step1.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave18-mandate-types.md"
+  "docs/contributing/SPLIT-CHECKLIST-mandate-types-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-mandate-types-step1.md"
+  "scripts/ci/review-mandate-types-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban, mandate ban)"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave18 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave18 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^crates/assay-evidence/src/mandate/' >/dev/null; then
+  echo "FAIL: Wave18 Step1 must not change crates/assay-evidence/src/mandate/**"
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- 'crates/assay-evidence/src/mandate/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under crates/assay-evidence/src/mandate/** are not allowed in Wave18 Step1"
+  git ls-files --others --exclude-standard -- 'crates/assay-evidence/src/mandate/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+
+cargo test -p assay-evidence --lib mandate::types::tests::test_mandate_kind_serialization -- --exact
+cargo test -p assay-evidence --lib mandate::types::tests::test_mandate_builder -- --exact
+cargo test -p assay-evidence --lib mandate::types::tests::test_operation_class_serialization -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave18 Step1 freeze plan/checklist/review-pack for crates/assay-evidence/src/mandate/types.rs
- add scripts/ci/review-mandate-types-step1.sh with strict allowlist + workflow-ban + mandate subtree bans
- pin deterministic --exact tests in mandate::types::tests

## Scope
- docs + reviewer script only
- no edits under crates/assay-evidence/src/mandate/**
- no workflow edits

## Validation
- BASE_REF=origin/main bash scripts/ci/review-mandate-types-step1.sh
- cargo fmt --check
- cargo clippy -p assay-evidence --all-targets -- -D warnings
- cargo test -p assay-evidence --lib mandate::types::tests::test_mandate_kind_serialization -- --exact
- cargo test -p assay-evidence --lib mandate::types::tests::test_mandate_builder -- --exact
- cargo test -p assay-evidence --lib mandate::types::tests::test_operation_class_serialization -- --exact
