### PR TITLE
chore(release): prepare v3.1.0 line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "aya",
  "chrono",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assay-core",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -69,15 +69,15 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.0.0" }
-assay-common = { path = "crates/assay-common", version = "3.0.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.0.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.0.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.0.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.0.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.0.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.0.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.0.0" }
+assay-core = { path = "crates/assay-core", version = "3.1.0" }
+assay-common = { path = "crates/assay-common", version = "3.1.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.1.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.1.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.1.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.1.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.1.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.1.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.1.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2026-03-15]
+
+- chore(release): prepare v3.1.0 release line for Wave24-Wave42 MCP policy enforcement work
+- feat(mcp): ship typed decisions, Decision Event v2, obligations execution, approval enforcement, restrict_scope enforcement, redact_args enforcement, and fulfillment normalization on the v3.1.0 line
+- feat(replay): ship replay diff basis, evidence compatibility normalization, deny-evidence convergence, consumer hardening, and context-envelope hardening on the v3.1.0 line
+
 - feat(e9c): replay bundle CLI flow + modular command refactor (single commit) (#168) @Rul1an
 - E9b: Scrubbing + bundle verify (scrub, read_bundle_tar_gz, verify_bundle) (#166) @Rul1an
 - feat(e9d.3): harden replay contract + strategic positioning & DX plan (#172) @Rul1an

--- a/docs/releases/v3.1.0.md
+++ b/docs/releases/v3.1.0.md
@@ -39,7 +39,7 @@ Downstream consumers should expect additive changes in MCP decision and replay p
 
 No new control-plane, auth transport, or external workflow semantics are introduced by this release line.
 
-## Publishability matrix
+## Publishability Matrix (Advisory)
 
 | Crate | Publish | Wave24-Wave42 impact | Semver advice | Notes |
 | --- | --- | --- | --- | --- |
@@ -54,7 +54,9 @@ No new control-plane, auth transport, or external workflow semantics are introdu
 | `assay-sim` | no by default | low | none | Not a primary surface in this release cluster. |
 | adapters / registry / ebpf / xtask | no by default | low | none | Only bump if older unreleased work needs to ship on the same tag. |
 
-Practical note: this workspace uses a shared release line, so the repo version bump is `3.1.0` even if only a subset of crates is actually published.
+Practical note: this workspace uses a shared release line, so the repo version bump is `3.1.0` even if only a subset of crates is the primary consumer-impact target.
+
+Automation note: the current `release.yml` default publish path is broader than the impact-based matrix above. The workflow runs `scripts/ci/publish_idempotent.sh`, which publishes in this order by default: `assay-common`, `assay-registry`, `assay-evidence`, `assay-adapter-api`, `assay-core`, `assay-metrics`, `assay-policy`, `assay-mcp-server`, `assay-monitor`, `assay-sim`, `assay-cli`. Treat the matrix above as semver and consumer-impact guidance, not as an override of release automation.
 
 ## Preflight
 
@@ -71,7 +73,7 @@ Expected before cut:
 - workspace version aligned to `3.1.0`
 - no mixed internal crate versions in `Cargo.toml`
 
-## Mandatory release gates
+## Mandatory Release Gates
 
 ```bash
 PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --workspace
@@ -93,7 +95,16 @@ BASE_REF=origin/main bash scripts/ci/review-wave42-context-envelope-step3.sh
 PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report
 ```
 
-## Release notes checklist
+Python / PyPI sanity:
+
+```bash
+cd assay-python-sdk
+python3 -m build
+python3 -m twine check dist/*
+cd -
+```
+
+## Release Notes Checklist
 
 Before tagging, make sure the final GitHub release notes call out:
 - typed decisions + Decision Event v2
@@ -103,16 +114,16 @@ Before tagging, make sure the final GitHub release notes call out:
 - consumer/read precedence and context-envelope hardening
 - additive payload fields that downstream readers may want to consume
 
-## Tag + publish
+## Tag + Publish
 
 ```bash
 git tag -a v3.1.0 -m "Assay v3.1.0"
 git push origin v3.1.0
 ```
 
-Then let `release.yml` build release assets and publish the selected crates.
+Then let `release.yml` build release assets, publish the default crate set, build Python wheels from `assay-python-sdk`, and publish the PyPI artifacts.
 
-## Rollback / abort
+## Rollback / Abort
 
 If mandatory gates fail:
 - do not tag

--- a/docs/releases/v3.1.0.md
+++ b/docs/releases/v3.1.0.md
@@ -1,0 +1,125 @@
+# Assay v3.1.0 Release Runbook
+
+**Target date**: 2026-03-15
+**Release type**: minor feature release
+
+## Why v3.1.0
+
+This line carries the Wave24-Wave42 MCP policy-enforcement stack forward from `v3.0.0`.
+
+Why this is a minor release instead of a patch:
+- additive but material expansion of decision and evidence payloads
+- new runtime enforcement for `approval_required`, `restrict_scope`, and `redact_args`
+- normalized replay/diff and consumer-facing payload contracts
+- stronger downstream compatibility expectations for decision, replay, and context-envelope readers
+
+This line is intended to stay backward-compatible for additive readers, but it is not small enough to hide inside a patch release.
+
+## Scope
+
+Wave clusters included in this release line:
+- Wave24: typed decisions + Decision Event v2
+- Wave25-Wave26: bounded `log` and `alert` obligation execution
+- Wave27-Wave28: approval artifact contract + `approval_required` enforcement
+- Wave29-Wave30: `restrict_scope` contract + enforcement
+- Wave31-Wave32 + Wave36: `redact_args` contract + enforcement hardening
+- Wave33 + Wave35: obligation fulfillment normalization
+- Wave34 + Wave40: fail-closed / deny evidence typing and convergence
+- Wave37-Wave42: decision/evidence convergence, replay diff basis, evidence compat, consumer hardening, context-envelope hardening
+
+## Consumer impact summary
+
+Downstream consumers should expect additive changes in MCP decision and replay payloads, including:
+- typed decision / outcome fields
+- richer obligation and fulfillment metadata
+- approval, scope, and redaction evidence fields
+- replay diff basis and compatibility markers
+- deny/evidence convergence markers
+- consumer-hardening and context-envelope completeness markers
+
+No new control-plane, auth transport, or external workflow semantics are introduced by this release line.
+
+## Publishability matrix
+
+| Crate | Publish | Wave24-Wave42 impact | Semver advice | Notes |
+| --- | --- | --- | --- | --- |
+| `assay-core` | yes | direct | minor | Main MCP policy/enforcement, decision, replay, and evidence changes landed here. |
+| `assay-cli` | yes | likely direct | minor | CLI consumes and emits machine-readable reporting tied to the new decision/evidence surfaces. |
+| `assay-mcp-server` | maybe | indirect | patch or none | Only publish if crate surface or dependency lockstep is required for this line. |
+| `assay-common` | maybe | indirect | patch or none | Publish only if downstream users consume changed shared public types directly. |
+| `assay-policy` | no by default | low | none | No clear standalone publish signal from this wave set. |
+| `assay-evidence` | no by default | low | none | Earlier waves touched evidence more heavily than this sequence. |
+| `assay-monitor` | no by default | low | none | Not a Wave24-Wave42 hotspot. |
+| `assay-metrics` | no by default | low | none | Not a primary surface in this release cluster. |
+| `assay-sim` | no by default | low | none | Not a primary surface in this release cluster. |
+| adapters / registry / ebpf / xtask | no by default | low | none | Only bump if older unreleased work needs to ship on the same tag. |
+
+Practical note: this workspace uses a shared release line, so the repo version bump is `3.1.0` even if only a subset of crates is actually published.
+
+## Preflight
+
+```bash
+git fetch origin --tags
+git checkout main
+git pull --ff-only
+rg -n '^version\s*=\s*"' Cargo.toml crates/*/Cargo.toml assay-python-sdk/Cargo.toml -g 'Cargo.toml'
+git tag --sort=-creatordate | head -n 10
+```
+
+Expected before cut:
+- previous release tag visible: `v3.0.0`
+- workspace version aligned to `3.1.0`
+- no mixed internal crate versions in `Cargo.toml`
+
+## Mandatory release gates
+
+```bash
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test --workspace
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Build / artifact sanity:
+
+```bash
+cargo build --release -p assay-cli
+./target/release/assay --version
+```
+
+Replay / MCP smoke checks:
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave42-context-envelope-step2.sh
+BASE_REF=origin/main bash scripts/ci/review-wave42-context-envelope-step3.sh
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test -p assay-cli mcp_wrap_coverage_cli_smoke_writes_report
+```
+
+## Release notes checklist
+
+Before tagging, make sure the final GitHub release notes call out:
+- typed decisions + Decision Event v2
+- approval / restrict_scope / redact_args enforcement additions
+- replay-diff and evidence-compat additions
+- deny-evidence convergence
+- consumer/read precedence and context-envelope hardening
+- additive payload fields that downstream readers may want to consume
+
+## Tag + publish
+
+```bash
+git tag -a v3.1.0 -m "Assay v3.1.0"
+git push origin v3.1.0
+```
+
+Then let `release.yml` build release assets and publish the selected crates.
+
+## Rollback / abort
+
+If mandatory gates fail:
+- do not tag
+- fix forward on the release-prep branch
+- rerun gates
+
+If a partial publish occurs:
+- do not retag `v3.1.0`
+- cut `v3.1.1` with the forward fix
+- document the partial state in GitHub release notes


### PR DESCRIPTION
Summary
- bump workspace release line from v3.0.0 to v3.1.0
- add v3.1.0 release runbook with publishability matrix
- add changelog top-section for the Wave24-Wave42 release cluster

Why minor
- material additive decision/evidence payload expansion
- new runtime enforcement for approval_required, restrict_scope, and redact_args
- replay/evidence/consumer/context-envelope hardening beyond patch scope

Validation
- cargo build --release -p assay-cli
- ./target/release/assay --version  # assay 3.1.0
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --workspace

Notes
- plain cargo check without the PyO3 ABI3 env fails on local Python 3.14; the release-lane env is now the authoritative validation path, matching the runbook