### PR TITLE
docs: close wave49 memory poison split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step3.md
@@ -1,0 +1,31 @@
+# Wave49 Memory Poison Step3 Checklist (Closure)
+
+## Scope lock
+
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave49-memory-poison.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step3.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step3.md`
+  - `scripts/ci/review-wave49-memory-poison-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-sim/src/attacks/**`
+- [ ] No edits under `crates/assay-sim/tests/**`
+- [ ] No new module proposals beyond the shipped `memory_poison_next/*` layout
+
+## Step3 closure contract
+
+- [ ] Step2 is recorded as shipped behind a stable facade
+- [ ] The fail-closed replay-basis hashing follow-up is recorded as shipped
+- [ ] Step3 is explicitly bounded to micro-cleanup only
+- [ ] `memory_poison.rs` remains the stable facade entrypoint
+- [ ] `memory_poison_next/*` remains the shipped implementation ownership boundary
+- [ ] No replay, context-envelope, status, or matrix-contract drift is proposed in Step3
+- [ ] No public `assay-sim` surface expansion is proposed in Step3
+
+## Validation
+
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-wave49-memory-poison-step3.sh` passes
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -p assay-sim --all-targets -- -D warnings` passes
+- [ ] Pinned memory-poison invariants pass

--- a/docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step3.md
@@ -1,0 +1,56 @@
+# Wave49 Step3 Move Map (Closure)
+
+Stable facade retained in `crates/assay-sim/src/attacks/memory_poison.rs`:
+
+- `PoisonResult`
+- `PoisonOutcome`
+- `vector1_replay_baseline_poisoning`
+- `vector2_deny_convergence_poisoning`
+- `vector3_context_envelope_poisoning`
+- `vector4_decay_escape`
+- `control_b1_run_metadata_recall`
+- `control_b2_tool_observation_recall`
+- `control_b3_approval_context_recall`
+- `run_memory_poison_matrix`
+- existing inline tests
+- `#[path = "memory_poison_next/mod.rs"] mod memory_poison_next;`
+
+Shipped implementation ownership in `crates/assay-sim/src/attacks/memory_poison_next/basis.rs`:
+
+- clean replay-diff basis builders
+- snapshot-hash helpers
+- fail-closed replay basis hashing path from `#975`
+
+Shipped implementation ownership in `crates/assay-sim/src/attacks/memory_poison_next/vectors.rs`:
+
+- Condition A vectors V1-V4
+- replay baseline poisoning path
+- deny convergence poisoning path
+- context-envelope poisoning path
+- decay/snapshot poisoning path
+
+Shipped implementation ownership in `crates/assay-sim/src/attacks/memory_poison_next/controls.rs`:
+
+- benign controls B1-B3
+- no-false-positive control evaluation paths
+
+Shipped implementation ownership in `crates/assay-sim/src/attacks/memory_poison_next/conditions.rs`:
+
+- Condition B/C defense paths for the applicable vectors
+
+Shipped implementation ownership in `crates/assay-sim/src/attacks/memory_poison_next/matrix.rs`:
+
+- result builder
+- matrix runner loop
+- condition/result assembly and naming logic
+
+Future cleanup still out of scope in Step3:
+
+- future internal visibility tightening only if it requires a separate code wave
+- memory-poison result or attack-name contract changes
+- replay/context semantics changes
+- `crates/assay-sim/tests/**`
+- `crates/assay-core/**`
+- `crates/assay-cli/**`
+- `crates/assay-evidence/**`
+- `.github/workflows/**`

--- a/docs/contributing/SPLIT-PLAN-wave49-memory-poison.md
+++ b/docs/contributing/SPLIT-PLAN-wave49-memory-poison.md
@@ -79,7 +79,9 @@ Step2 may reorganize internal ownership behind `memory_poison.rs`, but must not 
 
 - Wave48 closed on `main` via `#971`.
 - Wave49 Step1 shipped on `main` via `#972`.
-- Step2 is the mechanical split slice for `memory_poison.rs`.
+- Wave49 Step2 shipped on `main` via `#973`.
+- `#975` shipped the follow-up fail-closed hashing fix for replay basis comparison.
+- Step3 is the closure slice for the shipped `memory_poison.rs` split.
 
 ## Step2 (mechanical split preview)
 
@@ -135,17 +137,34 @@ Current Step2 LOC snapshot on this branch:
 
 ## Step3 (closure)
 
-Step3 will close the shipped Wave49 memory-poison split with docs/gates only once Step2 lands on
-`main`.
+Branch: `codex/wave49-memory-poison-step3` (base: `main`)
+
+Step3 closes the shipped Wave49 memory-poison split with docs/gates only.
+
+Step3 constraints:
+- docs+gate only
+- no edits under `crates/assay-sim/src/attacks/**`
+- no edits under `crates/assay-sim/tests/**`
+- no workflow edits
+- no `assay-core`, `assay-cli`, `assay-evidence`, or report-surface edits
+- keep `memory_poison.rs` as the stable facade entrypoint
+- no new module cuts
+- no behavior cleanup beyond internal follow-up notes
+
+Step3 deliverables:
+- `docs/contributing/SPLIT-PLAN-wave49-memory-poison.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step3.md`
+- `scripts/ci/review-wave49-memory-poison-step3.sh`
 
 ## Promote
 
-Stacked chain:
-- Step1 -> `main`
-- Step2 -> Step1
-- Step3 -> Step2
-
-Final promote PR to `main` from Step3 once the chain is clean.
+Completed chain:
+- Step1 -> `main` via `#972`
+- Step2 -> `main` via `#973`
+- follow-up fix -> `main` via `#975`
+- Step3 -> current closure PR to `main`
 
 ## Reviewer notes
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step3.md
@@ -1,0 +1,57 @@
+# Wave49 Memory Poison Step3 Review Pack (Closure)
+
+## Intent
+
+Close the shipped `memory_poison.rs` split with docs/gates only and explicitly forbid any new
+memory-poison semantic or surface drift in the closure slice.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave49-memory-poison.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step3.md`
+- `scripts/ci/review-wave49-memory-poison-step3.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-sim/src/attacks/**`
+- no edits under `crates/assay-sim/tests/**`
+- no new vectors or controls
+- no matrix redesign
+- no replay/context/status/result drift
+- no `assay-core`, `assay-cli`, or `assay-evidence` coupling drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave49-memory-poison-step3.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-sim --all-targets -- -D warnings
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector1_activates_under_condition_a' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector3_activates_under_condition_a' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::controls_produce_no_false_positives' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::full_matrix_runs_without_panic' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_b_blocks_v1_and_v2' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_c_blocks_v3' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::overarching_invariant_controls_never_misclassify' -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant overarching_invariant_no_silent_downgrades_in_controls -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant attack_vectors_activate_under_condition_a -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant condition_b_blocks_replay_vectors -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant condition_c_blocks_context_envelope -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant full_matrix_structure -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step3 allowlist.
+2. Confirm the plan records both `#973` and the fail-closed follow-up `#975` as shipped on `main`.
+3. Confirm the move-map reflects the shipped `memory_poison_next/*` ownership boundary and proposes no new module cuts.
+4. Confirm `crates/assay-sim/src/attacks/**` and `crates/assay-sim/tests/**` stayed untouched.
+5. Confirm the reviewer script reruns the pinned memory-poison invariants without adding new scope.

--- a/scripts/ci/review-wave49-memory-poison-step3.sh
+++ b/scripts/ci/review-wave49-memory-poison-step3.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave49-memory-poison.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave49-memory-poison-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave49-memory-poison-step3.md"
+  "scripts/ci/review-wave49-memory-poison-step3.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-sim/src/attacks"
+  "crates/assay-sim/tests"
+)
+
+changed_files() {
+  git diff --name-only "$BASE_REF"...HEAD || true
+  git diff --name-only || true
+  git diff --name-only --cached || true
+  git ls-files --others --exclude-standard || true
+}
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave49 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave49 Step3: $f"
+    exit 1
+  fi
+done < <(changed_files | awk 'NF' | sort -u)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave49 Step3 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave49-memory-poison.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave49-memory-poison-step3.md"
+
+for marker in \
+  'Wave49 Step2 shipped on `main` via `#973`.' \
+  '`#975` shipped the follow-up fail-closed hashing fix for replay basis comparison.' \
+  'keep `memory_poison.rs` as the stable facade entrypoint' \
+  'Step3 constraints:' \
+  'no new module cuts' \
+  'no behavior cleanup beyond internal follow-up notes'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-sim/src/attacks/memory_poison.rs' \
+  'crates/assay-sim/src/attacks/memory_poison_next/basis.rs' \
+  'crates/assay-sim/src/attacks/memory_poison_next/vectors.rs' \
+  'crates/assay-sim/src/attacks/memory_poison_next/controls.rs' \
+  'crates/assay-sim/src/attacks/memory_poison_next/conditions.rs' \
+  'crates/assay-sim/src/attacks/memory_poison_next/matrix.rs' \
+  'future internal visibility tightening only if it requires a separate code wave' \
+  'memory-poison result or attack-name contract changes'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-sim --all-targets -- -D warnings
+
+echo "[review] pinned memory-poison invariants"
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector1_activates_under_condition_a' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::vector3_activates_under_condition_a' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::controls_produce_no_false_positives' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::full_matrix_runs_without_panic' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_b_blocks_v1_and_v2' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::condition_c_blocks_v3' -- --exact
+cargo test -q -p assay-sim --lib 'attacks::memory_poison::tests::overarching_invariant_controls_never_misclassify' -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant overarching_invariant_no_silent_downgrades_in_controls -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant attack_vectors_activate_under_condition_a -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant condition_b_blocks_replay_vectors -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant condition_c_blocks_context_envelope -- --exact
+cargo test -q -p assay-sim --test memory_poison_invariant full_matrix_structure -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- close Wave49 with a docs-and-gates-only Step3 slice
- record Step2 and the replay-basis hashing follow-up as shipped on main
- add a Step3 reviewer gate that enforces allowlist-only scope and reruns pinned memory-poison invariants

## Testing
- git diff --check
- BASE_REF=origin/main bash scripts/ci/review-wave49-memory-poison-step3.sh