### PR TITLE
feat(wave38-step2): add replay diff basis and deterministic buckets

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -14,7 +14,11 @@ use std::io::Write;
 use std::sync::Arc;
 
 mod outcome_convergence;
+mod replay_diff;
 pub use outcome_convergence::{DecisionOrigin, DecisionOutcomeKind, OutcomeCompatState};
+pub use replay_diff::{
+    basis_from_decision_data, classify_replay_diff, ReplayDiffBasis, ReplayDiffBucket,
+};
 
 /// Reason codes for tool decisions (SPEC-Mandate-v1.0.4 §7.10).
 pub mod reason_codes {

--- a/crates/assay-core/src/mcp/decision/replay_diff.rs
+++ b/crates/assay-core/src/mcp/decision/replay_diff.rs
@@ -1,5 +1,6 @@
 use super::{
-    DecisionData, DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath, OutcomeCompatState,
+    Decision, DecisionData, DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath,
+    OutcomeCompatState,
 };
 use crate::mcp::policy::TypedPolicyDecision;
 use serde::{Deserialize, Serialize};
@@ -26,6 +27,8 @@ pub struct ReplayDiffBasis {
     pub typed_decision: Option<TypedPolicyDecision>,
     pub policy_version: Option<String>,
     pub policy_digest: Option<String>,
+    pub decision: Decision,
+    pub fail_closed_applied: bool,
 }
 
 /// Build replay basis from an emitted decision payload.
@@ -39,6 +42,12 @@ pub fn basis_from_decision_data(data: &DecisionData) -> ReplayDiffBasis {
         typed_decision: data.typed_decision,
         policy_version: data.policy_version.clone(),
         policy_digest: data.policy_digest.clone(),
+        decision: data.decision,
+        fail_closed_applied: data
+            .fail_closed
+            .as_ref()
+            .map(|ctx| ctx.fail_closed_applied)
+            .unwrap_or(false),
     }
 }
 
@@ -76,6 +85,8 @@ fn same_effective_decision_class(baseline: &ReplayDiffBasis, candidate: &ReplayD
         && baseline.fulfillment_decision_path == candidate.fulfillment_decision_path
         && baseline.reason_code == candidate.reason_code
         && baseline.typed_decision == candidate.typed_decision
+        && baseline.decision == candidate.decision
+        && baseline.fail_closed_applied == candidate.fail_closed_applied
 }
 
 fn restrictiveness_rank(basis: &ReplayDiffBasis) -> u8 {
@@ -90,7 +101,11 @@ fn restrictiveness_rank(basis: &ReplayDiffBasis) -> u8 {
             Some(FulfillmentDecisionPath::PolicyDeny)
             | Some(FulfillmentDecisionPath::FailClosedDeny)
             | Some(FulfillmentDecisionPath::DecisionError) => 2,
-            Some(FulfillmentDecisionPath::PolicyAllow) | None => 1,
+            Some(FulfillmentDecisionPath::PolicyAllow) => 1,
+            None => match basis.decision {
+                Decision::Deny | Decision::Error => 2,
+                Decision::Allow => 1,
+            },
         },
     }
 }
@@ -109,6 +124,8 @@ mod tests {
             typed_decision: Some(TypedPolicyDecision::AllowWithObligations),
             policy_version: Some("v1".to_string()),
             policy_digest: Some("sha1".to_string()),
+            decision: Decision::Allow,
+            fail_closed_applied: false,
         }
     }
 
@@ -157,15 +174,47 @@ mod tests {
     fn classifies_reclassified() {
         let mut baseline = make_basis(Some(DecisionOutcomeKind::PolicyDeny), "P_POLICY_DENY");
         baseline.fulfillment_decision_path = Some(FulfillmentDecisionPath::PolicyDeny);
+        baseline.decision = Decision::Deny;
 
         let mut candidate = baseline.clone();
         candidate.decision_outcome_kind = Some(DecisionOutcomeKind::FailClosedDeny);
         candidate.decision_origin = Some(DecisionOrigin::FailClosedMatrix);
         candidate.fulfillment_decision_path = Some(FulfillmentDecisionPath::FailClosedDeny);
+        candidate.fail_closed_applied = true;
 
         assert_eq!(
             classify_replay_diff(&baseline, &candidate),
             ReplayDiffBucket::Reclassified
+        );
+    }
+
+    #[test]
+    fn classifies_legacy_events_with_decision_fallback() {
+        let baseline = ReplayDiffBasis {
+            decision_outcome_kind: None,
+            decision_origin: None,
+            outcome_compat_state: None,
+            fulfillment_decision_path: None,
+            reason_code: "P_POLICY_ALLOW".to_string(),
+            typed_decision: None,
+            policy_version: None,
+            policy_digest: None,
+            decision: Decision::Allow,
+            fail_closed_applied: false,
+        };
+        let candidate = ReplayDiffBasis {
+            decision: Decision::Deny,
+            reason_code: "P_POLICY_DENY".to_string(),
+            ..baseline.clone()
+        };
+
+        assert_eq!(
+            classify_replay_diff(&baseline, &candidate),
+            ReplayDiffBucket::Stricter
+        );
+        assert_eq!(
+            classify_replay_diff(&candidate, &baseline),
+            ReplayDiffBucket::Looser
         );
     }
 }

--- a/crates/assay-core/src/mcp/decision/replay_diff.rs
+++ b/crates/assay-core/src/mcp/decision/replay_diff.rs
@@ -1,0 +1,171 @@
+use super::{
+    DecisionData, DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath, OutcomeCompatState,
+};
+use crate::mcp::policy::TypedPolicyDecision;
+use serde::{Deserialize, Serialize};
+
+/// Canonical replay-diff bucket for deterministic policy comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayDiffBucket {
+    Unchanged,
+    Stricter,
+    Looser,
+    Reclassified,
+    EvidenceOnly,
+}
+
+/// Frozen replay basis used for deterministic diffing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplayDiffBasis {
+    pub decision_outcome_kind: Option<DecisionOutcomeKind>,
+    pub decision_origin: Option<DecisionOrigin>,
+    pub outcome_compat_state: Option<OutcomeCompatState>,
+    pub fulfillment_decision_path: Option<FulfillmentDecisionPath>,
+    pub reason_code: String,
+    pub typed_decision: Option<TypedPolicyDecision>,
+    pub policy_version: Option<String>,
+    pub policy_digest: Option<String>,
+}
+
+/// Build replay basis from an emitted decision payload.
+pub fn basis_from_decision_data(data: &DecisionData) -> ReplayDiffBasis {
+    ReplayDiffBasis {
+        decision_outcome_kind: data.decision_outcome_kind,
+        decision_origin: data.decision_origin,
+        outcome_compat_state: data.outcome_compat_state,
+        fulfillment_decision_path: data.fulfillment_decision_path,
+        reason_code: data.reason_code.clone(),
+        typed_decision: data.typed_decision,
+        policy_version: data.policy_version.clone(),
+        policy_digest: data.policy_digest.clone(),
+    }
+}
+
+/// Classify replay diff between baseline and candidate basis.
+pub fn classify_replay_diff(
+    baseline: &ReplayDiffBasis,
+    candidate: &ReplayDiffBasis,
+) -> ReplayDiffBucket {
+    if baseline == candidate {
+        return ReplayDiffBucket::Unchanged;
+    }
+
+    if same_effective_decision_class(baseline, candidate) {
+        return ReplayDiffBucket::EvidenceOnly;
+    }
+
+    let baseline_rank = restrictiveness_rank(baseline);
+    let candidate_rank = restrictiveness_rank(candidate);
+
+    if candidate_rank > baseline_rank {
+        return ReplayDiffBucket::Stricter;
+    }
+
+    if candidate_rank < baseline_rank {
+        return ReplayDiffBucket::Looser;
+    }
+
+    ReplayDiffBucket::Reclassified
+}
+
+fn same_effective_decision_class(baseline: &ReplayDiffBasis, candidate: &ReplayDiffBasis) -> bool {
+    baseline.decision_outcome_kind == candidate.decision_outcome_kind
+        && baseline.decision_origin == candidate.decision_origin
+        && baseline.outcome_compat_state == candidate.outcome_compat_state
+        && baseline.fulfillment_decision_path == candidate.fulfillment_decision_path
+        && baseline.reason_code == candidate.reason_code
+        && baseline.typed_decision == candidate.typed_decision
+}
+
+fn restrictiveness_rank(basis: &ReplayDiffBasis) -> u8 {
+    match basis.decision_outcome_kind {
+        Some(DecisionOutcomeKind::PolicyDeny)
+        | Some(DecisionOutcomeKind::FailClosedDeny)
+        | Some(DecisionOutcomeKind::EnforcementDeny) => 2,
+        Some(DecisionOutcomeKind::ObligationApplied)
+        | Some(DecisionOutcomeKind::ObligationSkipped)
+        | Some(DecisionOutcomeKind::ObligationError) => 1,
+        None => match basis.fulfillment_decision_path {
+            Some(FulfillmentDecisionPath::PolicyDeny)
+            | Some(FulfillmentDecisionPath::FailClosedDeny)
+            | Some(FulfillmentDecisionPath::DecisionError) => 2,
+            Some(FulfillmentDecisionPath::PolicyAllow) | None => 1,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_basis(kind: Option<DecisionOutcomeKind>, reason: &str) -> ReplayDiffBasis {
+        ReplayDiffBasis {
+            decision_outcome_kind: kind,
+            decision_origin: Some(DecisionOrigin::PolicyEngine),
+            outcome_compat_state: Some(OutcomeCompatState::LegacyFieldsPreserved),
+            fulfillment_decision_path: Some(FulfillmentDecisionPath::PolicyAllow),
+            reason_code: reason.to_string(),
+            typed_decision: Some(TypedPolicyDecision::AllowWithObligations),
+            policy_version: Some("v1".to_string()),
+            policy_digest: Some("sha1".to_string()),
+        }
+    }
+
+    #[test]
+    fn classifies_unchanged() {
+        let a = make_basis(
+            Some(DecisionOutcomeKind::ObligationApplied),
+            "P_POLICY_ALLOW",
+        );
+        assert_eq!(classify_replay_diff(&a, &a), ReplayDiffBucket::Unchanged);
+    }
+
+    #[test]
+    fn classifies_evidence_only() {
+        let baseline = make_basis(
+            Some(DecisionOutcomeKind::ObligationApplied),
+            "P_POLICY_ALLOW",
+        );
+        let mut candidate = baseline.clone();
+        candidate.policy_version = Some("v2".to_string());
+        candidate.policy_digest = Some("sha2".to_string());
+        assert_eq!(
+            classify_replay_diff(&baseline, &candidate),
+            ReplayDiffBucket::EvidenceOnly
+        );
+    }
+
+    #[test]
+    fn classifies_stricter_and_looser() {
+        let allow = make_basis(
+            Some(DecisionOutcomeKind::ObligationApplied),
+            "P_POLICY_ALLOW",
+        );
+        let deny = make_basis(Some(DecisionOutcomeKind::PolicyDeny), "P_POLICY_DENY");
+        assert_eq!(
+            classify_replay_diff(&allow, &deny),
+            ReplayDiffBucket::Stricter
+        );
+        assert_eq!(
+            classify_replay_diff(&deny, &allow),
+            ReplayDiffBucket::Looser
+        );
+    }
+
+    #[test]
+    fn classifies_reclassified() {
+        let mut baseline = make_basis(Some(DecisionOutcomeKind::PolicyDeny), "P_POLICY_DENY");
+        baseline.fulfillment_decision_path = Some(FulfillmentDecisionPath::PolicyDeny);
+
+        let mut candidate = baseline.clone();
+        candidate.decision_outcome_kind = Some(DecisionOutcomeKind::FailClosedDeny);
+        candidate.decision_origin = Some(DecisionOrigin::FailClosedMatrix);
+        candidate.fulfillment_decision_path = Some(FulfillmentDecisionPath::FailClosedDeny);
+
+        assert_eq!(
+            classify_replay_diff(&baseline, &candidate),
+            ReplayDiffBucket::Reclassified
+        );
+    }
+}

--- a/crates/assay-core/tests/replay_diff_contract.rs
+++ b/crates/assay-core/tests/replay_diff_contract.rs
@@ -1,7 +1,7 @@
 use assay_core::mcp::decision::{
-    basis_from_decision_data, classify_replay_diff, reason_codes, DecisionEvent, DecisionOrigin,
-    DecisionOutcomeKind, FulfillmentDecisionPath, OutcomeCompatState, PolicyDecisionEventContext,
-    ReplayDiffBucket,
+    basis_from_decision_data, classify_replay_diff, reason_codes, Decision, DecisionEvent,
+    DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath, OutcomeCompatState,
+    PolicyDecisionEventContext, ReplayDiffBucket,
 };
 use assay_core::mcp::policy::TypedPolicyDecision;
 
@@ -50,6 +50,8 @@ fn basis_extraction_contains_frozen_fields() {
     );
     assert_eq!(basis.policy_version.as_deref(), Some("v1"));
     assert_eq!(basis.policy_digest.as_deref(), Some("sha1"));
+    assert_eq!(basis.decision, Decision::Allow);
+    assert!(!basis.fail_closed_applied);
 }
 
 #[test]
@@ -138,5 +140,37 @@ fn classify_replay_diff_reclassified() {
     assert_eq!(
         classify_replay_diff(&baseline, &candidate),
         ReplayDiffBucket::Reclassified
+    );
+}
+
+#[test]
+fn classify_replay_diff_legacy_decision_fallback() {
+    let allow_event = allow_event("v1", "sha1");
+    let deny_event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_204".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(reason_codes::P_POLICY_DENY, Some("blocked".to_string()));
+
+    let mut baseline = basis_from_decision_data(&allow_event.data);
+    baseline.decision_outcome_kind = None;
+    baseline.decision_origin = None;
+    baseline.outcome_compat_state = None;
+    baseline.fulfillment_decision_path = None;
+
+    let mut candidate = basis_from_decision_data(&deny_event.data);
+    candidate.decision_outcome_kind = None;
+    candidate.decision_origin = None;
+    candidate.outcome_compat_state = None;
+    candidate.fulfillment_decision_path = None;
+
+    assert_eq!(
+        classify_replay_diff(&baseline, &candidate),
+        ReplayDiffBucket::Stricter
+    );
+    assert_eq!(
+        classify_replay_diff(&candidate, &baseline),
+        ReplayDiffBucket::Looser
     );
 }

--- a/crates/assay-core/tests/replay_diff_contract.rs
+++ b/crates/assay-core/tests/replay_diff_contract.rs
@@ -1,0 +1,142 @@
+use assay_core::mcp::decision::{
+    basis_from_decision_data, classify_replay_diff, reason_codes, DecisionEvent, DecisionOrigin,
+    DecisionOutcomeKind, FulfillmentDecisionPath, OutcomeCompatState, PolicyDecisionEventContext,
+    ReplayDiffBucket,
+};
+use assay_core::mcp::policy::TypedPolicyDecision;
+
+fn allow_event(policy_version: &str, policy_digest: &str) -> DecisionEvent {
+    let context = PolicyDecisionEventContext {
+        typed_decision: Some(TypedPolicyDecision::AllowWithObligations),
+        policy_version: Some(policy_version.to_string()),
+        policy_digest: Some(policy_digest.to_string()),
+        ..PolicyDecisionEventContext::default()
+    };
+
+    DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_200".to_string(),
+        "deploy_service".to_string(),
+    )
+    .allow(reason_codes::P_POLICY_ALLOW)
+    .with_policy_context(context)
+}
+
+#[test]
+fn basis_extraction_contains_frozen_fields() {
+    let event = allow_event("v1", "sha1");
+    let basis = basis_from_decision_data(&event.data);
+
+    assert_eq!(
+        basis.decision_outcome_kind,
+        Some(DecisionOutcomeKind::ObligationSkipped)
+    );
+    assert_eq!(
+        basis.decision_origin,
+        Some(DecisionOrigin::ObligationExecutor)
+    );
+    assert_eq!(
+        basis.outcome_compat_state,
+        Some(OutcomeCompatState::LegacyFieldsPreserved)
+    );
+    assert_eq!(
+        basis.fulfillment_decision_path,
+        Some(FulfillmentDecisionPath::PolicyAllow)
+    );
+    assert_eq!(basis.reason_code, reason_codes::P_POLICY_ALLOW);
+    assert_eq!(
+        basis.typed_decision,
+        Some(TypedPolicyDecision::AllowWithObligations)
+    );
+    assert_eq!(basis.policy_version.as_deref(), Some("v1"));
+    assert_eq!(basis.policy_digest.as_deref(), Some("sha1"));
+}
+
+#[test]
+fn classify_replay_diff_unchanged() {
+    let event = allow_event("v1", "sha1");
+    let baseline = basis_from_decision_data(&event.data);
+    let candidate = basis_from_decision_data(&event.data);
+
+    assert_eq!(
+        classify_replay_diff(&baseline, &candidate),
+        ReplayDiffBucket::Unchanged
+    );
+}
+
+#[test]
+fn classify_replay_diff_evidence_only() {
+    let baseline_event = allow_event("v1", "sha1");
+    let candidate_event = allow_event("v2", "sha2");
+
+    let baseline = basis_from_decision_data(&baseline_event.data);
+    let candidate = basis_from_decision_data(&candidate_event.data);
+
+    assert_eq!(
+        classify_replay_diff(&baseline, &candidate),
+        ReplayDiffBucket::EvidenceOnly
+    );
+}
+
+#[test]
+fn classify_replay_diff_stricter_and_looser() {
+    let baseline = basis_from_decision_data(&allow_event("v1", "sha1").data);
+    let deny_event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_201".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(reason_codes::P_POLICY_DENY, Some("blocked".to_string()));
+    let candidate = basis_from_decision_data(&deny_event.data);
+
+    assert_eq!(
+        classify_replay_diff(&baseline, &candidate),
+        ReplayDiffBucket::Stricter
+    );
+    assert_eq!(
+        classify_replay_diff(&candidate, &baseline),
+        ReplayDiffBucket::Looser
+    );
+}
+
+#[test]
+fn classify_replay_diff_reclassified() {
+    let baseline_event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_202".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(
+        reason_codes::P_POLICY_DENY,
+        Some("policy blocked".to_string()),
+    );
+
+    let mut candidate_event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_203".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(reason_codes::S_DB_ERROR, Some("store down".to_string()));
+
+    // Mimic fail-closed reclassification while preserving deny strictness.
+    candidate_event.data.fail_closed = Some(assay_core::mcp::policy::FailClosedContext {
+        tool_risk_class: assay_core::mcp::policy::ToolRiskClass::HighRisk,
+        fail_closed_mode: assay_core::mcp::policy::FailClosedMode::FailClosed,
+        fail_closed_trigger: Some(
+            assay_core::mcp::policy::FailClosedTrigger::RuntimeDependencyError,
+        ),
+        fail_closed_applied: true,
+        fail_closed_error_code: Some("fail_closed_runtime_dependency_error".to_string()),
+    });
+    // Refresh normalization by reapplying deny with the same reason.
+    candidate_event =
+        candidate_event.deny(reason_codes::S_DB_ERROR, Some("store down".to_string()));
+
+    let baseline = basis_from_decision_data(&baseline_event.data);
+    let candidate = basis_from_decision_data(&candidate_event.data);
+
+    assert_eq!(
+        classify_replay_diff(&baseline, &candidate),
+        ReplayDiffBucket::Reclassified
+    );
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave38-replay-diff-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave38-replay-diff-step2.md
@@ -1,0 +1,32 @@
+# SPLIT CHECKLIST - Wave38 Replay Diff Step2
+
+## Scope discipline
+- [ ] Diff is limited to bounded runtime + tests + Step2 docs/gate
+- [ ] No `.github/workflows/*` changes
+- [ ] No scope leaks outside replay/diff implementation paths
+- [ ] No new runtime capability added
+- [ ] No policy backend/control-plane/auth transport changes
+
+## Implementation contract
+- [ ] Typed replay basis is additive and present:
+  - `ReplayDiffBasis`
+  - `basis_from_decision_data`
+- [ ] Typed replay diff buckets are additive and present:
+  - `unchanged`
+  - `stricter`
+  - `looser`
+  - `reclassified`
+  - `evidence_only`
+- [ ] Deterministic classifier is present:
+  - `classify_replay_diff`
+
+## Compatibility and behavior
+- [ ] Existing decision/event fields remain backward-compatible
+- [ ] Existing runtime enforcement behavior remains unchanged
+- [ ] Replay classifier is deterministic for unchanged/strictness/reclassification
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave38-replay-diff-step2.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave38-replay-diff-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave38-replay-diff-step2.md
@@ -1,0 +1,29 @@
+# SPLIT MOVE MAP - Wave38 Replay Diff Step2
+
+## Intent
+Bounded implementation for typed replay basis + deterministic diff buckets, with additive evidence comparison contract only.
+
+## Touched runtime paths
+- `crates/assay-core/src/mcp/decision/replay_diff.rs`
+  - introduces:
+    - `ReplayDiffBasis`
+    - `ReplayDiffBucket`
+    - `basis_from_decision_data`
+    - `classify_replay_diff`
+- `crates/assay-core/src/mcp/decision.rs`
+  - exports replay/diff contract APIs from decision module
+
+## Touched tests
+- `crates/assay-core/tests/replay_diff_contract.rs`
+  - validates deterministic buckets:
+    - unchanged
+    - stricter
+    - looser
+    - reclassified
+    - evidence_only
+
+## Out-of-scope guarantees
+- no new obligation types
+- no runtime enforcement expansion
+- no policy backend/control-plane additions
+- no auth transport changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave38-replay-diff-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave38-replay-diff-step2.md
@@ -1,0 +1,27 @@
+# SPLIT REVIEW PACK - Wave38 Replay Diff Step2
+
+## Intent
+Implement bounded replay/diff contract primitives for deterministic evidence comparison.
+
+This slice must:
+- keep runtime behavior unchanged
+- add typed replay basis + diff buckets
+- keep changes additive and backward-compatible
+
+This slice must not:
+- add new runtime capabilities
+- expand policy-engine scope
+- add UI/control-plane/auth transport work
+- touch workflow files
+
+## Reviewer focus
+1. Diff stays inside bounded runtime/test/docs/gate scope.
+2. Replay basis fields are present and deterministic.
+3. Diff bucket classifier is deterministic and additive.
+4. Existing runtime behavior remains unchanged.
+5. No scope creep into non-goals.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave38-replay-diff-step2.sh
+```

--- a/scripts/ci/review-wave38-replay-diff-step2.sh
+++ b/scripts/ci/review-wave38-replay-diff-step2.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-core/src/mcp/decision/replay_diff.rs"
+  "crates/assay-core/tests/replay_diff_contract.rs"
+
+  "docs/contributing/SPLIT-CHECKLIST-wave38-replay-diff-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave38-replay-diff-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave38-replay-diff-step2.md"
+
+  "scripts/ci/review-wave38-replay-diff-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave38 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave38 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  while IFS= read -r uf; do
+    [[ -z "${uf:-}" ]] && continue
+    allowed="false"
+    for a in "${ALLOWLIST[@]}"; do
+      [[ "$uf" == "$a" ]] && allowed="true" && break
+    done
+    if [[ "$allowed" != "true" ]]; then
+      echo "FAIL: untracked file present under $p: $uf"
+      exit 1
+    fi
+  done < <(git ls-files --others --exclude-standard -- "$p")
+done
+
+echo "[review] replay diff markers"
+for marker in \
+  'ReplayDiffBasis' \
+  'ReplayDiffBucket' \
+  'basis_from_decision_data' \
+  'classify_replay_diff' \
+  'Unchanged' \
+  'Stricter' \
+  'Looser' \
+  'Reclassified' \
+  'EvidenceOnly'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing replay-diff marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing convergence markers remain present"
+for marker in \
+  'DecisionOutcomeKind' \
+  'DecisionOrigin' \
+  'OutcomeCompatState' \
+  'fulfillment_decision_path' \
+  'normalization_version'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing existing convergence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'new obligation type|runtime enforcement expansion|policy backend replacement|control-plane|auth transport' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'new obligation type|runtime enforcement expansion|policy backend replacement|control-plane|auth transport' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add typed replay basis extraction (`ReplayDiffBasis`) from decision events
- add deterministic replay diff buckets (`unchanged`, `stricter`, `looser`, `reclassified`, `evidence_only`)
- add replay diff classifier and coverage tests
- add Wave38 Step2 docs + reviewer gate

## Scope
- bounded core MCP decision module + tests + Step2 docs/gate
- no workflow changes
- no runtime capability expansion

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave38-replay-diff-step2.sh`
