### PR TITLE
docs(wave29-step3): add restrict_scope closure gate and review templates

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step3.md
@@ -1,0 +1,55 @@
+# SPLIT CHECKLIST — Wave29 Restrict Scope Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step3.md`
+  - `scripts/ci/review-wave29-restrict-scope-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave29 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves bounded restrict_scope contract/evidence semantics
+
+## Restrict scope invariants
+- [ ] Restrict scope contract markers remain present:
+  - `restrict_scope`
+  - `scope_type`
+  - `scope_value`
+  - `scope_match_mode`
+  - `scope_evaluation_state`
+  - `scope_failure_reason`
+- [ ] Restrict scope evidence markers remain present:
+  - `restrict_scope_present`
+  - `restrict_scope_target`
+  - `restrict_scope_match`
+  - `restrict_scope_reason`
+- [ ] `restrict_scope_mismatch_does_not_deny` remains true
+- [ ] `restrict_scope_match_sets_additive_fields` remains true
+
+## Non-goals still enforced
+- [ ] No restrict_scope runtime enforcement added
+- [ ] No arg rewriting or filtering added
+- [ ] No `redact_args` execution added
+- [ ] No broad/global scope semantics added
+
+## Existing obligation line still intact
+- [ ] `log` execution remains present
+- [ ] `alert` execution remains present
+- [ ] `approval_required` enforcement remains present
+- [ ] `legacy_warning -> log` compatibility remains present
+- [ ] `obligation_outcomes` remains additive
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step3.md
@@ -1,0 +1,45 @@
+# SPLIT REVIEW PACK — Wave29 Restrict Scope Step3
+
+## Intent
+Close Wave29 with a docs+gate-only closure slice after the bounded implementation of `restrict_scope` contract/evidence shape.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add `restrict_scope` runtime enforcement
+- add arg rewriting/filtering/redaction behavior
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step3.md`
+- `scripts/ci/review-wave29-restrict-scope-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Restrict-scope contract/evidence markers remain present.
+4. Restrict-scope behavior remains contract-only and non-enforcing.
+5. Existing `log`/`alert`/`approval_required`/`legacy_warning` line remains intact.
+6. No scope creep appears in runtime scope.
+7. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave29-restrict-scope-step2-impl \
+  bash scripts/ci/review-wave29-restrict-scope-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave29-restrict-scope-step3.sh
+```
+
+## Expected outcome
+- Step3 adds no runtime behavior
+- closure remains diff-proof
+- promote can happen cleanly after stacked validation

--- a/scripts/ci/review-wave29-restrict-scope-step3.sh
+++ b/scripts/ci/review-wave29-restrict-scope-step3.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave29-restrict-scope-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave29-restrict-scope-step3.md"
+  "scripts/ci/review-wave29-restrict-scope-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave29 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave29 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] marker checks: restrict_scope shape + evidence"
+for marker in \
+  'restrict_scope' \
+  'scope_type' \
+  'scope_value' \
+  'scope_match_mode' \
+  'scope_evaluation_state' \
+  'scope_failure_reason' \
+  'restrict_scope_present' \
+  'restrict_scope_target' \
+  'restrict_scope_match' \
+  'restrict_scope_reason'
+do
+  rg -n "$marker" crates/assay-core/src/mcp crates/assay-core/tests >/dev/null || {
+    echo "FAIL: missing marker in runtime/tests: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no restrict_scope execution/enforcement in this wave"
+if rg -n \
+  'P_RESTRICT_SCOPE|enforce_restrict_scope|validate_restrict_scope|restrict_scope_required|restrict_scope.*emit_deny|emit_deny.*restrict_scope|restrict_scope.*PolicyDecision::Deny|rewrite_args|filter_args|redact_args' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server >/dev/null; then
+  echo "FAIL: restrict_scope enforcement/rewriting markers detected"
+  rg -n \
+    'P_RESTRICT_SCOPE|enforce_restrict_scope|validate_restrict_scope|restrict_scope_required|restrict_scope.*emit_deny|emit_deny.*restrict_scope|restrict_scope.*PolicyDecision::Deny|rewrite_args|filter_args|redact_args' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server
+  exit 1
+fi
+
+echo "[review] existing obligation line remains present"
+rg -n 'obligation_outcomes|legacy_warning|approval_required|log|alert' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: existing obligation markers missing"
+  exit 1
+}
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_does_not_deny
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core execute_log_only_marks_restrict_scope_as_contract_only
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave29 Step3 closure checklist (docs+gate only)
- add Wave29 Step3 review pack
- add Wave29 Step3 reviewer gate script that reruns Step2 invariants

## Scope
- docs+script only
- no runtime code changes
- no workflow changes

## Validation
- pre-commit hooks passed on commit/push (fmt, clippy workspace gate, shellcheck)
- reviewer gate logic mirrors Step2 invariants and keeps non-goals explicit