### PR TITLE
docs(wave40-step1): freeze deny evidence convergence contract

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step1.md
@@ -1,0 +1,27 @@
+# SPLIT CHECKLIST - Wave40 Deny Evidence Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave40-deny-evidence-convergence.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step1.md`
+  - `scripts/ci/review-wave40-deny-evidence-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] Deny separation markers are explicit:
+  - `policy_deny`
+  - `fail_closed_deny`
+  - `enforcement_deny`
+- [ ] Deterministic deny precedence is explicit
+- [ ] Legacy deny fallback compatibility is explicit
+- [ ] Non-goals are explicit (no runtime behavior change)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave40-deny-evidence-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned replay/decision tests pass

--- a/docs/contributing/SPLIT-PLAN-wave40-deny-evidence-convergence.md
+++ b/docs/contributing/SPLIT-PLAN-wave40-deny-evidence-convergence.md
@@ -1,0 +1,100 @@
+# SPLIT PLAN - Wave40 Deny Evidence Convergence
+
+## Intent
+Freeze a bounded deny-path evidence convergence contract before any further runtime capability work.
+
+This wave is about:
+- explicit deny evidence separation across deny classes
+- deterministic precedence for deny classification
+- additive compatibility signaling for legacy payload shapes
+- reviewer gates that lock the convergence contract
+
+It explicitly does **not** add:
+- new obligation types
+- runtime behavior changes
+- policy language expansion
+- control-plane or auth transport changes
+- UI or external integrations
+
+## Problem
+Wave39 normalized replay/evidence compatibility fields across broad decision shapes.
+
+Current gap:
+- deny-path evidence is still easy to read inconsistently across consumers
+- precedence between deny classes is not frozen as a dedicated contract
+- legacy deny payload fallback signaling is not frozen as deny-specific contract language
+
+## Frozen deny evidence contract
+Wave40 freezes deny evidence separation between:
+- `policy_deny`
+- `fail_closed_deny`
+- `enforcement_deny`
+
+## Frozen deny precedence contract
+Wave40 freezes deterministic precedence for deny classification:
+1. `decision_outcome_kind` (canonical)
+2. `decision_origin` + deny context markers
+3. `fulfillment_decision_path` fallback
+4. legacy deny fallback from base `decision`
+
+This precedence is contract-level in Step1 and must remain deterministic.
+
+## Frozen compatibility requirements
+Wave40 freezes additive legacy compatibility expectations for deny evidence:
+- legacy payloads remain classifiable as deny/non-deny deterministically
+- fallback application is explicitly signaled in evidence metadata
+- no existing deny consumers are broken by the convergence slice
+
+## Suggested additive markers for Step2
+Wave40 Step2 may add deny-specific compatibility metadata, additively only, such as:
+- `deny_precedence_version`
+- `deny_classification_source`
+- `deny_legacy_fallback_applied`
+- `deny_convergence_reason`
+
+Names can vary in Step2 implementation, but semantics above are frozen in this plan.
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. deny evidence separation is explicit and testable (`policy_deny` / `fail_closed_deny` / `enforcement_deny`)
+2. deny precedence is deterministic and test-covered
+3. legacy deny fallback is additive and backward-compatible
+4. existing runtime decision behavior remains unchanged
+5. no new runtime capability or policy surface is introduced
+
+## Scope boundaries
+### In scope
+- deny evidence convergence contract freeze
+- deterministic deny precedence contract
+- additive legacy compatibility contract for deny payloads
+- tests and reviewer gates for the above
+
+### Out of scope
+- new obligation types
+- runtime behavior changes
+- policy language extension
+- control-plane or auth transport changes
+- UI/external integration work
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- deny-path convergence normalization
+- deterministic precedence representation
+- additive legacy compatibility metadata
+- no runtime behavior change
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must remain convergence-only and additive.
+
+Primary failure modes:
+- introducing behavior changes under convergence scope
+- reducing deny-path clarity in emitted evidence
+- breaking older deny-event consumers via non-additive changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step1.md
@@ -1,0 +1,38 @@
+# SPLIT REVIEW PACK - Wave40 Deny Evidence Step1
+
+## Intent
+Freeze the bounded deny evidence convergence contract before any Step2 implementation.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add new obligation/runtime capability
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave40-deny-evidence-convergence.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step1.md`
+- `scripts/ci/review-wave40-deny-evidence-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Deny separation markers are explicit (`policy_deny`, `fail_closed_deny`, `enforcement_deny`).
+3. Deny precedence contract is explicit and deterministic.
+4. Legacy deny fallback compatibility is explicit.
+5. Runtime paths are untouched.
+6. No runtime behavior change is introduced in this wave.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave40-deny-evidence-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- deny convergence contract is frozen cleanly
+- Step2 can implement bounded normalization without reopening semantics

--- a/scripts/ci/review-wave40-deny-evidence-step1.sh
+++ b/scripts/ci/review-wave40-deny-evidence-step1.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave40-deny-evidence-convergence.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step1.md"
+  "scripts/ci/review-wave40-deny-evidence-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-core/tests"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave40 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave40 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave40 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN - Wave40 Deny Evidence Convergence$' \
+  docs/contributing/SPLIT-PLAN-wave40-deny-evidence-convergence.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'policy_deny' \
+  'fail_closed_deny' \
+  'enforcement_deny' \
+  'deterministic precedence' \
+  'legacy deny fallback' \
+  'no runtime behavior change'
+do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave40-deny-evidence-convergence.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave40 Step1 split plan for deny evidence convergence
- add Step1 checklist and review pack
- add Step1 reviewer gate script

## Scope
- docs+gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave40-deny-evidence-step1.sh` (PASS locally)
- pre-commit hooks passed on commit and push (fmt, clippy workspace gate, shellcheck, linux compile gate)
