### PR TITLE
docs(exp): freeze wave23 interleaving step1

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-interleaving-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-interleaving-step1.md
@@ -1,0 +1,20 @@
+# SPLIT CHECKLIST — Wave23 Interleaving Step1 (freeze)
+
+## Scope discipline
+- [ ] Only Step1 files changed:
+  - `docs/contributing/SPLIT-PLAN-wave23-interleaving.md`
+  - `docs/contributing/SPLIT-CHECKLIST-interleaving-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-interleaving-step1.md`
+  - `scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh`
+- [ ] No `.github/workflows/*` changes.
+- [ ] No changes under `scripts/ci/exp-mcp-fragmented-ipi/**`.
+- [ ] No changes under `scripts/ci/test-exp-mcp-fragmented-ipi*.sh`.
+
+## Step1 intent
+- [ ] Docs+gate only.
+- [ ] Interleaving hypothesis bounded and explicit.
+- [ ] Attempt-based primary metric freeze retained.
+- [ ] No policy/harness semantic changes included.
+
+## Gate
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh` passes.

--- a/docs/contributing/SPLIT-PLAN-wave23-interleaving.md
+++ b/docs/contributing/SPLIT-PLAN-wave23-interleaving.md
@@ -1,0 +1,69 @@
+# SPLIT PLAN — Wave23 Interleaving (MCP Fragmented IPI)
+
+## Summary
+Wave23 opens a new bounded hypothesis after the Wave20-Wave22 line closure:
+- mixed legit + malicious interleaving in one bounded run shape
+- optional near-parallel tool-call ordering pressure inside the same harness family
+
+The experiment line remains bounded:
+- no workflow changes
+- no policy-semantic rewrites
+- no sink-fidelity expansion beyond current line in Step2
+- primary governance metric stays attempt-based (`success_any_sink_canary`)
+
+## A/B/C slicing
+### Step1 freeze (this slice)
+Branch: `codex/wave23-interleaving-step1-freeze` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave23-interleaving.md`
+- `docs/contributing/SPLIT-CHECKLIST-interleaving-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-interleaving-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh`
+
+Step1 is docs+gate only.
+
+### Step2 bounded implementation (preview)
+Intended scope (bounded):
+- `scripts/ci/test-exp-mcp-fragmented-ipi-interleaving.sh`
+- `scripts/ci/exp-mcp-fragmented-ipi/drive_fragmented_ipi.py`
+- `scripts/ci/exp-mcp-fragmented-ipi/score_interleaving.py` (new)
+- `scripts/ci/fixtures/exp-mcp-fragmented-ipi/interleaving/**` (new)
+- `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-INTERLEAVING-2026Q1-RERUN.md`
+- `docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-INTERLEAVING-2026Q1-RESULTS.md`
+- Step2 checklist/review-pack/reviewer script
+
+Frozen Step2 intent:
+- keep mode set: `wrap_only`, `sequence_only`, `combined`
+- keep attempt-based primary metric semantics
+- publish per-run interleaving markers (ordering class + route class)
+- keep legit controls explicit and report false-positive with CI
+
+### Step3 closure (preview)
+Docs+gate only:
+- Step3 checklist
+- Step3 review pack
+- Step3 reviewer gate
+
+## Step1 reviewer gate requirements
+- allowlist-only on Step1 files
+- workflow-ban (`.github/workflows/*`)
+- fail if tracked diff touches:
+  - `scripts/ci/exp-mcp-fragmented-ipi/**`
+  - `scripts/ci/test-exp-mcp-fragmented-ipi*.sh`
+- fail if untracked files appear under:
+  - `scripts/ci/exp-mcp-fragmented-ipi/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-cli -- -D warnings`
+- deterministic smoke:
+  - `cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact`
+
+## Acceptance (Step1)
+- freeze scope and boundaries are explicit
+- no runtime/harness mutation
+- reviewer gate passes against `origin/main`
+
+## Non-goals
+- no external egress or new network dependencies in Step1
+- no semantic claim expansion in Step1
+- no CI workflow edits

--- a/docs/contributing/SPLIT-REVIEW-PACK-interleaving-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-interleaving-step1.md
@@ -1,0 +1,29 @@
+# SPLIT REVIEW PACK — Wave23 Interleaving Step1
+
+## Intent
+Freeze the next bounded hypothesis slice:
+- mixed legit + malicious interleaving inside the fragmented-IPI harness family
+
+Step1 is docs+gate only and must not mutate harness/runtime behavior.
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave23-interleaving.md`
+- `docs/contributing/SPLIT-CHECKLIST-interleaving-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-interleaving-step1.md`
+- `scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh`
+
+## Not allowed
+- `.github/workflows/*`
+- `scripts/ci/exp-mcp-fragmented-ipi/**`
+- `scripts/ci/test-exp-mcp-fragmented-ipi*.sh`
+- scorer/harness/runtime code drift
+
+## Reviewer checks
+1. Diff is Step1 docs+gate only.
+2. Boundaries and non-goals are explicit in the plan.
+3. Gate enforces no-touch on experiment harness paths.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh
+```

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave23-interleaving.md"
+  "docs/contributing/SPLIT-CHECKLIST-interleaving-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-interleaving-step1.md"
+  "scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave23 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave23 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no-touch gates for experiment harness paths"
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^scripts/ci/exp-mcp-fragmented-ipi/' >/dev/null; then
+  echo "FAIL: Wave23 Step1 must not change scripts/ci/exp-mcp-fragmented-ipi/**"
+  exit 1
+fi
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^scripts/ci/test-exp-mcp-fragmented-ipi.*\.sh$' >/dev/null; then
+  echo "FAIL: Wave23 Step1 must not change scripts/ci/test-exp-mcp-fragmented-ipi*.sh"
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- 'scripts/ci/exp-mcp-fragmented-ipi/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under scripts/ci/exp-mcp-fragmented-ipi/** are not allowed in Wave23 Step1"
+  git ls-files --others --exclude-standard -- 'scripts/ci/exp-mcp-fragmented-ipi/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+echo "[review] hygiene checks"
+cargo fmt --check
+cargo clippy -p assay-cli -- -D warnings
+cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- freeze Wave23 as the next bounded experiment slice after the Wave20-Wave22 closure
- define interleaving hypothesis boundaries (mixed legit + malicious interleaving) without runtime changes
- add Step1 reviewer gate for strict no-touch containment

## Added files
- `docs/contributing/SPLIT-PLAN-wave23-interleaving.md`
- `docs/contributing/SPLIT-CHECKLIST-interleaving-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-interleaving-step1.md`
- `scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh`

## Scope guard
- docs+gate only
- no changes to `scripts/ci/exp-mcp-fragmented-ipi/**`
- no changes to `scripts/ci/test-exp-mcp-fragmented-ipi*.sh`
- no workflow changes

## Local validation
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-interleaving-step1.sh` -> PASS
