### PR TITLE
feat(wave24): promote step2+step3 typed decisions to main

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -3,6 +3,7 @@
 //! This module implements the "always emit decision" invariant (I1):
 //! Every tool call attempt MUST emit exactly one decision event.
 
+use super::policy::{PolicyObligation, TypedPolicyDecision};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::io::Write;
@@ -53,6 +54,19 @@ pub enum Decision {
     Error,
 }
 
+/// Additional runtime policy context for Decision Event v2.
+#[derive(Debug, Clone, Default)]
+pub struct PolicyDecisionEventContext {
+    pub typed_decision: Option<TypedPolicyDecision>,
+    pub policy_version: Option<String>,
+    pub policy_digest: Option<String>,
+    pub obligations: Vec<PolicyObligation>,
+    pub approval_state: Option<String>,
+    pub lane: Option<String>,
+    pub principal: Option<String>,
+    pub auth_context_summary: Option<String>,
+}
+
 /// A tool decision event (CloudEvents compliant).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DecisionEvent {
@@ -88,6 +102,30 @@ pub struct DecisionData {
     /// Rule or policy field that matched
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matched_rule: Option<String>,
+    /// Typed policy decision shape (Wave24 Decision Event v2)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub typed_decision: Option<TypedPolicyDecision>,
+    /// Policy bundle version used for evaluation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_version: Option<String>,
+    /// Policy bundle digest used for evaluation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_digest: Option<String>,
+    /// Obligations attached to an allow/deny decision
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub obligations: Vec<PolicyObligation>,
+    /// Approval state summary for runtime decisioning
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_state: Option<String>,
+    /// Lane identifier summary
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lane: Option<String>,
+    /// Principal identifier summary
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub principal: Option<String>,
+    /// Authentication context summary (non-sensitive, compact)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_context_summary: Option<String>,
     /// Decision outcome
     pub decision: Decision,
     /// Machine-parseable reason code (MUST)
@@ -141,6 +179,14 @@ impl DecisionEvent {
                 matched_tool_classes: Vec::new(),
                 match_basis: None,
                 matched_rule: None,
+                typed_decision: None,
+                policy_version: None,
+                policy_digest: None,
+                obligations: Vec::new(),
+                approval_state: None,
+                lane: None,
+                principal: None,
+                auth_context_summary: None,
                 decision: Decision::Error, // Default to error, will be set
                 reason_code: reason_codes::S_INTERNAL_ERROR.to_string(),
                 reason: Some("Decision not finalized (guard dropped without emit)".to_string()),
@@ -233,6 +279,19 @@ impl DecisionEvent {
         self.data.matched_tool_classes = matched_tool_classes;
         self.data.match_basis = match_basis;
         self.data.matched_rule = matched_rule;
+        self
+    }
+
+    /// Set policy context fields for Decision Event v2.
+    pub fn with_policy_context(mut self, context: PolicyDecisionEventContext) -> Self {
+        self.data.typed_decision = context.typed_decision;
+        self.data.policy_version = context.policy_version;
+        self.data.policy_digest = context.policy_digest;
+        self.data.obligations = context.obligations;
+        self.data.approval_state = context.approval_state;
+        self.data.lane = context.lane;
+        self.data.principal = context.principal;
+        self.data.auth_context_summary = context.auth_context_summary;
         self
     }
 }
@@ -367,6 +426,20 @@ impl DecisionEmitterGuard {
             event.data.matched_tool_classes = matched_tool_classes;
             event.data.match_basis = match_basis;
             event.data.matched_rule = matched_rule;
+        }
+    }
+
+    /// Set policy context metadata for Decision Event v2.
+    pub fn set_policy_context(&mut self, context: PolicyDecisionEventContext) {
+        if let Some(ref mut event) = self.event {
+            event.data.typed_decision = context.typed_decision;
+            event.data.policy_version = context.policy_version;
+            event.data.policy_digest = context.policy_digest;
+            event.data.obligations = context.obligations;
+            event.data.approval_state = context.approval_state;
+            event.data.lane = context.lane;
+            event.data.principal = context.principal;
+            event.data.auth_context_summary = context.auth_context_summary;
         }
     }
 

--- a/crates/assay-core/src/mcp/policy/engine.rs
+++ b/crates/assay-core/src/mcp/policy/engine.rs
@@ -26,8 +26,10 @@ pub(super) fn evaluate_with_metadata(
     if let Some(pinned) = policy.tool_pins.get(tool_name) {
         if let Some(runtime) = runtime_identity {
             if pinned != runtime {
-                return PolicyEvaluation {
-                    decision: PolicyDecision::Deny {
+                return finalize_evaluation(
+                    policy,
+                    metadata,
+                    PolicyDecision::Deny {
                         tool: tool_name.to_string(),
                         code: "E_TOOL_DRIFT".to_string(),
                         reason: format!(
@@ -41,15 +43,14 @@ pub(super) fn evaluate_with_metadata(
                             "Tool metadata or schema has changed without policy update (SOTA Moat)",
                         ),
                     },
-                    metadata,
-                };
+                );
             }
         }
     }
 
     // 1. Rate limits
     if let Some(decision) = check_rate_limits(policy, state) {
-        return PolicyEvaluation { decision, metadata };
+        return finalize_evaluation(policy, metadata, decision);
     }
 
     let deny_name_match = is_denied(policy, tool_name);
@@ -72,22 +73,25 @@ pub(super) fn evaluate_with_metadata(
             "Tool is explicitly denylisted by class"
         };
 
-        return PolicyEvaluation {
-            decision: PolicyDecision::Deny {
+        return finalize_evaluation(
+            policy,
+            metadata,
+            PolicyDecision::Deny {
                 tool: tool_name.to_string(),
                 code: "E_TOOL_DENIED".to_string(),
                 reason: deny_reason.to_string(),
                 contract: format_deny_contract(tool_name, "E_TOOL_DENIED", deny_reason),
             },
-            metadata,
-        };
+        );
     }
 
     let allow_name_match = is_allowed(policy, tool_name);
     let allow_class_matches = matched_allow_classes(policy, &tool_classes);
     if has_allowlist(policy) && !allow_name_match && allow_class_matches.is_empty() {
-        return PolicyEvaluation {
-            decision: PolicyDecision::Deny {
+        return finalize_evaluation(
+            policy,
+            metadata,
+            PolicyDecision::Deny {
                 tool: tool_name.to_string(),
                 code: "E_TOOL_NOT_ALLOWED".to_string(),
                 reason: "Tool is not in the allowlist".to_string(),
@@ -97,8 +101,7 @@ pub(super) fn evaluate_with_metadata(
                     "Tool is not in allowlist",
                 ),
             },
-            metadata,
-        };
+        );
     }
 
     if allow_name_match || !allow_class_matches.is_empty() {
@@ -125,8 +128,10 @@ pub(super) fn evaluate_with_metadata(
                     })
                 })
                 .collect();
-            return PolicyEvaluation {
-                decision: PolicyDecision::Deny {
+            return finalize_evaluation(
+                policy,
+                metadata,
+                PolicyDecision::Deny {
                     tool: tool_name.to_string(),
                     code: "E_ARG_SCHEMA".to_string(),
                     reason: "JSON Schema validation failed".to_string(),
@@ -137,13 +142,9 @@ pub(super) fn evaluate_with_metadata(
                         "violations": violations,
                     }),
                 },
-                metadata,
-            };
+            );
         }
-        return PolicyEvaluation {
-            decision: PolicyDecision::Allow,
-            metadata,
-        };
+        return finalize_evaluation(policy, metadata, PolicyDecision::Allow);
     }
 
     // 5. Unconstrained Mode
@@ -166,7 +167,7 @@ pub(super) fn evaluate_with_metadata(
         UnconstrainedMode::Allow => PolicyDecision::Allow,
     };
 
-    PolicyEvaluation { decision, metadata }
+    finalize_evaluation(policy, metadata, decision)
 }
 
 pub(super) fn check(
@@ -221,6 +222,24 @@ fn check_rate_limits(policy: &McpPolicy, state: &mut PolicyState) -> Option<Poli
         }
     }
     None
+}
+
+fn finalize_evaluation(
+    policy: &McpPolicy,
+    mut metadata: PolicyMatchMetadata,
+    decision: PolicyDecision,
+) -> PolicyEvaluation {
+    metadata.policy_version = Some(if policy.version.trim().is_empty() {
+        "unspecified".to_string()
+    } else {
+        policy.version.clone()
+    });
+    metadata.policy_digest = policy.policy_digest();
+    let typed_contract = decision.typed_contract();
+    metadata.typed_decision = Some(typed_contract.decision);
+    metadata.obligations = typed_contract.obligations;
+
+    PolicyEvaluation { decision, metadata }
 }
 
 fn is_denied(policy: &McpPolicy, tool_name: &str) -> bool {

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -4,9 +4,11 @@ mod response;
 mod schema;
 
 use super::identity::ToolIdentity;
+use super::jcs;
 use super::jsonrpc::JsonRpcRequest;
 use super::tool_match::MatchBasis;
 use super::tool_taxonomy::ToolTaxonomy;
+use crate::fingerprint::sha256_hex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
@@ -122,6 +124,14 @@ pub struct PolicyMatchMetadata {
     pub matched_tool_classes: Vec<String>,
     pub match_basis: MatchBasis,
     pub matched_rule: Option<String>,
+    pub typed_decision: Option<TypedPolicyDecision>,
+    pub policy_version: Option<String>,
+    pub policy_digest: Option<String>,
+    pub obligations: Vec<PolicyObligation>,
+    pub approval_state: Option<String>,
+    pub lane: Option<String>,
+    pub principal: Option<String>,
+    pub auth_context_summary: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -169,6 +179,68 @@ pub enum PolicyDecision {
         reason: String,
         contract: Value,
     },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TypedPolicyDecision {
+    Allow,
+    #[serde(rename = "allow_with_obligations")]
+    AllowWithObligations,
+    Deny,
+    #[serde(rename = "deny_with_alert")]
+    DenyWithAlert,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PolicyObligation {
+    #[serde(rename = "type")]
+    pub obligation_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl PolicyObligation {
+    pub fn warning_compat(code: &str, reason: &str) -> Self {
+        Self {
+            obligation_type: "legacy_warning".to_string(),
+            detail: Some(format!("{code}:{reason}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PolicyDecisionContract {
+    pub decision: TypedPolicyDecision,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub obligations: Vec<PolicyObligation>,
+}
+
+impl PolicyDecision {
+    pub fn typed_contract(&self) -> PolicyDecisionContract {
+        match self {
+            Self::Allow => PolicyDecisionContract {
+                decision: TypedPolicyDecision::Allow,
+                obligations: Vec::new(),
+            },
+            Self::AllowWithWarning { code, reason, .. } => PolicyDecisionContract {
+                decision: TypedPolicyDecision::AllowWithObligations,
+                obligations: vec![PolicyObligation::warning_compat(code, reason)],
+            },
+            Self::Deny { code, .. } if is_alert_deny_code(code) => PolicyDecisionContract {
+                decision: TypedPolicyDecision::DenyWithAlert,
+                obligations: Vec::new(),
+            },
+            Self::Deny { .. } => PolicyDecisionContract {
+                decision: TypedPolicyDecision::Deny,
+                obligations: Vec::new(),
+            },
+        }
+    }
+}
+
+fn is_alert_deny_code(code: &str) -> bool {
+    matches!(code, "E_TOOL_DRIFT")
 }
 
 // Dual-Shape Deserializer Helper (Legacy)
@@ -282,6 +354,11 @@ impl McpPolicy {
 
     pub fn compile_all_schemas(&self) -> HashMap<String, Arc<jsonschema::Validator>> {
         schema::compile_all_schemas(self)
+    }
+
+    pub fn policy_digest(&self) -> Option<String> {
+        let canonical = jcs::to_string(self).ok()?;
+        Some(format!("sha256:{}", sha256_hex(&canonical)))
     }
 
     /// Single evaluation entry point for CLI and Server

--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -509,6 +509,14 @@ impl McpProxy {
         event.data.matched_tool_classes = metadata.matched_tool_classes.clone();
         event.data.match_basis = metadata.match_basis.as_str().map(ToString::to_string);
         event.data.matched_rule = metadata.matched_rule.clone();
+        event.data.typed_decision = metadata.typed_decision;
+        event.data.policy_version = metadata.policy_version.clone();
+        event.data.policy_digest = metadata.policy_digest.clone();
+        event.data.obligations = metadata.obligations.clone();
+        event.data.approval_state = metadata.approval_state.clone();
+        event.data.lane = metadata.lane.clone();
+        event.data.principal = metadata.principal.clone();
+        event.data.auth_context_summary = metadata.auth_context_summary.clone();
         emitter.emit(&event);
     }
 }

--- a/crates/assay-core/src/mcp/tool_call_handler/emit.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/emit.rs
@@ -1,26 +1,52 @@
-use super::super::decision::{reason_codes, DecisionEvent};
+use super::super::decision::{reason_codes, DecisionEvent, PolicyDecisionEventContext};
+use super::super::policy::PolicyMatchMetadata;
 use super::types::HandleResult;
 use crate::runtime::AuthzReceipt;
 
+#[derive(Clone)]
 pub(super) struct ToolMatchMetadata {
     pub(super) tool_classes: Vec<String>,
     pub(super) matched_tool_classes: Vec<String>,
     pub(super) match_basis: Option<String>,
     pub(super) matched_rule: Option<String>,
+    pub(super) typed_decision: Option<super::super::policy::TypedPolicyDecision>,
+    pub(super) policy_version: Option<String>,
+    pub(super) policy_digest: Option<String>,
+    pub(super) obligations: Vec<super::super::policy::PolicyObligation>,
+    pub(super) approval_state: Option<String>,
+    pub(super) lane: Option<String>,
+    pub(super) principal: Option<String>,
+    pub(super) auth_context_summary: Option<String>,
 }
 
 impl ToolMatchMetadata {
-    pub(super) fn new(
-        tool_classes: Vec<String>,
-        matched_tool_classes: Vec<String>,
-        match_basis: Option<String>,
-        matched_rule: Option<String>,
-    ) -> Self {
+    pub(super) fn from_policy_metadata(metadata: &PolicyMatchMetadata) -> Self {
         Self {
-            tool_classes,
-            matched_tool_classes,
-            match_basis,
-            matched_rule,
+            tool_classes: metadata.tool_classes.clone(),
+            matched_tool_classes: metadata.matched_tool_classes.clone(),
+            match_basis: metadata.match_basis.as_str().map(ToString::to_string),
+            matched_rule: metadata.matched_rule.clone(),
+            typed_decision: metadata.typed_decision,
+            policy_version: metadata.policy_version.clone(),
+            policy_digest: metadata.policy_digest.clone(),
+            obligations: metadata.obligations.clone(),
+            approval_state: metadata.approval_state.clone(),
+            lane: metadata.lane.clone(),
+            principal: metadata.principal.clone(),
+            auth_context_summary: metadata.auth_context_summary.clone(),
+        }
+    }
+
+    pub(super) fn policy_context(&self) -> PolicyDecisionEventContext {
+        PolicyDecisionEventContext {
+            typed_decision: self.typed_decision,
+            policy_version: self.policy_version.clone(),
+            policy_digest: self.policy_digest.clone(),
+            obligations: self.obligations.clone(),
+            approval_state: self.approval_state.clone(),
+            lane: self.lane.clone(),
+            principal: self.principal.clone(),
+            auth_context_summary: self.auth_context_summary.clone(),
         }
     }
 }
@@ -52,11 +78,12 @@ pub(super) fn deny(
     let decision_event = DecisionEvent::new(event_source.to_string(), tool_call_id, tool_name)
         .deny(reason_code, Some(reason.clone()))
         .with_tool_match(
-            tool_match.tool_classes,
-            tool_match.matched_tool_classes,
-            tool_match.match_basis,
-            tool_match.matched_rule,
-        );
+            tool_match.tool_classes.clone(),
+            tool_match.matched_tool_classes.clone(),
+            tool_match.match_basis.clone(),
+            tool_match.matched_rule.clone(),
+        )
+        .with_policy_context(tool_match.policy_context());
 
     HandleResult::Deny {
         reason_code: reason_code.to_string(),
@@ -76,11 +103,12 @@ pub(super) fn allow(
     let decision_event = DecisionEvent::new(event_source.to_string(), tool_call_id, tool_name)
         .allow(reason_code)
         .with_tool_match(
-            tool_match.tool_classes,
-            tool_match.matched_tool_classes,
-            tool_match.match_basis,
-            tool_match.matched_rule,
-        );
+            tool_match.tool_classes.clone(),
+            tool_match.matched_tool_classes.clone(),
+            tool_match.match_basis.clone(),
+            tool_match.matched_rule.clone(),
+        )
+        .with_policy_context(tool_match.policy_context());
 
     HandleResult::Allow {
         receipt,

--- a/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
@@ -58,20 +58,14 @@ pub(super) fn handle_tool_call(
         state,
         runtime_identity,
     );
-    let tool_classes = policy_eval.metadata.tool_classes.clone();
-    let matched_tool_classes = policy_eval.metadata.matched_tool_classes.clone();
-    let match_basis = policy_eval
-        .metadata
-        .match_basis
-        .as_str()
-        .map(ToString::to_string);
-    let matched_rule = policy_eval.metadata.matched_rule.clone();
+    let tool_match = emit::ToolMatchMetadata::from_policy_metadata(&policy_eval.metadata);
     guard.set_tool_match(
-        policy_eval.metadata.tool_classes.clone(),
-        policy_eval.metadata.matched_tool_classes.clone(),
-        match_basis.clone(),
-        matched_rule.clone(),
+        tool_match.tool_classes.clone(),
+        tool_match.matched_tool_classes.clone(),
+        tool_match.match_basis.clone(),
+        tool_match.matched_rule.clone(),
     );
+    guard.set_policy_context(tool_match.policy_context());
 
     match policy_eval.decision {
         PolicyDecision::Deny {
@@ -89,12 +83,7 @@ pub(super) fn handle_tool_call(
                 tool_name,
                 &reason_code,
                 reason,
-                emit::ToolMatchMetadata::new(
-                    tool_classes,
-                    matched_tool_classes,
-                    match_basis,
-                    matched_rule,
-                ),
+                tool_match,
             );
         }
         PolicyDecision::AllowWithWarning { .. } | PolicyDecision::Allow => {
@@ -114,12 +103,7 @@ pub(super) fn handle_tool_call(
             tool_name,
             reason_codes::P_MANDATE_REQUIRED,
             reason,
-            emit::ToolMatchMetadata::new(
-                tool_classes,
-                matched_tool_classes,
-                match_basis,
-                matched_rule,
-            ),
+            tool_match,
         );
     }
 
@@ -163,12 +147,7 @@ pub(super) fn handle_tool_call(
                     tool_name,
                     reason_codes::P_MANDATE_VALID,
                     Some(receipt),
-                    emit::ToolMatchMetadata::new(
-                        tool_classes,
-                        matched_tool_classes,
-                        match_basis,
-                        matched_rule,
-                    ),
+                    tool_match,
                 );
             }
             Err(e) => {
@@ -182,12 +161,7 @@ pub(super) fn handle_tool_call(
                     tool_name,
                     &reason_code,
                     reason,
-                    emit::ToolMatchMetadata::new(
-                        tool_classes,
-                        matched_tool_classes,
-                        match_basis,
-                        matched_rule,
-                    ),
+                    tool_match,
                 );
             }
         }
@@ -204,12 +178,7 @@ pub(super) fn handle_tool_call(
         tool_name,
         reason_codes::P_POLICY_ALLOW,
         None,
-        emit::ToolMatchMetadata::new(
-            tool_classes,
-            matched_tool_classes,
-            match_basis,
-            matched_rule,
-        ),
+        tool_match,
     )
 }
 

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -6,7 +6,7 @@
 use assay_core::mcp::decision::{
     reason_codes, Decision, DecisionEmitter, DecisionEmitterGuard, DecisionEvent,
 };
-use assay_core::mcp::policy::{McpPolicy, PolicyState, ToolPolicy};
+use assay_core::mcp::policy::{McpPolicy, PolicyState, ToolPolicy, TypedPolicyDecision};
 use assay_core::mcp::tool_call_handler::{HandleResult, ToolCallHandler, ToolCallHandlerConfig};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -351,4 +351,11 @@ fn test_event_contains_required_fields() {
     assert!(!event.data.tool.is_empty());
     assert!(!event.data.tool_call_id.is_empty());
     assert!(!event.data.reason_code.is_empty());
+    assert!(event.data.policy_version.is_some());
+    assert!(event.data.policy_digest.is_some());
+    assert_eq!(
+        event.data.typed_decision,
+        Some(TypedPolicyDecision::AllowWithObligations)
+    );
+    assert!(!event.data.obligations.is_empty());
 }

--- a/crates/assay-core/tests/tool_taxonomy_policy_match.rs
+++ b/crates/assay-core/tests/tool_taxonomy_policy_match.rs
@@ -1,6 +1,6 @@
 use assay_core::mcp::decision::{Decision, NullDecisionEmitter};
 use assay_core::mcp::jsonrpc::JsonRpcRequest;
-use assay_core::mcp::policy::{McpPolicy, PolicyDecision, PolicyState};
+use assay_core::mcp::policy::{McpPolicy, PolicyDecision, PolicyState, TypedPolicyDecision};
 use assay_core::mcp::tool_call_handler::{HandleResult, ToolCallHandler, ToolCallHandlerConfig};
 use assay_core::mcp::{ToolRuleSelector, ToolTaxonomy};
 use serde_json::json;
@@ -121,6 +121,12 @@ fn tool_taxonomy_policy_match_handler_decision_event_records_classes() {
                 decision_event.data.matched_rule.as_deref(),
                 Some("tools.deny_classes")
             );
+            assert_eq!(
+                decision_event.data.typed_decision,
+                Some(TypedPolicyDecision::Deny)
+            );
+            assert!(decision_event.data.policy_version.is_some());
+            assert!(decision_event.data.policy_digest.is_some());
         }
         other => panic!("expected deny result, got {:?}", other),
     }

--- a/docs/contributing/SPLIT-CHECKLIST-typed-decisions-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-typed-decisions-step2.md
@@ -1,0 +1,47 @@
+# SPLIT CHECKLIST — Wave24 Typed Decisions Step2
+
+## Scope discipline
+- [ ] Diff blijft binnen Wave24 Step2 implementatiescope:
+  - `crates/assay-core/src/mcp/**`
+  - `crates/assay-core/tests/{decision_emit_invariant.rs,tool_taxonomy_policy_match.rs}`
+  - optioneel compat: `crates/assay-cli/src/cli/commands/{mcp.rs,session_state_window.rs,coverage/**}`
+  - optioneel server compat: `crates/assay-mcp-server/{src/auth.rs,tests/auth_integration.rs}`
+  - Step2 docs + gate:
+    - `docs/contributing/SPLIT-CHECKLIST-typed-decisions-step2.md`
+    - `docs/contributing/SPLIT-MOVE-MAP-typed-decisions-step2.md`
+    - `docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step2.md`
+    - `scripts/ci/review-wave24-typed-decisions-step2.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] Geen scope leaks buiten Wave24 Step2
+
+## Contract invariants
+- [ ] Typed decision markers aanwezig:
+  - `allow_with_obligations`
+  - `deny_with_alert`
+- [ ] `AllowWithWarning` compat-path blijft aanwezig
+- [ ] Decision Event v2 markers aanwezig:
+  - `policy_version`
+  - `policy_digest`
+  - `obligations`
+  - `approval_state`
+  - `lane`
+  - `principal`
+  - `auth_context_summary`
+- [ ] Legacy eventvelden blijven aanwezig:
+  - `tool_classes`
+  - `matched_tool_classes`
+  - `match_basis`
+  - `matched_rule`
+  - `reason_code`
+
+## Non-goals in Step2
+- [ ] No obligations execution toegevoegd
+- [ ] No approval enforcement toegevoegd
+- [ ] No backend swap (Cedar/OPA) toegevoegd
+- [ ] No auth transport model wijzigingen toegevoegd
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave24-typed-decisions-step2.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned tests blijven groen

--- a/docs/contributing/SPLIT-CHECKLIST-typed-decisions-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-typed-decisions-step2.md
@@ -41,7 +41,7 @@
 - [ ] No auth transport model wijzigingen toegevoegd
 
 ## Validation
-- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave24-typed-decisions-step2.sh` passes
+- [ ] `BASE_REF=origin/codex/wave24-typed-decisions-step1-freeze bash scripts/ci/review-wave24-typed-decisions-step2.sh` passes
 - [ ] `cargo fmt --check` passes
 - [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
 - [ ] Pinned tests blijven groen

--- a/docs/contributing/SPLIT-CHECKLIST-typed-decisions-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-typed-decisions-step3.md
@@ -1,0 +1,52 @@
+# SPLIT CHECKLIST — Wave24 Typed Decisions Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-typed-decisions-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step3.md`
+  - `scripts/ci/review-wave24-typed-decisions-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave24 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves the frozen compatibility rule for `AllowWithWarning`
+
+## Typed decision invariants
+- [ ] Typed decision markers remain present:
+  - `allow_with_obligations`
+  - `deny_with_alert`
+- [ ] `AllowWithWarning` compatibility path remains present
+- [ ] Decision Event v2 field markers remain present:
+  - `policy_version`
+  - `policy_digest`
+  - `obligations`
+  - `approval_state`
+  - `lane`
+  - `principal`
+  - `auth_context_summary`
+- [ ] Existing event fields remain present:
+  - `tool_classes`
+  - `matched_tool_classes`
+  - `match_basis`
+  - `matched_rule`
+  - `reason_code`
+
+## Non-goals still enforced
+- [ ] No obligations execution added
+- [ ] No approval enforcement added
+- [ ] No new policy backend introduced
+- [ ] No auth transport model changes introduced
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests remain green

--- a/docs/contributing/SPLIT-MOVE-MAP-typed-decisions-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-typed-decisions-step2.md
@@ -1,0 +1,90 @@
+# SPLIT-MOVE-MAP — Wave24 Step2 — Typed Decisions + Decision Event v2
+
+## Goal
+Implement the Wave24 contract upgrade with bounded scope and no execution-semantics expansion:
+1. typed decision contract surface
+2. Decision Event v2 enrichment
+3. `AllowWithWarning` compatibility preservation
+
+## Contract mapping
+
+### Decision model
+- Legacy logical surface:
+  - `Allow`
+  - `AllowWithWarning`
+  - `Deny`
+- Target logical surface:
+  - `allow`
+  - `allow_with_obligations`
+  - `deny`
+  - `deny_with_alert`
+
+Compatibility mapping:
+- `AllowWithWarning` remains parseable and usable
+- internal mapping may target `allow_with_obligations`
+- warning context remains available as obligation metadata and/or compatibility fields
+
+### Decision event model
+Decision Event v2 adds:
+- `policy_version`
+- `policy_digest`
+- `obligations`
+- `approval_state`
+- `lane`
+- `principal`
+- `auth_context_summary`
+
+Existing event shape must retain:
+- `tool`
+- `tool_classes`
+- `matched_tool_classes`
+- `match_basis`
+- `matched_rule`
+- `reason_code`
+
+## File-level implementation map
+
+### Core runtime/policy path
+- `crates/assay-core/src/mcp/policy/**`
+  - introduce typed decision output contract
+  - preserve legacy compatibility path
+- `crates/assay-core/src/mcp/decision.rs`
+  - emit Decision Event v2 fields
+- `crates/assay-core/src/mcp/tool_call_handler/**`
+  - keep pre-execution decision/emit path aligned with new contract
+
+### Core tests
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+  - preserve required event fields + v2 additions
+- `crates/assay-core/tests/tool_taxonomy_policy_match.rs`
+  - preserve class matching + decision-event compatibility invariants
+
+### CLI compat consumers (if needed)
+- `crates/assay-cli/src/cli/commands/mcp.rs`
+- `crates/assay-cli/src/cli/commands/session_state_window.rs`
+- `crates/assay-cli/src/cli/commands/coverage/**`
+
+Intent:
+- keep normalizers/reports functioning with additive event fields
+- prevent regressions in coverage/state-window projections
+
+### MCP server compat (if needed)
+- `crates/assay-mcp-server/src/auth.rs`
+- `crates/assay-mcp-server/tests/auth_integration.rs`
+
+Intent:
+- only touch if required for compile/test compatibility
+- no transport-auth redesign in this wave
+
+## Behavior parity notes
+- Existing allow/deny behavior remains stable.
+- Decision-event flow remains deterministic and replay-friendly.
+- No obligation execution behavior is introduced in Step2.
+- No approval enforcement path is introduced in Step2.
+- No policy-backend architecture changes in Step2.
+
+## Out-of-scope guardrails
+- no `approval_required` runtime execution logic
+- no `redact_args` / `restrict_scope` execution logic
+- no obligation fulfillment state machine
+- no lane control-plane additions

--- a/docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step2.md
@@ -1,0 +1,52 @@
+# SPLIT REVIEW PACK — Wave24 Typed Decisions Step2
+
+## Intent
+Implement Wave24 contract upgrades in bounded runtime scope:
+- typed decisions
+- Decision Event v2
+- `AllowWithWarning` compatibility
+
+No execution-semantics expansion is allowed in this slice.
+
+## Scope
+- `crates/assay-core/src/mcp/**`
+- `crates/assay-core/tests/{decision_emit_invariant.rs,tool_taxonomy_policy_match.rs}`
+- optional compat:
+  - `crates/assay-cli/src/cli/commands/{mcp.rs,session_state_window.rs,coverage/**}`
+  - `crates/assay-mcp-server/{src/auth.rs,tests/auth_integration.rs}`
+- Step2 docs/gate:
+  - `docs/contributing/SPLIT-CHECKLIST-typed-decisions-step2.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-typed-decisions-step2.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step2.md`
+  - `scripts/ci/review-wave24-typed-decisions-step2.sh`
+
+## Non-goals
+- no obligations execution
+- no approval enforcement
+- no policy-backend rewrite
+- no auth transport redesign
+- no workflow edits
+
+## Validation
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave24-typed-decisions-step2.sh
+```
+
+Gate includes:
+```bash
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+```
+
+## Reviewer 60s scan
+1. Confirm diff remains inside Step2 allowlist.
+2. Confirm typed decision markers exist (`allow_with_obligations`, `deny_with_alert`).
+3. Confirm `AllowWithWarning` compatibility path remains.
+4. Confirm Decision Event v2 markers are present.
+5. Confirm no obligations execution markers appear in runtime scope.

--- a/docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step2.md
@@ -29,7 +29,7 @@ No execution-semantics expansion is allowed in this slice.
 
 ## Validation
 ```bash
-BASE_REF=origin/main bash scripts/ci/review-wave24-typed-decisions-step2.sh
+BASE_REF=origin/codex/wave24-typed-decisions-step1-freeze bash scripts/ci/review-wave24-typed-decisions-step2.sh
 ```
 
 Gate includes:

--- a/docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step3.md
@@ -1,0 +1,48 @@
+# SPLIT REVIEW PACK — Wave24 Typed Decisions Step3
+
+## Intent
+Close Wave24 with a docs+gate-only closure slice after the typed decision and Decision Event v2 implementation.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server auth/runtime behavior
+- add obligations execution
+- add approval enforcement
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-typed-decisions-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step3.md`
+- `scripts/ci/review-wave24-typed-decisions-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Typed decision markers remain present:
+   - `allow_with_obligations`
+   - `deny_with_alert`
+4. `AllowWithWarning` compatibility remains intact.
+5. Decision Event v2 field markers remain present.
+6. Existing event fields remain present.
+7. No obligations execution markers appear in runtime scope.
+8. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave24-typed-decisions-step2-impl \
+  bash scripts/ci/review-wave24-typed-decisions-step3.sh
+```
+
+### Against `origin/main` after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave24-typed-decisions-step3.sh
+```
+
+Expected outcome:
+- Step3 adds no runtime behavior
+- closure remains diff-proof
+- promote can happen cleanly after stacked validation

--- a/scripts/ci/review-wave24-typed-decisions-step2.sh
+++ b/scripts/ci/review-wave24-typed-decisions-step2.sh
@@ -101,10 +101,12 @@ done
 
 echo "[review] typed decision markers"
 
-rg -n 'allow_with_obligations|deny_with_alert' crates/assay-core/src/mcp >/dev/null || {
-  echo "FAIL: missing typed decision markers allow_with_obligations / deny_with_alert"
-  exit 1
-}
+for marker in allow_with_obligations deny_with_alert; do
+  rg -n "$marker" crates/assay-core/src/mcp >/dev/null || {
+    echo "FAIL: missing typed decision marker: $marker"
+    exit 1
+  }
+done
 
 rg -n 'AllowWithWarning' crates/assay-core/src/mcp >/dev/null || {
   echo "FAIL: missing AllowWithWarning compatibility path"
@@ -112,11 +114,12 @@ rg -n 'AllowWithWarning' crates/assay-core/src/mcp >/dev/null || {
 }
 
 echo "[review] Decision Event v2 field markers"
-rg -n 'policy_version|policy_digest|obligations|approval_state|lane|principal|auth_context_summary' \
-  crates/assay-core/src/mcp >/dev/null || {
-  echo "FAIL: missing Decision Event v2 field markers"
-  exit 1
-}
+for field in policy_version policy_digest obligations approval_state lane principal auth_context_summary; do
+  rg -n "$field" crates/assay-core/src/mcp >/dev/null || {
+    echo "FAIL: missing Decision Event v2 field marker: $field"
+    exit 1
+  }
+done
 
 echo "[review] required legacy decision markers still present"
 rg -n 'tool_classes|matched_tool_classes|match_basis|matched_rule|reason_code' \

--- a/scripts/ci/review-wave24-typed-decisions-step2.sh
+++ b/scripts/ci/review-wave24-typed-decisions-step2.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  # core MCP runtime
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-core/src/mcp/policy.rs"
+  "crates/assay-core/src/mcp/policy/mod.rs"
+  "crates/assay-core/src/mcp/policy/engine.rs"
+  "crates/assay-core/src/mcp/policy/legacy.rs"
+  "crates/assay-core/src/mcp/policy/schema.rs"
+  "crates/assay-core/src/mcp/policy/response.rs"
+  "crates/assay-core/src/mcp/tool_call_handler.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/mod.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/evaluate.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/emit.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/types.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/tests.rs"
+
+  # core tests
+  "crates/assay-core/tests/decision_emit_invariant.rs"
+  "crates/assay-core/tests/tool_taxonomy_policy_match.rs"
+
+  # CLI compat consumers, only if needed
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-cli/src/cli/commands/coverage.rs"
+  "crates/assay-cli/src/cli/commands/coverage/mod.rs"
+  "crates/assay-cli/src/cli/commands/coverage/generate.rs"
+  "crates/assay-cli/src/cli/commands/coverage/legacy.rs"
+  "crates/assay-cli/src/cli/commands/coverage/io.rs"
+  "crates/assay-cli/src/cli/commands/coverage/report.rs"
+  "crates/assay-cli/src/cli/commands/coverage/schema.rs"
+  "crates/assay-cli/src/cli/commands/coverage/format_md.rs"
+
+  # MCP server, only if needed
+  "crates/assay-mcp-server/src/auth.rs"
+  "crates/assay-mcp-server/tests/auth_integration.rs"
+
+  # docs if marker sync is needed
+  "docs/architecture/ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md"
+  "docs/architecture/PLAN-ADR-032-MCP-POLICY-ENFORCEMENT-2026q2.md"
+
+  # step2 docs
+  "docs/contributing/SPLIT-CHECKLIST-typed-decisions-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-typed-decisions-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step2.md"
+
+  # gate
+  "scripts/ci/review-wave24-typed-decisions-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave24 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  # allow bounded expansion inside MCP runtime dirs only
+  if [[ "$ok" != "true" && "$f" == crates/assay-core/src/mcp/* ]]; then
+    ok="true"
+  fi
+  if [[ "$ok" != "true" && "$f" == crates/assay-core/tests/* ]]; then
+    ok="true"
+  fi
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave24 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under MCP runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] typed decision markers"
+
+rg -n 'allow_with_obligations|deny_with_alert' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing typed decision markers allow_with_obligations / deny_with_alert"
+  exit 1
+}
+
+rg -n 'AllowWithWarning' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing AllowWithWarning compatibility path"
+  exit 1
+}
+
+echo "[review] Decision Event v2 field markers"
+rg -n 'policy_version|policy_digest|obligations|approval_state|lane|principal|auth_context_summary' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing Decision Event v2 field markers"
+  exit 1
+}
+
+echo "[review] required legacy decision markers still present"
+rg -n 'tool_classes|matched_tool_classes|match_basis|matched_rule|reason_code' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing existing decision-event fields"
+  exit 1
+}
+
+echo "[review] no obligations execution in this wave"
+if rg -n 'approval_required|redact_args|restrict_scope|obligation_fulfillment|execute_obligation' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: obligations execution markers detected in implementation scope"
+  rg -n 'approval_required|redact_args|restrict_scope|obligation_fulfillment|execute_obligation' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"

--- a/scripts/ci/review-wave24-typed-decisions-step3.sh
+++ b/scripts/ci/review-wave24-typed-decisions-step3.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-typed-decisions-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-typed-decisions-step3.md"
+  "scripts/ci/review-wave24-typed-decisions-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave24 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave24 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] typed decision markers"
+rg -n 'allow_with_obligations|deny_with_alert' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing typed decision markers allow_with_obligations / deny_with_alert"
+  exit 1
+}
+
+rg -n 'AllowWithWarning' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing AllowWithWarning compatibility path"
+  exit 1
+}
+
+echo "[review] Decision Event v2 field markers"
+rg -n 'policy_version|policy_digest|obligations|approval_state|lane|principal|auth_context_summary' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing Decision Event v2 field markers"
+  exit 1
+}
+
+echo "[review] required legacy decision markers still present"
+rg -n 'tool_classes|matched_tool_classes|match_basis|matched_rule|reason_code' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing existing decision-event fields"
+  exit 1
+}
+
+echo "[review] no obligations execution in this wave"
+if rg -n 'approval_required|redact_args|restrict_scope|obligation_fulfillment|execute_obligation' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: obligations execution markers detected in implementation scope"
+  rg -n 'approval_required|redact_args|restrict_scope|obligation_fulfillment|execute_obligation' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
Promote stacked Wave24 Step2 and Step3 to main after Step1 landed via #724.\n\nIncludes:\n- Step2 runtime implementation (typed decision contract + Decision Event v2 + AllowWithWarning compat path)\n- Step2 docs/gate artifacts\n- Step3 closure docs/gate artifacts\n\nNo additional scope beyond the stacked branch diff.