### PR TITLE
feat: implement T1a trust basis compiler MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1355,7 +1355,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1533,7 +1533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2754,7 +2754,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4058,7 +4058,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4607,9 +4607,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -4632,7 +4632,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5457,7 +5457,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -12,6 +12,7 @@ pub mod replay;
 pub mod run;
 pub mod runtime;
 pub mod sim;
+pub mod trust_basis;
 
 pub use baseline::*;
 pub use bundle::*;
@@ -25,6 +26,7 @@ pub use replay::*;
 pub use run::*;
 pub use runtime::*;
 pub use sim::*;
+pub use trust_basis::*;
 
 #[derive(Parser)]
 #[command(
@@ -89,6 +91,9 @@ pub enum Command {
     Setup(SetupArgs),
     /// Tool signing and verification
     Tool(ToolArgs),
+    /// Generate canonical trust-basis artifacts from verified evidence bundles
+    #[command(name = "trust-basis")]
+    TrustBasis(TrustBasisArgs),
 }
 
 #[derive(Parser, Debug)]

--- a/crates/assay-cli/src/cli/args/trust_basis.rs
+++ b/crates/assay-cli/src/cli/args/trust_basis.rs
@@ -1,0 +1,33 @@
+use clap::{Args, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+pub struct TrustBasisArgs {
+    #[command(subcommand)]
+    pub cmd: TrustBasisSub,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TrustBasisSub {
+    /// Generate canonical trust-basis.json from a verified evidence bundle
+    Generate(TrustBasisGenerateArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct TrustBasisGenerateArgs {
+    /// Evidence bundle archive (.tar.gz)
+    #[arg(value_name = "BUNDLE")]
+    pub bundle: PathBuf,
+
+    /// Optional output path for canonical trust-basis.json (defaults to stdout)
+    #[arg(long, short = 'o')]
+    pub out: Option<PathBuf>,
+
+    /// Comma-separated pack references to execute while classifying pack findings
+    #[arg(long, value_delimiter = ',')]
+    pub pack: Option<Vec<String>>,
+
+    /// Maximum lint results considered when pack execution is enabled
+    #[arg(long, default_value = "500")]
+    pub max_results: usize,
+}

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -46,6 +46,7 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         Command::Sim(args) => super::sim::run(args),
         Command::Setup(args) => super::setup::run(args).await,
         Command::Tool(args) => Ok(super::tool::cmd_tool(args.cmd)),
+        Command::TrustBasis(args) => super::trust_basis::run(args),
         Command::Version => {
             println!("{}", env!("CARGO_PKG_VERSION"));
             Ok(EXIT_SUCCESS)

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -44,6 +44,7 @@ pub mod setup;
 #[cfg(feature = "sim")]
 pub mod sim;
 pub mod tool;
+pub mod trust_basis;
 pub mod validate;
 pub mod watch;
 pub use dispatch::dispatch;

--- a/crates/assay-cli/src/cli/commands/trust_basis.rs
+++ b/crates/assay-cli/src/cli/commands/trust_basis.rs
@@ -1,0 +1,59 @@
+use crate::cli::args::{TrustBasisArgs, TrustBasisGenerateArgs, TrustBasisSub};
+use crate::exit_codes::EXIT_SUCCESS;
+use anyhow::{Context, Result};
+use assay_evidence::lint::engine::LintOptions;
+use assay_evidence::lint::packs::load_packs;
+use assay_evidence::{
+    generate_trust_basis, to_canonical_json_bytes, TrustBasisOptions, VerifyLimits,
+};
+use std::fs::File;
+use std::io::Write;
+
+pub fn run(args: TrustBasisArgs) -> Result<i32> {
+    match args.cmd {
+        TrustBasisSub::Generate(args) => cmd_generate(args),
+    }
+}
+
+fn cmd_generate(args: TrustBasisGenerateArgs) -> Result<i32> {
+    let bundle = File::open(&args.bundle)
+        .with_context(|| format!("failed to open bundle {}", args.bundle.display()))?;
+
+    let lint = if let Some(pack_refs) = &args.pack {
+        let packs = load_packs(pack_refs).context("failed to load trust-basis packs")?;
+        Some(LintOptions {
+            packs,
+            max_results: Some(args.max_results),
+            bundle_path: Some(args.bundle.display().to_string()),
+        })
+    } else {
+        None
+    };
+
+    let trust_basis =
+        generate_trust_basis(bundle, VerifyLimits::default(), TrustBasisOptions { lint })
+            .context("failed to generate trust basis")?;
+
+    let output =
+        to_canonical_json_bytes(&trust_basis).context("failed to serialize trust basis")?;
+
+    if let Some(out_path) = args.out {
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create trust-basis output directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+        std::fs::write(&out_path, output)
+            .with_context(|| format!("failed to write trust basis to {}", out_path.display()))?;
+        eprintln!("Wrote canonical trust basis to {}", out_path.display());
+    } else {
+        std::io::stdout()
+            .write_all(&output)
+            .context("failed to write trust basis to stdout")?;
+    }
+
+    Ok(EXIT_SUCCESS)
+}

--- a/crates/assay-cli/tests/trust_basis_test.rs
+++ b/crates/assay-cli/tests/trust_basis_test.rs
@@ -1,0 +1,156 @@
+use assay_evidence::{BundleWriter, EvidenceEvent};
+use assert_cmd::Command;
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+use std::fs;
+use tempfile::tempdir;
+
+fn make_event(type_: &str, run_id: &str, seq: u64, payload: serde_json::Value) -> EvidenceEvent {
+    let mut event = EvidenceEvent::new(
+        type_,
+        "urn:assay:test:trust-basis-cli",
+        run_id,
+        seq,
+        payload,
+    );
+    event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
+    event
+}
+
+fn write_bundle(path: &std::path::Path, events: Vec<EvidenceEvent>) {
+    let file = fs::File::create(path).unwrap();
+    let mut writer = BundleWriter::new(file);
+    for event in events {
+        writer.add_event(event);
+    }
+    writer.finish().unwrap();
+}
+
+fn claim<'a>(claims: &'a [serde_json::Value], id: &str) -> &'a serde_json::Value {
+    claims
+        .iter()
+        .find(|claim| claim["id"] == id)
+        .expect("claim should exist")
+}
+
+#[test]
+fn trust_basis_generate_stdout_emits_all_frozen_claims() {
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("trust-basis.tar.gz");
+    write_bundle(
+        &bundle,
+        vec![
+            make_event(
+                "assay.tool.decision",
+                "run_stdout",
+                0,
+                json!({
+                    "tool": "tool.commit",
+                    "decision": "allow",
+                    "delegated_from": "agent:planner"
+                }),
+            ),
+            make_event(
+                "assay.sandbox.degraded",
+                "run_stdout",
+                1,
+                json!({
+                    "reason_code": "policy_conflict",
+                    "degradation_mode": "audit_fallback",
+                    "component": "landlock"
+                }),
+            ),
+        ],
+    );
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("generate")
+        .arg(&bundle)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claims = json["claims"].as_array().unwrap();
+    assert_eq!(
+        claims.len(),
+        6,
+        "all frozen claims should always be present"
+    );
+
+    assert_eq!(claim(claims, "bundle_verified")["level"], "verified");
+    assert_eq!(
+        claim(claims, "delegation_context_visible")["level"],
+        "verified"
+    );
+    assert_eq!(
+        claim(claims, "containment_degradation_observed")["level"],
+        "verified"
+    );
+    assert_eq!(claim(claims, "signing_evidence_present")["level"], "absent");
+    assert_eq!(
+        claim(claims, "provenance_backed_claims_present")["level"],
+        "absent"
+    );
+    assert_eq!(
+        claim(claims, "applied_pack_findings_present")["level"],
+        "absent"
+    );
+}
+
+#[test]
+fn trust_basis_generate_is_byte_stable_and_pack_aware() {
+    let dir = tempdir().unwrap();
+    let bundle = dir.path().join("trust-basis-pack.tar.gz");
+    write_bundle(
+        &bundle,
+        vec![make_event(
+            "assay.tool.decision",
+            "run_pack",
+            0,
+            json!({
+                "tool": "tool.commit",
+                "decision": "allow",
+                "principal": "user:alice"
+            }),
+        )],
+    );
+
+    let run = || {
+        Command::cargo_bin("assay")
+            .unwrap()
+            .arg("trust-basis")
+            .arg("generate")
+            .arg(&bundle)
+            .arg("--pack")
+            .arg("owasp-agentic-a3-a5-signal-followup")
+            .output()
+            .unwrap()
+    };
+
+    let first = run();
+    let second = run();
+    assert!(first.status.success());
+    assert!(second.status.success());
+    assert_eq!(
+        first.stdout, second.stdout,
+        "canonical trust basis should regenerate byte-for-byte"
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&first.stdout).unwrap();
+    let claims = json["claims"].as_array().unwrap();
+    assert_eq!(
+        claim(claims, "applied_pack_findings_present")["level"],
+        "verified"
+    );
+    assert_eq!(
+        claim(claims, "applied_pack_findings_present")["source"],
+        "pack_execution_results"
+    );
+    assert_eq!(
+        claim(claims, "applied_pack_findings_present")["boundary"],
+        "pack-execution-only"
+    );
+}

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -7,6 +7,7 @@ pub mod mandate;
 pub mod ndjson;
 pub mod sanitize;
 pub mod store;
+pub mod trust_basis;
 pub mod types;
 
 // Convenience re-exports
@@ -20,6 +21,10 @@ pub use ndjson::{read_events, write_events, NdjsonEvents};
 pub use store::config::{resolve_store_url, StoreConfig};
 pub use store::{
     BundleMeta, BundleStore, ObjectStoreBundleStore, StoreError, StoreSpec, StoreStatus,
+};
+pub use trust_basis::{
+    generate_trust_basis, to_canonical_json_bytes, TrustBasis, TrustBasisClaim, TrustBasisOptions,
+    TrustClaimBoundary, TrustClaimId, TrustClaimLevel, TrustClaimSource,
 };
 pub use types::{Envelope, EvidenceEvent, ProducerMeta, SPEC_VERSION};
 

--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -1,7 +1,7 @@
 use crate::bundle::{BundleReader, VerifyLimits};
 use crate::lint::engine::{lint_bundle_with_options, LintOptions, LintReportWithPacks};
 use crate::types::EvidenceEvent;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::io::{Cursor, Read};
 
@@ -70,8 +70,14 @@ pub fn generate_trust_basis<R: Read>(
     options: TrustBasisOptions,
 ) -> Result<TrustBasis> {
     let mut bundle_data = Vec::new();
-    let mut reader = reader;
-    reader.read_to_end(&mut bundle_data)?;
+    let mut limited_reader = reader.take(limits.max_bundle_bytes.saturating_add(1));
+    limited_reader.read_to_end(&mut bundle_data)?;
+    if bundle_data.len() as u64 > limits.max_bundle_bytes {
+        bail!(
+            "trust basis bundle exceeds compressed input limit of {} bytes",
+            limits.max_bundle_bytes
+        );
+    }
 
     let bundle_reader = BundleReader::open_with_limits(Cursor::new(&bundle_data), limits)?;
     let events = bundle_reader.events_vec()?;
@@ -456,6 +462,35 @@ mod tests {
         assert_eq!(
             claim(&trust_basis, TrustClaimId::AppliedPackFindingsPresent).level,
             TrustClaimLevel::Verified
+        );
+    }
+
+    #[test]
+    fn trust_basis_respects_max_bundle_bytes_before_verification() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_size_limit",
+            0,
+            json!({
+                "tool": "tool.commit",
+                "decision": "allow"
+            }),
+        )]);
+
+        let err = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits {
+                max_bundle_bytes: 8,
+                ..VerifyLimits::default()
+            },
+            TrustBasisOptions::default(),
+        )
+        .expect_err("trust basis generation should fail when compressed input exceeds limit");
+
+        assert!(
+            err.to_string()
+                .contains("trust basis bundle exceeds compressed input limit"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -1,0 +1,461 @@
+use crate::bundle::{BundleReader, VerifyLimits};
+use crate::lint::engine::{lint_bundle_with_options, LintOptions, LintReportWithPacks};
+use crate::types::EvidenceEvent;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::io::{Cursor, Read};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustClaimId {
+    BundleVerified,
+    SigningEvidencePresent,
+    ProvenanceBackedClaimsPresent,
+    DelegationContextVisible,
+    ContainmentDegradationObserved,
+    AppliedPackFindingsPresent,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustClaimLevel {
+    Verified,
+    SelfReported,
+    Inferred,
+    Absent,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustClaimSource {
+    BundleVerification,
+    BundleProofSurface,
+    CanonicalDecisionEvidence,
+    CanonicalEventPresence,
+    PackExecutionResults,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum TrustClaimBoundary {
+    BundleWide,
+    SupportedDelegatedFlowsOnly,
+    SupportedContainmentFallbackPathsOnly,
+    ProofSurfacesOnly,
+    PackExecutionOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustBasisClaim {
+    pub id: TrustClaimId,
+    pub level: TrustClaimLevel,
+    pub source: TrustClaimSource,
+    pub boundary: TrustClaimBoundary,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustBasis {
+    pub claims: Vec<TrustBasisClaim>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TrustBasisOptions {
+    pub lint: Option<LintOptions>,
+}
+
+pub fn generate_trust_basis<R: Read>(
+    reader: R,
+    limits: VerifyLimits,
+    options: TrustBasisOptions,
+) -> Result<TrustBasis> {
+    let mut bundle_data = Vec::new();
+    let mut reader = reader;
+    reader.read_to_end(&mut bundle_data)?;
+
+    let bundle_reader = BundleReader::open_with_limits(Cursor::new(&bundle_data), limits)?;
+    let events = bundle_reader.events_vec()?;
+
+    let lint_result = match options.lint {
+        Some(lint_options) if !lint_options.packs.is_empty() => Some(lint_bundle_with_options(
+            Cursor::new(&bundle_data),
+            limits,
+            lint_options,
+        )?),
+        _ => None,
+    };
+
+    Ok(TrustBasis {
+        claims: vec![
+            TrustBasisClaim {
+                id: TrustClaimId::BundleVerified,
+                level: TrustClaimLevel::Verified,
+                source: TrustClaimSource::BundleVerification,
+                boundary: TrustClaimBoundary::BundleWide,
+                note: None,
+            },
+            TrustBasisClaim {
+                id: TrustClaimId::SigningEvidencePresent,
+                level: classify_signing_evidence(&bundle_reader),
+                source: TrustClaimSource::BundleProofSurface,
+                boundary: TrustClaimBoundary::ProofSurfacesOnly,
+                note: None,
+            },
+            TrustBasisClaim {
+                id: TrustClaimId::ProvenanceBackedClaimsPresent,
+                level: classify_provenance_evidence(&bundle_reader),
+                source: TrustClaimSource::BundleProofSurface,
+                boundary: TrustClaimBoundary::ProofSurfacesOnly,
+                note: None,
+            },
+            TrustBasisClaim {
+                id: TrustClaimId::DelegationContextVisible,
+                level: classify_delegation_context(&events),
+                source: TrustClaimSource::CanonicalDecisionEvidence,
+                boundary: TrustClaimBoundary::SupportedDelegatedFlowsOnly,
+                note: None,
+            },
+            TrustBasisClaim {
+                id: TrustClaimId::ContainmentDegradationObserved,
+                level: classify_containment_degradation(&events),
+                source: TrustClaimSource::CanonicalEventPresence,
+                boundary: TrustClaimBoundary::SupportedContainmentFallbackPathsOnly,
+                note: None,
+            },
+            TrustBasisClaim {
+                id: TrustClaimId::AppliedPackFindingsPresent,
+                level: classify_pack_findings(lint_result.as_ref()),
+                source: TrustClaimSource::PackExecutionResults,
+                boundary: TrustClaimBoundary::PackExecutionOnly,
+                note: None,
+            },
+        ],
+    })
+}
+
+pub fn to_canonical_json_bytes(trust_basis: &TrustBasis) -> Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(b"  ");
+    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
+    trust_basis.serialize(&mut serializer)?;
+    output.push(b'\n');
+    Ok(output)
+}
+
+fn classify_signing_evidence(_bundle_reader: &BundleReader) -> TrustClaimLevel {
+    // T1a v1 stays conservative: ordinary evidence bundles do not yet carry a
+    // dedicated signed proof surface for runtime trust claims.
+    TrustClaimLevel::Absent
+}
+
+fn classify_provenance_evidence(_bundle_reader: &BundleReader) -> TrustClaimLevel {
+    // T1a v1 stays conservative: ordinary evidence bundles do not yet carry a
+    // dedicated provenance-proof surface strong enough for this claim.
+    TrustClaimLevel::Absent
+}
+
+fn classify_delegation_context(events: &[EvidenceEvent]) -> TrustClaimLevel {
+    let has_supported_delegation = events.iter().any(|event| {
+        event.type_ == "assay.tool.decision"
+            && event
+                .payload
+                .get("delegated_from")
+                .and_then(|value| value.as_str())
+                .map(|value| !value.trim().is_empty())
+                .unwrap_or(false)
+    });
+
+    if has_supported_delegation {
+        TrustClaimLevel::Verified
+    } else {
+        TrustClaimLevel::Absent
+    }
+}
+
+fn classify_containment_degradation(events: &[EvidenceEvent]) -> TrustClaimLevel {
+    if events
+        .iter()
+        .any(|event| event.type_ == "assay.sandbox.degraded")
+    {
+        TrustClaimLevel::Verified
+    } else {
+        TrustClaimLevel::Absent
+    }
+}
+
+fn classify_pack_findings(lint_result: Option<&LintReportWithPacks>) -> TrustClaimLevel {
+    let Some(lint_result) = lint_result else {
+        return TrustClaimLevel::Absent;
+    };
+
+    let Some(pack_meta) = lint_result.pack_meta.as_ref() else {
+        return TrustClaimLevel::Absent;
+    };
+
+    let prefixes: Vec<String> = pack_meta
+        .packs
+        .iter()
+        .map(|pack| format!("{}@{}:", pack.name, pack.version))
+        .collect();
+
+    let has_pack_finding = lint_result.report.findings.iter().any(|finding| {
+        prefixes
+            .iter()
+            .any(|prefix| finding.rule_id.starts_with(prefix))
+    });
+
+    if has_pack_finding {
+        TrustClaimLevel::Verified
+    } else {
+        TrustClaimLevel::Absent
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bundle::BundleWriter;
+    use crate::lint::packs::load_pack;
+    use chrono::{TimeZone, Utc};
+    use serde_json::json;
+
+    fn make_event(
+        type_: &str,
+        run_id: &str,
+        seq: u64,
+        payload: serde_json::Value,
+    ) -> EvidenceEvent {
+        let mut event =
+            EvidenceEvent::new(type_, "urn:assay:test:trust-basis", run_id, seq, payload);
+        event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
+        event
+    }
+
+    fn make_bundle(events: Vec<EvidenceEvent>) -> Vec<u8> {
+        let mut buffer = Vec::new();
+        let mut writer = BundleWriter::new(&mut buffer);
+        for event in events {
+            writer.add_event(event);
+        }
+        writer.finish().expect("bundle should finish");
+        buffer
+    }
+
+    fn claim(trust_basis: &TrustBasis, id: TrustClaimId) -> &TrustBasisClaim {
+        trust_basis
+            .claims
+            .iter()
+            .find(|claim| claim.id == id)
+            .expect("claim should exist")
+    }
+
+    #[test]
+    fn trust_basis_always_emits_all_frozen_claims() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_all_claims",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            trust_basis
+                .claims
+                .iter()
+                .map(|claim| (claim.id, claim.source, claim.boundary))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    TrustClaimId::BundleVerified,
+                    TrustClaimSource::BundleVerification,
+                    TrustClaimBoundary::BundleWide,
+                ),
+                (
+                    TrustClaimId::SigningEvidencePresent,
+                    TrustClaimSource::BundleProofSurface,
+                    TrustClaimBoundary::ProofSurfacesOnly,
+                ),
+                (
+                    TrustClaimId::ProvenanceBackedClaimsPresent,
+                    TrustClaimSource::BundleProofSurface,
+                    TrustClaimBoundary::ProofSurfacesOnly,
+                ),
+                (
+                    TrustClaimId::DelegationContextVisible,
+                    TrustClaimSource::CanonicalDecisionEvidence,
+                    TrustClaimBoundary::SupportedDelegatedFlowsOnly,
+                ),
+                (
+                    TrustClaimId::ContainmentDegradationObserved,
+                    TrustClaimSource::CanonicalEventPresence,
+                    TrustClaimBoundary::SupportedContainmentFallbackPathsOnly,
+                ),
+                (
+                    TrustClaimId::AppliedPackFindingsPresent,
+                    TrustClaimSource::PackExecutionResults,
+                    TrustClaimBoundary::PackExecutionOnly,
+                ),
+            ]
+        );
+        assert_eq!(
+            trust_basis
+                .claims
+                .iter()
+                .map(|claim| claim.level)
+                .collect::<Vec<_>>(),
+            vec![
+                TrustClaimLevel::Verified,
+                TrustClaimLevel::Absent,
+                TrustClaimLevel::Absent,
+                TrustClaimLevel::Absent,
+                TrustClaimLevel::Absent,
+                TrustClaimLevel::Absent,
+            ]
+        );
+    }
+
+    #[test]
+    fn trust_basis_regeneration_is_byte_stable() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_stable",
+            0,
+            json!({
+                "tool": "tool.commit",
+                "decision": "allow",
+                "delegated_from": "agent:planner"
+            }),
+        )]);
+
+        let first = generate_trust_basis(
+            Cursor::new(&bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("first trust basis");
+        let second = generate_trust_basis(
+            Cursor::new(&bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("second trust basis");
+
+        assert_eq!(
+            to_canonical_json_bytes(&first).expect("first json"),
+            to_canonical_json_bytes(&second).expect("second json")
+        );
+    }
+
+    #[test]
+    fn trust_basis_detects_supported_delegation_and_degradation() {
+        let bundle = make_bundle(vec![
+            make_event(
+                "assay.tool.decision",
+                "run_signals",
+                0,
+                json!({
+                    "tool": "tool.commit",
+                    "decision": "allow",
+                    "delegated_from": "agent:planner"
+                }),
+            ),
+            make_event(
+                "assay.sandbox.degraded",
+                "run_signals",
+                1,
+                json!({
+                    "reason_code": "policy_conflict",
+                    "degradation_mode": "audit_fallback",
+                    "component": "landlock"
+                }),
+            ),
+        ]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(&trust_basis, TrustClaimId::DelegationContextVisible).level,
+            TrustClaimLevel::Verified
+        );
+        assert_eq!(
+            claim(&trust_basis, TrustClaimId::ContainmentDegradationObserved).level,
+            TrustClaimLevel::Verified
+        );
+    }
+
+    #[test]
+    fn trust_basis_keeps_signing_and_provenance_absent_despite_tempting_metadata() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_conservative",
+            0,
+            json!({
+                "tool": "tool.commit",
+                "decision": "allow",
+                "signature": "pretend",
+                "provenance": { "claimed": true }
+            }),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(&trust_basis, TrustClaimId::SigningEvidencePresent).level,
+            TrustClaimLevel::Absent
+        );
+        assert_eq!(
+            claim(&trust_basis, TrustClaimId::ProvenanceBackedClaimsPresent).level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_marks_pack_findings_only_when_explicit_pack_execution_finds_results() {
+        let pack = load_pack("owasp-agentic-a3-a5-signal-followup").expect("pack should load");
+        let bundle = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_pack_findings",
+            0,
+            json!({
+                "tool": "tool.commit",
+                "decision": "allow",
+                "principal": "user:alice"
+            }),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions {
+                lint: Some(LintOptions {
+                    packs: vec![pack],
+                    max_results: Some(500),
+                    bundle_path: Some("trust-basis-pack.tar.gz".to_string()),
+                }),
+            },
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(&trust_basis, TrustClaimId::AppliedPackFindingsPresent).level,
+            TrustClaimLevel::Verified
+        );
+    }
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave-t1a-trust-basis-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave-t1a-trust-basis-step1.md
@@ -1,0 +1,11 @@
+# Wave T1a Trust Basis Step1 Checklist
+
+- [x] `trust-basis.json` is introduced as the canonical T1a compiler output.
+- [x] The frozen v1 claim-key set is emitted in stable order and always fully present.
+- [x] Claim classification happens only in the trust-basis/compiler stage.
+- [x] The implementation stays scoreless and badge-less.
+- [x] No `trustcard.json` or `trustcard.md` surface is introduced in T1a.
+- [x] No new signals, packs, or engine semantics are introduced.
+- [x] Canonical serialization stays deterministic, diff-friendly, and free of wall-clock or host-volatile fields.
+- [x] Low-level CLI generation exists for advanced workflows without turning T1a into the Trust Card UX.
+- [x] Artifact-first tests cover golden regeneration, conservative absent behavior, and explicit pack-execution behavior.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave-t1a-trust-basis-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave-t1a-trust-basis-step1.md
@@ -1,0 +1,33 @@
+# Wave T1a Trust Basis Step1 Move Map
+
+## New surfaces
+
+- `crates/assay-evidence/src/trust_basis.rs`
+  - canonical trust-basis schema
+  - claim classification
+  - canonical JSON serialization
+  - unit tests for fixed claim set and deterministic regeneration
+- `crates/assay-cli/src/cli/args/trust_basis.rs`
+  - low-level CLI argument surface
+- `crates/assay-cli/src/cli/commands/trust_basis.rs`
+  - verified bundle -> `trust-basis.json` generation path
+- `crates/assay-cli/tests/trust_basis_test.rs`
+  - command-level artifact tests
+
+## Existing surfaces touched
+
+- `crates/assay-evidence/src/lib.rs`
+  - module export + re-exports
+- `crates/assay-cli/src/cli/args/mod.rs`
+  - top-level `trust-basis` command registration
+- `crates/assay-cli/src/cli/commands/mod.rs`
+  - command module registration
+- `crates/assay-cli/src/cli/commands/dispatch.rs`
+  - command dispatch wiring
+
+## Explicit non-moves
+
+- no `trustcard.json` / `trustcard.md`
+- no pack semantics changes
+- no engine/policy changes
+- no raw OTel ingest semantics changes

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave-t1a-trust-basis-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave-t1a-trust-basis-step1.md
@@ -1,0 +1,27 @@
+# Wave T1a Trust Basis Step1 Review Pack
+
+## Intent
+
+Ship the smallest possible implementation of the T1a compiler contract:
+
+- verified bundle in
+- canonical `trust-basis.json` out
+- fixed claim vocabulary
+- deterministic serialization
+- no Trust Card rendering
+
+## Reviewer focus
+
+- Do all six frozen claims always exist, even when `absent`?
+- Are `source` and `boundary` limited to the frozen vocabularies?
+- Does any claim classification depend on raw OTel or upstream protocol material?
+- Do signing/provenance stay conservative instead of opportunistically upgrading?
+- Does the CLI stay low-level and artifact-first rather than becoming a Trust Card surface?
+
+## Red flags
+
+- any `trustcard.` files or rendering logic
+- aggregate scores, badges, or `trusted/untrusted` output
+- new signals, packs, or engine semantics
+- non-deterministic serialization
+- claims inferred from markdown, prose, or raw upstream formats

--- a/scripts/ci/review-wave-t1a-trust-basis-step1.sh
+++ b/scripts/ci/review-wave-t1a-trust-basis-step1.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+base_ref="${BASE_REF:-${1:-}}"
+if [[ -z "$base_ref" ]]; then
+  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    base_ref="origin/${GITHUB_BASE_REF}"
+  else
+    base_ref="origin/main"
+  fi
+fi
+
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  echo "BASE_REF not found: ${base_ref}" >&2
+  exit 1
+fi
+
+rg_bin="$(command -v rg || true)"
+if [[ -z "$rg_bin" ]]; then
+  echo "rg is required for reviewer anchors" >&2
+  exit 1
+fi
+
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  case "$file" in
+    crates/assay-evidence/src/lib.rs|\
+    crates/assay-evidence/src/trust_basis.rs|\
+    crates/assay-cli/src/cli/args/mod.rs|\
+    crates/assay-cli/src/cli/args/trust_basis.rs|\
+    crates/assay-cli/src/cli/commands/mod.rs|\
+    crates/assay-cli/src/cli/commands/dispatch.rs|\
+    crates/assay-cli/src/cli/commands/trust_basis.rs|\
+    crates/assay-cli/tests/trust_basis_test.rs|\
+    docs/contributing/SPLIT-CHECKLIST-wave-t1a-trust-basis-step1.md|\
+    docs/contributing/SPLIT-MOVE-MAP-wave-t1a-trust-basis-step1.md|\
+    docs/contributing/SPLIT-REVIEW-PACK-wave-t1a-trust-basis-step1.md|\
+    scripts/ci/review-wave-t1a-trust-basis-step1.sh)
+      ;;
+    *)
+      echo "ERROR: out-of-scope file changed for T1a step1: $file" >&2
+      exit 1
+      ;;
+  esac
+done < <(git diff --name-only "${base_ref}...HEAD")
+
+trust_basis_file="crates/assay-evidence/src/trust_basis.rs"
+cli_file="crates/assay-cli/src/cli/commands/trust_basis.rs"
+test_file="crates/assay-cli/tests/trust_basis_test.rs"
+
+for required_pattern in \
+  'BundleVerified' \
+  'SigningEvidencePresent' \
+  'ProvenanceBackedClaimsPresent' \
+  'DelegationContextVisible' \
+  'ContainmentDegradationObserved' \
+  'AppliedPackFindingsPresent'; do
+  "$rg_bin" -n -F "$required_pattern" "$trust_basis_file" >/dev/null
+done
+
+for required_pattern in \
+  'BundleVerification' \
+  'BundleProofSurface' \
+  'CanonicalDecisionEvidence' \
+  'CanonicalEventPresence' \
+  'PackExecutionResults'; do
+  "$rg_bin" -n -F "$required_pattern" "$trust_basis_file" >/dev/null
+done
+
+for required_pattern in \
+  'BundleWide' \
+  'SupportedDelegatedFlowsOnly' \
+  'SupportedContainmentFallbackPathsOnly' \
+  'ProofSurfacesOnly' \
+  'PackExecutionOnly'; do
+  "$rg_bin" -n -F "$required_pattern" "$trust_basis_file" >/dev/null
+done
+
+for forbidden_pattern in \
+  'trustcard.json' \
+  'trustcard.md' \
+  'trusted/untrusted' \
+  'safe/unsafe' \
+  'trust score' \
+  'maturity badge'; do
+  if grep -R -n -i -F "$forbidden_pattern" "$trust_basis_file" "$cli_file" "$test_file" >/dev/null; then
+    echo "ERROR: forbidden Trust Card or score-first text present: $forbidden_pattern" >&2
+    exit 1
+  fi
+done
+
+"$rg_bin" -n -F 'fn trust_basis_regeneration_is_byte_stable(' "$trust_basis_file" >/dev/null
+"$rg_bin" -n -F 'fn trust_basis_keeps_signing_and_provenance_absent_despite_tempting_metadata(' "$trust_basis_file" >/dev/null
+"$rg_bin" -n -F 'fn trust_basis_generate_is_byte_stable_and_pack_aware(' "$test_file" >/dev/null
+
+cargo fmt --check
+cargo clippy -q -p assay-evidence -p assay-cli --all-targets -- -D warnings
+cargo test -q -p assay-evidence trust_basis_
+cargo test -q -p assay-cli --test trust_basis_test
+git diff --check
+
+echo "Wave T1a Step1 reviewer script: PASS"


### PR DESCRIPTION
## Summary
- add canonical `trust-basis.json` generation in `assay-evidence`
- introduce a low-level `assay trust-basis generate <bundle>` CLI surface
- add artifact-first tests and a reviewer gate for the bounded T1a implementation wave

## What changed
- added the frozen T1a claim set, source vocabulary, boundary vocabulary, and deterministic serializer
- classify delegation and containment strictly from canonical evidence, while keeping signing/provenance conservative
- support optional explicit pack execution for `applied_pack_findings_present`
- added CLI tests for canonical output and byte-stable regeneration
- added T1a review artifacts and `scripts/ci/review-wave-t1a-trust-basis-step1.sh`

## Validation
- `cargo fmt --all`
- `cargo test -q -p assay-evidence trust_basis_`
- `cargo test -q -p assay-cli --test trust_basis_test`
- `BASE_REF=codex/plan-t1a-trust-basis-20260323 bash scripts/ci/review-wave-t1a-trust-basis-step1.sh`
