### PR TITLE
fix(copilot): resolve latest review findings in wave gates/tests

### DIFF
--- a/crates/assay-core/src/mcp/tool_call_handler/tests.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/tests.rs
@@ -211,10 +211,6 @@ fn test_allow_with_warning_emits_log_obligation_outcome() {
             assert_eq!(outcome.enforcement_stage.as_deref(), Some("executor"));
             assert_eq!(outcome.normalization_version.as_deref(), Some("v1"));
             assert_eq!(
-                outcome.reason_code.as_deref(),
-                Some("legacy_warning_mapped")
-            );
-            assert_eq!(
                 decision_event.data.fulfillment_decision_path,
                 Some(FulfillmentDecisionPath::PolicyAllow)
             );

--- a/scripts/ci/review-wave35-fulfillment-normalization-step1.sh
+++ b/scripts/ci/review-wave35-fulfillment-normalization-step1.sh
@@ -94,8 +94,8 @@ echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
 cargo test -p assay-core test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
-cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies -- --exact
 cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
 cargo test -p assay-core redact_args_target_missing_denies -- --exact

--- a/scripts/ci/review-wave35-fulfillment-normalization-step2.sh
+++ b/scripts/ci/review-wave35-fulfillment-normalization-step2.sh
@@ -120,8 +120,8 @@ cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_recor
 cargo test -p assay-core test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core --test fulfillment_normalization
-cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies
 cargo test -p assay-core approval_required_expired_denies
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies

--- a/scripts/ci/review-wave35-fulfillment-normalization-step3.sh
+++ b/scripts/ci/review-wave35-fulfillment-normalization-step3.sh
@@ -115,8 +115,8 @@ cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_recor
 cargo test -p assay-core test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core --test fulfillment_normalization
-cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies
 cargo test -p assay-core approval_required_expired_denies
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies

--- a/scripts/ci/review-wave36-redact-args-enforcement-step1.sh
+++ b/scripts/ci/review-wave36-redact-args-enforcement-step1.sh
@@ -94,8 +94,8 @@ echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
 cargo test -p assay-core test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
-cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies -- --exact
 cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
 cargo test -p assay-core redact_args_target_missing_denies -- --exact


### PR DESCRIPTION
## Summary
- address the two actionable Copilot findings from recent Wave35/Wave36 PR reviews
- fix pinned `cargo test -- --exact` filters so intended tests actually execute
- remove duplicate `reason_code` assertion in tool-call-handler unit test

## Scope
- no behavior change in runtime logic
- test/gate hygiene only
- no workflow changes

## Changes
- `scripts/ci/review-wave35-fulfillment-normalization-step1.sh`
- `scripts/ci/review-wave35-fulfillment-normalization-step2.sh`
- `scripts/ci/review-wave35-fulfillment-normalization-step3.sh`
- `scripts/ci/review-wave36-redact-args-enforcement-step1.sh`
- `crates/assay-core/src/mcp/tool_call_handler/tests.rs`

## Validation
- `cargo fmt --check`
- `cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact`
- `cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact`
