### PR TITLE
docs(exp): finalize fragmented-ipi line closure with wave23

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-line-closure.md
+++ b/docs/contributing/SPLIT-CHECKLIST-exp-mcp-fragmented-ipi-line-closure.md
@@ -19,6 +19,7 @@
   - sink-failure
   - sink-failure partial
   - sink-fidelity HTTP
+  - interleaving (mixed legit+malicious)
 - [ ] Main results doc includes bounded core claim:
   - `sequence_only` decisive
   - `combined` follows `sequence_only`

--- a/docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-line-closure.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-exp-mcp-fragmented-ipi-line-closure.md
@@ -5,6 +5,7 @@ Close the fragmented-IPI experiment family with a docs-only closure slice.
 
 This slice finalizes:
 - one line-wide summary table in the main results doc
+- interleaving inclusion in the final line table (Wave23)
 - one explicit DEC-007 closure note in the Wave22 fidelity results doc
 - one reviewer gate to keep scope and claims bounded
 

--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md
@@ -146,7 +146,7 @@ The next low-blast-radius follow-ups are:
 - The current harness uses a local mock MCP tool server for reproducibility; it is not a live external-tool benchmark.
 
 ## 2026Q1 line closure summary
-The March 2026 fragmented-IPI line is now closed-loop across all bounded variants.
+The March 2026 fragmented-IPI line is now closed-loop across all bounded variants through Wave23 interleaving.
 
 ### Final line table
 | Variant | Wrap-only result | Sequence-only result | Combined result | Legit false-positive note |
@@ -158,11 +158,12 @@ The March 2026 fragmented-IPI line is now closed-loop across all bounded variant
 | Sink-failure (`timeout`) | protected TPR/FNR/FPR: `0.0 / 1.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | no false positives observed |
 | Sink-failure (`partial`) | protected TPR/FNR/FPR: `0.0 / 1.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | bounded smoke, no false positives observed |
 | Sink-fidelity HTTP (offline localhost) | protected TPR/FNR/FPR: `0.0 / 1.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | aggregate false-positive rate `0.0`, CI high `0.0126` |
+| Interleaving (mixed legit+malicious) | protected TPR/FNR/FPR: `0.0 / 1.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | protected TPR/FNR/FPR: `1.0 / 0.0 / 0.0` | aggregate false-positive rate `0.0`, CI high `0.0064` |
 
 ### Bounded core claim
 - `sequence_only` is the decisive governance layer in this experiment family.
 - `combined` follows `sequence_only` in observed decisive blocking behavior.
-- `wrap_only` is insufficient as a standalone control across wrap-bypass, second-sink, cross-session, sink-failure (`timeout`/`partial`), and sink-fidelity variants.
+- `wrap_only` is insufficient as a standalone control across wrap-bypass, second-sink, cross-session, sink-failure (`timeout`/`partial`), sink-fidelity, and interleaving variants.
 
 ### Explicit limits
 - Primary metric remains attempt-based (`success_any_sink_canary`).

--- a/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md
+++ b/docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md
@@ -79,6 +79,7 @@ The core governance conclusion remains stable:
 ### Proven in this bounded line
 - route/state governance remains robust across:
   - payload fragmentation and tool-hopping variants
+  - mixed legit + malicious interleaving variants
   - delayed cross-session sink attempts
   - sink-failure timeout and partial branches
   - offline localhost HTTP-egress sink fidelity

--- a/scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh
+++ b/scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh
@@ -56,6 +56,10 @@ rg -n 'Sink-fidelity HTTP \(offline localhost\)' docs/ops/EXPERIMENT-MCP-FRAGMEN
   echo "FAIL: final line table missing sink-fidelity HTTP row"
   exit 1
 }
+rg -n 'Interleaving \(mixed legit\+malicious\)' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-2026Q1-RESULTS.md >/dev/null || {
+  echo "FAIL: final line table missing interleaving row"
+  exit 1
+}
 
 echo "[review] marker checks: DEC-007 closure note"
 rg -n '^## DEC-007 closure note$' docs/ops/EXPERIMENT-MCP-FRAGMENTED-IPI-SINK-FAILURE-FIDELITY-HTTP-2026Q1-RESULTS.md >/dev/null || {


### PR DESCRIPTION
## Summary
- finalize the fragmented-IPI line closure table to include Wave23 interleaving
- extend DEC-007 proven-boundary note with interleaving coverage
- keep closure reviewer artifacts/gate aligned with updated closure scope

## Scope
- docs + reviewer gate only
- no workflow edits
- no harness/scorer/runtime changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-exp-mcp-fragmented-ipi-line-closure.sh`
