### PR TITLE
docs: close wave46 pack schema split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step3.md
@@ -1,0 +1,31 @@
+# Wave46 Pack Schema Step3 Checklist (Closure)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave46-pack-schema.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step3.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step3.md`
+  - `scripts/ci/review-wave46-pack-schema-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-evidence/src/lint/packs/**`
+- [ ] No edits under `crates/assay-evidence/tests/**`
+- [ ] No edits under `packs/open/**`
+- [ ] No new module proposals beyond the shipped Step2 layout
+
+## Step3 closure contract
+
+- [ ] Step2 is recorded as shipped behind a stable facade
+- [ ] Step3 is explicitly bounded to micro-cleanup only
+- [ ] `schema.rs` remains the stable facade entrypoint
+- [ ] `schema_next/*` remains the split implementation ownership boundary
+- [ ] No validation, conditional-shape, parity, or error-meaning drift is allowed in Step3
+- [ ] No public pack-schema surface expansion is proposed in Step3
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave46-pack-schema-step3.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-evidence --all-targets -- -D warnings` passes
+- [ ] Pinned schema/loader/parity invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step3.md
@@ -1,0 +1,42 @@
+# SPLIT-MOVE-MAP — Wave46 Step3 — `lint/packs/schema.rs` Closure
+
+## Shipped layout
+
+Wave46 Step2 is now the shipped split shape on `main`:
+- `crates/assay-evidence/src/lint/packs/schema.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/mod.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/types.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/serde.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/validation.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/conditional.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/errors.rs`
+
+## Ownership freeze
+
+- `crates/assay-evidence/src/lint/packs/schema.rs`
+  remains the stable facade for schema exports and inline contract tests.
+- `crates/assay-evidence/src/lint/packs/schema_next/types.rs`
+  remains the schema type-definition boundary.
+- `crates/assay-evidence/src/lint/packs/schema_next/serde.rs`
+  remains the pack severity serde helper boundary.
+- `crates/assay-evidence/src/lint/packs/schema_next/validation.rs`
+  remains the schema validation and pack-name grammar boundary.
+- `crates/assay-evidence/src/lint/packs/schema_next/conditional.rs`
+  remains the supported conditional subset parsing boundary.
+- `crates/assay-evidence/src/lint/packs/schema_next/errors.rs`
+  remains the validation error definition boundary.
+
+## Allowed follow-up after closure
+
+- documentation updates only
+- reviewer-gate tightening only
+- internal visibility tightening only if it requires no code edits in this wave
+
+## Explicitly deferred
+
+- new module cuts
+- schema or DSL redesign
+- `checks.rs` execution refactors
+- pack validation behavior cleanup
+- built-in/open parity changes
+- validation error or reason-meaning changes

--- a/docs/contributing/SPLIT-PLAN-wave46-pack-schema.md
+++ b/docs/contributing/SPLIT-PLAN-wave46-pack-schema.md
@@ -4,18 +4,18 @@
 
 Split `crates/assay-evidence/src/lint/packs/schema.rs` behind a stable facade so the pack-schema contract can be reviewed in smaller, responsibility-based modules without changing validation behavior.
 
-Current hotspot baseline on `origin/main @ dcac6383`:
-- `crates/assay-evidence/src/lint/packs/schema.rs`: `844` LOC
+Current hotspot baseline on `origin/main @ 23685893`:
+- `crates/assay-evidence/src/lint/packs/schema.rs`: `844` LOC before Step2, `245` LOC after Step2
 - `crates/assay-evidence/src/lint/packs/checks.rs`: `785` LOC
 - `crates/assay-evidence/tests/pack_engine_conditional_test.rs`: conditional contract companion
 - `crates/assay-evidence/tests/a2a_discovery_card_followup_pack.rs`: built-in/open parity companion
 - `crates/assay-evidence/tests/mcp_signal_followup_pack.rs`: built-in/open parity companion
 
-## Step sequence
+## Status
 
-1. Step1 freeze/gates only — merged on `main` via `#963`
-2. Step2 mechanical split to `schema_next/*`
-3. Step3 closure / micro-cleanup gates only
+- Wave46 Step1 merged on `main` via `#963`.
+- Wave46 Step2 shipped on `main` via `#964`.
+- Step3 is the closure slice that records the shipped split and forbids follow-on redesign drift in this wave.
 
 ## Frozen public surface
 
@@ -37,10 +37,9 @@ Step2 may reorganize internal ownership behind `schema.rs`, but must not redefin
 - loader-visible built-in/open pack loadability and parity assumptions
 - validation error category or reason-string meaning
 
-## Step2 scope
+## Shipped Step2 layout
 
-Allowed implementation files:
-- `crates/assay-evidence/src/lint/packs/schema.rs`
+- `crates/assay-evidence/src/lint/packs/schema.rs` keeps `schema.rs` as the stable facade entrypoint
 - `crates/assay-evidence/src/lint/packs/schema_next/mod.rs`
 - `crates/assay-evidence/src/lint/packs/schema_next/types.rs`
 - `crates/assay-evidence/src/lint/packs/schema_next/serde.rs`
@@ -48,35 +47,15 @@ Allowed implementation files:
 - `crates/assay-evidence/src/lint/packs/schema_next/conditional.rs`
 - `crates/assay-evidence/src/lint/packs/schema_next/errors.rs`
 
-Allowed review artifacts:
-- `docs/contributing/SPLIT-PLAN-wave46-pack-schema.md`
-- `docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step2.md`
-- `docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step2.md`
-- `docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step2.md`
-- `scripts/ci/review-wave46-pack-schema-step2.sh`
+## Step3 constraints
 
-Step2 principles:
-- 1:1 body moves
-- stable schema types and validation behavior
-- no `json_path_exists` / `value_equals` drift
-- no conditional-shape or unsupported-path drift
-- no loader or built-in/open pack parity drift
+- docs+gates only
+- no edits under `crates/assay-evidence/src/lint/packs/**`
 - no edits under `crates/assay-evidence/tests/**`
 - no edits under `packs/open/**`
 - no workflow edits
-
-Target layout:
-- `schema.rs` as thin facade + stable exports + existing inline tests
-- `schema_next/types.rs`
-- `schema_next/serde.rs`
-- `schema_next/validation.rs`
-- `schema_next/conditional.rs`
-- `schema_next/errors.rs`
-
-## Step3 (closure)
-
-Docs+gate-only closure slice that re-runs Step2 invariants and limits any follow-up to
-micro-cleanup only.
+- no new module cuts
+- no behavior cleanup beyond internal follow-up notes
 
 ## Reviewer notes
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step3.md
@@ -1,0 +1,58 @@
+# Wave46 Pack Schema Step3 Review Pack (Closure)
+
+## Intent
+
+Close the shipped Wave46 pack-schema split with docs/gates only and forbid post-Step2 redesign drift.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave46-pack-schema.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step3.md`
+- `scripts/ci/review-wave46-pack-schema-step3.sh`
+
+## Non-goals
+
+- no workflow changes
+- no changes under `crates/assay-evidence/src/lint/packs/**`
+- no changes under `crates/assay-evidence/tests/**`
+- no changes under `packs/open/**`
+- no new module cuts
+- no schema validation, conditional-shape, parity, or error-meaning drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave46-pack-schema-step3.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_is_valid_pack_name' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_builtin_wins_over_local' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_local_invalid_yaml_fails' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_path_wins_over_builtin' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_supported_conditional_shape_parses' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_with_multiple_then_paths_is_unsupported' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_condition_object' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_then_object' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_json_path_exists_value_equals_requires_exactly_one_path' -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test conditional_rule_fails_when_matching_event_lacks_required_path -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test json_path_exists_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_still_skips_for_security_pack -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_fails_for_compliance_pack -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_discovery_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp_followup_builtin_and_open_pack_are_exactly_equivalent -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step3 allowlist.
+2. Confirm `crates/assay-evidence/src/lint/packs/**`, `crates/assay-evidence/tests/**`, and `packs/open/**` are frozen in this wave.
+3. Confirm the plan records `#964` as shipped and bounds Step3 to closure only.
+4. Confirm the move-map freezes the current module ownership and does not propose another split.
+5. Confirm the reviewer script re-runs the pinned schema/loader/parity invariants.

--- a/scripts/ci/review-wave46-pack-schema-step3.sh
+++ b/scripts/ci/review-wave46-pack-schema-step3.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave46-pack-schema.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave46-pack-schema-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave46-pack-schema-step3.md"
+  "scripts/ci/review-wave46-pack-schema-step3.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-evidence/src/lint/packs"
+  "crates/assay-evidence/tests"
+  "packs/open"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r file; do
+  [[ -z "${file:-}" ]] && continue
+
+  if [[ "$file" == .github/workflows/* ]]; then
+    echo "FAIL: Wave46 Step3 must not touch workflows ($file)"
+    exit 1
+  fi
+
+  ok="false"
+  for allowed in "${ALLOWLIST[@]}"; do
+    [[ "$file" == "$allowed" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave46 Step3: $file"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for path in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$path" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave46 Step3 must not change frozen path: $path"
+    git diff --name-only "$BASE_REF"...HEAD -- "$path"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for path in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$path" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $path"
+    git ls-files --others --exclude-standard -- "$path" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave46-pack-schema.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave46-pack-schema-step3.md"
+
+for marker in \
+  'Wave46 Step2 shipped on `main` via `#964`.' \
+  'keeps `schema.rs` as the stable facade entrypoint' \
+  'Step3 constraints' \
+  'no new module cuts' \
+  'no behavior cleanup beyond internal follow-up notes'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-evidence/src/lint/packs/schema.rs' \
+  'crates/assay-evidence/src/lint/packs/schema_next/conditional.rs' \
+  'crates/assay-evidence/src/lint/packs/schema_next/errors.rs' \
+  'internal visibility tightening only if it requires no code edits in this wave' \
+  'validation error or reason-meaning changes'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+
+echo "[review] pinned schema invariants"
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_is_valid_pack_name' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_builtin_wins_over_local' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_local_invalid_yaml_fails' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::loader::loader_internal::tests::test_path_wins_over_builtin' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_supported_conditional_shape_parses' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_with_multiple_then_paths_is_unsupported' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_condition_object' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_conditional_validation_requires_then_object' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_json_path_exists_value_equals_requires_exactly_one_path' -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test conditional_rule_fails_when_matching_event_lacks_required_path -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test json_path_exists_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_still_skips_for_security_pack -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_fails_for_compliance_pack -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_discovery_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp_followup_builtin_and_open_pack_are_exactly_equivalent -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- record Wave46 Step2 as shipped on `main` via `#964`
- add Wave46 Step3 closure checklist, move-map, review pack, and reviewer gate
- keep Step3 docs/gates only with no edits under `crates/assay-evidence/src/lint/packs/**`, tests, or `packs/open/**`

## Validation
- `git diff --check`
- `BASE_REF=origin/main bash scripts/ci/review-wave46-pack-schema-step3.sh`

## Closure focus
- keep `schema.rs` as the stable facade entrypoint
- keep `schema_next/*` as the shipped ownership boundary
- forbid new module cuts or post-Step2 schema behavior drift in this wave
