### PR TITLE
docs: add test hotspot split plans

### DIFF
--- a/docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md
+++ b/docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md
@@ -77,6 +77,7 @@ Step1 constraints:
 Step1 gate should pin representative tests from each family, for example:
 
 - `cargo test -q -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact`
+- `cargo test -q -p assay-core --test decision_emit_invariant test_delegation_fields_are_additive_on_emitted_decisions -- --exact`
 - `cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact`
 - `cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact`
 - `cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact`
@@ -88,6 +89,10 @@ Step1 gate should pin representative tests from each family, for example:
 
 Step2 should replace the single-file target with one multi-file target directory while preserving
 the test target name and its black-box contract role.
+
+Converting `tests/decision_emit_invariant.rs` to
+`tests/decision_emit_invariant/main.rs` must preserve the same Cargo integration-test target
+identity.
 
 Target layout:
 
@@ -105,6 +110,8 @@ Step2 principles:
 
 - keep one integration-test binary by default
 - keep `main.rs` as the test-target root and top-level module wiring only
+- keep `main.rs` limited to module wiring and, if strictly necessary, a minimal shared prelude
+- do not leave the bulk of test bodies in `main.rs`
 - move helper/setup code into `fixtures.rs`
 - move test bodies by scenario family, not by arbitrary file-size chunks
 - keep the suite black-box; do not convert any part of it into white-box/private-item tests
@@ -112,8 +119,8 @@ Step2 principles:
 
 Step2 family ownership:
 
-- `fixtures.rs`: emitters, request builders, policy builders, artifact builders
-- `emission.rs`: allow/deny, multiple-call emission, event-source, tool-call-id, required fields, non-tool-call, obligation basics
+- `fixtures.rs`: shared emitters, request builders, policy builders, and artifact builders only; no scenario-specific assertions or scenario-owned behavior unless genuinely reused across families
+- `emission.rs`: allow/deny, multiple-call emission, event-source, tool-call-id, required fields, non-tool-call, and cross-cutting obligation basics only; if one subgroup grows disproportionately, that is a later follow-up candidate rather than part of this split
 - `approval.rs`: `approval_required_*`
 - `restrict_scope.rs`: `restrict_scope_*`
 - `redaction.rs`: `redact_args_*`
@@ -148,6 +155,7 @@ Primary failure modes:
 - No production edits under `crates/assay-core/src/**`.
 - No new integration-test binaries in the first split.
 - No test-helper sharing via `tests/common/mod.rs` unless a later wave actually introduces
-  multiple top-level integration targets.
+  multiple top-level integration targets; in this wave there is exactly one preserved integration
+  target, so shared helpers belong inside that target.
 - No ownership reshuffle of emitted decision semantics.
 - No renaming of test target, contract families, or assertion intent.

--- a/docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md
+++ b/docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md
@@ -1,0 +1,153 @@
+# T-R1 Plan — `tests/decision_emit_invariant.rs` Integration Target Decomposition
+
+## Goal
+
+Split `crates/assay-core/tests/decision_emit_invariant.rs` into a multi-file integration-test
+target without changing emitted decision-contract behavior, test target identity, or black-box
+coverage meaning.
+
+This plan intentionally follows Rust/Cargo integration-test conventions:
+
+- keep this suite under `tests/`
+- keep it as one coherent integration-test target by default
+- decompose it internally via `tests/<target>/main.rs` plus submodules
+- avoid fragmenting one contract surface into many top-level integration-test crates unless
+  later CI or ownership pressure clearly justifies that
+
+Current hotspot baseline on `origin/main @ 66c424c1`:
+
+- `crates/assay-core/tests/decision_emit_invariant.rs`: `1293` LOC
+- `crates/assay-core/src/mcp/decision.rs`: already split in Wave43 and now the primary emitted-decision companion
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`: already split in Wave44 and now a behavior companion
+- `crates/assay-core/src/mcp/policy/engine.rs`: already split in Wave45 and now a policy-semantic companion
+
+## Why this plan exists
+
+`decision_emit_invariant.rs` is now one of the largest handwritten Rust files left on `main`,
+but it is still a **black-box contract target**, not a production runtime hotspot.
+
+That means the right split shape is:
+
+- one integration-test binary
+- one coherent emitted-decision contract surface
+- shared fixtures/helpers kept inside that target
+- no conversion into multiple top-level `tests/*.rs` crates as a first move
+
+The primary reason for this shape is contract coherence, not just runtime. One integration target
+keeps the emitted JSON assertions, fixture setup, and reviewer context together and avoids
+duplicating setup across many integration crates.
+
+## Frozen target surface
+
+T-R1 freezes the expectation that any later split keeps these test-surface properties stable:
+
+- the target name remains `decision_emit_invariant`
+- the suite remains an integration-test target under `crates/assay-core/tests`
+- the suite continues to validate emitted-decision behavior through black-box request/emitter flows
+- the existing helpers remain semantically equivalent in setup intent:
+  - `TestEmitter`
+  - `make_tool_request`
+  - `make_tool_request_with_args`
+  - `approval_required_policy`
+  - `restrict_scope_policy_with_contract`
+  - `redact_args_policy_with_contract`
+  - `approval_artifact`
+- the current emitted-contract families remain stable in meaning:
+  - allow/deny emission
+  - delegation additive fields
+  - approval-required deny paths
+  - restrict-scope deny/additive-field paths
+  - redact-args deny/additive-field paths
+  - guard drop/panic emission
+  - required emitted field coverage
+  - G3 auth projection filtering
+
+## Step1 (freeze)
+
+Step1 should be docs/gates only.
+
+Step1 constraints:
+
+- no edits under `crates/assay-core/tests/decision_emit_invariant.rs`
+- no edits under `crates/assay-core/src/mcp/**`
+- no edits under `crates/assay-core/src/mcp/policy/**`
+- no workflow edits
+- no event-shape, reason-code, or emitted JSON contract drift
+
+Step1 gate should pin representative tests from each family, for example:
+
+- `cargo test -q -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact`
+- `cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact`
+- `cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact`
+- `cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact`
+- `cargo test -q -p assay-core --test decision_emit_invariant test_guard_emits_on_panic -- --exact`
+- `cargo test -q -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact`
+- `cargo test -q -p assay-core --test decision_emit_invariant g3_auth_projection_emits_allowlisted_scheme_trimmed_issuer_principal_in_decision_json -- --exact`
+
+## Step2 (mechanical split preview)
+
+Step2 should replace the single-file target with one multi-file target directory while preserving
+the test target name and its black-box contract role.
+
+Target layout:
+
+- `crates/assay-core/tests/decision_emit_invariant/main.rs`
+- `crates/assay-core/tests/decision_emit_invariant/fixtures.rs`
+- `crates/assay-core/tests/decision_emit_invariant/emission.rs`
+- `crates/assay-core/tests/decision_emit_invariant/approval.rs`
+- `crates/assay-core/tests/decision_emit_invariant/restrict_scope.rs`
+- `crates/assay-core/tests/decision_emit_invariant/redaction.rs`
+- `crates/assay-core/tests/decision_emit_invariant/guard.rs`
+- `crates/assay-core/tests/decision_emit_invariant/delegation.rs`
+- `crates/assay-core/tests/decision_emit_invariant/g3_auth.rs`
+
+Step2 principles:
+
+- keep one integration-test binary by default
+- keep `main.rs` as the test-target root and top-level module wiring only
+- move helper/setup code into `fixtures.rs`
+- move test bodies by scenario family, not by arbitrary file-size chunks
+- keep the suite black-box; do not convert any part of it into white-box/private-item tests
+- do not introduce a second integration-test target in the first cut
+
+Step2 family ownership:
+
+- `fixtures.rs`: emitters, request builders, policy builders, artifact builders
+- `emission.rs`: allow/deny, multiple-call emission, event-source, tool-call-id, required fields, non-tool-call, obligation basics
+- `approval.rs`: `approval_required_*`
+- `restrict_scope.rs`: `restrict_scope_*`
+- `redaction.rs`: `redact_args_*`
+- `guard.rs`: guard drop/panic tests
+- `delegation.rs`: additive delegation-field tests
+- `g3_auth.rs`: G3 auth projection filtering tests
+
+## Step3 (closure)
+
+Step3 should be docs/gates only.
+
+Step3 constraints:
+
+- keep `crates/assay-core/tests/decision_emit_invariant/main.rs` as the stable target root
+- no new module cuts
+- no promotion to multiple integration binaries
+- no drift in emitted-contract assertions
+- no fixture cleanup beyond notes/follow-ups
+
+## Reviewer notes
+
+Primary failure modes:
+
+- splitting one contract target into many top-level integration crates without a real need
+- moving shared fixtures into duplicated per-file setup
+- drifting emitted decision JSON expectations under a “test-only refactor” label
+- leaking white-box assumptions into a suite that should stay black-box
+- mixing production behavior changes into a test decomposition wave
+
+## Non-goals
+
+- No production edits under `crates/assay-core/src/**`.
+- No new integration-test binaries in the first split.
+- No test-helper sharing via `tests/common/mod.rs` unless a later wave actually introduces
+  multiple top-level integration targets.
+- No ownership reshuffle of emitted decision semantics.
+- No renaming of test target, contract families, or assertion intent.

--- a/docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md
+++ b/docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md
@@ -78,6 +78,7 @@ Step1 gate should pin representative tests from each family, for example:
 - `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::restrict_scope_target_missing_denies' -- --exact`
 - `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::redact_args_target_missing_denies' -- --exact`
 - `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_tool_drift_deny_emits_alert_obligation_outcome' -- --exact`
+- `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_operation_class_for_tool' -- --exact`
 - `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_lifecycle_emitter_not_called_when_none' -- --exact`
 
 ## Step2 (mechanical split preview)
@@ -101,21 +102,23 @@ Step2 principles:
 
 - keep the suite a unit-test tree, not an integration-test target
 - keep the parent `mod tests;` declaration stable
-- keep `mod.rs` thin: module wiring and shared imports only
+- keep `mod.rs` thin: module wiring, shared imports, and only the smallest common prelude needed for private access
+- do not leave the bulk of test bodies in `mod.rs`
 - move helper/setup code into `fixtures.rs`
 - move test bodies by scenario family
 - preserve private access through `super::*`
+- module decomposition must preserve the existing private-access pattern; submodules should continue to rely on `super::*` / parent-module access rather than forcing visibility widening in production code
 
 Step2 family ownership:
 
-- `fixtures.rs`: emitters, request builders, policy builders, approval artifacts, outcome helpers
-- `emission.rs`: basic allow/deny emission and obligation outcome tests
+- `fixtures.rs`: shared emitters, request builders, policy builders, approval artifacts, and outcome helpers only; no scenario-specific assertions or family-owned behavior unless genuinely reused across families
+- `emission.rs`: handler decision emission and obligation outcome tests only
 - `delegation.rs`: delegated/direct/unstructured delegation tests
 - `approval.rs`: `approval_required_*`
 - `scope.rs`: `restrict_scope_*`
 - `redaction.rs`: `redact_args_*`
-- `classification.rs`: commit-tool/classification helper tests
-- `lifecycle.rs`: lifecycle emitter tests
+- `classification.rs`: existing commit-tool and operation-class helper tests only; it must not become a place to reinterpret or reorganize handler taxonomy semantics during the split
+- `lifecycle.rs`: lifecycle-emitter-specific behavior only
 
 ## Step3 (closure)
 

--- a/docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md
+++ b/docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md
@@ -1,0 +1,148 @@
+# T-R2 Plan — `mcp/tool_call_handler/tests.rs` Unit Test Tree Decomposition
+
+## Goal
+
+Split `crates/assay-core/src/mcp/tool_call_handler/tests.rs` into a unit-test module tree without
+changing handler behavior, private-access coverage shape, or the white-box meaning of the suite.
+
+This plan intentionally follows Rust unit-test conventions:
+
+- keep this suite in `src/`
+- keep it under the existing `#[cfg(test)] mod tests;` surface
+- decompose it as `tests/mod.rs` plus submodules
+- preserve private access through `super::*`
+
+Current hotspot baseline on `origin/main @ 66c424c1`:
+
+- `crates/assay-core/src/mcp/tool_call_handler/tests.rs`: `1242` LOC
+- `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`: already split in Wave44 and now the closest behavior companion
+- `crates/assay-core/src/mcp/decision.rs`: already split in Wave43 and now the closest emitted-event companion
+- `crates/assay-core/src/mcp/policy/engine.rs`: already split in Wave45 and now the closest policy companion
+
+## Why this plan exists
+
+`tool_call_handler/tests.rs` is large, but it is not an integration target. It is a **white-box
+unit-test surface** that exists specifically to validate internal behavior with private-access
+visibility.
+
+That means the right split shape is:
+
+- keep the tests in `src/`
+- keep private access through `super::*`
+- replace one large `tests.rs` with `tests/mod.rs` plus scenario-family submodules
+- do not convert this suite into integration tests
+
+## Frozen target surface
+
+T-R2 freezes the expectation that any later split keeps these unit-test properties stable:
+
+- the suite remains under `crates/assay-core/src/mcp/tool_call_handler`
+- the suite continues to use unit-test/private-access placement
+- the existing helper/setup intent remains stable:
+  - `CountingEmitter`
+  - `make_tool_call_request`
+  - `approval_required_policy`
+  - `restrict_scope_policy_with_contract`
+  - `redact_args_policy_with_contract`
+  - `approval_artifact`
+  - `outcome_for`
+  - `assert_fail_closed_defaults`
+  - `CountingLifecycleEmitter`
+- the current internal behavior families remain stable in meaning:
+  - handler decision emission
+  - delegation typed-field projection
+  - approval-required deny paths
+  - restrict-scope deny/additive-field paths
+  - redact-args deny/additive-field paths
+  - tool drift / obligation outcome behavior
+  - commit-tool classification helpers
+  - lifecycle emitter behavior
+
+## Step1 (freeze)
+
+Step1 should be docs/gates only.
+
+Step1 constraints:
+
+- no edits under `crates/assay-core/src/mcp/tool_call_handler/**`
+- no edits under `crates/assay-core/tests/**`
+- no edits under `crates/assay-core/src/mcp/decision.rs`
+- no edits under `crates/assay-core/src/mcp/policy/**`
+- no workflow edits
+
+Step1 gate should pin representative tests from each family, for example:
+
+- `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_handler_emits_decision_on_policy_allow' -- --exact`
+- `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::delegated_context_emits_typed_fields_for_supported_flow' -- --exact`
+- `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval_required_missing_denies' -- --exact`
+- `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::restrict_scope_target_missing_denies' -- --exact`
+- `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::redact_args_target_missing_denies' -- --exact`
+- `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_tool_drift_deny_emits_alert_obligation_outcome' -- --exact`
+- `cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_lifecycle_emitter_not_called_when_none' -- --exact`
+
+## Step2 (mechanical split preview)
+
+Step2 should replace the single `tests.rs` file with a directory-backed unit-test module tree
+while keeping the parent module declaration unchanged.
+
+Target layout:
+
+- `crates/assay-core/src/mcp/tool_call_handler/tests/mod.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/fixtures.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/emission.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/delegation.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/approval.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/scope.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/redaction.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/classification.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/lifecycle.rs`
+
+Step2 principles:
+
+- keep the suite a unit-test tree, not an integration-test target
+- keep the parent `mod tests;` declaration stable
+- keep `mod.rs` thin: module wiring and shared imports only
+- move helper/setup code into `fixtures.rs`
+- move test bodies by scenario family
+- preserve private access through `super::*`
+
+Step2 family ownership:
+
+- `fixtures.rs`: emitters, request builders, policy builders, approval artifacts, outcome helpers
+- `emission.rs`: basic allow/deny emission and obligation outcome tests
+- `delegation.rs`: delegated/direct/unstructured delegation tests
+- `approval.rs`: `approval_required_*`
+- `scope.rs`: `restrict_scope_*`
+- `redaction.rs`: `redact_args_*`
+- `classification.rs`: commit-tool/classification helper tests
+- `lifecycle.rs`: lifecycle emitter tests
+
+## Step3 (closure)
+
+Step3 should be docs/gates only.
+
+Step3 constraints:
+
+- keep `tests/mod.rs` as the stable unit-test root
+- no promotion into `crates/assay-core/tests/**`
+- no production behavior cleanup inside handler/decision/policy code
+- no new module cuts
+- no drift in private-access coverage shape
+
+## Reviewer notes
+
+Primary failure modes:
+
+- converting a white-box unit-test suite into an integration-test suite
+- accidentally changing production behavior while “just moving tests”
+- duplicating fixtures across many files instead of centralizing them
+- letting private-access assumptions drift because imports or module roots changed
+- mixing new handler semantics into a test decomposition wave
+
+## Non-goals
+
+- No production edits under `crates/assay-core/src/mcp/tool_call_handler/*.rs`.
+- No edits under `crates/assay-core/tests/**`.
+- No conversion to integration tests.
+- No new handler/evaluate/policy semantics.
+- No assertion or helper cleanup beyond strictly mechanical relocation.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -7,3 +7,5 @@ Guidelines for contributing to the Assay project.
 - [Releases](releases.md)
 - [Outstanding TODOs](TODOS.md) — tracked work items referenced in code as `TODO(tag):`
 - [Split Program Review Pack (Q1 2026)](SPLIT-REVIEW-PACK-2026q1-program.md) — merged-wave closure evidence and reproducible verification commands
+- [T-R1 Plan — `decision_emit_invariant` integration target decomposition](SPLIT-PLAN-tr1-decision-emit-invariant.md)
+- [T-R2 Plan — `tool_call_handler/tests.rs` unit test tree decomposition](SPLIT-PLAN-tr2-tool-call-handler-tests.md)


### PR DESCRIPTION
## Summary
- add T-R1 plan for splitting `decision_emit_invariant.rs` as one multi-file integration target
- add T-R2 plan for splitting `tool_call_handler/tests.rs` as a unit-test module tree
- update the contributing index with both new split-plan docs

## Why
- align the next two test-heavy hotspot decompositions with Rust/Cargo test-organization conventions
- keep the integration-target and unit-test shapes explicitly distinct
- freeze the intended Step1/Step2/Step3 discipline before any code movement

## Testing
- git diff --check
