### PR TITLE
feat: emit K1-A handoff seam

### DIFF
--- a/crates/assay-adapter-a2a/src/adapter_impl/convert.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/convert.rs
@@ -51,6 +51,8 @@ pub(super) fn convert(
     let artifact_media_type = nested_string_field(&packet, &["artifact", "media_type"]);
     let message_id = nested_string_field(&packet, &["message", "id"]);
     let message_role = nested_string_field(&packet, &["message", "role"]);
+    let typed_task_id_present = task_id.is_some();
+    let typed_message_id_present = message_id.is_some();
     let mapped_event_type = map_event_type(event_type.as_deref());
 
     if matches!(options.mode, ConvertMode::Strict) {
@@ -145,6 +147,7 @@ pub(super) fn convert(
         adapter.adapter_id,
         adapter.adapter_version,
         &version,
+        mapped_event_type,
         event_type.as_deref(),
         &agent_id,
         agent_name.as_deref(),
@@ -157,6 +160,8 @@ pub(super) fn convert(
         artifact_name.as_deref(),
         artifact_media_type.as_deref(),
         message_id.as_deref(),
+        typed_task_id_present,
+        typed_message_id_present,
         message_role.as_deref(),
         packet.get("attributes"),
         unmapped_fields_count,

--- a/crates/assay-adapter-a2a/src/adapter_impl/handoff.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/handoff.rs
@@ -1,0 +1,144 @@
+//! K1-A Phase 1 `payload.handoff` computation (adapter-emitted, Assay-namespaced).
+//!
+//! v1 is intentionally narrow: the only positive path is a canonical
+//! `assay.adapter.a2a.task.requested` event with typed `task.kind == "delegation"`.
+//! All other packets emit the default handoff object.
+
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct HandoffFields {
+    pub visible: bool,
+    pub source_kind: &'static str,
+    pub task_ref_visible: bool,
+    pub message_ref_visible: bool,
+}
+
+impl Default for HandoffFields {
+    fn default() -> Self {
+        Self {
+            visible: false,
+            source_kind: "unknown",
+            task_ref_visible: false,
+            message_ref_visible: false,
+        }
+    }
+}
+
+#[must_use]
+pub(super) fn compute_handoff_fields(
+    canonical_event_type: &str,
+    task_kind: Option<&str>,
+    typed_task_id_present: bool,
+    typed_message_id_present: bool,
+) -> HandoffFields {
+    let mut out = HandoffFields::default();
+
+    if canonical_event_type == "assay.adapter.a2a.task.requested"
+        && matches!(task_kind, Some("delegation"))
+    {
+        out.visible = true;
+        out.source_kind = "typed_payload";
+        out.task_ref_visible = typed_task_id_present;
+        out.message_ref_visible = typed_message_id_present;
+    }
+
+    out
+}
+
+#[must_use]
+pub(super) fn handoff_object(
+    canonical_event_type: &str,
+    task_kind: Option<&str>,
+    typed_task_id_present: bool,
+    typed_message_id_present: bool,
+) -> Value {
+    let h = compute_handoff_fields(
+        canonical_event_type,
+        task_kind,
+        typed_task_id_present,
+        typed_message_id_present,
+    );
+    let mut m = Map::new();
+    m.insert("visible".to_string(), Value::Bool(h.visible));
+    m.insert(
+        "source_kind".to_string(),
+        Value::String(h.source_kind.to_string()),
+    );
+    m.insert(
+        "task_ref_visible".to_string(),
+        Value::Bool(h.task_ref_visible),
+    );
+    m.insert(
+        "message_ref_visible".to_string(),
+        Value::Bool(h.message_ref_visible),
+    );
+    Value::Object(m)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_requested_delegation_sets_typed_payload_visibility() {
+        assert_eq!(
+            compute_handoff_fields(
+                "assay.adapter.a2a.task.requested",
+                Some("delegation"),
+                true,
+                true,
+            ),
+            HandoffFields {
+                visible: true,
+                source_kind: "typed_payload",
+                task_ref_visible: true,
+                message_ref_visible: true,
+            }
+        );
+    }
+
+    #[test]
+    fn lenient_missing_task_id_still_keeps_route_visible() {
+        assert_eq!(
+            compute_handoff_fields(
+                "assay.adapter.a2a.task.requested",
+                Some("delegation"),
+                false,
+                true,
+            ),
+            HandoffFields {
+                visible: true,
+                source_kind: "typed_payload",
+                task_ref_visible: false,
+                message_ref_visible: true,
+            }
+        );
+    }
+
+    #[test]
+    fn task_updated_is_not_positive_in_v1() {
+        assert_eq!(
+            compute_handoff_fields(
+                "assay.adapter.a2a.task.updated",
+                Some("delegation"),
+                true,
+                true,
+            ),
+            HandoffFields::default()
+        );
+    }
+
+    #[test]
+    fn non_delegation_task_requested_stays_default() {
+        assert_eq!(
+            compute_handoff_fields(
+                "assay.adapter.a2a.task.requested",
+                Some("analysis"),
+                true,
+                true,
+            ),
+            HandoffFields::default()
+        );
+    }
+}

--- a/crates/assay-adapter-a2a/src/adapter_impl/mod.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/mod.rs
@@ -45,6 +45,7 @@ pub(super) fn capabilities() -> AdapterCapabilities {
 mod convert;
 mod discovery;
 mod fields;
+mod handoff;
 mod mapping;
 mod parse;
 mod payload;

--- a/crates/assay-adapter-a2a/src/adapter_impl/payload.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/payload.rs
@@ -1,12 +1,13 @@
 use serde_json::{Map, Value};
 
-use super::{discovery::discovery_object, PROTOCOL_NAME};
+use super::{discovery::discovery_object, handoff::handoff_object, PROTOCOL_NAME};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_payload(
     adapter_id: &str,
     adapter_version: &str,
     version: &str,
+    canonical_event_type: &str,
     upstream_event_type: Option<&str>,
     agent_id: &str,
     agent_name: Option<&str>,
@@ -19,6 +20,8 @@ pub(super) fn build_payload(
     artifact_name: Option<&str>,
     artifact_media_type: Option<&str>,
     message_id: Option<&str>,
+    typed_task_id_present: bool,
+    typed_message_id_present: bool,
     message_role: Option<&str>,
     attributes: Option<&Value>,
     unmapped_fields_count: u32,
@@ -113,6 +116,15 @@ pub(super) fn build_payload(
     }
 
     payload.insert("discovery".to_string(), discovery_object(attributes));
+    payload.insert(
+        "handoff".to_string(),
+        handoff_object(
+            canonical_event_type,
+            task_kind,
+            typed_task_id_present,
+            typed_message_id_present,
+        ),
+    );
 
     payload.insert(
         "unmapped_fields_count".to_string(),

--- a/crates/assay-adapter-a2a/src/adapter_impl/tests.rs
+++ b/crates/assay-adapter-a2a/src/adapter_impl/tests.rs
@@ -56,6 +56,14 @@ fn assert_discovery_v1_defaults(payload: &Value) {
     assert_eq!(d["signature_material_visible"], Value::Bool(false));
 }
 
+fn assert_handoff_v1_defaults(payload: &Value) {
+    let h = &payload["handoff"];
+    assert_eq!(h["visible"], Value::Bool(false));
+    assert_eq!(h["source_kind"], Value::String("unknown".to_string()));
+    assert_eq!(h["task_ref_visible"], Value::Bool(false));
+    assert_eq!(h["message_ref_visible"], Value::Bool(false));
+}
+
 /// Golden digests over `payload.discovery` via `digest_canonical_json` (sorted keys).
 /// If `discovery` shape or types change intentionally, update hashes and this comment.
 const G4_DISCOVERY_DIGEST_DEFAULT: &str =
@@ -67,6 +75,12 @@ const G4_DISCOVERY_DIGEST_BOTH_FLAGS: &str =
 /// Extended visibility only (`agent_card_source_kind` stays `unknown`).
 const G4_DISCOVERY_DIGEST_EXTENDED_ONLY: &str =
     "13e23c6783de838b52ca92d787569bccd3cadc0f8900f1bf76b42262959f77ba";
+const K1_HANDOFF_DIGEST_DEFAULT: &str =
+    "60e992b4881c03d816cd94929856d8c8cade113f62273d42a8a75412533a294a";
+const K1_HANDOFF_DIGEST_TYPED_POSITIVE: &str =
+    "e478af7359a254678c90b5eb2737d63f79c6d667a2b5c4bc323442f07d09d33b";
+const K1_HANDOFF_DIGEST_LENIENT_PARTIAL: &str =
+    "0be260743587b9594018a4ab7809560157be088be0372a8ae7c7faa6a744effe";
 
 #[test]
 fn protocol_metadata_uses_exact_version_and_range_capability() {
@@ -117,9 +131,14 @@ fn strict_agent_capabilities_fixture_emits_deterministic_event() {
         serde_json::json!(["agent.describe", "artifacts.share", "tasks.update"])
     );
     assert_discovery_v1_defaults(&first.events[0].payload);
+    assert_handoff_v1_defaults(&first.events[0].payload);
     assert_eq!(
         digest_canonical_json(&first.events[0].payload["discovery"]),
         G4_DISCOVERY_DIGEST_DEFAULT
+    );
+    assert_eq!(
+        digest_canonical_json(&first.events[0].payload["handoff"]),
+        K1_HANDOFF_DIGEST_DEFAULT
     );
 }
 
@@ -218,6 +237,12 @@ fn strict_task_requested_fixture_maps_expected_event() {
         batch.events[0].payload["protocol_name"],
         Value::String(PROTOCOL_NAME.to_string())
     );
+    let h = &batch.events[0].payload["handoff"];
+    assert_eq!(h["visible"], Value::Bool(true));
+    assert_eq!(h["source_kind"], Value::String("typed_payload".to_string()));
+    assert_eq!(h["task_ref_visible"], Value::Bool(true));
+    assert_eq!(h["message_ref_visible"], Value::Bool(true));
+    assert_eq!(digest_canonical_json(h), K1_HANDOFF_DIGEST_TYPED_POSITIVE);
 }
 
 #[test]
@@ -237,6 +262,11 @@ fn strict_artifact_shared_fixture_maps_expected_event() {
 
     assert_eq!(batch.events[0].type_, "assay.adapter.a2a.artifact.shared");
     assert_eq!(batch.events[0].subject.as_deref(), Some("artifact-7"));
+    assert_handoff_v1_defaults(&batch.events[0].payload);
+    assert_eq!(
+        digest_canonical_json(&batch.events[0].payload["handoff"]),
+        K1_HANDOFF_DIGEST_DEFAULT
+    );
 }
 
 #[test]
@@ -284,6 +314,12 @@ fn lenient_missing_task_id_substitutes_unknown_task() {
     assert_eq!(batch.events[0].subject.as_deref(), Some("unknown-task"));
     assert!(batch.lossiness.unmapped_fields_count >= 1);
     assert!(batch.lossiness.raw_payload_ref.is_some());
+    let h = &batch.events[0].payload["handoff"];
+    assert_eq!(h["visible"], Value::Bool(true));
+    assert_eq!(h["source_kind"], Value::String("typed_payload".to_string()));
+    assert_eq!(h["task_ref_visible"], Value::Bool(false));
+    assert_eq!(h["message_ref_visible"], Value::Bool(true));
+    assert_eq!(digest_canonical_json(h), K1_HANDOFF_DIGEST_LENIENT_PARTIAL);
 }
 
 #[test]
@@ -323,6 +359,67 @@ fn lenient_invalid_event_type_emits_generic_message_event_and_lossiness() {
     assert_eq!(
         batch.events[0].payload["adapter_version"],
         Value::String(env!("CARGO_PKG_VERSION").to_string())
+    );
+    assert_handoff_v1_defaults(&batch.events[0].payload);
+    assert_eq!(
+        digest_canonical_json(&batch.events[0].payload["handoff"]),
+        K1_HANDOFF_DIGEST_DEFAULT
+    );
+}
+
+#[test]
+fn k1_typed_positive_full_batch_digest_is_deterministic() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let payload = fixture("a2a_happy_task_requested.json");
+    let input = AdapterInput {
+        payload: &payload,
+        media_type: "application/json",
+        protocol_version: Some("0.2"),
+    };
+    let first = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    let second = adapter
+        .convert(input, &ConvertOptions::default(), &writer)
+        .expect("convert");
+    assert_eq!(
+        digest_canonical_json(&first),
+        digest_canonical_json(&second)
+    );
+}
+
+#[test]
+fn k1_task_updated_delegation_does_not_promote_handoff_in_v1() {
+    let adapter = A2aAdapter;
+    let writer = TestWriter;
+    let payload = br#"{
+      "protocol":"a2a",
+      "version":"0.2.0",
+      "event_type":"task.updated",
+      "timestamp":"2026-02-27T11:05:00Z",
+      "agent":{"id":"agent://worker"},
+      "task":{"id":"task-999","status":"running","kind":"delegation"},
+      "message":{"id":"msg-update","role":"assistant"}
+    }"#;
+
+    let batch = adapter
+        .convert(
+            AdapterInput {
+                payload,
+                media_type: "application/json",
+                protocol_version: Some("0.2.0"),
+            },
+            &ConvertOptions::default(),
+            &writer,
+        )
+        .expect("task.updated should still convert");
+
+    assert_eq!(batch.events[0].type_, "assay.adapter.a2a.task.updated");
+    assert_handoff_v1_defaults(&batch.events[0].payload);
+    assert_eq!(
+        digest_canonical_json(&batch.events[0].payload["handoff"]),
+        K1_HANDOFF_DIGEST_DEFAULT
     );
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated `handoff` helper for the K1-A top-level A2A adapter seam
- emit `payload.handoff` as a sibling to `discovery`, keyed only from canonical `task.requested` plus typed `task.kind == "delegation"`
- cover typed positive, lenient partial visibility, generic fallback, artifact.shared, and `task.updated` non-promotion with golden handoff digests

## Testing
- cargo fmt --all --check
- cargo clippy -p assay-adapter-a2a --all-targets -- -D warnings
- cargo test -p assay-adapter-a2a
- cargo test -q -p assay-adapter-a2a
