### PR TITLE
ci: fix release wheel Python interpreter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -665,7 +665,9 @@ jobs:
         with:
           working-directory: assay-python-sdk
           target: ${{ matrix.target }}
-          args: --release --out dist --locked
+          # setup-python does not affect the manylinux container, so the
+          # interpreter must be explicit for Linux wheel builds.
+          args: --release --out dist --locked -i python3.12 --compatibility pypi
           sccache: 'true'
           manylinux: auto
 


### PR DESCRIPTION
What changed

Updates the release wheel build to pass an explicit Python 3.12 interpreter to maturin and enable PyPI compatibility checking.

Why

The v3.6.0 tag release built binaries, created the GitHub Release, and published crates.io successfully, but the Linux manylinux wheel job failed because setup-python does not affect the manylinux container and maturin could not find `python3` inside it.

Boundary

This is release workflow plumbing only. It does not change Assay product code, release artifacts, evidence semantics, or Promptfoo/P39 messaging.

Validation

Ran locally:

```
git diff --check
pre-commit push hooks: check yaml, actionlint, cargo fmt, workspace clippy, linux compile gate
```
