### PR TITLE
chore(wave40-hygiene): resolve replay diff review follow-ups

### DIFF
--- a/crates/assay-core/src/mcp/decision/replay_diff.rs
+++ b/crates/assay-core/src/mcp/decision/replay_diff.rs
@@ -211,7 +211,7 @@ mod tests {
             fail_closed_deny: false,
             enforcement_deny: false,
             deny_precedence_version: DENY_PRECEDENCE_VERSION_V1.to_string(),
-            deny_classification_source: DenyClassificationSource::NotDeny,
+            deny_classification_source: DenyClassificationSource::OutcomeKind,
             deny_legacy_fallback_applied: false,
             deny_convergence_reason: "outcome_not_deny".to_string(),
             reason_code: reason.to_string(),

--- a/docs/architecture/ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md
+++ b/docs/architecture/ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md
@@ -90,3 +90,17 @@ Tradeoffs:
 - more policy/event surface area to maintain
 - slower delivery by design due to bounded wave discipline
 - temporary compatibility code paths remain until explicit deprecation waves complete
+
+## Public API Note (Wave39/Wave40 Replay Evidence)
+The replay/evidence hardening waves widened `assay_core::mcp::decision::ReplayDiffBasis`
+with additional deny-convergence and compatibility fields.
+
+This widening is intentional public API surface within the `v3.x` line, not an accidental
+internal-only detail:
+
+- downstream code that constructs `ReplayDiffBasis` directly must treat the new fields as part
+  of the frozen replay basis contract
+- downstream consumers that deserialize emitted replay basis data should expect these fields to
+  be present after Wave39/Wave40 normalization
+- no retroactive compatibility shim is introduced in this hygiene follow-up; any future external
+  compatibility adapter should be handled as a separate, explicit follow-up

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -27,6 +27,14 @@ Semver implication:
 - External code constructing these structs via struct literals must add the new fields.
 - This is why the release line is `v3.0.0` instead of `v2.19.0`.
 
+Replay/evidence contract note:
+
+- `assay_core::mcp::decision::ReplayDiffBasis` was later widened in the Wave39/Wave40 line with
+  additive deny-convergence and replay-compat fields.
+- That widening is treated as intentional public `v3` contract surface, not as an internal-only
+  shape that will be shimmed retroactively in patch releases.
+- External crates constructing `ReplayDiffBasis` directly must update alongside the `v3` line.
+
 ## Preflight
 
 ```bash


### PR DESCRIPTION
## Summary
- align the internal replay diff test helper with current deny-classification invariants
- document the explicit semver posture for `ReplayDiffBasis` widening in ADR-032 and the v3.0.0 release runbook

## Scope
- 1 low-risk test/helper fix
- 1 docs-only semver clarification commit
- no runtime behavior changes
- no workflow changes

## Validation
- `cargo test -p assay-core replay_diff`
- `cargo test -p assay-core decision_emit_invariant`

## Notes
This PR intentionally does **not** add a retroactive compatibility shim such as `#[non_exhaustive]` or optional fields. It makes the existing choice explicit instead of changing public runtime behavior in a hygiene slice.