### PR TITLE
feat(wave39-step2): implement replay/evidence compat normalization

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -4,6 +4,7 @@
 //! Every tool call attempt MUST emit exactly one decision event.
 
 use self::outcome_convergence::classify_decision_outcome;
+use self::replay_compat::project_replay_compat;
 use super::policy::{
     ApprovalArtifact, ApprovalFreshness, FailClosedContext, PolicyObligation, RedactArgsContract,
     RestrictScopeContract, TypedPolicyDecision,
@@ -14,8 +15,10 @@ use std::io::Write;
 use std::sync::Arc;
 
 mod outcome_convergence;
+mod replay_compat;
 mod replay_diff;
 pub use outcome_convergence::{DecisionOrigin, DecisionOutcomeKind, OutcomeCompatState};
+pub use replay_compat::{ReplayClassificationSource, DECISION_BASIS_VERSION_V1};
 pub use replay_diff::{
     basis_from_decision_data, classify_replay_diff, ReplayDiffBasis, ReplayDiffBucket,
 };
@@ -298,6 +301,21 @@ pub struct DecisionData {
     /// Normalized decision path for fulfillment evidence.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fulfillment_decision_path: Option<FulfillmentDecisionPath>,
+    /// Version tag for replay basis compatibility normalization.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision_basis_version: Option<String>,
+    /// Whether compatibility fallback was applied during classification.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compat_fallback_applied: Option<bool>,
+    /// Deterministic source used for compatibility classification precedence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classification_source: Option<ReplayClassificationSource>,
+    /// Deterministic replay classification reason token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_diff_reason: Option<String>,
+    /// Whether legacy event shape was detected by compatibility normalization.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legacy_shape_detected: Option<bool>,
     /// Whether any obligation outcome is normalized as applied.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub obligation_applied_present: Option<bool>,
@@ -433,6 +451,18 @@ fn refresh_fulfillment_normalization(data: &mut DecisionData) {
     data.decision_origin = Some(outcome.origin);
     data.outcome_compat_state = Some(outcome.compat_state);
     data.fulfillment_decision_path = Some(classify_fulfillment_decision_path(data));
+    let replay_projection = project_replay_compat(
+        data.decision_outcome_kind,
+        data.decision_origin,
+        data.outcome_compat_state,
+        data.fulfillment_decision_path,
+        data.decision,
+    );
+    data.decision_basis_version = Some(DECISION_BASIS_VERSION_V1.to_string());
+    data.compat_fallback_applied = Some(replay_projection.compat_fallback_applied);
+    data.classification_source = Some(replay_projection.classification_source);
+    data.replay_diff_reason = Some(replay_projection.replay_diff_reason.to_string());
+    data.legacy_shape_detected = Some(replay_projection.legacy_shape_detected);
 }
 
 impl DecisionEvent {
@@ -490,6 +520,11 @@ impl DecisionEvent {
                 decision_origin: None,
                 outcome_compat_state: None,
                 fulfillment_decision_path: None,
+                decision_basis_version: None,
+                compat_fallback_applied: None,
+                classification_source: None,
+                replay_diff_reason: None,
+                legacy_shape_detected: None,
                 obligation_applied_present: None,
                 obligation_skipped_present: None,
                 obligation_error_present: None,

--- a/crates/assay-core/src/mcp/decision/replay_compat.rs
+++ b/crates/assay-core/src/mcp/decision/replay_compat.rs
@@ -1,0 +1,147 @@
+use super::{
+    Decision, DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath, OutcomeCompatState,
+};
+use serde::{Deserialize, Serialize};
+
+pub const DECISION_BASIS_VERSION_V1: &str = "wave39_v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplayClassificationSource {
+    ConvergedOutcome,
+    FulfillmentPath,
+    LegacyFallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplayCompatProjection {
+    pub compat_fallback_applied: bool,
+    pub classification_source: ReplayClassificationSource,
+    pub replay_diff_reason: &'static str,
+    pub legacy_shape_detected: bool,
+}
+
+pub fn project_replay_compat(
+    decision_outcome_kind: Option<DecisionOutcomeKind>,
+    decision_origin: Option<DecisionOrigin>,
+    outcome_compat_state: Option<OutcomeCompatState>,
+    fulfillment_decision_path: Option<FulfillmentDecisionPath>,
+    decision: Decision,
+) -> ReplayCompatProjection {
+    let legacy_shape_detected = decision_outcome_kind.is_none()
+        || decision_origin.is_none()
+        || outcome_compat_state.is_none()
+        || fulfillment_decision_path.is_none();
+
+    let (classification_source, replay_diff_reason) = if let Some(kind) = decision_outcome_kind {
+        (
+            ReplayClassificationSource::ConvergedOutcome,
+            reason_from_outcome_kind(kind),
+        )
+    } else if let Some(path) = fulfillment_decision_path {
+        (
+            ReplayClassificationSource::FulfillmentPath,
+            reason_from_fulfillment_path(path),
+        )
+    } else {
+        (
+            ReplayClassificationSource::LegacyFallback,
+            reason_from_legacy_decision(decision),
+        )
+    };
+
+    ReplayCompatProjection {
+        compat_fallback_applied: classification_source
+            != ReplayClassificationSource::ConvergedOutcome,
+        classification_source,
+        replay_diff_reason,
+        legacy_shape_detected,
+    }
+}
+
+fn reason_from_outcome_kind(kind: DecisionOutcomeKind) -> &'static str {
+    match kind {
+        DecisionOutcomeKind::PolicyDeny => "converged_policy_deny",
+        DecisionOutcomeKind::FailClosedDeny => "converged_fail_closed_deny",
+        DecisionOutcomeKind::ObligationApplied => "converged_obligation_applied",
+        DecisionOutcomeKind::ObligationSkipped => "converged_obligation_skipped",
+        DecisionOutcomeKind::ObligationError => "converged_obligation_error",
+        DecisionOutcomeKind::EnforcementDeny => "converged_enforcement_deny",
+    }
+}
+
+fn reason_from_fulfillment_path(path: FulfillmentDecisionPath) -> &'static str {
+    match path {
+        FulfillmentDecisionPath::PolicyAllow => "fulfillment_policy_allow",
+        FulfillmentDecisionPath::PolicyDeny => "fulfillment_policy_deny",
+        FulfillmentDecisionPath::FailClosedDeny => "fulfillment_fail_closed_deny",
+        FulfillmentDecisionPath::DecisionError => "fulfillment_decision_error",
+    }
+}
+
+fn reason_from_legacy_decision(decision: Decision) -> &'static str {
+    match decision {
+        Decision::Allow => "legacy_decision_allow",
+        Decision::Deny => "legacy_decision_deny",
+        Decision::Error => "legacy_decision_error",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn precedence_prefers_converged_markers() {
+        let projection = project_replay_compat(
+            Some(DecisionOutcomeKind::ObligationApplied),
+            Some(DecisionOrigin::ObligationExecutor),
+            Some(OutcomeCompatState::LegacyFieldsPreserved),
+            Some(FulfillmentDecisionPath::PolicyAllow),
+            Decision::Allow,
+        );
+
+        assert_eq!(
+            projection.classification_source,
+            ReplayClassificationSource::ConvergedOutcome
+        );
+        assert_eq!(
+            projection.replay_diff_reason,
+            "converged_obligation_applied"
+        );
+        assert!(!projection.compat_fallback_applied);
+        assert!(!projection.legacy_shape_detected);
+    }
+
+    #[test]
+    fn precedence_falls_back_to_fulfillment_path() {
+        let projection = project_replay_compat(
+            None,
+            None,
+            None,
+            Some(FulfillmentDecisionPath::PolicyAllow),
+            Decision::Allow,
+        );
+
+        assert_eq!(
+            projection.classification_source,
+            ReplayClassificationSource::FulfillmentPath
+        );
+        assert_eq!(projection.replay_diff_reason, "fulfillment_policy_allow");
+        assert!(projection.compat_fallback_applied);
+        assert!(projection.legacy_shape_detected);
+    }
+
+    #[test]
+    fn precedence_falls_back_to_legacy_decision() {
+        let projection = project_replay_compat(None, None, None, None, Decision::Deny);
+
+        assert_eq!(
+            projection.classification_source,
+            ReplayClassificationSource::LegacyFallback
+        );
+        assert_eq!(projection.replay_diff_reason, "legacy_decision_deny");
+        assert!(projection.compat_fallback_applied);
+        assert!(projection.legacy_shape_detected);
+    }
+}

--- a/crates/assay-core/src/mcp/decision/replay_diff.rs
+++ b/crates/assay-core/src/mcp/decision/replay_diff.rs
@@ -1,6 +1,7 @@
 use super::{
+    replay_compat::{project_replay_compat, DECISION_BASIS_VERSION_V1},
     Decision, DecisionData, DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath,
-    OutcomeCompatState,
+    OutcomeCompatState, ReplayClassificationSource,
 };
 use crate::mcp::policy::TypedPolicyDecision;
 use serde::{Deserialize, Serialize};
@@ -23,6 +24,11 @@ pub struct ReplayDiffBasis {
     pub decision_origin: Option<DecisionOrigin>,
     pub outcome_compat_state: Option<OutcomeCompatState>,
     pub fulfillment_decision_path: Option<FulfillmentDecisionPath>,
+    pub decision_basis_version: String,
+    pub compat_fallback_applied: bool,
+    pub classification_source: ReplayClassificationSource,
+    pub replay_diff_reason: String,
+    pub legacy_shape_detected: bool,
     pub reason_code: String,
     pub typed_decision: Option<TypedPolicyDecision>,
     pub policy_version: Option<String>,
@@ -33,11 +39,36 @@ pub struct ReplayDiffBasis {
 
 /// Build replay basis from an emitted decision payload.
 pub fn basis_from_decision_data(data: &DecisionData) -> ReplayDiffBasis {
+    let replay_projection = project_replay_compat(
+        data.decision_outcome_kind,
+        data.decision_origin,
+        data.outcome_compat_state,
+        data.fulfillment_decision_path,
+        data.decision,
+    );
+
     ReplayDiffBasis {
         decision_outcome_kind: data.decision_outcome_kind,
         decision_origin: data.decision_origin,
         outcome_compat_state: data.outcome_compat_state,
         fulfillment_decision_path: data.fulfillment_decision_path,
+        decision_basis_version: data
+            .decision_basis_version
+            .clone()
+            .unwrap_or_else(|| DECISION_BASIS_VERSION_V1.to_string()),
+        compat_fallback_applied: data
+            .compat_fallback_applied
+            .unwrap_or(replay_projection.compat_fallback_applied),
+        classification_source: data
+            .classification_source
+            .unwrap_or(replay_projection.classification_source),
+        replay_diff_reason: data
+            .replay_diff_reason
+            .clone()
+            .unwrap_or_else(|| replay_projection.replay_diff_reason.to_string()),
+        legacy_shape_detected: data
+            .legacy_shape_detected
+            .unwrap_or(replay_projection.legacy_shape_detected),
         reason_code: data.reason_code.clone(),
         typed_decision: data.typed_decision,
         policy_version: data.policy_version.clone(),
@@ -83,6 +114,11 @@ fn same_effective_decision_class(baseline: &ReplayDiffBasis, candidate: &ReplayD
         && baseline.decision_origin == candidate.decision_origin
         && baseline.outcome_compat_state == candidate.outcome_compat_state
         && baseline.fulfillment_decision_path == candidate.fulfillment_decision_path
+        && baseline.decision_basis_version == candidate.decision_basis_version
+        && baseline.compat_fallback_applied == candidate.compat_fallback_applied
+        && baseline.classification_source == candidate.classification_source
+        && baseline.replay_diff_reason == candidate.replay_diff_reason
+        && baseline.legacy_shape_detected == candidate.legacy_shape_detected
         && baseline.reason_code == candidate.reason_code
         && baseline.typed_decision == candidate.typed_decision
         && baseline.decision == candidate.decision
@@ -120,6 +156,11 @@ mod tests {
             decision_origin: Some(DecisionOrigin::PolicyEngine),
             outcome_compat_state: Some(OutcomeCompatState::LegacyFieldsPreserved),
             fulfillment_decision_path: Some(FulfillmentDecisionPath::PolicyAllow),
+            decision_basis_version: DECISION_BASIS_VERSION_V1.to_string(),
+            compat_fallback_applied: false,
+            classification_source: ReplayClassificationSource::ConvergedOutcome,
+            replay_diff_reason: "converged_obligation_applied".to_string(),
+            legacy_shape_detected: false,
             reason_code: reason.to_string(),
             typed_decision: Some(TypedPolicyDecision::AllowWithObligations),
             policy_version: Some("v1".to_string()),
@@ -195,6 +236,11 @@ mod tests {
             decision_origin: None,
             outcome_compat_state: None,
             fulfillment_decision_path: None,
+            decision_basis_version: DECISION_BASIS_VERSION_V1.to_string(),
+            compat_fallback_applied: true,
+            classification_source: ReplayClassificationSource::LegacyFallback,
+            replay_diff_reason: "legacy_decision_allow".to_string(),
+            legacy_shape_detected: true,
             reason_code: "P_POLICY_ALLOW".to_string(),
             typed_decision: None,
             policy_version: None,

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -6,6 +6,7 @@
 use assay_core::mcp::decision::{
     reason_codes, Decision, DecisionEmitter, DecisionEmitterGuard, DecisionEvent, DecisionOrigin,
     DecisionOutcomeKind, FulfillmentDecisionPath, ObligationOutcomeStatus, OutcomeCompatState,
+    ReplayClassificationSource, DECISION_BASIS_VERSION_V1,
 };
 use assay_core::mcp::policy::{
     ApprovalFreshness, McpPolicy, PolicyState, RedactArgsContract, RestrictScopeContract,
@@ -1055,6 +1056,20 @@ fn test_event_contains_required_fields() {
         event.data.outcome_compat_state,
         Some(OutcomeCompatState::LegacyFieldsPreserved)
     );
+    assert_eq!(
+        event.data.decision_basis_version.as_deref(),
+        Some(DECISION_BASIS_VERSION_V1)
+    );
+    assert_eq!(event.data.compat_fallback_applied, Some(false));
+    assert_eq!(
+        event.data.classification_source,
+        Some(ReplayClassificationSource::ConvergedOutcome)
+    );
+    assert_eq!(
+        event.data.replay_diff_reason.as_deref(),
+        Some("converged_obligation_applied")
+    );
+    assert_eq!(event.data.legacy_shape_detected, Some(false));
     assert_eq!(event.data.obligation_applied_present, Some(true));
     assert_eq!(event.data.obligation_skipped_present, Some(false));
     assert_eq!(event.data.obligation_error_present, Some(false));

--- a/crates/assay-core/tests/replay_diff_contract.rs
+++ b/crates/assay-core/tests/replay_diff_contract.rs
@@ -1,7 +1,8 @@
 use assay_core::mcp::decision::{
     basis_from_decision_data, classify_replay_diff, reason_codes, Decision, DecisionEvent,
     DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath, OutcomeCompatState,
-    PolicyDecisionEventContext, ReplayDiffBucket,
+    PolicyDecisionEventContext, ReplayClassificationSource, ReplayDiffBucket,
+    DECISION_BASIS_VERSION_V1,
 };
 use assay_core::mcp::policy::TypedPolicyDecision;
 
@@ -43,6 +44,14 @@ fn basis_extraction_contains_frozen_fields() {
         basis.fulfillment_decision_path,
         Some(FulfillmentDecisionPath::PolicyAllow)
     );
+    assert_eq!(basis.decision_basis_version, DECISION_BASIS_VERSION_V1);
+    assert!(!basis.compat_fallback_applied);
+    assert_eq!(
+        basis.classification_source,
+        ReplayClassificationSource::ConvergedOutcome
+    );
+    assert_eq!(basis.replay_diff_reason, "converged_obligation_skipped");
+    assert!(!basis.legacy_shape_detected);
     assert_eq!(basis.reason_code, reason_codes::P_POLICY_ALLOW);
     assert_eq!(
         basis.typed_decision,
@@ -52,6 +61,53 @@ fn basis_extraction_contains_frozen_fields() {
     assert_eq!(basis.policy_digest.as_deref(), Some("sha1"));
     assert_eq!(basis.decision, Decision::Allow);
     assert!(!basis.fail_closed_applied);
+}
+
+#[test]
+fn basis_extraction_prefers_fulfillment_path_when_converged_markers_missing() {
+    let mut event = allow_event("v1", "sha1");
+    event.data.decision_outcome_kind = None;
+    event.data.decision_origin = None;
+    event.data.outcome_compat_state = None;
+    event.data.decision_basis_version = None;
+    event.data.compat_fallback_applied = None;
+    event.data.classification_source = None;
+    event.data.replay_diff_reason = None;
+    event.data.legacy_shape_detected = None;
+
+    let basis = basis_from_decision_data(&event.data);
+    assert_eq!(basis.decision_basis_version, DECISION_BASIS_VERSION_V1);
+    assert!(basis.compat_fallback_applied);
+    assert_eq!(
+        basis.classification_source,
+        ReplayClassificationSource::FulfillmentPath
+    );
+    assert_eq!(basis.replay_diff_reason, "fulfillment_policy_allow");
+    assert!(basis.legacy_shape_detected);
+}
+
+#[test]
+fn basis_extraction_marks_legacy_fallback_when_shape_is_missing() {
+    let mut event = allow_event("v1", "sha1");
+    event.data.decision_outcome_kind = None;
+    event.data.decision_origin = None;
+    event.data.outcome_compat_state = None;
+    event.data.fulfillment_decision_path = None;
+    event.data.decision_basis_version = None;
+    event.data.compat_fallback_applied = None;
+    event.data.classification_source = None;
+    event.data.replay_diff_reason = None;
+    event.data.legacy_shape_detected = None;
+
+    let basis = basis_from_decision_data(&event.data);
+    assert_eq!(basis.decision_basis_version, DECISION_BASIS_VERSION_V1);
+    assert!(basis.compat_fallback_applied);
+    assert_eq!(
+        basis.classification_source,
+        ReplayClassificationSource::LegacyFallback
+    );
+    assert_eq!(basis.replay_diff_reason, "legacy_decision_allow");
+    assert!(basis.legacy_shape_detected);
 }
 
 #[test]

--- a/docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step2.md
@@ -1,0 +1,32 @@
+# SPLIT CHECKLIST - Wave39 Evidence Compat Step2
+
+## Scope discipline
+- [ ] Diff is limited to bounded replay/evidence runtime + tests + Step2 docs/gate
+- [ ] No `.github/workflows/*` changes
+- [ ] No scope leaks outside replay/evidence compatibility paths
+- [ ] No new runtime capability added
+- [ ] No policy backend/control-plane/auth transport changes
+
+## Implementation contract
+- [ ] Additive compatibility fields are present:
+  - `decision_basis_version`
+  - `compat_fallback_applied`
+  - `classification_source`
+  - `replay_diff_reason`
+  - `legacy_shape_detected`
+- [ ] Deterministic classification precedence is represented:
+  - converged markers
+  - fulfillment-path fallback
+  - legacy fallback
+- [ ] Legacy shape detection/fallback remains backward-compatible
+
+## Compatibility and behavior
+- [ ] Existing decision/event fields remain backward-compatible
+- [ ] Existing runtime enforcement behavior remains unchanged
+- [ ] Replay diff classifier remains deterministic for unchanged/strictness/reclassification
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave39-evidence-compat-step2.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned runtime/event tests pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave39-evidence-compat-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave39-evidence-compat-step2.md
@@ -1,0 +1,33 @@
+# SPLIT MOVE MAP - Wave39 Evidence Compat Step2
+
+## Intent
+Bounded implementation for replay/evidence compatibility normalization fields and deterministic precedence, additive only.
+
+## Touched runtime paths
+- `crates/assay-core/src/mcp/decision.rs`
+  - adds additive Decision Event fields:
+    - `decision_basis_version`
+    - `compat_fallback_applied`
+    - `classification_source`
+    - `replay_diff_reason`
+    - `legacy_shape_detected`
+  - populates fields via deterministic compatibility projection in normalization flow
+- `crates/assay-core/src/mcp/decision/replay_compat.rs`
+  - introduces deterministic compatibility projection and precedence helpers
+  - exposes `ReplayClassificationSource` + `DECISION_BASIS_VERSION_V1`
+- `crates/assay-core/src/mcp/decision/replay_diff.rs`
+  - extends `ReplayDiffBasis` with compatibility normalization fields
+  - derives deterministic fallback metadata from decision payloads
+
+## Touched tests
+- `crates/assay-core/tests/replay_diff_contract.rs`
+  - validates additive basis fields
+  - validates precedence fallback behavior for fulfillment-path and legacy shapes
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+  - validates emitted events include deterministic Wave39 compatibility markers
+
+## Out-of-scope guarantees
+- no runtime behavior change
+- no new obligation types
+- no policy backend/control-plane/auth transport scope
+- no workflow changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step2.md
@@ -1,0 +1,27 @@
+# SPLIT REVIEW PACK - Wave39 Evidence Compat Step2
+
+## Intent
+Implement bounded replay/evidence compatibility normalization fields and deterministic classification precedence.
+
+This slice must:
+- remain additive and backward-compatible
+- normalize legacy fallback metadata deterministically
+- keep runtime behavior unchanged
+
+This slice must not:
+- add new runtime capability
+- change enforcement semantics
+- expand policy-engine/control-plane/auth transport scope
+- touch workflow files
+
+## Reviewer focus
+1. Diff stays inside bounded runtime/test/docs/gate scope.
+2. Compatibility fields are present and additive in decision payload + replay basis.
+3. Classification precedence is deterministic (converged > fulfillment > legacy).
+4. Legacy fallback signaling remains backward-compatible.
+5. No scope creep into non-goals.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave39-evidence-compat-step2.sh
+```

--- a/scripts/ci/review-wave39-evidence-compat-step2.sh
+++ b/scripts/ci/review-wave39-evidence-compat-step2.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-core/src/mcp/decision/replay_diff.rs"
+  "crates/assay-core/src/mcp/decision/replay_compat.rs"
+  "crates/assay-core/tests/replay_diff_contract.rs"
+  "crates/assay-core/tests/decision_emit_invariant.rs"
+
+  "docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave39-evidence-compat-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step2.md"
+
+  "scripts/ci/review-wave39-evidence-compat-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave39 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave39 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  while IFS= read -r uf; do
+    [[ -z "${uf:-}" ]] && continue
+    allowed="false"
+    for a in "${ALLOWLIST[@]}"; do
+      [[ "$uf" == "$a" ]] && allowed="true" && break
+    done
+    if [[ "$allowed" != "true" ]]; then
+      echo "FAIL: untracked file present under $p: $uf"
+      exit 1
+    fi
+  done < <(git ls-files --others --exclude-standard -- "$p")
+done
+
+echo "[review] Wave39 compatibility markers"
+for marker in \
+  'decision_basis_version' \
+  'compat_fallback_applied' \
+  'classification_source' \
+  'replay_diff_reason' \
+  'legacy_shape_detected' \
+  'ReplayClassificationSource' \
+  'DECISION_BASIS_VERSION_V1'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs crates/assay-core/src/mcp/decision/replay_compat.rs >/dev/null || {
+    echo "FAIL: missing Wave39 compatibility marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] deterministic precedence markers"
+for marker in \
+  'ConvergedOutcome' \
+  'FulfillmentPath' \
+  'LegacyFallback' \
+  'project_replay_compat' \
+  'converged_' \
+  'fulfillment_' \
+  'legacy_decision_'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision/replay_compat.rs crates/assay-core/tests/replay_diff_contract.rs >/dev/null || {
+    echo "FAIL: missing deterministic precedence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing replay/decision contract markers remain present"
+for marker in \
+  'ReplayDiffBasis' \
+  'ReplayDiffBucket' \
+  'classify_replay_diff' \
+  'DecisionOutcomeKind' \
+  'OutcomeCompatState' \
+  'fulfillment_decision_path'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing existing replay/decision marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'runtime enforcement change|new obligation type|policy language expansion|control-plane|auth transport|external integration|UI integration' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'runtime enforcement change|new obligation type|policy language expansion|control-plane|auth transport|external integration|UI integration' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave39 additive replay/evidence compatibility fields to decision payloads:
  - `decision_basis_version`
  - `compat_fallback_applied`
  - `classification_source`
  - `replay_diff_reason`
  - `legacy_shape_detected`
- add deterministic precedence projection module (`converged > fulfillment > legacy`) and reuse it in event normalization + replay basis extraction
- extend replay basis tests and include Wave39 Step2 docs/gate artifacts

## Scope
- bounded Wave39 Step2 implementation only
- no runtime enforcement behavior change
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave39-evidence-compat-step2.sh` (PASS locally)
- pre-commit hooks on commit/push (fmt, clippy, shellcheck, linux compile gate)
