### PR TITLE
feat(wave42-step2): harden context envelope payloads

### DIFF
--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -4,6 +4,7 @@
 //! Every tool call attempt MUST emit exactly one decision event.
 
 use self::consumer_contract::project_consumer_contract;
+use self::context_contract::project_context_contract;
 use self::deny_convergence::project_deny_convergence;
 use self::outcome_convergence::classify_decision_outcome;
 use self::replay_compat::project_replay_compat;
@@ -17,6 +18,7 @@ use std::io::Write;
 use std::sync::Arc;
 
 mod consumer_contract;
+mod context_contract;
 mod deny_convergence;
 mod outcome_convergence;
 mod replay_compat;
@@ -24,6 +26,9 @@ mod replay_diff;
 pub use consumer_contract::{
     required_consumer_fields_v1, ConsumerPayloadState, ConsumerReadPath,
     DECISION_CONSUMER_CONTRACT_VERSION_V1,
+};
+pub use context_contract::{
+    required_context_fields_v1, ContextPayloadState, DECISION_CONTEXT_CONTRACT_VERSION_V1,
 };
 pub use deny_convergence::{DenyClassificationSource, DENY_PRECEDENCE_VERSION_V1};
 pub use outcome_convergence::{DecisionOrigin, DecisionOutcomeKind, OutcomeCompatState};
@@ -340,6 +345,18 @@ pub struct DecisionData {
     /// Contract-level required fields for bounded consumer reads.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required_consumer_fields: Vec<String>,
+    /// Version tag for bounded context-envelope compatibility reads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision_context_contract_version: Option<String>,
+    /// Overall context-envelope completeness state for downstream consumers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_payload_state: Option<ContextPayloadState>,
+    /// Contract-level required fields for bounded context-envelope reads.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_context_fields: Vec<String>,
+    /// Missing context fields for the current envelope projection.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_context_fields: Vec<String>,
     /// Explicit deny classification marker: policy deny path.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy_deny: Option<bool>,
@@ -536,6 +553,16 @@ fn refresh_fulfillment_normalization(data: &mut DecisionData) {
     data.consumer_fallback_applied = Some(consumer_projection.fallback_applied);
     data.consumer_payload_state = Some(consumer_projection.payload_state);
     data.required_consumer_fields = consumer_projection.required_consumer_fields;
+    let context_projection = project_context_contract(
+        data.lane.as_deref(),
+        data.principal.as_deref(),
+        data.auth_context_summary.as_deref(),
+        data.approval_state.as_deref(),
+    );
+    data.decision_context_contract_version = Some(DECISION_CONTEXT_CONTRACT_VERSION_V1.to_string());
+    data.context_payload_state = Some(context_projection.payload_state);
+    data.required_context_fields = context_projection.required_context_fields;
+    data.missing_context_fields = context_projection.missing_context_fields;
     data.policy_deny = Some(deny_projection.policy_deny);
     data.fail_closed_deny = Some(deny_projection.fail_closed_deny);
     data.enforcement_deny = Some(deny_projection.enforcement_deny);
@@ -610,6 +637,10 @@ impl DecisionEvent {
                 consumer_fallback_applied: None,
                 consumer_payload_state: None,
                 required_consumer_fields: Vec::new(),
+                decision_context_contract_version: None,
+                context_payload_state: None,
+                required_context_fields: Vec::new(),
+                missing_context_fields: Vec::new(),
                 policy_deny: None,
                 fail_closed_deny: None,
                 enforcement_deny: None,
@@ -1064,6 +1095,10 @@ impl Drop for DecisionEmitterGuard {
     }
 }
 
+pub(crate) fn refresh_contract_projections(data: &mut DecisionData) {
+    refresh_fulfillment_normalization(data);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1244,6 +1279,60 @@ mod tests {
             event.data.approval_freshness,
             Some(ApprovalFreshness::Fresh)
         );
+        assert_eq!(
+            event.data.decision_context_contract_version.as_deref(),
+            Some(DECISION_CONTEXT_CONTRACT_VERSION_V1)
+        );
+        assert_eq!(
+            event.data.context_payload_state,
+            Some(ContextPayloadState::PartialEnvelope)
+        );
+        assert_eq!(
+            event.data.missing_context_fields,
+            vec![
+                "lane".to_string(),
+                "principal".to_string(),
+                "auth_context_summary".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_with_policy_context_sets_complete_context_contract_fields() {
+        let context = PolicyDecisionEventContext {
+            lane: Some("lane-prod".to_string()),
+            principal: Some("alice@example.com".to_string()),
+            auth_context_summary: Some("aud=deploy scopes=tool:deploy".to_string()),
+            approval_state: Some("approved".to_string()),
+            ..PolicyDecisionEventContext::default()
+        };
+
+        let event = DecisionEvent::new(
+            "assay://test".to_string(),
+            "tc_007".to_string(),
+            "deploy_service".to_string(),
+        )
+        .allow(reason_codes::P_POLICY_ALLOW)
+        .with_policy_context(context);
+
+        assert_eq!(
+            event.data.decision_context_contract_version.as_deref(),
+            Some(DECISION_CONTEXT_CONTRACT_VERSION_V1)
+        );
+        assert_eq!(
+            event.data.context_payload_state,
+            Some(ContextPayloadState::CompleteEnvelope)
+        );
+        assert_eq!(
+            event.data.required_context_fields,
+            vec![
+                "lane".to_string(),
+                "principal".to_string(),
+                "auth_context_summary".to_string(),
+                "approval_state".to_string(),
+            ]
+        );
+        assert!(event.data.missing_context_fields.is_empty());
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/decision/context_contract.rs
+++ b/crates/assay-core/src/mcp/decision/context_contract.rs
@@ -1,0 +1,118 @@
+use serde::{Deserialize, Serialize};
+
+pub const DECISION_CONTEXT_CONTRACT_VERSION_V1: &str = "wave42_v1";
+
+const REQUIRED_CONTEXT_FIELDS_V1: &[&str] = &[
+    "lane",
+    "principal",
+    "auth_context_summary",
+    "approval_state",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextPayloadState {
+    CompleteEnvelope,
+    PartialEnvelope,
+    AbsentEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextContractProjection {
+    pub payload_state: ContextPayloadState,
+    pub required_context_fields: Vec<String>,
+    pub missing_context_fields: Vec<String>,
+}
+
+pub fn project_context_contract(
+    lane: Option<&str>,
+    principal: Option<&str>,
+    auth_context_summary: Option<&str>,
+    approval_state: Option<&str>,
+) -> ContextContractProjection {
+    let fields = [
+        ("lane", lane),
+        ("principal", principal),
+        ("auth_context_summary", auth_context_summary),
+        ("approval_state", approval_state),
+    ];
+
+    let present = fields.iter().filter(|(_, value)| value.is_some()).count();
+    let payload_state = match present {
+        0 => ContextPayloadState::AbsentEnvelope,
+        n if n == fields.len() => ContextPayloadState::CompleteEnvelope,
+        _ => ContextPayloadState::PartialEnvelope,
+    };
+
+    let missing_context_fields = fields
+        .iter()
+        .filter_map(|(field, value)| value.is_none().then_some((*field).to_string()))
+        .collect();
+
+    ContextContractProjection {
+        payload_state,
+        required_context_fields: required_context_fields_v1(),
+        missing_context_fields,
+    }
+}
+
+pub fn required_context_fields_v1() -> Vec<String> {
+    REQUIRED_CONTEXT_FIELDS_V1
+        .iter()
+        .map(|field| (*field).to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_complete_context_envelope() {
+        let projection = project_context_contract(
+            Some("lane-prod"),
+            Some("alice@example.com"),
+            Some("aud=deploy scopes=tool:deploy"),
+            Some("approved"),
+        );
+
+        assert_eq!(
+            projection.payload_state,
+            ContextPayloadState::CompleteEnvelope
+        );
+        assert!(projection.missing_context_fields.is_empty());
+        assert_eq!(
+            projection.required_context_fields,
+            required_context_fields_v1()
+        );
+    }
+
+    #[test]
+    fn classifies_partial_context_envelope() {
+        let projection =
+            project_context_contract(Some("lane-prod"), None, Some("aud=deploy"), None);
+
+        assert_eq!(
+            projection.payload_state,
+            ContextPayloadState::PartialEnvelope
+        );
+        assert_eq!(
+            projection.missing_context_fields,
+            vec!["principal".to_string(), "approval_state".to_string()]
+        );
+    }
+
+    #[test]
+    fn classifies_absent_context_envelope() {
+        let projection = project_context_contract(None, None, None, None);
+
+        assert_eq!(
+            projection.payload_state,
+            ContextPayloadState::AbsentEnvelope
+        );
+        assert_eq!(
+            projection.missing_context_fields,
+            required_context_fields_v1()
+        );
+    }
+}

--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -1,7 +1,7 @@
 use super::audit::{AuditEvent, AuditLog};
 use super::decision::{
-    reason_codes, Decision, DecisionEmitter, DecisionEvent, FileDecisionEmitter,
-    NullDecisionEmitter,
+    reason_codes, refresh_contract_projections, Decision, DecisionEmitter, DecisionEvent,
+    FileDecisionEmitter, NullDecisionEmitter,
 };
 use super::jsonrpc::JsonRpcRequest;
 use super::policy::{
@@ -551,6 +551,7 @@ impl McpProxy {
         event.data.lane = metadata.lane.clone();
         event.data.principal = metadata.principal.clone();
         event.data.auth_context_summary = metadata.auth_context_summary.clone();
+        refresh_contract_projections(&mut event.data);
         emitter.emit(&event);
     }
 }

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -4,11 +4,11 @@
 //! one decision event being emitted, regardless of outcome.
 
 use assay_core::mcp::decision::{
-    reason_codes, ConsumerPayloadState, ConsumerReadPath, Decision, DecisionEmitter,
-    DecisionEmitterGuard, DecisionEvent, DecisionOrigin, DecisionOutcomeKind,
+    reason_codes, ConsumerPayloadState, ConsumerReadPath, ContextPayloadState, Decision,
+    DecisionEmitter, DecisionEmitterGuard, DecisionEvent, DecisionOrigin, DecisionOutcomeKind,
     DenyClassificationSource, FulfillmentDecisionPath, ObligationOutcomeStatus, OutcomeCompatState,
     ReplayClassificationSource, DECISION_BASIS_VERSION_V1, DECISION_CONSUMER_CONTRACT_VERSION_V1,
-    DENY_PRECEDENCE_VERSION_V1,
+    DECISION_CONTEXT_CONTRACT_VERSION_V1, DENY_PRECEDENCE_VERSION_V1,
 };
 use assay_core::mcp::policy::{
     ApprovalFreshness, McpPolicy, PolicyState, RedactArgsContract, RestrictScopeContract,
@@ -1115,6 +1115,32 @@ fn test_event_contains_required_fields() {
     assert_eq!(event.data.obligation_applied_present, Some(true));
     assert_eq!(event.data.obligation_skipped_present, Some(false));
     assert_eq!(event.data.obligation_error_present, Some(false));
+    assert_eq!(
+        event.data.decision_context_contract_version.as_deref(),
+        Some(DECISION_CONTEXT_CONTRACT_VERSION_V1)
+    );
+    assert_eq!(
+        event.data.context_payload_state,
+        Some(ContextPayloadState::AbsentEnvelope)
+    );
+    assert_eq!(
+        event.data.required_context_fields,
+        vec![
+            "lane".to_string(),
+            "principal".to_string(),
+            "auth_context_summary".to_string(),
+            "approval_state".to_string(),
+        ]
+    );
+    assert_eq!(
+        event.data.missing_context_fields,
+        vec![
+            "lane".to_string(),
+            "principal".to_string(),
+            "auth_context_summary".to_string(),
+            "approval_state".to_string(),
+        ]
+    );
     assert!(event.data.approval_state.is_none());
     assert!(event.data.approval_id.is_none());
     assert!(event.data.approval_freshness.is_none());

--- a/docs/contributing/SPLIT-CHECKLIST-wave42-context-envelope-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave42-context-envelope-step2.md
@@ -1,0 +1,31 @@
+# SPLIT CHECKLIST - Wave42 Context Envelope Step2
+
+## Scope discipline
+- [ ] Diff is limited to bounded context-envelope runtime + tests + Step2 docs/gate.
+- [ ] No `.github/workflows/*` changes.
+- [ ] No scope leaks outside decision/context-envelope payload paths.
+- [ ] No runtime behavior change is introduced.
+- [ ] No new policy-engine/control-plane/auth transport scope is added.
+
+## Implementation contract
+- [ ] Additive context-envelope fields are present:
+  - `decision_context_contract_version`
+  - `context_payload_state`
+  - `required_context_fields`
+  - `missing_context_fields`
+- [ ] Deterministic completeness semantics are represented and test-covered:
+  - complete envelope
+  - partial envelope
+  - absent envelope
+- [ ] Context-facing metadata remains additive and backward-compatible.
+
+## Compatibility and behavior
+- [ ] Existing decision/event fields remain backward-compatible.
+- [ ] Existing runtime decision behavior remains unchanged.
+- [ ] Downstream readers can reason about envelope completeness deterministically.
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave42-context-envelope-step2.sh` passes.
+- [ ] `cargo fmt --check` passes.
+- [ ] `cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings` passes.
+- [ ] Pinned runtime/event tests pass.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave42-context-envelope-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave42-context-envelope-step2.md
@@ -1,0 +1,25 @@
+# SPLIT MOVE MAP - Wave42 Context Envelope Step2
+
+## Intent
+Keep Wave42 Step2 bounded to additive context-envelope completeness metadata over the existing decision payload surfaces.
+
+## Allowed implementation scope
+- `crates/assay-core/src/mcp/decision.rs`
+- `crates/assay-core/src/mcp/decision/context_contract.rs`
+- `crates/assay-core/src/mcp/proxy.rs`
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+- Step2 docs/gate files
+
+## Move rationale
+- `decision.rs`: additive event payload fields and normalization hook-up
+- `context_contract.rs`: bounded context-envelope completeness projection
+- `proxy.rs`: align proxy-emitted decision payloads with the same additive contract projection
+- tests: downstream context-envelope invariants and completeness coverage
+
+## Explicitly out of scope
+- tool-call handler behavior changes
+- policy evaluation changes
+- replay classification changes
+- CLI/runtime consumer changes outside existing decision payload tests
+- MCP server changes
+- workflow changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave42-context-envelope-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave42-context-envelope-step2.md
@@ -1,0 +1,28 @@
+# SPLIT REVIEW PACK - Wave42 Context Envelope Step2
+
+## Intent
+Implement bounded context-envelope hardening with additive completeness metadata for decision payload consumers.
+
+This slice must:
+- remain additive and backward-compatible
+- expose deterministic envelope completeness
+- signal missing context fields explicitly
+- keep runtime behavior unchanged
+
+This slice must not:
+- add new runtime capability
+- change enforcement semantics
+- expand policy-engine/control-plane/auth transport scope
+- touch workflow files
+
+## Reviewer focus
+1. Diff stays inside bounded decision/context/test/docs/gate scope.
+2. Context-envelope fields are present and additive in event payloads.
+3. Envelope completeness is deterministic and explicit.
+4. Missing-field signaling remains backward-compatible.
+5. No scope creep into runtime behavior changes.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave42-context-envelope-step2.sh
+```

--- a/scripts/ci/review-wave42-context-envelope-step2.sh
+++ b/scripts/ci/review-wave42-context-envelope-step2.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-core/src/mcp/decision/context_contract.rs"
+  "crates/assay-core/src/mcp/proxy.rs"
+  "crates/assay-core/tests/decision_emit_invariant.rs"
+
+  "docs/contributing/SPLIT-CHECKLIST-wave42-context-envelope-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave42-context-envelope-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave42-context-envelope-step2.md"
+
+  "scripts/ci/review-wave42-context-envelope-step2.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave42 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave42 Step2: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] no untracked files under bounded runtime scope"
+for p in \
+  "crates/assay-core/src/mcp" \
+  "crates/assay-core/tests" \
+  "crates/assay-cli/src/cli/commands" \
+  "crates/assay-mcp-server"
+do
+  while IFS= read -r uf; do
+    [[ -z "${uf:-}" ]] && continue
+    allowed="false"
+    for a in "${ALLOWLIST[@]}"; do
+      [[ "$uf" == "$a" ]] && allowed="true" && break
+    done
+    if [[ "$allowed" != "true" ]]; then
+      echo "FAIL: untracked file present under $p: $uf"
+      exit 1
+    fi
+  done < <(git ls-files --others --exclude-standard -- "$p")
+done
+
+echo "[review] Wave42 context-envelope markers"
+for marker in \
+  'decision_context_contract_version' \
+  'context_payload_state' \
+  'required_context_fields' \
+  'missing_context_fields' \
+  'ContextPayloadState' \
+  'DECISION_CONTEXT_CONTRACT_VERSION_V1' \
+  'project_context_contract'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision.rs \
+    crates/assay-core/src/mcp/decision/context_contract.rs \
+    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    echo "FAIL: missing Wave42 context-envelope marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] deterministic context completeness markers"
+for marker in \
+  'CompleteEnvelope' \
+  'PartialEnvelope' \
+  'AbsentEnvelope' \
+  'lane' \
+  'principal' \
+  'auth_context_summary' \
+  'approval_state'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision/context_contract.rs \
+    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    echo "FAIL: missing deterministic context completeness marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] existing replay/decision markers remain present"
+for marker in \
+  'DecisionOutcomeKind' \
+  'OutcomeCompatState' \
+  'fulfillment_decision_path' \
+  'decision_consumer_contract_version' \
+  'consumer_payload_state'
+do
+  rg -n "$marker" \
+    crates/assay-core/src/mcp/decision.rs \
+    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    echo "FAIL: missing existing replay/decision marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] no runtime behavior scope creep"
+if git diff --name-only "$BASE_REF"...HEAD -- \
+  crates/assay-core/src/mcp/tool_call_handler \
+  crates/assay-core/src/mcp/policy \
+  crates/assay-cli/src/cli/commands/mcp.rs \
+  crates/assay-mcp-server \
+  | rg -n '.' >/dev/null; then
+  echo "FAIL: Wave42 Step2 must not modify runtime behavior paths outside decision/context scope"
+  git diff --name-only "$BASE_REF"...HEAD -- \
+    crates/assay-core/src/mcp/tool_call_handler \
+    crates/assay-core/src/mcp/policy \
+    crates/assay-cli/src/cli/commands/mcp.rs \
+    crates/assay-mcp-server
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D warnings
+
+echo "[review] pinned replay/decision tests"
+cargo test -p assay-core context_contract
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization
+cargo test -p assay-cli mcp_wrap_coverage
+cargo test -p assay-cli mcp_wrap_state_window_out
+cargo test -p assay-mcp-server --test auth_integration
+
+echo "[review] PASS"


### PR DESCRIPTION
Summary
- add bounded context-envelope completeness metadata for decision payloads
- add context contract projection module
- align proxy-emitted decision payloads with the same additive projection
- add Step2 docs/gate

Scope
- additive decision payload metadata only
- no runtime behavior change
- no workflow changes

Validation
- BASE_REF=origin/main bash scripts/ci/review-wave42-context-envelope-step2.sh
- pre-commit hooks passed on commit