### PR TITLE
fix: refresh decision invariant reviewer scripts

### DIFF
--- a/scripts/ci/review-mcp-policy-step1.sh
+++ b/scripts/ci/review-mcp-policy-step1.sh
@@ -22,7 +22,7 @@ echo '== MCP Policy Step1 quality checks =='
 cargo fmt --check
 cargo clippy -p assay-core --all-targets -- -D warnings
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core test_mixed_tools_config -- --exact
 
 echo '== MCP Policy Step1 freeze checks =='

--- a/scripts/ci/review-mcp-policy-step2.sh
+++ b/scripts/ci/review-mcp-policy-step2.sh
@@ -22,7 +22,7 @@ echo '== MCP Policy Step2 quality checks =='
 cargo fmt --check
 cargo clippy -p assay-core --all-targets -- -D warnings
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core test_mixed_tools_config -- --exact
 
 echo '== MCP Policy Step2 scope checks =='

--- a/scripts/ci/review-mcp-policy-step3.sh
+++ b/scripts/ci/review-mcp-policy-step3.sh
@@ -41,7 +41,7 @@ echo '== MCP Policy Step3 quality checks =='
 cargo fmt --check
 cargo clippy -p assay-core --all-targets -- -D warnings
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core test_mixed_tools_config -- --exact
 
 echo '== MCP Policy Step3 facade invariants =='

--- a/scripts/ci/review-tool-call-handler-step1.sh
+++ b/scripts/ci/review-tool-call-handler-step1.sh
@@ -51,6 +51,6 @@ cargo fmt --check
 cargo clippy -p assay-core --all-targets -- -D warnings
 
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 
 echo "[review] PASS"

--- a/scripts/ci/review-tool-call-handler-step2.sh
+++ b/scripts/ci/review-tool-call-handler-step2.sh
@@ -22,7 +22,7 @@ echo '== Tool call handler Step2 quality checks =='
 cargo fmt --check
 cargo clippy -p assay-core --all-targets -- -D warnings
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 
 echo '== Tool call handler Step2 scope checks =='
 leaks="$({ git diff --name-only "${base_ref}...HEAD" | \

--- a/scripts/ci/review-tool-call-handler-step3.sh
+++ b/scripts/ci/review-tool-call-handler-step3.sh
@@ -41,7 +41,7 @@ echo '== Tool call handler Step3 quality checks =='
 cargo fmt --check
 cargo clippy -p assay-core --all-targets -- -D warnings
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 
 echo '== Tool call handler Step3 facade invariants =='
 facade='crates/assay-core/src/mcp/tool_call_handler/mod.rs'

--- a/scripts/ci/review-tr1-decision-emit-invariant-step1.sh
+++ b/scripts/ci/review-tr1-decision-emit-invariant-step1.sh
@@ -65,13 +65,13 @@ done <"$tmp_changed"
 cargo fmt --all --check
 cargo clippy -q -p assay-core --all-targets -- -D warnings
 
-cargo test -q -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant test_delegation_fields_are_additive_on_emitted_decisions -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant test_guard_emits_on_panic -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant g3_auth_projection_emits_allowlisted_scheme_trimmed_issuer_principal_in_decision_json -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant emission::test_policy_allow_emits_once -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant delegation::test_delegation_fields_are_additive_on_emitted_decisions -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant guard::test_guard_emits_on_panic -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant g3_auth::g3_auth_projection_emits_allowlisted_scheme_trimmed_issuer_principal_in_decision_json -- --exact
 
 echo "[review] PASS"

--- a/scripts/ci/review-wave-g2-delegation-context-signal-step1.sh
+++ b/scripts/ci/review-wave-g2-delegation-context-signal-step1.sh
@@ -30,7 +30,7 @@ emit_file="crates/assay-core/src/mcp/tool_call_handler/emit.rs"
 decision_file="crates/assay-core/src/mcp/decision.rs"
 proxy_file="crates/assay-core/src/mcp/proxy.rs"
 tool_tests="crates/assay-core/src/mcp/tool_call_handler/tests.rs"
-decision_invariant="crates/assay-core/tests/decision_emit_invariant.rs"
+decision_invariant="crates/assay-core/tests/decision_emit_invariant"
 evidence_types="crates/assay-evidence/src/types.rs"
 adr_doc="docs/architecture/ADR-006-Evidence-Contract.md"
 c1_doc="docs/security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md"
@@ -50,7 +50,7 @@ while IFS= read -r file; do
     crates/assay-core/src/mcp/decision.rs|\
     crates/assay-core/src/mcp/proxy.rs|\
     crates/assay-core/src/mcp/tool_call_handler/tests.rs|\
-    crates/assay-core/tests/decision_emit_invariant.rs|\
+    crates/assay-core/tests/decision_emit_invariant/main.rs|\
     crates/assay-evidence/src/types.rs|\
     docs/architecture/ADR-006-Evidence-Contract.md|\
     docs/security/OWASP-AGENTIC-A1-A3-A5-C1-MAPPING.md|\
@@ -143,7 +143,7 @@ cargo test -q -p assay-core parse_delegation_context_
 cargo test -q -p assay-core delegated_context_emits_typed_fields_for_supported_flow
 cargo test -q -p assay-core direct_authorization_flow_omits_delegation_fields
 cargo test -q -p assay-core unstructured_delegation_hints_do_not_emit_typed_fields
-cargo test -q -p assay-core --test decision_emit_invariant test_delegation_fields_are_additive_on_emitted_decisions -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant delegation::test_delegation_fields_are_additive_on_emitted_decisions -- --exact
 cargo test -q -p assay-evidence tool_decision_payload_delegation_fields_are_additive
 git diff --check
 

--- a/scripts/ci/review-wave24-typed-decisions-step1.sh
+++ b/scripts/ci/review-wave24-typed-decisions-step1.sh
@@ -91,7 +91,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out
 cargo test -p assay-mcp-server auth_integration

--- a/scripts/ci/review-wave24-typed-decisions-step2.sh
+++ b/scripts/ci/review-wave24-typed-decisions-step2.sh
@@ -145,7 +145,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave24-typed-decisions-step3.sh
+++ b/scripts/ci/review-wave24-typed-decisions-step3.sh
@@ -78,7 +78,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave25-obligations-step1.sh
+++ b/scripts/ci/review-wave25-obligations-step1.sh
@@ -95,7 +95,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave25-obligations-step2.sh
+++ b/scripts/ci/review-wave25-obligations-step2.sh
@@ -74,7 +74,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core execute_log_only_
 cargo test -p assay-cli mcp_wrap_coverage

--- a/scripts/ci/review-wave25-obligations-step3.sh
+++ b/scripts/ci/review-wave25-obligations-step3.sh
@@ -65,7 +65,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core execute_log_only_
 cargo test -p assay-cli mcp_wrap_coverage

--- a/scripts/ci/review-wave26-obligations-step1.sh
+++ b/scripts/ci/review-wave26-obligations-step1.sh
@@ -80,7 +80,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core execute_log_only_
 cargo test -p assay-cli mcp_wrap_coverage

--- a/scripts/ci/review-wave26-obligations-step2.sh
+++ b/scripts/ci/review-wave26-obligations-step2.sh
@@ -62,7 +62,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
 cargo test -p assay-core execute_log_only_

--- a/scripts/ci/review-wave26-obligations-step3.sh
+++ b/scripts/ci/review-wave26-obligations-step3.sh
@@ -69,7 +69,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact
 cargo test -p assay-core execute_log_only_

--- a/scripts/ci/review-wave27-approval-step1.sh
+++ b/scripts/ci/review-wave27-approval-step1.sh
@@ -90,7 +90,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-cli mcp_wrap_coverage

--- a/scripts/ci/review-wave27-approval-step2.sh
+++ b/scripts/ci/review-wave27-approval-step2.sh
@@ -72,7 +72,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_with_policy_context_sets_approval_artifact_fields -- --exact
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact

--- a/scripts/ci/review-wave27-approval-step3.sh
+++ b/scripts/ci/review-wave27-approval-step3.sh
@@ -66,7 +66,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_with_policy_context_sets_approval_artifact_fields -- --exact
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact

--- a/scripts/ci/review-wave28-approval-required-step1.sh
+++ b/scripts/ci/review-wave28-approval-required-step1.sh
@@ -90,7 +90,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave28-approval-required-step2.sh
+++ b/scripts/ci/review-wave28-approval-required-step2.sh
@@ -149,7 +149,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave28-approval-required-step3.sh
+++ b/scripts/ci/review-wave28-approval-required-step3.sh
@@ -84,7 +84,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave29-restrict-scope-step1.sh
+++ b/scripts/ci/review-wave29-restrict-scope-step1.sh
@@ -96,10 +96,10 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies
 cargo test -p assay-core approval_required_expired_denies
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies

--- a/scripts/ci/review-wave29-restrict-scope-step2.sh
+++ b/scripts/ci/review-wave29-restrict-scope-step2.sh
@@ -84,7 +84,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave29-restrict-scope-step3.sh
+++ b/scripts/ci/review-wave29-restrict-scope-step3.sh
@@ -77,7 +77,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh
+++ b/scripts/ci/review-wave30-restrict-scope-enforcement-step1.sh
@@ -96,7 +96,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave30-restrict-scope-enforcement-step2.sh
+++ b/scripts/ci/review-wave30-restrict-scope-enforcement-step2.sh
@@ -99,7 +99,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh
+++ b/scripts/ci/review-wave30-restrict-scope-enforcement-step3.sh
@@ -96,7 +96,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave31-redact-args-step1.sh
+++ b/scripts/ci/review-wave31-redact-args-step1.sh
@@ -92,7 +92,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave31-redact-args-step2.sh
+++ b/scripts/ci/review-wave31-redact-args-step2.sh
@@ -94,7 +94,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome

--- a/scripts/ci/review-wave31-redact-args-step3.sh
+++ b/scripts/ci/review-wave31-redact-args-step3.sh
@@ -85,7 +85,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave32-redact-args-enforcement-step1.sh
+++ b/scripts/ci/review-wave32-redact-args-enforcement-step1.sh
@@ -98,7 +98,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome

--- a/scripts/ci/review-wave32-redact-args-enforcement-step2.sh
+++ b/scripts/ci/review-wave32-redact-args-enforcement-step2.sh
@@ -128,7 +128,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave32-redact-args-enforcement-step3.sh
+++ b/scripts/ci/review-wave32-redact-args-enforcement-step3.sh
@@ -102,7 +102,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
 cargo test -p assay-core test_tool_drift_deny_emits_alert_obligation_outcome -- --exact

--- a/scripts/ci/review-wave33-obligation-outcomes-step1.sh
+++ b/scripts/ci/review-wave33-obligation-outcomes-step1.sh
@@ -107,10 +107,10 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies
 cargo test -p assay-core approval_required_expired_denies
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies

--- a/scripts/ci/review-wave34-fail-closed-step1.sh
+++ b/scripts/ci/review-wave34-fail-closed-step1.sh
@@ -99,10 +99,10 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies
 cargo test -p assay-core approval_required_expired_denies
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies

--- a/scripts/ci/review-wave34-fail-closed-step2.sh
+++ b/scripts/ci/review-wave34-fail-closed-step2.sh
@@ -122,10 +122,10 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies
 cargo test -p assay-core approval_required_expired_denies
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies

--- a/scripts/ci/review-wave34-fail-closed-step3.sh
+++ b/scripts/ci/review-wave34-fail-closed-step3.sh
@@ -86,10 +86,10 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies
 cargo test -p assay-core approval_required_expired_denies
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies

--- a/scripts/ci/review-wave35-fulfillment-normalization-step1.sh
+++ b/scripts/ci/review-wave35-fulfillment-normalization-step1.sh
@@ -92,13 +92,13 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
-cargo test -p assay-core approval_required_missing_denies -- --exact
-cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
-cargo test -p assay-core redact_args_target_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out
 cargo test -p assay-mcp-server auth_integration

--- a/scripts/ci/review-wave35-fulfillment-normalization-step2.sh
+++ b/scripts/ci/review-wave35-fulfillment-normalization-step2.sh
@@ -117,11 +117,11 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies
 cargo test -p assay-core approval_required_expired_denies
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies

--- a/scripts/ci/review-wave35-fulfillment-normalization-step3.sh
+++ b/scripts/ci/review-wave35-fulfillment-normalization-step3.sh
@@ -112,11 +112,11 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core approval_required_missing_denies
 cargo test -p assay-core approval_required_expired_denies
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies

--- a/scripts/ci/review-wave36-redact-args-enforcement-step1.sh
+++ b/scripts/ci/review-wave36-redact-args-enforcement-step1.sh
@@ -92,16 +92,16 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
-cargo test -p assay-core approval_required_missing_denies -- --exact
-cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
-cargo test -p assay-core redact_args_target_missing_denies -- --exact
-cargo test -p assay-core redact_args_mode_unsupported_denies -- --exact
-cargo test -p assay-core redact_args_scope_unsupported_denies -- --exact
-cargo test -p assay-core redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_apply_failed_denies -- --exact
 cargo test -p assay-core fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave36-redact-args-enforcement-step2.sh
+++ b/scripts/ci/review-wave36-redact-args-enforcement-step2.sh
@@ -69,7 +69,7 @@ do
     crates/assay-core/src/mcp/tool_call_handler/emit.rs \
     crates/assay-core/src/mcp/tool_call_handler/evaluate.rs \
     crates/assay-core/src/mcp/tool_call_handler/tests.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
       echo "FAIL: missing runtime redaction marker: $marker"
       exit 1
     }
@@ -86,7 +86,7 @@ do
   rg -n "$marker" \
     crates/assay-core/src/mcp/tool_call_handler/evaluate.rs \
     crates/assay-core/src/mcp/tool_call_handler/tests.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
       echo "FAIL: missing deterministic failure marker: $marker"
       exit 1
     }
@@ -108,7 +108,7 @@ for marker in \
   'obligation_outcomes' \
   'validated_in_handler'
 do
-  rg -n "$marker" crates/assay-core/src/mcp/tool_call_handler/evaluate.rs crates/assay-core/src/mcp/tool_call_handler/tests.rs crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+  rg -n "$marker" crates/assay-core/src/mcp/tool_call_handler/evaluate.rs crates/assay-core/src/mcp/tool_call_handler/tests.rs crates/assay-core/tests/decision_emit_invariant >/dev/null || {
     echo "FAIL: missing additive evidence marker: $marker"
     exit 1
   }
@@ -146,22 +146,22 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_contract_sets_additive_fields -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_target_missing_denies -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_mode_unsupported_denies -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_scope_unsupported_denies -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_apply_failed_denies -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_contract_sets_additive_fields -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_mode_unsupported_denies -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_scope_unsupported_denies -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_apply_failed_denies -- --exact
-cargo test -p assay-core approval_required_missing_denies -- --exact
-cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_contract_sets_additive_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_mismatch_denies -- --exact
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out
 cargo test -p assay-mcp-server auth_integration

--- a/scripts/ci/review-wave36-redact-args-enforcement-step3.sh
+++ b/scripts/ci/review-wave36-redact-args-enforcement-step3.sh
@@ -49,7 +49,7 @@ do
     crates/assay-core/src/mcp/tool_call_handler/emit.rs \
     crates/assay-core/src/mcp/tool_call_handler/evaluate.rs \
     crates/assay-core/src/mcp/tool_call_handler/tests.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
       echo "FAIL: missing runtime redaction marker: $marker"
       exit 1
     }
@@ -66,7 +66,7 @@ do
   rg -n "$marker" \
     crates/assay-core/src/mcp/tool_call_handler/evaluate.rs \
     crates/assay-core/src/mcp/tool_call_handler/tests.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
       echo "FAIL: missing deterministic failure marker: $marker"
       exit 1
     }
@@ -88,7 +88,7 @@ for marker in \
   'obligation_outcomes' \
   'validated_in_handler'
 do
-  rg -n "$marker" crates/assay-core/src/mcp/tool_call_handler/evaluate.rs crates/assay-core/src/mcp/tool_call_handler/tests.rs crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+  rg -n "$marker" crates/assay-core/src/mcp/tool_call_handler/evaluate.rs crates/assay-core/src/mcp/tool_call_handler/tests.rs crates/assay-core/tests/decision_emit_invariant >/dev/null || {
     echo "FAIL: missing additive evidence marker: $marker"
     exit 1
   }
@@ -126,22 +126,22 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_contract_sets_additive_fields -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_target_missing_denies -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_mode_unsupported_denies -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_scope_unsupported_denies -- --exact
 cargo test -p assay-core mcp::tool_call_handler::tests::redact_args_apply_failed_denies -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_contract_sets_additive_fields -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_mode_unsupported_denies -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_scope_unsupported_denies -- --exact
-cargo test -p assay-core --test decision_emit_invariant redact_args_apply_failed_denies -- --exact
-cargo test -p assay-core approval_required_missing_denies -- --exact
-cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_contract_sets_additive_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_mismatch_denies -- --exact
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out
 cargo test -p assay-mcp-server auth_integration

--- a/scripts/ci/review-wave37-decision-evidence-step1.sh
+++ b/scripts/ci/review-wave37-decision-evidence-step1.sh
@@ -93,16 +93,16 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
-cargo test -p assay-core approval_required_missing_denies -- --exact
-cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
-cargo test -p assay-core redact_args_target_missing_denies -- --exact
-cargo test -p assay-core redact_args_mode_unsupported_denies -- --exact
-cargo test -p assay-core redact_args_scope_unsupported_denies -- --exact
-cargo test -p assay-core redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_mode_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_scope_unsupported_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_apply_failed_denies -- --exact
 cargo test -p assay-core fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave37-decision-evidence-step2.sh
+++ b/scripts/ci/review-wave37-decision-evidence-step2.sh
@@ -128,19 +128,19 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
-cargo test -p assay-core approval_required_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
 cargo test -p assay-core approval_required_expired_denies -- --exact
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies -- --exact
 cargo test -p assay-core approval_required_bound_resource_mismatch_denies -- --exact
-cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_mismatch_denies -- --exact
 cargo test -p assay-core restrict_scope_match_sets_additive_fields -- --exact
-cargo test -p assay-core redact_args_target_missing_denies -- --exact
-cargo test -p assay-core redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_apply_failed_denies -- --exact
 cargo test -p assay-core fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
 cargo test -p assay-core fulfillment_sets_policy_deny_convergence_fields -- --exact
 cargo test -p assay-cli mcp_wrap_coverage

--- a/scripts/ci/review-wave37-decision-evidence-step3.sh
+++ b/scripts/ci/review-wave37-decision-evidence-step3.sh
@@ -117,19 +117,19 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-core mcp::tool_call_handler::tests::test_allow_with_warning_emits_log_obligation_outcome -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_alert_obligation_outcome_emitted -- --exact
-cargo test -p assay-core approval_required_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_alert_obligation_outcome_emitted -- --exact
+cargo test -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
 cargo test -p assay-core approval_required_expired_denies -- --exact
 cargo test -p assay-core approval_required_bound_tool_mismatch_denies -- --exact
 cargo test -p assay-core approval_required_bound_resource_mismatch_denies -- --exact
-cargo test -p assay-core restrict_scope_mismatch_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_mismatch_denies -- --exact
 cargo test -p assay-core restrict_scope_match_sets_additive_fields -- --exact
-cargo test -p assay-core redact_args_target_missing_denies -- --exact
-cargo test -p assay-core redact_args_apply_failed_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
+cargo test -p assay-core --test decision_emit_invariant redaction::redact_args_apply_failed_denies -- --exact
 cargo test -p assay-core fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
 cargo test -p assay-core fulfillment_sets_policy_deny_convergence_fields -- --exact
 cargo test -p assay-cli mcp_wrap_coverage

--- a/scripts/ci/review-wave38-replay-diff-step1.sh
+++ b/scripts/ci/review-wave38-replay-diff-step1.sh
@@ -94,7 +94,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -p assay-core test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test decision_emit_invariant
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage

--- a/scripts/ci/review-wave38-replay-diff-step2.sh
+++ b/scripts/ci/review-wave38-replay-diff-step2.sh
@@ -108,7 +108,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave38-replay-diff-step3.sh
+++ b/scripts/ci/review-wave38-replay-diff-step3.sh
@@ -105,7 +105,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave39-evidence-compat-step1.sh
+++ b/scripts/ci/review-wave39-evidence-compat-step1.sh
@@ -86,7 +86,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave39-evidence-compat-step2.sh
+++ b/scripts/ci/review-wave39-evidence-compat-step2.sh
@@ -125,7 +125,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave39-evidence-compat-step3.sh
+++ b/scripts/ci/review-wave39-evidence-compat-step3.sh
@@ -113,7 +113,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave40-deny-evidence-step1.sh
+++ b/scripts/ci/review-wave40-deny-evidence-step1.sh
@@ -88,7 +88,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave40-deny-evidence-step2.sh
+++ b/scripts/ci/review-wave40-deny-evidence-step2.sh
@@ -140,7 +140,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave40-deny-evidence-step3.sh
+++ b/scripts/ci/review-wave40-deny-evidence-step3.sh
@@ -123,7 +123,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave41-consumer-hardening-step1.sh
+++ b/scripts/ci/review-wave41-consumer-hardening-step1.sh
@@ -89,7 +89,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave41-consumer-hardening-step2.sh
+++ b/scripts/ci/review-wave41-consumer-hardening-step2.sh
@@ -140,7 +140,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core consumer_contract
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave41-consumer-hardening-step3.sh
+++ b/scripts/ci/review-wave41-consumer-hardening-step3.sh
@@ -123,7 +123,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core consumer_contract
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave42-context-envelope-step1.sh
+++ b/scripts/ci/review-wave42-context-envelope-step1.sh
@@ -96,7 +96,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core --test replay_diff_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave42-context-envelope-step2.sh
+++ b/scripts/ci/review-wave42-context-envelope-step2.sh
@@ -73,7 +73,7 @@ do
   rg -n "$marker" \
     crates/assay-core/src/mcp/decision.rs \
     crates/assay-core/src/mcp/decision/context_contract.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
     echo "FAIL: missing Wave42 context-envelope marker: $marker"
     exit 1
   }
@@ -91,7 +91,7 @@ for marker in \
 do
   rg -n "$marker" \
     crates/assay-core/src/mcp/decision/context_contract.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
     echo "FAIL: missing deterministic context completeness marker: $marker"
     exit 1
   }
@@ -107,7 +107,7 @@ for marker in \
 do
   rg -n "$marker" \
     crates/assay-core/src/mcp/decision.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
     echo "FAIL: missing existing replay/decision marker: $marker"
     exit 1
   }
@@ -135,7 +135,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core context_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave42-context-envelope-step3.sh
+++ b/scripts/ci/review-wave42-context-envelope-step3.sh
@@ -62,7 +62,7 @@ do
   rg -n "$marker" \
     crates/assay-core/src/mcp/decision.rs \
     crates/assay-core/src/mcp/decision/context_contract.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
     echo "FAIL: missing Wave42 context-envelope marker: $marker"
     exit 1
   }
@@ -80,7 +80,7 @@ for marker in \
 do
   rg -n "$marker" \
     crates/assay-core/src/mcp/decision/context_contract.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
     echo "FAIL: missing deterministic context completeness marker: $marker"
     exit 1
   }
@@ -96,7 +96,7 @@ for marker in \
 do
   rg -n "$marker" \
     crates/assay-core/src/mcp/decision.rs \
-    crates/assay-core/tests/decision_emit_invariant.rs >/dev/null || {
+    crates/assay-core/tests/decision_emit_invariant >/dev/null || {
     echo "FAIL: missing existing replay/decision marker: $marker"
     exit 1
   }
@@ -119,7 +119,7 @@ cargo clippy -p assay-core -p assay-cli -p assay-mcp-server --all-targets -- -D 
 
 echo "[review] pinned replay/decision tests"
 cargo test -p assay-core context_contract
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization
 cargo test -p assay-cli mcp_wrap_coverage
 cargo test -p assay-cli mcp_wrap_state_window_out

--- a/scripts/ci/review-wave43-decision-kernel-step1.sh
+++ b/scripts/ci/review-wave43-decision-kernel-step1.sh
@@ -116,10 +116,10 @@ cargo clippy -p assay-core --all-targets -- -D warnings
 echo "[review] pinned decision tests"
 cargo test -p assay-core test_event_serialization -- --exact
 cargo test -p assay-core test_reason_codes_are_string_constants -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_delegation_fields_are_additive_on_emitted_decisions -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_guard_drop_emits_on_early_return -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_policy_allow_emits_once -- --exact
+cargo test -p assay-core --test decision_emit_invariant delegation::test_delegation_fields_are_additive_on_emitted_decisions -- --exact
+cargo test -p assay-core --test decision_emit_invariant guard::test_guard_drop_emits_on_early_return -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
 
 echo "[review] PASS"

--- a/scripts/ci/review-wave43-decision-kernel-step2.sh
+++ b/scripts/ci/review-wave43-decision-kernel-step2.sh
@@ -108,10 +108,10 @@ echo "[review] pinned decision and replay tests"
 cargo test -p assay-core --lib mcp::decision::tests::test_event_serialization -- --exact
 cargo test -p assay-core --lib mcp::decision::tests::test_reason_codes_are_string_constants -- --exact
 cargo test -p assay-core --lib mcp::decision::tests::test_decision_event_omits_delegation_fields_when_absent -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_delegation_fields_are_additive_on_emitted_decisions -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_guard_drop_emits_on_early_return -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_event_contains_required_fields -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_policy_allow_emits_once -- --exact
+cargo test -p assay-core --test decision_emit_invariant delegation::test_delegation_fields_are_additive_on_emitted_decisions -- --exact
+cargo test -p assay-core --test decision_emit_invariant guard::test_guard_drop_emits_on_early_return -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_event_contains_required_fields -- --exact
 cargo test -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
 cargo test -p assay-core --test replay_diff_contract classify_replay_diff_unchanged -- --exact
 

--- a/scripts/ci/review-wave43-decision-kernel-step3.sh
+++ b/scripts/ci/review-wave43-decision-kernel-step3.sh
@@ -96,7 +96,7 @@ cargo clippy -p assay-core --all-targets -- -D warnings
 echo "[review] pinned decision and replay tests"
 cargo test -p assay-core --lib mcp::decision::tests::test_event_serialization -- --exact
 cargo test -p assay-core --lib mcp::decision::tests::test_reason_codes_are_string_constants -- --exact
-cargo test -p assay-core --test decision_emit_invariant test_policy_allow_emits_once -- --exact
+cargo test -p assay-core --test decision_emit_invariant emission::test_policy_allow_emits_once -- --exact
 cargo test -p assay-core --test fulfillment_normalization fulfillment_normalizes_outcomes_and_sets_policy_deny_path -- --exact
 cargo test -p assay-core --test replay_diff_contract classify_replay_diff_unchanged -- --exact
 

--- a/scripts/ci/review-wave44-evaluate-kernel-step1.sh
+++ b/scripts/ci/review-wave44-evaluate-kernel-step1.sh
@@ -71,8 +71,14 @@ echo "[review] no-drift baseline"
   echo "FAIL: tool_call_handler/tests.rs LOC drifted during Step1"
   exit 1
 }
-[[ "$(line_count crates/assay-core/tests/decision_emit_invariant.rs)" == "1293" ]] || {
-  echo "FAIL: decision_emit_invariant.rs LOC drifted during Step1"
+decision_emit_total="$(
+  find crates/assay-core/tests/decision_emit_invariant -name '*.rs' -print0 \
+    | xargs -0 wc -l \
+    | tail -n1 \
+    | awk '{print $1}'
+)"
+[[ "$decision_emit_total" == "1290" ]] || {
+  echo "FAIL: decision_emit_invariant target LOC drifted during Step1"
   exit 1
 }
 [[ "$(line_count crates/assay-core/tests/fulfillment_normalization.rs)" == "165" ]] || {

--- a/scripts/ci/review-wave45-policy-engine-step1.sh
+++ b/scripts/ci/review-wave45-policy-engine-step1.sh
@@ -100,9 +100,9 @@ cargo test -q -p assay-core --test policy_engine_test test_mixed_tools_config --
 cargo test -q -p assay-core --test policy_engine_test test_constraint_enforcement -- --exact
 cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class -- --exact
 cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
 cargo test -q -p assay-core --lib 'mcp::policy::engine::tests::parse_delegation_context_uses_explicit_depth_only' -- --exact
 
 echo "[review] PASS"

--- a/scripts/ci/review-wave45-policy-engine-step2.sh
+++ b/scripts/ci/review-wave45-policy-engine-step2.sh
@@ -125,9 +125,9 @@ cargo test -q -p assay-core --test policy_engine_test test_mixed_tools_config --
 cargo test -q -p assay-core --test policy_engine_test test_constraint_enforcement -- --exact
 cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class -- --exact
 cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
 cargo test -q -p assay-core --lib 'mcp::policy::engine::tests::parse_delegation_context_uses_explicit_depth_only' -- --exact
 
 echo "[review] PASS"

--- a/scripts/ci/review-wave45-policy-engine-step3.sh
+++ b/scripts/ci/review-wave45-policy-engine-step3.sh
@@ -100,9 +100,9 @@ cargo test -q -p assay-core --test policy_engine_test test_mixed_tools_config --
 cargo test -q -p assay-core --test policy_engine_test test_constraint_enforcement -- --exact
 cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_policy_file_blocks_alt_sink_by_class -- --exact
 cargo test -q -p assay-core --test tool_taxonomy_policy_match tool_taxonomy_policy_match_handler_decision_event_records_classes -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant approval_required_missing_denies -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant restrict_scope_target_missing_denies -- --exact
-cargo test -q -p assay-core --test decision_emit_invariant redact_args_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant approval::approval_required_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant restrict_scope::restrict_scope_target_missing_denies -- --exact
+cargo test -q -p assay-core --test decision_emit_invariant redaction::redact_args_target_missing_denies -- --exact
 cargo test -q -p assay-core --lib 'mcp::policy::engine::tests::parse_delegation_context_uses_explicit_depth_only' -- --exact
 
 echo "[review] PASS"


### PR DESCRIPTION
## Summary
- refresh older reviewer scripts to follow the new `decision_emit_invariant` target layout after T-R1 Step2
- replace stale exact selectors with module-qualified `--test decision_emit_invariant` selectors
- remove the remaining runtime checks that hardcode the deleted `decision_emit_invariant.rs` path

## Testing
- `bash -n $(git diff --name-only -- scripts/ci/*.sh)`
- representative exact selector runs under `--test decision_emit_invariant`
