### PR TITLE
docs(wave30-step3): close restrict_scope enforcement wave

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step3.md
@@ -1,0 +1,58 @@
+# SPLIT CHECKLIST — Wave30 Restrict Scope Enforcement Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step3.md`
+  - `scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave30 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves the bounded `restrict_scope` enforcement contract
+
+## Restrict scope enforcement invariants
+- [ ] Enforced deny reason remains present: `P_RESTRICT_SCOPE`
+- [ ] Validation entrypoint remains present: `validate_restrict_scope`
+- [ ] Failure reasons remain deterministic:
+  - `scope_target_missing`
+  - `scope_target_mismatch`
+  - `scope_match_mode_unsupported`
+  - `scope_type_unsupported`
+- [ ] Scope evidence markers remain present:
+  - `scope_type`
+  - `scope_value`
+  - `scope_match_mode`
+  - `scope_evaluation_state`
+  - `scope_failure_reason`
+  - `restrict_scope_present`
+  - `restrict_scope_target`
+  - `restrict_scope_match`
+  - `restrict_scope_reason`
+
+## Non-goals still enforced
+- [ ] No rewrite/filter behavior added
+- [ ] No `redact_args` execution added
+- [ ] No broad/global scope semantics added
+- [ ] No control-plane/auth transport changes added
+
+## Existing obligation line still intact
+- [ ] `log` execution remains present
+- [ ] `alert` execution remains present
+- [ ] `approval_required` enforcement remains present
+- [ ] `legacy_warning -> log` compatibility remains present
+- [ ] `obligation_outcomes` remains additive
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step3.md
@@ -1,0 +1,46 @@
+# SPLIT REVIEW PACK — Wave30 Restrict Scope Enforcement Step3
+
+## Intent
+Close Wave30 with a docs+gate-only closure slice after bounded `restrict_scope` runtime enforcement landed in Step2.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add rewrite/filter/redact behavior
+- add broad/global scope semantics
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step3.md`
+- `scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. `restrict_scope` runtime enforcement markers remain present.
+4. Deterministic deny behavior for scope validation failures remains present.
+5. Scope evidence remains additive and backward-compatible.
+6. Existing `log`/`alert`/`approval_required` line remains intact.
+7. No scope creep appears in runtime scope.
+8. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave30-restrict-scope-step2-impl \
+  bash scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh
+```
+
+## Expected outcome
+- Step3 adds no runtime behavior.
+- Closure remains diff-proof.
+- Promote can happen cleanly after stacked validation.

--- a/scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh
+++ b/scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave30-restrict-scope-enforcement-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave30-restrict-scope-enforcement-step3.md"
+  "scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave30 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave30 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] enforcement markers"
+for marker in \
+  'P_RESTRICT_SCOPE' \
+  'validate_restrict_scope' \
+  'scope_target_missing' \
+  'scope_target_mismatch' \
+  'scope_match_mode_unsupported' \
+  'scope_type_unsupported'
+do
+  rg -n "$marker" crates/assay-core/src/mcp crates/assay-core/tests >/dev/null || {
+    echo "FAIL: missing enforcement marker: $marker"
+    exit 1
+  }
+done
+
+rg -n 'emit_deny\(reason_codes::P_RESTRICT_SCOPE' crates/assay-core/src/mcp/tool_call_handler/evaluate.rs >/dev/null || {
+  echo "FAIL: missing deny emission for P_RESTRICT_SCOPE"
+  exit 1
+}
+
+echo "[review] additive evidence markers remain present"
+for marker in \
+  'scope_type' \
+  'scope_value' \
+  'scope_match_mode' \
+  'scope_evaluation_state' \
+  'scope_failure_reason' \
+  'restrict_scope_present' \
+  'restrict_scope_target' \
+  'restrict_scope_match' \
+  'restrict_scope_reason'
+do
+  rg -n "$marker" crates/assay-core/src/mcp crates/assay-core/tests >/dev/null || {
+    echo "FAIL: missing scope evidence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'rewrite_args|filter_args|redact_args|global_scope|scope_inheritance|scope_grace' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected"
+  rg -n 'rewrite_args|filter_args|redact_args|global_scope|scope_inheritance|scope_grace' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] existing obligation line remains present"
+rg -n 'obligation_outcomes|legacy_warning|approval_required|log|alert' crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: existing obligation markers missing"
+  exit 1
+}
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_denies
+cargo test -p assay-core restrict_scope_target_missing_denies
+cargo test -p assay-core restrict_scope_unsupported_match_mode_denies
+cargo test -p assay-core restrict_scope_unsupported_scope_type_denies
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core execute_log_only_marks_restrict_scope_as_contract_only
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave30 Step3 docs+gate-only closure slice
- add closure checklist and review pack for restrict_scope enforcement
- add Step3 reviewer gate script that reruns Wave30 Step2 invariants

## Scope
- exactly 3 files (docs + reviewer script)
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh` (PASS)
- Step3 gate reruns fmt/clippy and pinned core/cli/server tests
