### PR TITLE
feat(wave35-step2): normalize obligation fulfillment evidence

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -85,6 +85,22 @@ pub struct ObligationOutcome {
     pub normalization_version: Option<String>,
 }
 
+/// Normalized decision path classification for fulfillment evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FulfillmentDecisionPath {
+    PolicyAllow,
+    PolicyDeny,
+    FailClosedDeny,
+    DecisionError,
+}
+
+const OUTCOME_STAGE_HANDLER: &str = "handler";
+const OUTCOME_REASON_CODE_APPLIED: &str = "obligation_applied";
+const OUTCOME_REASON_CODE_SKIPPED: &str = "obligation_skipped";
+const OUTCOME_REASON_CODE_ERROR: &str = "obligation_error";
+const OUTCOME_NORMALIZATION_VERSION_V1: &str = "v1";
+
 /// Additional runtime policy context for Decision Event v2.
 #[derive(Debug, Clone, Default)]
 pub struct PolicyDecisionEventContext {
@@ -262,6 +278,18 @@ pub struct DecisionData {
     /// Additive fail-closed matrix context for this decision
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fail_closed: Option<FailClosedContext>,
+    /// Normalized decision path for fulfillment evidence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fulfillment_decision_path: Option<FulfillmentDecisionPath>,
+    /// Whether any obligation outcome is normalized as applied.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub obligation_applied_present: Option<bool>,
+    /// Whether any obligation outcome is normalized as skipped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub obligation_skipped_present: Option<bool>,
+    /// Whether any obligation outcome is normalized as error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub obligation_error_present: Option<bool>,
     /// Lane identifier summary
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lane: Option<String>,
@@ -307,6 +335,73 @@ pub struct DecisionData {
     /// Store latency in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub store_latency_ms: Option<u64>,
+}
+
+fn normalize_obligation_outcome(mut outcome: ObligationOutcome) -> ObligationOutcome {
+    if outcome.reason_code.is_none() {
+        outcome.reason_code = Some(
+            match outcome.status {
+                ObligationOutcomeStatus::Applied => OUTCOME_REASON_CODE_APPLIED,
+                ObligationOutcomeStatus::Skipped => OUTCOME_REASON_CODE_SKIPPED,
+                ObligationOutcomeStatus::Error => OUTCOME_REASON_CODE_ERROR,
+            }
+            .to_string(),
+        );
+    }
+    if outcome.enforcement_stage.is_none() {
+        outcome.enforcement_stage = Some(OUTCOME_STAGE_HANDLER.to_string());
+    }
+    if outcome.normalization_version.is_none() {
+        outcome.normalization_version = Some(OUTCOME_NORMALIZATION_VERSION_V1.to_string());
+    }
+    outcome
+}
+
+fn normalize_obligation_outcomes(outcomes: Vec<ObligationOutcome>) -> Vec<ObligationOutcome> {
+    outcomes
+        .into_iter()
+        .map(normalize_obligation_outcome)
+        .collect()
+}
+
+fn classify_fulfillment_decision_path(data: &DecisionData) -> FulfillmentDecisionPath {
+    match data.decision {
+        Decision::Allow => FulfillmentDecisionPath::PolicyAllow,
+        Decision::Deny => {
+            if data
+                .fail_closed
+                .as_ref()
+                .map(|ctx| ctx.fail_closed_applied)
+                .unwrap_or(false)
+            {
+                FulfillmentDecisionPath::FailClosedDeny
+            } else {
+                FulfillmentDecisionPath::PolicyDeny
+            }
+        }
+        Decision::Error => FulfillmentDecisionPath::DecisionError,
+    }
+}
+
+fn refresh_fulfillment_normalization(data: &mut DecisionData) {
+    let outcomes = std::mem::take(&mut data.obligation_outcomes);
+    data.obligation_outcomes = normalize_obligation_outcomes(outcomes);
+    data.obligation_applied_present = Some(
+        data.obligation_outcomes
+            .iter()
+            .any(|outcome| outcome.status == ObligationOutcomeStatus::Applied),
+    );
+    data.obligation_skipped_present = Some(
+        data.obligation_outcomes
+            .iter()
+            .any(|outcome| outcome.status == ObligationOutcomeStatus::Skipped),
+    );
+    data.obligation_error_present = Some(
+        data.obligation_outcomes
+            .iter()
+            .any(|outcome| outcome.status == ObligationOutcomeStatus::Error),
+    );
+    data.fulfillment_decision_path = Some(classify_fulfillment_decision_path(data));
 }
 
 impl DecisionEvent {
@@ -360,6 +455,10 @@ impl DecisionEvent {
                 redact_args_result: None,
                 redact_args_reason: None,
                 fail_closed: None,
+                fulfillment_decision_path: None,
+                obligation_applied_present: None,
+                obligation_skipped_present: None,
+                obligation_error_present: None,
                 lane: None,
                 principal: None,
                 auth_context_summary: None,
@@ -385,6 +484,7 @@ impl DecisionEvent {
         self.data.decision = Decision::Allow;
         self.data.reason_code = reason_code.to_string();
         self.data.reason = None;
+        refresh_fulfillment_normalization(&mut self.data);
         self
     }
 
@@ -393,6 +493,7 @@ impl DecisionEvent {
         self.data.decision = Decision::Deny;
         self.data.reason_code = reason_code.to_string();
         self.data.reason = reason;
+        refresh_fulfillment_normalization(&mut self.data);
         self
     }
 
@@ -401,6 +502,7 @@ impl DecisionEvent {
         self.data.decision = Decision::Error;
         self.data.reason_code = reason_code.to_string();
         self.data.reason = reason;
+        refresh_fulfillment_normalization(&mut self.data);
         self
     }
 
@@ -537,6 +639,7 @@ impl DecisionEvent {
         self.data.lane = lane;
         self.data.principal = principal;
         self.data.auth_context_summary = auth_context_summary;
+        refresh_fulfillment_normalization(&mut self.data);
         self
     }
 }
@@ -754,6 +857,7 @@ impl DecisionEmitterGuard {
             event.data.lane = lane;
             event.data.principal = principal;
             event.data.auth_context_summary = auth_context_summary;
+            refresh_fulfillment_normalization(&mut event.data);
         }
     }
 

--- a/crates/assay-core/src/mcp/tool_call_handler/tests.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::mcp::decision::{
-    reason_codes, DecisionEvent, NullDecisionEmitter, ObligationOutcomeStatus,
+    reason_codes, DecisionEvent, FulfillmentDecisionPath, NullDecisionEmitter,
+    ObligationOutcomeStatus,
 };
 use crate::mcp::identity::ToolIdentity;
 use crate::mcp::lifecycle::{LifecycleEmitter, LifecycleEvent};
@@ -209,6 +210,17 @@ fn test_allow_with_warning_emits_log_obligation_outcome() {
             );
             assert_eq!(outcome.enforcement_stage.as_deref(), Some("executor"));
             assert_eq!(outcome.normalization_version.as_deref(), Some("v1"));
+            assert_eq!(
+                outcome.reason_code.as_deref(),
+                Some("legacy_warning_mapped")
+            );
+            assert_eq!(
+                decision_event.data.fulfillment_decision_path,
+                Some(FulfillmentDecisionPath::PolicyAllow)
+            );
+            assert_eq!(decision_event.data.obligation_applied_present, Some(true));
+            assert_eq!(decision_event.data.obligation_skipped_present, Some(false));
+            assert_eq!(decision_event.data.obligation_error_present, Some(false));
         }
         other => panic!("expected allow result, got {:?}", other),
     }
@@ -267,9 +279,16 @@ fn test_tool_drift_deny_emits_alert_obligation_outcome() {
             assert_eq!(outcome.obligation_type, "alert");
             assert_eq!(outcome.status, ObligationOutcomeStatus::Applied);
             assert!(outcome.reason.is_none());
-            assert!(outcome.reason_code.is_none());
+            assert_eq!(outcome.reason_code.as_deref(), Some("obligation_applied"));
             assert_eq!(outcome.enforcement_stage.as_deref(), Some("executor"));
             assert_eq!(outcome.normalization_version.as_deref(), Some("v1"));
+            assert_eq!(
+                decision_event.data.fulfillment_decision_path,
+                Some(FulfillmentDecisionPath::PolicyDeny)
+            );
+            assert_eq!(decision_event.data.obligation_applied_present, Some(true));
+            assert_eq!(decision_event.data.obligation_skipped_present, Some(false));
+            assert_eq!(decision_event.data.obligation_error_present, Some(false));
         }
         other => panic!("expected deny result, got {:?}", other),
     }
@@ -312,6 +331,10 @@ fn approval_required_missing_denies() {
             assert_eq!(reason_code, reason_codes::P_APPROVAL_REQUIRED);
             assert_eq!(reason, "missing approval");
             assert_fail_closed_defaults(&decision_event);
+            assert_eq!(
+                decision_event.data.fulfillment_decision_path,
+                Some(FulfillmentDecisionPath::PolicyDeny)
+            );
             assert_eq!(
                 decision_event.data.approval_failure_reason.as_deref(),
                 Some("missing approval")
@@ -602,7 +625,7 @@ fn restrict_scope_match_sets_additive_fields() {
                 .any(|outcome| {
                     outcome.obligation_type == "restrict_scope"
                         && outcome.status == ObligationOutcomeStatus::Applied
-                        && outcome.reason_code.is_none()
+                        && outcome.reason_code.as_deref() == Some("obligation_applied")
                         && outcome.enforcement_stage.as_deref() == Some("handler")
                         && outcome.normalization_version.as_deref() == Some("v1")
                 }));
@@ -801,7 +824,7 @@ fn redact_args_contract_sets_additive_fields() {
                     outcome.obligation_type == "redact_args"
                         && outcome.status == ObligationOutcomeStatus::Applied
                         && outcome.reason.is_none()
-                        && outcome.reason_code.is_none()
+                        && outcome.reason_code.as_deref() == Some("obligation_applied")
                         && outcome.enforcement_stage.as_deref() == Some("handler")
                         && outcome.normalization_version.as_deref() == Some("v1")
                 }));

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -5,7 +5,7 @@
 
 use assay_core::mcp::decision::{
     reason_codes, Decision, DecisionEmitter, DecisionEmitterGuard, DecisionEvent,
-    ObligationOutcomeStatus,
+    FulfillmentDecisionPath, ObligationOutcomeStatus,
 };
 use assay_core::mcp::policy::{
     ApprovalFreshness, McpPolicy, PolicyState, RedactArgsContract, RestrictScopeContract,
@@ -1009,6 +1009,17 @@ fn test_event_contains_required_fields() {
         event.data.obligation_outcomes[0].status,
         ObligationOutcomeStatus::Applied
     );
+    assert_eq!(
+        event.data.obligation_outcomes[0].reason_code.as_deref(),
+        Some("legacy_warning_mapped")
+    );
+    assert_eq!(
+        event.data.fulfillment_decision_path,
+        Some(FulfillmentDecisionPath::PolicyAllow)
+    );
+    assert_eq!(event.data.obligation_applied_present, Some(true));
+    assert_eq!(event.data.obligation_skipped_present, Some(false));
+    assert_eq!(event.data.obligation_error_present, Some(false));
     assert!(event.data.approval_state.is_none());
     assert!(event.data.approval_id.is_none());
     assert!(event.data.approval_freshness.is_none());

--- a/crates/assay-core/tests/fulfillment_normalization.rs
+++ b/crates/assay-core/tests/fulfillment_normalization.rs
@@ -1,0 +1,88 @@
+use assay_core::mcp::decision::{
+    reason_codes, DecisionEvent, FulfillmentDecisionPath, ObligationOutcome,
+    ObligationOutcomeStatus, PolicyDecisionEventContext,
+};
+use assay_core::mcp::policy::{
+    FailClosedContext, FailClosedMode, FailClosedTrigger, ToolRiskClass,
+};
+
+#[test]
+fn fulfillment_normalizes_outcomes_and_sets_policy_deny_path() {
+    let context = PolicyDecisionEventContext {
+        obligation_outcomes: vec![ObligationOutcome {
+            obligation_type: "restrict_scope".to_string(),
+            status: ObligationOutcomeStatus::Applied,
+            reason: None,
+            reason_code: None,
+            enforcement_stage: None,
+            normalization_version: None,
+        }],
+        ..PolicyDecisionEventContext::default()
+    };
+
+    let event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_007".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(
+        reason_codes::P_RESTRICT_SCOPE,
+        Some("scope target mismatch".to_string()),
+    )
+    .with_policy_context(context);
+
+    assert_eq!(
+        event.data.fulfillment_decision_path,
+        Some(FulfillmentDecisionPath::PolicyDeny)
+    );
+    assert_eq!(event.data.obligation_applied_present, Some(true));
+    assert_eq!(event.data.obligation_skipped_present, Some(false));
+    assert_eq!(event.data.obligation_error_present, Some(false));
+    assert_eq!(event.data.obligation_outcomes.len(), 1);
+    assert_eq!(
+        event.data.obligation_outcomes[0].reason_code.as_deref(),
+        Some("obligation_applied")
+    );
+    assert_eq!(
+        event.data.obligation_outcomes[0]
+            .enforcement_stage
+            .as_deref(),
+        Some("handler")
+    );
+    assert_eq!(
+        event.data.obligation_outcomes[0]
+            .normalization_version
+            .as_deref(),
+        Some("v1")
+    );
+}
+
+#[test]
+fn fulfillment_sets_fail_closed_deny_path() {
+    let context = PolicyDecisionEventContext {
+        fail_closed: Some(FailClosedContext {
+            tool_risk_class: ToolRiskClass::HighRisk,
+            fail_closed_mode: FailClosedMode::FailClosed,
+            fail_closed_trigger: Some(FailClosedTrigger::RuntimeDependencyError),
+            fail_closed_applied: true,
+            fail_closed_error_code: Some("fail_closed_runtime_dependency_error".to_string()),
+        }),
+        ..PolicyDecisionEventContext::default()
+    };
+
+    let event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_008".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(
+        reason_codes::S_DB_ERROR,
+        Some("store unavailable".to_string()),
+    )
+    .with_policy_context(context);
+
+    assert_eq!(
+        event.data.fulfillment_decision_path,
+        Some(FulfillmentDecisionPath::FailClosedDeny)
+    );
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave35-fulfillment-normalization-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave35-fulfillment-normalization-step2.md
@@ -1,0 +1,42 @@
+# SPLIT CHECKLIST - Wave35 Fulfillment Normalization Step2
+
+## Scope discipline
+- [ ] Diff is limited to bounded runtime + tests + Step2 docs/gate
+- [ ] No `.github/workflows/*` changes
+- [ ] No scope leaks outside MCP runtime/consumer paths
+- [ ] No new obligation types added
+- [ ] No policy backend/control-plane/auth transport changes
+
+## Implementation contract
+- [ ] Normalized fulfillment shape remains additive:
+  - `obligation_type`
+  - `status`
+  - `reason`
+  - `reason_code`
+  - `enforcement_stage`
+  - `normalization_version`
+- [ ] Deterministic reason-code defaults exist for normalized outcomes:
+  - `obligation_applied`
+  - `obligation_skipped`
+  - `obligation_error`
+- [ ] Deterministic fulfillment path mapping is represented:
+  - `policy_allow`
+  - `policy_deny`
+  - `fail_closed_deny`
+  - `decision_error`
+- [ ] Additive presence markers are emitted:
+  - `obligation_applied_present`
+  - `obligation_skipped_present`
+  - `obligation_error_present`
+
+## Compatibility and behavior
+- [ ] Existing typed decisions remain unchanged
+- [ ] Existing obligation execution (`log`, `alert`, `approval_required`, `restrict_scope`, `redact_args`) remains intact
+- [ ] Existing event fields remain present and backward-compatible
+- [ ] `policy_deny` and `fail_closed_deny` stay explicitly distinguishable
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave35-fulfillment-normalization-step2.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave35-fulfillment-normalization-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave35-fulfillment-normalization-step2.md
@@ -1,0 +1,25 @@
+# SPLIT MOVE MAP - Wave35 Fulfillment Normalization Step2
+
+## Intent
+Bounded implementation for additive obligation fulfillment normalization across existing MCP runtime paths.
+
+## Touched runtime paths
+- `crates/assay-core/src/mcp/decision.rs`
+  - adds deterministic normalization defaults (`reason_code`, `enforcement_stage`, `normalization_version`)
+  - adds additive fulfillment-path classification (`policy_allow`, `policy_deny`, `fail_closed_deny`, `decision_error`)
+  - adds additive outcome-presence flags (`obligation_applied_present`, `obligation_skipped_present`, `obligation_error_present`)
+- `crates/assay-core/src/mcp/tool_call_handler/tests.rs`
+  - updates assertions to validate normalized outcome reason codes and fulfillment-path mapping
+
+## Touched tests
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+  - extends invariants with additive normalization fields and compat expectations
+- `crates/assay-core/tests/fulfillment_normalization.rs`
+  - validates deterministic normalization defaults and policy-vs-fail-closed deny separation
+
+## Out of scope guarantees
+- no new obligation types
+- no new policy backend semantics
+- no control-plane additions
+- no auth transport changes
+- no additional execution workflows beyond existing obligations

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave35-fulfillment-normalization-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave35-fulfillment-normalization-step2.md
@@ -1,0 +1,27 @@
+# SPLIT REVIEW PACK - Wave35 Fulfillment Normalization Step2
+
+## Intent
+Implement bounded, additive normalization for obligation fulfillment evidence.
+
+This slice must:
+- preserve current execution behavior
+- normalize fulfillment evidence deterministically
+- keep event payload changes additive
+
+This slice must not:
+- add new obligation types
+- expand policy-engine scope
+- add UI/control-plane/auth transport work
+- touch workflow files
+
+## Reviewer focus
+1. Diff stays inside bounded runtime/test/docs/gate scope.
+2. Normalized outcome fields are deterministic (`reason_code`, `enforcement_stage`, `normalization_version`).
+3. Fulfillment path separation is explicit (`policy_deny` vs `fail_closed_deny`).
+4. Existing obligation paths remain intact.
+5. No scope creep into non-goals.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave35-fulfillment-normalization-step2.sh
+```

--- a/scripts/ci/review-wave35-fulfillment-normalization-step2.sh
+++ b/scripts/ci/review-wave35-fulfillment-normalization-step2.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/tests.rs"
+  "crates/assay-core/tests/decision_emit_invariant.rs"
+  "crates/assay-core/tests/fulfillment_normalization.rs"
+
+  "docs/contributing/SPLIT-CHECKLIST-wave35-fulfillment-normalization-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave35-fulfillment-normalization-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave35-fulfillment-normalization-step2.md"
+
+  "scripts/ci/review-wave35-fulfillment-normalization-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave35 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave35 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] fulfillment normalization markers"
+for marker in \
+  'fulfillment_decision_path' \
+  'obligation_applied_present' \
+  'obligation_skipped_present' \
+  'obligation_error_present' \
+  'reason_code' \
+  'enforcement_stage' \
+  'normalization_version'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs >/dev/null || {
+    echo "FAIL: missing fulfillment normalization marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] deterministic mapping markers"
+for marker in \
+  'PolicyAllow' \
+  'PolicyDeny' \
+  'FailClosedDeny' \
+  'DecisionError' \
+  'obligation_applied' \
+  'obligation_skipped' \
+  'obligation_error' \
+  'OUTCOME_NORMALIZATION_VERSION_V1'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs >/dev/null || {
+    echo "FAIL: missing deterministic mapping marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] policy deny vs fail-closed deny separation"
+rg -n 'classify_fulfillment_decision_path|fail_closed_applied' crates/assay-core/src/mcp/decision.rs >/dev/null || {
+  echo "FAIL: missing deny-path separation markers"
+  exit 1
+}
+
+echo "[review] existing obligation line remains present"
+rg -n 'obligation_outcomes|legacy_warning|approval_required|restrict_scope|redact_args|log|alert' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: existing obligation markers missing"
+  exit 1
+}
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'policy backend replacement|approval UI|case management|external approval|control-plane|auth transport' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'policy backend replacement|approval UI|case management|external approval|control-plane|auth transport' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core approval_required_missing_denies
+cargo test -p assay-core approval_required_expired_denies
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies
+cargo test -p assay-core restrict_scope_mismatch_denies
+cargo test -p assay-core restrict_scope_match_sets_additive_fields
+cargo test -p assay-core redact_args_target_missing_denies
+cargo test -p assay-core redact_args_apply_failed_denies
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add bounded Wave35 Step2 implementation for fulfillment normalization
- normalize additive obligation outcome defaults (`reason_code`, `enforcement_stage`, `normalization_version`)
- add explicit additive fulfillment-path mapping (`policy_allow`, `policy_deny`, `fail_closed_deny`, `decision_error`)
- add additive presence flags (`obligation_applied_present`, `obligation_skipped_present`, `obligation_error_present`)
- keep behavior backward-compatible for existing obligation execution paths

## Scope
- runtime: `crates/assay-core/src/mcp/decision.rs`
- tests: `crates/assay-core/src/mcp/tool_call_handler/tests.rs`, `crates/assay-core/tests/decision_emit_invariant.rs`, `crates/assay-core/tests/fulfillment_normalization.rs`
- docs+gate: Wave35 Step2 checklist/move-map/review-pack + reviewer gate script

## Validation
```bash
BASE_REF=origin/main bash scripts/ci/review-wave35-fulfillment-normalization-step2.sh
```
- includes: allowlist/workflow-ban, marker checks, fmt/clippy, pinned core/cli/server tests

## Non-goals held
- no new obligation types
- no policy-engine scope expansion
- no UI/control-plane/auth transport changes
