### PR TITLE
docs(exp): freeze wave21 sink-failure legit-volume step1

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-sink-failure-legit-volume-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-sink-failure-legit-volume-step1.md
@@ -17,14 +17,22 @@ Scope lock:
   - `sink_attempted`
   - `sink_completed`
   - `compat_mode`
-- Step2 will only increase legit volume; no semantic reinterpretation
+- Step2 is confidence-only: scorer semantics unchanged
 
-## Step2 preview (frozen target)
+## Frozen Wave21 Step2 target
 
 - keep cases: `primary_partial`, `alt_partial`, `mixed_partial`
 - keep modes: `wrap_only`, `sequence_only`, `combined`
 - keep `RUNS_ATTACK=2`
-- raise `RUNS_LEGIT` from `1` to `10`
+- raise `RUNS_LEGIT` from `1` to `100`
+
+## Frozen publication metrics
+
+- `protected_tpr`, `protected_fnr`, `protected_false_positive_rate`
+- `protected_tpr_ci`, `protected_fnr_ci`, `protected_false_positive_rate_ci`
+- `success_any_sink_canary`
+- `sink_attempted_rate` (derived)
+- `blocked_before_attempt_rate` (derived)
 
 ## Gate expectations
 

--- a/docs/contributing/SPLIT-CHECKLIST-sink-failure-legit-volume-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-sink-failure-legit-volume-step1.md
@@ -1,0 +1,44 @@
+# Sink-failure Legit Volume Step1 Checklist (Freeze)
+
+Scope lock:
+- `docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md`
+- `docs/contributing/SPLIT-CHECKLIST-sink-failure-legit-volume-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-failure-legit-volume-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh`
+- no edits under `scripts/ci/exp-mcp-fragmented-ipi/**`
+- no edits to `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- no workflow edits
+
+## Frozen semantics
+
+- attempt-based metric remains `success_any_sink_canary`
+- required per-run fields remain:
+  - `sink_outcome_class`
+  - `sink_attempted`
+  - `sink_completed`
+  - `compat_mode`
+- Step2 will only increase legit volume; no semantic reinterpretation
+
+## Step2 preview (frozen target)
+
+- keep cases: `primary_partial`, `alt_partial`, `mixed_partial`
+- keep modes: `wrap_only`, `sequence_only`, `combined`
+- keep `RUNS_ATTACK=2`
+- raise `RUNS_LEGIT` from `1` to `10`
+
+## Gate expectations
+
+- allowlist-only diff vs `BASE_REF` (default `origin/main`)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in:
+  - `scripts/ci/exp-mcp-fragmented-ipi/**`
+  - `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- hard fail untracked files in `scripts/ci/exp-mcp-fragmented-ipi/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+- `cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact`
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh` passes
+- Step1 diff contains only the 4 allowlisted files

--- a/docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md
+++ b/docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md
@@ -1,12 +1,18 @@
-# Wave21 Plan — Sink-failure Legit Volume Increase
+# Wave21 Plan — Sink-failure Confidence Upgrade (Legit Volume)
 
 ## Goal
 
-Increase legit-run volume in the sink-failure experiment line without changing experiment semantics.
+Strengthen confidence in the existing sink-failure governance claim without changing scorer semantics.
 
-This wave is bounded to the sink-failure experiment harness and reporting surface.
+This wave remains within the current fragmented-IPI/sink-governance line.
 
-## Step1 (freeze)
+## A/B/C slicing
+
+- A: Step1 freeze (docs+gate only)
+- B: Step2 bounded implementation (legit-volume increase, scorer unchanged)
+- C: Step3 closure (docs+gate only)
+
+## Step1 (A) — freeze
 
 Branch: `codex/wave21-sink-failure-legit-volume-step1-freeze` (base: `main`)
 
@@ -42,14 +48,15 @@ Step1 gate:
   - `sink_attempted`
   - `sink_completed`
   - `compat_mode`
-- partial/timing interpretation must not be changed by this wave
+- no semantic reinterpretation of `partial` in Wave21
 
-## Step2 (bounded implementation preview)
+## Step2 (B) — bounded confidence upgrade preview
 
 Bounded scope (preview):
 - increase legit volume in sink-failure matrix execution
 - keep attack volume unchanged for this slice
-- update docs/results for legit-volume batch
+- scorer stays unchanged
+- publish tighter confidence bands from higher legit volume
 
 Planned bounded run shape:
 - keep matrix cases:
@@ -59,7 +66,18 @@ Planned bounded run shape:
 - keep modes:
   - `wrap_only`, `sequence_only`, `combined`
 - keep `RUNS_ATTACK=2`
-- increase `RUNS_LEGIT` from `1` to `10`
+- increase `RUNS_LEGIT` from `1` to `100`
+
+Frozen metric set for Wave21 publication:
+- `protected_tpr`
+- `protected_fnr`
+- `protected_false_positive_rate`
+- `protected_tpr_ci`
+- `protected_fnr_ci`
+- `protected_false_positive_rate_ci`
+- `success_any_sink_canary`
+- `sink_attempted_rate` (derived from `sink_attempted`)
+- `blocked_before_attempt_rate` (derived from `sink_attempted=false`)
 
 Hard acceptance criteria:
 - attack-path behavior remains unchanged:
@@ -69,9 +87,10 @@ Hard acceptance criteria:
 - legit controls remain strict at higher volume:
   - `false_positive=false`
   - no protected legit `success_any_sink_canary=true`
+- confidence bands are reported (not point estimates only)
 - required per-run fields remain present in scorer output
 
-## Step3 (closure)
+## Step3 (C) — closure
 
 Docs+gate only closure slice.
 
@@ -87,3 +106,10 @@ Stacked chain:
 - Step3 -> Step2
 
 Final clean promote PR to `main` from Step3 once chain is clean.
+
+## Wave22 preview (fidelity upgrade, next)
+
+After Wave21 confidence upgrade:
+- add local offline HTTP-egress sink
+- keep hermetic/offline/deterministic harness constraints
+- keep governance-vs-completion scoring separated

--- a/docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md
+++ b/docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md
@@ -1,0 +1,89 @@
+# Wave21 Plan — Sink-failure Legit Volume Increase
+
+## Goal
+
+Increase legit-run volume in the sink-failure experiment line without changing experiment semantics.
+
+This wave is bounded to the sink-failure experiment harness and reporting surface.
+
+## Step1 (freeze)
+
+Branch: `codex/wave21-sink-failure-legit-volume-step1-freeze` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md`
+- `docs/contributing/SPLIT-CHECKLIST-sink-failure-legit-volume-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-failure-legit-volume-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `scripts/ci/exp-mcp-fragmented-ipi/**`
+- no edits to `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- no workflow edits
+
+Step1 gate:
+- allowlist-only diff (the 4 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in:
+  - `scripts/ci/exp-mcp-fragmented-ipi/**`
+  - `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- hard fail untracked files in `scripts/ci/exp-mcp-fragmented-ipi/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+- `cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact`
+
+## Frozen semantics (must stay stable)
+
+- scoring remains attempt-based:
+  - primary metric: `success_any_sink_canary`
+- required per-run fields remain published:
+  - `sink_outcome_class`
+  - `sink_attempted`
+  - `sink_completed`
+  - `compat_mode`
+- partial/timing interpretation must not be changed by this wave
+
+## Step2 (bounded implementation preview)
+
+Bounded scope (preview):
+- increase legit volume in sink-failure matrix execution
+- keep attack volume unchanged for this slice
+- update docs/results for legit-volume batch
+
+Planned bounded run shape:
+- keep matrix cases:
+  - `primary_partial`
+  - `alt_partial`
+  - `mixed_partial`
+- keep modes:
+  - `wrap_only`, `sequence_only`, `combined`
+- keep `RUNS_ATTACK=2`
+- increase `RUNS_LEGIT` from `1` to `10`
+
+Hard acceptance criteria:
+- attack-path behavior remains unchanged:
+  - `wrap_only` may fail under attempt-based scoring
+  - `sequence_only` remains robust
+  - `combined == sequence_only`
+- legit controls remain strict at higher volume:
+  - `false_positive=false`
+  - no protected legit `success_any_sink_canary=true`
+- required per-run fields remain present in scorer output
+
+## Step3 (closure)
+
+Docs+gate only closure slice.
+
+Closure gate must pass against:
+- stacked Step2 base
+- `origin/main` after sync
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final clean promote PR to `main` from Step3 once chain is clean.

--- a/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-legit-volume-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-legit-volume-step1.md
@@ -2,7 +2,9 @@
 
 ## Intent
 
-Freeze Wave21 scope for increasing legit-run volume in the sink-failure experiment line.
+Freeze Wave21 scope for confidence upgrade in the sink-failure experiment line.
+
+Wave21 increases legit-run volume only; it does not change scorer semantics.
 
 ## Scope
 
@@ -18,11 +20,15 @@ Freeze Wave21 scope for increasing legit-run volume in the sink-failure experime
 - no workflow changes
 - no scoring semantics changes in Step1
 
-## Frozen constraints
+## Frozen Wave21 contract
 
 - attempt-based metric remains: `success_any_sink_canary`
 - required fields remain: `sink_outcome_class`, `sink_attempted`, `sink_completed`, `compat_mode`
-- Step2 only increases legit-run volume (`RUNS_LEGIT 1 -> 10`) while keeping attack volume stable (`RUNS_ATTACK=2`)
+- Step2 target is fixed:
+  - `RUNS_ATTACK=2`
+  - `RUNS_LEGIT=100`
+  - modes/cases unchanged
+- publication must include confidence bands + derived attempt/pre-attempt rates
 
 ## Validation
 
@@ -41,6 +47,7 @@ cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
 ## Reviewer 60s scan
 
 1. Confirm diff is only the 4 Step1 files.
-2. Confirm workflow-ban and experiment-subtree bans exist in script.
-3. Confirm legit-volume target is frozen (`RUNS_ATTACK=2`, `RUNS_LEGIT=10`).
-4. Run reviewer script and expect PASS.
+2. Confirm workflow-ban and subtree bans are present in script.
+3. Confirm Step2 target freeze (`RUNS_ATTACK=2`, `RUNS_LEGIT=100`).
+4. Confirm scorer semantics stay unchanged in Step1.
+5. Run reviewer script and expect PASS.

--- a/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-legit-volume-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-sink-failure-legit-volume-step1.md
@@ -1,0 +1,46 @@
+# Sink-failure Legit Volume Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze Wave21 scope for increasing legit-run volume in the sink-failure experiment line.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md`
+- `docs/contributing/SPLIT-CHECKLIST-sink-failure-legit-volume-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-failure-legit-volume-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh`
+
+## Non-goals
+
+- no changes under `scripts/ci/exp-mcp-fragmented-ipi/**`
+- no changes to `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- no workflow changes
+- no scoring semantics changes in Step1
+
+## Frozen constraints
+
+- attempt-based metric remains: `success_any_sink_canary`
+- required fields remain: `sink_outcome_class`, `sink_attempted`, `sink_completed`, `compat_mode`
+- Step2 only increases legit-run volume (`RUNS_LEGIT 1 -> 10`) while keeping attack volume stable (`RUNS_ATTACK=2`)
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm diff is only the 4 Step1 files.
+2. Confirm workflow-ban and experiment-subtree bans exist in script.
+3. Confirm legit-volume target is frozen (`RUNS_ATTACK=2`, `RUNS_LEGIT=10`).
+4. Run reviewer script and expect PASS.

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh
@@ -51,6 +51,25 @@ if git ls-files --others --exclude-standard -- 'scripts/ci/exp-mcp-fragmented-ip
   exit 1
 fi
 
+echo "[review] marker checks (frozen run shape + metrics)"
+rg -n 'RUNS_ATTACK.*2' docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md >/dev/null || {
+  echo "FAIL: frozen RUNS_ATTACK=2 marker missing"
+  exit 1
+}
+rg -n 'RUNS_LEGIT.*100' docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md >/dev/null || {
+  echo "FAIL: frozen RUNS_LEGIT=100 marker missing"
+  exit 1
+}
+rg -n 'success_any_sink_canary' docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md >/dev/null || {
+  echo "FAIL: frozen attempt-based metric marker missing"
+  exit 1
+}
+rg -n 'blocked_before_attempt_rate|sink_attempted_rate|protected_false_positive_rate_ci' \
+  docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md >/dev/null || {
+  echo "FAIL: frozen Wave21 publication metrics markers missing"
+  exit 1
+}
+
 cargo fmt --check
 cargo clippy -p assay-cli -- -D warnings
 cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md"
+  "docs/contributing/SPLIT-CHECKLIST-sink-failure-legit-volume-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-sink-failure-legit-volume-step1.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban, sink-failure subtree ban)"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave21 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave21 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^scripts/ci/exp-mcp-fragmented-ipi/' >/dev/null; then
+  echo "FAIL: Wave21 Step1 must not change scripts/ci/exp-mcp-fragmented-ipi/**"
+  exit 1
+fi
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh$' >/dev/null; then
+  echo "FAIL: Wave21 Step1 must not change scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh"
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- 'scripts/ci/exp-mcp-fragmented-ipi/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under scripts/ci/exp-mcp-fragmented-ipi/** are not allowed in Wave21 Step1"
+  git ls-files --others --exclude-standard -- 'scripts/ci/exp-mcp-fragmented-ipi/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- freeze Wave21 scope for sink-failure legit-volume increase
- add Step1 checklist and review pack
- add Step1 reviewer gate with strict allowlist/workflow-ban and explicit cargo test

## Scope
- docs/contributing/SPLIT-PLAN-wave21-sink-failure-legit-volume.md
- docs/contributing/SPLIT-CHECKLIST-sink-failure-legit-volume-step1.md
- docs/contributing/SPLIT-REVIEW-PACK-sink-failure-legit-volume-step1.md
- scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-failure-legit-volume-step1.sh`
