### PR TITLE
docs: tighten k2-a source-boundary wording

### DIFF
--- a/docs/architecture/K2-A-PHASE1-FREEZE.md
+++ b/docs/architecture/K2-A-PHASE1-FREEZE.md
@@ -22,7 +22,7 @@ issuer-trust signal, and not an enterprise-readiness claim.
 
 - **one bounded MCP authorization-discovery seam**
 - **repo-reality first**
-- **adapter/server/proxy emitted evidence only**
+- **supported MCP import / runtime evidence only**
 - **no pack in the same slice**
 - **no reuse of `G3` authorization-context semantics**
 


### PR DESCRIPTION
## Summary
- align the K2-A freeze wording with the shipped Phase 1 code path on main
- replace the stale "adapter/server/proxy only" phrasing with source-boundary language that matches the bounded import/runtime seam

## Testing
- git diff --check
- typos docs/architecture/K2-A-PHASE1-FREEZE.md