### PR TITLE
chore(docs): post-release hardening for v3.3.0 line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,7 +379,11 @@ jobs:
 
       - name: Generate release notes
         id: notes
+        env:
+          REPO: ${{ github.repository }}
+        shell: bash
         run: |
+          set -euo pipefail
           cat > release_notes.md << 'EOF'
           ## Assay ${{ steps.version.outputs.version }}
 
@@ -410,8 +414,9 @@ jobs:
 
           ### Changelog
 
-          See [CHANGELOG.md](https://github.com/assay-dev/assay/blob/main/CHANGELOG.md) for details.
+          See [CHANGELOG.md](__CHANGELOG_URL__) for details.
           EOF
+          sed -i "s|__CHANGELOG_URL__|https://github.com/${REPO}/blob/main/CHANGELOG.md|g" release_notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Your MCP agent calls `read_file`, `exec`, `web_search` — but should it, and wh
 
 No hosted backend. No API keys for core flows. **Deterministic** — same input, same decision, every time.
 
+> **Trust Compiler line:** Release **v3.3.0** is the first to ship **both** built-in evidence lint companion packs (`mcp-signal-followup`, `a2a-signal-followup`) in published binaries; pack YAML still documents the substrate floor `>=3.2.3` — see [MIGRATION — Trust Compiler 3.2](docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md) (*two-layer version truth*).
+
 ```
   Agent ──► Assay ──► MCP Server
               │
@@ -231,6 +233,8 @@ Assay ships adapters that map protocol events into **canonical evidence** (same 
 | **ACP** (OpenAI/Stripe) | `assay-adapter-acp` | Checkout events, payment intents, tool calls |
 | **A2A** (Google) | `assay-adapter-a2a` | Agent capabilities, task delegation, artifacts |
 | **UCP** (Google/Shopify) | `assay-adapter-ucp` | Discover/buy/post-purchase state transitions |
+
+Adapter crates are **workspace / binary–driven** (not published as separate `crates.io` packages); consume them via this repo or released **assay** builds.
 
 Governance stays protocol-agnostic; **the evidence and claim layer stays the same** as protocols evolve.
 

--- a/docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md
+++ b/docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md
@@ -6,6 +6,11 @@
 
 For the hardening wave that introduced this document, see [PLAN-H1 — Trust Kernel Alignment & Release Hardening](PLAN-H1-TRUST-KERNEL-ALIGNMENT-RELEASE-HARDENING.md).
 
+## Two-layer version truth (substrate floor vs embedded packs)
+
+- **`requires.assay_min_version: ">=3.2.3"`** on companion packs is the **evidence-substrate floor** (G3 + Trust Card schema 2 + seven claims). The **v3.2.3** tag is the usual reference for that prerequisite line — it does **not** imply that every built-in companion pack was already embedded in the CLI.
+- **First release embedding both** built-in companion packs (`mcp-signal-followup` **and** `a2a-signal-followup`) in published **assay** binaries is **v3.3.0** — see [CHANGELOG.md](../../CHANGELOG.md) § 3.3.0. Do not read substrate tags (e.g. v3.2.3) as “both packs were already in the binary.”
+
 ## Consumer contract (non-negotiable)
 
 **Integrations must key trust claims by `claim.id`, not by table position, row index, or implicit row count.** Order and count can change when `schema_version` changes; stable `id` is the only portable selector. Treat “seven rows” or “row N” as documentation hints for **schema_version = 2** only, not API contracts.


### PR DESCRIPTION
## Scope (only)

- `README.md` — Trust Compiler v3.3.0 blockquote + adapter crates not on crates.io
- `docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md` — two-layer version truth (substrate floor vs first binary with both built-in packs)
- `.github/workflows/release.yml` — generated GitHub release notes: Changelog link uses `${REPO}` (quoted heredoc + sed; actionlint-clean)

The v3.3.0 GitHub release body was already corrected manually (changelog URL).

No functional/code changes.

Made with [Cursor](https://cursor.com)