### PR TITLE
docs: freeze wave49 memory poison split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step1.md
@@ -1,0 +1,30 @@
+# Wave49 Memory Poison Step1 Checklist (Freeze)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave49-memory-poison.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step1.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step1.md`
+  - `scripts/ci/review-wave49-memory-poison-step1.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-sim/src/attacks/**`
+- [ ] No edits under `crates/assay-sim/tests/**`
+- [ ] No `assay-core`, `assay-cli`, `assay-evidence`, or report-surface changes
+
+## Frozen contract
+
+- [ ] `PoisonResult`, `PoisonOutcome`, and `run_memory_poison_matrix` are explicitly frozen as the stable facade surface
+- [ ] No replay-diff or context-envelope behavior drift is allowed in Step2
+- [ ] No snapshot-hash, benign-control, or `AttackStatus` mapping drift is allowed in Step2
+- [ ] No result-count, ordering intent, or attack-name drift is allowed in Step2
+- [ ] No integration-test expectation drift is allowed in Step2
+- [ ] Step2 non-goals explicitly forbid attack redesign, optimization, or test reorganization
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave49-memory-poison-step1.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-sim --all-targets -- -D warnings` passes
+- [ ] Pinned memory-poison invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step1.md
@@ -1,0 +1,48 @@
+# Wave49 Step1 Move Map — `sim/attacks/memory_poison.rs`
+
+## Stable facade to preserve in Step2
+
+The following surface remains owned by `crates/assay-sim/src/attacks/memory_poison.rs` in Step1
+and must keep the same meaning in Step2:
+- `PoisonResult`
+- `PoisonOutcome`
+- `vector1_replay_baseline_poisoning`
+- `vector2_deny_convergence_poisoning`
+- `vector3_context_envelope_poisoning`
+- `vector4_decay_escape`
+- `control_b1_run_metadata_recall`
+- `control_b2_tool_observation_recall`
+- `control_b3_approval_context_recall`
+- `run_memory_poison_matrix`
+- existing inline tests
+
+## Proposed Step2 ownership split
+
+- `crates/assay-sim/src/attacks/memory_poison_next/basis.rs`
+  - clean replay-diff basis builders
+  - snapshot/hash helper construction inputs
+- `crates/assay-sim/src/attacks/memory_poison_next/vectors.rs`
+  - Condition A attack vectors V1-V4
+- `crates/assay-sim/src/attacks/memory_poison_next/controls.rs`
+  - benign controls B1-B3
+- `crates/assay-sim/src/attacks/memory_poison_next/conditions.rs`
+  - Condition B/C detection helpers and vector wrappers
+- `crates/assay-sim/src/attacks/memory_poison_next/matrix.rs`
+  - result builder and matrix runner assembly
+
+## Pinned invariants
+
+- identical replay-diff bucket behavior
+- identical Condition B/C detection behavior
+- identical benign-control no-false-positive behavior
+- identical `PoisonOutcome` / `AttackStatus` mapping
+- identical matrix cardinality and attack-name formatting
+- identical integration-test expectations in `memory_poison_invariant`
+
+## Explicitly unchanged in this wave
+
+- `crates/assay-sim/tests/**`
+- `crates/assay-core/**`
+- `crates/assay-cli/**`
+- `crates/assay-evidence/**`
+- `.github/workflows/**`

--- a/docs/contributing/SPLIT-PLAN-wave49-memory-poison.md
+++ b/docs/contributing/SPLIT-PLAN-wave49-memory-poison.md
@@ -1,0 +1,127 @@
+# Wave49 Plan — `sim/attacks/memory_poison.rs` Kernel Split
+
+## Goal
+
+Split `crates/assay-sim/src/attacks/memory_poison.rs` behind a stable facade with zero
+memory-poison semantic drift and no downstream replay, context-envelope, or report-output drift.
+
+Current hotspot baseline on `origin/main @ b2a83c58`:
+- `crates/assay-sim/src/attacks/memory_poison.rs`: `954` LOC
+- `crates/assay-sim/tests/memory_poison_invariant.rs`: memory-poison matrix companion
+- `crates/assay-core/src/mcp/decision.rs`: replay-diff / context contract companion
+
+## Step1 (freeze)
+
+Branch: `codex/wave49-memory-poison-step1` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave49-memory-poison.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step1.md`
+- `scripts/ci/review-wave49-memory-poison-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-sim/src/attacks/**`
+- no edits under `crates/assay-sim/tests/**`
+- no workflow edits
+- no `assay-core`, `assay-cli`, `assay-evidence`, or report-surface edits
+
+Step1 gate:
+- allowlist-only diff (the 5 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail on tracked changes in `crates/assay-sim/src/attacks/**`
+- hard fail on untracked files in `crates/assay-sim/src/attacks/**`
+- hard fail on tracked changes in `crates/assay-sim/tests/**`
+- hard fail on untracked files in `crates/assay-sim/tests/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-sim --all-targets -- -D warnings`
+- targeted tests:
+  - `cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector1_activates_under_condition_a' -- --exact`
+  - `cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector3_activates_under_condition_a' -- --exact`
+  - `cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::controls_produce_no_false_positives' -- --exact`
+  - `cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::full_matrix_runs_without_panic' -- --exact`
+  - `cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_b_blocks_v1_and_v2' -- --exact`
+  - `cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_c_blocks_v3' -- --exact`
+  - `cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::overarching_invariant_controls_never_misclassify' -- --exact`
+  - `cargo test -q -p assay-sim --test memory_poison_invariant overarching_invariant_no_silent_downgrades_in_controls -- --exact`
+  - `cargo test -q -p assay-sim --test memory_poison_invariant attack_vectors_activate_under_condition_a -- --exact`
+  - `cargo test -q -p assay-sim --test memory_poison_invariant condition_b_blocks_replay_vectors -- --exact`
+  - `cargo test -q -p assay-sim --test memory_poison_invariant condition_c_blocks_context_envelope -- --exact`
+  - `cargo test -q -p assay-sim --test memory_poison_invariant full_matrix_structure -- --exact`
+
+## Frozen public surface
+
+Wave49 freezes the expectation that Step2 keeps these memory-poison entrypoints and outputs
+unchanged in meaning:
+- `PoisonResult`
+- `PoisonOutcome`
+- `vector1_replay_baseline_poisoning`
+- `vector2_deny_convergence_poisoning`
+- `vector3_context_envelope_poisoning`
+- `vector4_decay_escape`
+- `control_b1_run_metadata_recall`
+- `control_b2_tool_observation_recall`
+- `control_b3_approval_context_recall`
+- `run_memory_poison_matrix`
+
+Step2 may reorganize internal ownership behind `memory_poison.rs`, but must not redefine:
+- replay-diff bucket behavior for Condition A/B paths
+- context-envelope completeness behavior for Condition A/C paths
+- snapshot-hash behavior for vector 4
+- benign-control no-false-positive behavior
+- `PoisonOutcome` meaning or `AttackStatus` mapping
+- matrix result count, ordering intent, or attack naming format
+- downstream invariant-test expectations
+
+## Status
+
+- Wave48 closed on `main` via `#971`.
+- Wave49 Step1 is the behavior-freeze slice for `memory_poison.rs`.
+
+## Step2 (mechanical split preview)
+
+Branch: `codex/wave49-memory-poison-step2` (base: `main`)
+
+Target layout:
+- `crates/assay-sim/src/attacks/memory_poison.rs` (thin facade + stable routing)
+- `crates/assay-sim/src/attacks/memory_poison_next/mod.rs`
+- `crates/assay-sim/src/attacks/memory_poison_next/basis.rs`
+- `crates/assay-sim/src/attacks/memory_poison_next/vectors.rs`
+- `crates/assay-sim/src/attacks/memory_poison_next/controls.rs`
+- `crates/assay-sim/src/attacks/memory_poison_next/conditions.rs`
+- `crates/assay-sim/src/attacks/memory_poison_next/matrix.rs`
+
+Step2 principles:
+- 1:1 body moves
+- stable `memory_poison.rs` facade behavior
+- no replay-diff or context-envelope drift
+- no `PoisonOutcome` / `AttackStatus` mapping drift
+- no matrix count or attack-name drift
+- no edits under `crates/assay-sim/tests/**`
+- no workflow edits
+
+## Step3 (closure)
+
+Step3 will close the shipped Wave49 memory-poison split with docs/gates only once Step2 lands on
+`main`.
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once the chain is clean.
+
+## Reviewer notes
+
+This wave must remain memory-poison split planning only.
+
+Primary failure modes:
+- sneaking attack-semantic cleanup into a mechanical split
+- changing result counts or attack names while chasing file size
+- changing Condition B/C detection semantics under a refactor label
+- drifting integration-test expectations via helper moves

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step1.md
@@ -1,0 +1,56 @@
+# Wave49 Memory Poison Step1 Review Pack (Freeze)
+
+## Intent
+
+Freeze the behavior of `memory_poison.rs` before any mechanical split so Step2 can be reviewed as
+relocation rather than redesign.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave49-memory-poison.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step1.md`
+- `scripts/ci/review-wave49-memory-poison-step1.sh`
+
+## Non-goals
+
+- no workflow changes
+- no changes under `crates/assay-sim/src/attacks/**`
+- no changes under `crates/assay-sim/tests/**`
+- no new attack vectors or controls
+- no matrix redesign
+- no replay/context/status/result drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave49-memory-poison-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-sim --all-targets -- -D warnings
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector1_activates_under_condition_a' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector3_activates_under_condition_a' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::controls_produce_no_false_positives' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::full_matrix_runs_without_panic' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_b_blocks_v1_and_v2' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_c_blocks_v3' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::overarching_invariant_controls_never_misclassify' -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant overarching_invariant_no_silent_downgrades_in_controls -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant attack_vectors_activate_under_condition_a -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant condition_b_blocks_replay_vectors -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant condition_c_blocks_context_envelope -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant full_matrix_structure -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step1 allowlist.
+2. Confirm `crates/assay-sim/src/attacks/**` and `crates/assay-sim/tests/**` are frozen in this wave.
+3. Confirm the plan freezes replay/context/status/result semantics before any split.
+4. Confirm the move-map proposes a mechanical Step2 ownership cut rather than a redesign.
+5. Confirm the reviewer script reruns both inline and integration memory-poison invariants.

--- a/scripts/ci/review-wave49-memory-poison-step1.sh
+++ b/scripts/ci/review-wave49-memory-poison-step1.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave49-memory-poison.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step1.md"
+  "scripts/ci/review-wave49-memory-poison-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-sim/src/attacks"
+  "crates/assay-sim/tests"
+  "crates/assay-core"
+  "crates/assay-cli"
+  "crates/assay-evidence"
+)
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave49 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave49 Step1: $f"
+    exit 1
+  fi
+done < <(git diff --name-only "$BASE_REF"...HEAD)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave49 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave49-memory-poison.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step1.md"
+
+for marker in \
+  'Split `crates/assay-sim/src/attacks/memory_poison.rs` behind a stable facade' \
+  'run_memory_poison_matrix' \
+  'Step2 principles:' \
+  'no replay-diff or context-envelope drift' \
+  'no `assay-core`, `assay-cli`, `assay-evidence`, or report-surface edits'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-sim/src/attacks/memory_poison_next/vectors.rs' \
+  'crates/assay-sim/src/attacks/memory_poison_next/conditions.rs' \
+  'identical `PoisonOutcome` / `AttackStatus` mapping' \
+  'memory_poison_invariant'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-sim --all-targets -- -D warnings
+
+echo "[review] pinned memory-poison invariants"
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector1_activates_under_condition_a' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector3_activates_under_condition_a' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::controls_produce_no_false_positives' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::full_matrix_runs_without_panic' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_b_blocks_v1_and_v2' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_c_blocks_v3' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::overarching_invariant_controls_never_misclassify' -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant overarching_invariant_no_silent_downgrades_in_controls -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant attack_vectors_activate_under_condition_a -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant condition_b_blocks_replay_vectors -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant condition_c_blocks_context_envelope -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant full_matrix_structure -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- freeze `memory_poison.rs` behavior before any mechanical split
- pin replay/context/status/result invariants for the attack matrix and benign controls
- add a Step1 reviewer script that enforces docs-only scope and reruns both inline and integration memory-poison tests

## Testing
- git diff --check
- BASE_REF=origin/main bash scripts/ci/review-wave49-memory-poison-step1.sh
