### PR TITLE
docs: freeze tr1 decision emit split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step1.md
@@ -1,0 +1,37 @@
+# T-R1 Step1 Checklist — `decision_emit_invariant`
+
+## Intent
+
+Freeze the split boundaries for `crates/assay-core/tests/decision_emit_invariant.rs` before any
+mechanical module moves.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md`
+- `docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step1.md`
+- `scripts/ci/review-tr1-decision-emit-invariant-step1.sh`
+
+## Step1 constraints
+
+- docs/gates only
+- no edits under `crates/assay-core/tests/**`
+- no edits under `crates/assay-core/src/mcp/**`
+- no edits under `crates/assay-core/src/mcp/policy/**`
+- no workflow edits
+- no event-shape, reason-code, or emitted JSON contract drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-tr1-decision-emit-invariant-step1.sh
+```
+
+## Reviewer quick scan
+
+1. Confirm the diff is limited to the 5 Step1 files.
+2. Confirm `crates/assay-core/tests/**` and `crates/assay-core/src/mcp/**` remain untouched.
+3. Confirm the plan freezes one coherent integration target, not multiple top-level test binaries.
+4. Confirm the move-map previews `tests/decision_emit_invariant/main.rs` plus family modules.
+5. Confirm the reviewer script re-runs pinned emitted-contract and delegation/auth invariants.

--- a/docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step1.md
@@ -1,0 +1,62 @@
+# SPLIT-MOVE-MAP — T-R1 Step1 — `tests/decision_emit_invariant.rs`
+
+## Goal
+
+Freeze the split boundaries for `crates/assay-core/tests/decision_emit_invariant.rs` before any
+mechanical module moves.
+
+## Planned Step2 layout
+
+- `crates/assay-core/tests/decision_emit_invariant/main.rs`
+- `crates/assay-core/tests/decision_emit_invariant/fixtures.rs`
+- `crates/assay-core/tests/decision_emit_invariant/emission.rs`
+- `crates/assay-core/tests/decision_emit_invariant/approval.rs`
+- `crates/assay-core/tests/decision_emit_invariant/restrict_scope.rs`
+- `crates/assay-core/tests/decision_emit_invariant/redaction.rs`
+- `crates/assay-core/tests/decision_emit_invariant/guard.rs`
+- `crates/assay-core/tests/decision_emit_invariant/delegation.rs`
+- `crates/assay-core/tests/decision_emit_invariant/g3_auth.rs`
+
+## Mapping preview
+
+- `main.rs` keeps the stable integration-target root, module wiring, and only the smallest shared prelude.
+- `fixtures.rs` is the planned home for shared emitters, request builders, policy builders, and artifact builders.
+- `emission.rs` is the planned home for cross-cutting emitted-decision contract tests:
+  - allow/deny emission
+  - multiple-call emission
+  - required fields
+  - event source
+  - tool-call ID
+  - non-tool-call error handling
+- `approval.rs` is the planned home for:
+  - `approval_required_*`
+- `restrict_scope.rs` is the planned home for:
+  - `restrict_scope_*`
+- `redaction.rs` is the planned home for:
+  - `redact_args_*`
+- `guard.rs` is the planned home for guard lifecycle tests:
+  - early return
+  - panic emission
+- `delegation.rs` is the planned home for additive delegation context tests.
+- `g3_auth.rs` is the planned home for G3 auth projection and filtering tests.
+
+## Frozen behavior boundaries
+
+- identical integration-target identity for `decision_emit_invariant`
+- identical emitted JSON contract coverage meaning
+- identical delegation additive-field expectations
+- identical approval/restrict-scope/redact-args deny semantics
+- identical guard drop/panic emission expectations
+- identical required-field and G3 auth projection expectations
+- no edits under `crates/assay-core/src/**` in Step2 beyond the later explicitly planned production waves
+
+## Test anchors to keep fixed in Step1
+
+- `test_policy_allow_emits_once`
+- `test_delegation_fields_are_additive_on_emitted_decisions`
+- `approval_required_missing_denies`
+- `restrict_scope_target_missing_denies`
+- `redact_args_target_missing_denies`
+- `test_guard_emits_on_panic`
+- `test_event_contains_required_fields`
+- `g3_auth_projection_emits_allowlisted_scheme_trimmed_issuer_principal_in_decision_json`

--- a/docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md
+++ b/docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md
@@ -14,7 +14,7 @@ This plan intentionally follows Rust/Cargo integration-test conventions:
 - avoid fragmenting one contract surface into many top-level integration-test crates unless
   later CI or ownership pressure clearly justifies that
 
-Current hotspot baseline on `origin/main @ 66c424c1`:
+Current hotspot baseline on `origin/main @ 2951b3ef`:
 
 - `crates/assay-core/tests/decision_emit_invariant.rs`: `1293` LOC
 - `crates/assay-core/src/mcp/decision.rs`: already split in Wave43 and now the primary emitted-decision companion
@@ -62,9 +62,26 @@ T-R1 freezes the expectation that any later split keeps these test-surface prope
   - required emitted field coverage
   - G3 auth projection filtering
 
+## Status
+
+- T-R1 plan shipped on `main` via `#978`.
+- Step1 is the freeze/gates-only slice for `decision_emit_invariant.rs`.
+- No code movement belongs in Step1.
+- T-R2 remains out of scope for this wave.
+
 ## Step1 (freeze)
 
 Step1 should be docs/gates only.
+
+Branch: `codex/tr1-decision-emit-step1` (base: `main`)
+
+Step1 deliverables:
+
+- `docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md`
+- `docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step1.md`
+- `scripts/ci/review-tr1-decision-emit-invariant-step1.sh`
 
 Step1 constraints:
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step1.md
@@ -1,0 +1,52 @@
+# T-R1 Decision Emit Invariant Step1 Review Pack
+
+## Intent
+
+Freeze the split boundaries for `crates/assay-core/tests/decision_emit_invariant.rs` before any
+mechanical module moves, while preserving one coherent black-box integration-test contract target.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md`
+- `docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step1.md`
+- `scripts/ci/review-tr1-decision-emit-invariant-step1.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-core/tests/**`
+- no edits under `crates/assay-core/src/mcp/**`
+- no edits under `crates/assay-core/src/mcp/policy/**`
+- no production behavior changes
+- no test-target fragmentation or helper reorganization beyond the Step2 preview
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-tr1-decision-emit-invariant-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --all --check
+cargo clippy -q -p assay-core --all-targets -- -D warnings
+cargo test -q -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant test_delegation_fields_are_additive_on_emitted_decisions -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant test_guard_emits_on_panic -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant g3_auth_projection_emits_allowlisted_scheme_trimmed_issuer_principal_in_decision_json -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the 5 Step1 files.
+2. Confirm the plan keeps `decision_emit_invariant` as one integration target.
+3. Confirm `main.rs` is planned as a thin root rather than a second giant test file.
+4. Confirm `fixtures.rs` is constrained to shared helpers only.
+5. Confirm the reviewer script re-runs delegation, deny-path, guard, required-field, and G3 auth anchors.

--- a/scripts/ci/review-tr1-decision-emit-invariant-step1.sh
+++ b/scripts/ci/review-tr1-decision-emit-invariant-step1.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+ALLOWED_FILES=(
+  "docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md"
+  "docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step1.md"
+  "scripts/ci/review-tr1-decision-emit-invariant-step1.sh"
+)
+
+if ! git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+  echo "BASE_REF does not resolve to a commit: $BASE_REF" >&2
+  exit 1
+fi
+
+tmp_changed="$(mktemp)"
+trap 'rm -f "$tmp_changed"' EXIT
+
+git diff --name-only "$BASE_REF"...HEAD >"$tmp_changed"
+git diff --name-only >>"$tmp_changed"
+git diff --name-only --cached >>"$tmp_changed"
+git ls-files --others --exclude-standard >>"$tmp_changed"
+
+sort -u -o "$tmp_changed" "$tmp_changed"
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  if [[ "$file" == .github/workflows/* ]]; then
+    echo "workflow file changed out of scope: $file" >&2
+    exit 1
+  fi
+
+  allowed=false
+  for allowed_file in "${ALLOWED_FILES[@]}"; do
+    if [[ "$file" == "$allowed_file" ]]; then
+      allowed=true
+      break
+    fi
+  done
+
+  if [[ "$allowed" == false ]]; then
+    echo "out-of-scope file changed: $file" >&2
+    exit 1
+  fi
+done <"$tmp_changed"
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  if [[ "$file" == crates/assay-core/tests/* ]]; then
+    echo "assay-core integration tests must remain untouched in T-R1 Step1" >&2
+    exit 1
+  fi
+  if [[ "$file" == crates/assay-core/src/mcp/* ]]; then
+    echo "assay-core mcp sources must remain untouched in T-R1 Step1" >&2
+    exit 1
+  fi
+done <"$tmp_changed"
+
+cargo fmt --all --check
+cargo clippy -q -p assay-core --all-targets -- -D warnings
+
+cargo test -q -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant test_delegation_fields_are_additive_on_emitted_decisions -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant test_guard_emits_on_panic -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant g3_auth_projection_emits_allowlisted_scheme_trimmed_issuer_principal_in_decision_json -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- add T-R1 Step1 freeze artifacts for `crates/assay-core/tests/decision_emit_invariant.rs`
- pin one coherent integration-target decomposition shape under `tests/decision_emit_invariant/main.rs`
- add a reviewer script that enforces docs-only scope and re-runs representative emitted-contract anchors

## Testing
- git diff --check
- BASE_REF=origin/main bash scripts/ci/review-tr1-decision-emit-invariant-step1.sh
