### PR TITLE
wave-p1: ship signal-aware OWASP follow-up pack

### DIFF
--- a/crates/assay-evidence/packs/owasp-agentic-a3-a5-signal-followup.yaml
+++ b/crates/assay-evidence/packs/owasp-agentic-a3-a5-signal-followup.yaml
@@ -1,0 +1,68 @@
+name: owasp-agentic-a3-a5-signal-followup
+version: "1.0.0"
+kind: security
+description: OWASP Agentic ASI03/ASI05 signal-aware evidence follow-up for supported delegated flows and supported containment fallback paths
+author: Assay Team
+license: Apache-2.0
+
+disclaimer: |
+  This pack verifies only supported delegation-context visibility and supported
+  containment degradation evidence for a narrow OWASP Agentic ASI03/ASI05
+  follow-up surface.
+  Passing these checks does NOT prove delegation validity, delegation-chain
+  integrity, inherited-scope correctness, temporal delegation correctness,
+  sandbox correctness, or full containment-failure coverage.
+
+requires:
+  assay_min_version: ">=3.2.2"
+  evidence_schema_version: "1.0"
+
+rules:
+  - id: A3-003
+    severity: warning
+    description: Decision evidence surfaces delegated authority context for supported delegated flows.
+    article_ref: "ASI03"
+    help_markdown: |
+      ## ASI03 Identity & Privilege Abuse - Delegation Context Evidence
+
+      This rule verifies that at least one `assay.tool.decision` event for
+      supported delegated flows contains `delegated_from`.
+
+      **What this checks:**
+      - At least one supported decision event contains `delegated_from`
+      - `delegation_depth` may appear as optional supporting context, but it is
+        not required
+
+      **What this does not prove:**
+      - Delegation validity
+      - Delegation chain integrity
+      - Inherited-scope correctness
+      - Temporal delegation correctness
+    event_types:
+      - assay.tool.decision
+    check:
+      type: event_field_present
+      paths_any_of:
+        - /data/delegated_from
+
+  - id: A5-002
+    severity: warning
+    description: Evidence records supported containment degradation fallback paths.
+    article_ref: "ASI05"
+    help_markdown: |
+      ## ASI05 Unexpected Code Execution - Containment Degradation Evidence
+
+      This rule verifies that the evidence bundle contains an
+      `assay.sandbox.degraded` event from a supported weaker-than-requested
+      containment fallback path.
+
+      **What this checks:**
+      - At least one event matches `assay.sandbox.degraded`
+
+      **What this does not prove:**
+      - Sandbox correctness
+      - Execution authorization
+      - All containment failures detected
+    check:
+      type: event_type_exists
+      pattern: assay.sandbox.degraded

--- a/crates/assay-evidence/src/lint/packs/mod.rs
+++ b/crates/assay-evidence/src/lint/packs/mod.rs
@@ -37,6 +37,10 @@ pub static BUILTIN_PACKS: &[(&str, &str)] = &[
         include_str!("../../../packs/owasp-agentic-control-evidence-baseline.yaml"),
     ),
     (
+        "owasp-agentic-a3-a5-signal-followup",
+        include_str!("../../../packs/owasp-agentic-a3-a5-signal-followup.yaml"),
+    ),
+    (
         "soc2-baseline",
         include_str!("../../../packs/soc2-baseline.yaml"),
     ),

--- a/crates/assay-evidence/tests/fixtures/packs/owasp-agentic-a3-probe.yaml
+++ b/crates/assay-evidence/tests/fixtures/packs/owasp-agentic-a3-probe.yaml
@@ -37,11 +37,8 @@ rules:
 
   - id: A3-003
     severity: warning
-    description: decision events capture delegated identity chain evidence
+    description: decision evidence surfaces delegated authority context for supported delegated flows
     check:
       type: event_field_present
       paths_any_of:
         - /data/delegated_from
-        - /data/actor_chain
-        - /data/inherited_scopes
-        - /data/delegation_depth

--- a/crates/assay-evidence/tests/owasp_agentic_c1_mapping.rs
+++ b/crates/assay-evidence/tests/owasp_agentic_c1_mapping.rs
@@ -104,7 +104,6 @@ fn authorization_bundle(include_mandate: bool, include_delegation_fields: bool) 
 
     if include_delegation_fields {
         payload["delegated_from"] = json!("service-account:runner");
-        payload["actor_chain"] = json!(["user:alice", "service-account:runner"]);
         payload["delegation_depth"] = json!(1);
     }
 

--- a/crates/assay-evidence/tests/owasp_agentic_p1_signal_followup.rs
+++ b/crates/assay-evidence/tests/owasp_agentic_p1_signal_followup.rs
@@ -1,0 +1,325 @@
+use assay_evidence::lint::engine::{lint_bundle_with_options, LintOptions, LintReportWithPacks};
+use assay_evidence::lint::packs::loader::{load_pack, load_pack_from_file};
+use assay_evidence::lint::packs::{CheckDefinition, LoadedPack};
+use assay_evidence::{BundleWriter, EvidenceEvent, VerifyLimits};
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repo root")
+        .to_path_buf()
+}
+
+fn open_pack_path() -> PathBuf {
+    repo_root()
+        .join("packs")
+        .join("open")
+        .join("owasp-agentic-a3-a5-signal-followup")
+        .join("pack.yaml")
+}
+
+fn readme_path() -> PathBuf {
+    repo_root()
+        .join("packs")
+        .join("open")
+        .join("owasp-agentic-a3-a5-signal-followup")
+        .join("README.md")
+}
+
+fn builtin_pack_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("packs")
+        .join("owasp-agentic-a3-a5-signal-followup.yaml")
+}
+
+fn load_open_pack() -> LoadedPack {
+    load_pack_from_file(&open_pack_path()).expect("open pack should load")
+}
+
+fn load_builtin_pack() -> LoadedPack {
+    load_pack("owasp-agentic-a3-a5-signal-followup").expect("built-in pack should load")
+}
+
+fn normalize_text(input: &str) -> String {
+    input.to_ascii_lowercase()
+}
+
+fn normalize_space_text(input: &str) -> String {
+    input
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+fn count_case_insensitive(haystack: &str, needle: &str) -> usize {
+    normalize_text(haystack)
+        .matches(&normalize_text(needle))
+        .count()
+}
+
+fn canonical_rule_ids(pack: &LoadedPack) -> Vec<&str> {
+    pack.definition
+        .rules
+        .iter()
+        .map(|rule| rule.id.as_str())
+        .collect()
+}
+
+fn make_event(type_: &str, run_id: &str, seq: u64, payload: serde_json::Value) -> EvidenceEvent {
+    let mut event = EvidenceEvent::new(type_, "urn:assay:test:p1", run_id, seq, payload);
+    event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
+    event
+}
+
+fn make_bundle(events: Vec<EvidenceEvent>) -> Vec<u8> {
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    for event in events {
+        writer.add_event(event);
+    }
+    writer.finish().expect("bundle should finish");
+    buffer
+}
+
+fn supported_delegated_flow_bundle() -> Vec<u8> {
+    make_bundle(vec![make_event(
+        "assay.tool.decision",
+        "run_p1_a3_pass",
+        0,
+        json!({
+            "tool": "tool.commit",
+            "decision": "allow",
+            "principal": "user:alice",
+            "approval_state": "granted",
+            "delegated_from": "agent:planner",
+            "delegation_depth": 1
+        }),
+    )])
+}
+
+fn direct_authorization_bundle() -> Vec<u8> {
+    make_bundle(vec![make_event(
+        "assay.tool.decision",
+        "run_p1_a3_fail",
+        0,
+        json!({
+            "tool": "tool.commit",
+            "decision": "allow",
+            "principal": "user:alice",
+            "approval_state": "granted"
+        }),
+    )])
+}
+
+fn supported_degraded_bundle() -> Vec<u8> {
+    make_bundle(vec![make_event(
+        "assay.sandbox.degraded",
+        "run_p1_a5_pass",
+        0,
+        json!({
+            "reason_code": "policy_conflict",
+            "degradation_mode": "audit_fallback",
+            "component": "landlock"
+        }),
+    )])
+}
+
+fn clean_bundle() -> Vec<u8> {
+    make_bundle(vec![make_event(
+        "assay.process.exec",
+        "run_p1_a5_fail",
+        0,
+        json!({
+            "hits": 1
+        }),
+    )])
+}
+
+fn lint_with_pack(pack: LoadedPack, bundle: &[u8]) -> LintReportWithPacks {
+    let options = LintOptions {
+        packs: vec![pack],
+        max_results: Some(500),
+        bundle_path: Some("p1-pack.tar.gz".to_string()),
+    };
+    lint_bundle_with_options(Cursor::new(bundle), VerifyLimits::default(), options)
+        .expect("lint should succeed")
+}
+
+fn has_rule_finding(result: &LintReportWithPacks, pack_name: &str, rule_id: &str) -> bool {
+    let prefix = format!("{pack_name}@");
+    result
+        .report
+        .findings
+        .iter()
+        .any(|finding| finding.rule_id.starts_with(&prefix) && finding.rule_id.ends_with(rule_id))
+}
+
+#[test]
+fn p1_loads_builtin_and_open_pack_with_two_rules() {
+    let builtin = load_builtin_pack();
+    let open = load_open_pack();
+
+    assert_eq!(
+        builtin.definition.name,
+        "owasp-agentic-a3-a5-signal-followup"
+    );
+    assert_eq!(open.definition.name, "owasp-agentic-a3-a5-signal-followup");
+    assert_eq!(builtin.definition.rules.len(), 2);
+    assert_eq!(open.definition.rules.len(), 2);
+}
+
+#[test]
+fn p1_builtin_and_open_pack_are_exactly_equivalent() {
+    let builtin_raw = fs::read_to_string(builtin_pack_path()).expect("read builtin yaml");
+    let open_raw = fs::read_to_string(open_pack_path()).expect("read open yaml");
+    assert_eq!(
+        builtin_raw, open_raw,
+        "open pack and built-in mirror must match exactly"
+    );
+
+    let builtin = load_builtin_pack();
+    let open = load_open_pack();
+    assert_eq!(builtin.digest, open.digest);
+    assert_eq!(
+        serde_json::to_value(&builtin.definition).expect("serialize builtin definition"),
+        serde_json::to_value(&open.definition).expect("serialize open definition")
+    );
+}
+
+#[test]
+fn p1_pack_contains_only_signal_aware_rules() {
+    let pack = load_builtin_pack();
+    assert_eq!(canonical_rule_ids(&pack), vec!["A3-003", "A5-002"]);
+}
+
+#[test]
+fn p1_baseline_pack_remains_unchanged() {
+    let baseline =
+        load_pack("owasp-agentic-control-evidence-baseline").expect("baseline pack should load");
+    assert_eq!(
+        canonical_rule_ids(&baseline),
+        vec!["A1-002", "A3-001", "A5-001"]
+    );
+}
+
+#[test]
+fn p1_pack_uses_only_supported_non_skip_prone_constructs() {
+    let pack = load_builtin_pack();
+    let a3 = pack
+        .definition
+        .rules
+        .iter()
+        .find(|rule| rule.id == "A3-003")
+        .expect("A3-003 rule");
+    let a5 = pack
+        .definition
+        .rules
+        .iter()
+        .find(|rule| rule.id == "A5-002")
+        .expect("A5-002 rule");
+
+    for rule in &pack.definition.rules {
+        assert!(rule.engine_min_version.is_none());
+        assert!(!rule.check.is_unsupported());
+    }
+
+    assert!(matches!(
+        a3.check,
+        CheckDefinition::EventFieldPresent { .. }
+    ));
+    assert_eq!(
+        a3.event_types.as_ref().expect("A3-003 event types"),
+        &vec!["assay.tool.decision".to_string()]
+    );
+    assert!(matches!(a5.check, CheckDefinition::EventTypeExists { .. }));
+}
+
+#[test]
+fn p1_readme_explicitly_states_non_goals() {
+    let readme = fs::read_to_string(readme_path()).expect("readme should be readable");
+    assert!(readme.contains("## Non-Goals"));
+    assert!(readme.contains("supported delegated flows"));
+    assert!(readme.contains("supported containment fallback paths"));
+
+    for phrase in [
+        "delegation chain integrity",
+        "delegation validity",
+        "inherited-scope correctness",
+        "temporal delegation correctness",
+        "sandbox correctness",
+        "all containment failures detected",
+    ] {
+        assert_eq!(
+            count_case_insensitive(&readme, phrase),
+            1,
+            "README should mention non-goal phrase exactly once: {phrase}"
+        );
+    }
+
+    assert!(normalize_space_text(&readme).contains(
+        "this pack proves only signal-aware evidence for supported delegated flows and supported containment fallback paths. it does not validate delegation chains, cryptographic provenance, inherited scopes, temporal authorization, or overall containment guarantees."
+    ));
+}
+
+#[test]
+fn p1_pack_wording_stays_signal_only() {
+    let open_yaml = fs::read_to_string(open_pack_path()).expect("open pack yaml");
+    let readme = fs::read_to_string(readme_path()).expect("readme");
+    let normalized_text = normalize_text(&(open_yaml + "\n" + &readme));
+
+    for forbidden in [
+        "verifies delegation",
+        "guarantees chain integrity",
+        "validates inherited scopes",
+        "proves sandboxing",
+        "all containment failures detected.",
+    ] {
+        assert!(
+            !normalized_text.contains(forbidden),
+            "companion pack wording must stay evidence-only: {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn p1_a3_003_passes_when_supported_delegation_fields_are_present() {
+    let result = lint_with_pack(load_builtin_pack(), &supported_delegated_flow_bundle());
+    assert!(
+        !has_rule_finding(&result, "owasp-agentic-a3-a5-signal-followup", "A3-003"),
+        "A3-003 should pass when delegated_from is present on supported decision evidence"
+    );
+}
+
+#[test]
+fn p1_a3_003_fails_when_supported_delegation_fields_are_absent() {
+    let result = lint_with_pack(load_builtin_pack(), &direct_authorization_bundle());
+    assert!(
+        has_rule_finding(&result, "owasp-agentic-a3-a5-signal-followup", "A3-003"),
+        "A3-003 should fail for direct flows without delegated_from"
+    );
+}
+
+#[test]
+fn p1_a5_002_passes_when_sandbox_degraded_event_is_present() {
+    let result = lint_with_pack(load_builtin_pack(), &supported_degraded_bundle());
+    assert!(
+        !has_rule_finding(&result, "owasp-agentic-a3-a5-signal-followup", "A5-002"),
+        "A5-002 should pass when assay.sandbox.degraded is present"
+    );
+}
+
+#[test]
+fn p1_a5_002_fails_when_supported_degradation_signal_is_absent() {
+    let result = lint_with_pack(load_builtin_pack(), &clean_bundle());
+    assert!(
+        has_rule_finding(&result, "owasp-agentic-a3-a5-signal-followup", "A5-002"),
+        "A5-002 should fail when the supported degradation signal is absent"
+    );
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
@@ -1,0 +1,12 @@
+# Wave P1 Checklist
+
+- [ ] `owasp-agentic-control-evidence-baseline` remains unchanged
+- [ ] new companion pack ships exactly `A3-003` and `A5-002`
+- [ ] `A3-003` wording explicitly says `supported delegated flows`
+- [ ] `A3-003` requires only `delegated_from`
+- [ ] `delegation_depth` is documented as optional context only
+- [ ] `A5-002` stays `event_type_exists(pattern=assay.sandbox.degraded)`
+- [ ] open pack and built-in mirror are byte-for-byte identical
+- [ ] README has an explicit `Non-Goals` section
+- [ ] docs remain evidence-only and do not claim delegation validation or sandbox correctness
+- [ ] `C1` probe/mapping truth is aligned with the shipped `G2`/`G1` signal seams

--- a/docs/contributing/SPLIT-INVENTORY-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
@@ -1,0 +1,48 @@
+# Wave P1 Inventory
+
+## Goal
+
+Ship a small companion pack that lets `G1` and `G2` land productmatig without
+broadening the baseline pack:
+
+- `A3-003` for supported delegated flows
+- `A5-002` for supported containment fallback paths
+
+## In Scope
+
+- new built-in companion pack YAML
+- open-pack mirror, README, and LICENSE
+- pack registry update
+- focused assay-evidence tests
+- narrow `C1` mapping / probe alignment
+- reviewer gate + wave artifacts
+
+## Out Of Scope
+
+- baseline pack changes
+- engine changes
+- signal-emitter changes
+- delegation validation / chain integrity
+- inherited-scope validation
+- temporal/reference semantics
+- sandbox correctness claims
+
+## Key Files
+
+- `crates/assay-evidence/packs/owasp-agentic-a3-a5-signal-followup.yaml`
+- `packs/open/owasp-agentic-a3-a5-signal-followup/pack.yaml`
+- `packs/open/owasp-agentic-a3-a5-signal-followup/README.md`
+- `packs/open/owasp-agentic-a3-a5-signal-followup/LICENSE`
+- `crates/assay-evidence/src/lint/packs/mod.rs`
+- `crates/assay-evidence/tests/owasp_agentic_p1_signal_followup.rs`
+- `crates/assay-evidence/tests/owasp_agentic_c1_mapping.rs`
+- `crates/assay-evidence/tests/fixtures/packs/owasp-agentic-a3-probe.yaml`
+- `docs/security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md`
+
+## Behavior Freeze
+
+- baseline pack stays exactly `A1-002`, `A3-001`, `A5-001`
+- companion pack ships exactly `A3-003`, `A5-002`
+- `A3-003` requires only `/data/delegated_from`
+- `delegation_depth` remains optional supporting context
+- `A5-002` remains `event_type_exists(pattern=assay.sandbox.degraded)`

--- a/docs/contributing/SPLIT-INVENTORY-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
+++ b/docs/contributing/SPLIT-INVENTORY-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Ship a small companion pack that lets `G1` and `G2` land productmatig without
+Ship a small companion pack that lets `G1` and `G2` land pragmatically without
 broadening the baseline pack:
 
 - `A3-003` for supported delegated flows

--- a/docs/contributing/SPLIT-MOVE-MAP-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
@@ -1,0 +1,29 @@
+# Wave P1 Move Map
+
+## New shipped surface
+
+- `owasp-agentic-a3-a5-signal-followup`
+  - `A3-003`
+  - `A5-002`
+
+## Registry
+
+- add new built-in pack entry in `crates/assay-evidence/src/lint/packs/mod.rs`
+
+## Open mirror
+
+- add open mirror YAML
+- add README with explicit non-goals
+- copy Apache-2.0 LICENSE
+
+## Probe alignment
+
+- narrow `owasp-agentic-a3-probe.yaml` so `A3-003` rests on `delegated_from`
+- keep `delegation_depth` as optional context in docs/tests only
+
+## Doc truth
+
+- update `docs/security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md`
+  - `A3-003` -> supported delegated flows, `delegated_from` seam
+  - `A5-002` -> presence-only supported fallback-path seam
+  - baseline unchanged; companion pack shipped separately

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave-p1-a3-a5-signal-aware-pack-followup-step1.md
@@ -1,0 +1,17 @@
+# Wave P1 Review Pack
+
+## Review Questions
+
+1. Does the new companion pack stay separate from the baseline pack?
+2. Is `A3-003` explicitly bounded to supported delegated flows and gated only by `delegated_from`?
+3. Does `delegation_depth` remain optional supporting context instead of a rule requirement?
+4. Does `A5-002` stay presence-only on `assay.sandbox.degraded`?
+5. Do README and mapping docs clearly state non-goals around delegation validation, chain integrity, and sandbox correctness?
+
+## Expected Outcomes
+
+- baseline pack unchanged
+- companion pack ships exactly two rules
+- no engine or signal changes
+- no unsupported constructs
+- built-in/open mirror exact equality

--- a/docs/security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md
+++ b/docs/security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md
@@ -75,7 +75,7 @@ re-authorization semantics.
 | --- | --- | --- | --- | --- | --- |
 | `A3-001` Authorization context fields exist on decisions | `event_field_present(paths_any_of=/data/principal,/data/approval_state,/data/mandate_id)` | `assay.tool.decision` authz fields | `Field Presence` | `Field Presence` | `yaml-only` |
 | `A3-002` Allow decisions must carry mandate context | `conditional(if decision=allow then mandate_id exists on same event)` | `assay.tool.decision`, mandate context on allow decisions | `Field Presence` | `Field Presence` | `yaml-only` |
-| `A3-003` Delegation or inherited-privilege chain is visible in evidence | `event_field_present(paths_any_of=/data/delegated_from,/data/actor_chain,/data/inherited_scopes,/data/delegation_depth)` | Supported decision flows can surface explicit delegation fields on `assay.tool.decision` | `Field Presence` | `Field Presence` | `yaml-only` |
+| `A3-003` Delegated authority context is visible in decision evidence for supported delegated flows | `event_field_present(paths_any_of=/data/delegated_from)` | Supported decision flows can surface explicit `delegated_from` on `assay.tool.decision`; `delegation_depth` may appear as optional context | `Field Presence` | `Field Presence` | `yaml-only` |
 
 Interpretation:
 - `A3-001` is a valid yaml-only control-evidence rule.
@@ -84,9 +84,10 @@ Interpretation:
   reference integrity or broader linkage semantics.
 - `A3-003` is no longer a pure signal gap. Supported tool-call flows can
   surface explicit `_meta.delegation` context as `delegated_from` and optional
-  `delegation_depth` on `assay.tool.decision`. This does not prove delegation
-  chain completeness, integrity, inherited-scope correctness, or temporal
-  validity.
+  `delegation_depth` on `assay.tool.decision`. The companion pack
+  `owasp-agentic-a3-a5-signal-followup` ships this rule only for supported
+  delegated flows. This does not prove delegation chain completeness,
+  integrity, inherited-scope correctness, or temporal validity.
 
 ## ASI05 Unexpected Code Execution
 
@@ -103,8 +104,10 @@ Interpretation:
 - `A5-001` can honestly claim only execution evidence presence.
 - `A5-002` is no longer a pure signal gap. Supported weaker-than-requested
   containment fallback paths can now emit `assay.sandbox.degraded` while
-  execution continues. Clean baseline fixtures still omit the event by design,
-  and the signal does not prove sandbox correctness or execution authorization.
+  execution continues. The companion pack `owasp-agentic-a3-a5-signal-followup`
+  ships this rule only in that presence-only form. Clean baseline fixtures
+  still omit the event by design, and the signal does not prove sandbox
+  correctness or execution authorization.
 
 ## C2 Go / No-Go Summary
 
@@ -115,6 +118,10 @@ rules yet. The honest next step is narrower:
 - no rule that depends on unsupported `conditional` behavior
 - no rule that depends on signals missing from the tested evidence flow
 
+The baseline pack remains narrow. The signal-aware companion pack
+`owasp-agentic-a3-a5-signal-followup` is the shipped follow-up surface for
+`A3-003` and `A5-002`.
+
 ## Candidate Summary Table
 
 | Candidate Rule | Max Provable Level | Ship in C2? | Reason |
@@ -123,6 +130,6 @@ rules yet. The honest next step is narrower:
 | `A1-002` | `Field Presence` | `Yes` | Can ship only as control evidence for goal governance fields. |
 | `A3-001` | `Field Presence` | `Yes` | Can ship only as authorization-context capture evidence. |
 | `A3-002` | `Field Presence` | `No` | Engine `1.1` can execute this narrow conditional-presence form, but it remains outside the current shipped subset and does not prove mandate reference integrity. |
-| `A3-003` | `Field Presence` | `No` | Supported flows can now surface explicit delegation context on decision evidence, but this remains outside the current shipped subset and does not validate chain completeness or integrity. |
+| `A3-003` | `Field Presence` | `No` | Shipped in the signal-aware companion pack for supported delegated flows; it does not validate chain completeness or integrity. |
 | `A5-001` | `Presence` | `Yes` | Can ship only as process-execution evidence presence. |
-| `A5-002` | `Presence` | `No` | Supported fallback paths now emit the signal, but it remains outside the current shipped subset and only proves degraded containment while execution continued. |
+| `A5-002` | `Presence` | `No` | Shipped in the signal-aware companion pack for supported fallback paths; it only proves degraded containment while execution continued. |

--- a/packs/open/owasp-agentic-a3-a5-signal-followup/LICENSE
+++ b/packs/open/owasp-agentic-a3-a5-signal-followup/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf of
+      any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025-2026 Assay Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packs/open/owasp-agentic-a3-a5-signal-followup/README.md
+++ b/packs/open/owasp-agentic-a3-a5-signal-followup/README.md
@@ -1,0 +1,68 @@
+# OWASP Agentic A3/A5 Signal-Aware Follow-Up
+
+**License:** Apache-2.0
+**Version:** 1.0.0
+**Scope:** Signal-aware follow-up for supported delegated flows and supported containment fallback paths
+
+## Overview
+
+This companion pack ships a deliberately small follow-up surface derived from
+the `C1` feasibility map in
+[OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md](../../../docs/security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md).
+
+It does not broaden the baseline pack. It checks only whether evidence records:
+
+- delegated authority context on `assay.tool.decision` for supported delegated flows
+- containment degradation fallback evidence for supported weaker-than-requested paths
+
+## Rules
+
+| Rule ID | Category | Severity | Description |
+| --- | --- | --- | --- |
+| `A3-003` | `ASI03` | `warning` | Decision evidence surfaces delegated authority context for supported delegated flows. |
+| `A5-002` | `ASI05` | `warning` | Evidence records supported containment degradation fallback paths. |
+
+## What The Rules Actually Check
+
+- `A3-003` passes when at least one `assay.tool.decision` event for supported delegated flows contains `delegated_from`.
+- `delegation_depth` may appear as supporting context for `A3-003`, but it is not required by the shipped rule.
+- `A5-002` passes when at least one event matches `assay.sandbox.degraded`.
+
+## Non-Goals
+
+This pack does not prove:
+
+- delegation chain integrity
+- delegation validity
+- inherited-scope correctness
+- temporal delegation correctness
+- sandbox correctness
+- all containment failures detected
+
+This pack proves only signal-aware evidence for supported delegated flows and
+supported containment fallback paths. It does not validate delegation chains,
+cryptographic provenance, inherited scopes, temporal authorization, or overall
+containment guarantees.
+
+## Usage
+
+```bash
+assay evidence lint --pack owasp-agentic-a3-a5-signal-followup bundle.tar.gz
+```
+
+Or alongside the narrow baseline:
+
+```bash
+assay evidence lint --pack owasp-agentic-control-evidence-baseline,owasp-agentic-a3-a5-signal-followup bundle.tar.gz
+```
+
+## Design Constraints
+
+- this is a companion pack; the baseline pack remains unchanged
+- `A3-003` is bounded to supported delegated flows
+- `A5-002` stays presence-only
+- no delegation validation, chain integrity, temporal semantics, or broader containment-assurance claims are shipped
+
+## License
+
+Apache-2.0 — see [LICENSE](./LICENSE)

--- a/packs/open/owasp-agentic-a3-a5-signal-followup/pack.yaml
+++ b/packs/open/owasp-agentic-a3-a5-signal-followup/pack.yaml
@@ -1,0 +1,68 @@
+name: owasp-agentic-a3-a5-signal-followup
+version: "1.0.0"
+kind: security
+description: OWASP Agentic ASI03/ASI05 signal-aware evidence follow-up for supported delegated flows and supported containment fallback paths
+author: Assay Team
+license: Apache-2.0
+
+disclaimer: |
+  This pack verifies only supported delegation-context visibility and supported
+  containment degradation evidence for a narrow OWASP Agentic ASI03/ASI05
+  follow-up surface.
+  Passing these checks does NOT prove delegation validity, delegation-chain
+  integrity, inherited-scope correctness, temporal delegation correctness,
+  sandbox correctness, or full containment-failure coverage.
+
+requires:
+  assay_min_version: ">=3.2.2"
+  evidence_schema_version: "1.0"
+
+rules:
+  - id: A3-003
+    severity: warning
+    description: Decision evidence surfaces delegated authority context for supported delegated flows.
+    article_ref: "ASI03"
+    help_markdown: |
+      ## ASI03 Identity & Privilege Abuse - Delegation Context Evidence
+
+      This rule verifies that at least one `assay.tool.decision` event for
+      supported delegated flows contains `delegated_from`.
+
+      **What this checks:**
+      - At least one supported decision event contains `delegated_from`
+      - `delegation_depth` may appear as optional supporting context, but it is
+        not required
+
+      **What this does not prove:**
+      - Delegation validity
+      - Delegation chain integrity
+      - Inherited-scope correctness
+      - Temporal delegation correctness
+    event_types:
+      - assay.tool.decision
+    check:
+      type: event_field_present
+      paths_any_of:
+        - /data/delegated_from
+
+  - id: A5-002
+    severity: warning
+    description: Evidence records supported containment degradation fallback paths.
+    article_ref: "ASI05"
+    help_markdown: |
+      ## ASI05 Unexpected Code Execution - Containment Degradation Evidence
+
+      This rule verifies that the evidence bundle contains an
+      `assay.sandbox.degraded` event from a supported weaker-than-requested
+      containment fallback path.
+
+      **What this checks:**
+      - At least one event matches `assay.sandbox.degraded`
+
+      **What this does not prove:**
+      - Sandbox correctness
+      - Execution authorization
+      - All containment failures detected
+    check:
+      type: event_type_exists
+      pattern: assay.sandbox.degraded

--- a/scripts/ci/review-wave-p1-a3-a5-signal-aware-pack-followup-step1.sh
+++ b/scripts/ci/review-wave-p1-a3-a5-signal-aware-pack-followup-step1.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+base_ref="${BASE_REF:-${1:-}}"
+if [[ -z "$base_ref" ]]; then
+  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    base_ref="origin/${GITHUB_BASE_REF}"
+  else
+    base_ref="origin/main"
+  fi
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}" >&2
+  exit 1
+fi
+
+rg_bin="$(command -v rg || true)"
+if [[ -z "$rg_bin" ]]; then
+  echo "rg is required for reviewer anchors" >&2
+  exit 1
+fi
+
+open_pack="packs/open/owasp-agentic-a3-a5-signal-followup/pack.yaml"
+builtin_pack="crates/assay-evidence/packs/owasp-agentic-a3-a5-signal-followup.yaml"
+readme="packs/open/owasp-agentic-a3-a5-signal-followup/README.md"
+test_file="crates/assay-evidence/tests/owasp_agentic_p1_signal_followup.rs"
+a3_probe="crates/assay-evidence/tests/fixtures/packs/owasp-agentic-a3-probe.yaml"
+c1_doc="docs/security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md"
+
+require_fixed_pattern() {
+  local pattern="$1"
+  local file="$2"
+  "$rg_bin" -n -F "$pattern" "$file" >/dev/null
+}
+
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  case "$file" in
+    crates/assay-evidence/packs/owasp-agentic-a3-a5-signal-followup.yaml|\
+    packs/open/owasp-agentic-a3-a5-signal-followup/pack.yaml|\
+    packs/open/owasp-agentic-a3-a5-signal-followup/README.md|\
+    packs/open/owasp-agentic-a3-a5-signal-followup/LICENSE|\
+    crates/assay-evidence/src/lint/packs/mod.rs|\
+    crates/assay-evidence/tests/owasp_agentic_p1_signal_followup.rs|\
+    crates/assay-evidence/tests/owasp_agentic_c1_mapping.rs|\
+    crates/assay-evidence/tests/fixtures/packs/owasp-agentic-a3-probe.yaml|\
+    docs/security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md|\
+    docs/contributing/SPLIT-INVENTORY-wave-p1-a3-a5-signal-aware-pack-followup-step1.md|\
+    docs/contributing/SPLIT-CHECKLIST-wave-p1-a3-a5-signal-aware-pack-followup-step1.md|\
+    docs/contributing/SPLIT-MOVE-MAP-wave-p1-a3-a5-signal-aware-pack-followup-step1.md|\
+    docs/contributing/SPLIT-REVIEW-PACK-wave-p1-a3-a5-signal-aware-pack-followup-step1.md|\
+    scripts/ci/review-wave-p1-a3-a5-signal-aware-pack-followup-step1.sh)
+      ;;
+    crates/assay-evidence/packs/*|\
+    packs/open/*|\
+    crates/assay-evidence/src/*|\
+    crates/assay-evidence/tests/*|\
+    docs/security/*)
+      echo "ERROR: forbidden file changed for P1 scope: $file" >&2
+      exit 1
+      ;;
+    *)
+      echo "ERROR: out-of-scope file changed: $file" >&2
+      exit 1
+      ;;
+  esac
+done < <(git diff --name-only "${base_ref}...HEAD")
+
+if git diff --name-only "${base_ref}...HEAD" | grep -Eq \
+  '(^crates/assay-evidence/packs/owasp-agentic-control-evidence-baseline.yaml$|^packs/open/owasp-agentic-control-evidence-baseline/)'; then
+  echo "ERROR: baseline pack must remain unchanged in P1" >&2
+  exit 1
+fi
+
+cmp -s "$open_pack" "$builtin_pack" || {
+  echo "ERROR: open pack and built-in mirror differ" >&2
+  exit 1
+}
+
+rule_count="$("$rg_bin" -c '^  - id:' "$open_pack")"
+[[ "$rule_count" == "2" ]] || {
+  echo "ERROR: expected exactly 2 shipped rules, found $rule_count" >&2
+  exit 1
+}
+
+for rule_id in A3-003 A5-002; do
+  "$rg_bin" -n "^  - id: ${rule_id}$" "$open_pack" >/dev/null
+done
+
+if "$rg_bin" -n '^  - id: (A1-002|A3-001|A3-002|A5-001)$' "$open_pack" >/dev/null; then
+  echo "ERROR: companion pack must ship only A3-003 and A5-002" >&2
+  exit 1
+fi
+
+require_fixed_pattern 'description: Decision evidence surfaces delegated authority context for supported delegated flows.' "$open_pack"
+require_fixed_pattern 'description: Evidence records supported containment degradation fallback paths.' "$open_pack"
+require_fixed_pattern 'pattern: assay.sandbox.degraded' "$open_pack"
+require_fixed_pattern 'type: event_type_exists' "$open_pack"
+require_fixed_pattern 'type: event_field_present' "$open_pack"
+
+grep -Eq '^[[:space:]]*-[[:space:]]+/data/delegated_from$' "$open_pack" || {
+  echo "ERROR: A3-003 must require delegated_from" >&2
+  exit 1
+}
+
+for forbidden_path in /data/delegation_depth /data/actor_chain /data/inherited_scopes; do
+  if grep -Eq "^[[:space:]]*-[[:space:]]+${forbidden_path}$" "$open_pack" "$a3_probe"; then
+    echo "ERROR: forbidden A3 signal path required: ${forbidden_path}" >&2
+    exit 1
+  fi
+done
+
+grep -Fq 'supported delegated flows' "$readme" || {
+  echo "ERROR: README must say supported delegated flows" >&2
+  exit 1
+}
+
+"$rg_bin" -n '^## Non-Goals$' "$readme" >/dev/null
+for required_phrase in \
+  "delegation chain integrity" \
+  "delegation validity" \
+  "inherited-scope correctness" \
+  "temporal delegation correctness" \
+  "sandbox correctness" \
+  "all containment failures detected"; do
+  count="$(grep -Fic "$required_phrase" "$readme")"
+  [[ "$count" == "1" ]] || {
+    echo "ERROR: README must contain non-goal phrase exactly once: $required_phrase" >&2
+    exit 1
+  }
+done
+
+lower_text="$(
+  cat "$open_pack" "$readme" "$c1_doc" \
+    | tr '[:upper:]' '[:lower:]'
+)"
+normalized_c1_doc="$(tr '\n' ' ' < "$c1_doc" | tr -s '[:space:]' ' ')"
+
+for forbidden_phrase in \
+  "verifies delegation" \
+  "guarantees chain integrity" \
+  "validates inherited scopes" \
+  "proves sandboxing" \
+  "cryptographically verified delegation"; do
+  if grep -Fq "$forbidden_phrase" <<<"$lower_text"; then
+    echo "ERROR: overclaim phrase present in P1 text: $forbidden_phrase" >&2
+    exit 1
+  fi
+done
+
+require_fixed_pattern 'event_field_present(paths_any_of=/data/delegated_from)' "$c1_doc"
+grep -Fq 'The companion pack `owasp-agentic-a3-a5-signal-followup` ships this rule only for supported delegated flows.' <<<"$normalized_c1_doc" || {
+  echo "ERROR: C1 doc missing A3 companion-pack truth" >&2
+  exit 1
+}
+grep -Fq 'The companion pack `owasp-agentic-a3-a5-signal-followup` ships this rule only in that presence-only form.' <<<"$normalized_c1_doc" || {
+  echo "ERROR: C1 doc missing A5 companion-pack truth" >&2
+  exit 1
+}
+require_fixed_pattern '| `A3-003` | `Field Presence` | `No` | Shipped in the signal-aware companion pack for supported delegated flows; it does not validate chain completeness or integrity. |' "$c1_doc"
+require_fixed_pattern '| `A5-002` | `Presence` | `No` | Shipped in the signal-aware companion pack for supported fallback paths; it only proves degraded containment while execution continued. |' "$c1_doc"
+
+for required_test in \
+  'fn p1_builtin_and_open_pack_are_exactly_equivalent(' \
+  'fn p1_baseline_pack_remains_unchanged(' \
+  'fn p1_readme_explicitly_states_non_goals(' \
+  'fn p1_a3_003_passes_when_supported_delegation_fields_are_present(' \
+  'fn p1_a3_003_fails_when_supported_delegation_fields_are_absent(' \
+  'fn p1_a5_002_passes_when_sandbox_degraded_event_is_present(' \
+  'fn p1_a5_002_fails_when_supported_degradation_signal_is_absent('; do
+  "$rg_bin" -n -F "$required_test" "$test_file" >/dev/null
+done
+
+cargo fmt --check
+cargo clippy -q -p assay-evidence --all-targets -- -D warnings
+cargo test -q -p assay-evidence --test owasp_agentic_p1_signal_followup
+cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping
+cargo test -q -p assay-evidence --test owasp_agentic_c2_pack
+cargo test -q -p assay-evidence --test pack_engine_manual_test
+git diff --check
+
+echo "Wave P1 Step1 reviewer script: PASS"


### PR DESCRIPTION
## Summary
- add the `owasp-agentic-a3-a5-signal-followup` companion pack as a built-in/open mirror pair
- ship `A3-003` for supported delegated flows on `delegated_from` and `A5-002` as presence-only on `assay.sandbox.degraded`
- align the `C1` mapping/probe truth, add focused tests, and add a bounded reviewer gate

## Validation
- `cargo fmt --all`
- `cargo test -q -p assay-evidence --test owasp_agentic_p1_signal_followup`
- `cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping`
- `BASE_REF=origin/main bash scripts/ci/review-wave-p1-a3-a5-signal-aware-pack-followup-step1.sh`
- `git diff --check`