### PR TITLE
fix: make assay-sim publishable

### DIFF
--- a/crates/assay-sim/Cargo.toml
+++ b/crates/assay-sim/Cargo.toml
@@ -22,6 +22,6 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 tempfile = { workspace = true }
 
-assay-adapter-api = { path = "../assay-adapter-api" }
+assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }
 assay-core = { workspace = true }
 assay-evidence = { workspace = true }


### PR DESCRIPTION
## Summary
- add the missing publishable version requirement for `assay-adapter-api` in `assay-sim`
- keep the wave manifest-only with no feature or semantics changes
- unblock the full `3.2.3` crates.io line from the remaining `assay-sim` manifest error

## Validation
- `git diff --check`
- `cargo check -q -p assay-sim`
- `cargo publish --dry-run --allow-dirty -p assay-sim` now advances past the missing-version error and only blocks on unpublished `3.2.3` dependencies
- `cargo publish --dry-run -p assay-cli` still blocks only on unpublished `3.2.3` dependencies, which is the expected post-fix state
