### PR TITLE
P34: harden Trust Basis diff contract

### DIFF
--- a/crates/assay-cli/src/cli/commands/trust_basis.rs
+++ b/crates/assay-cli/src/cli/commands/trust_basis.rs
@@ -1,14 +1,15 @@
 use crate::cli::args::{
     OutputFormat, TrustBasisArgs, TrustBasisDiffArgs, TrustBasisGenerateArgs, TrustBasisSub,
 };
-use crate::exit_codes::EXIT_SUCCESS;
+use crate::exit_codes::{EXIT_SUCCESS, EXIT_TEST_FAILURE};
 use anyhow::{bail, Context, Result};
 use assay_evidence::lint::engine::LintOptions;
 use assay_evidence::lint::packs::load_packs;
 use assay_evidence::{
-    diff_trust_basis, generate_trust_basis, to_canonical_json_bytes, TrustBasis, TrustBasisClaim,
-    TrustBasisClaimLevelDiff, TrustBasisClaimMetadataDiff, TrustBasisDiffReport, TrustBasisOptions,
-    TrustClaimBoundary, TrustClaimId, TrustClaimLevel, TrustClaimSource, VerifyLimits,
+    diff_trust_basis, duplicate_trust_basis_claim_ids, generate_trust_basis,
+    to_canonical_json_bytes, TrustBasis, TrustBasisClaimLevelDiff, TrustBasisClaimMetadataDiff,
+    TrustBasisClaimPresenceDiff, TrustBasisDiffReport, TrustBasisOptions, TrustClaimBoundary,
+    TrustClaimId, TrustClaimLevel, TrustClaimSource, VerifyLimits,
 };
 use std::fs::File;
 use std::io::Write;
@@ -66,6 +67,8 @@ fn cmd_generate(args: TrustBasisGenerateArgs) -> Result<i32> {
 fn cmd_diff(args: TrustBasisDiffArgs) -> Result<i32> {
     let baseline = read_trust_basis(&args.baseline)?;
     let candidate = read_trust_basis(&args.candidate)?;
+    ensure_unique_claim_ids("baseline", &baseline)?;
+    ensure_unique_claim_ids("candidate", &candidate)?;
     let report = diff_trust_basis(&baseline, &candidate);
 
     match args.format {
@@ -74,7 +77,8 @@ fn cmd_diff(args: TrustBasisDiffArgs) -> Result<i32> {
     }
 
     if args.fail_on_regression && report.has_regressions() {
-        bail!("Trust Basis regression check failed");
+        eprintln!("Trust Basis regression check failed");
+        return Ok(EXIT_TEST_FAILURE);
     }
 
     Ok(EXIT_SUCCESS)
@@ -87,6 +91,20 @@ fn read_trust_basis(path: &std::path::Path) -> Result<TrustBasis> {
         .with_context(|| format!("failed to parse trust basis {}", path.display()))
 }
 
+fn ensure_unique_claim_ids(label: &str, trust_basis: &TrustBasis) -> Result<()> {
+    let duplicates = duplicate_trust_basis_claim_ids(trust_basis);
+    if duplicates.is_empty() {
+        return Ok(());
+    }
+
+    let duplicate_labels = duplicates
+        .into_iter()
+        .map(id_label)
+        .collect::<Vec<_>>()
+        .join(", ");
+    bail!("{label} Trust Basis contains duplicate claim id(s): {duplicate_labels}");
+}
+
 fn write_diff_json(report: &TrustBasisDiffReport) -> Result<()> {
     let mut stdout = std::io::stdout();
     serde_json::to_writer_pretty(&mut stdout, report)?;
@@ -97,17 +115,18 @@ fn write_diff_json(report: &TrustBasisDiffReport) -> Result<()> {
 fn write_diff_text(report: &TrustBasisDiffReport) -> Result<()> {
     let mut stdout = std::io::stdout();
     writeln!(stdout, "Assay Trust Basis Diff")?;
+    writeln!(stdout, "Claim identity: {}", report.claim_identity)?;
     if !report.has_changes() {
         writeln!(stdout, "No Trust Basis differences found.")?;
         return Ok(());
     }
 
-    write_level_diffs(&mut stdout, "Regressions", &report.regressions)?;
-    write_level_diffs(&mut stdout, "Improvements", &report.improvements)?;
-    write_claims(&mut stdout, "Removed claims", &report.removals)?;
-    write_claims(&mut stdout, "Added claims", &report.additions)?;
+    write_level_diffs(&mut stdout, "Regressions", &report.regressed_claims)?;
+    write_level_diffs(&mut stdout, "Improvements", &report.improved_claims)?;
+    write_presence_diffs(&mut stdout, "Removed claims", &report.removed_claims)?;
+    write_presence_diffs(&mut stdout, "Added claims", &report.added_claims)?;
     write_metadata_diffs(&mut stdout, &report.metadata_changes)?;
-    writeln!(stdout, "Unchanged claims: {}", report.unchanged)?;
+    writeln!(stdout, "Unchanged claims: {}", report.unchanged_claim_count)?;
     Ok(())
 }
 
@@ -125,7 +144,7 @@ fn write_level_diffs(
         writeln!(
             writer,
             "- {}: {} -> {}",
-            id_label(diff.id),
+            id_label(diff.claim_id),
             level_label(diff.baseline_level),
             level_label(diff.candidate_level)
         )?;
@@ -133,20 +152,24 @@ fn write_level_diffs(
     Ok(())
 }
 
-fn write_claims(writer: &mut impl Write, title: &str, claims: &[TrustBasisClaim]) -> Result<()> {
-    if claims.is_empty() {
+fn write_presence_diffs(
+    writer: &mut impl Write,
+    title: &str,
+    diffs: &[TrustBasisClaimPresenceDiff],
+) -> Result<()> {
+    if diffs.is_empty() {
         return Ok(());
     }
 
     writeln!(writer, "{title}:")?;
-    for claim in claims {
+    for diff in diffs {
         writeln!(
             writer,
             "- {}: {} ({}, {})",
-            id_label(claim.id),
-            level_label(claim.level),
-            source_label(claim.source),
-            boundary_label(claim.boundary)
+            id_label(diff.claim_id),
+            optional_level_label(diff.baseline_level.or(diff.candidate_level)),
+            optional_source_label(diff.baseline_source.or(diff.candidate_source)),
+            optional_boundary_label(diff.baseline_boundary.or(diff.candidate_boundary))
         )?;
     }
     Ok(())
@@ -164,12 +187,13 @@ fn write_metadata_diffs(
     for diff in diffs {
         writeln!(
             writer,
-            "- {}: source {} -> {}, boundary {} -> {}",
-            id_label(diff.id),
+            "- {}: source {} -> {}, boundary {} -> {}, note changed: {}",
+            id_label(diff.claim_id),
             source_label(diff.baseline_source),
             source_label(diff.candidate_source),
             boundary_label(diff.baseline_boundary),
-            boundary_label(diff.candidate_boundary)
+            boundary_label(diff.candidate_boundary),
+            diff.note_changed
         )?;
     }
     Ok(())
@@ -189,6 +213,24 @@ fn source_label(source: TrustClaimSource) -> String {
 
 fn boundary_label(boundary: TrustClaimBoundary) -> String {
     json_label(boundary)
+}
+
+fn optional_level_label(level: Option<TrustClaimLevel>) -> String {
+    level
+        .map(level_label)
+        .unwrap_or_else(|| "absent".to_string())
+}
+
+fn optional_source_label(source: Option<TrustClaimSource>) -> String {
+    source
+        .map(source_label)
+        .unwrap_or_else(|| "unknown-source".to_string())
+}
+
+fn optional_boundary_label(boundary: Option<TrustClaimBoundary>) -> String {
+    boundary
+        .map(boundary_label)
+        .unwrap_or_else(|| "unknown-boundary".to_string())
 }
 
 fn json_label(value: impl serde::Serialize) -> String {

--- a/crates/assay-cli/tests/trust_basis_test.rs
+++ b/crates/assay-cli/tests/trust_basis_test.rs
@@ -54,6 +54,26 @@ fn write_trust_basis_json(path: &std::path::Path, external_eval_level: &str) {
     fs::write(path, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
 }
 
+fn write_duplicate_claim_trust_basis_json(path: &std::path::Path) {
+    let value = json!({
+        "claims": [
+            {
+                "id": "bundle_verified",
+                "level": "verified",
+                "source": "bundle_verification",
+                "boundary": "bundle-wide"
+            },
+            {
+                "id": "bundle_verified",
+                "level": "verified",
+                "source": "bundle_verification",
+                "boundary": "bundle-wide"
+            }
+        ]
+    });
+    fs::write(path, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
+}
+
 #[test]
 fn trust_basis_generate_stdout_emits_all_frozen_claims() {
     let dir = tempdir().unwrap();
@@ -204,12 +224,18 @@ fn trust_basis_diff_fails_on_external_receipt_claim_regression_when_requested() 
         .output()
         .unwrap();
 
-    assert!(!output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("\"regressions\""));
-    assert!(stdout.contains("\"external_eval_receipt_boundary_visible\""));
-    assert!(stdout.contains("\"baseline_level\": \"verified\""));
-    assert!(stdout.contains("\"candidate_level\": \"absent\""));
+    assert_eq!(output.status.code(), Some(1));
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(stdout["schema"], "assay.trust-basis.diff.v1");
+    assert_eq!(stdout["claim_identity"], "claim.id");
+    assert_eq!(stdout["summary"]["has_regressions"], true);
+    assert_eq!(stdout["summary"]["regressed_claims"], 1);
+    assert_eq!(
+        stdout["regressed_claims"][0]["claim_id"],
+        "external_eval_receipt_boundary_visible"
+    );
+    assert_eq!(stdout["regressed_claims"][0]["baseline_level"], "verified");
+    assert_eq!(stdout["regressed_claims"][0]["candidate_level"], "absent");
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains("Trust Basis regression check failed"));
 }
@@ -234,5 +260,27 @@ fn trust_basis_diff_reports_external_receipt_claim_improvement_without_failing()
         .stdout(predicate::str::contains("Improvements:"))
         .stdout(predicate::str::contains(
             "external_eval_receipt_boundary_visible: absent -> verified",
+        ));
+}
+
+#[test]
+fn trust_basis_diff_rejects_duplicate_claim_identity() {
+    let dir = tempdir().unwrap();
+    let baseline = dir.path().join("baseline.trust-basis.json");
+    let candidate = dir.path().join("candidate.trust-basis.json");
+    write_duplicate_claim_trust_basis_json(&baseline);
+    write_trust_basis_json(&candidate, "verified");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("diff")
+        .arg(&baseline)
+        .arg(&candidate)
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "baseline Trust Basis contains duplicate claim id(s): bundle_verified",
         ));
 }

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -25,9 +25,11 @@ pub use store::{
     BundleMeta, BundleStore, ObjectStoreBundleStore, StoreError, StoreSpec, StoreStatus,
 };
 pub use trust_basis::{
-    diff_trust_basis, generate_trust_basis, to_canonical_json_bytes, TrustBasis, TrustBasisClaim,
-    TrustBasisClaimLevelDiff, TrustBasisClaimMetadataDiff, TrustBasisDiffReport, TrustBasisOptions,
-    TrustClaimBoundary, TrustClaimId, TrustClaimLevel, TrustClaimSource,
+    diff_trust_basis, duplicate_trust_basis_claim_ids, generate_trust_basis,
+    to_canonical_json_bytes, TrustBasis, TrustBasisClaim, TrustBasisClaimLevelDiff,
+    TrustBasisClaimMetadataDiff, TrustBasisClaimPresenceDiff, TrustBasisDiffClass,
+    TrustBasisDiffReport, TrustBasisDiffSummary, TrustBasisOptions, TrustClaimBoundary,
+    TrustClaimId, TrustClaimLevel, TrustClaimSource, TRUST_BASIS_DIFF_SCHEMA,
 };
 pub use trust_card::{
     trust_basis_to_trust_card, trust_card_to_canonical_json_bytes, trust_card_to_markdown,

--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -3,9 +3,12 @@ use crate::lint::engine::{lint_bundle_with_options, LintOptions, LintReportWithP
 use crate::types::EvidenceEvent;
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::io::{Cursor, Read};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub const TRUST_BASIS_DIFF_SCHEMA: &str = "assay.trust-basis.diff.v1";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum TrustClaimId {
     BundleVerified,
@@ -66,43 +69,87 @@ pub struct TrustBasis {
     pub claims: Vec<TrustBasisClaim>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustBasisDiffClass {
+    Regressed,
+    Improved,
+    Removed,
+    Added,
+    MetadataChanged,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrustBasisClaimLevelDiff {
-    pub id: TrustClaimId,
+    pub diff_class: TrustBasisDiffClass,
+    pub claim_id: TrustClaimId,
     pub baseline_level: TrustClaimLevel,
     pub candidate_level: TrustClaimLevel,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrustBasisClaimMetadataDiff {
-    pub id: TrustClaimId,
+    pub diff_class: TrustBasisDiffClass,
+    pub claim_id: TrustClaimId,
+    pub baseline_level: TrustClaimLevel,
+    pub candidate_level: TrustClaimLevel,
     pub baseline_source: TrustClaimSource,
     pub candidate_source: TrustClaimSource,
     pub baseline_boundary: TrustClaimBoundary,
     pub candidate_boundary: TrustClaimBoundary,
+    pub note_changed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustBasisClaimPresenceDiff {
+    pub diff_class: TrustBasisDiffClass,
+    pub claim_id: TrustClaimId,
+    pub baseline_level: Option<TrustClaimLevel>,
+    pub candidate_level: Option<TrustClaimLevel>,
+    pub baseline_source: Option<TrustClaimSource>,
+    pub candidate_source: Option<TrustClaimSource>,
+    pub baseline_boundary: Option<TrustClaimBoundary>,
+    pub candidate_boundary: Option<TrustClaimBoundary>,
+    pub baseline_note: Option<String>,
+    pub candidate_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustBasisDiffSummary {
+    pub regressed_claims: usize,
+    pub improved_claims: usize,
+    pub removed_claims: usize,
+    pub added_claims: usize,
+    pub metadata_changes: usize,
+    pub unchanged_claim_count: usize,
+    pub has_regressions: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TrustBasisDiffReport {
-    pub regressions: Vec<TrustBasisClaimLevelDiff>,
-    pub improvements: Vec<TrustBasisClaimLevelDiff>,
-    pub removals: Vec<TrustBasisClaim>,
-    pub additions: Vec<TrustBasisClaim>,
+    pub schema: String,
+    pub claim_identity: String,
+    pub level_order: Vec<TrustClaimLevel>,
+    pub summary: TrustBasisDiffSummary,
+    pub regressed_claims: Vec<TrustBasisClaimLevelDiff>,
+    pub improved_claims: Vec<TrustBasisClaimLevelDiff>,
+    pub removed_claims: Vec<TrustBasisClaimPresenceDiff>,
+    pub added_claims: Vec<TrustBasisClaimPresenceDiff>,
     pub metadata_changes: Vec<TrustBasisClaimMetadataDiff>,
-    pub unchanged: usize,
+    pub unchanged_claim_count: usize,
 }
 
 impl TrustBasisDiffReport {
     pub fn has_changes(&self) -> bool {
-        !self.regressions.is_empty()
-            || !self.improvements.is_empty()
-            || !self.removals.is_empty()
-            || !self.additions.is_empty()
+        !self.regressed_claims.is_empty()
+            || !self.improved_claims.is_empty()
+            || !self.removed_claims.is_empty()
+            || !self.added_claims.is_empty()
             || !self.metadata_changes.is_empty()
     }
 
     pub fn has_regressions(&self) -> bool {
-        !self.regressions.is_empty() || !self.removals.is_empty()
+        !self.regressed_claims.is_empty() || !self.removed_claims.is_empty()
     }
 }
 
@@ -112,68 +159,149 @@ pub struct TrustBasisOptions {
 }
 
 pub fn diff_trust_basis(baseline: &TrustBasis, candidate: &TrustBasis) -> TrustBasisDiffReport {
-    let mut regressions = Vec::new();
-    let mut improvements = Vec::new();
-    let mut removals = Vec::new();
+    let mut candidate_by_id: HashMap<TrustClaimId, &TrustBasisClaim> = HashMap::new();
+    for claim in &candidate.claims {
+        candidate_by_id.entry(claim.id).or_insert(claim);
+    }
+
+    let mut regressed_claims = Vec::new();
+    let mut improved_claims = Vec::new();
+    let mut removed_claims = Vec::new();
     let mut metadata_changes = Vec::new();
-    let mut unchanged = 0;
-    let mut seen_candidate_ids = Vec::new();
+    let mut unchanged_claim_count = 0;
+    let mut seen_candidate_ids = HashSet::new();
 
     for baseline_claim in &baseline.claims {
-        let Some(candidate_claim) = candidate
-            .claims
-            .iter()
-            .find(|claim| claim.id == baseline_claim.id)
-        else {
-            removals.push(baseline_claim.clone());
+        let Some(candidate_claim) = candidate_by_id.get(&baseline_claim.id).copied() else {
+            removed_claims.push(presence_diff_removed(baseline_claim));
             continue;
         };
-        seen_candidate_ids.push(candidate_claim.id);
+        seen_candidate_ids.insert(candidate_claim.id);
 
         let baseline_rank = trust_claim_level_rank(baseline_claim.level);
         let candidate_rank = trust_claim_level_rank(candidate_claim.level);
         if candidate_rank < baseline_rank {
-            regressions.push(TrustBasisClaimLevelDiff {
-                id: baseline_claim.id,
+            regressed_claims.push(TrustBasisClaimLevelDiff {
+                diff_class: TrustBasisDiffClass::Regressed,
+                claim_id: baseline_claim.id,
                 baseline_level: baseline_claim.level,
                 candidate_level: candidate_claim.level,
             });
         } else if candidate_rank > baseline_rank {
-            improvements.push(TrustBasisClaimLevelDiff {
-                id: baseline_claim.id,
+            improved_claims.push(TrustBasisClaimLevelDiff {
+                diff_class: TrustBasisDiffClass::Improved,
+                claim_id: baseline_claim.id,
                 baseline_level: baseline_claim.level,
                 candidate_level: candidate_claim.level,
             });
         } else if baseline_claim.source != candidate_claim.source
             || baseline_claim.boundary != candidate_claim.boundary
+            || baseline_claim.note != candidate_claim.note
         {
             metadata_changes.push(TrustBasisClaimMetadataDiff {
-                id: baseline_claim.id,
+                diff_class: TrustBasisDiffClass::MetadataChanged,
+                claim_id: baseline_claim.id,
+                baseline_level: baseline_claim.level,
+                candidate_level: candidate_claim.level,
                 baseline_source: baseline_claim.source,
                 candidate_source: candidate_claim.source,
                 baseline_boundary: baseline_claim.boundary,
                 candidate_boundary: candidate_claim.boundary,
+                note_changed: baseline_claim.note != candidate_claim.note,
             });
         } else {
-            unchanged += 1;
+            unchanged_claim_count += 1;
         }
     }
 
-    let additions = candidate
+    let mut added_claims: Vec<TrustBasisClaimPresenceDiff> = candidate
         .claims
         .iter()
         .filter(|claim| !seen_candidate_ids.contains(&claim.id))
-        .cloned()
+        .map(presence_diff_added)
         .collect();
 
+    regressed_claims.sort_by_key(|diff| diff.claim_id);
+    improved_claims.sort_by_key(|diff| diff.claim_id);
+    removed_claims.sort_by_key(|diff| diff.claim_id);
+    added_claims.sort_by_key(|diff| diff.claim_id);
+    metadata_changes.sort_by_key(|diff| diff.claim_id);
+
+    let summary = TrustBasisDiffSummary {
+        regressed_claims: regressed_claims.len(),
+        improved_claims: improved_claims.len(),
+        removed_claims: removed_claims.len(),
+        added_claims: added_claims.len(),
+        metadata_changes: metadata_changes.len(),
+        unchanged_claim_count,
+        has_regressions: !regressed_claims.is_empty() || !removed_claims.is_empty(),
+    };
+
     TrustBasisDiffReport {
-        regressions,
-        improvements,
-        removals,
-        additions,
+        schema: TRUST_BASIS_DIFF_SCHEMA.to_string(),
+        claim_identity: "claim.id".to_string(),
+        level_order: vec![
+            TrustClaimLevel::Absent,
+            TrustClaimLevel::Inferred,
+            TrustClaimLevel::SelfReported,
+            TrustClaimLevel::Verified,
+        ],
+        summary,
+        regressed_claims,
+        improved_claims,
+        removed_claims,
+        added_claims,
         metadata_changes,
-        unchanged,
+        unchanged_claim_count,
     }
+}
+
+fn presence_diff_removed(claim: &TrustBasisClaim) -> TrustBasisClaimPresenceDiff {
+    TrustBasisClaimPresenceDiff {
+        diff_class: TrustBasisDiffClass::Removed,
+        claim_id: claim.id,
+        baseline_level: Some(claim.level),
+        candidate_level: None,
+        baseline_source: Some(claim.source),
+        candidate_source: None,
+        baseline_boundary: Some(claim.boundary),
+        candidate_boundary: None,
+        baseline_note: claim.note.clone(),
+        candidate_note: None,
+    }
+}
+
+fn presence_diff_added(claim: &TrustBasisClaim) -> TrustBasisClaimPresenceDiff {
+    TrustBasisClaimPresenceDiff {
+        diff_class: TrustBasisDiffClass::Added,
+        claim_id: claim.id,
+        baseline_level: None,
+        candidate_level: Some(claim.level),
+        baseline_source: None,
+        candidate_source: Some(claim.source),
+        baseline_boundary: None,
+        candidate_boundary: Some(claim.boundary),
+        baseline_note: None,
+        candidate_note: claim.note.clone(),
+    }
+}
+
+pub fn duplicate_trust_basis_claim_ids(trust_basis: &TrustBasis) -> Vec<TrustClaimId> {
+    let mut seen = HashSet::new();
+    let mut duplicates: Vec<TrustClaimId> = trust_basis
+        .claims
+        .iter()
+        .filter_map(|claim| {
+            if seen.insert(claim.id) {
+                None
+            } else {
+                Some(claim.id)
+            }
+        })
+        .collect();
+    duplicates.sort();
+    duplicates.dedup();
+    duplicates
 }
 
 fn trust_claim_level_rank(level: TrustClaimLevel) -> u8 {
@@ -527,6 +655,20 @@ mod tests {
             .iter()
             .find(|claim| claim.id == id)
             .expect("claim should exist")
+    }
+
+    fn trust_basis_claim(
+        id: TrustClaimId,
+        level: TrustClaimLevel,
+        note: Option<&str>,
+    ) -> TrustBasisClaim {
+        TrustBasisClaim {
+            id,
+            level,
+            source: TrustClaimSource::ExternalEvidenceReceipt,
+            boundary: TrustClaimBoundary::SupportedExternalEvalReceiptEventsOnly,
+            note: note.map(str::to_string),
+        }
     }
 
     fn promptfoo_receipt_payload(extra: serde_json::Value) -> serde_json::Value {
@@ -1012,6 +1154,74 @@ mod tests {
         assert_eq!(
             claim(&trust_basis, TrustClaimId::AppliedPackFindingsPresent).level,
             TrustClaimLevel::Verified
+        );
+    }
+
+    #[test]
+    fn trust_basis_diff_keys_by_claim_id_and_reports_note_metadata_nonblocking() {
+        let baseline = TrustBasis {
+            claims: vec![trust_basis_claim(
+                TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+                TrustClaimLevel::Verified,
+                Some("old note"),
+            )],
+        };
+        let candidate = TrustBasis {
+            claims: vec![trust_basis_claim(
+                TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+                TrustClaimLevel::Verified,
+                Some("new note"),
+            )],
+        };
+
+        let report = diff_trust_basis(&baseline, &candidate);
+
+        assert_eq!(report.schema, TRUST_BASIS_DIFF_SCHEMA);
+        assert_eq!(report.claim_identity, "claim.id");
+        assert!(!report.has_regressions());
+        assert!(report.regressed_claims.is_empty());
+        assert!(report.removed_claims.is_empty());
+        assert_eq!(report.metadata_changes.len(), 1);
+        assert_eq!(
+            report.metadata_changes[0].claim_id,
+            TrustClaimId::ExternalEvalReceiptBoundaryVisible
+        );
+        assert!(report.metadata_changes[0].note_changed);
+    }
+
+    #[test]
+    fn duplicate_trust_basis_claim_ids_are_reported_deterministically() {
+        let trust_basis = TrustBasis {
+            claims: vec![
+                trust_basis_claim(
+                    TrustClaimId::BundleVerified,
+                    TrustClaimLevel::Verified,
+                    None,
+                ),
+                trust_basis_claim(
+                    TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+                    TrustClaimLevel::Verified,
+                    None,
+                ),
+                trust_basis_claim(
+                    TrustClaimId::BundleVerified,
+                    TrustClaimLevel::Verified,
+                    None,
+                ),
+                trust_basis_claim(
+                    TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+                    TrustClaimLevel::Verified,
+                    None,
+                ),
+            ],
+        };
+
+        assert_eq!(
+            duplicate_trust_basis_claim_ids(&trust_basis),
+            vec![
+                TrustClaimId::BundleVerified,
+                TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+            ]
         );
     }
 

--- a/docs/architecture/PLAN-P34-TRUST-BASIS-DIFF-GATE-2026q2.md
+++ b/docs/architecture/PLAN-P34-TRUST-BASIS-DIFF-GATE-2026q2.md
@@ -58,6 +58,18 @@ Trust Basis claims, not Promptfoo semantics.
 
 ## 3. Comparison Semantics
 
+P34 v1 accepts canonical Trust Basis JSON produced by
+`assay trust-basis generate`.
+
+Claim comparison is keyed by stable claim identity:
+
+```text
+claim.id
+```
+
+Duplicate claim IDs in either input are invalid. Without unique claim identity,
+the command cannot distinguish an actual regression from ambiguous input.
+
 Trust Basis claim levels are ordered:
 
 ```text
@@ -77,11 +89,30 @@ The diff also reports:
 
 - added claims
 - removed claims
-- source/boundary metadata changes
+- source/boundary/note metadata changes
 - unchanged claim count
 
-Metadata changes are visible but do not fail by default. They may represent a
-spec or compiler evolution rather than a runtime regression.
+P34 v1 gates on claim presence and claim level only. Metadata changes are
+visible but do not fail by default. They may represent a spec or compiler
+evolution rather than a runtime regression.
+
+Added claims, including unknown or newly introduced claim IDs, are not
+regressions by default.
+
+Machine-readable JSON output uses the stable schema
+`assay.trust-basis.diff.v1` and includes:
+
+- `summary`
+- `regressed_claims`
+- `improved_claims`
+- `removed_claims`
+- `added_claims`
+- `metadata_changes`
+- `unchanged_claim_count`
+
+Each diff item carries the matching `claim_id`, its diff class, and the
+baseline/candidate fields needed by later Harness or SARIF/JUnit projection.
+All arrays are sorted deterministically by `claim.id`.
 
 ---
 
@@ -110,6 +141,13 @@ This keeps the compiler path and the gate policy separate:
 - `assay trust-basis diff` compares those artifacts.
 - Harness can later decide how to surface regressions in PR feedback.
 
+Exit code contract:
+
+- `0` means the comparison completed and no enabled gate failed.
+- `1` means `--fail-on-regression` was set and a missing/lowered baseline claim
+  was found.
+- Other non-zero exits are reserved for input, parse, or validation failures.
+
 ---
 
 ## 5. Acceptance Criteria
@@ -118,7 +156,11 @@ P34 is complete when:
 
 - `assay trust-basis diff` accepts two canonical Trust Basis JSON files.
 - text and JSON output are available.
-- `--fail-on-regression` exits non-zero only for missing/lowered baseline claims.
+- claim comparison is keyed by `claim.id`.
+- JSON output exposes the stable `assay.trust-basis.diff.v1` shape.
+- output ordering is deterministic.
+- metadata changes are visible and non-blocking in v1.
+- `--fail-on-regression` exits with code `1` only for missing/lowered baseline claims.
 - Promptfoo-origin Trust Basis claim improvements and regressions are covered by CLI tests.
 - docs explain that this command compares Trust Basis artifacts, not external eval payloads.
 

--- a/docs/reference/cli/trust-basis.md
+++ b/docs/reference/cli/trust-basis.md
@@ -34,6 +34,10 @@ Compare a baseline Trust Basis artifact with a candidate Trust Basis artifact:
 assay trust-basis diff baseline.trust-basis.json candidate.trust-basis.json
 ```
 
+Both inputs are canonical Trust Basis JSON files produced by
+`assay trust-basis generate`. The diff keys claim comparison by stable
+`claim.id`; duplicate claim IDs are rejected as invalid inputs.
+
 Use JSON output for CI and Harness-style consumers:
 
 ```bash
@@ -52,8 +56,8 @@ assay trust-basis diff \
   --fail-on-regression
 ```
 
-The diff compares Trust Basis claim levels only. It does not parse Promptfoo
-JSONL, inspect external eval payloads, or infer model correctness.
+The diff compares Trust Basis claim presence and levels only. It does not parse
+Promptfoo JSONL, inspect external eval payloads, or infer model correctness.
 
 Claim levels are ordered as:
 
@@ -64,6 +68,30 @@ absent < inferred < self_reported < verified
 Lowering a claim level, or removing a baseline claim, is a regression.
 Improving a level, adding a claim, or changing claim metadata is reported but
 does not fail unless a future caller adds a stricter policy above this command.
+New or unknown claim IDs in the candidate are additions, not regressions.
+
+Source, boundary, and note changes are reported as metadata changes. In v1 they
+are review-visible and non-blocking; the gate fails only on missing baseline
+claims or lowered levels when `--fail-on-regression` is set.
+
+JSON output uses the stable machine-readable schema
+`assay.trust-basis.diff.v1` and includes:
+
+- `summary`
+- `regressed_claims`
+- `improved_claims`
+- `removed_claims`
+- `added_claims`
+- `metadata_changes`
+- `unchanged_claim_count`
+
+Diff arrays are sorted deterministically by `claim.id`.
+
+Exit codes are:
+
+- `0` for successful comparisons with no gate failure.
+- `1` when `--fail-on-regression` is set and regressions are present.
+- Other non-zero codes for input, parse, or validation failures.
 
 ---
 


### PR DESCRIPTION
What changed

Hardens the already-merged P34 Trust Basis diff gate contract.

This follow-up makes the diff semantics more explicit and machine-stable:

- claim comparison is keyed by stable `claim.id`
- duplicate claim IDs are rejected before diffing
- JSON output now carries the stable `assay.trust-basis.diff.v1` shape
- diff arrays are split into `regressed_claims`, `improved_claims`, `removed_claims`, `added_claims`, and `metadata_changes`
- metadata changes now include note drift and remain non-blocking in v1
- `--fail-on-regression` returns exit code 1 for gate failures instead of surfacing as a config/error exit
- docs now spell out canonical inputs, exit codes, deterministic ordering, and the v1 gate boundary

Why

P34 deliberately compares compiled Trust Basis artifacts rather than raw evidence. This patch tightens the output and gate contract before Harness or SARIF/JUnit projection starts depending on it.

It also addresses the useful Copilot review points from the merged P34 PR: avoid O(n^2) diff lookups, include note metadata drift, and preserve the intended exit-code split between regressions and input failures.

Boundary

This does not add Harness wiring, SARIF/JUnit projection, stricter metadata-fail policy, Promptfoo parsing, or new Trust Basis claims.

Validation

Ran locally:

- `cargo fmt --check`
- `cargo test -p assay-evidence trust_basis_diff -- --nocapture`
- `cargo test -p assay-evidence trust_basis -- --nocapture`
- `cargo test -p assay-cli --test trust_basis_test -- --nocapture`
- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- local docs link check for changed docs
- `cargo run -p assay-cli -- trust-basis diff --help`
- `git diff --check`

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.
