### PR TITLE
docs: freeze wave43 decision kernel split step1

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step1.md
@@ -1,0 +1,28 @@
+# SPLIT CHECKLIST - Wave43 Decision Kernel Step1
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step1.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step1.md`
+  - `scripts/ci/review-wave43-decision-kernel-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-core/src/mcp/**`
+- [ ] No edits under `crates/assay-core/tests/**`
+- [ ] No CLI or MCP server changes
+
+## Contract freeze
+- [ ] Stable `decision.rs` facade is explicit
+- [ ] Stable public decision/event symbols are explicit
+- [ ] Proposed `decision_next/` boundaries are explicit
+- [ ] Non-goals are explicit
+- [ ] Event payload shape freeze is explicit
+- [ ] Reason-code freeze is explicit
+- [ ] Replay/contract refresh freeze is explicit
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave43-decision-kernel-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core --all-targets -- -D warnings` passes
+- [ ] Pinned decision/replay tests pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step1.md
@@ -1,0 +1,42 @@
+# SPLIT MOVE MAP - Wave43 Decision Kernel Step1
+
+## Intent
+Preview the bounded Step2 move set for the `mcp/decision.rs` split without changing runtime code in
+Step1.
+
+## Allowed Step2 implementation scope
+- `crates/assay-core/src/mcp/decision.rs`
+- `crates/assay-core/src/mcp/decision_next/mod.rs`
+- `crates/assay-core/src/mcp/decision_next/event_types.rs`
+- `crates/assay-core/src/mcp/decision_next/builder.rs`
+- `crates/assay-core/src/mcp/decision_next/emitters.rs`
+- `crates/assay-core/src/mcp/decision_next/guard.rs`
+- `crates/assay-core/src/mcp/decision_next/normalization.rs`
+- `crates/assay-core/src/mcp/decision_next/tests.rs`
+- `crates/assay-core/tests/decision_emit_invariant.rs`
+- `crates/assay-core/tests/fulfillment_normalization.rs`
+
+## Move rationale
+- `decision.rs`
+  - becomes facade/orchestration only
+- `event_types.rs`
+  - owns core decision/event/data types
+- `builder.rs`
+  - owns allow/deny/error event construction helpers
+- `emitters.rs`
+  - owns file/null emitter implementations and trait placement
+- `guard.rs`
+  - owns single-emission invariant lifecycle
+- `normalization.rs`
+  - owns fulfillment normalization and projection refresh helpers
+- tests
+  - verify public behavior did not drift while logic moved behind the facade
+
+## Explicitly out of scope
+- policy engine changes
+- tool-call handler changes
+- new event fields
+- reason-code changes
+- CLI changes
+- MCP server changes
+- workflow changes

--- a/docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md
+++ b/docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md
@@ -1,0 +1,156 @@
+# SPLIT PLAN - Wave43 Decision Kernel Split
+
+## Intent
+Freeze a bounded split plan for `crates/assay-core/src/mcp/decision.rs` before any mechanical
+module moves.
+
+This wave is about:
+- turning the current large decision kernel into a thin facade behind internal modules
+- keeping the public decision/event contract stable
+- isolating emitter, guard, normalization, and replay-facing logic into reviewable seams
+- locking reviewer gates before any Step2 code movement
+
+It explicitly does **not** add:
+- new MCP runtime behavior
+- new decision/event fields
+- policy engine behavior changes
+- tool-call handler behavior changes
+- CLI or MCP server behavior changes
+- workflow changes
+
+## Problem
+`crates/assay-core/src/mcp/decision.rs` is currently one of the largest handwritten production
+Rust files on `main` (baseline inventory: 1426 LOC at `origin/main` `47b67769`).
+
+The file is already partially decomposed through internal submodules:
+- `consumer_contract`
+- `context_contract`
+- `deny_convergence`
+- `outcome_convergence`
+- `replay_compat`
+- `replay_diff`
+
+But the main facade still co-locates too much:
+- core event/data types
+- builder-style event construction
+- emitter implementations
+- guard lifecycle
+- fulfillment normalization
+- contract projection refresh
+- inline unit tests
+
+That makes review and later bounded changes harder than they need to be.
+
+## Frozen public surface
+Wave43 freezes the expectation that Step2 keeps these public or externally relied-on surfaces
+stable in meaning:
+- `Decision`
+- `DecisionEvent`
+- `DecisionData`
+- `ObligationOutcome`
+- `PolicyDecisionEventContext`
+- `DecisionEmitter`
+- `DecisionEmitterGuard`
+- `FileDecisionEmitter`
+- `NullDecisionEmitter`
+- `refresh_contract_projections`
+- `reason_codes`
+
+Step2 may reorganize implementation ownership behind these surfaces, but must not redefine their
+contract.
+
+## Frozen contract rules
+Wave43 freezes the following rules for the split:
+
+1. `decision.rs` becomes thinner, but remains the stable facade.
+2. No event payload shape changes are allowed in this wave.
+3. No reason-code renames are allowed in this wave.
+4. No replay-basis behavior changes are allowed in this wave.
+5. Existing internal convergence modules remain semantically stable while the main file is split.
+6. Step2 is mechanical-first: move bodies 1:1 before any cleanup.
+
+## Suggested Step2 target layout
+
+```text
+crates/assay-core/src/mcp/decision.rs              # stable facade
+crates/assay-core/src/mcp/decision_next/
+  mod.rs
+  event_types.rs
+  builder.rs
+  emitters.rs
+  guard.rs
+  normalization.rs
+  tests.rs
+```
+
+Current internal contract modules may remain where they are during Step2:
+- `consumer_contract`
+- `context_contract`
+- `deny_convergence`
+- `outcome_convergence`
+- `replay_compat`
+- `replay_diff`
+
+The point of Step2 is not to redesign those modules; it is to reduce the main facade file and make
+ownership clearer.
+
+## Frozen mechanical boundaries
+The intended mechanical split boundaries are:
+
+- `event_types.rs`
+  - decision/event/data structs and enums
+- `builder.rs`
+  - event construction helpers such as allow/deny/error builder flow
+- `emitters.rs`
+  - `DecisionEmitter`, `FileDecisionEmitter`, `NullDecisionEmitter`
+- `guard.rs`
+  - `DecisionEmitterGuard` lifecycle and single-emission invariant handling
+- `normalization.rs`
+  - obligation normalization, fulfillment path classification, projection refresh
+
+## Acceptance shape for Step2
+A Step2 implementation is acceptable only if all of the following are true:
+
+1. `decision.rs` remains the stable top-level facade
+2. public decision/event surfaces remain compatible
+3. event payload shape is unchanged
+4. reason-code constants are unchanged
+5. replay/contract refresh behavior is unchanged
+6. tool-call handler, policy engine, CLI, and MCP server behavior are untouched
+
+## Scope boundaries
+### In scope
+- freeze of the decision-kernel split plan
+- explicit module-boundary proposal
+- explicit public-surface freeze
+- reviewer gates for the future mechanical split
+
+### Out of scope
+- implementation moves in `crates/assay-core/src/mcp/decision.rs`
+- test rewrites in `crates/assay-core/tests/decision_emit_invariant.rs`
+- policy engine changes
+- tool-call handler changes
+- CLI or MCP server changes
+- workflow edits
+
+## Planned wave structure
+### Step1
+Docs + gate only
+
+### Step2
+Mechanical split only:
+- introduce `decision_next/`
+- move bodies 1:1 behind a stable facade
+- keep current contract modules semantically unchanged
+
+### Step3
+Docs + gate only closure
+
+## Reviewer notes
+This wave must remain decision-kernel split planning only.
+
+Primary failure modes:
+- sneaking behavior changes into a mechanical split
+- changing event payload shape while chasing file size
+- renaming reason codes or replay semantics under a refactor label
+- expanding scope into handler/policy/server work

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step1.md
@@ -1,0 +1,40 @@
+# SPLIT REVIEW PACK - Wave43 Decision Kernel Step1
+
+## Intent
+Freeze a bounded split plan for the MCP decision kernel before any Step2 implementation work.
+
+This slice is docs + gate only.
+
+It must not:
+- change MCP runtime behavior
+- change event payload shape
+- rename reason codes
+- change replay/contract refresh behavior
+- touch workflow files
+
+## Allowed files
+- `docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step1.md`
+- `scripts/ci/review-wave43-decision-kernel-step1.sh`
+
+## What reviewers should verify
+1. Diff is limited to the five Step1 files.
+2. Stable public decision/event surfaces are explicit.
+3. Proposed `decision_next/` boundaries are explicit and mechanical.
+4. Event payload and reason-code freezes are explicit.
+5. Replay/contract refresh freeze is explicit.
+6. Runtime code and tests are untouched in this step.
+7. Scope does not expand into handler, policy, CLI, or MCP server work.
+
+## Reviewer command
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave43-decision-kernel-step1.sh
+```
+
+Expected outcome:
+- gate passes
+- runtime code is untouched
+- the future Step2 move set is explicit
+- Step2 can proceed mechanically without reopening contract scope

--- a/scripts/ci/review-wave43-decision-kernel-step1.sh
+++ b/scripts/ci/review-wave43-decision-kernel-step1.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step1.md"
+  "scripts/ci/review-wave43-decision-kernel-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-core/tests"
+  "crates/assay-cli/src/cli/commands"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave43 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave43 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave43 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step1.md"
+
+rg -n '^# SPLIT PLAN - Wave43 Decision Kernel Split$' "$PLAN" >/dev/null || {
+  echo "FAIL: missing plan title"
+  exit 1
+}
+
+for marker in \
+  'DecisionEvent' \
+  'DecisionData' \
+  'DecisionEmitter' \
+  'DecisionEmitterGuard' \
+  'reason_codes' \
+  'consumer_contract' \
+  'context_contract' \
+  'deny_convergence' \
+  'outcome_convergence' \
+  'replay_compat' \
+  'replay_diff' \
+  'decision_next/' \
+  'event_types.rs' \
+  'builder.rs' \
+  'emitters.rs' \
+  'guard.rs' \
+  'normalization.rs' \
+  'No event payload shape changes are allowed in this wave.' \
+  'No reason-code renames are allowed in this wave.' \
+  'No replay-basis behavior changes are allowed in this wave.'
+do
+  rg -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-core/src/mcp/decision.rs' \
+  'crates/assay-core/src/mcp/decision_next/mod.rs' \
+  'crates/assay-core/tests/decision_emit_invariant.rs' \
+  'crates/assay-core/tests/fulfillment_normalization.rs'
+do
+  rg -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+
+echo "[review] pinned decision tests"
+cargo test -p assay-core test_event_serialization -- --exact
+cargo test -p assay-core test_reason_codes_are_string_constants -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_delegation_fields_are_additive_on_emitted_decisions -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_guard_drop_emits_on_early_return -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- freeze Wave43 as a bounded split plan for `crates/assay-core/src/mcp/decision.rs`
- add Step1 review artifacts: checklist, move-map, review pack, and reviewer script
- keep Step1 docs + gate only, with no runtime code changes

## Included
- `docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md`
- `docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step1.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step1.md`
- `scripts/ci/review-wave43-decision-kernel-step1.sh`

## Validation
- `git -C /private/tmp/assay-wave43-Y3fyZx diff --check`
- `BASE_REF=origin/main bash /private/tmp/assay-wave43-Y3fyZx/scripts/ci/review-wave43-decision-kernel-step1.sh`
