### PR TITLE
docs(wave30-step1): freeze restrict_scope enforcement contract

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step1.md
@@ -1,0 +1,24 @@
+# SPLIT CHECKLIST — Wave30 Restrict Scope Enforcement Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave30-restrict-scope-enforcement.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step1.md`
+  - `scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] `restrict_scope` enforcement validity checks are explicit
+- [ ] Mismatch/missing/unsupported deny behavior is explicit
+- [ ] Required scope evidence fields are explicit
+- [ ] Non-goals are explicit (no rewrite/filter/redaction behavior)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-PLAN-wave30-restrict-scope-enforcement.md
+++ b/docs/contributing/SPLIT-PLAN-wave30-restrict-scope-enforcement.md
@@ -1,0 +1,132 @@
+# SPLIT PLAN — Wave30 Restrict Scope Enforcement
+
+## Intent
+Freeze a bounded runtime enforcement contract for `restrict_scope`, using the contract/evidence shape introduced in Wave29.
+
+This wave is about:
+- when `restrict_scope` is evaluated as enforceable
+- how mismatch/missing/unsupported scope signals are handled
+- which decision outcome applies
+- which evidence fields are required for deny paths
+
+It explicitly does **not** add:
+- argument rewriting/filtering
+- `redact_args` execution
+- approval workflow changes
+- control-plane semantics
+- policy backend replacement
+- auth transport changes
+
+## Problem
+Wave29 introduced a typed `restrict_scope` contract and additive evidence, but deliberately kept runtime behavior non-blocking.
+
+Current gap:
+- `restrict_scope` is present but not enforced
+- mismatches do not deterministically deny yet
+- deny-path evidence for scope enforcement is not frozen as a contract
+
+## Frozen enforcement contract
+Wave30 freezes `restrict_scope` runtime evaluation to these checks:
+
+1. A `restrict_scope` obligation is present for the evaluated tool path.
+2. Scope contract fields are available:
+   - `scope_type`
+   - `scope_value`
+   - `scope_match_mode`
+3. Scope evaluation result is interpreted deterministically:
+   - `scope_evaluation_state=matched` => allow path may proceed
+   - `scope_evaluation_state=mismatch` => deny
+   - `scope_evaluation_state=not_evaluated` => deny
+
+## Frozen failure handling
+Wave30 freezes the following failure reasons as deny-path causes:
+
+- `scope_target_missing`
+- `scope_target_mismatch`
+- `scope_match_mode_unsupported`
+- `scope_type_unsupported`
+
+Default outcome in this wave is bounded to `deny` for invalid/mismatched scope.
+`deny_with_alert` is out of scope unless a later wave explicitly freezes it.
+
+## Frozen evidence contract
+Wave30 freezes additive evidence fields for `restrict_scope` enforcement outcomes.
+
+Minimum required evidence fields:
+- `scope_type`
+- `scope_value`
+- `scope_match_mode`
+- `scope_evaluation_state`
+- `scope_failure_reason`
+- `restrict_scope_present`
+- `restrict_scope_target`
+- `restrict_scope_match`
+- `restrict_scope_reason`
+
+For deny paths, `scope_failure_reason` must be present and deterministic.
+
+## Frozen semantics
+### Valid restrict scope
+A valid scope evaluation in Wave30 means:
+- obligation is present
+- scope target exists for the configured `scope_type`
+- match-mode is supported
+- evaluated result is `matched`
+
+### Invalid restrict scope
+Invalid means one of:
+- missing scope target
+- target mismatch
+- unsupported match mode
+- unsupported scope type
+
+### Out of scope
+This wave does not define:
+- argument rewriting/filtering for scope correction
+- grace/partial scope acceptance
+- broad/global scope grants
+- cross-session scope inheritance
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. `restrict_scope` is runtime-enforced.
+2. Mismatch/missing/unsupported scope conditions yield deterministic `deny`.
+3. Existing `log`, `alert`, and `approval_required` behavior remains stable.
+4. Scope evidence fields remain additive and backward-compatible.
+5. No argument rewriting/filtering/redaction is introduced.
+
+## Scope boundaries
+### In scope
+- runtime enforcement for `restrict_scope`
+- deterministic deny handling for frozen failure reasons
+- additive deny-path evidence for scope enforcement
+- tests and reviewer gates for the above
+
+### Out of scope
+- argument rewrite/filter pipelines
+- `redact_args` execution
+- approval workflow expansion
+- control-plane and external orchestration
+- policy backend replacement
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- runtime `restrict_scope` enforcement
+- deterministic deny on frozen failure reasons
+- additive evidence updates
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must stay narrow and deterministic.
+
+Primary failure modes:
+- sneaking in rewrite/redaction behavior
+- changing existing obligation behavior unintentionally
+- emitting non-additive event schema changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step1.md
@@ -1,0 +1,38 @@
+# SPLIT REVIEW PACK — Wave30 Restrict Scope Enforcement Step1
+
+## Intent
+Freeze the bounded runtime enforcement contract for `restrict_scope` before implementation.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add rewrite/filter/redaction runtime paths
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave30-restrict-scope-enforcement.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step1.md`
+- `scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. `restrict_scope` validity checks are explicit.
+3. Mismatch/missing/unsupported handling is explicit.
+4. Scope evidence requirements are explicit.
+5. Runtime paths are untouched.
+6. No rewrite/filter/redaction scope expansion appears.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- enforcement contract is frozen cleanly
+- Step2 can implement bounded enforcement without reopening semantics

--- a/scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh
+++ b/scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave30-restrict-scope-enforcement.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step1.md"
+  "scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave30 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave30 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave30 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN — Wave30 Restrict Scope Enforcement$' \
+  docs/contributing/SPLIT-PLAN-wave30-restrict-scope-enforcement.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'restrict_scope' \
+  'scope_type' \
+  'scope_value' \
+  'scope_match_mode' \
+  'scope_evaluation_state' \
+  'scope_failure_reason' \
+  'restrict_scope_present' \
+  'restrict_scope_target' \
+  'restrict_scope_match' \
+  'restrict_scope_reason' \
+  'scope_target_missing' \
+  'scope_target_mismatch' \
+  'scope_match_mode_unsupported' \
+  'scope_type_unsupported' \
+  'deny'
+do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave30-restrict-scope-enforcement.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_does_not_deny
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core execute_log_only_marks_restrict_scope_as_contract_only
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave30 Step1 split plan for bounded `restrict_scope` runtime enforcement
- add Step1 checklist and review pack
- add Step1 reviewer gate script

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh` (PASS)
- pre-commit and push hooks passed (`fmt`, `shellcheck`, `clippy`, linux compile gate)
