### PR TITLE
docs: freeze wave48 registry trust split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step1.md
@@ -1,0 +1,31 @@
+# Wave48 Registry Trust Step1 Checklist (Freeze)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step1.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step1.md`
+  - `scripts/ci/review-wave48-registry-trust-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-registry/src/**`
+- [ ] No edits under `crates/assay-registry/tests/**`
+- [ ] No verify / resolver / client / CLI / evidence changes
+
+## Frozen contract
+
+- [ ] `TrustStore` and its public entrypoints are explicitly frozen as the stable facade
+- [ ] No pinned-root loading drift is allowed in Step2
+- [ ] No key-id / SPKI validation drift is allowed in Step2
+- [ ] No revoked/expired-key handling drift is allowed in Step2
+- [ ] No cache/refresh drift is allowed in Step2
+- [ ] No resolver / verification coupling drift is allowed in Step2
+- [ ] Step2 non-goals explicitly forbid trust-policy redesign, optimization, or test reorganization
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave48-registry-trust-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-registry --all-targets -- -D warnings` passes
+- [ ] Pinned trust/resolver invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step1.md
@@ -1,0 +1,59 @@
+# SPLIT-MOVE-MAP — Wave48 Step1 — `registry/trust.rs`
+
+## Goal
+
+Freeze the split boundaries for `crates/assay-registry/src/trust.rs` before any mechanical
+module moves.
+
+## Planned Step2 layout
+
+- `crates/assay-registry/src/trust.rs`
+- `crates/assay-registry/src/trust_next/mod.rs`
+- `crates/assay-registry/src/trust_next/decode.rs`
+- `crates/assay-registry/src/trust_next/pinned.rs`
+- `crates/assay-registry/src/trust_next/manifest.rs`
+- `crates/assay-registry/src/trust_next/cache.rs`
+- `crates/assay-registry/src/trust_next/access.rs`
+
+## Mapping preview
+
+- `trust.rs` keeps the stable routing surface for `TrustStore`, `KeyMetadata`, and public store accessors.
+- `decode.rs` is the planned home for decode/validation helpers:
+  - `decode_verifying_key`
+  - `decode_public_key_bytes`
+- `pinned.rs` is the planned home for pinned-root parsing and insertion helpers:
+  - `parse_pinned_roots_json_impl`
+  - `load_production_roots_impl`
+  - `insert_pinned_key`
+- `manifest.rs` is the planned home for manifest ingest and trust-rotation helpers extracted from:
+  - `TrustStore::add_from_manifest`
+- `cache.rs` is the planned home for refresh/cache helpers extracted from:
+  - `TrustStore::needs_refresh`
+  - `TrustStore::clear_cached_keys`
+  - `TrustStore::empty_inner`
+- `access.rs` is the planned home for access/query helpers extracted from:
+  - `TrustStore::get_key_inner`
+  - `TrustStore::is_trusted`
+  - `TrustStore::list_keys`
+  - `TrustStore::get_metadata`
+
+## Frozen behavior boundaries
+
+- identical pinned-root loading behavior
+- identical key-id verification behavior
+- identical revoked/expired-key handling
+- identical cache/refresh behavior
+- identical sync/async key lookup behavior
+- no drift in resolver or verification trust lookup contracts
+- no edits under `crates/assay-registry/tests/**` in Step2
+
+## Test anchors to keep fixed in Step1
+
+- `trust::tests::test_with_production_roots_loads_embedded_roots`
+- `trust::tests::test_add_from_manifest`
+- `trust::tests::test_pinned_key_not_overwritten`
+- `trust::tests::test_needs_refresh`
+- `trust::tests::test_trust_rotation_revoke_old_key`
+- `trust::tests::test_trust_rotation_pinned_root_survives_revocation`
+- `trust::tests::test_trust_rotation_key_expires_after_added`
+- `resolver_accepts_signed_pack_with_embedded_production_root`

--- a/docs/contributing/SPLIT-PLAN-wave48-registry-trust.md
+++ b/docs/contributing/SPLIT-PLAN-wave48-registry-trust.md
@@ -1,0 +1,153 @@
+# Wave48 Plan — `registry/trust.rs` Kernel Split
+
+## Goal
+
+Split `crates/assay-registry/src/trust.rs` behind a stable facade with zero trust-store semantic
+drift and no downstream resolver or verification contract drift.
+
+Current hotspot baseline on `origin/main @ ba8ef734`:
+- `crates/assay-registry/src/trust.rs`: `838` LOC
+- `crates/assay-registry/src/auth.rs`: `685` LOC
+- `crates/assay-registry/tests/resolver_production_roots.rs`: production-root resolver companion
+- `crates/assay-registry/src/verify_internal/tests/dsse.rs`: trust lookup companion
+
+## Step1 (freeze)
+
+Branch: `codex/wave48-registry-trust-step1` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step1.md`
+- `scripts/ci/review-wave48-registry-trust-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-registry/src/**`
+- no edits under `crates/assay-registry/tests/**`
+- no workflow edits
+- no verify / resolver / client / CLI / evidence edits
+
+Step1 gate:
+- allowlist-only diff (the 5 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail on tracked changes in `crates/assay-registry/src/**`
+- hard fail on untracked files in `crates/assay-registry/src/**`
+- hard fail on tracked changes in `crates/assay-registry/tests/**`
+- hard fail on untracked files in `crates/assay-registry/tests/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-registry --all-targets -- -D warnings`
+- targeted tests:
+  - `cargo test -q -p assay-registry --lib 'trust::tests::test_with_production_roots_loads_embedded_roots' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'trust::tests::test_add_from_manifest' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'trust::tests::test_pinned_key_not_overwritten' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'trust::tests::test_needs_refresh' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_revoke_old_key' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_pinned_root_survives_revocation' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_key_expires_after_added' -- --exact`
+  - `cargo test -q -p assay-registry --test resolver_production_roots resolver_accepts_signed_pack_with_embedded_production_root -- --exact`
+
+## Frozen public surface
+
+Wave48 freezes the expectation that Step2 keeps these trust-store entrypoints and consumer-facing
+contracts unchanged in meaning:
+- `TrustStore`
+- `KeyMetadata`
+- `TrustStore::new`
+- `TrustStore::from_pinned_roots`
+- `TrustStore::from_production_roots`
+- `TrustStore::add_pinned_key`
+- `TrustStore::add_from_manifest`
+- `TrustStore::get_key_async`
+- `TrustStore::get_key`
+- `TrustStore::needs_refresh`
+- `TrustStore::is_trusted`
+- `TrustStore::list_keys`
+- `TrustStore::get_metadata`
+- `TrustStore::clear_cached_keys`
+
+Step2 may reorganize internal ownership behind `trust.rs`, but must not redefine:
+- pinned-root loading semantics
+- key-id verification semantics
+- revoked/expired-key handling
+- manifest refresh / cache TTL behavior
+- sync/async key lookup behavior
+- production-root resolver behavior
+- downstream verification trust lookup semantics
+
+## Step2 (mechanical split preview)
+
+Branch: `codex/wave48-registry-trust-step2` (base: `main`)
+
+Target layout:
+- `crates/assay-registry/src/trust.rs` (thin facade + stable routing)
+- `crates/assay-registry/src/trust_next/mod.rs`
+- `crates/assay-registry/src/trust_next/decode.rs`
+- `crates/assay-registry/src/trust_next/pinned.rs`
+- `crates/assay-registry/src/trust_next/manifest.rs`
+- `crates/assay-registry/src/trust_next/cache.rs`
+- `crates/assay-registry/src/trust_next/access.rs`
+
+Step2 scope:
+- `crates/assay-registry/src/trust.rs`
+- `crates/assay-registry/src/trust_next/mod.rs`
+- `crates/assay-registry/src/trust_next/decode.rs`
+- `crates/assay-registry/src/trust_next/pinned.rs`
+- `crates/assay-registry/src/trust_next/manifest.rs`
+- `crates/assay-registry/src/trust_next/cache.rs`
+- `crates/assay-registry/src/trust_next/access.rs`
+- `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step2.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step2.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step2.md`
+- `scripts/ci/review-wave48-registry-trust-step2.sh`
+
+Step2 principles:
+- 1:1 body moves
+- stable `TrustStore` facade behavior
+- no pinned-root or key-id verification drift
+- no revoked/expired-key drift
+- no cache/refresh drift
+- no resolver/verify coupling drift
+- no edits under `crates/assay-registry/tests/**`
+- no workflow edits
+
+Current Step2 shape:
+- `trust.rs`: facade target `<= 300` LOC
+- `trust_next/decode.rs`: base64 / SPKI / key-id decode helpers
+- `trust_next/pinned.rs`: production-root parsing and pinned insertion helpers
+- `trust_next/manifest.rs`: manifest ingest and trust-rotation helpers
+- `trust_next/cache.rs`: refresh / cache state helpers
+- `trust_next/access.rs`: get/list/metadata access helpers
+
+## Step3 (closure)
+
+Step3 will close the shipped Wave48 trust split with docs/gates only once Step2 lands on `main`.
+
+Step3 constraints:
+- docs+gate only
+- no edits under `crates/assay-registry/src/**`
+- no edits under `crates/assay-registry/tests/**`
+- no new module cuts
+- no behavior cleanup beyond internal follow-up notes
+- no pinned-root, manifest, cache, or verification coupling drift
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once the chain is clean.
+
+## Reviewer notes
+
+This wave must remain trust-store split planning only.
+
+Primary failure modes:
+- sneaking trust-store behavior cleanup into a mechanical split
+- changing pinned-root or manifest semantics while chasing file size
+- changing key-id or SPKI validation behavior under a refactor label
+- drifting resolver or verification coupling via helper moves

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step1.md
@@ -1,0 +1,51 @@
+# Wave48 Registry Trust Step1 Review Pack
+
+## Intent
+
+Freeze the split boundaries for `crates/assay-registry/src/trust.rs` before any mechanical module
+moves, while preserving pinned-root, manifest, cache, and verification semantics.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step1.md`
+- `scripts/ci/review-wave48-registry-trust-step1.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-registry/src/**`
+- no edits under `crates/assay-registry/tests/**`
+- no verify / resolver / client / CLI / evidence changes
+- no trust-store redesign, optimization, or test reorganization
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave48-registry-trust-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-registry --all-targets -- -D warnings
+cargo test -q -p assay-registry --lib 'trust::tests::test_with_production_roots_loads_embedded_roots' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_add_from_manifest' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_pinned_key_not_overwritten' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_needs_refresh' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_revoke_old_key' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_pinned_root_survives_revocation' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_key_expires_after_added' -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_accepts_signed_pack_with_embedded_production_root -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the 5 Step1 files.
+2. Confirm `crates/assay-registry/src/**` and `crates/assay-registry/tests/**` remain untouched.
+3. Confirm the plan freezes `TrustStore` as the stable facade.
+4. Confirm the move-map previews module cuts by trust responsibility, not redesign.
+5. Confirm the reviewer script re-runs pinned trust/resolver invariants.

--- a/scripts/ci/review-wave48-registry-trust-step1.sh
+++ b/scripts/ci/review-wave48-registry-trust-step1.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave48-registry-trust.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step1.md"
+  "scripts/ci/review-wave48-registry-trust-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-registry/src"
+  "crates/assay-registry/tests"
+  "crates/assay-registry/src/verify.rs"
+  "crates/assay-registry/src/resolver.rs"
+  "crates/assay-cli"
+  "crates/assay-evidence"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave48 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave48 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave48 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave48-registry-trust.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step1.md"
+
+for marker in \
+  'Split `crates/assay-registry/src/trust.rs` behind a stable facade' \
+  'TrustStore::add_from_manifest' \
+  'Step2 principles:' \
+  'no pinned-root or key-id verification drift' \
+  'no verify / resolver / client / CLI / evidence edits'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-registry/src/trust_next/manifest.rs' \
+  'crates/assay-registry/src/trust_next/cache.rs' \
+  'identical cache/refresh behavior' \
+  'resolver_accepts_signed_pack_with_embedded_production_root'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-registry --all-targets -- -D warnings
+
+echo "[review] pinned trust invariants"
+cargo test -q -p assay-registry --lib 'trust::tests::test_with_production_roots_loads_embedded_roots' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_add_from_manifest' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_pinned_key_not_overwritten' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_needs_refresh' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_revoke_old_key' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_pinned_root_survives_revocation' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_key_expires_after_added' -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_accepts_signed_pack_with_embedded_production_root -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- freeze the split boundaries for `crates/assay-registry/src/trust.rs`
- pin trust-store contracts before any mechanical module moves
- add Wave48 Step1 checklist, move-map, review pack, and reviewer script

## Scope
- `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
- `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step1.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step1.md`
- `scripts/ci/review-wave48-registry-trust-step1.sh`

## Contract
- docs/gates only
- no changes under `crates/assay-registry/src/**`
- no changes under `crates/assay-registry/tests/**`
- no pinned-root, manifest, cache, or verification coupling drift

## Validation
- `git diff --check`
- `BASE_REF=origin/main bash scripts/ci/review-wave48-registry-trust-step1.sh`
