### PR TITLE
P34: add Trust Basis diff gate

### DIFF
--- a/crates/assay-cli/src/cli/args/trust_basis.rs
+++ b/crates/assay-cli/src/cli/args/trust_basis.rs
@@ -1,3 +1,4 @@
+use super::common::OutputFormat;
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
 
@@ -11,6 +12,8 @@ pub struct TrustBasisArgs {
 pub enum TrustBasisSub {
     /// Generate canonical trust-basis.json from a verified evidence bundle
     Generate(TrustBasisGenerateArgs),
+    /// Compare two canonical trust-basis.json artifacts
+    Diff(TrustBasisDiffArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -30,4 +33,23 @@ pub struct TrustBasisGenerateArgs {
     /// Maximum lint results considered when pack execution is enabled
     #[arg(long, default_value = "500")]
     pub max_results: usize,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct TrustBasisDiffArgs {
+    /// Baseline trust-basis.json
+    #[arg(value_name = "BASELINE")]
+    pub baseline: PathBuf,
+
+    /// Candidate trust-basis.json
+    #[arg(value_name = "CANDIDATE")]
+    pub candidate: PathBuf,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+
+    /// Exit non-zero when the candidate removes or lowers a baseline claim
+    #[arg(long)]
+    pub fail_on_regression: bool,
 }

--- a/crates/assay-cli/src/cli/commands/trust_basis.rs
+++ b/crates/assay-cli/src/cli/commands/trust_basis.rs
@@ -1,10 +1,14 @@
-use crate::cli::args::{TrustBasisArgs, TrustBasisGenerateArgs, TrustBasisSub};
+use crate::cli::args::{
+    OutputFormat, TrustBasisArgs, TrustBasisDiffArgs, TrustBasisGenerateArgs, TrustBasisSub,
+};
 use crate::exit_codes::EXIT_SUCCESS;
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use assay_evidence::lint::engine::LintOptions;
 use assay_evidence::lint::packs::load_packs;
 use assay_evidence::{
-    generate_trust_basis, to_canonical_json_bytes, TrustBasisOptions, VerifyLimits,
+    diff_trust_basis, generate_trust_basis, to_canonical_json_bytes, TrustBasis, TrustBasisClaim,
+    TrustBasisClaimLevelDiff, TrustBasisClaimMetadataDiff, TrustBasisDiffReport, TrustBasisOptions,
+    TrustClaimBoundary, TrustClaimId, TrustClaimLevel, TrustClaimSource, VerifyLimits,
 };
 use std::fs::File;
 use std::io::Write;
@@ -12,6 +16,7 @@ use std::io::Write;
 pub fn run(args: TrustBasisArgs) -> Result<i32> {
     match args.cmd {
         TrustBasisSub::Generate(args) => cmd_generate(args),
+        TrustBasisSub::Diff(args) => cmd_diff(args),
     }
 }
 
@@ -56,4 +61,139 @@ fn cmd_generate(args: TrustBasisGenerateArgs) -> Result<i32> {
     }
 
     Ok(EXIT_SUCCESS)
+}
+
+fn cmd_diff(args: TrustBasisDiffArgs) -> Result<i32> {
+    let baseline = read_trust_basis(&args.baseline)?;
+    let candidate = read_trust_basis(&args.candidate)?;
+    let report = diff_trust_basis(&baseline, &candidate);
+
+    match args.format {
+        OutputFormat::Text => write_diff_text(&report).context("failed to write diff output")?,
+        OutputFormat::Json => write_diff_json(&report).context("failed to write diff output")?,
+    }
+
+    if args.fail_on_regression && report.has_regressions() {
+        bail!("Trust Basis regression check failed");
+    }
+
+    Ok(EXIT_SUCCESS)
+}
+
+fn read_trust_basis(path: &std::path::Path) -> Result<TrustBasis> {
+    let file = File::open(path)
+        .with_context(|| format!("failed to open trust basis {}", path.display()))?;
+    serde_json::from_reader(file)
+        .with_context(|| format!("failed to parse trust basis {}", path.display()))
+}
+
+fn write_diff_json(report: &TrustBasisDiffReport) -> Result<()> {
+    let mut stdout = std::io::stdout();
+    serde_json::to_writer_pretty(&mut stdout, report)?;
+    stdout.write_all(b"\n")?;
+    Ok(())
+}
+
+fn write_diff_text(report: &TrustBasisDiffReport) -> Result<()> {
+    let mut stdout = std::io::stdout();
+    writeln!(stdout, "Assay Trust Basis Diff")?;
+    if !report.has_changes() {
+        writeln!(stdout, "No Trust Basis differences found.")?;
+        return Ok(());
+    }
+
+    write_level_diffs(&mut stdout, "Regressions", &report.regressions)?;
+    write_level_diffs(&mut stdout, "Improvements", &report.improvements)?;
+    write_claims(&mut stdout, "Removed claims", &report.removals)?;
+    write_claims(&mut stdout, "Added claims", &report.additions)?;
+    write_metadata_diffs(&mut stdout, &report.metadata_changes)?;
+    writeln!(stdout, "Unchanged claims: {}", report.unchanged)?;
+    Ok(())
+}
+
+fn write_level_diffs(
+    writer: &mut impl Write,
+    title: &str,
+    diffs: &[TrustBasisClaimLevelDiff],
+) -> Result<()> {
+    if diffs.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(writer, "{title}:")?;
+    for diff in diffs {
+        writeln!(
+            writer,
+            "- {}: {} -> {}",
+            id_label(diff.id),
+            level_label(diff.baseline_level),
+            level_label(diff.candidate_level)
+        )?;
+    }
+    Ok(())
+}
+
+fn write_claims(writer: &mut impl Write, title: &str, claims: &[TrustBasisClaim]) -> Result<()> {
+    if claims.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(writer, "{title}:")?;
+    for claim in claims {
+        writeln!(
+            writer,
+            "- {}: {} ({}, {})",
+            id_label(claim.id),
+            level_label(claim.level),
+            source_label(claim.source),
+            boundary_label(claim.boundary)
+        )?;
+    }
+    Ok(())
+}
+
+fn write_metadata_diffs(
+    writer: &mut impl Write,
+    diffs: &[TrustBasisClaimMetadataDiff],
+) -> Result<()> {
+    if diffs.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(writer, "Metadata changes:")?;
+    for diff in diffs {
+        writeln!(
+            writer,
+            "- {}: source {} -> {}, boundary {} -> {}",
+            id_label(diff.id),
+            source_label(diff.baseline_source),
+            source_label(diff.candidate_source),
+            boundary_label(diff.baseline_boundary),
+            boundary_label(diff.candidate_boundary)
+        )?;
+    }
+    Ok(())
+}
+
+fn id_label(id: TrustClaimId) -> String {
+    json_label(id)
+}
+
+fn level_label(level: TrustClaimLevel) -> String {
+    json_label(level)
+}
+
+fn source_label(source: TrustClaimSource) -> String {
+    json_label(source)
+}
+
+fn boundary_label(boundary: TrustClaimBoundary) -> String {
+    json_label(boundary)
+}
+
+fn json_label(value: impl serde::Serialize) -> String {
+    serde_json::to_string(&value)
+        .expect("trust basis labels should serialize")
+        .trim_matches('"')
+        .to_string()
 }

--- a/crates/assay-cli/tests/trust_basis_test.rs
+++ b/crates/assay-cli/tests/trust_basis_test.rs
@@ -1,6 +1,7 @@
 use assay_evidence::{BundleWriter, EvidenceEvent};
 use assert_cmd::Command;
 use chrono::{TimeZone, Utc};
+use predicates::prelude::*;
 use serde_json::json;
 use std::fs;
 use tempfile::tempdir;
@@ -31,6 +32,26 @@ fn claim<'a>(claims: &'a [serde_json::Value], id: &str) -> &'a serde_json::Value
         .iter()
         .find(|claim| claim["id"] == id)
         .expect("claim should exist")
+}
+
+fn write_trust_basis_json(path: &std::path::Path, external_eval_level: &str) {
+    let value = json!({
+        "claims": [
+            {
+                "id": "bundle_verified",
+                "level": "verified",
+                "source": "bundle_verification",
+                "boundary": "bundle-wide"
+            },
+            {
+                "id": "external_eval_receipt_boundary_visible",
+                "level": external_eval_level,
+                "source": "external_evidence_receipt",
+                "boundary": "supported-external-eval-receipt-events-only"
+            }
+        ]
+    });
+    fs::write(path, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
 }
 
 #[test]
@@ -161,4 +182,57 @@ fn trust_basis_generate_is_byte_stable_and_pack_aware() {
         claim(claims, "applied_pack_findings_present")["boundary"],
         "pack-execution-only"
     );
+}
+
+#[test]
+fn trust_basis_diff_fails_on_external_receipt_claim_regression_when_requested() {
+    let dir = tempdir().unwrap();
+    let baseline = dir.path().join("baseline.trust-basis.json");
+    let candidate = dir.path().join("candidate.trust-basis.json");
+    write_trust_basis_json(&baseline, "verified");
+    write_trust_basis_json(&candidate, "absent");
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--format")
+        .arg("json")
+        .arg("--fail-on-regression")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("\"regressions\""));
+    assert!(stdout.contains("\"external_eval_receipt_boundary_visible\""));
+    assert!(stdout.contains("\"baseline_level\": \"verified\""));
+    assert!(stdout.contains("\"candidate_level\": \"absent\""));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("Trust Basis regression check failed"));
+}
+
+#[test]
+fn trust_basis_diff_reports_external_receipt_claim_improvement_without_failing() {
+    let dir = tempdir().unwrap();
+    let baseline = dir.path().join("baseline.trust-basis.json");
+    let candidate = dir.path().join("candidate.trust-basis.json");
+    write_trust_basis_json(&baseline, "absent");
+    write_trust_basis_json(&candidate, "verified");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .arg("--fail-on-regression")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Improvements:"))
+        .stdout(predicate::str::contains(
+            "external_eval_receipt_boundary_visible: absent -> verified",
+        ));
 }

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -25,7 +25,8 @@ pub use store::{
     BundleMeta, BundleStore, ObjectStoreBundleStore, StoreError, StoreSpec, StoreStatus,
 };
 pub use trust_basis::{
-    generate_trust_basis, to_canonical_json_bytes, TrustBasis, TrustBasisClaim, TrustBasisOptions,
+    diff_trust_basis, generate_trust_basis, to_canonical_json_bytes, TrustBasis, TrustBasisClaim,
+    TrustBasisClaimLevelDiff, TrustBasisClaimMetadataDiff, TrustBasisDiffReport, TrustBasisOptions,
     TrustClaimBoundary, TrustClaimId, TrustClaimLevel, TrustClaimSource,
 };
 pub use trust_card::{

--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -66,9 +66,123 @@ pub struct TrustBasis {
     pub claims: Vec<TrustBasisClaim>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustBasisClaimLevelDiff {
+    pub id: TrustClaimId,
+    pub baseline_level: TrustClaimLevel,
+    pub candidate_level: TrustClaimLevel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustBasisClaimMetadataDiff {
+    pub id: TrustClaimId,
+    pub baseline_source: TrustClaimSource,
+    pub candidate_source: TrustClaimSource,
+    pub baseline_boundary: TrustClaimBoundary,
+    pub candidate_boundary: TrustClaimBoundary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustBasisDiffReport {
+    pub regressions: Vec<TrustBasisClaimLevelDiff>,
+    pub improvements: Vec<TrustBasisClaimLevelDiff>,
+    pub removals: Vec<TrustBasisClaim>,
+    pub additions: Vec<TrustBasisClaim>,
+    pub metadata_changes: Vec<TrustBasisClaimMetadataDiff>,
+    pub unchanged: usize,
+}
+
+impl TrustBasisDiffReport {
+    pub fn has_changes(&self) -> bool {
+        !self.regressions.is_empty()
+            || !self.improvements.is_empty()
+            || !self.removals.is_empty()
+            || !self.additions.is_empty()
+            || !self.metadata_changes.is_empty()
+    }
+
+    pub fn has_regressions(&self) -> bool {
+        !self.regressions.is_empty() || !self.removals.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TrustBasisOptions {
     pub lint: Option<LintOptions>,
+}
+
+pub fn diff_trust_basis(baseline: &TrustBasis, candidate: &TrustBasis) -> TrustBasisDiffReport {
+    let mut regressions = Vec::new();
+    let mut improvements = Vec::new();
+    let mut removals = Vec::new();
+    let mut metadata_changes = Vec::new();
+    let mut unchanged = 0;
+    let mut seen_candidate_ids = Vec::new();
+
+    for baseline_claim in &baseline.claims {
+        let Some(candidate_claim) = candidate
+            .claims
+            .iter()
+            .find(|claim| claim.id == baseline_claim.id)
+        else {
+            removals.push(baseline_claim.clone());
+            continue;
+        };
+        seen_candidate_ids.push(candidate_claim.id);
+
+        let baseline_rank = trust_claim_level_rank(baseline_claim.level);
+        let candidate_rank = trust_claim_level_rank(candidate_claim.level);
+        if candidate_rank < baseline_rank {
+            regressions.push(TrustBasisClaimLevelDiff {
+                id: baseline_claim.id,
+                baseline_level: baseline_claim.level,
+                candidate_level: candidate_claim.level,
+            });
+        } else if candidate_rank > baseline_rank {
+            improvements.push(TrustBasisClaimLevelDiff {
+                id: baseline_claim.id,
+                baseline_level: baseline_claim.level,
+                candidate_level: candidate_claim.level,
+            });
+        } else if baseline_claim.source != candidate_claim.source
+            || baseline_claim.boundary != candidate_claim.boundary
+        {
+            metadata_changes.push(TrustBasisClaimMetadataDiff {
+                id: baseline_claim.id,
+                baseline_source: baseline_claim.source,
+                candidate_source: candidate_claim.source,
+                baseline_boundary: baseline_claim.boundary,
+                candidate_boundary: candidate_claim.boundary,
+            });
+        } else {
+            unchanged += 1;
+        }
+    }
+
+    let additions = candidate
+        .claims
+        .iter()
+        .filter(|claim| !seen_candidate_ids.contains(&claim.id))
+        .cloned()
+        .collect();
+
+    TrustBasisDiffReport {
+        regressions,
+        improvements,
+        removals,
+        additions,
+        metadata_changes,
+        unchanged,
+    }
+}
+
+fn trust_claim_level_rank(level: TrustClaimLevel) -> u8 {
+    match level {
+        TrustClaimLevel::Absent => 0,
+        TrustClaimLevel::Inferred => 1,
+        TrustClaimLevel::SelfReported => 2,
+        TrustClaimLevel::Verified => 3,
+    }
 }
 
 pub fn generate_trust_basis<R: Read>(

--- a/docs/architecture/PLAN-P34-TRUST-BASIS-DIFF-GATE-2026q2.md
+++ b/docs/architecture/PLAN-P34-TRUST-BASIS-DIFF-GATE-2026q2.md
@@ -1,0 +1,136 @@
+# PLAN — P34 Trust Basis Diff Gate (Q2 2026)
+
+Status: implemented in this slice
+Owner: Assay core / CLI
+Scope: compare two canonical Trust Basis artifacts, not raw external evidence
+
+---
+
+## 1. Why This Exists
+
+P31 made the Promptfoo compiler path real:
+
+```text
+Promptfoo assertion component result -> Assay evidence receipt bundle
+```
+
+P33 made that receipt boundary visible to the Trust Basis compiler:
+
+```text
+receipt bundle -> trust-basis.json with external_eval_receipt_boundary_visible
+```
+
+P34 adds the next small bridge:
+
+```text
+baseline trust-basis.json + candidate trust-basis.json -> claim-level diff
+```
+
+That gives Harness a stable gate foundation without asking Harness to parse
+Promptfoo JSONL, understand external eval receipt payloads, or re-run Trust
+Basis classification logic.
+
+---
+
+## 2. Boundary
+
+P34 compares compiled Assay artifacts only.
+
+It does not:
+
+- parse Promptfoo JSONL
+- inspect raw prompts, outputs, expected values, vars, provider payloads, stats, or full rows
+- compare evidence bundles directly
+- infer model correctness or Promptfoo run success
+- add Trust Card rendering changes
+- add Harness baseline/candidate UI
+
+The command is deliberately generic:
+
+```bash
+assay trust-basis diff baseline.trust-basis.json candidate.trust-basis.json
+```
+
+Promptfoo is only the first motivating receipt lane. The diff layer is about
+Trust Basis claims, not Promptfoo semantics.
+
+---
+
+## 3. Comparison Semantics
+
+Trust Basis claim levels are ordered:
+
+```text
+absent < inferred < self_reported < verified
+```
+
+A candidate is a regression when:
+
+- a baseline claim is missing from the candidate
+- a candidate claim level is lower than the baseline claim level
+
+A candidate is an improvement when:
+
+- a candidate claim level is higher than the baseline claim level
+
+The diff also reports:
+
+- added claims
+- removed claims
+- source/boundary metadata changes
+- unchanged claim count
+
+Metadata changes are visible but do not fail by default. They may represent a
+spec or compiler evolution rather than a runtime regression.
+
+---
+
+## 4. Gate Posture
+
+The default command reports differences and exits successfully.
+
+Use this mode for local inspection:
+
+```bash
+assay trust-basis diff baseline.trust-basis.json candidate.trust-basis.json
+```
+
+Use `--fail-on-regression` when the diff should become a gate:
+
+```bash
+assay trust-basis diff \
+  baseline.trust-basis.json \
+  candidate.trust-basis.json \
+  --fail-on-regression
+```
+
+This keeps the compiler path and the gate policy separate:
+
+- Assay core compiles Trust Basis artifacts.
+- `assay trust-basis diff` compares those artifacts.
+- Harness can later decide how to surface regressions in PR feedback.
+
+---
+
+## 5. Acceptance Criteria
+
+P34 is complete when:
+
+- `assay trust-basis diff` accepts two canonical Trust Basis JSON files.
+- text and JSON output are available.
+- `--fail-on-regression` exits non-zero only for missing/lowered baseline claims.
+- Promptfoo-origin Trust Basis claim improvements and regressions are covered by CLI tests.
+- docs explain that this command compares Trust Basis artifacts, not external eval payloads.
+
+---
+
+## 6. Follow-Ups
+
+Future slices may add:
+
+- Harness baseline/candidate wiring over `trust-basis diff` JSON output
+- SARIF/JUnit projection for Trust Basis regressions
+- stricter metadata-change policy for release gates
+- multi-artifact comparison summaries
+
+Those should stay above this generic diff layer.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -51,6 +51,7 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [PLAN — P31 Promptfoo JSONL Component Result Receipt Import (Q2 2026)](./PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md) — planned compiler-path follow-up to P28 that imports one Promptfoo JSONL assertion component result into one portable Assay evidence receipt, not full Promptfoo eval-run truth or Harness regression gating
 - [PLAN — P32 Promptfoo Receipt Trust Basis Readiness (Q2 2026)](./PLAN-P32-PROMPTFOO-RECEIPT-TRUST-BASIS-READINESS-2026q2.md) — execution slice that proves P31 receipt bundles feed the current Trust Basis compiler without adding a Promptfoo-specific claim row or Trust Card schema bump
 - [PLAN — P33 External Eval Receipt Trust Basis Claim (Q2 2026)](./PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) — execution slice that adds one bounded Trust Basis claim for supported external evaluation receipt boundaries, starting with Promptfoo assertion-component receipts
+- [PLAN — P34 Trust Basis Diff Gate (Q2 2026)](./PLAN-P34-TRUST-BASIS-DIFF-GATE-2026q2.md) — execution slice that compares canonical Trust Basis artifacts for claim-level regressions without parsing Promptfoo JSONL or external eval payloads
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 
 ## Active RFCs

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -51,7 +51,7 @@ assay evidence verify promptfoo-evidence.tar.gz
 The same bundle can also feed the current Trust Basis compiler:
 
 ```bash
-assay trust-basis generate promptfoo-evidence.tar.gz
+assay trust-basis generate promptfoo-evidence.tar.gz --out promptfoo.trust-basis.json
 ```
 
 This proves the imported receipts are bundleable, verifiable, and readable by
@@ -62,6 +62,9 @@ does not mean the Promptfoo eval run passed, the model output was correct, or
 the raw Promptfoo payload is imported as Assay truth.
 
 Use `--import-time <RFC3339>` for deterministic fixture generation.
+
+To compare the resulting claim artifact against another run, use
+[`assay trust-basis diff`](./trust-basis.md).
 
 ### Options
 
@@ -78,5 +81,6 @@ Use `--import-time <RFC3339>` for deterministic fixture generation.
 ## See Also
 
 - [Evidence Contract v1](../../spec/EVIDENCE-CONTRACT-v1.md)
+- [Trust Basis CLI](./trust-basis.md)
 - [P31 Promptfoo receipt import plan](../../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md)
 - [Promptfoo assertion grading-result example](../../../examples/promptfoo-assertion-grading-result-evidence/README.md)

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -31,6 +31,7 @@ assay --version
 | [`assay bundle`](bundle.md) | Create/verify replay bundles |
 | [`assay replay`](replay.md) | Replay from a replay bundle |
 | [`assay evidence`](evidence.md) | Manage evidence bundles and external evidence imports |
+| [`assay trust-basis`](trust-basis.md) | Generate and compare canonical Trust Basis artifacts |
 | [`assay import`](import.md) | Import sessions from MCP Inspector, etc. |
 | [`assay migrate`](migrate.md) | Upgrade config from v0 to v1 |
 | [`assay doctor`](doctor.md) | Diagnose setup and optionally auto-fix known issues |
@@ -255,6 +256,14 @@ See [Configuration](../config/index.md) for full reference.
     Manage evidence bundles and import external evidence receipts.
 
     [:octicons-arrow-right-24: Full reference](evidence.md)
+
+-   :material-shield-search:{ .lg .middle } __assay trust-basis__
+
+    ---
+
+    Generate and compare canonical Trust Basis artifacts.
+
+    [:octicons-arrow-right-24: Full reference](trust-basis.md)
 
 -   :material-server:{ .lg .middle } __assay mcp wrap__
 

--- a/docs/reference/cli/trust-basis.md
+++ b/docs/reference/cli/trust-basis.md
@@ -1,0 +1,74 @@
+# assay trust-basis
+
+Generate and compare canonical Trust Basis artifacts.
+
+---
+
+## Synopsis
+
+```bash
+assay trust-basis <COMMAND> [OPTIONS]
+```
+
+---
+
+## Generate
+
+Generate `trust-basis.json` from a verified evidence bundle:
+
+```bash
+assay trust-basis generate evidence.tar.gz --out trust-basis.json
+```
+
+`trust-basis.json` is the small claim artifact above an evidence bundle. It
+does not re-state raw evidence payloads; it records which bounded trust claims
+were visible to the compiler and at what level.
+
+---
+
+## Diff
+
+Compare a baseline Trust Basis artifact with a candidate Trust Basis artifact:
+
+```bash
+assay trust-basis diff baseline.trust-basis.json candidate.trust-basis.json
+```
+
+Use JSON output for CI and Harness-style consumers:
+
+```bash
+assay trust-basis diff \
+  baseline.trust-basis.json \
+  candidate.trust-basis.json \
+  --format json
+```
+
+Use `--fail-on-regression` when the comparison should become a gate:
+
+```bash
+assay trust-basis diff \
+  baseline.trust-basis.json \
+  candidate.trust-basis.json \
+  --fail-on-regression
+```
+
+The diff compares Trust Basis claim levels only. It does not parse Promptfoo
+JSONL, inspect external eval payloads, or infer model correctness.
+
+Claim levels are ordered as:
+
+```text
+absent < inferred < self_reported < verified
+```
+
+Lowering a claim level, or removing a baseline claim, is a regression.
+Improving a level, adding a claim, or changing claim metadata is reported but
+does not fail unless a future caller adds a stricter policy above this command.
+
+---
+
+## See Also
+
+- [Evidence imports](./evidence.md)
+- [Evidence Contract v1](../../spec/EVIDENCE-CONTRACT-v1.md)
+- [P34 Trust Basis diff gate plan](../../architecture/PLAN-P34-TRUST-BASIS-DIFF-GATE-2026q2.md)


### PR DESCRIPTION
What changed

Adds the P34 Trust Basis diff gate foundation.

This PR includes:

- `assay trust-basis diff <baseline> <candidate>`
- text and JSON diff output
- `--fail-on-regression` for gate use
- Trust Basis level comparison in `assay-evidence`
- CLI tests covering external eval receipt claim regression and improvement
- CLI docs and a P34 architecture plan

Why

P31 made Promptfoo component results importable as Assay evidence receipts. P33 made the supported external eval receipt boundary visible in Trust Basis. P34 adds the next safe bridge: compare compiled Trust Basis artifacts without teaching Harness or the diff layer how to parse Promptfoo JSONL or external eval payloads.

Boundary

This PR does not:

- parse Promptfoo JSONL
- inspect external eval raw payloads
- compare evidence bundles directly
- infer Promptfoo run success or model correctness
- add Trust Card rendering changes
- add Harness PR output, SARIF, or JUnit projection

The diff is over canonical `trust-basis.json` claims only.

Validation

Ran locally:

- `cargo fmt --check`
- `cargo test -p assay-evidence trust_basis -- --nocapture`
- `cargo test -p assay-cli --test trust_basis_test -- --nocapture`
- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `cargo run -p assay-cli -- trust-basis diff --help`
- changed-docs local link check
- `git diff --check origin/main..HEAD`

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.
