### PR TITLE
docs(split): add refactor wave status closure

### DIFF
--- a/docs/contributing/REFACTOR-WAVE-STATUS.md
+++ b/docs/contributing/REFACTOR-WAVE-STATUS.md
@@ -1,0 +1,95 @@
+# Refactor Wave Status
+
+## Intent
+This document is the operational status page for the bounded refactor wave program.
+
+It answers four questions:
+
+1. which waves are closed-loop on `main`
+2. which PRs are canonical
+3. which hotspot classes were reduced
+4. which refactor rules are now standing policy
+
+## Closed-loop waves on `main`
+
+| Wave | Area | Canonical PR line | Status | Result |
+|---|---|---|---|---|
+| Wave8 | Adapters | adapter split line landed on `main` | Closed-loop | A2A and UCP moved to facade + bounded implementation modules |
+| Wave10 | Mandate store | `#621`, `#625`, `#623` | Closed-loop | mandate store internals split into smaller bounded units |
+| Wave11 | Registry client tests | `#628`, `#629` | Closed-loop | `registry_client.rs` split into scenario modules + shared support |
+| Wave12 | Agentic | `#632`, `#633`, `#634`, `#635` | Closed-loop | `agentic/mod.rs` split into facade, builder, policy helpers, tests |
+| Wave13 | Model | Step1 + Step2 landed, `#643`, `#644` | Closed-loop | model monolith moved to bounded module layout |
+| Wave14 | ACP adapter | `#646`, `#648`, `#649`, `#652` | Closed-loop | ACP split into facade, convert, mapping, lossiness, normalize, raw payload, tests |
+| Wave15 | MCP policy | `#654`, `#656`, `#658`, `#659` | Closed-loop | MCP policy split into facade, engine, legacy, schema, response |
+| Wave16 | MCP tool call handler | `#661`, `#663` | Closed-loop | tool call handler split into facade, evaluate, emit, types, tests |
+| Wave17 | Replay bundle | `#666`, `#668` | Closed-loop | replay bundle split into bounded replay/bundle modules |
+| Wave18 | Mandate types | `#670`, `#672`, `#674`, `#675` | Closed-loop | mandate types split into facade, core, serde, schema, tests |
+| Wave19 | Coverage command | Step1 landed, `#679`, `#680` | Closed-loop | coverage command split into facade, generate, legacy, IO, supporting modules |
+
+## What changed
+The refactor program reduced large single-file hotspots in these areas:
+
+- adapters
+- runtime/mandate internals
+- agentic suggestion flow
+- MCP governance path
+- replay/bundle path
+- evidence type surface
+- coverage CLI command surface
+
+## Standing refactor policy
+The following rules are now default policy:
+
+- use wave slicing:
+  - Step1 freeze
+  - Step2 mechanical split
+  - Step3 closure
+  - single clean promote when needed
+- closure slices are docs+gate only
+- reviewer gates are allowlist-only
+- workflow edits are banned unless explicitly scoped
+- prefer merge-based sync over rebase for promote hygiene
+- do not mix semantic cleanup with mechanical split work
+- require post-merge validation on `main`
+
+## Canonical PR rule
+When a wave has superseded or obsolete PRs, the canonical PR line is the one that actually lands the final clean scope on `main`.
+
+Superseded PRs must not be treated as source-of-truth.
+
+## Current hotspot posture
+Historical hotspot lists are no longer authoritative.
+
+Future wave selection must start from the live `main` tree.
+
+Selection priority:
+1. runtime/core governance surfaces
+2. evidence/replay surfaces
+3. CLI surfaces
+4. tests only when they are still dominant hotspots
+
+## How to choose the next wave
+Start a new wave only when all of the following are true:
+
+- the target is still large on current `main`
+- the target has a bounded public surface
+- there is a clear zero-behavior-change split plan
+- deterministic contract tests can be pinned in Step1
+
+## Definition of done
+A wave is only done when all of the following are true:
+
+- freeze, mechanical, and closure slices are merged
+- promote path is merged when applicable
+- post-merge checks on `main` are green
+- superseded PRs do not remain ambiguous
+- no scope leaks remain open
+
+## Notes
+This document stays intentionally short.
+
+Detailed wave context remains in each wave's:
+- split plan
+- checklist
+- review pack
+- reviewer gate

--- a/docs/contributing/SPLIT-CHECKLIST-refactor-wave-status.md
+++ b/docs/contributing/SPLIT-CHECKLIST-refactor-wave-status.md
@@ -1,0 +1,23 @@
+# SPLIT CHECKLIST — Refactor Wave Status closure
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/REFACTOR-WAVE-STATUS.md`
+  - `docs/contributing/SPLIT-CHECKLIST-refactor-wave-status.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-refactor-wave-status.md`
+  - `scripts/ci/review-refactor-wave-status.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No code changes
+- [ ] No changelog / release-note drift
+
+## Content checks
+- [ ] Closed-loop waves listed are actually on `main`
+- [ ] Status text does not claim unfinished waves are complete
+- [ ] Standing refactor policy matches current practice
+- [ ] "Definition of done" matches current merge discipline
+- [ ] Document is brief and operational, not narrative
+
+## Reviewer gate
+- [ ] Allowlist-only
+- [ ] Workflow-ban
+- [ ] Marker checks for title and key sections

--- a/docs/contributing/SPLIT-REVIEW-PACK-refactor-wave-status.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-refactor-wave-status.md
@@ -1,0 +1,31 @@
+# SPLIT REVIEW PACK — Refactor Wave Status closure
+
+## Intent
+Close the refactor-wave line with a single operational status page.
+
+This slice is docs+gate only.
+It does not change runtime behavior, CI behavior, or any code path.
+
+## Allowed files
+- `docs/contributing/REFACTOR-WAVE-STATUS.md`
+- `docs/contributing/SPLIT-CHECKLIST-refactor-wave-status.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-refactor-wave-status.md`
+- `scripts/ci/review-refactor-wave-status.sh`
+
+## Reviewer expectations
+Reviewers should verify:
+
+1. the diff is docs+script only
+2. no workflow files are touched
+3. the listed waves are actually closed-loop on `main`
+4. the standing refactor policy matches the current repo practice
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-refactor-wave-status.sh
+```
+
+## Expected outcome
+- gate passes
+- status page is accurate
+- future wave planning starts from current `main`, not stale hotspot lists

--- a/scripts/ci/review-refactor-wave-status.sh
+++ b/scripts/ci/review-refactor-wave-status.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/REFACTOR-WAVE-STATUS.md"
+  "docs/contributing/SPLIT-CHECKLIST-refactor-wave-status.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-refactor-wave-status.md"
+  "scripts/ci/review-refactor-wave-status.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: refactor-wave-status slice must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in refactor-wave-status slice: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+
+rg -n '^# Refactor Wave Status$' docs/contributing/REFACTOR-WAVE-STATUS.md >/dev/null || {
+  echo "FAIL: missing Refactor Wave Status title"
+  exit 1
+}
+
+rg -n '^## Closed-loop waves on `main`$' docs/contributing/REFACTOR-WAVE-STATUS.md >/dev/null || {
+  echo "FAIL: missing closed-loop waves section"
+  exit 1
+}
+
+rg -n '^## Standing refactor policy$' docs/contributing/REFACTOR-WAVE-STATUS.md >/dev/null || {
+  echo "FAIL: missing standing refactor policy section"
+  exit 1
+}
+
+rg -n '^## Definition of done$' docs/contributing/REFACTOR-WAVE-STATUS.md >/dev/null || {
+  echo "FAIL: missing definition of done section"
+  exit 1
+}
+
+echo "[review] done"


### PR DESCRIPTION
## Refactor Wave Status closure (docs-only)

Docs-only closure slice to consolidate refactor wave status and standing policy.

### Scope
- `docs/contributing/REFACTOR-WAVE-STATUS.md`
- `docs/contributing/SPLIT-CHECKLIST-refactor-wave-status.md`
- `docs/contributing/SPLIT-REVIEW-PACK-refactor-wave-status.md`
- `scripts/ci/review-refactor-wave-status.sh`

### Guarantees
- no runtime code changes
- no workflow changes
- allowlist-only reviewer gate

### Validation
```bash
BASE_REF=origin/main bash scripts/ci/review-refactor-wave-status.sh
cargo fmt --check
cargo clippy -p assay-cli -- -D warnings
```
