### PR TITLE
docs(wave28-step3): add closure gate and review templates

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave28-approval-required-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave28-approval-required-step3.md
@@ -1,0 +1,58 @@
+# SPLIT CHECKLIST — Wave28 Approval Required Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave28-approval-required-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave28-approval-required-step3.md`
+  - `scripts/ci/review-wave28-approval-required-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave28 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves the bounded `approval_required` enforcement contract
+
+## Approval enforcement invariants
+- [ ] Approval artifact/evidence markers remain present:
+  - `approval_id`
+  - `approver`
+  - `issued_at`
+  - `expires_at`
+  - `scope`
+  - `approval_bound_tool`
+  - `approval_bound_resource`
+  - `approval_freshness`
+  - `approval_state`
+- [ ] `approval_required` runtime marker remains present
+- [ ] Missing approval deny behavior remains present
+- [ ] Expired approval deny behavior remains present
+- [ ] Bound tool mismatch deny behavior remains present
+- [ ] Bound resource mismatch deny behavior remains present
+- [ ] `approval_failure_reason` remains present
+
+## Non-goals still enforced
+- [ ] No approval UI added
+- [ ] No case-management added
+- [ ] No external approval service added
+- [ ] No `restrict_scope` execution added
+- [ ] No `redact_args` execution added
+- [ ] No grace/renewal/global approval semantics added
+
+## Existing obligation line still intact
+- [ ] `log` execution remains present
+- [ ] `alert` execution remains present
+- [ ] `legacy_warning -> log` compatibility remains present
+- [ ] `obligation_outcomes` remains additive
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave28-approval-required-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave28-approval-required-step3.md
@@ -1,0 +1,47 @@
+# SPLIT REVIEW PACK — Wave28 Approval Required Step3
+
+## Intent
+Close Wave28 with a docs+gate-only closure slice after the bounded implementation of `approval_required` runtime enforcement.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add approval UI/case-management
+- add external approval services
+- add `restrict_scope` or `redact_args`
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave28-approval-required-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave28-approval-required-step3.md`
+- `scripts/ci/review-wave28-approval-required-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Approval artifact/evidence markers remain present.
+4. `approval_required` runtime enforcement remains bounded.
+5. Missing/expired/mismatch approval still yields deny behavior.
+6. Existing `log`/`alert`/`legacy_warning` line remains intact.
+7. No scope creep appears in runtime scope.
+8. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave28-approval-required-step2-impl \
+  bash scripts/ci/review-wave28-approval-required-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave28-approval-required-step3.sh
+```
+
+## Expected outcome
+- Step3 adds no runtime behavior
+- closure remains diff-proof
+- promote can happen cleanly after stacked validation

--- a/scripts/ci/review-wave28-approval-required-step3.sh
+++ b/scripts/ci/review-wave28-approval-required-step3.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave28-approval-required-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave28-approval-required-step3.md"
+  "scripts/ci/review-wave28-approval-required-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave28 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave28 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] approval artifact/evidence markers"
+rg -n 'approval_id|approver|issued_at|expires_at|scope|approval_bound_tool|approval_bound_resource|approval_freshness|approval_state' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing approval artifact/evidence markers"
+  exit 1
+}
+
+echo "[review] approval_required enforcement markers"
+rg -n 'approval_required' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing approval_required marker"
+  exit 1
+}
+
+rg -n 'missing approval|expired approval|bound tool mismatch|bound resource mismatch|approval_failure_reason' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing approval failure markers/reasons"
+  exit 1
+}
+
+echo "[review] deny outcome markers for approval failures"
+rg -n 'deny|Deny' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing deny markers"
+  exit 1
+}
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'approval UI|case management|external approval|restrict_scope|redact_args|grace period|approval renewal|broad/global approval' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'approval UI|case management|external approval|restrict_scope|redact_args|grace period|approval renewal|broad/global approval' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] existing obligation execution remains present"
+rg -n 'obligation_outcomes|legacy_warning|log|alert' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: existing obligation execution markers missing"
+  exit 1
+}
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave28 Step3 docs+gate closure assets
- add Step3 checklist and review pack templates
- add Step3 reviewer gate to rerun Step2 invariants with docs+script-only diff discipline

## Scope
- docs + gate only
- no runtime code changes in this PR

## Notes
- intended base: `codex/wave28-approval-required-step2-impl`
- keeps closure strictly bounded to 3 files
