### PR TITLE
ci: automate dependabot queue maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      # These two move together through the digest crate line and do not land
+      # reliably as separate PRs.
+      crypto-digest-line:
+        patterns:
+          - "sha2"
+          - "hmac"
     commit-message:
       prefix: "chore(deps)"
     labels:

--- a/.github/workflows/dependabot-maintenance.yml
+++ b/.github/workflows/dependabot-maintenance.yml
@@ -1,0 +1,62 @@
+name: Dependabot Queue Maintenance
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 */4 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: dependabot-maintenance
+  cancel-in-progress: false
+
+jobs:
+  enable-auto-merge:
+    name: Enable auto-merge for Dependabot PRs
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          already_enabled="$(
+            gh pr view "$PR_NUMBER" --repo "$REPO" --json autoMergeRequest --jq 'if .autoMergeRequest then "true" else "false" end'
+          )"
+
+          if [[ "$already_enabled" == "true" ]]; then
+            echo "Auto-merge already enabled for Dependabot PR #$PR_NUMBER" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --merge --auto
+          echo "Enabled auto-merge for Dependabot PR #$PR_NUMBER" >> "$GITHUB_STEP_SUMMARY"
+
+  refresh-queue:
+    name: Refresh dependency queue PR branches
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Refresh queue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: ./scripts/ci/dependabot-maintenance.sh "$REPO"

--- a/scripts/ci/dependabot-maintenance.sh
+++ b/scripts/ci/dependabot-maintenance.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:-${GITHUB_REPOSITORY:-}}"
+if [[ -z "$repo" ]]; then
+  echo "usage: $0 <owner/repo>" >&2
+  exit 2
+fi
+
+summary_file="${GITHUB_STEP_SUMMARY:-}"
+
+append_summary() {
+  if [[ -n "$summary_file" ]]; then
+    printf '%s\n' "$1" >> "$summary_file"
+  fi
+}
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "gh authentication is required" >&2
+  exit 1
+fi
+
+dependabot_prs="$(
+  gh pr list \
+    --repo "$repo" \
+    --state open \
+    --author "app/dependabot" \
+    --json number,title,mergeStateStatus,isDraft,autoMergeRequest,url
+)"
+
+replacement_prs="$(
+  gh pr list \
+    --repo "$repo" \
+    --state open \
+    --search "head:codex/dependabot- state:open" \
+    --json number,title,mergeStateStatus,isDraft,autoMergeRequest,url
+)"
+
+prs_json="$(jq -s 'add | unique_by(.number)' <<<"$dependabot_prs"$'\n'"$replacement_prs")"
+
+count="$(jq 'length' <<<"$prs_json")"
+append_summary "## Dependency queue maintenance"
+append_summary "- repo: $repo"
+append_summary "- open_dependency_queue_prs: $count"
+
+if [[ "$count" == "0" ]]; then
+  append_summary "- result: no open dependency queue PRs"
+  exit 0
+fi
+
+updated=0
+update_failures=0
+automerge_enabled=0
+automerge_failures=0
+
+while IFS=$'\t' read -r number title merge_state is_draft auto_enabled; do
+  update_status="not-needed"
+  auto_status="already-enabled"
+
+  if [[ "$merge_state" == "BEHIND" ]]; then
+    if gh pr update-branch "$number" --repo "$repo" >/dev/null; then
+      updated=$((updated + 1))
+      update_status="updated"
+    else
+      update_failures=$((update_failures + 1))
+      update_status="update-failed"
+    fi
+  fi
+
+  if [[ "$is_draft" != "true" && "$auto_enabled" != "true" ]]; then
+    if gh pr merge "$number" --repo "$repo" --merge --auto >/dev/null; then
+      automerge_enabled=$((automerge_enabled + 1))
+      auto_status="enabled"
+    else
+      automerge_failures=$((automerge_failures + 1))
+      auto_status="enable-failed"
+    fi
+  elif [[ "$is_draft" == "true" ]]; then
+    auto_status="draft"
+  fi
+
+  append_summary "- PR #$number: $title | merge_state=$merge_state | branch=$update_status | auto_merge=$auto_status"
+  echo "PR #$number ($title): merge_state=$merge_state, branch=$update_status, auto_merge=$auto_status"
+done < <(
+  jq -r '.[] | [.number, .title, .mergeStateStatus, .isDraft, (.autoMergeRequest != null)] | @tsv' <<<"$prs_json"
+)
+
+append_summary "- updated_branches: $updated"
+append_summary "- update_failures: $update_failures"
+append_summary "- auto_merge_enabled: $automerge_enabled"
+append_summary "- auto_merge_failures: $automerge_failures"
+
+if [[ "$update_failures" -gt 0 || "$automerge_failures" -gt 0 ]]; then
+  append_summary "- note: some PRs could not be updated automatically; inspect workflow logs for details"
+fi


### PR DESCRIPTION
This hardens the dependency-update lane so we do not have to keep manually rescuing open Dependabot PRs after every merge to `main`.

What this adds:
- a new `Dependabot Queue Maintenance` workflow that
  - enables native auto-merge for new Dependabot PRs
  - refreshes open dependency queue branches on push to `main`, on a 4-hour schedule, and on manual dispatch
  - also covers replacement PRs on `codex/dependabot-*` heads
- a `sha2` + `hmac` Dependabot group so the digest-0.11 crypto line lands as one coordinated PR instead of two half-broken ones

Validation:
- repo commit hooks passed (yaml, actionlint, shellcheck, fmt)
- `./scripts/ci/dependabot-maintenance.sh Rul1an/assay` ran cleanly and summarized the current queue

This follows the current GitHub-native best-practice line: native auto-merge, no deprecated `@dependabot merge`, and branch refresh after `main` moves instead of repeated manual babysitting.