### PR TITLE
docs: close wave50 registry auth split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step3.md
@@ -1,0 +1,51 @@
+# Wave50 Registry Auth Step3 Checklist (Closure)
+
+Scope lock:
+- `docs/contributing/SPLIT-PLAN-wave50-registry-auth.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step3.md`
+- `scripts/ci/review-wave50-registry-auth-step3.sh`
+- no code changes in Step3
+- no workflow changes
+
+## Closure invariants
+
+- re-run Step2 quality checks (`fmt`, `clippy`, `cargo check`)
+- re-run Step2 auth invariants (`TokenProvider` / `OidcProvider` facade still stable in `auth.rs`)
+- re-run Step2 behavior pins (static/env precedence, OIDC exchange flow, cache/refresh, retry/backoff)
+- re-run downstream registry-client auth-header and unauthorized-response selectors
+- keep `auth_next/*` as the only internal implementation split
+
+## Gate requirements
+
+- allowlist-only diff vs `origin/main`
+- workflow-ban (`.github/workflows/*`)
+- hard fail on tracked changes in `crates/assay-registry/src/**`
+- hard fail on untracked files in `crates/assay-registry/src/**`
+- hard fail on tracked changes in `crates/assay-registry/tests/**`
+- hard fail on untracked files in `crates/assay-registry/tests/**`
+- quality checks:
+  - `cargo fmt --all --check`
+  - `cargo clippy -q -p assay-registry --all-targets -- -D warnings`
+  - `cargo check -q -p assay-registry`
+  - `cargo check -q -p assay-registry --features oidc`
+- pinned tests:
+  - `cargo test -q -p assay-registry --lib 'auth::tests::test_static_token' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_static' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_empty_token' -- --exact`
+  - `cargo test -q -p assay-registry --lib 'auth::tests::test_get_static_token' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_full_flow' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_github_failure' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_cache_clear' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_token_expiry_triggers_refresh' -- --exact`
+  - `cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_retry_backoff_on_failure' -- --exact`
+  - `cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_authentication_header' -- --exact`
+  - `cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_no_auth_when_no_token' -- --exact`
+  - `cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized' -- --exact`
+
+## Definition of done
+
+- `BASE_REF=origin/main bash scripts/ci/review-wave50-registry-auth-step3.sh` passes
+- Step3 diff is docs+script only
+- `auth.rs` remains the stable entrypoint and `auth_next/*` remains the internal implementation seam

--- a/docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step3.md
@@ -1,0 +1,27 @@
+# Wave50 Registry Auth Step3 Move Map
+
+Step3 is a closure slice. No Rust bodies move in this step.
+
+## Shipped Step2 shape being closed
+
+- `crates/assay-registry/src/auth.rs`
+  - stable facade for `TokenProvider` / `OidcProvider`
+  - existing inline auth and OIDC tests remain in-place
+- `crates/assay-registry/src/auth_next/providers.rs`
+  - static/env precedence, auth-state helpers, provider constructors
+- `crates/assay-registry/src/auth_next/oidc.rs`
+  - GitHub Actions OIDC environment detection, request/exchange, retry/backoff
+- `crates/assay-registry/src/auth_next/cache.rs`
+  - cache hit, refresh, and clear behavior
+- `crates/assay-registry/src/auth_next/headers.rs`
+  - bearer/header and request-url helpers
+- `crates/assay-registry/src/auth_next/diagnostics.rs`
+  - error shaping for request/exchange failure paths
+
+## Step3 closure assertion
+
+Wave50 Step3 adds no new module cuts and performs no behavior cleanup. It only:
+- records that Step2 shipped on `main`
+- re-runs Step2 auth invariants
+- re-runs downstream registry-client auth-header and unauthorized-response pins
+- keeps the auth split audit trail complete

--- a/docs/contributing/SPLIT-PLAN-wave50-registry-auth.md
+++ b/docs/contributing/SPLIT-PLAN-wave50-registry-auth.md
@@ -82,7 +82,8 @@ Step2 may reorganize internal ownership behind `auth.rs`, but must not redefine:
 - T-R1 closed on `main` via `#982`.
 - T-R2 closed on `main` via `#985`.
 - Wave50 Step1 shipped on `main` via `#986`.
-- Wave50 Step2 is the mechanical split slice for the next unsplit production hotspot.
+- Wave50 Step2 shipped on `main` via `#987`.
+- Wave50 Step3 is the closure/docs+gates-only slice for the shipped auth split.
 
 ## Step2 (mechanical split preview)
 
@@ -141,7 +142,9 @@ Current Step2 LOC snapshot on this branch:
 
 ## Step3 (closure)
 
-Step3 will close the shipped Wave50 auth split with docs/gates only once Step2 lands on `main`.
+Branch: `codex/wave50-registry-auth-step3` (base: `main`)
+
+Step3 closes the shipped Wave50 auth split with docs/gates only after Step2 lands on `main`.
 
 Step3 constraints:
 - docs+gate only
@@ -151,6 +154,13 @@ Step3 constraints:
 - no new module cuts
 - no behavior cleanup beyond internal follow-up notes
 - no auth-header, cache, retry, or exchange-path drift
+
+Step3 deliverables:
+- `docs/contributing/SPLIT-PLAN-wave50-registry-auth.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step3.md`
+- `scripts/ci/review-wave50-registry-auth-step3.sh`
 
 ## Promote
 

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step3.md
@@ -1,0 +1,57 @@
+# Wave50 Registry Auth Step3 Review Pack
+
+## Intent
+
+Close the shipped `registry/auth.rs` split with docs/gates only, while re-running the Step2 auth
+invariants and proving no follow-on drift in registry-client auth behavior.
+
+## Scope
+
+- `docs/contributing/SPLIT-PLAN-wave50-registry-auth.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step3.md`
+- `scripts/ci/review-wave50-registry-auth-step3.sh`
+
+## Non-goals
+
+- no workflow changes
+- no edits under `crates/assay-registry/src/**`
+- no edits under `crates/assay-registry/tests/**`
+- no auth semantic redesign
+- no env precedence, OIDC exchange, cache, retry, or downstream header drift
+
+## Validation
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave50-registry-auth-step3.sh
+```
+
+Gate includes:
+
+```bash
+cargo fmt --all --check
+cargo clippy -q -p assay-registry --all-targets -- -D warnings
+cargo check -q -p assay-registry
+cargo check -q -p assay-registry --features oidc
+cargo test -q -p assay-registry --lib 'auth::tests::test_static_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_static' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_empty_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_get_static_token' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_full_flow' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_github_failure' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_cache_clear' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_token_expiry_triggers_refresh' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_retry_backoff_on_failure' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_authentication_header' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_no_auth_when_no_token' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized' -- --exact
+```
+
+## Reviewer 60s scan
+
+1. Confirm the diff is limited to the Step3 docs and the reviewer script.
+2. Confirm the plan records that Step2 shipped on `main` via `#987`.
+3. Confirm Step3 does not touch `crates/assay-registry/src/**` or `crates/assay-registry/tests/**`.
+4. Confirm the reviewer script re-runs both auth-lib and downstream registry-client selectors.
+5. Confirm the closure docs say there are no new module cuts in Step3.

--- a/scripts/ci/review-wave50-registry-auth-step3.sh
+++ b/scripts/ci/review-wave50-registry-auth-step3.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+git rev-parse --verify "$BASE_REF" >/dev/null
+
+ALLOWLIST=(
+  "docs/contributing/SPLIT-PLAN-wave50-registry-auth.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave50-registry-auth-step3.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave50-registry-auth-step3.md"
+  "scripts/ci/review-wave50-registry-auth-step3.sh"
+)
+
+changed_files() {
+  git diff --name-only "$BASE_REF"...HEAD || true
+  git diff --name-only || true
+  git diff --name-only --cached || true
+  git ls-files --others --exclude-standard || true
+}
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow-ban"
+while IFS= read -r f; do
+  [[ -z "${f:-}" ]] && continue
+
+  if [[ "$f" == .github/workflows/* ]]; then
+    echo "FAIL: Wave50 Step3 must not touch workflows ($f)"
+    exit 1
+  fi
+
+  ok="false"
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$f" == "$a" ]] && ok="true" && break
+  done
+
+  if [[ "$ok" != "true" ]]; then
+    echo "FAIL: file not allowed in Wave50 Step3: $f"
+    exit 1
+  fi
+done < <(changed_files | awk 'NF' | sort -u)
+
+echo "[review] auth source and tests must remain untouched"
+if git diff --name-only "$BASE_REF"...HEAD -- "crates/assay-registry/src" | rg -n '.' >/dev/null; then
+  echo "FAIL: registry source changed in Wave50 Step3"
+  git diff --name-only "$BASE_REF"...HEAD -- "crates/assay-registry/src"
+  exit 1
+fi
+
+if git diff --name-only "$BASE_REF"...HEAD -- "crates/assay-registry/tests" | rg -n '.' >/dev/null; then
+  echo "FAIL: registry tests changed in Wave50 Step3"
+  git diff --name-only "$BASE_REF"...HEAD -- "crates/assay-registry/tests"
+  exit 1
+fi
+
+if git status --porcelain -- crates/assay-registry/src crates/assay-registry/tests | rg -n '^\?\?' >/dev/null; then
+  echo "FAIL: untracked files under crates/assay-registry/src/** or tests/** are forbidden in Step3"
+  git status --porcelain -- crates/assay-registry/src crates/assay-registry/tests
+  exit 1
+fi
+
+echo "[review] closure markers"
+rg -F -n 'Wave50 Step2 shipped on `main` via `#987`.' docs/contributing/SPLIT-PLAN-wave50-registry-auth.md >/dev/null || {
+  echo "FAIL: plan must record Step2 landing on main"
+  exit 1
+}
+rg -F -n 'Wave50 Step3 is the closure/docs+gates-only slice for the shipped auth split.' docs/contributing/SPLIT-PLAN-wave50-registry-auth.md >/dev/null || {
+  echo "FAIL: plan must describe Step3 as closure/docs+gates only"
+  exit 1
+}
+rg -F -n 'Step3 is a closure slice. No Rust bodies move in this step.' docs/contributing/SPLIT-MOVE-MAP-wave50-registry-auth-step3.md >/dev/null || {
+  echo "FAIL: Step3 move-map must assert no Rust-body moves"
+  exit 1
+}
+
+echo "[review] quality checks"
+cargo fmt --all --check
+cargo clippy -q -p assay-registry --all-targets -- -D warnings
+cargo check -q -p assay-registry
+cargo check -q -p assay-registry --features oidc
+
+echo "[review] auth invariants"
+cargo test -q -p assay-registry --lib 'auth::tests::test_static_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_static' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_from_env_empty_token' -- --exact
+cargo test -q -p assay-registry --lib 'auth::tests::test_get_static_token' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_full_flow' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_github_failure' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_cache_clear' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_token_expiry_triggers_refresh' -- --exact
+cargo test -q -p assay-registry --lib --features oidc 'auth::oidc_tests::test_oidc_retry_backoff_on_failure' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_authentication_header' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_auth_headers::test_no_auth_when_no_token' -- --exact
+cargo test -q -p assay-registry --test registry_client 'registry_client::scenarios_pack_fetch::test_fetch_pack_unauthorized' -- --exact
+
+echo "[review] facade invariants"
+rg -F -n '#[path = "auth_next/mod.rs"]' crates/assay-registry/src/auth.rs >/dev/null || {
+  echo 'FAIL: auth.rs must continue wiring auth_next/mod.rs'
+  exit 1
+}
+
+auth_loc="$(awk 'NF{c++} END{print c+0}' crates/assay-registry/src/auth.rs)"
+if [ "$auth_loc" -gt 540 ]; then
+  echo "FAIL: auth.rs facade LOC budget exceeded ($auth_loc > 540)"
+  exit 1
+fi
+
+rg -n 'ASSAY_REGISTRY_TOKEN|ASSAY_REGISTRY_OIDC' crates/assay-registry/src/auth_next/providers.rs >/dev/null || {
+  echo "FAIL: providers.rs must continue owning env precedence"
+  exit 1
+}
+rg -n 'ACTIONS_ID_TOKEN_REQUEST_URL|ACTIONS_ID_TOKEN_REQUEST_TOKEN|exchange_token_with_retry|get_github_oidc_token|exchange_for_registry_token' crates/assay-registry/src/auth_next/oidc.rs >/dev/null || {
+  echo "FAIL: oidc.rs must continue owning exchange/request flow"
+  exit 1
+}
+rg -n 'cached_token\.read|cached_token\.write' crates/assay-registry/src/auth_next/cache.rs >/dev/null || {
+  echo "FAIL: cache.rs must continue owning cached token access"
+  exit 1
+}
+rg -n 'api-version=2\.0|Bearer \{\}' crates/assay-registry/src/auth_next/headers.rs >/dev/null || {
+  echo "FAIL: headers.rs must continue owning OIDC header helpers"
+  exit 1
+}
+
+echo "[review] PASS"


### PR DESCRIPTION
Summary
- close the shipped `registry/auth.rs` split with docs+gates only
- record that Step2 landed on `main` and keep the auth closure trail complete
- add a Step3 reviewer gate that reruns the pinned auth and downstream registry-client invariants

Testing
- `BASE_REF=origin/main bash scripts/ci/review-wave50-registry-auth-step3.sh`