### PR TITLE
feat: add mcp auth-discovery visibility seam

### DIFF
--- a/crates/assay-cli/tests/mcp_transport_import.rs
+++ b/crates/assay-cli/tests/mcp_transport_import.rs
@@ -96,6 +96,47 @@ fn contract_trace_import_mcp_sse_legacy_alias_writes_trace() {
     assert_trace_contains_tools(&output, &["Calculator"]);
 }
 
+#[test]
+#[allow(deprecated)]
+fn contract_import_streamable_http_401_www_authenticate_writes_k2_auth_discovery_summary() {
+    let dir = tempdir().expect("tempdir");
+    let input = dir.path().join("streamable-http-authz.json");
+    let output = dir.path().join("streamable-http-authz.trace.jsonl");
+    fs::write(&input, streamable_http_authz_fixture()).expect("write input");
+
+    Command::cargo_bin("assay")
+        .expect("assay binary")
+        .arg("trace")
+        .arg("import-mcp")
+        .arg("--input")
+        .arg(&input)
+        .arg("--out-trace")
+        .arg(&output)
+        .arg("--format")
+        .arg("streamable-http")
+        .assert()
+        .success();
+
+    let text = fs::read_to_string(&output).expect("read trace output");
+    let episode_start: Value = serde_json::from_str(
+        text.lines()
+            .find(|line| line.contains("\"type\":\"episode_start\""))
+            .expect("episode_start present"),
+    )
+    .expect("valid episode_start");
+
+    assert_eq!(
+        episode_start["meta"]["mcp"]["authorization_discovery"],
+        json!({
+            "visible": true,
+            "source_kind": "www_authenticate",
+            "resource_metadata_visible": true,
+            "authorization_servers_visible": false,
+            "scope_challenge_visible": true
+        })
+    );
+}
+
 fn assert_trace_contains_tools(path: &Path, tools: &[&str]) {
     let text = fs::read_to_string(path).expect("read trace output");
     assert!(!text.trim().is_empty(), "trace output should not be empty");
@@ -188,6 +229,41 @@ fn http_sse_fixture() -> String {
                     "event": "message",
                     "id": "evt-1",
                     "data": "{\"jsonrpc\":\"2.0\",\"id\":\"call-1\",\"result\":{\"sum\":3}}"
+                }
+            }
+        ]
+    })
+    .to_string()
+}
+
+fn streamable_http_authz_fixture() -> String {
+    json!({
+        "transport": "streamable-http",
+        "entries": [
+            {
+                "timestamp_ms": 1000,
+                "request": {
+                    "jsonrpc": "2.0",
+                    "id": "call-1",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "Calculator",
+                        "arguments": { "a": 1, "b": 2 }
+                    }
+                }
+            },
+            {
+                "timestamp_ms": 1001,
+                "transport_context": {
+                    "status": 401,
+                    "headers": {
+                        "WWW-Authenticate": "Bearer resource_metadata=\"https://mcp.example/.well-known/oauth-protected-resource\", scope=\"tools/call\""
+                    }
+                },
+                "response": {
+                    "jsonrpc": "2.0",
+                    "id": "call-1",
+                    "error": { "code": 401, "message": "unauthorized" }
                 }
             }
         ]

--- a/crates/assay-core/src/mcp/mapper_v2.rs
+++ b/crates/assay-core/src/mcp/mapper_v2.rs
@@ -45,6 +45,12 @@ pub fn mcp_events_to_v2_trace(
     let mut meta = serde_json::Map::new();
     meta.insert("source".into(), json!("mcp_import"));
     meta.insert("episode_id".into(), json!(episode_id));
+    meta.insert(
+        "mcp".into(),
+        json!({
+            "authorization_discovery": summarize_auth_discovery(&events)
+        }),
+    );
 
     if let Some(tid) = test_id {
         meta.insert("test_id".into(), json!(tid));
@@ -245,6 +251,14 @@ pub fn mcp_events_to_v2_trace(
     }));
 
     out
+}
+
+fn summarize_auth_discovery(events: &[McpEvent]) -> McpAuthorizationDiscovery {
+    let mut summary = McpAuthorizationDiscovery::default();
+    for event in events {
+        summary.merge_from(&event.auth_discovery);
+    }
+    summary
 }
 
 fn now_ms() -> u64 {

--- a/crates/assay-core/src/mcp/parser.rs
+++ b/crates/assay-core/src/mcp/parser.rs
@@ -27,7 +27,12 @@ fn parse_jsonrpc_jsonl(text: &str) -> Result<Vec<McpEvent>> {
         let v: serde_json::Value = serde_json::from_str(line)
             .with_context(|| format!("invalid JSON on line {}", lineno + 1))?;
 
-        let event = parse_jsonrpc_message(v, (lineno + 1) as u64, None)?;
+        let event = parse_jsonrpc_message(
+            v,
+            (lineno + 1) as u64,
+            None,
+            McpAuthorizationDiscovery::default(),
+        )?;
         out.push(event);
     }
 
@@ -50,7 +55,12 @@ fn parse_inspector_best_effort(text: &str) -> Result<Vec<McpEvent>> {
     let mut out = Vec::new();
     for (idx, item) in arr.into_iter().enumerate() {
         // Use array index as source_line for sorting stability
-        let event = parse_jsonrpc_message(item, (idx + 1) as u64, None)?;
+        let event = parse_jsonrpc_message(
+            item,
+            (idx + 1) as u64,
+            None,
+            McpAuthorizationDiscovery::default(),
+        )?;
         out.push(event);
     }
 
@@ -104,15 +114,19 @@ fn parse_transport_transcript(
                 request,
                 source_line,
                 entry.timestamp_ms,
+                McpAuthorizationDiscovery::default(),
             )?);
             continue;
         }
+
+        let auth_discovery = parse_transport_auth_discovery(&entry);
 
         if let Some(response) = entry.response {
             out.push(parse_jsonrpc_message(
                 response,
                 source_line,
                 entry.timestamp_ms,
+                auth_discovery,
             )?);
             continue;
         }
@@ -123,6 +137,7 @@ fn parse_transport_transcript(
                     jsonrpc,
                     source_line,
                     entry.timestamp_ms,
+                    McpAuthorizationDiscovery::default(),
                 )?);
             }
         }
@@ -135,6 +150,7 @@ fn parse_jsonrpc_message(
     v: serde_json::Value,
     source_line: u64,
     timestamp_ms_override: Option<u64>,
+    auth_discovery: McpAuthorizationDiscovery,
 ) -> Result<McpEvent> {
     if !v.is_object() {
         bail!(
@@ -210,8 +226,121 @@ fn parse_jsonrpc_message(
         source_line,
         timestamp_ms: ts_ms,
         jsonrpc_id: id_str,
+        auth_discovery,
         payload,
     })
+}
+
+fn parse_transport_auth_discovery(entry: &TransportTranscriptEntry) -> McpAuthorizationDiscovery {
+    let Some(status) = extract_http_status(entry) else {
+        return McpAuthorizationDiscovery::default();
+    };
+
+    if status != 401 {
+        return McpAuthorizationDiscovery::default();
+    }
+
+    let header_value = entry
+        .transport_context
+        .as_ref()
+        .and_then(|value| find_header_case_insensitive(value, "www-authenticate"))
+        .or_else(|| {
+            entry
+                .headers
+                .as_ref()
+                .and_then(|value| find_header_case_insensitive(value, "www-authenticate"))
+        });
+
+    let Some(www_authenticate) = header_value else {
+        return McpAuthorizationDiscovery::default();
+    };
+
+    let resource_metadata_visible = auth_param_visible(&www_authenticate, "resource_metadata");
+    let scope_challenge_visible = auth_param_visible(&www_authenticate, "scope");
+
+    if !resource_metadata_visible && !scope_challenge_visible {
+        return McpAuthorizationDiscovery::default();
+    }
+
+    McpAuthorizationDiscovery {
+        visible: true,
+        source_kind: McpAuthorizationDiscoverySourceKind::WwwAuthenticate,
+        resource_metadata_visible,
+        authorization_servers_visible: false,
+        scope_challenge_visible,
+    }
+}
+
+fn extract_http_status(entry: &TransportTranscriptEntry) -> Option<u16> {
+    entry
+        .transport_context
+        .as_ref()
+        .and_then(extract_http_status_from_value)
+        .or_else(|| {
+            entry
+                .headers
+                .as_ref()
+                .and_then(extract_http_status_from_value)
+        })
+}
+
+fn extract_http_status_from_value(value: &serde_json::Value) -> Option<u16> {
+    match value {
+        serde_json::Value::Object(map) => {
+            for key in ["status", "status_code", "http_status"] {
+                if let Some(status) = map.get(key).and_then(json_value_to_u16) {
+                    return Some(status);
+                }
+            }
+
+            map.get("response").and_then(extract_http_status_from_value)
+        }
+        _ => None,
+    }
+}
+
+fn json_value_to_u16(value: &serde_json::Value) -> Option<u16> {
+    match value {
+        serde_json::Value::Number(n) => n.as_u64().and_then(|n| u16::try_from(n).ok()),
+        serde_json::Value::String(s) => s.parse::<u16>().ok(),
+        _ => None,
+    }
+}
+
+fn find_header_case_insensitive(value: &serde_json::Value, header_name: &str) -> Option<String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(headers) = map.get("headers") {
+                if let Some(found) = find_header_case_insensitive(headers, header_name) {
+                    return Some(found);
+                }
+            }
+
+            if let Some(response) = map.get("response") {
+                if let Some(found) = find_header_case_insensitive(response, header_name) {
+                    return Some(found);
+                }
+            }
+
+            map.iter().find_map(|(key, value)| {
+                if key.eq_ignore_ascii_case(header_name) {
+                    value.as_str().map(ToString::to_string)
+                } else {
+                    None
+                }
+            })
+        }
+        _ => None,
+    }
+}
+
+fn auth_param_visible(header_value: &str, param_name: &str) -> bool {
+    let lower = header_value.to_ascii_lowercase();
+    let needle = format!("{param_name}=");
+
+    lower
+        .match_indices(&needle)
+        .any(|(idx, _)| idx == 0 || matches!(lower.as_bytes()[idx - 1], b' ' | b',' | b'\t'))
 }
 
 fn normalize_jsonrpc_id(

--- a/crates/assay-core/src/mcp/types.rs
+++ b/crates/assay-core/src/mcp/types.rs
@@ -48,7 +48,42 @@ pub struct McpEvent {
     /// JSON-RPC ID (stringified) for request/response correlation (P0.2).
     pub jsonrpc_id: Option<String>,
 
+    /// Bounded MCP authorization-discovery summary observed on this event path.
+    pub auth_discovery: McpAuthorizationDiscovery,
+
     pub payload: McpPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct McpAuthorizationDiscovery {
+    pub visible: bool,
+    pub source_kind: McpAuthorizationDiscoverySourceKind,
+    pub resource_metadata_visible: bool,
+    pub authorization_servers_visible: bool,
+    pub scope_challenge_visible: bool,
+}
+
+impl McpAuthorizationDiscovery {
+    pub fn merge_from(&mut self, other: &Self) {
+        self.visible |= other.visible;
+        self.resource_metadata_visible |= other.resource_metadata_visible;
+        self.authorization_servers_visible |= other.authorization_servers_visible;
+        self.scope_challenge_visible |= other.scope_challenge_visible;
+
+        if self.source_kind == McpAuthorizationDiscoverySourceKind::Unknown
+            && other.source_kind != McpAuthorizationDiscoverySourceKind::Unknown
+        {
+            self.source_kind = other.source_kind;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum McpAuthorizationDiscoverySourceKind {
+    #[default]
+    Unknown,
+    WwwAuthenticate,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/assay-core/tests/mcp_transport_compat.rs
+++ b/crates/assay-core/tests/mcp_transport_compat.rs
@@ -528,6 +528,122 @@ fn contract_transport_families_normalize_to_same_semantics() {
     );
 }
 
+#[test]
+fn contract_streamable_http_401_www_authenticate_promotes_k2_auth_discovery() {
+    let input = json!({
+        "transport": "streamable-http",
+        "entries": [
+            {
+                "timestamp_ms": 1000,
+                "request": {
+                    "jsonrpc": "2.0",
+                    "id": "call-1",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "Calculator",
+                        "arguments": { "a": 1, "b": 2 }
+                    }
+                }
+            },
+            {
+                "timestamp_ms": 1001,
+                "transport_context": {
+                    "status": 401,
+                    "headers": {
+                        "WWW-Authenticate": "Bearer resource_metadata=\"https://mcp.example/.well-known/oauth-protected-resource\", scope=\"tools/call\""
+                    }
+                },
+                "response": {
+                    "jsonrpc": "2.0",
+                    "id": "call-1",
+                    "error": { "code": 401, "message": "unauthorized" }
+                }
+            }
+        ]
+    })
+    .to_string();
+
+    let trace = mcp_events_to_v2_trace(
+        parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).unwrap(),
+        "authz_discovery".into(),
+        None,
+        None,
+    );
+
+    let TraceEvent::EpisodeStart(start) = &trace[0] else {
+        panic!("first event must be episode_start");
+    };
+
+    assert_eq!(
+        start.meta["mcp"]["authorization_discovery"],
+        json!({
+            "visible": true,
+            "source_kind": "www_authenticate",
+            "resource_metadata_visible": true,
+            "authorization_servers_visible": false,
+            "scope_challenge_visible": true
+        })
+    );
+}
+
+#[test]
+fn contract_www_authenticate_not_promoted_without_401_status() {
+    let input = json!({
+        "transport": "streamable-http",
+        "entries": [
+            {
+                "timestamp_ms": 1000,
+                "request": {
+                    "jsonrpc": "2.0",
+                    "id": "call-1",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "Calculator",
+                        "arguments": { "a": 1, "b": 2 }
+                    }
+                }
+            },
+            {
+                "timestamp_ms": 1001,
+                "transport_context": {
+                    "status": 200,
+                    "headers": {
+                        "WWW-Authenticate": "Bearer resource_metadata=\"https://mcp.example/.well-known/oauth-protected-resource\", scope=\"tools/call\""
+                    }
+                },
+                "response": {
+                    "jsonrpc": "2.0",
+                    "id": "call-1",
+                    "result": { "sum": 3 }
+                }
+            }
+        ]
+    })
+    .to_string();
+
+    let trace = mcp_events_to_v2_trace(
+        parse_mcp_transcript(&input, McpInputFormat::StreamableHttp).unwrap(),
+        "authz_discovery".into(),
+        None,
+        None,
+    );
+
+    let TraceEvent::EpisodeStart(start) = &trace[0] else {
+        panic!("first event must be episode_start");
+    };
+
+    assert_eq!(
+        start.meta["mcp"]["authorization_discovery"],
+        json!({
+            "visible": false,
+            "source_kind": "unknown",
+            "resource_metadata_visible": false,
+            "authorization_servers_visible": false,
+            "scope_challenge_visible": false
+        })
+    );
+}
+
 fn normalize_trace(input: &str, format: McpInputFormat) -> Value {
     let events = parse_mcp_transcript(input, format).expect("parse transcript");
     let trace = mcp_events_to_v2_trace(events, "transport_ep".into(), None, None);

--- a/docs/architecture/K2-A-PHASE1-FREEZE.md
+++ b/docs/architecture/K2-A-PHASE1-FREEZE.md
@@ -43,16 +43,20 @@ allowed inputs first. Any later implementation must keep the seam singular and t
 
 - authorization succeeded
 - required scopes were sufficient
+- any advertised scope requirement was adequate, correct, or enforced
 - the discovered authorization server is trusted
 - the server is secure or compliant in the broad sense
 - a client is correctly configured
 - OAuth/OIDC discovery was complete end-to-end
+- client registration or broader auth bootstrap was correct or complete
 
 ## 3. Allowed positive source classes (v1 freeze)
 
 These source classes are the **only** classes that a future `K2-A` implementation may promote in
 v1, and only when they are observed on a supported MCP runtime/discovery path with exact source
-provenance.
+provenance. Static config, documentation hints, client-side remembered metadata, and other
+non-runtime sources are not MCP authorization-discovery evidence in this freeze unless a later
+freeze explicitly adds them.
 
 | Source class | May imply | Must not imply |
 |--------------|-----------|----------------|
@@ -67,12 +71,14 @@ provenance.
 
 - bearer tokens, access tokens, refresh tokens, client secrets, or credential-like headers
 - opaque auth blobs or copied header strings without typed source provenance
-- static config or docs that were not observed on a supported MCP discovery/runtime path
+- static config files, docs hints, or client-side remembered auth metadata that were not observed on
+  a supported MCP discovery/runtime path
 - generic logs or trace text
 - policy decisions alone
 - `G3` authorization-context fields (`auth_scheme`, `auth_issuer`, `principal`)
 - inferred issuer trust or inferred compliance
-- OAuth AS metadata / OIDC discovery fetched outside the bounded v1 source classes
+- OAuth AS metadata, OIDC discovery, or client registration fetched outside the bounded v1 source
+  classes
 
 ## 5. Repo-reality gate before implementation
 
@@ -94,9 +100,10 @@ Any future `K2-A` implementation must hard-fail review if it:
 
 - promotes anything from outside the source classes in §3
 - reuses `G3` fields as if they were discovery evidence
-- promotes authorization-discovery from static config without observed runtime/discovery provenance
+- promotes authorization-discovery from static config, docs, or client memory without observed
+  runtime/discovery provenance
 - emits credentials or secret-bearing material
-- turns visibility into auth correctness, server trust, or compliance language
+- turns visibility into auth correctness, scope adequacy, server trust, or compliance language
 - widens the work into a pack, engine bump, or broader Trust Basis / Trust Card expansion
 
 ## 7. Status meaning

--- a/docs/architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md
+++ b/docs/architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md
@@ -3,7 +3,7 @@
 - **Current status:** Planned next bounded trust-compiler wave after `K1-A` stabilization on `main`; `K2-A` Phase 1 now has a formal pre-implementation freeze, but no implementation or release is shipped.
 - **Date:** 2026-03-29
 - **Owner:** Evidence / Product
-- **Inputs:** [ROADMAP](../ROADMAP.md), [RFC-005](./RFC-005-trust-compiler-mvp-2026q2.md), [PLAN — K1](./PLAN-K1-A2A-HANDOFF-DELEGATION-ROUTE-EVIDENCE-2026q2.md), [K1-A — Phase 1 formal freeze](./K1-A-PHASE1-FREEZE.md), [Trust Compiler Audit Matrix](./AUDIT-MATRIX-TRUST-COMPILER-2026-03-26.md), [MCP Authorization](https://modelcontextprotocol.io/specification/2025-11-05/basic/authorization)
+- **Inputs:** [ROADMAP](../ROADMAP.md), [RFC-005](./RFC-005-trust-compiler-mvp-2026q2.md), [PLAN — K1](./PLAN-K1-A2A-HANDOFF-DELEGATION-ROUTE-EVIDENCE-2026q2.md), [K1-A — Phase 1 formal freeze](./K1-A-PHASE1-FREEZE.md), [Trust Compiler Audit Matrix](./AUDIT-MATRIX-TRUST-COMPILER-2026-03-26.md), [MCP Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
 - **Scope (this PR):** Formalize the next wave choice and its guardrails only. No MCP adapter/runtime code, no pack YAML, no engine work, and no Trust Basis / Trust Card expansion.
 
 ## 1. Why this plan exists
@@ -46,6 +46,10 @@ visibility** on the MCP side:
 Those questions matter for CI-native governance and auditability, but they are still **evidence**
 questions first.
 
+This is also the stronger next enterprise wedge because MCP's current direction explicitly
+emphasizes enterprise-managed auth, discovery, and audit/observability surfaces more than general
+"more MCP features" productization.
+
 ### 3.2 Why this is not a pack-first move
 
 Even though MCP authorization-discovery is strategically important, Assay should not jump straight
@@ -79,6 +83,8 @@ That distinction must stay explicit; `K2` must not silently reuse `G3` semantics
 - token validation, auth success, scope correctness, or issuer trust
 - claims that a server is compliant, secure, or enterprise-ready
 - reusing G3 authorization context as if it were discovery evidence
+- static config files, documentation hints, or client-side remembered auth metadata as evidence
+- OIDC discovery, client registration, or broader OAuth AS metadata expansion beyond the frozen v1 sources
 - Trust Basis or Trust Card expansion in the same slice
 - broad OTel/OpenInference schema work in the same slice
 
@@ -93,6 +99,7 @@ That distinction must stay explicit; `K2` must not silently reuse `G3` semantics
 - the authorization server is trusted
 - the configured flow is valid
 - the required scopes were sufficient
+- any advertised scope requirement was adequate, correct, or enforced
 - a request was authorized successfully
 - the server is compliant with the full MCP auth model
 
@@ -107,13 +114,14 @@ This PLAN only freezes the shape discipline:
 - one meaning
 - typed beats blob
 - observed discovery beats auth-success claims
+- only explicitly frozen, runtime-observed MCP discovery sources may be promoted
 
 Illustrative questions the seam may answer later:
 
 - was protected-resource metadata visible at all?
 - were `authorization_servers` visible?
 - did the discovery source come from a `WWW-Authenticate` challenge, a well-known URI, or another
-  frozen supported source?
+  explicitly frozen runtime-observed MCP discovery source?
 - was a bounded scope challenge visible?
 
 These examples are illustrative discovery directions, not provisional field commitments.
@@ -127,6 +135,9 @@ Before any implementation PR, `K2` must produce a freeze-ready discovery record 
 3. Which signals are only honest as visibility flags and not stronger claims?
 4. What is the smallest honest seam?
 5. Which inputs must **not** become typed authorization-discovery evidence?
+
+Discovery answers must be grounded in shipped adapter/server/proxy evidence paths and repo reality,
+not solely in standards text or static configuration examples.
 
 Minimum artifacts required before freeze:
 
@@ -144,9 +155,11 @@ the resulting active contract now lives in [K2-A — Phase 1 formal freeze](./K2
 Any future `K2` implementation slice should hard-fail review if it:
 
 - turns discovery visibility into authorization correctness
-- promotes static config or docs as runtime-observed evidence without an explicit source rule
+- promotes static config, docs, or client-remembered auth metadata as runtime-observed evidence
+- treats visible scope or metadata as evidence of adequacy, correctness, or compliance
 - promotes raw tokens, bearer headers, or other secrets into evidence
 - silently reuses `G3` auth-context fields for discovery semantics
+- silently reuses `G3` or `payload.discovery` semantics for a distinct authorization-discovery seam
 - sneaks in a pack, engine bump, or Trust Card expansion in the same wave
 - widens the seam beyond one bounded authorization-discovery surface
 
@@ -178,4 +191,4 @@ No downstream pack or trust-surface follow-up should be assumed as part of `K2` 
 - [K2-A — Phase 1 formal freeze](./K2-A-PHASE1-FREEZE.md)
 - [K2-A — Phase 1 freeze prep](./K2-A-PHASE1-FREEZE-PREP.md)
 - [Trust Compiler Audit Matrix](./AUDIT-MATRIX-TRUST-COMPILER-2026-03-26.md)
-- [MCP Authorization](https://modelcontextprotocol.io/specification/2025-11-05/basic/authorization)
+- [MCP Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)

--- a/docs/mcp/import-formats.md
+++ b/docs/mcp/import-formats.md
@@ -107,7 +107,9 @@ Rules:
 - `sse.data` may be an object or a string. If it carries a JSON-RPC message, Assay normalizes it through the same JSON-RPC path as `request` and `response`.
 - `sse.event == "message"` may contribute MCP semantics.
 - Legacy control events such as `endpoint`, keepalives, and other transport-only SSE events are ignored for tool/evidence semantics.
-- `transport_context`, `headers`, `MCP-Protocol-Version`, `Mcp-Session-Id`, and `Last-Event-ID` remain transport context in T1. They are accepted in the envelope, but are not promoted into V2 trace fields and do not change semantic equivalence assertions.
+- `transport_context`, `headers`, `MCP-Protocol-Version`, `Mcp-Session-Id`, and `Last-Event-ID` remain transport context by default.
+- **`K2-A` exception:** on HTTP transcript imports, Assay may now promote one bounded authorization-discovery summary into `episode_start.meta.mcp.authorization_discovery`, but only from explicit `401` response context plus typed `WWW-Authenticate` challenge visibility (`resource_metadata` and/or `scope`).
+- Outside that bounded `K2-A` exception, transport context still does not change MCP tool-call semantic equivalence assertions.
 
 ---
 
@@ -124,6 +126,36 @@ T1 is a transcript compatibility wave. Its goal is canonical semantic equivalenc
 - orphan response behavior
 
 Equivalent sessions imported from `jsonrpc`, `streamable-http`, or `http-sse` should normalize to the same MCP tool semantics and the same Assay V2 tool-call meaning.
+
+`K2-A` does **not** change that core guarantee. It only adds an optional bounded visibility summary on `episode_start.meta` when an HTTP transcript explicitly carries a `401` authorization challenge with typed discovery parameters.
+
+### K2-A Authorization-Discovery Summary
+
+When a supported HTTP transcript entry contains:
+
+- a response-path `401` status in `transport_context`
+- a typed `WWW-Authenticate` header
+- and visible `resource_metadata` and/or `scope` challenge parameters
+
+Assay may emit:
+
+```json
+{
+  "meta": {
+    "mcp": {
+      "authorization_discovery": {
+        "visible": true,
+        "source_kind": "www_authenticate",
+        "resource_metadata_visible": true,
+        "authorization_servers_visible": false,
+        "scope_challenge_visible": true
+      }
+    }
+  }
+}
+```
+
+This summary is **visibility-only**. It does not imply auth success, scope correctness, issuer trust, or MCP auth compliance.
 
 ---
 

--- a/docs/reference/cli/import.md
+++ b/docs/reference/cli/import.md
@@ -16,7 +16,7 @@ assay import <INPUT_FILE> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--format <inspector\|jsonrpc>` | Input format (default: `inspector`) |
+| `--format <inspector\|jsonrpc\|streamable-http\|http-sse>` | Input format (default: `inspector`) |
 | `--out-trace <PATH>` | Output trace path (default: `<input>.trace.jsonl`) |
 | `--init` | Generate starter scaffolding after import |
 
@@ -49,9 +49,11 @@ When `--init` is used, the current implementation generates legacy MCP scaffoldi
 
 ## Troubleshooting
 
-- `unknown format`: use `inspector` or `jsonrpc`.
+- `unknown format`: use `inspector`, `jsonrpc`, `streamable-http`, or `http-sse`.
 - Parse errors: validate your transcript JSON first.
 - Empty import: confirm the transcript actually contains MCP tool traffic.
+
+For HTTP transcript imports, bounded MCP authorization-discovery visibility may appear in `episode_start.meta.mcp.authorization_discovery` when the input explicitly carries a `401` response-path `WWW-Authenticate` challenge with supported typed discovery parameters.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a bounded K2-A MCP authorization-discovery visibility seam to imported MCP traces
- promote only typed, runtime-observed `WWW-Authenticate` discovery on supported `401` transport paths
- document the seam and tighten K2 source-boundary/non-implication language

## Testing
- cargo test -q -p assay-core --test mcp_transport_compat
- cargo test -q -p assay-cli --test mcp_transport_import
- git diff --check
- typos docs/architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md docs/architecture/K2-A-PHASE1-FREEZE.md docs/mcp/import-formats.md docs/reference/cli/import.md