### PR TITLE
G4-A Phase 1: executable freeze + adapter payload.discovery (1b)

### DIFF
--- a/crates/assay-adapter-a2a/src/adapter_impl/discovery.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/discovery.rs
@@ -4,6 +4,9 @@
 //! **v1 rules never produce them** — no typed upstream card path and no unmapped-key rules are
 //! wired yet. Resolution still follows the §3 precedence order so future freezes can add sources
 //! without reordering.
+//!
+//! **Emitted v1 values for `agent_card_source_kind`:** only `"attributes"` or `"unknown"` — do not
+//! read `typed_payload` / `unmapped` as “supported today” until a later freeze wires matchers.
 
 use serde_json::{Map, Value};
 

--- a/crates/assay-adapter-a2a/src/adapter_impl/discovery.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/discovery.rs
@@ -1,0 +1,196 @@
+//! G4-A Phase 1 `payload.discovery` computation (adapter-emitted, Assay-namespaced).
+//!
+//! Frozen enum strings for `agent_card_source_kind` include `typed_payload` and `unmapped`, but
+//! **v1 rules never produce them** — no typed upstream card path and no unmapped-key rules are
+//! wired yet. Resolution still follows the §3 precedence order so future freezes can add sources
+//! without reordering.
+
+use serde_json::{Map, Value};
+
+/// Resolve `agent_card_source_kind` from abstract precedence flags (highest wins).
+///
+/// v1 call sites pass `matched_typed_payload` and `matched_unmapped` as `false` until a freeze
+/// adds real matchers.
+#[must_use]
+pub(super) fn resolve_agent_card_source_kind(
+    matched_typed_payload: bool,
+    matched_attributes: bool,
+    matched_unmapped: bool,
+) -> &'static str {
+    if matched_typed_payload {
+        "typed_payload"
+    } else if matched_attributes {
+        "attributes"
+    } else if matched_unmapped {
+        "unmapped"
+    } else {
+        "unknown"
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DiscoveryFields {
+    pub agent_card_visible: bool,
+    pub agent_card_source_kind: &'static str,
+    pub extended_card_access_visible: bool,
+}
+
+impl Default for DiscoveryFields {
+    fn default() -> Self {
+        Self {
+            agent_card_visible: false,
+            agent_card_source_kind: "unknown",
+            extended_card_access_visible: false,
+        }
+    }
+}
+
+fn agent_card_visible_from_attributes(g4: &Map<String, Value>) -> bool {
+    let Some(ac) = g4.get("agent_card") else {
+        return false;
+    };
+    let Value::Object(ac_obj) = ac else {
+        return false;
+    };
+    matches!(ac_obj.get("visible"), Some(Value::Bool(true)))
+}
+
+fn extended_card_access_visible_from_attributes(g4: &Map<String, Value>) -> bool {
+    let Some(ec) = g4.get("extended_card_access") else {
+        return false;
+    };
+    let Value::Object(ec_obj) = ec else {
+        return false;
+    };
+    matches!(ec_obj.get("visible"), Some(Value::Bool(true)))
+}
+
+/// Compute discovery fields from upstream `attributes` (raw JSON), before payload normalization.
+#[must_use]
+pub(super) fn compute_discovery_fields(attributes: Option<&Value>) -> DiscoveryFields {
+    let mut out = DiscoveryFields::default();
+
+    let Some(Value::Object(attrs)) = attributes else {
+        return out;
+    };
+
+    let Some(g4_val) = attrs.get("assay_g4") else {
+        return out;
+    };
+
+    let Value::Object(g4) = g4_val else {
+        return out;
+    };
+
+    out.agent_card_visible = agent_card_visible_from_attributes(g4);
+    out.extended_card_access_visible = extended_card_access_visible_from_attributes(g4);
+
+    let matched_attributes = out.agent_card_visible;
+    let matched_typed = false;
+    let matched_unmapped = false;
+    out.agent_card_source_kind =
+        resolve_agent_card_source_kind(matched_typed, matched_attributes, matched_unmapped);
+
+    out
+}
+
+/// JSON object for `payload.discovery` (v1: `signature_material_visible` always `false`).
+#[must_use]
+pub(super) fn discovery_object(attributes: Option<&Value>) -> Value {
+    let d = compute_discovery_fields(attributes);
+    let mut m = Map::new();
+    m.insert(
+        "agent_card_visible".to_string(),
+        Value::Bool(d.agent_card_visible),
+    );
+    m.insert(
+        "agent_card_source_kind".to_string(),
+        Value::String(d.agent_card_source_kind.to_string()),
+    );
+    m.insert(
+        "extended_card_access_visible".to_string(),
+        Value::Bool(d.extended_card_access_visible),
+    );
+    m.insert("signature_material_visible".to_string(), Value::Bool(false));
+    Value::Object(m)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn precedence_only_attributes_matches_attributes() {
+        assert_eq!(
+            resolve_agent_card_source_kind(false, true, false),
+            "attributes"
+        );
+    }
+
+    #[test]
+    fn precedence_nothing_matches_unknown() {
+        assert_eq!(
+            resolve_agent_card_source_kind(false, false, false),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn precedence_typed_wins_over_attributes() {
+        assert_eq!(
+            resolve_agent_card_source_kind(true, true, false),
+            "typed_payload"
+        );
+    }
+
+    #[test]
+    fn precedence_unmapped_ranking_when_no_higher_match() {
+        assert_eq!(
+            resolve_agent_card_source_kind(false, false, true),
+            "unmapped"
+        );
+    }
+
+    #[test]
+    fn v1_attributes_path_sets_agent_card_and_kind() {
+        let attrs = json!({
+            "assay_g4": { "agent_card": { "visible": true } },
+            "priority": "high"
+        });
+        let d = compute_discovery_fields(Some(&attrs));
+        assert!(d.agent_card_visible);
+        assert_eq!(d.agent_card_source_kind, "attributes");
+        assert!(!d.extended_card_access_visible);
+    }
+
+    #[test]
+    fn extended_only_leaves_agent_card_unknown() {
+        let attrs = json!({
+            "assay_g4": { "extended_card_access": { "visible": true } }
+        });
+        let d = compute_discovery_fields(Some(&attrs));
+        assert!(!d.agent_card_visible);
+        assert_eq!(d.agent_card_source_kind, "unknown");
+        assert!(d.extended_card_access_visible);
+    }
+
+    #[test]
+    fn assay_g4_wrong_shape_no_promotion() {
+        let attrs = json!({ "assay_g4": "not-an-object" });
+        assert_eq!(
+            compute_discovery_fields(Some(&attrs)),
+            DiscoveryFields::default()
+        );
+    }
+
+    #[test]
+    fn agent_card_visible_false_does_not_set_kind_attributes() {
+        let attrs = json!({
+            "assay_g4": { "agent_card": { "visible": false } }
+        });
+        let d = compute_discovery_fields(Some(&attrs));
+        assert!(!d.agent_card_visible);
+        assert_eq!(d.agent_card_source_kind, "unknown");
+    }
+}

--- a/crates/assay-adapter-a2a/src/adapter_impl/discovery.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/discovery.rs
@@ -69,6 +69,10 @@ fn extended_card_access_visible_from_attributes(g4: &Map<String, Value>) -> bool
 }
 
 /// Compute discovery fields from upstream `attributes` (raw JSON), before payload normalization.
+///
+/// Bounded meaning and paths are normative in `docs/architecture/G4-A-PHASE1-FREEZE.md` §2b and §4
+/// (including: `extended_card_access_visible` is an **observed** flag only; `agent_card_source_kind`
+/// in v1 is only `"attributes"` or `"unknown"` on the wire).
 #[must_use]
 pub(super) fn compute_discovery_fields(attributes: Option<&Value>) -> DiscoveryFields {
     let mut out = DiscoveryFields::default();

--- a/crates/assay-adapter-a2a/src/adapter_impl/mod.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/mod.rs
@@ -43,6 +43,7 @@ pub(super) fn capabilities() -> AdapterCapabilities {
 }
 
 mod convert;
+mod discovery;
 mod fields;
 mod mapping;
 mod parse;

--- a/crates/assay-adapter-a2a/src/adapter_impl/payload.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/payload.rs
@@ -1,6 +1,6 @@
 use serde_json::{Map, Value};
 
-use super::PROTOCOL_NAME;
+use super::{discovery::discovery_object, PROTOCOL_NAME};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_payload(
@@ -111,6 +111,8 @@ pub(super) fn build_payload(
     if let Some(attributes) = attributes {
         payload.insert("attributes".to_string(), normalize_json(attributes));
     }
+
+    payload.insert("discovery".to_string(), discovery_object(attributes));
 
     payload.insert(
         "unmapped_fields_count".to_string(),

--- a/crates/assay-adapter-a2a/src/adapter_impl/tests.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/tests.rs
@@ -56,6 +56,18 @@ fn assert_discovery_v1_defaults(payload: &Value) {
     assert_eq!(d["signature_material_visible"], Value::Bool(false));
 }
 
+/// Golden digests over `payload.discovery` via `digest_canonical_json` (sorted keys).
+/// If `discovery` shape or types change intentionally, update hashes and this comment.
+const G4_DISCOVERY_DIGEST_DEFAULT: &str =
+    "26b4d9c0105f4cc26d4b413e7b6b27effe5829f9f319a60b91ca490fd7776a13";
+const G4_DISCOVERY_DIGEST_AGENT_CARD_ATTR: &str =
+    "93f5c26d149e7400d38104c4479f332df4df23df0d1f4d25aef252aac87b9769";
+const G4_DISCOVERY_DIGEST_BOTH_FLAGS: &str =
+    "9d0f24e430e00ee3ec1bc595cb59e6e7d7d5b12c0c90e102ea4d26ad3890e665";
+/// Extended visibility only (`agent_card_source_kind` stays `unknown`).
+const G4_DISCOVERY_DIGEST_EXTENDED_ONLY: &str =
+    "13e23c6783de838b52ca92d787569bccd3cadc0f8900f1bf76b42262959f77ba";
+
 #[test]
 fn protocol_metadata_uses_exact_version_and_range_capability() {
     let adapter = A2aAdapter;
@@ -105,6 +117,10 @@ fn strict_agent_capabilities_fixture_emits_deterministic_event() {
         serde_json::json!(["agent.describe", "artifacts.share", "tasks.update"])
     );
     assert_discovery_v1_defaults(&first.events[0].payload);
+    assert_eq!(
+        digest_canonical_json(&first.events[0].payload["discovery"]),
+        G4_DISCOVERY_DIGEST_DEFAULT
+    );
 }
 
 #[test]
@@ -532,6 +548,34 @@ fn g4_attributes_driven_agent_card_sets_kind_attributes() {
     );
     assert_eq!(d["extended_card_access_visible"], Value::Bool(false));
     assert_eq!(d["signature_material_visible"], Value::Bool(false));
+    assert_eq!(
+        digest_canonical_json(d),
+        G4_DISCOVERY_DIGEST_AGENT_CARD_ATTR
+    );
+}
+
+#[test]
+fn g4_both_visibility_flags_true_fixture_shows_independence() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let payload = fixture("a2a_happy_agent_capabilities_g4_both_visible.json");
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2.0"),
+    };
+    let batch = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    let d = &batch.events[0].payload["discovery"];
+    assert_eq!(d["agent_card_visible"], Value::Bool(true));
+    assert_eq!(
+        d["agent_card_source_kind"],
+        Value::String("attributes".to_string())
+    );
+    assert_eq!(d["extended_card_access_visible"], Value::Bool(true));
+    assert_eq!(d["signature_material_visible"], Value::Bool(false));
+    assert_eq!(digest_canonical_json(d), G4_DISCOVERY_DIGEST_BOTH_FLAGS);
 }
 
 #[test]
@@ -555,6 +599,7 @@ fn g4_extended_access_visible_positive_fixture() {
     );
     assert_eq!(d["extended_card_access_visible"], Value::Bool(true));
     assert_eq!(d["signature_material_visible"], Value::Bool(false));
+    assert_eq!(digest_canonical_json(d), G4_DISCOVERY_DIGEST_EXTENDED_ONLY);
 }
 
 #[test]

--- a/crates/assay-adapter-a2a/src/adapter_impl/tests.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/tests.rs
@@ -554,6 +554,30 @@ fn g4_attributes_driven_agent_card_sets_kind_attributes() {
     );
 }
 
+/// When `discovery` is non-default, full `AdapterBatch` digests must still be byte-stable across
+/// repeated conversion (not only `payload["discovery"]` golden hashes).
+#[test]
+fn g4_non_default_discovery_full_batch_digest_is_deterministic() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let payload = fixture("a2a_happy_agent_capabilities_g4_agent_card.json");
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2.0"),
+    };
+    let first = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    let second = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    assert_eq!(
+        digest_canonical_json(&first),
+        digest_canonical_json(&second)
+    );
+}
+
 #[test]
 fn g4_both_visibility_flags_true_fixture_shows_independence() {
     let adapter = A2aAdapter;

--- a/crates/assay-adapter-a2a/src/adapter_impl/tests.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/tests.rs
@@ -45,6 +45,17 @@ fn reserved_key(key: &str) -> bool {
     )
 }
 
+fn assert_discovery_v1_defaults(payload: &Value) {
+    let d = &payload["discovery"];
+    assert_eq!(d["agent_card_visible"], Value::Bool(false));
+    assert_eq!(
+        d["agent_card_source_kind"],
+        Value::String("unknown".to_string())
+    );
+    assert_eq!(d["extended_card_access_visible"], Value::Bool(false));
+    assert_eq!(d["signature_material_visible"], Value::Bool(false));
+}
+
 #[test]
 fn protocol_metadata_uses_exact_version_and_range_capability() {
     let adapter = A2aAdapter;
@@ -93,6 +104,7 @@ fn strict_agent_capabilities_fixture_emits_deterministic_event() {
         first.events[0].payload["agent"]["capabilities"],
         serde_json::json!(["agent.describe", "artifacts.share", "tasks.update"])
     );
+    assert_discovery_v1_defaults(&first.events[0].payload);
 }
 
 #[test]
@@ -432,6 +444,185 @@ fn excessive_array_length_fails_measurement_contract() {
         .expect_err("oversized array must fail");
     assert_eq!(err.kind, AdapterErrorKind::Measurement);
     assert!(err.message.contains("max_array_length"));
+}
+
+#[test]
+fn g4_n1_non_allowlisted_attributes_only_yields_unknown_kind() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let payload = fixture("a2a_happy_agent_capabilities.json");
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2.0"),
+    };
+    let batch = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    assert_discovery_v1_defaults(&batch.events[0].payload);
+}
+
+#[test]
+fn g4_n2_assay_g4_wrong_shape_does_not_promote() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let mut packet: Value =
+        serde_json::from_slice(&fixture("a2a_happy_agent_capabilities.json")).unwrap();
+    packet
+        .as_object_mut()
+        .unwrap()
+        .get_mut("attributes")
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
+        .insert("assay_g4".to_string(), Value::String("bad".to_string()));
+    let payload = serde_json::to_vec(&packet).unwrap();
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2.0"),
+    };
+    let batch = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    assert_discovery_v1_defaults(&batch.events[0].payload);
+}
+
+#[test]
+fn g4_n3_unmapped_top_level_fields_alone_do_not_affect_discovery() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let mut packet: Value =
+        serde_json::from_slice(&fixture("a2a_happy_agent_capabilities.json")).unwrap();
+    packet
+        .as_object_mut()
+        .unwrap()
+        .insert("extra_top_level".to_string(), Value::Number(1.into()));
+    let payload = serde_json::to_vec(&packet).unwrap();
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2.0"),
+    };
+    let batch = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    assert!(batch.lossiness.unmapped_fields_count >= 1);
+    assert_discovery_v1_defaults(&batch.events[0].payload);
+}
+
+#[test]
+fn g4_attributes_driven_agent_card_sets_kind_attributes() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let payload = fixture("a2a_happy_agent_capabilities_g4_agent_card.json");
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2.0"),
+    };
+    let batch = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    let d = &batch.events[0].payload["discovery"];
+    assert_eq!(d["agent_card_visible"], Value::Bool(true));
+    assert_eq!(
+        d["agent_card_source_kind"],
+        Value::String("attributes".to_string())
+    );
+    assert_eq!(d["extended_card_access_visible"], Value::Bool(false));
+    assert_eq!(d["signature_material_visible"], Value::Bool(false));
+}
+
+#[test]
+fn g4_extended_access_visible_positive_fixture() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let payload = fixture("a2a_happy_agent_capabilities_g4_extended.json");
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2.0"),
+    };
+    let batch = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    let d = &batch.events[0].payload["discovery"];
+    assert_eq!(d["agent_card_visible"], Value::Bool(false));
+    assert_eq!(
+        d["agent_card_source_kind"],
+        Value::String("unknown".to_string())
+    );
+    assert_eq!(d["extended_card_access_visible"], Value::Bool(true));
+    assert_eq!(d["signature_material_visible"], Value::Bool(false));
+}
+
+#[test]
+fn g4_n5_strict_and_lenient_same_discovery_without_assay_g4() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let payload = fixture("a2a_happy_task_requested.json");
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2"),
+    };
+    let strict = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("strict");
+    let lenient = adapter
+        .convert(
+            input,
+            &ConvertOptions {
+                mode: ConvertMode::Lenient,
+                max_payload_bytes: Some(8_192),
+                max_json_depth: None,
+                max_array_length: None,
+            },
+            &writer,
+        )
+        .expect("lenient");
+    assert_eq!(
+        strict.events[0].payload["discovery"],
+        lenient.events[0].payload["discovery"]
+    );
+    assert_discovery_v1_defaults(&strict.events[0].payload);
+}
+
+#[test]
+fn g4_missing_agent_card_object_does_not_promote() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let mut packet: Value =
+        serde_json::from_slice(&fixture("a2a_happy_agent_capabilities.json")).unwrap();
+    packet
+        .as_object_mut()
+        .unwrap()
+        .get_mut("attributes")
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
+        .insert(
+            "assay_g4".to_string(),
+            serde_json::json!({ "priority": "nested" }),
+        );
+    let payload = serde_json::to_vec(&packet).unwrap();
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2.0"),
+    };
+    let batch = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    assert_eq!(
+        batch.events[0].payload["discovery"]["agent_card_visible"],
+        false
+    );
+    assert_eq!(
+        batch.events[0].payload["discovery"]["agent_card_source_kind"],
+        Value::String("unknown".to_string())
+    );
 }
 
 proptest! {

--- a/docs/architecture/G4-A-PHASE1-FREEZE.md
+++ b/docs/architecture/G4-A-PHASE1-FREEZE.md
@@ -58,6 +58,8 @@ This matches **defer unless proven** and avoids weakening the seam with a half-d
 
 **Reviewer note:** `extended_card_access_visible` uses a parallel `attributes` path; give it the **strictest** product review — if the path is not meaningful for your producers, defer tightening or keep default-only until a producer contract exists.
 
+**One-line semantics guardrail (all booleans):** When `true`, each visibility boolean means **only** that a producer placed JSON boolean `true` on the **frozen allowlisted path** with **valid nested-object shape**. It does **not** mean authentication **succeeded**, authorization **held**, access **completed**, the client was **trusted**, or any operation **succeeded** — unless a **later** freeze and evidence contract say otherwise.
+
 ---
 
 ## 3. Precedence rule (`agent_card_source_kind`)
@@ -134,9 +136,11 @@ Clarification: precedence row “unmapped” applies when a **frozen** rule name
 
 ---
 
-## 7. Two complete emitted JSON examples (full payload shape)
+## 7. Complete emitted JSON examples (full payload shape)
 
-Field order below follows the **logical** sibling set: adapter metadata, protocol, agent, task, …, `attributes`, **`discovery`**, `unmapped_fields_count` (exact key order in JSON may vary; canonical ordering is defined in implementation/tests).
+**Build note:** `adapter_version` in examples uses **`3.3.0` as an illustration**; **real** emission uses the crate’s `CARGO_PKG_VERSION` at build time. Normative for reviewers: **presence and shape** of top-level keys (including always-present `discovery` **before** `unmapped_fields_count`), and the **`discovery` object fields** — not the patch digit of `adapter_version`.
+
+Field order below follows the **logical** sibling set: adapter metadata, protocol, agent, task, …, `attributes`, **`discovery`**, `unmapped_fields_count` (exact key order in JSON may vary; canonical ordering is defined in implementation/tests and [`digest_canonical_json`](../../crates/assay-adapter-api/src/canonical.rs)).
 
 ### 7.1 Weak positive (attributes-driven)
 
@@ -205,6 +209,19 @@ Typical conversion from [a2a_happy_agent_capabilities.json](../../scripts/ci/fix
 }
 ```
 
+### 7.3 Both visibility flags `true` (independence)
+
+Upstream with **both** allowlisted paths `true` shows that `agent_card_visible` and `extended_card_access_visible` move **independently** from single-flag fixtures (`*_g4_agent_card.json` vs `*_g4_extended.json`). Fixture: [a2a_happy_agent_capabilities_g4_both_visible.json](../../scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities_g4_both_visible.json). Emitted **`discovery`** (illustrative):
+
+```json
+{
+  "agent_card_visible": true,
+  "agent_card_source_kind": "attributes",
+  "extended_card_access_visible": true,
+  "signature_material_visible": false
+}
+```
+
 ---
 
 ## 8. Negative test matrix (minimum before merge of 1b)
@@ -232,8 +249,24 @@ Typical conversion from [a2a_happy_agent_capabilities.json](../../scripts/ci/fix
 ## 10. Link to implementation
 
 - Implement **`attributes.assay_g4`** parsing only after `attributes` is read; validate shape; set `discovery` before `build_payload` inserts `unmapped_fields_count`.
-- **Fixtures:** §7.1 positive (`agent_card`), §7.2 default, §8 matrix, and **§8 extended positive** (`extended_card_access` = true).
+- **Fixtures:** §7.1 positive (`agent_card`), §7.2 default, §7.3 **both flags** (`a2a_happy_agent_capabilities_g4_both_visible.json`), §8 matrix, and **§8 extended positive** (`extended_card_access` = true).
 - **Precedence tests (minimum):** (1) **Unit-level** test for the precedence helper: when only attributes-path matches → `attributes`; when nothing matches → `unknown`. (2) **Integration** test that attributes-driven visibility yields `agent_card_source_kind: "attributes"` and that fixture without `assay_g4` yields `"unknown"`. It is acceptable that `typed_payload` / `unmapped` branches are covered only by unit tests with synthetic “would match if frozen” inputs **or** are asserted unreachable in v1 via a single doc-tested guard — but **attributes vs unknown** must be exercised.
+- **Canonical stability:** Integration tests should assert `digest_canonical_json` is **identical** for repeated conversion of the same upstream bytes (full batch), and **golden** digests for the emitted **`discovery` sub-object alone** (SHA-256 over [`canonical_json_bytes`](../../crates/assay-adapter-api/src/canonical.rs)) so accidental field renames or type changes fail CI.
+
+---
+
+## 11. Reviewer checklist (contract closure)
+
+Use this to close **strategy** review and focus on **contract** review:
+
+| # | Check | Where |
+|---|--------|--------|
+| 1 | **Bounded meaning** for all four `discovery` fields: what it may / must not imply | §2b |
+| 2 | **v1 honesty:** `typed_payload` / `unmapped` frozen but not emitted by v1 rules | §2 (enum reachability), §3, adapter `discovery.rs` module docs |
+| 3 | **Representative outputs:** default + weak positive + both-flags (`§7.1`, `§7.2`, `§7.3`); `adapter_version` illustrative only | §7 |
+| 4 | **Independence:** two single-flag fixtures + one **both `true`** fixture | §7.3, `a2a_happy_agent_capabilities_g4_both_visible.json` |
+| 5 | **Payload / digest:** `discovery` before `unmapped_fields_count`; deterministic full-batch digest; golden `discovery` object digest | `payload.rs`, tests in `adapter_impl/tests.rs` |
+| 6 | **Scope:** no `assay-evidence`, pack, or classification seam changes in the G4-A adapter PR | §9; verify `git diff main -- crates/assay-evidence packs/` empty |
 
 ---
 
@@ -243,3 +276,4 @@ Typical conversion from [a2a_happy_agent_capabilities.json](../../scripts/ci/fix
 |------|--------|
 | 2026-03-25 | Initial executable freeze: Assay `attributes` contract, deferred `signature_material_visible`, defaults, precedence, JSON examples, negative matrix, assay-evidence line. |
 | 2026-03-25 | Review pass: contract honesty; v1 enum reachability; bounded-meaning table; stricter `extended_card_access`; N7 + extended positive fixture; precedence test minimums. |
+| 2026-03-25 | Review closure: one-line boolean semantics guardrail; §7 build note; §7.3 both-flags fixture; §11 reviewer checklist; canonical `discovery` golden digest expectation in §10. |

--- a/docs/architecture/G4-A-PHASE1-FREEZE.md
+++ b/docs/architecture/G4-A-PHASE1-FREEZE.md
@@ -1,0 +1,214 @@
+# G4-A — Phase 1 formal freeze (executable)
+
+**Status:** Frozen for implementation **1b** (adapter-first).
+**Parent:** [PLAN-G4-A2A-DISCOVERY-CARD-EVIDENCE-2026q2.md](PLAN-G4-A2A-DISCOVERY-CARD-EVIDENCE-2026q2.md).
+**Repo snapshot:** Current [`assay-adapter-a2a`](../../crates/assay-adapter-a2a/) + [ADR026 fixtures](../../scripts/ci/fixtures/adr026/a2a/v0.2/) have **no** first-class upstream Agent Card / discovery **typed** columns; this freeze defines an **Assay-namespaced `attributes` contract** plus strict negatives so **1b** is not open-ended.
+
+---
+
+## 1. Definitive decision: `signature_material_visible` (v1)
+
+**Decision:** **Deferred for semantic v1** — no upstream path maps to `true` in this freeze.
+
+- **Emitted contract:** The key **`signature_material_visible`** is **always present** on `payload.discovery` and is **`false`** for all packets in v1.
+- **Normative meaning:** “No bounded signature-related material signal in v1”; product and docs must **not** imply verification (see PLAN-G4 must-not table).
+- **Revisit:** A later freeze (v1.1+) may add allowlisted paths **and** require positive/negative fixtures **before** `true` is allowed.
+
+This matches **defer unless proven** and avoids weakening the seam with a half-defined path.
+
+---
+
+## 2. Payload placement and default shape (hard contract)
+
+**Placement:** `discovery` is a **top-level sibling** on the **emitted canonical adapter payload** (same object as `agent`, `task`, `attributes`, `unmapped_fields_count`).
+
+**Presence:** **`discovery` is always present** on every emitted event (diff-stable, no optional omission).
+
+**Default values (when no rule sets a non-default):**
+
+| Field | Default | JSON type |
+|-------|---------|-----------|
+| `agent_card_visible` | `false` | bool |
+| `agent_card_source_kind` | `"unknown"` | string (enum) |
+| `extended_card_access_visible` | `false` | bool |
+| `signature_material_visible` | `false` | bool (fixed in v1; see §1) |
+
+**Enum values for `agent_card_source_kind`:** `typed_payload` \| `attributes` \| `unmapped` \| `unknown`
+
+---
+
+## 3. Precedence rule (`agent_card_source_kind`)
+
+**Order (highest wins first):**
+
+1. `typed_payload`
+2. `attributes`
+3. `unmapped`
+4. `unknown`
+
+**Decision table (deterministic):**
+
+| Situation | Result kind |
+|-----------|-------------|
+| A frozen **typed** upstream path matched for the same field’s visibility (see §4.1) **and** optional `attributes.assay_g4` also present | `typed_payload` |
+| No typed match, but **allowlisted** `attributes.assay_g4` shape matched for that visibility | `attributes` |
+| No typed and no attributes match, but a **frozen unmapped top-level key** rule matched (see §4.2) | `unmapped` |
+| Otherwise | `unknown` |
+
+**v1 note:** With this freeze, **`typed_payload` is unreachable for `agent_card_visible` / `extended_card_access_visible`** until a future freeze adds a typed upstream path (none in current ADR026 fixtures). Implementations must still implement precedence so adding typed paths does not change resolution order later.
+
+---
+
+## 4. Filled 1a freeze table (per field)
+
+### 4.1 `agent_card_visible`
+
+| | |
+|--|--|
+| **Exact source paths (v1)** | **Only** allowlisted Assay namespace under upstream `attributes`: key **`assay_g4`** (object). Inside it, key **`agent_card`** (object) with boolean **`visible`** required to consider promotion. **Path:** `attributes.assay_g4.agent_card.visible` → boolean `true` required for `agent_card_visible: true`. |
+| **Minimal shape** | `attributes` is an object; `assay_g4` is an object; `agent_card` is an object; `visible` is JSON boolean. Anything else (string, missing `agent_card`, etc.) → **no promotion** (stay default `false`). |
+| **May use `attributes`?** | **Yes**, only via the path above. No other attribute key may set this field. |
+| **Multiple signals required?** | **No.** One matching allowlisted path with valid shape is **sufficient** for `true`. |
+| **Explicit negatives (must not promote)** | (1) `agent.capabilities` present alone; (2) any non-allowlisted `attributes` key (e.g. `priority`, `session` per fixtures); (3) `attributes.assay_g4` present but wrong shape; (4) blob fragment without the nested boolean; (5) `unmapped_fields_count > 0` **alone**; (6) any heuristic on generic keys. |
+
+**Hard rule — `agent.capabilities`:** Presence of **`agent.capabilities`** (or the capabilities event) **does not** set `agent_card_visible` to `true`. Capabilities remain **discovery-adjacent** only (PLAN Phase 0). Card visibility in v1 is **only** via the frozen **`attributes.assay_g4.agent_card.visible`** contract (or future typed path in a later freeze).
+
+### 4.2 `extended_card_access_visible`
+
+| | |
+|--|--|
+| **Exact source paths (v1)** | **Only** `attributes.assay_g4.extended_card_access.visible` → boolean `true` with same namespace rules: `assay_g4` and `extended_card_access` objects, `visible` boolean. |
+| **Minimal shape** | Same discipline as §4.1 (nested objects + boolean). |
+| **May use `attributes`?** | **Yes**, only this path. |
+| **Multiple signals required?** | **No.** |
+| **Explicit negatives** | Same style as §4.1; **no** inference from auth-like or generic keys. `agent_card_visible` and `extended_card_access_visible` are **independent** booleans (both may be true if both paths true). |
+
+### 4.3 `signature_material_visible`
+
+| | |
+|--|--|
+| **v1 decision** | **Deferred:** always **`false`**; **no** path maps to `true` (see §1). |
+| **Future (non-normative)** | Any later freeze must list bounded paths + positive/negative fixtures before `true` is allowed. |
+
+---
+
+## 5. `unmapped_fields_count` and unmapped keys
+
+- **`unmapped_fields_count`:** Never used **alone** to set any `discovery.*` field.
+- **Unmapped top-level keys:** For this freeze, **no** `unmapped` branch sets visibility booleans; `agent_card_source_kind` may be `unmapped` only if a **future** freeze adds explicit rules. **v1:** treat as **never** matching unmapped for card signals — effectively **`unmapped` kind is unused for visibility in v1** unless only attributes/typed apply; if nothing matches → `unknown`.
+
+Clarification: precedence row “unmapped” applies when a **frozen** rule names a specific unmapped key; **none** are frozen in this document → implement **no unmapped promotion** in v1.
+
+---
+
+## 6. Strict vs lenient
+
+- **Same semantic defaults** in both modes: `discovery` always present with defaults in §2.
+- **Difference:** strict may **reject** invalid packets per existing adapter rules; lenient may substitute unknown agent, etc. **Discovery** does not add hidden promotion in lenient mode: if `attributes.assay_g4` shape is invalid, visibility stays **false** and kind **`unknown`** (unless a higher-precedence source matched).
+
+---
+
+## 7. Two complete emitted JSON examples (full payload shape)
+
+Field order below follows the **logical** sibling set: adapter metadata, protocol, agent, task, …, `attributes`, **`discovery`**, `unmapped_fields_count` (exact key order in JSON may vary; canonical ordering is defined in implementation/tests).
+
+### 7.1 Weak positive (attributes-driven)
+
+Upstream input must satisfy `attributes.assay_g4.agent_card.visible == true` (and shape). Emitted payload **illustrative**:
+
+```json
+{
+  "adapter_id": "assay-adapter-a2a",
+  "adapter_version": "3.3.0",
+  "protocol": "a2a",
+  "protocol_name": "a2a",
+  "protocol_version": "0.2.0",
+  "upstream_event_type": "agent.capabilities",
+  "agent": {
+    "id": "agent://planner",
+    "name": "Planner",
+    "role": "assistant",
+    "capabilities": ["agent.describe", "artifacts.share", "tasks.update"]
+  },
+  "attributes": {
+    "assay_g4": {
+      "agent_card": { "visible": true }
+    },
+    "priority": "high",
+    "session": "alpha"
+  },
+  "discovery": {
+    "agent_card_visible": true,
+    "agent_card_source_kind": "attributes",
+    "extended_card_access_visible": false,
+    "signature_material_visible": false
+  },
+  "unmapped_fields_count": 0
+}
+```
+
+### 7.2 Fully default (no promotion)
+
+Typical conversion from [a2a_happy_agent_capabilities.json](../../scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities.json) **without** `assay_g4`:
+
+```json
+{
+  "adapter_id": "assay-adapter-a2a",
+  "adapter_version": "3.3.0",
+  "protocol": "a2a",
+  "protocol_name": "a2a",
+  "protocol_version": "0.2.0",
+  "upstream_event_type": "agent.capabilities",
+  "agent": {
+    "id": "agent://planner",
+    "name": "Planner",
+    "role": "assistant",
+    "capabilities": ["agent.describe", "artifacts.share", "tasks.update"]
+  },
+  "attributes": {
+    "priority": "high",
+    "session": "alpha"
+  },
+  "discovery": {
+    "agent_card_visible": false,
+    "agent_card_source_kind": "unknown",
+    "extended_card_access_visible": false,
+    "signature_material_visible": false
+  },
+  "unmapped_fields_count": 0
+}
+```
+
+---
+
+## 8. Negative test matrix (minimum before merge of 1b)
+
+| # | Case | Expected `discovery` |
+|---|------|------------------------|
+| N1 | Non-allowlisted `attributes` only (`priority`, `session`) | All bools false; `agent_card_source_kind` `unknown` |
+| N2 | `attributes.assay_g4` present but wrong shape (e.g. string, or missing `agent_card`) | `agent_card_visible` false; kind `unknown` |
+| N3 | `unmapped_fields_count > 0` only, no `assay_g4` | No discovery semantics from count; defaults unless §4 matches |
+| N4 | Precedence: frozen typed path **not in v1** — use fixture with only `attributes.assay_g4` valid | `agent_card_source_kind` `attributes` |
+| N5 | Strict vs lenient: same `attributes` without `assay_g4` | Same defaults as N1 |
+| N6 | `signature_material_visible` | Always `false` in v1 |
+
+---
+
+## 9. assay-evidence scope
+
+**No change to `assay-evidence` for G4-A v1** unless a **later** change is **objectively** required to represent a **new trust-basis or classification seam** that cannot be expressed in emitted adapter JSON and blocks **testability** of the adapter contract. **Not** for documentation parity, convenience, or pre-building P2c pack logic.
+
+---
+
+## 10. Link to implementation
+
+- Implement **`attributes.assay_g4`** parsing only after `attributes` is read; validate shape; set `discovery` before `build_payload` inserts `unmapped_fields_count`.
+- Add fixtures: one positive (§7.1), one default (§7.2), plus rows in §8.
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-03-25 | Initial executable freeze: Assay `attributes` contract, deferred `signature_material_visible`, defaults, precedence, JSON examples, negative matrix, assay-evidence line. |

--- a/docs/architecture/G4-A-PHASE1-FREEZE.md
+++ b/docs/architecture/G4-A-PHASE1-FREEZE.md
@@ -109,7 +109,7 @@ This matches **defer unless proven** and avoids weakening the seam with a half-d
 | **May use `attributes`?** | **Yes**, only this path. |
 | **Multiple signals required?** | **No.** |
 | **Explicit negatives** | Same style as §4.1; **no** inference from auth-like or generic keys. `agent_card_visible` and `extended_card_access_visible` are **independent** booleans (both may be true if both paths true). |
-| **Bounded meaning (strict)** | **Only** “producer asserted extended/authenticated card **surface** visibility” via the allowlisted flag — **not** that authentication **succeeded**, authorization **held**, or access was **legitimate**. See §2b table. |
+| **Bounded meaning (strict)** | **Only** “producer asserted visibility of an extended card **surface**” via the allowlisted flag (same literal sense as §2b / one-line guardrail) — **not** that authentication **succeeded**, authorization **held**, access was **legitimate**, or any party was **trusted**. See §2b table. |
 
 ### 4.3 `signature_material_visible`
 
@@ -251,13 +251,13 @@ Upstream with **both** allowlisted paths `true` shows that `agent_card_visible` 
 - Implement **`attributes.assay_g4`** parsing only after `attributes` is read; validate shape; set `discovery` before `build_payload` inserts `unmapped_fields_count`.
 - **Fixtures:** §7.1 positive (`agent_card`), §7.2 default, §7.3 **both flags** (`a2a_happy_agent_capabilities_g4_both_visible.json`), §8 matrix, and **§8 extended positive** (`extended_card_access` = true).
 - **Precedence tests (minimum):** (1) **Unit-level** test for the precedence helper: when only attributes-path matches → `attributes`; when nothing matches → `unknown`. (2) **Integration** test that attributes-driven visibility yields `agent_card_source_kind: "attributes"` and that fixture without `assay_g4` yields `"unknown"`. It is acceptable that `typed_payload` / `unmapped` branches are covered only by unit tests with synthetic “would match if frozen” inputs **or** are asserted unreachable in v1 via a single doc-tested guard — but **attributes vs unknown** must be exercised.
-- **Canonical stability:** Integration tests should assert `digest_canonical_json` is **identical** for repeated conversion of the same upstream bytes (full batch), and **golden** digests for the emitted **`discovery` sub-object alone** (SHA-256 over [`canonical_json_bytes`](../../crates/assay-adapter-api/src/canonical.rs)) so accidental field renames or type changes fail CI.
+- **Canonical stability:** Integration tests should assert `digest_canonical_json` is **identical** for repeated conversion of the same upstream bytes (**full `AdapterBatch`**, including when `discovery` is non-default — not only the default happy path), and **golden** digests for the emitted **`discovery` sub-object alone** (SHA-256 over [`canonical_json_bytes`](../../crates/assay-adapter-api/src/canonical.rs)) so accidental field renames or type changes fail CI.
 
 ---
 
 ## 11. Reviewer checklist (contract closure)
 
-Use this to close **strategy** review and focus on **contract** review:
+Use this to close **strategy** review and focus on **contract** review. **Keep this section to the table below** — if something needs nuance, put it in §2b, §4, §7, or §10 instead of growing §11.
 
 | # | Check | Where |
 |---|--------|--------|
@@ -277,3 +277,4 @@ Use this to close **strategy** review and focus on **contract** review:
 | 2026-03-25 | Initial executable freeze: Assay `attributes` contract, deferred `signature_material_visible`, defaults, precedence, JSON examples, negative matrix, assay-evidence line. |
 | 2026-03-25 | Review pass: contract honesty; v1 enum reachability; bounded-meaning table; stricter `extended_card_access`; N7 + extended positive fixture; precedence test minimums. |
 | 2026-03-25 | Review closure: one-line boolean semantics guardrail; §7 build note; §7.3 both-flags fixture; §11 reviewer checklist; canonical `discovery` golden digest expectation in §10. |
+| 2026-03-25 | Pre-merge: §4.2 bounded wording aligned with §2b (no “authenticated” in positive read); §11 “keep table-only”; full-batch digest test when `discovery` non-default. |

--- a/docs/architecture/G4-A-PHASE1-FREEZE.md
+++ b/docs/architecture/G4-A-PHASE1-FREEZE.md
@@ -4,6 +4,10 @@
 **Parent:** [PLAN-G4-A2A-DISCOVERY-CARD-EVIDENCE-2026q2.md](PLAN-G4-A2A-DISCOVERY-CARD-EVIDENCE-2026q2.md).
 **Repo snapshot:** Current [`assay-adapter-a2a`](../../crates/assay-adapter-a2a/) + [ADR026 fixtures](../../scripts/ci/fixtures/adr026/a2a/v0.2/) have **no** first-class upstream Agent Card / discovery **typed** columns; this freeze defines an **Assay-namespaced `attributes` contract** plus strict negatives so **1b** is not open-ended.
 
+### Contract honesty (product / review)
+
+**G4-A v1 is not a protocol-native typed upstream seam yet.** It is **adapter-emitted**, **Assay-namespaced** under `attributes.assay_g4`, and **bounded by this freeze**. That is a deliberate trade-off: repo-truth has no stable A2A-native card columns in fixtures, so visibility signals are **contracted** where producers can opt in. Do **not** market this as “full A2A Agent Card surface in typed upstream” until a later freeze adds real typed paths.
+
 ---
 
 ## 1. Definitive decision: `signature_material_visible` (v1)
@@ -35,6 +39,25 @@ This matches **defer unless proven** and avoids weakening the seam with a half-d
 
 **Enum values for `agent_card_source_kind`:** `typed_payload` \| `attributes` \| `unmapped` \| `unknown`
 
+**v1 reachability (implementers + docs):** All four enum strings remain part of the **frozen** contract (forwards-compatible). In **this** freeze, however:
+
+- **`typed_payload`** — **unreachable** in v1 (no frozen typed upstream path). Code and docs must **not** imply typed card paths are already supported.
+- **`unmapped`** — **unreachable** in v1 (no frozen unmapped-key rules). Same caution.
+- **Practically active for visibility today:** `attributes` (when §4 matches) and **`unknown`** (when nothing matches).
+
+---
+
+## 2b. Bounded meaning — may imply / must **not** imply (all four fields)
+
+| Field | May imply (visibility / presence only) | Must **not** imply |
+|-------|----------------------------------------|-------------------|
+| `agent_card_visible` | An allowlisted `attributes.assay_g4.agent_card.visible` signal was **observed** as `true` with valid shape | Card valid, authentic, complete, or “real” vs spoof |
+| `agent_card_source_kind` | Which **class** of source won precedence per §3 (for v1 usually `attributes` vs `unknown`) | Correctness, trustworthiness, or strength of that source |
+| `extended_card_access_visible` | An allowlisted `attributes.assay_g4.extended_card_access.visible` signal was **observed** as `true` with valid shape | **Authenticated**, **authorized**, **sufficient** authz, client trusted, token valid, or “extended access succeeded” |
+| `signature_material_visible` (v1) | **Nothing** beyond “slot present, value false” — deferred semantic | Any verification, validity, signer trust, provenance, or signing outcome |
+
+**Reviewer note:** `extended_card_access_visible` uses a parallel `attributes` path; give it the **strictest** product review — if the path is not meaningful for your producers, defer tightening or keep default-only until a producer contract exists.
+
 ---
 
 ## 3. Precedence rule (`agent_card_source_kind`)
@@ -56,6 +79,8 @@ This matches **defer unless proven** and avoids weakening the seam with a half-d
 | Otherwise | `unknown` |
 
 **v1 note:** With this freeze, **`typed_payload` is unreachable for `agent_card_visible` / `extended_card_access_visible`** until a future freeze adds a typed upstream path (none in current ADR026 fixtures). Implementations must still implement precedence so adding typed paths does not change resolution order later.
+
+**Implementation/doc requirement:** State explicitly in code comments (or module-level doc) and in any consumer-facing summary that **`typed_payload` and `unmapped` are frozen enum members but not produced by v1 rules** — avoids the false impression that protocol-native typed or unmapped discovery is already wired.
 
 ---
 
@@ -82,6 +107,7 @@ This matches **defer unless proven** and avoids weakening the seam with a half-d
 | **May use `attributes`?** | **Yes**, only this path. |
 | **Multiple signals required?** | **No.** |
 | **Explicit negatives** | Same style as §4.1; **no** inference from auth-like or generic keys. `agent_card_visible` and `extended_card_access_visible` are **independent** booleans (both may be true if both paths true). |
+| **Bounded meaning (strict)** | **Only** “producer asserted extended/authenticated card **surface** visibility” via the allowlisted flag — **not** that authentication **succeeded**, authorization **held**, or access was **legitimate**. See §2b table. |
 
 ### 4.3 `signature_material_visible`
 
@@ -191,6 +217,9 @@ Typical conversion from [a2a_happy_agent_capabilities.json](../../scripts/ci/fix
 | N4 | Precedence: frozen typed path **not in v1** — use fixture with only `attributes.assay_g4` valid | `agent_card_source_kind` `attributes` |
 | N5 | Strict vs lenient: same `attributes` without `assay_g4` | Same defaults as N1 |
 | N6 | `signature_material_visible` | Always `false` in v1 |
+| N7 | **Precedence semantics** | With only `attributes.assay_g4.agent_card` valid → `agent_card_source_kind` is **`attributes`**; with no matching paths → **`unknown`** (not `attributes`) |
+
+**Additional fixture (implementation PR, recommended):** One **positive** upstream packet where `attributes.assay_g4.extended_card_access.visible` is `true` (valid shape), asserting emitted `extended_card_access_visible: true` and appropriate `agent_card_source_kind` — so this bool is not only covered by negatives. (Optional second full JSON snippet in docs mirroring §7.1.)
 
 ---
 
@@ -203,7 +232,8 @@ Typical conversion from [a2a_happy_agent_capabilities.json](../../scripts/ci/fix
 ## 10. Link to implementation
 
 - Implement **`attributes.assay_g4`** parsing only after `attributes` is read; validate shape; set `discovery` before `build_payload` inserts `unmapped_fields_count`.
-- Add fixtures: one positive (§7.1), one default (§7.2), plus rows in §8.
+- **Fixtures:** §7.1 positive (`agent_card`), §7.2 default, §8 matrix, and **§8 extended positive** (`extended_card_access` = true).
+- **Precedence tests (minimum):** (1) **Unit-level** test for the precedence helper: when only attributes-path matches → `attributes`; when nothing matches → `unknown`. (2) **Integration** test that attributes-driven visibility yields `agent_card_source_kind: "attributes"` and that fixture without `assay_g4` yields `"unknown"`. It is acceptable that `typed_payload` / `unmapped` branches are covered only by unit tests with synthetic “would match if frozen” inputs **or** are asserted unreachable in v1 via a single doc-tested guard — but **attributes vs unknown** must be exercised.
 
 ---
 
@@ -212,3 +242,4 @@ Typical conversion from [a2a_happy_agent_capabilities.json](../../scripts/ci/fix
 | Date | Change |
 |------|--------|
 | 2026-03-25 | Initial executable freeze: Assay `attributes` contract, deferred `signature_material_visible`, defaults, precedence, JSON examples, negative matrix, assay-evidence line. |
+| 2026-03-25 | Review pass: contract honesty; v1 enum reachability; bounded-meaning table; stricter `extended_card_access`; N7 + extended positive fixture; precedence test minimums. |

--- a/docs/architecture/PLAN-G4-A2A-DISCOVERY-CARD-EVIDENCE-2026q2.md
+++ b/docs/architecture/PLAN-G4-A2A-DISCOVERY-CARD-EVIDENCE-2026q2.md
@@ -208,6 +208,8 @@ This PLAN is **complete enough** for **discovery review** and **direction** (Pha
 | 2 | **Representative emitted JSON** — **grounded** in the **current** adapter payload layout (top-level siblings like `agent`, `attributes`, …), not only a conceptual snippet; includes **`discovery`** with at least one realistic **`agent_card_source_kind`** | Proves placement and shape **before** code argues structure. |
 | 3 | **Explicit drop rules** — when upstream/`attributes` hints **must not** be promoted to typed `discovery.*` | Prevents inflation (“everything becomes visible”). Complements freeze rule 5 above. |
 
+**Executable freeze (filled):** The **[G4-A Phase 1 formal freeze](G4-A-PHASE1-FREEZE.md)** document contains the **per-field mapping tables**, **precedence with examples**, **hard defaults**, **two full emitted-payload JSON examples**, **negative test matrix**, **`signature_material_visible` v1 decision** (deferred), and **assay-evidence** scope line — so **1b** can proceed adapter-first without reopening semantics.
+
 **Remaining semantic closures (owned by Phase 1 freeze, not this PLAN PR):**
 
 - **`agent_card_visible` = true** — must be **fully specified** via the mapping table: frozen paths **+** minimum bounded shape **+** exclusion of mere blob fragments (see **Minimum threshold for `agent_card_visible`** in the G4-A section above).

--- a/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities_g4_agent_card.json
+++ b/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities_g4_agent_card.json
@@ -1,0 +1,23 @@
+{
+  "protocol": "a2a",
+  "version": "0.2.0",
+  "event_type": "agent.capabilities",
+  "timestamp": "2026-02-27T10:00:00Z",
+  "agent": {
+    "id": "agent://planner",
+    "name": "Planner",
+    "role": "assistant",
+    "capabilities": [
+      "tasks.update",
+      "artifacts.share",
+      "agent.describe"
+    ]
+  },
+  "attributes": {
+    "assay_g4": {
+      "agent_card": { "visible": true }
+    },
+    "priority": "high",
+    "session": "alpha"
+  }
+}

--- a/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities_g4_both_visible.json
+++ b/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities_g4_both_visible.json
@@ -1,0 +1,23 @@
+{
+  "protocol": "a2a",
+  "version": "0.2.0",
+  "event_type": "agent.capabilities",
+  "timestamp": "2026-02-27T10:00:00Z",
+  "agent": {
+    "id": "agent://planner",
+    "name": "Planner",
+    "role": "assistant",
+    "capabilities": [
+      "tasks.update",
+      "artifacts.share",
+      "agent.describe"
+    ]
+  },
+  "attributes": {
+    "assay_g4": {
+      "agent_card": { "visible": true },
+      "extended_card_access": { "visible": true }
+    },
+    "priority": "high"
+  }
+}

--- a/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities_g4_extended.json
+++ b/scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities_g4_extended.json
@@ -1,0 +1,22 @@
+{
+  "protocol": "a2a",
+  "version": "0.2.0",
+  "event_type": "agent.capabilities",
+  "timestamp": "2026-02-27T10:00:00Z",
+  "agent": {
+    "id": "agent://planner",
+    "name": "Planner",
+    "role": "assistant",
+    "capabilities": [
+      "tasks.update",
+      "artifacts.share",
+      "agent.describe"
+    ]
+  },
+  "attributes": {
+    "assay_g4": {
+      "extended_card_access": { "visible": true }
+    },
+    "priority": "high"
+  }
+}


### PR DESCRIPTION
## Summary

Ships **G4-A Phase 1** as a combined **normative freeze** (docs) and **adapter implementation** (1b):

- **Freeze:** [`docs/architecture/G4-A-PHASE1-FREEZE.md`](docs/architecture/G4-A-PHASE1-FREEZE.md) — executable contract for `payload.discovery` (placement, defaults, Assay-namespaced `attributes.assay_g4` paths, precedence for `agent_card_source_kind`, deferred `signature_material_visible`, negative test matrix, JSON examples).
- **Adapter:** [`assay-adapter-a2a`](crates/assay-adapter-a2a/) — new [`discovery.rs`](crates/assay-adapter-a2a/src/adapter_impl/discovery.rs) + [`build_payload`](crates/assay-adapter-a2a/src/adapter_impl/payload.rs) always emits `discovery` before `unmapped_fields_count`.
- **Fixtures:** [`a2a_happy_agent_capabilities_g4_agent_card.json`](scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities_g4_agent_card.json), [`a2a_happy_agent_capabilities_g4_extended.json`](scripts/ci/fixtures/adr026/a2a/v0.2/a2a_happy_agent_capabilities_g4_extended.json).
- **Tests:** unit (precedence + shape) + integration (freeze matrix N1–N5, extended positive, strict/lenient parity without `assay_g4`).

## Contract highlights (v1)

| Topic | Decision |
|-------|----------|
| Honesty | Adapter-emitted seam under `attributes.assay_g4`; not protocol-native typed card columns yet. |
| `discovery` | Always present; defaults: all visibility bools `false`, `agent_card_source_kind` `"unknown"`. |
| Promotion | Only strict nested-object + JSON boolean `true` on allowlisted paths (see freeze §4). |
| `agent.capabilities` | Does **not** set `agent_card_visible` (freeze §4.1). |
| `unmapped_fields_count` | Never alone promotes any discovery field. |
| `agent_card_source_kind` | Precedence implemented; v1 only emits `attributes` or `unknown` (`typed_payload` / `unmapped` frozen but unreachable until a later freeze). |
| `signature_material_visible` | Always `false` in v1 (deferred semantic). |

## Out of scope (this PR)

- **assay-evidence** / **P2c pack** changes (per freeze §9).
- No new lint pack rules.

## Parent

- [`PLAN-G4-A2A-DISCOVERY-CARD-EVIDENCE-2026q2.md`](docs/architecture/PLAN-G4-A2A-DISCOVERY-CARD-EVIDENCE-2026q2.md)

## How to test

```bash
cargo test -p assay-adapter-a2a
cargo clippy -p assay-adapter-a2a --all-targets -- -D warnings
```


Made with [Cursor](https://cursor.com)