### PR TITLE
G3: Authorization context evidence + Trust Card schema v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - **T1a Trust Basis Compiler MVP**: Assay now ships a canonical `trust-basis.json` compiler surface on `main`, derived from verified bundles with fixed claim keys, fixed evidence vocabularies, and deterministic regeneration.
 - **Low-level trust compiler CLI**: Repository builds now expose `assay trust-basis generate <bundle>` for advanced CI, diffing, and review workflows.
+- **G3 Authorization Context Evidence**: Supported MCP tool-call paths can merge policy-projected `auth_scheme`, `auth_issuer`, and `principal` onto `assay.tool.decision` evidence; normalization allowlists schemes, trims issuer, rejects JWS-compact and `Bearer ` credential material, and omits whitespace-only principals.
+- **Trust Card schema v2**: Trust Basis emits **seven** claims (adds `authorization_context_visible` between delegation and containment); `trustcard.json` uses `schema_version` **2**. Downstream consumers should select claims by stable `id`, not assume a fixed row count.
 
 ### Notes
 

--- a/crates/assay-cli/tests/trust_basis_test.rs
+++ b/crates/assay-cli/tests/trust_basis_test.rs
@@ -76,7 +76,7 @@ fn trust_basis_generate_stdout_emits_all_frozen_claims() {
     let claims = json["claims"].as_array().unwrap();
     assert_eq!(
         claims.len(),
-        6,
+        7,
         "all frozen claims should always be present"
     );
 
@@ -84,6 +84,10 @@ fn trust_basis_generate_stdout_emits_all_frozen_claims() {
     assert_eq!(
         claim(claims, "delegation_context_visible")["level"],
         "verified"
+    );
+    assert_eq!(
+        claim(claims, "authorization_context_visible")["level"],
+        "absent"
     );
     assert_eq!(
         claim(claims, "containment_degradation_observed")["level"],

--- a/crates/assay-cli/tests/trustcard_test.rs
+++ b/crates/assay-cli/tests/trustcard_test.rs
@@ -66,20 +66,21 @@ fn trustcard_generate_writes_json_and_md_matching_trust_basis_claims() {
     let card_json: serde_json::Value =
         serde_json::from_slice(&fs::read(out_dir.join("trustcard.json")).unwrap()).unwrap();
 
-    assert_eq!(card_json["schema_version"], json!(1));
+    assert_eq!(card_json["schema_version"], json!(2));
     assert_eq!(card_json["claims"], basis_json["claims"]);
 
     let claims = card_json["claims"].as_array().expect("claims array");
     assert_eq!(
         claims.len(),
-        6,
-        "trustcard must carry exactly six frozen claims"
+        7,
+        "trustcard must carry exactly seven frozen claims"
     );
     let expected_ids = [
         "bundle_verified",
         "signing_evidence_present",
         "provenance_backed_claims_present",
         "delegation_context_visible",
+        "authorization_context_visible",
         "containment_degradation_observed",
         "applied_pack_findings_present",
     ];

--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -158,6 +158,10 @@ pub struct PolicyDecisionEventContext {
     pub lane: Option<String>,
     pub principal: Option<String>,
     pub auth_context_summary: Option<String>,
+    /// G3 v1: allowlisted scheme when policy-projected
+    pub auth_scheme: Option<String>,
+    /// G3 v1: trimmed issuer string
+    pub auth_issuer: Option<String>,
     pub delegated_from: Option<String>,
     pub delegation_depth: Option<u32>,
 }
@@ -398,6 +402,12 @@ pub struct DecisionData {
     /// Authentication context summary (non-sensitive, compact)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_context_summary: Option<String>,
+    /// G3 v1: `oauth2` | `jwt_bearer` (policy-projected)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_scheme: Option<String>,
+    /// G3 v1: trimmed issuer (`iss`) string
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_issuer: Option<String>,
     /// Upstream delegated authority identifier, when explicitly carried by the supported flow
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delegated_from: Option<String>,
@@ -662,6 +672,8 @@ impl DecisionEvent {
                 lane: None,
                 principal: None,
                 auth_context_summary: None,
+                auth_scheme: None,
+                auth_issuer: None,
                 delegated_from: None,
                 delegation_depth: None,
                 decision: Decision::Error, // Default to error, will be set
@@ -794,6 +806,8 @@ impl DecisionEvent {
             lane,
             principal,
             auth_context_summary,
+            auth_scheme,
+            auth_issuer,
             delegated_from,
             delegation_depth,
         } = context;
@@ -843,6 +857,8 @@ impl DecisionEvent {
         self.data.lane = lane;
         self.data.principal = principal;
         self.data.auth_context_summary = auth_context_summary;
+        self.data.auth_scheme = auth_scheme;
+        self.data.auth_issuer = auth_issuer;
         self.data.delegated_from = delegated_from;
         self.data.delegation_depth = delegation_depth;
         refresh_fulfillment_normalization(&mut self.data);
@@ -1016,6 +1032,8 @@ impl DecisionEmitterGuard {
                 lane,
                 principal,
                 auth_context_summary,
+                auth_scheme,
+                auth_issuer,
                 delegated_from,
                 delegation_depth,
             } = context;
@@ -1065,6 +1083,8 @@ impl DecisionEmitterGuard {
             event.data.lane = lane;
             event.data.principal = principal;
             event.data.auth_context_summary = auth_context_summary;
+            event.data.auth_scheme = auth_scheme;
+            event.data.auth_issuer = auth_issuer;
             event.data.delegated_from = delegated_from;
             event.data.delegation_depth = delegation_depth;
             refresh_fulfillment_normalization(&mut event.data);

--- a/crates/assay-core/src/mcp/g3_auth_context.rs
+++ b/crates/assay-core/src/mcp/g3_auth_context.rs
@@ -1,0 +1,156 @@
+//! G3 v1 — Authorization Context Evidence (policy-projected fields only).
+//!
+//! See `docs/architecture/PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md`.
+
+use super::policy::PolicyMatchMetadata;
+
+/// Allowlisted `auth_scheme` values (lowercase JSON).
+pub const AUTH_SCHEME_OAUTH2: &str = "oauth2";
+pub const AUTH_SCHEME_JWT_BEARER: &str = "jwt_bearer";
+
+/// Maximum stored length for `auth_issuer` after trim (drop if exceeded).
+const MAX_AUTH_ISSUER_BYTES: usize = 2048;
+
+/// Rejects JWS compact strings (`header.payload.signature`) — not valid `iss` / principal (v1: no JWT dumps).
+fn looks_like_jws_compact(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('.').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    let (h, p, sig) = (parts[0], parts[1], parts[2]);
+    if h.len() < 4 || p.len() < 4 || sig.len() < 4 {
+        return false;
+    }
+    // Typical JWT header base64url begins with `{"` → `eyJ`
+    if !h.starts_with("eyJ") {
+        return false;
+    }
+    let is_b64url = |part: &str| {
+        part.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    };
+    is_b64url(h) && is_b64url(p) && is_b64url(sig)
+}
+
+fn has_bearer_credential_prefix(s: &str) -> bool {
+    let b = s.trim().as_bytes();
+    b.len() >= 7 && b[..7].eq_ignore_ascii_case(b"bearer ")
+}
+
+/// Optional projection merged into [`PolicyMatchMetadata`] after policy evaluation
+/// on the supported MCP tool-call / decision path (tests and configured handlers).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuthContextProjection {
+    pub auth_scheme: Option<String>,
+    pub auth_issuer: Option<String>,
+    pub principal: Option<String>,
+}
+
+impl AuthContextProjection {
+    /// Normalize and assign G3 fields on metadata. Unknown `auth_scheme` values are dropped.
+    pub fn merge_into_metadata(&self, metadata: &mut PolicyMatchMetadata) {
+        if let Some(s) = normalize_auth_scheme(self.auth_scheme.as_deref()) {
+            metadata.auth_scheme = Some(s);
+        }
+        if let Some(i) = normalize_auth_issuer(self.auth_issuer.as_deref()) {
+            metadata.auth_issuer = Some(i);
+        }
+        if let Some(p) = normalize_principal(self.principal.as_deref()) {
+            metadata.principal = Some(p);
+        }
+    }
+}
+
+/// Returns allowlisted scheme string or `None` if unknown / empty.
+pub fn normalize_auth_scheme(input: Option<&str>) -> Option<String> {
+    let s = input?.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let lower = s.to_ascii_lowercase();
+    match lower.as_str() {
+        AUTH_SCHEME_OAUTH2 | AUTH_SCHEME_JWT_BEARER => Some(lower),
+        _ => None,
+    }
+}
+
+/// v1 norm: trimmed JWT `iss`-style string (no raw JWT dump). Oversized input dropped.
+pub fn normalize_auth_issuer(input: Option<&str>) -> Option<String> {
+    let s = input?.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if has_bearer_credential_prefix(s) || looks_like_jws_compact(s) {
+        return None;
+    }
+    if s.len() > MAX_AUTH_ISSUER_BYTES {
+        return None;
+    }
+    Some(s.to_string())
+}
+
+/// Principal for G3: Unicode-trimmed; whitespace-only ⇒ absent.
+pub fn normalize_principal(input: Option<&str>) -> Option<String> {
+    let s = input.map(str::trim)?;
+    if s.is_empty() {
+        return None;
+    }
+    if has_bearer_credential_prefix(s) || looks_like_jws_compact(s) {
+        return None;
+    }
+    Some(s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheme_allowlist() {
+        assert_eq!(
+            normalize_auth_scheme(Some("JWT_BEARER")).as_deref(),
+            Some(AUTH_SCHEME_JWT_BEARER)
+        );
+        assert_eq!(
+            normalize_auth_scheme(Some("  oauth2  ")).as_deref(),
+            Some("oauth2")
+        );
+        assert_eq!(normalize_auth_scheme(Some("openid")), None);
+    }
+
+    #[test]
+    fn issuer_trim_and_cap() {
+        assert_eq!(
+            normalize_auth_issuer(Some("  https://issuer.example  ")).as_deref(),
+            Some("https://issuer.example")
+        );
+        let huge = "x".repeat(MAX_AUTH_ISSUER_BYTES + 1);
+        assert_eq!(normalize_auth_issuer(Some(&huge)), None);
+    }
+
+    #[test]
+    fn principal_whitespace_absent() {
+        assert_eq!(normalize_principal(Some("   \n\t  ")), None);
+        assert_eq!(normalize_principal(Some("alice")).as_deref(), Some("alice"));
+    }
+
+    /// Synthetic JWS-shaped string (not a real credential; avoids well-known JWT literals in scanners).
+    const SYNTHETIC_JWS_COMPACT: &str =
+        "eyJxxxxxxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyy.zzzzzzzzzzzzzzzzzzzzzzzz";
+
+    #[test]
+    fn issuer_and_principal_reject_jws_compact_and_bearer_material() {
+        assert_eq!(normalize_auth_issuer(Some(SYNTHETIC_JWS_COMPACT)), None);
+        assert_eq!(normalize_auth_issuer(Some("Bearer secret-token")), None);
+        assert_eq!(normalize_principal(Some(SYNTHETIC_JWS_COMPACT)), None);
+        assert_eq!(normalize_principal(Some("Bearer opaque-credential")), None);
+    }
+
+    #[test]
+    fn bearer_prefix_check_does_not_panic_on_non_ascii_leading_chars() {
+        // Must not slice `str` at byte 7 — use byte prefix compare only.
+        let s = "\u{00e9}Bearer token";
+        assert!(!has_bearer_credential_prefix(s));
+        assert!(has_bearer_credential_prefix("Bearer ok"));
+    }
+}

--- a/crates/assay-core/src/mcp/mod.rs
+++ b/crates/assay-core/src/mcp/mod.rs
@@ -1,5 +1,8 @@
 pub mod audit;
 pub mod decision;
+pub mod g3_auth_context;
+
+pub use g3_auth_context::AuthContextProjection;
 pub mod identity;
 pub mod jcs;
 pub mod jsonrpc;

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -172,6 +172,10 @@ pub struct PolicyMatchMetadata {
     pub lane: Option<String>,
     pub principal: Option<String>,
     pub auth_context_summary: Option<String>,
+    /// G3 v1: `oauth2` | `jwt_bearer` when policy-projected
+    pub auth_scheme: Option<String>,
+    /// G3 v1: trimmed issuer (`iss`) string
+    pub auth_issuer: Option<String>,
     pub delegated_from: Option<String>,
     pub delegation_depth: Option<u32>,
 }

--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -551,6 +551,8 @@ impl McpProxy {
         event.data.lane = metadata.lane.clone();
         event.data.principal = metadata.principal.clone();
         event.data.auth_context_summary = metadata.auth_context_summary.clone();
+        event.data.auth_scheme = metadata.auth_scheme.clone();
+        event.data.auth_issuer = metadata.auth_issuer.clone();
         event.data.delegated_from = metadata.delegated_from.clone();
         event.data.delegation_depth = metadata.delegation_depth;
         refresh_contract_projections(&mut event.data);

--- a/crates/assay-core/src/mcp/tool_call_handler/emit.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/emit.rs
@@ -38,6 +38,8 @@ pub(super) struct ToolMatchMetadata {
     pub(super) lane: Option<String>,
     pub(super) principal: Option<String>,
     pub(super) auth_context_summary: Option<String>,
+    pub(super) auth_scheme: Option<String>,
+    pub(super) auth_issuer: Option<String>,
     pub(super) delegated_from: Option<String>,
     pub(super) delegation_depth: Option<u32>,
 }
@@ -104,6 +106,8 @@ impl ToolMatchMetadata {
             lane: metadata.lane.clone(),
             principal: metadata.principal.clone(),
             auth_context_summary: metadata.auth_context_summary.clone(),
+            auth_scheme: metadata.auth_scheme.clone(),
+            auth_issuer: metadata.auth_issuer.clone(),
             delegated_from: metadata.delegated_from.clone(),
             delegation_depth: metadata.delegation_depth,
         }
@@ -140,6 +144,8 @@ impl ToolMatchMetadata {
             lane: self.lane.clone(),
             principal: self.principal.clone(),
             auth_context_summary: self.auth_context_summary.clone(),
+            auth_scheme: self.auth_scheme.clone(),
+            auth_issuer: self.auth_issuer.clone(),
             delegated_from: self.delegated_from.clone(),
             delegation_depth: self.delegation_depth,
         }

--- a/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
@@ -66,12 +66,15 @@ pub(super) fn handle_tool_call(
     let mut effective_arguments = original_arguments.clone();
 
     // Step 1: Policy evaluation
-    let policy_eval = handler.policy.evaluate_with_metadata(
+    let mut policy_eval = handler.policy.evaluate_with_metadata(
         &tool_name,
         &effective_arguments,
         state,
         runtime_identity,
     );
+    if let Some(proj) = &handler.config.auth_context_projection {
+        proj.merge_into_metadata(&mut policy_eval.metadata);
+    }
     let mut tool_match = emit::ToolMatchMetadata::from_policy_metadata(&policy_eval.metadata);
     tool_match.obligation_outcomes =
         obligations::execute_log_only(&tool_match.obligations, &tool_name);

--- a/crates/assay-core/src/mcp/tool_call_handler/tests.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/tests.rs
@@ -1135,6 +1135,7 @@ fn test_commit_tool_without_mandate_denied() {
         require_mandate_for_commit: true,
         commit_tools: vec!["purchase_*".to_string()],
         write_tools: vec![],
+        ..Default::default()
     };
 
     let handler = ToolCallHandler::new(policy, None, emitter.clone(), config);

--- a/crates/assay-core/src/mcp/tool_call_handler/types.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/types.rs
@@ -1,4 +1,5 @@
 use super::super::decision::{DecisionEmitter, DecisionEvent};
+use super::super::g3_auth_context::AuthContextProjection;
 use super::super::lifecycle::LifecycleEmitter;
 use super::super::policy::McpPolicy;
 use crate::runtime::{Authorizer, AuthzReceipt};
@@ -40,6 +41,8 @@ pub struct ToolCallHandlerConfig {
     pub commit_tools: Vec<String>,
     /// Tools classified as write operations (non-commit; glob or exact). Used for mandate operation_class.
     pub write_tools: Vec<String>,
+    /// G3 v1: merged into policy metadata after evaluation when set (policy-projected auth context).
+    pub auth_context_projection: Option<AuthContextProjection>,
 }
 
 impl Default for ToolCallHandlerConfig {
@@ -49,6 +52,7 @@ impl Default for ToolCallHandlerConfig {
             require_mandate_for_commit: true,
             commit_tools: vec![],
             write_tools: vec![],
+            auth_context_projection: None,
         }
     }
 }

--- a/crates/assay-core/tests/decision_emit_invariant.rs
+++ b/crates/assay-core/tests/decision_emit_invariant.rs
@@ -10,12 +10,14 @@ use assay_core::mcp::decision::{
     ReplayClassificationSource, DECISION_BASIS_VERSION_V1, DECISION_CONSUMER_CONTRACT_VERSION_V1,
     DECISION_CONTEXT_CONTRACT_VERSION_V1, DENY_PRECEDENCE_VERSION_V1,
 };
+use assay_core::mcp::g3_auth_context::AuthContextProjection;
 use assay_core::mcp::policy::{
     ApprovalFreshness, McpPolicy, PolicyState, RedactArgsContract, RestrictScopeContract,
     ToolPolicy, TypedPolicyDecision,
 };
 use assay_core::mcp::tool_call_handler::{HandleResult, ToolCallHandler, ToolCallHandlerConfig};
 use chrono::{Duration, Utc};
+use serde_json::json;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -248,6 +250,7 @@ fn test_commit_tool_no_mandate_emits_deny() {
         require_mandate_for_commit: true,
         commit_tools: vec!["purchase_*".to_string()],
         write_tools: vec![],
+        ..Default::default()
     };
     let handler = ToolCallHandler::new(policy, None, emitter.clone(), config);
 
@@ -924,6 +927,7 @@ fn test_event_source_from_config() {
         require_mandate_for_commit: false,
         commit_tools: vec![],
         write_tools: vec![],
+        ..Default::default()
     };
     let handler = ToolCallHandler::new(policy, None, emitter.clone(), config);
 
@@ -1178,4 +1182,112 @@ fn test_event_contains_required_fields() {
     assert!(event.data.approval_state.is_none());
     assert!(event.data.approval_id.is_none());
     assert!(event.data.approval_freshness.is_none());
+}
+
+// =============================================================================
+// G3: policy-projected auth context on emitted decisions (contract)
+// =============================================================================
+
+/// Synthetic JWS-shaped string for redaction tests (not a real credential).
+const SYNTHETIC_JWS_COMPACT: &str =
+    "eyJxxxxxxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyy.zzzzzzzzzzzzzzzzzzzzzzzz";
+
+#[test]
+fn g3_auth_projection_emits_allowlisted_scheme_trimmed_issuer_principal_in_decision_json() {
+    let emitter = Arc::new(TestEmitter::new());
+    let policy = McpPolicy::default();
+    let config = ToolCallHandlerConfig {
+        auth_context_projection: Some(AuthContextProjection {
+            auth_scheme: Some("  OAUTH2  ".to_string()),
+            auth_issuer: Some("  https://issuer.example/realms/acme  ".to_string()),
+            principal: Some("alice@corp".to_string()),
+        }),
+        ..Default::default()
+    };
+    let handler = ToolCallHandler::new(policy, None, emitter.clone(), config);
+
+    let request = make_tool_request("safe_tool");
+    let mut state = PolicyState::default();
+    let result = handler.handle_tool_call(&request, &mut state, None, None, None);
+    assert!(matches!(result, HandleResult::Allow { .. }));
+
+    let event = emitter.last_event().expect("event");
+    let v = serde_json::to_value(&event.data).expect("serde data");
+    assert_eq!(v["auth_scheme"], json!("oauth2"));
+    assert_eq!(
+        v["auth_issuer"],
+        json!("https://issuer.example/realms/acme")
+    );
+    assert_eq!(v["principal"], json!("alice@corp"));
+
+    let wire = serde_json::to_string(&event).expect("wire");
+    assert!(
+        wire.contains("\"auth_scheme\":\"oauth2\""),
+        "emitted JSON must carry normalized auth_scheme"
+    );
+}
+
+#[test]
+fn g3_unknown_auth_scheme_dropped_whitespace_principal_absent_in_decision_json() {
+    let emitter = Arc::new(TestEmitter::new());
+    let policy = McpPolicy::default();
+    let config = ToolCallHandlerConfig {
+        auth_context_projection: Some(AuthContextProjection {
+            auth_scheme: Some("openid".to_string()),
+            auth_issuer: Some("https://issuer.ok".to_string()),
+            principal: Some("  \n\t  ".to_string()),
+        }),
+        ..Default::default()
+    };
+    let handler = ToolCallHandler::new(policy, None, emitter.clone(), config);
+
+    let request = make_tool_request("safe_tool");
+    let mut state = PolicyState::default();
+    let _ = handler.handle_tool_call(&request, &mut state, None, None, None);
+
+    let event = emitter.last_event().expect("event");
+    let v = serde_json::to_value(&event.data).expect("serde data");
+    assert!(
+        v.get("auth_scheme").is_none(),
+        "unknown scheme must not emit"
+    );
+    assert_eq!(v["auth_issuer"], json!("https://issuer.ok"));
+    assert!(
+        v.get("principal").is_none(),
+        "whitespace-only principal absent"
+    );
+}
+
+#[test]
+fn g3_jwt_and_bearer_material_never_appear_on_emitted_decision_json() {
+    let emitter = Arc::new(TestEmitter::new());
+    let policy = McpPolicy::default();
+    let config = ToolCallHandlerConfig {
+        auth_context_projection: Some(AuthContextProjection {
+            auth_scheme: Some("jwt_bearer".to_string()),
+            auth_issuer: Some(SYNTHETIC_JWS_COMPACT.to_string()),
+            principal: Some(format!("Bearer {}", SYNTHETIC_JWS_COMPACT)),
+        }),
+        ..Default::default()
+    };
+    let handler = ToolCallHandler::new(policy, None, emitter.clone(), config);
+
+    let request = make_tool_request("safe_tool");
+    let mut state = PolicyState::default();
+    let _ = handler.handle_tool_call(&request, &mut state, None, None, None);
+
+    let event = emitter.last_event().expect("event");
+    let wire = serde_json::to_string(&event).expect("wire");
+    assert!(
+        !wire.contains(SYNTHETIC_JWS_COMPACT),
+        "JWS-shaped credential material must not appear on the wire"
+    );
+    assert!(
+        !wire.to_ascii_lowercase().contains("bearer "),
+        "bearer credential material must not appear"
+    );
+    let v = serde_json::to_value(&event.data).expect("serde data");
+    assert_eq!(v["auth_scheme"], json!("jwt_bearer"));
+    assert!(v.get("auth_issuer").is_none());
+    assert!(v.get("principal").is_none());
 }

--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -12,6 +12,8 @@ pub enum TrustClaimId {
     SigningEvidencePresent,
     ProvenanceBackedClaimsPresent,
     DelegationContextVisible,
+    /// G3 v1: policy-projected `principal` + `auth_scheme` + `auth_issuer` on decision evidence
+    AuthorizationContextVisible,
     ContainmentDegradationObserved,
     AppliedPackFindingsPresent,
 }
@@ -40,6 +42,8 @@ pub enum TrustClaimSource {
 pub enum TrustClaimBoundary {
     BundleWide,
     SupportedDelegatedFlowsOnly,
+    /// G3 v1: auth context fields from supported policy-projected MCP decision path only
+    SupportedAuthProjectedFlowsOnly,
     SupportedContainmentFallbackPathsOnly,
     ProofSurfacesOnly,
     PackExecutionOnly,
@@ -122,6 +126,13 @@ pub fn generate_trust_basis<R: Read>(
                 note: None,
             },
             TrustBasisClaim {
+                id: TrustClaimId::AuthorizationContextVisible,
+                level: classify_authorization_context(&events),
+                source: TrustClaimSource::CanonicalDecisionEvidence,
+                boundary: TrustClaimBoundary::SupportedAuthProjectedFlowsOnly,
+                note: None,
+            },
+            TrustBasisClaim {
                 id: TrustClaimId::ContainmentDegradationObserved,
                 level: classify_containment_degradation(&events),
                 source: TrustClaimSource::CanonicalEventPresence,
@@ -172,6 +183,89 @@ fn classify_delegation_context(events: &[EvidenceEvent]) -> TrustClaimLevel {
     });
 
     if has_supported_delegation {
+        TrustClaimLevel::Verified
+    } else {
+        TrustClaimLevel::Absent
+    }
+}
+
+// --- G3 v1 classification helpers (must stay aligned with
+// `crates/assay-core/src/mcp/g3_auth_context.rs` normalization) ---
+
+const G3_MAX_AUTH_ISSUER_BYTES: usize = 2048;
+
+fn g3_looks_like_jws_compact(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('.').collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    let (h, p, sig) = (parts[0], parts[1], parts[2]);
+    if h.len() < 4 || p.len() < 4 || sig.len() < 4 {
+        return false;
+    }
+    if !h.starts_with("eyJ") {
+        return false;
+    }
+    let is_b64url = |part: &str| {
+        part.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    };
+    is_b64url(h) && is_b64url(p) && is_b64url(sig)
+}
+
+fn g3_has_bearer_credential_prefix(s: &str) -> bool {
+    let b = s.trim().as_bytes();
+    b.len() >= 7 && b[..7].eq_ignore_ascii_case(b"bearer ")
+}
+
+fn g3_principal_field_satisfies_v1(p: &str) -> bool {
+    let t = p.trim();
+    if t.is_empty() {
+        return false;
+    }
+    !g3_has_bearer_credential_prefix(t) && !g3_looks_like_jws_compact(t)
+}
+
+fn g3_auth_issuer_field_satisfies_v1(iss: &str) -> bool {
+    let t = iss.trim();
+    if t.is_empty() || t.len() > G3_MAX_AUTH_ISSUER_BYTES {
+        return false;
+    }
+    !g3_has_bearer_credential_prefix(t) && !g3_looks_like_jws_compact(t)
+}
+
+/// G3 v1: `principal` + allowlisted `auth_scheme` + `auth_issuer` on the same decision event,
+/// with the same normalization rules as MCP emission (no JWS dumps, no `Bearer ` material, cap issuer).
+fn classify_authorization_context(events: &[EvidenceEvent]) -> TrustClaimLevel {
+    let has = events.iter().any(|event| {
+        if event.type_ != "assay.tool.decision" {
+            return false;
+        }
+        let Some(p) = event.payload.get("principal").and_then(|v| v.as_str()) else {
+            return false;
+        };
+        if !g3_principal_field_satisfies_v1(p) {
+            return false;
+        }
+        let Some(scheme) = event
+            .payload
+            .get("auth_scheme")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+        else {
+            return false;
+        };
+        let scheme = scheme.to_ascii_lowercase();
+        if scheme != "oauth2" && scheme != "jwt_bearer" {
+            return false;
+        }
+        let Some(iss) = event.payload.get("auth_issuer").and_then(|v| v.as_str()) else {
+            return false;
+        };
+        g3_auth_issuer_field_satisfies_v1(iss)
+    });
+
+    if has {
         TrustClaimLevel::Verified
     } else {
         TrustClaimLevel::Absent
@@ -256,6 +350,33 @@ mod tests {
     }
 
     #[test]
+    fn g3_authorization_claim_is_after_delegation_before_containment() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_g3_order",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let ids: Vec<_> = trust_basis.claims.iter().map(|c| c.id).collect();
+        let pos = |id| ids.iter().position(|&x| x == id).expect("claim id");
+        assert_eq!(ids.len(), 7);
+        assert!(
+            pos(TrustClaimId::DelegationContextVisible)
+                < pos(TrustClaimId::AuthorizationContextVisible)
+        );
+        assert!(
+            pos(TrustClaimId::AuthorizationContextVisible)
+                < pos(TrustClaimId::ContainmentDegradationObserved)
+        );
+    }
+
+    #[test]
     fn trust_basis_always_emits_all_frozen_claims() {
         let bundle = make_bundle(vec![make_event(
             "assay.process.exec",
@@ -299,6 +420,11 @@ mod tests {
                     TrustClaimBoundary::SupportedDelegatedFlowsOnly,
                 ),
                 (
+                    TrustClaimId::AuthorizationContextVisible,
+                    TrustClaimSource::CanonicalDecisionEvidence,
+                    TrustClaimBoundary::SupportedAuthProjectedFlowsOnly,
+                ),
+                (
                     TrustClaimId::ContainmentDegradationObserved,
                     TrustClaimSource::CanonicalEventPresence,
                     TrustClaimBoundary::SupportedContainmentFallbackPathsOnly,
@@ -318,6 +444,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 TrustClaimLevel::Verified,
+                TrustClaimLevel::Absent,
                 TrustClaimLevel::Absent,
                 TrustClaimLevel::Absent,
                 TrustClaimLevel::Absent,
@@ -398,6 +525,136 @@ mod tests {
         assert_eq!(
             claim(&trust_basis, TrustClaimId::ContainmentDegradationObserved).level,
             TrustClaimLevel::Verified
+        );
+        assert_eq!(
+            claim(&trust_basis, TrustClaimId::AuthorizationContextVisible).level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_detects_g3_authorization_context_when_all_fields_present() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_g3",
+            0,
+            json!({
+                "tool": "t",
+                "decision": "allow",
+                "principal": "alice@example.com",
+                "auth_scheme": "jwt_bearer",
+                "auth_issuer": "https://issuer.example/"
+            }),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(&trust_basis, TrustClaimId::AuthorizationContextVisible).level,
+            TrustClaimLevel::Verified
+        );
+    }
+
+    #[test]
+    fn trust_basis_g3_absent_when_principal_whitespace_only() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_g3_ws",
+            0,
+            json!({
+                "principal": "   \n\t  ",
+                "auth_scheme": "jwt_bearer",
+                "auth_issuer": "https://issuer.example/"
+            }),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(&trust_basis, TrustClaimId::AuthorizationContextVisible).level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_g3_absent_when_auth_issuer_jws_shaped_or_principal_bearer() {
+        let jws = "eyJxxxxxxxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyyyyyyyyyy.zzzzzzzzzzzzzzzzzzzzzzzz";
+        let bundle_jws_iss = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_g3_jws_iss",
+            0,
+            json!({
+                "principal": "alice",
+                "auth_scheme": "oauth2",
+                "auth_issuer": jws
+            }),
+        )]);
+        let tb1 = generate_trust_basis(
+            Cursor::new(bundle_jws_iss),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        assert_eq!(
+            claim(&tb1, TrustClaimId::AuthorizationContextVisible).level,
+            TrustClaimLevel::Absent
+        );
+
+        let bundle_bearer_princ = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_g3_bearer_p",
+            0,
+            json!({
+                "principal": "Bearer leaked-token",
+                "auth_scheme": "oauth2",
+                "auth_issuer": "https://issuer.example/"
+            }),
+        )]);
+        let tb2 = generate_trust_basis(
+            Cursor::new(bundle_bearer_princ),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        assert_eq!(
+            claim(&tb2, TrustClaimId::AuthorizationContextVisible).level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_g3_absent_when_auth_issuer_exceeds_cap() {
+        let huge_iss = "x".repeat(G3_MAX_AUTH_ISSUER_BYTES + 1);
+        let bundle = make_bundle(vec![make_event(
+            "assay.tool.decision",
+            "run_g3_huge_iss",
+            0,
+            json!({
+                "principal": "alice",
+                "auth_scheme": "oauth2",
+                "auth_issuer": huge_iss
+            }),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        assert_eq!(
+            claim(&trust_basis, TrustClaimId::AuthorizationContextVisible).level,
+            TrustClaimLevel::Absent
         );
     }
 

--- a/crates/assay-evidence/src/trust_card.rs
+++ b/crates/assay-evidence/src/trust_card.rs
@@ -6,8 +6,8 @@ use crate::trust_basis::{TrustBasis, TrustBasisClaim};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-/// Frozen for T1b v1; no branching on future versions in this wave.
-pub const TRUST_CARD_SCHEMA_VERSION: u32 = 1;
+/// Trust Card schema: `2` adds G3 `authorization_context_visible` claim (same row layout as v1).
+pub const TRUST_CARD_SCHEMA_VERSION: u32 = 2;
 
 /// Markdown table cell when T1a leaves `note` empty (`None` or blank). Do not vary by test/renderer.
 pub const TRUST_CARD_NOTE_EMPTY_PLACEHOLDER: &str = "-";
@@ -120,11 +120,12 @@ mod tests {
     use std::io::Cursor;
 
     /// Must match `TrustBasis::claims` order from [`crate::trust_basis::generate_trust_basis`].
-    const FROZEN_T1A_CLAIM_ID_ORDER: [TrustClaimId; 6] = [
+    const FROZEN_TRUST_BASIS_CLAIM_ID_ORDER: [TrustClaimId; 7] = [
         TrustClaimId::BundleVerified,
         TrustClaimId::SigningEvidencePresent,
         TrustClaimId::ProvenanceBackedClaimsPresent,
         TrustClaimId::DelegationContextVisible,
+        TrustClaimId::AuthorizationContextVisible,
         TrustClaimId::ContainmentDegradationObserved,
         TrustClaimId::AppliedPackFindingsPresent,
     ];
@@ -232,10 +233,10 @@ mod tests {
     }
 
     #[test]
-    fn trust_card_json_always_exactly_six_frozen_claim_ids_once_in_t1a_order() {
+    fn trust_card_json_always_exactly_seven_frozen_claim_ids_once_in_trust_basis_order() {
         let bundle = make_bundle(vec![make_event(
             "assay.process.exec",
-            "run_six",
+            "run_seven",
             0,
             json!({ "hits": 1 }),
         )]);
@@ -247,10 +248,9 @@ mod tests {
         .expect("trust basis");
         let card = trust_basis_to_trust_card(&basis);
 
-        assert_eq!(card.claims.len(), 6);
+        assert_eq!(card.claims.len(), 7);
         let ids: Vec<TrustClaimId> = card.claims.iter().map(|c| c.id).collect();
-        assert_eq!(ids, FROZEN_T1A_CLAIM_ID_ORDER);
-        // `FROZEN_T1A_CLAIM_ID_ORDER` has six distinct ids; matching it implies each appears once.
+        assert_eq!(ids, FROZEN_TRUST_BASIS_CLAIM_ID_ORDER);
     }
 
     #[test]
@@ -298,7 +298,7 @@ mod tests {
         let card = trust_basis_to_trust_card(&basis);
         let md = trust_card_to_markdown(&card);
         let col = markdown_table_id_column(&md);
-        let expected: Vec<String> = FROZEN_T1A_CLAIM_ID_ORDER
+        let expected: Vec<String> = FROZEN_TRUST_BASIS_CLAIM_ID_ORDER
             .iter()
             .map(super::serde_cell_string)
             .collect();
@@ -342,7 +342,44 @@ mod tests {
     }
 
     #[test]
-    fn trust_card_schema_version_is_one() {
+    fn trust_card_markdown_has_only_trust_card_title_table_and_non_goals_section() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_md_shape",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        let md = trust_card_to_markdown(&card);
+        assert!(md.starts_with("# Trust card\n\n"));
+        assert_eq!(
+            md.matches("\n## ").count(),
+            1,
+            "only ## Non-goals after the table; no Summary/Prose/Appendix sections"
+        );
+        assert!(
+            md.contains("\n## Non-goals\n\n"),
+            "frozen non-goals heading only"
+        );
+        let table_rows = md
+            .lines()
+            .filter(|l| l.starts_with('|') && !l.contains("| id | level |"))
+            .filter(|l| !l.contains("| --- |"))
+            .count();
+        assert_eq!(
+            table_rows, 7,
+            "schema 2 adds one claim row; no extra markdown table blocks"
+        );
+    }
+
+    #[test]
+    fn trust_card_schema_version_is_two() {
         let bundle = make_bundle(vec![make_event(
             "assay.process.exec",
             "run_schema",
@@ -356,11 +393,11 @@ mod tests {
         )
         .expect("trust basis");
         let card = trust_basis_to_trust_card(&basis);
-        assert_eq!(card.schema_version, 1);
+        assert_eq!(card.schema_version, 2);
         let v: serde_json::Value =
             serde_json::from_slice(&trust_card_to_canonical_json_bytes(&card).expect("json"))
                 .expect("parse");
-        assert_eq!(v["schema_version"], json!(1));
+        assert_eq!(v["schema_version"], json!(2));
     }
 
     #[test]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,12 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-03-23):** Q1 DX/refactor convergence is closed on `main` (RFC-001/002/003/004).
+> **Status sync (2026-03-24):** Q1 DX/refactor convergence is closed on `main` (RFC-001/002/003/004).
 > Evidence-as-a-product (ADR-025), protocol adapters (ADR-026), and MCP governance/enforcement (ADR-032 Wave24-Wave42) are materially implemented on `main`.
 > Governance support ADRs [ADR-027](architecture/ADR-027-Tool-Taxonomy.md) through [ADR-031](architecture/ADR-031-Coverage-v1.1-DX-Polish.md) are implemented on `main` and should be read as delivered contracts, not pending proposals.
 > **BYOS truth (ADR-015):** Phase 1 is complete on `main`: `push`, `pull`, `list`, `store-status`, `.assay/store.yaml` config, and provider quickstart docs (S3, B2, MinIO) are all shipped.
 > Split refactor program is closed loop through Wave7C Step3 on `main` (see [plan](architecture/PLAN-split-refactor-2026q1.md), [report](architecture/REPORT-split-refactor-2026q1.md), [program review pack](contributing/SPLIT-REVIEW-PACK-2026q1-program.md)).
-> `E1`, `G1`, `G2`, `P1`, and `T1a` are merged on `main`, and the only post-`P1` release-line nuance is closed: workspace version is now `3.2.3`, and the OWASP signal-aware pack floors align to `>=3.2.3`.
-> Next product priorities: `G3` Authorization Evidence Signal and `P2` Protocol Claim Packs. `T1b` Trust Card (`trustcard.json` / `trustcard.md`) is implemented on `main`.
+> `E1`, `G1`, `G2`, `P1`, `T1a`, `T1b`, and `G3` are merged on `main`; workspace version is `3.2.3` and OWASP signal-aware pack floors align to `>=3.2.3`.
+> **Next wave (fixed order [RFC-005](architecture/RFC-005-trust-compiler-mvp-2026q2.md)):** `P2` Protocol Claim Packs (`T1a → T1b → G3 → P2` sequence: `G3` closed). `T1b` ships `trustcard.json` / `trustcard.md` via `assay trustcard generate` (see [PLAN-T1b](architecture/PLAN-T1b-TRUST-CARD-2026q2.md)); `G3` adds policy-projected auth context on decision evidence (see [PLAN-G3](architecture/PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md)).
 
 **Strategic Focus:** Agent Runtime Evidence, Trust Compilation & Control Plane.
 **Core Value:** Verifiable Evidence + Claims-as-Code for Agent Systems.
@@ -210,9 +210,9 @@ The current substrate on `main` is strong enough to shift from "more packs" towa
 | Order | Lane | Why now | Boundary |
 |-------|------|---------|----------|
 | **1** | `T1a` OTel-native Trust Compiler MVP | ✅ Merged on `main`: verified bundle -> deterministic `trust-basis.json` with bounded claim classification. | Kept small: no Trust Card rendering, no new signals, no packs, no score-first surface. |
-| **2** | `T1b` Trust Card MVP | Assay now has a canonical trust basis; the next step is to render that into a visible, portable artifact. | Trust Card stays evidence-classified, signed/attested later, and does not become a generic risk score. |
-| **3** | `G3` Authorization Evidence Signal | MCP auth extensions and identity/authz standards make auth context the cleanest next signal seam. | Supported flows only; no auth validation or cryptographic chain semantics. |
-| **4** | `P2` Protocol Claim Packs | After `G3`, protocol-aware claim packs become honest product surfaces. | Small MCP/A2A claim packs, not broad compliance theater. |
+| **2** | `T1b` Trust Card MVP | ✅ Merged on `main`: deterministic `trustcard.json` + `trustcard.md` from verified bundles (`assay trustcard generate --out-dir`), derived from T1a only. | Evidence-classified output; signed/attestation later; no generic risk score. |
+| **3** | `G3` Authorization Evidence Signal | ✅ Merged on `main`: bounded `auth_scheme` / `auth_issuer` / `principal` on policy-projected MCP decision evidence; Trust Basis + Trust Card updated (see [PLAN-G3](architecture/PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md)). | Supported flows only; no auth validation or cryptographic chain semantics. |
+| **4** | `P2` Protocol Claim Packs | **Next wave** — after `G3`, protocol-aware claim packs become honest product surfaces. | Small MCP/A2A claim packs, not broad compliance theater. |
 | **Later** | Reference/temporal/capability attestation | These semantics are valuable but heavier. | Ship only after the claim product line is stable. |
 
 Work that primarily improves dashboarding, generic observability UX, or score-first reporting should be treated as secondary until this sequence is complete.
@@ -229,7 +229,7 @@ Closed lines on `main`:
 - **OTel ingest and evidence pipeline**: `trace ingest-otel` plus the `ProfileCollector -> EvidenceMapper -> EvidenceEvent` collector-style pipeline are shipped
 - **Supply chain and governance surfaces**: BYOS Phase 1, tool signing, GitHub Action v2/v2.1, mandate evidence, and starter/baseline pack infrastructure are shipped
 - **Evidence-as-a-product**: soak, closure, completeness, and the OTel bridge slices from ADR-025 are shipped
-- **Bounded claim waves**: `E1`, `G1`, `G2`, `P1`, and the `3.2.3` release-line truth fix are shipped
+- **Bounded claim waves**: `E1`, `G1`, `G2`, `P1`, `T1a`, `T1b`, `G3`, and the `3.2.3` release-line truth fix are shipped
 
 For detailed historical delivery records, see the relevant ADRs and companion docs:
 
@@ -249,14 +249,14 @@ For detailed historical delivery records, see the relevant ADRs and companion do
 
 ### Trust Compiler Core (Highest Priority)
 
-March 2026 evidence and signal waves change the ordering inside Q3. The next product gap is not "more observability" or "more packs"; it is turning the existing OTel-collector-style evidence path into a first-class claims compiler with a portable output artifact.
+March 2026 evidence and signal waves change the ordering inside Q3. `T1a`, `T1b`, and `G3` are shipped; the next product gap is **`P2`** (protocol claim packs), not more observability UI or unconstrained pack expansion.
 
 | Priority | Capability | Why now | MVP boundary |
 |----------|------------|---------|--------------|
-| **P0** | `T1a` OTel-native Trust Compiler MVP | `trace ingest-otel`, `ProfileCollector -> EvidenceMapper -> EvidenceEvent`, and signal-aware packs already exist on `main`. | Official compiler inputs/outputs, claim basis export, no dashboard, no new semantics. |
-| **P0** | `T1b` Trust Card MVP | The trust-compiler thesis needs a product artifact that non-authors can review and diff. | `trustcard.json` + `trustcard.md`, evidence-level classification, no opaque global score. |
-| **P1** | `G3` Authorization Evidence Signal | MCP auth extensions and NIST/OWASP identity guidance make auth context the cleanest next supported signal seam. | Supported flows only; no cryptographic or temporal auth-validation semantics. |
-| **P1** | `P2` Protocol Claim Packs | Once auth context is visible, protocol claim packs become honest follow-ons. | MCP/A2A claim packs with bounded wording; no broad compliance theater. |
+| **P0** | `T1a` OTel-native Trust Compiler MVP | ✅ Shipped on `main`: verified bundle → `trust-basis.json` / bounded claim classification. | Compiler inputs/outputs, claim basis export; no dashboard-first surface. |
+| **P0** | `T1b` Trust Card MVP | ✅ Shipped on `main`: portable `trustcard.json` + `trustcard.md` for review and diff. | Evidence-level rows + frozen non-goals; no opaque global score. |
+| **P1** | `G3` Authorization Evidence Signal | ✅ Shipped on `main`: authorization context fields on supported MCP decision evidence; Trust Card schema `2` / seven trust-basis claims. | Supported flows only; no cryptographic or temporal auth-validation semantics. |
+| **P1** | `P2` Protocol Claim Packs | **Next** — protocol claim packs as follow-on now that auth context is visible in evidence. | MCP/A2A claim packs with bounded wording; no broad compliance theater. |
 | **P2** | Collector processor / sidecar form factor | This is the "outside-the-box" deployment surface that competitors are not targeting. | OTel-native compile path that emits canonical evidence, not a dashboard. |
 
 These items outrank growth-only work because Assay's strongest differentiator is now trace -> evidence -> claim -> proof, not surface-area expansion.

--- a/docs/architecture/PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md
+++ b/docs/architecture/PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md
@@ -1,0 +1,48 @@
+# PLAN — G3 Authorization Context Evidence (2026 Q2)
+
+> Status: Implemented on `main` (March 2026)
+> Scope: G3 v1 signal on `assay.tool.decision`, trust claim `authorization_context_visible`, Trust Card schema `2`.
+
+## Goal
+
+Emit a **bounded authorization-context** signal on policy-projected MCP decision evidence: `auth_scheme`, `auth_issuer`, and subject via existing `principal` — without token material, validation semantics, or trust scoring.
+
+## v1 field set (frozen)
+
+| Field | Rule |
+|-------|------|
+| `auth_scheme` | Allowlist only: `oauth2`, `jwt_bearer` (lowercase in JSON). Unknown values dropped at emit. |
+| `auth_issuer` | Trimmed string; max 2048 bytes; no JWT dumps. |
+| `principal` | Unicode-trimmed; whitespace-only treated as absent for G3. |
+
+No `auth_subject`, no `auth_audience` in v1.
+
+## Supported flow
+
+Merge path: `ToolCallHandlerConfig.auth_context_projection` → `AuthContextProjection::merge_into_metadata` after `evaluate_with_metadata` (`crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`). Production callers pass `None` unless they supply policy-projected metadata.
+
+## Trust compiler
+
+- `TrustClaimId::AuthorizationContextVisible` / `TrustClaimBoundary::SupportedAuthProjectedFlowsOnly`.
+- Claim order: after `delegation_context_visible`, before `containment_degradation_observed`.
+- Classifier: `crates/assay-evidence/src/trust_basis.rs` — `verified` only when all three fields satisfy v1 rules on at least one `assay.tool.decision` event.
+
+## Trust Card
+
+- `TRUST_CARD_SCHEMA_VERSION = 2` (`crates/assay-evidence/src/trust_card.rs`).
+- Renderer unchanged: one extra table row only; no new prose sections.
+
+## Language contract
+
+**May:** authorization **context** is **visible** in evidence for supported flows.
+
+**Must not imply:** valid authorization, trustworthy token, verified issuer chain, sufficient scopes, correct authorization, temporal validity checked.
+
+## Migration
+
+Consumers must not rely on exactly six trust-basis claims; identify claims by `id`.
+
+## References
+
+- [ADR-006: Evidence Contract](./ADR-006-Evidence-Contract.md)
+- [ADR-033: OTel Trust Compiler Positioning](./ADR-033-OTel-Trust-Compiler-Positioning.md)

--- a/docs/architecture/PLAN-T1b-TRUST-CARD-2026q2.md
+++ b/docs/architecture/PLAN-T1b-TRUST-CARD-2026q2.md
@@ -8,12 +8,12 @@
 
 Ship `trustcard.json` (canonical) and `trustcard.md` (secondary) derived **only** from `generate_trust_basis` → `trust_basis_to_trust_card`. No second classification pass, no aggregate score, no badge semantics, no `trust_basis_sha256` in v1.
 
-## 2) Frozen contract (v1)
+## 2) Frozen contract (T1b baseline; extended by G3)
 
 | Item | Rule |
 |------|------|
-| `schema_version` | Always `1` for this wave (`TRUST_CARD_SCHEMA_VERSION`). |
-| `claims[]` | `Vec<TrustBasisClaim>` — same serde as T1a; six frozen ids, same order as `TrustBasis::claims`. |
+| `schema_version` | `2` after [G3](./PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md) (`TRUST_CARD_SCHEMA_VERSION`); was `1` for the original T1b-only ship. |
+| `claims[]` | `Vec<TrustBasisClaim>` — same serde as trust basis; **seven** frozen ids after G3, same order as `TrustBasis::claims` (was six for T1a-only). |
 | `non_goals` | Three fixed strings in fixed order (`TRUST_CARD_NON_GOALS` in code); identical in JSON and Markdown. |
 | Markdown `note` column | Empty T1a `note` renders as placeholder `-` (`TRUST_CARD_NOTE_EMPTY_PLACEHOLDER`); no multiline cells. |
 | Markdown shape | Title + fixed five-column table + `## Non-goals` with literal bullets. |

--- a/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
+++ b/docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md
@@ -1,6 +1,6 @@
 # RFC-005: Trust Compiler MVP and Trust Card (Q2 2026)
 
-- Status: Active (`T1a` merged on `main`; `T1b` pending)
+- Status: Active (`T1a`, `T1b`, and `G3` merged on `main`; next: `P2`)
 - Date: 2026-03-23
 - Owner: Evidence / Product
 - Scope: bounded execution framing for `T1a` and `T1b`
@@ -32,7 +32,8 @@ This RFC defines that bridge in two steps:
 Current delivery status on `main`:
 
 - `T1a` is merged on `main` as the canonical `trust-basis.json` compiler output and low-level `assay trust-basis generate` surface
-- `T1b` remains pending and must stay a rendering/artifact wave above the trust basis rather than a second semantic layer
+- `T1b` is merged on `main` as deterministic `trustcard.json` / `trustcard.md` (`assay trustcard generate`) derived from the trust basis, without a second semantic classification layer
+- `G3` is merged on `main` as bounded authorization-context fields on supported MCP `assay.tool.decision` evidence (`auth_scheme`, `auth_issuer`, `principal`) with normalization that rejects JWT/Bearer credential material; Trust Basis emits **seven** claims (adds `authorization_context_visible`), and Trust Card JSON uses **`schema_version` `2`** (see [PLAN-G3](./PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md))
 
 ## 1.5 Why This Wedge And Not The Alternatives
 
@@ -196,12 +197,13 @@ Suggested outputs:
 
 Trust Card rendering must not invent new claim semantics. Claim classification happens in the trust basis / compiler stage, not in Markdown rendering.
 
-The first Trust Card should stay small and explicitly bounded. A minimal v1 claim set should be close to:
+The first Trust Card should stay small and explicitly bounded. The shipped claim set is **seven** rows (fixed order in the trust basis; consumers must key by `id`, not positional length):
 
 - `bundle_verified`
 - `signing_evidence_present`
 - `provenance_backed_claims_present`
 - `delegation_context_visible`
+- `authorization_context_visible` (`G3`; Trust Card JSON `schema_version` **2**)
 - `containment_degradation_observed`
 - `applied_pack_findings_present`
 
@@ -240,11 +242,10 @@ The Trust Card must not:
 
 ## 6. Follow-On Sequencing
 
-After `T1a` and `T1b`, the preferred sequence is:
+After `T1a`, `T1b`, and `G3` on `main`, the preferred sequence is:
 
-1. `G3` — Authorization Evidence Signal
-2. `P2` — Protocol Claim Packs
-3. only later: reference existence, temporal validity, capability attestation, richer compliance packs
+1. `P2` — Protocol Claim Packs
+2. only later: reference existence, temporal validity, capability attestation, richer compliance packs
 
 ## 7. Review Gates For Future Execution
 


### PR DESCRIPTION
## Summary

Implements **G3** (bounded authorization context on `assay.tool.decision`) and bumps **Trust Card** to **schema v2** with a seventh trust-basis claim (`authorization_context_visible`).

## Changes

- **assay-core**: `AuthContextProjection` merged after policy eval; `auth_scheme` / `auth_issuer` / `principal` on metadata and decision payloads; proxy + tool handler wired; normalization rejects JWS-compact and `Bearer ` credential material.
- **assay-evidence**: New claim + `TRUST_CARD_SCHEMA_VERSION = 2`; tests for 7-claim order, JSON shape, markdown section guards.
- **assay-cli**: `trustcard_test` updated for schema 2 / seven claims.
- **Docs**: PLAN-G3, ROADMAP/RFC-005/T1b sync, CHANGELOG \[Unreleased\].

## Tests

- `cargo test -p assay-core --test decision_emit_invariant g3_`
- `cargo test -p assay-evidence` (trust_basis / trust_card new tests)
- `cargo test -p assay-cli --test trustcard_test`
- Pre-push: clippy workspace + linux compile gate (passed on push).

## Notes

Consumers should key trust-basis / trust-card claims by `id`, not assume a fixed row count.

Made with [Cursor](https://cursor.com)