### PR TITLE
refactor: split registry trust facade

### DIFF
--- a/crates/assay-registry/src/trust.rs
+++ b/crates/assay-registry/src/trust.rs
@@ -6,21 +6,33 @@
 //! - Configuration file
 //! - Remote keys manifest (fetched from registry)
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use chrono::{DateTime, Utc};
 use ed25519_dalek::VerifyingKey;
 use tokio::sync::RwLock;
 
 use crate::error::{RegistryError, RegistryResult};
 use crate::types::{KeysManifest, TrustedKey};
+#[cfg(test)]
 use crate::verify::compute_key_id;
+#[cfg(test)]
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 
 /// Default cache TTL for keys manifest (24 hours).
 const DEFAULT_KEYS_TTL_SECS: i64 = 24 * 60 * 60;
 const PRODUCTION_TRUST_ROOTS_JSON: &str = include_str!("../assets/production-trust-roots.json");
+
+#[path = "trust_next/mod.rs"]
+mod trust_next;
+
+use trust_next::access;
+use trust_next::cache;
+use trust_next::manifest;
+#[cfg(test)]
+use trust_next::pinned::parse_pinned_roots_json_impl;
+use trust_next::pinned::{insert_pinned_key, load_production_roots_impl};
 
 /// Trust store for signing keys.
 #[derive(Debug, Clone)]
@@ -69,7 +81,7 @@ impl TrustStore {
     /// Create an empty trust store.
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(Self::empty_inner())),
+            inner: Arc::new(RwLock::new(cache::empty_inner())),
         }
     }
 
@@ -77,7 +89,7 @@ impl TrustStore {
     ///
     /// Pinned roots are always trusted and cannot be revoked remotely.
     pub fn from_pinned_roots(roots: Vec<TrustedKey>) -> RegistryResult<Self> {
-        let mut inner = Self::empty_inner();
+        let mut inner = cache::empty_inner();
         for root in &roots {
             insert_pinned_key(&mut inner, root)?;
         }
@@ -106,169 +118,37 @@ impl TrustStore {
 
     /// Add a pinned root key.
     pub async fn add_pinned_key(&self, key: &TrustedKey) -> RegistryResult<()> {
-        let verifying_key = decode_verifying_key(&key.public_key)?;
-        let computed_id = compute_key_id(&decode_public_key_bytes(&key.public_key)?);
-
-        // Verify key_id matches
-        if computed_id != key.key_id {
-            return Err(RegistryError::SignatureInvalid {
-                reason: format!(
-                    "key_id mismatch: claimed {}, computed {}",
-                    key.key_id, computed_id
-                ),
-            });
-        }
-
         let mut inner = self.inner.write().await;
-        inner.keys.insert(key.key_id.clone(), verifying_key);
-        inner.metadata.insert(
-            key.key_id.clone(),
-            KeyMetadata {
-                description: key.description.clone(),
-                added_at: key.added_at,
-                expires_at: key.expires_at,
-                revoked: false, // Pinned keys cannot be revoked
-                is_pinned: true,
-            },
-        );
-        if !inner.pinned_roots.contains(&key.key_id) {
-            inner.pinned_roots.push(key.key_id.clone());
-        }
-
-        Ok(())
+        insert_pinned_key(&mut inner, key)
     }
 
     /// Add keys from a manifest (fetched from registry).
     pub async fn add_from_manifest(&self, manifest: &KeysManifest) -> RegistryResult<()> {
-        let now = Utc::now();
-
         let mut inner = self.inner.write().await;
-
-        for key in &manifest.keys {
-            // Skip revoked keys
-            if key.revoked {
-                // If the key exists and is not pinned, remove it
-                if !inner.pinned_roots.contains(&key.key_id) {
-                    inner.keys.remove(&key.key_id);
-                    if let Some(meta) = inner.metadata.get_mut(&key.key_id) {
-                        meta.revoked = true;
-                    }
-                }
-                continue;
-            }
-
-            // Skip expired keys
-            if let Some(expires_at) = key.expires_at {
-                if expires_at < now {
-                    continue;
-                }
-            }
-
-            // Don't overwrite pinned roots
-            if inner.pinned_roots.contains(&key.key_id) {
-                continue;
-            }
-
-            // Decode and add key
-            match decode_verifying_key(&key.public_key) {
-                Ok(verifying_key) => {
-                    // Verify key_id
-                    let computed_id = match decode_public_key_bytes(&key.public_key) {
-                        Ok(bytes) => compute_key_id(&bytes),
-                        Err(_) => continue,
-                    };
-
-                    if computed_id != key.key_id {
-                        tracing::warn!(
-                            claimed = %key.key_id,
-                            computed = %computed_id,
-                            "key_id mismatch, skipping"
-                        );
-                        continue;
-                    }
-
-                    inner.keys.insert(key.key_id.clone(), verifying_key);
-                    inner.metadata.insert(
-                        key.key_id.clone(),
-                        KeyMetadata {
-                            description: key.description.clone(),
-                            added_at: key.added_at,
-                            expires_at: key.expires_at,
-                            revoked: false,
-                            is_pinned: false,
-                        },
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(key_id = %key.key_id, error = %e, "failed to decode key");
-                }
-            }
-        }
-
-        // Update cache metadata
-        inner.manifest_fetched_at = Some(now);
-        inner.manifest_expires_at = manifest
-            .expires_at
-            .or(Some(now + chrono::Duration::seconds(DEFAULT_KEYS_TTL_SECS)));
-
-        Ok(())
+        manifest::add_from_manifest(&mut inner, manifest)
     }
 
     /// Get a key by ID.
     pub async fn get_key_async(&self, key_id: &str) -> RegistryResult<VerifyingKey> {
         let inner = self.inner.read().await;
-        self.get_key_inner(&inner, key_id)
+        access::get_key_inner(&inner, key_id)
     }
 
     /// Get a key by ID (blocking version for sync contexts).
     pub fn get_key(&self, key_id: &str) -> RegistryResult<VerifyingKey> {
         // Use try_read to avoid blocking
         match self.inner.try_read() {
-            Ok(inner) => self.get_key_inner(&inner, key_id),
+            Ok(inner) => access::get_key_inner(&inner, key_id),
             Err(_) => Err(RegistryError::KeyNotTrusted {
                 key_id: key_id.to_string(),
             }),
         }
     }
 
-    fn get_key_inner(&self, inner: &TrustStoreInner, key_id: &str) -> RegistryResult<VerifyingKey> {
-        // Check if key exists
-        let key = inner
-            .keys
-            .get(key_id)
-            .ok_or_else(|| RegistryError::KeyNotTrusted {
-                key_id: key_id.to_string(),
-            })?;
-
-        // Check if revoked
-        if let Some(meta) = inner.metadata.get(key_id) {
-            if meta.revoked {
-                return Err(RegistryError::KeyNotTrusted {
-                    key_id: key_id.to_string(),
-                });
-            }
-
-            // Check if expired
-            if let Some(expires_at) = meta.expires_at {
-                if expires_at < Utc::now() {
-                    return Err(RegistryError::KeyNotTrusted {
-                        key_id: key_id.to_string(),
-                    });
-                }
-            }
-        }
-
-        Ok(*key)
-    }
-
     /// Check if the keys manifest needs refresh.
     pub async fn needs_refresh(&self) -> bool {
         let inner = self.inner.read().await;
-
-        match inner.manifest_expires_at {
-            Some(expires_at) => Utc::now() >= expires_at,
-            None => inner.manifest_fetched_at.is_none(),
-        }
+        cache::needs_refresh(&inner)
     }
 
     /// Check if a key is trusted.
@@ -279,38 +159,19 @@ impl TrustStore {
     /// Get all trusted key IDs.
     pub async fn list_keys(&self) -> Vec<String> {
         let inner = self.inner.read().await;
-        inner.keys.keys().cloned().collect()
+        access::list_keys(&inner)
     }
 
     /// Get metadata for a key.
     pub async fn get_metadata(&self, key_id: &str) -> Option<KeyMetadata> {
         let inner = self.inner.read().await;
-        inner.metadata.get(key_id).cloned()
+        access::get_metadata(&inner, key_id)
     }
 
     /// Clear all non-pinned keys (for testing or force refresh).
     pub async fn clear_cached_keys(&self) {
         let mut inner = self.inner.write().await;
-
-        // Capture pinned roots to avoid borrow conflict
-        let pinned_roots: std::collections::HashSet<_> =
-            inner.pinned_roots.iter().cloned().collect();
-
-        // Keep only pinned roots
-        inner.keys.retain(|k, _| pinned_roots.contains(k));
-        inner.metadata.retain(|k, _| pinned_roots.contains(k));
-        inner.manifest_fetched_at = None;
-        inner.manifest_expires_at = None;
-    }
-
-    fn empty_inner() -> TrustStoreInner {
-        TrustStoreInner {
-            keys: HashMap::new(),
-            metadata: HashMap::new(),
-            pinned_roots: Vec::new(),
-            manifest_fetched_at: None,
-            manifest_expires_at: None,
-        }
+        cache::clear_cached_keys(&mut inner);
     }
 }
 
@@ -318,110 +179,6 @@ impl Default for TrustStore {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Decode a Base64-encoded SPKI public key to VerifyingKey.
-fn decode_verifying_key(b64: &str) -> RegistryResult<VerifyingKey> {
-    use pkcs8::DecodePublicKey;
-
-    let bytes = BASE64.decode(b64).map_err(|e| RegistryError::Config {
-        message: format!("invalid base64 public key: {}", e),
-    })?;
-
-    VerifyingKey::from_public_key_der(&bytes).map_err(|e| RegistryError::Config {
-        message: format!("invalid SPKI public key: {}", e),
-    })
-}
-
-/// Decode Base64 public key bytes.
-fn decode_public_key_bytes(b64: &str) -> RegistryResult<Vec<u8>> {
-    BASE64.decode(b64).map_err(|e| RegistryError::Config {
-        message: format!("invalid base64 public key: {}", e),
-    })
-}
-
-fn parse_pinned_roots_json_impl(raw: &str) -> RegistryResult<Vec<TrustedKey>> {
-    let roots: Vec<TrustedKey> = serde_json::from_str(raw).map_err(|e| RegistryError::Config {
-        message: format!("invalid production trust roots: {}", e),
-    })?;
-
-    if roots.is_empty() {
-        return Err(RegistryError::Config {
-            message: "production trust roots are empty".to_string(),
-        });
-    }
-
-    let mut seen = HashSet::new();
-    for root in &roots {
-        if root.algorithm != "Ed25519" {
-            return Err(RegistryError::Config {
-                message: format!(
-                    "production trust root {} uses unsupported algorithm {}",
-                    root.key_id, root.algorithm
-                ),
-            });
-        }
-
-        if root.revoked {
-            return Err(RegistryError::Config {
-                message: format!("production trust root {} is revoked", root.key_id),
-            });
-        }
-
-        if !seen.insert(root.key_id.clone()) {
-            return Err(RegistryError::Config {
-                message: format!("duplicate production trust root {}", root.key_id),
-            });
-        }
-    }
-
-    Ok(roots)
-}
-
-fn load_production_roots_impl(raw: &str) -> RegistryResult<TrustStore> {
-    let roots = parse_pinned_roots_json_impl(raw)?;
-    let mut inner = TrustStore::empty_inner();
-
-    for root in &roots {
-        insert_pinned_key(&mut inner, root).map_err(|err| RegistryError::Config {
-            message: format!("invalid production trust root {}: {}", root.key_id, err),
-        })?;
-    }
-
-    Ok(TrustStore {
-        inner: Arc::new(RwLock::new(inner)),
-    })
-}
-
-fn insert_pinned_key(inner: &mut TrustStoreInner, key: &TrustedKey) -> RegistryResult<()> {
-    let verifying_key = decode_verifying_key(&key.public_key)?;
-    let computed_id = compute_key_id(&decode_public_key_bytes(&key.public_key)?);
-
-    if computed_id != key.key_id {
-        return Err(RegistryError::SignatureInvalid {
-            reason: format!(
-                "key_id mismatch: claimed {}, computed {}",
-                key.key_id, computed_id
-            ),
-        });
-    }
-
-    inner.keys.insert(key.key_id.clone(), verifying_key);
-    inner.metadata.insert(
-        key.key_id.clone(),
-        KeyMetadata {
-            description: key.description.clone(),
-            added_at: key.added_at,
-            expires_at: key.expires_at,
-            revoked: false,
-            is_pinned: true,
-        },
-    );
-    if !inner.pinned_roots.contains(&key.key_id) {
-        inner.pinned_roots.push(key.key_id.clone());
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/assay-registry/src/trust_next/access.rs
+++ b/crates/assay-registry/src/trust_next/access.rs
@@ -1,0 +1,43 @@
+use chrono::Utc;
+use ed25519_dalek::VerifyingKey;
+
+use crate::error::{RegistryError, RegistryResult};
+use crate::trust::{KeyMetadata, TrustStoreInner};
+
+pub(in crate::trust) fn get_key_inner(
+    inner: &TrustStoreInner,
+    key_id: &str,
+) -> RegistryResult<VerifyingKey> {
+    let key = inner
+        .keys
+        .get(key_id)
+        .ok_or_else(|| RegistryError::KeyNotTrusted {
+            key_id: key_id.to_string(),
+        })?;
+
+    if let Some(meta) = inner.metadata.get(key_id) {
+        if meta.revoked {
+            return Err(RegistryError::KeyNotTrusted {
+                key_id: key_id.to_string(),
+            });
+        }
+
+        if let Some(expires_at) = meta.expires_at {
+            if expires_at < Utc::now() {
+                return Err(RegistryError::KeyNotTrusted {
+                    key_id: key_id.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(*key)
+}
+
+pub(in crate::trust) fn list_keys(inner: &TrustStoreInner) -> Vec<String> {
+    inner.keys.keys().cloned().collect()
+}
+
+pub(in crate::trust) fn get_metadata(inner: &TrustStoreInner, key_id: &str) -> Option<KeyMetadata> {
+    inner.metadata.get(key_id).cloned()
+}

--- a/crates/assay-registry/src/trust_next/cache.rs
+++ b/crates/assay-registry/src/trust_next/cache.rs
@@ -1,0 +1,31 @@
+use std::collections::{HashMap, HashSet};
+
+use chrono::Utc;
+
+use crate::trust::TrustStoreInner;
+
+pub(in crate::trust) fn needs_refresh(inner: &TrustStoreInner) -> bool {
+    match inner.manifest_expires_at {
+        Some(expires_at) => Utc::now() >= expires_at,
+        None => inner.manifest_fetched_at.is_none(),
+    }
+}
+
+pub(in crate::trust) fn clear_cached_keys(inner: &mut TrustStoreInner) {
+    let pinned_roots: HashSet<_> = inner.pinned_roots.iter().cloned().collect();
+
+    inner.keys.retain(|k, _| pinned_roots.contains(k));
+    inner.metadata.retain(|k, _| pinned_roots.contains(k));
+    inner.manifest_fetched_at = None;
+    inner.manifest_expires_at = None;
+}
+
+pub(in crate::trust) fn empty_inner() -> TrustStoreInner {
+    TrustStoreInner {
+        keys: HashMap::new(),
+        metadata: HashMap::new(),
+        pinned_roots: Vec::new(),
+        manifest_fetched_at: None,
+        manifest_expires_at: None,
+    }
+}

--- a/crates/assay-registry/src/trust_next/decode.rs
+++ b/crates/assay-registry/src/trust_next/decode.rs
@@ -1,0 +1,24 @@
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use ed25519_dalek::VerifyingKey;
+
+use crate::error::{RegistryError, RegistryResult};
+
+/// Decode a Base64-encoded SPKI public key to VerifyingKey.
+pub(in crate::trust) fn decode_verifying_key(b64: &str) -> RegistryResult<VerifyingKey> {
+    use pkcs8::DecodePublicKey;
+
+    let bytes = BASE64.decode(b64).map_err(|e| RegistryError::Config {
+        message: format!("invalid base64 public key: {}", e),
+    })?;
+
+    VerifyingKey::from_public_key_der(&bytes).map_err(|e| RegistryError::Config {
+        message: format!("invalid SPKI public key: {}", e),
+    })
+}
+
+/// Decode Base64 public key bytes.
+pub(in crate::trust) fn decode_public_key_bytes(b64: &str) -> RegistryResult<Vec<u8>> {
+    BASE64.decode(b64).map_err(|e| RegistryError::Config {
+        message: format!("invalid base64 public key: {}", e),
+    })
+}

--- a/crates/assay-registry/src/trust_next/manifest.rs
+++ b/crates/assay-registry/src/trust_next/manifest.rs
@@ -1,0 +1,77 @@
+use chrono::Utc;
+
+use crate::error::RegistryResult;
+use crate::trust::{KeyMetadata, TrustStoreInner, DEFAULT_KEYS_TTL_SECS};
+use crate::types::KeysManifest;
+use crate::verify::compute_key_id;
+
+use super::decode::{decode_public_key_bytes, decode_verifying_key};
+
+pub(in crate::trust) fn add_from_manifest(
+    inner: &mut TrustStoreInner,
+    manifest: &KeysManifest,
+) -> RegistryResult<()> {
+    let now = Utc::now();
+
+    for key in &manifest.keys {
+        if key.revoked {
+            if !inner.pinned_roots.contains(&key.key_id) {
+                inner.keys.remove(&key.key_id);
+                if let Some(meta) = inner.metadata.get_mut(&key.key_id) {
+                    meta.revoked = true;
+                }
+            }
+            continue;
+        }
+
+        if let Some(expires_at) = key.expires_at {
+            if expires_at < now {
+                continue;
+            }
+        }
+
+        if inner.pinned_roots.contains(&key.key_id) {
+            continue;
+        }
+
+        match decode_verifying_key(&key.public_key) {
+            Ok(verifying_key) => {
+                let computed_id = match decode_public_key_bytes(&key.public_key) {
+                    Ok(bytes) => compute_key_id(&bytes),
+                    Err(_) => continue,
+                };
+
+                if computed_id != key.key_id {
+                    tracing::warn!(
+                        claimed = %key.key_id,
+                        computed = %computed_id,
+                        "key_id mismatch, skipping"
+                    );
+                    continue;
+                }
+
+                inner.keys.insert(key.key_id.clone(), verifying_key);
+                inner.metadata.insert(
+                    key.key_id.clone(),
+                    KeyMetadata {
+                        description: key.description.clone(),
+                        added_at: key.added_at,
+                        expires_at: key.expires_at,
+                        revoked: false,
+                        is_pinned: false,
+                    },
+                );
+            }
+            Err(e) => {
+                tracing::warn!(key_id = %key.key_id, error = %e, "failed to decode key");
+            }
+        }
+    }
+
+    inner.manifest_fetched_at = Some(now);
+    inner.manifest_expires_at = manifest
+        .expires_at
+        .or(Some(now + chrono::Duration::seconds(DEFAULT_KEYS_TTL_SECS)));
+
+    Ok(())
+}

--- a/crates/assay-registry/src/trust_next/mod.rs
+++ b/crates/assay-registry/src/trust_next/mod.rs
@@ -1,0 +1,5 @@
+pub(in crate::trust) mod access;
+pub(in crate::trust) mod cache;
+pub(in crate::trust) mod decode;
+pub(in crate::trust) mod manifest;
+pub(in crate::trust) mod pinned;

--- a/crates/assay-registry/src/trust_next/pinned.rs
+++ b/crates/assay-registry/src/trust_next/pinned.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::error::{RegistryError, RegistryResult};
+use crate::trust::{KeyMetadata, TrustStore, TrustStoreInner};
+use crate::types::TrustedKey;
+use crate::verify::compute_key_id;
+
+use super::cache;
+use super::decode::{decode_public_key_bytes, decode_verifying_key};
+
+pub(in crate::trust) fn parse_pinned_roots_json_impl(raw: &str) -> RegistryResult<Vec<TrustedKey>> {
+    let roots: Vec<TrustedKey> = serde_json::from_str(raw).map_err(|e| RegistryError::Config {
+        message: format!("invalid production trust roots: {}", e),
+    })?;
+
+    if roots.is_empty() {
+        return Err(RegistryError::Config {
+            message: "production trust roots are empty".to_string(),
+        });
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    for root in &roots {
+        if root.algorithm != "Ed25519" {
+            return Err(RegistryError::Config {
+                message: format!(
+                    "production trust root {} uses unsupported algorithm {}",
+                    root.key_id, root.algorithm
+                ),
+            });
+        }
+
+        if root.revoked {
+            return Err(RegistryError::Config {
+                message: format!("production trust root {} is revoked", root.key_id),
+            });
+        }
+
+        if !seen.insert(root.key_id.clone()) {
+            return Err(RegistryError::Config {
+                message: format!("duplicate production trust root {}", root.key_id),
+            });
+        }
+    }
+
+    Ok(roots)
+}
+
+pub(in crate::trust) fn load_production_roots_impl(raw: &str) -> RegistryResult<TrustStore> {
+    let roots = parse_pinned_roots_json_impl(raw)?;
+    let mut inner = cache::empty_inner();
+
+    for root in &roots {
+        insert_pinned_key(&mut inner, root).map_err(|err| RegistryError::Config {
+            message: format!("invalid production trust root {}: {}", root.key_id, err),
+        })?;
+    }
+
+    Ok(TrustStore {
+        inner: Arc::new(RwLock::new(inner)),
+    })
+}
+
+pub(in crate::trust) fn insert_pinned_key(
+    inner: &mut TrustStoreInner,
+    key: &TrustedKey,
+) -> RegistryResult<()> {
+    let verifying_key = decode_verifying_key(&key.public_key)?;
+    let computed_id = compute_key_id(&decode_public_key_bytes(&key.public_key)?);
+
+    if computed_id != key.key_id {
+        return Err(RegistryError::SignatureInvalid {
+            reason: format!(
+                "key_id mismatch: claimed {}, computed {}",
+                key.key_id, computed_id
+            ),
+        });
+    }
+
+    inner.keys.insert(key.key_id.clone(), verifying_key);
+    inner.metadata.insert(
+        key.key_id.clone(),
+        KeyMetadata {
+            description: key.description.clone(),
+            added_at: key.added_at,
+            expires_at: key.expires_at,
+            revoked: false,
+            is_pinned: true,
+        },
+    );
+    if !inner.pinned_roots.contains(&key.key_id) {
+        inner.pinned_roots.push(key.key_id.clone());
+    }
+
+    Ok(())
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step2.md
@@ -1,0 +1,40 @@
+# Wave48 Registry Trust Step2 Checklist (Mechanical Split)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `crates/assay-registry/src/trust.rs`
+  - `crates/assay-registry/src/trust_next/mod.rs`
+  - `crates/assay-registry/src/trust_next/decode.rs`
+  - `crates/assay-registry/src/trust_next/pinned.rs`
+  - `crates/assay-registry/src/trust_next/manifest.rs`
+  - `crates/assay-registry/src/trust_next/cache.rs`
+  - `crates/assay-registry/src/trust_next/access.rs`
+  - `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step2.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step2.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step2.md`
+  - `scripts/ci/review-wave48-registry-trust-step2.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-registry/tests/**`
+- [ ] No edits under `crates/assay-registry/src/resolver.rs`
+- [ ] No edits under `crates/assay-registry/src/verify.rs`
+- [ ] No verify / resolver / client / CLI / evidence scope leak
+
+## Mechanical split contract
+
+- [ ] `trust.rs` remains the stable facade entrypoint for `TrustStore` and `KeyMetadata`
+- [ ] `trust_next/*` carries the moved implementation bodies
+- [ ] No pinned-root loading drift
+- [ ] No key-id / SPKI validation drift
+- [ ] No revoked/expired-key handling drift
+- [ ] No cache/refresh drift
+- [ ] No resolver / verification coupling drift
+- [ ] Inline tests remain in `trust.rs`
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave48-registry-trust-step2.sh` passes
+- [ ] `cargo fmt --all --check` passes
+- [ ] `cargo clippy -p assay-registry --all-targets -- -D warnings` passes
+- [ ] Pinned trust/resolver invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step2.md
@@ -1,0 +1,59 @@
+# Wave48 Step2 Move Map
+
+Facade retained in `crates/assay-registry/src/trust.rs`:
+
+- `TrustStore`
+- `KeyMetadata`
+- `TrustStore::new`
+- `TrustStore::from_pinned_roots`
+- `TrustStore::with_pinned_roots`
+- `TrustStore::from_production_roots`
+- `TrustStore::with_production_roots`
+- `TrustStore::add_pinned_key`
+- `TrustStore::add_from_manifest`
+- `TrustStore::get_key_async`
+- `TrustStore::get_key`
+- `TrustStore::needs_refresh`
+- `TrustStore::is_trusted`
+- `TrustStore::list_keys`
+- `TrustStore::get_metadata`
+- `TrustStore::clear_cached_keys`
+- existing inline tests
+- `#[path = "trust_next/mod.rs"] mod trust_next;`
+
+Moved to `crates/assay-registry/src/trust_next/decode.rs`:
+
+- `decode_verifying_key`
+- `decode_public_key_bytes`
+
+Moved to `crates/assay-registry/src/trust_next/pinned.rs`:
+
+- `parse_pinned_roots_json_impl`
+- `load_production_roots_impl`
+- `insert_pinned_key`
+
+Moved to `crates/assay-registry/src/trust_next/manifest.rs`:
+
+- manifest ingest loop from `TrustStore::add_from_manifest`
+- trust rotation / revocation / expiry handling
+- manifest cache expiry update
+
+Moved to `crates/assay-registry/src/trust_next/cache.rs`:
+
+- `needs_refresh`
+- `clear_cached_keys`
+- `empty_inner`
+
+Moved to `crates/assay-registry/src/trust_next/access.rs`:
+
+- `get_key_inner`
+- `list_keys`
+- `get_metadata`
+
+Explicitly unchanged in this wave:
+
+- `crates/assay-registry/tests/**`
+- `crates/assay-registry/src/resolver.rs`
+- `crates/assay-registry/src/verify.rs`
+- `crates/assay-cli/**`
+- `crates/assay-evidence/**`

--- a/docs/contributing/SPLIT-PLAN-wave48-registry-trust.md
+++ b/docs/contributing/SPLIT-PLAN-wave48-registry-trust.md
@@ -76,6 +76,12 @@ Step2 may reorganize internal ownership behind `trust.rs`, but must not redefine
 - production-root resolver behavior
 - downstream verification trust lookup semantics
 
+## Status
+
+- Wave47 closed on `main` via `#968`.
+- Wave48 Step1 shipped on `main` via `#969`.
+- Step2 is the mechanical split slice for `trust.rs`.
+
 ## Step2 (mechanical split preview)
 
 Branch: `codex/wave48-registry-trust-step2` (base: `main`)
@@ -114,12 +120,20 @@ Step2 principles:
 - no workflow edits
 
 Current Step2 shape:
-- `trust.rs`: facade target `<= 300` LOC
+- `trust.rs`: stable facade, public `TrustStore`/`KeyMetadata`, and existing inline tests
 - `trust_next/decode.rs`: base64 / SPKI / key-id decode helpers
 - `trust_next/pinned.rs`: production-root parsing and pinned insertion helpers
 - `trust_next/manifest.rs`: manifest ingest and trust-rotation helpers
 - `trust_next/cache.rs`: refresh / cache state helpers
 - `trust_next/access.rs`: get/list/metadata access helpers
+
+Current Step2 LOC snapshot on this branch:
+- `crates/assay-registry/src/trust.rs`: `838 -> 595`
+- `crates/assay-registry/src/trust_next/pinned.rs`: `98`
+- `crates/assay-registry/src/trust_next/manifest.rs`: `77`
+- `crates/assay-registry/src/trust_next/access.rs`: `43`
+- `crates/assay-registry/src/trust_next/cache.rs`: `31`
+- `crates/assay-registry/src/trust_next/decode.rs`: `24`
 
 ## Step3 (closure)
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step2.md
@@ -1,0 +1,60 @@
+# Wave48 Registry Trust Step2 Review Pack
+
+## Intent
+
+Mechanically split `crates/assay-registry/src/trust.rs` behind a stable facade, without changing
+trust-store semantics or resolver/verification-visible behavior.
+
+## Scope
+
+- `crates/assay-registry/src/trust.rs`
+- `crates/assay-registry/src/trust_next/mod.rs`
+- `crates/assay-registry/src/trust_next/decode.rs`
+- `crates/assay-registry/src/trust_next/pinned.rs`
+- `crates/assay-registry/src/trust_next/manifest.rs`
+- `crates/assay-registry/src/trust_next/cache.rs`
+- `crates/assay-registry/src/trust_next/access.rs`
+- `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step2.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step2.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step2.md`
+- `scripts/ci/review-wave48-registry-trust-step2.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-registry/tests/**`
+- no edits to `resolver.rs` or `verify.rs`
+- no trust-store redesign or optimization wave
+- no public registry contract changes
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave48-registry-trust-step2.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --all --check
+cargo clippy -q -p assay-registry --all-targets -- -D warnings
+cargo check -q -p assay-registry
+cargo test -q -p assay-registry --lib 'trust::tests::test_with_production_roots_loads_embedded_roots' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_add_from_manifest' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_pinned_key_not_overwritten' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_needs_refresh' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_revoke_old_key' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_pinned_root_survives_revocation' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_key_expires_after_added' -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_accepts_signed_pack_with_embedded_production_root -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_rejects_signed_pack_with_untrusted_key_id -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to `trust.rs`, `trust_next/*`, and Step2 docs/script.
+2. Confirm `crates/assay-registry/tests/**`, `resolver.rs`, and `verify.rs` remain untouched.
+3. Confirm `trust.rs` is now a thin facade with stable `TrustStore` entrypoints and inline tests.
+4. Confirm the move-map treats this as responsibility-based relocation, not redesign.
+5. Confirm the reviewer script pins trust-store semantics plus resolver coupling tests.

--- a/scripts/ci/review-wave48-registry-trust-step2.sh
+++ b/scripts/ci/review-wave48-registry-trust-step2.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+ALLOWED_FILES=(
+  "crates/assay-registry/src/trust.rs"
+  "crates/assay-registry/src/trust_next/mod.rs"
+  "crates/assay-registry/src/trust_next/decode.rs"
+  "crates/assay-registry/src/trust_next/pinned.rs"
+  "crates/assay-registry/src/trust_next/manifest.rs"
+  "crates/assay-registry/src/trust_next/cache.rs"
+  "crates/assay-registry/src/trust_next/access.rs"
+  "docs/contributing/SPLIT-PLAN-wave48-registry-trust.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step2.md"
+  "scripts/ci/review-wave48-registry-trust-step2.sh"
+)
+
+DIFF_FILES=()
+while IFS= read -r file; do
+  DIFF_FILES+=("$file")
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+while IFS= read -r file; do
+  DIFF_FILES+=("$file")
+done < <(git ls-files --others --exclude-standard)
+
+if (( ${#DIFF_FILES[@]} > 0 )); then
+  for file in "${DIFF_FILES[@]}"; do
+    [[ -z "$file" ]] && continue
+    if [[ "$file" == .github/workflows/* ]]; then
+      echo "workflow file changed out of scope: $file" >&2
+      exit 1
+    fi
+
+    allowed=false
+    for allowed_file in "${ALLOWED_FILES[@]}"; do
+      if [[ "$file" == "$allowed_file" ]]; then
+        allowed=true
+        break
+      fi
+    done
+    if [[ "$allowed" == false ]]; then
+      echo "out-of-scope file changed: $file" >&2
+      exit 1
+    fi
+  done
+fi
+
+if (( ${#DIFF_FILES[@]} > 0 )); then
+  for file in "${DIFF_FILES[@]}"; do
+    [[ -z "$file" ]] && continue
+    if [[ "$file" == crates/assay-registry/tests/* ]]; then
+      echo "registry tests must remain untouched in Step2" >&2
+      exit 1
+    fi
+    if [[ "$file" == crates/assay-registry/src/resolver.rs ]]; then
+      echo "resolver.rs must remain untouched in Wave48 Step2" >&2
+      exit 1
+    fi
+    if [[ "$file" == crates/assay-registry/src/verify.rs ]]; then
+      echo "verify.rs must remain untouched in Wave48 Step2" >&2
+      exit 1
+    fi
+  done
+fi
+
+if ! rg -n '^#\[path = "trust_next/mod.rs"\]$' crates/assay-registry/src/trust.rs >/dev/null; then
+  echo "trust.rs must declare the sibling trust_next path override" >&2
+  exit 1
+fi
+
+if ! rg -n '^mod trust_next;$' crates/assay-registry/src/trust.rs >/dev/null; then
+  echo "trust.rs must declare trust_next module" >&2
+  exit 1
+fi
+
+for forbidden in \
+  '^fn decode_verifying_key\(' \
+  '^fn decode_public_key_bytes\(' \
+  '^fn parse_pinned_roots_json_impl\(' \
+  '^fn load_production_roots_impl\(' \
+  '^fn insert_pinned_key\(' \
+  '^fn get_key_inner\(' \
+  '^fn empty_inner\('
+do
+  if rg -n "$forbidden" crates/assay-registry/src/trust.rs >/dev/null; then
+    echo "trust.rs still contains extracted implementation symbol: $forbidden" >&2
+    exit 1
+  fi
+done
+
+RUST_SCOPE_FILES=(
+  "crates/assay-registry/src/trust.rs"
+  "crates/assay-registry/src/trust_next/mod.rs"
+  "crates/assay-registry/src/trust_next/decode.rs"
+  "crates/assay-registry/src/trust_next/pinned.rs"
+  "crates/assay-registry/src/trust_next/manifest.rs"
+  "crates/assay-registry/src/trust_next/cache.rs"
+  "crates/assay-registry/src/trust_next/access.rs"
+)
+
+count_base_matches() {
+  local pattern="$1"
+  local total=0
+  local count
+  for file in "${RUST_SCOPE_FILES[@]}"; do
+    if git cat-file -e "$BASE_REF:$file" 2>/dev/null; then
+      count=$(git show "$BASE_REF:$file" | rg -o "$pattern" | wc -l | tr -d ' ' || true)
+      total=$((total + count))
+    fi
+  done
+  echo "$total"
+}
+
+count_head_matches() {
+  local pattern="$1"
+  local total=0
+  local count
+  for file in "${RUST_SCOPE_FILES[@]}"; do
+    if [[ -f "$file" ]]; then
+      count=$(rg -o "$pattern" "$file" | wc -l | tr -d ' ' || true)
+      total=$((total + count))
+    fi
+  done
+  echo "$total"
+}
+
+for pattern in 'unwrap\(' 'expect\(' '\bunsafe\b' 'println!\(' 'eprintln!\(' 'panic!\(' 'todo!\(' 'unimplemented!\('; do
+  base_count="$(count_base_matches "$pattern")"
+  head_count="$(count_head_matches "$pattern")"
+  if (( head_count > base_count )); then
+    echo "pattern '$pattern' increased in trust split scope: $base_count -> $head_count" >&2
+    exit 1
+  fi
+done
+
+cargo fmt --all --check
+cargo clippy -q -p assay-registry --all-targets -- -D warnings
+cargo check -q -p assay-registry
+
+cargo test -q -p assay-registry --lib 'trust::tests::test_with_production_roots_loads_embedded_roots' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_add_from_manifest' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_pinned_key_not_overwritten' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_needs_refresh' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_revoke_old_key' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_pinned_root_survives_revocation' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_key_expires_after_added' -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_accepts_signed_pack_with_embedded_production_root -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_rejects_signed_pack_with_untrusted_key_id -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- mechanically split `crates/assay-registry/src/trust.rs` behind the existing `TrustStore` facade
- move trust-store implementation into `trust_next/*` modules by responsibility
- add Wave48 Step2 review artifacts and reviewer script

## Scope
- `crates/assay-registry/src/trust.rs`
- `crates/assay-registry/src/trust_next/*`
- `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
- `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step2.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step2.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step2.md`
- `scripts/ci/review-wave48-registry-trust-step2.sh`

## Contract
- no pinned-root loading drift
- no key-id / SPKI validation drift
- no revoked/expired-key handling drift
- no cache/refresh drift
- no resolver / verification coupling drift
- no edits under `crates/assay-registry/tests/**`, `resolver.rs`, or `verify.rs`

## Validation
- `git diff --check`
- `cargo fmt --all --check`
- `cargo clippy -q -p assay-registry --all-targets -- -D warnings`
- `cargo check -q -p assay-registry`
- `BASE_REF=origin/main bash scripts/ci/review-wave48-registry-trust-step2.sh`
