### PR TITLE
docs: close wave47 pack checks split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step3.md
@@ -1,0 +1,31 @@
+# Wave47 Pack Checks Step3 Checklist (Closure)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave47-pack-checks.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step3.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step3.md`
+  - `scripts/ci/review-wave47-pack-checks-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-evidence/src/lint/packs/**`
+- [ ] No edits under `crates/assay-evidence/tests/**`
+- [ ] No edits under `packs/open/**`
+- [ ] No new module proposals beyond the shipped Step2 layout
+
+## Step3 closure contract
+
+- [ ] Step2 is recorded as shipped behind a stable facade
+- [ ] Step3 is explicitly bounded to micro-cleanup only
+- [ ] `checks.rs` remains the stable facade entrypoint
+- [ ] `checks_next/*` remains the split implementation ownership boundary
+- [ ] No execution, conditional, parity, or finding-meaning drift is allowed in Step3
+- [ ] No public pack-check surface expansion is proposed in Step3
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave47-pack-checks-step3.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-evidence --all-targets -- -D warnings` passes
+- [ ] Pinned check/parity invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step3.md
@@ -1,0 +1,44 @@
+# SPLIT-MOVE-MAP — Wave47 Step3 — `lint/packs/checks.rs` Closure
+
+## Shipped layout
+
+Wave47 Step2 is now the shipped split shape on `main`:
+- `crates/assay-evidence/src/lint/packs/checks.rs`
+- `crates/assay-evidence/src/lint/packs/checks_next/mod.rs`
+- `crates/assay-evidence/src/lint/packs/checks_next/event.rs`
+- `crates/assay-evidence/src/lint/packs/checks_next/json_path.rs`
+- `crates/assay-evidence/src/lint/packs/checks_next/conditional.rs`
+- `crates/assay-evidence/src/lint/packs/checks_next/manifest.rs`
+- `crates/assay-evidence/src/lint/packs/checks_next/finding.rs`
+
+## Ownership freeze
+
+- `crates/assay-evidence/src/lint/packs/checks.rs`
+  remains the stable facade for `CheckContext`, `CheckResult`, `ENGINE_VERSION`,
+  top-level dispatch, unsupported-check handling, and inline contract tests.
+- `crates/assay-evidence/src/lint/packs/checks_next/event.rs`
+  remains the event-family and G3/scoped-event helper boundary.
+- `crates/assay-evidence/src/lint/packs/checks_next/json_path.rs`
+  remains the `json_path_exists` and `value_pointer` boundary.
+- `crates/assay-evidence/src/lint/packs/checks_next/conditional.rs`
+  remains the conditional execution boundary.
+- `crates/assay-evidence/src/lint/packs/checks_next/manifest.rs`
+  remains the manifest-field execution boundary.
+- `crates/assay-evidence/src/lint/packs/checks_next/finding.rs`
+  remains the finding creation, fingerprint, location, and metadata helper boundary.
+
+## Allowed follow-up after closure
+
+- documentation updates only
+- reviewer-gate tightening only
+- internal visibility tightening only if it requires no code edits in this wave
+
+## Explicitly deferred
+
+- new module cuts
+- new check types or engine bump
+- dispatch redesign
+- finding wording cleanup
+- runtime execution cleanup
+- built-in/open parity changes
+- validation-chain or error-meaning changes

--- a/docs/contributing/SPLIT-PLAN-wave47-pack-checks.md
+++ b/docs/contributing/SPLIT-PLAN-wave47-pack-checks.md
@@ -17,8 +17,9 @@ Current hotspot baseline on `origin/main @ b5f359fa`:
 ## Status
 
 - Wave46 closed on `main` via `#965`.
-- Step1 is the freeze slice for `checks.rs`.
-- Step2 is the mechanical split slice for `checks.rs`.
+- Wave47 Step1 shipped on `main` via `#966`.
+- Wave47 Step2 shipped on `main` via `#967`.
+- Step3 is the closure slice for `checks.rs`.
 - `schema.rs` and `schema_next/*` are already shipped from Wave46 and are explicitly out of scope.
 - `checks.rs` follows `schema.rs` in the required `schema.rs -> checks.rs` order for `R4`.
 
@@ -74,6 +75,15 @@ Step2 may reorganize internal ownership behind `checks.rs`, but must not redefin
 - `checks_next/conditional.rs`: conditional execution and missing-required-path messaging
 - `checks_next/manifest.rs`: manifest-field execution
 - `checks_next/finding.rs`: finding creation, event locations, fingerprints, and metadata helpers
+
+## Step3 constraints
+
+- Step3 keeps `checks.rs` as the stable facade entrypoint.
+- Step3 keeps `checks_next/*` as the shipped implementation ownership boundary.
+- Step3 is docs/gates only.
+- No new module cuts.
+- No behavior cleanup beyond internal follow-up notes.
+- No execution, finding, parity, or validation-chain drift is allowed in Step3.
 
 ## Reviewer notes
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step3.md
@@ -1,0 +1,59 @@
+# Wave47 Pack Checks Step3 Review Pack (Closure)
+
+## Intent
+
+Close the shipped Wave47 pack-check split with docs/gates only and forbid post-Step2 redesign drift.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave47-pack-checks.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step3.md`
+- `scripts/ci/review-wave47-pack-checks-step3.sh`
+
+## Non-goals
+
+- no workflow changes
+- no changes under `crates/assay-evidence/src/lint/packs/**`
+- no changes under `crates/assay-evidence/tests/**`
+- no changes under `packs/open/**`
+- no new module cuts
+- no check execution, finding, parity, or validation-chain drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave47-pack-checks-step3.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::g3_authorization_check_uses_scoped_events_not_full_bundle' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::test_value_pointer' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::test_glob_matching' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_json_path_exists_value_equals_requires_exactly_one_path' -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test conditional_rule_fails_when_matching_event_lacks_required_path -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test event_field_present_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test json_path_exists_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_still_skips_for_security_pack -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_fails_for_compliance_pack -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp001_aligns_trust_basis_verified_and_pack_passes -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp001_aligns_trust_basis_absent_and_pack_fails -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp_followup_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_discovery_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_dc_001_fails_when_agent_card_visible_is_string_not_bool -- --exact
+cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping a3_conditional_presence_rule_is_supported_in_engine_v1_1 -- --exact
+cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping a3_conditional_presence_rule_fails_without_mandate_context -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step3 allowlist.
+2. Confirm `crates/assay-evidence/src/lint/packs/**`, `crates/assay-evidence/tests/**`, and `packs/open/**` are frozen in this wave.
+3. Confirm the plan records `#967` as shipped and bounds Step3 to closure only.
+4. Confirm the move-map freezes the current module ownership and does not propose another split.
+5. Confirm the reviewer script re-runs the pinned check/parity invariants.

--- a/scripts/ci/review-wave47-pack-checks-step3.sh
+++ b/scripts/ci/review-wave47-pack-checks-step3.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave47-pack-checks.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step3.md"
+  "scripts/ci/review-wave47-pack-checks-step3.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-evidence/src/lint/packs"
+  "crates/assay-evidence/tests"
+  "packs/open"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r file; do
+  [[ -z "${file:-}" ]] && continue
+
+  if [[ "$file" == .github/workflows/* ]]; then
+    echo "FAIL: Wave47 Step3 must not touch workflows ($file)"
+    exit 1
+  fi
+
+  ok="false"
+  for allowed in "${ALLOWLIST[@]}"; do
+    [[ "$file" == "$allowed" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave47 Step3: $file"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for path in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$path" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave47 Step3 must not change frozen path: $path"
+    git diff --name-only "$BASE_REF"...HEAD -- "$path"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for path in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$path" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $path"
+    git ls-files --others --exclude-standard -- "$path" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave47-pack-checks.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step3.md"
+
+for marker in \
+  'Wave47 Step2 shipped on `main` via `#967`.' \
+  'Step3 keeps `checks.rs` as the stable facade entrypoint.' \
+  'Step3 constraints' \
+  'No new module cuts.' \
+  'No behavior cleanup beyond internal follow-up notes.'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-evidence/src/lint/packs/checks.rs' \
+  'crates/assay-evidence/src/lint/packs/checks_next/conditional.rs' \
+  'crates/assay-evidence/src/lint/packs/checks_next/finding.rs' \
+  'internal visibility tightening only if it requires no code edits in this wave' \
+  'validation-chain or error-meaning changes'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+
+echo "[review] pinned check invariants"
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::g3_authorization_check_uses_scoped_events_not_full_bundle' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::test_value_pointer' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::checks::tests::test_glob_matching' -- --exact
+cargo test -q -p assay-evidence --lib 'lint::packs::schema::tests::test_json_path_exists_value_equals_requires_exactly_one_path' -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test conditional_rule_fails_when_matching_event_lacks_required_path -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test event_field_present_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test json_path_exists_respects_event_types_filter -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_still_skips_for_security_pack -- --exact
+cargo test -q -p assay-evidence --test pack_engine_conditional_test unsupported_conditional_shape_fails_for_compliance_pack -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp001_aligns_trust_basis_verified_and_pack_passes -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp001_aligns_trust_basis_absent_and_pack_fails -- --exact
+cargo test -q -p assay-evidence --test mcp_signal_followup_pack mcp_followup_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_discovery_builtin_and_open_pack_are_exactly_equivalent -- --exact
+cargo test -q -p assay-evidence --test a2a_discovery_card_followup_pack a2a_dc_001_fails_when_agent_card_visible_is_string_not_bool -- --exact
+cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping a3_conditional_presence_rule_is_supported_in_engine_v1_1 -- --exact
+cargo test -q -p assay-evidence --test owasp_agentic_c1_mapping a3_conditional_presence_rule_fails_without_mandate_context -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- close the shipped Wave47 pack-check split with docs/gates only
- record `#967` as shipped on `main` behind the stable `checks.rs` facade
- add Step3 closure checklist, move-map, review pack, and reviewer script

## Scope
- `docs/contributing/SPLIT-PLAN-wave47-pack-checks.md`
- `docs/contributing/SPLIT-CHECKLIST-wave47-pack-checks-step3.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave47-pack-checks-step3.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave47-pack-checks-step3.md`
- `scripts/ci/review-wave47-pack-checks-step3.sh`

## Contract
- docs/gates only
- no changes under `crates/assay-evidence/src/lint/packs/**`
- no changes under `crates/assay-evidence/tests/**`
- no changes under `packs/open/**`
- no execution, finding, parity, or validation-chain drift

## Validation
- `git diff --check`
- `BASE_REF=origin/main bash scripts/ci/review-wave47-pack-checks-step3.sh`
