### PR TITLE
[codex] add paused approval capture pattern

### DIFF
--- a/patterns/__init__.py
+++ b/patterns/__init__.py
@@ -1,0 +1,1 @@
+"""Assay-side reusable Python patterns."""

--- a/patterns/paused_approval/FIELD_PRESENCE.md
+++ b/patterns/paused_approval/FIELD_PRESENCE.md
@@ -1,0 +1,62 @@
+# Paused Approval Field Presence
+
+This note records the current observed-versus-derived posture for the paused
+approval pattern.
+
+The goal is simple: keep raw capture material separate from the reduced
+pause-only artifact so later helper code has a stable boundary to target.
+
+## Source posture
+
+This pattern is anchored to the currently documented `P22` paused approval
+seam under
+[`examples/openai-agents-js-approval-interruption-evidence`](../../examples/openai-agents-js-approval-interruption-evidence/README.md).
+
+The raw fixtures in this directory are intentionally fixture-sized and
+reviewable. They are not claims that Assay now stores or exports full runtime
+state as canonical evidence.
+
+## Raw fixture inputs
+
+- [`fixtures/raw/openai_agents_js.paused_result.json`](./fixtures/raw/openai_agents_js.paused_result.json)
+- [`fixtures/raw/openai_agents_js.serialized_state.txt`](./fixtures/raw/openai_agents_js.serialized_state.txt)
+
+## Presence table
+
+| Artifact field | Status | Source | Notes |
+|---|---|---|---|
+| `timestamp` | observed | raw paused result | Comes from the paused result envelope. |
+| `pause_reason` | fixed pattern constant | pattern | v1 stays on `tool_approval` only. |
+| `interruptions[*].tool_name` | observed, reduced | raw interruption item | Accept reduced aliases such as `toolName` / `tool_name`. |
+| `interruptions[*].call_id_ref` | observed, reduced | raw interruption item | Capture may accept `call_id`, `tool_call_id`, `tool_use_id`, `id`, or `rawItem.callId`, but reduces to canonical `call_id_ref`. |
+| `interruptions[*].agent_ref` | observed, reduced optional reviewer aid | raw interruption item | Only included when naturally present. |
+| `active_agent_ref` | observed, reduced optional reviewer aid | raw paused result | Optional. |
+| `last_agent_ref` | observed, reduced optional reviewer aid | raw paused result | Optional. |
+| `metadata_ref` | observed, reduced optional reviewer aid | raw paused result | Optional and opaque only. |
+| `resume_state_ref` | derived | serialized paused state | Derived fingerprint over serialized paused state; not a native runtime field. |
+| `policy_snapshot_hash` | tolerated extension | caller-supplied | Reviewer aid only; not part of the pattern minimum. |
+| `policy_decisions` | tolerated extension | caller-supplied | Reviewer aid only; not part of the pattern minimum. |
+| `interruptions[*].arguments_hash` | tolerated extension | caller-supplied | Lets richer lanes point at arguments without importing them inline. |
+
+## Explicitly not part of the canonical artifact
+
+These stay out of the canonical pause-only artifact even if a runtime exposes
+them:
+
+- raw serialized state
+- transcript history
+- session identifiers
+- `newItems`
+- provider continuation hints such as `lastResponseId`
+- resolved approval decision data
+- raw tool arguments
+
+## Observed vs derived
+
+Observed and derived fields must stay visibly different:
+
+- observed: pause state, bounded interruptions, naturally present reviewer aids
+- derived: `resume_state_ref`
+
+That distinction is the pattern. If later helper code blurs it, the pattern has
+grown too large.

--- a/patterns/paused_approval/README.md
+++ b/patterns/paused_approval/README.md
@@ -1,0 +1,119 @@
+# Paused Approval Pattern
+
+This directory holds the runtime-near Harness-side counterpart of the paused
+HITL evidence pattern.
+
+It is deliberately small:
+
+- capture one paused approval result
+- derive one `resume_state_ref` from serialized paused state
+- emit one pause-only artifact
+- validate that artifact against the bounded pattern
+
+## Layout note
+
+The original `P23A` plan sketch used `harness/patterns/paused_approval/`.
+
+In this repository, `harness/` is the TypeScript package. The Python paused
+approval pattern therefore lives under `patterns/paused_approval/` parallel to
+the existing Python-facing repo-root surfaces instead of leaking Python modules
+into the TypeScript package tree.
+
+## Public API
+
+The public imports are:
+
+- `capture_paused_approval`
+- `derive_resume_state_ref`
+- `emit_pause_artifact`
+- `validate_pause_artifact`
+
+These are meant to work on plain Python dicts and serialized state values.
+
+## Observed vs derived
+
+This pattern keeps the same core distinction as the Assay-side reference docs:
+
+- observed: `timestamp`, `interruptions`, naturally present reviewer aids
+- derived: `resume_state_ref`
+
+See [`FIELD_PRESENCE.md`](./FIELD_PRESENCE.md) for the explicit presence table.
+
+## Canonical names
+
+The canonical pause-only fields remain:
+
+- `pause_reason`
+- `interruptions`
+- `call_id_ref`
+- `resume_state_ref`
+
+Known runtime aliases are accepted during capture, but the emitted artifact
+always reduces back to those canonical names.
+
+## Tolerated extensions
+
+The pattern minimum is intentionally small.
+
+When a caller needs reviewer aids without widening the artifact, these
+extensions are tolerated:
+
+- top-level: `policy_snapshot_hash`, `policy_decisions`
+- per interruption item: `arguments_hash`
+
+They are not part of the pattern minimum.
+
+## Forbidden drift
+
+The validator explicitly rejects pause-only drift such as:
+
+- transcript history
+- session identifiers
+- `newItems`
+- provider continuation hints
+- raw serialized state inline
+- resolved approval decision data
+
+## Smoke path
+
+The quickest end-to-end reviewer path is:
+
+```bash
+python3 patterns/paused_approval/smoke.py \
+  --paused-result patterns/paused_approval/fixtures/raw/openai_agents_js.paused_result.json \
+  --serialized-state patterns/paused_approval/fixtures/raw/openai_agents_js.serialized_state.txt
+```
+
+That path uses only the public imports and emits one clean pause-only artifact.
+
+## Public import one-liner
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+from patterns.paused_approval import (
+    capture_paused_approval,
+    derive_resume_state_ref,
+    emit_pause_artifact,
+)
+
+raw = json.loads(Path("patterns/paused_approval/fixtures/raw/openai_agents_js.paused_result.json").read_text())
+state = Path("patterns/paused_approval/fixtures/raw/openai_agents_js.serialized_state.txt").read_text()
+
+captured = capture_paused_approval(raw)
+artifact = emit_pause_artifact(
+    captured,
+    framework="openai_agents_js",
+    schema="openai-agents-js.tool-approval-interruption.export.v1",
+    surface="tool_approval_interruption_resumable_state",
+    resume_state_ref=derive_resume_state_ref(state),
+)
+print(json.dumps(artifact, indent=2, sort_keys=True))
+PY
+```
+
+That one-liner is intentionally close to how a second runtime would reuse the
+same pattern later: observed capture in, derived state fingerprint in, bounded
+artifact out.

--- a/patterns/paused_approval/__init__.py
+++ b/patterns/paused_approval/__init__.py
@@ -1,0 +1,13 @@
+"""Paused approval capture pattern for runtime-near Harness integrations."""
+
+from .capture import capture_paused_approval
+from .emit import emit_pause_artifact
+from .fingerprint import derive_resume_state_ref
+from .validate import validate_pause_artifact
+
+__all__ = [
+    "capture_paused_approval",
+    "derive_resume_state_ref",
+    "emit_pause_artifact",
+    "validate_pause_artifact",
+]

--- a/patterns/paused_approval/_common.py
+++ b/patterns/paused_approval/_common.py
@@ -1,0 +1,123 @@
+"""Small shared helpers for the paused approval pattern."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
+
+
+PAUSE_REASON_TOOL_APPROVAL = "tool_approval"
+DEFAULT_SCHEMA = "assay.harness.paused-approval.v1"
+DEFAULT_SURFACE = "approval_interruption"
+MAX_TEXT_LENGTH = 180
+MAX_REF_LENGTH = 180
+MAX_INTERRUPTION_COUNT = 8
+MAX_TOOL_NAME_LENGTH = 64
+ALLOWED_TOP_LEVEL_OPTIONAL_KEYS = {
+    "active_agent_ref",
+    "last_agent_ref",
+    "metadata_ref",
+}
+TOLERATED_TOP_LEVEL_EXTENSION_KEYS = {
+    "policy_snapshot_hash",
+    "policy_decisions",
+}
+ALLOWED_INTERRUPTION_KEYS = {
+    "tool_name",
+    "call_id_ref",
+    "agent_ref",
+    "arguments_hash",
+}
+FORBIDDEN_TOP_LEVEL_KEY_MESSAGES = {
+    "history": "artifact: history is out of scope for pause-only evidence",
+    "session": "artifact: session is out of scope for pause-only evidence",
+    "session_id": "artifact: session identifiers are out of scope for pause-only evidence",
+    "newItems": "artifact: newItems/new_items is out of scope for pause-only evidence",
+    "new_items": "artifact: newItems/new_items is out of scope for pause-only evidence",
+    "lastResponseId": "artifact: provider continuation fields are out of scope for pause-only evidence",
+    "last_response_id": "artifact: provider continuation fields are out of scope for pause-only evidence",
+    "previousResponseId": "artifact: provider continuation fields are out of scope for pause-only evidence",
+    "previous_response_id": "artifact: provider continuation fields are out of scope for pause-only evidence",
+    "state": "artifact: raw serialized state must not be embedded in the canonical artifact",
+    "run_state": "artifact: raw serialized state must not be embedded in the canonical artifact",
+    "serialized_state": "artifact: raw serialized state must not be embedded in the canonical artifact",
+    "approval_decision": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+    "approval_outcome": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+    "approved": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+    "rejected": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+    "reject_reason": "artifact: resolved approval decision data is out of scope for pause-only evidence",
+}
+
+
+def validate_non_empty_string(value: Any, line_label: str, field_name: str, max_length: int) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{line_label}: {field_name} must be a non-empty string")
+    normalized = value.strip()
+    if len(normalized) > max_length:
+        raise ValueError(f"{line_label}: {field_name} must be at most {max_length} characters")
+    return normalized
+
+
+def validate_classifier(value: Any, line_label: str, field_name: str, max_length: int = 80) -> str:
+    classifier = validate_non_empty_string(value, line_label, field_name, max_length)
+    for char in classifier:
+        if not (char.islower() or char.isdigit() or char in {"_", "-"}):
+            raise ValueError(
+                f"{line_label}: {field_name} must use lowercase letters, digits, '_' or '-' only"
+            )
+    return classifier
+
+
+def validate_opaque_ref(value: Any, line_label: str, field_name: str) -> str:
+    ref = validate_non_empty_string(value, line_label, field_name, MAX_REF_LENGTH)
+    lowered = ref.lower()
+    if lowered.startswith("http://") or lowered.startswith("https://") or "://" in lowered:
+        raise ValueError(f"{line_label}: {field_name} must be an opaque id, not a URL")
+    return ref
+
+
+def parse_rfc3339_datetime(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"invalid RFC3339 timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def parse_rfc3339_utc(value: str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return parse_rfc3339_datetime(value).isoformat().replace("+00:00", "Z")
+
+
+def first_present(mapping: Mapping[str, Any], aliases: Iterable[str]) -> Any:
+    for alias in aliases:
+        if alias in mapping:
+            return mapping[alias]
+    return None
+
+
+def nested_present(mapping: Mapping[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = mapping
+    for segment in path:
+        if not isinstance(current, Mapping) or segment not in current:
+            return None
+        current = current[segment]
+    return current
+
+
+def reduce_agent_ref(value: Any, line_label: str, field_name: str = "agent_ref") -> str:
+    if isinstance(value, str):
+        return validate_opaque_ref(value, line_label, field_name)
+    if isinstance(value, Mapping):
+        direct = first_present(value, ("agent_ref", "agentRef", "ref", "id"))
+        if direct is not None:
+            return validate_opaque_ref(direct, line_label, field_name)
+        name = first_present(value, ("name", "agent_name", "agentName"))
+        if name is not None:
+            normalized_name = validate_non_empty_string(name, line_label, field_name, MAX_TEXT_LENGTH)
+            return f"agent:{normalized_name}"
+    raise ValueError(f"{line_label}: {field_name} must be a string or agent-like object")

--- a/patterns/paused_approval/capture.py
+++ b/patterns/paused_approval/capture.py
@@ -1,0 +1,165 @@
+"""Observed pause-state capture helpers for paused approval artifacts."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ._common import (
+    MAX_INTERRUPTION_COUNT,
+    MAX_TOOL_NAME_LENGTH,
+    PAUSE_REASON_TOOL_APPROVAL,
+    first_present,
+    nested_present,
+    parse_rfc3339_utc,
+    reduce_agent_ref,
+    validate_classifier,
+    validate_non_empty_string,
+    validate_opaque_ref,
+)
+
+
+INTERRUPTION_LIST_ALIASES = ("interruptions", "approval_items", "pending_approvals")
+TIMESTAMP_ALIASES = ("timestamp", "time", "created_at", "createdAt")
+ACTIVE_AGENT_ALIASES = ("active_agent_ref", "activeAgentRef", "active_agent", "activeAgent")
+LAST_AGENT_ALIASES = ("last_agent_ref", "lastAgentRef", "last_agent", "lastAgent")
+METADATA_REF_ALIASES = ("metadata_ref", "metadataRef")
+CALL_ID_ALIASES = ("call_id_ref", "call_id", "callId", "tool_call_id", "toolCallId", "tool_use_id", "toolUseId", "id")
+TOOL_NAME_ALIASES = ("tool_name", "toolName", "name")
+AGENT_REF_ALIASES = ("agent_ref", "agentRef", "agent", "agent_name", "agentName")
+ARGUMENTS_HASH_ALIASES = ("arguments_hash", "argumentsHash")
+
+
+def _extract_call_id(item: Mapping[str, Any], line_label: str) -> str:
+    direct = first_present(item, CALL_ID_ALIASES)
+    if direct is not None:
+        return validate_opaque_ref(direct, line_label, "call_id_ref")
+
+    for path in (("rawItem", "callId"), ("raw_item", "call_id"), ("rawItem", "id"), ("raw_item", "id")):
+        nested = nested_present(item, path)
+        if nested is not None:
+            return validate_opaque_ref(nested, line_label, "call_id_ref")
+
+    raise ValueError(f"{line_label}: call_id_ref could not be derived from known aliases")
+
+
+def _extract_tool_name(item: Mapping[str, Any], line_label: str) -> str:
+    tool_name = first_present(item, TOOL_NAME_ALIASES)
+    if tool_name is None:
+        raise ValueError(f"{line_label}: tool_name could not be derived from known aliases")
+    return validate_classifier(tool_name, line_label, "tool_name", MAX_TOOL_NAME_LENGTH)
+
+
+def _extract_optional_agent_ref(item: Mapping[str, Any], line_label: str) -> str | None:
+    agent_value = first_present(item, AGENT_REF_ALIASES)
+    if agent_value is None:
+        return None
+    return reduce_agent_ref(agent_value, line_label)
+
+
+def _extract_optional_arguments_hash(item: Mapping[str, Any], line_label: str) -> str | None:
+    arguments_hash = first_present(item, ARGUMENTS_HASH_ALIASES)
+    if arguments_hash is None:
+        return None
+    return validate_opaque_ref(arguments_hash, line_label, "arguments_hash")
+
+
+def _extract_interruptions(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw_interruptions = first_present(payload, INTERRUPTION_LIST_ALIASES)
+    if not isinstance(raw_interruptions, list) or not raw_interruptions:
+        raise ValueError("capture: interruptions must be a non-empty list")
+    if len(raw_interruptions) > MAX_INTERRUPTION_COUNT:
+        raise ValueError(f"capture: interruptions must contain at most {MAX_INTERRUPTION_COUNT} items")
+
+    normalized: list[dict[str, Any]] = []
+    seen_call_ids: set[str] = set()
+    for index, item in enumerate(raw_interruptions):
+        line_label = f"capture: interruptions[{index}]"
+        if not isinstance(item, Mapping):
+            raise ValueError(f"{line_label} must be an object")
+
+        call_id_ref = _extract_call_id(item, line_label)
+        if call_id_ref in seen_call_ids:
+            raise ValueError(f"{line_label}: duplicate call_id_ref: {call_id_ref}")
+        seen_call_ids.add(call_id_ref)
+
+        normalized_item = {
+            "tool_name": _extract_tool_name(item, line_label),
+            "call_id_ref": call_id_ref,
+        }
+
+        agent_ref = _extract_optional_agent_ref(item, line_label)
+        if agent_ref is not None:
+            normalized_item["agent_ref"] = agent_ref
+
+        arguments_hash = _extract_optional_arguments_hash(item, line_label)
+        if arguments_hash is not None:
+            normalized_item["arguments_hash"] = arguments_hash
+
+        normalized.append(normalized_item)
+
+    return normalized
+
+
+def _optional_agent_ref(payload: Mapping[str, Any], aliases: tuple[str, ...], field_name: str) -> str | None:
+    value = first_present(payload, aliases)
+    if value is None:
+        return None
+    return reduce_agent_ref(value, "capture", field_name)
+
+
+def capture_paused_approval(
+    payload: Mapping[str, Any],
+    *,
+    timestamp: str | None = None,
+    pause_reason: str = PAUSE_REASON_TOOL_APPROVAL,
+    active_agent_ref: str | None = None,
+    last_agent_ref: str | None = None,
+    metadata_ref: str | None = None,
+) -> dict[str, Any]:
+    """Capture the observed pause-only shape from a runtime-near payload."""
+
+    if not isinstance(payload, Mapping):
+        raise ValueError("capture: payload must be a mapping")
+
+    observed_timestamp = timestamp or first_present(payload, TIMESTAMP_ALIASES)
+    if observed_timestamp is None:
+        raise ValueError("capture: timestamp could not be derived from known aliases")
+
+    normalized = {
+        "timestamp": parse_rfc3339_utc(validate_non_empty_string(observed_timestamp, "capture", "timestamp", 180)),
+        "pause_reason": validate_classifier(pause_reason, "capture", "pause_reason", 80),
+        "interruptions": _extract_interruptions(payload),
+    }
+
+    if normalized["pause_reason"] != PAUSE_REASON_TOOL_APPROVAL:
+        raise ValueError("capture: pause_reason must be tool_approval")
+
+    resolved_active_agent = active_agent_ref or _optional_agent_ref(payload, ACTIVE_AGENT_ALIASES, "active_agent_ref")
+    if resolved_active_agent is not None:
+        normalized["active_agent_ref"] = validate_opaque_ref(
+            resolved_active_agent, "capture", "active_agent_ref"
+        )
+
+    resolved_last_agent = last_agent_ref or _optional_agent_ref(payload, LAST_AGENT_ALIASES, "last_agent_ref")
+    if resolved_last_agent is not None:
+        normalized["last_agent_ref"] = validate_opaque_ref(resolved_last_agent, "capture", "last_agent_ref")
+
+    resolved_metadata_ref = metadata_ref or first_present(payload, METADATA_REF_ALIASES)
+    if resolved_metadata_ref is not None:
+        normalized["metadata_ref"] = validate_opaque_ref(resolved_metadata_ref, "capture", "metadata_ref")
+
+    policy_snapshot_hash = payload.get("policy_snapshot_hash")
+    if policy_snapshot_hash is not None:
+        normalized["policy_snapshot_hash"] = validate_opaque_ref(
+            policy_snapshot_hash, "capture", "policy_snapshot_hash"
+        )
+
+    policy_decisions = payload.get("policy_decisions")
+    if policy_decisions is not None:
+        if not isinstance(policy_decisions, list) or not policy_decisions:
+            raise ValueError("capture: policy_decisions must be a non-empty list when present")
+        normalized["policy_decisions"] = [
+            validate_classifier(decision, "capture", "policy_decisions", 64) for decision in policy_decisions
+        ]
+
+    return normalized

--- a/patterns/paused_approval/emit.py
+++ b/patterns/paused_approval/emit.py
@@ -1,0 +1,44 @@
+"""Artifact emission helpers for the paused approval pattern."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ._common import DEFAULT_SCHEMA, DEFAULT_SURFACE
+from .validate import validate_pause_artifact
+
+
+def emit_pause_artifact(
+    captured: Mapping[str, Any],
+    *,
+    framework: str,
+    resume_state_ref: str,
+    schema: str = DEFAULT_SCHEMA,
+    surface: str = DEFAULT_SURFACE,
+    validate: bool = True,
+) -> dict[str, Any]:
+    """Emit the canonical pause-only artifact from captured pause-state data."""
+
+    artifact = {
+        "schema": schema,
+        "framework": framework,
+        "surface": surface,
+        "timestamp": captured["timestamp"],
+        "pause_reason": captured["pause_reason"],
+        "interruptions": captured["interruptions"],
+        "resume_state_ref": resume_state_ref,
+    }
+
+    for field_name in (
+        "active_agent_ref",
+        "last_agent_ref",
+        "metadata_ref",
+        "policy_snapshot_hash",
+        "policy_decisions",
+    ):
+        if field_name in captured:
+            artifact[field_name] = captured[field_name]
+
+    if validate:
+        return validate_pause_artifact(artifact)
+    return artifact

--- a/patterns/paused_approval/fingerprint.py
+++ b/patterns/paused_approval/fingerprint.py
@@ -1,0 +1,54 @@
+"""Derived continuation anchor helpers for paused approval state."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any
+
+
+def _normalize_for_hash(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("non-finite floats are not valid in canonical JSON")
+        if value.is_integer():
+            return int(value)
+        raise ValueError("non-integer floats are not valid in this pattern's canonical JSON subset")
+    if isinstance(value, dict):
+        return {str(key): _normalize_for_hash(nested) for key, nested in value.items()}
+    if isinstance(value, list):
+        return [_normalize_for_hash(item) for item in value]
+    if isinstance(value, tuple):
+        return [_normalize_for_hash(item) for item in value]
+    raise TypeError(f"unsupported canonical JSON value: {type(value).__name__}")
+
+
+def _canonical_json(value: Any) -> str:
+    normalized = _normalize_for_hash(value)
+    return json.dumps(
+        normalized,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        allow_nan=False,
+    )
+
+
+def derive_resume_state_ref(serialized_state: Any) -> str:
+    """Derive the canonical pause-only continuation anchor.
+
+    This helper always returns a derived `resume_state_ref`. It does not expose
+    raw serialized state as part of the pattern output.
+    """
+
+    if isinstance(serialized_state, bytes):
+        payload = serialized_state
+    elif isinstance(serialized_state, str):
+        payload = serialized_state.encode("utf-8")
+    else:
+        payload = _canonical_json(serialized_state).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
+    return f"runstate:sha256:{digest}"

--- a/patterns/paused_approval/fixtures/failure.paused.json
+++ b/patterns/paused_approval/fixtures/failure.paused.json
@@ -1,0 +1,14 @@
+{
+  "schema": "openai-agents-js.tool-approval-interruption.export.v1",
+  "framework": "openai_agents_js",
+  "surface": "tool_approval_interruption_resumable_state",
+  "timestamp": "2026-04-16T11:37:00Z",
+  "pause_reason": "tool_approval",
+  "interruptions": [
+    {
+      "tool_name": "send_email",
+      "call_id_ref": "call_p23a_failure_1"
+    }
+  ],
+  "resume_state_ref": "runstate:example-minimal-approval-1"
+}

--- a/patterns/paused_approval/fixtures/malformed.history.paused.json
+++ b/patterns/paused_approval/fixtures/malformed.history.paused.json
@@ -1,0 +1,20 @@
+{
+  "schema": "openai-agents-js.tool-approval-interruption.export.v1",
+  "framework": "openai_agents_js",
+  "surface": "tool_approval_interruption_resumable_state",
+  "timestamp": "2026-04-16T11:40:00Z",
+  "pause_reason": "tool_approval",
+  "interruptions": [
+    {
+      "tool_name": "send_email",
+      "call_id_ref": "call_p23a_bad_history_1"
+    }
+  ],
+  "resume_state_ref": "runstate:bad-history-1",
+  "history": [
+    {
+      "role": "user",
+      "content": "Please email ops with a short status update."
+    }
+  ]
+}

--- a/patterns/paused_approval/fixtures/malformed.raw_state.paused.json
+++ b/patterns/paused_approval/fixtures/malformed.raw_state.paused.json
@@ -1,0 +1,15 @@
+{
+  "schema": "openai-agents-js.tool-approval-interruption.export.v1",
+  "framework": "openai_agents_js",
+  "surface": "tool_approval_interruption_resumable_state",
+  "timestamp": "2026-04-16T11:41:00Z",
+  "pause_reason": "tool_approval",
+  "interruptions": [
+    {
+      "tool_name": "send_email",
+      "call_id_ref": "call_p23a_bad_state_1"
+    }
+  ],
+  "resume_state_ref": "runstate:bad-state-1",
+  "state": "{\"opaque\":true}"
+}

--- a/patterns/paused_approval/fixtures/malformed.resolved.paused.json
+++ b/patterns/paused_approval/fixtures/malformed.resolved.paused.json
@@ -1,0 +1,15 @@
+{
+  "schema": "openai-agents-js.tool-approval-interruption.export.v1",
+  "framework": "openai_agents_js",
+  "surface": "tool_approval_interruption_resumable_state",
+  "timestamp": "2026-04-16T11:42:00Z",
+  "pause_reason": "tool_approval",
+  "interruptions": [
+    {
+      "tool_name": "send_email",
+      "call_id_ref": "call_p23a_bad_approved_1"
+    }
+  ],
+  "resume_state_ref": "runstate:bad-approved-1",
+  "approved": true
+}

--- a/patterns/paused_approval/fixtures/raw/openai_agents_js.paused_result.json
+++ b/patterns/paused_approval/fixtures/raw/openai_agents_js.paused_result.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": "2026-04-16T11:32:00Z",
+  "interruptions": [
+    {
+      "toolName": "send_email",
+      "agent": {
+        "name": "P22ApprovalProbe"
+      },
+      "rawItem": {
+        "callId": "call_p23a_raw_1"
+      }
+    }
+  ],
+  "activeAgent": {
+    "name": "P22ApprovalProbe"
+  },
+  "metadataRef": "meta:p23a-raw-openai-agents-js"
+}

--- a/patterns/paused_approval/fixtures/raw/openai_agents_js.serialized_state.txt
+++ b/patterns/paused_approval/fixtures/raw/openai_agents_js.serialized_state.txt
@@ -1,0 +1,1 @@
+{"run":"paused","pauseReason":"tool_approval","agent":"P22ApprovalProbe","interruptions":[{"toolName":"send_email","callId":"call_p23a_raw_1"}]}

--- a/patterns/paused_approval/fixtures/valid.paused.json
+++ b/patterns/paused_approval/fixtures/valid.paused.json
@@ -1,0 +1,16 @@
+{
+  "schema": "openai-agents-js.tool-approval-interruption.export.v1",
+  "framework": "openai_agents_js",
+  "surface": "tool_approval_interruption_resumable_state",
+  "timestamp": "2026-04-16T11:32:00Z",
+  "pause_reason": "tool_approval",
+  "interruptions": [
+    {
+      "tool_name": "send_email",
+      "call_id_ref": "call_p23a_valid_1",
+      "agent_ref": "agent:P22ApprovalProbe"
+    }
+  ],
+  "resume_state_ref": "runstate:sha256:a136d3d331cff5810ec27c7afc5fed9b0e16ed8608e5e698358eedbffb83fd51",
+  "active_agent_ref": "agent:P22ApprovalProbe"
+}

--- a/patterns/paused_approval/smoke.py
+++ b/patterns/paused_approval/smoke.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Minimal reviewer smoke path for the paused approval pattern."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from patterns.paused_approval import (
+    capture_paused_approval,
+    derive_resume_state_ref,
+    emit_pause_artifact,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Emit one paused approval artifact from raw fixture inputs.")
+    parser.add_argument("--paused-result", type=Path, required=True, help="Raw paused result JSON input.")
+    parser.add_argument("--serialized-state", type=Path, required=True, help="Serialized paused state input.")
+    parser.add_argument("--framework", default="openai_agents_js", help="Originating runtime family token.")
+    parser.add_argument(
+        "--schema",
+        default="openai-agents-js.tool-approval-interruption.export.v1",
+        help="Artifact schema identifier to emit.",
+    )
+    parser.add_argument(
+        "--surface",
+        default="tool_approval_interruption_resumable_state",
+        help="Bounded runtime seam identifier to emit.",
+    )
+    parser.add_argument("--output", type=Path, default=None, help="Optional output path. Defaults to stdout.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    raw = json.loads(args.paused_result.read_text(encoding="utf-8"))
+    serialized_state = args.serialized_state.read_text(encoding="utf-8")
+
+    captured = capture_paused_approval(raw)
+    artifact = emit_pause_artifact(
+        captured,
+        framework=args.framework,
+        schema=args.schema,
+        surface=args.surface,
+        resume_state_ref=derive_resume_state_ref(serialized_state),
+    )
+
+    rendered = json.dumps(artifact, indent=2, sort_keys=True)
+    if args.output is None:
+        print(rendered)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(f"{rendered}\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/patterns/paused_approval/tests/__init__.py
+++ b/patterns/paused_approval/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the paused approval pattern."""

--- a/patterns/paused_approval/tests/test_capture.py
+++ b/patterns/paused_approval/tests/test_capture.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from patterns.paused_approval import capture_paused_approval
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "raw"
+
+
+class CapturePausedApprovalTests(unittest.TestCase):
+    def test_capture_from_raw_fixture(self) -> None:
+        payload = json.loads((FIXTURE_DIR / "openai_agents_js.paused_result.json").read_text())
+        captured = capture_paused_approval(payload)
+        self.assertEqual(captured["pause_reason"], "tool_approval")
+        self.assertEqual(captured["interruptions"][0]["tool_name"], "send_email")
+        self.assertEqual(captured["interruptions"][0]["call_id_ref"], "call_p23a_raw_1")
+        self.assertEqual(captured["interruptions"][0]["agent_ref"], "agent:P22ApprovalProbe")
+        self.assertEqual(captured["active_agent_ref"], "agent:P22ApprovalProbe")
+        self.assertEqual(captured["metadata_ref"], "meta:p23a-raw-openai-agents-js")
+
+    def test_accepts_tool_call_id_alias(self) -> None:
+        captured = capture_paused_approval(
+            {"timestamp": "2026-04-18T10:00:00Z", "interruptions": [{"tool_name": "send_email", "tool_call_id": "call_1"}]}
+        )
+        self.assertEqual(captured["interruptions"][0]["call_id_ref"], "call_1")
+
+    def test_accepts_tool_use_id_alias(self) -> None:
+        captured = capture_paused_approval(
+            {"timestamp": "2026-04-18T10:00:00Z", "interruptions": [{"tool_name": "send_email", "tool_use_id": "call_2"}]}
+        )
+        self.assertEqual(captured["interruptions"][0]["call_id_ref"], "call_2")
+
+    def test_accepts_call_id_alias(self) -> None:
+        captured = capture_paused_approval(
+            {"timestamp": "2026-04-18T10:00:00Z", "interruptions": [{"tool_name": "send_email", "call_id": "call_3"}]}
+        )
+        self.assertEqual(captured["interruptions"][0]["call_id_ref"], "call_3")
+
+    def test_accepts_plain_id_alias(self) -> None:
+        captured = capture_paused_approval(
+            {"timestamp": "2026-04-18T10:00:00Z", "interruptions": [{"tool_name": "send_email", "id": "call_4"}]}
+        )
+        self.assertEqual(captured["interruptions"][0]["call_id_ref"], "call_4")
+
+    def test_accepts_raw_item_alias(self) -> None:
+        captured = capture_paused_approval(
+            {
+                "timestamp": "2026-04-18T10:00:00Z",
+                "interruptions": [{"tool_name": "send_email", "rawItem": {"callId": "call_5"}}],
+            }
+        )
+        self.assertEqual(captured["interruptions"][0]["call_id_ref"], "call_5")
+
+    def test_accepts_pending_approvals_alias(self) -> None:
+        captured = capture_paused_approval(
+            {
+                "timestamp": "2026-04-18T10:00:00Z",
+                "pending_approvals": [{"toolName": "send_email", "callId": "call_6"}],
+            }
+        )
+        self.assertEqual(captured["interruptions"][0]["call_id_ref"], "call_6")
+
+    def test_accepts_optional_arguments_hash(self) -> None:
+        captured = capture_paused_approval(
+            {
+                "timestamp": "2026-04-18T10:00:00Z",
+                "interruptions": [
+                    {
+                        "tool_name": "send_email",
+                        "call_id": "call_7",
+                        "arguments_hash": "sha256:abc123",
+                    }
+                ],
+            }
+        )
+        self.assertEqual(captured["interruptions"][0]["arguments_hash"], "sha256:abc123")
+
+    def test_accepts_policy_extensions(self) -> None:
+        captured = capture_paused_approval(
+            {
+                "timestamp": "2026-04-18T10:00:00Z",
+                "interruptions": [{"tool_name": "send_email", "call_id": "call_8"}],
+                "policy_snapshot_hash": "sha256:policy123",
+                "policy_decisions": ["allow", "log_only"],
+            }
+        )
+        self.assertEqual(captured["policy_snapshot_hash"], "sha256:policy123")
+        self.assertEqual(captured["policy_decisions"], ["allow", "log_only"])
+
+    def test_rejects_missing_interruptions(self) -> None:
+        with self.assertRaisesRegex(ValueError, "interruptions must be a non-empty list"):
+            capture_paused_approval({"timestamp": "2026-04-18T10:00:00Z"})
+
+    def test_rejects_empty_interruptions(self) -> None:
+        with self.assertRaisesRegex(ValueError, "interruptions must be a non-empty list"):
+            capture_paused_approval({"timestamp": "2026-04-18T10:00:00Z", "interruptions": []})
+
+    def test_rejects_missing_tool_name(self) -> None:
+        with self.assertRaisesRegex(ValueError, "tool_name could not be derived"):
+            capture_paused_approval({"timestamp": "2026-04-18T10:00:00Z", "interruptions": [{"call_id": "call_9"}]})
+
+    def test_rejects_missing_call_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "call_id_ref could not be derived"):
+            capture_paused_approval(
+                {"timestamp": "2026-04-18T10:00:00Z", "interruptions": [{"tool_name": "send_email"}]}
+            )
+
+    def test_rejects_duplicate_call_ids(self) -> None:
+        with self.assertRaisesRegex(ValueError, "duplicate call_id_ref"):
+            capture_paused_approval(
+                {
+                    "timestamp": "2026-04-18T10:00:00Z",
+                    "interruptions": [
+                        {"tool_name": "send_email", "call_id": "same"},
+                        {"tool_name": "send_email", "call_id": "same"},
+                    ],
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/patterns/paused_approval/tests/test_corpus.py
+++ b/patterns/paused_approval/tests/test_corpus.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from patterns.paused_approval import validate_pause_artifact
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+MAPPER = (
+    Path(__file__).resolve().parents[3]
+    / "examples"
+    / "openai-agents-js-approval-interruption-evidence"
+    / "map_to_assay.py"
+)
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text())
+
+
+class PausedApprovalCorpusTests(unittest.TestCase):
+    def _run_mapper(self, fixture_name: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "artifact.ndjson"
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(MAPPER),
+                    str(FIXTURE_DIR / fixture_name),
+                    "--output",
+                    str(output_path),
+                    "--import-time",
+                    "2026-04-18T10:30:00Z",
+                    "--overwrite",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    def test_valid_fixture_passes_validator_and_mapper(self) -> None:
+        normalized = validate_pause_artifact(_load_fixture("valid.paused.json"))
+        self.assertEqual(normalized["framework"], "openai_agents_js")
+        result = self._run_mapper("valid.paused.json")
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+
+    def test_failure_fixture_passes_validator_and_mapper(self) -> None:
+        normalized = validate_pause_artifact(_load_fixture("failure.paused.json"))
+        self.assertEqual(normalized["pause_reason"], "tool_approval")
+        result = self._run_mapper("failure.paused.json")
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+
+    def test_history_fixture_fails_validator_and_mapper(self) -> None:
+        fixture = _load_fixture("malformed.history.paused.json")
+        with self.assertRaisesRegex(ValueError, "history is out of scope"):
+            validate_pause_artifact(fixture)
+        result = self._run_mapper("malformed.history.paused.json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("history is out of scope", result.stderr or result.stdout)
+
+    def test_raw_state_fixture_fails_validator_and_mapper(self) -> None:
+        fixture = _load_fixture("malformed.raw_state.paused.json")
+        with self.assertRaisesRegex(ValueError, "raw serialized state"):
+            validate_pause_artifact(fixture)
+        result = self._run_mapper("malformed.raw_state.paused.json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("raw serialized state", result.stderr or result.stdout)
+
+    def test_resolved_decision_fixture_fails_validator_and_mapper(self) -> None:
+        fixture = _load_fixture("malformed.resolved.paused.json")
+        with self.assertRaisesRegex(ValueError, "resolved approval decision"):
+            validate_pause_artifact(fixture)
+        result = self._run_mapper("malformed.resolved.paused.json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("resolved approval decision", result.stderr or result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/patterns/paused_approval/tests/test_emit.py
+++ b/patterns/paused_approval/tests/test_emit.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import unittest
+
+from patterns.paused_approval import emit_pause_artifact
+
+
+class EmitPauseArtifactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.captured = {
+            "timestamp": "2026-04-18T10:00:00Z",
+            "pause_reason": "tool_approval",
+            "interruptions": [{"tool_name": "send_email", "call_id_ref": "call_1"}],
+        }
+
+    def test_emit_minimal_artifact(self) -> None:
+        artifact = emit_pause_artifact(
+            self.captured,
+            framework="openai_agents_js",
+            resume_state_ref="runstate:sha256:abc",
+        )
+        self.assertEqual(artifact["schema"], "assay.harness.paused-approval.v1")
+        self.assertEqual(artifact["surface"], "approval_interruption")
+
+    def test_emit_carries_optional_fields(self) -> None:
+        artifact = emit_pause_artifact(
+            {
+                **self.captured,
+                "active_agent_ref": "agent:active",
+                "metadata_ref": "meta:1",
+                "policy_snapshot_hash": "sha256:policy",
+                "policy_decisions": ["allow"],
+            },
+            framework="openai_agents_js",
+            resume_state_ref="runstate:sha256:def",
+        )
+        self.assertEqual(artifact["active_agent_ref"], "agent:active")
+        self.assertEqual(artifact["policy_decisions"], ["allow"])
+
+    def test_emit_uses_custom_schema_and_surface(self) -> None:
+        artifact = emit_pause_artifact(
+            self.captured,
+            framework="openai_agents_js",
+            resume_state_ref="runstate:sha256:ghi",
+            schema="custom.schema.v1",
+            surface="tool_approval_interruption_resumable_state",
+        )
+        self.assertEqual(artifact["schema"], "custom.schema.v1")
+        self.assertEqual(artifact["surface"], "tool_approval_interruption_resumable_state")
+
+    def test_emit_rejects_bad_framework(self) -> None:
+        with self.assertRaisesRegex(ValueError, "framework"):
+            emit_pause_artifact(self.captured, framework="OpenAI", resume_state_ref="runstate:sha256:jkl")
+
+    def test_emit_can_skip_validation(self) -> None:
+        artifact = emit_pause_artifact(
+            self.captured,
+            framework="OpenAI",
+            resume_state_ref="https://bad.example/ref",
+            validate=False,
+        )
+        self.assertEqual(artifact["framework"], "OpenAI")
+
+    def test_emit_requires_resume_state_ref(self) -> None:
+        with self.assertRaises(TypeError):
+            emit_pause_artifact(self.captured, framework="openai_agents_js")  # type: ignore[call-arg]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/patterns/paused_approval/tests/test_fingerprint.py
+++ b/patterns/paused_approval/tests/test_fingerprint.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import unittest
+
+from patterns.paused_approval.fingerprint import derive_resume_state_ref
+
+
+class DeriveResumeStateRefTests(unittest.TestCase):
+    def test_same_mapping_content_same_hash(self) -> None:
+        left = {"b": 1, "a": [True, "x"]}
+        right = {"a": [True, "x"], "b": 1}
+        self.assertEqual(derive_resume_state_ref(left), derive_resume_state_ref(right))
+
+    def test_string_and_bytes_match(self) -> None:
+        self.assertEqual(
+            derive_resume_state_ref("serialized-state"),
+            derive_resume_state_ref(b"serialized-state"),
+        )
+
+    def test_integer_float_normalizes(self) -> None:
+        self.assertEqual(derive_resume_state_ref({"x": 1.0}), derive_resume_state_ref({"x": 1}))
+
+    def test_non_integer_float_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "non-integer floats"):
+            derive_resume_state_ref({"x": 1.25})
+
+    def test_non_finite_float_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "non-finite floats"):
+            derive_resume_state_ref({"x": float("inf")})
+
+    def test_list_payload_supported(self) -> None:
+        result = derive_resume_state_ref([{"call_id": "one"}, {"call_id": "two"}])
+        self.assertTrue(result.startswith("runstate:sha256:"))
+
+    def test_nested_payload_supported(self) -> None:
+        result = derive_resume_state_ref({"pause": {"reason": "tool_approval"}})
+        self.assertTrue(result.startswith("runstate:sha256:"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/patterns/paused_approval/tests/test_smoke.py
+++ b/patterns/paused_approval/tests/test_smoke.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from patterns.paused_approval import validate_pause_artifact
+
+
+ROOT = Path(__file__).resolve().parents[3]
+RAW_RESULT = ROOT / "patterns" / "paused_approval" / "fixtures" / "raw" / "openai_agents_js.paused_result.json"
+RAW_STATE = ROOT / "patterns" / "paused_approval" / "fixtures" / "raw" / "openai_agents_js.serialized_state.txt"
+SMOKE = ROOT / "patterns" / "paused_approval" / "smoke.py"
+MAPPER = ROOT / "examples" / "openai-agents-js-approval-interruption-evidence" / "map_to_assay.py"
+
+
+class PausedApprovalSmokeTests(unittest.TestCase):
+    def test_smoke_script_stdout_emits_valid_artifact(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SMOKE),
+                "--paused-result",
+                str(RAW_RESULT),
+                "--serialized-state",
+                str(RAW_STATE),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        artifact = json.loads(result.stdout)
+        normalized = validate_pause_artifact(artifact)
+        self.assertEqual(normalized["framework"], "openai_agents_js")
+
+    def test_public_import_one_liner_emits_valid_artifact(self) -> None:
+        command = """
+import json
+from pathlib import Path
+from patterns.paused_approval import capture_paused_approval, derive_resume_state_ref, emit_pause_artifact
+raw = json.loads(Path("patterns/paused_approval/fixtures/raw/openai_agents_js.paused_result.json").read_text())
+state = Path("patterns/paused_approval/fixtures/raw/openai_agents_js.serialized_state.txt").read_text()
+artifact = emit_pause_artifact(
+    capture_paused_approval(raw),
+    framework="openai_agents_js",
+    schema="openai-agents-js.tool-approval-interruption.export.v1",
+    surface="tool_approval_interruption_resumable_state",
+    resume_state_ref=derive_resume_state_ref(state),
+)
+print(json.dumps(artifact))
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", command],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        artifact = json.loads(result.stdout)
+        normalized = validate_pause_artifact(artifact)
+        self.assertEqual(normalized["pause_reason"], "tool_approval")
+
+    def test_smoke_output_is_mapper_compatible(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_path = Path(temp_dir) / "artifact.json"
+            ndjson_path = Path(temp_dir) / "artifact.ndjson"
+            smoke = subprocess.run(
+                [
+                    sys.executable,
+                    str(SMOKE),
+                    "--paused-result",
+                    str(RAW_RESULT),
+                    "--serialized-state",
+                    str(RAW_STATE),
+                    "--output",
+                    str(artifact_path),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(smoke.returncode, 0, smoke.stderr)
+            mapper = subprocess.run(
+                [
+                    sys.executable,
+                    str(MAPPER),
+                    str(artifact_path),
+                    "--output",
+                    str(ndjson_path),
+                    "--import-time",
+                    "2026-04-18T10:45:00Z",
+                    "--overwrite",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=ROOT,
+                check=False,
+            )
+            self.assertEqual(mapper.returncode, 0, mapper.stderr or mapper.stdout)
+            self.assertTrue(ndjson_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/patterns/paused_approval/tests/test_validate.py
+++ b/patterns/paused_approval/tests/test_validate.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import unittest
+
+from patterns.paused_approval import validate_pause_artifact
+
+
+def _valid_artifact() -> dict[str, object]:
+    return {
+        "schema": "assay.harness.paused-approval.v1",
+        "framework": "openai_agents_js",
+        "surface": "approval_interruption",
+        "timestamp": "2026-04-18T10:00:00Z",
+        "pause_reason": "tool_approval",
+        "interruptions": [{"tool_name": "send_email", "call_id_ref": "call_1"}],
+        "resume_state_ref": "runstate:sha256:abc123",
+    }
+
+
+class ValidatePauseArtifactTests(unittest.TestCase):
+    def test_valid_artifact_passes(self) -> None:
+        normalized = validate_pause_artifact(_valid_artifact())
+        self.assertEqual(normalized["pause_reason"], "tool_approval")
+
+    def test_optional_fields_pass(self) -> None:
+        artifact = _valid_artifact()
+        artifact["active_agent_ref"] = "agent:active"
+        artifact["last_agent_ref"] = "agent:last"
+        artifact["metadata_ref"] = "meta:1"
+        normalized = validate_pause_artifact(artifact)
+        self.assertEqual(normalized["active_agent_ref"], "agent:active")
+
+    def test_tolerated_extensions_pass(self) -> None:
+        artifact = _valid_artifact()
+        artifact["policy_snapshot_hash"] = "sha256:policy"
+        artifact["policy_decisions"] = ["allow", "log_only"]
+        artifact["interruptions"] = [
+            {"tool_name": "send_email", "call_id_ref": "call_1", "arguments_hash": "sha256:args"}
+        ]
+        normalized = validate_pause_artifact(artifact)
+        self.assertEqual(normalized["policy_decisions"], ["allow", "log_only"])
+        self.assertEqual(normalized["interruptions"][0]["arguments_hash"], "sha256:args")
+
+    def test_rejects_history(self) -> None:
+        artifact = _valid_artifact()
+        artifact["history"] = []
+        with self.assertRaisesRegex(ValueError, "history is out of scope"):
+            validate_pause_artifact(artifact)
+
+    def test_rejects_session(self) -> None:
+        artifact = _valid_artifact()
+        artifact["session"] = "sess_1"
+        with self.assertRaisesRegex(ValueError, "session is out of scope"):
+            validate_pause_artifact(artifact)
+
+    def test_rejects_new_items_spelling(self) -> None:
+        artifact = _valid_artifact()
+        artifact["new_items"] = []
+        with self.assertRaisesRegex(ValueError, "newItems/new_items"):
+            validate_pause_artifact(artifact)
+
+    def test_rejects_raw_state(self) -> None:
+        artifact = _valid_artifact()
+        artifact["state"] = "{}"
+        with self.assertRaisesRegex(ValueError, "raw serialized state"):
+            validate_pause_artifact(artifact)
+
+    def test_rejects_resolved_decision(self) -> None:
+        artifact = _valid_artifact()
+        artifact["approved"] = True
+        with self.assertRaisesRegex(ValueError, "resolved approval decision"):
+            validate_pause_artifact(artifact)
+
+    def test_rejects_url_resume_state_ref(self) -> None:
+        artifact = _valid_artifact()
+        artifact["resume_state_ref"] = "https://example.com/state"
+        with self.assertRaisesRegex(ValueError, "opaque id, not a URL"):
+            validate_pause_artifact(artifact)
+
+    def test_rejects_empty_interruptions(self) -> None:
+        artifact = _valid_artifact()
+        artifact["interruptions"] = []
+        with self.assertRaisesRegex(ValueError, "non-empty array"):
+            validate_pause_artifact(artifact)
+
+    def test_rejects_bad_pause_reason(self) -> None:
+        artifact = _valid_artifact()
+        artifact["pause_reason"] = "needs_human"
+        with self.assertRaisesRegex(ValueError, "pause_reason must be tool_approval"):
+            validate_pause_artifact(artifact)
+
+    def test_rejects_unknown_interruption_key(self) -> None:
+        artifact = _valid_artifact()
+        artifact["interruptions"] = [{"tool_name": "send_email", "call_id_ref": "call_1", "arguments": {}}]
+        with self.assertRaisesRegex(ValueError, "unsupported keys: arguments"):
+            validate_pause_artifact(artifact)
+
+    def test_rejects_duplicate_call_id_ref(self) -> None:
+        artifact = _valid_artifact()
+        artifact["interruptions"] = [
+            {"tool_name": "send_email", "call_id_ref": "same"},
+            {"tool_name": "send_email", "call_id_ref": "same"},
+        ]
+        with self.assertRaisesRegex(ValueError, "duplicate call_id_ref"):
+            validate_pause_artifact(artifact)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/patterns/paused_approval/validate.py
+++ b/patterns/paused_approval/validate.py
@@ -1,0 +1,137 @@
+"""Pause-only artifact validation for the paused approval pattern."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ._common import (
+    ALLOWED_INTERRUPTION_KEYS,
+    ALLOWED_TOP_LEVEL_OPTIONAL_KEYS,
+    DEFAULT_SCHEMA,
+    DEFAULT_SURFACE,
+    FORBIDDEN_TOP_LEVEL_KEY_MESSAGES,
+    MAX_INTERRUPTION_COUNT,
+    MAX_TOOL_NAME_LENGTH,
+    PAUSE_REASON_TOOL_APPROVAL,
+    TOLERATED_TOP_LEVEL_EXTENSION_KEYS,
+    parse_rfc3339_utc,
+    validate_classifier,
+    validate_opaque_ref,
+)
+
+
+REQUIRED_TOP_LEVEL_KEYS = (
+    "schema",
+    "framework",
+    "surface",
+    "timestamp",
+    "pause_reason",
+    "interruptions",
+    "resume_state_ref",
+)
+ALLOWED_TOP_LEVEL_KEYS = set(REQUIRED_TOP_LEVEL_KEYS) | ALLOWED_TOP_LEVEL_OPTIONAL_KEYS | TOLERATED_TOP_LEVEL_EXTENSION_KEYS
+
+
+def _raise_on_forbidden_top_level_keys(artifact: Mapping[str, Any]) -> None:
+    present_forbidden = sorted(key for key in artifact if key in FORBIDDEN_TOP_LEVEL_KEY_MESSAGES)
+    if not present_forbidden:
+        return
+    details = "; ".join(FORBIDDEN_TOP_LEVEL_KEY_MESSAGES[key] for key in present_forbidden)
+    raise ValueError(
+        f"artifact: forbidden top-level keys found: {', '.join(present_forbidden)} ({details})"
+    )
+
+
+def _validate_interruptions(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise ValueError("artifact: interruptions must be a non-empty array")
+    if len(value) > MAX_INTERRUPTION_COUNT:
+        raise ValueError(f"artifact: interruptions must contain at most {MAX_INTERRUPTION_COUNT} items")
+
+    normalized: list[dict[str, Any]] = []
+    seen_call_ids: set[str] = set()
+    for index, item in enumerate(value):
+        line_label = f"artifact: interruptions[{index}]"
+        if not isinstance(item, Mapping):
+            raise ValueError(f"{line_label} must be an object")
+        unknown = set(item) - ALLOWED_INTERRUPTION_KEYS
+        if unknown:
+            raise ValueError(f"{line_label}: unsupported keys: {', '.join(sorted(unknown))}")
+        missing = {"tool_name", "call_id_ref"} - set(item)
+        if missing:
+            raise ValueError(f"{line_label}: missing required keys: {', '.join(sorted(missing))}")
+
+        call_id_ref = validate_opaque_ref(item["call_id_ref"], line_label, "call_id_ref")
+        if call_id_ref in seen_call_ids:
+            raise ValueError(f"{line_label}: duplicate call_id_ref: {call_id_ref}")
+        seen_call_ids.add(call_id_ref)
+
+        normalized_item = {
+            "tool_name": validate_classifier(item["tool_name"], line_label, "tool_name", MAX_TOOL_NAME_LENGTH),
+            "call_id_ref": call_id_ref,
+        }
+
+        if "agent_ref" in item:
+            normalized_item["agent_ref"] = validate_opaque_ref(item["agent_ref"], line_label, "agent_ref")
+
+        if "arguments_hash" in item:
+            normalized_item["arguments_hash"] = validate_opaque_ref(
+                item["arguments_hash"], line_label, "arguments_hash"
+            )
+
+        normalized.append(normalized_item)
+
+    return normalized
+
+
+def validate_pause_artifact(artifact: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize the canonical pause-only artifact."""
+
+    if not isinstance(artifact, Mapping):
+        raise ValueError("artifact: top-level value must be an object")
+
+    _raise_on_forbidden_top_level_keys(artifact)
+
+    unknown = set(artifact) - ALLOWED_TOP_LEVEL_KEYS
+    if unknown:
+        raise ValueError(f"artifact: unsupported top-level keys: {', '.join(sorted(unknown))}")
+
+    missing = [key for key in REQUIRED_TOP_LEVEL_KEYS if key not in artifact]
+    if missing:
+        raise ValueError(f"artifact: missing required keys: {', '.join(missing)}")
+
+    normalized = {
+        "schema": artifact["schema"] if isinstance(artifact["schema"], str) else None,
+        "framework": validate_classifier(artifact["framework"], "artifact", "framework"),
+        "surface": validate_classifier(artifact["surface"], "artifact", "surface"),
+        "timestamp": parse_rfc3339_utc(artifact["timestamp"]),
+        "pause_reason": validate_classifier(artifact["pause_reason"], "artifact", "pause_reason"),
+        "interruptions": _validate_interruptions(artifact["interruptions"]),
+        "resume_state_ref": validate_opaque_ref(artifact["resume_state_ref"], "artifact", "resume_state_ref"),
+    }
+
+    if normalized["schema"] is None or not normalized["schema"].strip():
+        raise ValueError("artifact: schema must be a non-empty string")
+    normalized["schema"] = normalized["schema"].strip()
+
+    if normalized["pause_reason"] != PAUSE_REASON_TOOL_APPROVAL:
+        raise ValueError(f"artifact: pause_reason must be {PAUSE_REASON_TOOL_APPROVAL}")
+
+    for field_name in ("active_agent_ref", "last_agent_ref", "metadata_ref"):
+        if field_name in artifact:
+            normalized[field_name] = validate_opaque_ref(artifact[field_name], "artifact", field_name)
+
+    if "policy_snapshot_hash" in artifact:
+        normalized["policy_snapshot_hash"] = validate_opaque_ref(
+            artifact["policy_snapshot_hash"], "artifact", "policy_snapshot_hash"
+        )
+
+    if "policy_decisions" in artifact:
+        if not isinstance(artifact["policy_decisions"], list) or not artifact["policy_decisions"]:
+            raise ValueError("artifact: policy_decisions must be a non-empty array when present")
+        normalized["policy_decisions"] = [
+            validate_classifier(decision, "artifact", "policy_decisions", 64)
+            for decision in artifact["policy_decisions"]
+        ]
+
+    return normalized


### PR DESCRIPTION
What changed
This implements P23A as the Harness-side paused approval capture pattern, split into four small commits that follow the plan phases.

The PR includes:
- Phase A: raw paused-result fixtures plus `FIELD_PRESENCE.md` to lock the observed-vs-derived posture before helper code
- Phase B: four reusable helpers under `patterns/paused_approval/`
  - `capture_paused_approval(...)`
  - `derive_resume_state_ref(...)`
  - `emit_pause_artifact(...)`
  - `validate_pause_artifact(...)`
- Phase C: valid/failure/malformed corpus fixtures plus tests that touch both the pattern validator and the existing OpenAI Agents JS mapper
- Phase D: packaging via a pattern README, public imports, and a smoke-path script that produces one clean pause-only artifact from the raw fixtures

Why
P23B is now landed on the Assay/reference side. This PR adds the corresponding runtime-near Harness-side capture pattern without broadening into a general continuation framework.

The pattern stays on the smallest honest seam:
- one paused approval capture
- one bounded `interruptions` list
- one derived `resume_state_ref`
- one pause-only artifact

Layout note
The original P23A sketch used `harness/patterns/paused_approval/`, but in this repo `harness/` is the TypeScript package. The Python paused approval pattern therefore lives under `patterns/paused_approval/` parallel to the existing Python-facing repo-root surfaces instead of leaking Python into the TypeScript package tree.

Boundary
This PR does not add:
- broad runtime adapter support
- transcript/session support
- resumed outcome artifacts
- provider-managed continuation support
- dashboard/UI surfaces

It is the Harness-side pause-only capture pattern only.

Validation
Ran locally:
- `python3 -m unittest discover -s patterns/paused_approval/tests -p 'test_*.py'`
- `python3 -m py_compile patterns/paused_approval/*.py patterns/paused_approval/tests/*.py`
- `python3 patterns/paused_approval/smoke.py --paused-result patterns/paused_approval/fixtures/raw/openai_agents_js.paused_result.json --serialized-state patterns/paused_approval/fixtures/raw/openai_agents_js.serialized_state.txt --output /tmp/p23a-smoke.json`
- `python3 examples/openai-agents-js-approval-interruption-evidence/map_to_assay.py /tmp/p23a-smoke.json --output /tmp/p23a-smoke.ndjson --import-time 2026-04-18T11:10:00Z --overwrite`
- `git diff --check`

Reviewer focus
Please review this as a pause-only Harness pattern landing:
- does capture stay smaller than runtime state?
- does `resume_state_ref` remain explicitly derived?
- do the corpus fixtures and smoke path prove the public API without widening into transcript/session/resolved-decision truth?
