### PR TITLE
fix(wave37): tighten convergence classification and gate test target

### DIFF
--- a/crates/assay-core/src/mcp/decision/outcome_convergence.rs
+++ b/crates/assay-core/src/mcp/decision/outcome_convergence.rs
@@ -82,7 +82,7 @@ pub(super) fn classify_decision_outcome(
             }
         }
         Decision::Error => (
-            DecisionOutcomeKind::ObligationError,
+            DecisionOutcomeKind::EnforcementDeny,
             DecisionOrigin::RuntimeEnforcement,
         ),
     };
@@ -95,13 +95,14 @@ pub(super) fn classify_decision_outcome(
 }
 
 fn is_enforcement_deny_reason(reason_code: &str) -> bool {
-    matches!(
-        reason_code,
-        reason_codes::P_APPROVAL_REQUIRED
-            | reason_codes::P_RESTRICT_SCOPE
-            | reason_codes::P_REDACT_ARGS
-            | reason_codes::P_MANDATE_REQUIRED
-    )
+    reason_code.starts_with("M_")
+        || matches!(
+            reason_code,
+            reason_codes::P_APPROVAL_REQUIRED
+                | reason_codes::P_RESTRICT_SCOPE
+                | reason_codes::P_REDACT_ARGS
+                | reason_codes::P_MANDATE_REQUIRED
+        )
 }
 
 #[cfg(test)]
@@ -149,6 +150,34 @@ mod tests {
             false,
             false,
             true,
+        );
+        assert_eq!(result.kind, DecisionOutcomeKind::EnforcementDeny);
+        assert_eq!(result.origin, DecisionOrigin::RuntimeEnforcement);
+    }
+
+    #[test]
+    fn classifies_mandate_deny_as_enforcement_deny() {
+        let result = classify_decision_outcome(
+            Decision::Deny,
+            reason_codes::M_EXPIRED,
+            false,
+            false,
+            false,
+            false,
+        );
+        assert_eq!(result.kind, DecisionOutcomeKind::EnforcementDeny);
+        assert_eq!(result.origin, DecisionOrigin::RuntimeEnforcement);
+    }
+
+    #[test]
+    fn classifies_decision_error_as_enforcement_deny() {
+        let result = classify_decision_outcome(
+            Decision::Error,
+            reason_codes::S_INTERNAL_ERROR,
+            false,
+            false,
+            false,
+            false,
         );
         assert_eq!(result.kind, DecisionOutcomeKind::EnforcementDeny);
         assert_eq!(result.origin, DecisionOrigin::RuntimeEnforcement);

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -976,6 +976,22 @@ fn test_non_tool_call_emits_error() {
     let event = emitter.last_event().expect("Should have event");
     assert_eq!(event.data.decision, Decision::Error);
     assert_eq!(event.data.reason_code, reason_codes::S_INTERNAL_ERROR);
+    assert_eq!(
+        event.data.fulfillment_decision_path,
+        Some(FulfillmentDecisionPath::DecisionError)
+    );
+    assert_eq!(
+        event.data.decision_outcome_kind,
+        Some(DecisionOutcomeKind::EnforcementDeny)
+    );
+    assert_eq!(
+        event.data.decision_origin,
+        Some(DecisionOrigin::RuntimeEnforcement)
+    );
+    assert_eq!(
+        event.data.outcome_compat_state,
+        Some(OutcomeCompatState::LegacyFieldsPreserved)
+    );
 }
 
 // =============================================================================

--- a/crates/assay-core/tests/fulfillment_normalization.rs
+++ b/crates/assay-core/tests/fulfillment_normalization.rs
@@ -136,3 +136,30 @@ fn fulfillment_sets_policy_deny_convergence_fields() {
         Some(OutcomeCompatState::LegacyFieldsPreserved)
     );
 }
+
+#[test]
+fn fulfillment_sets_mandate_deny_convergence_fields() {
+    let event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_010".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(reason_codes::M_EXPIRED, Some("mandate expired".to_string()));
+
+    assert_eq!(
+        event.data.fulfillment_decision_path,
+        Some(FulfillmentDecisionPath::PolicyDeny)
+    );
+    assert_eq!(
+        event.data.decision_outcome_kind,
+        Some(DecisionOutcomeKind::EnforcementDeny)
+    );
+    assert_eq!(
+        event.data.decision_origin,
+        Some(DecisionOrigin::RuntimeEnforcement)
+    );
+    assert_eq!(
+        event.data.outcome_compat_state,
+        Some(OutcomeCompatState::LegacyFieldsPreserved)
+    );
+}

--- a/scripts/ci/review-wave37-decision-evidence-step1.sh
+++ b/scripts/ci/review-wave37-decision-evidence-step1.sh
@@ -106,6 +106,6 @@ cargo test -p assay-core redact_args_apply_failed_denies -- --exact
 cargo test -p assay-core fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out
-cargo test -p assay-mcp-server auth_integration
+cargo test -p assay-mcp-server --test auth_integration
 
 echo "[review] PASS"


### PR DESCRIPTION
## Summary
- classify mandate failure reason codes (`M_*`) as enforcement-deny in convergence mapping
- classify `Decision::Error` convergence as runtime enforcement-deny (instead of obligation error)
- extend convergence coverage tests for mandate-deny and error-path invariants
- fix Wave37 Step1 gate test invocation to run `--test auth_integration`

## Why
This addresses concrete Copilot review findings from Wave37 PRs and keeps decision/evidence convergence semantics deterministic without adding new capability.

## Validation
- `cargo fmt --check`
- `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings`
- `cargo test -p assay-core --test fulfillment_normalization`
- `cargo test -p assay-core --test decision_emit_invariant test_non_tool_call_emits_error -- --exact`
- `cargo test -p assay-core outcome_convergence`
