### PR TITLE
feat(wave41-step2): harden consumer decision payloads

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -3,6 +3,7 @@
 //! This module implements the "always emit decision" invariant (I1):
 //! Every tool call attempt MUST emit exactly one decision event.
 
+use self::consumer_contract::project_consumer_contract;
 use self::deny_convergence::project_deny_convergence;
 use self::outcome_convergence::classify_decision_outcome;
 use self::replay_compat::project_replay_compat;
@@ -15,10 +16,15 @@ use serde_json::Value;
 use std::io::Write;
 use std::sync::Arc;
 
+mod consumer_contract;
 mod deny_convergence;
 mod outcome_convergence;
 mod replay_compat;
 mod replay_diff;
+pub use consumer_contract::{
+    required_consumer_fields_v1, ConsumerPayloadState, ConsumerReadPath,
+    DECISION_CONSUMER_CONTRACT_VERSION_V1,
+};
 pub use deny_convergence::{DenyClassificationSource, DENY_PRECEDENCE_VERSION_V1};
 pub use outcome_convergence::{DecisionOrigin, DecisionOutcomeKind, OutcomeCompatState};
 pub use replay_compat::{ReplayClassificationSource, DECISION_BASIS_VERSION_V1};
@@ -319,6 +325,21 @@ pub struct DecisionData {
     /// Whether legacy event shape was detected by compatibility normalization.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub legacy_shape_detected: Option<bool>,
+    /// Version tag for bounded consumer-facing compatibility reads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision_consumer_contract_version: Option<String>,
+    /// Consumer-facing precedence path selected for deterministic reads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub consumer_read_path: Option<ConsumerReadPath>,
+    /// Whether consumer-facing reads depended on compatibility fallback.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub consumer_fallback_applied: Option<bool>,
+    /// Overall consumer-facing payload robustness state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub consumer_payload_state: Option<ConsumerPayloadState>,
+    /// Contract-level required fields for bounded consumer reads.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_consumer_fields: Vec<String>,
     /// Explicit deny classification marker: policy deny path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy_deny: Option<bool>,
@@ -500,6 +521,21 @@ fn refresh_fulfillment_normalization(data: &mut DecisionData) {
     data.classification_source = Some(replay_projection.classification_source);
     data.replay_diff_reason = Some(replay_projection.replay_diff_reason.to_string());
     data.legacy_shape_detected = Some(replay_projection.legacy_shape_detected);
+    let consumer_projection = project_consumer_contract(
+        data.decision_outcome_kind,
+        data.decision_origin,
+        data.fulfillment_decision_path,
+        data.decision_basis_version.as_deref(),
+        data.compat_fallback_applied,
+        data.classification_source,
+        data.legacy_shape_detected,
+    );
+    data.decision_consumer_contract_version =
+        Some(DECISION_CONSUMER_CONTRACT_VERSION_V1.to_string());
+    data.consumer_read_path = Some(consumer_projection.read_path);
+    data.consumer_fallback_applied = Some(consumer_projection.fallback_applied);
+    data.consumer_payload_state = Some(consumer_projection.payload_state);
+    data.required_consumer_fields = consumer_projection.required_consumer_fields;
     data.policy_deny = Some(deny_projection.policy_deny);
     data.fail_closed_deny = Some(deny_projection.fail_closed_deny);
     data.enforcement_deny = Some(deny_projection.enforcement_deny);
@@ -569,6 +605,11 @@ impl DecisionEvent {
                 classification_source: None,
                 replay_diff_reason: None,
                 legacy_shape_detected: None,
+                decision_consumer_contract_version: None,
+                consumer_read_path: None,
+                consumer_fallback_applied: None,
+                consumer_payload_state: None,
+                required_consumer_fields: Vec::new(),
                 policy_deny: None,
                 fail_closed_deny: None,
                 enforcement_deny: None,

--- a/crates/assay-core/src/mcp/decision/consumer_contract.rs
+++ b/crates/assay-core/src/mcp/decision/consumer_contract.rs
@@ -63,15 +63,18 @@ pub fn project_consumer_contract(
         ConsumerReadPath::LegacyDecision
     };
 
-    let fallback_applied =
-        compat_fallback_applied.unwrap_or(read_path != ConsumerReadPath::ConvergedDecision);
+    let fallback_applied = read_path != ConsumerReadPath::ConvergedDecision;
 
-    let payload_state = if read_path == ConsumerReadPath::LegacyDecision {
-        ConsumerPayloadState::LegacyBase
-    } else if fallback_applied || legacy_shape_detected.unwrap_or(false) {
-        ConsumerPayloadState::CompatibilityFallback
-    } else {
-        ConsumerPayloadState::Converged
+    let payload_state = match read_path {
+        ConsumerReadPath::ConvergedDecision => {
+            if compat_fallback_applied.unwrap_or(false) || legacy_shape_detected.unwrap_or(false) {
+                ConsumerPayloadState::CompatibilityFallback
+            } else {
+                ConsumerPayloadState::Converged
+            }
+        }
+        ConsumerReadPath::CompatibilityMarkers => ConsumerPayloadState::CompatibilityFallback,
+        ConsumerReadPath::LegacyDecision => ConsumerPayloadState::LegacyBase,
     };
 
     ConsumerContractProjection {
@@ -141,5 +144,25 @@ mod tests {
         assert_eq!(projection.read_path, ConsumerReadPath::LegacyDecision);
         assert!(projection.fallback_applied);
         assert_eq!(projection.payload_state, ConsumerPayloadState::LegacyBase);
+    }
+
+    #[test]
+    fn partial_markers_still_count_as_consumer_fallback() {
+        let projection = project_consumer_contract(
+            Some(DecisionOutcomeKind::ObligationApplied),
+            None,
+            None,
+            Some("wave39_v1"),
+            Some(false),
+            Some(ReplayClassificationSource::ConvergedOutcome),
+            Some(false),
+        );
+
+        assert_eq!(projection.read_path, ConsumerReadPath::CompatibilityMarkers);
+        assert!(projection.fallback_applied);
+        assert_eq!(
+            projection.payload_state,
+            ConsumerPayloadState::CompatibilityFallback
+        );
     }
 }

--- a/crates/assay-core/src/mcp/decision/consumer_contract.rs
+++ b/crates/assay-core/src/mcp/decision/consumer_contract.rs
@@ -1,0 +1,145 @@
+use super::{
+    DecisionOrigin, DecisionOutcomeKind, FulfillmentDecisionPath, ReplayClassificationSource,
+};
+use serde::{Deserialize, Serialize};
+
+pub const DECISION_CONSUMER_CONTRACT_VERSION_V1: &str = "wave41_v1";
+
+const REQUIRED_CONSUMER_FIELDS_V1: &[&str] = &[
+    "decision",
+    "reason_code",
+    "decision_outcome_kind",
+    "decision_origin",
+    "fulfillment_decision_path",
+    "decision_basis_version",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerReadPath {
+    ConvergedDecision,
+    CompatibilityMarkers,
+    LegacyDecision,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerPayloadState {
+    Converged,
+    CompatibilityFallback,
+    LegacyBase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsumerContractProjection {
+    pub read_path: ConsumerReadPath,
+    pub fallback_applied: bool,
+    pub payload_state: ConsumerPayloadState,
+    pub required_consumer_fields: Vec<String>,
+}
+
+pub fn project_consumer_contract(
+    decision_outcome_kind: Option<DecisionOutcomeKind>,
+    decision_origin: Option<DecisionOrigin>,
+    fulfillment_decision_path: Option<FulfillmentDecisionPath>,
+    decision_basis_version: Option<&str>,
+    compat_fallback_applied: Option<bool>,
+    classification_source: Option<ReplayClassificationSource>,
+    legacy_shape_detected: Option<bool>,
+) -> ConsumerContractProjection {
+    let converged_present = decision_outcome_kind.is_some()
+        && decision_origin.is_some()
+        && fulfillment_decision_path.is_some();
+    let compatibility_present = decision_basis_version.is_some()
+        || compat_fallback_applied.is_some()
+        || classification_source.is_some()
+        || legacy_shape_detected.is_some();
+
+    let read_path = if converged_present {
+        ConsumerReadPath::ConvergedDecision
+    } else if compatibility_present {
+        ConsumerReadPath::CompatibilityMarkers
+    } else {
+        ConsumerReadPath::LegacyDecision
+    };
+
+    let fallback_applied =
+        compat_fallback_applied.unwrap_or(read_path != ConsumerReadPath::ConvergedDecision);
+
+    let payload_state = if read_path == ConsumerReadPath::LegacyDecision {
+        ConsumerPayloadState::LegacyBase
+    } else if fallback_applied || legacy_shape_detected.unwrap_or(false) {
+        ConsumerPayloadState::CompatibilityFallback
+    } else {
+        ConsumerPayloadState::Converged
+    };
+
+    ConsumerContractProjection {
+        read_path,
+        fallback_applied,
+        payload_state,
+        required_consumer_fields: required_consumer_fields_v1(),
+    }
+}
+
+pub fn required_consumer_fields_v1() -> Vec<String> {
+    REQUIRED_CONSUMER_FIELDS_V1
+        .iter()
+        .map(|field| (*field).to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_converged_decision_fields() {
+        let projection = project_consumer_contract(
+            Some(DecisionOutcomeKind::ObligationApplied),
+            Some(DecisionOrigin::ObligationExecutor),
+            Some(FulfillmentDecisionPath::PolicyAllow),
+            Some("wave39_v1"),
+            Some(false),
+            Some(ReplayClassificationSource::ConvergedOutcome),
+            Some(false),
+        );
+
+        assert_eq!(projection.read_path, ConsumerReadPath::ConvergedDecision);
+        assert!(!projection.fallback_applied);
+        assert_eq!(projection.payload_state, ConsumerPayloadState::Converged);
+        assert_eq!(
+            projection.required_consumer_fields,
+            required_consumer_fields_v1()
+        );
+    }
+
+    #[test]
+    fn falls_back_to_compatibility_markers() {
+        let projection = project_consumer_contract(
+            None,
+            None,
+            None,
+            Some("wave39_v1"),
+            Some(true),
+            Some(ReplayClassificationSource::FulfillmentPath),
+            Some(true),
+        );
+
+        assert_eq!(projection.read_path, ConsumerReadPath::CompatibilityMarkers);
+        assert!(projection.fallback_applied);
+        assert_eq!(
+            projection.payload_state,
+            ConsumerPayloadState::CompatibilityFallback
+        );
+    }
+
+    #[test]
+    fn falls_back_to_legacy_decision_when_no_markers_exist() {
+        let projection = project_consumer_contract(None, None, None, None, None, None, None);
+
+        assert_eq!(projection.read_path, ConsumerReadPath::LegacyDecision);
+        assert!(projection.fallback_applied);
+        assert_eq!(projection.payload_state, ConsumerPayloadState::LegacyBase);
+    }
+}

--- a/crates/assay-core/src/mcp/decision/replay_diff.rs
+++ b/crates/assay-core/src/mcp/decision/replay_diff.rs
@@ -1,4 +1,8 @@
 use super::{
+    consumer_contract::{
+        project_consumer_contract, required_consumer_fields_v1, ConsumerPayloadState,
+        ConsumerReadPath, DECISION_CONSUMER_CONTRACT_VERSION_V1,
+    },
     deny_convergence::{project_deny_convergence, DENY_PRECEDENCE_VERSION_V1},
     replay_compat::{project_replay_compat, DECISION_BASIS_VERSION_V1},
     Decision, DecisionData, DecisionOrigin, DecisionOutcomeKind, DenyClassificationSource,
@@ -30,6 +34,11 @@ pub struct ReplayDiffBasis {
     pub classification_source: ReplayClassificationSource,
     pub replay_diff_reason: String,
     pub legacy_shape_detected: bool,
+    pub decision_consumer_contract_version: String,
+    pub consumer_read_path: ConsumerReadPath,
+    pub consumer_fallback_applied: bool,
+    pub consumer_payload_state: ConsumerPayloadState,
+    pub required_consumer_fields: Vec<String>,
     pub policy_deny: bool,
     pub fail_closed_deny: bool,
     pub enforcement_deny: bool,
@@ -59,6 +68,26 @@ pub fn basis_from_decision_data(data: &DecisionData) -> ReplayDiffBasis {
         data.outcome_compat_state,
         data.fulfillment_decision_path,
         data.decision,
+    );
+    let consumer_projection = project_consumer_contract(
+        data.decision_outcome_kind,
+        data.decision_origin,
+        data.fulfillment_decision_path,
+        data.decision_basis_version
+            .as_deref()
+            .or(Some(DECISION_BASIS_VERSION_V1)),
+        Some(
+            data.compat_fallback_applied
+                .unwrap_or(replay_projection.compat_fallback_applied),
+        ),
+        Some(
+            data.classification_source
+                .unwrap_or(replay_projection.classification_source),
+        ),
+        Some(
+            data.legacy_shape_detected
+                .unwrap_or(replay_projection.legacy_shape_detected),
+        ),
     );
     let deny_projection = project_deny_convergence(
         data.decision_outcome_kind,
@@ -91,6 +120,24 @@ pub fn basis_from_decision_data(data: &DecisionData) -> ReplayDiffBasis {
         legacy_shape_detected: data
             .legacy_shape_detected
             .unwrap_or(replay_projection.legacy_shape_detected),
+        decision_consumer_contract_version: data
+            .decision_consumer_contract_version
+            .clone()
+            .unwrap_or_else(|| DECISION_CONSUMER_CONTRACT_VERSION_V1.to_string()),
+        consumer_read_path: data
+            .consumer_read_path
+            .unwrap_or(consumer_projection.read_path),
+        consumer_fallback_applied: data
+            .consumer_fallback_applied
+            .unwrap_or(consumer_projection.fallback_applied),
+        consumer_payload_state: data
+            .consumer_payload_state
+            .unwrap_or(consumer_projection.payload_state),
+        required_consumer_fields: if data.required_consumer_fields.is_empty() {
+            required_consumer_fields_v1()
+        } else {
+            data.required_consumer_fields.clone()
+        },
         policy_deny: data.policy_deny.unwrap_or(deny_projection.policy_deny),
         fail_closed_deny: data
             .fail_closed_deny
@@ -158,6 +205,12 @@ fn same_effective_decision_class(baseline: &ReplayDiffBasis, candidate: &ReplayD
         && baseline.classification_source == candidate.classification_source
         && baseline.replay_diff_reason == candidate.replay_diff_reason
         && baseline.legacy_shape_detected == candidate.legacy_shape_detected
+        && baseline.decision_consumer_contract_version
+            == candidate.decision_consumer_contract_version
+        && baseline.consumer_read_path == candidate.consumer_read_path
+        && baseline.consumer_fallback_applied == candidate.consumer_fallback_applied
+        && baseline.consumer_payload_state == candidate.consumer_payload_state
+        && baseline.required_consumer_fields == candidate.required_consumer_fields
         && baseline.policy_deny == candidate.policy_deny
         && baseline.fail_closed_deny == candidate.fail_closed_deny
         && baseline.enforcement_deny == candidate.enforcement_deny
@@ -207,6 +260,11 @@ mod tests {
             classification_source: ReplayClassificationSource::ConvergedOutcome,
             replay_diff_reason: "converged_obligation_applied".to_string(),
             legacy_shape_detected: false,
+            decision_consumer_contract_version: DECISION_CONSUMER_CONTRACT_VERSION_V1.to_string(),
+            consumer_read_path: ConsumerReadPath::ConvergedDecision,
+            consumer_fallback_applied: false,
+            consumer_payload_state: ConsumerPayloadState::Converged,
+            required_consumer_fields: required_consumer_fields_v1(),
             policy_deny: false,
             fail_closed_deny: false,
             enforcement_deny: false,
@@ -294,6 +352,11 @@ mod tests {
             classification_source: ReplayClassificationSource::LegacyFallback,
             replay_diff_reason: "legacy_decision_allow".to_string(),
             legacy_shape_detected: true,
+            decision_consumer_contract_version: DECISION_CONSUMER_CONTRACT_VERSION_V1.to_string(),
+            consumer_read_path: ConsumerReadPath::LegacyDecision,
+            consumer_fallback_applied: true,
+            consumer_payload_state: ConsumerPayloadState::LegacyBase,
+            required_consumer_fields: required_consumer_fields_v1(),
             policy_deny: false,
             fail_closed_deny: false,
             enforcement_deny: false,

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -4,10 +4,11 @@
 //! one decision event being emitted, regardless of outcome.
 
 use assay_core::mcp::decision::{
-    reason_codes, Decision, DecisionEmitter, DecisionEmitterGuard, DecisionEvent, DecisionOrigin,
-    DecisionOutcomeKind, DenyClassificationSource, FulfillmentDecisionPath,
-    ObligationOutcomeStatus, OutcomeCompatState, ReplayClassificationSource,
-    DECISION_BASIS_VERSION_V1, DENY_PRECEDENCE_VERSION_V1,
+    reason_codes, ConsumerPayloadState, ConsumerReadPath, Decision, DecisionEmitter,
+    DecisionEmitterGuard, DecisionEvent, DecisionOrigin, DecisionOutcomeKind,
+    DenyClassificationSource, FulfillmentDecisionPath, ObligationOutcomeStatus, OutcomeCompatState,
+    ReplayClassificationSource, DECISION_BASIS_VERSION_V1, DECISION_CONSUMER_CONTRACT_VERSION_V1,
+    DENY_PRECEDENCE_VERSION_V1,
 };
 use assay_core::mcp::policy::{
     ApprovalFreshness, McpPolicy, PolicyState, RedactArgsContract, RestrictScopeContract,
@@ -1071,6 +1072,30 @@ fn test_event_contains_required_fields() {
         Some("converged_obligation_applied")
     );
     assert_eq!(event.data.legacy_shape_detected, Some(false));
+    assert_eq!(
+        event.data.decision_consumer_contract_version.as_deref(),
+        Some(DECISION_CONSUMER_CONTRACT_VERSION_V1)
+    );
+    assert_eq!(
+        event.data.consumer_read_path,
+        Some(ConsumerReadPath::ConvergedDecision)
+    );
+    assert_eq!(event.data.consumer_fallback_applied, Some(false));
+    assert_eq!(
+        event.data.consumer_payload_state,
+        Some(ConsumerPayloadState::Converged)
+    );
+    assert_eq!(
+        event.data.required_consumer_fields,
+        vec![
+            "decision".to_string(),
+            "reason_code".to_string(),
+            "decision_outcome_kind".to_string(),
+            "decision_origin".to_string(),
+            "fulfillment_decision_path".to_string(),
+            "decision_basis_version".to_string(),
+        ]
+    );
     assert_eq!(event.data.policy_deny, Some(false));
     assert_eq!(event.data.fail_closed_deny, Some(false));
     assert_eq!(event.data.enforcement_deny, Some(false));

--- a/crates/assay-core/tests/replay_diff_contract.rs
+++ b/crates/assay-core/tests/replay_diff_contract.rs
@@ -1,8 +1,9 @@
 use assay_core::mcp::decision::{
-    basis_from_decision_data, classify_replay_diff, reason_codes, Decision, DecisionEvent,
-    DecisionOrigin, DecisionOutcomeKind, DenyClassificationSource, FulfillmentDecisionPath,
-    OutcomeCompatState, PolicyDecisionEventContext, ReplayClassificationSource, ReplayDiffBucket,
-    DECISION_BASIS_VERSION_V1, DENY_PRECEDENCE_VERSION_V1,
+    basis_from_decision_data, classify_replay_diff, reason_codes, ConsumerPayloadState,
+    ConsumerReadPath, Decision, DecisionEvent, DecisionOrigin, DecisionOutcomeKind,
+    DenyClassificationSource, FulfillmentDecisionPath, OutcomeCompatState,
+    PolicyDecisionEventContext, ReplayClassificationSource, ReplayDiffBucket,
+    DECISION_BASIS_VERSION_V1, DECISION_CONSUMER_CONTRACT_VERSION_V1, DENY_PRECEDENCE_VERSION_V1,
 };
 use assay_core::mcp::policy::TypedPolicyDecision;
 
@@ -52,6 +53,30 @@ fn basis_extraction_contains_frozen_fields() {
     );
     assert_eq!(basis.replay_diff_reason, "converged_obligation_skipped");
     assert!(!basis.legacy_shape_detected);
+    assert_eq!(
+        basis.decision_consumer_contract_version,
+        DECISION_CONSUMER_CONTRACT_VERSION_V1
+    );
+    assert_eq!(
+        basis.consumer_read_path,
+        ConsumerReadPath::ConvergedDecision
+    );
+    assert!(!basis.consumer_fallback_applied);
+    assert_eq!(
+        basis.consumer_payload_state,
+        ConsumerPayloadState::Converged
+    );
+    assert_eq!(
+        basis.required_consumer_fields,
+        vec![
+            "decision".to_string(),
+            "reason_code".to_string(),
+            "decision_outcome_kind".to_string(),
+            "decision_origin".to_string(),
+            "fulfillment_decision_path".to_string(),
+            "decision_basis_version".to_string(),
+        ]
+    );
     assert!(!basis.policy_deny);
     assert!(!basis.fail_closed_deny);
     assert!(!basis.enforcement_deny);
@@ -84,6 +109,11 @@ fn basis_extraction_prefers_fulfillment_path_when_converged_markers_missing() {
     event.data.classification_source = None;
     event.data.replay_diff_reason = None;
     event.data.legacy_shape_detected = None;
+    event.data.decision_consumer_contract_version = None;
+    event.data.consumer_read_path = None;
+    event.data.consumer_fallback_applied = None;
+    event.data.consumer_payload_state = None;
+    event.data.required_consumer_fields.clear();
     event.data.policy_deny = None;
     event.data.fail_closed_deny = None;
     event.data.enforcement_deny = None;
@@ -101,6 +131,19 @@ fn basis_extraction_prefers_fulfillment_path_when_converged_markers_missing() {
     );
     assert_eq!(basis.replay_diff_reason, "fulfillment_policy_allow");
     assert!(basis.legacy_shape_detected);
+    assert_eq!(
+        basis.decision_consumer_contract_version,
+        DECISION_CONSUMER_CONTRACT_VERSION_V1
+    );
+    assert_eq!(
+        basis.consumer_read_path,
+        ConsumerReadPath::CompatibilityMarkers
+    );
+    assert!(basis.consumer_fallback_applied);
+    assert_eq!(
+        basis.consumer_payload_state,
+        ConsumerPayloadState::CompatibilityFallback
+    );
     assert_eq!(
         basis.deny_classification_source,
         DenyClassificationSource::FulfillmentPath
@@ -121,6 +164,11 @@ fn basis_extraction_marks_legacy_fallback_when_shape_is_missing() {
     event.data.classification_source = None;
     event.data.replay_diff_reason = None;
     event.data.legacy_shape_detected = None;
+    event.data.decision_consumer_contract_version = None;
+    event.data.consumer_read_path = None;
+    event.data.consumer_fallback_applied = None;
+    event.data.consumer_payload_state = None;
+    event.data.required_consumer_fields.clear();
     event.data.policy_deny = None;
     event.data.fail_closed_deny = None;
     event.data.enforcement_deny = None;
@@ -138,6 +186,19 @@ fn basis_extraction_marks_legacy_fallback_when_shape_is_missing() {
     );
     assert_eq!(basis.replay_diff_reason, "legacy_decision_allow");
     assert!(basis.legacy_shape_detected);
+    assert_eq!(
+        basis.decision_consumer_contract_version,
+        DECISION_CONSUMER_CONTRACT_VERSION_V1
+    );
+    assert_eq!(
+        basis.consumer_read_path,
+        ConsumerReadPath::CompatibilityMarkers
+    );
+    assert!(basis.consumer_fallback_applied);
+    assert_eq!(
+        basis.consumer_payload_state,
+        ConsumerPayloadState::CompatibilityFallback
+    );
     assert_eq!(
         basis.deny_classification_source,
         DenyClassificationSource::NotDeny

--- a/docs/contributing/SPLIT-CHECKLIST-wave41-consumer-hardening-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave41-consumer-hardening-step2.md
@@ -1,0 +1,32 @@
+# SPLIT CHECKLIST - Wave41 Consumer Hardening Step2
+
+## Scope discipline
+- [ ] Diff is limited to bounded consumer-hardening runtime + tests + Step2 docs/gate.
+- [ ] No `.github/workflows/*` changes.
+- [ ] No scope leaks outside decision/replay consumer-compat paths.
+- [ ] No runtime behavior change is introduced.
+- [ ] No new policy-engine/control-plane/auth transport scope is added.
+
+## Implementation contract
+- [ ] Additive consumer-hardening fields are present:
+  - `decision_consumer_contract_version`
+  - `consumer_read_path`
+  - `consumer_fallback_applied`
+  - `consumer_payload_state`
+  - `required_consumer_fields`
+- [ ] Deterministic consumer precedence is represented and test-covered:
+  - converged decision fields
+  - compatibility markers
+  - legacy decision fallback
+- [ ] Consumer-facing fallback metadata remains additive and backward-compatible.
+
+## Compatibility and behavior
+- [ ] Existing decision/event fields remain backward-compatible.
+- [ ] Existing runtime decision behavior remains unchanged.
+- [ ] Replay/diff consumers can read payloads deterministically without bespoke precedence logic.
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave41-consumer-hardening-step2.sh` passes.
+- [ ] `cargo fmt --check` passes.
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes.
+- [ ] Pinned runtime/event tests pass.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave41-consumer-hardening-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave41-consumer-hardening-step2.md
@@ -1,0 +1,25 @@
+# SPLIT MOVE MAP - Wave41 Consumer Hardening Step2
+
+## Intent
+Keep Wave41 Step2 bounded to additive consumer/read precedence metadata over the existing decision and replay compatibility surfaces.
+
+## Allowed implementation scope
+- `crates/assay-core/src/mcp/decision.rs`
+- `crates/assay-core/src/mcp/decision/consumer_contract.rs`
+- `crates/assay-core/src/mcp/decision/replay_diff.rs`
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+- `crates/assay-core/tests/replay_diff_contract.rs`
+- Step2 docs/gate files
+
+## Move rationale
+- `decision.rs`: additive event payload fields and normalization hook-up
+- `consumer_contract.rs`: bounded consumer-read precedence projection
+- `replay_diff.rs`: replay basis projection and fallback reconstruction
+- tests: consumer-facing invariants and fallback coverage
+
+## Explicitly out of scope
+- tool-call handler changes
+- policy evaluation changes
+- CLI/runtime consumer changes outside replay/decision payload tests
+- MCP server changes
+- workflow changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave41-consumer-hardening-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave41-consumer-hardening-step2.md
@@ -1,0 +1,28 @@
+# SPLIT REVIEW PACK - Wave41 Consumer Hardening Step2
+
+## Intent
+Implement bounded consumer/read precedence hardening with additive compatibility metadata for decision and replay payload consumers.
+
+This slice must:
+- remain additive and backward-compatible
+- expose deterministic consumer read precedence
+- signal consumer-facing fallback explicitly
+- keep runtime behavior unchanged
+
+This slice must not:
+- add new runtime capability
+- change enforcement semantics
+- expand policy-engine/control-plane/auth transport scope
+- touch workflow files
+
+## Reviewer focus
+1. Diff stays inside bounded decision/replay/test/docs/gate scope.
+2. Consumer-hardening fields are present and additive in event payload + replay basis.
+3. Consumer read precedence is deterministic and explicit.
+4. Consumer fallback signaling remains backward-compatible.
+5. No scope creep into runtime behavior changes.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave41-consumer-hardening-step2.sh
+```

--- a/scripts/ci/review-wave41-consumer-hardening-step2.sh
+++ b/scripts/ci/review-wave41-consumer-hardening-step2.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-core/src/mcp/decision/consumer_contract.rs"
+  "crates/assay-core/src/mcp/decision/replay_diff.rs"
+  "crates/assay-core/tests/replay_diff_contract.rs"
+  "crates/assay-core/tests/decision_emit_invariant.rs"
+
+  "docs/contributing/SPLIT-CHECKLIST-wave41-consumer-hardening-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave41-consumer-hardening-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave41-consumer-hardening-step2.md"
+
+  "scripts/ci/review-wave41-consumer-hardening-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave41 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave41 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  while IFS= read -r uf; do
+    [[ -z "${uf:-}" ]] && continue
+    allowed="false"
+    for a in "${ALLOWLIST[@]}"; do
+      [[ "$uf" == "$a" ]] && allowed="true" && break
+    done
+    if [[ "$allowed" != "true" ]]; then
+      echo "FAIL: untracked file present under $p: $uf"
+      exit 1
+    fi
+  done < <(git ls-files --others --exclude-standard -- "$p")
+done
+
+echo "[review] Wave41 consumer-hardening markers"
+for marker in \
+  'decision_consumer_contract_version' \
+  'consumer_read_path' \
+  'consumer_fallback_applied' \
+  'consumer_payload_state' \
+  'required_consumer_fields' \
+  'ConsumerReadPath' \
+  'ConsumerPayloadState' \
+  'DECISION_CONSUMER_CONTRACT_VERSION_V1' \
+  'project_consumer_contract'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision.rs \
+    crates/assay-core/src/mcp/decision/consumer_contract.rs \
+    crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing Wave41 consumer-hardening marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] deterministic consumer precedence markers"
+for marker in \
+  'ConvergedDecision' \
+  'CompatibilityMarkers' \
+  'LegacyDecision' \
+  'decision_outcome_kind' \
+  'classification_source' \
+  'legacy_shape_detected'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision/consumer_contract.rs \
+    crates/assay-core/tests/replay_diff_contract.rs >/dev/null || {
+    echo "FAIL: missing deterministic consumer precedence marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing replay/decision markers remain present"
+for marker in \
+  'ReplayDiffBasis' \
+  'ReplayDiffBucket' \
+  'DecisionOutcomeKind' \
+  'OutcomeCompatState' \
+  'fulfillment_decision_path' \
+  'decision_basis_version' \
+  'classification_source'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision.rs \
+    crates/assay-core/src/mcp/decision/replay_diff.rs >/dev/null || {
+    echo "FAIL: missing existing replay/decision marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no runtime behavior scope creep"
+if git diff --name-only "$BASE_REF"...HEAD -- \
+  crates/assay-core/src/mcp/tool_call_handler \
+  crates/assay-core/src/mcp/policy \
+  crates/assay-cli/src/cli/commands/mcp.rs \
+  crates/assay-mcp-server \
+  | rg -n '.' >/dev/null; then
+  echo "FAIL: Wave41 Step2 must not modify runtime behavior paths outside decision/replay consumer scope"
+  git diff --name-only "$BASE_REF"...HEAD -- \
+    crates/assay-core/src/mcp/tool_call_handler \
+    crates/assay-core/src/mcp/policy \
+    crates/assay-cli/src/cli/commands/mcp.rs \
+    crates/assay-mcp-server
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core consumer_contract
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add bounded consumer-read precedence metadata for decision and replay payloads
- derive additive consumer fallback signals in decision emission and replay basis reconstruction
- add Step2 docs/gate plus tests for converged, compatibility, and legacy fallback paths

## Scope
- bounded decision/replay consumer-hardening only
- no runtime behavior change
- no workflow changes

## Validation
- `BASE_REF=origin/main bash scripts/ci/review-wave41-consumer-hardening-step2.sh`
