### PR TITLE
docs(wave41-step1): freeze consumer hardening contract

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave41-consumer-hardening-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave41-consumer-hardening-step1.md
@@ -1,0 +1,28 @@
+# SPLIT CHECKLIST - Wave41 Consumer Hardening Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave41-consumer-hardening.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave41-consumer-hardening-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave41-consumer-hardening-step1.md`
+  - `scripts/ci/review-wave41-consumer-hardening-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] Consumer payload surfaces are explicit:
+  - `DecisionEvent`
+  - `DecisionData`
+  - `ReplayDiffBasis`
+- [ ] Deterministic consumer read precedence is explicit
+- [ ] Required consumer signals are explicit
+- [ ] Additive consumer compatibility expectations are explicit
+- [ ] Non-goals are explicit (no runtime behavior change)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave41-consumer-hardening-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned replay/decision tests pass

--- a/docs/contributing/SPLIT-PLAN-wave41-consumer-hardening.md
+++ b/docs/contributing/SPLIT-PLAN-wave41-consumer-hardening.md
@@ -1,0 +1,109 @@
+# SPLIT PLAN - Wave41 Consumer Hardening
+
+## Intent
+Freeze a bounded downstream consumer contract for decision and replay payloads before any further runtime capability work.
+
+This wave is about:
+- stable consumer-facing read semantics for `DecisionEvent` / `DecisionData` / `ReplayDiffBasis`
+- deterministic read precedence across normalized and legacy payload shapes
+- additive compatibility signaling for payload consumers
+- reviewer gates that lock the consumer contract
+
+It explicitly does **not** add:
+- new runtime behavior
+- new obligation types
+- policy language expansion
+- control-plane or auth transport changes
+- UI or external integrations
+
+## Problem
+Waves 37 through 40 converged the runtime evidence model, replay basis, and deny-path evidence.
+
+Current gap:
+- downstream consumers still have to infer which payload shape to trust first
+- read precedence across converged fields, replay compatibility markers, and legacy fields is not frozen as a dedicated contract
+- consumer-oriented fallback signaling is not yet frozen independently from runtime normalization
+
+## Frozen consumer contract
+Wave41 freezes a consumer-facing read contract for these payload surfaces:
+- `DecisionEvent`
+- `DecisionData`
+- `ReplayDiffBasis`
+
+## Frozen read precedence
+Wave41 freezes deterministic consumer read precedence:
+1. normalized / converged decision fields
+2. replay and compatibility markers
+3. legacy base decision fields
+
+This precedence is contract-level in Step1 and must remain deterministic.
+
+## Frozen required consumer signals
+Wave41 freezes the expectation that these signals remain available to downstream consumers:
+- `decision`
+- `reason_code`
+- `decision_outcome_kind`
+- `decision_origin`
+- `fulfillment_decision_path`
+- `decision_basis_version`
+
+## Suggested additive markers for Step2
+Wave41 Step2 may add consumer-facing compatibility metadata, additively only, such as:
+- `decision_consumer_contract_version`
+- `consumer_read_path`
+- `consumer_fallback_applied`
+- `consumer_payload_state`
+- `required_consumer_fields`
+
+Names can vary in Step2 implementation, but the semantics above are frozen in this plan.
+
+## Frozen compatibility requirements
+Wave41 freezes additive compatibility expectations for payload consumers:
+- consumers can determine which payload path won without re-deriving runtime semantics
+- fallback application is explicitly signaled for consumer-facing reads
+- existing payload consumers are not broken by the hardening slice
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. consumer read precedence is explicit and testable
+2. consumer-facing compatibility metadata is additive and backward-compatible
+3. existing runtime decision behavior remains unchanged
+4. replay/diff consumers can read payloads deterministically without bespoke precedence logic
+5. no new runtime capability or policy surface is introduced
+
+## Scope boundaries
+### In scope
+- decision/replay consumer contract freeze
+- deterministic consumer read precedence contract
+- additive consumer compatibility contract
+- tests and reviewer gates for the above
+
+### Out of scope
+- runtime behavior changes
+- new obligation types
+- policy language extension
+- control-plane or auth transport changes
+- UI/external integration work
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- consumer-facing compatibility normalization
+- deterministic read precedence representation
+- additive consumer metadata
+- no runtime behavior change
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must remain consumer-hardening only.
+
+Primary failure modes:
+- introducing runtime behavior changes under a consumer-compat label
+- making read precedence less deterministic for downstream consumers
+- breaking existing event/replay consumers via non-additive changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave41-consumer-hardening-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave41-consumer-hardening-step1.md
@@ -1,0 +1,38 @@
+# SPLIT REVIEW PACK - Wave41 Consumer Hardening Step1
+
+## Intent
+Freeze the bounded decision/replay consumer hardening contract before any Step2 implementation.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add new runtime capability
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave41-consumer-hardening.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave41-consumer-hardening-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave41-consumer-hardening-step1.md`
+- `scripts/ci/review-wave41-consumer-hardening-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Consumer payload surfaces are explicit (`DecisionEvent`, `DecisionData`, `ReplayDiffBasis`).
+3. Consumer read precedence is explicit and deterministic.
+4. Additive consumer compatibility expectations are explicit.
+5. Runtime paths are untouched.
+6. No runtime behavior change is introduced in this wave.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave41-consumer-hardening-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- consumer hardening contract is frozen cleanly
+- Step2 can implement bounded consumer normalization without reopening semantics

--- a/scripts/ci/review-wave41-consumer-hardening-step1.sh
+++ b/scripts/ci/review-wave41-consumer-hardening-step1.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave41-consumer-hardening.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave41-consumer-hardening-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave41-consumer-hardening-step1.md"
+  "scripts/ci/review-wave41-consumer-hardening-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-core/tests"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave41 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave41 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave41 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN - Wave41 Consumer Hardening$' \
+  docs/contributing/SPLIT-PLAN-wave41-consumer-hardening.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'DecisionEvent' \
+  'DecisionData' \
+  'ReplayDiffBasis' \
+  'deterministic consumer read precedence' \
+  'decision_consumer_contract_version' \
+  'consumer_fallback_applied' \
+  'no runtime behavior change'
+do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave41-consumer-hardening.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave41 Step1 consumer-hardening split plan
- add Step1 checklist and review pack
- add Step1 reviewer gate script

## Scope
- docs + gate only
- no runtime code changes
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave41-consumer-hardening-step1.sh`
- `cargo fmt --check`
- `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings`
- pinned replay/decision tests via the Step1 gate

## Notes
This freeze is intentionally bounded to decision/replay payload consumer hardening. It does not introduce runtime behavior changes or new engine scope.