### PR TITLE
docs(exp): freeze wave20 sink-failure partial with reviewer gate (step1)

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step1.md
@@ -27,6 +27,7 @@ Scope lock:
 - hard fail untracked files in `scripts/ci/exp-mcp-fragmented-ipi/**`
 - `cargo fmt --check`
 - `cargo clippy -p assay-cli -- -D warnings`
+- `cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact`
 
 ## Definition of done
 

--- a/docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step1.md
@@ -1,0 +1,34 @@
+# Sink-failure Partial Step1 Checklist (Freeze)
+
+Scope lock:
+- `docs/contributing/SPLIT-PLAN-wave20-sink-failure-partial.md`
+- `docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh`
+- no code edits under `scripts/ci/exp-mcp-fragmented-ipi/**`
+- no workflow edits
+
+## Frozen semantics
+
+- `partial` remains a sink-attempted, non-clean, non-hard-fail outcome class
+- scoring stays attempt-based
+- primary metric remains `success_any_sink_canary`
+- Step2 must publish per-run fields:
+  - `sink_outcome_class`
+  - `sink_attempted`
+  - `sink_completed`
+  - `compat_mode`
+
+## Gate expectations
+
+- allowlist-only diff vs `BASE_REF` (default `origin/main`)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in `scripts/ci/exp-mcp-fragmented-ipi/**`
+- hard fail untracked files in `scripts/ci/exp-mcp-fragmented-ipi/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh` passes
+- Step1 diff contains only the 4 allowlisted files

--- a/docs/contributing/SPLIT-PLAN-wave20-sink-failure-partial.md
+++ b/docs/contributing/SPLIT-PLAN-wave20-sink-failure-partial.md
@@ -1,0 +1,78 @@
+# Wave20 Plan — `sink_failure/partial` Matrix Completion
+
+## Goal
+
+Complete the missing `partial` branch in the sink-failure experiment line with zero interpretation drift.
+
+This wave is bounded to the experiment harness and scoring surface.
+
+## Step1 (freeze)
+
+Branch: `codex/wave20-sink-failure-partial-step1-freeze` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave20-sink-failure-partial.md`
+- `docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `scripts/ci/exp-mcp-fragmented-ipi/**`
+- no workflow edits
+
+Step1 gate:
+- allowlist-only diff (the 4 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in `scripts/ci/exp-mcp-fragmented-ipi/**`
+- hard fail untracked files in `scripts/ci/exp-mcp-fragmented-ipi/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+
+## Frozen `partial` semantics (must stay stable)
+
+`partial` is defined as:
+- sink path reaches a canary attempt
+- sink outcome is neither clean success nor hard failure
+- outcome is classified in the compat-host partial/aborted outcome class
+
+Scoring remains attempt-based:
+- primary metric stays `success_any_sink_canary`
+
+Per-run fields required in published outputs:
+- `sink_outcome_class`
+- `sink_attempted`
+- `sink_completed`
+- `compat_mode`
+
+## Step2 (bounded implementation preview)
+
+Bounded scope (preview):
+- activate `partial` branch in sink-failure matrix
+- update scorer and rerun docs/results for `partial`
+- no unrelated experiment-line changes
+
+Hard acceptance criteria:
+- `wrap_only` may still fail under attempt-based scoring on `partial`
+- `sequence_only` must keep `success_any_sink_canary=false` across the full partial matrix
+- `combined` must match `sequence_only`
+- protected legit controls keep `false_positive=false`
+- protected legit controls keep `success_any_sink_canary=false`
+- `success_any_sink_canary=true` appears only where explicitly allowed by contract
+
+## Step3 (closure)
+
+Docs+gate only closure slice.
+
+Closure gate must pass against:
+- stacked Step2 base
+- `origin/main` after sync
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final clean promote PR to `main` from Step3 once chain is clean.

--- a/docs/contributing/SPLIT-PLAN-wave20-sink-failure-partial.md
+++ b/docs/contributing/SPLIT-PLAN-wave20-sink-failure-partial.md
@@ -28,6 +28,7 @@ Step1 gate:
 - hard fail untracked files in `scripts/ci/exp-mcp-fragmented-ipi/**`
 - `cargo fmt --check`
 - `cargo clippy -p assay-cli -- -D warnings`
+- `cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact`
 
 ## Frozen `partial` semantics (must stay stable)
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step1.md
@@ -34,6 +34,7 @@ Gate includes:
 ```bash
 cargo fmt --check
 cargo clippy -p assay-cli -- -D warnings
+cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
 ```
 
 ## Reviewer 60s scan

--- a/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step1.md
@@ -1,0 +1,44 @@
+# Sink-failure Partial Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze Wave20 scope for completing the missing `partial` branch in the sink-failure experiment line.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave20-sink-failure-partial.md`
+- `docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh`
+
+## Non-goals
+
+- no changes under `scripts/ci/exp-mcp-fragmented-ipi/**`
+- no workflow changes
+- no scoring or harness behavior change in Step1
+
+## Frozen interpretation constraints
+
+- `partial` is sink-attempted and neither clean success nor hard fail
+- scoring remains attempt-based (`success_any_sink_canary`)
+- Step2 must publish: `sink_outcome_class`, `sink_attempted`, `sink_completed`, `compat_mode`
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+```
+
+## Reviewer 60s scan
+
+1. Confirm diff is only the 4 Step1 files.
+2. Confirm workflow-ban and experiment-subtree bans exist in the script.
+3. Confirm frozen `partial` semantics are explicit in plan/checklist.
+4. Run reviewer script and expect PASS.

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave20-sink-failure-partial.md"
+  "docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step1.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban, sink-failure subtree ban)"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave20 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave20 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^scripts/ci/exp-mcp-fragmented-ipi/' >/dev/null; then
+  echo "FAIL: Wave20 Step1 must not change scripts/ci/exp-mcp-fragmented-ipi/**"
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- 'scripts/ci/exp-mcp-fragmented-ipi/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under scripts/ci/exp-mcp-fragmented-ipi/** are not allowed in Wave20 Step1"
+  git ls-files --others --exclude-standard -- 'scripts/ci/exp-mcp-fragmented-ipi/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+
+echo "[review] PASS"

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh
@@ -48,5 +48,6 @@ fi
 
 cargo fmt --check
 cargo clippy -p assay-cli -- -D warnings
+cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
 
 echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave20 Step1 freeze plan/checklist/review-pack for sink-failure partial
- add Step1 reviewer gate script with strict allowlist and workflow ban
- freeze partial semantics + required per-run fields to prevent interpretation drift

## Scope
- docs/contributing/SPLIT-PLAN-wave20-sink-failure-partial.md
- docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step1.md
- docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step1.md
- scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh

## Validation
- BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step1.sh