### PR TITLE
fix: unbreak docs publish on Python 3.14

### DIFF
--- a/docs/AIcontext/architecture-diagrams.md
+++ b/docs/AIcontext/architecture-diagrams.md
@@ -820,7 +820,7 @@ flowchart TB
 ## Generated Diagrams
 
 The following diagrams are automatically generated from the codebase by the
-[docs-auto-update workflow](../../.github/workflows/docs-auto-update.yml).
+[docs-auto-update workflow](https://github.com/Rul1an/assay/blob/main/.github/workflows/docs-auto-update.yml).
 
 ### Crate Dependencies (Auto-Generated)
 

--- a/docs/AIcontext/index.md
+++ b/docs/AIcontext/index.md
@@ -115,9 +115,9 @@ These documents should be updated when:
 ## Related Documentation
 
 - [Run Output](run-output.md) - run.json / summary.json contract (seeds, judge_metrics, reason_code)
-- [Architecture ADRs](../architecture/) - Architecture Decision Records
-- [Core Concepts](../concepts/) - User-facing concept documentation
-- [CLI Reference](../reference/cli/) - Detailed CLI command documentation
-- [Python SDK](../python-sdk/) - Python SDK documentation
+- [Architecture ADRs](../architecture/index.md) - Architecture Decision Records
+- [Core Concepts](../concepts/index.md) - User-facing concept documentation
+- [CLI Reference](../reference/cli/index.md) - Detailed CLI command documentation
+- [Python SDK](../python-sdk/index.md) - Python SDK documentation
 - [SPEC-PR-Gate-Outputs-v1](../architecture/SPEC-PR-Gate-Outputs-v1.md) - PR gate output spec
 - [DX Roadmap](../DX-ROADMAP.md) - Current DX execution plan

--- a/docs/requirements-ci.txt
+++ b/docs/requirements-ci.txt
@@ -1,3 +1,3 @@
 mkdocs-material==9.5.28
 mkdocs-minify-plugin==0.8.0
-pymdown-extensions==10.8.1
+pymdown-extensions==10.21.2


### PR DESCRIPTION
## Summary
- bump `pymdown-extensions` in the docs CI toolchain to a Python 3.14-compatible version
- fix two AIcontext doc links surfaced by the same `mkdocs` build log
- restore the docs publish path without changing the active nav/warning baseline

## Validation
- `source .venv-docs/bin/activate && mkdocs build`
- `git diff --check`
- `typos docs/AIcontext/index.md docs/AIcontext/architecture-diagrams.md`
