### PR TITLE
docs: sync python package outward-facing truth

### DIFF
--- a/assay-python-sdk/README.md
+++ b/assay-python-sdk/README.md
@@ -1,0 +1,64 @@
+# Assay Python Bindings
+
+`assay-it` is the Python package for the `assay` import namespace.
+
+It currently provides a small, bounded surface on top of Assay core:
+
+- `AssayClient` for writing JSONL trace records from Python
+- `Coverage` for policy coverage analysis against trace/tool-call inputs
+- `Explainer` for rule-by-rule explanation of a single trace
+- a `pytest` fixture plugin exposed as `assay_client`
+
+## Install
+
+```bash
+pip install assay-it
+```
+
+Import path:
+
+```python
+from assay import AssayClient, Coverage, Explainer, validate
+```
+
+## What It Is
+
+This package is for Python-side trace capture and lightweight policy-analysis helpers.
+It is useful when you want to:
+
+- append structured trace events to a JSONL file from Python
+- analyze tool-call traces against an Assay policy
+- explain why a given trace matched or violated policy rules
+- use a simple pytest fixture around the Python client
+
+## What It Is Not
+
+This package is not the full Assay CLI or the full trust-compiler surface.
+It does **not** replace:
+
+- `assay mcp wrap` and runtime MCP enforcement
+- evidence bundle generation and verification workflows
+- Trust Basis / Trust Card generation
+- the GitHub Action or release-binary install path
+
+Those outward-facing product surfaces live in the main Assay CLI and repository docs.
+
+## Example
+
+```python
+from assay import AssayClient, Coverage, Explainer
+
+client = AssayClient("traces.jsonl")
+client.record_trace({"tool": "ToolA", "args": {"q": "weather"}})
+
+coverage = Coverage("assay.yaml")
+report = coverage.analyze([[{"tool": "ToolA", "args": {"q": "weather"}}]])
+
+explainer = Explainer("assay.yaml")
+details = explainer.explain([{"tool": "ToolA", "args": {"q": "weather"}}])
+```
+
+## Repository
+
+- Main project: <https://github.com/Rul1an/assay>
+- Current CLI and trust-compiler docs: <https://github.com/Rul1an/assay/blob/main/README.md>

--- a/assay-python-sdk/pyproject.toml
+++ b/assay-python-sdk/pyproject.toml
@@ -4,13 +4,29 @@ build-backend = "maturin"
 
 [project]
 name = "assay-it"
+description = "Python bindings for Assay trace capture, policy coverage, and explanation helpers."
+readme = "README.md"
 requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [{ name = "Assay" }]
 classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Rust",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Software Development :: Quality Assurance",
 ]
+keywords = ["assay", "policy", "testing", "coverage", "tracing"]
 dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/Rul1an/assay"
+Repository = "https://github.com/Rul1an/assay"
+Issues = "https://github.com/Rul1an/assay/issues"
+Documentation = "https://github.com/Rul1an/assay/blob/main/README.md"
 
 [project.entry-points.pytest11]
 assay = "assay.pytest_plugin"


### PR DESCRIPTION
## Summary
- add an explicit README for the Python package so PyPI metadata reflects the real current surface
- fill in bounded package metadata in `assay-python-sdk/pyproject.toml`
- keep the Python package story aligned with the current Assay CLI/trust-compiler positioning without overclaiming

## Testing
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check -q -p assay-it`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test -q -p assay-it`
- `git diff --check`

## Notes
- `python3 -m build` could not run locally because the `build` module is not installed in this environment.