### PR TITLE
test: rerun signed receipt probe on verifier 0.2.5

### DIFF
--- a/docs/maintainers/PROTECT-MCP-INTEROP-PROBE-2026-04-06.md
+++ b/docs/maintainers/PROTECT-MCP-INTEROP-PROBE-2026-04-06.md
@@ -1,0 +1,94 @@
+# Protect MCP Receipt Interop Probe Follow-Up
+
+Date: 2026-04-06
+
+## Summary
+
+This follow-up reran the external verifier boundary after Tom shipped `@veritasacta/verify@0.2.5` with the promised 3-way exit code split.
+
+The result is materially better than the `@0.2.4` state:
+
+- the cleaner verifier classification now holds on our side
+- the repo-local Assay probe still stays clean and bounded
+- the current maintainer call does not change: this remains a probe, not a product seam
+
+## What changed
+
+The pinned manual boundary script now targets:
+
+- `npx @veritasacta/verify@0.2.5`
+
+The current observed exit-code contract on our side is:
+
+- `0` = valid signature
+- `1` = invalid signature
+- `2` = verifier error
+
+This is the split we had asked for in the discussion because it keeps genuine tamper failures separate from "the verifier could not make a determination."
+
+## Repo-local probe result
+
+Passed:
+
+- `cargo test -q -p assay-core --test receipt_interop_probe`
+- `cargo test -q -p assay-core --test mcp_transport_compat`
+- `cargo test -q -p assay-core --test mcp_id_correlation`
+- `cargo test -q -p assay-cli --test mcp_transport_import`
+
+Observed outcome:
+
+- the bounded Assay-side interpretation did not need to widen
+- valid and tampered samples still behave the same in the local harness
+- existing MCP import seams remain unaffected
+
+## External verifier probe result
+
+Passed:
+
+- `bash tests/probes/protect_mcp_receipt_verifier_boundary.sh`
+
+Observed behavior with `@veritasacta/verify@0.2.5`:
+
+1. `valid_allow.json`
+   - exit: `0`
+   - stdout contains: `Signature: VALID`
+
+2. `valid_deny.json`
+   - exit: `0`
+   - stdout contains: `Signature: VALID`
+
+3. `tampered.json`
+   - exit: `1`
+   - stdout contains: `Signature: INVALID`
+
+4. `malformed.json`
+   - exit: `2`
+   - stdout contains: `no_public_key`
+
+Important nuance:
+
+- the exit-code split is now much cleaner
+- the human-readable stream output is still not something Assay should treat as a semantic contract
+- the stable boundary worth freezing, if this ever graduates, is version plus invocation shape plus exit-code behavior
+
+## Maintainer call
+
+This improves confidence in the verifier boundary, but it still does not justify opening an Assay wave.
+
+Current call remains:
+
+- keep this at probe status
+- do not imply adoption
+- do not freeze public Assay schema from it yet
+
+The verifier side is now in better shape. The remaining caution is still around contract scope:
+
+- timestamp semantics remain claim-shaped
+- `tool_input_hash` remains an opaque binding token, not a hard fact
+- binding identity assumptions still need deliberate freezing if this ever moves beyond probe status
+
+See also:
+
+- `docs/maintainers/PROTECT-MCP-INTEROP-PROBE-2026-04-04.md`
+- `docs/maintainers/PROTECT-MCP-RECEIPT-CONTRACT-NOTE-2026-04-04.md`
+- `docs/maintainers/PROTECT-MCP-RECEIPT-DECISION-2026-04-04.md`

--- a/docs/maintainers/PROTECT-MCP-RECEIPT-CONTRACT-NOTE-2026-04-04.md
+++ b/docs/maintainers/PROTECT-MCP-RECEIPT-CONTRACT-NOTE-2026-04-04.md
@@ -2,6 +2,14 @@
 
 Date: 2026-04-04
 
+Update: 2026-04-06
+
+The verifier boundary improved after the `@veritasacta/verify@0.2.5` rerun. The preferred contract now assumes the 3-way exit split:
+
+- `0 = valid`
+- `1 = invalid`
+- `2 = error`
+
 ## Purpose
 
 This note records the smallest contract we would need to freeze if the current signed-receipt probe ever graduates beyond probe status.
@@ -16,7 +24,7 @@ Current working probe shape:
   - `payload`
   - `signature`
 - verifier boundary
-  - `npx @veritasacta/verify@0.2.4`
+  - `npx @veritasacta/verify@0.2.5`
   - explicit `--key <public_key_hex>` for signed sample receipts
 
 The current bounded receipt fields of interest are:
@@ -43,6 +51,7 @@ If this ever moves beyond probe status, the current bounded interpretation shoul
   - derived from envelope presence
 - `verification_result`
   - derived by Assay from the pinned verifier boundary
+  - preferred interpretation is `valid | invalid | error`
 - `issuer_id`
   - observed metadata only
 - `claimed_issuer_tier`
@@ -77,6 +86,6 @@ These still need to be tightened before any real seam would be justified:
 
 - `issued_at` remains a signed claim, not a trusted fact
 - `tool_input_hash` semantics remain too loose for hard Assay-side reasoning beyond opaque binding
-- malformed behavior is still not rich or separately classified by the public verifier CLI
+- the public verifier text output remains human-oriented, so Assay should freeze exit-code semantics rather than stdout or stderr wording
 - key handling is still explicit and manual in the working probe path
 - the verifier boundary only becomes meaningful if Assay pins version and invocation shape deliberately

--- a/docs/maintainers/PROTECT-MCP-RECEIPT-DECISION-2026-04-04.md
+++ b/docs/maintainers/PROTECT-MCP-RECEIPT-DECISION-2026-04-04.md
@@ -2,6 +2,16 @@
 
 Date: 2026-04-04
 
+Update: 2026-04-06
+
+The `@0.2.5` rerun improved the verifier boundary in exactly the direction we asked for by separating:
+
+- `0 = valid`
+- `1 = invalid`
+- `2 = error`
+
+That improves probe confidence, but it does not change the decision below.
+
 ## Decision
 
 Keep the ScopeBlind / VeritasActa signed-receipt line at **probe status**.
@@ -27,7 +37,7 @@ The remaining blockers are contract quality, not basic feasibility:
 - timestamp semantics are still claim-shaped
 - `tool_input_hash` is still not strong enough for hard reasoning without a tighter interop story
 - binding identity still needs a frozen statement of assumptions
-- malformed and key-handling behavior are still too young to treat as stable public boundary semantics
+- key-handling and human-readable verifier output are still too young to treat as stable public boundary semantics
 
 ## Maintainer call
 

--- a/tests/probes/protect_mcp_receipt_verifier_boundary.sh
+++ b/tests/probes/protect_mcp_receipt_verifier_boundary.sh
@@ -19,6 +19,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 FIXTURE_DIR="${REPO_ROOT}/tests/fixtures/interop/protect_mcp_receipts"
+VERIFIER_VERSION="0.2.5"
 KEY="$(jq -r '.public_key_hex' "${FIXTURE_DIR}/issuer_key.json")"
 if [[ -z "${KEY}" || "${KEY}" == "null" ]]; then
   echo "invalid issuer key fixture: .public_key_hex is missing, null, or empty in ${FIXTURE_DIR}/issuer_key.json" >&2
@@ -54,10 +55,10 @@ run_case() {
 
   set +e
   if [[ "${use_key}" == "true" ]]; then
-    npm_config_loglevel=error npx --yes @veritasacta/verify@0.2.4 \
+    npm_config_loglevel=error npx --yes "@veritasacta/verify@${VERIFIER_VERSION}" \
       "${FIXTURE_DIR}/${file}" --key "${KEY}" >"${stdout_file}" 2>"${stderr_file}"
   else
-    npm_config_loglevel=error npx --yes @veritasacta/verify@0.2.4 \
+    npm_config_loglevel=error npx --yes "@veritasacta/verify@${VERIFIER_VERSION}" \
       "${FIXTURE_DIR}/${file}" >"${stdout_file}" 2>"${stderr_file}"
   fi
   local status=$?
@@ -98,7 +99,7 @@ run_case() {
 run_case "valid_allow.json" 0 stdout "Signature: VALID" true
 run_case "valid_deny.json" 0 stdout "Signature: VALID" true
 run_case "tampered.json" 1 stdout "Signature: INVALID" true
-run_case "malformed.json" 1 stdout "no_public_key" false
+run_case "malformed.json" 2 stdout "no_public_key" false
 
 echo
 if [[ "${FAILURES}" -gt 0 ]]; then


### PR DESCRIPTION
Summary
Reruns the signed receipt verifier probe against `@veritasacta/verify@0.2.5` and records the cleaner 3-way exit-code boundary.

What it does
- updates the manual verifier boundary script to pin `@0.2.5`
- expects `0 = valid`, `1 = invalid`, `2 = error` for the frozen fixture corpus
- adds a follow-up maintainer probe note for the 2026-04-06 rerun
- updates the existing contract and decision notes to reflect the cleaner verifier split

Why
Tom shipped the exact verifier boundary we asked for in discussion `#1029`, so the logical next step was to rerun the probe and record whether the cleaner contract actually holds on our side.

Validation
- `cargo test -q -p assay-core --test receipt_interop_probe`
- `cargo test -q -p assay-core --test mcp_transport_compat`
- `cargo test -q -p assay-core --test mcp_id_correlation`
- `cargo test -q -p assay-cli --test mcp_transport_import`
- `bash tests/probes/protect_mcp_receipt_verifier_boundary.sh`
- `shellcheck tests/probes/protect_mcp_receipt_verifier_boundary.sh`
- `git diff --check`