### PR TITLE
Wave O1: export monitor ringbuf pressure telemetry

### DIFF
--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -365,5 +365,37 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         }
     }
 
+    match monitor.snapshot_stats() {
+        Ok(stats) => {
+            emit_err!("Monitor summary:");
+            emit_err!(
+                "  • Tracepoint ringbuf: emitted={} dropped={}",
+                stats.tracepoint_events_emitted,
+                stats.tracepoint_ringbuf_dropped
+            );
+            emit_err!(
+                "  • LSM ringbuf:        emitted={} dropped={}",
+                stats.lsm_events_emitted,
+                stats.lsm_ringbuf_dropped
+            );
+            emit_err!(
+                "  • Socket policy:      checks={} blocked_cidr={} blocked_port={} allowed={} emitted={} dropped={}",
+                stats.socket_checks,
+                stats.socket_blocked_cidr,
+                stats.socket_blocked_port,
+                stats.socket_allowed,
+                stats.socket_events_emitted,
+                stats.socket_ringbuf_dropped
+            );
+            if stats.has_ringbuf_pressure() {
+                emit_err!(
+                    "  ⚠️  Ring buffer pressure detected: {} dropped event(s)",
+                    stats.total_ringbuf_dropped()
+                );
+            }
+        }
+        Err(e) => emit_err!("Warning: Failed to read monitor stats: {}", e),
+    }
+
     Ok(exit_codes::OK)
 }

--- a/crates/assay-common/src/lib.rs
+++ b/crates/assay-common/src/lib.rs
@@ -20,6 +20,20 @@ pub const EVENT_CONNECT_BLOCKED: u32 = 20;
 
 pub const DATA_LEN: usize = 512;
 
+pub const MONITOR_STATS_LEN: u32 = 10;
+pub const MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED: u32 = 0;
+pub const MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED: u32 = 1;
+pub const MONITOR_STAT_LSM_EVENTS_EMITTED: u32 = 2;
+pub const MONITOR_STAT_LSM_RINGBUF_DROPPED: u32 = 3;
+
+pub const SOCKET_STATS_LEN: u32 = 8;
+pub const SOCKET_STAT_CHECKS: u32 = 0;
+pub const SOCKET_STAT_BLOCKED_CIDR: u32 = 1;
+pub const SOCKET_STAT_BLOCKED_PORT: u32 = 2;
+pub const SOCKET_STAT_ALLOWED: u32 = 3;
+pub const SOCKET_STAT_EVENTS_EMITTED: u32 = 4;
+pub const SOCKET_STAT_RINGBUF_DROPPED: u32 = 5;
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MonitorEvent {

--- a/crates/assay-ebpf/src/lsm.rs
+++ b/crates/assay-ebpf/src/lsm.rs
@@ -2,7 +2,9 @@ use crate::vmlinux::{file, inode, super_block};
 use crate::{
     CONFIG, DENY_INO, LSM_BYPASS, LSM_DENY, LSM_EVENTS, LSM_HIT, MONITORED_CGROUPS, STATS,
 };
-use assay_common::KEY_MONITOR_ALL;
+use assay_common::{
+    KEY_MONITOR_ALL, MONITOR_STAT_LSM_EVENTS_EMITTED, MONITOR_STAT_LSM_RINGBUF_DROPPED,
+};
 use aya_ebpf::{
     helpers::{bpf_get_current_cgroup_id, bpf_get_current_pid_tgid, bpf_probe_read_kernel},
     macros::{lsm, map},
@@ -17,6 +19,13 @@ const FILE_BLOCKED_DEV_OFFSET: usize = 0;
 const FILE_BLOCKED_INO_OFFSET: usize = 8;
 const FILE_BLOCKED_CGROUP_OFFSET: usize = 16;
 const FILE_BLOCKED_RULE_ID_OFFSET: usize = 24;
+
+#[inline(always)]
+fn inc_stat(index: u32) {
+    if let Some(val) = STATS.get_ptr_mut(index) {
+        unsafe { *val += 1 };
+    }
+}
 
 #[map]
 static DENY_PATHS_EXACT: HashMap<u64, u32> = HashMap::with_max_entries(MAX_DENY_PATHS, 0);
@@ -72,7 +81,10 @@ fn emit_event(
             }
         }
         entry.submit(0);
+        inc_stat(MONITOR_STAT_LSM_EVENTS_EMITTED);
         info!(ctx, "LSM Event {} Submitted", event_id);
+    } else {
+        inc_stat(MONITOR_STAT_LSM_RINGBUF_DROPPED);
     }
 }
 

--- a/crates/assay-ebpf/src/main.rs
+++ b/crates/assay-ebpf/src/main.rs
@@ -14,7 +14,10 @@ pub mod socket_lsm;
 #[allow(clippy::all)]
 pub mod vmlinux;
 
-use assay_common::{MonitorEvent, EVENT_CONNECT, KEY_MONITOR_ALL};
+use assay_common::{
+    MonitorEvent, EVENT_CONNECT, KEY_MONITOR_ALL, MONITOR_STATS_LEN,
+    MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
+};
 use aya_ebpf::{
     helpers::{
         bpf_get_current_ancestor_cgroup_id, bpf_get_current_cgroup_id, bpf_get_current_pid_tgid,
@@ -27,6 +30,13 @@ use aya_ebpf::{
 #[inline(always)]
 fn current_tgid() -> u32 {
     (bpf_get_current_pid_tgid() >> 32) as u32
+}
+
+#[inline(always)]
+fn inc_stat(index: u32) {
+    if let Some(val) = STATS.get_ptr_mut(index) {
+        unsafe { *val += 1 };
+    }
 }
 
 #[map]
@@ -65,7 +75,7 @@ pub static DENY_INO: HashMap<assay_common::InodeKeyMap, u32> = HashMap::with_max
 pub static LSM_EVENTS: RingBuf = RingBuf::with_byte_size(256 * 1024, 0);
 
 #[map]
-pub static STATS: Array<u32> = Array::with_max_entries(10, 0);
+pub static STATS: Array<u32> = Array::with_max_entries(MONITOR_STATS_LEN, 0);
 
 const KEY_OFFSET_FILENAME: u32 = 0;
 const KEY_OFFSET_SOCKADDR: u32 = 1;
@@ -218,6 +228,9 @@ fn try_connect(ctx: TracePointContext) -> Result<u32, u32> {
             core::ptr::copy_nonoverlapping(raw_sockaddr.as_ptr(), data_ptr, n);
         }
         entry.submit(0);
+        inc_stat(MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED);
+    } else {
+        inc_stat(MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED);
     }
 
     Ok(0)
@@ -267,6 +280,9 @@ fn try_fork(ctx: TracePointContext) -> Result<u32, u32> {
             core::ptr::write(data_ptr as *mut u32, child_pid);
         }
         entry.submit(0);
+        inc_stat(MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED);
+    } else {
+        inc_stat(MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED);
     }
 
     Ok(0)

--- a/crates/assay-ebpf/src/socket_lsm.rs
+++ b/crates/assay-ebpf/src/socket_lsm.rs
@@ -1,3 +1,7 @@
+use assay_common::{
+    SOCKET_STATS_LEN, SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR, SOCKET_STAT_BLOCKED_PORT,
+    SOCKET_STAT_CHECKS, SOCKET_STAT_EVENTS_EMITTED, SOCKET_STAT_RINGBUF_DROPPED,
+};
 use aya_ebpf::{
     bindings::bpf_sock_addr,
     helpers::{bpf_get_current_cgroup_id, bpf_get_current_pid_tgid, bpf_ktime_get_ns},
@@ -31,12 +35,7 @@ static ALLOW_PORTS: HashMap<u16, u8> = HashMap::with_max_entries(MAX_PORT_RULES,
 static SOCKET_EVENTS: RingBuf = RingBuf::with_byte_size(128 * 1024, 0);
 
 #[map]
-static SOCKET_STATS: Array<u64> = Array::with_max_entries(8, 0);
-
-const STAT_CHECKS: u32 = 0;
-const STAT_BLOCKED_CIDR: u32 = 1;
-const STAT_BLOCKED_PORT: u32 = 2;
-const STAT_ALLOWED: u32 = 3;
+static SOCKET_STATS: Array<u64> = Array::with_max_entries(SOCKET_STATS_LEN, 0);
 
 #[repr(C)]
 struct SocketEvent {
@@ -68,7 +67,7 @@ pub fn connect4_hook(ctx: SockAddrContext) -> i32 {
 
 #[inline(always)]
 fn try_connect4(ctx: &SockAddrContext) -> Result<bool, i64> {
-    inc_stat(STAT_CHECKS);
+    inc_stat(SOCKET_STAT_CHECKS);
 
     let cgroup_id = unsafe { bpf_get_current_cgroup_id() };
     let sock_addr = unsafe { &*(ctx.as_ptr() as *const bpf_sock_addr) };
@@ -85,12 +84,12 @@ fn try_connect4(ctx: &SockAddrContext) -> Result<bool, i64> {
             rule_id,
             0,
         );
-        inc_stat(STAT_BLOCKED_PORT);
+        inc_stat(SOCKET_STAT_BLOCKED_PORT);
         return Ok(false);
     }
 
     if unsafe { ALLOW_PORTS.get(&dst_port).is_some() } {
-        inc_stat(STAT_ALLOWED);
+        inc_stat(SOCKET_STAT_ALLOWED);
         return Ok(true);
     }
 
@@ -143,13 +142,13 @@ fn try_connect4(ctx: &SockAddrContext) -> Result<bool, i64> {
                 action, // Use the value from map as rule_id (assuming we change map to store rule_id)
                 0,
             );
-            inc_stat(STAT_BLOCKED_CIDR);
+            inc_stat(SOCKET_STAT_BLOCKED_CIDR);
             return Ok(false);
         }
     }
 
     // Correctly close try_connect4
-    inc_stat(STAT_ALLOWED);
+    inc_stat(SOCKET_STAT_ALLOWED);
     Ok(true)
 }
 
@@ -169,7 +168,7 @@ pub fn connect6_hook(ctx: SockAddrContext) -> i32 {
 
 #[inline(always)]
 fn try_connect6(ctx: &SockAddrContext) -> Result<bool, i64> {
-    inc_stat(STAT_CHECKS);
+    inc_stat(SOCKET_STAT_CHECKS);
 
     let cgroup_id = unsafe { bpf_get_current_cgroup_id() };
     let sock_addr = unsafe { &*(ctx.as_ptr() as *const bpf_sock_addr) };
@@ -187,12 +186,12 @@ fn try_connect6(ctx: &SockAddrContext) -> Result<bool, i64> {
             rule_id,
             0,
         );
-        inc_stat(STAT_BLOCKED_PORT);
+        inc_stat(SOCKET_STAT_BLOCKED_PORT);
         return Ok(false);
     }
 
     if unsafe { ALLOW_PORTS.get(&dst_port).is_some() } {
-        inc_stat(STAT_ALLOWED);
+        inc_stat(SOCKET_STAT_ALLOWED);
         return Ok(true);
     }
 
@@ -210,12 +209,12 @@ fn try_connect6(ctx: &SockAddrContext) -> Result<bool, i64> {
                 action, // Use rule_id
                 0,
             );
-            inc_stat(STAT_BLOCKED_CIDR);
+            inc_stat(SOCKET_STAT_BLOCKED_CIDR);
             return Ok(false);
         }
     }
 
-    inc_stat(STAT_ALLOWED);
+    inc_stat(SOCKET_STAT_ALLOWED);
     Ok(true)
 }
 
@@ -253,5 +252,8 @@ fn emit_socket_event(
             ev.addr_v6[i] = addr_v6[i];
         }
         event.submit(0);
+        inc_stat(SOCKET_STAT_EVENTS_EMITTED);
+    } else {
+        inc_stat(SOCKET_STAT_RINGBUF_DROPPED);
     }
 }

--- a/crates/assay-monitor/Cargo.toml
+++ b/crates/assay-monitor/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-assay-common = { workspace = true }
+assay-common = { workspace = true, features = ["std"] }
 assay-policy.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true

--- a/crates/assay-monitor/src/lib.rs
+++ b/crates/assay-monitor/src/lib.rs
@@ -14,6 +14,32 @@ use assay_common::MonitorEvent;
 // We use the alias from events, or define it here.
 pub type EventStream = tokio_stream::wrappers::ReceiverStream<Result<MonitorEvent, MonitorError>>;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MonitorStatsSnapshot {
+    pub tracepoint_events_emitted: u32,
+    pub tracepoint_ringbuf_dropped: u32,
+    pub lsm_events_emitted: u32,
+    pub lsm_ringbuf_dropped: u32,
+    pub socket_checks: u64,
+    pub socket_blocked_cidr: u64,
+    pub socket_blocked_port: u64,
+    pub socket_allowed: u64,
+    pub socket_events_emitted: u64,
+    pub socket_ringbuf_dropped: u64,
+}
+
+impl MonitorStatsSnapshot {
+    pub fn total_ringbuf_dropped(&self) -> u64 {
+        u64::from(self.tracepoint_ringbuf_dropped)
+            + u64::from(self.lsm_ringbuf_dropped)
+            + self.socket_ringbuf_dropped
+    }
+
+    pub fn has_ringbuf_pressure(&self) -> bool {
+        self.total_ringbuf_dropped() > 0
+    }
+}
+
 pub struct Monitor {
     #[cfg(target_os = "linux")]
     inner: loader::LinuxMonitor,
@@ -150,5 +176,31 @@ impl Monitor {
 
         #[cfg(not(target_os = "linux"))]
         Err(MonitorError::NotSupported)
+    }
+
+    pub fn snapshot_stats(&mut self) -> Result<MonitorStatsSnapshot, MonitorError> {
+        #[cfg(target_os = "linux")]
+        return self.inner.snapshot_stats();
+
+        #[cfg(not(target_os = "linux"))]
+        Err(MonitorError::NotSupported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MonitorStatsSnapshot;
+
+    #[test]
+    fn monitor_stats_snapshot_reports_ringbuf_pressure() {
+        let stats = MonitorStatsSnapshot {
+            tracepoint_ringbuf_dropped: 2,
+            lsm_ringbuf_dropped: 1,
+            socket_ringbuf_dropped: 3,
+            ..Default::default()
+        };
+
+        assert!(stats.has_ringbuf_pressure());
+        assert_eq!(stats.total_ringbuf_dropped(), 6);
     }
 }

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -1,10 +1,15 @@
 use crate::events::{self, EventStream};
-use crate::MonitorError;
-use assay_common::KEY_MONITOR_ALL;
+use crate::{MonitorError, MonitorStatsSnapshot};
+use assay_common::{
+    KEY_MONITOR_ALL, MONITOR_STAT_LSM_EVENTS_EMITTED, MONITOR_STAT_LSM_RINGBUF_DROPPED,
+    MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
+    SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR, SOCKET_STAT_BLOCKED_PORT, SOCKET_STAT_CHECKS,
+    SOCKET_STAT_EVENTS_EMITTED, SOCKET_STAT_RINGBUF_DROPPED,
+};
 use assay_policy::tiers::CompiledPolicy;
 use aya::maps::lpm_trie::Key;
 use aya::{
-    maps::{HashMap as AyaHashMap, LpmTrie, RingBuf},
+    maps::{Array as AyaArray, HashMap as AyaHashMap, LpmTrie, RingBuf},
     programs::{Lsm, TracePoint},
     Btf, Ebpf,
 };
@@ -295,6 +300,36 @@ impl LinuxMonitor {
     ) -> Result<(), MonitorError> {
         // Stub for compatibility
         Ok(())
+    }
+
+    pub fn snapshot_stats(&mut self) -> Result<MonitorStatsSnapshot, MonitorError> {
+        let bpf = self.bpf.lock().unwrap();
+        let mut stats = MonitorStatsSnapshot::default();
+
+        if let Some(map) = bpf.map("STATS") {
+            let array: AyaArray<_, u32> = AyaArray::try_from(map)?;
+            stats.tracepoint_events_emitted = array
+                .get(&MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, 0)
+                .unwrap_or(0);
+            stats.tracepoint_ringbuf_dropped = array
+                .get(&MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED, 0)
+                .unwrap_or(0);
+            stats.lsm_events_emitted = array.get(&MONITOR_STAT_LSM_EVENTS_EMITTED, 0).unwrap_or(0);
+            stats.lsm_ringbuf_dropped =
+                array.get(&MONITOR_STAT_LSM_RINGBUF_DROPPED, 0).unwrap_or(0);
+        }
+
+        if let Some(map) = bpf.map("SOCKET_STATS") {
+            let array: AyaArray<_, u64> = AyaArray::try_from(map)?;
+            stats.socket_checks = array.get(&SOCKET_STAT_CHECKS, 0).unwrap_or(0);
+            stats.socket_blocked_cidr = array.get(&SOCKET_STAT_BLOCKED_CIDR, 0).unwrap_or(0);
+            stats.socket_blocked_port = array.get(&SOCKET_STAT_BLOCKED_PORT, 0).unwrap_or(0);
+            stats.socket_allowed = array.get(&SOCKET_STAT_ALLOWED, 0).unwrap_or(0);
+            stats.socket_events_emitted = array.get(&SOCKET_STAT_EVENTS_EMITTED, 0).unwrap_or(0);
+            stats.socket_ringbuf_dropped = array.get(&SOCKET_STAT_RINGBUF_DROPPED, 0).unwrap_or(0);
+        }
+
+        Ok(stats)
     }
 
     pub fn listen(&mut self) -> Result<EventStream, MonitorError> {

--- a/docs/contributing/SPLIT-CHECKLIST-wave-o1-ringbuf-telemetry-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave-o1-ringbuf-telemetry-step1.md
@@ -1,0 +1,30 @@
+# SPLIT CHECKLIST — Wave O1 Ringbuf Telemetry Step1
+
+## Scope discipline
+- [ ] Only allowlisted files changed for this step
+- [ ] No `.github/workflows/*` changes
+- [ ] No `crates/assay-core/src/engine/*` changes
+- [ ] No registry, Python SDK, fuzz, or release-workflow changes
+- [ ] No new CLI flags or command modes
+
+## Contract checks
+- [ ] Kernel tracepoint paths increment emit/drop counters
+- [ ] LSM path increments emit/drop counters
+- [ ] Socket path increments emit/drop counters
+- [ ] Userspace can snapshot both `STATS` and `SOCKET_STATS`
+- [ ] `assay monitor` prints an end-of-run summary
+- [ ] Ring-buffer pressure is surfaced as an explicit warning when any drop counter is non-zero
+
+## Non-goals
+- [ ] No policy-evaluation OTel spans in this step
+- [ ] No trust-root implementation changes in this step
+- [ ] No workflow or release artifact changes in this step
+
+## Validation
+- [ ] `BASE_REF=origin/codex/codebase-analysis-followups bash scripts/ci/review-wave-o1-ringbuf-telemetry-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-monitor -p assay-cli --all-targets -- -D warnings` passes
+- [ ] `cargo check -p assay-monitor` passes
+- [ ] `cargo test -p assay-monitor` passes
+- [ ] `cargo check -p assay-cli` passes
+- [ ] eBPF target check is either green or explicitly skipped because `bpfel-unknown-none` is not installed

--- a/docs/contributing/SPLIT-INVENTORY-wave-o1-ringbuf-telemetry-step1.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave-o1-ringbuf-telemetry-step1.md
@@ -1,0 +1,57 @@
+# SPLIT INVENTORY — Wave O1 Ringbuf Telemetry Step1
+
+## Stack context
+- Base branch: `codex/codebase-analysis-followups`
+- Step branch: `codex/codebase-analysis-observability`
+- Intent: export ring-buffer emit/drop pressure from kernel monitor paths through userspace and surface it in `assay monitor`
+
+## Scope lock
+- In scope:
+  - shared monitor/socket stat IDs in `assay-common`
+  - kernel-side emit/drop counters in `assay-ebpf`
+  - userspace stats snapshot + summary rendering in `assay-monitor` and `assay-cli`
+  - monitor crate build hygiene needed to validate the touched code path
+- Out of scope:
+  - policy-evaluation OpenTelemetry spans
+  - registry trust-root work
+  - Python SDK, fuzzing, SBOM, docs positioning, workflows
+  - new CLI flags or changed monitor attach semantics
+
+## Touched implementation files
+- `crates/assay-common/src/lib.rs`
+- `crates/assay-ebpf/src/main.rs`
+- `crates/assay-ebpf/src/lsm.rs`
+- `crates/assay-ebpf/src/socket_lsm.rs`
+- `crates/assay-monitor/Cargo.toml`
+- `crates/assay-monitor/src/lib.rs`
+- `crates/assay-monitor/src/loader.rs`
+- `crates/assay-cli/src/cli/commands/monitor_next/mod.rs`
+
+## Public surface inventory
+- New public type: `assay_monitor::MonitorStatsSnapshot`
+- New public method: `assay_monitor::Monitor::snapshot_stats()`
+- Existing CLI surface preserved:
+  - no new flags
+  - no removed flags
+  - monitor prints an end-of-run summary only after the event loop exits
+
+## LOC baseline vs current
+
+| File | Base LOC | Current LOC | Delta |
+|---|---:|---:|---:|
+| `crates/assay-common/src/lib.rs` | 197 | 211 | +14 |
+| `crates/assay-ebpf/src/main.rs` | 273 | 289 | +16 |
+| `crates/assay-ebpf/src/lsm.rs` | 257 | 269 | +12 |
+| `crates/assay-ebpf/src/socket_lsm.rs` | 257 | 259 | +2 |
+| `crates/assay-monitor/Cargo.toml` | 24 | 24 | +0 |
+| `crates/assay-monitor/src/lib.rs` | 154 | 206 | +52 |
+| `crates/assay-monitor/src/loader.rs` | 345 | 380 | +35 |
+| `crates/assay-cli/src/cli/commands/monitor_next/mod.rs` | 369 | 401 | +32 |
+
+## Validation target
+- `cargo fmt --check`
+- `cargo clippy -p assay-monitor -p assay-cli --all-targets -- -D warnings`
+- `cargo check -p assay-monitor`
+- `cargo test -p assay-monitor`
+- `cargo check -p assay-cli`
+- Optional: `cargo check -p assay-ebpf --features ebpf --target bpfel-unknown-none` when the target is installed

--- a/docs/contributing/SPLIT-MOVE-MAP-wave-o1-ringbuf-telemetry-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave-o1-ringbuf-telemetry-step1.md
@@ -1,0 +1,26 @@
+# SPLIT MOVE MAP — Wave O1 Ringbuf Telemetry Step1
+
+## Intent
+This step is additive telemetry only. There is no facade split and no behavior move from one module tree to another.
+
+## Data flow map
+1. `crates/assay-common/src/lib.rs`
+   - defines shared stat slot IDs for tracepoint, LSM, and socket monitor paths
+2. `crates/assay-ebpf/src/main.rs`
+   - increments tracepoint emit/drop counters when `EVENTS.reserve()` succeeds or fails
+3. `crates/assay-ebpf/src/lsm.rs`
+   - increments LSM emit/drop counters when `LSM_EVENTS.reserve()` succeeds or fails
+4. `crates/assay-ebpf/src/socket_lsm.rs`
+   - increments socket checks / allowed / blocked / emitted / dropped counters
+5. `crates/assay-monitor/src/loader.rs`
+   - reads `STATS` and `SOCKET_STATS` maps into a userspace snapshot
+6. `crates/assay-monitor/src/lib.rs`
+   - exposes `MonitorStatsSnapshot` and `Monitor::snapshot_stats()`
+7. `crates/assay-cli/src/cli/commands/monitor_next/mod.rs`
+   - renders the final monitor summary and explicit pressure warning
+
+## Reviewer focus
+- Counter IDs remain shared and consistent across kernel/userspace
+- No event payload ABI changes are introduced here
+- Summary output is post-loop only and does not alter live event handling
+- `assay-monitor` build hygiene change is limited to enabling the `std` feature needed by the touched crate

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave-o1-ringbuf-telemetry-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave-o1-ringbuf-telemetry-step1.md
@@ -1,0 +1,47 @@
+# SPLIT REVIEW PACK — Wave O1 Ringbuf Telemetry Step1
+
+## Intent
+Make ring-buffer pressure observable in the Linux runtime monitor path without changing monitor policy semantics or broadening the current stacked scope.
+
+## Allowed files
+- `crates/assay-common/src/lib.rs`
+- `crates/assay-ebpf/src/main.rs`
+- `crates/assay-ebpf/src/lsm.rs`
+- `crates/assay-ebpf/src/socket_lsm.rs`
+- `crates/assay-monitor/Cargo.toml`
+- `crates/assay-monitor/src/lib.rs`
+- `crates/assay-monitor/src/loader.rs`
+- `crates/assay-cli/src/cli/commands/monitor_next/mod.rs`
+- `docs/contributing/SPLIT-INVENTORY-wave-o1-ringbuf-telemetry-step1.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave-o1-ringbuf-telemetry-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave-o1-ringbuf-telemetry-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave-o1-ringbuf-telemetry-step1.md`
+- `scripts/ci/review-wave-o1-ringbuf-telemetry-step1.sh`
+
+## What reviewers should verify
+1. The diff stays inside the allowlist above.
+2. Shared stat-slot constants are defined once in `assay-common`.
+3. Every kernel ring-buffer producer now distinguishes reserve success vs failure.
+4. Userspace can read the new counters without changing monitor attach/listen behavior.
+5. The CLI prints a deterministic summary and a clear warning when drops occur.
+6. No `assay-core` runner or OTel policy-eval work appears in this step.
+
+## Proof snippets
+- Kernel counters:
+  - `MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED`
+  - `MONITOR_STAT_LSM_RINGBUF_DROPPED`
+  - `SOCKET_STAT_RINGBUF_DROPPED`
+- Userspace export:
+  - `MonitorStatsSnapshot`
+  - `snapshot_stats()`
+- CLI surfacing:
+  - `Monitor summary:`
+  - `Ring buffer pressure detected`
+
+## Reviewer command
+```bash
+BASE_REF=origin/codex/codebase-analysis-followups bash scripts/ci/review-wave-o1-ringbuf-telemetry-step1.sh
+```
+
+## Validation note
+The reviewer script runs the monitor and CLI checks directly. The eBPF target check is conditional and prints `SKIP` when `bpfel-unknown-none` is unavailable locally.

--- a/scripts/ci/review-wave-o1-ringbuf-telemetry-step1.sh
+++ b/scripts/ci/review-wave-o1-ringbuf-telemetry-step1.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/codebase-analysis-followups}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-common/src/lib.rs"
+  "crates/assay-ebpf/src/main.rs"
+  "crates/assay-ebpf/src/lsm.rs"
+  "crates/assay-ebpf/src/socket_lsm.rs"
+  "crates/assay-monitor/Cargo.toml"
+  "crates/assay-monitor/src/lib.rs"
+  "crates/assay-monitor/src/loader.rs"
+  "crates/assay-cli/src/cli/commands/monitor_next/mod.rs"
+  "docs/contributing/SPLIT-INVENTORY-wave-o1-ringbuf-telemetry-step1.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave-o1-ringbuf-telemetry-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave-o1-ringbuf-telemetry-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave-o1-ringbuf-telemetry-step1.md"
+  "scripts/ci/review-wave-o1-ringbuf-telemetry-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave O1 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave O1 Step1: $f"
+    exit 1
+  fi
+done < <({
+  git diff --name-only "$BASE_REF"...HEAD
+  git diff --name-only
+  git diff --name-only --cached
+  git ls-files --others --exclude-standard
+} | awk 'NF' | sort -u)
+
+echo "[review] marker checks"
+rg -n 'MonitorStatsSnapshot' crates/assay-monitor/src/lib.rs >/dev/null || {
+  echo "FAIL: missing MonitorStatsSnapshot"
+  exit 1
+}
+rg -n 'snapshot_stats' crates/assay-monitor/src/loader.rs crates/assay-cli/src/cli/commands/monitor_next/mod.rs >/dev/null || {
+  echo "FAIL: missing snapshot_stats path"
+  exit 1
+}
+rg -n 'Ring buffer pressure detected' crates/assay-cli/src/cli/commands/monitor_next/mod.rs >/dev/null || {
+  echo "FAIL: missing ring buffer pressure warning"
+  exit 1
+}
+rg -n 'MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED|MONITOR_STAT_LSM_RINGBUF_DROPPED|SOCKET_STAT_RINGBUF_DROPPED' \
+  crates/assay-common/src/lib.rs \
+  crates/assay-ebpf/src/main.rs \
+  crates/assay-ebpf/src/lsm.rs \
+  crates/assay-ebpf/src/socket_lsm.rs >/dev/null || {
+  echo "FAIL: missing ringbuf drop counters"
+  exit 1
+}
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -q -p assay-monitor -p assay-cli --all-targets -- -D warnings
+cargo check -q -p assay-monitor
+cargo test -q -p assay-monitor
+cargo check -q -p assay-cli
+
+if rustup target list --installed | rg -qx 'bpfel-unknown-none'; then
+  cargo check -q -p assay-ebpf --features ebpf --target bpfel-unknown-none
+else
+  echo "[review] SKIP: bpfel-unknown-none target not installed"
+fi
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- export kernel ring-buffer emit/drop counters for tracepoint, LSM, and socket monitor paths
- expose monitor stats snapshots in `assay-monitor` and print an end-of-run pressure summary in `assay monitor`
- enable `assay-common/std` for the touched monitor crate so the step validates cleanly at package level
- add Wave O1 review artifacts: inventory, checklist, move-map, review-pack, and a strict allowlist reviewer script

## Wave Artifacts
- `docs/contributing/SPLIT-INVENTORY-wave-o1-ringbuf-telemetry-step1.md`
- `docs/contributing/SPLIT-CHECKLIST-wave-o1-ringbuf-telemetry-step1.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave-o1-ringbuf-telemetry-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave-o1-ringbuf-telemetry-step1.md`
- `scripts/ci/review-wave-o1-ringbuf-telemetry-step1.sh`

## Verification
- `BASE_REF=origin/codex/codebase-analysis-followups bash scripts/ci/review-wave-o1-ringbuf-telemetry-step1.sh`
- `cargo clippy -q -p assay-monitor -p assay-cli --all-targets -- -D warnings`
- `git diff --check`

## Notes
- This step is intentionally scoped to monitor ring-buffer telemetry only.
- Policy-evaluation OTel spans were explicitly left out for a later wave.
- The reviewer script skips the eBPF target check when `bpfel-unknown-none` is not installed locally.
