### PR TITLE
docs(wave26-step1): freeze alert obligations execution scope

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step1.md
@@ -1,0 +1,24 @@
+# SPLIT CHECKLIST - Wave26 Obligations Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave26-obligations-alert.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step1.md`
+  - `scripts/ci/review-wave26-obligations-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] Wave26 execution scope is frozen to `log` + `alert`
+- [ ] `legacy_warning` compatibility path is explicitly preserved
+- [ ] `obligation_outcomes` remains additive and unchanged at schema level
+- [ ] Non-goals are explicit (`approval_required`, `restrict_scope`, `redact_args`)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave26-obligations-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-PLAN-wave26-obligations-alert.md
+++ b/docs/contributing/SPLIT-PLAN-wave26-obligations-alert.md
@@ -1,0 +1,96 @@
+# SPLIT PLAN - Wave26 Obligations Alert Execution
+
+## Intent
+Introduce a bounded Step1 freeze for Wave26 that extends the Wave25 runtime obligations path with one additional low-risk obligation type.
+
+This wave is about **incremental obligation execution** with strict scope control.
+
+It freezes:
+- runtime execution scope to `log` + `alert`
+- compatibility handling for `legacy_warning` -> `log`
+- additive fulfillment evidence via existing `obligation_outcomes`
+
+It explicitly does **not** add:
+- `approval_required` enforcement
+- `restrict_scope` enforcement
+- `redact_args` enforcement
+- auth transport changes
+- policy backend changes
+
+## Problem
+Wave25 delivered bounded runtime execution for `log`, but one additional low-risk obligation path is still missing before moving to higher-risk obligations.
+
+Current gap:
+- `allow_with_obligations` can execute `log`
+- no first-class runtime execution path exists yet for `alert`
+- no explicit freeze exists for this intermediate scope
+
+## Frozen execution contract (Wave26)
+Wave26 freezes executable obligation scope as:
+- `log`
+- `alert`
+
+Compatibility rule remains:
+- `legacy_warning` is treated as compatibility input and executed as `log`
+- existing `AllowWithWarning` parse and mapping behavior must remain intact
+
+## Frozen `alert` semantics
+`alert` execution in Wave26 is explicitly bounded:
+- non-blocking for tool execution
+- emits deterministic fulfillment outcome (`applied` / `skipped` / `error`)
+- does not introduce external incident/case-management dependencies in this wave
+
+## Frozen evidence semantics
+Decision Event continues to use additive `obligation_outcomes` introduced in Wave25.
+
+Each outcome entry remains minimally:
+- `type`
+- `status`
+- `reason` (optional)
+
+No new Decision Event field is required for Wave26 Step1 freeze.
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. Runtime can execute `alert` obligations in the same bounded path as `log`.
+2. `legacy_warning` compatibility path still produces `log` outcomes.
+3. `obligation_outcomes` remains additive and backward-compatible.
+4. Existing allow/deny behavior remains stable.
+5. Existing event consumers continue to parse events without breakage.
+6. No approval/restrict/redact execution is introduced.
+
+## Scope boundaries
+### In scope
+- MCP runtime obligation handling for `alert`
+- preserving existing `log` and `legacy_warning` behavior
+- tests and reviewer gates needed for the above
+
+### Out of scope
+- approval-required runtime enforcement
+- scope restriction runtime enforcement
+- argument redaction runtime enforcement
+- fail-closed matrix redesign
+- policy backend/pluggable PDP work
+- auth transport redesign
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- execute `alert` obligations
+- preserve existing `log` + `legacy_warning` behavior
+- keep evidence additive via existing `obligation_outcomes`
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must remain narrow and additive.
+
+Primary failure modes:
+- accidental scope creep into high-risk obligations
+- event compatibility regressions
+- hidden behavior changes in existing allow/deny paths

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step1.md
@@ -1,0 +1,36 @@
+# SPLIT REVIEW PACK - Wave26 Obligations Step1
+
+## Intent
+Freeze Wave26 scope before implementation by defining a bounded `alert` obligations execution contract.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime code
+- change CLI normalization code
+- change MCP server behavior
+- change workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave26-obligations-alert.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step1.md`
+- `scripts/ci/review-wave26-obligations-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Wave26 execution scope is explicit (`log` + `alert`).
+3. `legacy_warning` compatibility is explicit.
+4. Non-goals (`approval_required`, `restrict_scope`, `redact_args`) are explicit.
+5. Runtime paths are untouched.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave26-obligations-step1.sh
+```
+
+## Expected outcome
+- gate passes
+- runtime code is untouched
+- scope is frozen cleanly
+- Step2 can implement `alert` execution without reopening semantics

--- a/scripts/ci/review-wave26-obligations-step1.sh
+++ b/scripts/ci/review-wave26-obligations-step1.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave26-obligations-alert.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step1.md"
+  "scripts/ci/review-wave26-obligations-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave26 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave26 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave26 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN - Wave26 Obligations Alert Execution$' \
+  docs/contributing/SPLIT-PLAN-wave26-obligations-alert.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in '`alert`' '`log`' 'legacy_warning' 'approval_required' 'restrict_scope' 'redact_args'; do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave26-obligations-alert.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core execute_log_only_
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave26 Step1 freeze plan for bounded obligations execution expansion (`alert`)
- add Step1 checklist and review pack
- add Step1 reviewer gate script with allowlist + frozen-path + marker checks

## Scope
- docs + gate only
- no runtime code changes
- no workflow file changes

## Frozen contract
- Wave26 executable obligations scope: `log` + `alert`
- preserve compat path: `legacy_warning` -> `log`
- keep `obligation_outcomes` additive
- non-goals remain explicit: `approval_required`, `restrict_scope`, `redact_args`

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave26-obligations-step1.sh` ✅ PASS
- `cargo fmt --check` ✅
- `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` ✅
- pinned tests in gate ✅
