### PR TITLE
ci: skip self-hosted eBPF lane for lightweight admin changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
             if [[ ! -s "$changed_file" ]]; then
               lightweight_only=false
-            elif grep -Ev '^(docs/|.*\.md$|mkdocs\.yml$|scripts/ci/review-[^/]+\.sh$)' "$changed_file" >/dev/null; then
+            elif grep -Ev '^(docs/|.*\.md$|mkdocs\.yml$|scripts/ci/review-[^/]+\.sh$|\.github/ISSUE_TEMPLATE/[^/]+\.ya?ml$|\.github/DISCUSSION_TEMPLATE/[^/]+\.ya?ml$)' "$changed_file" >/dev/null; then
               lightweight_only=false
             else
               lightweight_only=true
@@ -367,8 +367,8 @@ jobs:
 
   ebpf-smoke-self-hosted:
     name: eBPF monitor smoke (Linux - Self-Hosted)
-    needs: [test]
-    if: github.event_name != 'pull_request'
+    needs: [scope, test]
+    if: github.event_name != 'pull_request' && needs.scope.outputs.lightweight_only != 'true'
     runs-on: [self-hosted, linux, assay-bpf-runner]
     timeout-minutes: 60
     concurrency:


### PR DESCRIPTION
## Summary
- treat issue/discussion template changes as lightweight-only CI scope
- skip the self-hosted eBPF smoke lane for lightweight-only pushes
- keep workflow trigger semantics branch-protection-safe by skipping internally, not by path-filtering the workflow

## Why
The merge of #1028 showed the current gap clearly: required CI was already green, but the push workflow stayed queued because `eBPF monitor smoke (Linux - Self-Hosted)` still ran for a lightweight admin/docs-style change and no matching self-hosted runner picked it up.

This keeps the self-hosted lane for real code changes while avoiding noisy stuck push runs for issue-intake and discussion-template maintenance.

## Validation
- `git diff --check`
- lightweight regex sanity-check for `.github/ISSUE_TEMPLATE/**` and `.github/DISCUSSION_TEMPLATE/**`
- workflow lint via repo pre-push hooks