### PR TITLE
docs: close wave45 policy split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step3.md
@@ -1,0 +1,30 @@
+# Wave45 Policy Engine Step3 Checklist (Closure)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave45-policy-engine.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step3.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step3.md`
+  - `scripts/ci/review-wave45-policy-engine-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-core/src/mcp/policy/**`
+- [ ] No edits under `crates/assay-core/tests/**`
+- [ ] No new module proposals beyond the shipped Step2 layout
+
+## Step3 closure contract
+
+- [ ] Step2 is recorded as shipped behind a stable facade
+- [ ] Step3 is explicitly bounded to micro-cleanup only
+- [ ] `engine.rs` remains the stable facade entrypoint
+- [ ] `engine_next/*` remains the split implementation ownership boundary
+- [ ] No allow/deny, precedence, fail-closed, or decision-contract drift is allowed in Step3
+- [ ] No public policy surface expansion is proposed in Step3
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave45-policy-engine-step3.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-core --all-targets -- -D warnings` passes
+- [ ] Pinned policy invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step3.md
@@ -1,0 +1,41 @@
+# SPLIT-MOVE-MAP — Wave45 Step3 — `mcp/policy/engine.rs` Closure
+
+## Shipped layout
+
+Wave45 Step2 is now the shipped split shape on `main`:
+- `crates/assay-core/src/mcp/policy/engine.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/mod.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/matcher.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/effects.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/precedence.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs`
+- `crates/assay-core/src/mcp/policy/engine_next/diagnostics.rs`
+
+## Ownership freeze
+
+- `crates/assay-core/src/mcp/policy/engine.rs`
+  remains the stable facade for policy entrypoints and top-level routing.
+- `crates/assay-core/src/mcp/policy/engine_next/matcher.rs`
+  remains the matching helper boundary.
+- `crates/assay-core/src/mcp/policy/engine_next/effects.rs`
+  remains the obligation and contract-evaluation boundary.
+- `crates/assay-core/src/mcp/policy/engine_next/precedence.rs`
+  remains the ordering and allow/deny precedence boundary.
+- `crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs`
+  remains the fail-closed and fallback boundary.
+- `crates/assay-core/src/mcp/policy/engine_next/diagnostics.rs`
+  remains the metadata finalization and delegation parsing boundary.
+
+## Allowed follow-up after closure
+
+- documentation updates only
+- reviewer-gate tightening only
+- internal visibility tightening only if it requires no code edits in this wave
+
+## Explicitly deferred
+
+- new module cuts
+- matcher or DSL redesign
+- allow/deny or fail-closed behavior cleanup
+- reason-code or precedence changes
+- handler, decision, evidence, or CLI coupling changes

--- a/docs/contributing/SPLIT-PLAN-wave45-policy-engine.md
+++ b/docs/contributing/SPLIT-PLAN-wave45-policy-engine.md
@@ -115,8 +115,18 @@ Current Step2 shape:
 
 ## Step3 (closure)
 
-Docs+gate-only closure slice that re-runs Step2 invariants and limits any follow-up to
-micro-cleanup only.
+Wave45 Step2 shipped on `main` via `#961`.
+
+Step3 constraints keep `engine.rs` as the stable facade entrypoint and treat `engine_next/*` as
+the shipped split ownership boundary.
+
+Step3 constraints:
+- docs+gate only
+- no edits under `crates/assay-core/src/mcp/policy/**`
+- no edits under `crates/assay-core/tests/**`
+- no new module cuts
+- no behavior cleanup beyond internal follow-up notes
+- no allow/deny, precedence, fail-closed, or decision-contract drift
 
 ## Promote
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step3.md
@@ -1,0 +1,51 @@
+# Wave45 Policy Engine Step3 Review Pack (Closure)
+
+## Intent
+
+Close the shipped Wave45 policy-engine split with docs/gates only and forbid post-Step2 redesign drift.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave45-policy-engine.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step3.md`
+- `scripts/ci/review-wave45-policy-engine-step3.sh`
+
+## Non-goals
+
+- no workflow changes
+- no changes under `crates/assay-core/src/mcp/policy/**`
+- no changes under `crates/assay-core/tests/**`
+- no new module cuts
+- no policy redesign
+- no allow/deny, precedence, or fail-closed drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave45-policy-engine-step3.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -q -p assay-core --test policy_engine_test test_mixed_tools_config -- --exact
+cargo test -q -p assay-core --test policy_engine_test test_constraint_enforcement -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --lib 'mcp::policy::engine::tests::parse_delegation_context_uses_explicit_depth_only' -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step3 allowlist.
+2. Confirm `crates/assay-core/src/mcp/policy/**` and `crates/assay-core/tests/**` are frozen in this wave.
+3. Confirm the plan records `#961` as shipped and bounds Step3 to closure only.
+4. Confirm the move-map freezes the current module ownership and does not propose another split.
+5. Confirm the reviewer script re-runs the pinned policy invariants.

--- a/scripts/ci/review-wave45-policy-engine-step3.sh
+++ b/scripts/ci/review-wave45-policy-engine-step3.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave45-policy-engine.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave45-policy-engine-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave45-policy-engine-step3.md"
+  "scripts/ci/review-wave45-policy-engine-step3.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp/policy"
+  "crates/assay-core/tests"
+  "crates/assay-core/src/mcp/tool_call_handler"
+  "crates/assay-cli/src/cli/commands"
+  "crates/assay-evidence"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave45 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave45 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave45 Step3 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave45-policy-engine.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave45-policy-engine-step3.md"
+
+for marker in \
+  'Wave45 Step2 shipped on `main` via `#961`.' \
+  'keep `engine.rs` as the stable facade entrypoint' \
+  'Step3 constraints:' \
+  'no new module cuts' \
+  'no behavior cleanup beyond internal follow-up notes'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-core/src/mcp/policy/engine.rs' \
+  'crates/assay-core/src/mcp/policy/engine_next/precedence.rs' \
+  'crates/assay-core/src/mcp/policy/engine_next/fail_closed.rs' \
+  'internal visibility tightening only if it requires no code edits in this wave' \
+  'reason-code or precedence changes'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-core --all-targets -- -D warnings
+
+echo "[review] pinned policy invariants"
+cargo test -q -p assay-core --test policy_engine_test test_mixed_tools_config -- --exact
+cargo test -q -p assay-core --test policy_engine_test test_constraint_enforcement -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class -- --exact
+cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --lib 'mcp::policy::engine::tests::parse_delegation_context_uses_explicit_depth_only' -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- close Wave45 with a docs/gates-only Step3 slice
- record Wave45 Step2 as shipped on `main` behind the stable `engine.rs` facade
- add the closure checklist, move-map, review pack, and reviewer script for the policy split

## Validation
- `git diff --check`
- `BASE_REF=origin/main bash scripts/ci/review-wave45-policy-engine-step3.sh`
