### PR TITLE
docs: close wave43 with micro-cleanup gates

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step3.md
@@ -1,0 +1,27 @@
+# SPLIT CHECKLIST - Wave43 Decision Kernel Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step3.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step3.md`
+  - `scripts/ci/review-wave43-decision-kernel-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-core/src/mcp/**`
+- [ ] No edits under `crates/assay-core/tests/**`
+- [ ] No CLI or MCP server changes
+
+## Step3 closure contract
+- [ ] Step2 is recorded as shipped behind a stable facade
+- [ ] Step3 is explicitly bounded to micro-cleanup only
+- [ ] No new module cuts are proposed in Step3
+- [ ] No payload / reason-code / replay drift is allowed in Step3
+- [ ] `decision.rs` remains the stable public entry point
+- [ ] `decision_next/*` remains the split implementation ownership boundary
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave43-decision-kernel-step3.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core --all-targets -- -D warnings` passes
+- [ ] Pinned decision/replay invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step3.md
@@ -1,0 +1,34 @@
+# SPLIT MOVE MAP - Wave43 Decision Kernel Step3
+
+## Intent
+Close Wave43 after the shipped Step2 split and bound any follow-up work to
+micro-cleanup only.
+
+## Shipped ownership baseline
+- `crates/assay-core/src/mcp/decision.rs`
+  - stable public facade
+  - inline unit tests
+- `crates/assay-core/src/mcp/decision_next/event_types.rs`
+  - public decision/event/data types and `reason_codes`
+- `crates/assay-core/src/mcp/decision_next/normalization.rs`
+  - fulfillment and contract projection refresh helpers
+- `crates/assay-core/src/mcp/decision_next/builder.rs`
+  - `DecisionEvent` builder methods
+- `crates/assay-core/src/mcp/decision_next/emitters.rs`
+  - emitter trait and file/null emitters
+- `crates/assay-core/src/mcp/decision_next/guard.rs`
+  - guard lifecycle and single-emission safety net
+
+## Allowed future Step3 cleanup categories
+- import cleanup
+- internal visibility tightening
+- doc comment cleanup
+- tiny helper placement cleanups that do not change public behavior
+
+## Explicitly out of scope
+- payload-shape changes
+- reason-code changes
+- replay / contract projection changes
+- new module cuts
+- external test rewrites
+- handler / policy / CLI / server changes

--- a/docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md
+++ b/docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md
@@ -69,7 +69,7 @@ Wave43 freezes the following rules for the split:
 5. Existing internal convergence modules remain semantically stable while the main file is split.
 6. Step2 is mechanical-first: move bodies 1:1 before any cleanup.
 
-## Suggested Step2 target layout
+## Shipped Step2 layout
 
 ```text
 crates/assay-core/src/mcp/decision.rs              # stable facade
@@ -148,7 +148,20 @@ Mechanical split only:
 - keep inline unit tests in `decision.rs`
 
 ### Step3
-Docs + gate only closure
+Stabilization + micro-cleanup only:
+- visibility cleanup if strictly internal
+- import/comment/doc cleanup
+- no public contract drift
+- no new modules
+- no handler/policy/server expansion
+
+## Shipped status
+Wave43 Step2 shipped on `main` via `#955`.
+
+Wave43 Step3 is intentionally smaller:
+- close the split with docs/gates that forbid redesign drift
+- bound any follow-up cleanup to internal polish only
+- keep `decision.rs` as the public facade and `decision_next/*` as the split implementation
 
 ## Reviewer notes
 This wave must remain decision-kernel split planning only.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step3.md
@@ -1,0 +1,20 @@
+# SPLIT REVIEW PACK - Wave43 Decision Kernel Step3
+
+## Reviewer intent
+Read Step3 as closure and scope control for the shipped Step2 split.
+
+## What this step should do
+- document the shipped `decision.rs` facade + `decision_next/*` ownership line
+- forbid redesign drift after the successful mechanical split
+- bound any later cleanup to internal polish only
+
+## What this step must not do
+- reopen the split design
+- propose new public API surfaces
+- loosen payload/reason/replay guarantees
+- spill into handler, policy, CLI, or MCP server work
+
+## Review questions
+- Does the plan now reflect the actual shipped Step2 layout?
+- Is Step3 clearly constrained to micro-cleanup only?
+- Do the gates still protect the key decision/replay invariants?

--- a/scripts/ci/review-wave43-decision-kernel-step3.sh
+++ b/scripts/ci/review-wave43-decision-kernel-step3.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step3.md"
+  "scripts/ci/review-wave43-decision-kernel-step3.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp"
+  "crates/assay-core/tests"
+  "crates/assay-cli/src/cli/commands"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave43 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave43 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave43 Step3 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step3.md"
+
+for marker in \
+  'Wave43 Step2 shipped on `main` via `#955`.' \
+  'keep inline unit tests in `decision.rs`' \
+  'Stabilization + micro-cleanup only:' \
+  'no public contract drift' \
+  'no new modules'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-core/src/mcp/decision.rs' \
+  'crates/assay-core/src/mcp/decision_next/event_types.rs' \
+  'internal visibility tightening' \
+  'payload-shape changes'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+
+echo "[review] pinned decision and replay tests"
+cargo test -p assay-core --lib mcp::decision::tests::test_event_serialization -- --exact
+cargo test -p assay-core --lib mcp::decision::tests::test_reason_codes_are_string_constants -- --exact
+cargo test -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact
+cargo test -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
+cargo test -p assay-core --test replay_diff_contract classify_replay_diff_unchanged -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- record Wave43 Step2 as shipped on `main`
- close Wave43 with Step3 docs/gates that bound any follow-up to micro-cleanup only
- keep the decision split closed against payload, reason-code, replay, and scope drift

## Scope
In:
- `docs/contributing/SPLIT-PLAN-wave43-decision-kernel.md`
- `docs/contributing/SPLIT-CHECKLIST-wave43-decision-kernel-step3.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave43-decision-kernel-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave43-decision-kernel-step3.md`
- `scripts/ci/review-wave43-decision-kernel-step3.sh`

Out:
- any edits under `crates/assay-core/src/mcp/**`
- any edits under `crates/assay-core/tests/**`
- payload-shape or reason-code changes
- replay/contract behavior changes
- handler / policy / CLI / MCP server scope

## Why this step exists
- `#955` already landed the mechanical split
- this Step3 PR makes the closure explicit so future cleanup stays tiny and internal
- it treats Wave43 as finished unless there is a clearly bounded polish-only need

## Validation
- `git diff --check`
- `BASE_REF=origin/main bash scripts/ci/review-wave43-decision-kernel-step3.sh`
