### PR TITLE
docs(wave40-step3): close deny evidence convergence wave

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step3.md
@@ -1,0 +1,63 @@
+# SPLIT CHECKLIST - Wave40 Deny Evidence Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step3.md`
+  - `scripts/ci/review-wave40-deny-evidence-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+- [ ] No scope leaks outside Wave40 Step3
+
+## Closure intent
+- [ ] Step3 is docs+gate only
+- [ ] Step3 introduces no runtime behavior changes
+- [ ] Step3 introduces no schema changes
+- [ ] Step3 reruns Step2 invariants without widening scope
+- [ ] Step3 preserves bounded deny/fail-closed evidence convergence contract
+
+## Wave40 invariants
+- [ ] Deny-convergence markers remain present:
+  - `policy_deny`
+  - `fail_closed_deny`
+  - `enforcement_deny`
+  - `deny_precedence_version`
+  - `deny_classification_source`
+  - `deny_legacy_fallback_applied`
+  - `deny_convergence_reason`
+  - `DenyClassificationSource`
+  - `DENY_PRECEDENCE_VERSION_V1`
+  - `project_deny_convergence`
+- [ ] Deterministic deny precedence markers remain present:
+  - `OutcomeKind`
+  - `OriginContext`
+  - `FulfillmentPath`
+  - `LegacyDecision`
+  - `outcome_policy_deny`
+  - `origin_fail_closed_matrix`
+  - `fulfillment_policy_deny`
+  - `legacy_policy_deny`
+- [ ] Existing replay/decision markers remain present:
+  - `ReplayDiffBasis`
+  - `ReplayDiffBucket`
+  - `DecisionOutcomeKind`
+  - `OutcomeCompatState`
+  - `fulfillment_decision_path`
+  - `decision_basis_version`
+  - `classification_source`
+
+## Non-goals still enforced
+- [ ] No runtime behavior change
+- [ ] No new deny semantics
+- [ ] No new obligation types
+- [ ] No policy-language expansion
+- [ ] No control-plane/auth transport changes
+
+## Validation
+- [ ] Step3 gate passes against stacked Step2 base
+- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned replay/decision tests remain green

--- a/docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step3.md
@@ -56,8 +56,8 @@
 - [ ] No control-plane/auth transport changes
 
 ## Validation
-- [ ] Step3 gate passes against stacked Step2 base
-- [ ] Step3 gate can also pass against `origin/main` after sync
+- [ ] Step3 gate passes against stacked Step2 base **when that ref is synced to current main history**
+- [ ] Step3 gate passes against `origin/main` after sync (authoritative closure validation)
 - [ ] `cargo fmt --check` passes
 - [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
 - [ ] Pinned replay/decision tests remain green

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step3.md
@@ -32,6 +32,7 @@ This slice must not:
 BASE_REF=origin/codex/wave40-deny-evidence-step2-impl-v2 \
   bash scripts/ci/review-wave40-deny-evidence-step3.sh
 ```
+Use this only when the stacked Step2 ref is synced with current `main` history.
 
 ### Against origin/main after sync
 ```bash
@@ -42,4 +43,4 @@ BASE_REF=origin/main \
 Expected outcome:
 - Step3 adds no runtime behavior.
 - closure remains diff-proof.
-- promote can happen cleanly after stacked validation.
+- promote can happen cleanly after authoritative `origin/main` validation.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step3.md
@@ -1,0 +1,45 @@
+# SPLIT REVIEW PACK - Wave40 Deny Evidence Step3
+
+## Intent
+Close Wave40 with a docs+gate-only closure slice after bounded deny/fail-closed evidence convergence implementation in Step2.
+
+This slice must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add runtime enforcement behavior changes
+- add policy-language/control-plane/auth transport scope
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step3.md`
+- `scripts/ci/review-wave40-deny-evidence-step3.sh`
+
+## What reviewers should verify
+1. Diff is docs+script only.
+2. Step3 reruns the same structural invariants from Step2.
+3. Wave40 deny-convergence markers remain present.
+4. Deterministic deny precedence markers remain present.
+5. Existing replay/decision markers remain present.
+6. No runtime behavior scope creep appears in closure slice.
+7. Pinned tests still pass.
+
+## Reviewer commands
+
+### Against stacked Step2 base
+```bash
+BASE_REF=origin/codex/wave40-deny-evidence-step2-impl-v2 \
+  bash scripts/ci/review-wave40-deny-evidence-step3.sh
+```
+
+### Against origin/main after sync
+```bash
+BASE_REF=origin/main \
+  bash scripts/ci/review-wave40-deny-evidence-step3.sh
+```
+
+Expected outcome:
+- Step3 adds no runtime behavior.
+- closure remains diff-proof.
+- promote can happen cleanly after stacked validation.

--- a/scripts/ci/review-wave40-deny-evidence-step3.sh
+++ b/scripts/ci/review-wave40-deny-evidence-step3.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step3.md"
+  "scripts/ci/review-wave40-deny-evidence-step3.sh"
+)
+
+echo "[review] step3 docs+script-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave40 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave40 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] rerun Step2 invariants"
+
+echo "[review] Wave40 deny-convergence markers"
+for marker in \
+  'policy_deny' \
+  'fail_closed_deny' \
+  'enforcement_deny' \
+  'deny_precedence_version' \
+  'deny_classification_source' \
+  'deny_legacy_fallback_applied' \
+  'deny_convergence_reason' \
+  'DenyClassificationSource' \
+  'DENY_PRECEDENCE_VERSION_V1' \
+  'project_deny_convergence'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision.rs \
+    crates/assay-core/src/mcp/decision/replay_diff.rs \
+    crates/assay-core/src/mcp/decision/deny_convergence.rs >/dev/null || {
+    echo "FAIL: missing Wave40 deny-convergence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] deterministic deny precedence markers"
+for marker in \
+  'OutcomeKind' \
+  'OriginContext' \
+  'FulfillmentPath' \
+  'LegacyDecision' \
+  'outcome_policy_deny' \
+  'origin_fail_closed_matrix' \
+  'fulfillment_policy_deny' \
+  'legacy_policy_deny'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision/deny_convergence.rs \
+    crates/assay-core/tests/replay_diff_contract.rs >/dev/null || {
+    echo "FAIL: missing deterministic precedence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing replay/decision markers remain present"
+for marker in \
+  'ReplayDiffBasis' \
+  'ReplayDiffBucket' \
+  'DecisionOutcomeKind' \
+  'OutcomeCompatState' \
+  'fulfillment_decision_path' \
+  'decision_basis_version' \
+  'classification_source'
+do
+  rg -n "$marker" crates/assay-core/src/mcp/decision.rs crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing existing replay/decision marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no runtime behavior scope creep"
+if rg -n 'runtime behavior change|new deny semantics|new obligation type|policy language expansion|control-plane|auth transport|external integration|UI integration' \
+  crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+  | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/' >/dev/null; then
+  echo "FAIL: non-goal scope markers detected in implementation scope"
+  rg -n 'runtime behavior change|new deny semantics|new obligation type|policy language expansion|control-plane|auth transport|external integration|UI integration' \
+    crates/assay-core/src/mcp crates/assay-cli/src/cli/commands crates/assay-mcp-server \
+    | rg -v 'SPLIT-|PLAN-ADR|ADR-032|docs/'
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave40 Step3 docs+gate-only closure slice
- add closure checklist and review pack
- add Step3 reviewer gate that reruns Wave40 Step2 invariants

## Scope
- `docs/contributing/SPLIT-CHECKLIST-wave40-deny-evidence-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave40-deny-evidence-step3.md`
- `scripts/ci/review-wave40-deny-evidence-step3.sh`

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave40-deny-evidence-step3.sh` (PASS)

## Note on stacked base check
- Running with `BASE_REF=origin/codex/wave40-deny-evidence-step2-impl-v2` currently fails the docs-only allowlist gate because that branch no longer matches current `main` history (first blocker observed: `crates/assay-core/src/mcp/decision.rs`).
- The closure gate remains green and authoritative against `origin/main`.
