### PR TITLE
fix(wave34): close remaining Copilot findings on fail-closed

### DIFF
--- a/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
@@ -17,7 +17,6 @@ use std::time::Instant;
 const OUTCOME_NORMALIZATION_VERSION: &str = "v1";
 const OUTCOME_STAGE_HANDLER: &str = "handler";
 const OUTCOME_REASON_VALIDATED_IN_HANDLER: &str = "validated_in_handler";
-const FAIL_CLOSED_CONTEXT_PROVIDER_UNAVAILABLE: &str = "fail_closed_context_provider_unavailable";
 const FAIL_CLOSED_RUNTIME_DEPENDENCY_ERROR: &str = "fail_closed_runtime_dependency_error";
 const DEGRADE_READ_ONLY_RUNTIME_DEPENDENCY_ERROR: &str =
     "degrade_read_only_runtime_dependency_error";
@@ -446,11 +445,6 @@ fn mark_approval_failure(
     tool_match: &mut emit::ToolMatchMetadata,
     failure: ApprovalFailure,
 ) -> ApprovalFailure {
-    mark_fail_closed(
-        tool_match,
-        FailClosedTrigger::ContextProviderUnavailable,
-        FAIL_CLOSED_CONTEXT_PROVIDER_UNAVAILABLE.to_string(),
-    );
     tool_match.approval_state = Some("denied".to_string());
     tool_match.approval_failure_reason = Some(failure.as_reason().to_string());
     mark_approval_outcome(
@@ -712,7 +706,7 @@ fn requested_resource(args: &Value) -> Option<&str> {
 
 fn seed_fail_closed_context(tool_match: &mut emit::ToolMatchMetadata, op: OperationClass) {
     let tool_risk_class = match op {
-        OperationClass::Read => ToolRiskClass::Default,
+        OperationClass::Read => ToolRiskClass::LowRiskRead,
         OperationClass::Write | OperationClass::Commit => ToolRiskClass::HighRisk,
     };
     let fail_closed_mode = match tool_risk_class {

--- a/crates/assay-core/src/mcp/tool_call_handler/tests.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/tests.rs
@@ -5,8 +5,8 @@ use crate::mcp::decision::{
 use crate::mcp::identity::ToolIdentity;
 use crate::mcp::lifecycle::{LifecycleEmitter, LifecycleEvent};
 use crate::mcp::policy::{
-    ApprovalFreshness, FailClosedMode, FailClosedTrigger, RedactArgsContract,
-    RestrictScopeContract, ToolPolicy, ToolRiskClass, TypedPolicyDecision,
+    ApprovalFreshness, FailClosedMode, RedactArgsContract, RestrictScopeContract, ToolPolicy,
+    ToolRiskClass, TypedPolicyDecision,
 };
 use chrono::{Duration, Utc};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -117,30 +117,11 @@ fn assert_fail_closed_defaults(event: &DecisionEvent) {
         .fail_closed
         .as_ref()
         .expect("expected fail_closed context");
-    assert_eq!(context.tool_risk_class, ToolRiskClass::Default);
-    assert_eq!(context.fail_closed_mode, FailClosedMode::FailClosed);
+    assert_eq!(context.tool_risk_class, ToolRiskClass::LowRiskRead);
+    assert_eq!(context.fail_closed_mode, FailClosedMode::DegradeReadOnly);
     assert_eq!(context.fail_closed_trigger, None);
     assert!(!context.fail_closed_applied);
     assert!(context.fail_closed_error_code.is_none());
-}
-
-fn assert_fail_closed_context_provider_deny(event: &DecisionEvent) {
-    let context = event
-        .data
-        .fail_closed
-        .as_ref()
-        .expect("expected fail_closed context");
-    assert_eq!(context.tool_risk_class, ToolRiskClass::Default);
-    assert_eq!(context.fail_closed_mode, FailClosedMode::FailClosed);
-    assert_eq!(
-        context.fail_closed_trigger,
-        Some(FailClosedTrigger::ContextProviderUnavailable)
-    );
-    assert!(context.fail_closed_applied);
-    assert_eq!(
-        context.fail_closed_error_code.as_deref(),
-        Some("fail_closed_context_provider_unavailable")
-    );
 }
 
 #[test]
@@ -330,7 +311,7 @@ fn approval_required_missing_denies() {
         } => {
             assert_eq!(reason_code, reason_codes::P_APPROVAL_REQUIRED);
             assert_eq!(reason, "missing approval");
-            assert_fail_closed_context_provider_deny(&decision_event);
+            assert_fail_closed_defaults(&decision_event);
             assert_eq!(
                 decision_event.data.approval_failure_reason.as_deref(),
                 Some("missing approval")
@@ -377,7 +358,7 @@ fn approval_required_expired_denies() {
         } => {
             assert_eq!(reason_code, reason_codes::P_APPROVAL_REQUIRED);
             assert_eq!(reason, "expired approval");
-            assert_fail_closed_context_provider_deny(&decision_event);
+            assert_fail_closed_defaults(&decision_event);
             assert_eq!(
                 decision_event.data.approval_failure_reason.as_deref(),
                 Some("expired approval")
@@ -427,7 +408,7 @@ fn approval_required_bound_tool_mismatch_denies() {
         } => {
             assert_eq!(reason_code, reason_codes::P_APPROVAL_REQUIRED);
             assert_eq!(reason, "bound tool mismatch");
-            assert_fail_closed_context_provider_deny(&decision_event);
+            assert_fail_closed_defaults(&decision_event);
             assert_eq!(
                 decision_event.data.approval_failure_reason.as_deref(),
                 Some("bound tool mismatch")
@@ -480,7 +461,7 @@ fn approval_required_bound_resource_mismatch_denies() {
         } => {
             assert_eq!(reason_code, reason_codes::P_APPROVAL_REQUIRED);
             assert_eq!(reason, "bound resource mismatch");
-            assert_fail_closed_context_provider_deny(&decision_event);
+            assert_fail_closed_defaults(&decision_event);
             assert_eq!(
                 decision_event.data.approval_failure_reason.as_deref(),
                 Some("bound resource mismatch")

--- a/scripts/ci/review-wave34-fail-closed-step2.sh
+++ b/scripts/ci/review-wave34-fail-closed-step2.sh
@@ -65,13 +65,6 @@ while IFS= read -r f; do
     [[ "$f" == "$a" ]] && ok="true" && break
   done
 
-  if [[ "$ok" != "true" && "$f" == crates/assay-core/src/mcp/* ]]; then
-    ok="true"
-  fi
-  if [[ "$ok" != "true" && "$f" == crates/assay-core/tests/* ]]; then
-    ok="true"
-  fi
-
   if [[ "$ok" != "true" ]]; then
     echo "FAIL: file not allowed in Wave34 Step2: $f"
     exit 1

--- a/scripts/ci/review-wave34-fail-closed-step3.sh
+++ b/scripts/ci/review-wave34-fail-closed-step3.sh
@@ -33,6 +33,20 @@ while IFS= read -r f; do
   fi
 done < <(git diff --name-only "$BASE_REF"...HEAD)
 
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
 echo "[review] rerun Step2 invariants"
 
 echo "[review] fail-closed matrix markers"


### PR DESCRIPTION
## Summary
- resolve remaining Copilot findings from Wave34 (`#788`, `#789`)
- keep fixes bounded to fail-closed semantics + reviewer gate correctness
- preserve additive decision/evidence model (no new obligation types or workflow expansion)

## What changed
1. Runtime semantics (`assay-core`)
- approval-required policy denials no longer stamp `fail_closed_context_provider_unavailable`
- read operations now seed as `tool_risk_class=low_risk_read` and `fail_closed_mode=degrade_read_only`
- tests updated to match intended fail-closed defaults for read paths

2. Gate hardening (`scripts/ci`)
- Wave34 Step2 gate now uses strict allowlist only (removed broad wildcards)
- Wave34 Step3 gate now reruns Step2 untracked-file invariant block

## Copilot findings addressed
- #788: misleading fail-closed trigger on approval policy failures
- #788: `LowRiskRead`/`DegradeReadOnly` unreachable in seed mapping
- #788: Step2 gate allowlist too broad due wildcard bypass
- #789: Step3 gate missing untracked-file invariant from Step2

## Validation
- `cargo fmt --all`
- `shellcheck scripts/ci/review-wave34-fail-closed-step2.sh scripts/ci/review-wave34-fail-closed-step3.sh`
- `cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact`
- `cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact`
- `cargo test -p assay-core approval_required_missing_denies -- --exact`
- `cargo test -p assay-core approval_required_expired_denies -- --exact`
- `cargo test -p assay-core approval_required_bound_tool_mismatch_denies -- --exact`
- `cargo test -p assay-core approval_required_bound_resource_mismatch_denies -- --exact`
- `cargo test -p assay-core --test decision_emit_invariant -- --exact approval_required_missing_denies`
- `cargo test -p assay-core --test decision_emit_invariant -- --exact approval_required_expired_denies`
- `cargo test -p assay-core --test decision_emit_invariant -- --exact approval_required_bound_tool_mismatch_denies`
- `cargo test -p assay-core --test decision_emit_invariant -- --exact approval_required_bound_resource_mismatch_denies`
