### PR TITLE
docs(wave27-step1): freeze approval artifact contract

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave27-approval-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave27-approval-step1.md
@@ -1,0 +1,25 @@
+# SPLIT CHECKLIST — Wave27 Approval Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave27-approval-artifact.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave27-approval-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step1.md`
+  - `scripts/ci/review-wave27-approval-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] Approval artifact minimum fields are explicit
+- [ ] Freshness / expiry semantics are explicit
+- [ ] Tool/resource binding is explicit
+- [ ] Additive approval evidence fields are explicit
+- [ ] Non-goals are explicit (`approval_required` enforcement not included yet)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave27-approval-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-PLAN-wave27-approval-artifact.md
+++ b/docs/contributing/SPLIT-PLAN-wave27-approval-artifact.md
@@ -1,0 +1,108 @@
+# SPLIT PLAN — Wave27 Approval Artifact Contract
+
+## Intent
+Freeze a bounded contract for approval artifacts before any runtime enforcement of `approval_required`.
+
+This wave is about:
+- approval artifact shape
+- freshness / expiry semantics
+- binding to tool/resource
+- additive decision-event/evidence fields
+
+It explicitly does **not** add:
+- runtime blocking on missing approval
+- approval UI or case management
+- external approval services
+- `restrict_scope` or `redact_args` execution
+- policy backend changes
+
+## Problem
+Wave24 introduced typed decisions and Decision Event v2.
+Wave25 and Wave26 introduced bounded execution for `log` and `alert`.
+
+Before `approval_required` can become executable, the approval artifact itself must be frozen as a stable contract.
+
+Current gap:
+- no first-class frozen approval artifact schema
+- no frozen freshness/expiry contract
+- no frozen binding rules for tool/resource
+- no additive evidence contract for approval state
+
+## Frozen approval artifact contract
+Wave27 freezes an approval artifact with, at minimum:
+
+- `approval_id`
+- `approver`
+- `issued_at`
+- `expires_at`
+- `scope`
+- `bound_tool`
+- `bound_resource`
+
+## Frozen semantics
+### Freshness / expiry
+- approval artifacts must be explicitly time-bounded
+- expiry is part of the artifact contract
+- no implicit infinite approval is allowed in the target model
+
+### Binding
+- approval must be bindable to:
+  - a specific tool
+  - a specific resource
+- broad/global approval semantics are out of scope for this wave
+
+### Evidence shape
+Decision/event evidence may add approval-related fields, but only additively.
+This wave freezes the target fields without enforcing them yet.
+
+Minimum target evidence fields:
+- `approval_state`
+- `approval_id` (or `approval_ref`)
+- `approval_freshness`
+- `approval_bound_tool`
+- `approval_bound_resource`
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. Approval artifact shape is represented in code.
+2. Approval freshness/expiry fields are represented.
+3. Tool/resource binding fields are represented.
+4. Event/evidence fields are additive and backward-compatible.
+5. No runtime enforcement of `approval_required` is introduced yet.
+6. Existing typed decision and obligations behavior remains stable.
+
+## Scope boundaries
+### In scope
+- approval artifact contract
+- additive event/evidence shape
+- tests and reviewer gates for the above
+
+### Out of scope
+- runtime enforcement of `approval_required`
+- approval execution flow
+- UI/case-management
+- external approval integrations
+- control-plane semantics
+- auth transport changes
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- artifact/data shape
+- additive event/evidence fields
+- no enforcement
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must stay contract-first.
+
+Primary failure modes:
+- sneaking in approval enforcement early
+- breaking existing event consumers
+- making approval semantics too broad

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step1.md
@@ -1,0 +1,39 @@
+# SPLIT REVIEW PACK — Wave27 Approval Step1
+
+## Intent
+Freeze the approval artifact contract before any runtime enforcement of `approval_required`.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add approval enforcement
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave27-approval-artifact.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave27-approval-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step1.md`
+- `scripts/ci/review-wave27-approval-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Approval artifact minimum fields are explicit.
+3. Freshness / expiry semantics are explicit.
+4. Tool/resource binding is explicit.
+5. Additive approval evidence fields are explicit.
+6. Runtime paths are untouched.
+7. No approval enforcement is introduced in this wave.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave27-approval-step1.sh
+```
+
+## Expected outcome
+- gate passes
+- runtime code is untouched
+- approval contract is frozen cleanly
+- Step2 can implement artifact/evidence shape without reopening semantics

--- a/scripts/ci/review-wave27-approval-step1.sh
+++ b/scripts/ci/review-wave27-approval-step1.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave27-approval-artifact.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave27-approval-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step1.md"
+  "scripts/ci/review-wave27-approval-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave27 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave27 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave27 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN — Wave27 Approval Artifact Contract$' \
+  docs/contributing/SPLIT-PLAN-wave27-approval-artifact.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'approval_id' \
+  'approver' \
+  'issued_at' \
+  'expires_at' \
+  'scope' \
+  'bound_tool' \
+  'bound_resource' \
+  'approval_state' \
+  'approval_freshness'
+do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave27-approval-artifact.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave27 Step1 split plan for approval artifact contract freeze
- add Step1 checklist and review pack
- add Step1 reviewer gate script

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Frozen contract
- approval artifact minimum fields: approval_id, approver, issued_at, expires_at, scope, bound_tool, bound_resource
- freshness/expiry semantics are explicit
- tool/resource binding semantics are explicit
- additive approval evidence fields are explicit

## Non-goals
- no runtime enforcement of approval_required
- no approval UI/case-management
- no external approval services
- no restrict_scope/redact_args execution
- no policy backend changes

## Validation
- BASE_REF=origin/main bash scripts/ci/review-wave27-approval-step1.sh (PASS)
- includes fmt/clippy and pinned tests
