### PR TITLE
docs(wave36-step1): freeze redact_args enforcement hardening contract

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step1.md
@@ -1,0 +1,27 @@
+# SPLIT CHECKLIST — Wave36 Redact Args Enforcement Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave36-redact-args-enforcement.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step1.md`
+  - `scripts/ci/review-wave36-redact-args-enforcement-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] `redact_args` enforcement hardening scope is explicit
+- [ ] frozen failure classes are explicit
+- [ ] deterministic `reason_code` is explicit
+- [ ] deterministic `enforcement_stage` is explicit
+- [ ] deterministic `normalization_version` is explicit
+- [ ] additive redact evidence fields are explicit
+- [ ] non-goals are explicit (no global redact policy / no DLP / no UI/control-plane)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave36-redact-args-enforcement-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-PLAN-wave36-redact-args-enforcement.md
+++ b/docs/contributing/SPLIT-PLAN-wave36-redact-args-enforcement.md
@@ -1,0 +1,108 @@
+# SPLIT PLAN — Wave36 Redact Args Enforcement Hardening
+
+## Intent
+Freeze a bounded hardening contract for `redact_args` runtime enforcement, aligned with Wave35 fulfillment normalization semantics.
+
+This wave is about:
+- deterministic `redact_args` enforcement semantics
+- deterministic mapping for redaction failure reasons
+- deterministic `reason_code`, `enforcement_stage`, and `normalization_version`
+- additive evidence stability for redact enforcement outcomes
+
+It explicitly does **not** add:
+- new obligation types
+- broad/global redact policy semantics
+- PII detection engines
+- external DLP integrations
+- UI/control-plane/auth transport changes
+
+## Problem
+Wave31 introduced the `redact_args` contract/evidence shape and Wave32 introduced bounded runtime enforcement.
+Wave35 introduced normalized obligation fulfillment semantics.
+
+Current gap:
+- redact enforcement determinism is present in code but not frozen in one hardening contract
+- failure-class mapping and normalization semantics need explicit freeze-level guarantees
+- replay/audit expectations should be contract-bound for future refactors
+
+## Frozen enforcement hardening contract
+Wave36 freezes `redact_args` runtime enforcement invariants as:
+
+1. `redact_args` remains a runtime-enforced obligation path.
+2. Invalid redaction requirements deterministically deny with `reason_code=P_REDACT_ARGS`.
+3. Fine-grained deny reasons remain deterministic in evidence via `redaction_failure_reason`.
+
+## Frozen failure classes
+Wave36 freezes these failure classes as deterministic redaction enforcement outcomes:
+
+- `redaction_target_missing`
+- `redaction_mode_unsupported`
+- `redaction_scope_unsupported`
+- `redaction_apply_failed`
+
+## Frozen normalization alignment
+Wave36 freezes alignment with normalized fulfillment semantics:
+
+- stable `reason_code`
+- stable `enforcement_stage`
+- stable `normalization_version`
+- deterministic separation of applied vs denied redact paths in `obligation_outcomes`
+
+## Frozen additive evidence contract
+Wave36 freezes these redact evidence fields as additive and backward-compatible:
+
+- `redaction_target`
+- `redaction_mode`
+- `redaction_scope`
+- `redaction_applied_state`
+- `redaction_reason`
+- `redaction_failure_reason`
+- `redact_args_present`
+- `redact_args_target`
+- `redact_args_mode`
+- `redact_args_result`
+- `redact_args_reason`
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. `redact_args` enforcement remains deterministic for the frozen failure classes.
+2. `reason_code`, `enforcement_stage`, and `normalization_version` stay deterministic.
+3. Redact evidence fields remain additive and backward-compatible.
+4. Existing `log`, `alert`, `approval_required`, and `restrict_scope` behavior remains stable.
+5. No global redact policy or external DLP workflow is introduced.
+
+## Scope boundaries
+### In scope
+- redact enforcement hardening contract
+- deterministic normalization alignment for redact outcomes
+- additive evidence stability checks
+- tests and reviewer gates for the above
+
+### Out of scope
+- new obligation type implementation
+- broad/global redact policy semantics
+- PII detection engines
+- external DLP integrations
+- UI/control-plane or auth transport scope
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- tighten deterministic mapping/normalization guarantees for redact enforcement
+- additive evidence compatibility hardening
+- no scope expansion
+
+### Step3
+Docs + gate-only closure
+
+## Reviewer notes
+This wave must remain hardening-first.
+
+Primary failure modes:
+- re-opening redact semantics beyond the frozen failure classes
+- weakening deterministic mapping guarantees
+- introducing non-additive schema drift in redact evidence fields

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step1.md
@@ -1,0 +1,40 @@
+# SPLIT REVIEW PACK — Wave36 Redact Args Enforcement Step1
+
+## Intent
+Freeze a bounded hardening contract for `redact_args` runtime enforcement before any Step2 tightening changes.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- widen redact semantics to global policy scope
+- add DLP/PII workflow integrations
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave36-redact-args-enforcement.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step1.md`
+- `scripts/ci/review-wave36-redact-args-enforcement-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Redact enforcement hardening scope is explicit.
+3. Frozen redaction failure classes are explicit.
+4. Deterministic normalization alignment (`reason_code`, `enforcement_stage`, `normalization_version`) is explicit.
+5. Additive redact evidence fields are explicit.
+6. Runtime paths are untouched.
+7. No scope expansion to global redaction semantics or DLP integrations.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave36-redact-args-enforcement-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- hardening contract is frozen cleanly
+- Step2 can tighten determinism without reopening scope

--- a/scripts/ci/review-wave36-redact-args-enforcement-step1.sh
+++ b/scripts/ci/review-wave36-redact-args-enforcement-step1.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave36-redact-args-enforcement.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step1.md"
+  "scripts/ci/review-wave36-redact-args-enforcement-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-core/tests"
+  "crates/assay-cli/src/cli/commands"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave36 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave36 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave36 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave36-redact-args-enforcement.md"
+
+rg -n '^# SPLIT PLAN — Wave36 Redact Args Enforcement Hardening$' "$PLAN" >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'redact_args' \
+  'P_REDACT_ARGS' \
+  'redaction_target_missing' \
+  'redaction_mode_unsupported' \
+  'redaction_scope_unsupported' \
+  'redaction_apply_failed' \
+  'reason_code' \
+  'enforcement_stage' \
+  'normalization_version' \
+  'redaction_failure_reason' \
+  'obligation_outcomes'
+do
+  rg -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant
+cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core approval_required_missing_denies -- --exact
+cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core redact_args_target_missing_denies -- --exact
+cargo test -p assay-core redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave36 Step1 split plan for redact_args enforcement hardening
- add Step1 checklist and review pack
- add Step1 reviewer gate script

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave36-redact-args-enforcement-step1.sh` passed locally (includes fmt/clippy + pinned tests)

## Note
- Wave32 introduced redact_args enforcement; Wave36 Step1 freezes hardening/normalization guarantees to keep future refactors deterministic and additive.
