### PR TITLE
docs(split): freeze wave19 coverage command with reviewer gates (step1)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-coverage-command-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-coverage-command-step1.md
@@ -1,0 +1,28 @@
+# Coverage Command Step1 Checklist (Freeze)
+
+Scope lock:
+- `docs/contributing/SPLIT-PLAN-wave19-coverage-command.md`
+- `docs/contributing/SPLIT-CHECKLIST-coverage-command-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step1.md`
+- `scripts/ci/review-coverage-command-step1.sh`
+- no code edits under `crates/assay-cli/src/cli/commands/coverage.rs`
+- no code edits under `crates/assay-cli/src/cli/commands/coverage/**`
+- no workflow edits
+
+## Gate expectations
+
+- allowlist-only diff vs `BASE_REF` (default `origin/main`)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in coverage command subtree
+- hard fail untracked files in coverage command subtree
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli --all-targets -- -D warnings`
+- targeted exact tests:
+  - `coverage_contract_generates_valid_report_from_basic_jsonl`
+  - `coverage_out_md_writes_json_and_markdown_artifacts`
+  - `coverage_declared_tools_file_union_with_flags`
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-coverage-command-step1.sh` passes
+- Step1 diff contains only the 4 allowlisted files

--- a/docs/contributing/SPLIT-PLAN-wave19-coverage-command.md
+++ b/docs/contributing/SPLIT-PLAN-wave19-coverage-command.md
@@ -1,0 +1,60 @@
+# Wave19 Plan — `coverage.rs` Command Split
+
+## Goal
+
+Split `crates/assay-cli/src/cli/commands/coverage.rs` into bounded modules with zero behavior change and stable CLI contract.
+
+## Step1 (freeze)
+
+Branch: `codex/wave19-coverage-command-step1-freeze` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave19-coverage-command.md`
+- `docs/contributing/SPLIT-CHECKLIST-coverage-command-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step1.md`
+- `scripts/ci/review-coverage-command-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-cli/src/cli/commands/coverage.rs` or `crates/assay-cli/src/cli/commands/coverage/**`
+- no workflow edits
+
+Step1 gate:
+- allowlist-only diff (the 4 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in coverage command subtree
+- hard fail untracked files in coverage command subtree
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli --all-targets -- -D warnings`
+- targeted exact tests:
+  - `cargo test -p assay-cli coverage_contract_generates_valid_report_from_basic_jsonl -- --exact`
+  - `cargo test -p assay-cli coverage_out_md_writes_json_and_markdown_artifacts -- --exact`
+  - `cargo test -p assay-cli coverage_declared_tools_file_union_with_flags -- --exact`
+
+## Step2 (mechanical split preview)
+
+Target layout (preview):
+- `crates/assay-cli/src/cli/commands/coverage/mod.rs` (facade + command entry)
+- `crates/assay-cli/src/cli/commands/coverage/generate.rs`
+- `crates/assay-cli/src/cli/commands/coverage/legacy.rs`
+- `crates/assay-cli/src/cli/commands/coverage/io.rs`
+- existing helper modules remain bounded (`format_md.rs`, `report.rs`, `schema.rs`)
+
+Step2 principles:
+- 1:1 body moves only
+- preserve exit-code semantics and output contracts
+- keep JSON/markdown schema/format behavior identical
+- no product behavior or policy changes
+
+## Step3 (closure)
+
+Docs+gate-only closure slice that re-runs Step2 invariants and keeps allowlist strict.
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once chain is clean.

--- a/docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step1.md
@@ -1,0 +1,41 @@
+# Coverage Command Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze Wave19 scope for `crates/assay-cli/src/cli/commands/coverage.rs` before any mechanical moves.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave19-coverage-command.md`
+- `docs/contributing/SPLIT-CHECKLIST-coverage-command-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step1.md`
+- `scripts/ci/review-coverage-command-step1.sh`
+
+## Non-goals
+
+- no changes under coverage command code
+- no workflow changes
+- no behavior/API changes
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-coverage-command-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-cli --all-targets -- -D warnings
+cargo test -p assay-cli coverage_contract_generates_valid_report_from_basic_jsonl -- --exact
+cargo test -p assay-cli coverage_out_md_writes_json_and_markdown_artifacts -- --exact
+cargo test -p assay-cli coverage_declared_tools_file_union_with_flags -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm diff is only the 4 Step1 files.
+2. Confirm workflow-ban and coverage subtree bans exist in the script.
+3. Confirm targeted tests are pinned with `--exact`.
+4. Run reviewer script and expect PASS.

--- a/scripts/ci/review-coverage-command-step1.sh
+++ b/scripts/ci/review-coverage-command-step1.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave19-coverage-command.md"
+  "docs/contributing/SPLIT-CHECKLIST-coverage-command-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step1.md"
+  "scripts/ci/review-coverage-command-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban, coverage-command ban)"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave19 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave19 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^crates/assay-cli/src/cli/commands/coverage(\.rs|/)' >/dev/null; then
+  echo "FAIL: Wave19 Step1 must not change coverage command code"
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- \
+  'crates/assay-cli/src/cli/commands/coverage.rs' \
+  'crates/assay-cli/src/cli/commands/coverage/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under coverage command subtree are not allowed in Wave19 Step1"
+  git ls-files --others --exclude-standard -- \
+    'crates/assay-cli/src/cli/commands/coverage.rs' \
+    'crates/assay-cli/src/cli/commands/coverage/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+cargo fmt --check
+cargo clippy -p assay-cli --all-targets -- -D warnings
+
+cargo test -p assay-cli coverage_contract_generates_valid_report_from_basic_jsonl -- --exact
+cargo test -p assay-cli coverage_out_md_writes_json_and_markdown_artifacts -- --exact
+cargo test -p assay-cli coverage_declared_tools_file_union_with_flags -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave19 Step1 freeze plan/checklist/review-pack for `crates/assay-cli/src/cli/commands/coverage.rs`
- add `scripts/ci/review-coverage-command-step1.sh` with strict allowlist + workflow-ban + coverage subtree bans
- pin deterministic `--exact` coverage tests

## Scope
- docs + reviewer script only
- no edits under `crates/assay-cli/src/cli/commands/coverage.rs`
- no edits under `crates/assay-cli/src/cli/commands/coverage/**`
- no workflow edits

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-coverage-command-step1.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `cargo test -p assay-cli coverage_contract_generates_valid_report_from_basic_jsonl -- --exact`
- `cargo test -p assay-cli coverage_out_md_writes_json_and_markdown_artifacts -- --exact`
- `cargo test -p assay-cli coverage_declared_tools_file_union_with_flags -- --exact`
