### PR TITLE
docs(wave38-step3): close replay-diff wave with docs+gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave38-replay-diff-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave38-replay-diff-step3.md
@@ -1,0 +1,48 @@
+# SPLIT CHECKLIST - Wave38 Replay Diff Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave38-replay-diff-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave38-replay-diff-step3.md`
+  - `scripts/ci/review-wave38-replay-diff-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave38 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves the bounded replay-diff contract
+
+## Replay-diff invariants
+- [ ] Replay-diff markers remain present:
+  - `ReplayDiffBasis`
+  - `ReplayDiffBucket`
+  - `basis_from_decision_data`
+  - `classify_replay_diff`
+  - `Unchanged`
+  - `Stricter`
+  - `Looser`
+  - `Reclassified`
+  - `EvidenceOnly`
+- [ ] Existing convergence markers remain present
+- [ ] Existing normalization markers remain present
+- [ ] Existing deny-path separation remains present
+
+## Non-goals still enforced
+- [ ] No new obligation types added
+- [ ] No runtime enforcement expansion added
+- [ ] No policy backend replacement added
+- [ ] No control-plane semantics added
+- [ ] No auth transport changes added
+
+## Validation
+- [ ] Step3 gate passes against stacked Step2 base
+- [ ] Step3 gate can also pass against `origin/main` after Step2 merge
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave38-replay-diff-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave38-replay-diff-step3.md
@@ -1,0 +1,45 @@
+# SPLIT REVIEW PACK - Wave38 Replay Diff Step3
+
+## Intent
+Close Wave38 with a docs+gate-only closure slice after bounded replay/diff basis and bucket implementation in Step2.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add new obligation types
+- expand runtime enforcement semantics
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave38-replay-diff-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave38-replay-diff-step3.md`
+- `scripts/ci/review-wave38-replay-diff-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Replay-diff basis and bucket markers remain present.
+4. Existing convergence + normalization markers remain present.
+5. Existing deny-path separation remains present.
+6. No non-goal scope creep appears in runtime scope.
+7. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave38-replay-diff-step2-impl \
+  bash scripts/ci/review-wave38-replay-diff-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave38-replay-diff-step3.sh
+```
+
+Expected outcome:
+- Step3 adds no runtime behavior.
+- closure remains diff-proof.
+- promote can happen cleanly after stacked validation.

--- a/scripts/ci/review-wave38-replay-diff-step3.sh
+++ b/scripts/ci/review-wave38-replay-diff-step3.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave38-replay-diff-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave38-replay-diff-step3.md"
+  "scripts/ci/review-wave38-replay-diff-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave38 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave38 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] replay diff markers"
+for marker in \
+  'ReplayDiffBasis' \
+  'ReplayDiffBucket' \
+  'basis_from_decision_data' \
+  'classify_replay_diff' \
+  'Unchanged' \
+  'Stricter' \
+  'Looser' \
+  'Reclassified' \
+  'EvidenceOnly'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing replay-diff marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing convergence markers remain present"
+for marker in \
+  'DecisionOutcomeKind' \
+  'DecisionOrigin' \
+  'OutcomeCompatState' \
+  'fulfillment_decision_path' \
+  'normalization_version'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing existing convergence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'new obligation type|runtime enforcement expansion|policy backend replacement|control-plane|auth transport' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'new obligation type|runtime enforcement expansion|policy backend replacement|control-plane|auth transport' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave38 Step3 docs+gate-only closure slice
- rerun Step2 invariants in Step3 reviewer gate
- keep closure scope to exactly 3 files

## Scope
- docs+script only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/codex/wave38-replay-diff-step2-impl bash scripts/ci/review-wave38-replay-diff-step3.sh` (PASS)
- includes `cargo fmt --check`, clippy, and pinned tests via gate script
