### PR TITLE
fix(wave34-gates): execute decision_emit_invariant test target

### DIFF
--- a/scripts/ci/review-wave34-fail-closed-step1.sh
+++ b/scripts/ci/review-wave34-fail-closed-step1.sh
@@ -100,7 +100,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
 cargo test -p assay-core test_event_contains_required_fields -- --exact
-cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies

--- a/scripts/ci/review-wave34-fail-closed-step2.sh
+++ b/scripts/ci/review-wave34-fail-closed-step2.sh
@@ -130,7 +130,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
 cargo test -p assay-core test_event_contains_required_fields -- --exact
-cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies

--- a/scripts/ci/review-wave34-fail-closed-step3.sh
+++ b/scripts/ci/review-wave34-fail-closed-step3.sh
@@ -73,7 +73,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
 cargo test -p assay-core test_event_contains_required_fields -- --exact
-cargo test -p assay-core decision_emit_invariant
+cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies


### PR DESCRIPTION
## Summary
- fix Wave34 reviewer gates to execute the intended integration test target
- replace ambiguous invocation with explicit `--test decision_emit_invariant` in Step1/2/3 scripts

## Why
Copilot correctly flagged that `cargo test -p assay-core decision_emit_invariant` can run zero tests if no function matches that name.

## Scope
- scripts/ci/review-wave34-fail-closed-step1.sh
- scripts/ci/review-wave34-fail-closed-step2.sh
- scripts/ci/review-wave34-fail-closed-step3.sh

## Validation
- cargo test -p assay-core --test decision_emit_invariant
