### PR TITLE
docs: freeze wave46 pack schema split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step1.md
@@ -1,0 +1,30 @@
+# Wave46 Pack Schema Step1 Checklist (Freeze)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave46-pack-schema.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step1.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step1.md`
+  - `scripts/ci/review-wave46-pack-schema-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-evidence/src/lint/packs/**`
+- [ ] No edits under `crates/assay-evidence/tests/**`
+- [ ] No edits under `packs/open/**`
+
+## Step1 freeze contract
+
+- [ ] `schema.rs` is explicitly identified as the first `R4` target
+- [ ] `checks.rs` is explicitly deferred until after the schema split
+- [ ] `json_path_exists` / `value_equals` rules are frozen
+- [ ] conditional validation and unsupported-shape boundaries are frozen
+- [ ] built-in/open pack loadability and parity are frozen
+- [ ] parsing / validation error categories and reason strings are treated as contract-sensitive
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave46-pack-schema-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-evidence --all-targets -- -D warnings` passes
+- [ ] targeted schema / conditional / loader parity tests pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step1.md
@@ -1,0 +1,41 @@
+# SPLIT-MOVE-MAP — Wave46 Step1 — `lint/packs/schema.rs`
+
+## Goal
+
+Freeze the pack-schema contract before any mechanical split of
+`crates/assay-evidence/src/lint/packs/schema.rs`.
+
+## Current hotspot boundary
+
+- `crates/assay-evidence/src/lint/packs/schema.rs`
+  currently co-locates pack metadata types, serde shape, validation rules, conditional support,
+  and validation error semantics.
+- `crates/assay-evidence/src/lint/packs/checks.rs`
+  consumes these definitions and `checks.rs` is explicitly **out of scope** for this wave.
+
+## Frozen behavior boundaries
+
+- pack YAML/schema parse and validation behavior
+- `json_path_exists` contract
+- `json_path_exists.value_equals` single-path rule
+- conditional-shape validation and unsupported-shape classification
+- built-in/open pack loadability and parity assumptions
+- validation error category and reason-string meaning
+- spec coupling around engine/schema version requirements
+
+## Intended Step2 ownership split
+
+- `schema.rs`: thin facade and stable exports
+- `schema_next/types.rs`: pack metadata and rule types
+- `schema_next/serde.rs`: serde helpers and compatibility parsing
+- `schema_next/validation.rs`: pack/rule validation orchestration
+- `schema_next/conditional.rs`: supported conditional subset parsing
+- `schema_next/errors.rs`: validation error types and reason helpers
+
+## Explicitly deferred
+
+- `crates/assay-evidence/src/lint/packs/checks.rs`
+- pack execution/runtime check logic
+- loader precedence redesign
+- built-in or open-pack content changes
+- spec or release-floor changes

--- a/docs/contributing/SPLIT-PLAN-wave46-pack-schema.md
+++ b/docs/contributing/SPLIT-PLAN-wave46-pack-schema.md
@@ -1,0 +1,135 @@
+# Wave46 Plan — `lint/packs/schema.rs` Kernel Split
+
+## Goal
+
+Split `crates/assay-evidence/src/lint/packs/schema.rs` behind a stable schema facade with zero pack
+validation drift and no built-in/open pack compatibility drift.
+
+Current hotspot baseline on `origin/main @ ee9cd502`:
+- `crates/assay-evidence/src/lint/packs/schema.rs`: `844` LOC
+- `crates/assay-evidence/src/lint/packs/checks.rs`: `785` LOC
+- `crates/assay-evidence/tests/pack_engine_conditional_test.rs`: contract companion
+- `crates/assay-evidence/tests/a2a_discovery_card_followup_pack.rs`: built-in/open parity companion
+- `crates/assay-evidence/tests/mcp_signal_followup_pack.rs`: built-in/open parity companion
+
+## Step1 (freeze)
+
+Branch: `codex/wave46-pack-schema-step1` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave46-pack-schema.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step1.md`
+- `scripts/ci/review-wave46-pack-schema-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-evidence/src/lint/packs/**`
+- no edits under `crates/assay-evidence/tests/**`
+- no edits under `packs/open/**`
+- no workflow edits
+- no loader/check execution changes
+
+Step1 gate:
+- allowlist-only diff (the 5 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail on tracked changes in `crates/assay-evidence/src/lint/packs/**`
+- hard fail on untracked files in `crates/assay-evidence/src/lint/packs/**`
+- hard fail on tracked changes in `crates/assay-evidence/tests/**`
+- hard fail on untracked files in `crates/assay-evidence/tests/**`
+- hard fail on tracked changes in `packs/open/**`
+- hard fail on untracked files in `packs/open/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
+- targeted tests:
+  - `cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_is_valid_pack_name' -- --exact`
+  - `cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_builtin_wins_over_local' -- --exact`
+  - `cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_local_invalid_yaml_fails' -- --exact`
+  - `cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_path_wins_over_builtin' -- --exact`
+  - `cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_supported_conditional_shape_parses' -- --exact`
+  - `cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_with_multiple_then_paths_is_unsupported' -- --exact`
+  - `cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_condition_object' -- --exact`
+  - `cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_then_object' -- --exact`
+  - `cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_json_path_exists_value_equals_requires_exactly_one_path' -- --exact`
+  - `cargo test -q -p assay-evidence --test pack_engine_conditional_test conditional_rule_fails_when_matching_event_lacks_required_path -- --exact`
+  - `cargo test -q -p assay-evidence --test pack_engine_conditional_test json_path_exists_respects_event_types_filter -- --exact`
+  - `cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_still_skips_for_security_pack -- --exact`
+  - `cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_fails_for_compliance_pack -- --exact`
+  - `cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_discovery_builtin_and_open_pack_are_exactly_equivalent -- --exact`
+  - `cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp_followup_builtin_and_open_pack_are_exactly_equivalent -- --exact`
+
+## Frozen public surface
+
+Wave46 freezes the expectation that Step2 keeps these schema-layer types and contracts stable in
+meaning:
+- `PackDefinition`
+- `PackRequirements`
+- `PackRule`
+- `CheckDefinition`
+- `PackValidationError`
+- `SupportedConditionalCheck`
+- `SupportedConditionalClause`
+
+Step2 may reorganize internal ownership behind `schema.rs`, but must not redefine:
+- pack YAML parse/validation behavior
+- `json_path_exists` and `value_equals` validation rules
+- the single-path requirement for `value_equals`
+- conditional-shape acceptance vs unsupported classification
+- loader-visible built-in/open pack loadability and parity assumptions
+- validation error category or reason-string meaning
+
+## Step2 (mechanical split preview)
+
+Branch: `codex/wave46-pack-schema-step2` (base: `main`)
+
+Target layout:
+- `crates/assay-evidence/src/lint/packs/schema.rs` (thin facade + stable exports)
+- `crates/assay-evidence/src/lint/packs/schema_next/mod.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/types.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/serde.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/validation.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/conditional.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/errors.rs`
+
+Step2 scope:
+- `crates/assay-evidence/src/lint/packs/schema.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/*`
+- `docs/contributing/SPLIT-PLAN-wave46-pack-schema.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step2.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step2.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step2.md`
+- `scripts/ci/review-wave46-pack-schema-step2.sh`
+
+Step2 principles:
+- 1:1 body moves
+- stable schema types and validation behavior
+- no `json_path_exists` / `value_equals` drift
+- no conditional-shape or unsupported-path drift
+- no loader or built-in/open pack parity drift
+- no edits under `crates/assay-evidence/tests/**`
+- no workflow edits
+
+## Step3 (closure)
+
+Docs+gate-only closure slice that re-runs Step2 invariants and limits any follow-up to
+micro-cleanup only.
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once the chain is clean.
+
+## Reviewer notes
+
+This wave must remain pack-schema split planning only.
+
+Primary failure modes:
+- moving validation semantics while claiming a mechanical split
+- relaxing `json_path_exists.value_equals` or conditional-shape rules during decomposition
+- changing loader-visible pack acceptance behavior via schema-only churn
+- mixing `checks.rs` execution logic into the `schema.rs` wave

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step1.md
@@ -1,0 +1,58 @@
+# Wave46 Pack Schema Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze the pack-schema contract before any split of `crates/assay-evidence/src/lint/packs/schema.rs`.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave46-pack-schema.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step1.md`
+- `scripts/ci/review-wave46-pack-schema-step1.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-evidence/src/lint/packs/**`
+- no edits under `crates/assay-evidence/tests/**`
+- no edits under `packs/open/**`
+- no `checks.rs` split in this wave
+- no pack-engine semantic cleanup
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave46-pack-schema-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_is_valid_pack_name' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_builtin_wins_over_local' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_local_invalid_yaml_fails' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_path_wins_over_builtin' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_supported_conditional_shape_parses' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_with_multiple_then_paths_is_unsupported' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_condition_object' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_then_object' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_json_path_exists_value_equals_requires_exactly_one_path' -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test conditional_rule_fails_when_matching_event_lacks_required_path -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test json_path_exists_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_still_skips_for_security_pack -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_fails_for_compliance_pack -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_discovery_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp_followup_builtin_and_open_pack_are_exactly_equivalent -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step1 allowlist.
+2. Confirm `schema.rs`, `checks.rs`, test files, and open-pack content are frozen in this wave.
+3. Confirm the plan makes `schema.rs -> checks.rs` the required order.
+4. Confirm the move-map freezes `json_path_exists`, `value_equals`, conditional, and loader parity semantics.
+5. Confirm the reviewer script pins both schema-unit and pack-parity tests.

--- a/scripts/ci/review-wave46-pack-schema-step1.sh
+++ b/scripts/ci/review-wave46-pack-schema-step1.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+changed_files() {
+  {
+    git diff --name-only "$BASE_REF"...HEAD
+    git diff --name-only
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  } | awk 'NF' | sort -u
+}
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave46-pack-schema.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step1.md"
+  "scripts/ci/review-wave46-pack-schema-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban)"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave46 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave46 Step1: $f"
+    exit 1
+  fi
+done < <(changed_files)
+
+for frozen in 'crates/assay-evidence/src/lint/packs/**' 'crates/assay-evidence/tests/**' 'packs/open/**'; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$frozen" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave46 Step1 must not change frozen path: $frozen"
+    git diff --name-only "$BASE_REF"...HEAD -- "$frozen"
+    exit 1
+  fi
+  if git ls-files --others --exclude-standard -- "$frozen" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $frozen"
+    git ls-files --others --exclude-standard -- "$frozen" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave46-pack-schema.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step1.md"
+
+for marker in \
+  'schema.rs` Kernel Split' \
+  'checks.rs` is explicitly **out of scope** for this wave' \
+  'json_path_exists` and `value_equals` validation rules' \
+  'conditional-shape acceptance vs unsupported classification' \
+  'built-in/open pack loadability and parity assumptions'
+do
+  rg -F -n "$marker" "$PLAN" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+
+echo "[review] pinned schema invariants"
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_is_valid_pack_name' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_builtin_wins_over_local' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_local_invalid_yaml_fails' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_path_wins_over_builtin' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_supported_conditional_shape_parses' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_with_multiple_then_paths_is_unsupported' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_condition_object' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_then_object' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_json_path_exists_value_equals_requires_exactly_one_path' -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test conditional_rule_fails_when_matching_event_lacks_required_path -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test json_path_exists_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_still_skips_for_security_pack -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_fails_for_compliance_pack -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_discovery_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp_followup_builtin_and_open_pack_are_exactly_equivalent -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- freeze Wave46 Step1 for `crates/assay-evidence/src/lint/packs/schema.rs`
- pin schema, conditional, `json_path_exists`/`value_equals`, and built-in/open pack parity invariants
- add the Step1 checklist, move-map, review pack, and reviewer script for the pack-schema split

## Validation
- `git diff --check`
- `BASE_REF=origin/main bash scripts/ci/review-wave46-pack-schema-step1.sh`
