### PR TITLE
docs(wave37-step1): freeze decision/evidence convergence

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave37-decision-evidence-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave37-decision-evidence-step1.md
@@ -1,0 +1,25 @@
+# SPLIT CHECKLIST — Wave37 Decision Evidence Convergence Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave37-decision-evidence-convergence.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave37-decision-evidence-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave37-decision-evidence-step1.md`
+  - `scripts/ci/review-wave37-decision-evidence-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] canonical outcome taxonomy is explicit
+- [ ] deterministic classification semantics are explicit
+- [ ] additive convergence evidence fields are explicit
+- [ ] downstream compatibility rules are explicit
+- [ ] non-goals are explicit (no new runtime capability in Wave37)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave37-decision-evidence-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-PLAN-wave37-decision-evidence-convergence.md
+++ b/docs/contributing/SPLIT-PLAN-wave37-decision-evidence-convergence.md
@@ -1,0 +1,106 @@
+# SPLIT PLAN — Wave37 Decision Evidence Convergence
+
+## Intent
+Freeze a bounded convergence contract for decision/evidence outcomes across existing MCP runtime paths.
+
+This wave is about:
+- one normalized outcome shape
+- deterministic outcome classification across deny/apply/skip/error paths
+- deterministic `reason_code`, `enforcement_stage`, and `normalization_version`
+- additive compatibility rules for downstream event consumers
+
+It explicitly does **not** add:
+- new obligation types
+- new runtime enforcement capabilities
+- policy-engine backend expansion
+- UI/control-plane/auth transport changes
+
+## Problem
+After Waves 24–36, Assay has multiple mature execution paths (`policy`, `fail_closed`, `approval_required`, `restrict_scope`, `redact_args`, and obligation fulfillment). The stack is correct, but evidence semantics can drift if each path evolves separately.
+
+Current gap:
+- no single frozen convergence contract for outcome semantics
+- risk of divergence between deny classes and obligation fulfillment classes
+- replay/audit consumers need a stable normalized classification contract
+
+## Frozen convergence contract
+Wave37 freezes a canonical normalized outcome taxonomy:
+
+- `policy_deny`
+- `fail_closed_deny`
+- `enforcement_deny`
+- `obligation_applied`
+- `obligation_skipped`
+- `obligation_error`
+
+## Frozen classification semantics
+Wave37 freezes deterministic classification mapping:
+
+1. Policy-rule deny paths classify as `policy_deny`.
+2. Fail-closed fallback deny paths classify as `fail_closed_deny`.
+3. Enforcement-time denies (for example approval/scope/redaction checks) classify as `enforcement_deny`.
+4. Obligation execution paths classify as one of:
+   - `obligation_applied`
+   - `obligation_skipped`
+   - `obligation_error`
+
+## Frozen additive evidence contract
+Wave37 freezes additive convergence fields (without removing existing fields):
+
+- `decision_outcome_kind`
+- `decision_origin`
+- `enforcement_stage`
+- `reason_code`
+- `normalization_version`
+- `outcome_compat_state`
+
+## Frozen downstream compatibility rules
+Wave37 freezes compatibility expectations for event consumers:
+
+- existing required decision/event fields must remain present
+- convergence fields are additive and backward-compatible
+- deterministic mapping from legacy outcome signals to `decision_outcome_kind`
+- no consumer-facing break in existing replay/diff pipelines
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. Canonical outcome taxonomy is represented in runtime/event contracts.
+2. Classification is deterministic for policy/fail-closed/enforcement/obligation paths.
+3. Convergence fields are additive and backward-compatible.
+4. Existing behavior for `log`, `alert`, `approval_required`, `restrict_scope`, and `redact_args` remains stable.
+5. No new runtime capability is introduced in this wave.
+
+## Scope boundaries
+### In scope
+- normalized decision/evidence convergence contract
+- deterministic classification mapping contract
+- additive convergence evidence fields
+- tests and reviewer gates for the above
+
+### Out of scope
+- new obligations or enforcement features
+- policy backend expansion
+- auth transport changes
+- UI/control-plane semantics
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- add convergence fields/mapping in runtime/event contracts
+- keep behavior additive and deterministic
+- no capability expansion
+
+### Step3
+Docs + gate-only closure
+
+## Reviewer notes
+This wave must remain convergence-first.
+
+Primary failure modes:
+- introducing a new capability instead of normalizing existing outcomes
+- weakening deterministic classification
+- breaking downstream consumers by non-additive event changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave37-decision-evidence-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave37-decision-evidence-step1.md
@@ -1,0 +1,39 @@
+# SPLIT REVIEW PACK — Wave37 Decision Evidence Convergence Step1
+
+## Intent
+Freeze a bounded convergence contract for decision/evidence outcomes before any Step2 implementation changes.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add new runtime capability
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave37-decision-evidence-convergence.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave37-decision-evidence-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave37-decision-evidence-step1.md`
+- `scripts/ci/review-wave37-decision-evidence-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Canonical outcome taxonomy is explicit.
+3. Deterministic classification semantics are explicit.
+4. Additive convergence evidence fields are explicit.
+5. Downstream compatibility rules are explicit.
+6. Runtime paths are untouched.
+7. No capability expansion is introduced in this wave.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave37-decision-evidence-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- convergence contract is frozen cleanly
+- Step2 can implement mapping/evidence convergence without reopening scope

--- a/scripts/ci/review-wave37-decision-evidence-step1.sh
+++ b/scripts/ci/review-wave37-decision-evidence-step1.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave37-decision-evidence-convergence.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave37-decision-evidence-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave37-decision-evidence-step1.md"
+  "scripts/ci/review-wave37-decision-evidence-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-core/tests"
+  "crates/assay-cli/src/cli/commands"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave37 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave37 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave37 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave37-decision-evidence-convergence.md"
+
+rg -n '^# SPLIT PLAN — Wave37 Decision Evidence Convergence$' "$PLAN" >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'policy_deny' \
+  'fail_closed_deny' \
+  'enforcement_deny' \
+  'obligation_applied' \
+  'obligation_skipped' \
+  'obligation_error' \
+  'decision_outcome_kind' \
+  'decision_origin' \
+  'enforcement_stage' \
+  'reason_code' \
+  'normalization_version' \
+  'outcome_compat_state'
+do
+  rg -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant
+cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core approval_required_missing_denies -- --exact
+cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core redact_args_target_missing_denies -- --exact
+cargo test -p assay-core redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave37 Step1 split plan for decision/evidence convergence
- add Step1 checklist and review pack
- add Step1 reviewer gate script

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave37-decision-evidence-step1.sh`
- local gate PASS (includes fmt, clippy, pinned tests)