### PR TITLE
P31: import Promptfoo JSONL receipts

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -2,6 +2,7 @@ pub mod diff;
 pub mod lint;
 pub mod list;
 pub mod mapping;
+pub mod promptfoo_jsonl;
 pub mod pull;
 pub mod push;
 pub mod store_status;
@@ -21,6 +22,8 @@ pub enum EvidenceCmd {
     Verify(EvidenceVerifyArgs),
     /// Inspect a bundle's contents (verify + show table)
     Show(EvidenceShowArgs),
+    /// Import external evidence into an Assay evidence bundle
+    Import(EvidenceImportArgs),
     /// Lint a bundle for quality and security issues
     Lint(lint::LintArgs),
     /// Diff two bundles and report changes
@@ -75,11 +78,25 @@ pub struct EvidenceShowArgs {
     pub format: String,
 }
 
+#[derive(Debug, Args, Clone)]
+pub struct EvidenceImportArgs {
+    #[command(subcommand)]
+    pub cmd: EvidenceImportCmd,
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum EvidenceImportCmd {
+    /// Import Promptfoo CLI JSONL assertion component results
+    #[command(name = "promptfoo-jsonl")]
+    PromptfooJsonl(promptfoo_jsonl::PromptfooJsonlArgs),
+}
+
 pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
     match args.cmd {
         EvidenceCmd::Export(a) => cmd_export(a),
         EvidenceCmd::Verify(a) => cmd_verify(a),
         EvidenceCmd::Show(a) => cmd_show(a),
+        EvidenceCmd::Import(a) => cmd_import(a),
         EvidenceCmd::Lint(a) => lint::cmd_lint(a),
         EvidenceCmd::Diff(a) => diff::cmd_diff(a),
         EvidenceCmd::Push(a) => push::cmd_push(a).await,
@@ -88,6 +105,12 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
         EvidenceCmd::StoreStatus(a) => store_status::cmd_store_status(a).await,
         #[cfg(feature = "tui")]
         EvidenceCmd::Explore(a) => explore::cmd_explore(a),
+    }
+}
+
+fn cmd_import(args: EvidenceImportArgs) -> Result<i32> {
+    match args.cmd {
+        EvidenceImportCmd::PromptfooJsonl(a) => promptfoo_jsonl::cmd_promptfoo_jsonl(a),
     }
 }
 

--- a/crates/assay-cli/src/cli/commands/evidence/promptfoo_jsonl.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/promptfoo_jsonl.rs
@@ -47,8 +47,16 @@ pub fn cmd_promptfoo_jsonl(args: PromptfooJsonlArgs) -> Result<i32> {
     let source_artifact_ref = args
         .source_artifact_ref
         .unwrap_or_else(|| default_source_artifact_ref(&args.input));
+    // Deliberately digest the full source artifact bytes before parsing. The
+    // receipt provenance binds to the exact JSONL artifact, independent of the
+    // reduced component payloads we choose to import.
     let source_artifact_digest = sha256_file(&args.input)
         .with_context(|| format!("failed to digest input {}", args.input.display()))?;
+    let producer = ProducerMeta {
+        name: "assay-cli".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        git: option_env!("ASSAY_GIT_SHA").map(str::to_string),
+    };
 
     let events = read_promptfoo_jsonl_events(
         &args.input,
@@ -56,11 +64,11 @@ pub fn cmd_promptfoo_jsonl(args: PromptfooJsonlArgs) -> Result<i32> {
         &source_artifact_digest,
         &args.run_id,
         import_time,
+        &producer,
     )?;
 
     let out_file = File::create(&args.bundle_out)
         .with_context(|| format!("failed to create bundle {}", args.bundle_out.display()))?;
-    let producer = ProducerMeta::new("assay-cli", env!("CARGO_PKG_VERSION"));
     let mut writer = BundleWriter::new(out_file).with_producer(producer);
     for event in events {
         writer.add_event(event);
@@ -83,6 +91,7 @@ fn read_promptfoo_jsonl_events(
     source_artifact_digest: &str,
     run_id: &str,
     import_time: DateTime<Utc>,
+    producer: &ProducerMeta,
 ) -> Result<Vec<EvidenceEvent>> {
     if run_id.contains(':') {
         bail!("run_id cannot contain ':' because event ids use run_id:seq");
@@ -126,7 +135,7 @@ fn read_promptfoo_jsonl_events(
             )?;
             let event = EvidenceEvent::new(EVENT_TYPE, EVENT_SOURCE, run_id, seq, payload)
                 .with_time(import_time)
-                .with_producer(&ProducerMeta::new("assay-cli", env!("CARGO_PKG_VERSION")));
+                .with_producer(producer);
             events.push(event);
         }
     }
@@ -226,6 +235,9 @@ fn binary_score(value: Option<&Value>, line_number: usize, component_index: usiz
 }
 
 fn safe_reason(value: Option<&Value>, pass: bool) -> Option<String> {
+    // Promptfoo equals failure reasons commonly quote the raw output and
+    // expected value. v1 keeps failure reasons out rather than trying to
+    // redact free text after the fact.
     if !pass {
         return None;
     }

--- a/crates/assay-cli/src/cli/commands/evidence/promptfoo_jsonl.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/promptfoo_jsonl.rs
@@ -1,0 +1,374 @@
+use crate::exit_codes;
+use anyhow::{bail, Context, Result};
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::types::{EvidenceEvent, ProducerMeta};
+use chrono::{DateTime, SecondsFormat, Utc};
+use clap::Args;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
+
+const EVENT_TYPE: &str = "assay.receipt.promptfoo.assertion_component.v1";
+const EVENT_SOURCE: &str = "urn:assay:external:promptfoo:assertion-component";
+const RECEIPT_SCHEMA: &str = "assay.receipt.promptfoo.assertion-component.v1";
+const SOURCE_SYSTEM: &str = "promptfoo";
+const SOURCE_SURFACE: &str = "cli-jsonl.gradingResult.componentResults";
+const REDUCER_VERSION: &str = "assay-promptfoo-jsonl-component-result@0.1.0";
+const DEFAULT_RUN_ID: &str = "import-promptfoo-jsonl";
+const MAX_REASON_CHARS: usize = 160;
+
+#[derive(Debug, Args, Clone)]
+pub struct PromptfooJsonlArgs {
+    /// Promptfoo CLI JSONL output file
+    #[arg(long, value_name = "PATH")]
+    pub input: PathBuf,
+
+    /// Output Assay evidence bundle path (.tar.gz)
+    #[arg(long, alias = "out", value_name = "PATH")]
+    pub bundle_out: PathBuf,
+
+    /// Reviewer-safe source artifact reference stored in receipts
+    #[arg(long)]
+    pub source_artifact_ref: Option<String>,
+
+    /// Assay import run id used for receipt event ids
+    #[arg(long, default_value = DEFAULT_RUN_ID)]
+    pub run_id: String,
+
+    /// Import timestamp for deterministic fixtures (RFC3339 UTC recommended)
+    #[arg(long)]
+    pub import_time: Option<String>,
+}
+
+pub fn cmd_promptfoo_jsonl(args: PromptfooJsonlArgs) -> Result<i32> {
+    let import_time = parse_import_time(args.import_time.as_deref())?;
+    let source_artifact_ref = args
+        .source_artifact_ref
+        .unwrap_or_else(|| default_source_artifact_ref(&args.input));
+    let source_artifact_digest = sha256_file(&args.input)
+        .with_context(|| format!("failed to digest input {}", args.input.display()))?;
+
+    let events = read_promptfoo_jsonl_events(
+        &args.input,
+        &source_artifact_ref,
+        &source_artifact_digest,
+        &args.run_id,
+        import_time,
+    )?;
+
+    let out_file = File::create(&args.bundle_out)
+        .with_context(|| format!("failed to create bundle {}", args.bundle_out.display()))?;
+    let producer = ProducerMeta::new("assay-cli", env!("CARGO_PKG_VERSION"));
+    let mut writer = BundleWriter::new(out_file).with_producer(producer);
+    for event in events {
+        writer.add_event(event);
+    }
+    writer
+        .finish()
+        .with_context(|| format!("failed to write bundle {}", args.bundle_out.display()))?;
+
+    eprintln!(
+        "Imported Promptfoo assertion component receipts to {}",
+        args.bundle_out.display()
+    );
+
+    Ok(exit_codes::OK)
+}
+
+fn read_promptfoo_jsonl_events(
+    input: &Path,
+    source_artifact_ref: &str,
+    source_artifact_digest: &str,
+    run_id: &str,
+    import_time: DateTime<Utc>,
+) -> Result<Vec<EvidenceEvent>> {
+    if run_id.contains(':') {
+        bail!("run_id cannot contain ':' because event ids use run_id:seq");
+    }
+
+    let file =
+        File::open(input).with_context(|| format!("failed to open input {}", input.display()))?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+    let mut saw_jsonl_row = false;
+
+    for (line_index, line_result) in reader.lines().enumerate() {
+        let line_number = line_index + 1;
+        let line = line_result.with_context(|| format!("failed to read line {line_number}"))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        saw_jsonl_row = true;
+        let row: Value = serde_json::from_str(&line)
+            .with_context(|| format!("invalid JSONL object at line {line_number}"))?;
+        let components = row
+            .pointer("/gradingResult/componentResults")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                anyhow::anyhow!("line {line_number} is missing gradingResult.componentResults[]")
+            })?;
+        if components.is_empty() {
+            bail!("line {line_number} has empty gradingResult.componentResults[]");
+        }
+
+        for (component_index, component) in components.iter().enumerate() {
+            let seq = events.len() as u64;
+            let payload = reduce_component_result(
+                &row,
+                component,
+                component_index,
+                source_artifact_ref,
+                source_artifact_digest,
+                import_time,
+                line_number,
+            )?;
+            let event = EvidenceEvent::new(EVENT_TYPE, EVENT_SOURCE, run_id, seq, payload)
+                .with_time(import_time)
+                .with_producer(&ProducerMeta::new("assay-cli", env!("CARGO_PKG_VERSION")));
+            events.push(event);
+        }
+    }
+
+    if !saw_jsonl_row {
+        bail!("input contains no JSONL rows");
+    }
+
+    Ok(events)
+}
+
+fn reduce_component_result(
+    row: &Value,
+    component: &Value,
+    component_index: usize,
+    source_artifact_ref: &str,
+    source_artifact_digest: &str,
+    import_time: DateTime<Utc>,
+    line_number: usize,
+) -> Result<Value> {
+    let pass = component
+        .get("pass")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| {
+            anyhow::anyhow!("line {line_number} component {component_index} missing boolean pass")
+        })?;
+    let score = binary_score(component.get("score"), line_number, component_index)?;
+    let assertion_type = assertion_type(row, component, component_index, line_number)?;
+    if assertion_type != "equals" {
+        bail!(
+            "line {line_number} component {component_index} has unsupported assertion type {assertion_type:?}; v1 supports only equals"
+        );
+    }
+
+    let mut result = Map::new();
+    result.insert("pass".to_string(), Value::Bool(pass));
+    result.insert("score".to_string(), Value::Number(score.into()));
+    if let Some(reason) = safe_reason(component.get("reason"), pass) {
+        result.insert("reason".to_string(), Value::String(reason));
+    }
+
+    Ok(json!({
+        "schema": RECEIPT_SCHEMA,
+        "source_system": SOURCE_SYSTEM,
+        "source_surface": SOURCE_SURFACE,
+        "source_artifact_ref": source_artifact_ref,
+        "source_artifact_digest": source_artifact_digest,
+        "reducer_version": REDUCER_VERSION,
+        "imported_at": import_time.to_rfc3339_opts(SecondsFormat::Secs, true),
+        "assertion_type": assertion_type,
+        "result": Value::Object(result),
+    }))
+}
+
+fn assertion_type<'a>(
+    row: &'a Value,
+    component: &'a Value,
+    component_index: usize,
+    line_number: usize,
+) -> Result<&'a str> {
+    if let Some(value) = component
+        .pointer("/assertion/type")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Ok(value);
+    }
+
+    row.pointer("/testCase/assert")
+        .and_then(Value::as_array)
+        .and_then(|assertions| assertions.get(component_index))
+        .and_then(|assertion| assertion.get("type"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "line {line_number} component {component_index} does not expose an assertion type"
+            )
+        })
+}
+
+fn binary_score(value: Option<&Value>, line_number: usize, component_index: usize) -> Result<i64> {
+    let value = value.ok_or_else(|| {
+        anyhow::anyhow!("line {line_number} component {component_index} missing integer score")
+    })?;
+    let score = value.as_i64().ok_or_else(|| {
+        anyhow::anyhow!(
+            "line {line_number} component {component_index} score must be integer 0 or 1"
+        )
+    })?;
+    match score {
+        0 | 1 => Ok(score),
+        _ => bail!(
+            "line {line_number} component {component_index} has non-binary score {score}; v1 accepts only 0 or 1"
+        ),
+    }
+}
+
+fn safe_reason(value: Option<&Value>, pass: bool) -> Option<String> {
+    if !pass {
+        return None;
+    }
+    let reason = value?.as_str()?.trim();
+    if reason.is_empty()
+        || reason.chars().count() > MAX_REASON_CHARS
+        || reason.contains('\n')
+        || reason.contains('\r')
+        || reason.contains('"')
+        || reason.contains('`')
+        || reason.contains('{')
+        || reason.contains('}')
+    {
+        return None;
+    }
+    Some(reason.to_string())
+}
+
+fn parse_import_time(value: Option<&str>) -> Result<DateTime<Utc>> {
+    match value {
+        Some(value) => Ok(DateTime::parse_from_rfc3339(value)
+            .with_context(|| format!("invalid --import-time {value:?}; expected RFC3339"))?
+            .with_timezone(&Utc)),
+        None => Ok(Utc::now()),
+    }
+}
+
+fn default_source_artifact_ref(input: &Path) -> String {
+    input
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("promptfoo-results.jsonl")
+        .to_string()
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_evidence::bundle::BundleReader;
+    use std::fs;
+
+    #[test]
+    fn import_writes_verifiable_bundle_without_raw_payloads() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("results.jsonl");
+        let output = dir.path().join("promptfoo.tar.gz");
+        fs::write(
+            &input,
+            concat!(
+                r#"{"gradingResult":{"componentResults":[{"pass":true,"score":1,"reason":"Assertion passed","assertion":{"type":"equals","value":"Hello world"}}]}}"#,
+                "\n",
+                r#"{"gradingResult":{"componentResults":[{"pass":false,"score":0,"reason":"Expected output \"Goodbye world\" to equal \"Hello world\"","assertion":{"type":"equals","value":"Hello world"}}]}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        let code = cmd_promptfoo_jsonl(PromptfooJsonlArgs {
+            input: input.clone(),
+            bundle_out: output.clone(),
+            source_artifact_ref: Some("results.jsonl".to_string()),
+            run_id: "promptfoo_test".to_string(),
+            import_time: Some("2026-04-26T12:00:00Z".to_string()),
+        })
+        .unwrap();
+        assert_eq!(code, exit_codes::OK);
+
+        let reader = BundleReader::open(File::open(output).unwrap()).unwrap();
+        assert_eq!(reader.manifest().event_count, 2);
+        let events = reader.events().collect::<Result<Vec<_>>>().unwrap();
+        assert_eq!(events[0].type_, EVENT_TYPE);
+        assert_eq!(events[0].source, EVENT_SOURCE);
+        assert_eq!(events[0].payload["source_surface"], SOURCE_SURFACE);
+        assert_eq!(events[0].payload["assertion_type"], "equals");
+        assert_eq!(events[0].payload["result"]["pass"], true);
+        assert_eq!(events[0].payload["result"]["score"], 1);
+        assert_eq!(events[0].payload["result"]["reason"], "Assertion passed");
+        assert_eq!(events[1].payload["result"]["pass"], false);
+        assert_eq!(events[1].payload["result"]["score"], 0);
+        assert!(events[1].payload["result"].get("reason").is_none());
+
+        let serialized = serde_json::to_string(&events).unwrap();
+        assert!(!serialized.contains("Goodbye world"));
+        assert!(!serialized.contains("Hello world"));
+        assert!(events[0].payload.get("componentResults").is_none());
+        assert!(events[1].payload.get("componentResults").is_none());
+    }
+
+    #[test]
+    fn import_fails_closed_without_component_results() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("results.jsonl");
+        let output = dir.path().join("promptfoo.tar.gz");
+        fs::write(&input, r#"{"gradingResult":{"pass":true,"score":1}}"#).unwrap();
+
+        let err = cmd_promptfoo_jsonl(PromptfooJsonlArgs {
+            input,
+            bundle_out: output,
+            source_artifact_ref: None,
+            run_id: "promptfoo_test".to_string(),
+            import_time: Some("2026-04-26T12:00:00Z".to_string()),
+        })
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("missing gradingResult.componentResults"));
+    }
+
+    #[test]
+    fn import_rejects_non_binary_scores() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("results.jsonl");
+        let output = dir.path().join("promptfoo.tar.gz");
+        fs::write(
+            &input,
+            r#"{"gradingResult":{"componentResults":[{"pass":true,"score":0.5,"assertion":{"type":"equals"}}]}}"#,
+        )
+        .unwrap();
+
+        let err = cmd_promptfoo_jsonl(PromptfooJsonlArgs {
+            input,
+            bundle_out: output,
+            source_artifact_ref: None,
+            run_id: "promptfoo_test".to_string(),
+            import_time: Some("2026-04-26T12:00:00Z".to_string()),
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("score must be integer 0 or 1"));
+    }
+}

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -32,7 +32,10 @@ pub use trust_card::{
     trust_basis_to_trust_card, trust_card_to_canonical_json_bytes, trust_card_to_markdown,
     TrustCard, TRUST_CARD_NON_GOALS, TRUST_CARD_NOTE_EMPTY_PLACEHOLDER, TRUST_CARD_SCHEMA_VERSION,
 };
-pub use types::{Envelope, EvidenceEvent, ProducerMeta, SPEC_VERSION};
+pub use types::{
+    Envelope, EvidenceEvent, ProducerMeta, ASSAY_EVIDENCE_SPEC_VERSION, CE_SPECVERSION,
+    SPEC_VERSION,
+};
 
 // Re-export bytes for CLI convenience
 pub use bytes::Bytes;

--- a/crates/assay-evidence/src/lint/packs/loader_internal/parse.rs
+++ b/crates/assay-evidence/src/lint/packs/loader_internal/parse.rs
@@ -27,6 +27,13 @@ pub(crate) fn load_pack_from_string_impl(
             message: format_yaml_error_impl(e),
         })?;
 
+    if definition.requires.evidence_schema_version.is_none() {
+        tracing::warn!(
+            pack = %definition.name,
+            "pack missing evidence_schema_version; assuming Assay Evidence Spec v1.0 for backward compatibility"
+        );
+    }
+
     // Validate the pack
     definition.validate()?;
 

--- a/crates/assay-evidence/src/types.rs
+++ b/crates/assay-evidence/src/types.rs
@@ -7,8 +7,18 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-/// Spec version for this implementation of the Evidence Contract.
-pub const SPEC_VERSION: &str = "1.0";
+/// CloudEvents specversion used by Evidence Contract v1 envelopes.
+pub const CE_SPECVERSION: &str = "1.0";
+
+/// Assay Evidence Spec version implemented by this crate.
+pub const ASSAY_EVIDENCE_SPEC_VERSION: &str = "1.0";
+
+/// Backward-compatible alias for the CloudEvents specversion.
+///
+/// New code should prefer `CE_SPECVERSION` when filling the CloudEvents
+/// envelope and `ASSAY_EVIDENCE_SPEC_VERSION` when referring to Assay's
+/// own evidence contract version.
+pub const SPEC_VERSION: &str = CE_SPECVERSION;
 
 /// Alias for clearer semantics
 pub type Envelope = EvidenceEvent;
@@ -69,7 +79,7 @@ pub struct EvidenceEvent {
     /// CloudEvents spec version (fixed "1.0")
     pub specversion: String,
 
-    /// Event Type URN (e.g., "assay.env.filtered")
+    /// Event type (dot-separated identifier, e.g., "assay.env.filtered")
     #[serde(rename = "type")]
     pub type_: String,
 
@@ -152,7 +162,7 @@ impl EvidenceEvent {
     ) -> Self {
         let run_id = run_id.into();
         Self {
-            specversion: SPEC_VERSION.into(),
+            specversion: CE_SPECVERSION.into(),
             type_: type_.into(),
             source: source.into(),
             id: format!("{}:{}", run_id, seq),
@@ -341,6 +351,22 @@ mod tests {
 
         let meta_no_git = ProducerMeta::new("assay-cli", "2.6.0");
         assert_eq!(meta_no_git.to_string_compact(), "assay-cli/2.6.0");
+    }
+
+    #[test]
+    fn version_constants_keep_cloudevents_and_assay_axes_separate() {
+        assert_eq!(CE_SPECVERSION, "1.0");
+        assert_eq!(ASSAY_EVIDENCE_SPEC_VERSION, "1.0");
+        assert_eq!(SPEC_VERSION, CE_SPECVERSION);
+
+        let event = EvidenceEvent::new(
+            "assay.test.event",
+            "urn:assay:test",
+            "run_version_constants",
+            0,
+            serde_json::json!({}),
+        );
+        assert_eq!(event.specversion, CE_SPECVERSION);
     }
 
     #[test]

--- a/crates/assay-evidence/tests/verify_strict_test.rs
+++ b/crates/assay-evidence/tests/verify_strict_test.rs
@@ -4,7 +4,9 @@
 
 use assay_evidence::bundle::writer::{verify_bundle, BundleWriter};
 use assay_evidence::crypto::id::compute_content_hash;
-use assay_evidence::types::EvidenceEvent;
+use assay_evidence::types::{
+    EvidenceEvent, PayloadEnvFiltered, PayloadSandboxDegraded, PayloadToolDecision,
+};
 use chrono::{TimeZone, Utc};
 use sha2::Digest;
 use std::io::Cursor;
@@ -34,6 +36,18 @@ fn create_valid_bundle(event_count: usize) -> Vec<u8> {
         writer.finish().unwrap();
     }
     buffer
+}
+
+fn verify_single_event(mut event: EvidenceEvent) {
+    event.time = Utc.timestamp_opt(1700000000, 0).unwrap();
+
+    let mut buffer = Vec::new();
+    let mut writer = BundleWriter::new(&mut buffer);
+    writer.add_event(event);
+    writer.finish().unwrap();
+
+    let result = verify_bundle(Cursor::new(&buffer)).unwrap();
+    assert_eq!(result.event_count, 1);
 }
 
 // ============================================================================
@@ -66,6 +80,129 @@ fn test_verify_run_root_matches() {
 
     // Computed run_root must match manifest
     assert_eq!(result.computed_run_root, result.manifest.run_root);
+}
+
+#[test]
+fn test_profile_started_stable_payload_conformance() {
+    let payload = serde_json::json!({
+        "profile_name": "default",
+        "profile_version": "1.0",
+        "total_runs_aggregated": 1
+    });
+    assert_eq!(payload["profile_name"], "default");
+    verify_single_event(EvidenceEvent::new(
+        "assay.profile.started",
+        "urn:assay:test",
+        "run_profile_started_contract",
+        0,
+        payload,
+    ));
+}
+
+#[test]
+fn test_profile_finished_stable_payload_conformance() {
+    let payload = serde_json::json!({
+        "files_count": 1,
+        "network_count": 0,
+        "processes_count": 1,
+        "sandbox_degradation_count": 0,
+        "integrity_scope": "observed"
+    });
+    assert_eq!(payload["integrity_scope"], "observed");
+    verify_single_event(EvidenceEvent::new(
+        "assay.profile.finished",
+        "urn:assay:test",
+        "run_profile_finished_contract",
+        0,
+        payload,
+    ));
+}
+
+#[test]
+fn test_fs_access_stable_payload_conformance() {
+    let payload = serde_json::json!({
+        "hits": 3
+    });
+    assert_eq!(payload["hits"], 3);
+    let event = EvidenceEvent::new(
+        "assay.fs.access",
+        "urn:assay:test",
+        "run_fs_access_contract",
+        0,
+        payload,
+    )
+    .with_subject("~/project/input.txt");
+    verify_single_event(event);
+}
+
+#[test]
+fn test_tool_decision_stable_payload_conformance() {
+    let payload = serde_json::json!({
+        "tool": "read_file",
+        "decision": "allow",
+        "reason_code": "P_POLICY_ALLOW",
+        "args_schema_hash": "sha256:abc",
+        "delegated_from": "agent:planner",
+        "delegation_depth": 1
+    });
+    let typed: PayloadToolDecision = serde_json::from_value(payload.clone())
+        .expect("tool decision payload contract should parse");
+    assert_eq!(typed.tool, "read_file");
+    assert_eq!(typed.delegation_depth, Some(1));
+    verify_single_event(EvidenceEvent::new(
+        "assay.tool.decision",
+        "urn:assay:test",
+        "run_tool_decision_contract",
+        0,
+        payload,
+    ));
+}
+
+#[test]
+fn test_env_filtered_stable_payload_conformance() {
+    let payload = serde_json::json!({
+        "mode": "strict",
+        "passed_keys": ["PATH"],
+        "dropped_keys": ["OPENAI_API_KEY"],
+        "counters": {
+            "passed": 1,
+            "dropped": 1
+        }
+    });
+    let typed: PayloadEnvFiltered = serde_json::from_value(payload.clone())
+        .expect("env filtered payload contract should parse");
+    assert_eq!(typed.mode, "strict");
+    assert_eq!(typed.dropped_keys, vec!["OPENAI_API_KEY"]);
+
+    verify_single_event(EvidenceEvent::new(
+        "assay.env.filtered",
+        "urn:assay:test",
+        "run_env_filtered_contract",
+        0,
+        payload,
+    ));
+}
+
+#[test]
+fn test_sandbox_degraded_stable_payload_conformance() {
+    let payload = serde_json::json!({
+        "reason_code": "policy_conflict",
+        "degradation_mode": "audit_fallback",
+        "component": "landlock"
+    });
+    let typed: PayloadSandboxDegraded = serde_json::from_value(payload.clone())
+        .expect("sandbox degraded payload contract should parse");
+    assert_eq!(
+        typed.reason_code,
+        assay_evidence::types::SandboxDegradationReasonCode::PolicyConflict
+    );
+    verify_single_event(EvidenceEvent::new(
+        "assay.sandbox.degraded",
+        "urn:assay:test",
+        "run_sandbox_degraded_contract",
+        0,
+        payload,
+    ));
 }
 
 // ============================================================================

--- a/docs/architecture/ADR-006-Evidence-Contract.md
+++ b/docs/architecture/ADR-006-Evidence-Contract.md
@@ -18,7 +18,7 @@ Every evidence record is an Event enveloping a type-specific Payload.
 | Field | Type | Description | Invariants |
 | :--- | :--- | :--- | :--- |
 | `specversion` | `1.0` | CloudEvents spec version | Fixed string. |
-| `type` | string | Event Type URN | e.g. `assay.env.filtered`, `assay.tool.decision`. |
+| `type` | string | Event type identifier | e.g. `assay.env.filtered`, `assay.tool.decision`. |
 | `source` | string | Producer Identifier | URI identifying the specific runner instance. |
 | `id` | string | Event ID | `{run_id}:{seq}` (e.g. `run_abc:0`). |
 | `time` | string | Timestamp (RFC3339) | UTC only. |
@@ -29,8 +29,15 @@ Every evidence record is an Event enveloping a type-specific Payload.
 | `assayseq` | int | Sequence (Flattened) | 0-indexed monotonic counter. |
 | `assayproducer` | string | Producer Name | e.g. "assay". |
 | `assayproducerversion`| string | Producer Version | e.g. "2.6.0". |
-| `assaycontenthash` | string | **Payload Integrity** | `sha256(canonical_payload)`. |
+| `assaycontenthash` | string | **Content Integrity** | `sha256` over the v1 canonical content-hash input. |
 | `data` | object | **Type-Specific Data** | Validated against `type` schema. |
+
+In v1, `assaycontenthash` covers the JCS-canonicalized content-hash input:
+`specversion`, `type`, `datacontenttype`, optional `subject`, and `data`.
+It does not cover the full CloudEvents envelope, stream identity, timestamp,
+producer metadata, policy metadata, privacy flags, or trace context. This is
+intentionally narrower than the full envelope but not data-only: changing the
+event type changes the content hash.
 
 ### 2. Privacy Classes (Data Protection)
 
@@ -44,10 +51,16 @@ The format enforces strict redaction categories to ensure evidence is "safe by d
 
 ### 3. Core Payload Schemas (v1.0)
 
-All payloads are defined via stable Rust types in `assay-evidence` and mapped from `assay-cli`.
+Core payloads are mapped from `assay-cli` into the Evidence envelope. Some
+payloads also have convenience Rust types in `assay-evidence`; the v1 envelope
+and content-hash contract remain generic over JSON payloads.
 
-#### A. `assay.profile.started` (Run Context)
-Records the start of an attestation run.
+<a id="payload-assay-profile-started"></a>
+<a id="payload-assay-profile-finished"></a>
+#### A. `assay.profile.started` / `assay.profile.finished` (Run Context)
+Records the start and end of a profile evidence export.
+
+`assay.profile.started`:
 ```json
 {
   "profile_name": "string",
@@ -56,6 +69,20 @@ Records the start of an attestation run.
 }
 ```
 
+`assay.profile.finished`:
+```json
+{
+  "files_count": 1,
+  "network_count": 1,
+  "processes_count": 1,
+  "sandbox_degradation_count": 0,
+  "integrity_scope": "observed"
+}
+```
+
+`integrity_scope` is optional and records the profile/export scope when present.
+
+<a id="payload-assay-tool-decision"></a>
 #### B. `assay.tool.decision` (Policy Enforcement)
 Records authorization decisions (HITL-ready, protocol-based).
 ```json
@@ -74,8 +101,8 @@ surfaced only when a supported decision flow carries explicit
 `_meta.delegation` context. They do not imply delegation-chain completeness or
 integrity, inherited-scope validation, or temporal correctness.
 
-
-#### C. `sandbox.degraded` (Operational Integrity)
+<a id="payload-assay-sandbox-degraded"></a>
+#### C. `assay.sandbox.degraded` (Operational Integrity)
 Records when stronger-than-audit containment was requested, weaker containment
 became effective, and execution continued.
 ```json
@@ -87,15 +114,43 @@ became effective, and execution continued.
 }
 ```
 
-#### D. `fs.observed` (Activity Log)
-Records filesystem activity with generalized paths.
+`reason_code` is currently `backend_unavailable` or `policy_conflict`.
+`degradation_mode` is currently `audit_fallback`. `component` is currently
+`landlock`. `detail` is optional and must be redacted operator context.
+
+<a id="payload-assay-fs-access"></a>
+#### D. `assay.fs.access` (Activity Log)
+Records filesystem activity with generalized paths. In observed mode, payloads
+are minimized and the generalized subject is carried in the envelope `subject`.
 ```json
 {
-  "op": "read|write|exec",
-  "path": "${ASSAY_TMP}/input.txt",
-  "backend": "landlock|ebpf"
+  "hits": 3
 }
 ```
+
+Full-detail local exports may include additional observed fields such as
+`file`, `first_seen`, `last_seen`, and `runs_seen`. Those fields are additive
+and not required for v1 stable consumption.
+
+<a id="payload-assay-env-filtered"></a>
+#### E. `assay.env.filtered` (Environment Filtering)
+Records environment-filtering posture and summary counts without raw
+environment values.
+```json
+{
+  "mode": "strict",
+  "passed_keys": ["PATH"],
+  "dropped_keys": ["OPENAI_API_KEY"],
+  "counters": {
+    "passed": 1,
+    "dropped": 1
+  }
+}
+```
+
+`mode` is the observed filter mode. `passed_keys` and `dropped_keys` are key
+names only; raw environment values must not appear in this payload. `counters`
+is an additive map of summary counters.
 
 ## Consequences
 - **Interoperability**: Standard envelope allows ingestion by any CloudEvents-compatible system (Splunk, Azure Event Grid).

--- a/docs/architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md
+++ b/docs/architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md
@@ -378,6 +378,11 @@ It may be omitted even when present on the source component if it is too long,
 too rich, multiline, rubric-like, provider-generated, or includes compared
 values that would leak raw evaluated payloads.
 
+For the first `equals` importer, failure reasons may be omitted by policy even
+when short, because Promptfoo failure messages commonly quote the compared
+output and expected values. This is stricter than the general optional-reason
+rule and should be documented in CLI help and fixtures.
+
 P31 should prefer omission over unsafe convenience.
 
 ## 7. Explicitly excluded fields

--- a/docs/architecture/SPEC-Pack-Engine-v1.md
+++ b/docs/architecture/SPEC-Pack-Engine-v1.md
@@ -429,7 +429,10 @@ Please upgrade Assay: cargo install assay-cli
 
 ### `evidence_schema_version` Check
 
-Optional field for future schema evolution. Currently informational.
+Optional field for future schema evolution. For Evidence Contract v1, absent
+`evidence_schema_version` is interpreted as `"1.0"` for backward
+compatibility. Lint SHOULD warn when the field is absent so older packs remain
+usable without making the implicit default invisible.
 
 ## SARIF Output
 

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -1,0 +1,59 @@
+# assay evidence
+
+Manage Assay evidence bundles and external evidence imports.
+
+---
+
+## Synopsis
+
+```bash
+assay evidence <COMMAND> [OPTIONS]
+```
+
+---
+
+## Promptfoo JSONL Import
+
+Import Promptfoo CLI JSONL assertion component results into a verifiable Assay
+evidence bundle:
+
+```bash
+assay evidence import promptfoo-jsonl \
+  --input results.jsonl \
+  --bundle-out promptfoo-evidence.tar.gz \
+  --source-artifact-ref results.jsonl
+```
+
+The importer is intentionally strict in v1:
+
+- input must be Promptfoo CLI JSONL rows
+- each row must carry `gradingResult.componentResults[]`
+- each component must be an `equals` assertion result
+- component scores must be binary (`0` or `1`)
+- raw prompt, output, expected value, vars, and full JSONL rows are excluded
+
+The output bundle can be verified with:
+
+```bash
+assay evidence verify promptfoo-evidence.tar.gz
+```
+
+Use `--import-time <RFC3339>` for deterministic fixture generation.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--input <PATH>` | Promptfoo CLI JSONL output file |
+| `--bundle-out <PATH>` | Output Assay evidence bundle path |
+| `--source-artifact-ref <REF>` | Reviewer-safe source artifact reference stored in receipts |
+| `--run-id <ID>` | Assay import run id used for receipt event ids |
+| `--import-time <RFC3339>` | Deterministic import timestamp override |
+
+---
+
+## See Also
+
+- [Evidence Contract v1](../../spec/EVIDENCE-CONTRACT-v1.md)
+- [P31 Promptfoo receipt import plan](../../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md)
+- [Promptfoo assertion grading-result example](../../../examples/promptfoo-assertion-grading-result-evidence/README.md)

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -32,6 +32,16 @@ The importer is intentionally strict in v1:
 - component scores must be binary (`0` or `1`)
 - raw prompt, output, expected value, vars, and full JSONL rows are excluded
 
+The importer first computes `source_artifact_digest` over the full JSONL file,
+then parses and reduces assertion components. That two-pass flow is intentional:
+the receipts stay small while still binding back to the exact source artifact
+bytes.
+
+`result.reason` is optional and bounded. For v1, failure reasons are omitted
+because Promptfoo `equals` failure messages commonly quote raw output and
+expected values. Passing reasons are included only when they remain short and
+reviewer-safe.
+
 The output bundle can be verified with:
 
 ```bash

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -30,6 +30,7 @@ assay --version
 | [`assay explain`](explain.md) | Explain why trace steps were allowed/blocked |
 | [`assay bundle`](bundle.md) | Create/verify replay bundles |
 | [`assay replay`](replay.md) | Replay from a replay bundle |
+| [`assay evidence`](evidence.md) | Manage evidence bundles and external evidence imports |
 | [`assay import`](import.md) | Import sessions from MCP Inspector, etc. |
 | [`assay migrate`](migrate.md) | Upgrade config from v0 to v1 |
 | [`assay doctor`](doctor.md) | Diagnose setup and optionally auto-fix known issues |
@@ -246,6 +247,14 @@ See [Configuration](../config/index.md) for full reference.
     Create and verify replay bundles.
 
     [:octicons-arrow-right-24: Full reference](bundle.md)
+
+-   :material-shield-check:{ .lg .middle } __assay evidence__
+
+    ---
+
+    Manage evidence bundles and import external evidence receipts.
+
+    [:octicons-arrow-right-24: Full reference](evidence.md)
 
 -   :material-server:{ .lg .middle } __assay mcp wrap__
 

--- a/docs/spec/EVIDENCE-CONTRACT-v1-VERIFICATION.md
+++ b/docs/spec/EVIDENCE-CONTRACT-v1-VERIFICATION.md
@@ -6,7 +6,8 @@ This document records verification of [EVIDENCE-CONTRACT-v1.md](./EVIDENCE-CONTR
 
 | Claim | Location | Status |
 |-------|----------|--------|
-| **SPEC_VERSION = "1.0"** | `crates/assay-evidence/src/types.rs`: `pub const SPEC_VERSION: &str = "1.0"` | ✓ |
+| **CloudEvents specversion = "1.0"** | `crates/assay-evidence/src/types.rs`: `pub const CE_SPECVERSION: &str = "1.0"`; `SPEC_VERSION` remains a backward-compatible alias. | ✓ |
+| **Assay Evidence Spec version = "1.0"** | `crates/assay-evidence/src/types.rs`: `pub const ASSAY_EVIDENCE_SPEC_VERSION: &str = "1.0"` | ✓ |
 | **Bundle schema_version only 1 accepted** | `crates/assay-evidence/src/bundle/writer.rs`: `verify_bundle_with_limits` rejects `m.schema_version != 1` with `ContractSchemaVersion` (lines 811–817). Reader uses same verify path. | ✓ |
 | **specversion "1.0" enforced** | `writer.rs`: after deserializing event, `if event.specversion != "1.0"` → reject (lines 941–946). | ✓ |
 | **Assay requires time** | `EvidenceEvent.time` is `DateTime<Utc>` (required). CloudEvents does not require it; Assay does. | ✓ |
@@ -14,7 +15,7 @@ This document records verification of [EVIDENCE-CONTRACT-v1.md](./EVIDENCE-CONTR
 | **Unknown fields ignored** | `EvidenceEvent` has no `#[serde(deny_unknown_fields)]`. Deserialization ignores unknown keys. | ✓ |
 | **Verify does not reject solely for unknown** | Verify uses `validate_json_strict` (duplicate keys, lone surrogates, limits) then `serde_json::from_str::<EvidenceEvent>`. Unknown keys are not checked; they are dropped by serde. Rejection only for security/integrity (duplicate keys, bad UTF-8, hash mismatch, etc.). | ✓ |
 | **Canonicalization: JCS (RFC 8785)** | `crates/assay-evidence/src/crypto/jcs.rs`: uses `serde_jcs`; module doc references RFC 8785. | ✓ |
-| **Content hash: SHA-256, lowercase hex, "sha256:" prefix** | `crates/assay-evidence/src/crypto/id.rs`: `Sha256::digest`, `format!("sha256:{}", hex::encode(hash))`. | ✓ |
+| **Content hash: SHA-256, lowercase hex, "sha256:" prefix** | `crates/assay-evidence/src/crypto/id.rs`: `Sha256::digest`, `format!("sha256:{}", hex::encode(hash))`. The v1 hash input is `specversion`, `type`, `datacontenttype`, optional `subject`, and `data`, not the full envelope. | ✓ |
 | **Pinned hashes location** | `crates/assay-evidence/tests/determinism_test.rs`, test `test_golden_hash`: manifest content hash, events content hash, container hash (lines 272–296). | ✓ |
 | **test-bundle.tar.gz generation** | `crates/assay-evidence/tests/generate_fixture.rs`: writes to `tests/fixtures/evidence/test-bundle.tar.gz`; command as in spec. | ✓ |
 | **Fixtures path** | `tests/fixtures/evidence/test-bundle.tar.gz` and `README.md` exist. | ✓ |
@@ -22,7 +23,7 @@ This document records verification of [EVIDENCE-CONTRACT-v1.md](./EVIDENCE-CONTR
 ## Pack evidence_schema_version
 
 - **Spec:** “For v1 freeze: exact match on 1.0”. Packs declare `evidence_schema_version: "1.0"` (e.g. `packs/eu-ai-act-baseline.yaml`, `crates/assay-evidence/packs/mandate-baseline.yaml`).
-- **Code:** `lint/packs/schema.rs` has `evidence_schema_version: Option<String>`. SPEC-Pack-Engine-v1 states the check is “Currently informational”.
+- **Code:** `lint/packs/schema.rs` has `evidence_schema_version: Option<String>`. The pack loader warns when the field is absent and assumes v1.0 for backward compatibility.
 - **Conclusion:** Contract is defined in this spec; enforcement (e.g. rejecting a pack run when bundle schema_version or event spec does not match) may be added in a future release. No change required for doc-only freeze.
 
 ## Golden fixture: determinism vs file fixture

--- a/docs/spec/EVIDENCE-CONTRACT-v1.md
+++ b/docs/spec/EVIDENCE-CONTRACT-v1.md
@@ -93,6 +93,7 @@ This table lists event types for Assay Evidence Spec v1.x (bundle schema_version
 | assay.mandate.used.v1 | stable | Mandate used lifecycle | SPEC-Mandate-v1 | mandate events tests |
 | assay.mandate.revoked.v1 | stable | Mandate revoked lifecycle | SPEC-Mandate-v1 | mandate events tests |
 | sandbox.degraded | stable | Operational integrity | [ADR-006 §3.C](../architecture/ADR-006-Evidence-Contract.md#3-core-payload-schemas-v10) | generate_fixture, evidence tests |
+| assay.receipt.promptfoo.assertion_component.v1 | experimental | Promptfoo CLI JSONL assertion component receipt | [PLAN-P31 §5-§6](../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md#5-receipt-v1-thesis) | promptfoo_jsonl importer tests |
 
 ## 5. Deprecation policy
 

--- a/docs/spec/EVIDENCE-CONTRACT-v1.md
+++ b/docs/spec/EVIDENCE-CONTRACT-v1.md
@@ -11,11 +11,11 @@
 
 | Layer | Identifier | Meaning |
 |-------|------------|---------|
-| **Assay Evidence Spec** | v1.0 (string) | Assay’s envelope + payload contract per ADR-006. Implemented as `SPEC_VERSION = "1.0"` in code. |
+| **Assay Evidence Spec** | v1.0 (string) | Assay’s envelope + payload contract per ADR-006. Implemented as `ASSAY_EVIDENCE_SPEC_VERSION = "1.0"` in code. |
 | Bundle container | schema_version = 1 (integer) | Manifest and .tar.gz layout. Only value 1 is valid for v1; any other is rejected by verify/reader. |
-| Pack compatibility | evidence_schema_version: "1.0" | Packs declare the Assay Evidence Spec version they support. **Interpretation (Pack Engine v1 policy):** Pack engines MUST interpret this field as follows. For v1 freeze: *exact match* on `"1.0"` (only bundles with Assay Evidence Spec v1.0 and bundle schema_version 1 are accepted). If the field is absent, assume v1.0. If the value is present and not recognized, the pack engine MUST fail closed (reject) unless explicitly configured otherwise. This is a contract between pack engine and pack. Enforcement lives in the pack engine and lint layer, not in evidence verify. Future Pack Engine specs MAY adopt SemVer range semantics; build metadata is ignored; prerelease has lower precedence than release. |
+| Pack compatibility | evidence_schema_version: "1.0" | Packs declare the Assay Evidence Spec version they support. **Interpretation (Pack Engine v1 policy):** Pack engines MUST interpret this field as follows. For v1 freeze: *exact match* on `"1.0"` (only bundles with Assay Evidence Spec v1.0 and bundle schema_version 1 are accepted). If the field is absent, assume v1.0; lint SHOULD warn when `evidence_schema_version` is absent, even if pack engines default it to v1.0 for backward compatibility. If the value is present and not recognized, the pack engine MUST fail closed (reject) unless explicitly configured otherwise. This is a contract between pack engine and pack. Enforcement lives in the pack engine and lint layer, not in evidence verify. Future Pack Engine specs MAY adopt SemVer range semantics; build metadata is ignored; prerelease has lower precedence than release. |
 
-**Naming note:** *CloudEvents* `specversion` is the string `"1.0"` (CloudEvents context attribute). *Assay Evidence Spec* is Assay’s contract version (also `"1.0"` for v1). They are distinct concepts; tooling and tickets should distinguish “CloudEvents specversion” from “Assay Evidence Spec”.
+**Naming note:** *CloudEvents* `specversion` is the string `"1.0"` (CloudEvents context attribute). *Assay Evidence Spec* is Assay’s contract version (also `"1.0"` for v1). They are distinct concepts; tooling and tickets should distinguish “CloudEvents specversion” from “Assay Evidence Spec”. Code and tooling SHOULD use distinct constant names for these axes (`CE_SPECVERSION` for CloudEvents; `ASSAY_EVIDENCE_SPEC_VERSION` for Assay Evidence) and SHOULD avoid ambiguous names such as `SPEC_VERSION` in new code.
 
 **Source of truth for breaking changes:** This spec and the bundle manifest schema_version. Event envelope or payload changes that break existing consumers require a new spec version (e.g. v2) or a new bundle schema_version, with migration notes.
 
@@ -34,6 +34,7 @@
 
 **Version axes and evolution (mechanically testable):**
 - In v1, bundle schema_version is always 1. There is no schema_version 2 while the Assay Evidence Spec is v1.x.
+- Any bundle schema_version greater than 1 is outside Assay Evidence Spec v1.x and therefore requires Assay Evidence Spec v2+ with migration notes.
 - Assay Evidence Spec minor (v1.1, v1.2, …) MAY contain only additive changes (new optional fields, new event types). Breaking changes are not allowed within v1.x.
 - **Breaking change rule:** (1) Container/layout breaking ⇒ bundle schema_version bump (e.g. 2) with migration notes. (2) Meaning or payload breaking for an existing event type ⇒ new type identifier (preferred) or Assay Evidence Spec major (v2). Prefer adding a new type over bumping the spec major to reduce disruption for tooling.
 
@@ -54,7 +55,7 @@
 - **No semantic change:** The meaning of existing fields MUST NOT change.
 - **No type change:** Changing the type of an existing field is breaking.
 - **Removal or rename:** Breaking. Allowed only after deprecation window and only in a new spec version (v2) or new bundle schema_version, with migration notes.
-- **Unknown fields (compatibility mode vs strict JSON):** Verify/reader MUST accept events that contain unknown JSON object keys, *unless* one of the following applies (closed list): duplicate keys at any nesting level, event line bytes not valid UTF-8 or invalid Unicode escapes (including lone surrogates)—event lines are UTF-8 NDJSON (events.ndjson), manifest or event size limit exceeded, event count limit exceeded, decompression limit exceeded. No other condition may be used to reject solely on “unknown” keys. **Compatibility mode:** Unknown keys MUST be ignored by consumers. **Strict JSON (parser hardening):** The conditions above are the only security overrides; this aligns with JCS/canonical JSON and fail-closed verification.
+- **Unknown fields (compatibility mode vs strict JSON):** Verify/reader MUST accept events that contain unknown JSON object keys, *unless* one of the following applies (closed list): duplicate keys at any nesting level, event line bytes not valid UTF-8 or invalid Unicode escapes (including lone surrogates)—event lines are UTF-8 NDJSON (events.ndjson), manifest or event size limit exceeded, event count limit exceeded, decompression limit exceeded. No other condition may be used to reject solely on “unknown” keys. **Compatibility mode:** Unknown keys MUST be ignored by consumers. **Strict JSON (parser hardening):** The conditions above are the only security overrides; this aligns with JCS/canonical JSON and fail-closed verification. Limit values used by security overrides MUST have a documented source of truth if intended to be normative across implementations; in the reference implementation these defaults live in `VerifyLimits`. Otherwise, such checks are implementation hardening behavior and MUST be documented by the verifier.
 
 ### 4.1 New event types (compatibility)
 
@@ -62,11 +63,11 @@
 
 1. It is added to the [Event types (v1)](#42-event-types-v1) registry table.
 2. Its payload contract is documented in [ADR-006](../architecture/ADR-006-Evidence-Contract.md) or the relevant spec: at minimum the type string, payload shape (required/optional fields + types), semantics (1–2 sentences), and versioning posture (v1 additive-only; breaking ⇒ new type or v2). A field-level contract is required; full JSON Schema is not.
-3. At least one conformance test verifies that an event of this type passes verify (happy path) and checks at least one required invariant. The payload must be validated/decoded by the consumer(s) that are supposed to understand it—at minimum: evidence verify can parse the envelope and content-hash invariants hold. **At minimum, the test MUST assert: (a) verify succeeds, and (b) assaycontenthash matches the canonicalized payload bytes per v1 rules (directly or indirectly via verify).** Lint/explore coverage is optional.
+3. At least one conformance test verifies that an event of this type passes verify (happy path) and checks at least one required invariant. The payload must be validated/decoded by the consumer(s) that are supposed to understand it—at minimum: evidence verify can parse the envelope and content-hash invariants hold. **At minimum, the test MUST assert: (a) verify succeeds, and (b) assaycontenthash matches the canonicalized v1 content-hash input (directly or indirectly via verify).** Lint/explore coverage is optional. Stable event types MUST have at least one type-specific conformance test that checks a payload-level invariant beyond envelope/hash validity.
 
 Existing type strings MUST NOT change payload meaning; breaking changes require a new type string.
 
-This policy applies to any new type intended for production/stable use. Experimental and test-only types MUST still be registered, but MAY use TBD links and MAY use weaker test coverage; they MUST NOT be emitted by default in released builds. **A type may only be marked experimental or test-only temporarily; promotion to stable requires the full bar (schema link + conformance test) and MUST be recorded in version history.**
+This policy applies to any new type intended for production/stable use. Experimental and test-only types MUST still be registered, but MAY use TBD links and MAY use weaker test coverage; they MUST NOT be emitted by default in released builds. Experimental rows whose payload contract points to a plan are provisional: they MAY be emitted only by an explicitly invoked experimental/importer surface, and MUST NOT be emitted by default or implicit evidence-export paths until the payload contract and conformance tests are merged. **A type may only be marked experimental or test-only temporarily; promotion to stable requires the full bar (schema link + conformance test) and MUST be recorded in version history.**
 
 Version suffixes in the type string (e.g. `.v1`) are allowed but not required; use them when the payload contract itself is versioned independently (e.g. mandate lifecycle).
 
@@ -82,18 +83,18 @@ This table lists event types for Assay Evidence Spec v1.x (bundle schema_version
 
 | Event type | Status | Description | Payload contract | Test coverage |
 |------------|--------|-------------|-------------------|---------------|
-| assay.profile.started | stable | Run context start | [ADR-006 §3.A](../architecture/ADR-006-Evidence-Contract.md#3-core-payload-schemas-v10) | generate_fixture, evidence mapping/lint/diff |
-| assay.profile.finished | stable | Run context end | ADR-006 §3.A (same) | generate_fixture, evidence mapping |
-| assay.fs.access | stable | Filesystem activity (generalized) | [ADR-006 §3.D](../architecture/ADR-006-Evidence-Contract.md#3-core-payload-schemas-v10) | generate_fixture, evidence diff_test, explore |
+| assay.profile.started | stable | Run context start | [ADR-006 §3.A](../architecture/ADR-006-Evidence-Contract.md#payload-assay-profile-started) | verify_strict_test::test_profile_started_stable_payload_conformance |
+| assay.profile.finished | stable | Run context end | [ADR-006 §3.A](../architecture/ADR-006-Evidence-Contract.md#payload-assay-profile-finished) | verify_strict_test::test_profile_finished_stable_payload_conformance |
+| assay.fs.access | stable | Filesystem activity (generalized) | [ADR-006 §3.D](../architecture/ADR-006-Evidence-Contract.md#payload-assay-fs-access) | verify_strict_test::test_fs_access_stable_payload_conformance |
 | assay.net.connect | experimental | Network connection | ADR-006 (no §anchor yet) — add payload section before stable | generate_fixture, evidence diff_test, lint |
 | assay.process.exec | experimental | Process execution | ADR-006 (no §anchor yet) — add payload section before stable | generate_fixture, evidence diff_test |
-| assay.tool.decision | stable | Policy enforcement decision | [ADR-006 §3.B](../architecture/ADR-006-Evidence-Contract.md#3-core-payload-schemas-v10) | evidence verify_strict_test, mandate/lint |
-| assay.env.filtered | stable | Env filtering | ADR-006 envelope + example | assay_evidence types unit test |
+| assay.tool.decision | stable | Policy enforcement decision | [ADR-006 §3.B](../architecture/ADR-006-Evidence-Contract.md#payload-assay-tool-decision) | verify_strict_test::test_tool_decision_stable_payload_conformance |
+| assay.env.filtered | stable | Env filtering | [ADR-006 §3.E](../architecture/ADR-006-Evidence-Contract.md#payload-assay-env-filtered) | verify_strict_test::test_env_filtered_stable_payload_conformance |
 | assay.mandate.v1 | stable | Mandate content | [SPEC-Mandate-v1](../architecture/SPEC-Mandate-v1.md) | mandate golden/crypto vectors |
 | assay.mandate.used.v1 | stable | Mandate used lifecycle | SPEC-Mandate-v1 | mandate events tests |
 | assay.mandate.revoked.v1 | stable | Mandate revoked lifecycle | SPEC-Mandate-v1 | mandate events tests |
-| sandbox.degraded | stable | Operational integrity | [ADR-006 §3.C](../architecture/ADR-006-Evidence-Contract.md#3-core-payload-schemas-v10) | generate_fixture, evidence tests |
-| assay.receipt.promptfoo.assertion_component.v1 | experimental | Promptfoo CLI JSONL assertion component receipt | [PLAN-P31 §5-§6](../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md#5-receipt-v1-thesis) | promptfoo_jsonl importer tests |
+| assay.sandbox.degraded | stable | Operational integrity | [ADR-006 §3.C](../architecture/ADR-006-Evidence-Contract.md#payload-assay-sandbox-degraded) | verify_strict_test::test_sandbox_degraded_stable_payload_conformance |
+| assay.receipt.promptfoo.assertion_component.v1 | experimental | Promptfoo CLI JSONL assertion component receipt | [PLAN-P31 §5-§6](../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md#5-receipt-v1-thesis) | promptfoo_jsonl::tests::import_writes_verifiable_bundle_without_raw_payloads |
 
 ## 5. Deprecation policy
 
@@ -112,13 +113,13 @@ The following fixtures are normative. Consumers (verify, lint, explore, and CI) 
 
 **Container golden vs event golden:** *Container golden* covers tar layout, manifest schema, file hashes, and entry ordering. *Event golden* covers CloudEvents envelope and payload semantics (required attributes, types, content hashes). Both are part of the normative contract; fixtures may target one or both.
 
-**Container determinism (tar.gz):** For reproducible “container golden” builds the canonical writer SHOULD normalize so output is platform-independent: tar entry ordering fixed (e.g. manifest.json first, then events.ndjson); tar header uid, gid, uname, gname, mtime (e.g. 0 / epoch); gzip mtime and OS byte (e.g. mtime=0, OS=255 “unknown”). determinism_test pins the container hash for the canonical writer output; implementations that produce different tar/gzip header bytes are not byte-for-byte compatible with that pinned output. They may still be semantically compatible (verify passes), but are not deterministic-identical to the canonical writer output.
+**Container determinism (tar.gz):** For reproducible “container golden” builds the canonical writer MUST normalize so output is platform-independent: tar entry ordering fixed (e.g. manifest.json first, then events.ndjson); tar header uid, gid, uname, gname, mtime (e.g. 0 / epoch); gzip mtime and OS byte (e.g. mtime=0, OS=255 “unknown”). Other implementations SHOULD do the same for byte-identical compatibility. determinism_test pins the container hash for the canonical writer output; implementations that produce different tar/gzip header bytes are not byte-for-byte compatible with that pinned output. They may still be semantically compatible (verify passes), but are not deterministic-identical to the canonical writer output.
 
 **Determinism goldens vs smoke goldens (do not conflate):**
 - **Determinism goldens (pinned hashes):** The pinned hashes in `determinism_test.rs` apply to a bundle *generated inside that test* (in-memory), not to the file `test-bundle.tar.gz`. Updating “pinned hashes” means updating the assertions in `test_golden_hash` after changing the writer or event format.
 - **Smoke goldens (file fixtures):** `test-bundle.tar.gz` is a separate file fixture used to verify layout, verify, lint, and explore; it uses a different event set (from `generate_fixture`). Regenerating `test-bundle.tar.gz` does not change the determinism_test pinned values.
 
-**What is pinned (exact inputs):** (1) SHA-256 of the manifest.json bytes as stored in the tar; (2) SHA-256 of the events.ndjson bytes (UTF-8, one event per line, newline `\n`); (3) SHA-256 of the entire compressed tar.gz. Event-level content hashes use JCS (RFC 8785) canonicalization for the hash input. JCS is the norm for deterministic hashing and signing in v1; implementations that hash different normalized bytes are not compatible.
+**What is pinned (exact inputs):** (1) SHA-256 of the manifest.json bytes as stored in the tar; (2) SHA-256 of the events.ndjson bytes (UTF-8, one event per line, newline `\n`); (3) SHA-256 of the entire compressed tar.gz. Event-level content hashes use JCS (RFC 8785) canonicalization for the v1 content-hash input: `specversion`, `type`, `datacontenttype`, optional `subject`, and `data`. They do not cover the full CloudEvents envelope. JCS is the norm for deterministic hashing and signing in v1; implementations that hash different normalized bytes are not compatible.
 
 | Fixture | Purpose | Location | Determinism | Tests / consumers |
 |---------|---------|----------|-------------|-------------------|
@@ -148,18 +149,19 @@ These IDs are stable; if a test is renamed, maintain a compatibility alias (e.g.
 | 1                        | 2026-01| Initial: manifest schema, events.ndjson, CloudEvents envelope per ADR-006/007. |
 | 1                        | 2026-02| Contract freeze: this spec (compat matrix, evolution rules, deprecation, golden fixtures). |
 | 1                        | 2026-02| New event types policy (§4.1): no new type without registry + schema + conformance test; Event types (v1) registry table (§4.2); §2 normative rule clarified (schema_version 1 + v1.0 baseline; verify MAY v1.x, pack MAY exact 1.0). |
+| 1                        | 2026-04| Tightened version-axis naming (`CE_SPECVERSION` vs `ASSAY_EVIDENCE_SPEC_VERSION`), stable event registry anchors, canonical-writer determinism language, content-hash input scope, and experimental receipt-type emission posture. |
 
 ## 8. Normative checklist (summary)
 
 Before treating this document as normative, confirm:
 
-- **Terminologie:** CloudEvents `specversion` vs Assay Evidence Spec are clearly separated; no conflation in tooling or tickets.
+- **Terminologie:** CloudEvents `specversion` vs Assay Evidence Spec are clearly separated; new code uses `CE_SPECVERSION` and `ASSAY_EVIDENCE_SPEC_VERSION` rather than conflating the axes.
 - **Unknown keys:** Verify MUST accept unknown keys unless one of the closed list applies (duplicate keys, invalid UTF-8/surrogate, size/count/decompression limits); no other reject reason for “unknown” alone.
 - **v1.x additive-only:** In v1, bundle schema_version remains 1; Assay Evidence Spec minor (v1.1, v1.2) contains only additive changes; breaking ⇒ v2 or schema_version bump.
 - **Deprecations:** Deprecations ship in a minor release; removals only in a major spec or new schema_version.
-- **Container determinism:** Canonical writer SHOULD normalize tar/gzip headers; determinism_test pins container hash for that output.
+- **Container determinism:** Canonical writer MUST normalize tar/gzip headers; determinism_test pins container hash for that output.
 - **Fixture regen:** Pinned-hash locations are exactly named (see §6: `determinism_test.rs`, test `test_golden_hash`, three `assert_eq!` hex values).
-- **New event types (§4.1):** No new type without registry row + payload contract (concrete section for stable) + conformance test (verify + assaycontenthash invariant). Stable rows no "implied"; experimental/test-only temporary until full bar; promotion in version history.
+- **New event types (§4.1):** No new type without registry row + payload contract (concrete section for stable) + conformance test (verify + assaycontenthash content-hash-input invariant). Stable rows no "implied"; experimental/test-only temporary until full bar; promotion in version history.
 
 ## 9. References
 


### PR DESCRIPTION
What changed

Adds the first P31 compiler-path implementation for Promptfoo CLI JSONL assertion component results.

The PR includes:

- `assay evidence import promptfoo-jsonl`
- strict streaming JSONL ingestion from `gradingResult.componentResults[]`
- one Assay `EvidenceEvent` receipt per assertion component result
- direct `BundleWriter` output to a verifiable evidence bundle
- binary-only `equals` score handling for v1
- source artifact digest, source surface, reducer version, and import time in the receipt body
- docs and an experimental Evidence Contract registry row

Why

P31 moves the Promptfoo lane from sample/reducer proof to a real compiler path: component result in, portable evidence receipt bundle out. Harness comparison and Trust Card rendering stay deliberately out of this slice.

Boundary

This does not import full Promptfoo rows, raw prompt/output/expected values, vars, provider payloads, stats, token/cost data, red-team reports, or run-level aggregate truth.

Validation

Ran locally:

```bash
cargo fmt --check
cargo test -p assay-cli promptfoo_jsonl -- --nocapture
cargo clippy -p assay-cli --all-targets -- -D warnings
jq -c . examples/promptfoo-assertion-grading-result-evidence/discovery/valid.full-jsonl-row.json examples/promptfoo-assertion-grading-result-evidence/discovery/failure.full-jsonl-row.json > /tmp/p31-promptfoo-results.jsonl
cargo run -p assay-cli -- evidence import promptfoo-jsonl --input /tmp/p31-promptfoo-results.jsonl --bundle-out /tmp/p31-promptfoo-evidence.tar.gz --source-artifact-ref results.jsonl --run-id p31_promptfoo_fixture --import-time 2026-04-26T12:00:00Z
cargo run -p assay-cli -- evidence verify /tmp/p31-promptfoo-evidence.tar.gz
cargo run -p assay-cli -- evidence import promptfoo-jsonl --help
git diff --check
```

Commit and push-time hooks also passed, including cargo fmt, cargo clippy, and the linux compile gate.
