### PR TITLE
docs(wave29-step1): freeze restrict_scope contract

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step1.md
@@ -1,0 +1,25 @@
+# SPLIT CHECKLIST — Wave29 Restrict Scope Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave29-restrict-scope.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step1.md`
+  - `scripts/ci/review-wave29-restrict-scope-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] `restrict_scope` contract fields are explicit
+- [ ] Scope match/mismatch semantics are explicit
+- [ ] Scope mismatch reasons are explicit
+- [ ] Additive scope evidence fields are explicit
+- [ ] Non-goals are explicit (`restrict_scope` runtime enforcement not included yet)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave29-restrict-scope-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-PLAN-wave29-restrict-scope.md
+++ b/docs/contributing/SPLIT-PLAN-wave29-restrict-scope.md
@@ -1,0 +1,108 @@
+# SPLIT PLAN — Wave29 Restrict Scope Contract
+
+## Intent
+Freeze a bounded contract for `restrict_scope` before any runtime execution semantics are introduced.
+
+This wave is about:
+- restrict-scope artifact/data shape
+- scope matching semantics
+- additive decision-event/evidence fields
+- compatibility boundaries for existing obligation behavior
+
+It explicitly does **not** add:
+- runtime blocking/enforcement for `restrict_scope`
+- policy backend changes
+- approval workflow changes
+- `redact_args` execution
+- external incident/case-management integrations
+
+## Problem
+Wave24–Wave28 established typed decisions, event v2, and bounded obligation execution (`log`, `alert`) plus `approval_required` enforcement.
+
+Current gap:
+- `restrict_scope` lacks a first-class frozen contract
+- no frozen semantics for what constitutes scope match/mismatch
+- no frozen additive evidence shape for scope outcomes
+
+## Frozen restrict_scope contract
+Wave29 freezes a minimum `restrict_scope` contract with:
+
+- `scope_profile`
+- `allowed_servers`
+- `allowed_tool_classes`
+- `allowed_resources`
+- `max_resource_selectors`
+
+The contract is policy/output-facing and does not imply execution in this wave.
+
+## Frozen semantics
+### Scope match basis
+A request can be evaluated against:
+- target `server_id`
+- matched `tool_classes`
+- requested `resource` selectors
+
+### Scope mismatch basis
+Mismatch conditions are frozen as named reasons:
+- `scope_server_mismatch`
+- `scope_tool_class_mismatch`
+- `scope_resource_mismatch`
+- `scope_selector_limit_exceeded`
+
+These are frozen as semantics/evidence markers only for this wave.
+
+## Frozen evidence contract
+Wave29 freezes additive scope-related evidence fields:
+
+- `scope_decision`
+- `scope_effective`
+- `scope_violation_reason`
+- `scope_profile`
+- `scope_policy_version`
+- `scope_policy_digest`
+
+Evidence additions must remain backward-compatible.
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. Restrict-scope contract shape is represented in code.
+2. Scope match/mismatch semantics are represented deterministically.
+3. Scope evidence fields are additive and backward-compatible.
+4. Existing `log`/`alert`/`approval_required` behavior remains stable.
+5. No runtime enforcement for `restrict_scope` is introduced yet.
+
+## Scope boundaries
+### In scope
+- `restrict_scope` contract freeze
+- additive evidence shape freeze
+- tests and reviewer gates for the contract freeze
+
+### Out of scope
+- runtime enforcement/execution of `restrict_scope`
+- `redact_args` execution
+- approval workflow expansion
+- policy backend replacement
+- control-plane work
+- auth transport changes
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- contract/data shape representation
+- additive evidence representation
+- no runtime enforcement
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must stay contract-first and additive.
+
+Primary failure modes:
+- introducing runtime `restrict_scope` enforcement too early
+- breaking event consumers with non-additive schema changes
+- scope-creep into approval/control-plane concerns

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step1.md
@@ -1,0 +1,38 @@
+# SPLIT REVIEW PACK — Wave29 Restrict Scope Step1
+
+## Intent
+Freeze the `restrict_scope` contract before any runtime enforcement/execution semantics are introduced.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add `restrict_scope` runtime enforcement
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave29-restrict-scope.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step1.md`
+- `scripts/ci/review-wave29-restrict-scope-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Restrict-scope contract fields are explicit.
+3. Scope mismatch reasons are explicit.
+4. Additive scope evidence fields are explicit.
+5. Runtime paths are untouched.
+6. No `restrict_scope` runtime execution is introduced in this wave.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave29-restrict-scope-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- restrict-scope contract is frozen cleanly
+- Step2 can implement contract representation without reopening semantics

--- a/scripts/ci/review-wave29-restrict-scope-step1.sh
+++ b/scripts/ci/review-wave29-restrict-scope-step1.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave29-restrict-scope.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step1.md"
+  "scripts/ci/review-wave29-restrict-scope-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave29 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave29 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave29 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN — Wave29 Restrict Scope Contract$' \
+  docs/contributing/SPLIT-PLAN-wave29-restrict-scope.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'restrict_scope' \
+  'scope_profile' \
+  'allowed_servers' \
+  'allowed_tool_classes' \
+  'allowed_resources' \
+  'max_resource_selectors' \
+  'scope_server_mismatch' \
+  'scope_tool_class_mismatch' \
+  'scope_resource_mismatch' \
+  'scope_selector_limit_exceeded' \
+  'scope_decision' \
+  'scope_effective' \
+  'scope_violation_reason' \
+  'scope_policy_version' \
+  'scope_policy_digest'
+do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave29-restrict-scope.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave29 Step1 split plan for `restrict_scope` contract freeze
- add Step1 checklist and review pack
- add Step1 reviewer gate script (`review-wave29-restrict-scope-step1.sh`)

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave29-restrict-scope-step1.sh` (PASS)
- pre-commit hooks passed (fmt/shellcheck)
- clippy + pinned tests passed via gate script
