### PR TITLE
chore(deps): align sha2 0.11 and hmac 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
 ]
 
@@ -192,7 +192,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -238,7 +238,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.11.0",
  "similar",
  "sysinfo",
  "tempfile",
@@ -275,7 +275,7 @@ dependencies = [
  "flate2",
  "globset",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "jsonschema",
  "lazy_static",
  "libc",
@@ -294,7 +294,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.11.0",
  "sha256",
  "spki",
  "strsim",
@@ -341,7 +341,7 @@ dependencies = [
  "serde_jcs",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -382,7 +382,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -404,7 +404,7 @@ dependencies = [
  "regex",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
  "tracing",
 ]
@@ -454,7 +454,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -477,7 +477,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "tempfile",
  "tokio",
@@ -790,6 +790,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +973,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1072,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1189,6 +1219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,15 +1238,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1295,7 +1343,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1355,10 +1403,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1427,7 +1487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1454,7 +1514,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1473,7 +1533,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -2005,7 +2065,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2014,7 +2074,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2067,6 +2136,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a79f2aff40c18ab8615ddc5caa9eb5b96314aef18fe5823090f204ad988e813"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2474,7 +2552,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -2483,7 +2561,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
 ]
@@ -2648,7 +2726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3036,7 +3114,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3048,7 +3126,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3149,7 +3227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3947,7 +4025,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3971,8 +4049,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -4374,8 +4452,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4387,7 +4476,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "hex",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -4449,7 +4538,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4711,7 +4800,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -5405,7 +5494,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ chrono = { version = "0.4", features = ["serde"], default-features = false }
 tempfile = "3"
 regex = "1"
 async-trait = "0.1"
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 aya = "0.13.0"
 aya-log = "0.2"

--- a/crates/assay-cli/src/cli/commands/replay/fs_ops.rs
+++ b/crates/assay-cli/src/cli/commands/replay/fs_ops.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 pub(super) fn apply_seed_override(config_path: &Path, seed: u64) -> anyhow::Result<()> {
@@ -114,7 +115,14 @@ pub(super) fn write_entries(workspace: &Path, entries: &[(String, Vec<u8>)]) -> 
 pub(super) fn sha256_file(path: &Path) -> anyhow::Result<String> {
     let mut f = std::fs::File::open(path)?;
     let mut hasher = Sha256::new();
-    std::io::copy(&mut f, &mut hasher)?;
+    let mut buf = [0_u8; 8192];
+    loop {
+        let read = f.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
     Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
 }
 

--- a/crates/assay-core/Cargo.toml
+++ b/crates/assay-core/Cargo.toml
@@ -33,7 +33,7 @@ tracing.workspace = true
 uuid.workspace = true
 chrono = { workspace = true, features = ["std", "clock"] }
 sha2.workspace = true
-hmac = "0.12"
+hmac = "0.13"
 lazy_static = "1.4"
 tokio = { workspace = true, features = ["sync", "time", "macros", "rt-multi-thread"] }
 

--- a/crates/assay-core/src/cache/key.rs
+++ b/crates/assay-core/src/cache/key.rs
@@ -11,5 +11,5 @@ pub fn cache_key(model: &str, prompt: &str, fingerprint: &str, trace_hash: Optio
         h.update(b"\n");
         h.update(th.as_bytes());
     }
-    format!("{:x}", h.finalize())
+    hex::encode(h.finalize())
 }

--- a/crates/assay-core/src/mcp/identity.rs
+++ b/crates/assay-core/src/mcp/identity.rs
@@ -52,11 +52,11 @@ fn compute_json_hash(val: &Option<serde_json::Value>) -> String {
     } else {
         hasher.update(b"null");
     }
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 fn compute_string_hash(s: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(s.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }

--- a/crates/assay-core/src/mcp/signing.rs
+++ b/crates/assay-core/src/mcp/signing.rs
@@ -99,7 +99,7 @@ impl VerifyError {
 /// Returns `sha256:<lowercase-hex>`.
 pub fn compute_key_id(spki_bytes: &[u8]) -> String {
     let hash = Sha256::digest(spki_bytes);
-    format!("sha256:{:x}", hash)
+    format!("sha256:{}", hex::encode(hash))
 }
 
 /// Compute key_id from a VerifyingKey.
@@ -150,7 +150,7 @@ fn strip_signature(tool: &Value) -> Result<Value> {
 /// Compute payload digest.
 fn compute_payload_digest(canonical: &[u8]) -> String {
     let hash = Sha256::digest(canonical);
-    format!("sha256:{:x}", hash)
+    format!("sha256:{}", hex::encode(hash))
 }
 
 /// Sign a tool definition.

--- a/crates/assay-core/src/otel/redaction.rs
+++ b/crates/assay-core/src/otel/redaction.rs
@@ -1,5 +1,5 @@
 use crate::config::otel::{PromptCaptureMode, RedactionConfig};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 pub struct RedactionService {

--- a/crates/assay-core/src/vcr/mod.rs
+++ b/crates/assay-core/src/vcr/mod.rs
@@ -208,7 +208,7 @@ impl VcrClient {
             hasher.update(canonical.as_bytes());
         }
 
-        format!("{:x}", hasher.finalize())
+        hex::encode(hasher.finalize())
     }
 
     /// Determine provider from URL

--- a/crates/assay-evidence/Cargo.toml
+++ b/crates/assay-evidence/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = { workspace = true, features = ["preserve_order", "std", "alloc"] }
 serde_jcs = "=0.1.0"
 
 # Crypto & IDs
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 base64 = "0.22"
 uuid = { version = "1.22", features = ["v7", "serde"] }

--- a/crates/assay-evidence/src/mandate/signing.rs
+++ b/crates/assay-evidence/src/mandate/signing.rs
@@ -94,7 +94,7 @@ pub struct VerifyResult {
 /// Returns `sha256:<lowercase-hex>`.
 pub fn compute_key_id(spki_bytes: &[u8]) -> String {
     let hash = Sha256::digest(spki_bytes);
-    format!("sha256:{:x}", hash)
+    format!("sha256:{}", hex::encode(hash))
 }
 
 /// Compute key_id from a VerifyingKey.

--- a/crates/assay-registry/Cargo.toml
+++ b/crates/assay-registry/Cargo.toml
@@ -31,7 +31,7 @@ chrono = { workspace = true, features = ["std", "clock", "serde"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # Crypto (for signature verification)
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 base64 = "0.22"
 ed25519-dalek = { version = "2.1", features = ["pkcs8", "rand_core"] }

--- a/crates/assay-registry/src/canonicalize/digest.rs
+++ b/crates/assay-registry/src/canonicalize/digest.rs
@@ -5,5 +5,5 @@ use sha2::{Digest, Sha256};
 /// Compute SHA-256 hash of bytes and format as `sha256:{hex}`.
 pub fn sha256_prefixed(bytes: &[u8]) -> String {
     let hash = Sha256::digest(bytes);
-    format!("sha256:{:x}", hash)
+    format!("sha256:{}", hex::encode(hash))
 }

--- a/crates/assay-registry/src/digest.rs
+++ b/crates/assay-registry/src/digest.rs
@@ -16,7 +16,7 @@ pub(crate) fn sha256_hex_reader<R: Read>(mut reader: R) -> std::io::Result<Strin
         hasher.update(&buf[..n]);
     }
 
-    Ok(format!("sha256:{:x}", hasher.finalize()))
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
 }
 
 pub(crate) fn sha256_hex_bytes(bytes: &[u8]) -> String {


### PR DESCRIPTION
Supersedes #1015 and #1016.

These two Dependabot bumps are coupled through the digest 0.11 line, so neither one landed cleanly on its own. This replacement PR upgrades them together and applies the minimal compatibility fixes needed across core, evidence, registry, and the CLI replay hashing helper.

Validation:
- cargo test -q -p assay-evidence
- cargo test -q -p assay-registry
- cargo test -q -p assay-core --lib
- cargo clippy -q --workspace --all-targets --exclude assay-it --exclude assay-ebpf -- -D warnings

Note: cargo test -q -p assay-cli hit two existing local e2e assertions that expect a prebuilt assay-mcp-server binary in target/debug; that is unrelated to this dependency change.