### PR TITLE
refactor: split registry auth facade

### DIFF
--- a/crates/assay-registry/src/auth.rs
+++ b/crates/assay-registry/src/auth.rs
@@ -23,10 +23,10 @@
 //!           ASSAY_REGISTRY_OIDC: "1"
 //! ```
 
-use crate::error::RegistryResult;
+#[path = "auth_next/mod.rs"]
+mod auth_next;
 
-#[cfg(feature = "oidc")]
-use crate::error::RegistryError;
+use crate::error::RegistryResult;
 
 /// Token provider for registry authentication.
 #[derive(Debug, Clone)]
@@ -45,7 +45,7 @@ pub enum TokenProvider {
 impl TokenProvider {
     /// Create a static token provider.
     pub fn static_token(token: impl Into<String>) -> Self {
-        Self::Static(token.into())
+        auth_next::providers::static_token(token)
     }
 
     /// Create from environment variable.
@@ -55,25 +55,7 @@ impl TokenProvider {
     /// 2. `ASSAY_REGISTRY_OIDC=1` + GitHub Actions env - OIDC exchange
     /// 3. Falls back to no auth
     pub fn from_env() -> Self {
-        // Check for static token
-        if let Ok(token) = std::env::var("ASSAY_REGISTRY_TOKEN") {
-            if !token.is_empty() {
-                return Self::Static(token);
-            }
-        }
-
-        // Check for OIDC (with feature)
-        #[cfg(feature = "oidc")]
-        if std::env::var("ASSAY_REGISTRY_OIDC")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
-        {
-            if let Ok(provider) = OidcProvider::from_github_actions() {
-                return Self::Oidc(provider);
-            }
-        }
-
-        Self::None
+        auth_next::providers::from_env()
     }
 
     /// Get the current token.
@@ -81,23 +63,18 @@ impl TokenProvider {
     /// For static tokens, returns the token directly.
     /// For OIDC, may perform token exchange if expired.
     pub async fn get_token(&self) -> RegistryResult<Option<String>> {
-        match self {
-            Self::Static(token) => Ok(Some(token.clone())),
-            Self::None => Ok(None),
-            #[cfg(feature = "oidc")]
-            Self::Oidc(provider) => provider.get_token().await,
-        }
+        auth_next::providers::get_token(self).await
     }
 
     /// Check if authentication is configured.
     pub fn is_authenticated(&self) -> bool {
-        !matches!(self, Self::None)
+        auth_next::providers::is_authenticated(self)
     }
 
     /// Create an OIDC provider for GitHub Actions.
     #[cfg(feature = "oidc")]
     pub fn github_oidc() -> RegistryResult<Self> {
-        Ok(Self::Oidc(OidcProvider::from_github_actions()?))
+        auth_next::providers::github_oidc()
     }
 }
 
@@ -138,21 +115,6 @@ struct CachedToken {
 
 /// OIDC token exchange response.
 #[cfg(feature = "oidc")]
-#[derive(Debug, serde::Deserialize)]
-struct OidcTokenResponse {
-    value: String,
-}
-
-/// Registry token exchange response.
-#[cfg(feature = "oidc")]
-#[derive(Debug, serde::Deserialize)]
-struct RegistryTokenResponse {
-    access_token: String,
-    expires_in: u64,
-    token_type: String,
-}
-
-#[cfg(feature = "oidc")]
 impl OidcProvider {
     /// Create from GitHub Actions environment.
     ///
@@ -163,29 +125,7 @@ impl OidcProvider {
     /// Optional:
     /// - `ASSAY_REGISTRY_URL`: Custom registry URL (default: https://registry.getassay.dev/v1)
     pub fn from_github_actions() -> RegistryResult<Self> {
-        let token_request_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").map_err(|_| {
-            RegistryError::Config {
-                message: "ACTIONS_ID_TOKEN_REQUEST_URL not set - not in GitHub Actions or id-token permission not granted".into(),
-            }
-        })?;
-
-        let request_token =
-            std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").map_err(|_| RegistryError::Config {
-                message: "ACTIONS_ID_TOKEN_REQUEST_TOKEN not set".into(),
-            })?;
-
-        let registry_base = std::env::var("ASSAY_REGISTRY_URL")
-            .unwrap_or_else(|_| "https://registry.getassay.dev/v1".to_string());
-        let registry_exchange_url =
-            format!("{}/auth/oidc/exchange", registry_base.trim_end_matches('/'));
-
-        Ok(Self {
-            token_request_url,
-            request_token,
-            registry_exchange_url,
-            audience: "https://registry.getassay.dev".to_string(),
-            cached_token: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
-        })
+        auth_next::oidc::from_github_actions()
     }
 
     /// Create with custom URLs (for testing).
@@ -195,177 +135,42 @@ impl OidcProvider {
         registry_exchange_url: impl Into<String>,
         audience: impl Into<String>,
     ) -> Self {
-        Self {
-            token_request_url: token_request_url.into(),
-            request_token: request_token.into(),
-            registry_exchange_url: registry_exchange_url.into(),
-            audience: audience.into(),
-            cached_token: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
-        }
+        auth_next::oidc::new(
+            token_request_url,
+            request_token,
+            registry_exchange_url,
+            audience,
+        )
     }
 
     /// Get token, refreshing if expired.
     pub async fn get_token(&self) -> RegistryResult<Option<String>> {
-        // Check cache first
-        {
-            let cache = self.cached_token.read().await;
-            if let Some(cached) = cache.as_ref() {
-                // Use 60-second buffer before expiry + 30s clock skew tolerance
-                let buffer = chrono::Duration::seconds(90);
-                if cached.expires_at > chrono::Utc::now() + buffer {
-                    tracing::debug!("using cached OIDC token");
-                    return Ok(Some(cached.token.clone()));
-                }
-            }
-        }
-
-        // Need to refresh
-        tracing::debug!("refreshing OIDC token");
-        let token = self.exchange_token_with_retry().await?;
-        Ok(Some(token))
+        auth_next::cache::get_token(self).await
     }
 
     /// Exchange token with exponential backoff retry.
     async fn exchange_token_with_retry(&self) -> RegistryResult<String> {
-        let mut retries = 0;
-        let max_retries = 3;
-
-        loop {
-            match self.exchange_token().await {
-                Ok(token) => return Ok(token),
-                Err(e) if retries < max_retries => {
-                    retries += 1;
-
-                    // Exponential backoff: 1s, 2s, 4s, capped at 30s
-                    let backoff = std::time::Duration::from_secs(1 << retries);
-                    let backoff = backoff.min(std::time::Duration::from_secs(30));
-
-                    tracing::warn!(
-                        error = %e,
-                        retry = retries,
-                        backoff_secs = backoff.as_secs(),
-                        "OIDC token exchange failed, retrying"
-                    );
-
-                    tokio::time::sleep(backoff).await;
-                }
-                Err(e) => return Err(e),
-            }
-        }
+        auth_next::oidc::exchange_token_with_retry(self).await
     }
 
     /// Exchange OIDC token for registry token.
     async fn exchange_token(&self) -> RegistryResult<String> {
-        // 1. Get OIDC token from GitHub
-        let oidc_token = self.get_github_oidc_token().await?;
-
-        // 2. Exchange for registry token
-        let registry_token = self.exchange_for_registry_token(&oidc_token).await?;
-
-        Ok(registry_token)
+        auth_next::oidc::exchange_token(self).await
     }
 
     /// Request OIDC token from GitHub Actions.
     async fn get_github_oidc_token(&self) -> RegistryResult<String> {
-        let client = reqwest::Client::new();
-
-        let url = format!("{}&audience={}", self.token_request_url, self.audience);
-
-        let response = client
-            .get(&url)
-            .header("Authorization", format!("Bearer {}", self.request_token))
-            .header("Accept", "application/json; api-version=2.0")
-            .header("Content-Type", "application/json")
-            .send()
-            .await
-            .map_err(|e| RegistryError::Network {
-                message: format!("failed to request GitHub OIDC token: {}", e),
-            })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(RegistryError::Unauthorized {
-                message: format!("GitHub OIDC request failed: HTTP {} - {}", status, body),
-            });
-        }
-
-        let token_response: OidcTokenResponse =
-            response
-                .json()
-                .await
-                .map_err(|e| RegistryError::InvalidResponse {
-                    message: format!("failed to parse GitHub OIDC response: {}", e),
-                })?;
-
-        Ok(token_response.value)
+        auth_next::oidc::get_github_oidc_token(self).await
     }
 
     /// Exchange GitHub OIDC token for registry access token.
     async fn exchange_for_registry_token(&self, oidc_token: &str) -> RegistryResult<String> {
-        let client = reqwest::Client::new();
-
-        let response = client
-            .post(&self.registry_exchange_url)
-            .json(&serde_json::json!({
-                "token": oidc_token,
-                "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-                "subject_token_type": "urn:ietf:params:oauth:token-type:jwt"
-            }))
-            .send()
-            .await
-            .map_err(|e| RegistryError::Network {
-                message: format!("failed to exchange token: {}", e),
-            })?;
-
-        let status = response.status();
-
-        if status == reqwest::StatusCode::UNAUTHORIZED {
-            return Err(RegistryError::Unauthorized {
-                message: "OIDC token exchange failed: unauthorized".to_string(),
-            });
-        }
-
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(RegistryError::Network {
-                message: format!("token exchange failed: HTTP {} - {}", status, body),
-            });
-        }
-
-        let token_response: RegistryTokenResponse =
-            response
-                .json()
-                .await
-                .map_err(|e| RegistryError::InvalidResponse {
-                    message: format!("failed to parse registry token response: {}", e),
-                })?;
-
-        // Cache the token
-        let expires_at =
-            chrono::Utc::now() + chrono::Duration::seconds(token_response.expires_in as i64);
-
-        {
-            let mut cache = self.cached_token.write().await;
-            *cache = Some(CachedToken {
-                token: token_response.access_token.clone(),
-                expires_at,
-            });
-        }
-
-        tracing::info!(
-            expires_in = token_response.expires_in,
-            token_type = %token_response.token_type,
-            "obtained registry access token"
-        );
-
-        Ok(token_response.access_token)
+        auth_next::oidc::exchange_for_registry_token(self, oidc_token).await
     }
 
     /// Clear the cached token.
     pub async fn clear_cache(&self) {
-        let mut cache = self.cached_token.write().await;
-        *cache = None;
+        auth_next::cache::clear_cache(self).await
     }
 }
 
@@ -497,7 +302,10 @@ mod oidc_tests {
         );
 
         let result = provider.get_token().await;
-        assert!(matches!(result, Err(RegistryError::Unauthorized { .. })));
+        assert!(matches!(
+            result,
+            Err(crate::error::RegistryError::Unauthorized { .. })
+        ));
     }
 
     #[tokio::test]
@@ -669,7 +477,7 @@ mod oidc_tests {
 
         // Should fail after max retries
         assert!(
-            matches!(result, Err(RegistryError::Network { .. })),
+            matches!(result, Err(crate::error::RegistryError::Network { .. })),
             "Should fail with network error after retries: {:?}",
             result
         );

--- a/crates/assay-registry/src/auth_next/cache.rs
+++ b/crates/assay-registry/src/auth_next/cache.rs
@@ -1,0 +1,32 @@
+use crate::error::RegistryResult;
+
+use super::super::{CachedToken, OidcProvider};
+
+pub(in crate::auth) async fn get_token(provider: &OidcProvider) -> RegistryResult<Option<String>> {
+    {
+        let cache = provider.cached_token.read().await;
+        if let Some(cached) = cache.as_ref() {
+            let buffer = chrono::Duration::seconds(90);
+            if cached.expires_at > chrono::Utc::now() + buffer {
+                tracing::debug!("using cached OIDC token");
+                return Ok(Some(cached.token.clone()));
+            }
+        }
+    }
+
+    tracing::debug!("refreshing OIDC token");
+    let token = provider.exchange_token_with_retry().await?;
+    Ok(Some(token))
+}
+
+pub(in crate::auth) async fn cache_token(provider: &OidcProvider, token: String, expires_in: u64) {
+    let expires_at = chrono::Utc::now() + chrono::Duration::seconds(expires_in as i64);
+
+    let mut cache = provider.cached_token.write().await;
+    *cache = Some(CachedToken { token, expires_at });
+}
+
+pub(in crate::auth) async fn clear_cache(provider: &OidcProvider) {
+    let mut cache = provider.cached_token.write().await;
+    *cache = None;
+}

--- a/crates/assay-registry/src/auth_next/diagnostics.rs
+++ b/crates/assay-registry/src/auth_next/diagnostics.rs
@@ -1,0 +1,46 @@
+use crate::error::RegistryError;
+
+pub(super) fn github_oidc_network_error(error: reqwest::Error) -> RegistryError {
+    RegistryError::Network {
+        message: format!("failed to request GitHub OIDC token: {}", error),
+    }
+}
+
+pub(super) fn github_oidc_request_failed(
+    status: reqwest::StatusCode,
+    body: String,
+) -> RegistryError {
+    RegistryError::Unauthorized {
+        message: format!("GitHub OIDC request failed: HTTP {} - {}", status, body),
+    }
+}
+
+pub(super) fn github_oidc_parse_error(error: reqwest::Error) -> RegistryError {
+    RegistryError::InvalidResponse {
+        message: format!("failed to parse GitHub OIDC response: {}", error),
+    }
+}
+
+pub(super) fn token_exchange_network_error(error: reqwest::Error) -> RegistryError {
+    RegistryError::Network {
+        message: format!("failed to exchange token: {}", error),
+    }
+}
+
+pub(super) fn token_exchange_unauthorized() -> RegistryError {
+    RegistryError::Unauthorized {
+        message: "OIDC token exchange failed: unauthorized".to_string(),
+    }
+}
+
+pub(super) fn token_exchange_failed(status: reqwest::StatusCode, body: String) -> RegistryError {
+    RegistryError::Network {
+        message: format!("token exchange failed: HTTP {} - {}", status, body),
+    }
+}
+
+pub(super) fn token_exchange_parse_error(error: reqwest::Error) -> RegistryError {
+    RegistryError::InvalidResponse {
+        message: format!("failed to parse registry token response: {}", error),
+    }
+}

--- a/crates/assay-registry/src/auth_next/headers.rs
+++ b/crates/assay-registry/src/auth_next/headers.rs
@@ -1,0 +1,20 @@
+use super::super::OidcProvider;
+
+pub(super) fn github_oidc_request_url(provider: &OidcProvider) -> String {
+    format!(
+        "{}&audience={}",
+        provider.token_request_url, provider.audience
+    )
+}
+
+pub(super) fn bearer(token: &str) -> String {
+    format!("Bearer {}", token)
+}
+
+pub(super) fn accept_header() -> &'static str {
+    "application/json; api-version=2.0"
+}
+
+pub(super) fn content_type_header() -> &'static str {
+    "application/json"
+}

--- a/crates/assay-registry/src/auth_next/mod.rs
+++ b/crates/assay-registry/src/auth_next/mod.rs
@@ -1,0 +1,10 @@
+pub(super) mod providers;
+
+#[cfg(feature = "oidc")]
+pub(super) mod cache;
+#[cfg(feature = "oidc")]
+pub(super) mod diagnostics;
+#[cfg(feature = "oidc")]
+pub(super) mod headers;
+#[cfg(feature = "oidc")]
+pub(super) mod oidc;

--- a/crates/assay-registry/src/auth_next/oidc.rs
+++ b/crates/assay-registry/src/auth_next/oidc.rs
@@ -1,0 +1,169 @@
+use crate::error::{RegistryError, RegistryResult};
+
+use super::super::OidcProvider;
+use super::{cache, diagnostics, headers};
+
+#[derive(Debug, serde::Deserialize)]
+struct OidcTokenResponse {
+    value: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RegistryTokenResponse {
+    access_token: String,
+    expires_in: u64,
+    token_type: String,
+}
+
+pub(in crate::auth) fn from_github_actions() -> RegistryResult<OidcProvider> {
+    let token_request_url = std::env::var("ACTIONS_ID_TOKEN_REQUEST_URL").map_err(|_| {
+        RegistryError::Config {
+            message: "ACTIONS_ID_TOKEN_REQUEST_URL not set - not in GitHub Actions or id-token permission not granted".into(),
+        }
+    })?;
+
+    let request_token =
+        std::env::var("ACTIONS_ID_TOKEN_REQUEST_TOKEN").map_err(|_| RegistryError::Config {
+            message: "ACTIONS_ID_TOKEN_REQUEST_TOKEN not set".into(),
+        })?;
+
+    let registry_base = std::env::var("ASSAY_REGISTRY_URL")
+        .unwrap_or_else(|_| "https://registry.getassay.dev/v1".to_string());
+    let registry_exchange_url =
+        format!("{}/auth/oidc/exchange", registry_base.trim_end_matches('/'));
+
+    Ok(OidcProvider {
+        token_request_url,
+        request_token,
+        registry_exchange_url,
+        audience: "https://registry.getassay.dev".to_string(),
+        cached_token: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+    })
+}
+
+pub(in crate::auth) fn new(
+    token_request_url: impl Into<String>,
+    request_token: impl Into<String>,
+    registry_exchange_url: impl Into<String>,
+    audience: impl Into<String>,
+) -> OidcProvider {
+    OidcProvider {
+        token_request_url: token_request_url.into(),
+        request_token: request_token.into(),
+        registry_exchange_url: registry_exchange_url.into(),
+        audience: audience.into(),
+        cached_token: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+    }
+}
+
+pub(in crate::auth) async fn exchange_token_with_retry(
+    provider: &OidcProvider,
+) -> RegistryResult<String> {
+    let mut retries = 0;
+    let max_retries = 3;
+
+    loop {
+        match provider.exchange_token().await {
+            Ok(token) => return Ok(token),
+            Err(e) if retries < max_retries => {
+                retries += 1;
+
+                let backoff = std::time::Duration::from_secs(1 << retries)
+                    .min(std::time::Duration::from_secs(30));
+
+                tracing::warn!(
+                    error = %e,
+                    retry = retries,
+                    backoff_secs = backoff.as_secs(),
+                    "OIDC token exchange failed, retrying"
+                );
+
+                tokio::time::sleep(backoff).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+pub(in crate::auth) async fn exchange_token(provider: &OidcProvider) -> RegistryResult<String> {
+    let oidc_token = provider.get_github_oidc_token().await?;
+    provider.exchange_for_registry_token(&oidc_token).await
+}
+
+pub(in crate::auth) async fn get_github_oidc_token(
+    provider: &OidcProvider,
+) -> RegistryResult<String> {
+    let client = reqwest::Client::new();
+    let url = headers::github_oidc_request_url(provider);
+
+    let response = client
+        .get(&url)
+        .header("Authorization", headers::bearer(&provider.request_token))
+        .header("Accept", headers::accept_header())
+        .header("Content-Type", headers::content_type_header())
+        .send()
+        .await
+        .map_err(diagnostics::github_oidc_network_error)?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(diagnostics::github_oidc_request_failed(status, body));
+    }
+
+    let token_response: OidcTokenResponse = response
+        .json()
+        .await
+        .map_err(diagnostics::github_oidc_parse_error)?;
+
+    Ok(token_response.value)
+}
+
+pub(in crate::auth) async fn exchange_for_registry_token(
+    provider: &OidcProvider,
+    oidc_token: &str,
+) -> RegistryResult<String> {
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(&provider.registry_exchange_url)
+        .json(&serde_json::json!({
+            "token": oidc_token,
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt"
+        }))
+        .send()
+        .await
+        .map_err(diagnostics::token_exchange_network_error)?;
+
+    let status = response.status();
+
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(diagnostics::token_exchange_unauthorized());
+    }
+
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(diagnostics::token_exchange_failed(status, body));
+    }
+
+    let token_response: RegistryTokenResponse = response
+        .json()
+        .await
+        .map_err(diagnostics::token_exchange_parse_error)?;
+
+    cache::cache_token(
+        provider,
+        token_response.access_token.clone(),
+        token_response.expires_in,
+    )
+    .await;
+
+    tracing::info!(
+        expires_in = token_response.expires_in,
+        token_type = %token_response.token_type,
+        "obtained registry access token"
+    );
+
+    Ok(token_response.access_token)
+}

--- a/crates/assay-registry/src/auth_next/providers.rs
+++ b/crates/assay-registry/src/auth_next/providers.rs
@@ -1,0 +1,47 @@
+use crate::error::RegistryResult;
+
+#[cfg(feature = "oidc")]
+use super::super::OidcProvider;
+use super::super::TokenProvider;
+
+pub(in crate::auth) fn static_token(token: impl Into<String>) -> TokenProvider {
+    TokenProvider::Static(token.into())
+}
+
+pub(in crate::auth) fn from_env() -> TokenProvider {
+    if let Ok(token) = std::env::var("ASSAY_REGISTRY_TOKEN") {
+        if !token.is_empty() {
+            return TokenProvider::Static(token);
+        }
+    }
+
+    #[cfg(feature = "oidc")]
+    if std::env::var("ASSAY_REGISTRY_OIDC")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        if let Ok(provider) = OidcProvider::from_github_actions() {
+            return TokenProvider::Oidc(provider);
+        }
+    }
+
+    TokenProvider::None
+}
+
+pub(in crate::auth) async fn get_token(provider: &TokenProvider) -> RegistryResult<Option<String>> {
+    match provider {
+        TokenProvider::Static(token) => Ok(Some(token.clone())),
+        TokenProvider::None => Ok(None),
+        #[cfg(feature = "oidc")]
+        TokenProvider::Oidc(provider) => provider.get_token().await,
+    }
+}
+
+pub(in crate::auth) fn is_authenticated(provider: &TokenProvider) -> bool {
+    !matches!(provider, TokenProvider::None)
+}
+
+#[cfg(feature = "oidc")]
+pub(in crate::auth) fn github_oidc() -> RegistryResult<TokenProvider> {
+    Ok(TokenProvider::Oidc(OidcProvider::from_github_actions()?))
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step2.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step2.md
@@ -1,0 +1,14 @@
+# Wave50 Registry Auth Step2 Checklist
+
+- [ ] `auth.rs` reduced to a stable facade with the public auth surface and existing inline tests.
+- [ ] OIDC/cache/provider internals moved under `auth_next/*`.
+- [ ] `crates/assay-registry/tests/**` left untouched.
+- [ ] No production edits outside `auth.rs` and `auth_next/*`.
+- [ ] Reviewer script enforces scope allowlist, thin-facade markers, and no-increase drift counters.
+- [ ] Local validation run:
+  - `git diff --check`
+  - `cargo fmt --all --check`
+  - `cargo clippy -q -p assay-registry --all-targets -- -D warnings`
+  - `cargo check -q -p assay-registry`
+  - `cargo check -q -p assay-registry --features oidc`
+  - `BASE_REF=origin/main bash scripts/ci/review-wave50-registry-auth-step2.sh`

--- a/docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step2.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step2.md
@@ -1,0 +1,71 @@
+# SPLIT-MOVE-MAP - Wave50 Step2 - `registry/auth.rs`
+
+## Goal
+
+Mechanically decompose `crates/assay-registry/src/auth.rs` behind a stable facade without changing
+registry-auth behavior, OIDC/cache semantics, or downstream client auth-header contracts.
+
+## New layout
+
+- `crates/assay-registry/src/auth.rs`
+- `crates/assay-registry/src/auth_next/mod.rs`
+- `crates/assay-registry/src/auth_next/providers.rs`
+- `crates/assay-registry/src/auth_next/oidc.rs`
+- `crates/assay-registry/src/auth_next/cache.rs`
+- `crates/assay-registry/src/auth_next/headers.rs`
+- `crates/assay-registry/src/auth_next/diagnostics.rs`
+
+## Mapping applied
+
+- `auth.rs`
+  - public `TokenProvider` enum
+  - public `OidcProvider` struct
+  - wrapper methods that preserve the stable facade
+  - existing inline tests
+- `auth_next/providers.rs`
+  - `TokenProvider::static_token`
+  - `TokenProvider::from_env`
+  - `TokenProvider::get_token`
+  - `TokenProvider::is_authenticated`
+  - `TokenProvider::github_oidc`
+- `auth_next/oidc.rs`
+  - `OidcProvider::from_github_actions`
+  - `OidcProvider::new`
+  - `OidcProvider::exchange_token_with_retry`
+  - `OidcProvider::exchange_token`
+  - `OidcProvider::get_github_oidc_token`
+  - `OidcProvider::exchange_for_registry_token`
+- `auth_next/cache.rs`
+  - `OidcProvider::get_token`
+  - `OidcProvider::clear_cache`
+  - cache storage/write helpers
+- `auth_next/headers.rs`
+  - OIDC request URL / bearer / accept / content-type helpers
+- `auth_next/diagnostics.rs`
+  - GitHub OIDC and token-exchange error-shaping helpers
+
+## Frozen behavior boundaries
+
+- identical static-token behavior
+- identical environment precedence and empty-token fallback behavior
+- identical OIDC enablement and GitHub Actions environment detection
+- identical GitHub OIDC request + registry exchange behavior
+- identical cache hit / expiry / refresh behavior
+- identical retry/backoff behavior
+- identical downstream auth-header and unauthorized-response behavior in the registry client
+- no visibility widening outside the auth split seam
+
+## Step2 anchor selectors
+
+- `auth::tests::test_static_token`
+- `auth::tests::test_from_env_static`
+- `auth::tests::test_from_env_empty_token`
+- `auth::tests::test_get_static_token`
+- `auth::oidc_tests::test_oidc_full_flow`
+- `auth::oidc_tests::test_oidc_github_failure`
+- `auth::oidc_tests::test_oidc_cache_clear`
+- `auth::oidc_tests::test_token_expiry_triggers_refresh`
+- `auth::oidc_tests::test_oidc_retry_backoff_on_failure`
+- `registry_client::scenarios_auth_headers::test_authentication_header`
+- `registry_client::scenarios_auth_headers::test_no_auth_when_no_token`
+- `registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized`

--- a/docs/contributing/SPLIT-PLAN-wave50-registry-auth.md
+++ b/docs/contributing/SPLIT-PLAN-wave50-registry-auth.md
@@ -81,7 +81,8 @@ Step2 may reorganize internal ownership behind `auth.rs`, but must not redefine:
 
 - T-R1 closed on `main` via `#982`.
 - T-R2 closed on `main` via `#985`.
-- Wave50 Step1 is the freeze slice for the next unsplit production hotspot.
+- Wave50 Step1 shipped on `main` via `#986`.
+- Wave50 Step2 is the mechanical split slice for the next unsplit production hotspot.
 
 ## Step2 (mechanical split preview)
 
@@ -121,6 +122,22 @@ Step2 principles:
 - no downstream header or unauthorized-response drift
 - no edits under `crates/assay-registry/tests/**`
 - no workflow edits
+
+Current Step2 shape:
+- `auth.rs`: stable facade, public `TokenProvider` / `OidcProvider`, private cache structs, and existing inline tests
+- `auth_next/providers.rs`: `TokenProvider` constructors, env precedence, and auth-state helpers
+- `auth_next/oidc.rs`: GitHub Actions environment detection, OIDC exchange, retry, and registry-token fetch flow
+- `auth_next/cache.rs`: cache hit / refresh / clear helpers
+- `auth_next/headers.rs`: GitHub OIDC header and request-url helpers
+- `auth_next/diagnostics.rs`: network / parse / unauthorized error shaping for OIDC exchange
+
+Current Step2 LOC snapshot on this branch:
+- `crates/assay-registry/src/auth.rs`: `685 -> 492`
+- `crates/assay-registry/src/auth_next/providers.rs`: `47`
+- `crates/assay-registry/src/auth_next/oidc.rs`: `165`
+- `crates/assay-registry/src/auth_next/cache.rs`: `32`
+- `crates/assay-registry/src/auth_next/headers.rs`: `17`
+- `crates/assay-registry/src/auth_next/diagnostics.rs`: `49`
 
 ## Step3 (closure)
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step2.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step2.md
@@ -1,0 +1,66 @@
+# Wave50 Registry Auth Step2 Review Pack
+
+## Intent
+
+Mechanically split `crates/assay-registry/src/auth.rs` behind a stable facade, while preserving
+static/env precedence, OIDC exchange + cache + retry behavior, and downstream registry-client
+auth-header contracts.
+
+## Scope
+
+- `crates/assay-registry/src/auth.rs`
+- `crates/assay-registry/src/auth_next/mod.rs`
+- `crates/assay-registry/src/auth_next/providers.rs`
+- `crates/assay-registry/src/auth_next/oidc.rs`
+- `crates/assay-registry/src/auth_next/cache.rs`
+- `crates/assay-registry/src/auth_next/headers.rs`
+- `crates/assay-registry/src/auth_next/diagnostics.rs`
+- `docs/contributing/SPLIT-PLAN-wave50-registry-auth.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step2.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step2.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step2.md`
+- `scripts/ci/review-wave50-registry-auth-step2.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-registry/tests/**`
+- no edits outside the auth seam inside `crates/assay-registry/src/**`
+- no auth semantic redesign
+- no request-header or unauthorized-response behavior changes
+- no cache or retry policy changes
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave50-registry-auth-step2.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --all --check
+cargo clippy -q -p assay-registry --all-targets -- -D warnings
+cargo check -q -p assay-registry
+cargo check -q -p assay-registry --features oidc
+cargo test -q -p assay-registry --lib 'auth::tests::test_static_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_static' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_empty_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_get_static_token' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_full_flow' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_github_failure' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_cache_clear' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_token_expiry_triggers_refresh' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_retry_backoff_on_failure' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_authentication_header' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_no_auth_when_no_token' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized' -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to `auth.rs`, `auth_next/*`, Step2 docs, and the reviewer script.
+2. Confirm `auth.rs` still owns the public types and inline tests, but not the OIDC body logic.
+3. Confirm provider/env logic, OIDC exchange logic, cache logic, and error-shaping each moved to the intended module.
+4. Confirm no registry-client or registry integration tests were edited.
+5. Confirm the reviewer script reruns both auth-lib and downstream auth-header selectors.

--- a/scripts/ci/review-wave50-registry-auth-step2.sh
+++ b/scripts/ci/review-wave50-registry-auth-step2.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "crates/assay-registry/src/auth.rs"
+  "crates/assay-registry/src/auth_next/mod.rs"
+  "crates/assay-registry/src/auth_next/providers.rs"
+  "crates/assay-registry/src/auth_next/oidc.rs"
+  "crates/assay-registry/src/auth_next/cache.rs"
+  "crates/assay-registry/src/auth_next/headers.rs"
+  "crates/assay-registry/src/auth_next/diagnostics.rs"
+  "docs/contributing/SPLIT-PLAN-wave50-registry-auth.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step2.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step2.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step2.md"
+  "scripts/ci/review-wave50-registry-auth-step2.sh"
+)
+
+RUST_SCOPE_FILES=(
+  "crates/assay-registry/src/auth.rs"
+  "crates/assay-registry/src/auth_next/mod.rs"
+  "crates/assay-registry/src/auth_next/providers.rs"
+  "crates/assay-registry/src/auth_next/oidc.rs"
+  "crates/assay-registry/src/auth_next/cache.rs"
+  "crates/assay-registry/src/auth_next/headers.rs"
+  "crates/assay-registry/src/auth_next/diagnostics.rs"
+)
+
+changed_files() {
+  git diff --name-only "$BASE_REF"...HEAD || true
+  git diff --name-only || true
+  git diff --name-only --cached || true
+  git ls-files --others --exclude-standard || true
+}
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave50 Step2 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave50 Step2: $f"
+    exit 1
+  fi
+done < <(changed_files | awk 'NF' | sort -u)
+
+echo "[review] registry tests must remain untouched"
+if git diff --name-only "$BASE_REF"...HEAD -- "crates/assay-registry/tests" | rg -n '.' >/dev/null; then
+  echo "FAIL: registry integration tests changed in Wave50 Step2"
+  git diff --name-only "$BASE_REF"...HEAD -- "crates/assay-registry/tests"
+  exit 1
+fi
+
+echo "[review] non-auth registry source must remain untouched"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+  if [[ "$f" == crates/assay-registry/src/* ]] && \
+     [[ "$f" != crates/assay-registry/src/auth.rs ]] && \
+     [[ "$f" != crates/assay-registry/src/auth_next/* ]]; then
+    echo "FAIL: non-auth registry source changed out of scope: $f"
+    exit 1
+  fi
+done < <(changed_files | awk 'NF' | sort -u)
+
+echo "[review] marker and boundary checks"
+PLAN="docs/contributing/SPLIT-PLAN-wave50-registry-auth.md"
+MOVE_MAP="docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step2.md"
+
+for marker in \
+  'Wave50 Step1 shipped on `main` via `#986`.' \
+  '`auth.rs`: stable facade, public `TokenProvider` / `OidcProvider`, private cache structs, and existing inline tests' \
+  'no static/env precedence drift' \
+  'no OIDC exchange or request-header drift' \
+  'no retry/backoff drift'
+do
+  rg -F -n "$marker" "$PLAN" >/dev/null || {
+    echo "FAIL: missing marker in plan: $marker"
+    exit 1
+  }
+done
+
+for marker in \
+  'auth_next/providers.rs' \
+  'auth_next/oidc.rs' \
+  'auth_next/cache.rs' \
+  'auth_next/headers.rs' \
+  'auth_next/diagnostics.rs' \
+  'identical downstream auth-header and unauthorized-response behavior in the registry client'
+do
+  rg -F -n "$marker" "$MOVE_MAP" >/dev/null || {
+    echo "FAIL: missing marker in move-map: $marker"
+    exit 1
+  }
+done
+
+if ! rg -F -n '#[path = "auth_next/mod.rs"]' crates/assay-registry/src/auth.rs >/dev/null; then
+  echo 'FAIL: auth.rs must wire auth_next/mod.rs via #[path = "auth_next/mod.rs"]'
+  exit 1
+fi
+
+if rg -n 'reqwest::Client::new|tokio::time::sleep|\.post\(&self\.registry_exchange_url\)|\.header\("Authorization"|tracing::warn!|tracing::info!' \
+  crates/assay-registry/src/auth.rs >/dev/null; then
+  echo "FAIL: auth.rs facade still contains provider/OIDC implementation details"
+  exit 1
+fi
+
+rg -n 'ASSAY_REGISTRY_TOKEN|ASSAY_REGISTRY_OIDC' crates/assay-registry/src/auth_next/providers.rs >/dev/null || {
+  echo "FAIL: providers.rs must own env precedence"
+  exit 1
+}
+
+rg -n 'ACTIONS_ID_TOKEN_REQUEST_URL|ACTIONS_ID_TOKEN_REQUEST_TOKEN|reqwest::Client::new|exchange_token_with_retry|get_github_oidc_token|exchange_for_registry_token' \
+  crates/assay-registry/src/auth_next/oidc.rs >/dev/null || {
+  echo "FAIL: oidc.rs must own exchange and request logic"
+  exit 1
+}
+
+rg -n 'cached_token\.read|cached_token\.write' crates/assay-registry/src/auth_next/cache.rs >/dev/null || {
+  echo "FAIL: cache.rs must own cached token access"
+  exit 1
+}
+
+rg -n 'api-version=2\.0|Bearer \{\}' crates/assay-registry/src/auth_next/headers.rs >/dev/null || {
+  echo "FAIL: headers.rs must own OIDC header helpers"
+  exit 1
+}
+
+count_base_matches() {
+  local pattern="$1"
+  local total=0
+  local count
+  for file in "${RUST_SCOPE_FILES[@]}"; do
+    if git cat-file -e "$BASE_REF:$file" 2>/dev/null; then
+      count=$(git show "$BASE_REF:$file" | rg -o "$pattern" | wc -l | tr -d ' ' || true)
+      total=$((total + count))
+    fi
+  done
+  echo "$total"
+}
+
+count_head_matches() {
+  local pattern="$1"
+  local total=0
+  local count
+  for file in "${RUST_SCOPE_FILES[@]}"; do
+    if [[ -f "$file" ]]; then
+      count=$(rg -o "$pattern" "$file" | wc -l | tr -d ' ' || true)
+      total=$((total + count))
+    fi
+  done
+  echo "$total"
+}
+
+for pattern in 'unwrap\(' 'expect\(' '\bunsafe\b' 'println!\(' 'eprintln!\(' 'panic!\(' 'todo!\(' 'unimplemented!\('; do
+  base_count="$(count_base_matches "$pattern")"
+  head_count="$(count_head_matches "$pattern")"
+  if (( head_count > base_count )); then
+    echo "FAIL: pattern '$pattern' increased in Wave50 Step2 scope: $base_count -> $head_count"
+    exit 1
+  fi
+done
+
+echo "[review] repo checks"
+cargo fmt --all --check
+cargo clippy -q -p assay-registry --all-targets -- -D warnings
+cargo check -q -p assay-registry
+cargo check -q -p assay-registry --features oidc
+
+echo "[review] pinned auth invariants"
+cargo test -q -p assay-registry --lib 'auth::tests::test_static_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_static' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_empty_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_get_static_token' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_full_flow' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_github_failure' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_cache_clear' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_token_expiry_triggers_refresh' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_retry_backoff_on_failure' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_authentication_header' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_no_auth_when_no_token' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized' -- --exact
+
+echo "[review] PASS"


### PR DESCRIPTION
Summary
- split `crates/assay-registry/src/auth.rs` into `auth_next/*` behind a stable facade
- keep inline auth/OIDC tests in `auth.rs` and leave `crates/assay-registry/tests/**` untouched
- add Step2 review artifacts and a reviewer script that reruns pinned auth invariants

Testing
- `BASE_REF=origin/main bash scripts/ci/review-wave50-registry-auth-step2.sh`