### PR TITLE
[codex] P14: tighten ScoreEvent seam after Mastra update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,7 +1612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4161,7 +4161,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4219,7 +4219,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4230,9 +4230,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4816,7 +4816,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5637,7 +5637,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/docs/architecture/PLAN-P14B-MASTRA-SCORE-EVENT-EVIDENCE-2026q2.md
+++ b/docs/architecture/PLAN-P14B-MASTRA-SCORE-EVENT-EVIDENCE-2026q2.md
@@ -186,35 +186,33 @@ Important framing rule:
 
 ## 6.1 Current upstream code reality
 
-The maintainer guidance points to `ObservabilityExporter` + `ScoreEvent` +
-`ExportedScore`, but the current upstream code shows one important asymmetry:
+The current upstream picture is now clearer than it was during the first
+re-cut.
+
+What still holds:
 
 - the score types define `ScoreEvent` and `ExportedScore`
 - `ObservabilityEvents` exposes `onScoreEvent`
-- the scorer hook currently calls `exporter.addScoreToTrace(...)`
-- that current callback shape is narrower than `ExportedScore`
+- the observability bus and several exporters already route score traffic
+  through `onScoreEvent`
 
-At the current upstream revision reviewed for this recut, the active
-`addScoreToTrace(...)` callback carries:
+What has changed in our understanding:
 
-- `traceId`
-- `spanId`
-- `score`
-- `reason`
-- `scorerName`
-- `metadata`
+- Mastra maintainers now explicitly point external consumers at
+  `ObservabilityExporter` + `ScoreEvent` + `ExportedScore`
+- Mastra maintainers also explicitly call `addScoreToTrace(...)` the old path
+  and say it will be deprecated soon
 
-Notably, that path does **not** obviously guarantee:
+So `P14b` should now be framed as:
 
-- `scorerId`
-- `targetEntityType`
-- `scoreSource`
-- `correlationContext`
+- **`ScoreEvent`-first by design**
+- still pre-proof on one captured live callback
+- careful not to overread every richer typed field as already proven in one
+  frozen external artifact
 
-So the current P14b sample must stay honest about two adjacent truths:
-
-- the richer typed seam exists in upstream types and maintainer guidance
-- the currently wired exporter callback visible in code is thinner
+The older `addScoreToTrace(...)` path still matters only as migration context.
+It explains why earlier code and docs looked thinner, but it is no longer the
+seam this lane should bless going forward.
 
 ## 7. v1 artifact contract
 
@@ -238,6 +236,7 @@ And it should require **at least one scorer identity field**:
 
 The first recut sample may include:
 
+- `score_id_ref`
 - `scorer_id`
 - `scorer_name`
 - `target_entity_type`
@@ -257,12 +256,13 @@ without a bounded identity for the scorer that produced it.
 
 Why this is not stricter:
 
-- the richer typed `ExportedScore` shape includes `scorerId`
-- the currently wired `addScoreToTrace(...)` callback in upstream code only
-  obviously guarantees `scorerName`
+- the typed `ExportedScore` shape includes both identity concepts
+- the current lane is still pre-proof on one captured live callback
+- the checked-in sample should not overclaim that one field is universally
+  present until a real callback proves it
 
 So the sample should require one bounded scorer identity, not pretend both are
-always present on the live exporter path.
+already proven universal on the live `ScoreEvent` path.
 
 In v1 they must stay small:
 
@@ -318,12 +318,36 @@ This field is optional in v1.
 Why:
 
 - the richer typed `ExportedScore` shape includes `targetEntityType`
-- the currently wired `addScoreToTrace(...)` callback does not obviously
-  guarantee it
+- this lane still has not captured one real callback and proven that field
+  present on the exact path we are targeting
 
 So this field is still useful when present, but it should not be a hard
 required field until a real capture proves it is consistently emitted on the
 path we are actually targeting.
+
+#### `score_id_ref`
+
+This field is optional in v1.
+
+Mastra maintainers have now called out `ScoreId` as an upcoming addition to the
+typed `ExportedScore` object, and it is likely to be the cleanest bounded
+anchor back into Mastra's own score plane.
+
+For Assay this should stay:
+
+- opaque
+- short
+- anchor-only
+
+Not allowed:
+
+- score lookup URLs
+- resolver paths
+- embedded score payloads
+
+The checked-in fixtures do not need to include this field yet. But the sample
+contract should keep a bounded slot ready for it instead of pretending the
+emerging anchor does not matter.
 
 It must remain:
 
@@ -392,21 +416,20 @@ The score event is one bounded external signal, not a framework truth import.
 
 This recut should not ship another purely speculative sample.
 
-Before the next sample PR, do one bounded discovery pass:
+Before closing this lane, do one bounded discovery pass:
 
 1. build a tiny real Mastra app with one scorer enabled
-2. register a custom `ObservabilityExporter`
+2. register a custom `ObservabilityExporter` implementing `onScoreEvent`
 3. capture one real `ScoreEvent`
 4. inspect the resulting `ExportedScore` shape
-5. inspect both the richer typed score-event path and the currently wired
-   `addScoreToTrace(...)` callback when possible
-6. reduce that shape to the smallest honest external-consumer artifact
+5. reduce that shape to the smallest honest external-consumer artifact
+6. only keep any `addScoreToTrace(...)` note if a real run still shows it as
+   historical compatibility context
 
 Discovery is only done when we have:
 
 - one captured real exporter callback payload
-- explicit note on whether the capture came from `onScoreEvent` or
-  `addScoreToTrace(...)`
+- explicit note that the capture came from `onScoreEvent`
 - one presence/absence table for the fields we call required vs optional
 - confirmation that the required sample fields are not just guessed from docs
 - at least one negative example showing an optional field truly absent, such as
@@ -420,8 +443,7 @@ cleaner.
 This lane is only complete when all of the following are true:
 
 - one live exporter callback payload has been captured from a real Mastra run
-- the capture path is named explicitly: `onScoreEvent` or
-  `addScoreToTrace(...)`
+- the capture path is explicitly the typed `onScoreEvent` path
 - the current required vs optional field split has been checked against that
   real capture
 - the frozen fixtures, README, and plan have been updated if the live payload
@@ -557,6 +579,7 @@ This recut does not:
 - [PLAN — P14 Mastra Scorer / Experiment-Result Evidence Interop](./PLAN-P14-MASTRA-SCORER-EXPERIMENT-RESULT-EVIDENCE-2026q2.md)
 - [Mastra issue #15206](https://github.com/mastra-ai/mastra/issues/15206)
 - [Maintainer exporter guidance on #15206](https://github.com/mastra-ai/mastra/issues/15206#issuecomment-4238852237)
+- [Maintainer note on `ScoreEvent` as the new path and upcoming `ScoreId`](https://github.com/mastra-ai/mastra/issues/15206#issuecomment-4252212575)
 - [Mastra observability](https://mastra.ai/observability)
 - [Introducing Scorers in Mastra](https://mastra.ai/blog/mastra-scorers)
 - [Change, Run, and Compare with Experiments in Mastra Studio](https://mastra.ai/blog/mastra-experiments)

--- a/examples/mastra-score-event-evidence/README.md
+++ b/examples/mastra-score-event-evidence/README.md
@@ -1,7 +1,8 @@
 # Mastra ScoreEvent / ExportedScore Evidence Sample
 
-This example turns one tiny frozen artifact derived from Mastra's score
-exporter path into bounded, reviewable external evidence for Assay.
+This example turns one tiny frozen artifact derived from Mastra's typed
+score-event exporter path into bounded, reviewable external evidence for
+Assay.
 
 It is intentionally small:
 
@@ -19,9 +20,9 @@ It is intentionally small:
 
 - `map_to_assay.py`: turns one tiny Mastra score artifact into an
   Assay-shaped placeholder envelope
-- `score_event_exporter.example.ts`: small exporter-side sketch that shows both
-  the richer typed `onScoreEvent` path and the currently wired
-  `addScoreToTrace(...)` path
+- `score_event_exporter.example.ts`: small exporter-side sketch centered on the
+  typed `onScoreEvent` path, with a legacy `addScoreToTrace(...)` note kept
+  only as migration context
 - `fixtures/valid.mastra.json`: one higher-score artifact
 - `fixtures/failure.mastra.json`: one lower-score artifact that intentionally
   uses the thinner scorer-name-only shape
@@ -36,51 +37,54 @@ It is intentionally small:
 This sample follows the maintainer-guided Mastra recut:
 
 - `ObservabilityExporter` is the narrow integration point
-- `ScoreEvent` / `ExportedScore` is the richer typed score shape
-- `addScoreToTrace(...)` is the currently wired scorer-hook callback in
-  upstream code today
+- `ScoreEvent` / `ExportedScore` is the primary typed score seam
+- older `addScoreToTrace(...)` mentions are legacy context, not the forward
+  seam this sample is trying to bless
 
 ## Current upstream seam
 
 This sample models the current score-export reality as carefully as we can see
-it today.
+it today, but it is now deliberately `ScoreEvent`-first.
 
 What that means in practice:
 
-- upstream types and maintainer guidance point to `ScoreEvent` /
-  `ExportedScore`
-- the currently wired scorer-hook path visible in code still calls
+- current Mastra observability code and maintainer guidance both point toward
+  `ScoreEvent` / `ExportedScore`
+- some older hooks, docs, and exporter helpers still mention
   `addScoreToTrace(...)`
-- this sample does **not** claim that Mastra already delivers a live
-  `onScoreEvent` callback in the exact frozen fixture shape checked in here
+- Mastra has now explicitly called `addScoreToTrace(...)` the old path and
+  said it will be deprecated soon
+- this sample still does **not** claim that one live `onScoreEvent` callback
+  has already been captured in the exact frozen fixture shape checked in here
 
-So this is a bounded mapping lane for the current exporter reality, not a
-claim that every live Mastra score callback already looks like the richer typed
-shape.
+So this is a bounded mapping lane for the `ScoreEvent` exporter reality we are
+targeting, not a claim that every live Mastra score callback has already been
+proven against the frozen fixture shape.
 
 ## Terminology alignment
 
-Mastra's public exporter story is usually explained in terms of the exporter
-score hook and payload fields such as `traceId`, `spanId`, `score`, `reason`,
-`scorerName`, and `metadata`.
+Mastra's public exporter story is now best read through `ScoreEvent` carrying
+`ExportedScore`.
 
-The maintainer reply on `#15206` also named the typed internal seam more
-explicitly as `ScoreEvent` carrying `ExportedScore`.
+The older `addScoreToTrace(...)` payload still matters only as historical
+context, because it explains why some older code and docs looked thinner than
+the typed score event seam.
 
-Current upstream code adds one important nuance:
+That leads to one careful but useful distinction:
 
 - the score types define `ScoreEvent` and `ExportedScore`
 - `ObservabilityEvents` exposes `onScoreEvent`
-- but the scorer hook currently calls `exporter.addScoreToTrace(...)` with a
-  narrower payload: `traceId`, `spanId`, `score`, `reason`, `scorerName`, and
-  `metadata`
+- `addScoreToTrace(...)` still exists in some codepaths and docs
+- but Mastra now calls that the old path and points external consumers to
+  `ScoreEvent` instead
 
-So this sample is still docs-backed and type-backed, not yet a real captured
-exporter callback. That is why the contract below stays careful about what is
-truly required.
+So this sample is maintainer-guided and type-backed around `ScoreEvent`, but
+still pre-proof until we capture one real live callback and compare the shape.
 
 This sample uses both names carefully:
 
+- `score_id_ref` is reserved for Mastra's upcoming `ScoreId` anchor when that
+  field lands on `ExportedScore`
 - `trace_id_ref` maps to `traceId`
 - `span_id_ref` maps to `spanId`
 - `score` maps to `score`
@@ -90,9 +94,10 @@ This sample uses both names carefully:
 - `target_ref` is a sample-level bounded anchor derived from the exporter
   payload, not a claim that upstream publishes one official `targetRef` field
 
-The current scorer-hook path does not appear to guarantee `scorer_id` or
-`target_entity_type`, so this sample now treats them as optional while still
-accepting them when the richer typed score-event shape is available.
+The checked-in fixtures do not yet include `score_id_ref`, because this sample
+has not captured a live callback carrying that field yet. But the sample now
+keeps the slot bounded and ready instead of pretending the new anchor does not
+exist.
 
 One small but important distinction:
 
@@ -130,9 +135,8 @@ The sample also includes one tiny exporter-side sketch in
 `score_event_exporter.example.ts`. It is not a production adapter. It only
 shows the smallest part of the exporter path we care about:
 
-- receive `ScoreEvent` when the typed path is available
-- or receive the thinner `addScoreToTrace(...)` payload on the current
-  scorer-hook path
+- receive `ScoreEvent` on the primary typed path
+- keep one historical `addScoreToTrace(...)` sketch only as a migration note
 - project one bounded frozen artifact for external evidence
 
 ## Map the checked-in valid artifact
@@ -196,8 +200,8 @@ Additional caps in this sample:
 
 - at least one scorer identity field must be present: `scorer_id` or
   `scorer_name`
-- `target_ref`, `trace_id_ref`, `span_id_ref`, and `metadata_ref` must stay
-  opaque ids, not URLs
+- `score_id_ref`, `target_ref`, `trace_id_ref`, `span_id_ref`, and
+  `metadata_ref` must stay opaque ids, not URLs
 - `reason` must stay short and single-line
 - `score` stays numeric in v1
 

--- a/examples/mastra-score-event-evidence/map_to_assay.py
+++ b/examples/mastra-score-event-evidence/map_to_assay.py
@@ -26,6 +26,7 @@ REQUIRED_KEYS = (
     "target_ref",
 )
 OPTIONAL_KEYS = {
+    "score_id_ref",
     "scorer_id",
     "scorer_name",
     "target_entity_type",
@@ -226,6 +227,8 @@ def _normalized_record(record: dict[str, Any]) -> dict[str, Any]:
     if scorer_id is None and scorer_name is None:
         raise ValueError("artifact: at least one scorer identity field is required: scorer_id or scorer_name")
 
+    if "score_id_ref" in record:
+        normalized["score_id_ref"] = _validate_opaque_ref(record["score_id_ref"], "artifact", "score_id_ref")
     if scorer_id is not None:
         normalized["scorer_id"] = _validate_short_string(scorer_id, "artifact", "scorer_id")
     if scorer_name is not None:

--- a/examples/mastra-score-event-evidence/score_event_exporter.example.ts
+++ b/examples/mastra-score-event-evidence/score_event_exporter.example.ts
@@ -5,6 +5,7 @@ type AssayScoreArtifact = {
   framework: 'mastra';
   surface: 'observability_score_event';
   timestamp: string;
+  score_id_ref?: string;
   scorer_id?: string;
   scorer_name?: string;
   score: number;
@@ -19,15 +20,14 @@ type AssayScoreArtifact = {
 };
 
 /**
- * Tiny illustrative sketch of the two adjacent exporter seams we care about.
+ * Tiny illustrative sketch of the primary exporter seam we care about.
  *
- * This is not a production adapter. It shows:
- * - the richer typed `onScoreEvent` path described by Mastra's score-event types
- * - the currently wired `addScoreToTrace` path used by the scorer hook
+ * This is not a production adapter. It shows the typed `onScoreEvent` path
+ * that Mastra now points external score consumers toward.
  *
- * The second path is important because it is thinner: it currently drops
- * fields such as `scorerId` and `targetEntityType`, so an external consumer
- * should not assume those are always present until a real capture confirms it.
+ * A legacy `addScoreToTrace` sketch is left below only as migration context
+ * because Mastra has explicitly called that pathway old and pending
+ * deprecation.
  */
 export class AssayScoreCaptureExporter {
   readonly scores: ExportedScore[] = [];
@@ -43,6 +43,12 @@ export class AssayScoreCaptureExporter {
   }
 }
 
+/**
+ * Historical / transitional sketch only.
+ *
+ * Keep this only to show why older docs and code samples may still mention a
+ * thinner score-attach payload. It is not the target seam for P14 anymore.
+ */
 export class AssayLegacyScoreAttachExporter {
   readonly scores: AssayScoreArtifact[] = [];
 
@@ -75,6 +81,10 @@ export class AssayLegacyScoreAttachExporter {
     return drained;
   }
 }
+
+type ForwardCompatibleExportedScore = ExportedScore & {
+  scoreId?: string;
+};
 
 function normalizeClassifier(value: unknown): string | undefined {
   if (value == null) {
@@ -111,6 +121,7 @@ function normalizeScoreSource(value: unknown): AssayScoreArtifact['score_source'
 }
 
 function toAssayScoreArtifact(score: ExportedScore): AssayScoreArtifact {
+  const forwardScore = score as ForwardCompatibleExportedScore;
   const targetRef = score.spanId ?? score.traceId ?? score.correlationContext?.entityId;
   if (!targetRef) {
     throw new Error('Score event is missing a bounded target anchor');
@@ -130,6 +141,7 @@ function toAssayScoreArtifact(score: ExportedScore): AssayScoreArtifact {
     framework: 'mastra',
     surface: 'observability_score_event',
     timestamp: score.timestamp.toISOString(),
+    ...(forwardScore.scoreId ? { score_id_ref: forwardScore.scoreId } : {}),
     ...(scorerId ? { scorer_id: scorerId } : {}),
     ...(scorerName ? { scorer_name: scorerName } : {}),
     score: score.score,

--- a/examples/mastra-score-event-evidence/score_event_exporter.example.ts
+++ b/examples/mastra-score-event-evidence/score_event_exporter.example.ts
@@ -86,6 +86,24 @@ type ForwardCompatibleExportedScore = ExportedScore & {
   scoreId?: string;
 };
 
+function normalizeOpaqueRef(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  const opaqueRefPattern = /^[A-Za-z0-9:_\-.]+$/;
+  if (!opaqueRefPattern.test(normalized) || normalized.includes('://')) {
+    throw new Error('Score event is missing a bounded opaque score id');
+  }
+
+  return normalized;
+}
+
 function normalizeClassifier(value: unknown): string | undefined {
   if (value == null) {
     return undefined;
@@ -128,11 +146,12 @@ function toAssayScoreArtifact(score: ExportedScore): AssayScoreArtifact {
   }
 
   const scorerId = score.scorerId;
-  const scorerName = score.scorerName ?? score.scorerId;
+  const scorerName = score.scorerName;
   if (!scorerId && !scorerName) {
     throw new Error('Score event is missing a scorer identity');
   }
 
+  const scoreIdRef = normalizeOpaqueRef(forwardScore.scoreId);
   const targetEntityType = normalizeClassifier(score.targetEntityType);
   const scoreSource = normalizeScoreSource(score.scoreSource);
 
@@ -141,7 +160,7 @@ function toAssayScoreArtifact(score: ExportedScore): AssayScoreArtifact {
     framework: 'mastra',
     surface: 'observability_score_event',
     timestamp: score.timestamp.toISOString(),
-    ...(forwardScore.scoreId ? { score_id_ref: forwardScore.scoreId } : {}),
+    ...(scoreIdRef ? { score_id_ref: scoreIdRef } : {}),
     ...(scorerId ? { scorer_id: scorerId } : {}),
     ...(scorerName ? { scorer_name: scorerName } : {}),
     score: score.score,


### PR DESCRIPTION
What changed
This follow-up tightens the P14 Mastra score-event lane after a fresh maintainer reply clarified that `addScoreToTrace(...)` is the old path and that `ScoreEvent` is the forward seam.

The PR:
- re-centers the plan and sample docs on `ScoreEvent` / `ExportedScore` as the primary seam
- demotes `addScoreToTrace(...)` to legacy / migration context instead of treating it like a co-equal current seam
- adds a bounded optional `score_id_ref` slot so the sample is ready for Mastra's upcoming `ScoreId`
- updates the exporter sketch and mapper to match that tighter posture

Why
The earlier recut was already much better than the scorer / experiment-item hypothesis, but it still leaned a bit too hard on the old score-attach path as "current reality".

The new maintainer guidance makes the right direction clearer:
- `ScoreEvent` is the new path
- `addScoreToTrace(...)` is legacy and expected to be deprecated
- `ExportedScore` is likely to gain a `ScoreId` anchor

So this PR makes the sample smaller and more honest again.

Important boundary
This does not close P14.

It still does not claim that we have already captured one real live `onScoreEvent` callback and proven the frozen fixture shape end-to-end.

It only tightens the lane so our sample and docs no longer overread the legacy path.

Validation
Ran locally:

`python3 examples/mastra-score-event-evidence/map_to_assay.py examples/mastra-score-event-evidence/fixtures/valid.mastra.json --output examples/mastra-score-event-evidence/fixtures/valid.assay.ndjson --import-time 2026-04-14T10:00:00Z --overwrite`

`python3 examples/mastra-score-event-evidence/map_to_assay.py examples/mastra-score-event-evidence/fixtures/failure.mastra.json --output examples/mastra-score-event-evidence/fixtures/failure.assay.ndjson --import-time 2026-04-14T10:05:00Z --overwrite`

`python3 examples/mastra-score-event-evidence/map_to_assay.py examples/mastra-score-event-evidence/fixtures/malformed.mastra.json --output /tmp/mastra-score-event-malformed.assay.ndjson --import-time 2026-04-14T10:10:00Z --overwrite`

Expected failure:
`artifact: unsupported top-level keys: metadata`

Additional guard checks:
- bounded `score_id_ref` is accepted when present
- URL-shaped `score_id_ref` is rejected

`python3 -m py_compile examples/mastra-score-event-evidence/map_to_assay.py`

`git diff --check`

Push-time hooks passed, including `cargo fmt --check`, `cargo clippy`, and the linux compile gate.

PR note
Change type: docs / sample contract hardening
Status vocabulary: main-only in-progress
Repo truth / release truth impact: repo truth only
Claim boundary impact: narrowed and clarified
Determinism impact: none
CI failure class, if applicable: none

Reviewer focus
This PR keeps P14 score-event-first, removes too much implicit trust in the legacy score-attach path, and prepares one bounded slot for the upcoming `ScoreId` anchor without pretending the live callback proof is already done.