### PR TITLE
fix(deps): patch quinn-proto to 0.11.14 (RUSTSEC-2026-0037)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3518,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
- Update `quinn-proto` in `Cargo.lock` from `0.11.13` to `0.11.14`
- Resolves `RUSTSEC-2026-0037` reported by `Dependency Security (cargo-deny + audit)`

## Validation
- `cargo audit`
- `cargo deny check advisories`

## Scope
- lockfile-only change (no code changes)
