### PR TITLE
docs: freeze tr2 tool-call-handler test split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step1.md
@@ -1,0 +1,38 @@
+# T-R2 Step1 Checklist — `tool_call_handler/tests.rs`
+
+## Intent
+
+Freeze the split boundaries for `crates/assay-core/src/mcp/tool_call_handler/tests.rs` before any
+mechanical unit-test module moves.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md`
+- `docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step1.md`
+- `scripts/ci/review-tr2-tool-call-handler-tests-step1.sh`
+
+## Step1 constraints
+
+- docs/gates only
+- no edits under `crates/assay-core/src/mcp/tool_call_handler/**`
+- no edits under `crates/assay-core/tests/**`
+- no edits under `crates/assay-core/src/mcp/decision.rs`
+- no edits under `crates/assay-core/src/mcp/policy/**`
+- no workflow edits
+- no handler behavior, private-access coverage, or emitted-decision coupling drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-tr2-tool-call-handler-tests-step1.sh
+```
+
+## Reviewer quick scan
+
+1. Confirm the diff is limited to the 5 Step1 files.
+2. Confirm `crates/assay-core/src/mcp/tool_call_handler/**` stays untouched in this freeze wave.
+3. Confirm the plan preserves a `src`-local unit-test tree rather than introducing an integration target.
+4. Confirm `tests/mod.rs` is explicitly planned as a thin module root and `fixtures.rs` as shared helpers only.
+5. Confirm the reviewer script re-runs emission, delegation, approval, scope, redaction, tool-drift, classification, and lifecycle anchors.

--- a/docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step1.md
@@ -1,0 +1,64 @@
+# SPLIT-MOVE-MAP — T-R2 Step1 — `mcp/tool_call_handler/tests.rs`
+
+## Goal
+
+Freeze the split boundaries for `crates/assay-core/src/mcp/tool_call_handler/tests.rs` before any
+mechanical module moves.
+
+## Planned Step2 layout
+
+- `crates/assay-core/src/mcp/tool_call_handler/tests/mod.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/fixtures.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/emission.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/delegation.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/approval.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/scope.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/redaction.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/classification.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/lifecycle.rs`
+
+## Mapping preview
+
+- `tests/mod.rs` keeps the stable unit-test root, module wiring, shared imports, and only the
+  smallest common prelude needed for private access.
+- `fixtures.rs` is the planned home for shared emitters, request builders, policy builders,
+  approval artifacts, outcome helpers, and lifecycle helpers only.
+- `emission.rs` is the planned home for:
+  - handler decision emission
+  - allow/deny contract anchors
+  - obligation outcome emission
+  - fail-closed default assertions tied to emitted events
+- `delegation.rs` is the planned home for:
+  - delegated/direct/unstructured delegation projections
+- `approval.rs` is the planned home for:
+  - `approval_required_*`
+- `scope.rs` is the planned home for:
+  - `restrict_scope_*`
+- `redaction.rs` is the planned home for:
+  - `redact_args_*`
+- `classification.rs` is the planned home for:
+  - existing commit-tool and operation-class helper tests only
+- `lifecycle.rs` is the planned home for:
+  - lifecycle-emitter-specific behavior
+
+## Frozen behavior boundaries
+
+- identical unit-test placement under `src/mcp/tool_call_handler`
+- identical private-access coverage through `super::*`
+- identical handler decision emission meaning
+- identical delegation typed-field projection expectations
+- identical approval/restrict-scope/redact-args deny semantics
+- identical tool-drift and obligation outcome semantics
+- identical commit-tool / operation-class helper expectations
+- identical lifecycle emitter behavior
+
+## Test anchors to keep fixed in Step1
+
+- `mcp::tool_call_handler::tests::test_handler_emits_decision_on_policy_allow`
+- `mcp::tool_call_handler::tests::delegated_context_emits_typed_fields_for_supported_flow`
+- `mcp::tool_call_handler::tests::approval_required_missing_denies`
+- `mcp::tool_call_handler::tests::restrict_scope_target_missing_denies`
+- `mcp::tool_call_handler::tests::redact_args_target_missing_denies`
+- `mcp::tool_call_handler::tests::test_tool_drift_deny_emits_alert_obligation_outcome`
+- `mcp::tool_call_handler::tests::test_operation_class_for_tool`
+- `mcp::tool_call_handler::tests::test_lifecycle_emitter_not_called_when_none`

--- a/docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md
+++ b/docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md
@@ -12,7 +12,7 @@ This plan intentionally follows Rust unit-test conventions:
 - decompose it as `tests/mod.rs` plus submodules
 - preserve private access through `super::*`
 
-Current hotspot baseline on `origin/main @ 66c424c1`:
+Current hotspot baseline on `origin/main @ 26152b87`:
 
 - `crates/assay-core/src/mcp/tool_call_handler/tests.rs`: `1242` LOC
 - `crates/assay-core/src/mcp/tool_call_handler/evaluate.rs`: already split in Wave44 and now the closest behavior companion

--- a/docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step1.md
@@ -1,0 +1,55 @@
+# T-R2 Tool Call Handler Tests Step1 Review Pack
+
+## Intent
+
+Freeze the split boundaries for `crates/assay-core/src/mcp/tool_call_handler/tests.rs` before any
+mechanical unit-test decomposition, while preserving the suite as one white-box `src`-local test
+tree with private access.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md`
+- `docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step1.md`
+- `scripts/ci/review-tr2-tool-call-handler-tests-step1.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-core/src/mcp/tool_call_handler/**`
+- no edits under `crates/assay-core/tests/**`
+- no edits under `crates/assay-core/src/mcp/decision.rs`
+- no edits under `crates/assay-core/src/mcp/policy/**`
+- no production behavior changes
+- no conversion into integration tests
+- no visibility widening in production code
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-tr2-tool-call-handler-tests-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --all --check
+cargo clippy -q -p assay-core --all-targets -- -D warnings
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_handler_emits_decision_on_policy_allow' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::delegated_context_emits_typed_fields_for_supported_flow' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval_required_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::restrict_scope_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::redact_args_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_tool_drift_deny_emits_alert_obligation_outcome' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_operation_class_for_tool' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_lifecycle_emitter_not_called_when_none' -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the 5 Step1 files.
+2. Confirm the plan keeps the suite in `src/` as a unit-test tree with private access.
+3. Confirm `tests/mod.rs` is planned as a thin root rather than another giant test file.
+4. Confirm `fixtures.rs` is constrained to genuinely shared helpers only.
+5. Confirm the reviewer script re-runs emission, delegation, approval, scope, redaction, tool-drift, classification, and lifecycle anchors.

--- a/scripts/ci/review-tr2-tool-call-handler-tests-step1.sh
+++ b/scripts/ci/review-tr2-tool-call-handler-tests-step1.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+ALLOWED_FILES=(
+  "docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md"
+  "docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step1.md"
+  "scripts/ci/review-tr2-tool-call-handler-tests-step1.sh"
+)
+
+if ! git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+  echo "BASE_REF does not resolve to a commit: $BASE_REF" >&2
+  exit 1
+fi
+
+tmp_changed="$(mktemp)"
+trap 'rm -f "$tmp_changed"' EXIT
+
+git diff --name-only "$BASE_REF"...HEAD >"$tmp_changed"
+git diff --name-only >>"$tmp_changed"
+git diff --name-only --cached >>"$tmp_changed"
+git ls-files --others --exclude-standard >>"$tmp_changed"
+
+sort -u -o "$tmp_changed" "$tmp_changed"
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  if [[ "$file" == .github/workflows/* ]]; then
+    echo "workflow file changed out of scope: $file" >&2
+    exit 1
+  fi
+
+  allowed=false
+  for allowed_file in "${ALLOWED_FILES[@]}"; do
+    if [[ "$file" == "$allowed_file" ]]; then
+      allowed=true
+      break
+    fi
+  done
+
+  if [[ "$allowed" == false ]]; then
+    echo "out-of-scope file changed: $file" >&2
+    exit 1
+  fi
+done <"$tmp_changed"
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  if [[ "$file" == crates/assay-core/src/mcp/tool_call_handler/* ]]; then
+    echo "tool_call_handler sources must remain untouched in T-R2 Step1" >&2
+    exit 1
+  fi
+  if [[ "$file" == crates/assay-core/tests/* ]]; then
+    echo "assay-core integration tests must remain untouched in T-R2 Step1" >&2
+    exit 1
+  fi
+  if [[ "$file" == crates/assay-core/src/mcp/policy/* ]]; then
+    echo "policy sources must remain untouched in T-R2 Step1" >&2
+    exit 1
+  fi
+  if [[ "$file" == crates/assay-core/src/mcp/decision.rs ]]; then
+    echo "decision.rs must remain untouched in T-R2 Step1" >&2
+    exit 1
+  fi
+done <"$tmp_changed"
+
+cargo fmt --all --check
+cargo clippy -q -p assay-core --all-targets -- -D warnings
+
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_handler_emits_decision_on_policy_allow' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::delegated_context_emits_typed_fields_for_supported_flow' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval_required_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::restrict_scope_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::redact_args_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_tool_drift_deny_emits_alert_obligation_outcome' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_operation_class_for_tool' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::test_lifecycle_emitter_not_called_when_none' -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- freeze the T-R2 split boundaries for `crates/assay-core/src/mcp/tool_call_handler/tests.rs`
- add Step1 checklist, move-map, review pack, and reviewer gate
- pin representative white-box unit-test anchors across emission, delegation, approval, scope, redaction, tool-drift, classification, and lifecycle families

## Testing
- `BASE_REF=origin/main bash scripts/ci/review-tr2-tool-call-handler-tests-step1.sh`