### PR TITLE
docs(wave36-step3): closure for redact_args enforcement

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step3.md
@@ -1,0 +1,66 @@
+# SPLIT CHECKLIST - Wave36 Redact Args Enforcement Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step3.md`
+  - `scripts/ci/review-wave36-redact-args-enforcement-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave36 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves bounded runtime `redact_args` execution semantics
+
+## Redaction enforcement invariants
+- [ ] Runtime execution markers remain present:
+  - `effective_arguments`
+  - `validate_redact_args`
+  - `apply_redact_args_runtime`
+  - `redaction_target_value_mut`
+  - `apply_value_redaction`
+- [ ] Deterministic failure classes remain present:
+  - `redaction_target_missing`
+  - `redaction_mode_unsupported`
+  - `redaction_scope_unsupported`
+  - `redaction_apply_failed`
+  - `P_REDACT_ARGS`
+- [ ] Additive redaction evidence markers remain present:
+  - `redaction_target`
+  - `redaction_mode`
+  - `redaction_scope`
+  - `redaction_applied_state`
+  - `redaction_reason`
+  - `redaction_failure_reason`
+  - `redact_args_present`
+  - `redact_args_target`
+  - `redact_args_mode`
+  - `redact_args_result`
+  - `redact_args_reason`
+  - `obligation_outcomes`
+
+## Non-goals still enforced
+- [ ] No PII detection engine
+- [ ] No external DLP integration
+- [ ] No broad/global redact semantics
+- [ ] No UI/control-plane additions
+
+## Existing obligation line still intact
+- [ ] `log` execution remains present
+- [ ] `alert` execution remains present
+- [ ] `approval_required` enforcement remains present
+- [ ] `restrict_scope` enforcement remains present
+- [ ] `legacy_warning -> log` compatibility remains present
+
+## Validation
+- [ ] Step3 gate passes against stacked base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step3.md
@@ -1,0 +1,46 @@
+# SPLIT REVIEW PACK - Wave36 Redact Args Enforcement Step3
+
+## Intent
+Close Wave36 with a docs+gate-only closure slice after bounded runtime `redact_args` enforcement landed.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add PII/DLP scope
+- add UI/control-plane scope
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step3.md`
+- `scripts/ci/review-wave36-redact-args-enforcement-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns Step2 structural invariants.
+3. Runtime redaction execution markers remain present.
+4. Deterministic redaction failure mapping remains present.
+5. Additive redaction evidence markers remain present.
+6. Existing obligation lines remain intact.
+7. No scope creep appears in runtime scope.
+8. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base (if used)
+```bash
+BASE_REF=origin/codex/wave36-redact-args-enforcement-step2-impl \
+  bash scripts/ci/review-wave36-redact-args-enforcement-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave36-redact-args-enforcement-step3.sh
+```
+
+Expected outcome:
+- Step3 adds no runtime behavior
+- closure remains diff-proof
+- promote can happen cleanly after stacked validation

--- a/scripts/ci/review-wave36-redact-args-enforcement-step3.sh
+++ b/scripts/ci/review-wave36-redact-args-enforcement-step3.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave36-redact-args-enforcement-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave36-redact-args-enforcement-step3.md"
+  "scripts/ci/review-wave36-redact-args-enforcement-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave36 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave36 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] runtime redaction execution markers"
+for marker in \
+  'effective_arguments' \
+  'validate_redact_args' \
+  'apply_redact_args_runtime' \
+  'redaction_target_value_mut' \
+  'apply_value_redaction' \
+  'partial_mask'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/tool_call_handler/types.rs \
+    crates/assay-core/src/mcp/tool_call_handler/emit.rs \
+    crates/assay-core/src/mcp/tool_call_handler/evaluate.rs \
+    crates/assay-core/src/mcp/tool_call_handler/tests.rs \
+    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+      echo "FAIL: missing runtime redaction marker: $marker"
+      exit 1
+    }
+done
+
+echo "[review] deterministic redaction failure markers"
+for marker in \
+  'redaction_target_missing' \
+  'redaction_mode_unsupported' \
+  'redaction_scope_unsupported' \
+  'redaction_apply_failed' \
+  'P_REDACT_ARGS'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/tool_call_handler/evaluate.rs \
+    crates/assay-core/src/mcp/tool_call_handler/tests.rs \
+    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+      echo "FAIL: missing deterministic failure marker: $marker"
+      exit 1
+    }
+done
+
+echo "[review] additive redaction evidence markers"
+for marker in \
+  'redaction_target' \
+  'redaction_mode' \
+  'redaction_scope' \
+  'redaction_applied_state' \
+  'redaction_reason' \
+  'redaction_failure_reason' \
+  'redact_args_present' \
+  'redact_args_target' \
+  'redact_args_mode' \
+  'redact_args_result' \
+  'redact_args_reason' \
+  'obligation_outcomes' \
+  'validated_in_handler'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/tool_call_handler/evaluate.rs crates/assay-core/src/mcp/tool_call_handler/tests.rs crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    echo "FAIL: missing additive evidence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing obligation line remains present"
+for marker in \
+  'legacy_warning' \
+  'log' \
+  'alert' \
+  'approval_required' \
+  'restrict_scope' \
+  'redact_args'
+do
+  rg -n "$marker" crates/assay-core/src/mcp >/dev/null || {
+    echo "FAIL: missing existing obligation marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'pii_detection|external_dlp|dlp_integration|global_redact|control_plane|auth transport' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'pii_detection|external_dlp|dlp_integration|global_redact|control_plane|auth transport' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant
+cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_contract_sets_additive_fields -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_target_missing_denies -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_contract_sets_additive_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core approval_required_missing_denies -- --exact
+cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave36 Step3 closure checklist
- add Wave36 Step3 review pack
- add Wave36 Step3 reviewer gate script

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave36-redact-args-enforcement-step3.sh`
- local gate PASS (includes fmt, clippy, pinned tests)