### PR TITLE
docs: close wave48 registry trust split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step3.md
@@ -1,0 +1,30 @@
+# Wave48 Registry Trust Step3 Checklist (Closure)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step3.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step3.md`
+  - `scripts/ci/review-wave48-registry-trust-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-registry/src/**`
+- [ ] No edits under `crates/assay-registry/tests/**`
+- [ ] No new module proposals beyond the shipped `trust_next/*` layout
+
+## Step3 closure contract
+
+- [ ] Step2 is recorded as shipped behind a stable facade
+- [ ] Step3 is explicitly bounded to micro-cleanup only
+- [ ] `trust.rs` remains the stable facade entrypoint
+- [ ] `trust_next/*` remains the split implementation ownership boundary
+- [ ] No trust, resolver, validation, cache, or verification coupling drift is allowed in Step3
+- [ ] No public registry trust surface expansion is proposed in Step3
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave48-registry-trust-step3.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-registry --all-targets -- -D warnings` passes
+- [ ] Pinned trust/resolver invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step3.md
@@ -1,0 +1,42 @@
+# SPLIT-MOVE-MAP — Wave48 Step3 — `registry/trust.rs` Closure
+
+## Shipped layout
+
+Wave48 Step2 is now the shipped split shape on `main`:
+- `crates/assay-registry/src/trust.rs`
+- `crates/assay-registry/src/trust_next/mod.rs`
+- `crates/assay-registry/src/trust_next/decode.rs`
+- `crates/assay-registry/src/trust_next/pinned.rs`
+- `crates/assay-registry/src/trust_next/manifest.rs`
+- `crates/assay-registry/src/trust_next/cache.rs`
+- `crates/assay-registry/src/trust_next/access.rs`
+
+## Ownership freeze
+
+- `crates/assay-registry/src/trust.rs`
+  remains the stable facade for `TrustStore`, `KeyMetadata`, and top-level routing.
+- `crates/assay-registry/src/trust_next/decode.rs`
+  remains the decode and key-material parsing boundary.
+- `crates/assay-registry/src/trust_next/pinned.rs`
+  remains the production-root and pinned-key loading boundary.
+- `crates/assay-registry/src/trust_next/manifest.rs`
+  remains the manifest ingest and trust-rotation boundary.
+- `crates/assay-registry/src/trust_next/cache.rs`
+  remains the refresh and cache-state boundary.
+- `crates/assay-registry/src/trust_next/access.rs`
+  remains the sync/async read access and metadata boundary.
+
+## Allowed follow-up after closure
+
+- documentation updates only
+- reviewer-gate tightening only
+- future internal visibility tightening only if it requires a separate code wave
+
+## Explicitly deferred
+
+- new module cuts
+- trust-store semantic cleanup
+- pinned-root, manifest, or cache behavior changes
+- resolver behavior or verification coupling changes
+- validation or result-shape changes
+- registry contract or public surface changes

--- a/docs/contributing/SPLIT-PLAN-wave48-registry-trust.md
+++ b/docs/contributing/SPLIT-PLAN-wave48-registry-trust.md
@@ -80,7 +80,8 @@ Step2 may reorganize internal ownership behind `trust.rs`, but must not redefine
 
 - Wave47 closed on `main` via `#968`.
 - Wave48 Step1 shipped on `main` via `#969`.
-- Step2 is the mechanical split slice for `trust.rs`.
+- Wave48 Step2 shipped on `main` via `#970`.
+- Step3 is the closure slice for the shipped `trust.rs` split.
 
 ## Step2 (mechanical split preview)
 
@@ -143,9 +144,17 @@ Step3 constraints:
 - docs+gate only
 - no edits under `crates/assay-registry/src/**`
 - no edits under `crates/assay-registry/tests/**`
+- keep `trust.rs` as the stable facade entrypoint
 - no new module cuts
 - no behavior cleanup beyond internal follow-up notes
 - no pinned-root, manifest, cache, or verification coupling drift
+
+Step3 deliverables:
+- `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step3.md`
+- `scripts/ci/review-wave48-registry-trust-step3.sh`
 
 ## Promote
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step3.md
@@ -1,0 +1,52 @@
+# Wave48 Registry Trust Step3 Review Pack (Closure)
+
+## Intent
+
+Close the shipped Wave48 registry-trust split with docs/gates only and forbid post-Step2 redesign drift.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave48-registry-trust.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step3.md`
+- `scripts/ci/review-wave48-registry-trust-step3.sh`
+
+## Non-goals
+
+- no workflow changes
+- no changes under `crates/assay-registry/src/**`
+- no changes under `crates/assay-registry/tests/**`
+- no new module cuts
+- no trust-store redesign
+- no resolver, validation, cache, or verification-coupling drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave48-registry-trust-step3.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-registry --all-targets -- -D warnings
+cargo test -q -p assay-registry --lib 'trust::tests::test_with_production_roots_loads_embedded_roots' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_add_from_manifest' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_pinned_key_not_overwritten' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_needs_refresh' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_revoke_old_key' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_pinned_root_survives_revocation' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_key_expires_after_added' -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_accepts_signed_pack_with_embedded_production_root -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_rejects_signed_pack_with_untrusted_key_id -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step3 allowlist.
+2. Confirm `crates/assay-registry/src/**` and `crates/assay-registry/tests/**` are frozen in this wave.
+3. Confirm the plan records `#970` as shipped and bounds Step3 to closure only.
+4. Confirm the move-map freezes the current module ownership and does not propose another split.
+5. Confirm the reviewer script re-runs the pinned trust/resolver invariants.

--- a/scripts/ci/review-wave48-registry-trust-step3.sh
+++ b/scripts/ci/review-wave48-registry-trust-step3.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave48-registry-trust.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave48-registry-trust-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave48-registry-trust-step3.md"
+  "scripts/ci/review-wave48-registry-trust-step3.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-registry/src"
+  "crates/assay-registry/tests"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave48 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave48 Step3: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave48 Step3 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave48-registry-trust.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave48-registry-trust-step3.md"
+
+for marker in \
+  'Wave48 Step2 shipped on `main` via `#970`.' \
+  'keep `trust.rs` as the stable facade entrypoint' \
+  'Step3 constraints:' \
+  'no new module cuts' \
+  'no behavior cleanup beyond internal follow-up notes'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-registry/src/trust.rs' \
+  'crates/assay-registry/src/trust_next/manifest.rs' \
+  'crates/assay-registry/src/trust_next/access.rs' \
+  'future internal visibility tightening only if it requires a separate code wave' \
+  'registry contract or public surface changes'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-registry --all-targets -- -D warnings
+
+echo "[review] pinned trust invariants"
+cargo test -q -p assay-registry --lib 'trust::tests::test_with_production_roots_loads_embedded_roots' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_add_from_manifest' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_pinned_key_not_overwritten' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_needs_refresh' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_revoke_old_key' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_pinned_root_survives_revocation' -- --exact
+cargo test -q -p assay-registry --lib 'trust::tests::test_trust_rotation_key_expires_after_added' -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_accepts_signed_pack_with_embedded_production_root -- --exact
+cargo test -q -p assay-registry --test resolver_production_roots resolver_rejects_signed_pack_with_untrusted_key_id -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- close Wave48 with docs/gates only after `trust.rs` Step2 landed on `main`
- freeze the shipped `trust_next/*` ownership map and forbid post-split redesign drift
- add a Step3 reviewer script that enforces allowlist-only closure scope and reruns pinned trust/resolver invariants

## Testing
- git diff --check
- BASE_REF=origin/main bash scripts/ci/review-wave48-registry-trust-step3.sh
