### PR TITLE
docs(wave42-step1): freeze context envelope hardening

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave42-context-envelope-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave42-context-envelope-step1.md
@@ -1,0 +1,31 @@
+# SPLIT CHECKLIST - Wave42 Context Envelope Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave42-context-envelope-hardening.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave42-context-envelope-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave42-context-envelope-step1.md`
+  - `scripts/ci/review-wave42-context-envelope-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No MCP runtime code changes
+- [ ] No CLI/runtime consumer changes
+- [ ] No MCP server changes
+
+## Contract freeze
+- [ ] Context payload surfaces are explicit:
+  - `DecisionEvent`
+  - `DecisionData`
+- [ ] Core context fields are explicit:
+  - `lane`
+  - `principal`
+  - `auth_context_summary`
+  - `approval_state`
+- [ ] Deterministic completeness semantics are explicit
+- [ ] Additive context compatibility expectations are explicit
+- [ ] Non-goals are explicit (no runtime behavior change)
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave42-context-envelope-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes
+- [ ] Pinned replay/decision tests pass

--- a/docs/contributing/SPLIT-PLAN-wave42-context-envelope-hardening.md
+++ b/docs/contributing/SPLIT-PLAN-wave42-context-envelope-hardening.md
@@ -1,0 +1,105 @@
+# SPLIT PLAN - Wave42 Context Envelope Hardening
+
+## Intent
+Freeze a bounded downstream context-envelope contract for decision payloads before any further runtime capability work.
+
+This wave is about:
+- stable consumer-facing semantics for `lane`, `principal`, `auth_context_summary`, and `approval_state`
+- deterministic context-envelope completeness signaling for downstream readers
+- additive context-contract metadata for emitted decision payloads
+- reviewer gates that lock the context envelope contract
+
+It explicitly does **not** add:
+- new runtime behavior
+- new obligation types
+- policy language expansion
+- control-plane or auth transport changes
+- UI or external integrations
+
+## Problem
+The runtime now emits context fields such as `lane`, `principal`, `auth_context_summary`, and `approval_state`,
+but that envelope is not yet frozen as a dedicated downstream contract.
+
+Current gap:
+- downstream consumers cannot distinguish complete envelope data from partial envelope data without bespoke field checks
+- context completeness and payload robustness are not frozen independently from runtime decision semantics
+- additive context-contract metadata is not yet defined as a bounded compatibility layer
+
+## Frozen context envelope contract
+Wave42 freezes a consumer-facing context envelope for these payload surfaces:
+- `DecisionEvent`
+- `DecisionData`
+
+## Frozen context fields
+Wave42 freezes the expectation that these fields remain available as the core context envelope:
+- `lane`
+- `principal`
+- `auth_context_summary`
+- `approval_state`
+
+## Frozen completeness semantics
+Wave42 freezes deterministic downstream semantics for context-envelope completeness:
+1. complete envelope
+2. partial envelope
+3. absent envelope
+
+This completeness classification is contract-level in Step1 and must remain deterministic.
+
+## Suggested additive markers for Step2
+Wave42 Step2 may add context-facing contract metadata, additively only, such as:
+- `decision_context_contract_version`
+- `context_payload_state`
+- `required_context_fields`
+- `missing_context_fields`
+
+Names can vary in Step2 implementation, but the semantics above are frozen in this plan.
+
+## Frozen compatibility requirements
+Wave42 freezes additive compatibility expectations for context-envelope consumers:
+- consumers can determine whether the envelope is complete, partial, or absent without re-deriving runtime semantics
+- existing payload consumers are not broken by the hardening slice
+- missing optional context does not introduce runtime behavior change in this wave
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. context-envelope completeness is explicit and testable
+2. context-facing contract metadata is additive and backward-compatible
+3. existing runtime decision behavior remains unchanged
+4. downstream readers can reason about envelope completeness deterministically
+5. no new runtime capability or policy surface is introduced
+
+## Scope boundaries
+### In scope
+- decision context-envelope contract freeze
+- deterministic completeness semantics for context fields
+- additive context compatibility contract
+- tests and reviewer gates for the above
+
+### Out of scope
+- runtime behavior changes
+- new obligation types
+- policy language extension
+- control-plane or auth transport changes
+- UI/external integration work
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Bounded implementation:
+- context-envelope completeness normalization
+- additive context contract metadata
+- no runtime behavior change
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must remain context-envelope hardening only.
+
+Primary failure modes:
+- introducing runtime behavior changes under a context-hardening label
+- making envelope completeness less deterministic for downstream consumers
+- breaking existing event consumers via non-additive changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave42-context-envelope-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave42-context-envelope-step1.md
@@ -1,0 +1,38 @@
+# SPLIT REVIEW PACK - Wave42 Context Envelope Step1
+
+## Intent
+Freeze the bounded decision context-envelope hardening contract before any Step2 implementation.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change CLI normalization behavior
+- change MCP server behavior
+- add new runtime capability
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave42-context-envelope-hardening.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave42-context-envelope-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave42-context-envelope-step1.md`
+- `scripts/ci/review-wave42-context-envelope-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the four Step1 files.
+2. Context payload surfaces are explicit (`DecisionEvent`, `DecisionData`).
+3. Core context fields are explicit (`lane`, `principal`, `auth_context_summary`, `approval_state`).
+4. Envelope completeness semantics are explicit and deterministic.
+5. Runtime paths are untouched.
+6. No runtime behavior change is introduced in this wave.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave42-context-envelope-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- context envelope contract is frozen cleanly
+- Step2 can implement bounded context normalization without reopening semantics

--- a/scripts/ci/review-wave42-context-envelope-step1.sh
+++ b/scripts/ci/review-wave42-context-envelope-step1.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave42-context-envelope-hardening.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave42-context-envelope-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave42-context-envelope-step1.md"
+  "scripts/ci/review-wave42-context-envelope-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-core/tests"
+  "crates/assay-cli/src/cli/commands/mcp.rs"
+  "crates/assay-cli/src/cli/commands/coverage"
+  "crates/assay-cli/src/cli/commands/session_state_window.rs"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave42 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave42 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave42 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+rg -n '^# SPLIT PLAN - Wave42 Context Envelope Hardening$' \
+  docs/contributing/SPLIT-PLAN-wave42-context-envelope-hardening.md >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'DecisionEvent' \
+  'DecisionData' \
+  'lane' \
+  'principal' \
+  'auth_context_summary' \
+  'approval_state' \
+  'complete envelope' \
+  'partial envelope' \
+  'absent envelope' \
+  'decision_context_contract_version' \
+  'context_payload_state' \
+  'required_context_fields' \
+  'missing_context_fields' \
+  'no runtime behavior change'
+do
+  rg -n "$marker" docs/contributing/SPLIT-PLAN-wave42-context-envelope-hardening.md >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core --test replay_diff_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
Summary
- add Wave42 Step1 split plan for context envelope hardening
- add Step1 checklist and review pack
- add Step1 reviewer gate script

Scope
- docs+gate only
- no runtime code changes
- no workflow changes

Validation
- BASE_REF=origin/main bash scripts/ci/review-wave42-context-envelope-step1.sh
- pre-commit hooks passed on commit