### PR TITLE
docs(wave38): align evidence_only wording in replay-diff contract

### DIFF
--- a/docs/contributing/SPLIT-PLAN-wave38-replay-diff-contract.md
+++ b/docs/contributing/SPLIT-PLAN-wave38-replay-diff-contract.md
@@ -56,7 +56,7 @@ Replay outcome is strictly less restrictive than baseline.
 ### Reclassified
 Decision remains effectively equivalent but shifts classification basis (e.g. policy deny vs fail-closed deny).
 
-### Evidence-only
+### evidence_only
 Decision equivalence holds; only additive evidence fields differ.
 
 ## Acceptance shape for Step2


### PR DESCRIPTION
## Summary
- align Wave38 Step1 plan heading with frozen bucket label format
- use `evidence_only` consistently in the contract doc

## Why
Copilot flagged the mixed label/heading formatting (`evidence_only` vs `Evidence-only`) as ambiguous for exact-label contract interpretation.

## Scope
- docs only
- no runtime changes
- no workflow changes
