### PR TITLE
docs(wave39-step3): close evidence-compat wave with docs+gate

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step3.md
@@ -1,0 +1,58 @@
+# SPLIT CHECKLIST - Wave39 Evidence Compat Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step3.md`
+  - `scripts/ci/review-wave39-evidence-compat-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave39 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves bounded replay/evidence compatibility normalization contract
+
+## Wave39 invariants
+- [ ] Compatibility markers remain present:
+  - `decision_basis_version`
+  - `compat_fallback_applied`
+  - `classification_source`
+  - `replay_diff_reason`
+  - `legacy_shape_detected`
+  - `ReplayClassificationSource`
+  - `DECISION_BASIS_VERSION_V1`
+- [ ] Deterministic precedence markers remain present:
+  - `ConvergedOutcome`
+  - `FulfillmentPath`
+  - `LegacyFallback`
+  - `project_replay_compat`
+  - `converged_`
+  - `fulfillment_`
+  - `legacy_decision_`
+- [ ] Existing replay/decision markers remain present:
+  - `ReplayDiffBasis`
+  - `ReplayDiffBucket`
+  - `classify_replay_diff`
+  - `DecisionOutcomeKind`
+  - `OutcomeCompatState`
+  - `fulfillment_decision_path`
+
+## Non-goals still enforced
+- [ ] No runtime enforcement behavior changes
+- [ ] No new obligation types
+- [ ] No policy-language expansion
+- [ ] No control-plane semantics
+- [ ] No auth transport changes
+
+## Validation
+- [ ] Step3 gate passes against stacked Step2 base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned replay/decision tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step3.md
@@ -1,0 +1,45 @@
+# SPLIT REVIEW PACK - Wave39 Evidence Compat Step3
+
+## Intent
+Close Wave39 with a docs+gate-only closure slice after bounded replay/evidence compatibility normalization implementation in Step2.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add runtime enforcement behavior changes
+- add policy-language/control-plane/auth transport scope
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step3.md`
+- `scripts/ci/review-wave39-evidence-compat-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Wave39 compatibility markers remain present.
+4. Deterministic precedence markers remain present.
+5. Existing replay/decision markers remain present.
+6. No non-goal scope creep appears in runtime scope.
+7. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave39-evidence-compat-step2-impl \
+  bash scripts/ci/review-wave39-evidence-compat-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave39-evidence-compat-step3.sh
+```
+
+Expected outcome:
+- Step3 adds no runtime behavior.
+- closure remains diff-proof.
+- promote can happen cleanly after stacked validation.

--- a/scripts/ci/review-wave39-evidence-compat-step3.sh
+++ b/scripts/ci/review-wave39-evidence-compat-step3.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave39-evidence-compat-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave39-evidence-compat-step3.md"
+  "scripts/ci/review-wave39-evidence-compat-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave39 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave39 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] Wave39 compatibility markers"
+for marker in \
+  'decision_basis_version' \
+  'compat_fallback_applied' \
+  'classification_source' \
+  'replay_diff_reason' \
+  'legacy_shape_detected' \
+  'ReplayClassificationSource' \
+  'DECISION_BASIS_VERSION_V1'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs crates/assay-core/src/mcp/decision/replay_compat.rs >/dev/null || {
+    echo "FAIL: missing Wave39 compatibility marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] deterministic precedence markers"
+for marker in \
+  'ConvergedOutcome' \
+  'FulfillmentPath' \
+  'LegacyFallback' \
+  'project_replay_compat' \
+  'converged_' \
+  'fulfillment_' \
+  'legacy_decision_'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision/replay_compat.rs crates/assay-core/tests/replay_diff_contract.rs >/dev/null || {
+    echo "FAIL: missing deterministic precedence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing replay/decision contract markers remain present"
+for marker in \
+  'ReplayDiffBasis' \
+  'ReplayDiffBucket' \
+  'classify_replay_diff' \
+  'DecisionOutcomeKind' \
+  'OutcomeCompatState' \
+  'fulfillment_decision_path'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing existing replay/decision marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no scope creep into non-goals"
+if rg -n 'runtime enforcement change|new obligation type|policy language expansion|control-plane|auth transport|external integration|UI integration' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'runtime enforcement change|new obligation type|policy language expansion|control-plane|auth transport|external integration|UI integration' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave39 Step3 closure checklist
- add Wave39 Step3 review pack
- add Wave39 Step3 reviewer gate script

## Scope
- docs + gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave39-evidence-compat-step3.sh` (PASS locally)
- pre-commit hooks passed on commit/push (fmt, clippy workspace gate, shellcheck, linux compile gate)
