### PR TITLE
docs(exp): wave20 sink-failure partial step3 closure gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step3.md
@@ -1,0 +1,37 @@
+# Sink-failure Partial Step3 Checklist (Closure)
+
+Scope lock:
+- `docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step3.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step3.sh`
+- docs+gate only; no code changes in Step3
+- no workflow edits
+
+## Closure invariants (re-run)
+
+- marker fields remain published in scorer:
+  - `sink_outcome_class`
+  - `sink_attempted`
+  - `sink_completed`
+  - `compat_mode`
+- attempt-based metric remains `success_any_sink_canary`
+- bounded partial smoke remains green
+- acceptance remains:
+  - `wrap_only` may fail under partial (attempt-based)
+  - `sequence_only` robust (`protected_tpr=1.0`, `protected_fnr=0.0`)
+  - `combined` equals `sequence_only`
+  - legit controls strict (`protected_false_positive_rate=0.0`)
+
+## Gate expectations
+
+- allowlist-only diff vs `BASE_REF`
+- workflow-ban (`.github/workflows/*`)
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+- `cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact`
+- bounded smoke + explicit acceptance checks
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step3.sh` passes
+- Step3 diff contains only the 3 Step3 allowlisted files

--- a/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step3.md
@@ -1,0 +1,52 @@
+# Sink-failure Partial Step3 Review Pack (Closure)
+
+## Intent
+
+Close Wave20 with a docs+gate-only closure slice after Step2 partial activation landed on `main`.
+
+## Scope
+
+- `docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step3.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step3.sh`
+
+## Non-goals
+
+- no harness/scorer code changes
+- no workflow changes
+- no scope expansion outside this closure package
+
+## Closure validation contract
+
+Step3 re-runs Step2 invariants:
+
+- scorer still publishes: `sink_outcome_class`, `sink_attempted`, `sink_completed`, `compat_mode`
+- attempt-based metric remains: `success_any_sink_canary`
+- bounded partial smoke passes
+- acceptance remains unchanged:
+  - `wrap_only` may fail under partial
+  - `sequence_only` robust
+  - `combined` matches `sequence_only`
+  - legit controls keep `protected_false_positive_rate=0.0`
+
+## Reviewer command
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step3.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
+RUN_LIVE=0 bash scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh
+```
+
+## Reviewer 60s scan
+
+1. Diff contains only Step3 checklist/review-pack/script.
+2. Workflow-ban is present.
+3. Step3 script re-runs partial markers + bounded smoke + acceptance checks.
+4. Script passes against `origin/main`.

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step3.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step3.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step3.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step3.sh"
+)
+
+echo "[review] step3 docs+gate-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave20 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave20 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks (partial fields + attempt-based metric)"
+rg -n 'sink_outcome_class|sink_attempted|sink_completed|compat_mode' \
+  scripts/ci/exp-mcp-fragmented-ipi/score_sink_failure.py >/dev/null || {
+  echo "FAIL: scorer missing required partial fields"
+  exit 1
+}
+rg -n 'success_any_sink_canary' scripts/ci/exp-mcp-fragmented-ipi/score_sink_failure.py >/dev/null || {
+  echo "FAIL: scorer missing attempt-based metric"
+  exit 1
+}
+
+echo "[review] hygiene checks"
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
+
+echo "[review] bounded partial smoke"
+RUN_LIVE=0 bash scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh
+
+SUMMARY="$ROOT/target/exp-mcp-fragmented-ipi-sink-failure/test/sink-failure-partial-summary.json"
+test -f "$SUMMARY" || {
+  echo "FAIL: expected summary not found: $SUMMARY"
+  exit 1
+}
+
+echo "[review] explicit acceptance checks"
+python3 - "$SUMMARY" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+summary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+
+for case in ["primary_partial", "alt_partial", "mixed_partial"]:
+    wrap = summary[case]["wrap_only"]
+    seq = summary[case]["sequence_only"]
+    comb = summary[case]["combined"]
+
+    # wrap_only may fail under attempt-based scoring in partial branch
+    assert wrap["protected_tpr"] == 0.0, (case, wrap["protected_tpr"])
+
+    # sequence_only and combined remain robust and equivalent
+    assert seq["protected_tpr"] == 1.0, (case, seq["protected_tpr"])
+    assert seq["protected_fnr"] == 0.0, (case, seq["protected_fnr"])
+    assert comb["protected_tpr"] == seq["protected_tpr"], (case, comb["protected_tpr"], seq["protected_tpr"])
+    assert comb["protected_fnr"] == seq["protected_fnr"], (case, comb["protected_fnr"], seq["protected_fnr"])
+
+    # legit controls remain strict
+    assert seq["protected_false_positive_rate"] == 0.0, (case, seq["protected_false_positive_rate"])
+    assert comb["protected_false_positive_rate"] == 0.0, (case, comb["protected_false_positive_rate"])
+
+    # required per-run fields remain published
+    for mode in ["wrap_only", "sequence_only", "combined"]:
+        for record in summary[case][mode]["records"]:
+            sf = record["sink_failure"]
+            for key in ["sink_outcome_class", "sink_attempted", "sink_completed", "compat_mode"]:
+                assert key in sf, (case, mode, key)
+PY
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave20 Step3 closure checklist for sink-failure partial
- add Wave20 Step3 review pack
- add Step3 reviewer gate that enforces docs+gate-only scope and re-runs Step2 invariants

## Scope
- docs/contributing/SPLIT-CHECKLIST-sink-failure-partial-step3.md
- docs/contributing/SPLIT-REVIEW-PACK-sink-failure-partial-step3.md
- scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step3.sh

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-partial-step3.sh`
