### PR TITLE
P33: add external eval receipt Trust Basis claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ Install from [crates.io](https://crates.io/crates/assay-cli) or source (`cargo i
 # Machine-readable claim basis (deterministic, claim-first)
 assay trust-basis generate demo/fixtures/bundle.tar.gz > trust-basis.json
 
-# Human + machine Trust Card (schema v2 — seven trust claims; key by `id`, not row count)
+# Human + machine Trust Card (schema v3 — eight trust claims; key by `id`, not row count)
 assay trustcard generate demo/fixtures/bundle.tar.gz --out-dir ./trust-out
 # → trust-out/trustcard.json , trust-out/trustcard.md
 ```
 
-`trust-basis.json` emits claims from a bounded, versioned vocabulary for this schema (examples: `bundle_verified`, `delegation_context_visible`, `authorization_context_visible`, `containment_degradation_observed`, …). Claim `id` values are stable across runs, but consumers **must not** rely on row count or ordering; always key by `id`. It is **not** a scalar trust score. The Trust Card is a deterministic render of the same claim rows plus frozen non-goals. **Contract versions, pack floors, and release checklist:** [docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md](docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md).
+`trust-basis.json` emits claims from a bounded, versioned vocabulary for this schema (examples: `bundle_verified`, `delegation_context_visible`, `authorization_context_visible`, `containment_degradation_observed`, `external_eval_receipt_boundary_visible`, …). Claim `id` values are stable across runs, but consumers **must not** rely on row count or ordering; always key by `id`. It is **not** a scalar trust score. The Trust Card is a deterministic render of the same claim rows plus frozen non-goals. **Contract versions, pack floors, and release checklist:** [docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md](docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md), [docs/architecture/PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md](docs/architecture/PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md).
 
 ## What you get
 

--- a/crates/assay-cli/tests/evidence_test.rs
+++ b/crates/assay-cli/tests/evidence_test.rs
@@ -139,15 +139,14 @@ fn test_promptfoo_imported_receipts_feed_trust_basis_generation() {
     let claims = json["claims"].as_array().unwrap();
     assert_eq!(
         claims.len(),
-        7,
-        "P32 locks Trust Basis readability without adding a Promptfoo-specific claim yet"
+        8,
+        "P33 adds one bounded external receipt boundary claim"
     );
     assert_eq!(claim(claims, "bundle_verified")["level"], "verified");
-    assert!(
-        claims
-            .iter()
-            .all(|claim| claim["id"] != "external_eval_receipt_boundary_visible"),
-        "Promptfoo-specific Trust Basis claim expansion is intentionally deferred"
+    assert_eq!(
+        claim(claims, "external_eval_receipt_boundary_visible")["level"],
+        "verified",
+        "Promptfoo receipts should now surface the bounded external receipt boundary claim"
     );
 }
 

--- a/crates/assay-cli/tests/trust_basis_test.rs
+++ b/crates/assay-cli/tests/trust_basis_test.rs
@@ -76,7 +76,7 @@ fn trust_basis_generate_stdout_emits_all_frozen_claims() {
     let claims = json["claims"].as_array().unwrap();
     assert_eq!(
         claims.len(),
-        7,
+        8,
         "all frozen claims should always be present"
     );
 
@@ -100,6 +100,10 @@ fn trust_basis_generate_stdout_emits_all_frozen_claims() {
     );
     assert_eq!(
         claim(claims, "applied_pack_findings_present")["level"],
+        "absent"
+    );
+    assert_eq!(
+        claim(claims, "external_eval_receipt_boundary_visible")["level"],
         "absent"
     );
 }

--- a/crates/assay-cli/tests/trustcard_test.rs
+++ b/crates/assay-cli/tests/trustcard_test.rs
@@ -66,14 +66,14 @@ fn trustcard_generate_writes_json_and_md_matching_trust_basis_claims() {
     let card_json: serde_json::Value =
         serde_json::from_slice(&fs::read(out_dir.join("trustcard.json")).unwrap()).unwrap();
 
-    assert_eq!(card_json["schema_version"], json!(2));
+    assert_eq!(card_json["schema_version"], json!(3));
     assert_eq!(card_json["claims"], basis_json["claims"]);
 
     let claims = card_json["claims"].as_array().expect("claims array");
     assert_eq!(
         claims.len(),
-        7,
-        "trustcard must carry exactly seven frozen claims"
+        8,
+        "trustcard must carry exactly eight frozen claims"
     );
     let expected_ids = [
         "bundle_verified",
@@ -82,6 +82,7 @@ fn trustcard_generate_writes_json_and_md_matching_trust_basis_claims() {
         "delegation_context_visible",
         "authorization_context_visible",
         "containment_degradation_observed",
+        "external_eval_receipt_boundary_visible",
         "applied_pack_findings_present",
     ];
     let ids: Vec<_> = claims

--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -15,6 +15,7 @@ pub enum TrustClaimId {
     /// G3 v1: policy-projected `principal` + `auth_scheme` + `auth_issuer` on decision evidence
     AuthorizationContextVisible,
     ContainmentDegradationObserved,
+    ExternalEvalReceiptBoundaryVisible,
     AppliedPackFindingsPresent,
 }
 
@@ -34,6 +35,7 @@ pub enum TrustClaimSource {
     BundleProofSurface,
     CanonicalDecisionEvidence,
     CanonicalEventPresence,
+    ExternalEvidenceReceipt,
     PackExecutionResults,
 }
 
@@ -45,6 +47,7 @@ pub enum TrustClaimBoundary {
     /// G3 v1: auth context fields from supported policy-projected MCP decision path only
     SupportedAuthProjectedFlowsOnly,
     SupportedContainmentFallbackPathsOnly,
+    SupportedExternalEvalReceiptEventsOnly,
     ProofSurfacesOnly,
     PackExecutionOnly,
 }
@@ -140,6 +143,13 @@ pub fn generate_trust_basis<R: Read>(
                 note: None,
             },
             TrustBasisClaim {
+                id: TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+                level: classify_external_eval_receipt_boundary(&events),
+                source: TrustClaimSource::ExternalEvidenceReceipt,
+                boundary: TrustClaimBoundary::SupportedExternalEvalReceiptEventsOnly,
+                note: None,
+            },
+            TrustBasisClaim {
                 id: TrustClaimId::AppliedPackFindingsPresent,
                 level: classify_pack_findings(lint_result.as_ref()),
                 source: TrustClaimSource::PackExecutionResults,
@@ -208,6 +218,128 @@ fn classify_containment_degradation(events: &[EvidenceEvent]) -> TrustClaimLevel
     }
 }
 
+const PROMPTFOO_RECEIPT_EVENT_TYPE: &str = "assay.receipt.promptfoo.assertion_component.v1";
+const PROMPTFOO_RECEIPT_SCHEMA: &str = "assay.receipt.promptfoo.assertion-component.v1";
+const PROMPTFOO_RECEIPT_SOURCE_SYSTEM: &str = "promptfoo";
+const PROMPTFOO_RECEIPT_SOURCE_SURFACE: &str = "cli-jsonl.gradingResult.componentResults";
+const PROMPTFOO_RECEIPT_REDUCER_PREFIX: &str = "assay-promptfoo-jsonl-component-result@";
+const PROMPTFOO_MAX_REASON_CHARS: usize = 160;
+
+fn classify_external_eval_receipt_boundary(events: &[EvidenceEvent]) -> TrustClaimLevel {
+    if events.iter().any(is_supported_promptfoo_receipt) {
+        TrustClaimLevel::Verified
+    } else {
+        TrustClaimLevel::Absent
+    }
+}
+
+fn is_supported_promptfoo_receipt(event: &EvidenceEvent) -> bool {
+    if event.type_ != PROMPTFOO_RECEIPT_EVENT_TYPE {
+        return false;
+    }
+
+    let Some(payload) = event.payload.as_object() else {
+        return false;
+    };
+    let allowed_fields = [
+        "schema",
+        "source_system",
+        "source_surface",
+        "source_artifact_ref",
+        "source_artifact_digest",
+        "reducer_version",
+        "imported_at",
+        "assertion_type",
+        "result",
+    ];
+    if payload
+        .keys()
+        .any(|key| !allowed_fields.contains(&key.as_str()))
+    {
+        return false;
+    }
+
+    string_field(payload, "schema") == Some(PROMPTFOO_RECEIPT_SCHEMA)
+        && string_field(payload, "source_system") == Some(PROMPTFOO_RECEIPT_SOURCE_SYSTEM)
+        && string_field(payload, "source_surface") == Some(PROMPTFOO_RECEIPT_SOURCE_SURFACE)
+        && non_empty_string_field(payload, "source_artifact_ref")
+        && string_field(payload, "source_artifact_digest")
+            .map(is_sha256_digest)
+            .unwrap_or(false)
+        && string_field(payload, "reducer_version")
+            .map(|value| value.starts_with(PROMPTFOO_RECEIPT_REDUCER_PREFIX))
+            .unwrap_or(false)
+        && non_empty_string_field(payload, "imported_at")
+        && string_field(payload, "assertion_type") == Some("equals")
+        && payload
+            .get("result")
+            .and_then(|value| value.as_object())
+            .map(is_supported_promptfoo_result)
+            .unwrap_or(false)
+}
+
+fn string_field<'a>(
+    payload: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<&'a str> {
+    payload.get(key).and_then(|value| value.as_str())
+}
+
+fn non_empty_string_field(payload: &serde_json::Map<String, serde_json::Value>, key: &str) -> bool {
+    string_field(payload, key)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+}
+
+fn is_sha256_digest(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return false;
+    };
+    hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_supported_promptfoo_result(result: &serde_json::Map<String, serde_json::Value>) -> bool {
+    let allowed_fields = ["pass", "score", "reason"];
+    if result
+        .keys()
+        .any(|key| !allowed_fields.contains(&key.as_str()))
+    {
+        return false;
+    }
+
+    if result
+        .get("pass")
+        .and_then(|value| value.as_bool())
+        .is_none()
+    {
+        return false;
+    }
+
+    if !matches!(
+        result.get("score").and_then(|value| value.as_i64()),
+        Some(0 | 1)
+    ) {
+        return false;
+    }
+
+    match result.get("reason") {
+        Some(value) => value.as_str().map(is_bounded_reason).unwrap_or(false),
+        None => true,
+    }
+}
+
+fn is_bounded_reason(reason: &str) -> bool {
+    let trimmed = reason.trim();
+    !trimmed.is_empty()
+        && trimmed.chars().count() <= PROMPTFOO_MAX_REASON_CHARS
+        && !trimmed.contains('\n')
+        && !trimmed.contains('\r')
+        && !trimmed.contains('"')
+        && !trimmed.contains('`')
+        && !trimmed.contains('{')
+        && !trimmed.contains('}')
+}
+
 fn classify_pack_findings(lint_result: Option<&LintReportWithPacks>) -> TrustClaimLevel {
     let Some(lint_result) = lint_result else {
         return TrustClaimLevel::Absent;
@@ -274,6 +406,31 @@ mod tests {
             .expect("claim should exist")
     }
 
+    fn promptfoo_receipt_payload(extra: serde_json::Value) -> serde_json::Value {
+        let mut payload = json!({
+            "schema": "assay.receipt.promptfoo.assertion-component.v1",
+            "source_system": "promptfoo",
+            "source_surface": "cli-jsonl.gradingResult.componentResults",
+            "source_artifact_ref": "results.jsonl",
+            "source_artifact_digest": format!("sha256:{}", "a".repeat(64)),
+            "reducer_version": "assay-promptfoo-jsonl-component-result@0.1.0",
+            "imported_at": "2026-04-26T12:00:00Z",
+            "assertion_type": "equals",
+            "result": {
+                "pass": true,
+                "score": 1,
+                "reason": "Assertion passed"
+            }
+        });
+        if let Some(extra) = extra.as_object() {
+            let obj = payload.as_object_mut().expect("payload object");
+            for (key, value) in extra {
+                obj.insert(key.clone(), value.clone());
+            }
+        }
+        payload
+    }
+
     #[test]
     fn g3_authorization_claim_is_after_delegation_before_containment() {
         let bundle = make_bundle(vec![make_event(
@@ -290,7 +447,7 @@ mod tests {
         .expect("trust basis");
         let ids: Vec<_> = trust_basis.claims.iter().map(|c| c.id).collect();
         let pos = |id| ids.iter().position(|&x| x == id).expect("claim id");
-        assert_eq!(ids.len(), 7);
+        assert_eq!(ids.len(), 8);
         assert!(
             pos(TrustClaimId::DelegationContextVisible)
                 < pos(TrustClaimId::AuthorizationContextVisible)
@@ -355,6 +512,11 @@ mod tests {
                     TrustClaimBoundary::SupportedContainmentFallbackPathsOnly,
                 ),
                 (
+                    TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+                    TrustClaimSource::ExternalEvidenceReceipt,
+                    TrustClaimBoundary::SupportedExternalEvalReceiptEventsOnly,
+                ),
+                (
                     TrustClaimId::AppliedPackFindingsPresent,
                     TrustClaimSource::PackExecutionResults,
                     TrustClaimBoundary::PackExecutionOnly,
@@ -369,6 +531,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 TrustClaimLevel::Verified,
+                TrustClaimLevel::Absent,
                 TrustClaimLevel::Absent,
                 TrustClaimLevel::Absent,
                 TrustClaimLevel::Absent,
@@ -453,6 +616,60 @@ mod tests {
         );
         assert_eq!(
             claim(&trust_basis, TrustClaimId::AuthorizationContextVisible).level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_detects_supported_external_eval_receipt_boundary() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.receipt.promptfoo.assertion_component.v1",
+            "run_promptfoo_receipt",
+            0,
+            promptfoo_receipt_payload(json!({})),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(
+                &trust_basis,
+                TrustClaimId::ExternalEvalReceiptBoundaryVisible
+            )
+            .level,
+            TrustClaimLevel::Verified
+        );
+    }
+
+    #[test]
+    fn trust_basis_rejects_promptfoo_receipt_boundary_when_raw_payload_leaks_in() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.receipt.promptfoo.assertion_component.v1",
+            "run_promptfoo_raw",
+            0,
+            promptfoo_receipt_payload(json!({
+                "output": "raw model output should not be in the receipt"
+            })),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(
+                &trust_basis,
+                TrustClaimId::ExternalEvalReceiptBoundaryVisible
+            )
+            .level,
             TrustClaimLevel::Absent
         );
     }

--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -269,7 +269,9 @@ fn is_supported_promptfoo_receipt(event: &EvidenceEvent) -> bool {
         && string_field(payload, "reducer_version")
             .map(|value| value.starts_with(PROMPTFOO_RECEIPT_REDUCER_PREFIX))
             .unwrap_or(false)
-        && non_empty_string_field(payload, "imported_at")
+        && string_field(payload, "imported_at")
+            .map(is_utc_rfc3339)
+            .unwrap_or(false)
         && string_field(payload, "assertion_type") == Some("equals")
         && payload
             .get("result")
@@ -296,6 +298,13 @@ fn is_sha256_digest(value: &str) -> bool {
         return false;
     };
     hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_utc_rfc3339(value: &str) -> bool {
+    let Ok(timestamp) = chrono::DateTime::parse_from_rfc3339(value) else {
+        return false;
+    };
+    timestamp.offset().local_minus_utc() == 0
 }
 
 fn is_supported_promptfoo_result(result: &serde_json::Map<String, serde_json::Value>) -> bool {
@@ -654,6 +663,34 @@ mod tests {
             0,
             promptfoo_receipt_payload(json!({
                 "output": "raw model output should not be in the receipt"
+            })),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(
+                &trust_basis,
+                TrustClaimId::ExternalEvalReceiptBoundaryVisible
+            )
+            .level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_rejects_promptfoo_receipt_boundary_when_import_time_is_not_utc_rfc3339() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.receipt.promptfoo.assertion_component.v1",
+            "run_promptfoo_bad_time",
+            0,
+            promptfoo_receipt_payload(json!({
+                "imported_at": "not-a-timestamp"
             })),
         )]);
 

--- a/crates/assay-evidence/src/trust_card.rs
+++ b/crates/assay-evidence/src/trust_card.rs
@@ -6,8 +6,8 @@ use crate::trust_basis::{TrustBasis, TrustBasisClaim};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-/// Trust Card schema: `2` adds G3 `authorization_context_visible` claim (same row layout as v1).
-pub const TRUST_CARD_SCHEMA_VERSION: u32 = 2;
+/// Trust Card schema: `3` adds `external_eval_receipt_boundary_visible`.
+pub const TRUST_CARD_SCHEMA_VERSION: u32 = 3;
 
 /// Markdown table cell when T1a leaves `note` empty (`None` or blank). Do not vary by test/renderer.
 pub const TRUST_CARD_NOTE_EMPTY_PLACEHOLDER: &str = "-";
@@ -120,13 +120,14 @@ mod tests {
     use std::io::Cursor;
 
     /// Must match `TrustBasis::claims` order from [`crate::trust_basis::generate_trust_basis`].
-    const FROZEN_TRUST_BASIS_CLAIM_ID_ORDER: [TrustClaimId; 7] = [
+    const FROZEN_TRUST_BASIS_CLAIM_ID_ORDER: [TrustClaimId; 8] = [
         TrustClaimId::BundleVerified,
         TrustClaimId::SigningEvidencePresent,
         TrustClaimId::ProvenanceBackedClaimsPresent,
         TrustClaimId::DelegationContextVisible,
         TrustClaimId::AuthorizationContextVisible,
         TrustClaimId::ContainmentDegradationObserved,
+        TrustClaimId::ExternalEvalReceiptBoundaryVisible,
         TrustClaimId::AppliedPackFindingsPresent,
     ];
 
@@ -233,7 +234,7 @@ mod tests {
     }
 
     #[test]
-    fn trust_card_json_always_exactly_seven_frozen_claim_ids_once_in_trust_basis_order() {
+    fn trust_card_json_always_exactly_eight_frozen_claim_ids_once_in_trust_basis_order() {
         let bundle = make_bundle(vec![make_event(
             "assay.process.exec",
             "run_seven",
@@ -248,7 +249,7 @@ mod tests {
         .expect("trust basis");
         let card = trust_basis_to_trust_card(&basis);
 
-        assert_eq!(card.claims.len(), 7);
+        assert_eq!(card.claims.len(), 8);
         let ids: Vec<TrustClaimId> = card.claims.iter().map(|c| c.id).collect();
         assert_eq!(ids, FROZEN_TRUST_BASIS_CLAIM_ID_ORDER);
     }
@@ -373,13 +374,13 @@ mod tests {
             .filter(|l| !l.contains("| --- |"))
             .count();
         assert_eq!(
-            table_rows, 7,
-            "schema 2 adds one claim row; no extra markdown table blocks"
+            table_rows, 8,
+            "schema 3 adds one external receipt row; no extra markdown table blocks"
         );
     }
 
     #[test]
-    fn trust_card_schema_version_is_two() {
+    fn trust_card_schema_version_is_three() {
         let bundle = make_bundle(vec![make_event(
             "assay.process.exec",
             "run_schema",
@@ -393,11 +394,11 @@ mod tests {
         )
         .expect("trust basis");
         let card = trust_basis_to_trust_card(&basis);
-        assert_eq!(card.schema_version, 2);
+        assert_eq!(card.schema_version, 3);
         let v: serde_json::Value =
             serde_json::from_slice(&trust_card_to_canonical_json_bytes(&card).expect("json"))
                 .expect("parse");
-        assert_eq!(v["schema_version"], json!(2));
+        assert_eq!(v["schema_version"], json!(3));
     }
 
     #[test]

--- a/crates/assay-evidence/tests/h1_trust_kernel_alignment.rs
+++ b/crates/assay-evidence/tests/h1_trust_kernel_alignment.rs
@@ -88,7 +88,7 @@ fn h1_trust_card_matches_trust_basis_claims_and_frozen_top_level() {
     let card = trust_basis_to_trust_card(&tb);
 
     assert_eq!(card.schema_version, TRUST_CARD_SCHEMA_VERSION);
-    assert_eq!(card.claims.len(), 7);
+    assert_eq!(card.claims.len(), 8);
     assert_eq!(
         card.claims, tb.claims,
         "Trust Card must not reclassify claims"

--- a/docs/architecture/PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md
+++ b/docs/architecture/PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md
@@ -1,0 +1,132 @@
+# PLAN — P33 External Eval Receipt Trust Basis Claim (Q2 2026)
+
+- **Date:** 2026-04-27
+- **Owner:** Evidence / Trust Compiler
+- **Status:** Execution slice
+- **Scope:** Add one bounded Trust Basis claim for supported external evaluation receipt evidence, starting with the P31 Promptfoo assertion-component receipt event.
+
+## 1. Why this exists
+
+P31 made the Promptfoo compiler path real:
+
+```text
+Promptfoo CLI JSONL component result
+  -> assay evidence import promptfoo-jsonl
+  -> Assay EvidenceEvent receipt bundle
+```
+
+P32 then proved those bundles are not dead-end files:
+
+```text
+receipt bundle
+  -> assay evidence verify
+  -> assay trust-basis generate
+```
+
+P33 is the next deliberate compatibility step. It adds one Trust Basis row that
+lets reviewers see that a supported external evaluation receipt boundary is
+present in the verified bundle.
+
+## 2. What P33 is
+
+P33 adds:
+
+- `external_eval_receipt_boundary_visible`
+- `source = external_evidence_receipt`
+- `boundary = supported-external-eval-receipt-events-only`
+- Trust Card schema `3`, because the visible claim table changes
+
+The claim is `verified` only when the bundle contains a supported receipt event
+whose payload still matches the bounded v1 receipt shape.
+
+For the first slice, the only supported event is:
+
+```text
+assay.receipt.promptfoo.assertion_component.v1
+```
+
+with:
+
+- `schema = "assay.receipt.promptfoo.assertion-component.v1"`
+- `source_system = "promptfoo"`
+- `source_surface = "cli-jsonl.gradingResult.componentResults"`
+- reviewer-safe source artifact ref and digest
+- reducer version
+- import timestamp
+- `assertion_type = "equals"`
+- `result.pass`
+- binary `result.score`
+- optional bounded `result.reason`
+
+## 3. What P33 is not
+
+P33 does not claim:
+
+- Promptfoo run pass/fail truth
+- model-output correctness
+- prompt/output/expected-value truth
+- Promptfoo config, provider, token, cost, stats, or red-team truth
+- broad external-evaluation support
+- Harness baseline/candidate regression semantics
+
+The claim means only:
+
+```text
+the verified bundle contains at least one supported bounded external eval receipt
+```
+
+It does not mean:
+
+```text
+the external evaluation result is correct or sufficient
+```
+
+## 4. Predicate rule
+
+The Trust Basis predicate must stay stricter than generic event presence.
+
+`external_eval_receipt_boundary_visible = verified` requires:
+
+- supported receipt event type
+- exact supported source system and source surface
+- digest-shaped source artifact binding
+- supported reducer-version prefix
+- supported assertion type
+- bounded result object
+- no top-level raw Promptfoo payload fields in the receipt payload
+
+Malformed, wider, or future-shaped receipt payloads remain accepted by evidence
+verify if the bundle contract allows them, but this Trust Basis claim should
+stay `absent` until the predicate is deliberately widened.
+
+## 5. Trust Card impact
+
+Adding a claim row changes the Trust Card visible surface. P33 therefore bumps:
+
+```text
+TRUST_CARD_SCHEMA_VERSION = 3
+```
+
+The Trust Card remains a deterministic render of Trust Basis. It does not add a
+second classifier, summary prose, aggregate score, or badge.
+
+## 6. Acceptance criteria
+
+- Trust Basis always emits the new claim row.
+- Ordinary bundles keep the claim `absent`.
+- Supported P31 Promptfoo receipt bundles classify it as `verified`.
+- Receipt-like events that include raw Promptfoo payload fields classify it as
+  `absent`.
+- Trust Card schema is bumped to `3`.
+- Trust Card JSON and Markdown still render only the same claim rows plus frozen
+  non-goals.
+- CLI docs explain the claim boundary without describing Promptfoo correctness
+  or run success.
+
+## 7. Sequencing
+
+P33 comes after P32 and before any Harness compare work.
+
+The next likely slice after P33 is Harness-level comparison over compiled
+receipts. Harness should compare Assay receipt/trust artifacts; it should not
+learn Promptfoo JSONL parsing semantics directly.

--- a/docs/architecture/PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md
+++ b/docs/architecture/PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md
@@ -52,7 +52,7 @@ with:
 - `source_surface = "cli-jsonl.gradingResult.componentResults"`
 - reviewer-safe source artifact ref and digest
 - reducer version
-- import timestamp
+- UTC RFC3339 import timestamp
 - `assertion_type = "equals"`
 - `result.pass`
 - binary `result.score`
@@ -90,6 +90,7 @@ The Trust Basis predicate must stay stricter than generic event presence.
 - supported receipt event type
 - exact supported source system and source surface
 - digest-shaped source artifact binding
+- UTC RFC3339 import timestamp
 - supported reducer-version prefix
 - supported assertion type
 - bounded result object

--- a/docs/architecture/PLAN-T1b-TRUST-CARD-2026q2.md
+++ b/docs/architecture/PLAN-T1b-TRUST-CARD-2026q2.md
@@ -8,12 +8,12 @@
 
 Ship `trustcard.json` (canonical) and `trustcard.md` (secondary) derived **only** from `generate_trust_basis` → `trust_basis_to_trust_card`. No second classification pass, no aggregate score, no badge semantics, no `trust_basis_sha256` in v1.
 
-## 2) Frozen contract (T1b baseline; extended by G3)
+## 2) Frozen contract (T1b baseline; extended by G3 and P33)
 
 | Item | Rule |
 |------|------|
-| `schema_version` | `2` after [G3](./PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md) (`TRUST_CARD_SCHEMA_VERSION`); was `1` for the original T1b-only ship. |
-| `claims[]` | `Vec<TrustBasisClaim>` — same serde as trust basis; **seven** frozen ids after G3, same order as `TrustBasis::claims` (was six for T1a-only). |
+| `schema_version` | `3` after [P33](./PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) (`TRUST_CARD_SCHEMA_VERSION`); was `2` after [G3](./PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md) and `1` for the original T1b-only ship. |
+| `claims[]` | `Vec<TrustBasisClaim>` — same serde as trust basis; **eight** frozen ids after P33, same order as `TrustBasis::claims` (was seven after G3 and six for T1a-only). |
 | `non_goals` | Three fixed strings in fixed order (`TRUST_CARD_NON_GOALS` in code); identical in JSON and Markdown. |
 | Markdown `note` column | Empty T1a `note` renders as placeholder `-` (`TRUST_CARD_NOTE_EMPTY_PLACEHOLDER`); no multiline cells. |
 | Markdown shape | Title + fixed five-column table + `## Non-goals` with literal bullets. |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -50,6 +50,7 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [PLAN — P30 OpenFeature EvaluationDetails Evidence (Q2 2026)](./PLAN-P30-OPENFEATURE-EVALUATION-DETAILS-EVIDENCE-2026q2.md) — planned governance-adjacent OpenFeature lane built around one returned `EvaluationDetails` object, not provider config, targeting, rollout, telemetry, or application correctness truth
 - [PLAN — P31 Promptfoo JSONL Component Result Receipt Import (Q2 2026)](./PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md) — planned compiler-path follow-up to P28 that imports one Promptfoo JSONL assertion component result into one portable Assay evidence receipt, not full Promptfoo eval-run truth or Harness regression gating
 - [PLAN — P32 Promptfoo Receipt Trust Basis Readiness (Q2 2026)](./PLAN-P32-PROMPTFOO-RECEIPT-TRUST-BASIS-READINESS-2026q2.md) — execution slice that proves P31 receipt bundles feed the current Trust Basis compiler without adding a Promptfoo-specific claim row or Trust Card schema bump
+- [PLAN — P33 External Eval Receipt Trust Basis Claim (Q2 2026)](./PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) — execution slice that adds one bounded Trust Basis claim for supported external evaluation receipt boundaries, starting with Promptfoo assertion-component receipts
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 
 ## Active RFCs

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -55,9 +55,11 @@ assay trust-basis generate promptfoo-evidence.tar.gz
 ```
 
 This proves the imported receipts are bundleable, verifiable, and readable by
-the Trust Basis path. It does not yet add Promptfoo-specific Trust Basis claims
-or bump the Trust Card schema; that claim expansion is a separate compatibility
-decision.
+the Trust Basis path. Trust Basis now emits
+`external_eval_receipt_boundary_visible` when the supported Promptfoo receipt
+shape is present. That claim means the bounded receipt boundary is visible; it
+does not mean the Promptfoo eval run passed, the model output was correct, or
+the raw Promptfoo payload is imported as Assay truth.
 
 Use `--import-time <RFC3339>` for deterministic fixture generation.
 


### PR DESCRIPTION
What changed

Adds the P33 Trust Basis claim expansion above the merged P31/P32 Promptfoo receipt path.

This PR includes:

- new `external_eval_receipt_boundary_visible` Trust Basis claim
- bounded predicate for supported Promptfoo assertion-component receipt events
- Trust Card schema bump to `3` because the visible claim table changes
- regression coverage for ordinary bundles, supported Promptfoo receipts, and raw-payload leakage
- P33 architecture plan and CLI/README docs updates

Why

P31 made the compiler path real: Promptfoo component result in, Assay receipt bundle out. P32 proved those bundles verify and feed the current Trust Basis compiler.

P33 is the next compatibility step: make the external receipt boundary visible as a named claim without claiming Promptfoo run success, model correctness, prompt/output/expected truth, or broad external-eval support.

Boundary

This does not add Harness comparison, Promptfoo run pass/fail semantics, model-output correctness semantics, provider/config/stat truth, or raw Promptfoo payload import.

Validation

Ran locally:

- `cargo fmt --check`
- `cargo test -p assay-evidence trust_basis -- --nocapture`
- `cargo test -p assay-evidence trust_card -- --nocapture`
- `cargo test -p assay-cli --test evidence_test -- --nocapture`
- `cargo test -p assay-cli --test trust_basis_test -- --nocapture`
- `cargo test -p assay-cli --test trustcard_test -- --nocapture`
- `cargo test -p assay-evidence --test h1_trust_kernel_alignment -- --nocapture`
- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `git diff --check`
- changed-docs local link check

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.
