### PR TITLE
test(evidence): H1a — shared trust-kernel bundle vectors (tests/common)

### DIFF
--- a/crates/assay-evidence/tests/common/mod.rs
+++ b/crates/assay-evidence/tests/common/mod.rs
@@ -1,0 +1,89 @@
+//! Shared evidence bundle bytes for H1 alignment tests and P2a `mcp-signal-followup` tests.
+//! Keep a single builder per vector so Trust Basis / MCP-001 lockstep cannot drift.
+
+use assay_evidence::{BundleWriter, EvidenceEvent};
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+
+fn event_with_payload(
+    type_: &str,
+    run_id: &str,
+    seq: u64,
+    payload: serde_json::Value,
+) -> EvidenceEvent {
+    let mut event = EvidenceEvent::new(
+        type_,
+        "urn:assay:test:trust-kernel-vectors",
+        run_id,
+        seq,
+        payload,
+    );
+    event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
+    event
+}
+
+/// Used by `mcp_signal_followup_pack` for MCP-002/003 vectors (same event source as alignment bundles).
+#[allow(dead_code)] // only referenced from the P2a test binary, not the H1 binary
+pub fn make_event(
+    type_: &str,
+    run_id: &str,
+    seq: u64,
+    payload: serde_json::Value,
+) -> EvidenceEvent {
+    event_with_payload(type_, run_id, seq, payload)
+}
+
+#[allow(dead_code)]
+pub fn make_bundle(events: Vec<EvidenceEvent>) -> Vec<u8> {
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    for event in events {
+        writer.add_event(event);
+    }
+    writer.finish().expect("bundle should finish");
+    buffer
+}
+
+/// G3 verified + delegation + degradation (H1 lockstep + P2a full-signal coverage).
+pub fn full_signal_bundle() -> Vec<u8> {
+    make_bundle(vec![
+        event_with_payload(
+            "assay.tool.decision",
+            "run_all",
+            0,
+            json!({
+                "tool": "t",
+                "decision": "allow",
+                "principal": "alice@example.com",
+                "auth_scheme": "jwt_bearer",
+                "auth_issuer": "https://issuer.example/",
+                "delegated_from": "agent:planner",
+            }),
+        ),
+        event_with_payload(
+            "assay.sandbox.degraded",
+            "run_all",
+            1,
+            json!({
+                "reason_code": "policy_conflict",
+                "degradation_mode": "audit_fallback",
+                "component": "landlock"
+            }),
+        ),
+    ])
+}
+
+/// G3 absent (principal-only path): MCP-001 should fail; Trust Basis G3 absent.
+pub fn g3_absent_principal_only_bundle() -> Vec<u8> {
+    make_bundle(vec![event_with_payload(
+        "assay.tool.decision",
+        "run_g3_absent",
+        0,
+        json!({
+            "tool": "t",
+            "decision": "allow",
+            "principal": "user:alice",
+            "approval_state": "granted"
+        }),
+    )])
+}

--- a/crates/assay-evidence/tests/common/mod.rs
+++ b/crates/assay-evidence/tests/common/mod.rs
@@ -33,7 +33,6 @@ pub fn make_event(
     event_with_payload(type_, run_id, seq, payload)
 }
 
-#[allow(dead_code)]
 pub fn make_bundle(events: Vec<EvidenceEvent>) -> Vec<u8> {
     let mut buffer = Vec::new();
     let mut writer = BundleWriter::new(&mut buffer);

--- a/crates/assay-evidence/tests/h1_trust_kernel_alignment.rs
+++ b/crates/assay-evidence/tests/h1_trust_kernel_alignment.rs
@@ -1,5 +1,7 @@
 //! H1 — same bundle bytes must yield consistent Trust Basis, MCP-001 (P2a), and Trust Card views.
 
+mod common;
+
 use assay_evidence::lint::engine::{lint_bundle_with_options, LintOptions, LintReportWithPacks};
 use assay_evidence::lint::packs::loader::load_pack;
 use assay_evidence::lint::packs::LoadedPack;
@@ -7,69 +9,7 @@ use assay_evidence::{
     generate_trust_basis, trust_basis_to_trust_card, TrustBasis, TrustBasisOptions, TrustClaimId,
     TrustClaimLevel, VerifyLimits, TRUST_CARD_NON_GOALS, TRUST_CARD_SCHEMA_VERSION,
 };
-use assay_evidence::{BundleWriter, EvidenceEvent};
-use chrono::{TimeZone, Utc};
-use serde_json::json;
 use std::io::Cursor;
-
-fn make_event(type_: &str, run_id: &str, seq: u64, payload: serde_json::Value) -> EvidenceEvent {
-    let mut event = EvidenceEvent::new(type_, "urn:assay:test:h1", run_id, seq, payload);
-    event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
-    event
-}
-
-fn make_bundle(events: Vec<EvidenceEvent>) -> Vec<u8> {
-    let mut buffer = Vec::new();
-    let mut writer = BundleWriter::new(&mut buffer);
-    for event in events {
-        writer.add_event(event);
-    }
-    writer.finish().expect("bundle should finish");
-    buffer
-}
-
-/// Full G3 + delegation + degradation (matches `mcp_signal_followup_pack::full_signal_bundle`).
-fn bundle_g3_full_pass() -> Vec<u8> {
-    make_bundle(vec![
-        make_event(
-            "assay.tool.decision",
-            "run_all",
-            0,
-            json!({
-                "tool": "t",
-                "decision": "allow",
-                "principal": "alice@example.com",
-                "auth_scheme": "jwt_bearer",
-                "auth_issuer": "https://issuer.example/",
-                "delegated_from": "agent:planner",
-            }),
-        ),
-        make_event(
-            "assay.sandbox.degraded",
-            "run_all",
-            1,
-            json!({
-                "reason_code": "policy_conflict",
-                "degradation_mode": "audit_fallback",
-                "component": "landlock"
-            }),
-        ),
-    ])
-}
-
-fn bundle_g3_absent_principal_only() -> Vec<u8> {
-    make_bundle(vec![make_event(
-        "assay.tool.decision",
-        "run_g3_absent",
-        0,
-        json!({
-            "tool": "t",
-            "decision": "allow",
-            "principal": "user:alice",
-            "approval_state": "granted"
-        }),
-    )])
-}
 
 fn load_mcp_pack() -> LoadedPack {
     load_pack("mcp-signal-followup").expect("built-in pack should load")
@@ -126,19 +66,19 @@ fn assert_kernel_lockstep(bundle: &[u8], expect_g3_verified: bool, expect_mcp001
 
 #[test]
 fn h1_same_bundle_trust_basis_and_mcp001_lockstep_full_signal() {
-    let bundle = bundle_g3_full_pass();
+    let bundle = common::full_signal_bundle();
     assert_kernel_lockstep(&bundle, true, false);
 }
 
 #[test]
 fn h1_same_bundle_trust_basis_and_mcp001_lockstep_g3_absent() {
-    let bundle = bundle_g3_absent_principal_only();
+    let bundle = common::g3_absent_principal_only_bundle();
     assert_kernel_lockstep(&bundle, false, true);
 }
 
 #[test]
 fn h1_trust_card_matches_trust_basis_claims_and_frozen_top_level() {
-    let bundle = bundle_g3_full_pass();
+    let bundle = common::full_signal_bundle();
     let tb = generate_trust_basis(
         Cursor::new(&bundle),
         VerifyLimits::default(),

--- a/crates/assay-evidence/tests/mcp_signal_followup_pack.rs
+++ b/crates/assay-evidence/tests/mcp_signal_followup_pack.rs
@@ -1,5 +1,7 @@
 //! P2a `mcp-signal-followup` pack: parity, MCP-002/003 behavior, Trust Basis alignment for MCP-001.
 
+mod common;
+
 use assay_evidence::lint::engine::{lint_bundle_with_options, LintOptions, LintReportWithPacks};
 use assay_evidence::lint::packs::loader::{load_pack, load_pack_from_file};
 use assay_evidence::lint::packs::schema::CheckDefinition;
@@ -8,8 +10,6 @@ use assay_evidence::{
     generate_trust_basis, TrustBasis, TrustBasisOptions, TrustClaimId, TrustClaimLevel,
     VerifyLimits,
 };
-use assay_evidence::{BundleWriter, EvidenceEvent};
-use chrono::{TimeZone, Utc};
 use serde_json::json;
 use std::fs;
 use std::io::Cursor;
@@ -53,22 +53,6 @@ fn load_builtin_pack() -> LoadedPack {
     load_pack("mcp-signal-followup").expect("built-in pack should load")
 }
 
-fn make_event(type_: &str, run_id: &str, seq: u64, payload: serde_json::Value) -> EvidenceEvent {
-    let mut event = EvidenceEvent::new(type_, "urn:assay:test:mcp", run_id, seq, payload);
-    event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
-    event
-}
-
-fn make_bundle(events: Vec<EvidenceEvent>) -> Vec<u8> {
-    let mut buffer = Vec::new();
-    let mut writer = BundleWriter::new(&mut buffer);
-    for event in events {
-        writer.add_event(event);
-    }
-    writer.finish().expect("bundle should finish");
-    buffer
-}
-
 fn claim_level(tb: &TrustBasis, id: TrustClaimId) -> TrustClaimLevel {
     tb.claims
         .iter()
@@ -96,51 +80,8 @@ fn has_rule_finding(result: &LintReportWithPacks, pack_name: &str, rule_id: &str
         .any(|finding| finding.rule_id.starts_with(&prefix) && finding.rule_id.ends_with(rule_id))
 }
 
-/// G3 verified + delegation + degradation (all P2a rules should pass).
-fn full_signal_bundle() -> Vec<u8> {
-    make_bundle(vec![
-        make_event(
-            "assay.tool.decision",
-            "run_all",
-            0,
-            json!({
-                "tool": "t",
-                "decision": "allow",
-                "principal": "alice@example.com",
-                "auth_scheme": "jwt_bearer",
-                "auth_issuer": "https://issuer.example/",
-                "delegated_from": "agent:planner",
-            }),
-        ),
-        make_event(
-            "assay.sandbox.degraded",
-            "run_all",
-            1,
-            json!({
-                "reason_code": "policy_conflict",
-                "degradation_mode": "audit_fallback",
-                "component": "landlock"
-            }),
-        ),
-    ])
-}
-
-fn g3_absent_principal_only_bundle() -> Vec<u8> {
-    make_bundle(vec![make_event(
-        "assay.tool.decision",
-        "run_g3_absent",
-        0,
-        json!({
-            "tool": "t",
-            "decision": "allow",
-            "principal": "user:alice",
-            "approval_state": "granted"
-        }),
-    )])
-}
-
 fn mcp002_only_bundle() -> Vec<u8> {
-    make_bundle(vec![make_event(
+    common::make_bundle(vec![common::make_event(
         "assay.tool.decision",
         "mcp2",
         0,
@@ -154,7 +95,7 @@ fn mcp002_only_bundle() -> Vec<u8> {
 }
 
 fn mcp002_fail_bundle() -> Vec<u8> {
-    make_bundle(vec![make_event(
+    common::make_bundle(vec![common::make_event(
         "assay.tool.decision",
         "mcp2f",
         0,
@@ -167,7 +108,7 @@ fn mcp002_fail_bundle() -> Vec<u8> {
 }
 
 fn mcp003_only_bundle() -> Vec<u8> {
-    make_bundle(vec![make_event(
+    common::make_bundle(vec![common::make_event(
         "assay.sandbox.degraded",
         "mcp3",
         0,
@@ -221,7 +162,7 @@ fn mcp001_uses_g3_check_definition() {
 
 #[test]
 fn mcp001_aligns_trust_basis_verified_and_pack_passes() {
-    let bundle = full_signal_bundle();
+    let bundle = common::full_signal_bundle();
     let tb = generate_trust_basis(
         Cursor::new(&bundle),
         VerifyLimits::default(),
@@ -252,7 +193,7 @@ fn mcp001_aligns_trust_basis_verified_and_pack_passes() {
 
 #[test]
 fn mcp001_aligns_trust_basis_absent_and_pack_fails() {
-    let bundle = g3_absent_principal_only_bundle();
+    let bundle = common::g3_absent_principal_only_bundle();
     let tb = generate_trust_basis(
         Cursor::new(&bundle),
         VerifyLimits::default(),
@@ -309,10 +250,14 @@ fn mcp_readme_lists_non_goals() {
 fn write_mcp_lint_demo_bundles() {
     let dir = repo_root().join("target").join("mcp-lint-demo");
     fs::create_dir_all(&dir).expect("create dir");
-    fs::write(dir.join("g3_full_pass.tar.gz"), full_signal_bundle()).expect("write full");
+    fs::write(
+        dir.join("g3_full_pass.tar.gz"),
+        common::full_signal_bundle(),
+    )
+    .expect("write full");
     fs::write(
         dir.join("g3_principal_only_fail.tar.gz"),
-        g3_absent_principal_only_bundle(),
+        common::g3_absent_principal_only_bundle(),
     )
     .expect("write fail");
     eprintln!(


### PR DESCRIPTION
## H1a (test-only follow-up)

Cherry-picked from `482a4001` (was first pushed on the P2a branch).

**Target:** `main` (H1 is merged via #937).

### What
- `tests/common/mod.rs`: single source for `full_signal_bundle` / `g3_absent_principal_only_bundle`
- H1 alignment tests + P2a pack tests use the same bytes (no drift)

### Scope
- Test infrastructure only; no product code or docs.