### PR TITLE
docs: close wave44 evaluate split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step3.md
@@ -1,0 +1,30 @@
+# Wave44 Evaluate Kernel Step3 Checklist (Closure)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step3.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step3.md`
+  - `scripts/ci/review-wave44-evaluate-kernel-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-core/src/mcp/tool_call_handler/**`
+- [ ] No edits under `crates/assay-core/tests/**`
+- [ ] No new module proposals beyond the shipped Step2 layout
+
+## Step3 closure contract
+
+- [ ] Step2 is recorded as shipped behind a stable facade
+- [ ] Step3 is explicitly bounded to micro-cleanup only
+- [ ] `evaluate.rs` remains the stable entry/routing facade
+- [ ] `evaluate_next/*` remains the split implementation ownership boundary
+- [ ] No deny-path, fulfillment, or replay drift is allowed in Step3
+- [ ] No public handler surface expansion is proposed in Step3
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave44-evaluate-kernel-step3.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core --all-targets -- -D warnings` passes
+- [ ] Pinned approval/taxonomy/fulfillment/replay invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step3.md
@@ -1,0 +1,41 @@
+# SPLIT-MOVE-MAP — Wave44 Step3 — `mcp/tool_call_handler/evaluate.rs`
+
+## Goal
+
+Close the shipped Wave44 Step2 split without reopening `tool_call_handler/**` code movement.
+
+## Shipped layout (frozen for Step3)
+
+- `crates/assay-core/src/mcp/tool_call_handler/mod.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/mod.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/approval.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/scope.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/redaction.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/fail_closed.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate_next/classification.rs`
+
+## Ownership freeze
+
+- `evaluate.rs` remains the stable facade and `handle_tool_call(...)` entrypoint.
+- `evaluate_next/approval.rs` remains the approval enforcement boundary.
+- `evaluate_next/scope.rs` remains the restrict-scope enforcement boundary.
+- `evaluate_next/redaction.rs` remains the redact-args enforcement boundary.
+- `evaluate_next/fail_closed.rs` remains the fail-closed helper boundary.
+- `evaluate_next/classification.rs` remains the request/resource/classification helper boundary.
+
+## Allowed Step3 follow-up
+
+- internal visibility tightening only if it requires no code edits in this wave
+- docs/review-pack clarification only
+- reviewer gate tightening only
+
+## Forbidden Step3 drift
+
+- edits to `crates/assay-core/src/mcp/tool_call_handler/**`
+- edits to `crates/assay-core/tests/**`
+- payload-shape changes
+- deny-path redesign
+- fulfillment normalization changes
+- replay classification changes
+- new module splits or ownership reshuffles

--- a/docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md
+++ b/docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md
@@ -95,7 +95,37 @@ Current Step2 shape:
 
 ## Step3 (closure)
 
-Docs+gate-only closure slice that re-runs Step2 invariants and limits any follow-up to micro-cleanup only.
+Branch: `codex/wave44-evaluate-kernel-step3` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step3.md`
+- `scripts/ci/review-wave44-evaluate-kernel-step3.sh`
+
+Step3 constraints:
+- docs+gate only
+- no edits under `crates/assay-core/src/mcp/tool_call_handler/**`
+- no edits under `crates/assay-core/tests/**`
+- no workflow edits
+- no new module cuts
+- no behavior cleanup beyond internal follow-up notes
+
+Step3 gate:
+- allowlist-only diff (the 5 Step3 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail on tracked changes in `crates/assay-core/src/mcp/tool_call_handler/**`
+- hard fail on untracked files in `crates/assay-core/src/mcp/tool_call_handler/**`
+- hard fail on tracked changes in `crates/assay-core/tests/**`
+- hard fail on untracked files in `crates/assay-core/tests/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- targeted tests:
+  - `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval_required_missing_denies' -- --exact`
+  - `cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact`
+  - `cargo test -q -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact`
+  - `cargo test -q -p assay-core --test replay_diff_contract classify_replay_diff_unchanged -- --exact`
 
 ## Promote
 
@@ -105,3 +135,23 @@ Stacked chain:
 - Step3 -> Step2
 
 Final promote PR to `main` from Step3 once the chain is clean.
+
+## Shipped status
+
+Wave44 Step2 shipped on `main` via `#958`.
+
+Wave44 Step3 is intentionally smaller:
+- close the split with docs/gates that forbid redesign drift
+- keep `evaluate.rs` as the stable facade entrypoint
+- keep `evaluate_next/*` as the split implementation ownership boundary
+- bound any follow-up to micro-cleanup only
+
+## Reviewer notes
+
+This wave must remain evaluate-kernel closure only.
+
+Primary failure modes:
+- sneaking new `tool_call_handler/**` edits into a closure slice
+- expanding Step3 into another code refactor
+- loosening deny/fulfillment/replay invariants after Step2 shipped
+- proposing new module cuts before the split has had time to harden on `main`

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step3.md
@@ -1,0 +1,46 @@
+# Wave44 Evaluate Kernel Step3 Review Pack (Closure)
+
+## Intent
+
+Close the shipped Wave44 evaluate-kernel split with docs/gates only and forbid redesign drift after Step2 landed on `main`.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step3.md`
+- `scripts/ci/review-wave44-evaluate-kernel-step3.sh`
+
+## Non-goals
+
+- no workflow changes
+- no changes under `crates/assay-core/src/mcp/tool_call_handler/**`
+- no changes under `crates/assay-core/tests/**`
+- no new module cuts
+- no deny/fulfillment/replay redesign
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave44-evaluate-kernel-step3.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval_required_missing_denies' -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -q -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
+cargo test -q -p assay-core --test replay_diff_contract classify_replay_diff_unchanged -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step3 allowlist.
+2. Confirm `tool_call_handler/**` and `crates/assay-core/tests/**` are completely frozen in this wave.
+3. Confirm the plan records `#958` as shipped and bounds Step3 to closure only.
+4. Confirm the move-map only freezes ownership and does not propose another split.
+5. Confirm the reviewer script re-runs the pinned approval/taxonomy/fulfillment/replay invariants.

--- a/scripts/ci/review-wave44-evaluate-kernel-step3.sh
+++ b/scripts/ci/review-wave44-evaluate-kernel-step3.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave44-evaluate-kernel-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave44-evaluate-kernel-step3.md"
+  "scripts/ci/review-wave44-evaluate-kernel-step3.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp/tool_call_handler"
+  "crates/assay-core/tests"
+  "crates/assay-cli/src/cli/commands"
+  "crates/assay-mcp-server"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave44 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave44 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave44 Step3 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave44-evaluate-kernel.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave44-evaluate-kernel-step3.md"
+
+for marker in \
+  'Wave44 Step2 shipped on `main` via `#958`.' \
+  'keep `evaluate.rs` as the stable facade entrypoint' \
+  'Step3 constraints:' \
+  'no new module cuts' \
+  'no behavior cleanup beyond internal follow-up notes'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-core/src/mcp/tool_call_handler/evaluate.rs' \
+  'crates/assay-core/src/mcp/tool_call_handler/evaluate_next/classification.rs' \
+  'internal visibility tightening only if it requires no code edits in this wave' \
+  'replay classification changes'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+
+echo "[review] pinned evaluate invariants"
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval_required_missing_denies' -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -q -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
+cargo test -q -p assay-core --test replay_diff_contract classify_replay_diff_unchanged -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave44 Step3 closure artifacts for the shipped evaluate split
- tighten reviewer gates so Step3 stays docs/gates only
- freeze follow-up work to micro-cleanup only after `#958`

## Validation
- git diff --check
- BASE_REF=origin/main bash scripts/ci/review-wave44-evaluate-kernel-step3.sh
