### PR TITLE
feat(wave26-step2): execute bounded alert obligations

### DIFF
--- a/crates/assay-core/src/mcp/obligations.rs
+++ b/crates/assay-core/src/mcp/obligations.rs
@@ -1,10 +1,11 @@
 use super::decision::{ObligationOutcome, ObligationOutcomeStatus};
 use super::policy::PolicyObligation;
 
-/// Execute Wave25 obligations with bounded scope.
+/// Execute bounded runtime obligations.
 ///
-/// Wave25 supports only log-style obligations:
+/// Supported in Wave26:
 /// - `log` is applied directly
+/// - `alert` is applied as a non-blocking runtime alert signal
 /// - `legacy_warning` is mapped to `log` for compatibility
 /// - any other type is emitted as skipped (non-blocking)
 pub fn execute_log_only(obligations: &[PolicyObligation], tool: &str) -> Vec<ObligationOutcome> {
@@ -21,6 +22,20 @@ pub fn execute_log_only(obligations: &[PolicyObligation], tool: &str) -> Vec<Obl
                 );
                 ObligationOutcome {
                     obligation_type: "log".to_string(),
+                    status: ObligationOutcomeStatus::Applied,
+                    reason: None,
+                }
+            }
+            "alert" => {
+                tracing::warn!(
+                    target: "assay::mcp::obligations",
+                    tool = %tool,
+                    obligation_type = "alert",
+                    detail = ?obligation.detail,
+                    "Applied alert obligation"
+                );
+                ObligationOutcome {
+                    obligation_type: "alert".to_string(),
                     status: ObligationOutcomeStatus::Applied,
                     reason: None,
                 }
@@ -81,6 +96,20 @@ mod tests {
             outcomes[0].reason.as_deref(),
             Some("mapped from legacy_warning")
         );
+    }
+
+    #[test]
+    fn execute_log_only_applies_alert_obligation() {
+        let obligations = vec![PolicyObligation {
+            obligation_type: "alert".to_string(),
+            detail: Some("notify-monitor".to_string()),
+        }];
+
+        let outcomes = execute_log_only(&obligations, "test_tool");
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].obligation_type, "alert");
+        assert_eq!(outcomes[0].status, ObligationOutcomeStatus::Applied);
+        assert!(outcomes[0].reason.is_none());
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -207,6 +207,13 @@ impl PolicyObligation {
             detail: Some(format!("{code}:{reason}")),
         }
     }
+
+    pub fn alert(code: &str, reason: &str) -> Self {
+        Self {
+            obligation_type: "alert".to_string(),
+            detail: Some(format!("{code}:{reason}")),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -227,9 +234,9 @@ impl PolicyDecision {
                 decision: TypedPolicyDecision::AllowWithObligations,
                 obligations: vec![PolicyObligation::warning_compat(code, reason)],
             },
-            Self::Deny { code, .. } if is_alert_deny_code(code) => PolicyDecisionContract {
+            Self::Deny { code, reason, .. } if is_alert_deny_code(code) => PolicyDecisionContract {
                 decision: TypedPolicyDecision::DenyWithAlert,
-                obligations: Vec::new(),
+                obligations: vec![PolicyObligation::alert(code, reason)],
             },
             Self::Deny { .. } => PolicyDecisionContract {
                 decision: TypedPolicyDecision::Deny,
@@ -390,3 +397,56 @@ impl McpPolicy {
 }
 
 pub use response::make_deny_response;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn typed_contract_maps_allow_with_warning_to_legacy_warning_obligation() {
+        let decision = PolicyDecision::AllowWithWarning {
+            tool: "tool_a".to_string(),
+            code: "E_TOOL_UNCONSTRAINED".to_string(),
+            reason: "Tool allowed but has no schema".to_string(),
+        };
+
+        let contract = decision.typed_contract();
+        assert_eq!(contract.decision, TypedPolicyDecision::AllowWithObligations);
+        assert_eq!(contract.obligations.len(), 1);
+        assert_eq!(contract.obligations[0].obligation_type, "legacy_warning");
+    }
+
+    #[test]
+    fn typed_contract_maps_tool_drift_to_deny_with_alert_obligation() {
+        let decision = PolicyDecision::Deny {
+            tool: "tool_a".to_string(),
+            code: "E_TOOL_DRIFT".to_string(),
+            reason: "Tool drifted".to_string(),
+            contract: json!({ "status": "deny" }),
+        };
+
+        let contract = decision.typed_contract();
+        assert_eq!(contract.decision, TypedPolicyDecision::DenyWithAlert);
+        assert_eq!(contract.obligations.len(), 1);
+        assert_eq!(contract.obligations[0].obligation_type, "alert");
+        assert_eq!(
+            contract.obligations[0].detail.as_deref(),
+            Some("E_TOOL_DRIFT:Tool drifted")
+        );
+    }
+
+    #[test]
+    fn typed_contract_maps_regular_deny_without_obligations() {
+        let decision = PolicyDecision::Deny {
+            tool: "tool_a".to_string(),
+            code: "E_TOOL_DENIED".to_string(),
+            reason: "Denied".to_string(),
+            contract: json!({ "status": "deny" }),
+        };
+
+        let contract = decision.typed_contract();
+        assert_eq!(contract.decision, TypedPolicyDecision::Deny);
+        assert!(contract.obligations.is_empty());
+    }
+}

--- a/crates/assay-core/src/mcp/tool_call_handler/tests.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::mcp::decision::{
     reason_codes, DecisionEvent, NullDecisionEmitter, ObligationOutcomeStatus,
 };
+use crate::mcp::identity::ToolIdentity;
 use crate::mcp::lifecycle::{LifecycleEmitter, LifecycleEvent};
 use crate::mcp::policy::TypedPolicyDecision;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -108,6 +109,64 @@ fn test_allow_with_warning_emits_log_obligation_outcome() {
         }
         other => panic!("expected allow result, got {:?}", other),
     }
+    assert_eq!(emitter.0.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn test_tool_drift_deny_emits_alert_obligation_outcome() {
+    let emitter = Arc::new(CountingEmitter(AtomicUsize::new(0)));
+    let mut policy = McpPolicy::default();
+    let pinned = ToolIdentity::new(
+        "server-a",
+        "drift_tool",
+        &Some(serde_json::json!({"shape": "pinned"})),
+        &Some("Pinned version".to_string()),
+    );
+    policy
+        .tool_pins
+        .insert("drift_tool".to_string(), pinned.clone());
+
+    let handler = ToolCallHandler::new(
+        policy,
+        None,
+        emitter.clone(),
+        ToolCallHandlerConfig::default(),
+    );
+
+    let runtime_identity = ToolIdentity::new(
+        "server-a",
+        "drift_tool",
+        &Some(serde_json::json!({"shape": "runtime"})),
+        &Some("Runtime version".to_string()),
+    );
+
+    let request = make_tool_call_request("drift_tool", serde_json::json!({}));
+    let mut state = PolicyState::default();
+    let result =
+        handler.handle_tool_call(&request, &mut state, Some(&runtime_identity), None, None);
+
+    match result {
+        HandleResult::Deny {
+            reason_code,
+            decision_event,
+            ..
+        } => {
+            assert_eq!(reason_code, reason_codes::P_TOOL_DRIFT);
+            assert_eq!(
+                decision_event.data.typed_decision,
+                Some(TypedPolicyDecision::DenyWithAlert)
+            );
+            assert_eq!(decision_event.data.obligations.len(), 1);
+            assert_eq!(decision_event.data.obligations[0].obligation_type, "alert");
+            assert_eq!(decision_event.data.obligation_outcomes.len(), 1);
+            let outcome = &decision_event.data.obligation_outcomes[0];
+            assert_eq!(outcome.obligation_type, "alert");
+            assert_eq!(outcome.status, ObligationOutcomeStatus::Applied);
+            assert!(outcome.reason.is_none());
+        }
+        other => panic!("expected deny result, got {:?}", other),
+    }
+
     assert_eq!(emitter.0.load(Ordering::SeqCst), 1);
 }
 

--- a/docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step2.md
@@ -1,0 +1,31 @@
+# SPLIT CHECKLIST - Wave26 Obligations Step2
+
+## Scope discipline
+- [ ] Step2 contains bounded runtime implementation for obligations `log` + `alert`
+- [ ] No `.github/workflows/*` changes
+- [ ] No auth transport changes
+- [ ] No policy backend architecture changes
+- [ ] No lane/control-plane expansion
+
+## Runtime contract checks
+- [ ] `alert` obligations execute in the same bounded path as `log`
+- [ ] `legacy_warning` compatibility path still maps to `log`
+- [ ] Unknown obligation types are non-blocking and marked `skipped`
+- [ ] Existing allow/deny semantics remain stable
+
+## Event contract checks
+- [ ] Decision events keep additive `obligation_outcomes`
+- [ ] Existing Wave24/Wave25 fields remain intact
+- [ ] Existing event consumers remain compatible
+
+## Non-goals enforced
+- [ ] No `approval_required` execution
+- [ ] No `restrict_scope` execution
+- [ ] No `redact_args` execution
+- [ ] No external incident/case-management integration
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave26-obligations-step2.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned tests remain green

--- a/docs/contributing/SPLIT-MOVE-MAP-wave26-obligations-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave26-obligations-step2.md
@@ -1,0 +1,38 @@
+# SPLIT-MOVE-MAP - Wave26 Step2 - Obligations Alert Execution
+
+## Goal
+Extend bounded obligations runtime handling with one additional low-risk type:
+1. execute `alert` obligations
+2. preserve `log` behavior
+3. preserve `legacy_warning` -> `log` compatibility
+4. keep `obligation_outcomes` additive
+
+## File-level map
+
+### Core runtime
+- `crates/assay-core/src/mcp/obligations.rs`
+  - extend bounded execution to include `alert`
+  - keep `legacy_warning` compatibility mapping to `log`
+  - keep unknown types as non-blocking `skipped`
+
+- `crates/assay-core/src/mcp/policy/mod.rs`
+  - map deny-with-alert policy decisions to typed `alert` obligations
+  - preserve typed decision compatibility contract
+
+### Tests
+- `crates/assay-core/src/mcp/obligations.rs` (unit tests)
+  - verify `alert` outcome behavior
+
+- `crates/assay-core/src/mcp/tool_call_handler/tests.rs`
+  - verify deny-with-alert path emits `alert` obligation outcomes
+
+## Behavior parity notes
+- Tool-call allow/deny end-state behavior remains unchanged.
+- Alert execution remains non-blocking.
+- No external incident/case-management dependency is added.
+
+## Out-of-scope guardrails
+- no `approval_required` enforcement
+- no `restrict_scope` enforcement
+- no `redact_args` enforcement
+- no event schema redesign

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step2.md
@@ -1,0 +1,38 @@
+# SPLIT REVIEW PACK - Wave26 Obligations Step2
+
+## Intent
+Implement Wave26 Step2 as a bounded obligations execution slice for `alert`.
+
+This slice must:
+- execute `alert` obligations in the existing bounded runtime path
+- preserve existing `log` behavior
+- preserve `legacy_warning` -> `log` compatibility
+- keep `obligation_outcomes` additive
+
+This slice must not:
+- add `approval_required` execution
+- add `restrict_scope` execution
+- add `redact_args` execution
+- add external incident/case-management integration
+- change workflow files
+
+## Allowed files
+- `crates/assay-core/src/mcp/obligations.rs`
+- `crates/assay-core/src/mcp/policy/mod.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests.rs`
+- `docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step2.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave26-obligations-step2.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step2.md`
+- `scripts/ci/review-wave26-obligations-step2.sh`
+
+## What reviewers should verify
+1. Runtime execution remains bounded and non-blocking.
+2. `alert` obligations are executed and recorded in outcomes.
+3. `legacy_warning` still maps to `log` outcomes.
+4. Decision/event compatibility remains additive.
+5. No high-risk obligations execution markers appear.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave26-obligations-step2.sh
+```

--- a/scripts/ci/review-wave26-obligations-step2.sh
+++ b/scripts/ci/review-wave26-obligations-step2.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/obligations.rs"
+  "crates/assay-core/src/mcp/policy/mod.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/tests.rs"
+  "docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave26-obligations-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step2.md"
+  "scripts/ci/review-wave26-obligations-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave26 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave26 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] marker checks"
+for marker in alert log legacy_warning obligation_outcomes deny_with_alert; do
+  rg -n "$marker" crates/assay-core/src/mcp >/dev/null || {
+    echo "FAIL: missing marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no high-risk obligation execution in this wave"
+if rg -n 'approval_required|restrict_scope|redact_args' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'docs/' >/dev/null; then
+  echo "FAIL: high-risk obligation execution markers detected"
+  rg -n 'approval_required|restrict_scope|redact_args' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core execute_log_only_
+cargo test -p assay-core typed_contract_maps_tool_drift_to_deny_with_alert_obligation -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add bounded runtime execution for alert obligations in the existing MCP obligations path
- keep existing log behavior and preserve legacy_warning -> log compatibility
- keep obligation_outcomes additive and non-blocking
- add Wave26 Step2 checklist/move-map/review-pack and reviewer gate script

## Scope
- crates/assay-core/src/mcp/obligations.rs
- crates/assay-core/src/mcp/policy/mod.rs
- crates/assay-core/src/mcp/tool_call_handler/tests.rs
- docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step2.md
- docs/contributing/SPLIT-MOVE-MAP-wave26-obligations-step2.md
- docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step2.md
- scripts/ci/review-wave26-obligations-step2.sh

## Non-goals
- no approval_required execution
- no restrict_scope execution
- no redact_args execution
- no external incident/case-management integration
- no auth transport changes

## Validation
- BASE_REF=origin/main bash scripts/ci/review-wave26-obligations-step2.sh (PASS)
- includes fmt/clippy and pinned core/cli/server tests
