### PR TITLE
docs: freeze wave50 registry auth split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step1.md
@@ -1,0 +1,15 @@
+# Wave50 Registry Auth Step1 Checklist
+
+- [ ] Step1 is docs+gate only.
+- [ ] Only these files changed:
+  - `docs/contributing/SPLIT-PLAN-wave50-registry-auth.md`
+  - `docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step1.md`
+  - `docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step1.md`
+  - `docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step1.md`
+  - `scripts/ci/review-wave50-registry-auth-step1.sh`
+- [ ] No `.github/workflows/*` changes.
+- [ ] No edits under `crates/assay-registry/src/**`.
+- [ ] No edits under `crates/assay-registry/tests/**`.
+- [ ] Step1 gate pins static/env auth semantics, OIDC exchange/cache/retry semantics, and downstream registry-client auth-header behavior.
+- [ ] Validation run:
+  - `BASE_REF=origin/main bash scripts/ci/review-wave50-registry-auth-step1.sh`

--- a/docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step1.md
@@ -1,0 +1,40 @@
+# SPLIT-MOVE-MAP - Wave50 Step1 - `registry/auth.rs`
+
+## Goal
+
+Freeze the current `crates/assay-registry/src/auth.rs` behavior before any mechanical split work.
+
+## Planned Step2 layout
+
+- `crates/assay-registry/src/auth.rs`
+- `crates/assay-registry/src/auth_next/mod.rs`
+- `crates/assay-registry/src/auth_next/providers.rs`
+- `crates/assay-registry/src/auth_next/oidc.rs`
+- `crates/assay-registry/src/auth_next/cache.rs`
+- `crates/assay-registry/src/auth_next/headers.rs`
+- `crates/assay-registry/src/auth_next/diagnostics.rs`
+
+## Frozen behavior boundaries
+
+- identical static-token behavior
+- identical environment precedence and empty-token fallback behavior
+- identical OIDC enablement and GitHub Actions environment detection
+- identical GitHub OIDC request + registry exchange behavior
+- identical cache hit / expiry / refresh behavior
+- identical retry/backoff behavior
+- identical downstream auth-header and unauthorized-response behavior in the registry client
+
+## Step1 anchor selectors
+
+- `auth::tests::test_static_token`
+- `auth::tests::test_from_env_static`
+- `auth::tests::test_from_env_empty_token`
+- `auth::tests::test_get_static_token`
+- `auth::oidc_tests::test_oidc_full_flow`
+- `auth::oidc_tests::test_oidc_github_failure`
+- `auth::oidc_tests::test_oidc_cache_clear`
+- `auth::oidc_tests::test_token_expiry_triggers_refresh`
+- `auth::oidc_tests::test_oidc_retry_backoff_on_failure`
+- `registry_client::scenarios_auth_headers::test_authentication_header`
+- `registry_client::scenarios_auth_headers::test_no_auth_when_no_token`
+- `registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized`

--- a/docs/contributing/SPLIT-PLAN-wave50-registry-auth.md
+++ b/docs/contributing/SPLIT-PLAN-wave50-registry-auth.md
@@ -1,0 +1,155 @@
+# Wave50 Plan - `registry/auth.rs` Kernel Split
+
+## Goal
+
+Split `crates/assay-registry/src/auth.rs` behind a stable facade with zero registry-auth semantic
+drift and no downstream client, resolver, or trust coupling drift.
+
+Current hotspot baseline on `origin/main @ 91bdd8b2`:
+- `crates/assay-registry/src/auth.rs`: `685` LOC
+- `crates/assay-registry/src/client/http.rs`: auth-header and unauthorized-response companion
+- `crates/assay-registry/tests/registry_client/scenarios_auth_headers.rs`: downstream auth-header contract companion
+- `crates/assay-core/src/mcp/proxy.rs`: next `P1` runtime companion after `R50`
+
+## Step1 (freeze)
+
+Branch: `codex/wave50-registry-auth-step1` (base: `main`)
+
+Deliverables:
+- `docs/contributing/SPLIT-PLAN-wave50-registry-auth.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step1.md`
+- `scripts/ci/review-wave50-registry-auth-step1.sh`
+
+Step1 constraints:
+- docs+gate only
+- no edits under `crates/assay-registry/src/**`
+- no edits under `crates/assay-registry/tests/**`
+- no workflow edits
+- no client / resolver / trust / CLI / evidence edits
+
+Step1 gate:
+- allowlist-only diff (the 5 Step1 files)
+- workflow-ban (`.github/workflows/*`)
+- hard fail on tracked changes in `crates/assay-registry/src/**`
+- hard fail on untracked files in `crates/assay-registry/src/**`
+- hard fail on tracked changes in `crates/assay-registry/tests/**`
+- hard fail on untracked files in `crates/assay-registry/tests/**`
+- `cargo fmt --check`
+- `cargo clippy -p assay-registry --all-targets -- -D warnings`
+- targeted tests:
+  - `cargo test -q -p assay-registry --lib 'auth::tests::test_static_token' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_static' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_empty_token' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'auth::tests::test_get_static_token' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_full_flow' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_github_failure' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_cache_clear' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_token_expiry_triggers_refresh' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_retry_backoff_on_failure' -- --exact`
+  - `cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_authentication_header' -- --exact`
+  - `cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_no_auth_when_no_token' -- --exact`
+  - `cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized' -- --exact`
+
+## Frozen public surface
+
+Wave50 freezes the expectation that Step2 keeps these auth entrypoints and consumer-facing
+contracts unchanged in meaning:
+- `TokenProvider`
+- `TokenProvider::static_token`
+- `TokenProvider::from_env`
+- `TokenProvider::get_token`
+- `TokenProvider::is_authenticated`
+- `TokenProvider::github_oidc`
+- `OidcProvider`
+- `OidcProvider::from_github_actions`
+- `OidcProvider::new`
+- `OidcProvider::get_token`
+- `OidcProvider::clear_cache`
+
+Step2 may reorganize internal ownership behind `auth.rs`, but must not redefine:
+- static-token semantics
+- environment precedence and empty-token fallback behavior
+- OIDC environment detection semantics
+- GitHub OIDC request and registry exchange behavior
+- cache hit/expiry/refresh behavior
+- retry/backoff behavior
+- downstream auth-header or unauthorized-response behavior in the registry client
+
+## Status
+
+- T-R1 closed on `main` via `#982`.
+- T-R2 closed on `main` via `#985`.
+- Wave50 Step1 is the freeze slice for the next unsplit production hotspot.
+
+## Step2 (mechanical split preview)
+
+Branch: `codex/wave50-registry-auth-step2` (base: `main`)
+
+Target layout:
+- `crates/assay-registry/src/auth.rs` (thin facade + stable routing)
+- `crates/assay-registry/src/auth_next/mod.rs`
+- `crates/assay-registry/src/auth_next/providers.rs`
+- `crates/assay-registry/src/auth_next/oidc.rs`
+- `crates/assay-registry/src/auth_next/cache.rs`
+- `crates/assay-registry/src/auth_next/headers.rs`
+- `crates/assay-registry/src/auth_next/diagnostics.rs`
+
+Step2 scope:
+- `crates/assay-registry/src/auth.rs`
+- `crates/assay-registry/src/auth_next/mod.rs`
+- `crates/assay-registry/src/auth_next/providers.rs`
+- `crates/assay-registry/src/auth_next/oidc.rs`
+- `crates/assay-registry/src/auth_next/cache.rs`
+- `crates/assay-registry/src/auth_next/headers.rs`
+- `crates/assay-registry/src/auth_next/diagnostics.rs`
+- `docs/contributing/SPLIT-PLAN-wave50-registry-auth.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step2.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step2.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step2.md`
+- `scripts/ci/review-wave50-registry-auth-step2.sh`
+
+Step2 principles:
+- 1:1 body moves
+- stable `TokenProvider` / `OidcProvider` facade behavior
+- no static/env precedence drift
+- no OIDC exchange or request-header drift
+- no cache/refresh drift
+- no retry/backoff drift
+- no downstream auth-header or unauthorized-response drift
+- no downstream header or unauthorized-response drift
+- no edits under `crates/assay-registry/tests/**`
+- no workflow edits
+
+## Step3 (closure)
+
+Step3 will close the shipped Wave50 auth split with docs/gates only once Step2 lands on `main`.
+
+Step3 constraints:
+- docs+gate only
+- no edits under `crates/assay-registry/src/**`
+- no edits under `crates/assay-registry/tests/**`
+- keep `auth.rs` as the stable facade entrypoint
+- no new module cuts
+- no behavior cleanup beyond internal follow-up notes
+- no auth-header, cache, retry, or exchange-path drift
+
+## Promote
+
+Stacked chain:
+- Step1 -> `main`
+- Step2 -> Step1
+- Step3 -> Step2
+
+Final promote PR to `main` from Step3 once the chain is clean.
+
+## Reviewer notes
+
+This wave must remain registry-auth split planning only.
+
+Primary failure modes:
+- sneaking auth behavior cleanup into a mechanical split
+- changing env precedence or empty-token behavior while chasing file size
+- changing OIDC request/exchange or retry semantics under a refactor label
+- drifting client auth-header behavior via helper moves

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step1.md
@@ -1,0 +1,56 @@
+# Wave50 Registry Auth Step1 Review Pack
+
+## Intent
+
+Freeze `crates/assay-registry/src/auth.rs` before any split, while pinning both the direct auth
+semantics and the downstream registry-client auth-header contract.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave50-registry-auth.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step1.md`
+- `scripts/ci/review-wave50-registry-auth-step1.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-registry/src/**`
+- no edits under `crates/assay-registry/tests/**`
+- no resolver / trust / client behavior changes
+- no CLI or evidence coupling changes
+- no auth semantic cleanup yet
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave50-registry-auth-step1.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --check
+cargo clippy -p assay-registry --all-targets -- -D warnings
+cargo test -q -p assay-registry --lib 'auth::tests::test_static_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_static' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_empty_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_get_static_token' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_full_flow' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_github_failure' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_cache_clear' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_token_expiry_triggers_refresh' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_retry_backoff_on_failure' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_authentication_header' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_no_auth_when_no_token' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized' -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the five Step1 files.
+2. Confirm the plan freezes `TokenProvider` / `OidcProvider` semantics rather than proposing redesign.
+3. Confirm the move-map names the exact `auth_next/*` seams and the downstream client-header contract.
+4. Confirm the reviewer script blocks any registry source or registry test edits.
+5. Confirm both lib auth tests and downstream registry-client auth tests are pinned.

--- a/scripts/ci/review-wave50-registry-auth-step1.sh
+++ b/scripts/ci/review-wave50-registry-auth-step1.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave50-registry-auth.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step1.md"
+  "scripts/ci/review-wave50-registry-auth-step1.sh"
+)
+
+FROZEN_PATHS=(
+  "crates/assay-registry/src"
+  "crates/assay-registry/tests"
+)
+
+changed_files() {
+  git diff --name-only "$BASE_REF"...HEAD || true
+  git diff --name-only || true
+  git diff --name-only --cached || true
+  git ls-files --others --exclude-standard || true
+}
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave50 Step1 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave50 Step1: $f"
+    exit 1
+  fi
+done < <(changed_files | awk 'NF' | sort -u)
+
+echo "[review] frozen tracked paths must not change"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git diff --name-only "$BASE_REF"...HEAD -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: Wave50 Step1 must not change frozen path: $p"
+    git diff --name-only "$BASE_REF"...HEAD -- "$p"
+    exit 1
+  fi
+done
+
+echo "[review] frozen paths must not contain untracked files"
+for p in "${FROZEN_PATHS[@]}"; do
+  if git ls-files --others --exclude-standard -- "$p" | rg -n '.' >/dev/null; then
+    echo "FAIL: untracked files present under frozen path: $p"
+    git ls-files --others --exclude-standard -- "$p" | sed 's/^/  - /'
+    exit 1
+  fi
+done
+
+echo "[review] marker checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave50-registry-auth.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step1.md"
+
+for marker in \
+  'Split `crates/assay-registry/src/auth.rs` behind a stable facade' \
+  '`TokenProvider::from_env`' \
+  '`OidcProvider::get_token`' \
+  'no static/env precedence drift' \
+  'no downstream auth-header or unauthorized-response drift'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'crates/assay-registry/src/auth_next/providers.rs' \
+  'crates/assay-registry/src/auth_next/oidc.rs' \
+  'identical retry/backoff behavior' \
+  'registry_client::scenarios_auth_headers::test_authentication_header'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo clippy -p assay-registry --all-targets -- -D warnings
+
+echo "[review] pinned auth invariants"
+cargo test -q -p assay-registry --lib 'auth::tests::test_static_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_static' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_empty_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_get_static_token' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_full_flow' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_github_failure' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_cache_clear' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_token_expiry_triggers_refresh' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_retry_backoff_on_failure' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_authentication_header' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_no_auth_when_no_token' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized' -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary
- freeze the next production hotspot at crates/assay-registry/src/auth.rs
- pin static/env auth semantics, OIDC exchange/cache/retry semantics, and downstream auth-header behavior
- add the Step1 checklist, move-map, review pack, and reviewer gate for Wave50

## Testing
- BASE_REF=origin/main bash scripts/ci/review-wave50-registry-auth-step1.sh