### PR TITLE
fix: use absolute asset paths in release proof kit

### DIFF
--- a/scripts/ci/release_proof_kit_build.sh
+++ b/scripts/ci/release_proof_kit_build.sh
@@ -293,6 +293,12 @@ require_bin "$INVENTORY_SCRIPT"
   echo "provenance summary checksum not found: $PROVENANCE_SUMMARY_SHA256" >&2
   exit 1
 }
+[ -d "$ASSETS_DIR" ] || {
+  echo "assets directory not found: $ASSETS_DIR" >&2
+  exit 1
+}
+
+ASSETS_DIR="$(cd "$ASSETS_DIR" && pwd)"
 
 repo="$(json_get '.verification_policy.repo')"
 predicate_type="$(json_get '.verification_policy.predicate_type')"

--- a/scripts/ci/test-release-proof-kit-build.sh
+++ b/scripts/ci/test-release-proof-kit-build.sh
@@ -220,6 +220,7 @@ run_success_case() {
   grep -F -- '--source-digest abc123def456' "$verify_log" >/dev/null
   grep -F -- '--predicate-type https://slsa.dev/provenance/v1' "$verify_log" >/dev/null
   grep -F -- '--deny-self-hosted-runners' "$verify_log" >/dev/null
+  grep -F "attestation download ${SUCCESS_ASSETS_DIR}/${SUCCESS_ASSET_NAME}" "$SUCCESS_GH_LOG" >/dev/null
 }
 
 run_asset_set_mismatch_case() {

--- a/scripts/ci/test-release-proof-kit-build.sh
+++ b/scripts/ci/test-release-proof-kit-build.sh
@@ -223,6 +223,38 @@ run_success_case() {
   grep -F "attestation download ${SUCCESS_ASSETS_DIR}/${SUCCESS_ASSET_NAME}" "$SUCCESS_GH_LOG" >/dev/null
 }
 
+# Relative ASSETS_DIR must be resolved to an absolute path before per-asset scratch
+# dirs run `gh attestation download` (see release_proof_kit_build.sh). A log grep
+# against an already-absolute mktemp path does not catch missing normalization.
+run_relative_assets_dir_normalization_case() {
+  local temp_dir="$1"
+  setup_success_fixture "$temp_dir"
+  local out_archive="$temp_dir/release/relative-assets-proof-kit.tar.gz"
+  mkdir -p "$(dirname "$out_archive")"
+
+  : >"$SUCCESS_GH_LOG"
+  (
+    cd "$temp_dir"
+    FAKE_GH_LOG="$SUCCESS_GH_LOG" \
+      FAKE_TRUSTED_ROOT_CONTENT="$SUCCESS_TRUSTED_ROOT" \
+      FAKE_DOWNLOAD_CONTENT="$SUCCESS_BUNDLE" \
+      FAKE_DOWNLOAD_FILENAME="sha256:1234.jsonl" \
+      FAKE_DOWNLOAD_MODE="single" \
+      GH_BIN="$SUCCESS_FAKE_GH" \
+      ASSETS_DIR="assets" \
+      PROVENANCE_SUMMARY="$SUCCESS_SUMMARY" \
+      PROVENANCE_SUMMARY_SHA256="$SUCCESS_SUMMARY_SHA" \
+      OUT_ARCHIVE="$out_archive" \
+      VERSION="v9.9.9" \
+      bash "$SCRIPT"
+  )
+
+  test -f "$out_archive"
+  local expected_asset_path
+  expected_asset_path="$(cd "$temp_dir/assets" && pwd)/$SUCCESS_ASSET_NAME"
+  grep -F "attestation download ${expected_asset_path}" "$SUCCESS_GH_LOG" >/dev/null
+}
+
 run_asset_set_mismatch_case() {
   local temp_dir="$1"
   setup_success_fixture "$temp_dir"
@@ -308,6 +340,7 @@ main() {
   trap cleanup EXIT
 
   run_success_case "$TEST_TEMP_DIR"
+  run_relative_assets_dir_normalization_case "$TEST_TEMP_DIR"
   run_asset_set_mismatch_case "$TEST_TEMP_DIR"
   run_missing_bundle_case "$TEST_TEMP_DIR"
   run_trusted_root_failure_case "$TEST_TEMP_DIR"


### PR DESCRIPTION
## Summary\n- normalize the release assets directory to an absolute path before attestation bundle downloads\n- prevent proof-kit builds from failing after changing into per-asset scratch directories\n- add a regression assertion that the proof-kit builder calls gh attestation download with the absolute asset path\n\n## Validation\n- git diff --check\n- bash scripts/ci/test-release-proof-kit-build.sh\n