### PR TITLE
chore(wave38): align step3 deny-path gate with checklist

### DIFF
--- a/scripts/ci/review-wave38-replay-diff-step3.sh
+++ b/scripts/ci/review-wave38-replay-diff-step3.sh
@@ -81,6 +81,13 @@ do
   }
 done
 
+echo "[review] deny-path separation markers remain present"
+rg -n 'classify_fulfillment_decision_path|fail_closed_applied' \
+  crates/assay-core/src/mcp/decision.rs >/dev/null || {
+  echo "FAIL: missing deny-path separation markers"
+  exit 1
+}
+
 echo "[review] no scope creep into non-goals"
 if rg -n 'new obligation type|runtime enforcement expansion|policy backend replacement|control-plane|auth transport' \
   crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \


### PR DESCRIPTION
## Summary
- align Wave38 Step3 gate with existing docs/checklist requirement for deny-path separation
- add explicit marker check in `review-wave38-replay-diff-step3.sh` for `classify_fulfillment_decision_path|fail_closed_applied`

## Scope
- hygiene only
- single-file change
- no runtime behavior change
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave38-replay-diff-step3.sh` (PASS locally)
- pre-commit hooks passed on commit/push (fmt, clippy workspace gate, shellcheck, linux compile gate)
