### PR TITLE
docs: strengthen MCP onboarding and evidence proof points

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ assay mcp wrap --policy examples/mcp-quickstart/policy.yaml \
 ❌ DENY   exec       cmd=ls                          reason=tool_denied
 ```
 
+Then inspect the audit artifact Assay can hand to security or compliance:
+
+```bash
+assay evidence show demo/fixtures/bundle.tar.gz
+```
+
+![Evidence Bundle Inspector](demo/output/screenshots/evidence-bundle-inspector.svg)
+
+The bundle is tamper-evident and cryptographically verifiable. If your run includes signed mandate events, the same bundle also carries the Ed25519-backed authorization trail for high-risk actions.
+
 ## Is This For Me?
 
 **Yes, if you:**
@@ -64,25 +74,87 @@ assay mcp wrap --policy examples/mcp-quickstart/policy.yaml \
 - Don't use MCP (Assay is MCP-native; other protocols are on the roadmap)
 - Need a hosted dashboard (Assay is CLI-first and offline)
 
+## Add to Cursor in 30 Seconds
+
+Assay ships a helper that finds your local Cursor MCP config path and prints a ready-to-paste entry:
+
+```bash
+assay mcp config-path cursor
+```
+
+It generates JSON like:
+
+```json
+{
+  "filesystem-secure": {
+    "command": "assay",
+    "args": [
+      "mcp",
+      "wrap",
+      "--policy",
+      "/path/to/policy.yaml",
+      "--",
+      "npx",
+      "-y",
+      "@modelcontextprotocol/server-filesystem",
+      "/Users/you"
+    ]
+  }
+}
+```
+
+The same wrapped command works in other MCP clients:
+- Cursor: paste the generated entry into `mcpServers`
+- Windsurf: paste the same `mcpServers` entry into `~/.codeium/windsurf/mcp_config.json`
+- Zed: paste the wrapped command into `context_servers` in your settings JSON
+
+See [MCP Quick Start](docs/mcp/quickstart.md) for client-specific examples.
+
 ## Policy Is Simple
 
 ```yaml
-version: "1.0"
+version: "2.0"
 name: "my-policy"
-allow: ["read_file", "list_dir"]
-deny: ["exec", "shell", "write_file"]
-constraints:
-  - tool: "read_file"
-    params:
+
+tools:
+  allow: ["read_file", "list_dir"]
+  deny: ["exec", "shell", "write_file"]
+
+schemas:
+  read_file:
+    type: object
+    additionalProperties: false
+    properties:
       path:
-        matches: "^/app/.*"
+        type: string
+        pattern: "^/app/.*"
+        minLength: 1
+    required: ["path"]
 ```
+
+Already have a legacy `constraints:` policy? Assay still reads it, warns once, and ships `assay policy migrate` to write the v2 JSON Schema form.
 
 Or don't write one — generate it from what your agent actually does:
 
 ```bash
 assay init --from-trace trace.jsonl
 ```
+
+See [Policy Files](docs/reference/config/policies.md) for the full YAML schema.
+
+## OpenTelemetry In, Evidence Out
+
+Already tracing with Langfuse or an OTel-enabled agent stack? Keep that pipeline. Assay ingests OpenTelemetry JSONL, turns it into replayable traces, and gives you deterministic policy gates plus exportable evidence bundles.
+
+```bash
+assay trace ingest-otel \
+  --input otel-export.jsonl \
+  --db .eval/eval.db \
+  --suite checkout-agent \
+  --out-trace traces/otel.v2.jsonl
+```
+
+Then run `assay ci` on the converted trace or export an Evidence Bundle for audit handoff. See [OpenTelemetry & Langfuse](docs/guides/otel-langfuse.md).
 
 ## Add to CI
 
@@ -102,6 +174,14 @@ jobs:
 ```
 
 PRs that violate policy get blocked. SARIF results show up in the Security tab.
+
+## Measured Latency
+
+On the M1 Pro/macOS fragmented-IPI harness, Assay's protected tool-decision path measured:
+- Main protection run: `0.771ms` p50 / `1.913ms` p95
+- Fast-path scenario: `0.345ms` p50 / `1.145ms` p95
+
+These are tool-decision timings, not end-to-end model latency.
 
 ## Beyond MCP: Protocol Adapters
 
@@ -125,7 +205,7 @@ The agent protocol landscape is fragmenting (ACP, A2A, UCP, AP2, x402). Assay's 
 | **MCP-native** | Built for MCP tool calls. Adapters for ACP, A2A, UCP. |
 | **Evidence trail** | Every decision is auditable, diffable, replayable. |
 | **Offline-first** | No backend, no API keys. Runs on your machine. |
-| **Fast** | < 5ms per tool call. |
+| **Measured** | `0.771ms` p50 / `1.913ms` p95 in the main M1 Pro/macOS tool-decision harness. |
 | **Tested** | [3 security experiments](docs/architecture/SYNTHESIS-TRUST-CHAIN-TRIFECTA-2026q2.md), 12 attack vectors, 0 false positives. |
 
 ## Install
@@ -141,6 +221,8 @@ Python SDK: `pip install assay-it`
 ## Learn More
 
 - [MCP Quickstart](examples/mcp-quickstart/) — full walkthrough with a filesystem server
+- [Policy Files](docs/reference/config/policies.md) — current YAML schema for `assay mcp wrap`
+- [OpenTelemetry & Langfuse](docs/guides/otel-langfuse.md) — turn existing traces into replay and evidence
 - [CI Guide](docs/guides/github-action.md) — GitHub Action setup
 - [OWASP MCP Top 10 Mapping](docs/security/OWASP-MCP-TOP10-MAPPING.md) — how Assay addresses each risk
 - [Evidence Store](docs/guides/evidence-store-aws-s3.md) — push bundles to S3, B2, or MinIO

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ Already tracing with Langfuse or an OTel-enabled agent stack? Keep that pipeline
 assay trace ingest-otel \
   --input otel-export.jsonl \
   --db .eval/eval.db \
-  --suite checkout-agent \
   --out-trace traces/otel.v2.jsonl
 ```
 

--- a/demo/output/screenshots/evidence-bundle-inspector.svg
+++ b/demo/output/screenshots/evidence-bundle-inspector.svg
@@ -1,0 +1,25 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="900" rx="28" fill="#0B1020"/>
+  <rect x="40" y="40" width="1520" height="820" rx="22" fill="#111827"/>
+  <rect x="40" y="40" width="1520" height="64" rx="22" fill="#1F2937"/>
+  <circle cx="86" cy="72" r="10" fill="#F87171"/>
+  <circle cx="118" cy="72" r="10" fill="#FBBF24"/>
+  <circle cx="150" cy="72" r="10" fill="#34D399"/>
+  <text x="190" y="80" fill="#93C5FD" font-family="Menlo, Monaco, Consolas, monospace" font-size="24">assay evidence show demo/fixtures/bundle.tar.gz</text>
+
+  <text x="80" y="150" fill="#F9FAFB" font-family="Menlo, Monaco, Consolas, monospace" font-size="28">Evidence Bundle Inspector</text>
+  <text x="80" y="190" fill="#6B7280" font-family="Menlo, Monaco, Consolas, monospace" font-size="24">=========================</text>
+  <text x="80" y="235" fill="#F9FAFB" font-family="Menlo, Monaco, Consolas, monospace" font-size="26">Verified:    OK</text>
+  <text x="80" y="275" fill="#F9FAFB" font-family="Menlo, Monaco, Consolas, monospace" font-size="26">Bundle ID:   sha256:634b7fef2127e156796b09339c690c9ce14d82cf1f775de63bfb11311115e4fa</text>
+  <text x="80" y="315" fill="#F9FAFB" font-family="Menlo, Monaco, Consolas, monospace" font-size="26">Producer:    assay v2.17.0</text>
+  <text x="80" y="355" fill="#F9FAFB" font-family="Menlo, Monaco, Consolas, monospace" font-size="26">Run ID:      demo-run-1</text>
+  <text x="80" y="395" fill="#F9FAFB" font-family="Menlo, Monaco, Consolas, monospace" font-size="26">Events:      2</text>
+  <text x="80" y="435" fill="#F9FAFB" font-family="Menlo, Monaco, Consolas, monospace" font-size="26">Run Root:    sha256:634b7fef2...</text>
+
+  <text x="80" y="510" fill="#93C5FD" font-family="Menlo, Monaco, Consolas, monospace" font-size="26">SEQ  TIME      TYPE                           SUBJECT</text>
+  <text x="80" y="550" fill="#F9FAFB" font-family="Menlo, Monaco, Consolas, monospace" font-size="26">0    09:54:51  assay.profile.started          urn:assay:phase:profile</text>
+  <text x="80" y="590" fill="#F9FAFB" font-family="Menlo, Monaco, Consolas, monospace" font-size="26">1    09:54:51  assay.profile.finished         urn:assay:phase:profile</text>
+
+  <text x="80" y="680" fill="#34D399" font-family="Menlo, Monaco, Consolas, monospace" font-size="28">Verified integrity</text>
+  <text x="80" y="742" fill="#9CA3AF" font-family="Menlo, Monaco, Consolas, monospace" font-size="22">Tamper-evident Evidence Bundle with content-addressed IDs and deterministic verification.</text>
+</svg>

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -10,3 +10,4 @@ Technical implementation guides and architectural patterns for Assay.
 
 *   [**CI/CD Integration**](../getting-started/ci-integration.md): Configuring Assay in GitHub Actions, GitLab CI, and other pipelines.
 *   [**Self-Correction**](../mcp/self-correction.md): Implementing runtime policy checks within MCP clients.
+*   [**OpenTelemetry & Langfuse**](otel-langfuse.md): Reuse existing traces for deterministic replay, policy gates, and evidence bundles.

--- a/docs/guides/otel-langfuse.md
+++ b/docs/guides/otel-langfuse.md
@@ -1,0 +1,82 @@
+# OpenTelemetry & Langfuse
+
+Assay does not try to replace your observability stack.
+
+Use Langfuse, OTel collectors, or your existing tracing pipeline for live visibility.
+Use Assay when you want to turn those traces into:
+
+- deterministic replay input
+- policy gates in CI
+- tamper-evident evidence bundles for audit handoff
+
+## The Flow
+
+```text
+Agent framework -> OTel / Langfuse -> JSONL export -> assay trace ingest-otel -> Assay replay + evidence
+```
+
+## 1. Export OpenTelemetry JSONL
+
+Assay's OTel ingest path expects OpenTelemetry-style JSONL spans aligned with GenAI semantic conventions.
+
+At minimum, emit:
+
+- `gen_ai.prompt`
+- `gen_ai.tool.name`
+- `gen_ai.tool.args`
+- `gen_ai.completion`
+
+If your stack already sends spans to Langfuse, keep doing that. Assay can consume the same exported trace data as a downstream governance step.
+
+## 2. Ingest Into Assay
+
+```bash
+assay trace ingest-otel \
+  --input otel-export.jsonl \
+  --db .eval/eval.db \
+  --suite checkout-agent \
+  --out-trace traces/otel.v2.jsonl
+```
+
+What this gives you:
+
+- a normalized Assay trace dataset in SQLite for structural assertions
+- an optional replay trace file for deterministic CI runs
+
+## 3. Gate and Replay
+
+```bash
+assay ci \
+  --config eval.yaml \
+  --db .eval/eval.db \
+  --trace-file traces/otel.v2.jsonl \
+  --replay-strict
+```
+
+`--replay-strict` keeps the run offline and deterministic. If a prompt is missing from the trace file, the run fails instead of calling a live model.
+
+## 4. Export Evidence
+
+```bash
+assay evidence export --profile profile.yaml --out evidence.tar.gz
+assay evidence verify evidence.tar.gz
+```
+
+Now you have both:
+
+- observability in your existing stack
+- a replayable, verifiable evidence artifact in Assay
+
+## Langfuse Positioning
+
+Langfuse is great for tracing, prompts, and production observability.
+Assay sits next to it:
+
+- Langfuse answers: "What happened in production?"
+- Assay answers: "Was this tool call allowed, reproducible, and audit-ready?"
+
+## See Also
+
+- [Testing Agents with Assay](../architecture/agents.md)
+- [MCP Quick Start](../mcp/quickstart.md)
+- [Policy Files](../reference/config/policies.md)

--- a/docs/guides/otel-langfuse.md
+++ b/docs/guides/otel-langfuse.md
@@ -34,13 +34,12 @@ If your stack already sends spans to Langfuse, keep doing that. Assay can consum
 assay trace ingest-otel \
   --input otel-export.jsonl \
   --db .eval/eval.db \
-  --suite checkout-agent \
   --out-trace traces/otel.v2.jsonl
 ```
 
 What this gives you:
 
-- a normalized Assay trace dataset in SQLite for structural assertions
+- a normalized Assay trace dataset in SQLite for downstream processing
 - an optional replay trace file for deterministic CI runs
 
 ## 3. Gate and Replay

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ curl -fsSL https://getassay.dev/install.sh | sh
 
     Validate tool calls against JSON Schema constraints, sequence rules, and allowlists. No LLM calls in CI.
 
-    [:octicons-arrow-right-24: Policy Reference](reference/policies.md)
+    [:octicons-arrow-right-24: Policy Reference](reference/config/policies.md)
 
 -   :material-package-variant-closed:{ .lg .middle } __Evidence Bundles__
 
@@ -125,5 +125,6 @@ sudo assay monitor --policy policy.yaml --pid <agent-pid>
 
 - [**Getting Started**](getting-started/index.md)
 - [**Python SDK**](getting-started/python-quickstart.md)
+- [**OpenTelemetry & Langfuse**](guides/otel-langfuse.md)
 - [**CLI Reference**](reference/cli/index.md)
 - [**Architecture**](architecture/index.md)

--- a/docs/mcp/quickstart.md
+++ b/docs/mcp/quickstart.md
@@ -193,11 +193,10 @@ If your agent stack already emits OpenTelemetry spans, import them instead of re
 assay trace ingest-otel \
   --input otel-export.jsonl \
   --db .eval/eval.db \
-  --suite my-agent \
   --out-trace traces/otel.v2.jsonl
 ```
 
-That gives you replayable Assay traces plus a database-backed dataset for assertions.
+That gives you replayable Assay traces you can reuse in your assertions pipeline.
 
 ## Next Steps
 

--- a/docs/mcp/quickstart.md
+++ b/docs/mcp/quickstart.md
@@ -7,6 +7,71 @@ Add a policy gate to your MCP server in under 5 minutes.
 - Assay CLI: `cargo install assay-cli`
 - An MCP server (any stdio-based server works)
 
+## Add Assay to Cursor, Windsurf, or Zed
+
+### Cursor
+
+Assay has a built-in helper for Cursor:
+
+```bash
+assay mcp config-path cursor
+```
+
+That command prints the detected config location plus a ready-to-paste `mcpServers` entry.
+
+### Windsurf
+
+Windsurf uses `mcpServers` in `~/.codeium/windsurf/mcp_config.json`.
+Use the same wrapped command Assay generates for Cursor:
+
+```json
+{
+  "mcpServers": {
+    "filesystem-secure": {
+      "command": "assay",
+      "args": [
+        "mcp",
+        "wrap",
+        "--policy",
+        "/path/to/policy.yaml",
+        "--",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/you"
+      ]
+    }
+  }
+}
+```
+
+### Zed
+
+Zed stores custom MCP commands under `context_servers` in the settings JSON:
+
+```json
+{
+  "context_servers": {
+    "filesystem-secure": {
+      "command": "assay",
+      "args": [
+        "mcp",
+        "wrap",
+        "--policy",
+        "/path/to/policy.yaml",
+        "--",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/you"
+      ]
+    }
+  }
+}
+```
+
+Assay only auto-detects Cursor and Claude today, but the wrapped command itself is portable across MCP clients.
+
 ## Step 1: Wrap Your Server
 
 ```bash
@@ -39,15 +104,23 @@ A policy is a YAML file that says which tools are allowed and which are denied:
 
 ```yaml
 # policy.yaml
-version: "1.0"
+version: "2.0"
 name: "my-policy"
-allow: ["read_file", "list_dir"]
-deny: ["exec", "shell", "write_file"]
-constraints:
-  - tool: "read_file"
-    params:
+
+tools:
+  allow: ["read_file", "list_dir"]
+  deny: ["exec", "shell", "write_file"]
+
+schemas:
+  read_file:
+    type: object
+    additionalProperties: false
+    properties:
       path:
-        matches: "^/app/.*"
+        type: string
+        pattern: "^/app/.*"
+        minLength: 1
+    required: ["path"]
 ```
 
 Or generate one from what your agent actually does:
@@ -112,9 +185,24 @@ assay mcp wrap \
 | `audit.ndjson` | Mandate lifecycle events |
 | `decisions.ndjson` | Tool-call ALLOW/DENY decisions |
 
+## Step 6: Reuse Existing OTel / Langfuse Traces (Optional)
+
+If your agent stack already emits OpenTelemetry spans, import them instead of recapturing everything:
+
+```bash
+assay trace ingest-otel \
+  --input otel-export.jsonl \
+  --db .eval/eval.db \
+  --suite my-agent \
+  --out-trace traces/otel.v2.jsonl
+```
+
+That gives you replayable Assay traces plus a database-backed dataset for assertions.
+
 ## Next Steps
 
 - [CI Integration Guide](../guides/github-action.md)
+- [OpenTelemetry & Langfuse](../guides/otel-langfuse.md)
 - [Evidence Store Setup](../guides/evidence-store-aws-s3.md)
 - [Full Example](../../examples/mcp-quickstart/)
 - [Architecture](../architecture/index.md)

--- a/docs/reference/config/index.md
+++ b/docs/reference/config/index.md
@@ -9,7 +9,7 @@ Learn how to configure Assay for your project.
 | File | Purpose |
 |------|---------|
 | `eval.yaml` | Main test suite configuration |
-| `policies/*.yaml` | Argument validation rules |
+| `policy.yaml` | MCP tool allow/deny rules plus per-tool JSON Schema |
 
 ---
 
@@ -37,7 +37,7 @@ output:
 ## Sections
 
 - [eval.yaml Reference](eval-yaml.md) — Full config options
-- [Policy Files](policies.md) — Argument validation schemas
+- [Policy Files](policies.md) — MCP policy YAML and JSON Schema reference
 - [Sequence Rules DSL](sequences.md) — Order constraints
 - [Migration Guide](migration.md) — Upgrading from v0
 

--- a/docs/reference/config/index.md
+++ b/docs/reference/config/index.md
@@ -9,7 +9,8 @@ Learn how to configure Assay for your project.
 | File | Purpose |
 |------|---------|
 | `eval.yaml` | Main test suite configuration |
-| `policy.yaml` | MCP tool allow/deny rules plus per-tool JSON Schema |
+| `assay.yaml` | Default MCP policy file for `assay mcp wrap` |
+| `policy.yaml` | Alternate MCP policy filename; load it with `assay mcp wrap --policy policy.yaml` |
 
 ---
 

--- a/docs/reference/config/policies.md
+++ b/docs/reference/config/policies.md
@@ -1,373 +1,260 @@
-# Policy Files
+# MCP Policy Files
 
-Detailed reference for policy YAML configuration.
+This page documents the YAML schema consumed by `assay mcp wrap`.
 
----
+Assay policy files decide:
 
-## Overview
+- which MCP tools are allowed or denied
+- how tool arguments are validated with JSON Schema
+- which tools need extra controls such as approval, scope restriction, or argument redaction
 
-Policy files define validation rules for tool arguments. They're YAML files that specify:
+## Supported Versions
 
-- Argument types (string, number, boolean, etc.)
-- Constraints (min, max, pattern, enum, etc.)
-- Required fields
-- Violation actions
+- `version: "2.0"`: current format, with per-tool JSON Schema under `schemas:`
+- `version: "1.0"`: legacy `constraints:` format
 
----
+Assay still reads v1 policies, warns once, and can migrate them with `assay policy migrate`.
 
-## File Structure
+## Minimal v2 Policy
 
 ```yaml
-# policies/customer-service.yaml
+version: "2.0"
+name: "starter"
 
-# Optional metadata
-description: "Customer service agent policies"
-version: "1.0"
-
-# Tool definitions
 tools:
-  tool_name:
-    description: "Optional description"
-    arguments:
-      arg_name:
-        type: string
-        # ... constraints
-```
+  allow: ["read_file", "list_dir"]
+  deny: ["exec", "shell", "write_file"]
 
----
-
-## Tool Definitions
-
-### Basic Structure
-
-```yaml
-tools:
-  get_customer:
-    arguments:
-      id:
-        type: string
-        required: true
-```
-
-### With Description
-
-```yaml
-tools:
-  apply_discount:
-    description: "Apply a percentage discount to an order"
-    arguments:
-      percent:
-        type: number
-        description: "Discount percentage (0-30)"
-        min: 0
-        max: 30
-```
-
----
-
-## Type Validation
-
-### Primitive Types
-
-```yaml
-arguments:
-  # String
-  name:
-    type: string
-
-  # Number (integer or float)
-  amount:
-    type: number
-
-  # Integer only
-  count:
-    type: integer
-
-  # Boolean
-  active:
-    type: boolean
-```
-
-### Complex Types
-
-```yaml
-arguments:
-  # Array
-  tags:
-    type: array
-    items:
-      type: string
-
-  # Object
-  address:
+schemas:
+  read_file:
     type: object
+    additionalProperties: false
     properties:
-      street: { type: string }
-      city: { type: string }
-```
+      path:
+        type: string
+        pattern: "^/workspace/.*"
+        minLength: 1
+        maxLength: 4096
+    required: ["path"]
 
----
-
-## Constraints
-
-### String Constraints
-
-```yaml
-arguments:
-  code:
-    type: string
-    minLength: 3          # Minimum length
-    maxLength: 10         # Maximum length
-    pattern: "^[A-Z]+$"   # Regex pattern
-    format: email         # Built-in format
-    enum:                 # Allowed values
-      - "pending"
-      - "approved"
-      - "rejected"
-```
-
-### Number Constraints
-
-```yaml
-arguments:
-  price:
-    type: number
-    min: 0                # Minimum value (inclusive)
-    max: 9999.99          # Maximum value (inclusive)
-    exclusiveMin: 0       # Minimum (exclusive)
-    exclusiveMax: 10000   # Maximum (exclusive)
-    multipleOf: 0.01      # Must be multiple of
-    enum: [1, 2, 3, 4, 5] # Allowed values
-```
-
-### Array Constraints
-
-```yaml
-arguments:
-  items:
-    type: array
-    minItems: 1           # Minimum items
-    maxItems: 100         # Maximum items
-    uniqueItems: true     # No duplicates
-    items:                # Item schema
-      type: string
-      maxLength: 50
-```
-
-### Object Constraints
-
-```yaml
-arguments:
-  config:
+  list_dir:
     type: object
+    additionalProperties: false
     properties:
-      enabled: { type: boolean }
-      threshold: { type: number, min: 0 }
-    required:
-      - enabled
-    additionalProperties: false  # No extra fields
-```
-
----
-
-## Built-in Formats
-
-| Format | Validates | Example |
-|--------|-----------|---------|
-| `email` | Email address | `user@example.com` |
-| `uri` | URI/URL | `https://example.com` |
-| `uuid` | UUID v4 | `550e8400-e29b-41d4-a716-446655440000` |
-| `date` | ISO date | `2025-12-27` |
-| `datetime` | ISO datetime | `2025-12-27T10:00:00Z` |
-| `time` | ISO time | `10:00:00` |
-| `ipv4` | IPv4 address | `192.168.1.1` |
-| `ipv6` | IPv6 address | `::1` |
-| `hostname` | Hostname | `example.com` |
-
-```yaml
-arguments:
-  email:
-    type: string
-    format: email
-
-  created_at:
-    type: string
-    format: datetime
-```
-
----
-
-## Required Fields
-
-```yaml
-arguments:
-  id:
-    type: string
-    required: true     # Must be present
-
-  nickname:
-    type: string
-    required: false    # Optional (default)
-```
-
----
-
-## Violation Actions
-
-Control behavior when validation fails:
-
-```yaml
-arguments:
-  percent:
-    type: number
-    max: 30
-    on_violation: block   # Fail the test (default)
-
-  legacy_field:
-    type: string
-    on_violation: warn    # Log warning, continue
-
-  debug_mode:
-    type: boolean
-    on_violation: log     # Silent log, continue
-```
-
-| Action | Test Result | Logs |
-|--------|-------------|------|
-| `block` | ❌ Fail | Error logged |
-| `warn` | ✅ Pass | Warning logged |
-| `log` | ✅ Pass | Debug logged |
-
----
-
-## References ($ref)
-
-Share definitions across tools:
-
-```yaml
-# policies/common.yaml
-definitions:
-  customer_id:
-    type: string
-    pattern: "^cust_[0-9]+$"
-    description: "Customer ID format: cust_<digits>"
-
-# policies/customer.yaml
-tools:
-  get_customer:
-    arguments:
-      id:
-        $ref: "common.yaml#/definitions/customer_id"
-
-  update_customer:
-    arguments:
-      id:
-        $ref: "common.yaml#/definitions/customer_id"
-      email:
+      path:
         type: string
-        format: email
+        pattern: "^/workspace/.*"
+        minLength: 1
+        maxLength: 4096
+    required: ["path"]
+
+enforcement:
+  unconstrained_tools: warn
 ```
 
----
+## Top-Level Fields
 
-## Conditional Validation
+| Field | Type | Meaning |
+|------|------|---------|
+| `version` | string | Policy schema version. Use `"2.0"` for new files. |
+| `name` | string | Optional human-readable label. |
+| `tools` | object | Allow/deny lists and obligation controls. |
+| `allow` / `deny` | list<string> | Legacy aliases merged into `tools.allow` / `tools.deny` on load. |
+| `schemas` | map<string, object> | JSON Schema per tool. `$defs` is reserved for shared definitions. |
+| `constraints` | list<object> | Legacy v1 regex constraints. Deprecated. |
+| `enforcement` | object | What to do with allowed tools that have no schema. |
+| `limits` | object | Optional request and tool-call ceilings. |
+| `signatures` | object | Optional tool-description integrity checks. |
+| `tool_pins` | map<string, object> | Cryptographic pins for expected tool identity. |
+| `discovery` | object | Advanced runtime discovery settings. |
+| `runtime_monitor` | object | Advanced runtime monitoring rules. |
+| `kill_switch` | object | Advanced kill-switch triggers. |
 
-*(Advanced, v1.1+)*
+Unknown fields are ignored with a warning, so it is worth keeping this page and your checked-in policies aligned.
+
+## `tools:` Fields
+
+The `tools` section handles both filtering and extra controls.
+
+| Field | Type | Meaning |
+|------|------|---------|
+| `allow` | list<string> | Allowed tool names or wildcard patterns. |
+| `deny` | list<string> | Blocked tool names or wildcard patterns. |
+| `allow_classes` | list<string> | Allow by tool taxonomy class. |
+| `deny_classes` | list<string> | Deny by tool taxonomy class. |
+| `approval_required` | list<string> | Tools that require a valid approval artifact. |
+| `approval_required_classes` | list<string> | Approval requirement by tool class. |
+| `restrict_scope` | list<string> | Tools whose arguments must match a scope contract. |
+| `restrict_scope_classes` | list<string> | Scope restriction by tool class. |
+| `restrict_scope_contract` | object | Shared contract used for `restrict_scope`. |
+| `redact_args` | list<string> | Tools whose arguments should be redacted. |
+| `redact_args_classes` | list<string> | Redaction by tool class. |
+| `redact_args_contract` | object | Shared contract used for `redact_args`. |
+
+### Wildcards
+
+Assay uses simple `*` wildcards:
+
+- `"*"` matches all tools
+- `"read_*"` matches by prefix
+- `"*_file"` matches by suffix
+- `"*search*"` matches by substring
+- patterns without `*` are exact matches
+
+## JSON Schema in `schemas:`
+
+Each tool can have a full JSON Schema for its argument object:
 
 ```yaml
-arguments:
-  payment_type:
-    type: string
-    enum: ["card", "bank_transfer"]
-
-  card_number:
-    type: string
-    pattern: "^[0-9]{16}$"
-    required_if:
-      payment_type: "card"
-
-  account_number:
-    type: string
-    required_if:
-      payment_type: "bank_transfer"
+schemas:
+  create_ticket:
+    type: object
+    additionalProperties: false
+    properties:
+      title:
+        type: string
+        minLength: 5
+        maxLength: 120
+      priority:
+        type: string
+        enum: ["low", "medium", "high"]
+      labels:
+        type: array
+        items:
+          type: string
+          maxLength: 32
+    required: ["title", "priority"]
 ```
 
----
+Recommended defaults for security-sensitive tools:
 
-## Complete Example
+- `additionalProperties: false`
+- `minLength: 1` on required strings
+- explicit `required: [...]`
+- bounded arrays and strings
+
+If a call violates the schema, Assay denies it with `E_ARG_SCHEMA`.
+
+## Shared Definitions With `$defs`
+
+Assay supports local shared definitions via `$defs`.
+Use `#/$defs/...` references inside tool schemas.
 
 ```yaml
-# policies/ecommerce.yaml
-description: "E-commerce agent validation rules"
+schemas:
+  $defs:
+    safe_path:
+      type: string
+      pattern: "^/workspace/.*"
+      minLength: 1
+      maxLength: 4096
+
+  read_file:
+    type: object
+    additionalProperties: false
+    properties:
+      path:
+        $ref: "#/$defs/safe_path"
+    required: ["path"]
+```
+
+## Enforcement
+
+Allowed tools can still be considered unsafe if you do not attach a schema.
+`enforcement.unconstrained_tools` decides what happens then:
+
+```yaml
+enforcement:
+  unconstrained_tools: warn
+```
+
+Supported values:
+
+- `warn`: allow the tool, but emit `E_TOOL_UNCONSTRAINED`
+- `deny`: block allowed tools that have no schema
+- `allow`: silently allow unconstrained tools
+
+## Limits
+
+```yaml
+limits:
+  max_requests_total: 1000
+  max_tool_calls_total: 500
+```
+
+Exceeding these limits produces `E_RATE_LIMIT`.
+
+## Approval, Scope Restriction, and Redaction
+
+These controls sit next to ordinary allow/deny rules:
+
+```yaml
+tools:
+  allow: ["read_file", "deploy_release", "create_ticket"]
+  approval_required: ["deploy_release"]
+  restrict_scope: ["read_file"]
+  redact_args: ["create_ticket"]
+
+  restrict_scope_contract:
+    scope_type: "path_prefix"
+    scope_value: "/workspace"
+    scope_match_mode: "prefix"
+
+  redact_args_contract:
+    redaction_target: "args"
+    redaction_mode: "mask"
+    redaction_scope: "sensitive_fields"
+```
+
+Use these when you want:
+
+- explicit human approval for risky tools
+- runtime enforcement that file or resource arguments stay in-bounds
+- redaction of secrets before downstream logging or evidence export
+
+## Tool Pins
+
+`tool_pins` protect against tool-definition drift by pinning the expected server, tool name, and hashes:
+
+```yaml
+tool_pins:
+  read_file:
+    server_id: "filesystem-prod"
+    tool_name: "read_file"
+    schema_hash: "9f4d4d0f..."
+    meta_hash: "42f5df3e..."
+```
+
+## Legacy v1 Compatibility
+
+Legacy v1 policies use `constraints:`:
+
+```yaml
 version: "1.0"
-
-tools:
-  add_to_cart:
-    description: "Add item to shopping cart"
-    arguments:
-      product_id:
-        type: string
-        required: true
-        pattern: "^prod_[a-z0-9]+$"
-      quantity:
-        type: integer
-        required: true
-        min: 1
-        max: 99
-
-  apply_coupon:
-    description: "Apply a coupon code"
-    arguments:
-      code:
-        type: string
-        required: true
-        pattern: "^[A-Z0-9]{6,12}$"
-        description: "Coupon code (6-12 alphanumeric chars)"
-
-  process_payment:
-    description: "Process payment for order"
-    arguments:
-      order_id:
-        type: string
-        required: true
-      amount:
-        type: number
-        required: true
-        min: 0.01
-        max: 10000
-      currency:
-        type: string
-        required: true
-        enum: ["USD", "EUR", "GBP"]
-      card_token:
-        type: string
-        required: true
-        description: "Tokenized card (never raw card numbers)"
-
-  refund:
-    description: "Process refund"
-    arguments:
-      order_id:
-        type: string
-        required: true
-      amount:
-        type: number
-        required: true
-        min: 0.01
-      reason:
-        type: string
-        required: true
-        enum:
-          - "customer_request"
-          - "item_defective"
-          - "wrong_item"
-          - "other"
+deny: ["exec"]
+constraints:
+  - tool: "read_file"
+    params:
+      path:
+        matches: "^/workspace/.*"
 ```
 
----
+Assay loads this shape, warns, normalizes `allow` / `deny` into `tools.*`, and auto-migrates constraints into in-memory JSON Schemas.
+
+To write the v2 form to disk:
+
+```bash
+assay policy migrate --input policy.yaml
+```
+
+To fail CI if deprecated constructs are still present:
+
+```bash
+assay policy validate --deny-deprecations --input policy.yaml
+```
 
 ## See Also
 
-- [Policies Concept](../concepts/policies.md)
-- [args_valid Metric](../metrics/args-valid.md)
-- [Sequence Rules](sequences.md)
+- [MCP Quick Start](../../mcp/quickstart.md)
+- [OpenTelemetry & Langfuse](../../guides/otel-langfuse.md)
+- [Migration Guide](../../migration/v1-to-v2.md)

--- a/examples/mcp-quickstart/README.md
+++ b/examples/mcp-quickstart/README.md
@@ -38,24 +38,38 @@ You'll see decisions for every tool call:
 
 ```yaml
 # policy.yaml - minimal MCP guardrail
-version: "1.0"
+version: "2.0"
 name: "mcp-quickstart"
-allow:
-  - "read_file"
-  - "list_dir"
-deny:
-  - "exec"
-  - "shell"
-  - "write_file"
-constraints:
-  - tool: "read_file"
-    params:
+
+tools:
+  allow:
+    - "read_file"
+    - "list_dir"
+  deny:
+    - "exec"
+    - "shell"
+    - "write_file"
+
+schemas:
+  read_file:
+    type: object
+    additionalProperties: false
+    properties:
       path:
-        matches: "^/tmp/assay-demo/.*"
-  - tool: "list_dir"
-    params:
+        type: string
+        pattern: "^/tmp/assay-demo/.*"
+        minLength: 1
+    required: ["path"]
+
+  list_dir:
+    type: object
+    additionalProperties: false
+    properties:
       path:
-        matches: "^/tmp/assay-demo/.*"
+        type: string
+        pattern: "^/tmp/assay-demo/.*"
+        minLength: 1
+    required: ["path"]
 ```
 
 ## Next steps

--- a/examples/mcp-quickstart/policy.yaml
+++ b/examples/mcp-quickstart/policy.yaml
@@ -1,18 +1,34 @@
-version: "1.0"
+version: "2.0"
 name: "mcp-quickstart"
-allow:
-  - "read_file"
-  - "list_dir"
-deny:
-  - "exec"
-  - "shell"
-  - "write_file"
-constraints:
-  - tool: "read_file"
-    params:
+
+tools:
+  allow:
+    - "read_file"
+    - "list_dir"
+  deny:
+    - "exec"
+    - "shell"
+    - "write_file"
+
+schemas:
+  read_file:
+    type: object
+    additionalProperties: false
+    properties:
       path:
-        matches: "^/tmp/assay-demo/.*"
-  - tool: "list_dir"
-    params:
+        type: string
+        pattern: "^/tmp/assay-demo/.*"
+        minLength: 1
+    required:
+      - "path"
+
+  list_dir:
+    type: object
+    additionalProperties: false
+    properties:
       path:
-        matches: "^/tmp/assay-demo/.*"
+        type: string
+        pattern: "^/tmp/assay-demo/.*"
+        minLength: 1
+    required:
+      - "path"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -203,6 +203,7 @@ nav:
     - guides/index.md
     - Sandbox Security: guides/sandbox-security.md
     - Gateway Pattern: guides/gateway-pattern.md
+    - OpenTelemetry & Langfuse: guides/otel-langfuse.md
 
   - Architecture:
     - architecture/index.md


### PR DESCRIPTION
## Summary
- tighten the README with an evidence bundle visual, measured latency proof points, and Cursor/Windsurf/Zed onboarding
- add an OpenTelemetry/Langfuse guide and wire it into docs navigation
- update the MCP quickstart and example policy to the current v2 JSON Schema format
- rewrite the MCP policy reference to match the live `assay mcp wrap` policy shape

## Verification
- `cargo run -q -p assay-cli -- policy validate --input examples/mcp-quickstart/policy.yaml`
- `git diff --check`