### PR TITLE
docs(wave39-step1): freeze replay/evidence compatibility contract

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step1.md
@@ -1,0 +1,30 @@
+# SPLIT CHECKLIST - Wave39 Evidence Compat Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave39-evidence-compat-normalization.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step1.md`
+  - `scripts/ci/review-wave39-evidence-compat-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] Replay/evidence compatibility contract is explicit
+- [ ] Additive legacy fallback semantics are explicit
+- [ ] Deterministic classification precedence is explicit
+- [ ] Required compatibility markers are explicit:
+  - `decision_basis_version`
+  - `compat_fallback_applied`
+  - `classification_source`
+  - `replay_diff_reason`
+  - `legacy_shape_detected`
+- [ ] Non-goals are explicit (no runtime capability expansion)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave39-evidence-compat-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned replay/decision tests pass

--- a/docs/contributing/SPLIT-PLAN-wave39-evidence-compat-normalization.md
+++ b/docs/contributing/SPLIT-PLAN-wave39-evidence-compat-normalization.md
@@ -1,0 +1,101 @@
+# SPLIT PLAN - Wave39 Evidence Compatibility Normalization
+
+## Intent
+Freeze a bounded replay-facing evidence compatibility contract before any additional runtime capability is added.
+
+This wave is about:
+- replay-safe evidence shape hardening
+- additive legacy fallback semantics
+- deterministic classification precedence for replay consumers
+- reviewer gates for contract lock-in
+
+It explicitly does **not** add:
+- new obligation types
+- runtime enforcement changes
+- policy language expansion
+- control-plane or auth transport changes
+- UI or external integrations
+
+## Problem
+Wave38 established replay diff basis and deterministic buckets.
+
+Current gap:
+- replay/evidence compatibility fields are not frozen as a dedicated contract
+- legacy-shape fallback signaling is not normalized for downstream consumers
+- classification provenance is not frozen for replay diagnostics
+
+## Frozen compatibility contract
+Wave39 freezes these replay/evidence compatibility concepts:
+- `decision_basis_version`
+- `compat_fallback_applied`
+- `classification_source`
+- `replay_diff_reason`
+- `legacy_shape_detected`
+
+## Frozen semantics
+### decision_basis_version
+Versioned identifier for the basis contract used to classify replay outcomes.
+
+### compat_fallback_applied
+Boolean signal that compatibility fallback logic was applied for this payload.
+
+### classification_source
+Deterministic source marker for classification precedence (for example: converged fields, fulfillment path, legacy fallback).
+
+### replay_diff_reason
+Deterministic reason token for replay-facing classification explanation.
+
+### legacy_shape_detected
+Boolean marker indicating legacy payload shape was detected during normalization.
+
+## Classification precedence (frozen)
+Wave39 freezes deterministic precedence order for replay/evidence compatibility classification:
+1. converged outcome markers
+2. fulfillment path markers
+3. legacy fallback markers
+
+This is a contract freeze only; behavior changes are out of scope for Step1.
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. Compatibility fields are represented additively in replay-facing evidence payloads.
+2. Classification precedence is deterministic and testable.
+3. Legacy fallback signaling remains backward-compatible.
+4. Existing runtime behavior stays stable.
+5. No new runtime enforcement capability is introduced.
+
+## Scope boundaries
+### In scope
+- replay/evidence compatibility contract freeze
+- additive compatibility field contract
+- deterministic precedence contract
+- tests and reviewer gates for the above
+
+### Out of scope
+- new obligation types
+- runtime enforcement changes
+- policy language extension
+- control-plane or auth transport changes
+- UI/external integration work
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- additive replay/evidence compatibility fields
+- deterministic precedence representation
+- no runtime capability expansion
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must stay compatibility-first and additive.
+
+Primary failure modes:
+- introducing runtime behavior changes under a compatibility label
+- breaking legacy event consumers
+- widening scope into policy/runtime engine changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step1.md
@@ -1,0 +1,39 @@
+# SPLIT REVIEW PACK - Wave39 Evidence Compat Step1
+
+## Intent
+Freeze a bounded replay-facing evidence compatibility contract before any additional runtime capability.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add runtime enforcement changes
+- add policy language expansion
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave39-evidence-compat-normalization.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step1.md`
+- `scripts/ci/review-wave39-evidence-compat-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Replay/evidence compatibility fields are explicitly frozen.
+3. Deterministic classification precedence is explicit.
+4. Legacy fallback semantics are additive and explicit.
+5. Runtime paths are untouched.
+6. No scope expansion beyond compatibility contract freeze.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave39-evidence-compat-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- compatibility contract is frozen cleanly
+- Step2 can implement additive replay/evidence fields without reopening semantics

--- a/scripts/ci/review-wave39-evidence-compat-step1.sh
+++ b/scripts/ci/review-wave39-evidence-compat-step1.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave39-evidence-compat-normalization.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step1.md"
+  "scripts/ci/review-wave39-evidence-compat-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave39 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave39 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave39 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN - Wave39 Evidence Compatibility Normalization$' \
+  docs/contributing/SPLIT-PLAN-wave39-evidence-compat-normalization.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'decision_basis_version' \
+  'compat_fallback_applied' \
+  'classification_source' \
+  'replay_diff_reason' \
+  'legacy_shape_detected'
+do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave39-evidence-compat-normalization.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave39 Step1 split plan for replay/evidence compatibility normalization
- add Step1 checklist and review pack
- add Step1 reviewer gate script

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave39-evidence-compat-step1.sh` (PASS)
- includes `cargo fmt --check`, clippy, and pinned replay/decision tests
