### PR TITLE
docs(exp): freeze wave22 sink-fidelity-http step1

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-sink-fidelity-http-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-sink-fidelity-http-step1.md
@@ -1,0 +1,55 @@
+# Sink-fidelity HTTP Step1 Checklist (Freeze)
+
+Scope lock:
+- `docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md`
+- `docs/contributing/SPLIT-CHECKLIST-sink-fidelity-http-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-fidelity-http-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh`
+- no edits under `scripts/ci/exp-mcp-fragmented-ipi/**`
+- no edits to `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- no workflow edits
+
+## Frozen semantics
+
+- primary metric remains attempt-based: `success_any_sink_canary`
+- required fields remain:
+  - `sink_outcome_class`
+  - `sink_attempted`
+  - `sink_completed`
+  - `compat_mode`
+- no policy changes in Wave22 Step1
+
+## Frozen Wave22 Step2 target
+
+- keep cases: `primary_partial`, `alt_partial`, `mixed_partial`
+- keep modes: `wrap_only`, `sequence_only`, `combined`
+- keep `RUNS_ATTACK=2`
+- keep `RUNS_LEGIT=100`
+- add bounded fidelity path only:
+  - localhost-only
+  - offline-only
+  - deterministic
+  - no external network dependency
+
+## Frozen publication additions
+
+- `egress_http_status_class`
+- `payload_delivered`
+- `response_observed`
+
+## Gate expectations
+
+- allowlist-only diff vs `BASE_REF` (default `origin/main`)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in:
+  - `scripts/ci/exp-mcp-fragmented-ipi/**`
+  - `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- hard fail untracked files in `scripts/ci/exp-mcp-fragmented-ipi/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+- `cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact`
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh` passes
+- Step1 diff contains only the 4 allowlisted files

--- a/docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md
+++ b/docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md
@@ -1,0 +1,94 @@
+# Wave22 Plan - Sink-failure Fidelity Upgrade (Offline HTTP)
+
+## Goal
+
+Increase sink fidelity in the existing fragmented-IPI sink-failure line by adding a local offline HTTP-egress sink path.
+
+This wave must preserve governance semantics and remain hermetic/deterministic.
+
+## A/B/C slicing
+
+- A: Step1 freeze (docs+gate only)
+- B: Step2 bounded implementation (offline HTTP sink fidelity path)
+- C: Step3 closure (docs+gate only)
+
+## Step1 (A) - freeze
+
+Branch: `codex/wave22-sink-fidelity-http-step1-freeze` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md`
+- `docs/contributing/SPLIT-CHECKLIST-sink-fidelity-http-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-fidelity-http-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `scripts/ci/exp-mcp-fragmented-ipi/**`
+- no edits to `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- no workflow edits
+
+Step1 gate:
+- allowlist-only diff (the 4 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in:
+  - `scripts/ci/exp-mcp-fragmented-ipi/**`
+  - `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- hard fail untracked files in `scripts/ci/exp-mcp-fragmented-ipi/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+- `cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact`
+
+## Frozen semantics (must stay stable)
+
+Primary governance metric remains unchanged:
+- `success_any_sink_canary` (attempt-based)
+
+Required per-run fields remain published:
+- `sink_outcome_class`
+- `sink_attempted`
+- `sink_completed`
+- `compat_mode`
+
+Wave22 adds completion-detail publication but does not reinterpret the primary metric.
+
+## Step2 (B) - bounded fidelity upgrade preview
+
+Bounded scope (preview):
+- add a local offline HTTP-egress sink path in experiment harness/compat host
+- keep governance policy behavior unchanged
+- keep matrix modes unchanged (`wrap_only`, `sequence_only`, `combined`)
+- keep run shape unchanged for comparability:
+  - `RUNS_ATTACK=2`
+  - `RUNS_LEGIT=100`
+- keep existing sink-failure case set (`primary_partial`, `alt_partial`, `mixed_partial`)
+
+Frozen fidelity constraints:
+- localhost-only
+- offline-only
+- deterministic fixtures/responses
+- no external network dependency
+
+Frozen publication additions (completion layer):
+- `egress_http_status_class`
+- `payload_delivered`
+- `response_observed`
+
+No new matrix axes in this slice.
+
+## Step3 (C) - closure
+
+Docs+gate only closure slice.
+
+Closure gate must pass against:
+- stacked Step2 base
+- `origin/main` after sync
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final clean promote PR to `main` from Step3 once chain is clean.

--- a/docs/contributing/SPLIT-REVIEW-PACK-sink-fidelity-http-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-sink-fidelity-http-step1.md
@@ -1,0 +1,60 @@
+# Sink-fidelity HTTP Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze Wave22 scope for bounded sink-fidelity upgrade in the fragmented-IPI sink-failure line.
+
+Wave22 introduces a local offline HTTP sink path, while preserving governance semantics.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md`
+- `docs/contributing/SPLIT-CHECKLIST-sink-fidelity-http-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-sink-fidelity-http-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh`
+
+## Non-goals
+
+- no changes under `scripts/ci/exp-mcp-fragmented-ipi/**`
+- no changes to `scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh`
+- no workflow changes
+- no policy or scorer semantics changes in Step1
+
+## Frozen Wave22 contract
+
+- primary metric remains: `success_any_sink_canary`
+- required fields remain: `sink_outcome_class`, `sink_attempted`, `sink_completed`, `compat_mode`
+- run shape remains fixed:
+  - `RUNS_ATTACK=2`
+  - `RUNS_LEGIT=100`
+- fidelity constraints are frozen:
+  - localhost-only
+  - offline-only
+  - deterministic
+  - no external network dependency
+- publication adds completion fields:
+  - `egress_http_status_class`
+  - `payload_delivered`
+  - `response_observed`
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm diff is only the 4 Step1 files.
+2. Confirm workflow-ban and experiment subtree bans are present.
+3. Confirm frozen run-shape markers remain fixed (`RUNS_ATTACK=2`, `RUNS_LEGIT=100`).
+4. Confirm frozen fidelity constraints are explicit (localhost/offline/deterministic).
+5. Run reviewer script and expect PASS.

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md"
+  "docs/contributing/SPLIT-CHECKLIST-sink-fidelity-http-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-sink-fidelity-http-step1.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban, sink-failure subtree ban)"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave22 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave22 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^scripts/ci/exp-mcp-fragmented-ipi/' >/dev/null; then
+  echo "FAIL: Wave22 Step1 must not change scripts/ci/exp-mcp-fragmented-ipi/**"
+  exit 1
+fi
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh$' >/dev/null; then
+  echo "FAIL: Wave22 Step1 must not change scripts/ci/test-exp-mcp-fragmented-ipi-sink-failure.sh"
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- 'scripts/ci/exp-mcp-fragmented-ipi/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under scripts/ci/exp-mcp-fragmented-ipi/** are not allowed in Wave22 Step1"
+  git ls-files --others --exclude-standard -- 'scripts/ci/exp-mcp-fragmented-ipi/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+echo "[review] marker checks (run shape, fidelity constraints, metrics)"
+
+rg -n 'RUNS_ATTACK.*2' docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md >/dev/null || {
+  echo "FAIL: frozen RUNS_ATTACK=2 marker missing"
+  exit 1
+}
+rg -n 'RUNS_LEGIT.*100' docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md >/dev/null || {
+  echo "FAIL: frozen RUNS_LEGIT=100 marker missing"
+  exit 1
+}
+rg -n 'success_any_sink_canary' docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md >/dev/null || {
+  echo "FAIL: primary metric marker missing"
+  exit 1
+}
+rg -n 'localhost-only|offline-only|deterministic|no external network dependency' \
+  docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md >/dev/null || {
+  echo "FAIL: frozen fidelity constraints markers missing"
+  exit 1
+}
+rg -n 'egress_http_status_class|payload_delivered|response_observed' \
+  docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md >/dev/null || {
+  echo "FAIL: completion-layer publication markers missing"
+  exit 1
+}
+
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- freeze Wave22 Step1 for sink-fidelity HTTP upgrade in the sink-failure experiment line
- keep Step1 docs+gate-only and block experiment subtree changes
- freeze fidelity constraints (localhost-only, offline-only, deterministic, no external network dependency)

## Scope
- `docs/contributing/SPLIT-PLAN-wave22-sink-fidelity-http.md`
- `docs/contributing/SPLIT-CHECKLIST-sink-fidelity-http-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-sink-fidelity-http-step1.md`
- `scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh`

## Frozen contract markers
- run shape remains `RUNS_ATTACK=2`, `RUNS_LEGIT=100`
- primary metric remains `success_any_sink_canary`
- publication additions frozen for Step2: `egress_http_status_class`, `payload_delivered`, `response_observed`

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-sink-fidelity-http-step1.sh`
