### PR TITLE
docs(wave31-step1): freeze redact_args contract and evidence

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step1.md
@@ -1,0 +1,25 @@
+# SPLIT CHECKLIST — Wave31 Redact Args Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave31-redact-args.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step1.md`
+  - `scripts/ci/review-wave31-redact-args-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] Typed `redact_args` shape is explicit
+- [ ] Redactable argument zones are explicit
+- [ ] Additive redaction evidence fields are explicit
+- [ ] Contract-only semantics are explicit
+- [ ] Non-goals are explicit (no runtime redaction execution)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave31-redact-args-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-PLAN-wave31-redact-args.md
+++ b/docs/contributing/SPLIT-PLAN-wave31-redact-args.md
@@ -1,0 +1,118 @@
+# SPLIT PLAN — Wave31 Redact Args Contract and Evidence Freeze
+
+## Intent
+Freeze a bounded `redact_args` contract and additive evidence shape before any runtime argument redaction is introduced.
+
+This wave is about:
+- typed `redact_args` obligation shape
+- redactable argument zones
+- additive evidence fields for redaction evaluation
+- compatibility and reviewer gates
+
+It explicitly does **not** add:
+- runtime arg redaction execution
+- mutation of tool payloads in execution paths
+- broad/global scrub policies
+- PII detection engines
+- external DLP integrations
+- UI/control-plane/auth transport changes
+
+## Problem
+Wave24–Wave30 established typed decisions, obligations, and enforcement for `log`, `alert`, `approval_required`, and `restrict_scope`.
+
+Current gap:
+- `redact_args` has no frozen typed contract
+- redactable zones are not frozen
+- additive evidence fields are not frozen
+- execution semantics could drift without a contract-first step
+
+## Frozen redact_args contract
+Wave31 freezes the target typed obligation shape with, at minimum:
+
+- `redaction_target`
+- `redaction_mode`
+- `redaction_scope`
+- `redaction_applied_state`
+- `redaction_reason`
+
+## Frozen redactable zones
+Wave31 freezes redactable argument zones as contract inputs only.
+
+Target zones in this wave:
+- request-like args fields (e.g. `path`, `query`, `headers`, `body`, `metadata`)
+- scalar and structured argument fields explicitly addressed by `redaction_target`
+
+Out of scope in this wave:
+- runtime payload mutation
+- implicit broad/global zone expansion
+- automatic detection-driven targeting
+
+## Frozen evidence contract
+Wave31 freezes additive evidence fields for `redact_args` evaluation.
+
+Minimum additive evidence fields:
+- `redact_args_present`
+- `redact_args_target`
+- `redact_args_mode`
+- `redact_args_result`
+- `redact_args_reason`
+
+Evidence must stay additive and backward-compatible.
+
+## Frozen semantics
+### Contract-only in Step1/Step2 of this wave
+- `redact_args` may be represented and evaluated for evidence
+- no runtime argument mutation may occur
+- no execution-time rewriting/scrubbing may occur
+
+### Out of scope
+This wave does not define:
+- runtime redaction side-effects
+- broad/global organization-wide scrub policies
+- PII classification logic
+- external DLP workflow coupling
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. Typed `redact_args` obligation shape exists in code.
+2. Redactable zones are explicitly represented as contract data.
+3. Additive redaction evidence fields are emitted/available.
+4. Existing runtime enforcement behavior remains stable.
+5. No runtime payload mutation/redaction execution is introduced.
+
+## Scope boundaries
+### In scope
+- typed `redact_args` shape
+- redactable-zone contract surface
+- additive evidence shape
+- tests and reviewer gates for the above
+
+### Out of scope
+- runtime redaction execution
+- payload rewriting/mutation
+- broad/global scrub policies
+- PII detection engines
+- external DLP integrations
+- UI/control-plane work
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- typed `redact_args` contract representation
+- additive evidence field support
+- no execution semantics
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must remain contract-first and additive.
+
+Primary failure modes:
+- sneaking in runtime redaction behavior
+- widening to global scrub policy semantics
+- breaking existing event consumers with non-additive schema changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step1.md
@@ -1,0 +1,38 @@
+# SPLIT REVIEW PACK — Wave31 Redact Args Step1
+
+## Intent
+Freeze the `redact_args` contract/evidence shape before any runtime redaction execution.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add runtime payload mutation/redaction
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave31-redact-args.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step1.md`
+- `scripts/ci/review-wave31-redact-args-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Typed `redact_args` shape is explicit.
+3. Redactable zones are explicit.
+4. Additive redaction evidence fields are explicit.
+5. Runtime paths are untouched.
+6. No runtime redaction execution is introduced.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave31-redact-args-step1.sh
+```
+
+## Expected outcome
+- gate passes
+- runtime code is untouched
+- redact_args contract/evidence is frozen cleanly
+- Step2 can implement shape/evidence without reopening semantics

--- a/scripts/ci/review-wave31-redact-args-step1.sh
+++ b/scripts/ci/review-wave31-redact-args-step1.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave31-redact-args.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step1.md"
+  "scripts/ci/review-wave31-redact-args-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave31 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave31 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave31 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN — Wave31 Redact Args Contract and Evidence Freeze$' \
+  docs/contributing/SPLIT-PLAN-wave31-redact-args.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'redact_args' \
+  'redaction_target' \
+  'redaction_mode' \
+  'redaction_scope' \
+  'redaction_applied_state' \
+  'redaction_reason' \
+  'redact_args_present' \
+  'redact_args_target' \
+  'redact_args_mode' \
+  'redact_args_result' \
+  'redact_args_reason'
+do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave31-redact-args.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_denies
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core execute_log_only_marks_restrict_scope_as_contract_only
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave31 Step1 freeze plan for `redact_args` contract/evidence shape
- add Step1 checklist and review pack
- add Step1 reviewer gate script with strict allowlist + frozen runtime paths

## Scope
- docs+gate only (exactly 4 files)
- no runtime code changes
- no workflow changes

## Freeze points
- typed redact_args shape
  - `redaction_target`
  - `redaction_mode`
  - `redaction_scope`
  - `redaction_applied_state`
  - `redaction_reason`
- additive evidence fields
  - `redact_args_present`
  - `redact_args_target`
  - `redact_args_mode`
  - `redact_args_result`
  - `redact_args_reason`

## Non-goals
- no runtime redaction execution
- no payload mutation in execution paths
- no broad/global scrub policy semantics
- no PII engine / external DLP integration

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave31-redact-args-step1.sh` (PASS)
