### PR TITLE
docs(adr-032): formalize MCP policy obligations and execution plan

### DIFF
--- a/docs/architecture/ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md
+++ b/docs/architecture/ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md
@@ -1,0 +1,92 @@
+# ADR-032: MCP Policy Enforcement, Obligations, and Evidence v2
+
+## Status
+Accepted (March 2026)
+
+## Context
+Assay's MCP governance line started as deterministic pre-execution gating (allow/deny + taxonomy and sequence controls).
+That foundation worked, but enterprise deployment required a broader runtime contract:
+
+- typed decisions beyond binary allow/deny
+- obligations as first-class runtime outcomes
+- richer, replayable decision evidence
+- explicit separation between identity/token issuance and policy enforcement
+
+Without this, policy remained too narrow for approval/scope/redaction controls and audit replay across policy revisions.
+
+## Decision
+Assay evolves to a runtime policy enforcement and evidence layer for MCP tool calls.
+
+### 1. Product role boundary
+Assay does not become an IdP, OAuth server, or token broker.
+Assay consumes auth context as policy input and stays above transport auth.
+
+### 2. Architecture boundary
+Assay uses an explicit PEP/PDP/PIP model:
+
+- PEP: MCP runtime hook (`mcp wrap` / tool-call path)
+- PDP: policy evaluator
+- PIP: runtime context providers (auth summary, approval state, scope bindings, risk/time/quota inputs)
+- Decision log: replayable evidence stream
+
+### 3. Runtime decision contract
+Decision output is typed and versioned:
+
+- `allow`
+- `allow_with_obligations`
+- `deny`
+- `deny_with_alert`
+
+Compatibility path is preserved for legacy `AllowWithWarning` until migration is complete.
+
+### 4. Obligations + evidence contract
+Obligations are modeled and emitted as additive evidence.
+Execution is introduced in bounded slices to avoid scope creep.
+
+### 5. Transport/auth scope
+HTTP and STDIO auth models are not collapsed into one transport contract.
+Assay consumes context; it does not own token issuance or browser auth flows.
+
+## Implementation Status (Closed on Main Through Wave32)
+Delivered slices on `main`:
+
+- Wave24: typed decisions + Decision Event v2 contract
+- Wave25: `log` obligation execution
+- Wave26: `alert` obligation execution
+- Wave27: approval artifact/data shape + additive evidence
+- Wave28: `approval_required` runtime enforcement (bounded deny semantics)
+- Wave29: `restrict_scope` shape/evidence (no execution)
+- Wave30: `restrict_scope` runtime enforcement
+- Wave31: `redact_args` shape/evidence (no execution)
+- Wave32: `redact_args` runtime enforcement + deterministic deny reasons
+
+## Short-Term Scope (What We Will Build)
+Near-term follow-up is limited to hardening and consistency work around this contract:
+
+- unify obligation fulfillment evidence semantics across all obligation types
+- tighten fail-closed matrix typing for high-risk classes
+- deepen replay/diff ergonomics against policy revisions
+- keep lane/principal/auth summary envelope additive and deterministic
+
+## Non-Goals (What We Will Not Build)
+Not in scope for this ADR line:
+
+- own OAuth/IdP/token issuance platform
+- approval UI/case-management platform
+- external incident/case orchestration as required runtime dependency
+- broad control-plane rewrite
+- big-bang policy engine migration
+
+## Consequences
+Positive:
+
+- runtime policy decisions are stronger, typed, and audit-ready
+- obligation execution is incremental and testable
+- compatibility path avoids breaking existing event consumers
+- replay and evidence contracts are now central product primitives
+
+Tradeoffs:
+
+- more policy/event surface area to maintain
+- slower delivery by design due to bounded wave discipline
+- temporary compatibility code paths remain until explicit deprecation waves complete

--- a/docs/architecture/PLAN-ADR-032-MCP-POLICY-ENFORCEMENT-2026q2.md
+++ b/docs/architecture/PLAN-ADR-032-MCP-POLICY-ENFORCEMENT-2026q2.md
@@ -1,0 +1,67 @@
+# Plan: ADR-032 MCP Policy Enforcement and Evidence (2026 Q2)
+
+> Status: Closed loop through Wave32 on `main`
+> Date: 2026-03-13
+> Scope: MCP runtime policy decisions, obligations, and decision evidence
+> Constraint: Bounded slices, deterministic behavior, backward-compatible event evolution
+
+## 1) Goal
+Deliver a production-safe evolution from tool-call gating to typed policy enforcement with obligations and replayable evidence, without taking ownership of identity/token infrastructure.
+
+## 2) Architecture Guardrails
+Always enforce:
+
+- Assay is not an IdP/OAuth/token broker
+- transport auth remains external; Assay consumes context
+- no broad workflow/control-plane expansion in runtime slices
+- no big-bang evaluator rewrite
+
+## 3) Wave Timeline (Completed)
+
+| Wave | Focus | Result on `main` |
+|---|---|---|
+| Wave24 | typed decisions + Decision Event v2 | merged |
+| Wave25 | `log` obligation execution | merged |
+| Wave26 | `alert` obligation execution | merged |
+| Wave27 | approval artifact/data shape | merged |
+| Wave28 | `approval_required` enforcement | merged |
+| Wave29 | `restrict_scope` shape/evidence | merged |
+| Wave30 | `restrict_scope` enforcement | merged |
+| Wave31 | `redact_args` shape/evidence | merged |
+| Wave32 | `redact_args` enforcement | merged |
+
+## 4) What Is Stable Now
+
+- typed decision contract (`allow`, `allow_with_obligations`, `deny`, `deny_with_alert`)
+- additive decision/event evidence model
+- bounded execution paths for `log`, `alert`, `approval_required`, `restrict_scope`, `redact_args`
+- deterministic deny reasons for bounded enforcement failures
+
+## 5) Immediate Follow-Up (Bounded)
+
+### F1: Obligation fulfillment normalization
+- standardize fulfillment/outcome shape across all executed obligations
+- keep additive event compatibility for legacy consumers
+
+### F2: Fail-closed matrix typing
+- explicit tool-class/risk defaults in runtime contract
+- deterministic error path when evaluator/context dependencies fail
+
+### F3: Replay and diff hardening
+- improve replay diagnostics for policy revision comparisons
+- keep evidence deterministic and policy-version keyed
+
+## 6) Explicit Non-Goals for Follow-Up
+
+- no OAuth/IdP feature work
+- no approval UI/case-management product work
+- no external incident integrations as mandatory runtime dependencies
+- no policy backend replacement as part of hardening slices
+
+## 7) Exit Criteria for ADR-032 Line
+ADR-032 execution line is considered operationally complete when:
+
+1. all bounded obligation executions emit normalized fulfillment evidence,
+2. fail-closed behavior is typed and deterministic by risk/tool class,
+3. replay/diff on policy revisions is stable in CI and evidence bundles,
+4. compatibility paths are either retained with explicit guarantees or deprecated by explicit wave.

--- a/docs/architecture/adrs.md
+++ b/docs/architecture/adrs.md
@@ -31,6 +31,8 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | [ADR-028](./ADR-028-Coverage-Report.md) | Coverage Report (Tool & Route Completeness) | Proposed | **P1** |
 | [ADR-029](./ADR-029-Session-State-Window.md) | Session & State Window Contract (MCP Governance) | Proposed | **P1** |
 | [ADR-030](./ADR-030-Coverage-Wrap-DX-Polish.md) | Coverage + Wrap DX Polish | Proposed | **P2** |
+| [ADR-031](./ADR-031-Coverage-v1.1-DX-Polish.md) | Coverage v1.1 DX Polish | Proposed | **P2** |
+| [ADR-032](./ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md) | MCP Policy Enforcement, Obligations, and Evidence v2 | Accepted | **P1** |
 | [ADR-020](./ADR-020-Dependency-Governance.md) | Dependency Governance | Accepted | - |
 
 ## Q2 2026 Priorities
@@ -51,6 +53,8 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | **P1** | [ADR-028](./ADR-028-Coverage-Report.md) | Proposed | A/B slices merged on `main` (coverage contract + generator + wrap emission); formal status update pending |
 | **P1** | [ADR-029](./ADR-029-Session-State-Window.md) | Proposed | A/B slices merged on `main` (session/state contract + informational export); formal status update pending |
 | **P2** | [ADR-030](./ADR-030-Coverage-Wrap-DX-Polish.md) | Proposed | A/B/C slices merged on `main` (coverage markdown/file input + closure docs); formal status update pending |
+| **P2** | [ADR-031](./ADR-031-Coverage-v1.1-DX-Polish.md) | Proposed | v1.1 DX contract accepted; follow-up implementation slices pending |
+| **P1** | [ADR-032](./ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md) | Accepted | Wave24-Wave32 merged on `main`; see plan for hardening follow-ups |
 | **P2** | [ADR-013](./ADR-013-EU-AI-Act-Pack.md) | Accepted | Article 12 mapping, `--pack` flag |
 | **P3** | [ADR-012](./ADR-012-Transparency-Log.md) | Proposed | Builds on ADR-011 |
 | Deferred | [ADR-009](./ADR-009-WORM-Storage.md) | Deferred | Managed WORM → Q3+ if demand |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -8,6 +8,7 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [Data Flow](./data-flow.md) — trace → gate → evidence pipeline
 - [Split Refactor Plan (Q1-Q2 2026)](./PLAN-split-refactor-2026q1.md) — wave-by-wave execution plan
 - [Split Refactor Report (Q1 2026)](./REPORT-split-refactor-2026q1.md) — verified closure and LOC outcomes
+- [ADR-032 Execution Plan (Q2 2026)](./PLAN-ADR-032-MCP-POLICY-ENFORCEMENT-2026q2.md) — MCP policy/obligation rollout status
 
 ## Active RFCs
 
@@ -27,6 +28,7 @@ Key ADRs:
 - [ADR-006: Evidence Contract](./ADR-006-Evidence-Contract.md) — schema v1
 - [ADR-014: GitHub Action v2](./ADR-014-GitHub-Action-v2.md) — CI integration
 - [ADR-015: BYOS Strategy](./ADR-015-BYOS-Storage-Strategy.md) — bring your own storage
+- [ADR-032: MCP Policy Enforcement v2](./ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md) — typed decisions + obligations + evidence
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- add `ADR-032` for MCP policy enforcement, obligations, and evidence v2
- add execution plan `PLAN-ADR-032-MCP-POLICY-ENFORCEMENT-2026q2.md`
- update architecture indices (`adrs.md`, `index.md`) to include ADR-032 and plan links

## Scope
- docs only
- no runtime code or workflow changes

## Validation
- pre-commit hooks passed on commit/push (`fmt`, `clippy`, linux compile gate)
- links are repository-local and resolve to tracked files
