### PR TITLE
feat(wave40-step2): converge deny evidence precedence and fallback

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -3,6 +3,7 @@
 //! This module implements the "always emit decision" invariant (I1):
 //! Every tool call attempt MUST emit exactly one decision event.
 
+use self::deny_convergence::project_deny_convergence;
 use self::outcome_convergence::classify_decision_outcome;
 use self::replay_compat::project_replay_compat;
 use super::policy::{
@@ -14,9 +15,11 @@ use serde_json::Value;
 use std::io::Write;
 use std::sync::Arc;
 
+mod deny_convergence;
 mod outcome_convergence;
 mod replay_compat;
 mod replay_diff;
+pub use deny_convergence::{DenyClassificationSource, DENY_PRECEDENCE_VERSION_V1};
 pub use outcome_convergence::{DecisionOrigin, DecisionOutcomeKind, OutcomeCompatState};
 pub use replay_compat::{ReplayClassificationSource, DECISION_BASIS_VERSION_V1};
 pub use replay_diff::{
@@ -316,6 +319,27 @@ pub struct DecisionData {
     /// Whether legacy event shape was detected by compatibility normalization.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub legacy_shape_detected: Option<bool>,
+    /// Explicit deny classification marker: policy deny path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_deny: Option<bool>,
+    /// Explicit deny classification marker: fail-closed deny path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_closed_deny: Option<bool>,
+    /// Explicit deny classification marker: runtime enforcement deny path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enforcement_deny: Option<bool>,
+    /// Version tag for deterministic deny-precedence convergence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deny_precedence_version: Option<String>,
+    /// Source selected by deterministic deny-classification precedence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deny_classification_source: Option<DenyClassificationSource>,
+    /// Whether deny classification used additive legacy fallback.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deny_legacy_fallback_applied: Option<bool>,
+    /// Deterministic reason token for deny convergence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deny_convergence_reason: Option<String>,
     /// Whether any obligation outcome is normalized as applied.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub obligation_applied_present: Option<bool>,
@@ -451,6 +475,11 @@ fn refresh_fulfillment_normalization(data: &mut DecisionData) {
     data.decision_origin = Some(outcome.origin);
     data.outcome_compat_state = Some(outcome.compat_state);
     data.fulfillment_decision_path = Some(classify_fulfillment_decision_path(data));
+    let fail_closed_applied = data
+        .fail_closed
+        .as_ref()
+        .map(|ctx| ctx.fail_closed_applied)
+        .unwrap_or(false);
     let replay_projection = project_replay_compat(
         data.decision_outcome_kind,
         data.decision_origin,
@@ -458,11 +487,26 @@ fn refresh_fulfillment_normalization(data: &mut DecisionData) {
         data.fulfillment_decision_path,
         data.decision,
     );
+    let deny_projection = project_deny_convergence(
+        data.decision_outcome_kind,
+        data.decision_origin,
+        data.fulfillment_decision_path,
+        data.decision,
+        fail_closed_applied,
+        data.reason_code.as_str(),
+    );
     data.decision_basis_version = Some(DECISION_BASIS_VERSION_V1.to_string());
     data.compat_fallback_applied = Some(replay_projection.compat_fallback_applied);
     data.classification_source = Some(replay_projection.classification_source);
     data.replay_diff_reason = Some(replay_projection.replay_diff_reason.to_string());
     data.legacy_shape_detected = Some(replay_projection.legacy_shape_detected);
+    data.policy_deny = Some(deny_projection.policy_deny);
+    data.fail_closed_deny = Some(deny_projection.fail_closed_deny);
+    data.enforcement_deny = Some(deny_projection.enforcement_deny);
+    data.deny_precedence_version = Some(DENY_PRECEDENCE_VERSION_V1.to_string());
+    data.deny_classification_source = Some(deny_projection.classification_source);
+    data.deny_legacy_fallback_applied = Some(deny_projection.legacy_fallback_applied);
+    data.deny_convergence_reason = Some(deny_projection.deny_convergence_reason.to_string());
 }
 
 impl DecisionEvent {
@@ -525,6 +569,13 @@ impl DecisionEvent {
                 classification_source: None,
                 replay_diff_reason: None,
                 legacy_shape_detected: None,
+                policy_deny: None,
+                fail_closed_deny: None,
+                enforcement_deny: None,
+                deny_precedence_version: None,
+                deny_classification_source: None,
+                deny_legacy_fallback_applied: None,
+                deny_convergence_reason: None,
                 obligation_applied_present: None,
                 obligation_skipped_present: None,
                 obligation_error_present: None,

--- a/crates/assay-core/src/mcp/decision/deny_convergence.rs
+++ b/crates/assay-core/src/mcp/decision/deny_convergence.rs
@@ -1,0 +1,357 @@
+use super::{reason_codes, Decision, DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath};
+use serde::{Deserialize, Serialize};
+
+pub const DENY_PRECEDENCE_VERSION_V1: &str = "wave40_v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DenyClassificationSource {
+    OutcomeKind,
+    OriginContext,
+    FulfillmentPath,
+    LegacyDecision,
+    NotDeny,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DenyConvergenceProjection {
+    pub policy_deny: bool,
+    pub fail_closed_deny: bool,
+    pub enforcement_deny: bool,
+    pub classification_source: DenyClassificationSource,
+    pub legacy_fallback_applied: bool,
+    pub deny_convergence_reason: &'static str,
+}
+
+pub fn project_deny_convergence(
+    decision_outcome_kind: Option<DecisionOutcomeKind>,
+    decision_origin: Option<DecisionOrigin>,
+    fulfillment_decision_path: Option<FulfillmentDecisionPath>,
+    decision: Decision,
+    fail_closed_applied: bool,
+    reason_code: &str,
+) -> DenyConvergenceProjection {
+    if let Some(kind) = decision_outcome_kind {
+        return match kind {
+            DecisionOutcomeKind::PolicyDeny => projection(
+                true,
+                false,
+                false,
+                DenyClassificationSource::OutcomeKind,
+                false,
+                "outcome_policy_deny",
+            ),
+            DecisionOutcomeKind::FailClosedDeny => projection(
+                false,
+                true,
+                false,
+                DenyClassificationSource::OutcomeKind,
+                false,
+                "outcome_fail_closed_deny",
+            ),
+            DecisionOutcomeKind::EnforcementDeny => projection(
+                false,
+                false,
+                true,
+                DenyClassificationSource::OutcomeKind,
+                false,
+                "outcome_enforcement_deny",
+            ),
+            DecisionOutcomeKind::ObligationApplied
+            | DecisionOutcomeKind::ObligationSkipped
+            | DecisionOutcomeKind::ObligationError => not_deny_projection(
+                DenyClassificationSource::OutcomeKind,
+                false,
+                "outcome_not_deny",
+            ),
+        };
+    }
+
+    if let Some(origin_projection) =
+        project_from_origin(decision_origin, decision, fail_closed_applied, reason_code)
+    {
+        return origin_projection;
+    }
+
+    if let Some(path_projection) = project_from_fulfillment_path(fulfillment_decision_path) {
+        return path_projection;
+    }
+
+    project_from_legacy_decision(decision, fail_closed_applied, reason_code)
+}
+
+fn projection(
+    policy_deny: bool,
+    fail_closed_deny: bool,
+    enforcement_deny: bool,
+    classification_source: DenyClassificationSource,
+    legacy_fallback_applied: bool,
+    deny_convergence_reason: &'static str,
+) -> DenyConvergenceProjection {
+    DenyConvergenceProjection {
+        policy_deny,
+        fail_closed_deny,
+        enforcement_deny,
+        classification_source,
+        legacy_fallback_applied,
+        deny_convergence_reason,
+    }
+}
+
+fn not_deny_projection(
+    source: DenyClassificationSource,
+    fallback: bool,
+    reason: &'static str,
+) -> DenyConvergenceProjection {
+    projection(false, false, false, source, fallback, reason)
+}
+
+fn project_from_origin(
+    decision_origin: Option<DecisionOrigin>,
+    decision: Decision,
+    fail_closed_applied: bool,
+    reason_code: &str,
+) -> Option<DenyConvergenceProjection> {
+    let origin = decision_origin?;
+    match origin {
+        DecisionOrigin::FailClosedMatrix => Some(projection(
+            false,
+            true,
+            false,
+            DenyClassificationSource::OriginContext,
+            true,
+            "origin_fail_closed_matrix",
+        )),
+        DecisionOrigin::RuntimeEnforcement => Some(projection(
+            false,
+            false,
+            true,
+            DenyClassificationSource::OriginContext,
+            true,
+            "origin_runtime_enforcement",
+        )),
+        DecisionOrigin::PolicyEngine => match decision {
+            Decision::Deny => Some(projection(
+                true,
+                false,
+                false,
+                DenyClassificationSource::OriginContext,
+                true,
+                "origin_policy_engine_deny",
+            )),
+            Decision::Error => Some(projection(
+                false,
+                false,
+                true,
+                DenyClassificationSource::OriginContext,
+                true,
+                "origin_policy_engine_error",
+            )),
+            Decision::Allow => Some(not_deny_projection(
+                DenyClassificationSource::OriginContext,
+                true,
+                "origin_policy_engine_allow",
+            )),
+        },
+        DecisionOrigin::ObligationExecutor => Some(project_from_legacy_decision(
+            decision,
+            fail_closed_applied,
+            reason_code,
+        )),
+    }
+}
+
+fn project_from_fulfillment_path(
+    fulfillment_decision_path: Option<FulfillmentDecisionPath>,
+) -> Option<DenyConvergenceProjection> {
+    let path = fulfillment_decision_path?;
+    match path {
+        FulfillmentDecisionPath::PolicyDeny => Some(projection(
+            true,
+            false,
+            false,
+            DenyClassificationSource::FulfillmentPath,
+            true,
+            "fulfillment_policy_deny",
+        )),
+        FulfillmentDecisionPath::FailClosedDeny => Some(projection(
+            false,
+            true,
+            false,
+            DenyClassificationSource::FulfillmentPath,
+            true,
+            "fulfillment_fail_closed_deny",
+        )),
+        FulfillmentDecisionPath::DecisionError => Some(projection(
+            false,
+            false,
+            true,
+            DenyClassificationSource::FulfillmentPath,
+            true,
+            "fulfillment_decision_error",
+        )),
+        FulfillmentDecisionPath::PolicyAllow => Some(not_deny_projection(
+            DenyClassificationSource::FulfillmentPath,
+            true,
+            "fulfillment_policy_allow",
+        )),
+    }
+}
+
+fn project_from_legacy_decision(
+    decision: Decision,
+    fail_closed_applied: bool,
+    reason_code: &str,
+) -> DenyConvergenceProjection {
+    match decision {
+        Decision::Deny => {
+            if fail_closed_applied {
+                projection(
+                    false,
+                    true,
+                    false,
+                    DenyClassificationSource::LegacyDecision,
+                    true,
+                    "legacy_fail_closed_deny",
+                )
+            } else if is_enforcement_deny_reason(reason_code) {
+                projection(
+                    false,
+                    false,
+                    true,
+                    DenyClassificationSource::LegacyDecision,
+                    true,
+                    "legacy_enforcement_deny",
+                )
+            } else {
+                projection(
+                    true,
+                    false,
+                    false,
+                    DenyClassificationSource::LegacyDecision,
+                    true,
+                    "legacy_policy_deny",
+                )
+            }
+        }
+        Decision::Error => projection(
+            false,
+            false,
+            true,
+            DenyClassificationSource::LegacyDecision,
+            true,
+            "legacy_decision_error",
+        ),
+        Decision::Allow => not_deny_projection(
+            DenyClassificationSource::NotDeny,
+            true,
+            "legacy_decision_allow",
+        ),
+    }
+}
+
+fn is_enforcement_deny_reason(reason_code: &str) -> bool {
+    reason_code.starts_with("M_")
+        || matches!(
+            reason_code,
+            reason_codes::P_APPROVAL_REQUIRED
+                | reason_codes::P_RESTRICT_SCOPE
+                | reason_codes::P_REDACT_ARGS
+                | reason_codes::P_MANDATE_REQUIRED
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_outcome_kind_for_policy_deny() {
+        let projection = project_deny_convergence(
+            Some(DecisionOutcomeKind::PolicyDeny),
+            Some(DecisionOrigin::PolicyEngine),
+            Some(FulfillmentDecisionPath::PolicyDeny),
+            Decision::Deny,
+            false,
+            reason_codes::P_POLICY_DENY,
+        );
+        assert!(projection.policy_deny);
+        assert!(!projection.fail_closed_deny);
+        assert!(!projection.enforcement_deny);
+        assert_eq!(
+            projection.classification_source,
+            DenyClassificationSource::OutcomeKind
+        );
+        assert!(!projection.legacy_fallback_applied);
+        assert_eq!(projection.deny_convergence_reason, "outcome_policy_deny");
+    }
+
+    #[test]
+    fn falls_back_to_origin_context() {
+        let projection = project_deny_convergence(
+            None,
+            Some(DecisionOrigin::FailClosedMatrix),
+            Some(FulfillmentDecisionPath::PolicyDeny),
+            Decision::Deny,
+            true,
+            reason_codes::S_DB_ERROR,
+        );
+        assert!(!projection.policy_deny);
+        assert!(projection.fail_closed_deny);
+        assert!(!projection.enforcement_deny);
+        assert_eq!(
+            projection.classification_source,
+            DenyClassificationSource::OriginContext
+        );
+        assert!(projection.legacy_fallback_applied);
+        assert_eq!(
+            projection.deny_convergence_reason,
+            "origin_fail_closed_matrix"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_fulfillment_path() {
+        let projection = project_deny_convergence(
+            None,
+            None,
+            Some(FulfillmentDecisionPath::DecisionError),
+            Decision::Error,
+            false,
+            reason_codes::S_INTERNAL_ERROR,
+        );
+        assert!(!projection.policy_deny);
+        assert!(!projection.fail_closed_deny);
+        assert!(projection.enforcement_deny);
+        assert_eq!(
+            projection.classification_source,
+            DenyClassificationSource::FulfillmentPath
+        );
+        assert!(projection.legacy_fallback_applied);
+        assert_eq!(
+            projection.deny_convergence_reason,
+            "fulfillment_decision_error"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_legacy_decision() {
+        let projection = project_deny_convergence(
+            None,
+            None,
+            None,
+            Decision::Deny,
+            false,
+            reason_codes::P_POLICY_DENY,
+        );
+        assert!(projection.policy_deny);
+        assert!(!projection.fail_closed_deny);
+        assert!(!projection.enforcement_deny);
+        assert_eq!(
+            projection.classification_source,
+            DenyClassificationSource::LegacyDecision
+        );
+        assert!(projection.legacy_fallback_applied);
+        assert_eq!(projection.deny_convergence_reason, "legacy_policy_deny");
+    }
+}

--- a/crates/assay-core/src/mcp/decision/replay_diff.rs
+++ b/crates/assay-core/src/mcp/decision/replay_diff.rs
@@ -1,7 +1,8 @@
 use super::{
+    deny_convergence::{project_deny_convergence, DENY_PRECEDENCE_VERSION_V1},
     replay_compat::{project_replay_compat, DECISION_BASIS_VERSION_V1},
-    Decision, DecisionData, DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath,
-    OutcomeCompatState, ReplayClassificationSource,
+    Decision, DecisionData, DecisionOrigin, DecisionOutcomeKind, DenyClassificationSource,
+    FulfillmentDecisionPath, OutcomeCompatState, ReplayClassificationSource,
 };
 use crate::mcp::policy::TypedPolicyDecision;
 use serde::{Deserialize, Serialize};
@@ -29,6 +30,13 @@ pub struct ReplayDiffBasis {
     pub classification_source: ReplayClassificationSource,
     pub replay_diff_reason: String,
     pub legacy_shape_detected: bool,
+    pub policy_deny: bool,
+    pub fail_closed_deny: bool,
+    pub enforcement_deny: bool,
+    pub deny_precedence_version: String,
+    pub deny_classification_source: DenyClassificationSource,
+    pub deny_legacy_fallback_applied: bool,
+    pub deny_convergence_reason: String,
     pub reason_code: String,
     pub typed_decision: Option<TypedPolicyDecision>,
     pub policy_version: Option<String>,
@@ -39,12 +47,26 @@ pub struct ReplayDiffBasis {
 
 /// Build replay basis from an emitted decision payload.
 pub fn basis_from_decision_data(data: &DecisionData) -> ReplayDiffBasis {
+    let fail_closed_applied = data
+        .fail_closed
+        .as_ref()
+        .map(|ctx| ctx.fail_closed_applied)
+        .unwrap_or(false);
+
     let replay_projection = project_replay_compat(
         data.decision_outcome_kind,
         data.decision_origin,
         data.outcome_compat_state,
         data.fulfillment_decision_path,
         data.decision,
+    );
+    let deny_projection = project_deny_convergence(
+        data.decision_outcome_kind,
+        data.decision_origin,
+        data.fulfillment_decision_path,
+        data.decision,
+        fail_closed_applied,
+        data.reason_code.as_str(),
     );
 
     ReplayDiffBasis {
@@ -69,16 +91,33 @@ pub fn basis_from_decision_data(data: &DecisionData) -> ReplayDiffBasis {
         legacy_shape_detected: data
             .legacy_shape_detected
             .unwrap_or(replay_projection.legacy_shape_detected),
+        policy_deny: data.policy_deny.unwrap_or(deny_projection.policy_deny),
+        fail_closed_deny: data
+            .fail_closed_deny
+            .unwrap_or(deny_projection.fail_closed_deny),
+        enforcement_deny: data
+            .enforcement_deny
+            .unwrap_or(deny_projection.enforcement_deny),
+        deny_precedence_version: data
+            .deny_precedence_version
+            .clone()
+            .unwrap_or_else(|| DENY_PRECEDENCE_VERSION_V1.to_string()),
+        deny_classification_source: data
+            .deny_classification_source
+            .unwrap_or(deny_projection.classification_source),
+        deny_legacy_fallback_applied: data
+            .deny_legacy_fallback_applied
+            .unwrap_or(deny_projection.legacy_fallback_applied),
+        deny_convergence_reason: data
+            .deny_convergence_reason
+            .clone()
+            .unwrap_or_else(|| deny_projection.deny_convergence_reason.to_string()),
         reason_code: data.reason_code.clone(),
         typed_decision: data.typed_decision,
         policy_version: data.policy_version.clone(),
         policy_digest: data.policy_digest.clone(),
         decision: data.decision,
-        fail_closed_applied: data
-            .fail_closed
-            .as_ref()
-            .map(|ctx| ctx.fail_closed_applied)
-            .unwrap_or(false),
+        fail_closed_applied,
     }
 }
 
@@ -119,6 +158,13 @@ fn same_effective_decision_class(baseline: &ReplayDiffBasis, candidate: &ReplayD
         && baseline.classification_source == candidate.classification_source
         && baseline.replay_diff_reason == candidate.replay_diff_reason
         && baseline.legacy_shape_detected == candidate.legacy_shape_detected
+        && baseline.policy_deny == candidate.policy_deny
+        && baseline.fail_closed_deny == candidate.fail_closed_deny
+        && baseline.enforcement_deny == candidate.enforcement_deny
+        && baseline.deny_precedence_version == candidate.deny_precedence_version
+        && baseline.deny_classification_source == candidate.deny_classification_source
+        && baseline.deny_legacy_fallback_applied == candidate.deny_legacy_fallback_applied
+        && baseline.deny_convergence_reason == candidate.deny_convergence_reason
         && baseline.reason_code == candidate.reason_code
         && baseline.typed_decision == candidate.typed_decision
         && baseline.decision == candidate.decision
@@ -161,6 +207,13 @@ mod tests {
             classification_source: ReplayClassificationSource::ConvergedOutcome,
             replay_diff_reason: "converged_obligation_applied".to_string(),
             legacy_shape_detected: false,
+            policy_deny: false,
+            fail_closed_deny: false,
+            enforcement_deny: false,
+            deny_precedence_version: DENY_PRECEDENCE_VERSION_V1.to_string(),
+            deny_classification_source: DenyClassificationSource::NotDeny,
+            deny_legacy_fallback_applied: false,
+            deny_convergence_reason: "outcome_not_deny".to_string(),
             reason_code: reason.to_string(),
             typed_decision: Some(TypedPolicyDecision::AllowWithObligations),
             policy_version: Some("v1".to_string()),
@@ -241,6 +294,13 @@ mod tests {
             classification_source: ReplayClassificationSource::LegacyFallback,
             replay_diff_reason: "legacy_decision_allow".to_string(),
             legacy_shape_detected: true,
+            policy_deny: false,
+            fail_closed_deny: false,
+            enforcement_deny: false,
+            deny_precedence_version: DENY_PRECEDENCE_VERSION_V1.to_string(),
+            deny_classification_source: DenyClassificationSource::NotDeny,
+            deny_legacy_fallback_applied: true,
+            deny_convergence_reason: "legacy_decision_allow".to_string(),
             reason_code: "P_POLICY_ALLOW".to_string(),
             typed_decision: None,
             policy_version: None,

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -5,8 +5,9 @@
 
 use assay_core::mcp::decision::{
     reason_codes, Decision, DecisionEmitter, DecisionEmitterGuard, DecisionEvent, DecisionOrigin,
-    DecisionOutcomeKind, FulfillmentDecisionPath, ObligationOutcomeStatus, OutcomeCompatState,
-    ReplayClassificationSource, DECISION_BASIS_VERSION_V1,
+    DecisionOutcomeKind, DenyClassificationSource, FulfillmentDecisionPath,
+    ObligationOutcomeStatus, OutcomeCompatState, ReplayClassificationSource,
+    DECISION_BASIS_VERSION_V1, DENY_PRECEDENCE_VERSION_V1,
 };
 use assay_core::mcp::policy::{
     ApprovalFreshness, McpPolicy, PolicyState, RedactArgsContract, RestrictScopeContract,
@@ -1070,6 +1071,22 @@ fn test_event_contains_required_fields() {
         Some("converged_obligation_applied")
     );
     assert_eq!(event.data.legacy_shape_detected, Some(false));
+    assert_eq!(event.data.policy_deny, Some(false));
+    assert_eq!(event.data.fail_closed_deny, Some(false));
+    assert_eq!(event.data.enforcement_deny, Some(false));
+    assert_eq!(
+        event.data.deny_precedence_version.as_deref(),
+        Some(DENY_PRECEDENCE_VERSION_V1)
+    );
+    assert_eq!(
+        event.data.deny_classification_source,
+        Some(DenyClassificationSource::OutcomeKind)
+    );
+    assert_eq!(event.data.deny_legacy_fallback_applied, Some(false));
+    assert_eq!(
+        event.data.deny_convergence_reason.as_deref(),
+        Some("outcome_not_deny")
+    );
     assert_eq!(event.data.obligation_applied_present, Some(true));
     assert_eq!(event.data.obligation_skipped_present, Some(false));
     assert_eq!(event.data.obligation_error_present, Some(false));

--- a/crates/assay-core/tests/replay_diff_contract.rs
+++ b/crates/assay-core/tests/replay_diff_contract.rs
@@ -1,8 +1,8 @@
 use assay_core::mcp::decision::{
     basis_from_decision_data, classify_replay_diff, reason_codes, Decision, DecisionEvent,
-    DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath, OutcomeCompatState,
-    PolicyDecisionEventContext, ReplayClassificationSource, ReplayDiffBucket,
-    DECISION_BASIS_VERSION_V1,
+    DecisionOrigin, DecisionOutcomeKind, DenyClassificationSource, FulfillmentDecisionPath,
+    OutcomeCompatState, PolicyDecisionEventContext, ReplayClassificationSource, ReplayDiffBucket,
+    DECISION_BASIS_VERSION_V1, DENY_PRECEDENCE_VERSION_V1,
 };
 use assay_core::mcp::policy::TypedPolicyDecision;
 
@@ -52,6 +52,16 @@ fn basis_extraction_contains_frozen_fields() {
     );
     assert_eq!(basis.replay_diff_reason, "converged_obligation_skipped");
     assert!(!basis.legacy_shape_detected);
+    assert!(!basis.policy_deny);
+    assert!(!basis.fail_closed_deny);
+    assert!(!basis.enforcement_deny);
+    assert_eq!(basis.deny_precedence_version, DENY_PRECEDENCE_VERSION_V1);
+    assert_eq!(
+        basis.deny_classification_source,
+        DenyClassificationSource::OutcomeKind
+    );
+    assert!(!basis.deny_legacy_fallback_applied);
+    assert_eq!(basis.deny_convergence_reason, "outcome_not_deny");
     assert_eq!(basis.reason_code, reason_codes::P_POLICY_ALLOW);
     assert_eq!(
         basis.typed_decision,
@@ -74,6 +84,13 @@ fn basis_extraction_prefers_fulfillment_path_when_converged_markers_missing() {
     event.data.classification_source = None;
     event.data.replay_diff_reason = None;
     event.data.legacy_shape_detected = None;
+    event.data.policy_deny = None;
+    event.data.fail_closed_deny = None;
+    event.data.enforcement_deny = None;
+    event.data.deny_precedence_version = None;
+    event.data.deny_classification_source = None;
+    event.data.deny_legacy_fallback_applied = None;
+    event.data.deny_convergence_reason = None;
 
     let basis = basis_from_decision_data(&event.data);
     assert_eq!(basis.decision_basis_version, DECISION_BASIS_VERSION_V1);
@@ -84,6 +101,12 @@ fn basis_extraction_prefers_fulfillment_path_when_converged_markers_missing() {
     );
     assert_eq!(basis.replay_diff_reason, "fulfillment_policy_allow");
     assert!(basis.legacy_shape_detected);
+    assert_eq!(
+        basis.deny_classification_source,
+        DenyClassificationSource::FulfillmentPath
+    );
+    assert!(basis.deny_legacy_fallback_applied);
+    assert_eq!(basis.deny_convergence_reason, "fulfillment_policy_allow");
 }
 
 #[test]
@@ -98,6 +121,13 @@ fn basis_extraction_marks_legacy_fallback_when_shape_is_missing() {
     event.data.classification_source = None;
     event.data.replay_diff_reason = None;
     event.data.legacy_shape_detected = None;
+    event.data.policy_deny = None;
+    event.data.fail_closed_deny = None;
+    event.data.enforcement_deny = None;
+    event.data.deny_precedence_version = None;
+    event.data.deny_classification_source = None;
+    event.data.deny_legacy_fallback_applied = None;
+    event.data.deny_convergence_reason = None;
 
     let basis = basis_from_decision_data(&event.data);
     assert_eq!(basis.decision_basis_version, DECISION_BASIS_VERSION_V1);
@@ -108,6 +138,11 @@ fn basis_extraction_marks_legacy_fallback_when_shape_is_missing() {
     );
     assert_eq!(basis.replay_diff_reason, "legacy_decision_allow");
     assert!(basis.legacy_shape_detected);
+    assert_eq!(
+        basis.deny_classification_source,
+        DenyClassificationSource::NotDeny
+    );
+    assert!(basis.deny_legacy_fallback_applied);
 }
 
 #[test]
@@ -229,4 +264,58 @@ fn classify_replay_diff_legacy_decision_fallback() {
         classify_replay_diff(&candidate, &baseline),
         ReplayDiffBucket::Looser
     );
+}
+
+#[test]
+fn basis_extracts_deny_convergence_for_policy_deny() {
+    let deny_event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_205".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(reason_codes::P_POLICY_DENY, Some("blocked".to_string()));
+
+    let basis = basis_from_decision_data(&deny_event.data);
+    assert!(basis.policy_deny);
+    assert!(!basis.fail_closed_deny);
+    assert!(!basis.enforcement_deny);
+    assert_eq!(
+        basis.deny_classification_source,
+        DenyClassificationSource::OutcomeKind
+    );
+    assert!(!basis.deny_legacy_fallback_applied);
+    assert_eq!(basis.deny_convergence_reason, "outcome_policy_deny");
+}
+
+#[test]
+fn basis_extracts_deny_convergence_legacy_fallback_for_missing_shape() {
+    let mut deny_event = DecisionEvent::new(
+        "assay://test".to_string(),
+        "tc_206".to_string(),
+        "deploy_service".to_string(),
+    )
+    .deny(reason_codes::P_POLICY_DENY, Some("blocked".to_string()));
+    deny_event.data.decision_outcome_kind = None;
+    deny_event.data.decision_origin = None;
+    deny_event.data.outcome_compat_state = None;
+    deny_event.data.fulfillment_decision_path = None;
+    deny_event.data.policy_deny = None;
+    deny_event.data.fail_closed_deny = None;
+    deny_event.data.enforcement_deny = None;
+    deny_event.data.deny_precedence_version = None;
+    deny_event.data.deny_classification_source = None;
+    deny_event.data.deny_legacy_fallback_applied = None;
+    deny_event.data.deny_convergence_reason = None;
+
+    let basis = basis_from_decision_data(&deny_event.data);
+    assert!(basis.policy_deny);
+    assert!(!basis.fail_closed_deny);
+    assert!(!basis.enforcement_deny);
+    assert_eq!(basis.deny_precedence_version, DENY_PRECEDENCE_VERSION_V1);
+    assert_eq!(
+        basis.deny_classification_source,
+        DenyClassificationSource::LegacyDecision
+    );
+    assert!(basis.deny_legacy_fallback_applied);
+    assert_eq!(basis.deny_convergence_reason, "legacy_policy_deny");
 }

--- a/docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step2.md
@@ -1,0 +1,35 @@
+# SPLIT CHECKLIST - Wave40 Deny Evidence Step2
+
+## Scope discipline
+- [ ] Diff is limited to bounded deny-evidence convergence runtime + tests + Step2 docs/gate.
+- [ ] No `.github/workflows/*` changes.
+- [ ] No scope leaks outside decision/evidence compatibility paths.
+- [ ] No new runtime capability added.
+- [ ] No policy backend/control-plane/auth transport changes.
+
+## Implementation contract
+- [ ] Additive deny-convergence fields are present:
+  - `policy_deny`
+  - `fail_closed_deny`
+  - `enforcement_deny`
+  - `deny_precedence_version`
+  - `deny_classification_source`
+  - `deny_legacy_fallback_applied`
+  - `deny_convergence_reason`
+- [ ] Deterministic deny precedence is represented and test-covered:
+  - `decision_outcome_kind`
+  - `decision_origin`
+  - `fulfillment_decision_path`
+  - legacy decision fallback
+- [ ] Legacy deny fallback remains additive and backward-compatible.
+
+## Compatibility and behavior
+- [ ] Existing decision/event fields remain backward-compatible.
+- [ ] Existing runtime enforcement behavior remains unchanged.
+- [ ] Replay diff classifier remains deterministic for unchanged/strictness/reclassification.
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave40-deny-evidence-step2.sh` passes.
+- [ ] `cargo fmt --check` passes.
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes.
+- [ ] Pinned runtime/event tests pass.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave40-deny-evidence-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave40-deny-evidence-step2.md
@@ -1,0 +1,28 @@
+# SPLIT MOVE MAP - Wave40 Deny Evidence Step2
+
+## Intent
+Bounded implementation for deny/fail-closed/enforcement evidence convergence with deterministic precedence and additive legacy fallback, without runtime behavior change.
+
+## Touched runtime paths
+- `crates/assay-core/src/mcp/decision/deny_convergence.rs`
+  - adds deterministic deny-classification projector and precedence chain
+  - defines additive deny classification source and precedence version
+- `crates/assay-core/src/mcp/decision.rs`
+  - adds additive Decision Event deny-convergence fields
+  - populates fields from projector during normalization flow
+- `crates/assay-core/src/mcp/decision/replay_diff.rs`
+  - extends replay basis with deny-convergence compatibility fields
+  - derives deterministic fallback metadata from decision payloads
+
+## Touched tests
+- `crates/assay-core/tests/replay_diff_contract.rs`
+  - validates additive deny-convergence basis fields
+  - validates deny fallback precedence behavior for missing legacy shape markers
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+  - validates emitted events include deterministic deny-convergence markers
+
+## Out-of-scope guarantees
+- no runtime behavior change
+- no new deny semantics or obligation types
+- no policy backend/control-plane/auth transport scope expansion
+- no workflow changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step2.md
@@ -1,0 +1,28 @@
+# SPLIT REVIEW PACK - Wave40 Deny Evidence Step2
+
+## Intent
+Implement bounded deny/fail-closed evidence convergence with deterministic precedence and additive legacy fallback metadata.
+
+This slice must:
+- remain additive and backward-compatible
+- separate deny classes explicitly in emitted evidence
+- represent deterministic deny precedence
+- keep runtime behavior unchanged
+
+This slice must not:
+- add new runtime capability
+- change enforcement semantics
+- expand policy-engine/control-plane/auth transport scope
+- touch workflow files
+
+## Reviewer focus
+1. Diff stays inside bounded decision/runtime/test/docs/gate scope.
+2. Deny classification fields are present and additive in event payload + replay basis.
+3. Deny precedence is deterministic (outcome > origin > fulfillment > legacy).
+4. Legacy deny fallback signaling remains backward-compatible.
+5. No scope creep into runtime behavior changes.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave40-deny-evidence-step2.sh
+```

--- a/scripts/ci/review-wave40-deny-evidence-step2.sh
+++ b/scripts/ci/review-wave40-deny-evidence-step2.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-core/src/mcp/decision/deny_convergence.rs"
+  "crates/assay-core/src/mcp/decision/replay_diff.rs"
+  "crates/assay-core/tests/replay_diff_contract.rs"
+  "crates/assay-core/tests/decision_emit_invariant.rs"
+
+  "docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave40-deny-evidence-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step2.md"
+
+  "scripts/ci/review-wave40-deny-evidence-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave40 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave40 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  while IFS= read -r uf; do
+    [[ -z "${uf:-}" ]] && continue
+    allowed="false"
+    for a in "${ALLOWLIST[@]}"; do
+      [[ "$uf" == "$a" ]] && allowed="true" && break
+    done
+    if [[ "$allowed" != "true" ]]; then
+      echo "FAIL: untracked file present under $p: $uf"
+      exit 1
+    fi
+  done < <(git ls-files --others --exclude-standard -- "$p")
+done
+
+echo "[review] Wave40 deny-convergence markers"
+for marker in \
+  'policy_deny' \
+  'fail_closed_deny' \
+  'enforcement_deny' \
+  'deny_precedence_version' \
+  'deny_classification_source' \
+  'deny_legacy_fallback_applied' \
+  'deny_convergence_reason' \
+  'DenyClassificationSource' \
+  'DENY_PRECEDENCE_VERSION_V1' \
+  'project_deny_convergence'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision.rs \
+    crates/assay-core/src/mcp/decision/replay_diff.rs \
+    crates/assay-core/src/mcp/decision/deny_convergence.rs >/dev/null || {
+    echo "FAIL: missing Wave40 deny-convergence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] deterministic deny precedence markers"
+for marker in \
+  'OutcomeKind' \
+  'OriginContext' \
+  'FulfillmentPath' \
+  'LegacyDecision' \
+  'outcome_policy_deny' \
+  'origin_fail_closed_matrix' \
+  'fulfillment_policy_deny' \
+  'legacy_policy_deny'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision/deny_convergence.rs \
+    crates/assay-core/tests/replay_diff_contract.rs >/dev/null || {
+    echo "FAIL: missing deterministic precedence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing replay/decision markers remain present"
+for marker in \
+  'ReplayDiffBasis' \
+  'ReplayDiffBucket' \
+  'DecisionOutcomeKind' \
+  'OutcomeCompatState' \
+  'fulfillment_decision_path' \
+  'decision_basis_version' \
+  'classification_source'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing existing replay/decision marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no runtime behavior scope creep"
+if git diff --name-only "$BASE_REF"...HEAD -- \
+  crates/assay-core/src/mcp/tool_call_handler \
+  crates/assay-core/src/mcp/policy \
+  crates/assay-cli/src/cli/commands/mcp.rs \
+  crates/assay-mcp-server \
+  | rg -n '.' >/dev/null; then
+  echo "FAIL: Wave40 Step2 must not modify runtime behavior paths outside decision/replay evidence scope"
+  git diff --name-only "$BASE_REF"...HEAD -- \
+    crates/assay-core/src/mcp/tool_call_handler \
+    crates/assay-core/src/mcp/policy \
+    crates/assay-cli/src/cli/commands/mcp.rs \
+    crates/assay-mcp-server
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- implement bounded Wave40 Step2 deny evidence convergence with deterministic precedence and additive legacy fallback
- add explicit deny separation markers in decision/replay payloads (`policy_deny`, `fail_closed_deny`, `enforcement_deny`)
- add deny precedence metadata (`deny_precedence_version`, `deny_classification_source`, `deny_legacy_fallback_applied`, `deny_convergence_reason`)
- keep runtime behavior unchanged (evidence/replay convergence only)

## Scope
- `crates/assay-core/src/mcp/decision.rs`
- `crates/assay-core/src/mcp/decision/deny_convergence.rs`
- `crates/assay-core/src/mcp/decision/replay_diff.rs`
- `crates/assay-core/tests/replay_diff_contract.rs`
- `crates/assay-core/tests/decision_emit_invariant.rs`
- Wave40 Step2 docs + reviewer gate

## Non-goals (preserved)
- no new obligation types
- no runtime enforcement behavior change
- no policy language/control-plane/auth transport changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave40-deny-evidence-step2.sh` (PASS)
