### PR TITLE
docs: freeze trust compiler north star

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,18 +1,21 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-03-15):** Q1 DX/refactor convergence is closed on `main` (RFC-001/002/003/004).
+> **Status sync (2026-03-23):** Q1 DX/refactor convergence is closed on `main` (RFC-001/002/003/004).
 > Evidence-as-a-product (ADR-025), protocol adapters (ADR-026), and MCP governance/enforcement (ADR-032 Wave24-Wave42) are materially implemented on `main`.
 > Governance support ADRs [ADR-027](architecture/ADR-027-Tool-Taxonomy.md) through [ADR-031](architecture/ADR-031-Coverage-v1.1-DX-Polish.md) are implemented on `main` and should be read as delivered contracts, not pending proposals.
 > **BYOS truth (ADR-015):** Phase 1 is complete on `main`: `push`, `pull`, `list`, `store-status`, `.assay/store.yaml` config, and provider quickstart docs (S3, B2, MinIO) are all shipped.
 > Split refactor program is closed loop through Wave7C Step3 on `main` (see [plan](architecture/PLAN-split-refactor-2026q1.md), [report](architecture/REPORT-split-refactor-2026q1.md), [program review pack](contributing/SPLIT-REVIEW-PACK-2026q1-program.md)).
-> Next repo-level priorities: release/changelog hygiene, then ADR-015 Phase 2 (GitHub Action integration) or next bounded wave.
+> `E1`, `G1`, `G2`, and `P1` are merged on `main`, and the only post-`P1` release-line nuance is closed: workspace version is now `3.2.3`, and the OWASP signal-aware pack floors align to `>=3.2.3`.
+> Next product priorities: `T1a` OTel-native Trust Compiler MVP, `T1b` Trust Card MVP, then `G3` Authorization Evidence Signal and `P2` Protocol Claim Packs.
 
-**Strategic Focus:** Agent Runtime Evidence & Control Plane.
-**Core Value:** Verifiable Evidence (Open Standard) + Governance Platform.
+**Strategic Focus:** Agent Runtime Evidence, Trust Compilation & Control Plane.
+**Core Value:** Verifiable Evidence + Claims-as-Code for Agent Systems.
 
 ## Executive Summary
 
-Assay is the "Evidence Recorder" for agentic workflows. We create verifiable, machine-readable audit trails that integrate with existing security/observability stacks. Assay aims to become the **standard evidence lint runtime** for agentic CI, with open engine + baseline packs and strong CI/SARIF integration as the adoption motor.
+Assay is evolving from an evidence recorder into an **OTel-native trust compiler for agent systems**. The product thesis is no longer "help teams inspect traces better"; it is "compile agent runtime truth into verifiable security claims with explicit evidence levels." Assay turns traces, protocol events, and bundle artifacts into canonical evidence, signal-aware packs, SARIF findings, offline-verifiable bundles, and future trust artifacts such as a signed Trust Card.
+
+This keeps Assay out of the wrong competitive lane. Promptfoo, Langfuse, LangSmith, and vendor eval platforms already own large parts of evals, dashboards, and red-team loops. Assay's moat is different: **claim provenance, bounded security semantics, and portable proof-bearing outputs**.
 
 **Standards Alignment:**
 - **CloudEvents v1.0** envelope — lingua franca for event routers and SIEM pipelines
@@ -21,6 +24,71 @@ Assay is the "Evidence Recorder" for agentic workflows. We create verifiable, ma
 - **EU AI Act Article 12** — record-keeping requirements make "evidence" commercially relevant; pack mappings are pinned to EUR-Lex text, and phased dates are treated as guidance
 - **OTel GenAI Semantic Conventions** — vendor-agnostic observability bridge for LLM/agent workloads; conventions are evolving, so integrations are version-pinned with mapping tests
 - **ENISA / SBOM / SLSA** — Supply-chain assurance (SBOM, provenance, attestation) aligns with ENISA priorities; SLSA-aligned attestation per ADR-018
+
+### 2026 Product Thesis: Claims-as-Code For Agent Systems
+
+Assay should be understood as:
+
+- **Input**: OTel spans, protocol events, Assay traces, and proof-bearing bundle artifacts
+- **Compile**: canonical evidence + bounded claim classification + pack evaluation
+- **Output**: findings, SARIF, verifiable bundles, and eventually a signed Trust Card
+
+`OTel-native` does **not** mean "OTel semconv is the only truth." The stable truth layer remains Assay's canonical evidence contract. OTel is a first-class ingest path and ecosystem bridge, but it must compile into Assay's own evidence model before stronger trust claims are made.
+
+The core differentiator is not "more detections." It is **better claim epistemology**:
+
+| Evidence Level | Meaning |
+|----------------|---------|
+| `verified` | Backed by direct evidence or offline verification in the bundle/runtime path |
+| `self_reported` | Emitted by the system itself without stronger independent corroboration |
+| `inferred` | Derived from bounded, documented interpretation rules |
+| `absent` | No trustworthy evidence currently supports the claim |
+
+This is the line that recent bounded waves now support on `main`:
+
+- `E1` unlocked a small, typed engine seam rather than a broad policy language.
+- `G1` made supported weaker-than-requested containment fallback visible in evidence.
+- `G2` made explicit delegation context visible on supported decision evidence.
+- `P1` productized those signals in a companion pack without broadening the baseline.
+- `R2` closed the only post-`P1` release-line mismatch by moving the workspace and OWASP pack floors to `3.2.3`.
+
+See [ADR-033](architecture/ADR-033-OTel-Trust-Compiler-Positioning.md) for the product-positioning decision and [RFC-005](architecture/RFC-005-trust-compiler-mvp-2026q2.md) for the bounded MVP execution frame.
+
+### North Star Guardrails
+
+- **Claim-first, not dashboard-first**: a prettier trace UI is not the product wedge. The wedge is evidence-classified trust claims.
+- **Canonical evidence first**: OTel is an ingest bridge, not the sole semantic authority.
+- **Canonical evidence wins operationally**: new ingest paths may enrich or map into canonical evidence, but they must not semantically override claim classification directly from raw upstream formats.
+- **Trust Card, not trust score**: the primary artifact must show what is `verified`, `self_reported`, `inferred`, or `absent`, not collapse into `trusted/untrusted`.
+- **No aggregate trust score in MVP**: no primary scalar trust score, no `safe/unsafe` badge, and no maturity badge as the main output.
+- **Fixed order**: `T1a -> T1b -> G3 -> P2` stays ahead of dashboard work, broad pack expansion, or heavier reference/temporal semantics.
+- **No broad correctness claims**: delegation validation, chain integrity, sandbox correctness, and temporal correctness remain out of scope until dedicated evidence and semantics exist.
+- **Anti-scope rule**: Assay is not a tracing platform, eval platform, or observability dashboard. Those may be integration surfaces, but not the product category.
+
+### Strategic Fit Test
+
+This direction should continue only if all three answers stay "yes":
+
+1. **External demand fit**
+   The external line in 2026 is identity/authz, auditability, protocol-level defenses, and bounded deployment controls for agents. Assay fits that line better as a trust compiler than as a generic eval or observability tool.
+
+2. **Repo capability fit**
+   Assay already ships the substrate this direction needs: canonical evidence, offline verification, signal-aware packs, proof-bearing bundles, OTel ingest, delegation context, and containment degradation signals.
+
+3. **Wedge fit vs alternatives**
+   A Trust Card and trust-compiler story differentiate Assay better than another pack wave, another engine feature, or a broader dashboard surface. Those alternatives are easier to explain, but they are also where the category is more crowded and Assay is less structurally unique.
+
+If any of these answers turns into "no", the default action is to stop a broader product-positioning wave:
+
+- if **external demand fit** is weak, do not broaden packaging or positioning
+- if **repo capability fit** is weak, close the missing signal/engine seam first
+- if **wedge fit** is weak, do not start a new product lane until the differentiator is sharper
+
+### Primary Risks
+
+- **Abstract product story**: "trust compiler" is less immediately legible than "eval" or "observability." The Trust Card is the required wedge that makes the compiler story tangible.
+- **Category confusion**: if Assay is marketed as a tracing platform, dashboard, firewall, or generic eval suite, it loses the category it is best positioned to own.
+- **Standards churn**: OTel GenAI and agent semantic conventions are still evolving. Assay must keep its canonical evidence layer stable and treat OTel as ingest, not truth.
 
 ---
 
@@ -133,6 +201,21 @@ Based on [competitive landscape analysis](architecture/RESEARCH-ci-cd-ai-agents-
 - **Not agent-building**: Dagger, Zencoder build agents. Assay validates them. Complementary, not competitive.
 - **Not universal semantic-hijacking detection**: LLM-as-judge or probabilistic semantic gates are not the core enforcement model. Assay stays deterministic and evidence-first.
 - **Not a full outbound egress firewall (yet)**: raw network containment belongs to OS/runtime isolation layers. Assay governs tool routes and records policy decisions; it does not replace platform egress controls as an MVP.
+- **Not a magic trust score**: primary outputs should stay evidence-classified (`verified`, `self_reported`, `inferred`, `absent`), not collapse into a single opaque number.
+
+## Post-P1 Product Lane (March 2026)
+
+The current substrate on `main` is strong enough to shift from "more packs" toward a clearer product line:
+
+| Order | Lane | Why now | Boundary |
+|-------|------|---------|----------|
+| **1** | `T1a` OTel-native Trust Compiler MVP | The evidence pipeline already follows the OTel Collector pattern and ships `trace ingest-otel`; the next step is to productize trace -> evidence -> claim compilation. | No dashboard, no new packs in the same slice, no broad scoring model. |
+| **2** | `T1b` Trust Card MVP | Assay needs a visible, portable output artifact for its claim model. | Trust Card stays evidence-classified, signed/attested later, and does not become a generic risk score. |
+| **3** | `G3` Authorization Evidence Signal | MCP auth extensions and identity/authz standards make auth context the cleanest next signal seam. | Supported flows only; no auth validation or cryptographic chain semantics. |
+| **4** | `P2` Protocol Claim Packs | After `G3`, protocol-aware claim packs become honest product surfaces. | Small MCP/A2A claim packs, not broad compliance theater. |
+| **Later** | Reference/temporal/capability attestation | These semantics are valuable but heavier. | Ship only after the claim product line is stable. |
+
+Work that primarily improves dashboarding, generic observability UX, or score-first reporting should be treated as secondary until this sequence is complete.
 
 ---
 
@@ -405,25 +488,23 @@ Formalize "Evidence-as-a-Product" with provenance and replayability scores.
 
 ---
 
-## Q3 2026: Enterprise Scale (Growth)
+## Q3 2026: Trust Compiler Productization
 
-**Objective:** Integration with the broader security ecosystem + agentic protocol support, led by route-governance primitives rather than broader surface area.
+**Objective:** Productize Assay as an OTel-native trust compiler and make protocol-aware claims portable before expanding dashboards or broader enterprise surfaces.
 
-### Route Governance Core (Highest Priority)
+### Trust Compiler Core (Highest Priority)
 
-March 2026 experiment evidence changes the ordering inside Q3. Before expanding adapter breadth or managed surfaces, Assay should close the product gap between experiment-only route governance and reusable platform primitives.
+March 2026 evidence and signal waves change the ordering inside Q3. The next product gap is not "more observability" or "more packs"; it is turning the existing OTel-collector-style evidence path into a first-class claims compiler with a portable output artifact.
 
 | Priority | Capability | Why now | MVP boundary |
 |----------|------------|---------|--------------|
-| **P0** | Tool taxonomy as first-class classes | Second-sink and tool-hopping results show raw tool names are brittle. | Source/sink/store/exec class map, policies written on classes, evidence logs record matched class. |
-| **P0** | Session identity + state store contract | Cross-session decay shows route memory is required beyond a single run. | Explicit session key, replayable state store interface, TTL/window semantics, evidence export/import. |
-| **P1** | Coverage/completeness reports | Governance without visibility into unknown tools and untested routes creates blind spots. | JSON + SARIF informational report for tools seen vs declared, unknown tools, and route coverage gaps. |
-| **P1** | Machine-readable decision logs | Enterprises need debugging without log archaeology. | JSONL decision events with `rule_id`, `reason_code`, `matched_fields`, `decision_path`, `policy_version`, `latency`. |
-| **P1** | Replay with state snapshots | The product claim is verifiability, not just blocking. | Replay tool-call logs plus policy + state snapshot, with decision diffs on policy/state changes. |
-| **P2** | Hardening defaults for ingest/proxy | Inline governance inherits parser attack surface. | Default caps, fuzz/property tests, and consistent fail-closed semantics. |
-| **P2** | Evidence-first interop bridges | OTel/MCP interop is useful only if enforcement and evidence stay first-class. | Lossiness-accounted bridges, adapter metadata everywhere, no LLM-judge in core enforcement. |
+| **P0** | `T1a` OTel-native Trust Compiler MVP | `trace ingest-otel`, `ProfileCollector -> EvidenceMapper -> EvidenceEvent`, and signal-aware packs already exist on `main`. | Official compiler inputs/outputs, claim basis export, no dashboard, no new semantics. |
+| **P0** | `T1b` Trust Card MVP | The trust-compiler thesis needs a product artifact that non-authors can review and diff. | `trustcard.json` + `trustcard.md`, evidence-level classification, no opaque global score. |
+| **P1** | `G3` Authorization Evidence Signal | MCP auth extensions and NIST/OWASP identity guidance make auth context the cleanest next supported signal seam. | Supported flows only; no cryptographic or temporal auth-validation semantics. |
+| **P1** | `P2` Protocol Claim Packs | Once auth context is visible, protocol claim packs become honest follow-ons. | MCP/A2A claim packs with bounded wording; no broad compliance theater. |
+| **P2** | Collector processor / sidecar form factor | This is the "outside-the-box" deployment surface that competitors are not targeting. | OTel-native compile path that emits canonical evidence, not a dashboard. |
 
-These items outrank additional dashboard and growth-only work because the experiment ladder shows Assay wins on route/state governance, not on content filtering or surface-area expansion alone.
+These items outrank growth-only work because Assay's strongest differentiator is now trace -> evidence -> claim -> proof, not surface-area expansion.
 
 ### A. Protocol Adapters (Adapter-First Strategy)
 
@@ -458,10 +539,10 @@ Status on `main`:
 - [ ] **GitLab CI**: Native integration
 - [ ] **OTel GenAI**: Align evidence export with [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) — conventions still experimental but Pydantic AI already follows them; monitor for stability before building bridge
 
-### C. Additional Compliance Packs
-- [ ] **SOC 2 Pack**: Control mapping for Type II audits
-- [ ] **MCPTox**: Regression testing against jailbreak/poisoning patterns
-- [ ] **Industry Packs**: Healthcare (HIPAA), Finance (PCI-DSS)
+### C. Protocol Claim Packs (Post-T1)
+- [ ] **MCP Claim Pack**: protocol-aware, signal-bounded authz and telemetry claims
+- [ ] **A2A Claim Pack**: capability/delegation/provenance claim surfaces for supported flows
+- [ ] **Additional domain packs only after signals exist**: broader compliance surfaces remain downstream of evidence reality
 
 ### D. Managed Evidence Store (Evaluate)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -94,7 +94,7 @@ If any of these answers turns into "no", the default action is to stop a broader
 
 ## Strategic Positioning: Protocol-Agnostic Governance
 
-The protocol landscape table below is a planning snapshot (hypothesis-driven) and is revisited as specs/programs evolve.
+The protocol landscape table below is a planning snapshot (hypothesis-driven) and is revisited as specs/programs evolve. It is a monitoring frame for protocol-agnostic governance, not a commitment matrix that Assay will pursue every protocol surface equally or simultaneously.
 
 The agentic commerce/interop space is fragmenting (Jan 2026):
 
@@ -132,7 +132,7 @@ The CI/CD-for-agents market is validating Assay's core assumptions:
 - **Fleet-of-small-agents pattern**: The dominant deployment pattern is many small specialized agents, not one generalist. More agents = more policies = more Assay usage per repo.
 - **Gartner risk signal**: >40% of agentic AI projects will be cancelled by end 2027 due to costs, unclear value, or inadequate risk controls. Governance tooling is a prerequisite, not a nice-to-have.
 
-**Competitive differentiation**: Agent CI (eval-as-service), Langfuse/LangSmith (observability), Dagger (agentic runtime) cover adjacent layers. None offers deterministic replay, evidence bundles with integrity guarantees, or compliance packs. Assay's unique position: governance + audit, not observability or eval-as-service.
+**Competitive differentiation**: Agent CI (eval-as-service), Langfuse/LangSmith (observability), and agent runtimes such as Dagger cover adjacent layers. Assay's differentiator is the combination of deterministic replay, integrity-bearing evidence bundles, and bounded claim packs. The unique position is governance + audit, not observability or eval-as-service.
 
 See [RESEARCH-ci-cd-ai-agents-feb2026.md](architecture/RESEARCH-ci-cd-ai-agents-feb2026.md) for detailed analysis
 
@@ -151,11 +151,10 @@ The **Evidence Contract v1** is production-ready.
 
 **Architecture Note:** The current pipeline follows the OTel Collector pattern (native format emission → transformation layer → canonical export). This is the recommended SOTA approach per OpenTelemetry best practices. See [ADR-008: Evidence Streaming](./architecture/ADR-008-Evidence-Streaming.md) for the decision to keep CloudEvents construction out of the hot path.
 
-### 🎯 Immediate Next Steps (Q1 Close-out)
-
-1. **v1 Contract Freeze** — Publish versioning policy, deprecation rules, golden bundle fixtures
-2. **Compatibility Tests** — No new event types without schema + tests
-3. **Docs Positioning** — "Assay Evidence = CloudEvents + Trace Context + Deterministic Bundle"
+Historical close-out note:
+- Q1 close-out is complete on `main`
+- the active product lane is now the trust-compiler line described above
+- detailed historical delivery status lives in the relevant ADRs and supporting docs rather than in the roadmap head
 
 ---
 
@@ -219,272 +218,27 @@ Work that primarily improves dashboarding, generic observability UX, or score-fi
 
 ---
 
-## Q1 2026: Trust & Telemetry ✅ Complete
+## Delivered Foundation (Historical)
 
-**Objective:** Establish Assay as the standard for agent auditability.
+The roadmap above is the live decision path. Historical delivery detail remains important, but it no longer belongs in the main decision flow.
 
-### Evidence Core
-- [x] Schema v1 (`assay.evidence.event.v1`) definitions
-- [x] JCS (RFC 8785) canonicalization
-- [x] Content-addressed ID generation (`sha256(canonical)`)
-- [x] CLI: export, verify, show
+Closed lines on `main`:
 
-### Evidence DX (Lint/Diff/Explore)
-- [x] **Linting**: Rule registry, SARIF output with `partialFingerprints`, `--fail-on` threshold
-- [x] **SARIF identity contract**: stable, unique `automationDetails.id` per tool/run lineage for deterministic dedupe and traceability
-- [x] **Diff**: Semantic comparison (hosts, file access), baseline support
-- [x] **Explore**: TUI viewer with ANSI/control char sanitization (`tui` feature flag)
+- **Evidence Contract v1**: canonical evidence, offline verification, SARIF, diff/explore, and OTel trace context are shipped
+- **OTel ingest and evidence pipeline**: `trace ingest-otel` plus the `ProfileCollector -> EvidenceMapper -> EvidenceEvent` collector-style pipeline are shipped
+- **Supply chain and governance surfaces**: BYOS Phase 1, tool signing, GitHub Action v2/v2.1, mandate evidence, and starter/baseline pack infrastructure are shipped
+- **Evidence-as-a-product**: soak, closure, completeness, and the OTel bridge slices from ADR-025 are shipped
+- **Bounded claim waves**: `E1`, `G1`, `G2`, `P1`, and the `3.2.3` release-line truth fix are shipped
 
-### Hardening (Chaos/Differential Testing)
-- [x] IO chaos (intermittent failures, short reads, `Interrupted`/`WouldBlock`)
-- [x] Stream chaos (partial writes, truncation)
-- [x] Differential verification (reference parity, spec drift, platform matrix)
+For detailed historical delivery records, see the relevant ADRs and companion docs:
 
-### Telemetry
-- [x] OTel Trace/Span context on all events
-- [x] OTel trace ingest (`assay trace ingest-otel`)
-- [x] OTel export in test results
-
----
-
-## Q2 2026: Supply Chain Security
-
-**Objective:** Launch compliance and signing features with zero infrastructure cost.
-
-**Strategy:** BYOS-first (Bring Your Own Storage) per [ADR-015](./architecture/ADR-015-BYOS-Storage-Strategy.md). Users provide their own S3-compatible storage. Managed infrastructure deferred until PMF.
-
-### Prioritized Deliverables
-
-| Priority | Item | Effort | Value | Status |
-|----------|------|--------|-------|--------|
-| **P0** | GitHub Action v2 | Medium | High | ✅ Complete |
-| **P0** | Exit Codes (V2) | Low | High | ✅ Complete (v2.12.0) |
-| **P0** | Report IO Robustness (Warnings) | Low | High | ✅ Complete (v2.12.0) |
-| **P1** | BYOS CLI Commands | Low | High | ✅ Complete (Phase 1: `push/pull/list/store-status`, `.assay/store.yaml` config, provider docs) |
-| **P1** | Tool Signing (`x-assay-sig`) | Medium | High | ✅ Complete (v2.9.0) |
-| **P2** | Pack Engine (OSS) | Medium | High | ✅ Complete (v2.10.0) |
-| **P2** | EU AI Act Baseline Pack (OSS) | Low | High | ✅ Complete (v2.10.0) |
-| **P2** | Mandate/Intent Evidence | Medium | High | ✅ Complete (v2.11.0) |
-| **P1** | Judge Reliability (SOTA E7) | High | High | ✅ Complete (Audit Grade) |
-| **P1** | Progress N/M (E4.3) | Low | High | ✅ Complete (PR #164) |
-| **P2** | GitHub Action v2.1 | Low | Medium | ✅ Complete (PR #185) |
-| **P1** | Golden path (<30 min first signal) | Medium | High | ✅ Complete (PR #187, `init --hello-trace --ci`) |
-| **P1** | Drift-aware feedback (`explain` + policy/tool diffs) | Medium | High | ✅ Complete (`generate --diff` PR #177, `explain` PR #179) |
-| **P1** | CLI debt reduction (Wave A/B: typed errors, pipeline, config) | Medium | High | ✅ Delivered on `main`; Wave C remains explicitly data-gated |
-| **P1** | Starter packs (OSS) | Low | High | ✅ Complete (ADR-023) |
-| **P1** | Audit Kit (Manifest/Provenance) (ADR-025) | Low | High | ✅ Complete (I1 closed-loop) |
-| **P1** | Soak Testing & Pass^k (ADR-025) | Medium | High | ✅ Complete (I1 closed-loop) |
-| **P2** | Closure Score & Completeness (ADR-025) | Medium | High | ✅ Complete (I2/I3 closed-loop) |
-| **P2** | Sim Engine Hardening (limits + budget) | Low | Medium | Superseded by ADR-025 Soak |
-| **P3** | Sigstore Keyless (Enterprise) | Medium | Medium | Pending |
-| **Defer** | Managed Evidence Store | High | Medium | Q3+ if demand |
-| **Defer** | Dashboard | High | Medium | Q3+ |
-
-See ADRs: [ADR-011 (Signing)](./architecture/ADR-011-Tool-Signing.md), [ADR-013 (EU AI Act)](./architecture/ADR-013-EU-AI-Act-Pack.md), [ADR-014 (Action)](./architecture/ADR-014-GitHub-Action-v2.md), [ADR-015 (BYOS)](./architecture/ADR-015-BYOS-Storage-Strategy.md), [ADR-016 (Pack Taxonomy)](./architecture/ADR-016-Pack-Taxonomy.md)
-See Spec: [SPEC-Tool-Signing-v1](./architecture/SPEC-Tool-Signing-v1.md)
-See Debt: [RFC-001 DX/UX Governance](./architecture/RFC-001-dx-ux-governance.md) (historical governance RFC: Wave A/B delivered, Wave C remains performance-only and data-gated)
-
-### GitHub Action v2 ✅ Complete
-
-Published to GitHub Marketplace: [assay-ai-agent-security](https://github.com/marketplace/actions/assay-ai-agent-security)
-
-```yaml
-- uses: Rul1an/assay-action@v2
-```
-
-Features:
-- Zero-config evidence bundle discovery
-- SARIF integration with GitHub Security tab
-- PR comments (only when findings)
-- Baseline comparison via cache
-- Job Summary reports
-
-### A. BYOS CLI Commands ✅ Complete (Phase 1)
-
-Per [ADR-015](./architecture/ADR-015-BYOS-Storage-Strategy.md), evidence storage uses user-provided S3-compatible buckets:
-
-```bash
-# CLI commands (--store optional when .assay/store.yaml is present)
-assay evidence push bundle.tar.gz
-assay evidence pull --bundle-id sha256:...
-assay evidence list --run-id run_123
-assay evidence store-status
-```
-
-- [x] **Generic S3 Client**: Using `object_store` crate
-- [x] **push command**: Upload verified bundle with immutability-safe writes
-- [x] **pull command**: Download bundle by ID or run
-- [x] **list command**: List bundles with filtering, JSON/table/plain output
-- [x] **store-status command**: Connectivity/access/inventory diagnostics (JSON/table/plain)
-- [x] **Conditional writes**: `If-None-Match: "*"` for immutability
-- [x] **Content-addressed keys**: SHA-256 bundle_id as source of truth
-- [x] **Structured config**: `.assay/store.yaml` with frozen precedence chain
-- [x] **Provider quickstart docs**: [AWS S3](guides/evidence-store-aws-s3.md), [Backblaze B2](guides/evidence-store-backblaze-b2.md), [MinIO](guides/evidence-store-minio.md)
-
-Supported backends: AWS S3, Backblaze B2, Wasabi, Cloudflare R2, MinIO, local filesystem (via S3-compatible endpoint or `file://`)
-
-### B. Tool Signing ✅ Complete
-
-Per [SPEC-Tool-Signing-v1](./architecture/SPEC-Tool-Signing-v1.md):
-
-```bash
-assay tool keygen --out ~/.assay/keys/      # Generate PKCS#8/SPKI keypair
-assay tool sign tool.json --key priv.pem --out signed.json
-assay tool verify signed.json --pubkey pub.pem  # Exit: 0=ok, 2=unsigned, 3=untrusted, 4=invalid
-```
-
-- [x] **`x-assay-sig` field**: Ed25519 + DSSE PAE encoding
-- [x] **JCS canonicalization**: RFC 8785 deterministic JSON
-- [x] **key_id trust model**: SHA-256 of SPKI bytes
-- [x] **Trust policies**: `require_signed`, `trusted_key_ids`
-- [ ] **Keyless (Enterprise)**: Sigstore Fulcio + Rekor integration
-
-### C. Mandate/Intent Evidence (P2) ✅ Complete (v2.11.0)
-
-Full mandate evidence implementation per [SPEC-Mandate-v1.0.5](./architecture/SPEC-Mandate-v1.md):
-
-- [x] **Evidence types**: Mandate content (intent/transaction), signed envelopes, lifecycle events
-- [x] **Runtime enforcement**: MandateStore (SQLite), 7-step Authorizer flow, revocation support
-- [x] **CloudEvents**: `mandate.used`, `mandate.revoked`, `tool.decision` lifecycle events
-- [x] **CLI integration**: `--audit-log`, `--decision-log`, `--event-source` flags
-- [x] **Idempotent retries**: Deterministic `use_id` + `was_new` flag for audit-log deduplication
-- [x] **Revocation**: Hard cutoff (no clock skew tolerance) per SPEC §7.6
-
-See [ADR-017](./architecture/ADR-017-Mandate-Evidence.md) for architecture decision.
-
-This strengthens EU AI Act Articles 12 & 14 compliance for commerce workflows.
-
-### C. Compliance Packs (P2) — Semgrep Model
-
-Per [ADR-016](./architecture/ADR-016-Pack-Taxonomy.md), we follow the Semgrep open core pattern:
-- **Engine + Baseline packs** = Open Source (Apache 2.0)
-- **Pro packs + Managed workflows** = Enterprise (Commercial)
-
-#### Pack Engine (OSS) ✅ Complete (v2.10.0)
-
-```bash
-assay evidence lint --pack eu-ai-act-baseline        # Single pack
-assay evidence lint --pack eu-ai-act-baseline,soc2   # Composition
-assay evidence lint --pack ./custom-pack.yaml        # Custom pack
-```
-
-- [x] **Pack loader**: YAML schema with `pack_kind` (compliance/security/quality)
-- [x] **Rule ID namespacing**: `{pack}@{version}:{rule_id}` for collision handling
-- [x] **Pack composition**: `--pack a,b` with deterministic merge
-- [x] **Version resolution**: `assay_min_version` + `evidence_schema_version`
-- [x] **Pack digest**: SHA256 (JCS RFC 8785) for supply chain integrity
-- [x] **SARIF output**: Pack metadata in `properties` bags (GitHub Code Scanning compatible)
-- [x] **Disclaimer enforcement**: `pack_kind == compliance` requires disclaimer
-- [x] **GitHub dedup**: `primaryLocationLineHash` fingerprint
-- [x] **Truncation**: `--max-results` for SARIF size limits
-
-#### EU AI Act Baseline Pack (OSS) ✅ Complete (v2.10.0)
-
-Direct Article 12(1) + 12(2)(a)(b)(c) mapping:
-
-| Rule ID | Article | Check | Status |
-|---------|---------|-------|--------|
-| EU12-001 | 12(1) | Evidence bundle contains automatically recorded events | ✅ |
-| EU12-002 | 12(2)(c) | Events include lifecycle fields for operation monitoring | ✅ |
-| EU12-003 | 12(2)(b) | Events include correlation IDs for post-market monitoring | ✅ |
-| EU12-004 | 12(2)(a) | Events include fields for risk situation identification | ✅ |
-
-See [ADR-013](./architecture/ADR-013-EU-AI-Act-Pack.md) for detailed mapping and [SPEC-Pack-Engine-v1](./architecture/SPEC-Pack-Engine-v1.md) for implementation spec.
-
-#### EU AI Act Pro Pack (Enterprise)
-
-- [ ] Biometric-specific rules (Article 12(3))
-- [ ] Retention policy validation
-- [ ] Advanced risk scoring
-- [ ] Org-specific exception workflows
-- [ ] PDF audit report generation
-
-#### Additional Packs (Future)
-
-- [ ] **Commerce Pack**: Mandate/intent required, signed-tools required (enabled by v2.11.0 mandate support)
-- [x] **SOC2 Baseline (OSS)**: Common Criteria mapping delivered (see ADR-022, pack in `packs/open/soc2-baseline/`)
-- [ ] **SOC2 Pro (Enterprise)**: assurance-depth mappings and workflow integrations
-- [x] **Starter packs (OSS)**: CICD hygiene, minimal traceability — compatibility floor; see §F
-- [x] **Pack Registry**: Local packs in `~/.assay/packs/` (ADR-021, implemented in PR #287)
-
-### E. GitHub Action v2.1 ✅ Complete
-
-Per [ADR-018](./architecture/ADR-018-GitHub-Action-v2.1.md):
-
-| Priority | Feature | Rationale |
-|----------|---------|-----------|
-| **P1** | Compliance pack support | EU AI Act compliance story |
-| **P2** | BYOS push with OIDC | Zero-credential enterprise posture |
-| **P3** | Artifact attestation | Supply chain integrity |
-| **P4** | Coverage badge | Developer DX |
-
-**Key design decisions:**
-- Write operations (push, attest, badge) only on `push` to main (fork PR threat model)
-- OIDC authentication per provider (explicit, not auto-detect)
-- Attestations provide "SLSA-aligned provenance" (no specific level claims)
-- Attestation lifecycle is staged: produce on push-to-main, verify in release/promote lanes, and keep fail-closed semantics scoped to release artifacts until stability is proven
-- EU AI Act timeline is treated as phased guidance (legal mapping source remains EUR-Lex text and versioned pack mappings)
-
-See [ADR-018](./architecture/ADR-018-GitHub-Action-v2.1.md) for full specification.
-
-### F. Starter Packs (OSS) (P1) ✅ Complete
-
-CICD-hygiene pack as compatibility floor for adoption—minimal traceability so teams get first value from `assay evidence lint` with minimal config. See [ADR-023](./architecture/ADR-023-CICD-Starter-Pack.md). Merged PR #289.
-
-```bash
-assay evidence lint --pack cicd-starter bundle.tar.gz
-assay evidence lint --pack cicd-starter,eu-ai-act-baseline bundle.tar.gz
-```
-
-**Status per step (codebase-check):**
-
-| Check | Status |
-|-------|--------|
-| `cicd-starter` or similar pack | ✅ Present (packs/open + vendored) |
-| Pack in `packs/open/` or `BUILTIN_PACKS` | ✅ cicd-starter in both |
-| CICD-hygiene rules | ✅ CICD-001..004 in pack |
-
-**Scope:**
-- [x] **Pack**: `cicd-starter` (kind: quality), in `packs/open/cicd-starter/`
-- [x] **Default**: cicd-starter when no `--pack` specified (PLG)
-- [x] **Rules**: CICD-001 (event count); CICD-002 (`assay.profile.started`/`.finished`); CICD-003 (traceparent/tracestate/run_id); CICD-004 (build_id/version, info)
-- [x] **BUILTIN_PACKS** + vendoring: packs/open vendored to crates/assay-evidence/packs/
-- [x] **Docs**: README per ADR-023 Appendix A; pinned GH Action; `--fail-on warning`; Next steps (follow-up)
-
-**Design decisions:**
-- `kind: quality` (no disclaimer; distinct from compliance packs)
-- Light rules only—reuse existing check types: `event_count`, `event_pairs`, `event_field_present`
-- Composable with eu-ai-act-baseline for teams graduating to compliance
-
-### G. Reliability Surface & Soak (P1) [ADR-025]
-
-Pivot from generic "simulation" to **Policy Soak Testing** as a reliability product. See [ADR-025](./architecture/ADR-025-Evidence-as-a-Product.md).
-
-```bash
-assay sim soak --iterations 100 --seed 42 --target bundle.tar.gz --report soak.json
-```
-
-**Scope (Iteration 1):**
-- [x] **CLI**: `assay sim soak` subcommand with `pass^k` semantics (pass_all, pass_rate)
-- [x] **Report**: `soak-report-v1` strict JSON schema (decision_policy, violations_by_rule)
-- [x] **Determinism**: Seeded execution for reproducible reliability
-- [x] **Limits**: Time budget and resource limits (inherited from ADR-024 work)
-
-**Design decisions:**
-- **Pass condition**: "Pass All K" is the gold standard for Agentic CI
-- **Evidence**: The *Soak Report* itself is an artifact in the evidence bundle
-- **Step3 rollout status**: informational nightly soak + informational readiness aggregation are active; no PR required-check impact in Step3
-- **Step4 rollout status**: fail-closed enforcement is active in release lane only (policy v1 + readiness enforcement script); PR lanes remain unchanged
-
-### H. Audit Kit & Closure (P2) [ADR-025] ✅ Complete
-
-Formalize "Evidence-as-a-Product" with provenance and replayability scores.
-
-**Scope (Iteration 1, 2, 3):**
-- [x] **Manifest Extensions**: `x-assay.packs_applied` and `mappings` for provenance (I2)
-- [x] **Completeness**: Pack-relative signal gaps (`required` vs `captured`) (I2)
-- [x] **Closure Score**: Replay-relative score (0.0-1.0) for hermetic replay readiness (I2)
-- [x] **OTEL Bridge**: Export Assay events to OTLP/GenAI SemConv (Iteration 3)
+- [ADR-015](./architecture/ADR-015-BYOS-Storage-Strategy.md)
+- [ADR-017](./architecture/ADR-017-Mandate-Evidence.md)
+- [ADR-018](./architecture/ADR-018-GitHub-Action-v2.1.md)
+- [ADR-023](./architecture/ADR-023-CICD-Starter-Pack.md)
+- [ADR-025](./architecture/ADR-025-Evidence-as-a-Product.md)
+- [ADR-026](./architecture/ADR-026-Protocol-Adapters.md)
+- [ADR-032](./architecture/ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md)
 
 ---
 
@@ -505,6 +259,22 @@ March 2026 evidence and signal waves change the ordering inside Q3. The next pro
 | **P2** | Collector processor / sidecar form factor | This is the "outside-the-box" deployment surface that competitors are not targeting. | OTel-native compile path that emits canonical evidence, not a dashboard. |
 
 These items outrank growth-only work because Assay's strongest differentiator is now trace -> evidence -> claim -> proof, not surface-area expansion.
+
+### T1 MVP Non-Goals
+
+For `T1a` and `T1b`, the roadmap stays explicit about what the MVP does **not** do:
+
+- no aggregate trust score
+- no `safe/unsafe` badge
+- no direct claim classification from raw OTel spans
+- no protocol-wide correctness claims
+- no dashboard-first product surface
+
+### T1 Mapping Rule
+
+- canonical evidence schema remains the stable product contract
+- OTel and protocol mappings are version-pinned bridges into that contract
+- every upstream semconv or protocol mapping bump must come with explicit mapping tests
 
 ### A. Protocol Adapters (Adapter-First Strategy)
 

--- a/docs/architecture/ADR-033-OTel-Trust-Compiler-Positioning.md
+++ b/docs/architecture/ADR-033-OTel-Trust-Compiler-Positioning.md
@@ -122,6 +122,19 @@ The primary evidence levels are:
 
 These evidence levels are the preferred external framing for future trust artifacts. Assay should not collapse them into a primary opaque trust score.
 
+### Adjacent Models We Borrow From, And What We Reject
+
+Assay does not invent this direction from nothing, but it also does not fit neatly into any one existing category.
+
+- from SLSA / in-toto style attestations, Assay borrows machine-readable, signable claim discipline
+- from GUAC-style metadata synthesis, Assay borrows ingest -> normalize -> synthesize separation
+- from AIBOM and card-style transparency artifacts, Assay borrows portable, reviewable output
+- from OTel, Assay borrows ingest and ecosystem fit
+
+Assay explicitly does **not** copy the hard provenance assumptions of supply-chain attestations into runtime claims, does **not** become a graph-first metadata lake before a bounded Trust Card exists, and does **not** adopt score-first output as the primary product surface.
+
+In practice, this means Assay should borrow the attestation model, not provenance hardness; borrow the compiler pattern, not the graph as the product; borrow the card metaphor, not self-reported capability theater; and borrow OTel interoperability, not upstream semantic authority.
+
 ### Trust Card Is The First Iconic Artifact
 
 The first product artifact of this compiler direction is a **Trust Card**:

--- a/docs/architecture/ADR-033-OTel-Trust-Compiler-Positioning.md
+++ b/docs/architecture/ADR-033-OTel-Trust-Compiler-Positioning.md
@@ -72,6 +72,8 @@ Those may be easier to explain, but they are weaker wedges for Assay. The strong
 
 Assay is positioned as an **OTel-native trust compiler for agent systems**.
 
+Trust compiler describes the product category; OTel-native describes the preferred ingest and ecosystem posture.
+
 The product model is:
 
 - **Input**: OTel spans, protocol/runtime events, Assay traces, and bundle artifacts
@@ -92,6 +94,7 @@ The following constraints are normative for roadmap and product decisions unless
    OTel, protocol adapters, and other sources are ingest paths. Trust claims must be grounded in Assay's canonical evidence contract and offline-verifiable bundle reality.
 
    Operational rule: new ingest paths may be additive or translational, but they must not replace the canonical evidence layer as the semantic authority for claim classification.
+   Any upstream OTel or protocol mapping change that could affect claim semantics must be covered by canonical evidence mapping tests before adoption.
 
 3. **Trust Card over trust score**
    The iconic artifact is a Trust Card that shows what is `verified`, `self_reported`, `inferred`, or `absent`. A scalar trust score or binary `trusted/untrusted` output must not become the primary interface.
@@ -99,7 +102,7 @@ The following constraints are normative for roadmap and product decisions unless
    MVP rule: no aggregate trust score, no `safe/unsafe` badge, and no maturity badge as the primary artifact.
 
 4. **Fixed execution order**
-   The preferred next order is `T1a -> T1b -> G3 -> P2`, then only later heavier semantics such as reference existence, temporal validity, or capability attestation.
+   The default execution order is `T1a -> T1b -> G3 -> P2`, then only later heavier semantics such as reference existence, temporal validity, or capability attestation, unless a later ADR explicitly supersedes it.
 
 5. **No premature correctness claims**
    Delegation validation, chain integrity/completeness, sandbox correctness, inherited-scope correctness, and temporal correctness remain out of scope until dedicated signals and semantics exist.
@@ -129,10 +132,11 @@ The first product artifact of this compiler direction is a **Trust Card**:
 - potentially signable / attestable later
 
 The Trust Card is an output of the compiler, not a separate dashboard product.
+The Trust Card is a portable manifestation of compiler output, not the full product category.
 
-### Protocol Claim Packs Become A Product Line
+### Protocol Claim Packs Are The Preferred Downstream Productization Path
 
-After the compiler and Trust Card surfaces exist, Assay should extend via **small protocol claim packs**, not via broad compliance theater.
+After the compiler and Trust Card surfaces stabilize, Assay should extend via **small protocol claim packs**, not via broad compliance theater.
 
 Examples:
 
@@ -199,6 +203,7 @@ Mitigation:
 - Assay intentionally does less in categories where competitors are already strong, such as experiments, dashboards, or generic eval UX.
 - Claim discipline must remain strict; overclaiming would undermine the entire positioning.
 - The first deliverables need careful wording so the compiler story does not sound like a full identity-validation or protocol-verification engine.
+- This positioning is less immediately legible than dashboard/eval categories and therefore depends on concrete artifacts and examples to remain understandable.
 
 ### Neutral
 

--- a/docs/architecture/ADR-033-OTel-Trust-Compiler-Positioning.md
+++ b/docs/architecture/ADR-033-OTel-Trust-Compiler-Positioning.md
@@ -1,0 +1,226 @@
+# ADR-033: Assay as an OTel-Native Trust Compiler for Agent Systems
+
+## Status
+Accepted (March 2026)
+
+## Context
+
+Assay's strongest 2026 delivery line is no longer "more agent tooling breadth." It is a sequence of small, bounded claim and evidence moves:
+
+- `C2` shipped a narrow, honest control-evidence baseline instead of a broad OWASP story.
+- `E1` added a minimal typed engine seam rather than a wider policy language.
+- `G1` surfaced supported weaker-than-requested containment fallback paths as evidence.
+- `G2` surfaced explicit delegation context on supported decision evidence.
+- `P1` productized those signals as a signal-aware companion pack without broadening the baseline.
+- the only post-`P1` release-line mismatch was closed on `main` by the `3.2.3` workspace bump and aligned OWASP pack version floors.
+
+At the same time, the external line is moving toward practical identity/authz metadata, auditability, and protocol-level measurable defenses:
+
+- OWASP MCP Top 10 emphasizes authorization and audit/telemetry as distinct control layers.
+- OWASP Top 10 for Agentic Applications 2026 keeps identity/privilege abuse and execution risk as first-order categories.
+- NIST NCCoE and CAISI work on software/AI agent identity and authorization centers explicit metadata and bounded controls.
+- Protocol-aware benchmarks such as A2ASecBench and MCP-SafetyBench reinforce that the frontier is in verifiable protocol/runtime claims, not generic prompt safety or dashboard breadth.
+
+Repo truth already supports this direction:
+
+- the evidence pipeline follows the OTel Collector pattern
+- `assay trace ingest-otel` already exists on `main`
+- evidence bundles, verification, signing, and proof-bearing packs are all implemented
+- trust-chain experiments on `main` already reason about provenance, delegation spoofing, and consumer-side evidence interpretation
+
+This means Assay is best positioned not as "another eval platform" or "another observability dashboard," but as the system that compiles runtime truth into verifiable security claims.
+
+## Strategic Fit Test
+
+This direction is considered strategically sound only while it passes all three tests below.
+
+### 1. External Demand Fit
+
+The strongest external demand in 2026 is not generic agent analytics. It is practical control surfaces around:
+
+- identity and authorization
+- audit and telemetry
+- protocol-level security posture
+- bounded, reviewable deployment claims
+
+That makes Assay a better fit for a trust-compiler category than for a broad observability or eval category.
+
+### 2. Repo Capability Fit
+
+Assay already has the substrate this direction requires:
+
+- canonical evidence and offline verification
+- OTel-style ingest and transformation
+- proof-bearing bundles and signing surfaces
+- bounded signal waves for containment degradation and delegation visibility
+- signal-aware companion packs
+
+This means the trust-compiler direction is a composition of real shipped capabilities, not a jump into a new product genus.
+
+### 3. Wedge Fit Against Alternatives
+
+The main alternatives are:
+
+- broader pack expansion
+- another engine/semantics wave
+- dashboards / observability UX
+- generic eval or red-team positioning
+
+Those may be easier to explain, but they are weaker wedges for Assay. The stronger wedge is to make claim provenance and evidence status portable and explicit through a Trust Card and associated claim surfaces.
+
+## Decision
+
+Assay is positioned as an **OTel-native trust compiler for agent systems**.
+
+The product model is:
+
+- **Input**: OTel spans, protocol/runtime events, Assay traces, and bundle artifacts
+- **Compile**: canonical evidence, bounded claim classification, and pack evaluation
+- **Output**: findings, SARIF, verifiable bundles, and a future signed Trust Card
+
+`OTel-native` is a direction for ingress and ecosystem fit, not a surrender of semantic control. Assay's own canonical evidence layer remains the stable source of truth for trust claims. OTel semantic conventions may evolve, and Assay should ingest and map them, not couple its truth model to any single moving semconv shape.
+Claims are classified on canonical evidence, not directly on raw OTel spans or other upstream ingest formats.
+
+### North Star Freeze
+
+The following constraints are normative for roadmap and product decisions unless a later ADR explicitly supersedes them:
+
+1. **Claim-first, not dashboard-first**
+   Assay's primary product surface is evidence-classified trust claims. Dashboards, trace browsers, and visual analytics are supporting surfaces, not the wedge.
+
+2. **Canonical evidence over ingest format**
+   OTel, protocol adapters, and other sources are ingest paths. Trust claims must be grounded in Assay's canonical evidence contract and offline-verifiable bundle reality.
+
+   Operational rule: new ingest paths may be additive or translational, but they must not replace the canonical evidence layer as the semantic authority for claim classification.
+
+3. **Trust Card over trust score**
+   The iconic artifact is a Trust Card that shows what is `verified`, `self_reported`, `inferred`, or `absent`. A scalar trust score or binary `trusted/untrusted` output must not become the primary interface.
+
+   MVP rule: no aggregate trust score, no `safe/unsafe` badge, and no maturity badge as the primary artifact.
+
+4. **Fixed execution order**
+   The preferred next order is `T1a -> T1b -> G3 -> P2`, then only later heavier semantics such as reference existence, temporal validity, or capability attestation.
+
+5. **No premature correctness claims**
+   Delegation validation, chain integrity/completeness, sandbox correctness, inherited-scope correctness, and temporal correctness remain out of scope until dedicated signals and semantics exist.
+
+### Claim Epistemology Is A First-Class Product Surface
+
+Assay differentiates by making the evidence level of a claim explicit, rather than by maximizing raw detection counts.
+
+The primary evidence levels are:
+
+| Level | Meaning |
+|-------|---------|
+| `verified` | Backed by direct runtime evidence or offline bundle verification |
+| `self_reported` | Reported by the observed system without stronger corroboration |
+| `inferred` | Derived by bounded, documented interpretation rules |
+| `absent` | No trustworthy evidence currently supports the claim |
+
+These evidence levels are the preferred external framing for future trust artifacts. Assay should not collapse them into a primary opaque trust score.
+
+### Trust Card Is The First Iconic Artifact
+
+The first product artifact of this compiler direction is a **Trust Card**:
+
+- portable
+- machine-readable
+- reviewable by humans
+- potentially signable / attestable later
+
+The Trust Card is an output of the compiler, not a separate dashboard product.
+
+### Protocol Claim Packs Become A Product Line
+
+After the compiler and Trust Card surfaces exist, Assay should extend via **small protocol claim packs**, not via broad compliance theater.
+
+Examples:
+
+- delegated authority context surfaced
+- weaker-than-requested containment surfaced
+- provenance-backed vs provenance-absent distinguished
+- capability overclaim detected
+
+### Deliberate Non-Plays
+
+This direction explicitly rejects:
+
+- becoming a tracing platform
+- becoming a general observability dashboard
+- becoming eval-as-a-service
+- becoming a generic red-team framework
+- shipping a delegation-validation or sandbox-correctness story that the signals do not support
+- using an opaque scalar trust score as the primary product output
+- binding Assay's truth model to any one evolving OTel/agent semconv form
+
+## Main Risks And Mitigations
+
+### Risk 1 — Abstract Product Story
+
+`trust compiler` is more abstract than `evals`, `guardrails`, or `observability`.
+
+Mitigation:
+
+- keep the first artifact concrete: Trust Card
+- keep the claim levels explicit and simple
+- tie the story to CI, release governance, procurement review, and vendor comparison
+
+### Risk 2 — Category Confusion
+
+If Assay presents itself as a tracing platform, dashboard, firewall, or generic eval suite, it competes in denser categories with a weaker wedge.
+
+Mitigation:
+
+- keep the north star claim-first
+- treat dashboards and visual analytics as supporting surfaces only
+- keep protocol claim packs and Trust Card artifacts as the visible outputs
+
+### Risk 3 — Standards Churn
+
+OTel GenAI and agent semantic conventions are still evolving, and protocol extensions will continue to move.
+
+Mitigation:
+
+- keep Assay's canonical evidence contract as the truth layer
+- ingest and map OTel/protocol forms into that layer
+- avoid coupling primary trust semantics to any single moving upstream semconv
+
+## Consequences
+
+### Positive
+
+- Assay's moat becomes clearer and more defensible: trace -> evidence -> claim -> proof.
+- The product aligns better with the strongest parts of the existing architecture: deterministic evidence, pack discipline, offline verification, and OTel-friendly ingestion.
+- Trust artifacts can become portable CI/CD, audit, and procurement objects rather than dashboard-only screenshots.
+- Future signal waves such as authorization context fit naturally into the compiler story.
+
+### Negative
+
+- Assay intentionally does less in categories where competitors are already strong, such as experiments, dashboards, or generic eval UX.
+- Claim discipline must remain strict; overclaiming would undermine the entire positioning.
+- The first deliverables need careful wording so the compiler story does not sound like a full identity-validation or protocol-verification engine.
+
+### Neutral
+
+- Existing evidence, pack, and verification surfaces remain valid. This ADR changes product posture and next-step ordering more than it changes the core architecture.
+
+## Immediate Follow-On Sequence
+
+1. `T1a` — OTel-native Trust Compiler MVP
+2. `T1b` — Trust Card MVP
+3. `G3` — Authorization Evidence Signal
+4. `P2` — Protocol Claim Packs
+5. Later: reference existence, temporal validity, capability attestation, and richer compliance packs
+
+Any proposal that primarily improves dashboards, generic observability UX, or score-first reporting should be considered out-of-lane until this sequence is materially complete.
+
+## References
+
+- [ADR-006: Evidence Contract](./ADR-006-Evidence-Contract.md)
+- [ADR-008: Evidence Streaming](./ADR-008-Evidence-Streaming.md)
+- [ADR-025: Evidence-as-a-Product](./ADR-025-Evidence-as-a-Product.md)
+- [ADR-026: Protocol Adapters](./ADR-026-Protocol-Adapters.md)
+- [SYNTHESIS-TRUST-CHAIN-TRIFECTA-2026q2](./SYNTHESIS-TRUST-CHAIN-TRIFECTA-2026q2.md)
+- [RESULTS-EXPERIMENT-DELEGATION-SPOOFING-2026q2](./RESULTS-EXPERIMENT-DELEGATION-SPOOFING-2026q2.md)
+- [RESULTS-EXPERIMENT-PROTOCOL-EVIDENCE-INTERPRETATION-2026q2](./RESULTS-EXPERIMENT-PROTOCOL-EVIDENCE-INTERPRETATION-2026q2.md)
+- [OWASP Agentic A1/A3/A5 C1 Mapping](../security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md)

--- a/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
+++ b/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
@@ -104,7 +104,10 @@ Make the compiler model explicit:
 
 - **inputs**: OTel exports, Assay traces, protocol/runtime evidence
 - **compiler stage**: canonicalization, mapping, bounded claim basis
-- **outputs**: verifiable bundles plus machine-readable trust-basis data for higher-level artifacts
+- **outputs**: verifiable bundles plus a bounded machine-readable trust basis for higher-level artifacts
+
+`T1a` should produce a concrete intermediate artifact derived from a verified bundle.
+Working name for planning: `trust-basis.json`.
 
 ### 4.2 In Scope
 
@@ -114,6 +117,7 @@ Make the compiler model explicit:
 - keep the existing `ProfileCollector -> EvidenceMapper -> EvidenceEvent` architecture as the base path
 - treat OTel exports as inputs that map into Assay's canonical evidence layer rather than as the final truth contract
 - ensure new ingest paths are additive/translational and cannot semantically overrule claim classification outside canonical evidence
+- make the trust basis the place where claim classification happens, rather than in later rendering layers
 
 ### 4.3 Out of Scope
 
@@ -127,9 +131,35 @@ Make the compiler model explicit:
 `T1a` is successful if:
 
 - Assay has a documented trust-compiler contract grounded in existing evidence surfaces
-- a verified bundle can produce a bounded machine-readable trust basis
+- a verified bundle can produce a deterministic bounded machine-readable trust basis artifact
 - the trust basis uses evidence-level classifications instead of a single scalar score
 - existing bundle verification and lint flows remain the source of truth for lower-level evidence
+
+### 4.5 Trust Basis Shape (MVP Planning Freeze)
+
+`T1a` does not need a final schema in this RFC, but it should converge on a small claim-first shape such as:
+
+```json
+{
+  "claims": [
+    {
+      "id": "bundle_verified",
+      "level": "verified",
+      "source": "bundle_verification",
+      "boundary": "bundle-wide",
+      "note": null
+    }
+  ]
+}
+```
+
+Planning constraints for the trust basis:
+
+- each item has a stable claim key / `id`
+- claim classification uses `verified`, `self_reported`, `inferred`, or `absent`
+- each claim identifies its evidence source
+- each claim identifies its supported-flow or scope boundary
+- free-form notes remain optional and non-authoritative
 
 ## 5. T1b — Trust Card MVP
 
@@ -148,17 +178,22 @@ Suggested outputs:
 - `trustcard.json`
 - `trustcard.md`
 
-### 5.2 Trust Card Sections
+`trustcard.json` is the canonical Trust Card artifact. `trustcard.md` is a deterministic human-readable rendering of the same claim set.
 
-The first Trust Card should stay small and explicitly bounded. It should summarize whether the bundle:
+### 5.2 Trust Card Claim Set
 
-- verifies offline
-- carries signing / trust-domain evidence
-- distinguishes provenance-backed vs provenance-absent claims
-- surfaces delegation context for supported flows
-- surfaces containment degradation for supported fallback paths
-- records applied packs and their bounded findings
-- declares supported-flow boundaries and non-goals
+Trust Card rendering must not invent new claim semantics. Claim classification happens in the trust basis / compiler stage, not in Markdown rendering.
+
+The first Trust Card should stay small and explicitly bounded. A minimal v1 claim set should be close to:
+
+- `bundle_verified`
+- `signing_evidence_present`
+- `provenance_backed_claims_present`
+- `delegation_context_visible`
+- `containment_degradation_observed`
+- `applied_pack_findings_present`
+
+These claims may then be rendered into grouped sections for human readability, but the claim set should come first.
 
 ### 5.3 Trust Card Evidence Levels
 
@@ -189,6 +224,7 @@ The Trust Card must not:
 - the language remains bounded and non-goal-aware
 - the Trust Card can be regenerated deterministically from the same verified bundle
 - the Trust Card does not reduce the primary result to a scalar score or binary `trusted/untrusted` label
+- `trustcard.json` remains the canonical artifact and `trustcard.md` remains a deterministic rendering of the same claim set
 
 ## 6. Follow-On Sequencing
 
@@ -216,3 +252,4 @@ Future implementation slices under this RFC should hard-fail review if they:
 - What is the smallest stable machine-readable "trust basis" schema that can sit between bundle verification and Trust Card generation?
 - Should the first collector-native deployment form factor be a CLI compiler only, or a sidecar/processor once the trust basis contract is stable?
 - Which minimal claim sections should be mandatory for `trustcard.json` v1?
+- What is the minimal stable claim key set for Trust Card v1?

--- a/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
+++ b/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
@@ -1,0 +1,218 @@
+# RFC-005: Trust Compiler MVP and Trust Card (Q2 2026)
+
+- Status: Proposed
+- Date: 2026-03-23
+- Owner: Evidence / Product
+- Scope: bounded execution framing for `T1a` and `T1b`
+- Inputs:
+  - [ADR-033: OTel-Native Trust Compiler Positioning](./ADR-033-OTel-Trust-Compiler-Positioning.md)
+  - [ADR-006: Evidence Contract](./ADR-006-Evidence-Contract.md)
+  - [ADR-008: Evidence Streaming](./ADR-008-Evidence-Streaming.md)
+  - [ADR-025: Evidence-as-a-Product](./ADR-025-Evidence-as-a-Product.md)
+  - [ADR-026: Protocol Adapters](./ADR-026-Protocol-Adapters.md)
+  - [OWASP Agentic A1/A3/A5 C1 Mapping](../security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md)
+  - [SYNTHESIS-TRUST-CHAIN-TRIFECTA-2026q2](./SYNTHESIS-TRUST-CHAIN-TRIFECTA-2026q2.md)
+
+## 1. Context
+
+Assay now has enough substrate on `main` to turn a documentation thesis into a bounded product line:
+
+- OTel-style ingest and transformation already exist
+- evidence bundles and offline verification are shipped
+- signal-aware pack surfaces now exist for supported delegation context and supported containment degradation
+- the last release-line truth issue left after `P1` is closed on `main` via `3.2.3`
+
+What is missing is a productized bridge from "we collect evidence" to "we emit reviewable trust claims."
+
+This RFC defines that bridge in two steps:
+
+1. `T1a` — make the evidence compiler line explicit and bounded
+2. `T1b` — generate a Trust Card as the first iconic output artifact
+
+## 1.5 Why This Wedge And Not The Alternatives
+
+This RFC assumes the following strategic comparison is already resolved:
+
+- **not another pack-first move**: packs matter, but they are downstream of claim and signal reality
+- **not another engine-first move**: heavier semantics are valuable later, but they are not the sharpest next wedge
+- **not dashboard-first**: dashboards help explain results, but they do not create the distinctive product category
+
+The Trust Compiler + Trust Card path is chosen because it best converts already-shipped evidence capabilities into a tangible product surface.
+
+## 2. Goals
+
+### Goal A — Productize Assay as a compiler, not a dashboard
+
+The MVP should clarify that Assay turns runtime truth into:
+
+- canonical evidence
+- bounded claim classification
+- portable proof-bearing outputs
+
+### Goal B — Make claim provenance legible to humans and machines
+
+The first public-facing artifact should tell reviewers what is:
+
+- `verified`
+- `self_reported`
+- `inferred`
+- `absent`
+
+without requiring them to reverse-engineer bundle details by hand.
+
+### Goal C — Preserve the bounded-claims discipline from `C2`, `E1`, `G1`, `G2`, and `P1`
+
+The MVP must not overclaim delegation validation, sandbox correctness, temporal correctness, or broad protocol security that the evidence cannot support.
+
+## 2.5 North Star Constraints
+
+This RFC inherits the following hard constraints from ADR-033:
+
+- **claim-first, not dashboard-first**
+- **Assay canonical evidence is the truth layer**
+- **OTel is a first-class ingest path, not the sole semantic authority**
+- **Trust Card is evidence-classified, not score-first**
+- **the preferred order stays `T1a -> T1b -> G3 -> P2`**
+- **Assay is not a tracing platform, eval platform, or observability dashboard**
+
+## 3. Non-Goals
+
+This RFC does not include:
+
+- a tracing platform
+- a general observability dashboard
+- eval-as-a-service
+- a generic risk score as the primary output
+- new pack semantics in the same slice
+- new signal emitters in the same slice
+- delegation-chain validation, cryptographic chain verification, or temporal/reference semantics
+- a fully general OTel Collector processor before the basic compiler and Trust Card contracts are stable
+- any primary `trusted/untrusted` or scalar trust-score output
+- any primary aggregate maturity badge or badge-first UX
+
+## 3.5 Primary Risks
+
+- **Abstractness**: without a concrete artifact, `trust compiler` is too architectural. `T1b` exists to solve this.
+- **Category drift**: it will be tempting to add dashboard-first or score-first surfaces because they are easier to market. This RFC explicitly rejects that as the main product lane.
+- **Standards volatility**: OTel/agent semconv will keep moving. Compiler inputs may evolve, but Assay's canonical evidence layer must remain the stable claim substrate.
+
+## 4. T1a — OTel-Native Trust Compiler MVP
+
+### 4.1 Objective
+
+Make the compiler model explicit:
+
+- **inputs**: OTel exports, Assay traces, protocol/runtime evidence
+- **compiler stage**: canonicalization, mapping, bounded claim basis
+- **outputs**: verifiable bundles plus machine-readable trust-basis data for higher-level artifacts
+
+### 4.2 In Scope
+
+- define and document the official trust-compiler input surfaces already supported on `main`
+- define a bounded machine-readable claim basis contract that can be derived from a verified bundle
+- wire the compiler story through existing CLI and docs, not through a dashboard
+- keep the existing `ProfileCollector -> EvidenceMapper -> EvidenceEvent` architecture as the base path
+- treat OTel exports as inputs that map into Assay's canonical evidence layer rather than as the final truth contract
+- ensure new ingest paths are additive/translational and cannot semantically overrule claim classification outside canonical evidence
+
+### 4.3 Out of Scope
+
+- replacing the existing bundle flow
+- emitting CloudEvents directly in the hot path
+- broadening pack semantics
+- introducing a collector-side processor/runtime before the claim basis contract is stable
+
+### 4.4 Acceptance
+
+`T1a` is successful if:
+
+- Assay has a documented trust-compiler contract grounded in existing evidence surfaces
+- a verified bundle can produce a bounded machine-readable trust basis
+- the trust basis uses evidence-level classifications instead of a single scalar score
+- existing bundle verification and lint flows remain the source of truth for lower-level evidence
+
+## 5. T1b — Trust Card MVP
+
+### 5.1 Objective
+
+Create the first iconic output artifact of the trust-compiler line.
+
+Suggested CLI:
+
+```bash
+assay trustcard generate bundle.tar.gz
+```
+
+Suggested outputs:
+
+- `trustcard.json`
+- `trustcard.md`
+
+### 5.2 Trust Card Sections
+
+The first Trust Card should stay small and explicitly bounded. It should summarize whether the bundle:
+
+- verifies offline
+- carries signing / trust-domain evidence
+- distinguishes provenance-backed vs provenance-absent claims
+- surfaces delegation context for supported flows
+- surfaces containment degradation for supported fallback paths
+- records applied packs and their bounded findings
+- declares supported-flow boundaries and non-goals
+
+### 5.3 Trust Card Evidence Levels
+
+Each claim section should classify its status using the evidence levels from ADR-033:
+
+- `verified`
+- `self_reported`
+- `inferred`
+- `absent`
+
+Optional future summaries may exist, but the primary Trust Card artifact must remain evidence-classified first.
+
+### 5.4 Non-Goals
+
+The Trust Card must not:
+
+- present itself as a universal security rating
+- imply chain integrity or chain completeness when only delegation context is visible
+- imply sandbox correctness when only degradation evidence is present
+- imply temporal/reference correctness that the engine does not support
+
+### 5.5 Acceptance
+
+`T1b` is successful if:
+
+- a verified bundle can produce `trustcard.json` and `trustcard.md`
+- the Trust Card contains explicit evidence-level classifications
+- the language remains bounded and non-goal-aware
+- the Trust Card can be regenerated deterministically from the same verified bundle
+- the Trust Card does not reduce the primary result to a scalar score or binary `trusted/untrusted` label
+
+## 6. Follow-On Sequencing
+
+After `T1a` and `T1b`, the preferred sequence is:
+
+1. `G3` — Authorization Evidence Signal
+2. `P2` — Protocol Claim Packs
+3. only later: reference existence, temporal validity, capability attestation, richer compliance packs
+
+## 7. Review Gates For Future Execution
+
+Future implementation slices under this RFC should hard-fail review if they:
+
+- turn the MVP into a tracing platform
+- turn the MVP into a dashboard project
+- introduce a magic trust score as the primary product surface
+- treat raw OTel semconv as the final trust schema instead of mapping through canonical evidence
+- add new protocol/security claims without backing signals
+- conflate delegation visibility with delegation validation
+- conflate degradation visibility with containment correctness
+- claim the compiler is a general observability replacement or generic eval suite
+
+## 8. Open Questions
+
+- What is the smallest stable machine-readable "trust basis" schema that can sit between bundle verification and Trust Card generation?
+- Should the first collector-native deployment form factor be a CLI compiler only, or a sidecar/processor once the trust basis contract is stable?
+- Which minimal claim sections should be mandatory for `trustcard.json` v1?

--- a/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
+++ b/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
@@ -106,7 +106,7 @@ Make the compiler model explicit:
 - **compiler stage**: canonicalization, mapping, bounded claim basis
 - **outputs**: verifiable bundles plus a bounded machine-readable trust basis for higher-level artifacts
 
-`T1a` should produce a concrete intermediate artifact derived from a verified bundle.
+`T1a` should produce a concrete canonical compiler-output artifact derived from a verified bundle.
 Working name for planning: `trust-basis.json`.
 
 ### 4.2 In Scope
@@ -118,6 +118,7 @@ Working name for planning: `trust-basis.json`.
 - treat OTel exports as inputs that map into Assay's canonical evidence layer rather than as the final truth contract
 - ensure new ingest paths are additive/translational and cannot semantically overrule claim classification outside canonical evidence
 - make the trust basis the place where claim classification happens, rather than in later rendering layers
+- keep `trust-basis.json` as the canonical compiler output that later Trust Card artifacts derive from
 
 ### 4.3 Out of Scope
 
@@ -134,6 +135,7 @@ Working name for planning: `trust-basis.json`.
 - a verified bundle can produce a deterministic bounded machine-readable trust basis artifact
 - the trust basis uses evidence-level classifications instead of a single scalar score
 - existing bundle verification and lint flows remain the source of truth for lower-level evidence
+- `trust-basis.json` is treated as the canonical compiler output rather than an incidental intermediate file
 
 ### 4.5 Trust Basis Shape (MVP Planning Freeze)
 
@@ -160,6 +162,9 @@ Planning constraints for the trust basis:
 - each claim identifies its evidence source
 - each claim identifies its supported-flow or scope boundary
 - free-form notes remain optional and non-authoritative
+- canonical JSON output should use stable ordering and deterministic regeneration
+- the canonical artifact should not include wall-clock timestamps or other host-specific volatile fields
+- the canonical artifact should remain diff-friendly by default
 
 ## 5. T1b — Trust Card MVP
 
@@ -178,7 +183,7 @@ Suggested outputs:
 - `trustcard.json`
 - `trustcard.md`
 
-`trustcard.json` is the canonical Trust Card artifact. `trustcard.md` is a deterministic human-readable rendering of the same claim set.
+`trustcard.json` is the canonical Trust Card artifact derived from `trust-basis.json`. `trustcard.md` is a deterministic human-readable rendering of the same claim set.
 
 ### 5.2 Trust Card Claim Set
 

--- a/docs/architecture/adrs.md
+++ b/docs/architecture/adrs.md
@@ -33,6 +33,7 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | [ADR-030](./ADR-030-Coverage-Wrap-DX-Polish.md) | Coverage + Wrap DX Polish | Accepted | **P2** |
 | [ADR-031](./ADR-031-Coverage-v1.1-DX-Polish.md) | Coverage v1.1 DX Polish | Accepted | **P2** |
 | [ADR-032](./ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md) | MCP Policy Enforcement, Obligations, and Evidence v2 | Accepted | **P1** |
+| [ADR-033](./ADR-033-OTel-Trust-Compiler-Positioning.md) | OTel-Native Trust Compiler Positioning | Accepted | **P1** |
 | [ADR-020](./ADR-020-Dependency-Governance.md) | Dependency Governance | Accepted | - |
 
 ## Q2 2026 Priorities
@@ -55,6 +56,7 @@ This directory contains Architecture Decision Records (ADRs) for the Assay proje
 | **P2** | [ADR-030](./ADR-030-Coverage-Wrap-DX-Polish.md) | Accepted | Implemented on `main` via PRs #578, #580, and #582 (coverage markdown/file input + wrap export log consistency + closure) |
 | **P2** | [ADR-031](./ADR-031-Coverage-v1.1-DX-Polish.md) | Accepted | Implemented on `main` via PRs #585, #587, and #588 (`--out-md`, `--routes-top`, and closure docs/gates) |
 | **P1** | [ADR-032](./ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md) | Accepted | Wave24-Wave42 merged on `main`; see overview + plan for capability grouping and historical rollout |
+| **P1** | [ADR-033](./ADR-033-OTel-Trust-Compiler-Positioning.md) | Accepted | Product direction after `P1`: Trust Compiler MVP, Trust Card, then auth signals and protocol claim packs |
 | **P2** | [ADR-013](./ADR-013-EU-AI-Act-Pack.md) | Accepted | Article 12 mapping, `--pack` flag |
 | **P3** | [ADR-012](./ADR-012-Transparency-Log.md) | Proposed | Builds on ADR-011 |
 | Deferred | [ADR-009](./ADR-009-WORM-Storage.md) | Deferred | Managed WORM → Q3+ if demand |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -15,6 +15,8 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [ADR-032 Obsidian View Layer Recommendations (Q2 2026)](./OBSIDIAN-ADR-032-VIEW-LAYER-2026q2.md) — recommended internal view-layer setup
 - [ADR-032 Documentation Maturity Gap Analysis (Q2 2026)](./GAP-ADR-032-MCP-POLICY-DOCS-MATURITY-2026q2.md) — current-state gap analysis and follow-up posture
 - [ADR-032 Execution Plan (Q2 2026)](./PLAN-ADR-032-MCP-POLICY-ENFORCEMENT-2026q2.md) — MCP policy/obligation rollout status
+- [ADR-033 Trust Compiler Positioning (Q2 2026)](./ADR-033-OTel-Trust-Compiler-Positioning.md) — product north star for Assay as an OTel-native trust compiler
+- [RFC-005 Trust Compiler MVP (Q2 2026)](./RFC-005-trust-compiler-mvp-2026q2.md) — bounded plan for `T1a` compiler and `T1b` Trust Card
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 
 ## Active RFCs
@@ -25,6 +27,7 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 | [RFC-002: Code Health Remediation](./RFC-002-code-health-remediation-q1-2026.md) | Complete (E1–E4 merged, E5→RFC-003) | Store, metrics, registry, comment cleanup |
 | [RFC-003: Generate Decomposition](./RFC-003-generate-decomposition-q1-2026.md) | Complete (G1–G6 merged) | `generate.rs` split into focused modules |
 | [RFC-004: Open Items Convergence](./RFC-004-open-items-convergence-q1-2026.md) | Closed (O1–O6 merged on `main`) | Historical closure ledger for the Q1 convergence line |
+| [RFC-005: Trust Compiler MVP](./RFC-005-trust-compiler-mvp-2026q2.md) | Proposed | Bounded plan for the trust-compiler and Trust Card line |
 
 ## Architecture Decision Records
 
@@ -36,6 +39,7 @@ Key ADRs:
 - [ADR-014: GitHub Action v2](./ADR-014-GitHub-Action-v2.md) — CI integration
 - [ADR-015: BYOS Strategy](./ADR-015-BYOS-Storage-Strategy.md) — bring your own storage
 - [ADR-032: MCP Policy Enforcement v2](./ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md) — typed decisions + obligations + evidence
+- [ADR-033: Trust Compiler Positioning](./ADR-033-OTel-Trust-Compiler-Positioning.md) — claims-as-code north star and Trust Card wedge
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- freeze Assay's north star as a claim-first trust compiler rather than a dashboard/eval direction
- add ADR-033 for the public product-positioning decision
- add RFC-005 for the bounded `T1a` / `T1b` execution frame
- update the roadmap and architecture indexes to reflect the fixed order: `T1a -> T1b -> G3 -> P2`
- record that the only post-`P1` release-line nuance is already closed on `main` via `3.2.3`

## Why this shape
This PR keeps the public docs on the right level:
- yes: north star, guardrails, non-goals, ordering, claim discipline
- no: private GTM details, pricing, or speculative internal strategy

## Guardrails locked here
- claim-first, not dashboard-first
- canonical evidence as the truth layer
- OTel as ingest/bridge, not sole semantic authority
- Trust Card over trust score
- no aggregate trust score / safe-unsafe badge in MVP
- no drift into tracing-platform / eval-platform / observability-dashboard positioning

## Validation
- `git diff --check`
- local pre-commit hooks via commit
- local pre-push hooks via push
