### PR TITLE
feat: T1b Trust Card (trustcard.json / trustcard.md) over T1a

### DIFF
--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -13,6 +13,7 @@ pub mod run;
 pub mod runtime;
 pub mod sim;
 pub mod trust_basis;
+pub mod trust_card;
 
 pub use baseline::*;
 pub use bundle::*;
@@ -27,6 +28,7 @@ pub use run::*;
 pub use runtime::*;
 pub use sim::*;
 pub use trust_basis::*;
+pub use trust_card::*;
 
 #[derive(Parser)]
 #[command(
@@ -94,6 +96,8 @@ pub enum Command {
     /// Generate canonical trust-basis artifacts from verified evidence bundles
     #[command(name = "trust-basis")]
     TrustBasis(TrustBasisArgs),
+    /// Generate trust card artifacts (trustcard.json + trustcard.md) from verified bundles
+    Trustcard(TrustCardArgs),
 }
 
 #[derive(Parser, Debug)]

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -97,7 +97,8 @@ pub enum Command {
     #[command(name = "trust-basis")]
     TrustBasis(TrustBasisArgs),
     /// Generate trust card artifacts (trustcard.json + trustcard.md) from verified bundles
-    Trustcard(TrustCardArgs),
+    #[command(name = "trustcard")]
+    TrustCard(TrustCardArgs),
 }
 
 #[derive(Parser, Debug)]

--- a/crates/assay-cli/src/cli/args/trust_card.rs
+++ b/crates/assay-cli/src/cli/args/trust_card.rs
@@ -1,0 +1,33 @@
+use clap::{Args, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+pub struct TrustCardArgs {
+    #[command(subcommand)]
+    pub cmd: TrustCardSub,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TrustCardSub {
+    /// Generate trustcard.json and trustcard.md from a verified evidence bundle
+    Generate(TrustCardGenerateArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct TrustCardGenerateArgs {
+    /// Evidence bundle archive (.tar.gz)
+    #[arg(value_name = "BUNDLE")]
+    pub bundle: PathBuf,
+
+    /// Output directory for trustcard.json and trustcard.md
+    #[arg(long = "out-dir", value_name = "DIR")]
+    pub out_dir: PathBuf,
+
+    /// Comma-separated pack references to execute while classifying pack findings
+    #[arg(long, value_delimiter = ',')]
+    pub pack: Option<Vec<String>>,
+
+    /// Maximum lint results considered when pack execution is enabled
+    #[arg(long, default_value = "500")]
+    pub max_results: usize,
+}

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -47,7 +47,7 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         Command::Setup(args) => super::setup::run(args).await,
         Command::Tool(args) => Ok(super::tool::cmd_tool(args.cmd)),
         Command::TrustBasis(args) => super::trust_basis::run(args),
-        Command::Trustcard(args) => super::trust_card::run(args),
+        Command::TrustCard(args) => super::trust_card::run(args),
         Command::Version => {
             println!("{}", env!("CARGO_PKG_VERSION"));
             Ok(EXIT_SUCCESS)

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -47,6 +47,7 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         Command::Setup(args) => super::setup::run(args).await,
         Command::Tool(args) => Ok(super::tool::cmd_tool(args.cmd)),
         Command::TrustBasis(args) => super::trust_basis::run(args),
+        Command::Trustcard(args) => super::trust_card::run(args),
         Command::Version => {
             println!("{}", env!("CARGO_PKG_VERSION"));
             Ok(EXIT_SUCCESS)

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -45,6 +45,7 @@ pub mod setup;
 pub mod sim;
 pub mod tool;
 pub mod trust_basis;
+pub mod trust_card;
 pub mod validate;
 pub mod watch;
 pub use dispatch::dispatch;

--- a/crates/assay-cli/src/cli/commands/trust_card.rs
+++ b/crates/assay-cli/src/cli/commands/trust_card.rs
@@ -1,0 +1,65 @@
+use crate::cli::args::{TrustCardArgs, TrustCardGenerateArgs, TrustCardSub};
+use crate::exit_codes::EXIT_SUCCESS;
+use anyhow::{Context, Result};
+use assay_evidence::lint::engine::LintOptions;
+use assay_evidence::lint::packs::load_packs;
+use assay_evidence::{
+    generate_trust_basis, trust_basis_to_trust_card, trust_card_to_canonical_json_bytes,
+    trust_card_to_markdown, TrustBasisOptions, VerifyLimits,
+};
+use std::fs::File;
+
+pub fn run(args: TrustCardArgs) -> Result<i32> {
+    match args.cmd {
+        TrustCardSub::Generate(args) => cmd_generate(args),
+    }
+}
+
+fn cmd_generate(args: TrustCardGenerateArgs) -> Result<i32> {
+    let bundle = File::open(&args.bundle)
+        .with_context(|| format!("failed to open bundle {}", args.bundle.display()))?;
+
+    let lint = if let Some(pack_refs) = &args.pack {
+        let packs = load_packs(pack_refs).context("failed to load trustcard packs")?;
+        Some(LintOptions {
+            packs,
+            max_results: Some(args.max_results),
+            bundle_path: Some(args.bundle.display().to_string()),
+        })
+    } else {
+        None
+    };
+
+    let trust_basis =
+        generate_trust_basis(bundle, VerifyLimits::default(), TrustBasisOptions { lint })
+            .context("failed to generate trust basis for trust card")?;
+
+    let card = trust_basis_to_trust_card(&trust_basis);
+
+    let json =
+        trust_card_to_canonical_json_bytes(&card).context("failed to serialize trust card json")?;
+    let md = trust_card_to_markdown(&card);
+
+    std::fs::create_dir_all(&args.out_dir).with_context(|| {
+        format!(
+            "failed to create trust card output directory {}",
+            args.out_dir.display()
+        )
+    })?;
+
+    let json_path = args.out_dir.join("trustcard.json");
+    let md_path = args.out_dir.join("trustcard.md");
+
+    std::fs::write(&json_path, json)
+        .with_context(|| format!("failed to write {}", json_path.display()))?;
+    std::fs::write(&md_path, md)
+        .with_context(|| format!("failed to write {}", md_path.display()))?;
+
+    eprintln!(
+        "Wrote trust card to {} and {}",
+        json_path.display(),
+        md_path.display()
+    );
+
+    Ok(EXIT_SUCCESS)
+}

--- a/crates/assay-cli/tests/trustcard_test.rs
+++ b/crates/assay-cli/tests/trustcard_test.rs
@@ -1,0 +1,162 @@
+use assay_evidence::{BundleWriter, EvidenceEvent, TRUST_CARD_NON_GOALS};
+use assert_cmd::Command;
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+use std::fs;
+
+fn make_event(type_: &str, run_id: &str, seq: u64, payload: serde_json::Value) -> EvidenceEvent {
+    let mut event = EvidenceEvent::new(type_, "urn:assay:test:trustcard-cli", run_id, seq, payload);
+    event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
+    event
+}
+
+fn write_bundle(path: &std::path::Path, events: Vec<EvidenceEvent>) {
+    let file = fs::File::create(path).unwrap();
+    let mut writer = BundleWriter::new(file);
+    for event in events {
+        writer.add_event(event);
+    }
+    writer.finish().unwrap();
+}
+
+#[test]
+fn trustcard_generate_writes_json_and_md_matching_trust_basis_claims() {
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = dir.path().join("bundle.tar.gz");
+    let out_dir = dir.path().join("out");
+    write_bundle(
+        &bundle,
+        vec![make_event(
+            "assay.tool.decision",
+            "run_tc",
+            0,
+            json!({
+                "tool": "tool.commit",
+                "decision": "allow",
+                "delegated_from": "agent:planner"
+            }),
+        )],
+    );
+
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trustcard")
+        .arg("generate")
+        .arg(&bundle)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let basis_out = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("generate")
+        .arg(&bundle)
+        .output()
+        .unwrap();
+    assert!(basis_out.status.success());
+    let basis_json: serde_json::Value = serde_json::from_slice(&basis_out.stdout).unwrap();
+
+    let card_json: serde_json::Value =
+        serde_json::from_slice(&fs::read(out_dir.join("trustcard.json")).unwrap()).unwrap();
+
+    assert_eq!(card_json["schema_version"], json!(1));
+    assert_eq!(card_json["claims"], basis_json["claims"]);
+
+    let claims = card_json["claims"].as_array().expect("claims array");
+    assert_eq!(
+        claims.len(),
+        6,
+        "trustcard must carry exactly six frozen claims"
+    );
+    let expected_ids = [
+        "bundle_verified",
+        "signing_evidence_present",
+        "provenance_backed_claims_present",
+        "delegation_context_visible",
+        "containment_degradation_observed",
+        "applied_pack_findings_present",
+    ];
+    let ids: Vec<_> = claims
+        .iter()
+        .map(|c| c["id"].as_str().expect("id"))
+        .collect();
+    assert_eq!(
+        ids,
+        expected_ids.to_vec(),
+        "claim id order must match T1a / generate_trust_basis"
+    );
+
+    let obj = card_json.as_object().expect("root object");
+    let mut root_keys: Vec<_> = obj.keys().map(String::as_str).collect();
+    root_keys.sort_unstable();
+    assert_eq!(
+        root_keys,
+        vec!["claims", "non_goals", "schema_version"],
+        "trustcard.json must not add hashes, section_id, summary fields, etc."
+    );
+
+    assert_eq!(
+        card_json["non_goals"],
+        serde_json::to_value(TRUST_CARD_NON_GOALS.as_slice()).unwrap()
+    );
+
+    let md = String::from_utf8(fs::read(out_dir.join("trustcard.md")).unwrap()).unwrap();
+    assert!(md.contains("## Non-goals"));
+    for line in TRUST_CARD_NON_GOALS {
+        assert!(md.contains(&format!("- {line}")));
+    }
+    assert!(md.contains("| id | level | source | boundary | note |"));
+}
+
+#[test]
+fn trustcard_generate_pack_flag_matches_trust_basis_pack_classification() {
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = dir.path().join("bundle-pack.tar.gz");
+    let out_dir = dir.path().join("out-pack");
+    write_bundle(
+        &bundle,
+        vec![make_event(
+            "assay.tool.decision",
+            "run_pack_tc",
+            0,
+            json!({
+                "tool": "tool.commit",
+                "decision": "allow",
+                "principal": "user:alice"
+            }),
+        )],
+    );
+
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trustcard")
+        .arg("generate")
+        .arg(&bundle)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--pack")
+        .arg("owasp-agentic-a3-a5-signal-followup")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let card_json: serde_json::Value =
+        serde_json::from_slice(&fs::read(out_dir.join("trustcard.json")).unwrap()).unwrap();
+    let claims = card_json["claims"].as_array().unwrap();
+    let pack_claim = claims
+        .iter()
+        .find(|c| c["id"] == "applied_pack_findings_present")
+        .expect("claim");
+    assert_eq!(pack_claim["level"], "verified");
+}

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -8,6 +8,7 @@ pub mod ndjson;
 pub mod sanitize;
 pub mod store;
 pub mod trust_basis;
+pub mod trust_card;
 pub mod types;
 
 // Convenience re-exports
@@ -25,6 +26,10 @@ pub use store::{
 pub use trust_basis::{
     generate_trust_basis, to_canonical_json_bytes, TrustBasis, TrustBasisClaim, TrustBasisOptions,
     TrustClaimBoundary, TrustClaimId, TrustClaimLevel, TrustClaimSource,
+};
+pub use trust_card::{
+    trust_basis_to_trust_card, trust_card_to_canonical_json_bytes, trust_card_to_markdown,
+    TrustCard, TRUST_CARD_NON_GOALS, TRUST_CARD_NOTE_EMPTY_PLACEHOLDER, TRUST_CARD_SCHEMA_VERSION,
 };
 pub use types::{Envelope, EvidenceEvent, ProducerMeta, SPEC_VERSION};
 

--- a/crates/assay-evidence/src/trust_card.rs
+++ b/crates/assay-evidence/src/trust_card.rs
@@ -1,0 +1,435 @@
+//! Trust Card (T1b): deterministic render layer over [`TrustBasis`](crate::TrustBasis).
+//!
+//! Semantics come only from `generate_trust_basis`; this module maps and serializes.
+
+use crate::trust_basis::{TrustBasis, TrustBasisClaim};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// Frozen for T1b v1; no branching on future versions in this wave.
+pub const TRUST_CARD_SCHEMA_VERSION: u32 = 1;
+
+/// Markdown table cell when T1a leaves `note` empty (`None` or blank). Do not vary by test/renderer.
+pub const TRUST_CARD_NOTE_EMPTY_PLACEHOLDER: &str = "-";
+
+/// Frozen `non_goals` strings (JSON and Markdown). Same order as serialized output.
+pub const TRUST_CARD_NON_GOALS: [&str; 3] = [
+    "No aggregate trust score",
+    "No safe/unsafe badge",
+    "No correctness guarantees beyond stated claim boundaries",
+];
+
+/// Canonical trust card document: same `claims` serde shape as [`TrustBasis`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustCard {
+    pub schema_version: u32,
+    pub claims: Vec<TrustBasisClaim>,
+    pub non_goals: Vec<String>,
+}
+
+/// Map a trust basis to a card: no classification, no filtering.
+pub fn trust_basis_to_trust_card(basis: &TrustBasis) -> TrustCard {
+    TrustCard {
+        schema_version: TRUST_CARD_SCHEMA_VERSION,
+        claims: basis.claims.clone(),
+        non_goals: TRUST_CARD_NON_GOALS
+            .iter()
+            .map(|line| (*line).to_string())
+            .collect(),
+    }
+}
+
+/// Pretty JSON with trailing newline, matching [`crate::to_canonical_json_bytes`] for trust basis.
+pub fn trust_card_to_canonical_json_bytes(card: &TrustCard) -> Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(b"  ");
+    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
+    card.serialize(&mut serializer)?;
+    output.push(b'\n');
+    Ok(output)
+}
+
+fn serde_cell_string<T: Serialize>(value: &T) -> String {
+    match serde_json::to_value(value).expect("trust card cell serde") {
+        serde_json::Value::String(s) => s,
+        other => other.to_string(),
+    }
+}
+
+fn md_cell(raw: &str) -> String {
+    raw.replace('|', "\\|").replace('\n', " ")
+}
+
+fn note_markdown(note: &Option<String>) -> String {
+    let trimmed = note.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty());
+    match trimmed {
+        Some(s) => md_cell(s),
+        None => TRUST_CARD_NOTE_EMPTY_PLACEHOLDER.to_string(),
+    }
+}
+
+/// Secondary human view: fixed five-column table, then frozen Non-goals.
+pub fn trust_card_to_markdown(card: &TrustCard) -> String {
+    let mut out = String::new();
+    out.push_str("# Trust card\n\n");
+    out.push_str("| id | level | source | boundary | note |\n");
+    out.push_str("| --- | --- | --- | --- | --- |\n");
+    for claim in &card.claims {
+        let line = format!(
+            "| {} | {} | {} | {} | {} |\n",
+            serde_cell_string(&claim.id),
+            serde_cell_string(&claim.level),
+            serde_cell_string(&claim.source),
+            serde_cell_string(&claim.boundary),
+            note_markdown(&claim.note)
+        );
+        out.push_str(&line);
+    }
+    out.push_str("\n## Non-goals\n\n");
+    for line in &card.non_goals {
+        out.push_str("- ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+/// Table + title only: substring guard for judgment language before `## Non-goals`.
+#[cfg(test)]
+fn markdown_body_before_non_goals(md: &str) -> &str {
+    md.split_once("## Non-goals")
+        .map(|(before, _)| before)
+        .unwrap_or(md)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bundle::BundleWriter;
+    use crate::bundle::VerifyLimits;
+    use crate::trust_basis::{
+        generate_trust_basis, to_canonical_json_bytes, TrustBasisOptions, TrustClaimId,
+    };
+    use crate::types::EvidenceEvent;
+    use chrono::{TimeZone, Utc};
+    use serde_json::json;
+    use std::io::Cursor;
+
+    /// Must match `TrustBasis::claims` order from [`crate::trust_basis::generate_trust_basis`].
+    const FROZEN_T1A_CLAIM_ID_ORDER: [TrustClaimId; 6] = [
+        TrustClaimId::BundleVerified,
+        TrustClaimId::SigningEvidencePresent,
+        TrustClaimId::ProvenanceBackedClaimsPresent,
+        TrustClaimId::DelegationContextVisible,
+        TrustClaimId::ContainmentDegradationObserved,
+        TrustClaimId::AppliedPackFindingsPresent,
+    ];
+
+    fn markdown_table_id_column(md: &str) -> Vec<String> {
+        let mut lines = md.lines();
+        let mut after_sep = false;
+        let mut out = Vec::new();
+        for line in lines.by_ref() {
+            if line.contains("| id | level | source | boundary | note |") {
+                continue;
+            }
+            if line.contains("| --- | --- | --- | --- | --- |") {
+                after_sep = true;
+                continue;
+            }
+            if !after_sep {
+                continue;
+            }
+            if line.trim().is_empty() {
+                break;
+            }
+            if line.starts_with("##") {
+                break;
+            }
+            if !line.starts_with('|') {
+                continue;
+            }
+            let parts: Vec<&str> = line
+                .split('|')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect();
+            if parts.len() >= 5 {
+                out.push(parts[0].to_string());
+            }
+        }
+        out
+    }
+
+    fn make_event(
+        type_: &str,
+        run_id: &str,
+        seq: u64,
+        payload: serde_json::Value,
+    ) -> EvidenceEvent {
+        let mut event =
+            EvidenceEvent::new(type_, "urn:assay:test:trust-card", run_id, seq, payload);
+        event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
+        event
+    }
+
+    fn make_bundle(events: Vec<EvidenceEvent>) -> Vec<u8> {
+        let mut buffer = Vec::new();
+        let mut writer = BundleWriter::new(&mut buffer);
+        for event in events {
+            writer.add_event(event);
+        }
+        writer.finish().expect("bundle should finish");
+        buffer
+    }
+
+    #[test]
+    fn trust_card_non_goals_match_const_golden() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_golden",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        assert_eq!(card.non_goals.len(), 3);
+        for (a, b) in card.non_goals.iter().zip(TRUST_CARD_NON_GOALS.iter()) {
+            assert_eq!(a, b);
+        }
+    }
+
+    #[test]
+    fn trust_card_json_always_exactly_six_frozen_claim_ids_once_in_t1a_order() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_six",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+
+        assert_eq!(card.claims.len(), 6);
+        let ids: Vec<TrustClaimId> = card.claims.iter().map(|c| c.id).collect();
+        assert_eq!(ids, FROZEN_T1A_CLAIM_ID_ORDER);
+        // `FROZEN_T1A_CLAIM_ID_ORDER` has six distinct ids; matching it implies each appears once.
+    }
+
+    #[test]
+    fn trust_card_json_top_level_has_only_schema_version_claims_non_goals() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_keys",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        let v: serde_json::Value =
+            serde_json::from_slice(&trust_card_to_canonical_json_bytes(&card).expect("json"))
+                .expect("parse");
+        let obj = v.as_object().expect("object");
+        let mut keys: Vec<_> = obj.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["claims", "non_goals", "schema_version"],
+            "trustcard.json must not gain section_id, hashes, display_order, summary, etc."
+        );
+    }
+
+    #[test]
+    fn trust_card_markdown_table_rows_follow_claim_id_order_not_sorted() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_md_order",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        let md = trust_card_to_markdown(&card);
+        let col = markdown_table_id_column(&md);
+        let expected: Vec<String> = FROZEN_T1A_CLAIM_ID_ORDER
+            .iter()
+            .map(super::serde_cell_string)
+            .collect();
+        assert_eq!(
+            col, expected,
+            "table rows must follow TrustBasis order, not alphabetical or regrouped"
+        );
+    }
+
+    #[test]
+    fn trust_card_claim_order_and_serde_match_trust_basis() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_order",
+            0,
+            json!({
+                "tool": "tool.commit",
+                "decision": "allow",
+                "delegated_from": "agent:x"
+            }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+
+        let basis_ids: Vec<_> = basis.claims.iter().map(|c| c.id).collect();
+        let card_ids: Vec<_> = card.claims.iter().map(|c| c.id).collect();
+        assert_eq!(basis_ids, card_ids);
+
+        let tb_json: serde_json::Value =
+            serde_json::from_slice(&to_canonical_json_bytes(&basis).expect("tb json"))
+                .expect("parse");
+        let tc_json: serde_json::Value =
+            serde_json::from_slice(&trust_card_to_canonical_json_bytes(&card).expect("tc json"))
+                .expect("parse");
+        assert_eq!(tc_json["claims"], tb_json["claims"]);
+    }
+
+    #[test]
+    fn trust_card_schema_version_is_one() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_schema",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        assert_eq!(card.schema_version, 1);
+        let v: serde_json::Value =
+            serde_json::from_slice(&trust_card_to_canonical_json_bytes(&card).expect("json"))
+                .expect("parse");
+        assert_eq!(v["schema_version"], json!(1));
+    }
+
+    #[test]
+    fn trust_card_markdown_note_placeholder_is_frozen() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_note",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        let md = trust_card_to_markdown(&card);
+        assert!(md.contains(&format!("| {} |", TRUST_CARD_NOTE_EMPTY_PLACEHOLDER)));
+    }
+
+    #[test]
+    fn trust_card_markdown_non_goals_literal_order() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_md_ng",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        let md = trust_card_to_markdown(&card);
+        let idx = md.find("## Non-goals").expect("heading");
+        let tail = &md[idx..];
+        for goal in TRUST_CARD_NON_GOALS {
+            assert!(
+                tail.contains(&format!("- {goal}")),
+                "missing frozen line: {goal}"
+            );
+        }
+    }
+
+    #[test]
+    fn trust_card_markdown_table_avoids_judgment_phrases_in_prose_scope() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_banned",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        let md = trust_card_to_markdown(&card);
+        let head = markdown_body_before_non_goals(&md);
+        let lower = head.to_lowercase();
+        assert!(
+            !lower.contains("strong posture"),
+            "unexpected judgment phrase in table/header"
+        );
+        assert!(
+            !lower.contains(" healthy "),
+            "unexpected judgment phrase in table/header"
+        );
+        assert!(
+            !lower.contains("overall trust"),
+            "unexpected judgment phrase in table/header (incl. overall-trust summaries)"
+        );
+        assert!(
+            !lower.contains("overall trust is"),
+            "no overall-trust summary sentences in table/header"
+        );
+        assert!(
+            !lower.contains("trust posture"),
+            "no trust-posture summary in table/header"
+        );
+        assert!(
+            !lower.contains("this bundle has"),
+            "no bundle-level trust narrative in table/header"
+        );
+        assert!(
+            !lower.contains("trust is high"),
+            "no high-trust summary in table/header"
+        );
+        assert!(
+            !lower.contains("safe/unsafe"),
+            "use frozen non-goals section for safe/unsafe wording, not table"
+        );
+    }
+}

--- a/crates/assay-evidence/src/trust_card.rs
+++ b/crates/assay-evidence/src/trust_card.rs
@@ -57,7 +57,10 @@ fn serde_cell_string<T: Serialize>(value: &T) -> String {
 }
 
 fn md_cell(raw: &str) -> String {
-    raw.replace('|', "\\|").replace('\n', " ")
+    raw.replace('|', "\\|")
+        .chars()
+        .map(|c| if matches!(c, '\r' | '\n') { ' ' } else { c })
+        .collect()
 }
 
 fn note_markdown(note: &Option<String>) -> String {
@@ -108,7 +111,8 @@ mod tests {
     use crate::bundle::BundleWriter;
     use crate::bundle::VerifyLimits;
     use crate::trust_basis::{
-        generate_trust_basis, to_canonical_json_bytes, TrustBasisOptions, TrustClaimId,
+        generate_trust_basis, to_canonical_json_bytes, TrustBasisClaim, TrustBasisOptions,
+        TrustClaimBoundary, TrustClaimId, TrustClaimLevel, TrustClaimSource,
     };
     use crate::types::EvidenceEvent;
     use chrono::{TimeZone, Utc};
@@ -181,6 +185,29 @@ mod tests {
         }
         writer.finish().expect("bundle should finish");
         buffer
+    }
+
+    #[test]
+    fn trust_card_markdown_note_strips_crlf_for_single_line_cell() {
+        let card = TrustCard {
+            schema_version: TRUST_CARD_SCHEMA_VERSION,
+            claims: vec![TrustBasisClaim {
+                id: TrustClaimId::BundleVerified,
+                level: TrustClaimLevel::Verified,
+                source: TrustClaimSource::BundleVerification,
+                boundary: TrustClaimBoundary::BundleWide,
+                note: Some("a\r\nb".to_string()),
+            }],
+            non_goals: TRUST_CARD_NON_GOALS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        };
+        let md = trust_card_to_markdown(&card);
+        assert!(
+            !md.contains('\r'),
+            "markdown table must not contain raw carriage returns"
+        );
     }
 
     #[test]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@
 > **BYOS truth (ADR-015):** Phase 1 is complete on `main`: `push`, `pull`, `list`, `store-status`, `.assay/store.yaml` config, and provider quickstart docs (S3, B2, MinIO) are all shipped.
 > Split refactor program is closed loop through Wave7C Step3 on `main` (see [plan](architecture/PLAN-split-refactor-2026q1.md), [report](architecture/REPORT-split-refactor-2026q1.md), [program review pack](contributing/SPLIT-REVIEW-PACK-2026q1-program.md)).
 > `E1`, `G1`, `G2`, `P1`, and `T1a` are merged on `main`, and the only post-`P1` release-line nuance is closed: workspace version is now `3.2.3`, and the OWASP signal-aware pack floors align to `>=3.2.3`.
-> Next product priorities: `T1b` Trust Card MVP, then `G3` Authorization Evidence Signal and `P2` Protocol Claim Packs.
+> Next product priorities: `G3` Authorization Evidence Signal and `P2` Protocol Claim Packs. `T1b` Trust Card (`trustcard.json` / `trustcard.md`) is implemented on `main`.
 
 **Strategic Focus:** Agent Runtime Evidence, Trust Compilation & Control Plane.
 **Core Value:** Verifiable Evidence + Claims-as-Code for Agent Systems.

--- a/docs/architecture/PLAN-T1b-TRUST-CARD-2026q2.md
+++ b/docs/architecture/PLAN-T1b-TRUST-CARD-2026q2.md
@@ -1,0 +1,47 @@
+# PLAN — T1b Trust Card MVP (2026q2)
+
+> Status: Implemented on `main` (March 2026)
+> Date: 2026-03-23
+> Scope: deterministic render layer over [T1a](./PLAN-T1a-TRUST-BASIS-COMPILER-2026q2.md); [ADR-033](./ADR-033-OTel-Trust-Compiler-Positioning.md); [RFC-005](./RFC-005-trust-compiler-mvp-2026q2.md)
+
+## 1) Goal
+
+Ship `trustcard.json` (canonical) and `trustcard.md` (secondary) derived **only** from `generate_trust_basis` → `trust_basis_to_trust_card`. No second classification pass, no aggregate score, no badge semantics, no `trust_basis_sha256` in v1.
+
+## 2) Frozen contract (v1)
+
+| Item | Rule |
+|------|------|
+| `schema_version` | Always `1` for this wave (`TRUST_CARD_SCHEMA_VERSION`). |
+| `claims[]` | `Vec<TrustBasisClaim>` — same serde as T1a; six frozen ids, same order as `TrustBasis::claims`. |
+| `non_goals` | Three fixed strings in fixed order (`TRUST_CARD_NON_GOALS` in code); identical in JSON and Markdown. |
+| Markdown `note` column | Empty T1a `note` renders as placeholder `-` (`TRUST_CARD_NOTE_EMPTY_PLACEHOLDER`); no multiline cells. |
+| Markdown shape | Title + fixed five-column table + `## Non-goals` with literal bullets. |
+
+## 3) Library API
+
+Implementation: [`crates/assay-evidence/src/trust_card.rs`](../../crates/assay-evidence/src/trust_card.rs)
+
+- `trust_basis_to_trust_card(&TrustBasis) -> TrustCard`
+- `trust_card_to_canonical_json_bytes(&TrustCard) -> Result<Vec<u8>>` (pretty JSON + trailing newline, same pattern as trust basis)
+- `trust_card_to_markdown(&TrustCard) -> String`
+
+## 4) CLI
+
+```bash
+assay trustcard generate <BUNDLE> --out-dir <DIR> [--pack …] [--max-results N]
+```
+
+Writes `<DIR>/trustcard.json` and `<DIR>/trustcard.md`. No stdout artifact stream in v1; stderr may log paths.
+
+## 5) Review gates
+
+- **`trust_basis.rs`:** T1b changes only for shared type/export/serde glue if ever needed — not `classify_*` or claim ordering/content.
+- Tests: `cargo test -p assay-evidence`, `cargo test -p assay-cli --test trustcard_test`, workspace `clippy` with `-D warnings`.
+
+## 6) Explicit non-scope (this wave)
+
+- `--from-trust-basis` / non-bundle input
+- Trust card bytes on stdout
+- Signing/attestation of card files
+- `trust_basis_sha256` (or similar) in `trustcard.json` v1


### PR DESCRIPTION
## Summary

- Add T1b Trust Card in `assay-evidence`: `TrustCard` (`schema_version` 1), shared `Vec<TrustBasisClaim>`, frozen `non_goals`, canonical JSON + fixed-column Markdown; semantics only via `generate_trust_basis` → `trust_basis_to_trust_card` (no `classify_*` changes in `trust_basis.rs`).
- Add CLI `assay trustcard generate <BUNDLE> --out-dir <DIR>` mirroring trust-basis `--pack` / `--max-results`; writes `trustcard.json` and `trustcard.md` (no card output on stdout).
- Contract tests: six frozen claim ids in T1a order, top-level JSON shape, Markdown row order, frozen `non_goals`, judgment-phrase guards; CLI tests use `TRUST_CARD_NON_GOALS` as single source.
- Docs: `PLAN-T1b-TRUST-CARD-2026q2.md`, ROADMAP T1b line.

## Validation

- `cargo test -p assay-evidence trust_card`
- `cargo test -p assay-cli --test trustcard_test`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy -p assay-evidence -p assay-cli --all-targets -- -D warnings`
