### PR TITLE
docs(wave35-step1): freeze obligation fulfillment normalization

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave35-fulfillment-normalization-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave35-fulfillment-normalization-step1.md
@@ -1,0 +1,31 @@
+# SPLIT CHECKLIST — Wave35 Fulfillment Normalization Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave35-obligation-fulfillment-normalization.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave35-fulfillment-normalization-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave35-fulfillment-normalization-step1.md`
+  - `scripts/ci/review-wave35-fulfillment-normalization-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] Normalized `obligation_outcomes` shape is explicit
+- [ ] Deterministic `reason_code` requirement is explicit
+- [ ] Deterministic `enforcement_stage` requirement is explicit
+- [ ] Fixed `normalization_version` requirement is explicit
+- [ ] Separation model is explicit:
+  - `policy_deny`
+  - `fail_closed_deny`
+  - `obligation_skipped`
+  - `obligation_applied`
+  - `obligation_error`
+- [ ] Non-goals are explicit
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave35-fulfillment-normalization-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-PLAN-wave35-obligation-fulfillment-normalization.md
+++ b/docs/contributing/SPLIT-PLAN-wave35-obligation-fulfillment-normalization.md
@@ -1,0 +1,99 @@
+# SPLIT PLAN — Wave35 Obligation Fulfillment Normalization
+
+## Intent
+Freeze a bounded contract for normalized obligation fulfillment evidence across existing runtime paths.
+
+This wave is about:
+- one normalized `obligation_outcomes` shape
+- deterministic `reason_code`
+- deterministic `enforcement_stage`
+- fixed `normalization_version`
+- explicit semantic separation between:
+  - `policy_deny`
+  - `fail_closed_deny`
+  - `obligation_skipped`
+  - `obligation_applied`
+  - `obligation_error`
+
+It explicitly does **not** add:
+- new obligation types
+- policy-engine scope expansion
+- UI/control-plane
+- auth transport changes
+- broad workflow semantics
+
+## Problem
+Wave24-34 landed typed decisions, event v2, obligations execution slices, approval/restrict/redact paths, and fail-closed matrix typing.
+
+Current gap:
+- fulfillment/evidence semantics can drift per path unless normalized under one explicit contract.
+
+## Frozen normalization contract
+Wave35 freezes the normalized fulfillment/evidence target shape for `obligation_outcomes`:
+- `obligation_type`
+- `status`
+- `reason`
+- `reason_code`
+- `enforcement_stage`
+- `normalization_version`
+
+## Frozen deterministic semantics
+### Deterministic `reason_code`
+- equivalent failures must map to stable `reason_code`
+- no path-specific ad-hoc reason code drift
+
+### Deterministic `enforcement_stage`
+- equivalent enforcement layers must emit stable stage labels
+- no mixed stage labels for same logical layer
+
+### Fixed `normalization_version`
+- normalization version is explicitly emitted
+- version drift must be intentional and reviewable
+
+## Frozen separation model
+Wave35 freezes explicit distinction between:
+- `policy_deny`: denied by policy decision
+- `fail_closed_deny`: denied by fail-closed fallback behavior
+- `obligation_skipped`: obligation present but intentionally not applied
+- `obligation_applied`: obligation successfully applied
+- `obligation_error`: obligation attempted but errored
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+1. Normalized fulfillment shape is represented additively.
+2. `reason_code`, `enforcement_stage`, and `normalization_version` are deterministic for covered paths.
+3. Separation of `policy_deny` vs `fail_closed_deny` is explicit in evidence semantics.
+4. Existing behavior remains backward-compatible for current consumers.
+5. No new obligation type is introduced.
+
+## Scope boundaries
+### In scope
+- fulfillment normalization contract
+- additive evidence contract
+- tests and reviewer gates for the above
+
+### Out of scope
+- new obligation type implementation
+- policy backend redesign
+- UI/control-plane
+- auth transport redesign
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- additive normalization/evidence contract updates
+- deterministic semantics hardening for existing paths
+
+### Step3
+Docs + gate-only closure
+
+## Reviewer notes
+This wave must remain normalization-first.
+
+Primary failure modes:
+- adding new execution semantics under a normalization label
+- conflating `policy_deny` and `fail_closed_deny`
+- weakening determinism for `reason_code`, `enforcement_stage`, or `normalization_version`

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave35-fulfillment-normalization-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave35-fulfillment-normalization-step1.md
@@ -1,0 +1,38 @@
+# SPLIT REVIEW PACK — Wave35 Fulfillment Normalization Step1
+
+## Intent
+Freeze the Wave35 fulfillment normalization contract before any implementation.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add new obligation types
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave35-obligation-fulfillment-normalization.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave35-fulfillment-normalization-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave35-fulfillment-normalization-step1.md`
+- `scripts/ci/review-wave35-fulfillment-normalization-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Normalized `obligation_outcomes` shape is explicit.
+3. Deterministic `reason_code`, `enforcement_stage`, `normalization_version` requirements are explicit.
+4. Separation model is explicit (`policy_deny` vs `fail_closed_deny` vs obligation statuses).
+5. Runtime paths are untouched.
+6. No new obligation type is introduced in this wave.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave35-fulfillment-normalization-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- normalization contract is frozen cleanly
+- Step2 can implement additive normalization without reopening semantics

--- a/scripts/ci/review-wave35-fulfillment-normalization-step1.sh
+++ b/scripts/ci/review-wave35-fulfillment-normalization-step1.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave35-obligation-fulfillment-normalization.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave35-fulfillment-normalization-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave35-fulfillment-normalization-step1.md"
+  "scripts/ci/review-wave35-fulfillment-normalization-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-core/tests"
+  "crates/assay-cli/src/cli/commands"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave35 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave35 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave35 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave35-obligation-fulfillment-normalization.md"
+
+rg -n '^# SPLIT PLAN — Wave35 Obligation Fulfillment Normalization$' "$PLAN" >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'obligation_outcomes' \
+  'obligation_type' \
+  'status' \
+  'reason_code' \
+  'enforcement_stage' \
+  'normalization_version' \
+  'policy_deny' \
+  'fail_closed_deny' \
+  'obligation_skipped' \
+  'obligation_applied' \
+  'obligation_error'
+do
+  rg -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core approval_required_missing_denies -- --exact
+cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core redact_args_target_missing_denies -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave35 Step1 freeze for obligation fulfillment normalization in the fail-closed line
- keep slice strictly docs+gate only
- freeze deterministic evidence contract for fulfillment semantics before implementation

## Scope
- docs/contributing/SPLIT-PLAN-wave35-obligation-fulfillment-normalization.md
- docs/contributing/SPLIT-CHECKLIST-wave35-fulfillment-normalization-step1.md
- docs/contributing/SPLIT-REVIEW-PACK-wave35-fulfillment-normalization-step1.md
- scripts/ci/review-wave35-fulfillment-normalization-step1.sh

## Frozen contract focus
- normalized `obligation_outcomes` shape
- deterministic `reason_code`
- deterministic `enforcement_stage`
- fixed `normalization_version`
- explicit separation of:
  - `policy_deny`
  - `fail_closed_deny`
  - `obligation_skipped`
  - `obligation_applied`
  - `obligation_error`

## Non-goals
- no new obligation types
- no policy-engine scope expansion
- no UI/control-plane/auth transport changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave35-fulfillment-normalization-step1.sh`
