### PR TITLE
docs(wave32-step1): freeze redact_args enforcement contract

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave32-redact-args-enforcement-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave32-redact-args-enforcement-step1.md
@@ -1,0 +1,24 @@
+# SPLIT CHECKLIST - Wave32 Redact Args Enforcement Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave32-redact-args-enforcement.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave32-redact-args-enforcement-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave32-redact-args-enforcement-step1.md`
+  - `scripts/ci/review-wave32-redact-args-enforcement-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] `redact_args` enforcement validity checks are explicit
+- [ ] Missing/unsupported/not-applied deny behavior is explicit
+- [ ] Required redaction evidence fields are explicit
+- [ ] Non-goals are explicit (no broad/global redaction behavior)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave32-redact-args-enforcement-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-PLAN-wave32-redact-args-enforcement.md
+++ b/docs/contributing/SPLIT-PLAN-wave32-redact-args-enforcement.md
@@ -1,0 +1,134 @@
+# SPLIT PLAN - Wave32 Redact Args Enforcement
+
+## Intent
+Freeze a bounded runtime enforcement contract for `redact_args`, using the typed contract and additive evidence shape introduced in Wave31.
+
+This wave is about:
+- when `redact_args` is enforceable at runtime
+- how missing/unsupported redaction inputs are handled
+- which decision outcome applies on invalid redaction requirements
+- which evidence fields are required on deny paths
+
+It explicitly does **not** add:
+- broad/global scrub policy semantics
+- PII detection engines
+- external DLP integrations
+- approval workflow changes
+- `restrict_scope` behavior changes
+- control-plane/auth transport changes
+
+## Problem
+Wave31 introduced `redact_args` as a typed, additive contract and kept it intentionally contract-only.
+
+Current gap:
+- `redact_args` is represented but not runtime-enforced
+- invalid redaction requirements do not deterministically deny yet
+- deny-path evidence for redaction enforcement is not frozen
+
+## Frozen enforcement contract
+Wave32 freezes `redact_args` runtime evaluation to these checks:
+
+1. A `redact_args` obligation is present for the evaluated tool path.
+2. Redaction contract fields are available:
+   - `redaction_target`
+   - `redaction_mode`
+   - `redaction_scope`
+3. Redaction evaluation state is interpreted deterministically:
+   - `redaction_applied_state=applied` -> allow path may proceed
+   - `redaction_applied_state=not_applied` -> deny
+   - `redaction_applied_state=not_evaluated` -> deny
+
+## Frozen failure handling
+Wave32 freezes the following failure reasons as deny-path causes:
+
+- `redaction_target_missing`
+- `redaction_mode_unsupported`
+- `redaction_scope_unsupported`
+- `redaction_apply_failed`
+
+Default outcome in this wave is bounded to `deny` for invalid/missing redaction requirements.
+`deny_with_alert` is out of scope unless a later wave freezes it explicitly.
+
+## Frozen evidence contract
+Wave32 freezes additive evidence fields for `redact_args` enforcement outcomes.
+
+Minimum required evidence fields:
+- `redaction_target`
+- `redaction_mode`
+- `redaction_scope`
+- `redaction_applied_state`
+- `redaction_reason`
+- `redaction_failure_reason`
+- `redact_args_present`
+- `redact_args_target`
+- `redact_args_mode`
+- `redact_args_result`
+- `redact_args_reason`
+
+For deny paths, `redaction_failure_reason` must be present and deterministic.
+
+## Frozen semantics
+### Valid redact_args
+A valid redaction evaluation in Wave32 means:
+- obligation is present
+- target/mode/scope are supported
+- evaluation result is `redaction_applied_state=applied`
+
+### Invalid redact_args
+Invalid means one of:
+- missing redaction target
+- unsupported redaction mode
+- unsupported redaction scope
+- redaction apply failure
+- not applied/not evaluated for required redaction
+
+### Out of scope
+This wave does not define:
+- broad/global org-wide redaction policies
+- PII/classifier-driven implicit redaction
+- external DLP orchestration
+- cross-session redaction inheritance
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. `redact_args` is runtime-enforced.
+2. Missing/unsupported/not-applied redaction requirements yield deterministic `deny`.
+3. Existing `log`, `alert`, `approval_required`, and `restrict_scope` behavior remains stable.
+4. Redaction evidence fields remain additive and backward-compatible.
+5. No broad/global redaction policy behavior is introduced.
+
+## Scope boundaries
+### In scope
+- runtime enforcement for `redact_args`
+- deterministic deny handling for frozen redaction failure reasons
+- additive deny-path evidence for redaction enforcement
+- tests and reviewer gates for the above
+
+### Out of scope
+- broad/global scrub policies
+- PII detection engines
+- external DLP integrations
+- approval/restrict_scope semantics expansion
+- policy backend replacement
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- runtime `redact_args` enforcement
+- deterministic deny on frozen redaction failure reasons
+- additive evidence updates
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must stay narrow and deterministic.
+
+Primary failure modes:
+- sneaking in broad/global redaction behavior
+- changing existing obligation behavior unintentionally
+- emitting non-additive event schema changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave32-redact-args-enforcement-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave32-redact-args-enforcement-step1.md
@@ -1,0 +1,38 @@
+# SPLIT REVIEW PACK - Wave32 Redact Args Enforcement Step1
+
+## Intent
+Freeze the bounded runtime enforcement contract for `redact_args` before implementation.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add broad/global redaction semantics
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave32-redact-args-enforcement.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave32-redact-args-enforcement-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave32-redact-args-enforcement-step1.md`
+- `scripts/ci/review-wave32-redact-args-enforcement-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Redaction validity checks are explicit.
+3. Missing/unsupported/not-applied deny behavior is explicit.
+4. Additive redaction evidence fields are explicit.
+5. Runtime paths are untouched.
+6. No scope expansion beyond bounded enforcement contract.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave32-redact-args-enforcement-step1.sh
+```
+
+## Expected outcome
+- gate passes
+- runtime code is untouched
+- redaction enforcement contract is frozen cleanly
+- Step2 can implement bounded enforcement without reopening semantics

--- a/scripts/ci/review-wave32-redact-args-enforcement-step1.sh
+++ b/scripts/ci/review-wave32-redact-args-enforcement-step1.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave32-redact-args-enforcement.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave32-redact-args-enforcement-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave32-redact-args-enforcement-step1.md"
+  "scripts/ci/review-wave32-redact-args-enforcement-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave32 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave32 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave32 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN - Wave32 Redact Args Enforcement$' \
+  docs/contributing/SPLIT-PLAN-wave32-redact-args-enforcement.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'redact_args' \
+  'redaction_target' \
+  'redaction_mode' \
+  'redaction_scope' \
+  'redaction_applied_state' \
+  'redaction_reason' \
+  'redaction_failure_reason' \
+  'redact_args_present' \
+  'redact_args_target' \
+  'redact_args_mode' \
+  'redact_args_result' \
+  'redact_args_reason' \
+  'redaction_target_missing' \
+  'redaction_mode_unsupported' \
+  'redaction_scope_unsupported' \
+  'redaction_apply_failed' \
+  'deny'
+do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave32-redact-args-enforcement.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_denies
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core execute_log_only_marks_restrict_scope_as_contract_only
+cargo test -p assay-core execute_log_only_marks_redact_args_as_contract_only
+cargo test -p assay-core redact_args_contract_sets_additive_fields
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave32 Step1 split plan for bounded `redact_args` runtime enforcement
- add Step1 checklist and review pack
- add Step1 reviewer gate script

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave32-redact-args-enforcement-step1.sh` (PASS)
- pre-commit hooks passed on commit/push (`fmt`, `clippy`, shell checks)
