### PR TITLE
docs: close tr2 tool-call-handler test split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step3.md
@@ -1,0 +1,26 @@
+# SPLIT CHECKLIST - T-R2 Tool Call Handler Tests Step3
+
+## Scope discipline
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md`
+  - `docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step3.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step3.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step3.md`
+  - `scripts/ci/review-tr2-tool-call-handler-tests-step3.sh`
+- [ ] No `.github/workflows/*` changes
+- [ ] No edits under `crates/assay-core/src/mcp/tool_call_handler/**`
+- [ ] No edits under `crates/assay-core/tests/**`
+- [ ] No edits under `crates/assay-core/src/mcp/policy/**`
+- [ ] No edits to `crates/assay-core/src/mcp/decision.rs`
+
+## Closure contract
+- [ ] `crates/assay-core/src/mcp/tool_call_handler/tests/mod.rs` remains the stable unit-test root
+- [ ] the Step2 module tree remains the final T-R2 shape
+- [ ] no new module cuts are introduced
+- [ ] no fixture reshuffle is introduced
+- [ ] no private-access or selector semantics are changed in Step3
+
+## Validation
+- [ ] `BASE_REF=origin/main bash scripts/ci/review-tr2-tool-call-handler-tests-step3.sh` passes
+- [ ] `cargo fmt --all --check` passes
+- [ ] `cargo clippy -q -p assay-core --all-targets -- -D warnings` passes

--- a/docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step3.md
@@ -1,0 +1,44 @@
+# SPLIT-MOVE-MAP - T-R2 Step3 - `mcp/tool_call_handler/tests.rs`
+
+## Goal
+
+Close T-R2 after the shipped Step2 module-tree split without changing handler behavior,
+private-access coverage shape, or the white-box meaning of the suite.
+
+## Final layout retained
+
+- `crates/assay-core/src/mcp/tool_call_handler/tests/mod.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/fixtures.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/emission.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/delegation.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/approval.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/scope.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/redaction.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/classification.rs`
+- `crates/assay-core/src/mcp/tool_call_handler/tests/lifecycle.rs`
+
+## Closure assertions
+
+- `tests/mod.rs` remains the stable unit-test root and stays thin
+- the split remains a `src` unit-test tree, not an integration target
+- the Step2 family boundaries remain intact:
+  - `fixtures`
+  - `emission`
+  - `delegation`
+  - `approval`
+  - `scope`
+  - `redaction`
+  - `classification`
+  - `lifecycle`
+- future helper cleanup or selector hygiene that reaches beyond closure-only docs/gates requires a separate wave
+- no private-access widening, production behavior cleanup, or test-family reinterpretation is part of Step3
+
+## Closure anchor selectors
+
+- `mcp::tool_call_handler::tests::emission::test_handler_emits_decision_on_policy_allow`
+- `mcp::tool_call_handler::tests::delegation::delegated_context_emits_typed_fields_for_supported_flow`
+- `mcp::tool_call_handler::tests::approval::approval_required_missing_denies`
+- `mcp::tool_call_handler::tests::scope::restrict_scope_target_missing_denies`
+- `mcp::tool_call_handler::tests::redaction::redact_args_target_missing_denies`
+- `mcp::tool_call_handler::tests::classification::test_operation_class_for_tool`
+- `mcp::tool_call_handler::tests::lifecycle::test_lifecycle_emitter_not_called_when_none`

--- a/docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md
+++ b/docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md
@@ -5,6 +5,9 @@
 Split `crates/assay-core/src/mcp/tool_call_handler/tests.rs` into a unit-test module tree without
 changing handler behavior, private-access coverage shape, or the white-box meaning of the suite.
 
+T-R2 Step1 shipped on `main` via `#983`.
+T-R2 Step2 shipped on `main` via `#984`.
+
 This plan intentionally follows Rust unit-test conventions:
 
 - keep this suite in `src/`
@@ -131,6 +134,7 @@ Step3 constraints:
 - no production behavior cleanup inside handler/decision/policy code
 - no new module cuts
 - no drift in private-access coverage shape
+- no selector churn beyond closure-gate alignment with the shipped module tree
 
 ## Reviewer notes
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step3.md
@@ -1,0 +1,54 @@
+# T-R2 Tool Call Handler Tests Step3 Review Pack
+
+## Intent
+
+Close the T-R2 unit-test-tree split after `#984`, while keeping `tests/mod.rs` as the stable
+white-box root and preserving the shipped scenario-family module tree.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md`
+- `docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step3.md`
+- `scripts/ci/review-tr2-tool-call-handler-tests-step3.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-core/src/mcp/tool_call_handler/**`
+- no edits under `crates/assay-core/tests/**`
+- no edits under `crates/assay-core/src/mcp/policy/**`
+- no edits under `crates/assay-core/src/mcp/decision.rs`
+- no production behavior changes
+- no fixture reshuffle
+- no new module cuts
+- no unit-test to integration-test conversion
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-tr2-tool-call-handler-tests-step3.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --all --check
+cargo clippy -q -p assay-core --all-targets -- -D warnings
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::emission::test_handler_emits_decision_on_policy_allow' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::delegation::delegated_context_emits_typed_fields_for_supported_flow' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval::approval_required_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::scope::restrict_scope_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::redaction::redact_args_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::classification::test_operation_class_for_tool' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::lifecycle::test_lifecycle_emitter_not_called_when_none' -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step3 docs and reviewer script.
+2. Confirm the plan now records Step1/Step2 as shipped on `main`.
+3. Confirm the move-map reflects the Step2 module tree as the final T-R2 shape.
+4. Confirm the reviewer script freezes the `tool_call_handler` test tree and reruns the module-qualified selectors.
+5. Confirm there is no production or integration-test scope leakage in the closure wave.

--- a/scripts/ci/review-tr2-tool-call-handler-tests-step3.sh
+++ b/scripts/ci/review-tr2-tool-call-handler-tests-step3.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md"
+  "docs/contributing/SPLIT-CHECKLIST-tr2-tool-call-handler-tests-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-tr2-tool-call-handler-tests-step3.md"
+  "scripts/ci/review-tr2-tool-call-handler-tests-step3.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-core/src/mcp/tool_call_handler"
+  "crates/assay-core/tests"
+  "crates/assay-core/src/mcp/policy"
+  "crates/assay-core/src/mcp/decision.rs"
+)
+
+changed_files() {
+  git diff --name-only "$BASE_REF"...HEAD || true
+  git diff --name-only || true
+  git diff --name-only --cached || true
+  git ls-files --others --exclude-standard || true
+}
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: T-R2 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in T-R2 Step3: $f"
+    exit 1
+  fi
+done < <(changed_files | awk 'NF' | sort -u)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: T-R2 Step3 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-tr2-tool-call-handler-tests.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-tr2-tool-call-handler-tests-step3.md"
+
+for marker in \
+  'T-R2 Step1 shipped on `main` via `#983`.' \
+  'T-R2 Step2 shipped on `main` via `#984`.' \
+  'keep `tests/mod.rs` as the stable unit-test root' \
+  'no promotion into `crates/assay-core/tests/**`' \
+  'no new module cuts' \
+  'no drift in private-access coverage shape'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-core/src/mcp/tool_call_handler/tests/mod.rs' \
+  'crates/assay-core/src/mcp/tool_call_handler/tests/fixtures.rs' \
+  'crates/assay-core/src/mcp/tool_call_handler/tests/emission.rs' \
+  'crates/assay-core/src/mcp/tool_call_handler/tests/delegation.rs' \
+  'crates/assay-core/src/mcp/tool_call_handler/tests/approval.rs' \
+  'crates/assay-core/src/mcp/tool_call_handler/tests/scope.rs' \
+  'crates/assay-core/src/mcp/tool_call_handler/tests/redaction.rs' \
+  'crates/assay-core/src/mcp/tool_call_handler/tests/classification.rs' \
+  'crates/assay-core/src/mcp/tool_call_handler/tests/lifecycle.rs' \
+  'future helper cleanup or selector hygiene that reaches beyond closure-only docs/gates requires a separate wave' \
+  'no private-access widening, production behavior cleanup, or test-family reinterpretation is part of Step3'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] root shape checks"
+for required in \
+  '^mod approval;$' \
+  '^mod classification;$' \
+  '^mod delegation;$' \
+  '^mod emission;$' \
+  '^mod fixtures;$' \
+  '^mod lifecycle;$' \
+  '^mod redaction;$' \
+  '^mod scope;$'
+do
+  if ! rg -n "$required" crates/assay-core/src/mcp/tool_call_handler/tests/mod.rs >/dev/null; then
+    echo "FAIL: tests/mod.rs is missing required module declaration: $required"
+    exit 1
+  fi
+done
+
+if rg -n '^#\[test\]|^fn test_|^fn approval_required_|^fn restrict_scope_|^fn redact_args_' \
+  crates/assay-core/src/mcp/tool_call_handler/tests/mod.rs >/dev/null; then
+  echo "FAIL: tests/mod.rs must remain a thin module root"
+  exit 1
+fi
+
+echo "[review] repo checks"
+cargo fmt --all --check
+cargo clippy -q -p assay-core --all-targets -- -D warnings
+
+echo "[review] pinned T-R2 invariants"
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::emission::test_handler_emits_decision_on_policy_allow' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::delegation::delegated_context_emits_typed_fields_for_supported_flow' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::approval::approval_required_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::scope::restrict_scope_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::redaction::redact_args_target_missing_denies' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::classification::test_operation_class_for_tool' -- --exact
+cargo test -q -p assay-core --lib 'mcp::tool_call_handler::tests::lifecycle::test_lifecycle_emitter_not_called_when_none' -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- close T-R2 with docs/gates-only Step3 artifacts
- record Step1 and Step2 as shipped on main in the T-R2 plan
- add a closure reviewer gate that freezes the tool_call_handler test tree and reruns post-split selectors

## Testing
- BASE_REF=origin/main bash scripts/ci/review-tr2-tool-call-handler-tests-step3.sh