### PR TITLE
feat(wave36-step2): enforce redact_args runtime execution

### DIFF
--- a/crates/assay-core/src/mcp/tool_call_handler/emit.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/emit.rs
@@ -187,6 +187,7 @@ pub(super) fn allow(
     tool_name: String,
     reason_code: &str,
     receipt: Option<AuthzReceipt>,
+    effective_arguments: Option<serde_json::Value>,
     tool_match: ToolMatchMetadata,
 ) -> HandleResult {
     let decision_event = DecisionEvent::new(event_source.to_string(), tool_call_id, tool_name)
@@ -201,6 +202,7 @@ pub(super) fn allow(
 
     HandleResult::Allow {
         receipt,
+        effective_arguments,
         decision_event,
     }
 }

--- a/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
@@ -62,11 +62,13 @@ pub(super) fn handle_tool_call(
     guard.set_request_id(request.id.clone());
 
     let start = Instant::now();
+    let original_arguments = params.arguments.clone();
+    let mut effective_arguments = original_arguments.clone();
 
     // Step 1: Policy evaluation
     let policy_eval = handler.policy.evaluate_with_metadata(
         &tool_name,
-        &params.arguments,
+        &effective_arguments,
         state,
         runtime_identity,
     );
@@ -112,7 +114,7 @@ pub(super) fn handle_tool_call(
 
     // Step 2: approval_required obligation enforcement (Wave28)
     if let Some(failure) =
-        validate_approval_required(&tool_name, &params.arguments, &mut tool_match)
+        validate_approval_required(&tool_name, &effective_arguments, &mut tool_match)
     {
         let reason = failure.to_string();
         guard.set_policy_context(tool_match.policy_context());
@@ -145,7 +147,7 @@ pub(super) fn handle_tool_call(
     }
 
     // Step 4: redact_args obligation enforcement (Wave32)
-    if let Some(failure) = validate_redact_args(&mut tool_match) {
+    if let Some(failure) = validate_redact_args(&mut effective_arguments, &mut tool_match) {
         let reason = failure.to_string();
         guard.set_policy_context(tool_match.policy_context());
         guard.emit_deny(reason_codes::P_REDACT_ARGS, Some(reason.clone()));
@@ -218,6 +220,7 @@ pub(super) fn handle_tool_call(
                     tool_name,
                     reason_codes::P_MANDATE_VALID,
                     Some(receipt),
+                    (effective_arguments != original_arguments).then_some(effective_arguments),
                     tool_match,
                 );
             }
@@ -259,6 +262,7 @@ pub(super) fn handle_tool_call(
         tool_name,
         reason_codes::P_POLICY_ALLOW,
         None,
+        (effective_arguments != original_arguments).then_some(effective_arguments),
         tool_match,
     )
 }
@@ -332,16 +336,6 @@ impl RedactArgsFailure {
             Self::ModeUnsupported => "redaction mode unsupported",
             Self::ScopeUnsupported => "redaction scope unsupported",
             Self::ApplyFailed => "redaction apply failed",
-        }
-    }
-
-    fn from_code(code: Option<&str>) -> Self {
-        match code {
-            Some("redaction_target_missing") => Self::TargetMissing,
-            Some("redaction_mode_unsupported") => Self::ModeUnsupported,
-            Some("redaction_scope_unsupported") => Self::ScopeUnsupported,
-            Some("redaction_apply_failed") => Self::ApplyFailed,
-            _ => Self::ApplyFailed,
         }
     }
 }
@@ -523,7 +517,10 @@ fn validate_restrict_scope(
     Some(mark_restrict_scope_failure(tool_match, failure))
 }
 
-fn validate_redact_args(tool_match: &mut emit::ToolMatchMetadata) -> Option<RedactArgsFailure> {
+fn validate_redact_args(
+    args: &mut Value,
+    tool_match: &mut emit::ToolMatchMetadata,
+) -> Option<RedactArgsFailure> {
     let requires_redaction = tool_match
         .obligations
         .iter()
@@ -532,31 +529,131 @@ fn validate_redact_args(tool_match: &mut emit::ToolMatchMetadata) -> Option<Reda
         return None;
     }
 
-    if matches!(
-        tool_match.redaction_applied_state.as_deref(),
-        Some("applied")
-    ) {
-        tool_match.redaction_failure_reason = None;
-        tool_match.redaction_reason = None;
-        tool_match.redact_args_reason = None;
-        tool_match.redact_args_result = Some("applied".to_string());
-        mark_redact_args_outcome(
+    let Some(contract) = tool_match.redaction_contract.as_ref() else {
+        return Some(mark_redact_args_failure(
             tool_match,
-            super::super::decision::ObligationOutcomeStatus::Applied,
-            None,
-            None,
-        );
-        return None;
+            RedactArgsFailure::TargetMissing,
+        ));
+    };
+
+    match apply_redact_args_runtime(args, contract) {
+        Ok(()) => {
+            tool_match.redaction_applied_state = Some("applied".to_string());
+            tool_match.redact_args_result = Some("applied".to_string());
+            tool_match.redaction_failure_reason = None;
+            tool_match.redaction_reason = None;
+            tool_match.redact_args_reason = None;
+            mark_redact_args_outcome(
+                tool_match,
+                super::super::decision::ObligationOutcomeStatus::Applied,
+                None,
+                Some(OUTCOME_REASON_VALIDATED_IN_HANDLER),
+            );
+            None
+        }
+        Err(failure) => {
+            let reason_code = failure.code();
+            let applied_state = match failure {
+                RedactArgsFailure::ModeUnsupported | RedactArgsFailure::ScopeUnsupported => {
+                    "not_evaluated"
+                }
+                RedactArgsFailure::TargetMissing | RedactArgsFailure::ApplyFailed => "not_applied",
+            };
+            tool_match.redaction_applied_state = Some(applied_state.to_string());
+            tool_match.redact_args_result = Some(applied_state.to_string());
+            tool_match.redaction_failure_reason = Some(reason_code.to_string());
+            tool_match.redaction_reason = Some(reason_code.to_string());
+            tool_match.redact_args_reason = Some(reason_code.to_string());
+            Some(mark_redact_args_failure(tool_match, failure))
+        }
+    }
+}
+
+fn apply_redact_args_runtime(
+    args: &mut Value,
+    contract: &super::super::policy::RedactArgsContract,
+) -> Result<(), RedactArgsFailure> {
+    let target = contract.redaction_target.trim().to_ascii_lowercase();
+    let mode = contract.redaction_mode.trim().to_ascii_lowercase();
+    let scope = contract.redaction_scope.trim().to_ascii_lowercase();
+
+    if !matches!(scope.as_str(), "request" | "args" | "metadata") {
+        return Err(RedactArgsFailure::ScopeUnsupported);
     }
 
-    let failure = RedactArgsFailure::from_code(
-        tool_match
-            .redaction_failure_reason
-            .as_deref()
-            .or(tool_match.redaction_reason.as_deref())
-            .or(tool_match.redact_args_reason.as_deref()),
-    );
-    Some(mark_redact_args_failure(tool_match, failure))
+    if mode == "drop" {
+        return apply_drop_redaction(args, &target);
+    }
+
+    let Some(target_value) = redaction_target_value_mut(args, &target) else {
+        return Err(RedactArgsFailure::TargetMissing);
+    };
+
+    apply_value_redaction(target_value, &mode)
+}
+
+fn apply_drop_redaction(args: &mut Value, target: &str) -> Result<(), RedactArgsFailure> {
+    match target {
+        "path" | "query" | "headers" | "body" => args
+            .as_object_mut()
+            .ok_or(RedactArgsFailure::ApplyFailed)?
+            .remove(target)
+            .map(|_| ())
+            .ok_or(RedactArgsFailure::TargetMissing),
+        "metadata" => args
+            .as_object_mut()
+            .ok_or(RedactArgsFailure::ApplyFailed)?
+            .remove("_meta")
+            .map(|_| ())
+            .ok_or(RedactArgsFailure::TargetMissing),
+        "args" => {
+            *args = Value::Object(serde_json::Map::new());
+            Ok(())
+        }
+        _ => Err(RedactArgsFailure::TargetMissing),
+    }
+}
+
+fn redaction_target_value_mut<'a>(args: &'a mut Value, target: &str) -> Option<&'a mut Value> {
+    match target {
+        "path" => args.get_mut("path"),
+        "query" => args.get_mut("query"),
+        "headers" => args.get_mut("headers"),
+        "body" => args.get_mut("body"),
+        "metadata" => args.get_mut("_meta"),
+        "args" => Some(args),
+        _ => None,
+    }
+}
+
+fn apply_value_redaction(target_value: &mut Value, mode: &str) -> Result<(), RedactArgsFailure> {
+    match mode {
+        "mask" => {
+            *target_value = Value::String("[REDACTED]".to_string());
+            Ok(())
+        }
+        "hash" => {
+            let input = target_value.to_string();
+            *target_value = Value::String(format!("md5:{:x}", md5::compute(input)));
+            Ok(())
+        }
+        "partial" => {
+            let Some(input) = target_value.as_str() else {
+                return Err(RedactArgsFailure::ApplyFailed);
+            };
+            *target_value = Value::String(partial_mask(input));
+            Ok(())
+        }
+        _ => Err(RedactArgsFailure::ModeUnsupported),
+    }
+}
+
+fn partial_mask(input: &str) -> String {
+    if input.is_empty() {
+        return "***".to_string();
+    }
+    let keep = input.chars().take(2).collect::<String>();
+    format!("{keep}***")
 }
 
 fn mark_restrict_scope_failure(

--- a/crates/assay-core/src/mcp/tool_call_handler/tests.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/tests.rs
@@ -782,7 +782,13 @@ fn redact_args_contract_sets_additive_fields() {
     let result = handler.handle_tool_call(&request, &mut state, None, None, None);
 
     match result {
-        HandleResult::Allow { decision_event, .. } => {
+        HandleResult::Allow {
+            effective_arguments,
+            decision_event,
+            ..
+        } => {
+            let redacted_args = effective_arguments.expect("redacted effective_arguments");
+            assert_eq!(redacted_args["body"], serde_json::json!("[REDACTED]"));
             assert_eq!(
                 decision_event.data.redaction_target.as_deref(),
                 Some("body")
@@ -820,7 +826,7 @@ fn redact_args_contract_sets_additive_fields() {
                     outcome.obligation_type == "redact_args"
                         && outcome.status == ObligationOutcomeStatus::Applied
                         && outcome.reason.is_none()
-                        && outcome.reason_code.as_deref() == Some("obligation_applied")
+                        && outcome.reason_code.as_deref() == Some("validated_in_handler")
                         && outcome.enforcement_stage.as_deref() == Some("handler")
                         && outcome.normalization_version.as_deref() == Some("v1")
                 }));

--- a/crates/assay-core/src/mcp/tool_call_handler/types.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/types.rs
@@ -10,6 +10,9 @@ pub enum HandleResult {
     /// Tool call is allowed, forward to server
     Allow {
         receipt: Option<AuthzReceipt>,
+        /// Runtime-redacted arguments when redact_args enforcement changed payload.
+        /// `None` means original args are unchanged.
+        effective_arguments: Option<serde_json::Value>,
         decision_event: DecisionEvent,
     },
     /// Tool call is denied, return error response

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -598,7 +598,16 @@ fn redact_args_contract_sets_additive_fields() {
     );
     let mut state = PolicyState::default();
     let result = handler.handle_tool_call(&request, &mut state, None, None, None);
-    assert!(matches!(result, HandleResult::Allow { .. }));
+    match result {
+        HandleResult::Allow {
+            effective_arguments,
+            ..
+        } => {
+            let redacted_args = effective_arguments.expect("redacted effective_arguments");
+            assert_eq!(redacted_args["body"], serde_json::json!("[REDACTED]"));
+        }
+        other => panic!("expected allow result, got {:?}", other),
+    }
     assert_eq!(emitter.event_count(), 1);
 
     let event = emitter.last_event().expect("Should have event");
@@ -620,6 +629,7 @@ fn redact_args_contract_sets_additive_fields() {
         outcome.obligation_type == "redact_args"
             && outcome.status == ObligationOutcomeStatus::Applied
             && outcome.reason.is_none()
+            && outcome.reason_code.as_deref() == Some("validated_in_handler")
     }));
 }
 

--- a/docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step2.md
@@ -1,0 +1,56 @@
+# SPLIT CHECKLIST - Wave36 Redact Args Enforcement Step2
+
+## Scope discipline
+- [ ] Diff is limited to bounded runtime + tests + Step2 docs/gate
+- [ ] No `.github/workflows/*` changes
+- [ ] No scope leaks outside MCP runtime/test paths
+- [ ] No new obligation types added
+- [ ] No policy backend/control-plane/auth transport changes
+
+## Implementation contract
+- [ ] Runtime redaction is executed in the handler for `redact_args`
+- [ ] Redaction runtime modes remain bounded:
+  - `mask`
+  - `hash`
+  - `drop`
+  - `partial`
+- [ ] Redaction targets remain bounded:
+  - `path`
+  - `query`
+  - `headers`
+  - `body`
+  - `metadata`
+  - `args`
+- [ ] Deterministic failure classes remain explicit:
+  - `redaction_target_missing`
+  - `redaction_mode_unsupported`
+  - `redaction_scope_unsupported`
+  - `redaction_apply_failed`
+
+## Evidence and compatibility
+- [ ] Redaction evidence fields remain additive and backward-compatible:
+  - `redaction_target`
+  - `redaction_mode`
+  - `redaction_scope`
+  - `redaction_applied_state`
+  - `redaction_reason`
+  - `redaction_failure_reason`
+  - `redact_args_present`
+  - `redact_args_target`
+  - `redact_args_mode`
+  - `redact_args_result`
+  - `redact_args_reason`
+- [ ] `obligation_outcomes` stays normalized with deterministic markers
+- [ ] Existing `log`, `alert`, `approval_required`, and `restrict_scope` behavior remains stable
+
+## Non-goals still enforced
+- [ ] No PII detection engine
+- [ ] No external DLP integration
+- [ ] No broad/global redact semantics
+- [ ] No UI/control-plane additions
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave36-redact-args-enforcement-step2.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave36-redact-args-enforcement-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave36-redact-args-enforcement-step2.md
@@ -1,0 +1,28 @@
+# SPLIT MOVE MAP - Wave36 Redact Args Enforcement Step2
+
+## Intent
+Bounded runtime implementation for `redact_args` execution, aligned with Wave36 hardening semantics.
+
+## Touched runtime paths
+- `crates/assay-core/src/mcp/tool_call_handler/types.rs`
+  - adds `effective_arguments` to allow-result contract (additive)
+- `crates/assay-core/src/mcp/tool_call_handler/emit.rs`
+  - plumbs `effective_arguments` into allow-result emission
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`
+  - introduces runtime redaction application for bounded targets/modes
+  - preserves deterministic deny mapping for unsupported/failed redaction
+  - keeps additive evidence + normalized obligation outcomes intact
+
+## Touched tests
+- `crates/assay-core/src/mcp/tool_call_handler/tests.rs`
+  - validates runtime redaction effect via `effective_arguments`
+  - validates deterministic outcome reason-code for applied path
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+  - validates additive evidence + runtime redaction in integration path
+
+## Out of scope guarantees
+- no new obligation types
+- no policy-engine backend changes
+- no control-plane additions
+- no auth transport changes
+- no external DLP/PII integrations

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step2.md
@@ -1,0 +1,28 @@
+# SPLIT REVIEW PACK - Wave36 Redact Args Enforcement Step2
+
+## Intent
+Implement bounded runtime redaction for `redact_args` while preserving deterministic evidence and backward-compatible event shape.
+
+This slice must:
+- execute runtime redaction in handler path
+- preserve deterministic deny reasons for frozen redaction failure classes
+- keep evidence and `obligation_outcomes` additive and normalized
+
+This slice must not:
+- add new obligation types
+- broaden redact semantics into global policy workflows
+- add PII engines or external DLP integrations
+- add UI/control-plane/auth transport work
+- touch workflow files
+
+## Reviewer focus
+1. Diff stays inside bounded runtime/test/docs/gate scope.
+2. Runtime redaction execution is real (not metadata-only).
+3. Failure classes are deterministic and mapped to `P_REDACT_ARGS` deny path.
+4. Event/evidence shape remains additive and compatible.
+5. Existing obligation lines remain stable (`log`, `alert`, `approval_required`, `restrict_scope`).
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave36-redact-args-enforcement-step2.sh
+```

--- a/scripts/ci/review-wave36-redact-args-enforcement-step2.sh
+++ b/scripts/ci/review-wave36-redact-args-enforcement-step2.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/tool_call_handler/types.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/emit.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/evaluate.rs"
+  "crates/assay-core/src/mcp/tool_call_handler/tests.rs"
+  "crates/assay-core/tests/decision_emit_invariant.rs"
+
+  "docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave36-redact-args-enforcement-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step2.md"
+
+  "scripts/ci/review-wave36-redact-args-enforcement-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave36 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave36 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] runtime redaction execution markers"
+for marker in \
+  'effective_arguments' \
+  'validate_redact_args' \
+  'apply_redact_args_runtime' \
+  'redaction_target_value_mut' \
+  'apply_value_redaction' \
+  'partial_mask'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/tool_call_handler/types.rs \
+    crates/assay-core/src/mcp/tool_call_handler/emit.rs \
+    crates/assay-core/src/mcp/tool_call_handler/evaluate.rs \
+    crates/assay-core/src/mcp/tool_call_handler/tests.rs \
+    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+      echo "FAIL: missing runtime redaction marker: $marker"
+      exit 1
+    }
+done
+
+echo "[review] deterministic redaction failure markers"
+for marker in \
+  'redaction_target_missing' \
+  'redaction_mode_unsupported' \
+  'redaction_scope_unsupported' \
+  'redaction_apply_failed' \
+  'P_REDACT_ARGS'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/tool_call_handler/evaluate.rs \
+    crates/assay-core/src/mcp/tool_call_handler/tests.rs \
+    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+      echo "FAIL: missing deterministic failure marker: $marker"
+      exit 1
+    }
+done
+
+echo "[review] additive redaction evidence markers"
+for marker in \
+  'redaction_target' \
+  'redaction_mode' \
+  'redaction_scope' \
+  'redaction_applied_state' \
+  'redaction_reason' \
+  'redaction_failure_reason' \
+  'redact_args_present' \
+  'redact_args_target' \
+  'redact_args_mode' \
+  'redact_args_result' \
+  'redact_args_reason' \
+  'obligation_outcomes' \
+  'validated_in_handler'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/tool_call_handler/evaluate.rs crates/assay-core/src/mcp/tool_call_handler/tests.rs crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    echo "FAIL: missing additive evidence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing obligation line remains present"
+for marker in \
+  'legacy_warning' \
+  'log' \
+  'alert' \
+  'approval_required' \
+  'restrict_scope' \
+  'redact_args'
+do
+  rg -n "$marker" crates/assay-core/src/mcp >/dev/null || {
+    echo "FAIL: missing existing obligation marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'pii_detection|external_dlp|dlp_integration|global_redact|control_plane|auth transport' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'pii_detection|external_dlp|dlp_integration|global_redact|control_plane|auth transport' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant
+cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_contract_sets_additive_fields -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_target_missing_denies -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_contract_sets_additive_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core approval_required_missing_denies -- --exact
+cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- implement bounded runtime `redact_args` execution in `tool_call_handler`
- keep decision/event payload additive and backward-compatible
- add `effective_arguments` on allow path when runtime redaction mutates args
- add Wave36 Step2 checklist/move-map/review-pack + reviewer gate script

## Scope
- runtime only in:
  - `crates/assay-core/src/mcp/tool_call_handler/types.rs`
  - `crates/assay-core/src/mcp/tool_call_handler/emit.rs`
  - `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`
  - tests in handler + decision invariant
- docs/gate only for Wave36 Step2 artifacts
- no workflow changes

## Notes
- supported runtime redaction modes: `mask`, `hash`, `drop`, `partial`
- supported runtime redaction targets: `path`, `query`, `headers`, `body`, `metadata`, `args`
- deterministic failure classes preserved:
  - `redaction_target_missing`
  - `redaction_mode_unsupported`
  - `redaction_scope_unsupported`
  - `redaction_apply_failed`
- no DLP/PII/control-plane scope expansion

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave36-redact-args-enforcement-step2.sh` (PASS)
- `cargo fmt --check` (PASS)
- `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` (PASS)
- pinned tests in Step2 gate (PASS)
