### PR TITLE
docs(wave27-step3): close approval artifact wave with docs+gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave27-approval-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave27-approval-step3.md
@@ -1,0 +1,46 @@
+# SPLIT CHECKLIST - Wave27 Approval Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave27-approval-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step3.md`
+  - `scripts/ci/review-wave27-approval-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave27 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+
+## Step2 invariants preserved
+- [ ] Approval artifact/data shape markers remain present:
+  - `approval_id`
+  - `approver`
+  - `issued_at`
+  - `expires_at`
+  - `scope`
+  - `bound_tool`
+  - `bound_resource`
+- [ ] Approval evidence markers remain present:
+  - `approval_state`
+  - `approval_freshness`
+- [ ] Existing typed decision + obligations behavior remains in place
+- [ ] No approval enforcement markers are introduced
+
+## Non-goals still enforced
+- [ ] No runtime enforcement of `approval_required`
+- [ ] No approval UI/case-management
+- [ ] No external approval services
+- [ ] No control-plane/auth transport changes
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned core/cli/server tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step3.md
@@ -1,0 +1,36 @@
+# SPLIT REVIEW PACK - Wave27 Approval Step3
+
+## Intent
+Close Wave27 with a docs+gate-only Step3 closure slice after Step2 approval artifact shape implementation.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add approval enforcement
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave27-approval-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step3.md`
+- `scripts/ci/review-wave27-approval-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns Step2 structural invariants.
+3. Approval artifact/data-shape markers remain present.
+4. Approval evidence markers remain present.
+5. No approval enforcement markers appear in runtime scope.
+6. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked base
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave27-approval-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave27-approval-step3.sh
+```

--- a/scripts/ci/review-wave27-approval-step3.sh
+++ b/scripts/ci/review-wave27-approval-step3.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave27-approval-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave27-approval-step3.md"
+  "scripts/ci/review-wave27-approval-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave27 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave27 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+for marker in \
+  'approval_id' \
+  'approver' \
+  'issued_at' \
+  'expires_at' \
+  'scope' \
+  'bound_tool' \
+  'bound_resource' \
+  'approval_state' \
+  'approval_freshness'
+do
+  rg -n "$marker" crates/assay-core/src/mcp >/dev/null || {
+    echo "FAIL: missing marker in MCP runtime: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no approval enforcement in this wave"
+if rg -n 'approval_required|enforce_approval|required_approval' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server >/dev/null; then
+  echo "FAIL: approval enforcement markers detected in implementation scope"
+  rg -n 'approval_required|enforce_approval|required_approval' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_with_policy_context_sets_approval_artifact_fields -- --exact
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- close Wave27 with a docs+gate-only Step3 closure slice
- add Step3 checklist and review pack
- add Step3 reviewer gate that enforces docs/script-only scope and reruns Step2 invariants

## Scope
- docs + gate script only
- no runtime/schema/behavior changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave27-approval-step3.sh` PASS
- `cargo fmt --check` PASS
- `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` PASS
- pinned core/cli/server tests in gate PASS
