### PR TITLE
docs: tighten k2-a post-release truth

### DIFF
--- a/docs/architecture/AUDIT-MATRIX-TRUST-COMPILER-2026-03-26.md
+++ b/docs/architecture/AUDIT-MATRIX-TRUST-COMPILER-2026-03-26.md
@@ -22,9 +22,9 @@ shipped on `main` and/or part of the public `v3.3.0` / `v3.4.0` / `v3.5.0` relea
 | `P2c` | `#949` | built-in `a2a-discovery-card-followup`, pack checks, open mirror | Built-in `A2A-DC-001` / `A2A-DC-002`; `json_path_exists` + `value_equals`; `requires.assay_min_version: ">=3.3.0"` | Yes | Yes — in `v3.4.0` |
 | `K1` formalization | `#989`, `#990`, `#991` | `docs/architecture/PLAN-K1-A2A-HANDOFF-DELEGATION-ROUTE-EVIDENCE-2026q2.md`, `docs/ROADMAP.md`, `docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md` | Next formal wave chosen as bounded A2A handoff / delegation-route visibility evidence; explicitly adapter-first, evidence-first, no pack in the same wave | Yes | Yes — public docs line through `v3.4.0` |
 | `K1-A` Phase 1 freeze + first adapter slice + closure | `#992`, `#994`, `#995` | `docs/architecture/K1-A-PHASE1-FREEZE.md`, `crates/assay-adapter-a2a/src/adapter_impl/handoff.rs`, `crates/assay-adapter-a2a/src/adapter_impl/payload.rs`, `crates/assay-adapter-a2a/src/adapter_impl/tests.rs`, trust-sync docs | Top-level `payload.handoff` seam always present; `typed_payload` / `unknown` only; positive only for `task.requested` + `task.kind == "delegation"`; explicit non-promotion for `task.updated`, `artifact.shared`, generic-message fallback, synthetic `unknown-task`, and non-`delegation` `task.kind` | Yes | Yes — in `v3.4.0` |
-| `K2` planning + `K2-A` freeze | docs-only follow-up on `main` | `docs/architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md`, `docs/architecture/K2-A-PHASE1-FREEZE.md`, `docs/architecture/K2-A-PHASE1-FREEZE-PREP.md`, `docs/ROADMAP.md`, `docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md` | `K2` is formalized as the next bounded MCP authorization-discovery wave; `K2-A` freezes one seam, repo-reality-first source classes, and hard non-promotion rules before implementation | Yes | Planned docs line on `main` |
+| `K2` planning + `K2-A` freeze | docs-only follow-up on `main` | `docs/architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md`, `docs/architecture/K2-A-PHASE1-FREEZE.md`, `docs/architecture/K2-A-PHASE1-FREEZE-PREP.md`, `docs/ROADMAP.md`, `docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md` | `K2` is formalized as the next bounded MCP authorization-discovery wave; `K2-A` freezes one seam, repo-reality-first source classes, and hard non-promotion rules before implementation | Yes | Yes — public docs line through `v3.5.0` |
 | `K2-A` Phase 1 implementation | `#1004` | `crates/assay-core/src/mcp/types.rs`, `crates/assay-core/src/mcp/parser.rs`, `crates/assay-core/src/mcp/mapper_v2.rs`, `crates/assay-core/tests/mcp_transport_compat.rs`, `crates/assay-cli/tests/mcp_transport_import.rs` | Bounded MCP authorization-discovery seam on imported MCP traces: top-level `episode_start.meta.mcp.authorization_discovery`, visibility-only, positive only for typed `WWW-Authenticate` discovery on supported `401` transport paths; explicit non-promotion without typed runtime-observed provenance | Yes | Yes — in `v3.5.0` |
-| Discovery-only next-wave note | discovery note on `main` | `docs/architecture/DISCOVERY-NEXT-EVIDENCE-WAVE-2026Q2.md` | Preferred next evidence-wave candidate: **A2A handoff / delegation-route visibility**; second candidate: **MCP authorization-discovery**; explicitly **not** automatically another pack | Yes | Yes — public docs line / discovery-only context through `v3.4.0` |
+| Discovery-only next-wave note | discovery note on `main` | `docs/architecture/DISCOVERY-NEXT-EVIDENCE-WAVE-2026Q2.md` | Preferred next evidence-wave candidate: **A2A handoff / delegation-route visibility**; second candidate: **MCP authorization-discovery**; explicitly **not** automatically another pack | Yes | Yes — historical public docs context through `v3.5.0` |
 
 ## Current call
 
@@ -36,7 +36,20 @@ documentation converges on this call:
 - current public slice now includes **bounded MCP authorization-discovery visibility evidence** via `K2-A`
 - active bounded evidence wave: **`K2` — MCP authorization-discovery evidence**
 - `K2-A` Phase 1 is now public in **`v3.5.0`**
+- `v3.5.0` release status does **not** imply an automatic second `K2` slice
 - keep protocol packs downstream of first-class evidence seams, not as the default next move
+
+## Post-release truth-check (`v3.5.0`)
+
+Checked and aligned for `K2-A` public release truth:
+
+- `CHANGELOG.md` now treats `K2-A` as publicly shipped in `v3.5.0`
+- `README.md` now lists `K2-A` inside the current public trust-compiler line
+- `docs/ROADMAP.md` now reflects `K2-A` as public in `v3.5.0`, not `main`-only
+- `docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md` now treats `K2-A` as part of the active public line
+- `docs/architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md` now describes `K2-A` with public release status, not `main`-only status
+- `docs/architecture/K2-A-PHASE1-FREEZE.md` now treats the Phase 1 seam as a released `v3.5.0` slice
+- `docs/architecture/index.md` now points at `K2-A` as public in `v3.5.0`
 
 See also:
 

--- a/docs/architecture/K2-A-PHASE1-FREEZE.md
+++ b/docs/architecture/K2-A-PHASE1-FREEZE.md
@@ -5,7 +5,7 @@
 **Prep input:** [K2-A-PHASE1-FREEZE-PREP.md](K2-A-PHASE1-FREEZE-PREP.md).
 **Repo snapshot:** Current `main` has bounded `G3` authorization **context** on supported
 `assay.tool.decision` evidence **and** a first-class bounded MCP authorization-discovery seam on
-imported MCP traces. This freeze remains the active contract for that shipped-on-`main` Phase 1
+imported MCP traces. This freeze remains the active contract for that public `v3.5.0` Phase 1
 implementation: it locks the honest source classes, semantic ceiling, and review gates that the
 runtime code must continue to honor.
 
@@ -111,7 +111,7 @@ Any future `K2-A` implementation must hard-fail review if it:
 This freeze means:
 
 - `K2` is the active bounded MCP authorization-discovery evidence wave
-- `K2-A` Phase 1 now has a formal contract **and** an implemented first slice on `main`
+- `K2-A` Phase 1 now has a formal contract **and** a released first slice in **`v3.5.0`**
 - any further implementation must stay inside the guardrails above
 
 This freeze does **not** mean:

--- a/docs/architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md
+++ b/docs/architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-03-29
 - **Owner:** Evidence / Product
 - **Inputs:** [ROADMAP](../ROADMAP.md), [RFC-005](./RFC-005-trust-compiler-mvp-2026q2.md), [PLAN — K1](./PLAN-K1-A2A-HANDOFF-DELEGATION-ROUTE-EVIDENCE-2026q2.md), [K1-A — Phase 1 formal freeze](./K1-A-PHASE1-FREEZE.md), [Trust Compiler Audit Matrix](./AUDIT-MATRIX-TRUST-COMPILER-2026-03-26.md), [MCP Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
-- **Scope (this document):** Record the formal `K2` wave choice, its guardrails, and the current `K2-A` Phase 1 shipped-on-`main` status. No pack semantics, no engine bump, and no Trust Basis / Trust Card expansion are implied by this plan.
+- **Scope (this document):** Record the formal `K2` wave choice, its guardrails, and the current `K2-A` Phase 1 public release status. No pack semantics, no engine bump, and no Trust Basis / Trust Card expansion are implied by this plan.
 
 ## 1. Why this plan exists
 
@@ -174,7 +174,8 @@ Any future `K2` implementation slice should hard-fail review if it:
 5. No pack or broader trust artifact is shipped in the same wave.
 
 `K2-A` Phase 1 now meets that bar through the bounded MCP import seam merged in `#1004`, and that
-slice is now part of the public **`v3.5.0`** release line.
+slice is now part of the public **`v3.5.0`** release line. That release status does **not** by
+itself authorize an automatic second `K2` slice.
 
 ## 10. What happens after `K2`
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -24,7 +24,7 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [PLAN — K1 A2A Handoff / Delegation-Route Evidence (Q2 2026)](./PLAN-K1-A2A-HANDOFF-DELEGATION-ROUTE-EVIDENCE-2026q2.md) — formal next-wave plan after `P2c`, adapter-first and evidence-first
 - [K1-A Phase 1 Freeze (Q2 2026)](./K1-A-PHASE1-FREEZE.md) — executable freeze for the first bounded typed `handoff` seam in A2A canonical adapter output
 - [PLAN — K2 MCP Authorization-Discovery Evidence (Q2 2026)](./PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md) — active bounded MCP authorization-discovery wave, focused on visibility before any auth-discovery pack
-- [K2-A Phase 1 Freeze (Q2 2026)](./K2-A-PHASE1-FREEZE.md) — active contract for the first bounded MCP authorization-discovery seam now implemented on `main`
+- [K2-A Phase 1 Freeze (Q2 2026)](./K2-A-PHASE1-FREEZE.md) — active contract for the first bounded MCP authorization-discovery seam now public in `v3.5.0`
 - [K2-A Phase 1 Freeze Prep (Q2 2026)](./K2-A-PHASE1-FREEZE-PREP.md) — pre-freeze source inventory and guardrails for the first bounded MCP authorization-discovery seam
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 


### PR DESCRIPTION
## Summary
- tighten the K2-A release-status wording now that `v3.5.0` is publicly live
- update the audit matrix to carry the post-release truth-check as the primary SSOT
- remove the last K2-A-specific `main`-only phrasing from the active plan/freeze/index docs

## Validation
- `git diff --check`
- `typos docs/architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md docs/architecture/K2-A-PHASE1-FREEZE.md docs/architecture/AUDIT-MATRIX-TRUST-COMPILER-2026-03-26.md docs/architecture/index.md`
