### PR TITLE
docs(wave26-step3): close obligations alert wave with docs+gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step3.md
@@ -1,0 +1,36 @@
+# SPLIT CHECKLIST - Wave26 Obligations Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step3.md`
+  - `scripts/ci/review-wave26-obligations-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server behavior changes
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 remains green against stacked base and `origin/main`
+
+## Step2 invariants retained
+- [ ] Executable obligations scope stays bounded to:
+  - `log`
+  - `alert`
+- [ ] `legacy_warning` -> `log` compatibility remains intact
+- [ ] `obligation_outcomes` stays additive
+- [ ] No high-risk obligations execution added:
+  - `approval_required`
+  - `restrict_scope`
+  - `redact_args`
+- [ ] No external incident/case-management integration markers added
+
+## Validation
+- [ ] `BASE_REF=origin/codex/wave26-obligations-alert-step2-impl bash scripts/ci/review-wave26-obligations-step3.sh` passes
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave26-obligations-step3.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step3.md
@@ -1,0 +1,41 @@
+# SPLIT REVIEW PACK - Wave26 Obligations Step3
+
+## Intent
+Close Wave26 with a docs+gate-only Step3 slice after Step2 alert execution landed.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add high-risk obligations execution
+- add external incident/case-management integration
+- change workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step3.md`
+- `scripts/ci/review-wave26-obligations-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Bounded executable scope remains `log` + `alert`.
+4. `legacy_warning` compatibility remains intact.
+5. `obligation_outcomes` remains additive.
+6. No high-risk obligations execution markers appear.
+7. No external incident/case-management integration markers appear.
+8. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave26-obligations-alert-step2-impl \
+  bash scripts/ci/review-wave26-obligations-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave26-obligations-step3.sh
+```

--- a/scripts/ci/review-wave26-obligations-step3.sh
+++ b/scripts/ci/review-wave26-obligations-step3.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step3.md"
+  "scripts/ci/review-wave26-obligations-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave26 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave26 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+for marker in alert log legacy_warning obligation_outcomes deny_with_alert; do
+  rg -n "$marker" crates/assay-core/src/mcp >/dev/null || {
+    echo "FAIL: missing marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no high-risk obligation execution in this wave"
+if rg -n 'approval_required|restrict_scope|redact_args' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'docs/' >/dev/null; then
+  echo "FAIL: high-risk obligation execution markers detected"
+  rg -n 'approval_required|restrict_scope|redact_args' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'docs/'
+  exit 1
+fi
+
+echo "[review] no external incident/case-management integration markers"
+if rg -n 'pagerduty|opsgenie|servicenow|incident_client|case_management' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'docs/' >/dev/null; then
+  echo "FAIL: external incident/case-management markers detected"
+  rg -n 'pagerduty|opsgenie|servicenow|incident_client|case_management' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core execute_log_only_
+cargo test -p assay-core typed_contract_maps_tool_drift_to_deny_with_alert_obligation -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave26 Step3 closure docs and reviewer gate
- enforce docs+script-only scope for Step3
- rerun Step2 invariants from Step3 gate

## Scope
- docs/contributing/SPLIT-CHECKLIST-wave26-obligations-step3.md
- docs/contributing/SPLIT-REVIEW-PACK-wave26-obligations-step3.md
- scripts/ci/review-wave26-obligations-step3.sh

## Invariants rerun
- executable obligation scope remains bounded to log + alert
- legacy_warning -> log remains intact
- obligation_outcomes remains additive
- no approval_required/restrict_scope/redact_args execution
- no external incident/case-management integration markers

## Validation
- BASE_REF=origin/codex/wave26-obligations-alert-step2-impl bash scripts/ci/review-wave26-obligations-step3.sh (PASS)
- BASE_REF=origin/main bash scripts/ci/review-wave26-obligations-step3.sh (PASS)
