### PR TITLE
feat(wave37-step2): decision/evidence convergence normalization

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -3,6 +3,7 @@
 //! This module implements the "always emit decision" invariant (I1):
 //! Every tool call attempt MUST emit exactly one decision event.
 
+use self::outcome_convergence::classify_decision_outcome;
 use super::policy::{
     ApprovalArtifact, ApprovalFreshness, FailClosedContext, PolicyObligation, RedactArgsContract,
     RestrictScopeContract, TypedPolicyDecision,
@@ -11,6 +12,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::io::Write;
 use std::sync::Arc;
+
+mod outcome_convergence;
+pub use outcome_convergence::{DecisionOrigin, DecisionOutcomeKind, OutcomeCompatState};
 
 /// Reason codes for tool decisions (SPEC-Mandate-v1.0.4 §7.10).
 pub mod reason_codes {
@@ -278,6 +282,15 @@ pub struct DecisionData {
     /// Additive fail-closed matrix context for this decision
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fail_closed: Option<FailClosedContext>,
+    /// Canonical decision/evidence convergence outcome classification.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision_outcome_kind: Option<DecisionOutcomeKind>,
+    /// Origin for the canonical convergence classification.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision_origin: Option<DecisionOrigin>,
+    /// Compatibility state for downstream consumers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outcome_compat_state: Option<OutcomeCompatState>,
     /// Normalized decision path for fulfillment evidence.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fulfillment_decision_path: Option<FulfillmentDecisionPath>,
@@ -401,6 +414,20 @@ fn refresh_fulfillment_normalization(data: &mut DecisionData) {
             .iter()
             .any(|outcome| outcome.status == ObligationOutcomeStatus::Error),
     );
+    let outcome = classify_decision_outcome(
+        data.decision,
+        data.reason_code.as_str(),
+        data.fail_closed
+            .as_ref()
+            .map(|ctx| ctx.fail_closed_applied)
+            .unwrap_or(false),
+        data.obligation_applied_present.unwrap_or(false),
+        data.obligation_skipped_present.unwrap_or(false),
+        data.obligation_error_present.unwrap_or(false),
+    );
+    data.decision_outcome_kind = Some(outcome.kind);
+    data.decision_origin = Some(outcome.origin);
+    data.outcome_compat_state = Some(outcome.compat_state);
     data.fulfillment_decision_path = Some(classify_fulfillment_decision_path(data));
 }
 
@@ -455,6 +482,9 @@ impl DecisionEvent {
                 redact_args_result: None,
                 redact_args_reason: None,
                 fail_closed: None,
+                decision_outcome_kind: None,
+                decision_origin: None,
+                outcome_compat_state: None,
                 fulfillment_decision_path: None,
                 obligation_applied_present: None,
                 obligation_skipped_present: None,

--- a/crates/assay-core/src/mcp/decision/outcome_convergence.rs
+++ b/crates/assay-core/src/mcp/decision/outcome_convergence.rs
@@ -1,0 +1,189 @@
+use super::{reason_codes, Decision};
+use serde::{Deserialize, Serialize};
+
+/// Canonical decision/evidence convergence outcome classification (Wave37).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecisionOutcomeKind {
+    PolicyDeny,
+    FailClosedDeny,
+    EnforcementDeny,
+    ObligationApplied,
+    ObligationSkipped,
+    ObligationError,
+}
+
+/// Origin for a canonical convergence outcome classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecisionOrigin {
+    PolicyEngine,
+    FailClosedMatrix,
+    RuntimeEnforcement,
+    ObligationExecutor,
+}
+
+/// Compatibility state for downstream event consumers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutcomeCompatState {
+    LegacyFieldsPreserved,
+}
+
+pub(super) struct OutcomeClassification {
+    pub(super) kind: DecisionOutcomeKind,
+    pub(super) origin: DecisionOrigin,
+    pub(super) compat_state: OutcomeCompatState,
+}
+
+pub(super) fn classify_decision_outcome(
+    decision: Decision,
+    reason_code: &str,
+    fail_closed_applied: bool,
+    obligation_applied_present: bool,
+    _obligation_skipped_present: bool,
+    obligation_error_present: bool,
+) -> OutcomeClassification {
+    let (kind, origin) = match decision {
+        Decision::Deny => {
+            if fail_closed_applied {
+                (
+                    DecisionOutcomeKind::FailClosedDeny,
+                    DecisionOrigin::FailClosedMatrix,
+                )
+            } else if is_enforcement_deny_reason(reason_code) {
+                (
+                    DecisionOutcomeKind::EnforcementDeny,
+                    DecisionOrigin::RuntimeEnforcement,
+                )
+            } else {
+                (
+                    DecisionOutcomeKind::PolicyDeny,
+                    DecisionOrigin::PolicyEngine,
+                )
+            }
+        }
+        Decision::Allow => {
+            if obligation_error_present {
+                (
+                    DecisionOutcomeKind::ObligationError,
+                    DecisionOrigin::ObligationExecutor,
+                )
+            } else if obligation_applied_present {
+                (
+                    DecisionOutcomeKind::ObligationApplied,
+                    DecisionOrigin::ObligationExecutor,
+                )
+            } else {
+                (
+                    DecisionOutcomeKind::ObligationSkipped,
+                    DecisionOrigin::ObligationExecutor,
+                )
+            }
+        }
+        Decision::Error => (
+            DecisionOutcomeKind::ObligationError,
+            DecisionOrigin::RuntimeEnforcement,
+        ),
+    };
+
+    OutcomeClassification {
+        kind,
+        origin,
+        compat_state: OutcomeCompatState::LegacyFieldsPreserved,
+    }
+}
+
+fn is_enforcement_deny_reason(reason_code: &str) -> bool {
+    matches!(
+        reason_code,
+        reason_codes::P_APPROVAL_REQUIRED
+            | reason_codes::P_RESTRICT_SCOPE
+            | reason_codes::P_REDACT_ARGS
+            | reason_codes::P_MANDATE_REQUIRED
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_policy_deny() {
+        let result = classify_decision_outcome(
+            Decision::Deny,
+            reason_codes::P_TOOL_DENIED,
+            false,
+            false,
+            false,
+            false,
+        );
+        assert_eq!(result.kind, DecisionOutcomeKind::PolicyDeny);
+        assert_eq!(result.origin, DecisionOrigin::PolicyEngine);
+        assert_eq!(
+            result.compat_state,
+            OutcomeCompatState::LegacyFieldsPreserved
+        );
+    }
+
+    #[test]
+    fn classifies_fail_closed_deny() {
+        let result = classify_decision_outcome(
+            Decision::Deny,
+            reason_codes::S_DB_ERROR,
+            true,
+            false,
+            false,
+            false,
+        );
+        assert_eq!(result.kind, DecisionOutcomeKind::FailClosedDeny);
+        assert_eq!(result.origin, DecisionOrigin::FailClosedMatrix);
+    }
+
+    #[test]
+    fn classifies_enforcement_deny() {
+        let result = classify_decision_outcome(
+            Decision::Deny,
+            reason_codes::P_APPROVAL_REQUIRED,
+            false,
+            false,
+            false,
+            true,
+        );
+        assert_eq!(result.kind, DecisionOutcomeKind::EnforcementDeny);
+        assert_eq!(result.origin, DecisionOrigin::RuntimeEnforcement);
+    }
+
+    #[test]
+    fn classifies_obligation_outcomes_on_allow() {
+        let applied = classify_decision_outcome(
+            Decision::Allow,
+            reason_codes::P_POLICY_ALLOW,
+            false,
+            true,
+            false,
+            false,
+        );
+        assert_eq!(applied.kind, DecisionOutcomeKind::ObligationApplied);
+
+        let skipped = classify_decision_outcome(
+            Decision::Allow,
+            reason_codes::P_POLICY_ALLOW,
+            false,
+            false,
+            true,
+            false,
+        );
+        assert_eq!(skipped.kind, DecisionOutcomeKind::ObligationSkipped);
+
+        let errored = classify_decision_outcome(
+            Decision::Allow,
+            reason_codes::P_POLICY_ALLOW,
+            false,
+            false,
+            false,
+            true,
+        );
+        assert_eq!(errored.kind, DecisionOutcomeKind::ObligationError);
+    }
+}

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -4,8 +4,8 @@
 //! one decision event being emitted, regardless of outcome.
 
 use assay_core::mcp::decision::{
-    reason_codes, Decision, DecisionEmitter, DecisionEmitterGuard, DecisionEvent,
-    FulfillmentDecisionPath, ObligationOutcomeStatus,
+    reason_codes, Decision, DecisionEmitter, DecisionEmitterGuard, DecisionEvent, DecisionOrigin,
+    DecisionOutcomeKind, FulfillmentDecisionPath, ObligationOutcomeStatus, OutcomeCompatState,
 };
 use assay_core::mcp::policy::{
     ApprovalFreshness, McpPolicy, PolicyState, RedactArgsContract, RestrictScopeContract,
@@ -1026,6 +1026,18 @@ fn test_event_contains_required_fields() {
     assert_eq!(
         event.data.fulfillment_decision_path,
         Some(FulfillmentDecisionPath::PolicyAllow)
+    );
+    assert_eq!(
+        event.data.decision_outcome_kind,
+        Some(DecisionOutcomeKind::ObligationApplied)
+    );
+    assert_eq!(
+        event.data.decision_origin,
+        Some(DecisionOrigin::ObligationExecutor)
+    );
+    assert_eq!(
+        event.data.outcome_compat_state,
+        Some(OutcomeCompatState::LegacyFieldsPreserved)
     );
     assert_eq!(event.data.obligation_applied_present, Some(true));
     assert_eq!(event.data.obligation_skipped_present, Some(false));

--- a/crates/assay-core/tests/fulfillment_normalization.rs
+++ b/crates/assay-core/tests/fulfillment_normalization.rs
@@ -1,6 +1,6 @@
 use assay_core::mcp::decision::{
-    reason_codes, DecisionEvent, FulfillmentDecisionPath, ObligationOutcome,
-    ObligationOutcomeStatus, PolicyDecisionEventContext,
+    reason_codes, DecisionEvent, DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath,
+    ObligationOutcome, ObligationOutcomeStatus, OutcomeCompatState, PolicyDecisionEventContext,
 };
 use assay_core::mcp::policy::{
     FailClosedContext, FailClosedMode, FailClosedTrigger, ToolRiskClass,
@@ -34,6 +34,18 @@ fn fulfillment_normalizes_outcomes_and_sets_policy_deny_path() {
     assert_eq!(
         event.data.fulfillment_decision_path,
         Some(FulfillmentDecisionPath::PolicyDeny)
+    );
+    assert_eq!(
+        event.data.decision_outcome_kind,
+        Some(DecisionOutcomeKind::EnforcementDeny)
+    );
+    assert_eq!(
+        event.data.decision_origin,
+        Some(DecisionOrigin::RuntimeEnforcement)
+    );
+    assert_eq!(
+        event.data.outcome_compat_state,
+        Some(OutcomeCompatState::LegacyFieldsPreserved)
     );
     assert_eq!(event.data.obligation_applied_present, Some(true));
     assert_eq!(event.data.obligation_skipped_present, Some(false));
@@ -84,5 +96,43 @@ fn fulfillment_sets_fail_closed_deny_path() {
     assert_eq!(
         event.data.fulfillment_decision_path,
         Some(FulfillmentDecisionPath::FailClosedDeny)
+    );
+    assert_eq!(
+        event.data.decision_outcome_kind,
+        Some(DecisionOutcomeKind::FailClosedDeny)
+    );
+    assert_eq!(
+        event.data.decision_origin,
+        Some(DecisionOrigin::FailClosedMatrix)
+    );
+}
+
+#[test]
+fn fulfillment_sets_policy_deny_convergence_fields() {
+    let event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_009".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(
+        reason_codes::P_POLICY_DENY,
+        Some("policy blocked".to_string()),
+    );
+
+    assert_eq!(
+        event.data.fulfillment_decision_path,
+        Some(FulfillmentDecisionPath::PolicyDeny)
+    );
+    assert_eq!(
+        event.data.decision_outcome_kind,
+        Some(DecisionOutcomeKind::PolicyDeny)
+    );
+    assert_eq!(
+        event.data.decision_origin,
+        Some(DecisionOrigin::PolicyEngine)
+    );
+    assert_eq!(
+        event.data.outcome_compat_state,
+        Some(OutcomeCompatState::LegacyFieldsPreserved)
     );
 }

--- a/docs/contributing/SPLIT-CHECKLIST-wave37-decision-evidence-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave37-decision-evidence-step2.md
@@ -1,0 +1,39 @@
+# SPLIT CHECKLIST - Wave37 Decision Evidence Convergence Step2
+
+## Scope discipline
+- [ ] Diff is limited to bounded runtime + tests + Step2 docs/gate
+- [ ] No `.github/workflows/*` changes
+- [ ] No scope leaks outside MCP runtime/test paths
+- [ ] No new obligation types added
+- [ ] No policy backend/control-plane/auth transport changes
+
+## Implementation contract
+- [ ] Canonical convergence outcome fields are additive:
+  - `decision_outcome_kind`
+  - `decision_origin`
+  - `outcome_compat_state`
+- [ ] Deterministic deny classification is explicit:
+  - `policy_deny`
+  - `fail_closed_deny`
+  - `enforcement_deny`
+- [ ] Deterministic obligation classification is explicit:
+  - `obligation_applied`
+  - `obligation_skipped`
+  - `obligation_error`
+- [ ] Existing fulfillment normalization remains intact:
+  - `fulfillment_decision_path`
+  - `obligation_applied_present`
+  - `obligation_skipped_present`
+  - `obligation_error_present`
+
+## Compatibility and behavior
+- [ ] Existing decision/event fields remain present and backward-compatible
+- [ ] Existing execution behavior (`log`, `alert`, `approval_required`, `restrict_scope`, `redact_args`) remains intact
+- [ ] `policy_deny` vs `fail_closed_deny` remains explicitly distinguishable
+- [ ] No new runtime capability is introduced in this wave
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave37-decision-evidence-step2.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave37-decision-evidence-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave37-decision-evidence-step2.md
@@ -1,0 +1,27 @@
+# SPLIT MOVE MAP - Wave37 Decision Evidence Convergence Step2
+
+## Intent
+Bounded implementation for additive decision/evidence convergence across existing MCP runtime paths.
+
+## Touched runtime paths
+- `crates/assay-core/src/mcp/decision.rs`
+  - adds additive convergence event fields:
+    - `decision_outcome_kind`
+    - `decision_origin`
+    - `outcome_compat_state`
+  - wires deterministic convergence refresh into existing normalization path
+- `crates/assay-core/src/mcp/decision/outcome_convergence.rs`
+  - introduces canonical convergence enums and deterministic classification logic
+  - keeps policy/fail-closed/enforcement/obligation mapping explicit
+
+## Touched tests
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+  - extends required-fields assertions with convergence fields
+- `crates/assay-core/tests/fulfillment_normalization.rs`
+  - validates deterministic convergence mapping for policy/fail-closed/enforcement paths
+
+## Out of scope guarantees
+- no new obligation types
+- no new enforcement capabilities
+- no policy backend/control-plane additions
+- no auth transport changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave37-decision-evidence-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave37-decision-evidence-step2.md
@@ -1,0 +1,28 @@
+# SPLIT REVIEW PACK - Wave37 Decision Evidence Convergence Step2
+
+## Intent
+Implement bounded, additive decision/evidence convergence normalization.
+
+This slice must:
+- keep existing execution behavior unchanged
+- add deterministic convergence classification fields
+- keep event payload changes additive and backward-compatible
+
+This slice must not:
+- add new obligation types
+- add new runtime capability
+- expand policy-engine scope
+- add UI/control-plane/auth transport work
+- touch workflow files
+
+## Reviewer focus
+1. Diff stays inside bounded runtime/test/docs/gate scope.
+2. Convergence fields are present and deterministic.
+3. Policy deny vs fail-closed deny remains explicitly separated.
+4. Existing obligation execution behavior remains intact.
+5. No scope creep into non-goals.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave37-decision-evidence-step2.sh
+```

--- a/scripts/ci/review-wave37-decision-evidence-step2.sh
+++ b/scripts/ci/review-wave37-decision-evidence-step2.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-core/src/mcp/decision/outcome_convergence.rs"
+  "crates/assay-core/tests/decision_emit_invariant.rs"
+  "crates/assay-core/tests/fulfillment_normalization.rs"
+
+  "docs/contributing/SPLIT-CHECKLIST-wave37-decision-evidence-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave37-decision-evidence-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave37-decision-evidence-step2.md"
+
+  "scripts/ci/review-wave37-decision-evidence-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave37 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave37 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  while IFS= read -r uf; do
+    [[ -z "${uf:-}" ]] && continue
+    allowed="false"
+    for a in "${ALLOWLIST[@]}"; do
+      [[ "$uf" == "$a" ]] && allowed="true" && break
+    done
+    if [[ "$allowed" != "true" ]]; then
+      echo "FAIL: untracked file present under $p: $uf"
+      exit 1
+    fi
+  done < <(git ls-files --others --exclude-standard -- "$p")
+done
+
+echo "[review] convergence markers"
+for marker in \
+  'DecisionOutcomeKind' \
+  'DecisionOrigin' \
+  'OutcomeCompatState' \
+  'decision_outcome_kind' \
+  'decision_origin' \
+  'outcome_compat_state' \
+  'PolicyDeny' \
+  'FailClosedDeny' \
+  'EnforcementDeny' \
+  'ObligationApplied' \
+  'ObligationSkipped' \
+  'ObligationError' \
+  'classify_decision_outcome'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/outcome_convergence.rs >/dev/null || {
+    echo "FAIL: missing convergence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing normalization markers remain present"
+for marker in \
+  'fulfillment_decision_path' \
+  'obligation_applied_present' \
+  'obligation_skipped_present' \
+  'obligation_error_present' \
+  'reason_code' \
+  'enforcement_stage' \
+  'normalization_version'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs >/dev/null || {
+    echo "FAIL: missing existing normalization marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] policy deny vs fail-closed deny separation"
+rg -n 'classify_fulfillment_decision_path|fail_closed_applied' crates/assay-core/src/mcp/decision.rs >/dev/null || {
+  echo "FAIL: missing deny-path separation markers"
+  exit 1
+}
+
+echo "[review] existing obligation line remains present"
+rg -n 'obligation_outcomes|legacy_warning|approval_required|restrict_scope|redact_args|log|alert' \
+  crates/assay-core/src/mcp >/dev/null || {
+  echo "FAIL: existing obligation markers missing"
+  exit 1
+}
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'policy backend replacement|approval UI|case management|external approval|control-plane|auth transport' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'policy backend replacement|approval UI|case management|external approval|control-plane|auth transport' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core approval_required_missing_denies -- --exact
+cargo test -p assay-core approval_required_expired_denies -- --exact
+cargo test -p assay-core approval_required_bound_tool_mismatch_denies -- --exact
+cargo test -p assay-core approval_required_bound_resource_mismatch_denies -- --exact
+cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core restrict_scope_match_sets_additive_fields -- --exact
+cargo test -p assay-core redact_args_target_missing_denies -- --exact
+cargo test -p assay-core redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
+cargo test -p assay-core fulfillment_sets_policy_deny_convergence_fields -- --exact
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add canonical convergence classification for decision/evidence outcomes
- add additive event fields (`decision_outcome_kind`, `decision_origin`, `outcome_compat_state`)
- keep existing fulfillment normalization and obligation paths intact
- add Wave37 Step2 docs/gate pack

## Scope
- bounded MCP runtime convergence slice
- no workflow changes
- no new runtime capability

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave37-decision-evidence-step2.sh`
- local gate PASS (fmt, clippy, pinned tests)
- `cargo test -p assay-core --test fulfillment_normalization`
- `cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact`