### PR TITLE
docs(wave31-step3): close redact_args contract and evidence wave

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step3.md
@@ -1,0 +1,54 @@
+# SPLIT CHECKLIST — Wave31 Redact Args Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step3.md`
+  - `scripts/ci/review-wave31-redact-args-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave31 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves bounded `redact_args` contract/evidence behavior
+
+## Redact args invariants
+- [ ] Redact shape markers remain present:
+  - `redaction_target`
+  - `redaction_mode`
+  - `redaction_scope`
+  - `redaction_applied_state`
+  - `redaction_reason`
+- [ ] Additive redact evidence markers remain present:
+  - `redact_args_present`
+  - `redact_args_target`
+  - `redact_args_mode`
+  - `redact_args_result`
+  - `redact_args_reason`
+- [ ] `redact_args` remains contract-only in this wave (no enforcement)
+
+## Non-goals still enforced
+- [ ] No runtime arg rewrite/mutation
+- [ ] No `redact_args` deny semantics
+- [ ] No broad/global scrub semantics
+- [ ] No PII engine or external DLP integration
+- [ ] No control-plane/auth transport changes
+
+## Existing obligation line still intact
+- [ ] `log` execution remains present
+- [ ] `alert` execution remains present
+- [ ] `approval_required` enforcement remains present
+- [ ] `restrict_scope` enforcement remains present
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step3.md
@@ -1,0 +1,39 @@
+# SPLIT REVIEW PACK — Wave31 Redact Args Step3
+
+## Intent
+Close Wave31 with a docs+gate-only closure slice after the bounded Step2 contract/evidence implementation for `redact_args`.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- introduce `redact_args` runtime mutation/enforcement
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step3.md`
+- `scripts/ci/review-wave31-redact-args-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Redaction shape and additive evidence markers remain present.
+4. `redact_args` remains contract-only (no deny/rewrite path).
+5. Existing `log`/`alert`/`approval_required`/`restrict_scope` line remains intact.
+6. No scope creep appears in runtime scope.
+7. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave31-redact-args-step2-impl \
+  bash scripts/ci/review-wave31-redact-args-step3.sh
+```
+
+### Against `origin/main` after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave31-redact-args-step3.sh
+```

--- a/scripts/ci/review-wave31-redact-args-step3.sh
+++ b/scripts/ci/review-wave31-redact-args-step3.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step3.md"
+  "scripts/ci/review-wave31-redact-args-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave31 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave31 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+for marker in \
+  'redact_args' \
+  'redaction_target' \
+  'redaction_mode' \
+  'redaction_scope' \
+  'redaction_applied_state' \
+  'redaction_reason' \
+  'redact_args_present' \
+  'redact_args_target' \
+  'redact_args_mode' \
+  'redact_args_result' \
+  'redact_args_reason'
+do
+  rg -n "$marker" crates/assay-core/src/mcp crates/assay-core/tests >/dev/null || {
+    echo "FAIL: missing redact marker in runtime/tests: $marker"
+    exit 1
+  }
+done
+
+echo "[review] redact_args stays contract-only"
+if rg -n \
+  'P_REDACT_ARGS|validate_redact_args|enforce_redact_args|redact_args.*emit_deny|emit_deny.*redact_args|rewrite_args|mutate_args|scrub_args|filter_args' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server >/dev/null; then
+  echo "FAIL: redact_args execution/enforcement markers detected"
+  rg -n \
+    'P_REDACT_ARGS|validate_redact_args|enforce_redact_args|redact_args.*emit_deny|emit_deny.*redact_args|rewrite_args|mutate_args|scrub_args|filter_args' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server
+  exit 1
+fi
+
+echo "[review] existing obligation line remains present"
+for marker in \
+  'obligation_outcomes' \
+  'legacy_warning' \
+  'log' \
+  'alert' \
+  'approval_required' \
+  'restrict_scope'
+do
+  rg -n "$marker" crates/assay-core/src/mcp >/dev/null || {
+    echo "FAIL: missing existing obligation marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_denies
+cargo test -p assay-core restrict_scope_target_missing_denies
+cargo test -p assay-core restrict_scope_unsupported_match_mode_denies
+cargo test -p assay-core restrict_scope_unsupported_scope_type_denies
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core execute_log_only_marks_restrict_scope_as_contract_only -- --exact
+cargo test -p assay-core execute_log_only_marks_redact_args_as_contract_only -- --exact
+cargo test -p assay-core redact_args_contract_sets_additive_fields
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave31 Step3 docs+gate-only closure slice
- rerun Step2 invariants for redact_args contract/evidence
- keep closure diff strictly limited to 3 files

## Scope
- `docs/contributing/SPLIT-CHECKLIST-wave31-redact-args-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave31-redact-args-step3.md`
- `scripts/ci/review-wave31-redact-args-step3.sh`

## Validation
- `BASE_REF=origin/codex/wave31-redact-args-step2-impl bash scripts/ci/review-wave31-redact-args-step3.sh` (PASS)
