### PR TITLE
docs(split): add wave19 coverage closure gate and review pack (step3)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md
@@ -1,0 +1,28 @@
+# Coverage Command Step3 Checklist (Closure)
+
+Scope lock:
+- `docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md`
+- `scripts/ci/review-coverage-command-step3.sh`
+- no code changes
+- no workflow edits
+
+## Gate expectations
+
+- docs+script-only diff vs `BASE_REF`
+- workflow-ban (`.github/workflows/*`)
+- rerun Step2 facade/module boundary invariants
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli --all-targets -- -D warnings`
+- replay coverage contract tests:
+  - `cargo test -p assay-cli coverage_contract`
+  - `cargo test -p assay-cli coverage_out_md`
+  - `cargo test -p assay-cli coverage_declared_tools_file`
+
+## Definition of done
+
+- Stacked check passes:
+  - `BASE_REF=origin/codex/wave19-coverage-command-step2-mechanical bash scripts/ci/review-coverage-command-step3.sh`
+- Promote sanity pass (after sync, if needed):
+  - `BASE_REF=origin/main bash scripts/ci/review-coverage-command-step3.sh`
+- Step3 diff contains only the 3 allowlisted files

--- a/docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md
@@ -1,28 +1,35 @@
-# Coverage Command Step3 Checklist (Closure)
+# SPLIT CHECKLIST — Wave19 Coverage Command Step3 (closure)
 
-Scope lock:
-- `docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md`
-- `docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md`
-- `scripts/ci/review-coverage-command-step3.sh`
-- no code changes
-- no workflow edits
+## Scope discipline
+- [ ] Step3 wijzigt alleen:
+  - `docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md`
+  - `scripts/ci/review-coverage-command-step3.sh`
+- [ ] Geen `.github/workflows/*` wijzigingen
+- [ ] Geen codewijzigingen onder `crates/assay-cli/src/cli/commands/coverage*`
+- [ ] Geen scope-leaks buiten Wave19
 
-## Gate expectations
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduceert geen nieuwe logic
+- [ ] Step3 introduceert geen nieuwe tests
+- [ ] Step3 rerunt Step2 invariants zonder verruiming
 
-- docs+script-only diff vs `BASE_REF`
-- workflow-ban (`.github/workflows/*`)
-- rerun Step2 facade/module boundary invariants
-- `cargo fmt --check`
-- `cargo clippy -p assay-cli --all-targets -- -D warnings`
-- replay coverage contract tests:
-  - `cargo test -p assay-cli coverage_contract`
-  - `cargo test -p assay-cli coverage_out_md`
-  - `cargo test -p assay-cli coverage_declared_tools_file`
+## Coverage command invariants
+- [ ] `cmd_coverage(...)` blijft beschikbaar via façade
+- [ ] façade bevat geen write helpers
+- [ ] façade bevat geen baseline/threshold bulk
+- [ ] `generate.rs` draagt generator-mode markers
+- [ ] `legacy.rs` draagt baseline/analyzer markers
+- [ ] `io.rs` draagt write/logging helpers
+- [ ] `io.rs` bevat geen schema validation / markdown render / report-build logic
 
-## Definition of done
+## Contract tests
+- [ ] `coverage_contract` blijft groen
+- [ ] `coverage_out_md` blijft groen
+- [ ] `coverage_declared_tools_file` blijft groen
 
-- Stacked check passes:
-  - `BASE_REF=origin/codex/wave19-coverage-command-step2-mechanical bash scripts/ci/review-coverage-command-step3.sh`
-- Promote sanity pass (after sync, if needed):
-  - `BASE_REF=origin/main bash scripts/ci/review-coverage-command-step3.sh`
-- Step3 diff contains only the 3 allowlisted files
+## Promote readiness
+- [ ] Step3 gate draait groen tegen stacked base
+- [ ] Step3 gate kan ook groen draaien tegen `origin/main` na sync
+- [ ] Closure kan promoted worden zonder extra codewijzigingen

--- a/docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md
@@ -1,38 +1,53 @@
-# Coverage Command Step3 Review Pack (Closure)
+# SPLIT REVIEW PACK — Wave19 Coverage Command Step3
 
 ## Intent
+Close Wave19 with a docs+gate-only closure slice after the mechanical split of `crates/assay-cli/src/cli/commands/coverage.rs`.
 
-Close Wave19 coverage-command split with a docs+gate-only slice while re-running Step2 invariants and contract checks.
+Step3 must not move or edit runtime code.
+It only:
+- documents the closure,
+- preserves reviewer context,
+- re-runs Step2 invariants through a dedicated reviewer gate.
 
 ## Scope
-
+Allowed files in this slice:
 - `docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md`
 - `docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md`
 - `scripts/ci/review-coverage-command-step3.sh`
 
-## Non-goals
+Not allowed:
+- `.github/workflows/*`
+- `crates/assay-cli/src/cli/commands/coverage.rs`
+- `crates/assay-cli/src/cli/commands/coverage/**`
+- unrelated docs or release files
 
-- no code changes under `crates/assay-cli/src/cli/commands/coverage/**`
-- no workflow changes
-- no behavior or exit-code changes
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 gate re-runs the same structural invariants from Step2:
+   - façade stays thin
+   - `generate.rs` owns generator-mode logic
+   - `legacy.rs` owns baseline/analyzer path
+   - `io.rs` owns write/logging helpers only
+3. Coverage contract tests still pass:
+   - `coverage_contract`
+   - `coverage_out_md`
+   - `coverage_declared_tools_file`
 
-## Validation
+## Reviewer commands
 
-Stacked base:
-
+### Against stacked Step2 base
 ```bash
-BASE_REF=origin/codex/wave19-coverage-command-step2-mechanical bash scripts/ci/review-coverage-command-step3.sh
+BASE_REF=origin/codex/wave19-coverage-command-step2-mechanical \
+  bash scripts/ci/review-coverage-command-step3.sh
 ```
 
-Promote sanity:
-
+### Against origin/main after sync
 ```bash
-BASE_REF=origin/main bash scripts/ci/review-coverage-command-step3.sh
+BASE_REF=origin/main \
+  bash scripts/ci/review-coverage-command-step3.sh
 ```
 
-## Reviewer 60s scan
-
-1. Confirm diff is only the 3 Step3 files.
-2. Confirm workflow-ban exists in the script.
-3. Confirm Step2 invariants are re-run in the script.
-4. Confirm coverage contract tests are re-run.
+## Expected outcome
+- Step3 adds no behavior changes
+- closure remains diff-proof
+- promote PR can be opened cleanly against main

--- a/docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md
@@ -1,0 +1,38 @@
+# Coverage Command Step3 Review Pack (Closure)
+
+## Intent
+
+Close Wave19 coverage-command split with a docs+gate-only slice while re-running Step2 invariants and contract checks.
+
+## Scope
+
+- `docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md`
+- `scripts/ci/review-coverage-command-step3.sh`
+
+## Non-goals
+
+- no code changes under `crates/assay-cli/src/cli/commands/coverage/**`
+- no workflow changes
+- no behavior or exit-code changes
+
+## Validation
+
+Stacked base:
+
+```bash
+BASE_REF=origin/codex/wave19-coverage-command-step2-mechanical bash scripts/ci/review-coverage-command-step3.sh
+```
+
+Promote sanity:
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-coverage-command-step3.sh
+```
+
+## Reviewer 60s scan
+
+1. Confirm diff is only the 3 Step3 files.
+2. Confirm workflow-ban exists in the script.
+3. Confirm Step2 invariants are re-run in the script.
+4. Confirm coverage contract tests are re-run.

--- a/scripts/ci/review-coverage-command-step3.sh
+++ b/scripts/ci/review-coverage-command-step3.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md"
+  "scripts/ci/review-coverage-command-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF (workflow-ban)"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave19 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave19 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+
+FACADE=""
+if [[ -f "crates/assay-cli/src/cli/commands/coverage/mod.rs" ]]; then
+  FACADE="crates/assay-cli/src/cli/commands/coverage/mod.rs"
+elif [[ -f "crates/assay-cli/src/cli/commands/coverage.rs" ]]; then
+  FACADE="crates/assay-cli/src/cli/commands/coverage.rs"
+else
+  echo "FAIL: neither coverage/mod.rs nor coverage.rs exists"
+  exit 1
+fi
+
+echo "[review] facade invariants: $FACADE"
+
+FACADE_LOC="$(python3 - <<'PY'
+from pathlib import Path
+p = Path("crates/assay-cli/src/cli/commands/coverage/mod.rs")
+if not p.exists():
+    p = Path("crates/assay-cli/src/cli/commands/coverage.rs")
+print(sum(1 for line in p.read_text(encoding="utf-8").splitlines() if line.strip()))
+PY
+)"
+if [[ "$FACADE_LOC" -gt 200 ]]; then
+  echo "FAIL: facade LOC budget exceeded ($FACADE_LOC > 200): $FACADE"
+  exit 1
+fi
+
+if [[ "$FACADE" == "crates/assay-cli/src/cli/commands/coverage/mod.rs" ]]; then
+  rg -n '^mod generate;\s*$' "$FACADE" >/dev/null || { echo "FAIL: missing 'mod generate;'"; exit 1; }
+  rg -n '^mod legacy;\s*$' "$FACADE" >/dev/null || { echo "FAIL: missing 'mod legacy;'"; exit 1; }
+  rg -n '^mod io;\s*$' "$FACADE" >/dev/null || { echo "FAIL: missing 'mod io;'"; exit 1; }
+fi
+
+rg -n 'pub\s+async\s+fn\s+cmd_coverage|pub\s+fn\s+cmd_coverage' "$FACADE" >/dev/null || {
+  echo "FAIL: facade must expose cmd_coverage(...)"
+  exit 1
+}
+
+# Keep direct file-write logic out of facade.
+if rg -n 'create_dir_all|tokio::fs::write' "$FACADE" >/dev/null; then
+  echo "FAIL: facade must not contain direct file-write logic"
+  rg -n 'create_dir_all|tokio::fs::write' "$FACADE"
+  exit 1
+fi
+
+if rg -n 'export_baseline|min_coverage|baseline_failed|threshold_failed' "$FACADE" >/dev/null; then
+  echo "FAIL: facade must not contain legacy baseline/threshold logic"
+  rg -n 'export_baseline|min_coverage|baseline_failed|threshold_failed' "$FACADE"
+  exit 1
+fi
+
+echo "[review] generate path markers"
+[[ -f "crates/assay-cli/src/cli/commands/coverage/generate.rs" ]] || {
+  echo "FAIL: missing generate.rs"
+  exit 1
+}
+rg -n 'out_md|routes_top|declared_tools_file|declared_tools' \
+  crates/assay-cli/src/cli/commands/coverage/generate.rs >/dev/null || {
+  echo "FAIL: generate.rs missing generator-mode markers"
+  exit 1
+}
+
+echo "[review] legacy path markers"
+[[ -f "crates/assay-cli/src/cli/commands/coverage/legacy.rs" ]] || {
+  echo "FAIL: missing legacy.rs"
+  exit 1
+}
+rg -n 'baseline|min_coverage|threshold_failed|baseline_failed|CoverageAnalyzer|Baseline::' \
+  crates/assay-cli/src/cli/commands/coverage/legacy.rs >/dev/null || {
+  echo "FAIL: legacy.rs missing baseline/analyzer markers"
+  exit 1
+}
+
+echo "[review] io path markers"
+[[ -f "crates/assay-cli/src/cli/commands/coverage/io.rs" ]] || {
+  echo "FAIL: missing io.rs"
+  exit 1
+}
+rg -n 'tokio::fs::write|create_dir_all|Wrote coverage_report_v1|Wrote coverage_report_v1 markdown' \
+  crates/assay-cli/src/cli/commands/coverage/io.rs >/dev/null || {
+  echo "FAIL: io.rs missing write/logging markers"
+  exit 1
+}
+
+if rg -n 'validate_coverage_report_v1|build_coverage_report_from_input|CoverageAnalyzer::from_policy|Baseline::from_coverage_report' \
+  crates/assay-cli/src/cli/commands/coverage/io.rs >/dev/null; then
+  echo "FAIL: io.rs must not contain schema/report-build/legacy analyzer logic"
+  rg -n 'validate_coverage_report_v1|build_coverage_report_from_input|CoverageAnalyzer::from_policy|Baseline::from_coverage_report' \
+    crates/assay-cli/src/cli/commands/coverage/io.rs
+  exit 1
+fi
+
+echo "[review] build + tests"
+cargo fmt --check
+cargo clippy -p assay-cli --all-targets -- -D warnings
+
+cargo test -p assay-cli coverage_contract
+cargo test -p assay-cli coverage_out_md
+cargo test -p assay-cli coverage_declared_tools_file
+
+echo "[review] PASS"


### PR DESCRIPTION
## Wave19 Step3 (Closure): coverage command

Docs+gate-only closure slice for Wave19.

## Scope

- `docs/contributing/SPLIT-CHECKLIST-coverage-command-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-coverage-command-step3.md`
- `scripts/ci/review-coverage-command-step3.sh`

## Non-goals

- no runtime code changes
- no workflow changes
- no behavior/contract changes

## Validation

```bash
BASE_REF=origin/codex/wave19-coverage-command-step2-mechanical bash scripts/ci/review-coverage-command-step3.sh
```
