### PR TITLE
docs: harden issue intake routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,18 +1,21 @@
 name: Bug Report
-description: Create a report to help us improve Verdict
+description: Report a reproducible bug in Assay
 title: "[BUG] "
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
+        Thanks for taking the time to report a bug in Assay.
+
+        Issues are for reproducible product bugs.
+        For questions, integration ideas, or partnership outreach, please use GitHub Discussions instead.
   - type: textarea
     id: description
     attributes:
       label: Bug Description
       description: A clear and concise description of what the bug is.
-      placeholder: "When I run verdict ci with --trace-file, it panics..."
+      placeholder: "When I run `assay ci --trace-file traces/ci.jsonl`, the command exits with a parser error..."
     validations:
       required: true
   - type: textarea
@@ -21,16 +24,16 @@ body:
       label: Steps to Reproduce
       description: Steps to reproduce the behavior.
       placeholder: |
-        1. Run 'verdict ci ...'
-        2. See error
+        1. Run `assay ci ...`
+        2. Observe the failing output
     validations:
       required: true
   - type: input
     id: version
     attributes:
-      label: Verdict Version
-      description: Output of `verdict --version`
-      placeholder: "v0.2.0"
+      label: Assay Version
+      description: Output of `assay --version`
+      placeholder: "v3.5.0"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions, integrations, and partnership ideas
+    url: https://github.com/Rul1an/assay/discussions
+    about: Use Discussions for product questions, integration proposals, and partnership or ecosystem outreach.
+  - name: Security vulnerability report
+    url: https://github.com/Rul1an/assay/security/advisories/new
+    about: Please report suspected vulnerabilities privately through GitHub Security Advisories.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,8 +1,14 @@
 name: Feature Request
-description: Suggest an idea for this project
+description: Propose a bounded product or developer-facing improvement for Assay
 title: "[FEAT] "
 labels: ["enhancement"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use Issues for concrete, bounded feature requests.
+
+        For broad product questions, integrations, vendor outreach, or partnership proposals, please start a GitHub Discussion first.
   - type: textarea
     id: problem
     attributes:
@@ -15,7 +21,7 @@ body:
     id: solution
     attributes:
       label: Describe the solution you'd like
-      description: A clear and concise description of what you want to happen.
+      description: A clear and concise description of the bounded change you want to happen.
     validations:
       required: true
   - type: textarea
@@ -23,3 +29,9 @@ body:
     attributes:
       label: Describe alternatives you've considered
       description: A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundaries
+      description: What should stay out of scope for this request?
+      placeholder: "Keep this limited to import-time evidence only; no new trust scoring, hosted service, or pack expansion."

--- a/.github/ISSUE_TEMPLATE/triage.yaml
+++ b/.github/ISSUE_TEMPLATE/triage.yaml
@@ -1,12 +1,15 @@
-name: "Design Partner Triage"
-description: "Submit a support request with a doctor report."
+name: "Support Triage"
+description: "Submit an Assay support request with a doctor report."
 title: "[Triage]: "
 labels: ["triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Please run `verdict doctor --config <your-config.yaml> --format json --out doctor.json` and paste the content below.
+        Please run `assay doctor --config <your-config.yaml> --format json --out doctor.json` and paste the content below.
+
+        This form is for setup and support triage.
+        For integrations, ecosystem ideas, or partnership requests, use GitHub Discussions.
 
   - type: textarea
     id: doctor_report


### PR DESCRIPTION
## Summary
- add issue template config so blank issues are disabled
- route integrations, partnerships, and general questions to Discussions
- update bug/support templates from old Verdict wording to current Assay commands and positioning

## Validation
- `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.{yml,yaml}"].each { |f| YAML.load_file(f) }; puts "yaml-ok"'`
- `git diff --check`
