### PR TITLE
docs: freeze wave45 policy split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step1.md
@@ -1,0 +1,31 @@
+# Wave45 Policy Engine Step1 Checklist (Freeze)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave45-policy-engine.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step1.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step1.md`
+  - `scripts/ci/review-wave45-policy-engine-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-core/src/mcp/policy/**`
+- [ ] No edits under `crates/assay-core/tests/**`
+- [ ] No handler / decision / evidence / CLI changes
+
+## Frozen contract
+
+- [ ] `McpPolicy::{evaluate,evaluate_with_metadata,check}` are explicitly frozen as the stable facade
+- [ ] No allow/deny outcome drift is allowed in Step2
+- [ ] No precedence / specificity drift is allowed in Step2
+- [ ] No default / fail-closed drift is allowed in Step2
+- [ ] No reason-code or policy-code drift is allowed in Step2
+- [ ] No downstream decision-event metadata drift is allowed in Step2
+- [ ] Step2 non-goals explicitly forbid policy-language redesign, optimization, or test reorganization
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave45-policy-engine-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core --all-targets -- -D warnings` passes
+- [ ] Pinned policy/taxonomy/decision-event invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step1.md
@@ -1,0 +1,69 @@
+# SPLIT-MOVE-MAP — Wave45 Step1 — `mcp/policy/engine.rs`
+
+## Goal
+
+Freeze the split boundaries for `crates/assay-core/src/mcp/policy/engine.rs` before any
+mechanical module moves.
+
+## Planned Step2 layout
+
+- `crates/assay-core/src/mcp/policy/engine.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/matcher.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/effects.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/precedence.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/diagnostics.rs`
+
+## Mapping preview
+
+- `engine.rs` keeps the stable routing surface for `evaluate_with_metadata(...)` and `check(...)`.
+- `matcher.rs` is the planned home for tool/class matching helpers:
+  - `is_denied`
+  - `has_allowlist`
+  - `is_allowed`
+  - `matched_deny_classes`
+  - `matched_allow_classes`
+  - `match_classes`
+  - `classify_match_basis`
+  - `matched_rule_name`
+- `effects.rs` is the planned home for obligation capture and contract evaluation helpers:
+  - `apply_approval_required_obligation`
+  - `apply_restrict_scope_obligation`
+  - `apply_redact_args_obligation`
+  - `default_restrict_scope_contract`
+  - `default_redact_args_contract`
+  - `evaluate_restrict_scope_contract`
+  - `evaluate_redact_args_contract`
+  - `redaction_target_value`
+  - `can_apply_redaction`
+- `precedence.rs` is the planned home for allow/deny precedence helpers and rule ordering glue
+  extracted from `evaluate_with_metadata(...)`.
+- `fail_closed.rs` is the planned home for default/fallback handling:
+  - `check_rate_limits`
+  - unconstrained-tool fallback handling
+  - schema-missing / unsupported-path default behavior
+- `diagnostics.rs` is the planned home for metadata and explainability helpers:
+  - `finalize_evaluation`
+  - `format_deny_contract`
+  - `apply_delegation_context`
+  - `parse_delegation_context`
+
+## Frozen behavior boundaries
+
+- identical allow/deny outcomes
+- identical precedence behavior
+- identical fail-closed behavior
+- identical reason/policy codes
+- no drift in downstream decision/event contracts
+- no edits under `crates/assay-core/tests/**` in Step2
+
+## Test anchors to keep fixed in Step1
+
+- `policy_engine_test::test_mixed_tools_config`
+- `policy_engine_test::test_constraint_enforcement`
+- `tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class`
+- `tool_taxonomy_policy_match_handler_decision_event_records_classes`
+- `approval_required_missing_denies`
+- `restrict_scope_target_missing_denies`
+- `redact_args_target_missing_denies`
+- `mcp::policy::engine::tests::parse_delegation_context_uses_explicit_depth_only`

--- a/docs/contributing/SPLIT-PLAN-wave45-policy-engine.md
+++ b/docs/contributing/SPLIT-PLAN-wave45-policy-engine.md
@@ -1,0 +1,130 @@
+# Wave45 Plan — `mcp/policy/engine.rs` Kernel Split
+
+## Goal
+
+Split `crates/assay-core/src/mcp/policy/engine.rs` behind a stable facade with zero policy
+semantic drift and no downstream decision/event contract drift.
+
+Current hotspot baseline on `origin/main @ 7709a25f`:
+- `crates/assay-core/src/mcp/policy/engine.rs`: `799` LOC
+- `crates/assay-core/tests/policy_engine_test.rs`: `128` LOC
+- `crates/assay-core/tests/tool_taxonomy_policy_match.rs`: `118` LOC
+- `crates/assay-core/tests/decision_emit_invariant.rs`: `1293` LOC
+
+## Step1 (freeze)
+
+Branch: `codex/wave45-policy-engine-step1` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave45-policy-engine.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step1.md`
+- `scripts/ci/review-wave45-policy-engine-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-core/src/mcp/policy/**`
+- no edits under `crates/assay-core/tests/**`
+- no workflow edits
+- no handler / decision / evidence / CLI edits
+
+Step1 gate:
+- allowlist-only diff (the 5 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail on tracked changes in `crates/assay-core/src/mcp/policy/**`
+- hard fail on untracked files in `crates/assay-core/src/mcp/policy/**`
+- hard fail on tracked changes in `crates/assay-core/tests/**`
+- hard fail on untracked files in `crates/assay-core/tests/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- targeted tests:
+  - `cargo test -q -p assay-core --test policy_engine_test test_mixed_tools_config -- --exact`
+  - `cargo test -q -p assay-core --test policy_engine_test test_constraint_enforcement -- --exact`
+  - `cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class -- --exact`
+  - `cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact`
+  - `cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact`
+  - `cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact`
+  - `cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact`
+  - `cargo test -q -p assay-core --lib 'mcp::policy::engine::tests::parse_delegation_context_uses_explicit_depth_only' -- --exact`
+
+## Frozen public surface
+
+Wave45 freezes the expectation that Step2 keeps these stable policy entrypoints and consumer-facing
+contracts unchanged in meaning:
+- `McpPolicy::evaluate`
+- `McpPolicy::evaluate_with_metadata`
+- `McpPolicy::check`
+- `PolicyEvaluation`
+- `PolicyDecision`
+- `PolicyMatchMetadata`
+- `PolicyObligation`
+
+Step2 may reorganize internal ownership behind `engine.rs`, but must not redefine:
+- allow/deny outcomes
+- precedence / specificity handling
+- default / fail-closed behavior
+- reason-code or policy-code strings
+- metadata fields projected into downstream decision events
+
+## Step2 (mechanical split preview)
+
+Branch: `codex/wave45-policy-engine-step2` (base: `main`)
+
+Target layout:
+- `crates/assay-core/src/mcp/policy/engine.rs` (thin facade + stable routing)
+- `crates/assay-core/src/mcp/policy/engine_next/mod.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/matcher.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/effects.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/precedence.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/diagnostics.rs`
+
+Step2 scope:
+- `crates/assay-core/src/mcp/policy/engine.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/mod.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/matcher.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/effects.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/precedence.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/diagnostics.rs`
+- `docs/contributing/SPLIT-PLAN-wave45-policy-engine.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step2.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step2.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step2.md`
+- `scripts/ci/review-wave45-policy-engine-step2.sh`
+
+Step2 principles:
+- 1:1 body moves
+- stable `McpPolicy::{evaluate,evaluate_with_metadata,check}` behavior
+- no allow/deny drift
+- no precedence or specificity drift
+- no default / fail-closed drift
+- no reason-code renames
+- no metadata projection drift into downstream decision events
+- no edits under `crates/assay-core/tests/**`
+- no workflow edits
+
+## Step3 (closure)
+
+Docs+gate-only closure slice that re-runs Step2 invariants and limits any follow-up to
+micro-cleanup only.
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once the chain is clean.
+
+## Reviewer notes
+
+This wave must remain policy-engine split planning only.
+
+Primary failure modes:
+- sneaking semantic cleanup into a mechanical split
+- changing precedence or fail-closed behavior while chasing file size
+- renaming reason/policy codes under a refactor label
+- leaking scope into handler, decision, evidence, or CLI surfaces

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step1.md
@@ -1,0 +1,52 @@
+# Wave45 Policy Engine Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze the Wave45 policy-engine split before any implementation moves in
+`crates/assay-core/src/mcp/policy/engine.rs`.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave45-policy-engine.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step1.md`
+- `scripts/ci/review-wave45-policy-engine-step1.sh`
+
+## Non-goals
+
+- no workflow changes
+- no changes under `crates/assay-core/src/mcp/policy/**`
+- no changes under `crates/assay-core/tests/**`
+- no policy-language redesign
+- no matcher/precedence optimization wave
+- no handler / decision / evidence / CLI drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave45-policy-engine-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -q -p assay-core --test policy_engine_test test_mixed_tools_config -- --exact
+cargo test -q -p assay-core --test policy_engine_test test_constraint_enforcement -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --lib 'mcp::policy::engine::tests::parse_delegation_context_uses_explicit_depth_only' -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step1 allowlist.
+2. Confirm `crates/assay-core/src/mcp/policy/**` and `crates/assay-core/tests/**` are untouched.
+3. Confirm the plan freezes `McpPolicy::{evaluate,evaluate_with_metadata,check}` as the stable facade.
+4. Confirm the move-map pins matching/effects/precedence/fail-closed/diagnostics as the intended Step2 seams.
+5. Confirm the reviewer script re-runs direct policy-engine tests plus downstream event-coupling tests.

--- a/scripts/ci/review-wave45-policy-engine-step1.sh
+++ b/scripts/ci/review-wave45-policy-engine-step1.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave45-policy-engine.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step1.md"
+  "scripts/ci/review-wave45-policy-engine-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp/policy"
+  "crates/assay-core/tests"
+  "crates/assay-core/src/mcp/tool_call_handler"
+  "crates/assay-core/src/mcp/decision.rs"
+  "crates/assay-evidence"
+  "crates/assay-cli/src/cli/commands"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave45 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave45 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave45 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave45-policy-engine.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step1.md"
+
+for marker in \
+  'Split `crates/assay-core/src/mcp/policy/engine.rs` behind a stable facade' \
+  'McpPolicy::evaluate_with_metadata' \
+  'Step2 principles:' \
+  'no precedence or specificity drift' \
+  'no handler / decision / evidence / CLI edits'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-core/src/mcp/policy/engine_next/matcher.rs' \
+  'crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs' \
+  'identical fail-closed behavior' \
+  'tool_taxonomy_policy_match_handler_decision_event_records_classes'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+
+echo "[review] pinned policy invariants"
+cargo test -q -p assay-core --test policy_engine_test test_mixed_tools_config -- --exact
+cargo test -q -p assay-core --test policy_engine_test test_constraint_enforcement -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --lib 'mcp::policy::engine::tests::parse_delegation_context_uses_explicit_depth_only' -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave45 Step1 freeze artifacts for the policy engine hotspot
- pin policy/matching/fail-closed invariants before any code movement
- bound the future split to a mechanical `engine_next/*` refactor behind the stable facade

## Validation
- git diff --check
- BASE_REF=origin/main bash scripts/ci/review-wave45-policy-engine-step1.sh
