### PR TITLE
docs: sync T1a release docs and messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Trust Compiler
+
+- **T1a Trust Basis Compiler MVP**: Assay now ships a canonical `trust-basis.json` compiler surface on `main`, derived from verified bundles with fixed claim keys, fixed evidence vocabularies, and deterministic regeneration.
+- **Low-level trust compiler CLI**: Repository builds now expose `assay trust-basis generate <bundle>` for advanced CI, diffing, and review workflows.
+
+### Notes
+
+- **Claim-first boundary**: `T1a` ships claim classification in the compiler layer, not in a Trust Card renderer.
+- **Deliberate non-goals**: This wave does not yet ship `trustcard.json`, `trustcard.md`, a trust score, a `safe/unsafe` badge, or new signal/pack/engine semantics.
+
 ### MCP Security
 
 - **New MCP integrity metrics**: Added `tool_description_integrity`, `tool_output_valid`, and `tool_collision_detect` to cover tool-definition drift, output-schema contracts, and cross-server tool shadowing.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <h1 align="center">Assay</h1>
   <p align="center">
-    <strong>The firewall for MCP tool calls — with a replayable audit trail.</strong>
+    <strong>Claim-first runtime governance and trust compilation for agent systems.</strong>
   </p>
   <p align="center">
     <a href="https://crates.io/crates/assay-cli"><img src="https://img.shields.io/crates/v/assay-cli.svg" alt="Crates.io"></a>
@@ -18,9 +18,9 @@
 
 ---
 
-Your MCP agent calls `read_file`, `exec`, `web_search` — but should it?
+Your MCP agent calls `read_file`, `exec`, `web_search` — but should it, and what can you honestly prove about that run afterward?
 
-Assay sits between your agent and its tools. It intercepts every MCP tool call, checks it against your policy, and blocks what shouldn't happen. Every decision produces an evidence trail you can audit, diff, and replay.
+Assay sits between your agent and its tools. It intercepts every MCP tool call, checks it against your policy, and blocks what shouldn't happen. Every decision produces an evidence trail you can audit, diff, replay, and compile into bounded trust claims.
 
 ```
   Agent ──► Assay ──► MCP Server
@@ -62,17 +62,35 @@ assay evidence show demo/fixtures/bundle.tar.gz
 
 The bundle is tamper-evident and cryptographically verifiable. If your run includes signed mandate events, the same bundle also carries the Ed25519-backed authorization trail for high-risk actions.
 
+Repository builds on `main` also expose the first low-level trust-compiler artifact:
+
+```bash
+assay trust-basis generate demo/fixtures/bundle.tar.gz > trust-basis.json
+```
+
+`trust-basis.json` is the canonical compiler output for the current Trust Compiler MVP. It emits a fixed, deterministic claim set such as:
+
+- `bundle_verified`
+- `signing_evidence_present`
+- `provenance_backed_claims_present`
+- `delegation_context_visible`
+- `containment_degradation_observed`
+- `applied_pack_findings_present`
+
+This is intentionally an advanced artifact, not a Trust Card and not a trust score. The Trust Card surface comes later; `T1a` keeps claim classification in the compiler layer.
+
 ## Is This For Me?
 
 **Yes, if you:**
 - Build with Claude Desktop, Cursor, Windsurf, or any MCP client
 - Ship agents that call tools and you need to control which ones
 - Want a CI gate that catches tool-call regressions before production
-- Need a deterministic audit trail, not sampled observability
+- Need a deterministic audit trail and bounded trust claims, not sampled observability
 
 **Not yet, if you:**
 - Don't use MCP (Assay is MCP-native; other protocols are on the roadmap)
 - Need a hosted dashboard (Assay is CLI-first and offline)
+- Want a magic trust score or badge as the main output
 
 ## Add to Cursor in 30 Seconds
 
@@ -142,7 +160,7 @@ assay init --from-trace trace.jsonl
 
 See [Policy Files](docs/reference/config/policies.md) for the full YAML schema.
 
-## OpenTelemetry In, Evidence Out
+## OpenTelemetry In, Canonical Evidence Out
 
 Already tracing with Langfuse or an OTel-enabled agent stack? Keep that pipeline. Assay ingests OpenTelemetry JSONL, turns it into replayable traces, and gives you deterministic policy gates plus exportable evidence bundles.
 
@@ -153,7 +171,7 @@ assay trace ingest-otel \
   --out-trace traces/otel.v2.jsonl
 ```
 
-Then run `assay ci` on the converted trace or export an Evidence Bundle for audit handoff. See [OpenTelemetry & Langfuse](docs/guides/otel-langfuse.md).
+Then run `assay ci` on the converted trace, export an Evidence Bundle for audit handoff, or compile a low-level trust basis from a verified bundle. See [OpenTelemetry & Langfuse](docs/guides/otel-langfuse.md).
 
 ## Add to CI
 
@@ -203,6 +221,7 @@ The agent protocol landscape is fragmenting (ACP, A2A, UCP, AP2, x402). Assay's 
 | **Deterministic** | Same input, same decision, every time. Not probabilistic. |
 | **MCP-native** | Built for MCP tool calls. Adapters for ACP, A2A, UCP. |
 | **Evidence trail** | Every decision is auditable, diffable, replayable. |
+| **Trust compiler** | Verified bundles can be compiled into bounded trust claims without collapsing into a single score. |
 | **Offline-first** | No backend, no API keys. Runs on your machine. |
 | **Measured** | `0.771ms` p50 / `1.913ms` p95 in the main M1 Pro/macOS tool-decision harness. |
 | **Tested** | [3 security experiments](docs/architecture/SYNTHESIS-TRUST-CHAIN-TRIFECTA-2026q2.md), 12 attack vectors, 0 false positives. |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,19 @@ assay evidence show demo/fixtures/bundle.tar.gz
 
 The bundle is tamper-evident and cryptographically verifiable. If your run includes signed mandate events, the same bundle also carries the Ed25519-backed authorization trail for high-risk actions.
 
-Repository builds on `main` also expose the first low-level trust-compiler artifact:
+Repository builds on `main` also expose the first low-level trust-compiler artifact. If you want to try it before the next crates.io line ships, install from source or from the GitHub repo:
+
+```bash
+cargo install --git https://github.com/Rul1an/assay assay-cli
+```
+
+or from a local checkout:
+
+```bash
+cargo install --path crates/assay-cli
+```
+
+Then generate the trust basis:
 
 ```bash
 assay trust-basis generate demo/fixtures/bundle.tar.gz > trust-basis.json

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,8 +5,8 @@
 > Governance support ADRs [ADR-027](architecture/ADR-027-Tool-Taxonomy.md) through [ADR-031](architecture/ADR-031-Coverage-v1.1-DX-Polish.md) are implemented on `main` and should be read as delivered contracts, not pending proposals.
 > **BYOS truth (ADR-015):** Phase 1 is complete on `main`: `push`, `pull`, `list`, `store-status`, `.assay/store.yaml` config, and provider quickstart docs (S3, B2, MinIO) are all shipped.
 > Split refactor program is closed loop through Wave7C Step3 on `main` (see [plan](architecture/PLAN-split-refactor-2026q1.md), [report](architecture/REPORT-split-refactor-2026q1.md), [program review pack](contributing/SPLIT-REVIEW-PACK-2026q1-program.md)).
-> `E1`, `G1`, `G2`, and `P1` are merged on `main`, and the only post-`P1` release-line nuance is closed: workspace version is now `3.2.3`, and the OWASP signal-aware pack floors align to `>=3.2.3`.
-> Next product priorities: `T1a` OTel-native Trust Compiler MVP, `T1b` Trust Card MVP, then `G3` Authorization Evidence Signal and `P2` Protocol Claim Packs.
+> `E1`, `G1`, `G2`, `P1`, and `T1a` are merged on `main`, and the only post-`P1` release-line nuance is closed: workspace version is now `3.2.3`, and the OWASP signal-aware pack floors align to `>=3.2.3`.
+> Next product priorities: `T1b` Trust Card MVP, then `G3` Authorization Evidence Signal and `P2` Protocol Claim Packs.
 
 **Strategic Focus:** Agent Runtime Evidence, Trust Compilation & Control Plane.
 **Core Value:** Verifiable Evidence + Claims-as-Code for Agent Systems.
@@ -51,6 +51,7 @@ This is the line that recent bounded waves now support on `main`:
 - `G2` made explicit delegation context visible on supported decision evidence.
 - `P1` productized those signals in a companion pack without broadening the baseline.
 - `R2` closed the only post-`P1` release-line mismatch by moving the workspace and OWASP pack floors to `3.2.3`.
+- `T1a` now ships the first canonical trust-basis compiler output on `main` as deterministic `trust-basis.json` derived from verified bundles.
 
 See [ADR-033](architecture/ADR-033-OTel-Trust-Compiler-Positioning.md) for the product-positioning decision and [RFC-005](architecture/RFC-005-trust-compiler-mvp-2026q2.md) for the bounded MVP execution frame.
 
@@ -208,8 +209,8 @@ The current substrate on `main` is strong enough to shift from "more packs" towa
 
 | Order | Lane | Why now | Boundary |
 |-------|------|---------|----------|
-| **1** | `T1a` OTel-native Trust Compiler MVP | The evidence pipeline already follows the OTel Collector pattern and ships `trace ingest-otel`; the next step is to productize trace -> evidence -> claim compilation. | No dashboard, no new packs in the same slice, no broad scoring model. |
-| **2** | `T1b` Trust Card MVP | Assay needs a visible, portable output artifact for its claim model. | Trust Card stays evidence-classified, signed/attested later, and does not become a generic risk score. |
+| **1** | `T1a` OTel-native Trust Compiler MVP | ✅ Merged on `main`: verified bundle -> deterministic `trust-basis.json` with bounded claim classification. | Kept small: no Trust Card rendering, no new signals, no packs, no score-first surface. |
+| **2** | `T1b` Trust Card MVP | Assay now has a canonical trust basis; the next step is to render that into a visible, portable artifact. | Trust Card stays evidence-classified, signed/attested later, and does not become a generic risk score. |
 | **3** | `G3` Authorization Evidence Signal | MCP auth extensions and identity/authz standards make auth context the cleanest next signal seam. | Supported flows only; no auth validation or cryptographic chain semantics. |
 | **4** | `P2` Protocol Claim Packs | After `G3`, protocol-aware claim packs become honest product surfaces. | Small MCP/A2A claim packs, not broad compliance theater. |
 | **Later** | Reference/temporal/capability attestation | These semantics are valuable but heavier. | Ship only after the claim product line is stable. |

--- a/docs/architecture/PLAN-T1a-TRUST-BASIS-COMPILER-2026q2.md
+++ b/docs/architecture/PLAN-T1a-TRUST-BASIS-COMPILER-2026q2.md
@@ -1,6 +1,6 @@
 # PLAN — T1a Trust Basis Compiler MVP (2026q2)
 
-> Status: Proposed
+> Status: Implemented on `main` (March 2026)
 > Date: 2026-03-23
 > Scope: first bounded implementation wave under [ADR-033](./ADR-033-OTel-Trust-Compiler-Positioning.md) and [RFC-005](./RFC-005-trust-compiler-mvp-2026q2.md)
 > Constraint: claim-first, canonical evidence first, no score/badge surface, no new signals in the same wave

--- a/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
+++ b/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
@@ -1,6 +1,6 @@
 # RFC-005: Trust Compiler MVP and Trust Card (Q2 2026)
 
-- Status: Proposed
+- Status: Active (`T1a` merged on `main`; `T1b` pending)
 - Date: 2026-03-23
 - Owner: Evidence / Product
 - Scope: bounded execution framing for `T1a` and `T1b`
@@ -28,6 +28,11 @@ This RFC defines that bridge in two steps:
 
 1. `T1a` — make the evidence compiler line explicit and bounded
 2. `T1b` — generate a Trust Card as the first iconic output artifact
+
+Current delivery status on `main`:
+
+- `T1a` is merged on `main` as the canonical `trust-basis.json` compiler output and low-level `assay trust-basis generate` surface
+- `T1b` remains pending and must stay a rendering/artifact wave above the trust basis rather than a second semantic layer
 
 ## 1.5 Why This Wedge And Not The Alternatives
 


### PR DESCRIPTION
## Summary
- sync `T1a` status across roadmap, RFC, plan, changelog, and README
- explain `trust-basis.json` as a low-level compiler artifact on `main`
- keep outward messaging honest about `main` vs crates.io availability

## Scope
- docs and outward communication only
- no engine, signal, or pack semantics changes
- no crates.io publish claims beyond current repo truth

## Validation
- `git diff --check`
- `cargo test -q -p assay-evidence trust_basis_`
- `cargo test -q -p assay-cli --test trust_basis_test`
