### PR TITLE
fix: address registry trust copilot feedback

### DIFF
--- a/crates/assay-registry/src/trust.rs
+++ b/crates/assay-registry/src/trust.rs
@@ -32,7 +32,9 @@ use trust_next::cache;
 use trust_next::manifest;
 #[cfg(test)]
 use trust_next::pinned::parse_pinned_roots_json_impl;
-use trust_next::pinned::{insert_pinned_key, load_production_roots_impl};
+use trust_next::pinned::{
+    insert_pinned_key, insert_prepared_pinned_key, load_production_roots_impl, prepare_pinned_key,
+};
 
 /// Trust store for signing keys.
 #[derive(Debug, Clone)]
@@ -118,8 +120,10 @@ impl TrustStore {
 
     /// Add a pinned root key.
     pub async fn add_pinned_key(&self, key: &TrustedKey) -> RegistryResult<()> {
+        let prepared = prepare_pinned_key(key)?;
         let mut inner = self.inner.write().await;
-        insert_pinned_key(&mut inner, key)
+        insert_prepared_pinned_key(&mut inner, prepared);
+        Ok(())
     }
 
     /// Add keys from a manifest (fetched from registry).

--- a/crates/assay-registry/src/trust_next/pinned.rs
+++ b/crates/assay-registry/src/trust_next/pinned.rs
@@ -11,9 +11,9 @@ use super::cache;
 use super::decode::{decode_public_key_bytes, decode_verifying_key};
 
 pub(in crate::trust) struct PreparedPinnedKey {
-    pub key_id: String,
-    pub verifying_key: ed25519_dalek::VerifyingKey,
-    pub metadata: KeyMetadata,
+    key_id: String,
+    verifying_key: ed25519_dalek::VerifyingKey,
+    metadata: KeyMetadata,
 }
 
 pub(in crate::trust) fn parse_pinned_roots_json_impl(raw: &str) -> RegistryResult<Vec<TrustedKey>> {

--- a/crates/assay-registry/src/trust_next/pinned.rs
+++ b/crates/assay-registry/src/trust_next/pinned.rs
@@ -10,6 +10,12 @@ use crate::verify::compute_key_id;
 use super::cache;
 use super::decode::{decode_public_key_bytes, decode_verifying_key};
 
+pub(in crate::trust) struct PreparedPinnedKey {
+    pub key_id: String,
+    pub verifying_key: ed25519_dalek::VerifyingKey,
+    pub metadata: KeyMetadata,
+}
+
 pub(in crate::trust) fn parse_pinned_roots_json_impl(raw: &str) -> RegistryResult<Vec<TrustedKey>> {
     let roots: Vec<TrustedKey> = serde_json::from_str(raw).map_err(|e| RegistryError::Config {
         message: format!("invalid production trust roots: {}", e),
@@ -63,10 +69,7 @@ pub(in crate::trust) fn load_production_roots_impl(raw: &str) -> RegistryResult<
     })
 }
 
-pub(in crate::trust) fn insert_pinned_key(
-    inner: &mut TrustStoreInner,
-    key: &TrustedKey,
-) -> RegistryResult<()> {
+pub(in crate::trust) fn prepare_pinned_key(key: &TrustedKey) -> RegistryResult<PreparedPinnedKey> {
     let verifying_key = decode_verifying_key(&key.public_key)?;
     let computed_id = compute_key_id(&decode_public_key_bytes(&key.public_key)?);
 
@@ -79,20 +82,41 @@ pub(in crate::trust) fn insert_pinned_key(
         });
     }
 
-    inner.keys.insert(key.key_id.clone(), verifying_key);
-    inner.metadata.insert(
-        key.key_id.clone(),
-        KeyMetadata {
+    Ok(PreparedPinnedKey {
+        key_id: key.key_id.clone(),
+        verifying_key,
+        metadata: KeyMetadata {
             description: key.description.clone(),
             added_at: key.added_at,
             expires_at: key.expires_at,
             revoked: false,
             is_pinned: true,
         },
-    );
-    if !inner.pinned_roots.contains(&key.key_id) {
-        inner.pinned_roots.push(key.key_id.clone());
-    }
+    })
+}
 
+pub(in crate::trust) fn insert_prepared_pinned_key(
+    inner: &mut TrustStoreInner,
+    prepared: PreparedPinnedKey,
+) {
+    let PreparedPinnedKey {
+        key_id,
+        verifying_key,
+        metadata,
+    } = prepared;
+
+    inner.keys.insert(key_id.clone(), verifying_key);
+    inner.metadata.insert(key_id.clone(), metadata);
+    if !inner.pinned_roots.contains(&key_id) {
+        inner.pinned_roots.push(key_id);
+    }
+}
+
+pub(in crate::trust) fn insert_pinned_key(
+    inner: &mut TrustStoreInner,
+    key: &TrustedKey,
+) -> RegistryResult<()> {
+    let prepared = prepare_pinned_key(key)?;
+    insert_prepared_pinned_key(inner, prepared);
     Ok(())
 }

--- a/scripts/ci/review-wave48-registry-trust-step2.sh
+++ b/scripts/ci/review-wave48-registry-trust-step2.sh
@@ -21,11 +21,16 @@ ALLOWED_FILES=(
 )
 
 changed_files() {
-  git diff --name-only "$BASE_REF"...HEAD || true
-  git diff --name-only || true
-  git diff --name-only --cached || true
-  git ls-files --others --exclude-standard || true
+  git diff --name-only "$BASE_REF"...HEAD
+  git diff --name-only
+  git diff --name-only --cached
+  git ls-files --others --exclude-standard
 }
+
+if ! git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+  echo "BASE_REF does not resolve to a commit: $BASE_REF" >&2
+  exit 1
+fi
 
 DIFF_FILES=()
 mapfile -t DIFF_FILES < <(changed_files | awk 'NF' | sort -u)

--- a/scripts/ci/review-wave48-registry-trust-step2.sh
+++ b/scripts/ci/review-wave48-registry-trust-step2.sh
@@ -20,13 +20,15 @@ ALLOWED_FILES=(
   "scripts/ci/review-wave48-registry-trust-step2.sh"
 )
 
+changed_files() {
+  git diff --name-only "$BASE_REF"...HEAD || true
+  git diff --name-only || true
+  git diff --name-only --cached || true
+  git ls-files --others --exclude-standard || true
+}
+
 DIFF_FILES=()
-while IFS= read -r file; do
-  DIFF_FILES+=("$file")
-done < <(git diff --name-only "$BASE_REF"...HEAD)
-while IFS= read -r file; do
-  DIFF_FILES+=("$file")
-done < <(git ls-files --others --exclude-standard)
+mapfile -t DIFF_FILES < <(changed_files | awk 'NF' | sort -u)
 
 if (( ${#DIFF_FILES[@]} > 0 )); then
   for file in "${DIFF_FILES[@]}"; do
@@ -53,7 +55,7 @@ fi
 if (( ${#DIFF_FILES[@]} > 0 )); then
   for file in "${DIFF_FILES[@]}"; do
     [[ -z "$file" ]] && continue
-    if [[ "$file" == crates/assay-registry/tests/* ]]; then
+    if [[ "$file" =~ ^crates/assay-registry/tests/ ]]; then
       echo "registry tests must remain untouched in Step2" >&2
       exit 1
     fi

--- a/scripts/ci/review-wave48-registry-trust-step3.sh
+++ b/scripts/ci/review-wave48-registry-trust-step3.sh
@@ -20,6 +20,13 @@ FROZEN_PATHS=(
   "crates/assay-registry/tests"
 )
 
+changed_files() {
+  git diff --name-only "$BASE_REF"...HEAD || true
+  git diff --name-only || true
+  git diff --name-only --cached || true
+  git ls-files --others --exclude-standard || true
+}
+
 echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
 while IFS= read -r f; do
   [[ -z "${f:-}" ]] && continue
@@ -38,7 +45,7 @@ while IFS= read -r f; do
     echo "FAIL: file not allowed in Wave48 Step3: $f"
     exit 1
   fi
-done < <(git diff --name-only "$BASE_REF"...HEAD)
+done < <(changed_files | awk 'NF' | sort -u)
 
 echo "[review] frozen tracked paths must not change"
 for p in "${FROZEN_PATHS[@]}"; do


### PR DESCRIPTION
## Summary
- shrink pinned-key write lock scope in the registry trust store
- harden the Wave48 Step2/Step3 reviewer scripts to see base, index, working-tree, and untracked changes
- fix the Step2 test-path guard so nested registry tests remain frozen

## Testing
- git diff --check
- bash -n scripts/ci/review-wave48-registry-trust-step2.sh
- bash -n scripts/ci/review-wave48-registry-trust-step3.sh
- cargo fmt --all --check
- cargo check -q -p assay-registry
- cargo clippy -q -p assay-registry --all-targets -- -D warnings
- cargo test -q -p assay-registry --lib trust::tests::test_with_production_roots_loads_embedded_roots -- --exact
- cargo test -q -p assay-registry --lib trust::tests::test_add_from_manifest -- --exact
- cargo test -q -p assay-registry --lib trust::tests::test_pinned_key_not_overwritten -- --exact
- cargo test -q -p assay-registry --test resolver_production_roots resolver_accepts_signed_pack_with_embedded_production_root -- --exact
- cargo test -q -p assay-registry --test resolver_production_roots resolver_rejects_signed_pack_with_untrusted_key_id -- --exact