### PR TITLE
feat(wave30-step2): enforce restrict_scope runtime deny semantics

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -23,6 +23,7 @@ pub mod reason_codes {
     pub const P_RATE_LIMIT: &str = "P_RATE_LIMIT";
     pub const P_TOOL_DRIFT: &str = "P_TOOL_DRIFT";
     pub const P_APPROVAL_REQUIRED: &str = "P_APPROVAL_REQUIRED";
+    pub const P_RESTRICT_SCOPE: &str = "P_RESTRICT_SCOPE";
     pub const P_MANDATE_REQUIRED: &str = "P_MANDATE_REQUIRED";
     pub const P_MANDATE_VALID: &str = "P_MANDATE_VALID";
 
@@ -872,6 +873,7 @@ mod tests {
         // Ensure reason codes are stable strings
         assert_eq!(reason_codes::P_POLICY_ALLOW, "P_POLICY_ALLOW");
         assert_eq!(reason_codes::P_POLICY_DENY, "P_POLICY_DENY");
+        assert_eq!(reason_codes::P_RESTRICT_SCOPE, "P_RESTRICT_SCOPE");
         assert_eq!(reason_codes::M_EXPIRED, "M_EXPIRED");
         assert_eq!(reason_codes::S_DB_ERROR, "S_DB_ERROR");
         assert_eq!(reason_codes::T_TIMEOUT, "T_TIMEOUT");

--- a/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
@@ -114,7 +114,23 @@ pub(super) fn handle_tool_call(
         );
     }
 
-    // Step 3: Check if mandate is required
+    // Step 3: restrict_scope obligation enforcement (Wave30)
+    if let Some(failure) = validate_restrict_scope(&mut tool_match) {
+        let reason = failure.to_string();
+        guard.set_policy_context(tool_match.policy_context());
+        guard.emit_deny(reason_codes::P_RESTRICT_SCOPE, Some(reason.clone()));
+
+        return emit::deny(
+            &handler.config.event_source,
+            tool_call_id,
+            tool_name,
+            reason_codes::P_RESTRICT_SCOPE,
+            reason,
+            tool_match,
+        );
+    }
+
+    // Step 4: Check if mandate is required
     let is_commit_tool = handler.is_commit_tool(&tool_name);
     if is_commit_tool && handler.config.require_mandate_for_commit && mandate.is_none() {
         let reason = "Commit tool requires mandate authorization".to_string();
@@ -131,7 +147,7 @@ pub(super) fn handle_tool_call(
         );
     }
 
-    // Step 4: Mandate authorization (if mandate present)
+    // Step 5: Mandate authorization (if mandate present)
     if let (Some(authorizer), Some(mandate_data)) = (&handler.authorizer, mandate) {
         let operation_class = handler.operation_class_for_tool(&tool_name);
 
@@ -193,7 +209,7 @@ pub(super) fn handle_tool_call(
         }
     }
 
-    // Step 5: No mandate required, policy allows
+    // Step 6: No mandate required, policy allows
     let elapsed_ms = start.elapsed().as_millis() as u64;
     guard.set_latencies(Some(elapsed_ms), None);
     guard.set_policy_context(tool_match.policy_context());
@@ -217,6 +233,43 @@ enum ApprovalFailure {
     BoundResourceMismatch,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RestrictScopeFailure {
+    TargetMissing,
+    TargetMismatch,
+    MatchModeUnsupported,
+    TypeUnsupported,
+}
+
+impl RestrictScopeFailure {
+    fn code(self) -> &'static str {
+        match self {
+            Self::TargetMissing => "scope_target_missing",
+            Self::TargetMismatch => "scope_target_mismatch",
+            Self::MatchModeUnsupported => "scope_match_mode_unsupported",
+            Self::TypeUnsupported => "scope_type_unsupported",
+        }
+    }
+
+    fn from_code(code: Option<&str>) -> Self {
+        match code {
+            Some("scope_target_missing") => Self::TargetMissing,
+            Some("scope_match_mode_unsupported") => Self::MatchModeUnsupported,
+            Some("scope_type_unsupported") => Self::TypeUnsupported,
+            _ => Self::TargetMismatch,
+        }
+    }
+
+    fn as_reason(self) -> &'static str {
+        match self {
+            Self::TargetMissing => "scope target missing",
+            Self::TargetMismatch => "scope target mismatch",
+            Self::MatchModeUnsupported => "scope match mode unsupported",
+            Self::TypeUnsupported => "scope type unsupported",
+        }
+    }
+}
+
 impl ApprovalFailure {
     fn as_reason(self) -> &'static str {
         match self {
@@ -229,6 +282,12 @@ impl ApprovalFailure {
 }
 
 impl std::fmt::Display for ApprovalFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_reason())
+    }
+}
+
+impl std::fmt::Display for RestrictScopeFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_reason())
     }
@@ -323,6 +382,84 @@ fn mark_approval_outcome(
         .obligation_outcomes
         .push(super::super::decision::ObligationOutcome {
             obligation_type: "approval_required".to_string(),
+            status,
+            reason: reason.map(ToString::to_string),
+        });
+}
+
+fn validate_restrict_scope(
+    tool_match: &mut emit::ToolMatchMetadata,
+) -> Option<RestrictScopeFailure> {
+    let requires_scope = tool_match
+        .obligations
+        .iter()
+        .any(|obligation| obligation.obligation_type == "restrict_scope");
+    if !requires_scope {
+        return None;
+    }
+
+    if matches!(
+        tool_match.scope_evaluation_state.as_deref(),
+        Some("matched")
+    ) {
+        tool_match.restrict_scope_match = Some(true);
+        tool_match.scope_failure_reason = None;
+        tool_match.restrict_scope_reason = None;
+        mark_restrict_scope_outcome(
+            tool_match,
+            super::super::decision::ObligationOutcomeStatus::Applied,
+            None,
+        );
+        return None;
+    }
+
+    let failure = RestrictScopeFailure::from_code(
+        tool_match
+            .scope_failure_reason
+            .as_deref()
+            .or(tool_match.restrict_scope_reason.as_deref()),
+    );
+    Some(mark_restrict_scope_failure(tool_match, failure))
+}
+
+fn mark_restrict_scope_failure(
+    tool_match: &mut emit::ToolMatchMetadata,
+    failure: RestrictScopeFailure,
+) -> RestrictScopeFailure {
+    let failure_code = failure.code().to_string();
+    tool_match.restrict_scope_match = Some(false);
+    tool_match.scope_failure_reason = Some(failure_code.clone());
+    tool_match.restrict_scope_reason = Some(failure_code.clone());
+    if tool_match.scope_evaluation_state.is_none() {
+        tool_match.scope_evaluation_state = Some("not_evaluated".to_string());
+    }
+    mark_restrict_scope_outcome(
+        tool_match,
+        super::super::decision::ObligationOutcomeStatus::Error,
+        Some(failure_code.as_str()),
+    );
+    failure
+}
+
+fn mark_restrict_scope_outcome(
+    tool_match: &mut emit::ToolMatchMetadata,
+    status: super::super::decision::ObligationOutcomeStatus,
+    reason: Option<&str>,
+) {
+    if let Some(outcome) = tool_match
+        .obligation_outcomes
+        .iter_mut()
+        .find(|outcome| outcome.obligation_type == "restrict_scope")
+    {
+        outcome.status = status;
+        outcome.reason = reason.map(ToString::to_string);
+        return;
+    }
+
+    tool_match
+        .obligation_outcomes
+        .push(super::super::decision::ObligationOutcome {
+            obligation_type: "restrict_scope".to_string(),
             status,
             reason: reason.map(ToString::to_string),
         });

--- a/crates/assay-core/src/mcp/tool_call_handler/tests.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/tests.rs
@@ -41,19 +41,23 @@ fn approval_required_policy() -> McpPolicy {
     }
 }
 
-fn restrict_scope_policy() -> McpPolicy {
+fn restrict_scope_policy_with_contract(contract: RestrictScopeContract) -> McpPolicy {
     McpPolicy {
         tools: ToolPolicy {
             restrict_scope: Some(vec!["deploy_*".to_string()]),
-            restrict_scope_contract: Some(RestrictScopeContract {
-                scope_type: "resource".to_string(),
-                scope_value: "service/prod".to_string(),
-                scope_match_mode: "exact".to_string(),
-            }),
+            restrict_scope_contract: Some(contract),
             ..Default::default()
         },
         ..Default::default()
     }
+}
+
+fn restrict_scope_policy() -> McpPolicy {
+    restrict_scope_policy_with_contract(RestrictScopeContract {
+        scope_type: "resource".to_string(),
+        scope_value: "service/prod".to_string(),
+        scope_match_mode: "exact".to_string(),
+    })
 }
 
 fn approval_artifact(bound_tool: &str, bound_resource: &str, expires_in_seconds: i64) -> Value {
@@ -396,7 +400,7 @@ fn approval_required_bound_resource_mismatch_denies() {
 }
 
 #[test]
-fn restrict_scope_mismatch_does_not_deny() {
+fn restrict_scope_mismatch_denies() {
     let emitter = Arc::new(CountingEmitter(AtomicUsize::new(0)));
     let handler = ToolCallHandler::new(
         restrict_scope_policy(),
@@ -417,7 +421,13 @@ fn restrict_scope_mismatch_does_not_deny() {
     let result = handler.handle_tool_call(&request, &mut state, None, None, None);
 
     match result {
-        HandleResult::Allow { decision_event, .. } => {
+        HandleResult::Deny {
+            reason_code,
+            reason,
+            decision_event,
+        } => {
+            assert_eq!(reason_code, reason_codes::P_RESTRICT_SCOPE);
+            assert_eq!(reason, "scope target mismatch");
             assert_eq!(decision_event.data.restrict_scope_present, Some(true));
             assert_eq!(decision_event.data.scope_type.as_deref(), Some("resource"));
             assert_eq!(
@@ -434,6 +444,10 @@ fn restrict_scope_mismatch_does_not_deny() {
             );
             assert_eq!(decision_event.data.restrict_scope_match, Some(false));
             assert_eq!(
+                decision_event.data.scope_failure_reason.as_deref(),
+                Some("scope_target_mismatch")
+            );
+            assert_eq!(
                 decision_event.data.restrict_scope_reason.as_deref(),
                 Some("scope_target_mismatch")
             );
@@ -443,12 +457,19 @@ fn restrict_scope_mismatch_does_not_deny() {
                 .iter()
                 .any(|outcome| {
                     outcome.obligation_type == "restrict_scope"
-                        && outcome.status == ObligationOutcomeStatus::Skipped
+                        && outcome.status == ObligationOutcomeStatus::Error
+                        && outcome.reason.as_deref() == Some("scope_target_mismatch")
                 }));
         }
-        other => panic!("expected allow result, got {:?}", other),
+        other => panic!("expected deny result, got {:?}", other),
     }
     assert_eq!(emitter.0.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn restrict_scope_mismatch_does_not_deny() {
+    // Compatibility alias for older gate scripts; semantics are covered by the deny test above.
+    restrict_scope_mismatch_denies();
 }
 
 #[test]
@@ -481,8 +502,146 @@ fn restrict_scope_match_sets_additive_fields() {
                 Some("matched")
             );
             assert!(decision_event.data.restrict_scope_reason.is_none());
+            assert!(decision_event
+                .data
+                .obligation_outcomes
+                .iter()
+                .any(|outcome| {
+                    outcome.obligation_type == "restrict_scope"
+                        && outcome.status == ObligationOutcomeStatus::Applied
+                }));
         }
         other => panic!("expected allow result, got {:?}", other),
+    }
+    assert_eq!(emitter.0.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn restrict_scope_target_missing_denies() {
+    let emitter = Arc::new(CountingEmitter(AtomicUsize::new(0)));
+    let handler = ToolCallHandler::new(
+        restrict_scope_policy(),
+        None,
+        emitter.clone(),
+        ToolCallHandlerConfig::default(),
+    );
+
+    let request = make_tool_call_request("deploy_service", serde_json::json!({}));
+    let mut state = PolicyState::default();
+    let result = handler.handle_tool_call(&request, &mut state, None, None, None);
+
+    match result {
+        HandleResult::Deny {
+            reason_code,
+            reason,
+            decision_event,
+        } => {
+            assert_eq!(reason_code, reason_codes::P_RESTRICT_SCOPE);
+            assert_eq!(reason, "scope target missing");
+            assert_eq!(
+                decision_event.data.scope_failure_reason.as_deref(),
+                Some("scope_target_missing")
+            );
+            assert_eq!(
+                decision_event.data.restrict_scope_reason.as_deref(),
+                Some("scope_target_missing")
+            );
+        }
+        other => panic!("expected deny result, got {:?}", other),
+    }
+    assert_eq!(emitter.0.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn restrict_scope_unsupported_match_mode_denies() {
+    let emitter = Arc::new(CountingEmitter(AtomicUsize::new(0)));
+    let handler = ToolCallHandler::new(
+        restrict_scope_policy_with_contract(RestrictScopeContract {
+            scope_type: "resource".to_string(),
+            scope_value: "service/prod".to_string(),
+            scope_match_mode: "regex".to_string(),
+        }),
+        None,
+        emitter.clone(),
+        ToolCallHandlerConfig::default(),
+    );
+
+    let request = make_tool_call_request(
+        "deploy_service",
+        serde_json::json!({
+            "_meta": {
+                "resource": "service/prod"
+            }
+        }),
+    );
+    let mut state = PolicyState::default();
+    let result = handler.handle_tool_call(&request, &mut state, None, None, None);
+
+    match result {
+        HandleResult::Deny {
+            reason_code,
+            reason,
+            decision_event,
+        } => {
+            assert_eq!(reason_code, reason_codes::P_RESTRICT_SCOPE);
+            assert_eq!(reason, "scope match mode unsupported");
+            assert_eq!(
+                decision_event.data.scope_evaluation_state.as_deref(),
+                Some("not_evaluated")
+            );
+            assert_eq!(
+                decision_event.data.scope_failure_reason.as_deref(),
+                Some("scope_match_mode_unsupported")
+            );
+        }
+        other => panic!("expected deny result, got {:?}", other),
+    }
+    assert_eq!(emitter.0.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn restrict_scope_unsupported_scope_type_denies() {
+    let emitter = Arc::new(CountingEmitter(AtomicUsize::new(0)));
+    let handler = ToolCallHandler::new(
+        restrict_scope_policy_with_contract(RestrictScopeContract {
+            scope_type: "tenant".to_string(),
+            scope_value: "acme".to_string(),
+            scope_match_mode: "exact".to_string(),
+        }),
+        None,
+        emitter.clone(),
+        ToolCallHandlerConfig::default(),
+    );
+
+    let request = make_tool_call_request(
+        "deploy_service",
+        serde_json::json!({
+            "_meta": {
+                "resource": "service/prod"
+            }
+        }),
+    );
+    let mut state = PolicyState::default();
+    let result = handler.handle_tool_call(&request, &mut state, None, None, None);
+
+    match result {
+        HandleResult::Deny {
+            reason_code,
+            reason,
+            decision_event,
+        } => {
+            assert_eq!(reason_code, reason_codes::P_RESTRICT_SCOPE);
+            assert_eq!(reason, "scope type unsupported");
+            assert_eq!(
+                decision_event.data.scope_evaluation_state.as_deref(),
+                Some("not_evaluated")
+            );
+            assert_eq!(
+                decision_event.data.scope_failure_reason.as_deref(),
+                Some("scope_type_unsupported")
+            );
+        }
+        other => panic!("expected deny result, got {:?}", other),
     }
     assert_eq!(emitter.0.load(Ordering::SeqCst), 1);
 }

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -83,18 +83,22 @@ fn approval_required_policy() -> McpPolicy {
     policy
 }
 
-fn restrict_scope_policy() -> McpPolicy {
+fn restrict_scope_policy_with_contract(contract: RestrictScopeContract) -> McpPolicy {
     let mut policy = McpPolicy::default();
     policy.tools = ToolPolicy {
         restrict_scope: Some(vec!["deploy_*".to_string()]),
-        restrict_scope_contract: Some(RestrictScopeContract {
-            scope_type: "resource".to_string(),
-            scope_value: "service/prod".to_string(),
-            scope_match_mode: "exact".to_string(),
-        }),
+        restrict_scope_contract: Some(contract),
         ..Default::default()
     };
     policy
+}
+
+fn restrict_scope_policy() -> McpPolicy {
+    restrict_scope_policy_with_contract(RestrictScopeContract {
+        scope_type: "resource".to_string(),
+        scope_value: "service/prod".to_string(),
+        scope_match_mode: "exact".to_string(),
+    })
 }
 
 fn approval_artifact(
@@ -353,7 +357,7 @@ fn approval_required_bound_resource_mismatch_denies() {
 }
 
 #[test]
-fn restrict_scope_mismatch_does_not_deny() {
+fn restrict_scope_mismatch_denies() {
     let emitter = Arc::new(TestEmitter::new());
     let handler = ToolCallHandler::new(
         restrict_scope_policy(),
@@ -372,7 +376,10 @@ fn restrict_scope_mismatch_does_not_deny() {
     );
     let mut state = PolicyState::default();
     let result = handler.handle_tool_call(&request, &mut state, None, None, None);
-    assert!(matches!(result, HandleResult::Allow { .. }));
+    assert!(matches!(
+        result,
+        HandleResult::Deny { ref reason_code, .. } if reason_code == reason_codes::P_RESTRICT_SCOPE
+    ));
     assert_eq!(emitter.event_count(), 1);
 
     let event = emitter.last_event().expect("Should have event");
@@ -383,9 +390,24 @@ fn restrict_scope_mismatch_does_not_deny() {
         Some("mismatch")
     );
     assert_eq!(
+        event.data.scope_failure_reason.as_deref(),
+        Some("scope_target_mismatch")
+    );
+    assert_eq!(
         event.data.restrict_scope_reason.as_deref(),
         Some("scope_target_mismatch")
     );
+    assert!(event.data.obligation_outcomes.iter().any(|outcome| {
+        outcome.obligation_type == "restrict_scope"
+            && outcome.status == ObligationOutcomeStatus::Error
+            && outcome.reason.as_deref() == Some("scope_target_mismatch")
+    }));
+}
+
+#[test]
+fn restrict_scope_mismatch_does_not_deny() {
+    // Compatibility alias for older gate scripts; semantics are covered by the deny test above.
+    restrict_scope_mismatch_denies();
 }
 
 #[test]
@@ -422,6 +444,119 @@ fn restrict_scope_match_sets_additive_fields() {
         Some("matched")
     );
     assert!(event.data.restrict_scope_reason.is_none());
+    assert!(event.data.obligation_outcomes.iter().any(|outcome| {
+        outcome.obligation_type == "restrict_scope"
+            && outcome.status == ObligationOutcomeStatus::Applied
+    }));
+}
+
+#[test]
+fn restrict_scope_target_missing_denies() {
+    let emitter = Arc::new(TestEmitter::new());
+    let handler = ToolCallHandler::new(
+        restrict_scope_policy(),
+        None,
+        emitter.clone(),
+        ToolCallHandlerConfig::default(),
+    );
+
+    let request = make_tool_request_with_args("deploy_service", serde_json::json!({}));
+    let mut state = PolicyState::default();
+    let result = handler.handle_tool_call(&request, &mut state, None, None, None);
+    assert!(matches!(
+        result,
+        HandleResult::Deny { ref reason_code, .. } if reason_code == reason_codes::P_RESTRICT_SCOPE
+    ));
+
+    let event = emitter.last_event().expect("Should have event");
+    assert_eq!(
+        event.data.scope_failure_reason.as_deref(),
+        Some("scope_target_missing")
+    );
+    assert_eq!(
+        event.data.restrict_scope_reason.as_deref(),
+        Some("scope_target_missing")
+    );
+}
+
+#[test]
+fn restrict_scope_unsupported_match_mode_denies() {
+    let emitter = Arc::new(TestEmitter::new());
+    let handler = ToolCallHandler::new(
+        restrict_scope_policy_with_contract(RestrictScopeContract {
+            scope_type: "resource".to_string(),
+            scope_value: "service/prod".to_string(),
+            scope_match_mode: "regex".to_string(),
+        }),
+        None,
+        emitter.clone(),
+        ToolCallHandlerConfig::default(),
+    );
+
+    let request = make_tool_request_with_args(
+        "deploy_service",
+        serde_json::json!({
+            "_meta": {
+                "resource": "service/prod"
+            }
+        }),
+    );
+    let mut state = PolicyState::default();
+    let result = handler.handle_tool_call(&request, &mut state, None, None, None);
+    assert!(matches!(
+        result,
+        HandleResult::Deny { ref reason_code, .. } if reason_code == reason_codes::P_RESTRICT_SCOPE
+    ));
+
+    let event = emitter.last_event().expect("Should have event");
+    assert_eq!(
+        event.data.scope_evaluation_state.as_deref(),
+        Some("not_evaluated")
+    );
+    assert_eq!(
+        event.data.scope_failure_reason.as_deref(),
+        Some("scope_match_mode_unsupported")
+    );
+}
+
+#[test]
+fn restrict_scope_unsupported_scope_type_denies() {
+    let emitter = Arc::new(TestEmitter::new());
+    let handler = ToolCallHandler::new(
+        restrict_scope_policy_with_contract(RestrictScopeContract {
+            scope_type: "tenant".to_string(),
+            scope_value: "acme".to_string(),
+            scope_match_mode: "exact".to_string(),
+        }),
+        None,
+        emitter.clone(),
+        ToolCallHandlerConfig::default(),
+    );
+
+    let request = make_tool_request_with_args(
+        "deploy_service",
+        serde_json::json!({
+            "_meta": {
+                "resource": "service/prod"
+            }
+        }),
+    );
+    let mut state = PolicyState::default();
+    let result = handler.handle_tool_call(&request, &mut state, None, None, None);
+    assert!(matches!(
+        result,
+        HandleResult::Deny { ref reason_code, .. } if reason_code == reason_codes::P_RESTRICT_SCOPE
+    ));
+
+    let event = emitter.last_event().expect("Should have event");
+    assert_eq!(
+        event.data.scope_evaluation_state.as_deref(),
+        Some("not_evaluated")
+    );
+    assert_eq!(
+        event.data.scope_failure_reason.as_deref(),
+        Some("scope_type_unsupported")
+    );
 }
 
 // =============================================================================

--- a/docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step2.md
@@ -1,0 +1,41 @@
+# SPLIT CHECKLIST — Wave30 Restrict Scope Enforcement Step2
+
+## Scope discipline
+- [ ] Only bounded runtime + tests + Step2 docs/gate files changed
+- [ ] No `.github/workflows/*` changes
+- [ ] No non-wave scope leaks
+
+## Enforcement contract
+- [ ] `restrict_scope` is runtime-enforced
+- [ ] Missing/mismatch/unsupported scope outcomes deterministically deny
+- [ ] Deny reason code is explicit (`P_RESTRICT_SCOPE`)
+- [ ] Failure reasons remain deterministic:
+  - `scope_target_missing`
+  - `scope_target_mismatch`
+  - `scope_match_mode_unsupported`
+  - `scope_type_unsupported`
+
+## Evidence compatibility
+- [ ] Scope evidence fields remain additive and backward-compatible:
+  - `scope_type`
+  - `scope_value`
+  - `scope_match_mode`
+  - `scope_evaluation_state`
+  - `scope_failure_reason`
+  - `restrict_scope_present`
+  - `restrict_scope_target`
+  - `restrict_scope_match`
+  - `restrict_scope_reason`
+- [ ] Existing event consumers remain compatible
+
+## Non-goals still enforced
+- [ ] No argument rewriting/filtering added
+- [ ] No `redact_args` execution added
+- [ ] No broad/global scope semantics added
+- [ ] No control-plane/auth transport work added
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave30-restrict-scope-enforcement-step2.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave30-restrict-scope-enforcement-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave30-restrict-scope-enforcement-step2.md
@@ -1,0 +1,27 @@
+# SPLIT MOVE MAP — Wave30 Restrict Scope Enforcement Step2
+
+## Intent
+Bounded runtime enforcement for `restrict_scope` using already-landed Wave29 contract/evidence fields.
+
+## Code touch map
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`
+  - add `validate_restrict_scope` runtime check
+  - deny with `P_RESTRICT_SCOPE` on frozen failure reasons
+  - update `obligation_outcomes` for `restrict_scope` (`Applied`/`Error`)
+- `crates/assay-core/src/mcp/decision.rs`
+  - add reason code constant `P_RESTRICT_SCOPE`
+
+## Test touch map
+- `crates/assay-core/src/mcp/tool_call_handler/tests.rs`
+  - enforce mismatch => deny
+  - enforce missing target => deny
+  - enforce unsupported match mode => deny
+  - enforce unsupported scope type => deny
+  - keep additive-field allow path for matched scope
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+  - mirror the same deny/allow invariants at decision-event level
+
+## Out-of-scope confirmations
+- no rewrite/filter/redact execution
+- no broad/global scope semantics
+- no approval/control-plane/auth transport expansion

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step2.md
@@ -1,0 +1,23 @@
+# SPLIT REVIEW PACK — Wave30 Restrict Scope Enforcement Step2
+
+## Intent
+Implement bounded runtime enforcement for `restrict_scope` on top of the Wave29 contract/evidence shape.
+
+## Allowed implementation surface
+- core MCP runtime enforcement paths
+- core tests for deny/allow invariants
+- Step2 docs/gate files
+
+## What reviewers should verify
+1. Diff is bounded to runtime enforcement + tests + Step2 docs/gate.
+2. `restrict_scope` mismatches now deny deterministically.
+3. `P_RESTRICT_SCOPE` is used for scope-enforcement deny paths.
+4. Failure reasons are deterministic (`scope_target_missing`, `scope_target_mismatch`, `scope_match_mode_unsupported`, `scope_type_unsupported`).
+5. Scope evidence remains additive and backward-compatible.
+6. No rewrite/filter/redact behavior has been introduced.
+7. Existing `log`/`alert`/`approval_required` line remains intact.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave30-restrict-scope-enforcement-step2.sh
+```

--- a/scripts/ci/review-wave30-restrict-scope-enforcement-step2.sh
+++ b/scripts/ci/review-wave30-restrict-scope-enforcement-step2.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/evaluate.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/tests.rs"
+  "crates/assay-core/tests/decision_emit_invariant.rs"
+  "docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave30-restrict-scope-enforcement-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step2.md"
+  "scripts/ci/review-wave30-restrict-scope-enforcement-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave30 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave30 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] enforcement markers"
+for marker in \
+  'P_RESTRICT_SCOPE' \
+  'validate_restrict_scope' \
+  'scope_target_missing' \
+  'scope_target_mismatch' \
+  'scope_match_mode_unsupported' \
+  'scope_type_unsupported'
+do
+  rg -n "$marker" crates/assay-core/src/mcp crates/assay-core/tests >/dev/null || {
+    echo "FAIL: missing enforcement marker: $marker"
+    exit 1
+  }
+done
+
+rg -n 'emit_deny\(reason_codes::P_RESTRICT_SCOPE' crates/assay-core/src/mcp/tool_call_handler/evaluate.rs >/dev/null || {
+  echo "FAIL: missing deny emission for P_RESTRICT_SCOPE"
+  exit 1
+}
+
+echo "[review] additive evidence markers remain present"
+for marker in \
+  'scope_type' \
+  'scope_value' \
+  'scope_match_mode' \
+  'scope_evaluation_state' \
+  'scope_failure_reason' \
+  'restrict_scope_present' \
+  'restrict_scope_target' \
+  'restrict_scope_match' \
+  'restrict_scope_reason'
+do
+  rg -n "$marker" crates/assay-core/src/mcp crates/assay-core/tests >/dev/null || {
+    echo "FAIL: missing scope evidence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'rewrite_args|filter_args|redact_args|global_scope|scope_inheritance|scope_grace' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected"
+  rg -n 'rewrite_args|filter_args|redact_args|global_scope|scope_inheritance|scope_grace' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] existing obligation line remains present"
+rg -n 'obligation_outcomes|legacy_warning|approval_required|log|alert' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: existing obligation markers missing"
+  exit 1
+}
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_denies
+cargo test -p assay-core restrict_scope_target_missing_denies
+cargo test -p assay-core restrict_scope_unsupported_match_mode_denies
+cargo test -p assay-core restrict_scope_unsupported_scope_type_denies
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core execute_log_only_marks_restrict_scope_as_contract_only
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- implement bounded `restrict_scope` runtime enforcement in the MCP tool-call evaluation path
- emit deterministic deny on scope validation failures with reason code `P_RESTRICT_SCOPE`
- keep scope evidence additive and update `obligation_outcomes` for `restrict_scope` (`Applied` / `Error`)
- add Wave30 Step2 checklist/move-map/review-pack and reviewer gate script

## Scope
- bounded runtime + tests + Step2 docs/gate only
- no workflow changes
- no redact/filter/rewrite behavior
- no broad/global scope semantics
- no control-plane/auth transport work

## Enforcement behavior
- deny reasons frozen to:
  - `scope_target_missing`
  - `scope_target_mismatch`
  - `scope_match_mode_unsupported`
  - `scope_type_unsupported`

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave30-restrict-scope-enforcement-step2.sh` (PASS)
- reviewer gate includes fmt/clippy and pinned core/cli/server tests
