### PR TITLE
docs(wave33-step3): closure docs and gate for outcome normalization

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave33-obligation-outcomes-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave33-obligation-outcomes-step3.md
@@ -1,0 +1,57 @@
+# SPLIT CHECKLIST — Wave33 Obligation Outcomes Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave33-obligation-outcomes-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave33-obligation-outcomes-step3.md`
+  - `scripts/ci/review-wave33-obligation-outcomes-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave33 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves bounded obligation-outcome normalization semantics
+
+## Normalization invariants
+- [ ] `ObligationOutcome` fields remain present:
+  - `obligation_type`
+  - `status`
+  - `reason`
+  - `reason_code`
+  - `enforcement_stage`
+  - `normalization_version`
+- [ ] Baseline reason-code markers remain present:
+  - `legacy_warning_mapped`
+  - `validated_in_handler`
+  - `contract_only`
+  - `unsupported_obligation_type`
+  - `approval_missing`
+  - `approval_expired`
+  - `approval_bound_tool_mismatch`
+  - `approval_bound_resource_mismatch`
+  - `scope_target_missing`
+  - `scope_target_mismatch`
+  - `scope_match_mode_unsupported`
+  - `scope_type_unsupported`
+  - `redaction_target_missing`
+  - `redaction_mode_unsupported`
+  - `redaction_scope_unsupported`
+  - `redaction_apply_failed`
+
+## Behavior containment still enforced
+- [ ] No allow/deny behavior changes introduced
+- [ ] No new obligation execution semantics added
+- [ ] Existing obligation line remains intact
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave33-obligation-outcomes-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave33-obligation-outcomes-step3.md
@@ -1,0 +1,40 @@
+# SPLIT REVIEW PACK — Wave33 Obligation Outcomes Step3
+
+## Intent
+Close Wave33 with a docs+gate-only closure slice after bounded obligation-outcome normalization in Step2.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add new obligation execution semantics
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave33-obligation-outcomes-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave33-obligation-outcomes-step3.md`
+- `scripts/ci/review-wave33-obligation-outcomes-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Additive normalization fields remain present.
+4. Baseline reason-code markers remain present.
+5. Existing allow/deny behavior remains unchanged.
+6. Existing obligation line remains intact.
+7. No scope creep appears in runtime scope.
+8. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave33-obligation-outcomes-step2-impl \
+  bash scripts/ci/review-wave33-obligation-outcomes-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave33-obligation-outcomes-step3.sh
+```

--- a/scripts/ci/review-wave33-obligation-outcomes-step3.sh
+++ b/scripts/ci/review-wave33-obligation-outcomes-step3.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave33-obligation-outcomes-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave33-obligation-outcomes-step3.md"
+  "scripts/ci/review-wave33-obligation-outcomes-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave33 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave33 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] normalization field markers"
+for marker in \
+  'reason_code' \
+  'enforcement_stage' \
+  'normalization_version' \
+  'obligation_type' \
+  'status' \
+  'reason'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs >/dev/null || {
+    echo "FAIL: missing outcome field marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] reason-code baseline markers"
+for marker in \
+  'legacy_warning_mapped' \
+  'validated_in_handler' \
+  'contract_only' \
+  'unsupported_obligation_type' \
+  'approval_missing' \
+  'approval_expired' \
+  'approval_bound_tool_mismatch' \
+  'approval_bound_resource_mismatch' \
+  'scope_target_missing' \
+  'scope_target_mismatch' \
+  'scope_match_mode_unsupported' \
+  'scope_type_unsupported' \
+  'redaction_target_missing' \
+  'redaction_mode_unsupported' \
+  'redaction_scope_unsupported' \
+  'redaction_apply_failed'
+do
+  rg -n "$marker" crates/assay-core/src/mcp crates/assay-core/src/mcp/tool_call_handler/tests.rs >/dev/null || {
+    echo "FAIL: missing reason-code marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no scope creep into new behavior"
+if rg -n 'execute_obligation|new_obligation_type|workflow_integration|control_plane' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected"
+  rg -n 'execute_obligation|new_obligation_type|workflow_integration|control_plane' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_denies
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core redact_args_contract_sets_additive_fields
+cargo test -p assay-core redact_args_target_missing_denies
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave33 Step3 closure checklist and review-pack
- add Step3 reviewer gate script that reruns Step2 invariants

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Validation
- BASE_REF=origin/codex/wave33-obligation-outcomes-step2-impl bash scripts/ci/review-wave33-obligation-outcomes-step3.sh
- pre-push hooks passed (fmt, clippy gate, shellcheck, linux compile gate)
