### PR TITLE
docs: close tr1 decision emit split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step3.md
@@ -1,0 +1,24 @@
+# SPLIT CHECKLIST - T-R1 Decision Emit Invariant Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md`
+  - `docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step3.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step3.md`
+  - `scripts/ci/review-tr1-decision-emit-invariant-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-core/tests/decision_emit_invariant/**`
+- [ ] No edits under `crates/assay-core/src/**`
+
+## Closure contract
+- [ ] `tests/decision_emit_invariant/main.rs` remains the stable target root
+- [ ] one integration target remains the final T-R1 shape
+- [ ] no new module cuts are introduced
+- [ ] no fixture reshuffle is introduced
+- [ ] no emitted-contract selector or assertion semantics are changed in Step3
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-tr1-decision-emit-invariant-step3.sh` passes
+- [ ] `cargo fmt --all --check` passes
+- [ ] `cargo clippy -q -p assay-core --all-targets -- -D warnings` passes

--- a/docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step3.md
@@ -1,0 +1,30 @@
+# SPLIT MOVE MAP - T-R1 Decision Emit Invariant Step3
+
+## Intent
+Record that T-R1 is closed with the Step2 target shape preserved unchanged.
+
+## Final target ownership
+- `crates/assay-core/tests/decision_emit_invariant/main.rs`
+  - stable integration target root
+  - module wiring only
+- `crates/assay-core/tests/decision_emit_invariant/fixtures.rs`
+  - shared black-box helpers only
+- `crates/assay-core/tests/decision_emit_invariant/emission.rs`
+  - allow/deny/emission contract tests
+- `crates/assay-core/tests/decision_emit_invariant/approval.rs`
+  - approval-required contract tests
+- `crates/assay-core/tests/decision_emit_invariant/restrict_scope.rs`
+  - restrict-scope contract tests
+- `crates/assay-core/tests/decision_emit_invariant/redaction.rs`
+  - redact-args contract tests
+- `crates/assay-core/tests/decision_emit_invariant/guard.rs`
+  - guard fallback contract tests
+- `crates/assay-core/tests/decision_emit_invariant/delegation.rs`
+  - delegation additive-field contract tests
+- `crates/assay-core/tests/decision_emit_invariant/g3_auth.rs`
+  - G3 auth projection contract tests
+
+## Explicit closure claim
+- no additional movement belongs in Step3
+- T-R1 is complete once this closure slice lands
+- any future change to this target is a new wave, not part of T-R1

--- a/docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md
+++ b/docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md
@@ -14,9 +14,20 @@ This plan intentionally follows Rust/Cargo integration-test conventions:
 - avoid fragmenting one contract surface into many top-level integration-test crates unless
   later CI or ownership pressure clearly justifies that
 
-Current hotspot baseline on `origin/main @ ff8deb26`:
+Current hotspot baseline on `origin/main @ 0cc94e08`:
 
-- `crates/assay-core/tests/decision_emit_invariant.rs`: `1293` LOC
+- legacy single-file target before Step2: `crates/assay-core/tests/decision_emit_invariant.rs`: `1293` LOC
+- current target after Step2:
+  - `crates/assay-core/tests/decision_emit_invariant/main.rs`: `13`
+  - `crates/assay-core/tests/decision_emit_invariant/fixtures.rs`: `130`
+  - `crates/assay-core/tests/decision_emit_invariant/emission.rs`: `407`
+  - `crates/assay-core/tests/decision_emit_invariant/approval.rs`: `113`
+  - `crates/assay-core/tests/decision_emit_invariant/restrict_scope.rs`: `210`
+  - `crates/assay-core/tests/decision_emit_invariant/redaction.rs`: `222`
+  - `crates/assay-core/tests/decision_emit_invariant/guard.rs`: `46`
+  - `crates/assay-core/tests/decision_emit_invariant/delegation.rs`: `39`
+  - `crates/assay-core/tests/decision_emit_invariant/g3_auth.rs`: `110`
+  - total: `1290`
 - `crates/assay-core/src/mcp/decision.rs`: already split in Wave43 and now the primary emitted-decision companion
 - `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`: already split in Wave44 and now a behavior companion
 - `crates/assay-core/src/mcp/policy/engine.rs`: already split in Wave45 and now a policy-semantic companion
@@ -66,7 +77,9 @@ T-R1 freezes the expectation that any later split keeps these test-surface prope
 
 - T-R1 plan shipped on `main` via `#978`.
 - T-R1 Step1 shipped on `main` via `#979`.
-- Step2 is the mechanical multi-file target conversion for `decision_emit_invariant`.
+- T-R1 Step2 shipped on `main` via `#980`.
+- reviewer-script consistency follow-up shipped on `main` via `#981`.
+- Step3 is the closure/docs+gates slice for `decision_emit_invariant`.
 - T-R2 remains out of scope for this wave.
 
 ## Step1 (freeze)

--- a/docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step3.md
@@ -1,0 +1,21 @@
+# SPLIT REVIEW PACK - T-R1 Decision Emit Invariant Step3
+
+## Summary
+This closure slice finishes T-R1 without changing the `decision_emit_invariant` target itself.
+
+The final shape remains:
+- one integration target under `tests/decision_emit_invariant/main.rs`
+- shared helpers in `fixtures.rs`
+- scenario families split across dedicated modules
+- no production changes and no new test-target fragmentation
+
+## Review focus
+- confirm only docs/gates changed
+- confirm the final target shape is documented consistently
+- confirm no edits landed under `crates/assay-core/tests/decision_emit_invariant/**`
+- confirm no edits landed under `crates/assay-core/src/**`
+
+## Validation
+- `BASE_REF=origin/main bash scripts/ci/review-tr1-decision-emit-invariant-step3.sh`
+- `cargo fmt --all --check`
+- `cargo clippy -q -p assay-core --all-targets -- -D warnings`

--- a/scripts/ci/review-tr1-decision-emit-invariant-step3.sh
+++ b/scripts/ci/review-tr1-decision-emit-invariant-step3.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+ALLOWED_FILES=(
+  "docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md"
+  "docs/contributing/SPLIT-CHECKLIST-tr1-decision-emit-invariant-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-tr1-decision-emit-invariant-step3.md"
+  "scripts/ci/review-tr1-decision-emit-invariant-step3.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/tests/decision_emit_invariant"
+  "crates/assay-core/src"
+)
+
+if ! git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+  echo "BASE_REF does not resolve to a commit: $BASE_REF" >&2
+  exit 1
+fi
+
+tmp_changed="$(mktemp)"
+trap 'rm -f "$tmp_changed"' EXIT
+
+git diff --name-only "$BASE_REF"...HEAD >"$tmp_changed"
+git diff --name-only >>"$tmp_changed"
+git diff --name-only --cached >>"$tmp_changed"
+git ls-files --others --exclude-standard >>"$tmp_changed"
+sort -u -o "$tmp_changed" "$tmp_changed"
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  if [[ "$file" == .github/workflows/* ]]; then
+    echo "workflow file changed out of scope: $file" >&2
+    exit 1
+  fi
+
+  allowed=false
+  for allowed_file in "${ALLOWED_FILES[@]}"; do
+    if [[ "$file" == "$allowed_file" ]]; then
+      allowed=true
+      break
+    fi
+  done
+
+  if [[ "$allowed" == false ]]; then
+    echo "out-of-scope file changed: $file" >&2
+    exit 1
+  fi
+done <"$tmp_changed"
+
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: T-R1 Step3 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+PLAN="docs/contributing/SPLIT-PLAN-tr1-decision-emit-invariant.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-tr1-decision-emit-invariant-step3.md"
+
+for marker in \
+  'T-R1 Step2 shipped on `main` via `#980`' \
+  'reviewer-script consistency follow-up shipped on `main` via `#981`' \
+  'Step3 is the closure/docs+gates slice' \
+  'tests/decision_emit_invariant/main.rs'
+do
+  rg -n -F "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'stable integration target root' \
+  'fixtures.rs' \
+  'emission.rs' \
+  'approval.rs' \
+  'restrict_scope.rs' \
+  'redaction.rs' \
+  'guard.rs' \
+  'delegation.rs' \
+  'g3_auth.rs' \
+  'T-R1 is complete once this closure slice lands'
+do
+  rg -n -F "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+cargo fmt --all --check
+cargo clippy -q -p assay-core --all-targets -- -D warnings
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- close T-R1 after the Step2 target conversion and post-merge reviewer-script hygiene landed on `main`
- add the final closure checklist, move-map, review pack, and Step3 reviewer script
- keep Step3 docs/gates only with no edits under `crates/assay-core/tests/decision_emit_invariant/**` or `crates/assay-core/src/**`

## Testing
- `BASE_REF=origin/main bash scripts/ci/review-tr1-decision-emit-invariant-step3.sh`
