### PR TITLE
test: add signed receipt interop probe

### DIFF
--- a/crates/assay-core/tests/receipt_interop_probe.rs
+++ b/crates/assay-core/tests/receipt_interop_probe.rs
@@ -120,7 +120,7 @@ fn contract_probe_valid_deny_maps_to_observed_view() {
 fn contract_probe_tampered_receipt_stays_unchecked_and_unpromoted() {
     let view = derive_probe_evidence("tampered.json").expect("tampered view");
 
-    assert_eq!(view.receipt_present, true);
+    assert!(view.receipt_present);
     assert_eq!(view.verification_result, VerificationResult::Unchecked);
     assert_eq!(view.tool_name.as_deref(), Some("delete_database"));
     assert_eq!(view.decision.as_deref(), Some("deny"));
@@ -143,7 +143,7 @@ fn contract_probe_malformed_receipt_is_rejected_as_malformed() {
     );
 
     let view = derive_malformed_probe_evidence("malformed.json");
-    assert_eq!(view.receipt_present, false);
+    assert!(!view.receipt_present);
     assert_eq!(view.verification_result, VerificationResult::Malformed);
     assert_eq!(view.elevatable_fields(), vec!["verification_result"]);
 }

--- a/crates/assay-core/tests/receipt_interop_probe.rs
+++ b/crates/assay-core/tests/receipt_interop_probe.rs
@@ -1,0 +1,285 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum VerificationResult {
+    Valid,
+    Invalid,
+    Malformed,
+    Unchecked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProbeEvidenceView {
+    receipt_present: bool,
+    verification_result: VerificationResult,
+    issuer_id: Option<String>,
+    claimed_issuer_tier: Option<String>,
+    policy_digest: Option<String>,
+    spec: Option<String>,
+    tool_name: Option<String>,
+    decision: Option<String>,
+    binding_key: Option<String>,
+}
+
+impl ProbeEvidenceView {
+    fn elevatable_fields(&self) -> Vec<&'static str> {
+        vec!["verification_result"]
+    }
+}
+
+#[test]
+fn contract_probe_fixture_inventory_is_complete() {
+    let fixture_dir = fixture_dir();
+    let expected = [
+        "README.md",
+        "issuer_key.json",
+        "malformed.json",
+        "tampered.json",
+        "valid_allow.json",
+        "valid_deny.json",
+    ];
+
+    let mut actual: Vec<String> = fs::read_dir(&fixture_dir)
+        .expect("read fixture dir")
+        .map(|entry| {
+            entry
+                .expect("valid fixture entry")
+                .file_name()
+                .into_string()
+                .expect("utf-8 filename")
+        })
+        .collect();
+    actual.sort();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn contract_probe_issuer_key_fixture_is_loadable() {
+    let value = read_fixture_json("issuer_key.json");
+
+    assert_eq!(value["kid"], "sb:issuer:1feed234c727");
+    assert_eq!(value["alg"], "EdDSA");
+    assert_eq!(
+        value["public_key_hex"],
+        "1feed234c727d30cf5b5f7f27df5d6168620bd8fcfd0a565efea65c08e93ed89"
+    );
+}
+
+#[test]
+fn contract_probe_valid_allow_maps_to_observed_view() {
+    let view = derive_probe_evidence("valid_allow.json").expect("valid allow view");
+
+    assert_eq!(
+        view,
+        ProbeEvidenceView {
+            receipt_present: true,
+            verification_result: VerificationResult::Unchecked,
+            issuer_id: Some("sb:issuer:1feed234c727".to_string()),
+            claimed_issuer_tier: Some("self-signed".to_string()),
+            policy_digest: Some("sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b".to_string()),
+            spec: Some("draft-farley-acta-signed-receipts-01".to_string()),
+            tool_name: Some("read_file".to_string()),
+            decision: Some("allow".to_string()),
+            binding_key: Some(
+                "sb:issuer:1feed234c727|sess_a1b2c3d4e5f6|1|sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76"
+                    .to_string(),
+            ),
+        }
+    );
+    assert_eq!(view.elevatable_fields(), vec!["verification_result"]);
+}
+
+#[test]
+fn contract_probe_valid_deny_maps_to_observed_view() {
+    let view = derive_probe_evidence("valid_deny.json").expect("valid deny view");
+
+    assert_eq!(
+        view,
+        ProbeEvidenceView {
+            receipt_present: true,
+            verification_result: VerificationResult::Unchecked,
+            issuer_id: Some("sb:issuer:1feed234c727".to_string()),
+            claimed_issuer_tier: Some("self-signed".to_string()),
+            policy_digest: Some("sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b".to_string()),
+            spec: Some("draft-farley-acta-signed-receipts-01".to_string()),
+            tool_name: Some("execute_command".to_string()),
+            decision: Some("deny".to_string()),
+            binding_key: Some(
+                "sb:issuer:1feed234c727|sess_a1b2c3d4e5f6|2|sha256:5c7923bd67b06c93279d49c466301c57023822eec29c49e269063e47aecd973c"
+                    .to_string(),
+            ),
+        }
+    );
+    assert_eq!(view.elevatable_fields(), vec!["verification_result"]);
+}
+
+#[test]
+fn contract_probe_tampered_receipt_stays_unchecked_and_unpromoted() {
+    let view = derive_probe_evidence("tampered.json").expect("tampered view");
+
+    assert_eq!(view.receipt_present, true);
+    assert_eq!(view.verification_result, VerificationResult::Unchecked);
+    assert_eq!(view.tool_name.as_deref(), Some("delete_database"));
+    assert_eq!(view.decision.as_deref(), Some("deny"));
+    assert_eq!(
+        view.binding_key.as_deref(),
+        Some(
+            "sb:issuer:1feed234c727|sess_a1b2c3d4e5f6|1|sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76"
+        )
+    );
+    assert_eq!(view.elevatable_fields(), vec!["verification_result"]);
+}
+
+#[test]
+fn contract_probe_malformed_receipt_is_rejected_as_malformed() {
+    let err = derive_probe_evidence("malformed.json").expect_err("malformed receipt must fail");
+
+    assert!(
+        err.contains("missing or invalid string field \"decision\""),
+        "unexpected malformed error: {err}"
+    );
+
+    let view = derive_malformed_probe_evidence("malformed.json");
+    assert_eq!(view.receipt_present, false);
+    assert_eq!(view.verification_result, VerificationResult::Malformed);
+    assert_eq!(view.elevatable_fields(), vec!["verification_result"]);
+}
+
+#[test]
+fn contract_probe_binding_key_is_deterministic() {
+    let first = derive_probe_evidence("valid_allow.json").expect("first load");
+    let second = derive_probe_evidence("valid_allow.json").expect("second load");
+
+    assert_eq!(first.binding_key, second.binding_key);
+}
+
+#[test]
+fn contract_probe_valid_and_invalid_variants_remain_reserved_for_future_boundary_work() {
+    let reserved = [
+        VerificationResult::Valid,
+        VerificationResult::Invalid,
+        VerificationResult::Malformed,
+        VerificationResult::Unchecked,
+    ];
+
+    assert_eq!(reserved.len(), 4);
+}
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/interop/protect_mcp_receipts")
+}
+
+fn read_fixture_json(name: &str) -> Value {
+    let path = fixture_dir().join(name);
+    let text = fs::read_to_string(&path).unwrap_or_else(|err| {
+        panic!("failed to read fixture {}: {err}", path.display());
+    });
+    serde_json::from_str(&text).unwrap_or_else(|err| {
+        panic!("failed to parse fixture {}: {err}", path.display());
+    })
+}
+
+fn derive_probe_evidence(name: &str) -> Result<ProbeEvidenceView, String> {
+    let value = read_fixture_json(name);
+    validate_minimal_shape(&value)?;
+
+    let issuer_id = get_string(&value, "issuer_id")?;
+    let session_id = get_string(&value, "session_id")?;
+    let sequence = get_u64(&value, "sequence")?;
+    let tool_input_hash = get_string(&value, "tool_input_hash")?;
+
+    Ok(ProbeEvidenceView {
+        receipt_present: true,
+        verification_result: VerificationResult::Unchecked,
+        issuer_id: Some(issuer_id.clone()),
+        claimed_issuer_tier: Some(get_string(&value, "claimed_issuer_tier")?),
+        policy_digest: Some(get_string(&value, "policy_digest")?),
+        spec: Some(get_string(&value, "spec")?),
+        tool_name: Some(get_string(&value, "tool_name")?),
+        decision: Some(get_string(&value, "decision")?),
+        binding_key: Some(format!(
+            "{issuer_id}|{session_id}|{sequence}|{tool_input_hash}"
+        )),
+    })
+}
+
+fn derive_malformed_probe_evidence(_name: &str) -> ProbeEvidenceView {
+    ProbeEvidenceView {
+        receipt_present: false,
+        verification_result: VerificationResult::Malformed,
+        issuer_id: None,
+        claimed_issuer_tier: None,
+        policy_digest: None,
+        spec: None,
+        tool_name: None,
+        decision: None,
+        binding_key: None,
+    }
+}
+
+fn validate_minimal_shape(value: &Value) -> Result<(), String> {
+    let type_name = get_string(value, "type")?;
+    if type_name != "protectmcp:decision" {
+        return Err(format!(
+            "unexpected type {:?}, expected \"protectmcp:decision\"",
+            type_name
+        ));
+    }
+
+    let decision = get_string(value, "decision")?;
+    if decision != "allow" && decision != "deny" {
+        return Err(format!(
+            "unexpected decision {:?}, expected \"allow\" or \"deny\"",
+            decision
+        ));
+    }
+
+    get_string(value, "tool_name")?;
+    get_string(value, "tool_input_hash")?;
+    get_string(value, "policy_digest")?;
+    get_string(value, "issued_at")?;
+    get_string(value, "issuer_id")?;
+    get_string(value, "spec")?;
+    get_string(value, "claimed_issuer_tier")?;
+    get_string(value, "session_id")?;
+    get_u64(value, "sequence")?;
+
+    let signature = value
+        .get("signature")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "missing or invalid object field \"signature\"".to_string())?;
+    get_string_from_object(signature, "alg")?;
+    get_string_from_object(signature, "kid")?;
+    get_string_from_object(signature, "sig")?;
+
+    Ok(())
+}
+
+fn get_string(value: &Value, field: &str) -> Result<String, String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("missing or invalid string field \"{field}\""))
+}
+
+fn get_u64(value: &Value, field: &str) -> Result<u64, String> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("missing or invalid integer field \"{field}\""))
+}
+
+fn get_string_from_object(
+    value: &serde_json::Map<String, Value>,
+    field: &str,
+) -> Result<String, String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("missing or invalid string field \"signature.{field}\""))
+}

--- a/docs/maintainers/PROTECT-MCP-INTEROP-PROBE-2026-04-04.md
+++ b/docs/maintainers/PROTECT-MCP-INTEROP-PROBE-2026-04-04.md
@@ -1,0 +1,132 @@
+# Protect MCP Receipt Interop Probe
+
+Date: 2026-04-04
+
+## Summary
+
+This probe was run as a bounded interop check, not as a product wave.
+
+The current state is mixed:
+
+- the Assay-side repo-local probe is clean and deterministic
+- existing MCP import regressions remain green
+- the advertised external verifier contract does not currently match reality
+
+The result is useful, but it does not justify opening a real evidence seam yet.
+
+## Corpus used
+
+Frozen fixture corpus:
+
+- `tests/fixtures/interop/protect_mcp_receipts/issuer_key.json`
+- `tests/fixtures/interop/protect_mcp_receipts/valid_allow.json`
+- `tests/fixtures/interop/protect_mcp_receipts/valid_deny.json`
+- `tests/fixtures/interop/protect_mcp_receipts/tampered.json`
+- `tests/fixtures/interop/protect_mcp_receipts/malformed.json`
+
+The receipt payloads were copied literally from the GitHub discussion corpus shared by `tomjwxf`, including the real Ed25519 signatures and the issuer public key.
+
+## Repo-local probe result
+
+Passed:
+
+- `cargo test -q -p assay-core --test receipt_interop_probe`
+
+Observed outcome:
+
+- all fixtures load deterministically
+- valid allow and valid deny receipts map to the bounded observed view
+- malformed input is rejected as malformed by the local shape gate
+- tampered input stays shape-valid but remains untrusted and unpromoted
+- only `verification_result` is treated as theoretically elevatable in the probe harness
+- binding is modeled as `issuer_id + session_id + sequence + tool_input_hash`
+
+Regression safety also passed:
+
+- `cargo test -q -p assay-core --test mcp_transport_compat`
+- `cargo test -q -p assay-core --test mcp_id_correlation`
+- `cargo test -q -p assay-cli --test mcp_transport_import`
+
+## External verifier probe result
+
+Verifier version tested:
+
+- `npx @veritasacta/verify@0.2.2`
+
+Manual boundary script:
+
+- `bash tests/probes/protect_mcp_receipt_verifier_boundary.sh`
+
+Result:
+
+- failed with 4 contract drift issues
+
+Observed drift against the discussion-stated contract:
+
+1. `valid_allow.json`
+   - expected: exit `0`
+   - actual: exit `1`
+   - stdout: `no_public_key`
+
+2. `valid_deny.json`
+   - expected: exit `0`
+   - actual: exit `1`
+   - stdout: `no_public_key`
+
+3. `tampered.json`
+   - expected: exit `1` with `FAILED:`
+   - actual: exit `1`, but not in the claimed failure shape
+   - stdout: `no_public_key`
+
+4. `malformed.json`
+   - expected: exit `2` with parse or malformed signal on `stderr`
+   - actual: exit `1`
+   - stdout: `no_public_key`
+
+Additional exploratory follow-up with the provided public key:
+
+- `npx @veritasacta/verify@0.2.2 --key <public_key_hex> valid_allow.json`
+  - exit `1`
+  - stdout: `verification_error`
+
+- `npx @veritasacta/verify@0.2.2 --key <public_key_hex> valid_deny.json`
+  - exit `1`
+  - stdout: `verification_error`
+
+- `npx @veritasacta/verify@0.2.2 --key <public_key_hex> tampered.json`
+  - exit `1`
+  - stdout: `verification_error`
+
+- `npx @veritasacta/verify@0.2.2 --key <public_key_hex> malformed.json`
+  - exit `1`
+  - stdout: `missing_signature`
+
+The verifier help output also diverges from the stated discussion contract:
+
+- help advertises only exit codes `0` and `1`
+- help does not advertise a dedicated exit code `2` path for malformed input
+
+## Unresolved contract gaps
+
+These remain the blocking gaps before a real Assay seam would make sense:
+
+- timestamp semantics stay signed-claim, not trusted fact
+- `tool_input_hash` still needs a canonicalization contract
+- binding identity is really issuer plus session plus sequence plus input hash
+- `verification_result` is only meaningful if Assay derives it or freezes a verifier boundary on purpose
+
+Additional probe-specific concern after the real run:
+
+- the current external verifier contract is not yet stable enough to treat as a clean boundary
+- even with the supplied public key, the "valid" sample receipts do not currently verify under `@veritasacta/verify@0.2.2`
+
+## Current maintainer call
+
+Do not open a product wave from this yet.
+
+The correct next step, if the discussion continues, is a tighter contract note on:
+
+- exact signature payload and canonicalization rules
+- exact verifier contract and versioned behavior
+- exact binding identity and collision assumptions
+- the difference between signed claims and Assay-promotable facts

--- a/tests/fixtures/interop/protect_mcp_receipts/README.md
+++ b/tests/fixtures/interop/protect_mcp_receipts/README.md
@@ -1,0 +1,17 @@
+This folder contains a probe corpus for external signed receipt interop.
+
+It is not a normative Assay schema.
+
+Only these fields are in scope for evaluation in the first probe:
+
+- `receipt_present`
+- `verification_result`
+- `issuer_id`
+- `claimed_issuer_tier`
+- `policy_digest`
+- `spec`
+- `tool_name`
+- `decision`
+- `session_id`
+- `sequence`
+- `tool_input_hash`

--- a/tests/fixtures/interop/protect_mcp_receipts/issuer_key.json
+++ b/tests/fixtures/interop/protect_mcp_receipts/issuer_key.json
@@ -1,0 +1,5 @@
+{
+  "kid": "sb:issuer:1feed234c727",
+  "alg": "EdDSA",
+  "public_key_hex": "1feed234c727d30cf5b5f7f27df5d6168620bd8fcfd0a565efea65c08e93ed89"
+}

--- a/tests/fixtures/interop/protect_mcp_receipts/malformed.json
+++ b/tests/fixtures/interop/protect_mcp_receipts/malformed.json
@@ -1,0 +1,4 @@
+{
+  "type": "protectmcp:decision",
+  "tool_name": "something"
+}

--- a/tests/fixtures/interop/protect_mcp_receipts/tampered.json
+++ b/tests/fixtures/interop/protect_mcp_receipts/tampered.json
@@ -1,0 +1,18 @@
+{
+  "type": "protectmcp:decision",
+  "tool_name": "delete_database",
+  "tool_input_hash": "sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76",
+  "decision": "deny",
+  "policy_digest": "sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b",
+  "issued_at": "2026-04-04T14:32:04.102Z",
+  "issuer_id": "sb:issuer:1feed234c727",
+  "spec": "draft-farley-acta-signed-receipts-01",
+  "claimed_issuer_tier": "self-signed",
+  "session_id": "sess_a1b2c3d4e5f6",
+  "sequence": 1,
+  "signature": {
+    "alg": "EdDSA",
+    "kid": "sb:issuer:1feed234c727",
+    "sig": "3da3162da83e2c99968f91059c5f56209f44a69c269a058ed7c2f0b80110ad878da25b86cf053386f31483001bfe50f3eca57d67f14f8114e629b3bd40dec30b"
+  }
+}

--- a/tests/fixtures/interop/protect_mcp_receipts/valid_allow.json
+++ b/tests/fixtures/interop/protect_mcp_receipts/valid_allow.json
@@ -1,0 +1,18 @@
+{
+  "type": "protectmcp:decision",
+  "tool_name": "read_file",
+  "tool_input_hash": "sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76",
+  "decision": "allow",
+  "policy_digest": "sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b",
+  "issued_at": "2026-04-04T14:32:04.102Z",
+  "issuer_id": "sb:issuer:1feed234c727",
+  "spec": "draft-farley-acta-signed-receipts-01",
+  "claimed_issuer_tier": "self-signed",
+  "session_id": "sess_a1b2c3d4e5f6",
+  "sequence": 1,
+  "signature": {
+    "alg": "EdDSA",
+    "kid": "sb:issuer:1feed234c727",
+    "sig": "3da3162da83e2c99968f91059c5f56209f44a69c269a058ed7c2f0b80110ad878da25b86cf053386f31483001bfe50f3eca57d67f14f8114e629b3bd40dec30b"
+  }
+}

--- a/tests/fixtures/interop/protect_mcp_receipts/valid_deny.json
+++ b/tests/fixtures/interop/protect_mcp_receipts/valid_deny.json
@@ -1,0 +1,19 @@
+{
+  "type": "protectmcp:decision",
+  "tool_name": "execute_command",
+  "tool_input_hash": "sha256:5c7923bd67b06c93279d49c466301c57023822eec29c49e269063e47aecd973c",
+  "decision": "deny",
+  "deny_reason": "Policy forbids destructive shell commands",
+  "policy_digest": "sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b",
+  "issued_at": "2026-04-04T14:32:05.218Z",
+  "issuer_id": "sb:issuer:1feed234c727",
+  "spec": "draft-farley-acta-signed-receipts-01",
+  "claimed_issuer_tier": "self-signed",
+  "session_id": "sess_a1b2c3d4e5f6",
+  "sequence": 2,
+  "signature": {
+    "alg": "EdDSA",
+    "kid": "sb:issuer:1feed234c727",
+    "sig": "d9ac58e7a399f3d4905ad564b5801e78cb5ea9ae96f229eea8d70770635780e6b63e47a40be5c02865ede2cd5fb4885093997daa4d86a194ab28a5f5316df20a"
+  }
+}

--- a/tests/probes/protect_mcp_receipt_verifier_boundary.sh
+++ b/tests/probes/protect_mcp_receipt_verifier_boundary.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "node is required for this probe" >&2
+  exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "npx is required for this probe" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+FIXTURE_DIR="${REPO_ROOT}/tests/fixtures/interop/protect_mcp_receipts"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+FAILURES=0
+
+report_failure() {
+  local message="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+
+  echo "${message}" >&2
+  echo "--- stdout ---" >&2
+  cat "${stdout_file}" >&2 || true
+  echo "--- stderr ---" >&2
+  cat "${stderr_file}" >&2 || true
+  FAILURES=$((FAILURES + 1))
+}
+
+run_case() {
+  local file="$1"
+  local expected_exit="$2"
+  local expected_stream="$3"
+  local expected_substring="$4"
+  local stdout_file="${TMP_DIR}/${file}.stdout"
+  local stderr_file="${TMP_DIR}/${file}.stderr"
+
+  echo "==> ${file}"
+
+  set +e
+  npm_config_loglevel=error npx --yes @veritasacta/verify@0.2.2 \
+    "${FIXTURE_DIR}/${file}" >"${stdout_file}" 2>"${stderr_file}"
+  local status=$?
+  set -e
+
+  if [[ "${status}" -ne "${expected_exit}" ]]; then
+    report_failure \
+      "unexpected exit code for ${file}: got ${status}, expected ${expected_exit}" \
+      "${stdout_file}" \
+      "${stderr_file}"
+    return
+  fi
+
+  case "${expected_stream}" in
+    stdout)
+      if ! grep -Fq "${expected_substring}" "${stdout_file}"; then
+        report_failure \
+          "expected stdout for ${file} to contain: ${expected_substring}" \
+          "${stdout_file}" \
+          "${stderr_file}"
+      fi
+      ;;
+    stderr_nonempty)
+      if [[ ! -s "${stderr_file}" ]]; then
+        report_failure \
+          "expected non-empty stderr for ${file}" \
+          "${stdout_file}" \
+          "${stderr_file}"
+      fi
+      ;;
+    *)
+      echo "unknown expected stream mode: ${expected_stream}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+run_case "valid_allow.json" 0 stdout "Verified:"
+run_case "valid_deny.json" 0 stdout "Verified:"
+run_case "tampered.json" 1 stdout "FAILED:"
+run_case "malformed.json" 2 stderr_nonempty ""
+
+echo
+if [[ "${FAILURES}" -gt 0 ]]; then
+  echo "protect-mcp verifier boundary probe detected ${FAILURES} contract drift issue(s)" >&2
+  exit 1
+fi
+
+echo "protect-mcp verifier boundary probe passed"


### PR DESCRIPTION
## Summary
- add a frozen ScopeBlind / VeritasActa signed-receipt probe corpus under `tests/fixtures/interop/protect_mcp_receipts`
- add a repo-local `assay-core` integration probe that derives the bounded evidence-only view without touching production code
- add a manual external verifier boundary script plus a maintainer note with the actual probe result

## Why
This is a probe, not a product wave.

The goal is to answer one question honestly: is there a real evidence-only seam here, or just a well-phrased proposal?

## Validation
- `cargo test -q -p assay-core --test receipt_interop_probe`
- `cargo test -q -p assay-core --test mcp_transport_compat`
- `cargo test -q -p assay-core --test mcp_id_correlation`
- `cargo test -q -p assay-cli --test mcp_transport_import`
- `bash tests/probes/protect_mcp_receipt_verifier_boundary.sh`

## Probe result
- repo-local probe: clean
- existing MCP import regressions: clean
- external verifier boundary: drift detected
  - keyless `npx @veritasacta/verify@0.2.2 <file>` does not match the stated discussion contract
  - `valid_allow.json` / `valid_deny.json` fail with `no_public_key`
  - even with the supplied public key, the "valid" receipts still fail with `verification_error`
  - malformed input does not expose the claimed exit-code split either
