### PR TITLE
docs: freeze evaluate kernel split scope

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step1.md
@@ -1,0 +1,41 @@
+# Wave44 Evaluate Kernel Step1 Checklist (Freeze)
+
+Scope lock:
+- `docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step1.md`
+- `scripts/ci/review-wave44-evaluate-kernel-step1.sh`
+- no code edits under `crates/assay-core/src/mcp/tool_call_handler/**`
+- no edits under `crates/assay-core/tests/**`
+- no workflow edits
+
+## Gate expectations
+
+- allowlist-only diff vs `BASE_REF` (default `origin/main`)
+- workflow-ban (`.github/workflows/*`)
+- hard fail tracked changes in `crates/assay-core/src/mcp/tool_call_handler/**`
+- hard fail untracked files in `crates/assay-core/src/mcp/tool_call_handler/**`
+- hard fail tracked changes in `crates/assay-core/tests/**`
+- hard fail untracked files in `crates/assay-core/tests/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- targeted tests:
+  - `mcp::tool_call_handler::tests::approval_required_missing_denies`
+  - `mcp::tool_call_handler::tests::restrict_scope_target_missing_denies`
+  - `mcp::tool_call_handler::tests::redact_args_target_missing_denies`
+  - `tool_taxonomy_policy_match_handler_decision_event_records_classes`
+  - `fulfillment_normalizes_outcomes_and_sets_policy_deny_path`
+  - `classify_replay_diff_unchanged`
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-wave44-evaluate-kernel-step1.sh` passes
+- Step1 diff contains only the 5 allowlisted files
+- no LOC drift in:
+  - `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`
+  - `crates/assay-core/src/mcp/tool_call_handler/tests.rs`
+  - `crates/assay-core/tests/decision_emit_invariant.rs`
+  - `crates/assay-core/tests/fulfillment_normalization.rs`
+  - `crates/assay-core/tests/replay_diff_contract.rs`
+  - `crates/assay-core/tests/tool_taxonomy_policy_match.rs`

--- a/docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step1.md
@@ -1,0 +1,41 @@
+# SPLIT-MOVE-MAP — Wave44 Step1 — `mcp/tool_call_handler/evaluate.rs`
+
+## Goal
+
+Freeze the split boundaries for `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs` before any mechanical module moves.
+
+## Planned Step2 layout
+
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/approval.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/scope.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/redaction.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/fail_closed.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/classification.rs`
+
+## Mapping preview
+
+- `handle_tool_call(...)` entrypoint and top-level evaluation flow stay in `evaluate.rs` as the stable facade.
+- `ApprovalFailure`, `validate_approval_required`, `mark_approval_*`, `parse_approval_artifact`, and `classify_approval_freshness` move to `evaluate_next/approval.rs`.
+- `RestrictScopeFailure`, `validate_restrict_scope`, and `mark_restrict_scope_*` move to `evaluate_next/scope.rs`.
+- `RedactArgsFailure`, `validate_redact_args`, `apply_redact_args_runtime`, `apply_drop_redaction`, `redaction_target_value_mut`, `apply_value_redaction`, `partial_mask`, and `mark_redact_args_*` move to `evaluate_next/redaction.rs`.
+- `seed_fail_closed_context`, `runtime_dependency_error_code`, and `mark_fail_closed` move to `evaluate_next/fail_closed.rs`.
+- `requested_resource` plus `ToolCallHandler::{extract_tool_call_id,is_commit_tool,is_write_tool,operation_class_for_tool,map_policy_code_to_reason,map_authz_error}` move to `evaluate_next/classification.rs`.
+
+## Frozen behavior boundaries
+
+- `HandleResult::{Allow,Deny,Error}` routing stays unchanged.
+- Decision-event additive fields for approval / restrict-scope / redact-args / fail-closed stay byte-for-byte equivalent.
+- Reason-code strings and error-code mapping stay unchanged.
+- Obligation outcome normalization stays at handler stage `v1`.
+- `tool_call_id` extraction fallback order stays unchanged.
+- Mandate authorization and lifecycle emission semantics stay unchanged.
+
+## Test anchors to keep fixed in Step1
+
+- `mcp::tool_call_handler::tests::approval_required_missing_denies`
+- `mcp::tool_call_handler::tests::restrict_scope_target_missing_denies`
+- `mcp::tool_call_handler::tests::redact_args_target_missing_denies`
+- `tool_taxonomy_policy_match_handler_decision_event_records_classes`
+- `fulfillment_normalizes_outcomes_and_sets_policy_deny_path`
+- `classify_replay_diff_unchanged`

--- a/docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md
+++ b/docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md
@@ -1,0 +1,79 @@
+# Wave44 Plan — `mcp/tool_call_handler/evaluate.rs` Kernel Split
+
+## Goal
+
+Split `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs` behind a stable facade with zero behavior change and no emitted contract drift.
+
+Current hotspot baseline on `origin/main @ aa10d921`:
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`: `1016` LOC
+- `crates/assay-core/src/mcp/tool_call_handler/tests.rs`: `1242` LOC
+- `crates/assay-core/tests/decision_emit_invariant.rs`: `1293` LOC
+- `crates/assay-core/tests/fulfillment_normalization.rs`: `165` LOC
+- `crates/assay-core/tests/replay_diff_contract.rs`: `382` LOC
+- `crates/assay-core/tests/tool_taxonomy_policy_match.rs`: `133` LOC
+
+## Step1 (freeze)
+
+Branch: `codex/wave44-evaluate-kernel-step1` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step1.md`
+- `scripts/ci/review-wave44-evaluate-kernel-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-core/src/mcp/tool_call_handler/**`
+- no edits under `crates/assay-core/tests/**`
+- no workflow edits
+
+Step1 gate:
+- allowlist-only diff (the 5 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail on tracked changes in `crates/assay-core/src/mcp/tool_call_handler/**`
+- hard fail on untracked files in `crates/assay-core/src/mcp/tool_call_handler/**`
+- hard fail on tracked changes in `crates/assay-core/tests/**`
+- hard fail on untracked files in `crates/assay-core/tests/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- targeted tests:
+  - `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval_required_missing_denies' -- --exact`
+  - `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::restrict_scope_target_missing_denies' -- --exact`
+  - `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::redact_args_target_missing_denies' -- --exact`
+  - `cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact`
+  - `cargo test -q -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact`
+  - `cargo test -q -p assay-core --test replay_diff_contract classify_replay_diff_unchanged -- --exact`
+
+## Step2 (mechanical split preview)
+
+Target layout preview:
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs` (thin facade + `handle_tool_call`)
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/approval.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/scope.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/redaction.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/fail_closed.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/classification.rs`
+
+Step2 principles:
+- 1:1 body moves
+- stable `handle_tool_call` behavior and same deny/allow routing
+- no changes to emitted payload shape or additive field presence
+- no reason-code renames
+- no obligation outcome normalization drift
+- no request-id / `tool_call_id` extraction drift
+- no mandate/authz semantic changes
+
+## Step3 (closure)
+
+Docs+gate-only closure slice that re-runs Step2 invariants and limits any follow-up to micro-cleanup only.
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once the chain is clean.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step1.md
@@ -1,0 +1,49 @@
+# Wave44 Evaluate Kernel Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze Wave44 scope for `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs` before any mechanical moves.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step1.md`
+- `scripts/ci/review-wave44-evaluate-kernel-step1.sh`
+
+## Non-goals
+
+- no changes under `crates/assay-core/src/mcp/tool_call_handler/**`
+- no changes under `crates/assay-core/tests/**`
+- no workflow changes
+- no payload-shape drift
+- no reason-code drift
+- no obligation-normalization drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave44-evaluate-kernel-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval_required_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::restrict_scope_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::redact_args_target_missing_denies' -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -q -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
+cargo test -q -p assay-core --test replay_diff_contract classify_replay_diff_unchanged -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm diff is only the 5 Step1 files.
+2. Confirm workflow-ban and source/test subtree bans exist in the script.
+3. Confirm targeted tests are pinned with `--exact`.
+4. Confirm Step2 preview is module-cut only, not redesign.
+5. Run reviewer script and expect PASS.

--- a/scripts/ci/review-wave44-evaluate-kernel-step1.sh
+++ b/scripts/ci/review-wave44-evaluate-kernel-step1.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+line_count() {
+  wc -l < "$1" | tr -d '[:space:]'
+}
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step1.md"
+  "scripts/ci/review-wave44-evaluate-kernel-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban, tool_call_handler ban, tests ban)"
+
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave44 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave44 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^crates/assay-core/src/mcp/tool_call_handler/' >/dev/null; then
+  echo "FAIL: Wave44 Step1 must not change crates/assay-core/src/mcp/tool_call_handler/**"
+  exit 1
+fi
+
+if git diff --name-only "$BASE_REF"...HEAD | rg -n '^crates/assay-core/tests/' >/dev/null; then
+  echo "FAIL: Wave44 Step1 must not change crates/assay-core/tests/**"
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- 'crates/assay-core/src/mcp/tool_call_handler/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under crates/assay-core/src/mcp/tool_call_handler/** are not allowed in Wave44 Step1"
+  git ls-files --others --exclude-standard -- 'crates/assay-core/src/mcp/tool_call_handler/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+if git ls-files --others --exclude-standard -- 'crates/assay-core/tests/**' | rg -n '.' >/dev/null; then
+  echo "FAIL: untracked files under crates/assay-core/tests/** are not allowed in Wave44 Step1"
+  git ls-files --others --exclude-standard -- 'crates/assay-core/tests/**' | sed 's/^/  - /'
+  exit 1
+fi
+
+echo "[review] no-drift baseline"
+[[ "$(line_count crates/assay-core/src/mcp/tool_call_handler/evaluate.rs)" == "1016" ]] || {
+  echo "FAIL: evaluate.rs LOC drifted during Step1"
+  exit 1
+}
+[[ "$(line_count crates/assay-core/src/mcp/tool_call_handler/tests.rs)" == "1242" ]] || {
+  echo "FAIL: tool_call_handler/tests.rs LOC drifted during Step1"
+  exit 1
+}
+[[ "$(line_count crates/assay-core/tests/decision_emit_invariant.rs)" == "1293" ]] || {
+  echo "FAIL: decision_emit_invariant.rs LOC drifted during Step1"
+  exit 1
+}
+[[ "$(line_count crates/assay-core/tests/fulfillment_normalization.rs)" == "165" ]] || {
+  echo "FAIL: fulfillment_normalization.rs LOC drifted during Step1"
+  exit 1
+}
+[[ "$(line_count crates/assay-core/tests/replay_diff_contract.rs)" == "382" ]] || {
+  echo "FAIL: replay_diff_contract.rs LOC drifted during Step1"
+  exit 1
+}
+[[ "$(line_count crates/assay-core/tests/tool_taxonomy_policy_match.rs)" == "133" ]] || {
+  echo "FAIL: tool_taxonomy_policy_match.rs LOC drifted during Step1"
+  exit 1
+}
+
+echo "[review] gates"
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval_required_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::restrict_scope_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::redact_args_target_missing_denies' -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -q -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
+cargo test -q -p assay-core --test replay_diff_contract classify_replay_diff_unchanged -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave44 Step1 freeze docs for `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`
- pin the Step2 preview split into approval/scope/redaction/fail_closed/classification modules
- add an allowlist-only reviewer script with no-drift LOC checks and pinned contract tests

## Scope
- docs/gates only
- no edits under `crates/assay-core/src/mcp/tool_call_handler/**`
- no edits under `crates/assay-core/tests/**`
- no workflow changes

## Validation
- `git diff --check`
- `BASE_REF=origin/main bash scripts/ci/review-wave44-evaluate-kernel-step1.sh`
