### PR TITLE
docs(wave34-promote): land step3 fail-closed closure on main

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave34-fail-closed-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave34-fail-closed-step3.md
@@ -1,0 +1,44 @@
+# SPLIT CHECKLIST - Wave34 Fail-Closed Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave34-fail-closed-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave34-fail-closed-step3.md`
+  - `scripts/ci/review-wave34-fail-closed-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave34 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema redesign
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves bounded fail-closed matrix typing contract
+
+## Fail-closed invariants
+- [ ] `FailClosedContext` remains present
+- [ ] `ToolRiskClass` remains present
+- [ ] `FailClosedMode` remains present
+- [ ] `FailClosedTrigger` remains present
+- [ ] Additive fail-closed event context remains present (`fail_closed`)
+- [ ] Baseline fail-closed reason codes remain present:
+  - `fail_closed_context_provider_unavailable`
+  - `fail_closed_runtime_dependency_error`
+  - `degrade_read_only_runtime_dependency_error`
+
+## Existing obligation line still intact
+- [ ] `log` execution remains present
+- [ ] `alert` execution remains present
+- [ ] `approval_required` enforcement remains present
+- [ ] `restrict_scope` enforcement remains present
+- [ ] `redact_args` enforcement remains present
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave34-fail-closed-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave34-fail-closed-step3.md
@@ -1,0 +1,40 @@
+# SPLIT REVIEW PACK - Wave34 Fail-Closed Step3
+
+## Intent
+Close Wave34 with a docs+gate-only closure slice after bounded fail-closed matrix typing implementation.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add new obligations
+- add control-plane workflows
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave34-fail-closed-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave34-fail-closed-step3.md`
+- `scripts/ci/review-wave34-fail-closed-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Fail-closed context markers remain present.
+4. Baseline fail-closed reason codes remain present.
+5. Existing obligation execution markers remain present.
+6. No non-goal scope creep appears in runtime scope.
+7. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave34-fail-closed-matrix-step2-impl \
+  bash scripts/ci/review-wave34-fail-closed-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave34-fail-closed-step3.sh
+```

--- a/scripts/ci/review-wave34-fail-closed-step3.sh
+++ b/scripts/ci/review-wave34-fail-closed-step3.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave34-fail-closed-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave34-fail-closed-step3.md"
+  "scripts/ci/review-wave34-fail-closed-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave34 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave34 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] fail-closed matrix markers"
+rg -n 'FailClosedContext|ToolRiskClass|FailClosedMode|FailClosedTrigger|fail_closed' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing fail-closed typed markers"
+  exit 1
+}
+
+rg -n 'fail_closed_context_provider_unavailable|fail_closed_runtime_dependency_error|degrade_read_only_runtime_dependency_error' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: missing fail-closed baseline error codes"
+  exit 1
+}
+
+echo "[review] existing obligation execution remains present"
+rg -n 'obligation_outcomes|legacy_warning|approval_required|restrict_scope|redact_args|log|alert' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: existing obligation execution markers missing"
+  exit 1
+}
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'approval UI|case management|external approval|policy backend replacement|control-plane|incident orchestration' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'approval UI|case management|external approval|policy backend replacement|control-plane|incident orchestration' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_denies
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core redact_args_target_missing_denies
+cargo test -p assay-core redact_args_apply_failed_denies
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- promote remaining Wave34 Step3 closure artifacts to `main`
- keep scope docs+gate only for Step3
- preserve bounded fail-closed matrix rollout without new runtime changes

## Scope
- docs/contributing/SPLIT-CHECKLIST-wave34-fail-closed-step3.md
- docs/contributing/SPLIT-REVIEW-PACK-wave34-fail-closed-step3.md
- scripts/ci/review-wave34-fail-closed-step3.sh

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave34-fail-closed-step3.sh`
