### PR TITLE
Wave O2: add metric evaluation spans

### DIFF
--- a/crates/assay-core/src/engine/runner.rs
+++ b/crates/assay-core/src/engine/runner.rs
@@ -361,12 +361,7 @@ mod tests {
     use crate::providers::llm::fake::FakeClient;
     use crate::providers::llm::LlmClient;
     use async_trait::async_trait;
-    use serial_test::serial;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc as StdArc, Mutex};
-    use tracing_subscriber::fmt::format::FmtSpan;
-    use tracing_subscriber::fmt::MakeWriter;
-    use tracing_subscriber::EnvFilter;
 
     #[derive(Clone, Copy)]
     enum MetricMode {
@@ -445,68 +440,6 @@ mod tests {
         fn provider_name(&self) -> &'static str {
             "error_client"
         }
-    }
-
-    #[derive(Clone)]
-    struct MockWriter {
-        buf: StdArc<Mutex<Vec<u8>>>,
-    }
-
-    impl std::io::Write for MockWriter {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.buf.lock().expect("writer lock").extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl<'a> MakeWriter<'a> for MockWriter {
-        type Writer = MockWriter;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            self.clone()
-        }
-    }
-
-    fn setup_span_capture() -> (MockWriter, tracing::subscriber::DefaultGuard) {
-        let buf = StdArc::new(Mutex::new(Vec::new()));
-        let writer = MockWriter { buf: buf.clone() };
-        let subscriber = tracing_subscriber::fmt()
-            .with_writer(writer.clone())
-            .json()
-            .with_span_events(FmtSpan::CLOSE)
-            .with_env_filter(EnvFilter::new("info"))
-            .finish();
-
-        (writer, tracing::subscriber::set_default(subscriber))
-    }
-
-    fn find_named_spans(
-        json_lines: &str,
-        target_name: &str,
-    ) -> Vec<serde_json::Map<String, serde_json::Value>> {
-        let mut spans = Vec::new();
-
-        for line in json_lines.lines() {
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-            let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-                continue;
-            };
-            let Some(span) = value.get("span").and_then(|span| span.as_object()) else {
-                continue;
-            };
-            if span.get("name").and_then(|v| v.as_str()) == Some(target_name) {
-                spans.push(span.clone());
-            }
-        }
-
-        spans
     }
 
     fn runner_for_contract_tests(
@@ -718,117 +651,6 @@ mod tests {
         assert_eq!(observed.len(), 3);
         assert_eq!(observed.last(), Some(&(3, 3)));
         assert!(observed.windows(2).all(|w| w[0].0 < w[1].0));
-        Ok(())
-    }
-
-    struct ErrorMetric;
-
-    #[async_trait]
-    impl Metric for ErrorMetric {
-        fn name(&self) -> &'static str {
-            "error_metric"
-        }
-
-        async fn evaluate(
-            &self,
-            _tc: &TestCase,
-            _expected: &Expected,
-            _resp: &LlmResponse,
-        ) -> anyhow::Result<MetricResult> {
-            Err(anyhow::anyhow!("metric exploded"))
-        }
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn runner_contract_metric_span_records_success_fields() -> anyhow::Result<()> {
-        let (writer, _guard) = setup_span_capture();
-        let cfg = single_test_config(ErrorPolicy::Block);
-        let client = Arc::new(FakeClient::new("fake-model".to_string()).with_response("ok".into()));
-        let metric = Arc::new(ScriptedMetric::always_pass());
-        let runner = runner_for_contract_tests(client, vec![metric], 0);
-
-        let (row, _resp) = runner.run_test_once(&cfg, &cfg.tests[0]).await?;
-        assert_eq!(row.status, TestStatus::Pass);
-
-        let output = String::from_utf8(writer.buf.lock().expect("writer lock").clone())?;
-        let spans = find_named_spans(&output, "assay.eval.metric");
-        assert_eq!(spans.len(), 1, "expected one metric span, got: {output}");
-
-        let span = &spans[0];
-        assert_eq!(
-            span.get("assay.eval.test_id").and_then(|v| v.as_str()),
-            Some("t1")
-        );
-        assert_eq!(
-            span.get("assay.eval.metric.name").and_then(|v| v.as_str()),
-            Some("scripted")
-        );
-        assert_eq!(
-            span.get("assay.eval.response.cached")
-                .and_then(|v| v.as_bool()),
-            Some(false)
-        );
-        assert_eq!(
-            span.get("assay.eval.metric.score").and_then(|v| v.as_f64()),
-            Some(1.0)
-        );
-        assert_eq!(
-            span.get("assay.eval.metric.passed")
-                .and_then(|v| v.as_bool()),
-            Some(true)
-        );
-        assert_eq!(
-            span.get("assay.eval.metric.unstable")
-                .and_then(|v| v.as_bool()),
-            Some(false)
-        );
-        assert!(
-            span.get("assay.eval.metric.duration_ms")
-                .and_then(|v| v.as_u64())
-                .is_some(),
-            "expected duration field in span: {output}"
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn runner_contract_metric_span_records_error_fields() -> anyhow::Result<()> {
-        let (writer, _guard) = setup_span_capture();
-        let cfg = single_test_config(ErrorPolicy::Block);
-        let client = Arc::new(FakeClient::new("fake-model".to_string()).with_response("ok".into()));
-        let runner = runner_for_contract_tests(client, vec![Arc::new(ErrorMetric)], 0);
-
-        let err = runner
-            .run_test_once(&cfg, &cfg.tests[0])
-            .await
-            .expect_err("metric failure should bubble");
-        assert!(
-            err.to_string().contains("metric exploded"),
-            "unexpected metric error: {err}"
-        );
-
-        let output = String::from_utf8(writer.buf.lock().expect("writer lock").clone())?;
-        let spans = find_named_spans(&output, "assay.eval.metric");
-        assert_eq!(spans.len(), 1, "expected one metric span, got: {output}");
-
-        let span = &spans[0];
-        assert_eq!(
-            span.get("assay.eval.metric.name").and_then(|v| v.as_str()),
-            Some("error_metric")
-        );
-        assert_eq!(span.get("error").and_then(|v| v.as_bool()), Some(true));
-        assert_eq!(
-            span.get("error.message").and_then(|v| v.as_str()),
-            Some("metric exploded")
-        );
-        assert!(
-            span.get("assay.eval.metric.duration_ms")
-                .and_then(|v| v.as_u64())
-                .is_some(),
-            "expected duration field in error span: {output}"
-        );
         Ok(())
     }
 

--- a/crates/assay-core/src/engine/runner.rs
+++ b/crates/assay-core/src/engine/runner.rs
@@ -8,6 +8,7 @@ use crate::report::progress::ProgressSink;
 use crate::report::RunArtifacts;
 use crate::storage::store::Store;
 use std::sync::Arc;
+use tracing::{info_span, Instrument};
 
 #[path = "runner_next/mod.rs"]
 mod runner_next;
@@ -216,8 +217,42 @@ impl Runner {
         let mut details = serde_json::json!({ "metrics": {} });
 
         for m in &self.metrics {
-            let r = m.evaluate(tc, &tc.expected, &resp).await?;
-            details["metrics"][m.name()] = serde_json::json!({
+            let metric_name = m.name();
+            let metric_span = info_span!(
+                "assay.eval.metric",
+                "assay.eval.test_id" = tc.id.as_str(),
+                "assay.eval.metric.name" = metric_name,
+                "assay.eval.response.cached" = resp.cached,
+                "assay.eval.metric.score" = tracing::field::Empty,
+                "assay.eval.metric.passed" = tracing::field::Empty,
+                "assay.eval.metric.unstable" = tracing::field::Empty,
+                "assay.eval.metric.duration_ms" = tracing::field::Empty,
+                "error" = tracing::field::Empty,
+                "error.message" = tracing::field::Empty
+            );
+            let metric_start = std::time::Instant::now();
+            let metric_result = async { m.evaluate(tc, &tc.expected, &resp).await }
+                .instrument(metric_span.clone())
+                .await;
+            let metric_duration_ms = metric_start.elapsed().as_millis() as u64;
+            metric_span.record("assay.eval.metric.duration_ms", metric_duration_ms);
+
+            let r = match metric_result {
+                Ok(result) => {
+                    metric_span.record("assay.eval.metric.score", result.score);
+                    metric_span.record("assay.eval.metric.passed", result.passed);
+                    metric_span.record("assay.eval.metric.unstable", result.unstable);
+                    result
+                }
+                Err(err) => {
+                    let error_message = err.to_string();
+                    metric_span.record("error", true);
+                    metric_span.record("error.message", error_message.as_str());
+                    return Err(err);
+                }
+            };
+
+            details["metrics"][metric_name] = serde_json::json!({
                 "score": r.score, "passed": r.passed, "unstable": r.unstable, "details": r.details
             });
             final_score = Some(r.score);
@@ -225,12 +260,12 @@ impl Runner {
             if r.unstable {
                 // gate stability first: treat unstable as warn in MVP
                 final_status = TestStatus::Warn;
-                msg = format!("unstable metric: {}", m.name());
+                msg = format!("unstable metric: {}", metric_name);
                 break;
             }
             if !r.passed {
                 final_status = TestStatus::Fail;
-                msg = format!("failed: {}", m.name());
+                msg = format!("failed: {}", metric_name);
                 break;
             }
         }
@@ -326,7 +361,12 @@ mod tests {
     use crate::providers::llm::fake::FakeClient;
     use crate::providers::llm::LlmClient;
     use async_trait::async_trait;
+    use serial_test::serial;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc as StdArc, Mutex};
+    use tracing_subscriber::fmt::format::FmtSpan;
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::EnvFilter;
 
     #[derive(Clone, Copy)]
     enum MetricMode {
@@ -405,6 +445,68 @@ mod tests {
         fn provider_name(&self) -> &'static str {
             "error_client"
         }
+    }
+
+    #[derive(Clone)]
+    struct MockWriter {
+        buf: StdArc<Mutex<Vec<u8>>>,
+    }
+
+    impl std::io::Write for MockWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.buf.lock().expect("writer lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for MockWriter {
+        type Writer = MockWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn setup_span_capture() -> (MockWriter, tracing::subscriber::DefaultGuard) {
+        let buf = StdArc::new(Mutex::new(Vec::new()));
+        let writer = MockWriter { buf: buf.clone() };
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .json()
+            .with_span_events(FmtSpan::CLOSE)
+            .with_env_filter(EnvFilter::new("info"))
+            .finish();
+
+        (writer, tracing::subscriber::set_default(subscriber))
+    }
+
+    fn find_named_spans(
+        json_lines: &str,
+        target_name: &str,
+    ) -> Vec<serde_json::Map<String, serde_json::Value>> {
+        let mut spans = Vec::new();
+
+        for line in json_lines.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+                continue;
+            };
+            let Some(span) = value.get("span").and_then(|span| span.as_object()) else {
+                continue;
+            };
+            if span.get("name").and_then(|v| v.as_str()) == Some(target_name) {
+                spans.push(span.clone());
+            }
+        }
+
+        spans
     }
 
     fn runner_for_contract_tests(
@@ -616,6 +718,117 @@ mod tests {
         assert_eq!(observed.len(), 3);
         assert_eq!(observed.last(), Some(&(3, 3)));
         assert!(observed.windows(2).all(|w| w[0].0 < w[1].0));
+        Ok(())
+    }
+
+    struct ErrorMetric;
+
+    #[async_trait]
+    impl Metric for ErrorMetric {
+        fn name(&self) -> &'static str {
+            "error_metric"
+        }
+
+        async fn evaluate(
+            &self,
+            _tc: &TestCase,
+            _expected: &Expected,
+            _resp: &LlmResponse,
+        ) -> anyhow::Result<MetricResult> {
+            Err(anyhow::anyhow!("metric exploded"))
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn runner_contract_metric_span_records_success_fields() -> anyhow::Result<()> {
+        let (writer, _guard) = setup_span_capture();
+        let cfg = single_test_config(ErrorPolicy::Block);
+        let client = Arc::new(FakeClient::new("fake-model".to_string()).with_response("ok".into()));
+        let metric = Arc::new(ScriptedMetric::always_pass());
+        let runner = runner_for_contract_tests(client, vec![metric], 0);
+
+        let (row, _resp) = runner.run_test_once(&cfg, &cfg.tests[0]).await?;
+        assert_eq!(row.status, TestStatus::Pass);
+
+        let output = String::from_utf8(writer.buf.lock().expect("writer lock").clone())?;
+        let spans = find_named_spans(&output, "assay.eval.metric");
+        assert_eq!(spans.len(), 1, "expected one metric span, got: {output}");
+
+        let span = &spans[0];
+        assert_eq!(
+            span.get("assay.eval.test_id").and_then(|v| v.as_str()),
+            Some("t1")
+        );
+        assert_eq!(
+            span.get("assay.eval.metric.name").and_then(|v| v.as_str()),
+            Some("scripted")
+        );
+        assert_eq!(
+            span.get("assay.eval.response.cached")
+                .and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(
+            span.get("assay.eval.metric.score").and_then(|v| v.as_f64()),
+            Some(1.0)
+        );
+        assert_eq!(
+            span.get("assay.eval.metric.passed")
+                .and_then(|v| v.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            span.get("assay.eval.metric.unstable")
+                .and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert!(
+            span.get("assay.eval.metric.duration_ms")
+                .and_then(|v| v.as_u64())
+                .is_some(),
+            "expected duration field in span: {output}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn runner_contract_metric_span_records_error_fields() -> anyhow::Result<()> {
+        let (writer, _guard) = setup_span_capture();
+        let cfg = single_test_config(ErrorPolicy::Block);
+        let client = Arc::new(FakeClient::new("fake-model".to_string()).with_response("ok".into()));
+        let runner = runner_for_contract_tests(client, vec![Arc::new(ErrorMetric)], 0);
+
+        let err = runner
+            .run_test_once(&cfg, &cfg.tests[0])
+            .await
+            .expect_err("metric failure should bubble");
+        assert!(
+            err.to_string().contains("metric exploded"),
+            "unexpected metric error: {err}"
+        );
+
+        let output = String::from_utf8(writer.buf.lock().expect("writer lock").clone())?;
+        let spans = find_named_spans(&output, "assay.eval.metric");
+        assert_eq!(spans.len(), 1, "expected one metric span, got: {output}");
+
+        let span = &spans[0];
+        assert_eq!(
+            span.get("assay.eval.metric.name").and_then(|v| v.as_str()),
+            Some("error_metric")
+        );
+        assert_eq!(span.get("error").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(
+            span.get("error.message").and_then(|v| v.as_str()),
+            Some("metric exploded")
+        );
+        assert!(
+            span.get("assay.eval.metric.duration_ms")
+                .and_then(|v| v.as_u64())
+                .is_some(),
+            "expected duration field in error span: {output}"
+        );
         Ok(())
     }
 

--- a/crates/assay-core/src/engine/runner_next/execute.rs
+++ b/crates/assay-core/src/engine/runner_next/execute.rs
@@ -11,6 +11,7 @@ use std::time::Instant;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tokio::time::{timeout, Duration};
+use tracing::instrument::WithSubscriber;
 
 pub(crate) async fn run_suite_impl(
     runner: &Runner,
@@ -47,10 +48,13 @@ pub(crate) async fn run_suite_impl(
         clone_overhead_ms = clone_overhead_ms.saturating_add(clone_started.elapsed().as_millis());
         let cfg = cfg.clone();
         let tc = tc.clone();
-        join_set.spawn(async move {
-            let _permit = permit;
-            run_test_with_policy_impl(&this, &cfg, &tc, run_id).await
-        });
+        join_set.spawn(
+            async move {
+                let _permit = permit;
+                run_test_with_policy_impl(&this, &cfg, &tc, run_id).await
+            }
+            .with_current_subscriber(),
+        );
     }
 
     let mut rows = Vec::new();

--- a/crates/assay-core/tests/runner_metric_spans.rs
+++ b/crates/assay-core/tests/runner_metric_spans.rs
@@ -1,0 +1,269 @@
+use assay_core::cache::vcr::VcrCache;
+use assay_core::engine::runner::{RunPolicy, Runner};
+use assay_core::metrics_api::{Metric, MetricResult};
+use assay_core::model::{
+    EvalConfig, Expected, LlmResponse, Settings, TestCase, TestInput, TestStatus,
+};
+use assay_core::on_error::ErrorPolicy;
+use assay_core::providers::llm::fake::FakeClient;
+use assay_core::providers::llm::LlmClient;
+use assay_core::quarantine::QuarantineMode;
+use assay_core::storage::Store;
+use async_trait::async_trait;
+use serial_test::serial;
+use std::sync::{Arc, Mutex};
+use tracing::instrument::WithSubscriber;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Clone)]
+struct MockWriter {
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl std::io::Write for MockWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buf.lock().expect("writer lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for MockWriter {
+    type Writer = MockWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn setup_span_capture() -> (MockWriter, tracing::Dispatch) {
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let writer = MockWriter { buf: buf.clone() };
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(writer.clone())
+        .json()
+        .with_span_events(FmtSpan::CLOSE)
+        .with_env_filter(EnvFilter::new("info"))
+        .finish();
+
+    (writer, tracing::Dispatch::new(subscriber))
+}
+
+fn find_named_spans(
+    json_lines: &str,
+    target_name: &str,
+) -> Vec<serde_json::Map<String, serde_json::Value>> {
+    let mut spans = Vec::new();
+
+    for line in json_lines.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let Some(span) = value.get("span").and_then(|span| span.as_object()) else {
+            continue;
+        };
+        if span.get("name").and_then(|v| v.as_str()) == Some(target_name) {
+            spans.push(span.clone());
+        }
+    }
+
+    spans
+}
+
+struct PassMetric;
+
+#[async_trait]
+impl Metric for PassMetric {
+    fn name(&self) -> &'static str {
+        "pass_metric"
+    }
+
+    async fn evaluate(
+        &self,
+        _tc: &TestCase,
+        _expected: &Expected,
+        _resp: &LlmResponse,
+    ) -> anyhow::Result<MetricResult> {
+        Ok(MetricResult::pass(1.0))
+    }
+}
+
+struct ErrorMetric;
+
+#[async_trait]
+impl Metric for ErrorMetric {
+    fn name(&self) -> &'static str {
+        "error_metric"
+    }
+
+    async fn evaluate(
+        &self,
+        _tc: &TestCase,
+        _expected: &Expected,
+        _resp: &LlmResponse,
+    ) -> anyhow::Result<MetricResult> {
+        Err(anyhow::anyhow!("metric exploded"))
+    }
+}
+
+fn runner_for_span_tests(client: Arc<dyn LlmClient>, metrics: Vec<Arc<dyn Metric>>) -> Runner {
+    let store = Store::memory().expect("in-memory store");
+    store.init_schema().expect("schema init");
+    Runner {
+        store: store.clone(),
+        cache: VcrCache::new(store),
+        client,
+        metrics,
+        policy: RunPolicy {
+            rerun_failures: 0,
+            quarantine_mode: QuarantineMode::Off,
+            replay_strict: false,
+        },
+        _network_guard: None,
+        embedder: None,
+        refresh_embeddings: false,
+        incremental: false,
+        refresh_cache: false,
+        judge: None,
+        baseline: None,
+    }
+}
+
+fn single_test_config() -> EvalConfig {
+    EvalConfig {
+        version: 1,
+        suite: "runner-metric-spans".to_string(),
+        model: "fake-model".to_string(),
+        settings: Settings {
+            parallel: Some(1),
+            cache: Some(false),
+            seed: Some(1234),
+            on_error: ErrorPolicy::Block,
+            ..Default::default()
+        },
+        thresholds: Default::default(),
+        otel: Default::default(),
+        tests: vec![TestCase {
+            id: "t1".to_string(),
+            input: TestInput {
+                prompt: "metric spans prompt".to_string(),
+                context: None,
+            },
+            expected: Expected::MustContain {
+                must_contain: vec!["ok".to_string()],
+            },
+            assertions: None,
+            on_error: None,
+            tags: vec![],
+            metadata: None,
+        }],
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn runner_metric_spans_record_success_fields() -> anyhow::Result<()> {
+    let (writer, dispatch) = setup_span_capture();
+    let cfg = single_test_config();
+    let client = Arc::new(FakeClient::new("fake-model".to_string()).with_response("ok".into()));
+    let runner = runner_for_span_tests(client, vec![Arc::new(PassMetric)]);
+
+    let artifacts = runner
+        .run_suite(&cfg, None)
+        .with_subscriber(dispatch)
+        .await?;
+    let row = artifacts.results.first().expect("result row");
+    assert_eq!(row.status, TestStatus::Pass);
+
+    let output = String::from_utf8(writer.buf.lock().expect("writer lock").clone())?;
+    let spans = find_named_spans(&output, "assay.eval.metric");
+    assert_eq!(spans.len(), 1, "expected one metric span, got: {output}");
+
+    let span = &spans[0];
+    assert_eq!(
+        span.get("assay.eval.test_id").and_then(|v| v.as_str()),
+        Some("t1")
+    );
+    assert_eq!(
+        span.get("assay.eval.metric.name").and_then(|v| v.as_str()),
+        Some("pass_metric")
+    );
+    assert_eq!(
+        span.get("assay.eval.response.cached")
+            .and_then(|v| v.as_bool()),
+        Some(false)
+    );
+    assert_eq!(
+        span.get("assay.eval.metric.score").and_then(|v| v.as_f64()),
+        Some(1.0)
+    );
+    assert_eq!(
+        span.get("assay.eval.metric.passed")
+            .and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        span.get("assay.eval.metric.unstable")
+            .and_then(|v| v.as_bool()),
+        Some(false)
+    );
+    assert!(
+        span.get("assay.eval.metric.duration_ms")
+            .and_then(|v| v.as_u64())
+            .is_some(),
+        "expected duration field in span: {output}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn runner_metric_spans_record_error_fields() -> anyhow::Result<()> {
+    let (writer, dispatch) = setup_span_capture();
+    let cfg = single_test_config();
+    let client = Arc::new(FakeClient::new("fake-model".to_string()).with_response("ok".into()));
+    let runner = runner_for_span_tests(client, vec![Arc::new(ErrorMetric)]);
+
+    let artifacts = runner
+        .run_suite(&cfg, None)
+        .with_subscriber(dispatch)
+        .await?;
+    let row = artifacts.results.first().expect("result row");
+    assert_eq!(row.status, TestStatus::Error);
+    assert!(
+        row.message.contains("metric exploded"),
+        "unexpected metric failure row: {}",
+        row.message
+    );
+
+    let output = String::from_utf8(writer.buf.lock().expect("writer lock").clone())?;
+    let spans = find_named_spans(&output, "assay.eval.metric");
+    assert_eq!(spans.len(), 1, "expected one metric span, got: {output}");
+
+    let span = &spans[0];
+    assert_eq!(
+        span.get("assay.eval.metric.name").and_then(|v| v.as_str()),
+        Some("error_metric")
+    );
+    assert_eq!(span.get("error").and_then(|v| v.as_bool()), Some(true));
+    assert_eq!(
+        span.get("error.message").and_then(|v| v.as_str()),
+        Some("metric exploded")
+    );
+    assert!(
+        span.get("assay.eval.metric.duration_ms")
+            .and_then(|v| v.as_u64())
+            .is_some(),
+        "expected duration field in error span: {output}"
+    );
+    Ok(())
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave-o2-metric-spans-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave-o2-metric-spans-step1.md
@@ -1,0 +1,29 @@
+# SPLIT CHECKLIST — Wave O2 Metric Spans Step1
+
+## Scope discipline
+- [ ] Only allowlisted files changed for this step
+- [ ] No `.github/workflows/*` changes
+- [ ] No `assay-monitor`, `assay-ebpf`, registry, Python SDK, fuzz, or release-workflow changes
+- [ ] No new CLI flags or config fields
+- [ ] No non-metric runner behavior changes
+
+## Contract checks
+- [ ] Every metric evaluation in `Runner::run_test_once()` is wrapped in an `assay.eval.metric` span
+- [ ] Success spans record metric name, cached bit, score, pass/fail state, unstable bit, and duration
+- [ ] Error spans record `error=true`, `error.message`, and duration before bubbling the error
+- [ ] Existing runner verdict semantics remain unchanged
+- [ ] Existing LLM tracing contract stays out of scope and remains green
+
+## Non-goals
+- [ ] No ring-buffer telemetry edits in this step
+- [ ] No rule-by-rule policy spans in this step
+- [ ] No workflow, release, or packaging changes in this step
+
+## Validation
+- [ ] `BASE_REF=origin/codex/codebase-analysis-observability bash scripts/ci/review-wave-o2-metric-spans-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core --all-targets -- -D warnings` passes
+- [ ] `cargo check -p assay-core` passes
+- [ ] `cargo test -p assay-core runner_contract_metric_span` passes
+- [ ] `cargo test -p assay-core --test otel_contract` passes
+- [ ] `git diff --check` passes

--- a/docs/contributing/SPLIT-CHECKLIST-wave-o2-metric-spans-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave-o2-metric-spans-step1.md
@@ -6,9 +6,11 @@
 - [ ] No `assay-monitor`, `assay-ebpf`, registry, Python SDK, fuzz, or release-workflow changes
 - [ ] No new CLI flags or config fields
 - [ ] No non-metric runner behavior changes
+- [ ] Metric span contract coverage lives in an isolated integration test process
 
 ## Contract checks
 - [ ] Every metric evaluation in `Runner::run_test_once()` is wrapped in an `assay.eval.metric` span
+- [ ] `run_suite()` propagates the active subscriber into spawned worker tasks
 - [ ] Success spans record metric name, cached bit, score, pass/fail state, unstable bit, and duration
 - [ ] Error spans record `error=true`, `error.message`, and duration before bubbling the error
 - [ ] Existing runner verdict semantics remain unchanged
@@ -24,6 +26,7 @@
 - [ ] `cargo fmt --check` passes
 - [ ] `cargo clippy -p assay-core --all-targets -- -D warnings` passes
 - [ ] `cargo check -p assay-core` passes
-- [ ] `cargo test -p assay-core runner_contract_metric_span` passes
+- [ ] `cargo test -p assay-core --lib` passes
+- [ ] `cargo test -p assay-core --test runner_metric_spans` passes
 - [ ] `cargo test -p assay-core --test otel_contract` passes
 - [ ] `git diff --check` passes

--- a/docs/contributing/SPLIT-INVENTORY-wave-o2-metric-spans-step1.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave-o2-metric-spans-step1.md
@@ -8,7 +8,8 @@
 ## Scope lock
 - In scope:
   - metric-evaluation span instrumentation in `assay-core` runner
-  - runner-local contract tests that prove success/error span fields are exported
+  - subscriber propagation from `run_suite` into worker tasks so the new spans are observable in real async runs
+  - dedicated integration tests that prove success/error span fields are exported
   - wave review artifacts and a scope-gated reviewer script
 - Out of scope:
   - ring-buffer telemetry follow-ups already covered by Wave O1
@@ -18,6 +19,8 @@
 
 ## Touched implementation files
 - `crates/assay-core/src/engine/runner.rs`
+- `crates/assay-core/src/engine/runner_next/execute.rs`
+- `crates/assay-core/tests/runner_metric_spans.rs`
 
 ## Public surface inventory
 - No new public Rust API
@@ -38,12 +41,15 @@
 
 | File | Base LOC | Current LOC | Delta |
 |---|---:|---:|---:|
-| `crates/assay-core/src/engine/runner.rs` | 661 | 873 | +212 |
+| `crates/assay-core/src/engine/runner.rs` | 661 | 696 | +35 |
+| `crates/assay-core/src/engine/runner_next/execute.rs` | 227 | 231 | +4 |
+| `crates/assay-core/tests/runner_metric_spans.rs` | 0 | 269 | +269 |
 
 ## Validation target
 - `cargo fmt --check`
 - `cargo clippy -p assay-core --all-targets -- -D warnings`
 - `cargo check -p assay-core`
-- `cargo test -p assay-core runner_contract_metric_span`
+- `cargo test -p assay-core --lib`
+- `cargo test -p assay-core --test runner_metric_spans`
 - `cargo test -p assay-core --test otel_contract`
 - `git diff --check`

--- a/docs/contributing/SPLIT-INVENTORY-wave-o2-metric-spans-step1.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave-o2-metric-spans-step1.md
@@ -1,0 +1,49 @@
+# SPLIT INVENTORY — Wave O2 Metric Spans Step1
+
+## Stack context
+- Base branch: `codex/codebase-analysis-observability`
+- Step branch: `codex/codebase-analysis-metric-spans`
+- Intent: emit per-metric evaluation spans from the core runner so operators can see metric latency and verdicts without widening the current observability wave
+
+## Scope lock
+- In scope:
+  - metric-evaluation span instrumentation in `assay-core` runner
+  - runner-local contract tests that prove success/error span fields are exported
+  - wave review artifacts and a scope-gated reviewer script
+- Out of scope:
+  - ring-buffer telemetry follow-ups already covered by Wave O1
+  - policy-rule spans beyond the existing per-metric loop
+  - LLM client span shape changes
+  - registry trust-root work, Python SDK, fuzzing, SBOM, or workflow changes
+
+## Touched implementation files
+- `crates/assay-core/src/engine/runner.rs`
+
+## Public surface inventory
+- No new public Rust API
+- No config schema changes
+- New internal tracing span name: `assay.eval.metric`
+- New span fields:
+  - `assay.eval.test_id`
+  - `assay.eval.metric.name`
+  - `assay.eval.response.cached`
+  - `assay.eval.metric.score`
+  - `assay.eval.metric.passed`
+  - `assay.eval.metric.unstable`
+  - `assay.eval.metric.duration_ms`
+  - `error`
+  - `error.message`
+
+## LOC baseline vs current
+
+| File | Base LOC | Current LOC | Delta |
+|---|---:|---:|---:|
+| `crates/assay-core/src/engine/runner.rs` | 661 | 873 | +212 |
+
+## Validation target
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- `cargo check -p assay-core`
+- `cargo test -p assay-core runner_contract_metric_span`
+- `cargo test -p assay-core --test otel_contract`
+- `git diff --check`

--- a/docs/contributing/SPLIT-MOVE-MAP-wave-o2-metric-spans-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave-o2-metric-spans-step1.md
@@ -8,10 +8,15 @@ This step is additive tracing only. There is no facade split and no module move;
    - creates an `assay.eval.metric` span for each metric in the existing evaluation loop
    - records verdict and duration fields on success
    - records error fields and duration before returning metric evaluation errors
-   - proves the export contract with runner-local tracing capture tests
+2. `crates/assay-core/src/engine/runner_next/execute.rs`
+   - propagates the current tracing subscriber into spawned worker tasks with `.with_current_subscriber()`
+3. `crates/assay-core/tests/runner_metric_spans.rs`
+   - proves the export contract in a dedicated integration-test process
+   - keeps tracing capture isolated from the parallel `--lib` suite
 
 ## Reviewer focus
 - Span creation stays inside the existing metric loop and does not alter cache or baseline flow
+- Spawned tasks inherit the active subscriber, so `run_suite()` actually emits the new spans
 - Recorded fields match the review pack exactly and are present on span close
 - Error recording happens before the original error is returned
-- The test harness is local to the runner and does not introduce new production dependencies or config knobs
+- The integration harness is process-isolated and does not introduce new production dependencies or config knobs

--- a/docs/contributing/SPLIT-MOVE-MAP-wave-o2-metric-spans-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave-o2-metric-spans-step1.md
@@ -1,0 +1,17 @@
+# SPLIT MOVE MAP — Wave O2 Metric Spans Step1
+
+## Intent
+This step is additive tracing only. There is no facade split and no module move; the runner keeps its current API and evaluation order.
+
+## Data flow map
+1. `crates/assay-core/src/engine/runner.rs`
+   - creates an `assay.eval.metric` span for each metric in the existing evaluation loop
+   - records verdict and duration fields on success
+   - records error fields and duration before returning metric evaluation errors
+   - proves the export contract with runner-local tracing capture tests
+
+## Reviewer focus
+- Span creation stays inside the existing metric loop and does not alter cache or baseline flow
+- Recorded fields match the review pack exactly and are present on span close
+- Error recording happens before the original error is returned
+- The test harness is local to the runner and does not introduce new production dependencies or config knobs

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave-o2-metric-spans-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave-o2-metric-spans-step1.md
@@ -1,10 +1,12 @@
 # SPLIT REVIEW PACK — Wave O2 Metric Spans Step1
 
 ## Intent
-Expose per-metric evaluation observability from the core runner while keeping the wave tightly scoped to a single implementation file plus review artifacts.
+Expose per-metric evaluation observability from the core runner while keeping the wave tightly scoped to the runner, one dedicated integration test, and review artifacts.
 
 ## Allowed files
 - `crates/assay-core/src/engine/runner.rs`
+- `crates/assay-core/src/engine/runner_next/execute.rs`
+- `crates/assay-core/tests/runner_metric_spans.rs`
 - `docs/contributing/SPLIT-INVENTORY-wave-o2-metric-spans-step1.md`
 - `docs/contributing/SPLIT-CHECKLIST-wave-o2-metric-spans-step1.md`
 - `docs/contributing/SPLIT-MOVE-MAP-wave-o2-metric-spans-step1.md`
@@ -14,15 +16,18 @@ Expose per-metric evaluation observability from the core runner while keeping th
 ## What reviewers should verify
 1. The diff stays inside the allowlist above.
 2. The runner still evaluates metrics in the same order and short-circuits the same way on unstable/fail outcomes.
-3. `assay.eval.metric` spans always capture metric identity and latency.
-4. Metric evaluation errors now surface in tracing without swallowing or rewriting the original error.
-5. Existing OTel contract tests still pass unchanged.
-6. No Wave O1 ringbuf or unrelated supply-chain changes leaked into this step.
+3. `run_suite()` propagates the active subscriber into spawned worker tasks.
+4. `assay.eval.metric` spans always capture metric identity and latency.
+5. Metric evaluation errors now surface in tracing without swallowing or rewriting the original error.
+6. Existing OTel contract tests still pass unchanged.
+7. No Wave O1 ringbuf or unrelated supply-chain changes leaked into this step.
 
 ## Proof snippets
 - Span hook:
   - `info_span!("assay.eval.metric", ...)`
   - `.instrument(metric_span.clone())`
+- Subscriber propagation:
+  - `.with_current_subscriber()`
 - Recorded success fields:
   - `assay.eval.metric.score`
   - `assay.eval.metric.passed`
@@ -31,8 +36,8 @@ Expose per-metric evaluation observability from the core runner while keeping th
   - `error`
   - `error.message`
 - Contract tests:
-  - `runner_contract_metric_span_records_success_fields`
-  - `runner_contract_metric_span_records_error_fields`
+  - `runner_metric_spans_record_success_fields`
+  - `runner_metric_spans_record_error_fields`
 
 ## Reviewer command
 ```bash
@@ -40,4 +45,4 @@ BASE_REF=origin/codex/codebase-analysis-observability bash scripts/ci/review-wav
 ```
 
 ## Validation note
-The reviewer script stays inside `assay-core` and reruns the existing `otel_contract` integration test to prove the new runner spans did not disturb the current LLM tracing contract.
+The reviewer script stays inside `assay-core`, reruns the full `--lib` suite to catch parallel-test regressions, and reruns the dedicated `runner_metric_spans` plus existing `otel_contract` integration tests to prove the new runner spans did not disturb the tracing contract.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave-o2-metric-spans-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave-o2-metric-spans-step1.md
@@ -1,0 +1,43 @@
+# SPLIT REVIEW PACK — Wave O2 Metric Spans Step1
+
+## Intent
+Expose per-metric evaluation observability from the core runner while keeping the wave tightly scoped to a single implementation file plus review artifacts.
+
+## Allowed files
+- `crates/assay-core/src/engine/runner.rs`
+- `docs/contributing/SPLIT-INVENTORY-wave-o2-metric-spans-step1.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave-o2-metric-spans-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave-o2-metric-spans-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave-o2-metric-spans-step1.md`
+- `scripts/ci/review-wave-o2-metric-spans-step1.sh`
+
+## What reviewers should verify
+1. The diff stays inside the allowlist above.
+2. The runner still evaluates metrics in the same order and short-circuits the same way on unstable/fail outcomes.
+3. `assay.eval.metric` spans always capture metric identity and latency.
+4. Metric evaluation errors now surface in tracing without swallowing or rewriting the original error.
+5. Existing OTel contract tests still pass unchanged.
+6. No Wave O1 ringbuf or unrelated supply-chain changes leaked into this step.
+
+## Proof snippets
+- Span hook:
+  - `info_span!("assay.eval.metric", ...)`
+  - `.instrument(metric_span.clone())`
+- Recorded success fields:
+  - `assay.eval.metric.score`
+  - `assay.eval.metric.passed`
+  - `assay.eval.metric.duration_ms`
+- Recorded error fields:
+  - `error`
+  - `error.message`
+- Contract tests:
+  - `runner_contract_metric_span_records_success_fields`
+  - `runner_contract_metric_span_records_error_fields`
+
+## Reviewer command
+```bash
+BASE_REF=origin/codex/codebase-analysis-observability bash scripts/ci/review-wave-o2-metric-spans-step1.sh
+```
+
+## Validation note
+The reviewer script stays inside `assay-core` and reruns the existing `otel_contract` integration test to prove the new runner spans did not disturb the current LLM tracing contract.

--- a/scripts/ci/review-wave-o2-metric-spans-step1.sh
+++ b/scripts/ci/review-wave-o2-metric-spans-step1.sh
@@ -9,6 +9,8 @@ git rev-parse --verify "$BASE_REF" >/dev/null
 
 ALLOWLIST=(
   "crates/assay-core/src/engine/runner.rs"
+  "crates/assay-core/src/engine/runner_next/execute.rs"
+  "crates/assay-core/tests/runner_metric_spans.rs"
   "docs/contributing/SPLIT-INVENTORY-wave-o2-metric-spans-step1.md"
   "docs/contributing/SPLIT-CHECKLIST-wave-o2-metric-spans-step1.md"
   "docs/contributing/SPLIT-MOVE-MAP-wave-o2-metric-spans-step1.md"
@@ -46,12 +48,18 @@ rg -n 'assay.eval.metric' crates/assay-core/src/engine/runner.rs >/dev/null || {
   echo "FAIL: missing assay.eval.metric span"
   exit 1
 }
-rg -n 'runner_contract_metric_span_records_success_fields|runner_contract_metric_span_records_error_fields' \
-  crates/assay-core/src/engine/runner.rs >/dev/null || {
+rg -n 'with_current_subscriber' crates/assay-core/src/engine/runner_next/execute.rs >/dev/null || {
+  echo "FAIL: missing subscriber propagation in run_suite"
+  exit 1
+}
+rg -n 'runner_metric_spans_record_success_fields|runner_metric_spans_record_error_fields' \
+  crates/assay-core/tests/runner_metric_spans.rs >/dev/null || {
   echo "FAIL: missing metric span contract tests"
   exit 1
 }
-rg -n 'error.message|assay.eval.metric.duration_ms' crates/assay-core/src/engine/runner.rs >/dev/null || {
+rg -n 'error.message|assay.eval.metric.duration_ms' \
+  crates/assay-core/src/engine/runner.rs \
+  crates/assay-core/tests/runner_metric_spans.rs >/dev/null || {
   echo "FAIL: missing metric span field recording"
   exit 1
 }
@@ -60,7 +68,8 @@ echo "[review] repo checks"
 cargo fmt --check
 cargo clippy -q -p assay-core --all-targets -- -D warnings
 cargo check -q -p assay-core
-cargo test -q -p assay-core runner_contract_metric_span
+cargo test -q -p assay-core --lib
+cargo test -q -p assay-core --test runner_metric_spans
 cargo test -q -p assay-core --test otel_contract
 git diff --check
 

--- a/scripts/ci/review-wave-o2-metric-spans-step1.sh
+++ b/scripts/ci/review-wave-o2-metric-spans-step1.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/codex/codebase-analysis-observability}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-core/src/engine/runner.rs"
+  "docs/contributing/SPLIT-INVENTORY-wave-o2-metric-spans-step1.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave-o2-metric-spans-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave-o2-metric-spans-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave-o2-metric-spans-step1.md"
+  "scripts/ci/review-wave-o2-metric-spans-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave O2 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave O2 Step1: $f"
+    exit 1
+  fi
+done < <({
+  git diff --name-only "$BASE_REF"...HEAD
+  git diff --name-only
+  git diff --name-only --cached
+  git ls-files --others --exclude-standard
+} | awk 'NF' | sort -u)
+
+echo "[review] marker checks"
+rg -n 'assay.eval.metric' crates/assay-core/src/engine/runner.rs >/dev/null || {
+  echo "FAIL: missing assay.eval.metric span"
+  exit 1
+}
+rg -n 'runner_contract_metric_span_records_success_fields|runner_contract_metric_span_records_error_fields' \
+  crates/assay-core/src/engine/runner.rs >/dev/null || {
+  echo "FAIL: missing metric span contract tests"
+  exit 1
+}
+rg -n 'error.message|assay.eval.metric.duration_ms' crates/assay-core/src/engine/runner.rs >/dev/null || {
+  echo "FAIL: missing metric span field recording"
+  exit 1
+}
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -q -p assay-core --all-targets -- -D warnings
+cargo check -q -p assay-core
+cargo test -q -p assay-core runner_contract_metric_span
+cargo test -q -p assay-core --test otel_contract
+git diff --check
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add `assay.eval.metric` spans around the existing runner metric loop
- record per-metric latency, cached bit, verdict fields, and evaluation errors without changing runner semantics
- add Wave O2 inventory/checklist/move-map/review-pack artifacts plus a scope-gated reviewer script
- keep this PR stacked on top of Wave O1 ringbuf telemetry via `codex/codebase-analysis-observability`

## Verification
- `BASE_REF=origin/codex/codebase-analysis-observability bash scripts/ci/review-wave-o2-metric-spans-step1.sh`
- `cargo clippy -q -p assay-core --all-targets -- -D warnings`
- `cargo check -q -p assay-core`
- `cargo test -q -p assay-core runner_contract_metric_span`
- `cargo test -q -p assay-core --test otel_contract`
- `git diff --check`
