### PR TITLE
docs(exp): close fragmented-ipi line with bounded final claim

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-line-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-line-closure.md
@@ -1,0 +1,35 @@
+# SPLIT CHECKLIST — MCP Fragmented-IPI Line Closure (docs-only)
+
+## Scope discipline
+- [ ] Diff is restricted to:
+  - `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md`
+  - `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md`
+  - `docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-line-closure.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-line-closure.md`
+  - `scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh`
+- [ ] No `.github/workflows/*` changes.
+- [ ] No harness/scorer/runtime code changes.
+
+## Closure content checks
+- [ ] Main results doc contains one final line table covering:
+  - main fragmented-IPI
+  - wrap-bypass
+  - second-sink
+  - cross-session decay
+  - sink-failure
+  - sink-failure partial
+  - sink-fidelity HTTP
+- [ ] Main results doc includes bounded core claim:
+  - `sequence_only` decisive
+  - `combined` follows `sequence_only`
+  - `wrap_only` insufficient
+- [ ] Main results doc includes explicit limits:
+  - attempt-based metric
+  - offline/local sink boundary
+  - bounded matrix + CI reporting boundary
+- [ ] Fidelity-HTTP results doc includes `DEC-007 closure note` with:
+  - proven scope
+  - not-proven scope
+
+## Reviewer command
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh` passes.

--- a/docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-line-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-line-closure.md
@@ -1,0 +1,37 @@
+# SPLIT REVIEW PACK — MCP Fragmented-IPI Line Closure
+
+## Intent
+Close the fragmented-IPI experiment family with a docs-only closure slice.
+
+This slice finalizes:
+- one line-wide summary table in the main results doc
+- one explicit DEC-007 closure note in the Wave22 fidelity results doc
+- one reviewer gate to keep scope and claims bounded
+
+## Allowed files
+- `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md`
+- `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md`
+- `docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-line-closure.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-line-closure.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh`
+
+## Not allowed
+- `.github/workflows/*`
+- any `scripts/ci/exp-mcp-fragmented-ipi/*` harness changes
+- any scorer/runtime/policy code changes
+
+## Reviewer checks
+1. Diff scope is docs + reviewer script only.
+2. Main results doc has final line table + bounded claim + explicit limits.
+3. Fidelity-HTTP results doc has DEC-007 closure note with proven and not-proven boundaries.
+4. No workflow or experiment-runtime drift.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh
+```
+
+Expected result:
+- gate passes
+- closure claims stay bounded
+- experiment line is ready to mark as closed-loop in companion logs

--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md
@@ -144,3 +144,28 @@ The next low-blast-radius follow-ups are:
 - "Blocked" attribution is based on the current harness instrumentation and sequence-sidecar path.
 - Entropy is not an enforcement rule in this experiment; it remains a shadow metric for follow-up work.
 - The current harness uses a local mock MCP tool server for reproducibility; it is not a live external-tool benchmark.
+
+## 2026Q1 line closure summary
+The March 2026 fragmented-IPI line is now closed-loop across all bounded variants.
+
+### Final line table
+| Variant | Wrap-only result | Sequence-only result | Combined result | Legit false-positive note |
+|---|---|---|---|---|
+| Main fragmented-IPI | N/A in main run (ablation isolates modes separately) | N/A in main run (ablation isolates modes separately) | protected TPR/FNR/false-positive rate: `1.0 / 0.0 / 0.0` | main run legit false-positive rate `0.0` (40 legit) |
+| Wrap-bypass | protected TPR/FNR/FPR: `0.0 / 1.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | no false positives observed |
+| Second-sink generality | fails on alternate sink (`alt_only`), `TPR=0.0` | robust across `primary_only`, `alt_only`, `mixed`, `TPR=1.0` | robust, sequence-dominated | no false positives observed |
+| Cross-session decay | no route memory; delayed sink succeeds across active window | blocks delayed sink across `k+1..k+N` active window | matches sequence behavior | legit control remains allowed, no false positives observed |
+| Sink-failure (`timeout`) | protected TPR/FNR/FPR: `0.0 / 1.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | no false positives observed |
+| Sink-failure (`partial`) | protected TPR/FNR/FPR: `0.0 / 1.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | bounded smoke, no false positives observed |
+| Sink-fidelity HTTP (offline localhost) | protected TPR/FNR/FPR: `0.0 / 1.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | aggregate false-positive rate `0.0`, CI high `0.0126` |
+
+### Bounded core claim
+- `sequence_only` is the decisive governance layer in this experiment family.
+- `combined` follows `sequence_only` in observed decisive blocking behavior.
+- `wrap_only` is insufficient as a standalone control across wrap-bypass, second-sink, cross-session, sink-failure (`timeout`/`partial`), and sink-fidelity variants.
+
+### Explicit limits
+- Primary metric remains attempt-based (`success_any_sink_canary`).
+- Sink-fidelity evidence is bounded to offline localhost HTTP egress, not production internet egress.
+- Claims remain bounded to this matrix/harness family and reported confidence intervals.
+- Legitimate-path safety is reported as false-positive rate `0.0` with CI bounds; this is not a universal low-false-positive guarantee outside this dataset.

--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md
@@ -75,6 +75,22 @@ The core governance conclusion remains stable:
 - sequence-governed modes block the protected attack route before effective sink completion in the same pattern as Wave20/21,
 - wrap-only remains structurally weaker under attempt-based interpretation.
 
+## DEC-007 closure note
+### Proven in this bounded line
+- route/state governance remains robust across:
+  - payload fragmentation and tool-hopping variants
+  - delayed cross-session sink attempts
+  - sink-failure timeout and partial branches
+  - offline localhost HTTP-egress sink fidelity
+- `sequence_only` is the decisive blocking layer in this experiment family.
+- `combined` adds no observed decisive blocking gain over `sequence_only` in this matrix.
+
+### Not proven
+- no claim of general semantic-hijacking prevention outside this harness family
+- no claim of production external-network egress prevention
+- no claim outside the bounded matrix/run-shape and confidence reporting in these result docs
+- no universal low-false-positive claim outside the reported CI bounds
+
 ## Limitations
 - bounded local run (`RUN_LIVE=0`)
 - not a paper-grade all-up rerun

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md"
+  "docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md"
+  "docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-line-closure.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-line-closure.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: closure slice must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in closure slice: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks: final line summary and bounded claim"
+rg -n '^## 2026Q1 line closure summary$' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: missing line closure heading in main results doc"
+  exit 1
+}
+rg -n '^### Final line table$' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: missing final line table heading"
+  exit 1
+}
+rg -n '^### Bounded core claim$' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: missing bounded core claim heading"
+  exit 1
+}
+rg -n '^### Explicit limits$' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: missing explicit limits heading"
+  exit 1
+}
+rg -n 'Sink-fidelity HTTP \(offline localhost\)' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: final line table missing sink-fidelity HTTP row"
+  exit 1
+}
+
+echo "[review] marker checks: DEC-007 closure note"
+rg -n '^## DEC-007 closure note$' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: missing DEC-007 closure note heading"
+  exit 1
+}
+rg -n '^### Proven in this bounded line$' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: missing proven-boundary heading"
+  exit 1
+}
+rg -n '^### Not proven$' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: missing not-proven heading"
+  exit 1
+}
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- finalize the fragmented-IPI experiment family with one line-wide closure section in the main results doc
- add an explicit `DEC-007` closure note (proven vs not-proven boundaries) in the Wave22 sink-fidelity results doc
- add docs-only closure reviewer artifacts:
  - `docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-line-closure.md`
  - `docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-line-closure.md`
  - `scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh`

## Scope
Allowed changes in this PR:
- `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md`
- `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md`
- closure checklist/review-pack/reviewer script

No harness, scorer, workflow, or runtime code changes.

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh`
- `cargo fmt --check`
