### PR TITLE
[codex] point paused HITL docs to Assay-Harness home

### DIFF
--- a/docs/reference/patterns/paused-hitl-evidence.md
+++ b/docs/reference/patterns/paused-hitl-evidence.md
@@ -14,6 +14,9 @@ This pattern was first internalized from the confirmed `P22` OpenAI Agents JS
 lane, but it is intentionally documented as an Assay-side reference shape, not
 as OpenAI Agents JS support in general.
 
+The corresponding runtime/capture pattern lives in the Assay-Harness
+repository; this document is the Assay-side reference/validation counterpart.
+
 ## What This Pattern Is For
 
 Use this pattern when a runtime:

--- a/examples/openai-agents-js-approval-interruption-evidence/README.md
+++ b/examples/openai-agents-js-approval-interruption-evidence/README.md
@@ -8,9 +8,10 @@ reference pattern in
 [`docs/reference/patterns/paused-hitl-evidence.md`](../../docs/reference/patterns/paused-hitl-evidence.md).
 
 That Assay-side shape is intended to stay aligned with the corresponding
-Assay Harness paused approval capture pattern, so this sample should be read
-as the reference/validation counterpart of the same pause-only pattern rather
-than as a standalone schema.
+Assay Harness paused approval capture pattern in the Assay-Harness
+repository, so this sample should be read as the reference/validation
+counterpart of the same pause-only pattern rather than as a standalone
+schema.
 
 It is intentionally small:
 


### PR DESCRIPTION
What changed
This tiny docs follow-up makes the canonical P23 split explicit in the Assay repo.

The PR includes:
- one sentence in the paused HITL reference pattern doc stating that the runtime/capture pattern lives in the Assay-Harness repository
- one matching sentence in the OpenAI Agents JS paused approval example README so the sample is clearly read as the Assay-side reference/validation counterpart

Why
Closing the non-canonical P23A PR in this repo fixed the architecture mechanically, but this small docs note makes the separation durable and visible to future readers.

Boundary
This PR does not change any validation behavior, examples, or runtime logic.

It only makes the canonical repo split explicit:
- Assay = P23B reference/validation side
- Assay-Harness = P23A runtime/capture side

Validation
Ran locally:
- `git diff --check -- docs/reference/patterns/paused-hitl-evidence.md examples/openai-agents-js-approval-interruption-evidence/README.md`

Reviewer focus
Please review this as a tiny canon-clarity patch: does it make the Assay-vs-Assay-Harness split visible without adding extra scope?
