### PR TITLE
[codex] align paused approval sample with P23B pattern

### DIFF
--- a/examples/openai-agents-js-approval-interruption-evidence/README.md
+++ b/examples/openai-agents-js-approval-interruption-evidence/README.md
@@ -3,6 +3,10 @@
 This example turns one tiny frozen artifact derived from a paused OpenAI
 Agents JS approval run into bounded, reviewable external evidence for Assay.
 
+It is also the first concrete example aligned to the Assay-side paused HITL
+reference pattern in
+[`docs/reference/patterns/paused-hitl-evidence.md`](../../docs/reference/patterns/paused-hitl-evidence.md).
+
 It is intentionally small:
 
 - start from one paused approval run only
@@ -49,6 +53,21 @@ The top-level `schema`, `framework`, and `surface` fields in these fixtures
 are sample wrapper metadata. They help identify the frozen artifact and the
 seam hypothesis, but they are not a claim that OpenAI Agents JS itself ships
 one canonical wrapper with those same labels.
+
+Within that wrapper, the fields play different roles:
+
+- `framework` identifies the originating runtime family
+- `surface` identifies the bounded runtime seam this sample reduces
+- `pause_reason` identifies why this specific artifact is paused
+
+For this sample, that means:
+
+- `framework = openai_agents_js`
+- `surface = tool_approval_interruption_resumable_state`
+- `pause_reason = tool_approval`
+
+So `surface` and `pause_reason` are intentionally related, but they are not
+the same field.
 
 ## Current discovery seam
 
@@ -153,9 +172,12 @@ python3 examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py
   --overwrite
 ```
 
-This third command is expected to fail because the malformed fixture smuggles a
-top-level `history` transcript into a lane that intentionally stays smaller
-than transcript truth.
+This third command is expected to fail with:
+
+- `artifact: history is out of scope for pause-only evidence`
+
+That is because the malformed fixture smuggles a top-level `history`
+transcript into a lane that intentionally stays smaller than transcript truth.
 
 That is an explicit product-boundary rejection, not just parser hygiene:
 
@@ -165,9 +187,10 @@ That is an explicit product-boundary rejection, not just parser hygiene:
   future explicitly narrowed slice
 
 The same rule applies to other continuation drift. For v1, artifacts that mix
-`history`, `session`, `lastResponseId`-style hints, or raw serialized
-`RunState` into the same lane should be treated as malformed rather than
-partially imported.
+`history`, `session`, `newItems`, `lastResponseId` / `previousResponseId`
+style hints, raw serialized `RunState`, or resolved approval decision data
+into the same lane should be treated as malformed rather than partially
+imported.
 
 ## Important boundary
 

--- a/examples/openai-agents-js-approval-interruption-evidence/README.md
+++ b/examples/openai-agents-js-approval-interruption-evidence/README.md
@@ -7,6 +7,11 @@ It is also the first concrete example aligned to the Assay-side paused HITL
 reference pattern in
 [`docs/reference/patterns/paused-hitl-evidence.md`](../../docs/reference/patterns/paused-hitl-evidence.md).
 
+That Assay-side shape is intended to stay aligned with the corresponding
+Assay Harness paused approval capture pattern, so this sample should be read
+as the reference/validation counterpart of the same pause-only pattern rather
+than as a standalone schema.
+
 It is intentionally small:
 
 - start from one paused approval run only

--- a/examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py
+++ b/examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py
@@ -231,6 +231,10 @@ def _validate_interruptions(value: Any) -> list[dict[str, Any]]:
 
 
 def _raise_on_forbidden_top_level_keys(record: dict[str, Any]) -> None:
+    # This mapper enforces the Assay-side pause-only evidence boundary. It is
+    # the reference/validation counterpart of a corresponding Harness capture
+    # pattern, so it stays intentionally smaller than full runtime or harness
+    # state.
     present_forbidden = sorted(key for key in record if key in FORBIDDEN_TOP_LEVEL_KEY_MESSAGES)
     if not present_forbidden:
         return

--- a/examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py
+++ b/examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py
@@ -17,6 +17,7 @@ PLACEHOLDER_PRODUCER = "assay-example"
 PLACEHOLDER_PRODUCER_VERSION = "0.1.0"
 PLACEHOLDER_GIT = "sample"
 EXTERNAL_SCHEMA = "openai-agents-js.tool-approval-interruption.export.v1"
+EXTERNAL_SURFACE = "tool_approval_interruption_resumable_state"
 REQUIRED_KEYS = (
     "schema",
     "framework",
@@ -32,6 +33,25 @@ OPTIONAL_KEYS = {
     "metadata_ref",
 }
 TOP_LEVEL_KEYS = set(REQUIRED_KEYS) | OPTIONAL_KEYS
+FORBIDDEN_TOP_LEVEL_KEY_MESSAGES = {
+    "history": "artifact: history is out of scope for pause-only evidence",
+    "session": "artifact: session is out of scope for pause-only evidence",
+    "session_id": "artifact: session identifiers are out of scope for pause-only evidence",
+    "newItems": "artifact: newItems is out of scope for pause-only evidence",
+    "new_items": "artifact: newItems is out of scope for pause-only evidence",
+    "lastResponseId": "artifact: provider continuation fields are out of scope for pause-only evidence",
+    "last_response_id": "artifact: provider continuation fields are out of scope for pause-only evidence",
+    "previousResponseId": "artifact: provider continuation fields are out of scope for pause-only evidence",
+    "previous_response_id": "artifact: provider continuation fields are out of scope for pause-only evidence",
+    "state": "artifact: raw serialized state must not be embedded in the canonical artifact",
+    "run_state": "artifact: raw serialized state must not be embedded in the canonical artifact",
+    "serialized_state": "artifact: raw serialized state must not be embedded in the canonical artifact",
+    "approval_decision": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+    "approval_outcome": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+    "approved": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+    "rejected": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+    "reject_reason": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+}
 ALLOWED_PAUSE_REASONS = {"tool_approval"}
 MAX_TEXT_LENGTH = 180
 MAX_REF_LENGTH = 120
@@ -210,7 +230,18 @@ def _validate_interruptions(value: Any) -> list[dict[str, Any]]:
     return normalized
 
 
+def _raise_on_forbidden_top_level_keys(record: dict[str, Any]) -> None:
+    present_forbidden = sorted(key for key in record if key in FORBIDDEN_TOP_LEVEL_KEY_MESSAGES)
+    if not present_forbidden:
+        return
+
+    first_key = present_forbidden[0]
+    raise ValueError(FORBIDDEN_TOP_LEVEL_KEY_MESSAGES[first_key])
+
+
 def _normalized_record(record: dict[str, Any]) -> dict[str, Any]:
+    _raise_on_forbidden_top_level_keys(record)
+
     unknown = set(record) - TOP_LEVEL_KEYS
     if unknown:
         raise ValueError(f"artifact: unsupported top-level keys: {', '.join(sorted(unknown))}")
@@ -228,8 +259,8 @@ def _normalized_record(record: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("artifact: framework must be openai_agents_js")
 
     surface = _validate_classifier(record["surface"], "artifact", "surface")
-    if surface != "tool_approval_interruption_resumable_state":
-        raise ValueError("artifact: surface must be tool_approval_interruption_resumable_state")
+    if surface != EXTERNAL_SURFACE:
+        raise ValueError(f"artifact: surface must be {EXTERNAL_SURFACE}")
 
     pause_reason = _validate_classifier(record["pause_reason"], "artifact", "pause_reason")
     if pause_reason not in ALLOWED_PAUSE_REASONS:


### PR DESCRIPTION
What changed
This follow-up aligns the existing OpenAI Agents JS paused approval sample with the new P23B paused HITL reference pattern.

The PR includes:
- a README tightening that explicitly ties the sample to the paused HITL reference pattern
- clearer field-role guidance for `framework`, `surface`, and `pause_reason`
- mapper-side boundary errors for pause-only drift surfaces such as `history`, `session`, `newItems`, raw serialized state, provider continuation hints, and resolved approval decision data

Why
P23B established the Assay-side reference pattern. This follow-up makes the first concrete sample behave more like that pattern in practice, without broadening the lane into runtime helpers or continuation support.

Boundary
This PR does not add harness helpers, new fixtures, resumed-flow support, session support, or a broader continuation framework.

It keeps the implementation slice on example/validator alignment only.

Validation
Ran locally:
- `python3 examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py examples/openai-agents-js-approval-interruption-evidence/fixtures/valid.openai-agents-js.json --output examples/openai-agents-js-approval-interruption-evidence/fixtures/valid.assay.ndjson --import-time 2026-04-16T12:10:00Z --overwrite`
- `python3 examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py examples/openai-agents-js-approval-interruption-evidence/fixtures/failure.openai-agents-js.json --output examples/openai-agents-js-approval-interruption-evidence/fixtures/failure.assay.ndjson --import-time 2026-04-16T12:15:00Z --overwrite`
- malformed check now fails on `artifact: history is out of scope for pause-only evidence`
- ad-hoc guards now fail correctly for inline raw state and resolved approval decision data
- `python3 -m py_compile examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py`
- `git diff --check -- examples/openai-agents-js-approval-interruption-evidence/README.md examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py`

Reviewer focus
This PR should be reviewed as a narrow P23B implementation follow-up: does the sample now speak the paused-HITL pattern more clearly, and does the mapper reject the right pause-only drift surfaces without widening the lane?
