### PR TITLE
P39: add evidence portability note

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@
 
 **Product story (repo root):** Assay is positioned as a **trust compiler for agent systems** — MCP policy enforcement as the wedge, plus verifiable evidence bundles, Trust Basis, Trust Card, and CI/SARIF. See the [main README](../README.md), [ADR-033](architecture/ADR-033-OTel-Trust-Compiler-Positioning.md), and [community discussion seeds](community/DISCUSSIONS.md).
 
+**Evidence portability note:** [From Promptfoo JSONL to Evidence Receipts](notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) explains the existing Promptfoo assertion-component receipt path as a downstream evidence-portability recipe, not a Promptfoo integration or partnership claim.
+
 ## 5-Minute Quickstart
 
 ### 1. Install

--- a/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md
+++ b/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md
@@ -1,0 +1,169 @@
+# From Promptfoo JSONL to Evidence Receipts
+
+> **Status:** technical note
+> **Last updated:** 2026-04-27
+> **Scope:** explains the existing Promptfoo receipt pipeline; adds no new schema, claim, or Harness semantics
+
+Promptfoo already makes AI behavior testable in CI. Assay shows how selected
+assertion outcomes can become portable evidence.
+
+This note is about evidence portability for AI eval outcomes. Promptfoo is the
+first concrete example, not the scope of the idea.
+
+## The Gap
+
+AI eval systems are good at running tests and producing CI outcomes. That is
+necessary, but it is not the same as preserving a small, reviewable evidence
+artifact for the outcome that mattered.
+
+For teams that need later review, incident analysis, or governance workflows,
+the important question is often not "did the eval tool run?" It is:
+
+- which outcome was selected for review,
+- where did it come from,
+- what was reduced out,
+- which compiler version produced the artifact,
+- and can another tool consume that artifact without understanding the whole
+  eval runner.
+
+That is the evidence portability gap.
+
+## The Boundary
+
+Assay does not replace Promptfoo and does not re-run Promptfoo evals.
+
+The boundary is:
+
+- Promptfoo runs assertions, evals, CI checks, and security workflows.
+- Assay imports one supported Promptfoo assertion component result into a
+  portable evidence receipt.
+- Trust Basis classifies whether the external eval receipt boundary is visible.
+- Assay Harness can gate and report the resulting Trust Basis diff.
+
+This is not a Promptfoo integration claim, partnership claim, or endorsement
+claim. It is a downstream recipe over public Promptfoo JSONL and assertion
+surfaces.
+
+## The Artifact Unit
+
+The first supported unit is one Promptfoo CLI JSONL assertion component result:
+
+```text
+Promptfoo CLI JSONL row -> gradingResult.componentResults[] -> one component
+```
+
+That is intentionally smaller than:
+
+- a full JSONL row,
+- a full eval run,
+- a Promptfoo JSON/YAML/XML export schema,
+- a red-team report,
+- a provider response,
+- raw prompt, output, expected value, vars, token, cost, or stats payloads.
+
+The first lane is deterministic-first: `equals` component results with binary
+scores only. That keeps the receipt boundary away from model-graded,
+LLM-as-judge, rubric, or red-team semantics until those have their own bounded
+surface and failure model.
+
+## The Compiler Path
+
+The current path is:
+
+```text
+Promptfoo CLI JSONL
+  -> assay evidence import promptfoo-jsonl
+  -> Assay evidence bundle
+  -> assay trust-basis generate
+  -> Trust Basis JSON
+  -> assay trust-basis diff
+  -> assay.trust-basis.diff.v1
+  -> Assay Harness gate/report
+```
+
+The receipt bundle is the portable Assay evidence artifact. The Trust Basis
+artifact is the canonical claim-level compiler output. The raw
+`assay.trust-basis.diff.v1` JSON is the canonical diff artifact for CI
+consumers.
+
+Markdown, JUnit, job summaries, and later review projections are derived views.
+They are useful for humans and CI systems, but they are not the source of
+truth.
+
+## What Trust Basis May Say
+
+For supported Promptfoo assertion-component receipts, Trust Basis may say:
+
+- a supported external eval receipt boundary is visible,
+- the receipt was carried through a verifiable Assay bundle,
+- the raw Promptfoo payload was not imported into the Trust Basis claim.
+
+It must not say:
+
+- the Promptfoo run passed,
+- the model output was correct,
+- the application is safe,
+- the eval was complete,
+- the provider response is trustworthy,
+- or the whole Promptfoo export is Assay truth.
+
+The claim is about evidence boundary visibility, not eval correctness.
+
+## Why This Is Not Observability
+
+Traces and observability events are useful for debugging. They are not
+automatically bounded evidence boundaries.
+
+The Assay receipt path deliberately reduces a selected outcome into a smaller
+artifact with explicit provenance and exclusion rules. That is different from
+importing a trace, platform run, or full export envelope.
+
+OpenTelemetry GenAI conventions are useful context for the ecosystem, but the
+current receipt lane does not depend on them. Assay keeps this path as a
+compiler boundary over a selected result surface, not a general telemetry
+mapping.
+
+## Why This Is Not Compliance Theater
+
+Governance and audit workflows may benefit from portable evidence, but this
+note does not lead with a compliance claim.
+
+The product claim is narrower:
+
+```text
+selected eval outcome -> portable evidence receipt -> claim-level artifact
+```
+
+That makes later review possible without turning Assay into a compliance
+dashboard, a Promptfoo viewer, or an eval-result truth oracle.
+
+## Try It
+
+The runnable recipe lives in Assay Harness:
+
+- [Promptfoo receipt pipeline recipe](https://github.com/Rul1an/Assay-Harness/blob/main/docs/PROMPTFOO_RECEIPT_PIPELINE.md)
+- [Recipe script](https://github.com/Rul1an/Assay-Harness/blob/main/demo/run-promptfoo-receipt-pipeline.sh)
+
+The Assay-side CLI entry points are:
+
+- [`assay evidence import promptfoo-jsonl`](../reference/cli/evidence.md#promptfoo-jsonl-import)
+- [`assay trust-basis diff`](../reference/cli/trust-basis.md#diff)
+
+The discovery sample that froze the first component-result lane is:
+
+- [Promptfoo Assertion GradingResult Evidence Sample](../../examples/promptfoo-assertion-grading-result-evidence/README.md)
+
+## What P39 Adds
+
+P39 adds no new receipt schema, no new Trust Basis claim, and no new Harness
+semantics. It explains the existing pipeline after the compiler path and
+recipe are already present.
+
+## References
+
+- [Promptfoo output formats](https://www.promptfoo.dev/docs/configuration/outputs/)
+- [Promptfoo deterministic assertions](https://www.promptfoo.dev/docs/configuration/expected-outputs/deterministic/)
+- [Promptfoo CI/CD integration](https://www.promptfoo.dev/docs/integrations/ci-cd/)
+- [NIST AI 600-1, Generative AI Profile](https://doi.org/10.6028/NIST.AI.600-1)
+- [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [GitHub SARIF support for code scanning](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning)

--- a/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md
+++ b/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md
@@ -8,7 +8,7 @@ Promptfoo already makes AI behavior testable in CI. Assay shows how selected
 assertion outcomes can become portable evidence.
 
 This note is about evidence portability for AI eval outcomes. Promptfoo is the
-first concrete example, not the scope of the idea.
+first concrete wedge, not the scope of the idea.
 
 ## The Gap
 
@@ -27,6 +27,9 @@ the important question is often not "did the eval tool run?" It is:
   eval runner.
 
 That is the evidence portability gap.
+
+The point is not to re-explain eval outputs. It is to show how a selected eval
+outcome becomes a portable evidence unit.
 
 ## The Boundary
 
@@ -92,7 +95,7 @@ truth.
 
 ## What Trust Basis May Say
 
-For supported Promptfoo assertion-component receipts, Trust Basis may say:
+For the current Promptfoo receipt pipeline, Trust Basis may say:
 
 - a supported external eval receipt boundary is visible,
 - the receipt was carried through a verifiable Assay bundle,

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -82,5 +82,6 @@ To compare the resulting claim artifact against another run, use
 
 - [Evidence Contract v1](../../spec/EVIDENCE-CONTRACT-v1.md)
 - [Trust Basis CLI](./trust-basis.md)
+- [From Promptfoo JSONL to Evidence Receipts](../../notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md)
 - [P31 Promptfoo receipt import plan](../../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md)
 - [Promptfoo assertion grading-result example](../../../examples/promptfoo-assertion-grading-result-evidence/README.md)

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -34,13 +34,11 @@ The importer is intentionally strict in v1:
 
 The importer first computes `source_artifact_digest` over the full JSONL file,
 then parses and reduces assertion components. That two-pass flow is intentional:
-the receipts stay small while still binding back to the exact source artifact
-bytes.
+receipts stay small while still binding back to the exact source artifact bytes.
 
 `result.reason` is optional and bounded. For v1, failure reasons are omitted
-because Promptfoo `equals` failure messages commonly quote raw output and
-expected values. Passing reasons are included only when they remain short and
-reviewer-safe.
+when they would leak raw compared values. Passing reasons are included only
+when they remain short and reviewer-safe.
 
 The output bundle can be verified with:
 
@@ -48,7 +46,7 @@ The output bundle can be verified with:
 assay evidence verify promptfoo-evidence.tar.gz
 ```
 
-The same bundle can also feed the current Trust Basis compiler:
+The same bundle can feed the Trust Basis compiler:
 
 ```bash
 assay trust-basis generate promptfoo-evidence.tar.gz --out promptfoo.trust-basis.json
@@ -63,7 +61,7 @@ the raw Promptfoo payload is imported as Assay truth.
 
 Use `--import-time <RFC3339>` for deterministic fixture generation.
 
-To compare the resulting claim artifact against another run, use
+To compare the resulting Trust Basis artifact against another run, use
 [`assay trust-basis diff`](./trust-basis.md).
 
 ### Options
@@ -73,7 +71,7 @@ To compare the resulting claim artifact against another run, use
 | `--input <PATH>` | Promptfoo CLI JSONL output file |
 | `--bundle-out <PATH>` | Output Assay evidence bundle path |
 | `--source-artifact-ref <REF>` | Reviewer-safe source artifact reference stored in receipts |
-| `--run-id <ID>` | Assay import run id used for receipt event ids |
+| `--run-id <ID>` | Assay import run id used for receipt provenance and event ids |
 | `--import-time <RFC3339>` | Deterministic import timestamp override |
 
 ---
@@ -82,6 +80,6 @@ To compare the resulting claim artifact against another run, use
 
 - [Evidence Contract v1](../../spec/EVIDENCE-CONTRACT-v1.md)
 - [Trust Basis CLI](./trust-basis.md)
+- [Promptfoo assertion grading-result example](../../../examples/promptfoo-assertion-grading-result-evidence/README.md)
 - [From Promptfoo JSONL to Evidence Receipts](../../notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md)
 - [P31 Promptfoo receipt import plan](../../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md)
-- [Promptfoo assertion grading-result example](../../../examples/promptfoo-assertion-grading-result-evidence/README.md)


### PR DESCRIPTION
What changed

Adds a small Assay-side technical note: From Promptfoo JSONL to Evidence Receipts.

The note frames Promptfoo as the first concrete wedge for evidence portability, not as the scope of the idea or an integration/partnership claim. It explains the existing pipeline:

Promptfoo CLI JSONL -> Assay receipt bundle -> Trust Basis -> trust-basis diff -> Assay Harness gate/report

Also adds small discoverability links from docs/README.md and the evidence CLI reference.

Why

P38 is now merged in Assay-Harness, so the runnable recipe exists on main. P39 can now safely explain the broader evidence-portability story without overclaiming new product semantics.

Boundary

This PR adds no new receipt schema, Trust Basis claim, Harness semantics, Promptfoo parser, Trust Card change, SARIF projection, or partnership/integration claim.

Promptfoo remains the CI/eval runner. Assay is the evidence portability layer for selected outcomes.

Validation

Ran locally:

- git diff --check
- external link check for Promptfoo docs, NIST DOI, OTel GenAI semconv, GitHub SARIF docs, and the merged P38 Harness recipe

Commit/push hooks also passed, including cargo fmt, cargo clippy, and the linux compile gate.
