### PR TITLE
Wave T1a: harden JSON-RPC id correlation

### DIFF
--- a/crates/assay-cli/tests/mcp_id_correlation_errors.rs
+++ b/crates/assay-cli/tests/mcp_id_correlation_errors.rs
@@ -1,0 +1,66 @@
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+#[allow(deprecated)]
+fn contract_import_rejects_boolean_jsonrpc_id() {
+    let dir = tempdir().expect("tempdir");
+    let input = dir.path().join("bool-id.jsonl");
+    fs::write(
+        &input,
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":true,"method":"tools/call","params":{"name":"BoolId","arguments":{"x":1}}}
+"#,
+    )
+    .expect("write input");
+
+    let assert = Command::cargo_bin("assay")
+        .expect("assay binary")
+        .arg("import")
+        .arg(&input)
+        .arg("--format")
+        .arg("jsonrpc")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("failed to parse MCP transcript"),
+        "missing parse context: {stderr}"
+    );
+    assert!(
+        stderr.contains("must not be a boolean"),
+        "missing boolean-id diagnostic: {stderr}"
+    );
+}
+
+#[test]
+#[allow(deprecated)]
+fn contract_import_rejects_duplicate_tool_call_request_ids() {
+    let dir = tempdir().expect("tempdir");
+    let input = dir.path().join("duplicate-id.jsonl");
+    fs::write(
+        &input,
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":"dup-1","method":"tools/call","params":{"name":"First","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":"dup-1","method":"tools/call","params":{"name":"Second","arguments":{"x":2}}}
+"#,
+    )
+    .expect("write input");
+
+    let assert = Command::cargo_bin("assay")
+        .expect("assay binary")
+        .arg("import")
+        .arg(&input)
+        .arg("--format")
+        .arg("jsonrpc")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("duplicate tools/call request id"),
+        "missing duplicate-id diagnostic: {stderr}"
+    );
+}

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -1,15 +1,18 @@
 use crate::mcp::types::*;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
+use std::collections::HashSet;
 
 /// Parse MCP transcript file contents into normalized McpEvents.
 pub fn parse_mcp_transcript(text: &str, format: McpInputFormat) -> Result<Vec<McpEvent>> {
-    match format {
+    let events = match format {
         McpInputFormat::JsonRpc => parse_jsonrpc_jsonl(text),
         McpInputFormat::Inspector => parse_inspector_best_effort(text),
         McpInputFormat::StreamableHttp => parse_streamable_http_transcript(text),
         McpInputFormat::HttpSse => parse_http_sse_transcript(text),
-    }
+    }?;
+    validate_mcp_events(&events)?;
+    Ok(events)
 }
 
 fn parse_jsonrpc_jsonl(text: &str) -> Result<Vec<McpEvent>> {
@@ -143,9 +146,7 @@ fn parse_jsonrpc_message(
     let ts_ms = timestamp_ms_override.or_else(|| extract_ts_ms(&v));
 
     // JSON-RPC ID extraction
-    let id_str = v
-        .get("id")
-        .map(|x| x.to_string().trim_matches('"').to_string());
+    let id_str = normalize_jsonrpc_id(v.get("id"), source_line)?;
 
     // Check for JSON-RPC Request (has method)
     let method = v
@@ -211,6 +212,55 @@ fn parse_jsonrpc_message(
         jsonrpc_id: id_str,
         payload,
     })
+}
+
+fn normalize_jsonrpc_id(
+    raw_id: Option<&serde_json::Value>,
+    source_line: u64,
+) -> Result<Option<String>> {
+    match raw_id {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(id)) => Ok(Some(id.clone())),
+        Some(serde_json::Value::Number(id)) => Ok(Some(id.to_string())),
+        Some(serde_json::Value::Bool(_)) => {
+            bail!(
+                "JSON-RPC id on source line {} must not be a boolean",
+                source_line
+            )
+        }
+        Some(serde_json::Value::Array(_)) => {
+            bail!(
+                "JSON-RPC id on source line {} must not be an array",
+                source_line
+            )
+        }
+        Some(serde_json::Value::Object(_)) => {
+            bail!(
+                "JSON-RPC id on source line {} must not be an object",
+                source_line
+            )
+        }
+    }
+}
+
+fn validate_mcp_events(events: &[McpEvent]) -> Result<()> {
+    let mut seen_tool_call_request_ids = HashSet::new();
+
+    for event in events {
+        if matches!(&event.payload, McpPayload::ToolCallRequest { .. }) {
+            if let Some(id) = &event.jsonrpc_id {
+                if !seen_tool_call_request_ids.insert(id.clone()) {
+                    bail!(
+                        "duplicate tools/call request id {:?} at source line {}",
+                        id,
+                        event.source_line
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn extract_jsonrpc_from_sse(

--- a/crates/assay-core/tests/mcp_id_correlation.rs
+++ b/crates/assay-core/tests/mcp_id_correlation.rs
@@ -1,0 +1,274 @@
+use assay_core::mcp::{mcp_events_to_v2_trace, parse_mcp_transcript, McpInputFormat};
+use assay_core::trace::schema::TraceEvent;
+use serde_json::json;
+
+#[test]
+fn contract_string_id_correlates() {
+    let trace = normalize_trace(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":"req-1","method":"tools/call","params":{"name":"StringId","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":"req-1","result":{"ok":true}}
+"#,
+    );
+
+    assert_tool_call(
+        &trace,
+        "StringId",
+        json!({"x": 1}),
+        Some(json!({"ok": true})),
+        None,
+    );
+}
+
+#[test]
+fn contract_numeric_id_canonicalizes_and_correlates() {
+    let events = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"NumericId","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":7,"result":{"ok":true}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap();
+
+    assert_eq!(events[0].jsonrpc_id.as_deref(), Some("7"));
+
+    let trace = mcp_events_to_v2_trace(events, "numeric".into(), None, None);
+    assert_tool_call(
+        &trace,
+        "NumericId",
+        json!({"x": 1}),
+        Some(json!({"ok": true})),
+        None,
+    );
+}
+
+#[test]
+fn contract_null_id_normalizes_to_none_and_does_not_correlate() {
+    let events = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":null,"method":"tools/call","params":{"name":"NullId","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":null,"result":{"ok":true}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap();
+
+    assert_eq!(events[0].jsonrpc_id, None);
+    assert_eq!(events[1].jsonrpc_id, None);
+
+    let trace = mcp_events_to_v2_trace(events, "null-id".into(), None, None);
+    assert_no_jsonrpc_id_literal_null(&trace);
+    assert_tool_call(&trace, "NullId", json!({"x": 1}), None, None);
+}
+
+#[test]
+fn contract_missing_request_id_does_not_correlate() {
+    let events = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","method":"tools/call","params":{"name":"MissingRequestId","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":"ghost","result":{"ok":true}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap();
+
+    let trace = mcp_events_to_v2_trace(events, "missing-request-id".into(), None, None);
+    assert_tool_call(&trace, "MissingRequestId", json!({"x": 1}), None, None);
+}
+
+#[test]
+fn contract_missing_response_id_remains_unmatched() {
+    let events = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":"req-1","method":"tools/call","params":{"name":"MissingResponseId","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","result":{"ok":true}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap();
+
+    let trace = mcp_events_to_v2_trace(events, "missing-response-id".into(), None, None);
+    assert_tool_call(
+        &trace,
+        "MissingResponseId",
+        json!({"x": 1}),
+        None,
+        Some("timeout/no_response"),
+    );
+}
+
+#[test]
+fn contract_mismatch_ids_leave_response_orphan_and_request_pending() {
+    let events = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":"req-1","method":"tools/call","params":{"name":"MismatchId","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":"req-2","result":{"ok":true}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap();
+
+    let trace = mcp_events_to_v2_trace(events, "mismatch-id".into(), None, None);
+    assert_tool_call(
+        &trace,
+        "MismatchId",
+        json!({"x": 1}),
+        None,
+        Some("timeout/no_response"),
+    );
+}
+
+#[test]
+fn contract_duplicate_request_ids_fail_hard() {
+    let err = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":"dup-1","method":"tools/call","params":{"name":"First","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":"dup-1","method":"tools/call","params":{"name":"Second","arguments":{"x":2}}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("duplicate tools/call request id \"dup-1\""),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn contract_first_response_wins_and_later_duplicate_responses_are_orphan() {
+    let events = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":"req-1","method":"tools/call","params":{"name":"FirstMatchWins","arguments":{"x":1}}}
+{"timestamp_ms":1001,"jsonrpc":"2.0","id":"req-1","result":{"ok":true}}
+{"timestamp_ms":1002,"jsonrpc":"2.0","id":"req-1","result":{"ok":"late"}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap();
+
+    let trace = mcp_events_to_v2_trace(events, "first-match-wins".into(), None, None);
+    let tool_calls: Vec<_> = trace
+        .iter()
+        .filter_map(|event| match event {
+            TraceEvent::ToolCall(call) => Some(call),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].result, Some(json!({"ok": true})));
+    assert_eq!(tool_calls[0].error, None);
+
+    let end = trace
+        .iter()
+        .find_map(|event| match event {
+            TraceEvent::EpisodeEnd(end) => Some(end),
+            _ => None,
+        })
+        .expect("episode end");
+    assert_eq!(end.final_output.as_deref(), Some("{\"ok\":\"late\"}"));
+}
+
+#[test]
+fn contract_bool_id_true_fails_hard() {
+    let err = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":true,"method":"tools/call","params":{"name":"BoolTrue","arguments":{"x":1}}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("must not be a boolean"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn contract_bool_id_false_fails_hard() {
+    let err = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":false,"method":"tools/call","params":{"name":"BoolFalse","arguments":{"x":1}}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("must not be a boolean"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn contract_object_id_fails_hard() {
+    let err = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":{"bad":1},"method":"tools/call","params":{"name":"ObjectId","arguments":{"x":1}}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("must not be an object"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn contract_array_id_fails_hard() {
+    let err = parse_mcp_transcript(
+        r#"
+{"timestamp_ms":1000,"jsonrpc":"2.0","id":[1,2],"method":"tools/call","params":{"name":"ArrayId","arguments":{"x":1}}}
+"#,
+        McpInputFormat::JsonRpc,
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("must not be an array"),
+        "unexpected error: {err}"
+    );
+}
+
+fn normalize_trace(input: &str) -> Vec<TraceEvent> {
+    let events = parse_mcp_transcript(input, McpInputFormat::JsonRpc).expect("parse transcript");
+    mcp_events_to_v2_trace(events, "id-correlation".into(), None, None)
+}
+
+fn assert_tool_call(
+    trace: &[TraceEvent],
+    tool_name: &str,
+    args: serde_json::Value,
+    result: Option<serde_json::Value>,
+    error: Option<&str>,
+) {
+    let tool_call = trace
+        .iter()
+        .find_map(|event| match event {
+            TraceEvent::ToolCall(call) if call.tool_name == tool_name => Some(call),
+            _ => None,
+        })
+        .expect("tool call");
+
+    assert_eq!(tool_call.args, args);
+    assert_eq!(tool_call.result, result);
+    assert_eq!(tool_call.error.as_deref(), error);
+}
+
+fn assert_no_jsonrpc_id_literal_null(trace: &[TraceEvent]) {
+    for event in trace {
+        if let TraceEvent::Step(step) = event {
+            assert_ne!(
+                step.meta.get("jsonrpc_id"),
+                Some(&json!("null")),
+                "JSON null must not normalize to literal string \"null\"",
+            );
+        }
+    }
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave-t1a-id-correlation-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave-t1a-id-correlation-step1.md
@@ -1,0 +1,38 @@
+# Wave T1a Step1 checklist: JSON-RPC id normalization and correlation
+
+Scope freeze:
+- [ ] Parser/correlation hardening only; no transport expansion.
+- [ ] No live runtime changes.
+- [ ] No V2 schema change.
+
+Files:
+- [ ] `crates/assay-core/src/mcp/parser.rs`
+- [ ] `crates/assay-core/tests/mcp_id_correlation.rs`
+- [ ] `crates/assay-core/tests/mcp_transport_compat.rs`
+- [ ] `crates/assay-cli/tests/mcp_id_correlation_errors.rs`
+- [ ] `docs/mcp/import-formats.md`
+- [ ] `scripts/ci/review-wave-t1a-id-correlation-step1.sh`
+- [ ] `docs/contributing/SPLIT-*wave-t1a-id-correlation-step1.md`
+
+Contract anchors:
+- [ ] string ids remain strings
+- [ ] numeric ids normalize to strings
+- [ ] JSON null ids normalize to none
+- [ ] missing ids normalize to none
+- [ ] literal string `"null"` is not produced from JSON null
+- [ ] bool ids fail hard
+- [ ] object ids fail hard
+- [ ] array ids fail hard
+- [ ] duplicate `tools/call` request ids fail hard
+- [ ] first matching response binds the request
+- [ ] later responses with the same id remain orphan and do not overwrite earlier correlation
+
+Validation:
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy -q -p assay-core -p assay-cli --all-targets -- -D warnings`
+- [ ] `cargo test -q -p assay-core --test mcp_id_correlation`
+- [ ] `cargo test -q -p assay-core --test mcp_transport_compat`
+- [ ] `cargo test -q -p assay-core --test mcp_import_smoke`
+- [ ] `cargo test -q -p assay-cli --test mcp_id_correlation_errors`
+- [ ] reviewer script passes against `origin/main`
+- [ ] `git diff --check`

--- a/docs/contributing/SPLIT-INVENTORY-wave-t1a-id-correlation-step1.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave-t1a-id-correlation-step1.md
@@ -1,0 +1,33 @@
+# Wave T1a Step1 inventory: JSON-RPC id normalization and correlation
+
+Snapshot baseline (`origin/main` before Step1): `d90ca7d5`
+Working branch head: see `git rev-parse --short HEAD`
+
+Target files:
+- `crates/assay-core/src/mcp/parser.rs`
+- `crates/assay-core/tests/mcp_id_correlation.rs`
+- `crates/assay-core/tests/mcp_transport_compat.rs`
+- `crates/assay-cli/tests/mcp_id_correlation_errors.rs`
+- `docs/mcp/import-formats.md`
+- `scripts/ci/review-wave-t1a-id-correlation-step1.sh`
+- `docs/contributing/SPLIT-*wave-t1a-id-correlation-step1.md`
+
+Step1 contract:
+- Normalize JSON-RPC ids as:
+  - string -> string
+  - numeric -> canonical string
+  - null -> none
+  - missing -> none
+- Reject invalid id types:
+  - bool
+  - object
+  - array
+- Reject duplicate `tools/call` request ids inside one transcript.
+- Preserve first-match-wins response binding; later duplicate responses remain orphan and do not overwrite prior correlation.
+
+Non-goals in Step1:
+- no extra transport compatibility work
+- no session or resumability work
+- no multi-stream handling
+- no broad `mapper_v2.rs` refactor
+- no runtime MCP behavior changes

--- a/docs/contributing/SPLIT-MOVE-MAP-wave-t1a-id-correlation-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave-t1a-id-correlation-step1.md
@@ -1,0 +1,23 @@
+# SPLIT MOVE MAP — Wave T1a Id Correlation Step1
+
+## Intent
+This step hardens the shared JSON-RPC id normalization and correlation contract. It does not add transport behavior or new runtime semantics.
+
+## Data flow map
+1. `crates/assay-core/src/mcp/parser.rs`
+   - normalizes JSON-RPC ids into the accepted set
+   - rejects invalid id types
+   - rejects duplicate `tools/call` request ids before mapping
+2. `crates/assay-core/tests/mcp_id_correlation.rs`
+   - freezes parser and correlation behavior for string/numeric/null/missing/invalid ids
+   - freezes first-match-wins and orphan behavior
+3. `crates/assay-cli/tests/mcp_id_correlation_errors.rs`
+   - verifies user-facing parse failures stay understandable
+4. `docs/mcp/import-formats.md`
+   - records the JSON-RPC id normalization contract
+
+## Reviewer focus
+- JSON null never becomes literal string `"null"`
+- duplicate request ids fail in parser scope rather than creating silent correlation ambiguity
+- first matching response still wins without mapper churn
+- no transport or session semantics leak into this slice

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave-t1a-id-correlation-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave-t1a-id-correlation-step1.md
@@ -1,0 +1,25 @@
+# Wave T1a Step1 review pack: JSON-RPC id normalization and correlation
+
+## Scope summary
+- Hardens the shared MCP JSON-RPC id contract without reopening T1 transport compatibility.
+- Makes null/missing ids non-correlating, rejects invalid id types, and rejects duplicate `tools/call` request ids.
+- Leaves transport, session, and runtime behavior out of scope.
+
+## Review questions
+1. Does JSON null now normalize to no id rather than literal `"null"`?
+2. Are numeric ids still accepted and correlated canonically?
+3. Do duplicate `tools/call` request ids fail before ambiguous mapping can happen?
+4. Is first-match-wins behavior explicit and still stable?
+5. Are CLI parse failures understandable for invalid id input?
+
+## Validation commands
+```bash
+cargo fmt --check
+cargo clippy -q -p assay-core -p assay-cli --all-targets -- -D warnings
+cargo test -q -p assay-core --test mcp_id_correlation
+cargo test -q -p assay-core --test mcp_transport_compat
+cargo test -q -p assay-core --test mcp_import_smoke
+cargo test -q -p assay-cli --test mcp_id_correlation_errors
+BASE_REF=origin/main bash scripts/ci/review-wave-t1a-id-correlation-step1.sh
+git diff --check
+```

--- a/docs/mcp/import-formats.md
+++ b/docs/mcp/import-formats.md
@@ -253,6 +253,24 @@ The legacy `endpoint` event is treated as transport-only context and does not af
 
 Assay correlates requests and responses by JSON-RPC `id`, just like the HTTP transcript formats.
 
+### JSON-RPC `id` Normalization
+
+For MCP import and correlation:
+
+- string `id` values are accepted as-is
+- numeric `id` values are accepted and normalized to strings
+- `null` `id` values normalize to no correlation id
+- missing `id` values also normalize to no correlation id
+- JSON `null` is not treated as the literal string `"null"`
+- boolean, object, and array `id` values are rejected as invalid input
+
+Correlation notes:
+
+- requests without a correlation id do not bind later responses
+- the first matching response binds a request
+- later responses with the same `id` stay orphan and do not overwrite the earlier match
+- duplicate `tools/call` request ids in one transcript fail at parse time
+
 ---
 
 ## Out Of Scope In T1

--- a/scripts/ci/review-wave-t1a-id-correlation-step1.sh
+++ b/scripts/ci/review-wave-t1a-id-correlation-step1.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${BASE_REF}" >&2
+  exit 1
+fi
+
+check_has_match() {
+  local pattern="$1"
+  local file="$2"
+  if ! rg -n -- "$pattern" "$file" >/dev/null; then
+    echo "missing expected pattern in ${file}: ${pattern}" >&2
+    exit 1
+  fi
+}
+
+echo "== formatting =="
+cargo fmt --check
+
+echo "== lint =="
+cargo clippy -q -p assay-core -p assay-cli --all-targets -- -D warnings
+
+echo "== contract tests =="
+cargo test -q -p assay-core --test mcp_id_correlation
+cargo test -q -p assay-core --test mcp_transport_compat
+cargo test -q -p assay-core --test mcp_import_smoke
+cargo test -q -p assay-cli --test mcp_id_correlation_errors
+
+echo "== parser anchors =="
+check_has_match 'normalize_jsonrpc_id' 'crates/assay-core/src/mcp/parser.rs'
+check_has_match 'Value::Null' 'crates/assay-core/src/mcp/parser.rs'
+check_has_match 'Ok\(None\)' 'crates/assay-core/src/mcp/parser.rs'
+check_has_match 'must not be a boolean' 'crates/assay-core/src/mcp/parser.rs'
+check_has_match 'duplicate tools/call request id' 'crates/assay-core/src/mcp/parser.rs'
+if rg -n -- 'get\("id"\).*trim_matches' crates/assay-core/src/mcp/parser.rs >/dev/null; then
+  echo 'raw JSON-RPC id stringification shortcut must not remain in parser.rs' >&2
+  exit 1
+fi
+
+echo "== test anchors =="
+check_has_match 'contract_bool_id_true_fails_hard' 'crates/assay-core/tests/mcp_id_correlation.rs'
+check_has_match 'contract_bool_id_false_fails_hard' 'crates/assay-core/tests/mcp_id_correlation.rs'
+check_has_match 'contract_first_response_wins_and_later_duplicate_responses_are_orphan' 'crates/assay-core/tests/mcp_id_correlation.rs'
+check_has_match 'assert_no_jsonrpc_id_literal_null' 'crates/assay-core/tests/mcp_id_correlation.rs'
+check_has_match 'must not be a boolean' 'crates/assay-cli/tests/mcp_id_correlation_errors.rs'
+check_has_match 'duplicate tools/call request id' 'crates/assay-cli/tests/mcp_id_correlation_errors.rs'
+
+echo "== docs anchors =="
+check_has_match '### JSON-RPC `id` Normalization' 'docs/mcp/import-formats.md'
+check_has_match 'literal string `"null"`' 'docs/mcp/import-formats.md'
+check_has_match 'duplicate `tools/call` request ids in one transcript fail at parse time' 'docs/mcp/import-formats.md'
+
+echo "== diff allowlist =="
+leaks="$(rg -v \
+  '^crates/assay-core/src/mcp/parser\.rs$|^crates/assay-core/tests/mcp_id_correlation\.rs$|^crates/assay-cli/tests/mcp_id_correlation_errors\.rs$|^docs/mcp/import-formats\.md$|^scripts/ci/review-wave-t1a-id-correlation-step1\.sh$|^docs/contributing/SPLIT-(INVENTORY|CHECKLIST|MOVE-MAP|REVIEW-PACK)-wave-t1a-id-correlation-step1\.md$' \
+  < <(git diff --name-only "${BASE_REF}...HEAD") || true)"
+if [ -n "$leaks" ]; then
+  echo "non-allowlisted files detected:" >&2
+  echo "$leaks" >&2
+  exit 1
+fi
+
+echo "== whitespace =="
+git diff --check "${BASE_REF}...HEAD"
+
+echo "Wave T1a Step1 reviewer script: PASS"


### PR DESCRIPTION
## Summary
- normalize JSON-RPC ids explicitly so string and numeric ids correlate canonically while `null` and missing ids never become literal `"null"`
- reject invalid id types and duplicate `tools/call` request ids before ambiguous MCP correlation can happen
- add focused core + CLI contract tests, plus a wave reviewer gate and docs note for the frozen T1a id contract

## Wave Artifacts
- `docs/contributing/SPLIT-INVENTORY-wave-t1a-id-correlation-step1.md`
- `docs/contributing/SPLIT-CHECKLIST-wave-t1a-id-correlation-step1.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave-t1a-id-correlation-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave-t1a-id-correlation-step1.md`
- `scripts/ci/review-wave-t1a-id-correlation-step1.sh`

## Verification
- `BASE_REF=origin/main bash scripts/ci/review-wave-t1a-id-correlation-step1.sh`
- `cargo fmt --check`
- `cargo clippy -q -p assay-core -p assay-cli --all-targets -- -D warnings`
- `cargo test -q -p assay-core --test mcp_id_correlation`
- `cargo test -q -p assay-core --test mcp_transport_compat`
- `cargo test -q -p assay-core --test mcp_import_smoke`
- `cargo test -q -p assay-cli --test mcp_id_correlation_errors`
- `git diff --check`

## Notes
- Scope is intentionally limited to parser/correlation hardening only; no transport/runtime expansion.
- The frozen contract is: string ids accepted, numeric ids canonicalized to strings, `null`/missing ids do not correlate, bool/object/array ids fail hard, first-match-wins, and later duplicate responses stay orphan.
