### PR TITLE
docs: freeze wave47 pack checks split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step1.md
@@ -1,0 +1,32 @@
+# Wave47 Pack Checks Step1 Checklist (Freeze)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave47-pack-checks.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step1.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step1.md`
+  - `scripts/ci/review-wave47-pack-checks-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-evidence/src/lint/packs/**`
+- [ ] No edits under `crates/assay-evidence/tests/**`
+- [ ] No edits under `packs/open/**`
+
+## Frozen contract
+
+- [ ] `CheckContext`, `CheckResult`, `ENGINE_VERSION`, and `execute_check` are explicitly frozen as the stable facade
+- [ ] No check-dispatch drift is allowed in Step2
+- [ ] No `json_path_exists` / `value_equals` runtime drift is allowed in Step2
+- [ ] No single-path `value_equals` invariant drift is allowed in Step2
+- [ ] No `event_type_exists`, `event_field_present`, `conditional`, or `g3_authorization_context_present` scoped-event drift is allowed in Step2
+- [ ] No finding severity / rule-id / explanation coupling drift is allowed in Step2
+- [ ] No built-in/open parity drift is allowed in Step2
+- [ ] Step2 non-goals explicitly forbid engine bumps, spec expansion, new check kinds, and test reorganization
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave47-pack-checks-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-evidence --all-targets -- -D warnings` passes
+- [ ] Pinned execution / parity invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step1.md
@@ -1,0 +1,43 @@
+# SPLIT-MOVE-MAP — Wave47 Step1 — `lint/packs/checks.rs`
+
+## Goal
+
+Freeze the pack-check execution contract before any mechanical split of
+`crates/assay-evidence/src/lint/packs/checks.rs`.
+
+## Current hotspot boundary
+
+- `crates/assay-evidence/src/lint/packs/checks.rs`
+  currently co-locates top-level check dispatch, event-scoped checks, JSON-path matching,
+  conditional execution, manifest checks, and finding/fingerprint metadata helpers.
+- `crates/assay-evidence/src/lint/packs/schema.rs`
+  and `schema_next/*` are already shipped from Wave46 and are explicitly out of scope.
+
+## Frozen behavior boundaries
+
+- check execution semantics remain identical across all existing `CheckDefinition` variants
+- `json_path_exists` runtime matching and `value_equals` strict JSON equality remain identical
+- the single-path `json_path_exists.value_equals` invariant remains identical in the
+  validation/execution chain
+- `event_type_exists`, `event_field_present`, `conditional`, and
+  `g3_authorization_context_present` scoped-event behavior remains identical
+- unsupported-check handling by pack kind remains identical
+- finding emission / severity / rule-id / explanation coupling remains identical
+- built-in/open pack parity and pack-lint baseline semantics remain identical
+
+## Intended Step2 ownership split
+
+- `checks.rs`: thin facade, stable exports, `ENGINE_VERSION`, and top-level dispatch
+- `checks_next/event.rs`: event count/pairs/field/type/G3 checks plus scoped/glob helpers
+- `checks_next/json_path.rs`: `check_json_path_exists` and `value_pointer`
+- `checks_next/conditional.rs`: conditional execution and required-path failure messaging
+- `checks_next/manifest.rs`: manifest-field checks
+- `checks_next/finding.rs`: `create_finding`, severity/fingerprint/metadata helpers, and `event_location`
+
+## Explicitly deferred
+
+- `crates/assay-evidence/src/lint/packs/schema.rs`
+- `crates/assay-evidence/src/lint/packs/schema_next/**`
+- new check definitions or pack-engine version changes
+- built-in/open pack content changes
+- dispatch redesign, caching, or optimization work

--- a/docs/contributing/SPLIT-PLAN-wave47-pack-checks.md
+++ b/docs/contributing/SPLIT-PLAN-wave47-pack-checks.md
@@ -1,0 +1,82 @@
+# Wave47 Plan — `lint/packs/checks.rs` Kernel Split
+
+## Goal
+
+Split `crates/assay-evidence/src/lint/packs/checks.rs` behind a stable facade so pack-check
+execution can be reviewed in smaller, responsibility-based modules without changing runtime
+semantics or pack-visible findings.
+
+Current hotspot baseline on `origin/main @ c723aff2`:
+- `crates/assay-evidence/src/lint/packs/checks.rs`: `785` LOC
+- `crates/assay-evidence/src/lint/packs/schema.rs`: `245` LOC after Wave46
+- `crates/assay-evidence/tests/pack_engine_conditional_test.rs`: execution contract companion
+- `crates/assay-evidence/tests/mcp_signal_followup_pack.rs`: G3/runtime parity companion
+- `crates/assay-evidence/tests/a2a_discovery_card_followup_pack.rs`: `value_equals` boolean and open/built-in parity companion
+- `crates/assay-evidence/tests/owasp_agentic_c1_mapping.rs`: conditional support companion
+
+## Status
+
+- Wave46 closed on `main` via `#965`.
+- Step1 is the freeze slice for `checks.rs`.
+- `schema.rs` and `schema_next/*` are already shipped from Wave46 and are explicitly out of scope.
+- `checks.rs` follows `schema.rs` in the required `schema.rs -> checks.rs` order for `R4`.
+
+## Frozen public surface
+
+Wave47 freezes the expectation that Step2 keeps these check-layer items stable in meaning:
+
+- `CheckContext`
+- `CheckResult`
+- `ENGINE_VERSION`
+- `execute_check`
+
+Step2 may reorganize internal ownership behind `checks.rs`, but must not redefine:
+
+- check execution semantics for `event_count`, `event_pairs`, `event_field_present`,
+  `event_type_exists`, `manifest_field`, `json_path_exists`,
+  `g3_authorization_context_present`, and `conditional`
+- `json_path_exists` and `value_equals` runtime behavior
+- the single-path invariant for `json_path_exists.value_equals` in the validation/execution chain
+- `event_type_exists`, `event_field_present`, `conditional`, and
+  `g3_authorization_context_present` scoped-event behavior
+- unsupported-check handling by pack kind
+- finding emission semantics (canonical rule id, severity, message meaning, fingerprint/pack metadata coupling)
+- built-in/open pack runtime parity for the existing follow-up pack line
+- pack-lint baseline semantics for existing golden/baseline cases
+
+## Step2 principles
+
+- `checks.rs` stays the stable facade entrypoint.
+- Step2 is mechanical relocation only.
+- No check-dispatch drift.
+- No pass/fail or finding-count drift.
+- No severity / rule-id / explanation coupling drift.
+- No built-in/open parity drift.
+- No pack-engine spec or version-line drift.
+
+## Intended Step2 ownership split
+
+- `checks.rs`: thin facade, stable exports, `ENGINE_VERSION`, and top-level dispatch surface
+- `checks_next/event.rs`: event-count/pairs/field/type/G3 checks plus scoped-event and glob helpers
+- `checks_next/json_path.rs`: `json_path_exists` execution and `value_pointer`
+- `checks_next/conditional.rs`: conditional execution and missing-required-path messaging
+- `checks_next/manifest.rs`: manifest-field execution
+- `checks_next/finding.rs`: finding creation, event locations, fingerprints, and metadata helpers
+
+## Reviewer notes
+
+Primary failure modes:
+
+- moving check execution semantics while claiming a mechanical split
+- relaxing `json_path_exists` / `value_equals` matching semantics
+- letting the single-path `value_equals` invariant drift indirectly during a `checks.rs` split
+- changing finding wording, severity, canonical IDs, or pack metadata coupling
+- mixing new check kinds, engine bumps, or pack-content churn into the split
+
+## Non-goals
+
+- No edits to `crates/assay-evidence/src/lint/packs/schema.rs` or `schema_next/*`.
+- No edits to `crates/assay-evidence/tests/**`.
+- No edits under `packs/open/**`.
+- No new check types, engine bump, spec expansion, or dispatch redesign.
+- No finding-wording cleanup or test reorganization in this wave.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step1.md
@@ -1,0 +1,61 @@
+# Wave47 Pack Checks Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze the pack-check execution contract before any split of
+`crates/assay-evidence/src/lint/packs/checks.rs`.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave47-pack-checks.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step1.md`
+- `scripts/ci/review-wave47-pack-checks-step1.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-evidence/src/lint/packs/**`
+- no edits under `crates/assay-evidence/tests/**`
+- no edits under `packs/open/**`
+- no `checks.rs` split in this wave
+- no schema, spec, or pack-engine semantic cleanup
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave47-pack-checks-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::g3_authorization_check_uses_scoped_events_not_full_bundle' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::test_value_pointer' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::test_glob_matching' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_json_path_exists_value_equals_requires_exactly_one_path' -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test conditional_rule_fails_when_matching_event_lacks_required_path -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test event_field_present_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test json_path_exists_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_still_skips_for_security_pack -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_fails_for_compliance_pack -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp001_aligns_trust_basis_verified_and_pack_passes -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp001_aligns_trust_basis_absent_and_pack_fails -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp_followup_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_discovery_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_dc_001_fails_when_agent_card_visible_is_string_not_bool -- --exact
+cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping a3_conditional_presence_rule_is_supported_in_engine_v1_1 -- --exact
+cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping a3_conditional_presence_rule_fails_without_mandate_context -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step1 allowlist.
+2. Confirm `checks.rs`, `schema.rs`, test files, and open-pack content are frozen in this wave.
+3. Confirm the plan keeps `schema.rs -> checks.rs` as the required order.
+4. Confirm the move-map freezes dispatch, `json_path_exists` / `value_equals`, conditional,
+   G3, and finding-emission semantics.
+5. Confirm the reviewer script pins both `checks.rs` unit behavior and pack-level parity/execution tests.

--- a/scripts/ci/review-wave47-pack-checks-step1.sh
+++ b/scripts/ci/review-wave47-pack-checks-step1.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+changed_files() {
+  {
+    git diff --name-only "$BASE_REF"...HEAD
+    git diff --name-only
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  } | awk 'NF' | sort -u
+}
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave47-pack-checks.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step1.md"
+  "scripts/ci/review-wave47-pack-checks-step1.sh"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF (workflow-ban)"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave47 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave47 Step1: $f"
+    exit 1
+  fi
+done < <(changed_files)
+
+for frozen in 'crates/assay-evidence/src/lint/packs/**' 'crates/assay-evidence/tests/**' 'packs/open/**'; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$frozen" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave47 Step1 must not change frozen path: $frozen"
+    git diff --name-only "$BASE_REF"...HEAD -- "$frozen"
+    exit 1
+  fi
+  if git ls-files --others --exclude-standard -- "$frozen" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $frozen"
+    git ls-files --others --exclude-standard -- "$frozen" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave47-pack-checks.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step1.md"
+
+for marker in \
+  'checks.rs` Kernel Split' \
+  'schema.rs` and `schema_next/*` are already shipped from Wave46 and are explicitly out of scope' \
+  'single-path invariant for `json_path_exists.value_equals`' \
+  'finding emission semantics (canonical rule id, severity, message meaning, fingerprint/pack metadata coupling)' \
+  'No new check types, engine bump, spec expansion, or dispatch redesign.'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'checks_next/event.rs' \
+  'checks_next/json_path.rs' \
+  'checks_next/conditional.rs' \
+  'checks_next/finding.rs' \
+  'built-in/open pack parity and pack-lint baseline semantics remain identical'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+
+echo "[review] pinned checks invariants"
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::g3_authorization_check_uses_scoped_events_not_full_bundle' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::test_value_pointer' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::test_glob_matching' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_json_path_exists_value_equals_requires_exactly_one_path' -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test conditional_rule_fails_when_matching_event_lacks_required_path -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test event_field_present_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test json_path_exists_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_still_skips_for_security_pack -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_fails_for_compliance_pack -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp001_aligns_trust_basis_verified_and_pack_passes -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp001_aligns_trust_basis_absent_and_pack_fails -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp_followup_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_discovery_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_dc_001_fails_when_agent_card_visible_is_string_not_bool -- --exact
+cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping a3_conditional_presence_rule_is_supported_in_engine_v1_1 -- --exact
+cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping a3_conditional_presence_rule_fails_without_mandate_context -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add Wave47 Step1 freeze/gates artifacts for `crates/assay-evidence/src/lint/packs/checks.rs`
- pin check-execution, finding-emission, pack-parity, and `json_path_exists` / `value_equals` invariants before any split
- add reviewer script that hard-fails on scope drift and reruns exact execution/parity checks

## Scope
- `docs/contributing/SPLIT-PLAN-wave47-pack-checks.md`
- `docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step1.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step1.md`
- `scripts/ci/review-wave47-pack-checks-step1.sh`

## Validation
- `git diff --check`
- `BASE_REF=origin/main bash scripts/ci/review-wave47-pack-checks-step1.sh`
