### PR TITLE
docs(wave25-step3): close obligations-log wave with docs+gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave25-obligations-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave25-obligations-step3.md
@@ -1,0 +1,39 @@
+# SPLIT CHECKLIST - Wave25 Obligations Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave25-obligations-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave25-obligations-step3.md`
+  - `scripts/ci/review-wave25-obligations-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+
+## Wave25 invariants
+- [ ] `allow_with_obligations` marker remains present
+- [ ] `execute_log_only` marker remains present
+- [ ] `legacy_warning` compatibility marker remains present
+- [ ] `obligation_outcomes` marker remains present
+- [ ] Outcome status markers remain present:
+  - `applied`
+  - `skipped`
+  - `error`
+
+## Non-goals still enforced
+- [ ] No `approval_required` execution
+- [ ] No `restrict_scope` execution
+- [ ] No `redact_args` execution
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave25-obligations-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave25-obligations-step3.md
@@ -1,0 +1,43 @@
+# SPLIT REVIEW PACK - Wave25 Obligations Step3
+
+## Intent
+Close Wave25 with a docs+gate-only closure slice after Step2 implementation.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add high-risk obligations execution
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave25-obligations-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave25-obligations-step3.md`
+- `scripts/ci/review-wave25-obligations-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns Step2 structural invariants.
+3. `allow_with_obligations`, `execute_log_only`, and `legacy_warning` markers remain present.
+4. `obligation_outcomes` and status markers remain present.
+5. No high-risk obligations execution markers appear in runtime scope.
+6. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave25-obligations-log-step2-impl \
+  bash scripts/ci/review-wave25-obligations-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave25-obligations-step3.sh
+```
+
+## Expected outcome
+- Step3 adds no runtime behavior
+- closure remains diff-proof
+- promote can happen cleanly after stacked validation

--- a/scripts/ci/review-wave25-obligations-step3.sh
+++ b/scripts/ci/review-wave25-obligations-step3.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave25-obligations-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave25-obligations-step3.md"
+  "scripts/ci/review-wave25-obligations-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave25 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave25 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+for marker in obligation_outcomes execute_log_only legacy_warning allow_with_obligations; do
+  rg -n "$marker" crates/assay-core/src/mcp >/dev/null || {
+    echo "FAIL: missing marker: $marker"
+    exit 1
+  }
+done
+
+for status in applied skipped error; do
+  rg -n "$status" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/obligations.rs >/dev/null || {
+    echo "FAIL: missing outcome status marker: $status"
+    exit 1
+  }
+done
+
+echo "[review] no high-risk obligation execution in this wave"
+if rg -n 'approval_required|restrict_scope|redact_args' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'docs/' >/dev/null; then
+  echo "FAIL: high-risk obligation execution markers detected"
+  rg -n 'approval_required|restrict_scope|redact_args' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core execute_log_only_
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave25 Step3 closure checklist and reviewer pack
- add Step3 reviewer gate script with docs+script-only scope enforcement
- rerun Step2 invariants in Step3 gate for diff-proof closure

## Scope
- docs + gate only
- no runtime changes
- no workflow changes

## Validation
- `BASE_REF=origin/codex/wave25-obligations-log-step2-impl bash scripts/ci/review-wave25-obligations-step3.sh` ✅ PASS

## Allowed files
- `docs/contributing/SPLIT-CHECKLIST-wave25-obligations-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave25-obligations-step3.md`
- `scripts/ci/review-wave25-obligations-step3.sh`
