### PR TITLE
docs: record recent contract changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### MCP Security
+
+- **New MCP integrity metrics**: Added `tool_description_integrity`, `tool_output_valid`, and `tool_collision_detect` to cover tool-definition drift, output-schema contracts, and cross-server tool shadowing.
+
+### Observability
+
+- **Runtime monitor output**: `assay monitor` blocked-file events now print structured `dev`, `ino`, `cgroup`, and `rule_id` fields instead of raw payload text.
+- **Ring buffer pressure summary**: `assay monitor` now reports emitted and dropped ring-buffer counters for tracepoint, LSM, and socket monitor paths at the end of a run.
+- **Metric evaluation spans**: The runner now emits one `assay.eval.metric` span per metric evaluation with stable fields for latency, cached status, pass/fail, unstable state, and error reporting.
+
+### Supply Chain
+
+- **CycloneDX release asset**: Release builds now publish `assay-${VERSION}-sbom-cyclonedx.tar.gz` and `assay-${VERSION}-sbom-cyclonedx.tar.gz.sha256` alongside the existing binaries.
+
 ---
 
 ## [v3.2.2] - 2026-03-17

--- a/docs/concepts/metrics.md
+++ b/docs/concepts/metrics.md
@@ -22,7 +22,9 @@ Metrics are:
 
 ## Built-in Metrics
 
-Assay ships with three core metrics:
+Assay ships with deterministic metrics for both classic eval checks and MCP-specific integrity checks.
+
+### Core Eval Metrics
 
 | Metric | Validates | Output |
 |--------|-----------|--------|
@@ -31,6 +33,65 @@ Assay ships with three core metrics:
 | `tool_blocklist` | Forbidden tools weren't called | Pass/Fail (count) |
 
 All three are **deterministic** — no floats, no subjective thresholds, no LLM-as-judge.
+
+### MCP Integrity Metrics
+
+These metrics are useful when your traces include MCP tool-definition metadata from a proxy or trace capture layer.
+
+| Metric | Validates | Key config |
+|--------|-----------|------------|
+| `tool_description_integrity` | Tool descriptions and input schemas stay pinned or unchanged across snapshots | `pinned_tools` |
+| `tool_output_valid` | Tool results match per-tool JSON Schemas | `schemas` |
+| `tool_collision_detect` | The same tool name is not registered by multiple MCP servers unless explicitly trusted | `trusted_servers` |
+
+#### `tool_description_integrity`
+
+Use pinned mode when you want to compare a trace against operator-approved tool definitions:
+
+```yaml
+tests:
+  - id: tool_pins
+    expected:
+      type: tool_description_integrity
+      pinned_tools:
+        - name: read_file
+          description: Reads a file from disk
+          schema_sha256: "4d8d8f0d7d4a0f4b9f47d59a3cce5d6e8f4e2b5a1a5ef9e8e2b5e8c6d2a4d901"
+```
+
+Leave `pinned_tools` empty to switch to snapshot mode. In that mode, Assay compares multiple `tools/list` snapshots in the same trace and flags mid-session mutations.
+
+#### `tool_output_valid`
+
+`tool_output_valid` complements `args_valid`: it validates what the tool returns, not just what the agent sent.
+
+```yaml
+tests:
+  - id: tool_outputs
+    expected:
+      type: tool_output_valid
+      schemas:
+        exec:
+          type: object
+          required: [exit_code]
+          properties:
+            exit_code: { type: integer }
+            stdout: { type: string }
+```
+
+#### `tool_collision_detect`
+
+Use `trusted_servers` when duplicate tool names are expected only inside a known MCP cluster.
+
+```yaml
+tests:
+  - id: no_tool_shadowing
+    expected:
+      type: tool_collision_detect
+      trusted_servers:
+        - trusted-fileserver
+        - trusted-search
+```
 
 ---
 

--- a/docs/guides/otel-langfuse.md
+++ b/docs/guides/otel-langfuse.md
@@ -66,6 +66,24 @@ Now you have both:
 - observability in your existing stack
 - a replayable, verifiable evidence artifact in Assay
 
+## Assay-Native Metric Spans
+
+When you run Assay directly, the runner now emits one `assay.eval.metric` span per metric evaluation. That span is additive to any upstream agent traces you already collect and gives you a stable place to inspect policy latency and result state.
+
+Fields recorded on `assay.eval.metric`:
+
+- `assay.eval.test_id`
+- `assay.eval.metric.name`
+- `assay.eval.response.cached`
+- `assay.eval.metric.score`
+- `assay.eval.metric.passed`
+- `assay.eval.metric.unstable`
+- `assay.eval.metric.duration_ms`
+- `error`
+- `error.message`
+
+This span intentionally records evaluation metadata, not raw prompts or tool arguments, so it stays useful for latency triage without widening the observability payload surface.
+
 ## Langfuse Positioning
 
 Langfuse is great for tracing, prompts, and production observability.

--- a/docs/guides/runtime-monitor.md
+++ b/docs/guides/runtime-monitor.md
@@ -71,5 +71,15 @@ The monitor requires `CAP_BPF` and `CAP_PERFMON` (or `sudo`).
 sudo assay monitor --ebpf ./target/assay-ebpf.o --policy policy.yaml
 ```
 
+### Operator Output
+
+Blocked-file denials are rendered as structured fields so operators can correlate the kernel event with the exact deny rule:
+
+```text
+[PID 4242] 🛡️ BLOCKED FILE: dev=2050 ino=918273 cgroup=4026532987 rule_id=7
+```
+
+At the end of a run, `assay monitor` also prints a summary of emitted and dropped ring-buffer events for the tracepoint, LSM, and socket paths. If any drop counter is non-zero, the CLI prints a `Ring buffer pressure detected` warning so an operator can distinguish "no events" from "events were dropped under load".
+
 > [!IMPORTANT]
 > Ensure your kernel is booted with `lsm=...,bpf` in the command line parameters to enable BPF LSM support.

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -35,11 +35,13 @@ This document outlines the canonical checklist for releasing new versions of Ass
   ```
 - [ ] **Watch CI**: Monitor the `release.yml` workflow.
   - Step: `Publish to Crates.io` (uses `scripts/ci/publish_idempotent.sh`).
-  - Step: `Create GitHub Release` (upload binaries).
+  - Step: `Create GitHub Release` (upload binaries and release assets).
+  - Step: `Generate CycloneDX SBOM bundle` (produces `release/assay-${VERSION}-sbom-cyclonedx.tar.gz` plus `.sha256`).
 
 ### 4. Verification
 - [ ] **Install Check**: `cargo install assay-cli --version 2.2.3`
 - [ ] **LSM Smoke Test**: Manually dispatch the `lsm-smoke-test` workflow or run `scripts/verify_lsm_docker.sh --release-tag v2.2.3`.
+- [ ] **SBOM Asset Check**: Confirm the GitHub release includes `assay-${VERSION}-sbom-cyclonedx.tar.gz` and `assay-${VERSION}-sbom-cyclonedx.tar.gz.sha256`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- document the new MCP integrity metrics in the metrics concepts page and changelog
- record the structured blocked-file monitor output and ring-buffer pressure summary in the runtime monitor guide
- document the `assay.eval.metric` span fields and the CycloneDX SBOM release asset in the observability and release docs

## Why
These are semipublic contract changes that landed across #896 through #899. This follow-up makes the operator-facing output, release assets, and tracing surface explicit in docs and release notes.

## Verification
- `git diff --check`
- `source /private/tmp/assay-docs-venv/bin/activate && mkdocs build -q`
