### PR TITLE
test: rerun signed receipt probe on corrected corpus

### DIFF
--- a/crates/assay-core/tests/receipt_interop_probe.rs
+++ b/crates/assay-core/tests/receipt_interop_probe.rs
@@ -50,6 +50,7 @@ fn contract_probe_fixture_inventory_is_complete() {
                 .into_string()
                 .expect("utf-8 filename")
         })
+        .filter(|name| !name.starts_with('.'))
         .collect();
     actual.sort();
 
@@ -223,6 +224,7 @@ fn derive_malformed_probe_evidence(_name: &str) -> ProbeEvidenceView {
 fn validate_minimal_shape(value: &Value) -> Result<&Value, String> {
     let payload = value
         .get("payload")
+        .filter(|payload| payload.is_object())
         .ok_or_else(|| "missing or invalid object field \"payload\"".to_string())?;
     let type_name = get_string(payload, "type")?;
     if type_name != "protectmcp:decision" {

--- a/crates/assay-core/tests/receipt_interop_probe.rs
+++ b/crates/assay-core/tests/receipt_interop_probe.rs
@@ -60,11 +60,11 @@ fn contract_probe_fixture_inventory_is_complete() {
 fn contract_probe_issuer_key_fixture_is_loadable() {
     let value = read_fixture_json("issuer_key.json");
 
-    assert_eq!(value["kid"], "sb:issuer:1feed234c727");
+    assert_eq!(value["kid"], "sb:issuer:de073ae64e43");
     assert_eq!(value["alg"], "EdDSA");
     assert_eq!(
         value["public_key_hex"],
-        "1feed234c727d30cf5b5f7f27df5d6168620bd8fcfd0a565efea65c08e93ed89"
+        "de073ae64e43c33ed5a0b3b238d44865052e0c7eed4f87f81f9f2c5ce37a1dfa"
     );
 }
 
@@ -77,14 +77,14 @@ fn contract_probe_valid_allow_maps_to_observed_view() {
         ProbeEvidenceView {
             receipt_present: true,
             verification_result: VerificationResult::Unchecked,
-            issuer_id: Some("sb:issuer:1feed234c727".to_string()),
+            issuer_id: Some("sb:issuer:de073ae64e43".to_string()),
             claimed_issuer_tier: Some("self-signed".to_string()),
             policy_digest: Some("sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b".to_string()),
             spec: Some("draft-farley-acta-signed-receipts-01".to_string()),
             tool_name: Some("read_file".to_string()),
             decision: Some("allow".to_string()),
             binding_key: Some(
-                "sb:issuer:1feed234c727|sess_a1b2c3d4e5f6|1|sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76"
+                "sb:issuer:de073ae64e43|sess_a1b2c3d4e5f6|1|sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76"
                     .to_string(),
             ),
         }
@@ -101,14 +101,14 @@ fn contract_probe_valid_deny_maps_to_observed_view() {
         ProbeEvidenceView {
             receipt_present: true,
             verification_result: VerificationResult::Unchecked,
-            issuer_id: Some("sb:issuer:1feed234c727".to_string()),
+            issuer_id: Some("sb:issuer:de073ae64e43".to_string()),
             claimed_issuer_tier: Some("self-signed".to_string()),
             policy_digest: Some("sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b".to_string()),
             spec: Some("draft-farley-acta-signed-receipts-01".to_string()),
             tool_name: Some("execute_command".to_string()),
             decision: Some("deny".to_string()),
             binding_key: Some(
-                "sb:issuer:1feed234c727|sess_a1b2c3d4e5f6|2|sha256:5c7923bd67b06c93279d49c466301c57023822eec29c49e269063e47aecd973c"
+                "sb:issuer:de073ae64e43|sess_a1b2c3d4e5f6|2|sha256:5c7923bd67b06c93279d49c466301c57023822eec29c49e269063e47aecd973c"
                     .to_string(),
             ),
         }
@@ -127,7 +127,7 @@ fn contract_probe_tampered_receipt_stays_unchecked_and_unpromoted() {
     assert_eq!(
         view.binding_key.as_deref(),
         Some(
-            "sb:issuer:1feed234c727|sess_a1b2c3d4e5f6|1|sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76"
+            "sb:issuer:de073ae64e43|sess_a1b2c3d4e5f6|1|sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76"
         )
     );
     assert_eq!(view.elevatable_fields(), vec!["verification_result"]);
@@ -138,7 +138,7 @@ fn contract_probe_malformed_receipt_is_rejected_as_malformed() {
     let err = derive_probe_evidence("malformed.json").expect_err("malformed receipt must fail");
 
     assert!(
-        err.contains("missing or invalid string field \"decision\""),
+        err.contains("missing or invalid object field \"payload\""),
         "unexpected malformed error: {err}"
     );
 
@@ -184,22 +184,22 @@ fn read_fixture_json(name: &str) -> Value {
 
 fn derive_probe_evidence(name: &str) -> Result<ProbeEvidenceView, String> {
     let value = read_fixture_json(name);
-    validate_minimal_shape(&value)?;
+    let payload = validate_minimal_shape(&value)?;
 
-    let issuer_id = get_string(&value, "issuer_id")?;
-    let session_id = get_string(&value, "session_id")?;
-    let sequence = get_u64(&value, "sequence")?;
-    let tool_input_hash = get_string(&value, "tool_input_hash")?;
+    let issuer_id = get_string(payload, "issuer_id")?;
+    let session_id = get_string(payload, "session_id")?;
+    let sequence = get_u64(payload, "sequence")?;
+    let tool_input_hash = get_string(payload, "tool_input_hash")?;
 
     Ok(ProbeEvidenceView {
         receipt_present: true,
         verification_result: VerificationResult::Unchecked,
         issuer_id: Some(issuer_id.clone()),
-        claimed_issuer_tier: Some(get_string(&value, "claimed_issuer_tier")?),
-        policy_digest: Some(get_string(&value, "policy_digest")?),
-        spec: Some(get_string(&value, "spec")?),
-        tool_name: Some(get_string(&value, "tool_name")?),
-        decision: Some(get_string(&value, "decision")?),
+        claimed_issuer_tier: Some(get_string(payload, "claimed_issuer_tier")?),
+        policy_digest: Some(get_string(payload, "policy_digest")?),
+        spec: Some(get_string(payload, "spec")?),
+        tool_name: Some(get_string(payload, "tool_name")?),
+        decision: Some(get_string(payload, "decision")?),
         binding_key: Some(format!(
             "{issuer_id}|{session_id}|{sequence}|{tool_input_hash}"
         )),
@@ -220,8 +220,11 @@ fn derive_malformed_probe_evidence(_name: &str) -> ProbeEvidenceView {
     }
 }
 
-fn validate_minimal_shape(value: &Value) -> Result<(), String> {
-    let type_name = get_string(value, "type")?;
+fn validate_minimal_shape(value: &Value) -> Result<&Value, String> {
+    let payload = value
+        .get("payload")
+        .ok_or_else(|| "missing or invalid object field \"payload\"".to_string())?;
+    let type_name = get_string(payload, "type")?;
     if type_name != "protectmcp:decision" {
         return Err(format!(
             "unexpected type {:?}, expected \"protectmcp:decision\"",
@@ -229,7 +232,7 @@ fn validate_minimal_shape(value: &Value) -> Result<(), String> {
         ));
     }
 
-    let decision = get_string(value, "decision")?;
+    let decision = get_string(payload, "decision")?;
     if decision != "allow" && decision != "deny" {
         return Err(format!(
             "unexpected decision {:?}, expected \"allow\" or \"deny\"",
@@ -237,15 +240,15 @@ fn validate_minimal_shape(value: &Value) -> Result<(), String> {
         ));
     }
 
-    get_string(value, "tool_name")?;
-    get_string(value, "tool_input_hash")?;
-    get_string(value, "policy_digest")?;
-    get_string(value, "issued_at")?;
-    get_string(value, "issuer_id")?;
-    get_string(value, "spec")?;
-    get_string(value, "claimed_issuer_tier")?;
-    get_string(value, "session_id")?;
-    get_u64(value, "sequence")?;
+    get_string(payload, "tool_name")?;
+    get_string(payload, "tool_input_hash")?;
+    get_string(payload, "policy_digest")?;
+    get_string(payload, "issued_at")?;
+    get_string(payload, "issuer_id")?;
+    get_string(payload, "spec")?;
+    get_string(payload, "claimed_issuer_tier")?;
+    get_string(payload, "session_id")?;
+    get_u64(payload, "sequence")?;
 
     let signature = value
         .get("signature")
@@ -255,7 +258,7 @@ fn validate_minimal_shape(value: &Value) -> Result<(), String> {
     get_string_from_object(signature, "kid")?;
     get_string_from_object(signature, "sig")?;
 
-    Ok(())
+    Ok(payload)
 }
 
 fn get_string(value: &Value, field: &str) -> Result<String, String> {

--- a/docs/maintainers/PROTECT-MCP-INTEROP-PROBE-2026-04-04.md
+++ b/docs/maintainers/PROTECT-MCP-INTEROP-PROBE-2026-04-04.md
@@ -6,13 +6,14 @@ Date: 2026-04-04
 
 This probe was run as a bounded interop check, not as a product wave.
 
-The current state is mixed:
+The current state is now clearer than in the first pass:
 
 - the Assay-side repo-local probe is clean and deterministic
 - existing MCP import regressions remain green
-- the advertised external verifier contract does not currently match reality
+- the original external verifier mismatch was caused by a wrong corpus envelope
+- the corrected Passport-envelope corpus now verifies under a pinned external boundary
 
-The result is useful, but it does not justify opening a real evidence seam yet.
+This is a better result than the first pass, but it still does not justify opening a real evidence seam yet.
 
 ## Corpus used
 
@@ -24,7 +25,12 @@ Frozen fixture corpus:
 - `tests/fixtures/interop/protect_mcp_receipts/tampered.json`
 - `tests/fixtures/interop/protect_mcp_receipts/malformed.json`
 
-The receipt payloads were copied literally from the GitHub discussion corpus shared by `tomjwxf`, including the real Ed25519 signatures and the issuer public key.
+The valid and tampered fixtures now use the corrected Passport envelope shape:
+
+- `payload`
+- `signature`
+
+The malformed fixture intentionally remains malformed.
 
 ## Repo-local probe result
 
@@ -51,7 +57,7 @@ Regression safety also passed:
 
 Verifier version tested:
 
-- `npx @veritasacta/verify@0.2.2`
+- `npx @veritasacta/verify@0.2.4`
 
 Manual boundary script:
 
@@ -59,72 +65,55 @@ Manual boundary script:
 
 Result:
 
-- failed with 4 contract drift issues
+- passed against the corrected corpus and command contract
 
-Observed drift against the discussion-stated contract:
+Observed behavior:
 
 1. `valid_allow.json`
-   - expected: exit `0`
-   - actual: exit `1`
-   - stdout: `no_public_key`
+   - command: `npx @veritasacta/verify@0.2.4 valid_allow.json --key <public_key_hex>`
+   - exit: `0`
+   - stdout contains: `Signature: VALID`
 
 2. `valid_deny.json`
-   - expected: exit `0`
-   - actual: exit `1`
-   - stdout: `no_public_key`
+   - command: `npx @veritasacta/verify@0.2.4 valid_deny.json --key <public_key_hex>`
+   - exit: `0`
+   - stdout contains: `Signature: VALID`
 
 3. `tampered.json`
-   - expected: exit `1` with `FAILED:`
-   - actual: exit `1`, but not in the claimed failure shape
-   - stdout: `no_public_key`
+   - command: `npx @veritasacta/verify@0.2.4 tampered.json --key <public_key_hex>`
+   - exit: `1`
+   - stdout contains: `Signature: INVALID`
 
 4. `malformed.json`
-   - expected: exit `2` with parse or malformed signal on `stderr`
-   - actual: exit `1`
-   - stdout: `no_public_key`
+   - command: `npx @veritasacta/verify@0.2.4 malformed.json`
+   - exit: `1`
+   - stdout contains: `no_public_key`
 
-Additional exploratory follow-up with the provided public key:
+Important correction from the discussion:
 
-- `npx @veritasacta/verify@0.2.2 --key <public_key_hex> valid_allow.json`
-  - exit `1`
-  - stdout: `verification_error`
-
-- `npx @veritasacta/verify@0.2.2 --key <public_key_hex> valid_deny.json`
-  - exit `1`
-  - stdout: `verification_error`
-
-- `npx @veritasacta/verify@0.2.2 --key <public_key_hex> tampered.json`
-  - exit `1`
-  - stdout: `verification_error`
-
-- `npx @veritasacta/verify@0.2.2 --key <public_key_hex> malformed.json`
-  - exit `1`
-  - stdout: `missing_signature`
-
-The verifier help output also diverges from the stated discussion contract:
-
-- help advertises only exit codes `0` and `1`
-- help does not advertise a dedicated exit code `2` path for malformed input
+- the first corpus was wrong because it used root-level payload fields instead of Passport envelope shape
+- the published verifier boundary that works here is the corrected one with `@0.2.4` plus explicit `--key` for the signed Passport-envelope receipts
+- malformed input does not expose a separate exit code split; the current public CLI still advertises only exit codes `0` and `1`
 
 ## Unresolved contract gaps
 
 These remain the blocking gaps before a real Assay seam would make sense:
 
 - timestamp semantics stay signed-claim, not trusted fact
-- `tool_input_hash` still needs a canonicalization contract
+- `tool_input_hash` still needs a sharper interoperability contract if Assay ever wants to reason about it beyond opaque binding
 - binding identity is really issuer plus session plus sequence plus input hash
 - `verification_result` is only meaningful if Assay derives it or freezes a verifier boundary on purpose
 
-Additional probe-specific concern after the real run:
+Additional probe-specific caution after the rerun:
 
-- the current external verifier contract is not yet stable enough to treat as a clean boundary
-- even with the supplied public key, the "valid" sample receipts do not currently verify under `@veritasacta/verify@0.2.2`
+- the verifier boundary is better, but still young enough that Assay should pin version and invocation shape explicitly if this ever moves beyond a probe
+- the current successful path depends on explicit `--key` usage for the signed Passport-envelope receipts
 
 ## Current maintainer call
 
 Do not open a product wave from this yet.
 
-The correct next step, if the discussion continues, is a tighter contract note on:
+The correct next step, if the discussion continues, is still a tighter contract note on:
 
 - exact signature payload and canonicalization rules
 - exact verifier contract and versioned behavior

--- a/docs/maintainers/PROTECT-MCP-INTEROP-PROBE-2026-04-04.md
+++ b/docs/maintainers/PROTECT-MCP-INTEROP-PROBE-2026-04-04.md
@@ -119,3 +119,8 @@ The correct next step, if the discussion continues, is still a tighter contract 
 - exact verifier contract and versioned behavior
 - exact binding identity and collision assumptions
 - the difference between signed claims and Assay-promotable facts
+
+See also:
+
+- `docs/maintainers/PROTECT-MCP-RECEIPT-CONTRACT-NOTE-2026-04-04.md`
+- `docs/maintainers/PROTECT-MCP-RECEIPT-DECISION-2026-04-04.md`

--- a/docs/maintainers/PROTECT-MCP-RECEIPT-CONTRACT-NOTE-2026-04-04.md
+++ b/docs/maintainers/PROTECT-MCP-RECEIPT-CONTRACT-NOTE-2026-04-04.md
@@ -1,0 +1,82 @@
+# Protect MCP Receipt Contract Note
+
+Date: 2026-04-04
+
+## Purpose
+
+This note records the smallest contract we would need to freeze if the current signed-receipt probe ever graduates beyond probe status.
+
+It is not a product commitment.
+
+## Candidate contract shape
+
+Current working probe shape:
+
+- Passport envelope
+  - `payload`
+  - `signature`
+- verifier boundary
+  - `npx @veritasacta/verify@0.2.4`
+  - explicit `--key <public_key_hex>` for signed sample receipts
+
+The current bounded receipt fields of interest are:
+
+- `payload.type`
+- `payload.tool_name`
+- `payload.tool_input_hash`
+- `payload.decision`
+- `payload.policy_digest`
+- `payload.issued_at`
+- `payload.issuer_id`
+- `payload.spec`
+- `payload.claimed_issuer_tier`
+- `payload.session_id`
+- `payload.sequence`
+- `signature.alg`
+- `signature.kid`
+
+## Assay-side interpretation
+
+If this ever moves beyond probe status, the current bounded interpretation should stay:
+
+- `receipt_present`
+  - derived from envelope presence
+- `verification_result`
+  - derived by Assay from the pinned verifier boundary
+- `issuer_id`
+  - observed metadata only
+- `claimed_issuer_tier`
+  - observed metadata only
+- `policy_digest`
+  - observed metadata only
+- `spec`
+  - observed metadata only
+- `tool_name`
+  - observed metadata only
+- `decision`
+  - observed metadata only
+
+No trust tier, certification, adequacy, or compliance semantics should be inferred from these fields.
+
+## Binding note
+
+The minimum identity shape we should reason about is:
+
+- `issuer_id + session_id + sequence`
+
+`tool_input_hash` is useful as an additional binding token, but should still be treated cautiously until the interoperability contract is sharper.
+
+For now, the safest reading is:
+
+- `issuer_id + session_id + sequence` identifies the claimed decision slot
+- `tool_input_hash` is an opaque adjunct claim about the input bound to that slot
+
+## Open contract gaps
+
+These still need to be tightened before any real seam would be justified:
+
+- `issued_at` remains a signed claim, not a trusted fact
+- `tool_input_hash` semantics remain too loose for hard Assay-side reasoning beyond opaque binding
+- malformed behavior is still not rich or separately classified by the public verifier CLI
+- key handling is still explicit and manual in the working probe path
+- the verifier boundary only becomes meaningful if Assay pins version and invocation shape deliberately

--- a/docs/maintainers/PROTECT-MCP-RECEIPT-DECISION-2026-04-04.md
+++ b/docs/maintainers/PROTECT-MCP-RECEIPT-DECISION-2026-04-04.md
@@ -1,0 +1,42 @@
+# Protect MCP Receipt Decision Note
+
+Date: 2026-04-04
+
+## Decision
+
+Keep the ScopeBlind / VeritasActa signed-receipt line at **probe status**.
+
+Do not open a product wave, schema freeze, public roadmap item, pack, or Trust Card extension from this yet.
+
+## Why
+
+The corrected second probe materially improved confidence:
+
+- Assay can ingest the bounded receipt shape cleanly in a test-only harness
+- existing MCP import behavior remains unaffected
+- the corrected Passport-envelope samples verify under a pinned external boundary
+
+That is enough to say the surface is credible.
+
+It is not enough to say the surface is ready.
+
+## What is still missing
+
+The remaining blockers are contract quality, not basic feasibility:
+
+- timestamp semantics are still claim-shaped
+- `tool_input_hash` is still not strong enough for hard reasoning without a tighter interop story
+- binding identity still needs a frozen statement of assumptions
+- malformed and key-handling behavior are still too young to treat as stable public boundary semantics
+
+## Maintainer call
+
+Current call:
+
+- keep exploring in discussion if useful
+- allow future bounded probes
+- do not imply adoption
+- do not imply trust promotion
+- do not imply that a real Assay evidence seam has been accepted
+
+If this line moves again, the next acceptable step is a tighter contract pass, not implementation.

--- a/tests/fixtures/interop/protect_mcp_receipts/README.md
+++ b/tests/fixtures/interop/protect_mcp_receipts/README.md
@@ -2,7 +2,14 @@ This folder contains a probe corpus for external signed receipt interop.
 
 It is not a normative Assay schema.
 
-Only these fields are in scope for evaluation in the first probe:
+The corrected valid fixtures use Passport envelope shape:
+
+- `payload`
+- `signature`
+
+The malformed fixture intentionally stays malformed.
+
+Only these fields are in scope for evaluation in this probe:
 
 - `receipt_present`
 - `verification_result`

--- a/tests/fixtures/interop/protect_mcp_receipts/issuer_key.json
+++ b/tests/fixtures/interop/protect_mcp_receipts/issuer_key.json
@@ -1,5 +1,5 @@
 {
-  "kid": "sb:issuer:1feed234c727",
+  "kid": "sb:issuer:de073ae64e43",
   "alg": "EdDSA",
-  "public_key_hex": "1feed234c727d30cf5b5f7f27df5d6168620bd8fcfd0a565efea65c08e93ed89"
+  "public_key_hex": "de073ae64e43c33ed5a0b3b238d44865052e0c7eed4f87f81f9f2c5ce37a1dfa"
 }

--- a/tests/fixtures/interop/protect_mcp_receipts/tampered.json
+++ b/tests/fixtures/interop/protect_mcp_receipts/tampered.json
@@ -1,18 +1,20 @@
 {
-  "type": "protectmcp:decision",
-  "tool_name": "delete_database",
-  "tool_input_hash": "sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76",
-  "decision": "deny",
-  "policy_digest": "sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b",
-  "issued_at": "2026-04-04T14:32:04.102Z",
-  "issuer_id": "sb:issuer:1feed234c727",
-  "spec": "draft-farley-acta-signed-receipts-01",
-  "claimed_issuer_tier": "self-signed",
-  "session_id": "sess_a1b2c3d4e5f6",
-  "sequence": 1,
+  "payload": {
+    "type": "protectmcp:decision",
+    "tool_name": "delete_database",
+    "tool_input_hash": "sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76",
+    "decision": "deny",
+    "policy_digest": "sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b",
+    "issued_at": "2026-04-04T14:32:04.102Z",
+    "issuer_id": "sb:issuer:de073ae64e43",
+    "spec": "draft-farley-acta-signed-receipts-01",
+    "claimed_issuer_tier": "self-signed",
+    "session_id": "sess_a1b2c3d4e5f6",
+    "sequence": 1
+  },
   "signature": {
     "alg": "EdDSA",
-    "kid": "sb:issuer:1feed234c727",
-    "sig": "3da3162da83e2c99968f91059c5f56209f44a69c269a058ed7c2f0b80110ad878da25b86cf053386f31483001bfe50f3eca57d67f14f8114e629b3bd40dec30b"
+    "kid": "sb:issuer:de073ae64e43",
+    "sig": "2a3b5022316e37abee4e02bf37aab97d7970db619e5d4e84365579a9d7b4034dd774fcd224eaebdc020469150994b6199f8d49385736f7074f89c8a3e685c702"
   }
 }

--- a/tests/fixtures/interop/protect_mcp_receipts/valid_allow.json
+++ b/tests/fixtures/interop/protect_mcp_receipts/valid_allow.json
@@ -1,18 +1,20 @@
 {
-  "type": "protectmcp:decision",
-  "tool_name": "read_file",
-  "tool_input_hash": "sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76",
-  "decision": "allow",
-  "policy_digest": "sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b",
-  "issued_at": "2026-04-04T14:32:04.102Z",
-  "issuer_id": "sb:issuer:1feed234c727",
-  "spec": "draft-farley-acta-signed-receipts-01",
-  "claimed_issuer_tier": "self-signed",
-  "session_id": "sess_a1b2c3d4e5f6",
-  "sequence": 1,
+  "payload": {
+    "type": "protectmcp:decision",
+    "tool_name": "read_file",
+    "tool_input_hash": "sha256:ff7e2796c004bfab32b6b81f06e4a70e21ca0b5231398b15035b0d4582331c76",
+    "decision": "allow",
+    "policy_digest": "sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b",
+    "issued_at": "2026-04-04T14:32:04.102Z",
+    "issuer_id": "sb:issuer:de073ae64e43",
+    "spec": "draft-farley-acta-signed-receipts-01",
+    "claimed_issuer_tier": "self-signed",
+    "session_id": "sess_a1b2c3d4e5f6",
+    "sequence": 1
+  },
   "signature": {
     "alg": "EdDSA",
-    "kid": "sb:issuer:1feed234c727",
-    "sig": "3da3162da83e2c99968f91059c5f56209f44a69c269a058ed7c2f0b80110ad878da25b86cf053386f31483001bfe50f3eca57d67f14f8114e629b3bd40dec30b"
+    "kid": "sb:issuer:de073ae64e43",
+    "sig": "2a3b5022316e37abee4e02bf37aab97d7970db619e5d4e84365579a9d7b4034dd774fcd224eaebdc020469150994b6199f8d49385736f7074f89c8a3e685c702"
   }
 }

--- a/tests/fixtures/interop/protect_mcp_receipts/valid_deny.json
+++ b/tests/fixtures/interop/protect_mcp_receipts/valid_deny.json
@@ -1,19 +1,21 @@
 {
-  "type": "protectmcp:decision",
-  "tool_name": "execute_command",
-  "tool_input_hash": "sha256:5c7923bd67b06c93279d49c466301c57023822eec29c49e269063e47aecd973c",
-  "decision": "deny",
-  "deny_reason": "Policy forbids destructive shell commands",
-  "policy_digest": "sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b",
-  "issued_at": "2026-04-04T14:32:05.218Z",
-  "issuer_id": "sb:issuer:1feed234c727",
-  "spec": "draft-farley-acta-signed-receipts-01",
-  "claimed_issuer_tier": "self-signed",
-  "session_id": "sess_a1b2c3d4e5f6",
-  "sequence": 2,
+  "payload": {
+    "type": "protectmcp:decision",
+    "tool_name": "execute_command",
+    "tool_input_hash": "sha256:5c7923bd67b06c93279d49c466301c57023822eec29c49e269063e47aecd973c",
+    "decision": "deny",
+    "deny_reason": "Policy forbids destructive shell commands",
+    "policy_digest": "sha256:9d0fd4c9e72c1d5d8a3b7f2e1c4d6a8b",
+    "issued_at": "2026-04-04T14:32:05.218Z",
+    "issuer_id": "sb:issuer:de073ae64e43",
+    "spec": "draft-farley-acta-signed-receipts-01",
+    "claimed_issuer_tier": "self-signed",
+    "session_id": "sess_a1b2c3d4e5f6",
+    "sequence": 2
+  },
   "signature": {
     "alg": "EdDSA",
-    "kid": "sb:issuer:1feed234c727",
-    "sig": "d9ac58e7a399f3d4905ad564b5801e78cb5ea9ae96f229eea8d70770635780e6b63e47a40be5c02865ede2cd5fb4885093997daa4d86a194ab28a5f5316df20a"
+    "kid": "sb:issuer:de073ae64e43",
+    "sig": "d77e3d49a2f771c6b6be2068b9712dac032a22993ed74c38bbc758b239cdb161465328417308711b6153f36dbf49fc637ddb9ed68d2893304193019d47313f0a"
   }
 }

--- a/tests/probes/protect_mcp_receipt_verifier_boundary.sh
+++ b/tests/probes/protect_mcp_receipt_verifier_boundary.sh
@@ -14,6 +14,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 FIXTURE_DIR="${REPO_ROOT}/tests/fixtures/interop/protect_mcp_receipts"
+KEY="$(jq -r '.public_key_hex' "${FIXTURE_DIR}/issuer_key.json")"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 FAILURES=0
@@ -36,14 +37,20 @@ run_case() {
   local expected_exit="$2"
   local expected_stream="$3"
   local expected_substring="$4"
+  local use_key="${5:-false}"
   local stdout_file="${TMP_DIR}/${file}.stdout"
   local stderr_file="${TMP_DIR}/${file}.stderr"
 
   echo "==> ${file}"
 
   set +e
-  npm_config_loglevel=error npx --yes @veritasacta/verify@0.2.2 \
-    "${FIXTURE_DIR}/${file}" >"${stdout_file}" 2>"${stderr_file}"
+  if [[ "${use_key}" == "true" ]]; then
+    npm_config_loglevel=error npx --yes @veritasacta/verify@0.2.4 \
+      "${FIXTURE_DIR}/${file}" --key "${KEY}" >"${stdout_file}" 2>"${stderr_file}"
+  else
+    npm_config_loglevel=error npx --yes @veritasacta/verify@0.2.4 \
+      "${FIXTURE_DIR}/${file}" >"${stdout_file}" 2>"${stderr_file}"
+  fi
   local status=$?
   set -e
 
@@ -79,10 +86,10 @@ run_case() {
   esac
 }
 
-run_case "valid_allow.json" 0 stdout "Verified:"
-run_case "valid_deny.json" 0 stdout "Verified:"
-run_case "tampered.json" 1 stdout "FAILED:"
-run_case "malformed.json" 2 stderr_nonempty ""
+run_case "valid_allow.json" 0 stdout "Signature: VALID" true
+run_case "valid_deny.json" 0 stdout "Signature: VALID" true
+run_case "tampered.json" 1 stdout "Signature: INVALID" true
+run_case "malformed.json" 1 stdout "no_public_key" false
 
 echo
 if [[ "${FAILURES}" -gt 0 ]]; then

--- a/tests/probes/protect_mcp_receipt_verifier_boundary.sh
+++ b/tests/probes/protect_mcp_receipt_verifier_boundary.sh
@@ -11,10 +11,19 @@ if ! command -v npx >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for this probe" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 FIXTURE_DIR="${REPO_ROOT}/tests/fixtures/interop/protect_mcp_receipts"
 KEY="$(jq -r '.public_key_hex' "${FIXTURE_DIR}/issuer_key.json")"
+if [[ -z "${KEY}" || "${KEY}" == "null" ]]; then
+  echo "invalid issuer key fixture: .public_key_hex is missing, null, or empty in ${FIXTURE_DIR}/issuer_key.json" >&2
+  exit 1
+fi
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 FAILURES=0


### PR DESCRIPTION
## Summary
- rerun the signed receipt interop probe against the corrected Passport-envelope corpus from discussion #1029
- update the repo-local probe to read `payload` plus `signature` instead of the incorrect root-level shape
- update the manual verifier boundary script to the pinned working command shape on `@veritasacta/verify@0.2.4`
- refresh the maintainer note with the real rerun outcome

## Why
The first probe was still useful, but it exposed a corpus/envelope mismatch rather than a settled verifier boundary.

This follow-up keeps the same bounded probe, but re-tests it against the corrected artifacts Tom provided.

## Validation
- `cargo test -q -p assay-core --test receipt_interop_probe`
- `cargo test -q -p assay-core --test mcp_transport_compat`
- `cargo test -q -p assay-core --test mcp_id_correlation`
- `cargo test -q -p assay-cli --test mcp_transport_import`
- `bash tests/probes/protect_mcp_receipt_verifier_boundary.sh`

## Rerun result
- repo-local probe: clean
- existing MCP import regressions: clean
- external verifier boundary on corrected corpus: clean with pinned invocation
  - `@veritasacta/verify@0.2.4`
  - Passport envelope fixtures
  - explicit `--key` for valid and tampered signed samples
- malformed input still remains a looser edge and does not expose a separate exit code split
