### PR TITLE
ci: pre-clean stale assay monitor before self-hosted checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,8 +411,14 @@ jobs:
       - name: Pre-clean workspace ownership
         shell: bash
         run: |
+          # A stale host-side assay monitor can survive a prior failed run and interfere with
+          # workspace cleanup or checkout. Clear it before touching the tree.
+          sudo pkill -x assay 2>/dev/null || true
+
           # Remove target/ with sudo so checkout can delete workspace (avoids EPERM on root-owned fingerprints)
           sudo rm -rf "$GITHUB_WORKSPACE/target" 2>/dev/null || true
+          sudo chattr -R -i "$GITHUB_WORKSPACE/.assay-test" 2>/dev/null || true
+          sudo rm -rf "$GITHUB_WORKSPACE/.assay-test" /tmp/assay-lsm-verify /tmp/assay-test 2>/dev/null || true
           sudo chown -R "$(id -u)":"$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
           sudo chown -R "$(id -u)":"$(id -g)" "$(dirname "$GITHUB_WORKSPACE")" 2>/dev/null || true
 
@@ -428,6 +434,11 @@ jobs:
           set -euo pipefail
           cd "$GITHUB_WORKSPACE"
           find . -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
+          if find . -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+            echo "ERROR: workspace not empty after pre-checkout cleanup"
+            find . -mindepth 1 -maxdepth 2 -ls | sed -n '1,200p'
+            exit 1
+          fi
           AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
             clone --depth 1 "https://github.com/${GH_REPO}.git" .


### PR DESCRIPTION
Summary
Harden the self-hosted eBPF checkout path so a stale host-side `assay monitor` from a prior failed run cannot corrupt the next manual clone into `GITHUB_WORKSPACE`.

What it does
- kills lingering `assay` processes before the self-hosted checkout path touches the workspace
- clears stale `.assay-test` and temp verification directories before clone
- fails early with a clear error if the workspace is still not empty after cleanup instead of letting `git clone` die mid-checkout

Why
The failed main push run for #1045 showed `git clone` on the self-hosted runner dying at checkout with `unable to create file tests/sequence_dsl_test.sh: File exists`. On-runner inspection showed a leftover host-side `./assay monitor ... --monitor-all` process plus a half-corrupted workspace, and killing that stale monitor immediately restored clean reclone behavior.

Validation
- reproduced that fresh temp-dir clones on the runner succeed
- inspected the live runner workspace and confirmed the failed run left a zero-byte `tests/sequence_dsl_test.sh` plus a lingering `assay monitor`
- killed the stale monitor and successfully re-cloned the live workspace in place
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/ci.yml\")"`
- `git diff --check`

Notes
This is a workflow hardening fix only. It does not change the eBPF smoke semantics themselves.