### PR TITLE
docs: add Langfuse experiment result interop plan

### DIFF
--- a/docs/architecture/PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md
+++ b/docs/architecture/PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md
@@ -190,8 +190,7 @@ run export and not a whole trace tree.
 The first artifact should therefore center on:
 
 - one experiment name
-- one dataset identity and, if the chosen sample shape carries it, one bounded
-  dataset version reference
+- one dataset identity and one bounded dataset version reference
 - one item reference
 - one short output representation
 - one bounded list of evaluations
@@ -420,10 +419,10 @@ If this plan is accepted, the next implementation PR should add:
   a small local or self-hosted generator is viable
 - `examples/langfuse-experiment-evidence/map_to_assay.py`
 - `examples/langfuse-experiment-evidence/fixtures/valid.langfuse.json`
-- `examples/langfuse-experiment-evidence/fixtures/weak.langfuse.json`
+- `examples/langfuse-experiment-evidence/fixtures/failure.langfuse.json`
 - `examples/langfuse-experiment-evidence/fixtures/malformed.langfuse.json`
 - `examples/langfuse-experiment-evidence/fixtures/valid.assay.ndjson`
-- `examples/langfuse-experiment-evidence/fixtures/weak.assay.ndjson`
+- `examples/langfuse-experiment-evidence/fixtures/failure.assay.ndjson`
 
 Fixture boundary notes:
 
@@ -478,7 +477,7 @@ artifact shape**.
 That fallback is acceptable here because the goal is the smallest honest
 external-consumer seam, not a full Langfuse platform tutorial.
 
-## 11. Valid, weak, malformed corpus
+## 11. Valid, failure, malformed corpus
 
 The first sample should follow the established corpus pattern.
 
@@ -490,9 +489,9 @@ One strong experiment item result with:
 - one or more bounded evaluations
 - a bounded dataset version reference
 
-### 11.2 Weak
+### 11.2 Failure
 
-One weaker experiment item result with:
+One lower-scoring experiment item result with:
 
 - short `output_ref`
 - one or more bounded evaluations showing a lower or negative result
@@ -500,7 +499,8 @@ One weaker experiment item result with:
 
 This is **not** a platform failure or infrastructure failure artifact.
 
-It is only a weaker experiment-result artifact.
+It is only a weaker experiment-result artifact represented in the repo corpus
+under the established `failure` naming pattern.
 
 ### 11.3 Malformed
 

--- a/docs/architecture/PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md
+++ b/docs/architecture/PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md
@@ -190,10 +190,12 @@ run export and not a whole trace tree.
 The first artifact should therefore center on:
 
 - one experiment name
-- one dataset identity and bounded dataset version reference
+- one dataset identity and, if the chosen sample shape carries it, one bounded
+  dataset version reference
 - one item reference
 - one short output representation
 - one bounded list of evaluations
+- no aggregate layer unless it is naturally present and still small
 - optional opaque run or trace references only if needed
 
 Important framing rule:
@@ -226,6 +228,11 @@ They must be described as:
 - sample-level reductions derived from documented Langfuse experiment results
 - not an upstream guarantee that Langfuse already ships one canonical
   serialized export object with these exact field names
+
+`dataset_version_ref` remains required in this v1 plan because it keeps the
+artifact reviewable in dataset/experiment context, but that is still a frozen
+sample-shape choice, not a claim that every smallest honest Langfuse export
+must carry that exact field in that exact form.
 
 ### 7.2 Optional fields
 
@@ -282,6 +289,10 @@ This field is required in the frozen sample shape.
 
 It should be framed as a **short frozen representation** derived from the
 experiment item output, not necessarily the full upstream output body.
+
+It should also be described explicitly as a **sample-level reduction of the
+documented experiment item output surface**, not as an upstream-guaranteed
+serialized export field.
 
 It remains upstream output semantics only.
 
@@ -349,6 +360,9 @@ It must not turn the lane back into a trace-first plan.
 This field is optional in v1.
 
 The sample remains complete without any aggregate score field.
+
+The v1 sample should prefer omitting it unless it is naturally present in the
+chosen experiment-result shape and still stays very small.
 
 If included, it must stay bounded:
 
@@ -432,6 +446,12 @@ Langfuse is more promising than some earlier lanes because:
 
 Even so, the first sample should still stay strict about setup cost.
 
+Practical expectation for v1:
+
+- start from a docs-backed frozen artifact shape by default
+- only switch to a real local generator if the setup turns out to be
+  surprisingly small and does not overshadow the seam
+
 ### 10.1 Preferred path
 
 Preferred:
@@ -509,6 +529,8 @@ Why `Support`:
 
 - it is the answerable category
 - the question is about the smallest honest seam
+- it is the best pragmatic fit for one technical boundary question even if it
+  is not a perfect semantic match for a planning-style interop post
 - that reads more like a technical boundary question than `Share your Work`
   or `Ideas`
 

--- a/docs/architecture/PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md
+++ b/docs/architecture/PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md
@@ -1,0 +1,560 @@
+# PLAN — P13 Langfuse Experiment Result Evidence Interop (2026 Q2)
+
+- **Date:** 2026-04-08
+- **Owner:** Evidence / Product
+- **Status:** Planning
+- **Scope (this PR):** Define the next platform-adjacent upstream interop lane
+  after Browser Use and Visa TAP. No sample implementation, no outward
+  Discussion, and no contract freeze in this slice.
+
+## 1. Why this plan exists
+
+After the current framework, protocol, runtime-accounting, eval-report,
+adjacent output/history, and TAP verification wave, the next lane should still
+pass the same three tests:
+
+1. the upstream project already exposes one bounded surface,
+2. Assay can consume that surface without inheriting upstream platform
+   semantics as truth,
+3. the repo has a natural maintainer channel for one small sample-backed
+   boundary question.
+
+`langfuse/langfuse` now fits that pattern well enough to justify a formal plan:
+
+- the repo is large, active, and visibly current
+- GitHub Discussions are enabled and actively used
+- the docs expose a clear evaluation stack through datasets, experiments, and
+  scores
+- the platform is explicitly API-first and already frames data exports as part
+  of the product story
+
+This lane is especially relevant at the bleeding edge in 2026 because Langfuse
+is evolving in two directions at once:
+
+- **observations-first observability**, which makes trace surfaces broader and
+  more operationally central
+- **experiments-first evaluation workflows**, which make offline, bounded eval
+  result surfaces easier to isolate from live production tracing
+
+That combination creates a clear planning rule:
+
+- do **not** open Langfuse as another trace-export lane
+- do **not** pitch Assay as a competing observability platform
+- do start from the smallest experiment-result seam that Langfuse already
+  documents
+
+This is **not** a trace export plan.
+
+This is **not** a dashboard or metrics export plan.
+
+This is **not** a prompt-management plan.
+
+This is a plan for a **bounded experiment-result surface derived from the
+documented Langfuse evaluation path**.
+
+## 2. Why Langfuse is now the next best candidate
+
+As of 2026-04-08, the current active and just-opened lanes already cover:
+
+- framework trace surfaces
+- eval-report surfaces
+- runtime-accounting surfaces
+- adjacent output/history surfaces
+- commerce / verification-first protocol surfaces
+
+That changes what “best next lane” means.
+
+The next lane should now:
+
+- stay GitHub-native
+- open a different seam from the work already live
+- still have strong momentum and a real maintainer channel
+- be current enough to reflect where the ecosystem is actually heading
+
+Langfuse is the strongest fit for that next move because:
+
+- its evaluation stack is now clearly first-class, not a side feature
+- its docs and SDK references already expose experiments, datasets, and custom
+  scores as explicit product surfaces
+- its Discussions categories include a natural answerable `Support` lane
+- it is strategically important without forcing us straight into a browser,
+  payment, or telemetry-heavy surface
+
+Why this is **not** Mastra first:
+
+- Mastra remains a good candidate
+- but the repo has no Discussions
+- and its issue channel is more bug and triage heavy right now
+
+Why this is **not** x402 first:
+
+- x402 remains technically interesting
+- but the repo currently has no Issues and no Discussions
+- and the public channel shape is too weak for the small sample-backed
+  question style that is working best for us
+
+Why this is **not** OpenLIT first:
+
+- OpenLIT remains a valid OTel-native special case
+- but it is smaller, and the lane would be much more observability-colored
+  than the current Langfuse opportunity
+
+## 3. Hard positioning rule
+
+This lane must not overclaim what the sample actually observes.
+
+Normative framing:
+
+> This sample targets the smallest honest Langfuse experiment-result surface,
+> not a trace export, dashboard export, metrics export, or production
+> observability truth surface.
+
+That means:
+
+- Langfuse is the upstream platform context, not the truth source
+- experiment results are bounded eval artifacts, not production truth
+- Assay stays an external evidence consumer, not a scorer, dashboard, or trace
+  authority
+
+## 4. Why not trace-first
+
+Trace-first would be the wrong first wedge here.
+
+Why:
+
+- Langfuse is publicly and product-wise strongest as an observability platform
+- trace-first would read immediately as platform-on-platform
+- the v4 observations-first direction makes live trace surfaces broader, not
+  smaller
+- Langfuse also supports live evaluators on production traces, which would make
+  it too easy to blur runtime monitoring semantics into Assay evidence truth
+
+The safer first seam is one step away from production observability:
+
+- dataset-backed
+- experiment-backed
+- offline or reviewable
+- smaller than traces
+- smaller than dashboards
+- smaller than metrics rollups
+
+This is the same best-practice move we used in earlier lanes:
+
+- choose the smallest documented surface that already exists
+- avoid the broadest operational surface just because it is prominent
+
+## 5. Why experiment-result-first and not score-only-first
+
+Langfuse also exposes **scores** as a first-class concept:
+
+- numeric, boolean, and categorical values
+- custom scores via SDK or API
+- scores attached across broader observability and evaluation workflows
+
+That is real, but score-only is still not the best v1 seam.
+
+Why not score-only first:
+
+- scores can belong to traces, observations, or experiments
+- score-only export loses the bounded experiment context that makes the seam
+  reviewable
+- score-only makes it easier to slide back into production-evaluation or
+  observability semantics
+
+The cleaner first wedge is:
+
+- one artifact derived from `run_experiment()`
+- one bounded `ExperimentItemResult`-style output
+- one bounded list of `Evaluation`-style results
+- optional `trace_ref` only if it is naturally present in the chosen sample
+  shape
+
+That still keeps Langfuse tied to scores and evaluation, but it does so inside
+the smallest experiment-result frame instead of the broadest scoring frame.
+
+## 6. Recommended v1 seam
+
+Use **one frozen serialized artifact derived from the documented Langfuse
+experiment result path** as the first external-consumer seam.
+
+The intended upstream anchors are:
+
+- `run_experiment()`
+- `ExperimentResult`
+- `ExperimentItemResult`
+- bounded `Evaluation` results
+
+The frozen sample shape should stay at the **item result** level, not the full
+run export and not a whole trace tree.
+
+The first artifact should therefore center on:
+
+- one experiment name
+- one dataset identity and bounded dataset version reference
+- one item reference
+- one short output representation
+- one bounded list of evaluations
+- optional opaque run or trace references only if needed
+
+Important framing rule:
+
+> The sample uses a frozen serialized artifact derived from the documented
+> Langfuse experiment-result surface, not a claim that Langfuse already
+> guarantees one fixed wire-export contract for external evidence consumers.
+
+## 7. v1 artifact contract
+
+### 7.1 Required fields
+
+The first sample should require:
+
+- `schema`
+- `platform`
+- `surface`
+- `experiment_name`
+- `dataset_name`
+- `dataset_version_ref`
+- `item_ref`
+- `timestamp`
+- `output_ref`
+- `evaluations`
+
+These required fields belong to the frozen sample artifact shape.
+
+They must be described as:
+
+- sample-level reductions derived from documented Langfuse experiment results
+- not an upstream guarantee that Langfuse already ships one canonical
+  serialized export object with these exact field names
+
+### 7.2 Optional fields
+
+The first sample may include:
+
+- `run_ref`
+- `trace_ref`
+- `experiment_description_ref`
+- `metadata_ref`
+- `aggregate_scores`
+
+### 7.3 Important field boundaries
+
+#### `dataset_version_ref`
+
+This field is required because dataset versioning is part of the documented
+Langfuse experiments story.
+
+In v1, it must stay a bounded version pointer only:
+
+- timestamp
+- short version label
+- short normalized version reference
+
+Not allowed in v1:
+
+- full dataset export
+- full dataset item payload replay
+- dataset schema dump
+
+This field belongs to the frozen sample shape, not to an upstream claim that
+Langfuse guarantees one universal serialized dataset-version contract for
+external consumers.
+
+#### `item_ref`
+
+This field is required and must stay an opaque dataset-item reference only.
+
+Allowed:
+
+- item id
+- short item label
+- short opaque reference
+
+Not allowed in v1:
+
+- full dataset input body as the primary seam
+- full expected-output body as the primary seam
+- large source-trace payloads
+
+#### `output_ref`
+
+This field is required in the frozen sample shape.
+
+It should be framed as a **short frozen representation** derived from the
+experiment item output, not necessarily the full upstream output body.
+
+It remains upstream output semantics only.
+
+It must not become:
+
+- model-quality truth
+- prompt-quality truth
+- business-outcome truth
+
+The sample should prefer:
+
+- short string output
+- short bounded object
+- short opaque output label
+
+Not:
+
+- full prompt transcript
+- full chain-of-thought style payload
+- large generated body
+
+#### `evaluations`
+
+This field is required in the frozen sample shape.
+
+It should be framed as a bounded list derived from documented `Evaluation`
+results, not as a claim that Langfuse already guarantees one universal
+serialized eval-result wire contract.
+
+Each evaluation entry should stay very small:
+
+- `name`
+- `value`
+- optional short `data_type`
+- optional short classifier or label only if the chosen sample shape naturally
+  carries one
+
+Not allowed in v1:
+
+- evaluator prompts
+- evaluator reasoning transcripts
+- large free-text judge explanations
+- raw dashboard rollups
+
+This field is where Langfuse’s eval-result seam is real, but it must still
+stay a bounded sample reduction rather than a platform export claim.
+
+#### `trace_ref`
+
+This field is optional in v1.
+
+The sample should prefer omitting it unless it is naturally present in the
+chosen experiment-result shape.
+
+If present, it must remain:
+
+- an opaque reference
+- a short id
+- a bounded link target
+
+It must not turn the lane back into a trace-first plan.
+
+#### `aggregate_scores`
+
+This field is optional in v1.
+
+The sample remains complete without any aggregate score field.
+
+If included, it must stay bounded:
+
+- one short summary object
+- one short scalar or small list
+
+It must not become:
+
+- dashboard export
+- metrics export
+- production health truth
+
+#### Optional references
+
+The optional reference fields must stay bounded:
+
+- short label
+- opaque id
+- short normalized reference
+
+Not allowed in v1:
+
+- full trace trees
+- prompt registry payloads
+- full metadata blobs
+- rich dashboard configuration
+
+## 8. Assay-side meaning
+
+The sample may only claim bounded experiment-result observation.
+
+Assay must not treat as truth:
+
+- production trace truth
+- dashboard truth
+- metrics truth
+- prompt-quality truth
+- model-quality truth beyond the observed eval artifact
+- user-feedback truth beyond the observed score or label
+- Langfuse platform semantics as a whole
+
+Common anti-overclaim sentence:
+
+> We are not asking Assay to inherit Langfuse trace semantics, dashboard
+> semantics, metrics semantics, or evaluation semantics as truth.
+
+## 9. Concrete repo deliverable
+
+If this plan is accepted, the next implementation PR should add:
+
+- `examples/langfuse-experiment-evidence/README.md`
+- `examples/langfuse-experiment-evidence/requirements.txt` only if a tiny
+  local generator truly needs it
+- `examples/langfuse-experiment-evidence/generate_synthetic_result.py` only if
+  a small local or self-hosted generator is viable
+- `examples/langfuse-experiment-evidence/map_to_assay.py`
+- `examples/langfuse-experiment-evidence/fixtures/valid.langfuse.json`
+- `examples/langfuse-experiment-evidence/fixtures/weak.langfuse.json`
+- `examples/langfuse-experiment-evidence/fixtures/malformed.langfuse.json`
+- `examples/langfuse-experiment-evidence/fixtures/valid.assay.ndjson`
+- `examples/langfuse-experiment-evidence/fixtures/weak.assay.ndjson`
+
+Fixture boundary notes:
+
+- v1 fixtures may omit every optional reference field
+- v1 fixtures must keep `trace_ref` optional and preferably absent
+- v1 fixtures must not include full trace trees or dashboard exports
+- v1 fixtures should keep the export shape obviously experiment-result-first
+  rather than trace-first
+
+## 10. Generator policy
+
+The implementation should prefer a real local generator **only if** it stays
+small and deterministic.
+
+Langfuse is more promising than some earlier lanes because:
+
+- the platform is open source and self-hostable
+- experiments can run against local or hosted datasets
+- the experiment runner is now an official SDK concept
+
+Even so, the first sample should still stay strict about setup cost.
+
+### 10.1 Preferred path
+
+Preferred:
+
+- a small SDK-driven experiment path
+- one local or tiny self-hosted Langfuse setup only if it is truly lightweight
+- one bounded evaluator
+- no production-trace dependency
+- no dashboard dependency
+- no prompt-management dependency
+
+### 10.2 Hard fallback rule
+
+If a real local generator would require:
+
+- a full Langfuse stack bootstrap heavy enough to dominate the seam
+- cloud credentials
+- project or environment setup that outweighs the sample itself
+- more observability plumbing than experiment-result logic
+
+then the sample should fall back to a **docs-backed frozen experiment-result
+artifact shape**.
+
+That fallback is acceptable here because the goal is the smallest honest
+external-consumer seam, not a full Langfuse platform tutorial.
+
+## 11. Valid, weak, malformed corpus
+
+The first sample should follow the established corpus pattern.
+
+### 11.1 Valid
+
+One strong experiment item result with:
+
+- short `output_ref`
+- one or more bounded evaluations
+- a bounded dataset version reference
+
+### 11.2 Weak
+
+One weaker experiment item result with:
+
+- short `output_ref`
+- one or more bounded evaluations showing a lower or negative result
+- the same bounded experiment-result shape
+
+This is **not** a platform failure or infrastructure failure artifact.
+
+It is only a weaker experiment-result artifact.
+
+### 11.3 Malformed
+
+One malformed artifact that fails fast, for example:
+
+- missing `evaluations`
+- missing `dataset_version_ref`
+- `evaluations` not a list
+- unsupported evaluation entry shape
+
+## 12. Outward strategy
+
+Do not open an outward Langfuse Discussion until the sample is on `main`.
+
+After that:
+
+- one small GitHub Discussion
+- category: `Support`
+- one link
+- one boundary question
+- no broad platform pitch
+- no trace pitch
+- no dashboard pitch
+
+Why `Support`:
+
+- it is the answerable category
+- the question is about the smallest honest seam
+- that reads more like a technical boundary question than `Share your Work`
+  or `Ideas`
+
+Suggested outward question:
+
+> If an external evidence consumer wants the smallest honest Langfuse
+> evaluation surface, is an artifact derived from `run_experiment()` /
+> `ExperimentItemResult` and bounded `Evaluation` results roughly the right
+> place to start, or is there a thinner experiment-result surface you would
+> rather point them at?
+
+## 13. Sequencing rule
+
+The active Browser Use and Visa TAP lanes are now live.
+
+Meaning:
+
+1. formalize `P13` now
+2. let the fresh Browser Use and TAP outward threads breathe unless a
+   maintainer responds
+3. if no hot follow-up needs attention, implement the `P13` sample next
+4. open the Langfuse `Support` Discussion only after the sample lands on
+   `main`
+
+## 14. Non-goals
+
+This plan does not:
+
+- define a Langfuse trace export contract
+- define a Langfuse dashboard export contract
+- define a metrics export contract
+- define a prompt-management export contract
+- define Langfuse evals or scores as Assay truth
+- define a platform-to-platform synchronization story
+
+## References
+
+- [TODO — Next Upstream Interop Lanes (2026 Q2)](./TODO-NEXT-UPSTREAM-INTEROP-LANES-2026q2.md)
+- [PLAN — P11A Visa TAP Intent Verification Evidence Interop](./PLAN-P11A-VISA-TAP-INTENT-VERIFICATION-EVIDENCE-2026q2.md)
+- [PLAN — P12 Browser Use History / Output Evidence Interop](./PLAN-P12-BROWSER-USE-HISTORY-OUTPUT-EVIDENCE-2026q2.md)
+- [ADR-033: OTel Trust Compiler Positioning](./ADR-033-OTel-Trust-Compiler-Positioning.md)
+- [Langfuse Docs — Overview](https://langfuse.com/docs)
+- [Langfuse Docs — Evaluation Overview](https://langfuse.com/docs/evaluation/overview)
+- [Langfuse Docs — Datasets / Experiments Overview](https://langfuse.com/docs/evaluation/experiments/overview)
+- [Langfuse Docs — Support](https://langfuse.com/support)
+- [Langfuse Docs — Roadmap](https://langfuse.com/docs/roadmap)
+- [Langfuse Changelog — Experiment Runner SDK](https://langfuse.com/changelog/2025-09-17-experiment-runner-sdk)
+- [Langfuse Python Reference — Experiment Runner](https://python.reference.langfuse.com/langfuse/experiment)
+- [langfuse/langfuse](https://github.com/langfuse/langfuse)

--- a/docs/architecture/TODO-NEXT-UPSTREAM-INTEROP-LANES-2026q2.md
+++ b/docs/architecture/TODO-NEXT-UPSTREAM-INTEROP-LANES-2026q2.md
@@ -4,9 +4,10 @@
 - **Owner:** Evidence / Product
 - **Status:** Active queue note. The `P11` commerce / trust-proof family is
   now formally started with [PLAN — P11A Visa TAP Intent Verification Evidence
-  Interop](./PLAN-P11A-VISA-TAP-INTENT-VERIFICATION-EVIDENCE-2026q2.md), while
-  Browser Use remains the active adjacent-space lane that should be finished
-  cleanly before opening another new branch.
+  Interop](./PLAN-P11A-VISA-TAP-INTENT-VERIFICATION-EVIDENCE-2026q2.md), the
+  Browser Use adjacent lane is now live, and
+  [PLAN — P13 Langfuse Experiment Result Evidence Interop](./PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md)
+  is the next planned platform-adjacent candidate.
 - **Scope (this document now):** Record the ranked post-Agno queue for the
   next upstream interop lanes, the reasons behind that ordering, and the
   execution rules learned from the current wave.
@@ -64,52 +65,37 @@ Tier 0 means:
 - no extra pushes on cold threads
 - keep current live lanes breathing unless an upstream maintainer responds
 
-### Tier 1 — highest net priority
+### Tier 1 — next best active candidate
 
 | Rank | Repo / lane | Status | Primary channel | First seam | Why it ranks here |
 |------|-------------|--------|-----------------|------------|-------------------|
-| 1 | `agno-agi/agno` | Already active | GitHub Discussion | `AccuracyEval` / `AccuracyResult` artifact | Cleanest same-space lane, eval-result-first, and socially much cleaner than frontier commerce lanes |
+| 1 | `langfuse/langfuse` | Active planning | GitHub Discussion (`Support`) | bounded experiment item result / evaluation export | Best next fit after Browser Use and TAP: strong repo momentum, natural maintainer channel, and a smaller eval-result seam than trace-first observability |
 
-### Tier 2 — frontier, but heavier
-
-| Rank | Repo / lane | Status | Primary channel | First seam | Why it ranks here |
-|------|-------------|--------|-----------------|------------|-------------------|
-| 2 | `P11A` — Visa TAP | Queued | GitHub issue | intent / auth verification result artifact | Most Assay-native frontier lane, but smaller ecosystem surface and higher semantic overclaim risk than Agno |
-
-### Tier 3 — highest upside adjacent
+### Tier 2 — clean fallback if Langfuse framing risk rises
 
 | Rank | Repo / lane | Status | Primary channel | First seam | Why it ranks here |
 |------|-------------|--------|-----------------|------------|-------------------|
-| 3 | `browser-use/browser-use` | Active planning | GitHub Discussion | `AgentHistoryList` / `action_history()` / `final_result()` / `errors()` | Strong adjacent-space momentum and a history/output seam that is clearly different from prior trace and eval lanes |
+| 2 | `mastra-ai/mastra` | Queued | GitHub issue | `evaluate()` / scorer result / CI eval result | Good candidate and less platform-on-platform risky than Langfuse, but weaker channel shape because the repo has no Discussions |
 
-### Tier 4 — strategically strong, socially harder
-
-| Rank | Repo / lane | Status | Primary channel | First seam | Why it ranks here |
-|------|-------------|--------|-----------------|------------|-------------------|
-| 4 | `langfuse/langfuse` | Queued | GitHub Discussion | dataset / experiment result export or score record export | Strategically strong, but most likely to read as platform-on-platform if the framing slips |
-
-### Tier 5 — frontier, but not first
+### Tier 3 — special-case OTel-native candidate
 
 | Rank | Repo / lane | Status | Primary channel | First seam | Why it ranks here |
 |------|-------------|--------|-----------------|------------|-------------------|
-| 5 | `P11B` — x402 | Queued | publish / integrate first | payment lifecycle evidence | Technically exciting, but the channel is weak and payment semantics are much riskier than TAP |
+| 3 | `openlit/openlit` | Watchlist | GitHub Discussion | eval/export or bounded score record export | Worth keeping as the main OTel-native special case, but still not the best general next lane |
 
-### Tier 6 — good lanes, less urgent
-
-| Rank | Repo / lane | Status | Primary channel | First seam | Why it ranks here |
-|------|-------------|--------|-----------------|------------|-------------------|
-| 6 | `mastra-ai/mastra` | Queued | GitHub issue | `evaluate()` / scorer result / CI eval result | Good candidate, but weaker channel than Agno and less distinctive than Browser Use |
-| 7 | `pydantic/pydantic-ai` | Already active | GitHub issue | `EvaluationReport`-derived artifact | Strong lane, but less urgent now that it is already live and Agno covers the same broad eval-result family |
-| 8 | `lastmile-ai/mcp-agent` | Already active | GitHub Discussion | token summary / runtime accounting | Strong lane, but more runtime-accounting-specific than the next frontier or adjacent priorities |
-
-### Tier 7 — later / watchlist
+### Tier 4 — later frontier and heavier infra lanes
 
 | Rank | Repo / lane | Status | Primary channel | First seam | Why it ranks here |
 |------|-------------|--------|-----------------|------------|-------------------|
-| 9 | `P11C` — Identus | Watchlist | GitHub Discussion | credential / delegation proof | Interesting, but heavier and more infrastructural than TAP |
-| 10 | `openlit/openlit` | Watchlist | GitHub Discussion | eval/export or score record export | Worth keeping as a special-case OTel-native candidate, but not the best next general lane |
-| 11 | `livekit/agents` | Watchlist | issue or discussion only if a small hook surface becomes clear | metrics / event hook evidence at most | Lower fit because the public seam is much more deployment and observability heavy than artifact-first |
-| 12 | `microsoft/autogen` | Deprioritized | GitHub Discussion | n/a | Keep low because the repo is explicitly in maintenance mode |
+| 4 | `P11B` — x402 | Queued | publish / integrate first | payment lifecycle evidence | Technically interesting, but the repo currently has no Issues or Discussions and the semantics are much riskier than TAP |
+| 5 | `P11C` — Identus | Watchlist | GitHub Discussion | credential / delegation proof | Interesting, but heavier and more infrastructural than the next eval/export lane |
+
+### Tier 5 — still lower fit
+
+| Rank | Repo / lane | Status | Primary channel | First seam | Why it ranks here |
+|------|-------------|--------|-----------------|------------|-------------------|
+| 6 | `livekit/agents` | Watchlist | issue or discussion only if a small hook surface becomes clear | metrics / event hook evidence at most | Lower fit because the public seam is much more deployment and observability heavy than artifact-first |
+| 7 | `microsoft/autogen` | Deprioritized | GitHub Discussion | n/a | Keep low because the repo is explicitly in maintenance mode |
 
 ## 4. Historical note on Agno
 
@@ -127,12 +113,13 @@ That lane is already in motion, so the queue no longer starts with Agno even
 though Agno remains the strongest general-purpose next-lane choice in the
 ranking.
 
-## 5. Why Browser Use is now the active lane to finish
+## 5. Historical note on Browser Use
 
-`browser-use/browser-use` is not the highest strategic priority overall, but it
-is the right **active adjacent lane to finish first** because:
+`browser-use/browser-use` was not the highest strategic priority overall, but
+it was the right adjacent lane to finish before opening the next platform lane
+because:
 
-- the planning slice is already in progress
+- the planning slice was already in progress
 - the seam is clean and materially different from the current wave
 - it can be finished without opening the heavier `P11A` commerce branch yet
 - it preserves one-lane-at-a-time discipline better than pivoting mid-plan
@@ -151,39 +138,41 @@ At the same time, Browser Use also documents Laminar, OpenLIT, and telemetry.
 That broader observability layer is exactly what Assay should avoid as the
 first wedge.
 
-The active Browser Use plan now lives in
+That lane is now live. The formal Browser Use plan lives in
 [PLAN — P12 Browser Use History / Output Evidence Interop](./PLAN-P12-BROWSER-USE-HISTORY-OUTPUT-EVIDENCE-2026q2.md).
 
-## 6. Why `P11A` stays above Browser Use in the broader ranking
+## 6. Historical note on `P11A`
 
-The `P11A` Visa TAP lane stays above Browser Use in the broader ranking because
-it has stronger frontier value:
+The `P11A` Visa TAP lane was ranked above Browser Use in the broader frontier
+ordering because it had stronger protocol value:
 
 - verification-first rather than platform-first
 - cryptographic and protocol-adjacent enough to fit Assay's trust-compiler
   direction closely
 - strategically different from another framework or eval lane
 
-Why it still is **not** the active lane right now:
-
-- issue-only channel
-- smaller ecosystem surface
-- much faster semantic overclaim risk
-- more explanation required per word
-
-That is why `P11A` remains the better frontier priority while Browser Use
-remains the better lane to finish first.
-
 The formal frontier plan now lives in
 [PLAN — P11A Visa TAP Intent Verification Evidence
 Interop](./PLAN-P11A-VISA-TAP-INTENT-VERIFICATION-EVIDENCE-2026q2.md).
 
-## 7. Why Langfuse stays below Browser Use
+That lane is now live too, so the queue no longer needs to choose between
+Browser Use and `P11A` as the next move.
 
-`langfuse/langfuse` remains strategically important, but it is still not the
-best immediate next move after Browser Use.
+## 7. Why Langfuse is now the next planned lane
 
-Why:
+`langfuse/langfuse` is now the next best planned lane because the two lanes
+that previously sat ahead of it in execution order are already in motion.
+
+Why it now moves up:
+
+- strong repo momentum
+- Discussions enabled with an answerable `Support` category
+- official eval docs around datasets, experiments, and scores
+- API-first and export-friendly positioning
+- a seam that is different from Browser Use history/output and TAP
+  verification
+
+Why it is still socially harder than the earlier framework lanes:
 
 - Langfuse already positions itself as a broad LLM engineering platform with
   observability, datasets, scores, and experiments
@@ -194,10 +183,12 @@ Why:
 The right posture there is:
 
 - export/import sample first
-- score or dataset/experiment result seam
-- only then one small GitHub Discussion
+- bounded experiment-result seam first
+- `Support` Discussion only after the sample lands
+- no trace-first framing
 
-That is still a good lane, just not the safest next one.
+The formal Langfuse plan now lives in
+[PLAN — P13 Langfuse Experiment Result Evidence Interop](./PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md).
 
 ## 8. Why Mastra stays below the top four
 
@@ -228,25 +219,24 @@ Additional queue rules:
 - reserve `P11` for the commerce / trust-proof family
 - Browser Use should stay output/history-first, not Laminar/OpenLIT-first
 - `P11A` should stay verification-first, not payment-truth-first
-- Langfuse should stay export/import-first, not trace-first
+- Langfuse should stay experiment-result-first, not trace-first
 - Mastra should stay eval-result-first, not tracing-first
 - OpenLIT should remain a special-case OTel-native candidate, not the default
   next lane
 
 ## 10. Next actions
 
-1. **Now active:** finish [PLAN — P12 Browser Use History / Output Evidence
-   Interop](./PLAN-P12-BROWSER-USE-HISTORY-OUTPUT-EVIDENCE-2026q2.md).
-2. After the Browser Use sample lands and the outward Browser Use question is
-   posted, let that lane breathe before opening another new outward thread.
-3. Decide next between:
-   - `P11A` if frontier / protocol depth is the next deliberate move
-   - `Langfuse` if export/import platform adjacency is the next deliberate move
+1. **Now active:** formalize
+   [PLAN — P13 Langfuse Experiment Result Evidence Interop](./PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md).
+2. Let the fresh Browser Use and Visa TAP outward threads breathe unless an
+   upstream maintainer responds.
+3. If no hot follow-up overrides the queue, build the `P13` sample next.
 4. Keep **Mastra** as the main fallback if the Langfuse positioning risk feels
-   too high at that time.
+   too high once implementation starts.
 
 ## References
 
 - [PLAN — P10 Agno Accuracy Eval Evidence Interop](./PLAN-P10-AGNO-ACCURACY-EVAL-EVIDENCE-2026q2.md)
 - [PLAN — P11A Visa TAP Intent Verification Evidence Interop](./PLAN-P11A-VISA-TAP-INTENT-VERIFICATION-EVIDENCE-2026q2.md)
 - [PLAN — P12 Browser Use History / Output Evidence Interop](./PLAN-P12-BROWSER-USE-HISTORY-OUTPUT-EVIDENCE-2026q2.md)
+- [PLAN — P13 Langfuse Experiment Result Evidence Interop](./PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md)

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -27,8 +27,9 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [K2-A Phase 1 Freeze (Q2 2026)](./K2-A-PHASE1-FREEZE.md) — active contract for the first bounded MCP authorization-discovery seam now public in `v3.5.0`
 - [K2-A Phase 1 Freeze Prep (Q2 2026)](./K2-A-PHASE1-FREEZE-PREP.md) — pre-freeze source inventory and guardrails for the first bounded MCP authorization-discovery seam
 - [PLAN — P11A Visa TAP Intent Verification Evidence Interop (Q2 2026)](./PLAN-P11A-VISA-TAP-INTENT-VERIFICATION-EVIDENCE-2026q2.md) — planned frontier commerce / trust-proof lane built around TAP verification-result evidence, not payment truth
-- [TODO — Next Upstream Interop Lanes (Q2 2026)](./TODO-NEXT-UPSTREAM-INTEROP-LANES-2026q2.md) — ranked post-Agno queue that now formalizes `P11A` and keeps Browser Use as the active adjacent lane
+- [TODO — Next Upstream Interop Lanes (Q2 2026)](./TODO-NEXT-UPSTREAM-INTEROP-LANES-2026q2.md) — ranked post-Agno queue that now records Langfuse as the next planned platform-adjacent lane after Browser Use and TAP
 - [PLAN — P12 Browser Use History / Output Evidence Interop (Q2 2026)](./PLAN-P12-BROWSER-USE-HISTORY-OUTPUT-EVIDENCE-2026q2.md) — planned adjacent-space lane built around Browser Use local run history and output, not observability export
+- [PLAN — P13 Langfuse Experiment Result Evidence Interop (Q2 2026)](./PLAN-P13-LANGFUSE-EXPERIMENT-RESULT-EVIDENCE-2026q2.md) — planned platform-adjacent lane built around bounded experiment item results and evaluations, not Langfuse trace export
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 
 ## Active RFCs


### PR DESCRIPTION
## Summary
- add a formal `P13` architecture plan for Langfuse experiment-result evidence interop
- update the upstream interop queue so Langfuse is now the next planned platform-adjacent lane after Browser Use and Visa TAP
- link the new plan from the architecture index

## Why
Browser Use and P11A are now live, so the next deliberate lane needed a formal plan. Langfuse is the strongest next candidate because its current official surfaces around datasets, experiments, and scores make a smaller eval-result seam available than a trace-first observability pitch.

## Non-goals
- this does not implement `examples/langfuse-experiment-evidence/`
- this does not open an outward Langfuse Discussion
- this does not define a trace-first, dashboard-first, or prompt-management-first interop lane
