### PR TITLE
P41: import OpenFeature decision receipts

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -2,6 +2,7 @@ pub mod diff;
 pub mod lint;
 pub mod list;
 pub mod mapping;
+pub mod openfeature_details;
 pub mod promptfoo_jsonl;
 pub mod pull;
 pub mod push;
@@ -86,6 +87,9 @@ pub struct EvidenceImportArgs {
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum EvidenceImportCmd {
+    /// Import bounded OpenFeature boolean EvaluationDetails decision artifacts
+    #[command(name = "openfeature-details")]
+    OpenFeatureDetails(openfeature_details::OpenFeatureDetailsArgs),
     /// Import Promptfoo CLI JSONL assertion component results
     #[command(name = "promptfoo-jsonl")]
     PromptfooJsonl(promptfoo_jsonl::PromptfooJsonlArgs),
@@ -110,6 +114,7 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
 
 fn cmd_import(args: EvidenceImportArgs) -> Result<i32> {
     match args.cmd {
+        EvidenceImportCmd::OpenFeatureDetails(a) => openfeature_details::cmd_openfeature_details(a),
         EvidenceImportCmd::PromptfooJsonl(a) => promptfoo_jsonl::cmd_promptfoo_jsonl(a),
     }
 }

--- a/crates/assay-cli/src/cli/commands/evidence/openfeature_details.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/openfeature_details.rs
@@ -1,0 +1,484 @@
+use crate::exit_codes;
+use anyhow::{bail, Context, Result};
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::types::{EvidenceEvent, ProducerMeta};
+use chrono::{DateTime, SecondsFormat, Utc};
+use clap::Args;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
+
+const EVENT_TYPE: &str = "assay.receipt.openfeature.evaluation_details.v1";
+const EVENT_SOURCE: &str = "urn:assay:external:openfeature:evaluation-details";
+const RECEIPT_SCHEMA: &str = "assay.receipt.openfeature.evaluation_details.v1";
+const SOURCE_SYSTEM: &str = "openfeature";
+const SOURCE_SURFACE: &str = "evaluation_details.boolean";
+const REDUCER_VERSION: &str = "assay-openfeature-evaluation-details@0.1.0";
+const INPUT_SCHEMA: &str = "openfeature.evaluation-details.export.v1";
+const DEFAULT_RUN_ID: &str = "import-openfeature-details";
+const MAX_FLAG_KEY_CHARS: usize = 200;
+const MAX_BOUNDARY_STRING_CHARS: usize = 120;
+
+#[derive(Debug, Args, Clone)]
+pub struct OpenFeatureDetailsArgs {
+    /// OpenFeature EvaluationDetails JSONL artifact file
+    #[arg(long, value_name = "PATH")]
+    pub input: PathBuf,
+
+    /// Output Assay evidence bundle path (.tar.gz)
+    #[arg(long, alias = "out", value_name = "PATH")]
+    pub bundle_out: PathBuf,
+
+    /// Reviewer-safe source artifact reference stored in receipts
+    #[arg(long)]
+    pub source_artifact_ref: Option<String>,
+
+    /// Assay import run id used for receipt provenance and event ids
+    #[arg(long, default_value = DEFAULT_RUN_ID)]
+    pub run_id: String,
+
+    /// Import timestamp for deterministic fixtures (RFC3339 UTC recommended)
+    #[arg(long)]
+    pub import_time: Option<String>,
+}
+
+pub fn cmd_openfeature_details(args: OpenFeatureDetailsArgs) -> Result<i32> {
+    let import_time = parse_import_time(args.import_time.as_deref())?;
+    let source_artifact_ref = args
+        .source_artifact_ref
+        .unwrap_or_else(|| default_source_artifact_ref(&args.input));
+    // The receipt intentionally contains a narrow decision projection, but its
+    // provenance binds back to the exact source artifact bytes.
+    let source_artifact_digest = sha256_file(&args.input)
+        .with_context(|| format!("failed to digest input {}", args.input.display()))?;
+    let producer = ProducerMeta {
+        name: "assay-cli".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        git: option_env!("ASSAY_GIT_SHA").map(str::to_string),
+    };
+
+    let events = read_openfeature_details_events(
+        &args.input,
+        &source_artifact_ref,
+        &source_artifact_digest,
+        &args.run_id,
+        import_time,
+        &producer,
+    )?;
+
+    let out_file = File::create(&args.bundle_out)
+        .with_context(|| format!("failed to create bundle {}", args.bundle_out.display()))?;
+    let mut writer = BundleWriter::new(out_file).with_producer(producer);
+    for event in events {
+        writer.add_event(event);
+    }
+    writer
+        .finish()
+        .with_context(|| format!("failed to write bundle {}", args.bundle_out.display()))?;
+
+    eprintln!(
+        "Imported OpenFeature EvaluationDetails decision receipts to {}",
+        args.bundle_out.display()
+    );
+
+    Ok(exit_codes::OK)
+}
+
+fn read_openfeature_details_events(
+    input: &Path,
+    source_artifact_ref: &str,
+    source_artifact_digest: &str,
+    run_id: &str,
+    import_time: DateTime<Utc>,
+    producer: &ProducerMeta,
+) -> Result<Vec<EvidenceEvent>> {
+    if run_id.contains(':') {
+        bail!("run_id cannot contain ':' because event ids use run_id:seq");
+    }
+
+    let file =
+        File::open(input).with_context(|| format!("failed to open input {}", input.display()))?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+    let mut saw_jsonl_row = false;
+
+    for (line_index, line_result) in reader.lines().enumerate() {
+        let line_number = line_index + 1;
+        let line = line_result.with_context(|| format!("failed to read line {line_number}"))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        saw_jsonl_row = true;
+        let row: Value = serde_json::from_str(&line)
+            .with_context(|| format!("invalid JSONL object at line {line_number}"))?;
+        let seq = events.len() as u64;
+        let payload = reduce_evaluation_details(
+            &row,
+            source_artifact_ref,
+            source_artifact_digest,
+            import_time,
+            line_number,
+        )?;
+        let event = EvidenceEvent::new(EVENT_TYPE, EVENT_SOURCE, run_id, seq, payload)
+            .with_time(import_time)
+            .with_producer(producer);
+        events.push(event);
+    }
+
+    if !saw_jsonl_row {
+        bail!("input contains no JSONL rows");
+    }
+
+    Ok(events)
+}
+
+fn reduce_evaluation_details(
+    row: &Value,
+    source_artifact_ref: &str,
+    source_artifact_digest: &str,
+    import_time: DateTime<Utc>,
+    line_number: usize,
+) -> Result<Value> {
+    let record = row
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("line {line_number} must be a JSON object"))?;
+    validate_top_level(record, line_number)?;
+
+    let flag_key = bounded_string(
+        record.get("flag_key"),
+        "flag_key",
+        MAX_FLAG_KEY_CHARS,
+        line_number,
+    )?;
+    let result = record
+        .get("result")
+        .and_then(Value::as_object)
+        .ok_or_else(|| anyhow::anyhow!("line {line_number} missing result object"))?;
+    validate_result_keys(result, line_number)?;
+
+    let value = result
+        .get("value")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| anyhow::anyhow!("line {line_number} result.value must be boolean"))?;
+
+    let mut decision = Map::new();
+    decision.insert("flag_key".to_string(), Value::String(flag_key));
+    decision.insert(
+        "value_type".to_string(),
+        Value::String("boolean".to_string()),
+    );
+    decision.insert("value".to_string(), Value::Bool(value));
+    if let Some(variant) = optional_bounded_string(
+        result.get("variant"),
+        "result.variant",
+        MAX_BOUNDARY_STRING_CHARS,
+        line_number,
+    )? {
+        decision.insert("variant".to_string(), Value::String(variant));
+    }
+    if let Some(reason) = optional_bounded_string(
+        result.get("reason"),
+        "result.reason",
+        MAX_BOUNDARY_STRING_CHARS,
+        line_number,
+    )? {
+        decision.insert("reason".to_string(), Value::String(reason));
+    }
+    if let Some(error_code) = optional_bounded_string(
+        result.get("error_code"),
+        "result.error_code",
+        MAX_BOUNDARY_STRING_CHARS,
+        line_number,
+    )? {
+        decision.insert("error_code".to_string(), Value::String(error_code));
+    }
+
+    Ok(json!({
+        "schema": RECEIPT_SCHEMA,
+        "source_system": SOURCE_SYSTEM,
+        "source_surface": SOURCE_SURFACE,
+        "source_artifact_ref": source_artifact_ref,
+        "source_artifact_digest": source_artifact_digest,
+        "reducer_version": REDUCER_VERSION,
+        "imported_at": import_time.to_rfc3339_opts(SecondsFormat::Secs, true),
+        "decision": Value::Object(decision),
+    }))
+}
+
+fn validate_top_level(record: &Map<String, Value>, line_number: usize) -> Result<()> {
+    let allowed = [
+        "schema",
+        "framework",
+        "surface",
+        "target_kind",
+        "flag_key",
+        "result",
+    ];
+    if let Some(key) = record.keys().find(|key| !allowed.contains(&key.as_str())) {
+        bail!(
+            "line {line_number} contains unsupported top-level key {key:?}; v1 excludes context, provider state, rules, and metadata"
+        );
+    }
+
+    string_equals(record, "schema", INPUT_SCHEMA, line_number)?;
+    string_equals(record, "framework", "openfeature", line_number)?;
+    string_equals(record, "surface", "evaluation_details", line_number)?;
+    string_equals(record, "target_kind", "feature_flag", line_number)?;
+    Ok(())
+}
+
+fn validate_result_keys(result: &Map<String, Value>, line_number: usize) -> Result<()> {
+    let allowed = ["value", "variant", "reason", "error_code"];
+    if let Some(key) = result.keys().find(|key| !allowed.contains(&key.as_str())) {
+        bail!(
+            "line {line_number} contains unsupported result key {key:?}; v1 excludes error_message and metadata"
+        );
+    }
+    if !result.contains_key("value") {
+        bail!("line {line_number} missing result.value");
+    }
+    Ok(())
+}
+
+fn string_equals(
+    record: &Map<String, Value>,
+    key: &str,
+    expected: &str,
+    line_number: usize,
+) -> Result<()> {
+    match record.get(key).and_then(Value::as_str) {
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => bail!("line {line_number} {key} must be {expected:?}, got {actual:?}"),
+        None => bail!("line {line_number} missing string {key}"),
+    }
+}
+
+fn bounded_string(
+    value: Option<&Value>,
+    field_name: &str,
+    max_chars: usize,
+    line_number: usize,
+) -> Result<String> {
+    let value = value
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("line {line_number} {field_name} must be a string"))?;
+    validate_bounded_string(value, field_name, max_chars, line_number)
+}
+
+fn optional_bounded_string(
+    value: Option<&Value>,
+    field_name: &str,
+    max_chars: usize,
+    line_number: usize,
+) -> Result<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    Ok(Some(validate_bounded_string(
+        value.as_str().ok_or_else(|| {
+            anyhow::anyhow!("line {line_number} {field_name} must be a string or null")
+        })?,
+        field_name,
+        max_chars,
+        line_number,
+    )?))
+}
+
+fn validate_bounded_string(
+    value: &str,
+    field_name: &str,
+    max_chars: usize,
+    line_number: usize,
+) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("line {line_number} {field_name} must not be empty");
+    }
+    if trimmed.chars().count() > max_chars {
+        bail!("line {line_number} {field_name} must be at most {max_chars} characters");
+    }
+    if trimmed.contains('\n')
+        || trimmed.contains('\r')
+        || trimmed.contains('"')
+        || trimmed.contains('`')
+        || trimmed.contains('{')
+        || trimmed.contains('}')
+    {
+        bail!("line {line_number} {field_name} is not reviewer-safe for v1");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn parse_import_time(value: Option<&str>) -> Result<DateTime<Utc>> {
+    match value {
+        Some(value) => Ok(DateTime::parse_from_rfc3339(value)
+            .with_context(|| format!("invalid --import-time {value:?}; expected RFC3339"))?
+            .with_timezone(&Utc)),
+        None => Ok(Utc::now()),
+    }
+}
+
+fn default_source_artifact_ref(input: &Path) -> String {
+    input
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("openfeature-details.jsonl")
+        .to_string()
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_evidence::bundle::BundleReader;
+    use std::fs;
+
+    #[test]
+    fn import_writes_verifiable_boolean_decision_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("openfeature-details.jsonl");
+        let output = dir.path().join("openfeature.tar.gz");
+        fs::write(
+            &input,
+            concat!(
+                r#"{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.new_flow","result":{"value":true,"variant":"on","reason":"STATIC"}}"#,
+                "\n",
+                r#"{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.missing","result":{"value":false,"reason":"ERROR","error_code":"FLAG_NOT_FOUND"}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        let code = cmd_openfeature_details(OpenFeatureDetailsArgs {
+            input: input.clone(),
+            bundle_out: output.clone(),
+            source_artifact_ref: Some("openfeature-details.jsonl".to_string()),
+            run_id: "openfeature_test".to_string(),
+            import_time: Some("2026-04-27T12:00:00Z".to_string()),
+        })
+        .unwrap();
+        assert_eq!(code, exit_codes::OK);
+
+        let reader = BundleReader::open(File::open(output).unwrap()).unwrap();
+        assert_eq!(reader.manifest().event_count, 2);
+        let events = reader.events().collect::<Result<Vec<_>>>().unwrap();
+        assert_eq!(events[0].type_, EVENT_TYPE);
+        assert_eq!(events[0].source, EVENT_SOURCE);
+        assert_eq!(events[0].payload["source_surface"], SOURCE_SURFACE);
+        assert_eq!(
+            events[0].payload["decision"]["flag_key"],
+            "checkout.new_flow"
+        );
+        assert_eq!(events[0].payload["decision"]["value_type"], "boolean");
+        assert_eq!(events[0].payload["decision"]["value"], true);
+        assert_eq!(events[0].payload["decision"]["variant"], "on");
+        assert_eq!(events[0].payload["decision"]["reason"], "STATIC");
+        assert_eq!(
+            events[1].payload["decision"]["flag_key"],
+            "checkout.missing"
+        );
+        assert_eq!(events[1].payload["decision"]["value"], false);
+        assert_eq!(events[1].payload["decision"]["reason"], "ERROR");
+        assert_eq!(
+            events[1].payload["decision"]["error_code"],
+            "FLAG_NOT_FOUND"
+        );
+
+        let serialized = serde_json::to_string(&events).unwrap();
+        assert!(!serialized.contains("evaluation_context"));
+        assert!(!serialized.contains("targeting_key"));
+        assert!(!serialized.contains("flag_metadata"));
+        assert!(!serialized.contains("provider_config"));
+        assert!(!serialized.contains("error_message"));
+    }
+
+    #[test]
+    fn import_rejects_non_boolean_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("openfeature-details.jsonl");
+        let output = dir.path().join("openfeature.tar.gz");
+        fs::write(
+            &input,
+            r#"{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.new_flow","result":{"value":"on","variant":"on","reason":"STATIC"}}"#,
+        )
+        .unwrap();
+
+        let err = cmd_openfeature_details(OpenFeatureDetailsArgs {
+            input,
+            bundle_out: output,
+            source_artifact_ref: None,
+            run_id: "openfeature_test".to_string(),
+            import_time: Some("2026-04-27T12:00:00Z".to_string()),
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("result.value must be boolean"));
+    }
+
+    #[test]
+    fn import_rejects_context_metadata_and_error_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("openfeature-details.jsonl");
+        let output = dir.path().join("openfeature.tar.gz");
+        fs::write(
+            &input,
+            r#"{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.new_flow","evaluation_context":{"targeting_key":"user-123"},"result":{"value":true,"error_message":"Flag leaked compared values"}}"#,
+        )
+        .unwrap();
+
+        let err = cmd_openfeature_details(OpenFeatureDetailsArgs {
+            input,
+            bundle_out: output,
+            source_artifact_ref: None,
+            run_id: "openfeature_test".to_string(),
+            import_time: Some("2026-04-27T12:00:00Z".to_string()),
+        })
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("unsupported top-level key \"evaluation_context\""));
+    }
+
+    #[test]
+    fn import_rejects_error_message_even_without_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("openfeature-details.jsonl");
+        let output = dir.path().join("openfeature.tar.gz");
+        fs::write(
+            &input,
+            r#"{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.new_flow","result":{"value":true,"error_message":"message stays out of v1 receipts"}}"#,
+        )
+        .unwrap();
+
+        let err = cmd_openfeature_details(OpenFeatureDetailsArgs {
+            input,
+            bundle_out: output,
+            source_artifact_ref: None,
+            run_id: "openfeature_test".to_string(),
+            import_time: Some("2026-04-27T12:00:00Z".to_string()),
+        })
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("unsupported result key \"error_message\""));
+    }
+}

--- a/crates/assay-cli/tests/evidence_test.rs
+++ b/crates/assay-cli/tests/evidence_test.rs
@@ -151,6 +151,76 @@ fn test_promptfoo_imported_receipts_feed_trust_basis_generation() {
 }
 
 #[test]
+fn test_openfeature_imported_decision_receipts_verify_and_feed_trust_basis_generation() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("openfeature-details.jsonl");
+    let bundle = dir.path().join("openfeature-receipts.tar.gz");
+    fs::write(
+        &input,
+        concat!(
+            r#"{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.new_flow","result":{"value":true,"variant":"on","reason":"STATIC"}}"#,
+            "\n",
+            r#"{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.missing","result":{"value":false,"reason":"ERROR","error_code":"FLAG_NOT_FOUND"}}"#,
+            "\n"
+        ),
+    )
+    .unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("import")
+        .arg("openfeature-details")
+        .arg("--input")
+        .arg(&input)
+        .arg("--bundle-out")
+        .arg(&bundle)
+        .arg("--source-artifact-ref")
+        .arg("openfeature-details.jsonl")
+        .arg("--run-id")
+        .arg("openfeature_trust_basis")
+        .arg("--import-time")
+        .arg("2026-04-27T12:00:00Z")
+        .assert()
+        .success();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("verify")
+        .arg(&bundle)
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("generate")
+        .arg(&bundle)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claims = json["claims"].as_array().unwrap();
+    assert_eq!(
+        claims.len(),
+        8,
+        "P41 does not add a Trust Basis claim yet; it proves bundle/readability first"
+    );
+    assert_eq!(claim(claims, "bundle_verified")["level"], "verified");
+    assert_eq!(
+        claim(claims, "external_eval_receipt_boundary_visible")["level"],
+        "absent",
+        "OpenFeature decision receipts are not external eval receipts"
+    );
+}
+
+#[test]
 fn test_evidence_export_deterministic() {
     let dir = tempdir().unwrap();
     let profile_path = dir.path().join("profile.yaml");

--- a/docs/architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md
+++ b/docs/architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md
@@ -1,9 +1,13 @@
-# PLAN - P41 OpenFeature EvaluationDetails Decision Receipt Import
+# PLAN — P41 OpenFeature EvaluationDetails Decision Receipt Import
 
-**Status:** execution slice
-**Target repo:** `Rul1an/assay`
-**Depends on:** P30, P31-P34
-**Date:** 2026-04-27
+- **Date:** 2026-04-27
+- **Owner:** Assay maintainers
+- **Status:** execution slice
+- **Scope:** Turn one bounded OpenFeature boolean `EvaluationDetails` artifact
+  into one portable Assay decision receipt, without importing provider,
+  context, rule, or application truth.
+- **Target repo:** `Rul1an/assay`
+- **Depends on:** P30, P31-P34
 
 ## One-line goal
 

--- a/docs/architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md
+++ b/docs/architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md
@@ -1,0 +1,205 @@
+# PLAN - P41 OpenFeature EvaluationDetails Decision Receipt Import
+
+**Status:** execution slice
+**Target repo:** `Rul1an/assay`
+**Depends on:** P30, P31-P34
+**Date:** 2026-04-27
+
+## One-line goal
+
+Turn one bounded OpenFeature boolean `EvaluationDetails` artifact into one
+portable Assay decision receipt, without importing provider, context, rule, or
+application truth.
+
+## 1. Why this slice exists
+
+P31 proved that a selected Promptfoo eval outcome can become a portable Assay
+receipt. P41 opens a second family: runtime decision receipts.
+
+OpenFeature is a good next wedge because `EvaluationDetails` is a small named
+public result surface. It can carry a flag key, returned value, optional
+variant, optional reason, and optional error code without requiring Assay to
+understand provider configuration, targeting rules, evaluation context, or
+application behavior.
+
+This is not an OpenFeature integration. It is an Assay-side compiler lane over
+one bounded decision-detail artifact.
+
+## 2. Layering
+
+The stack boundary is:
+
+```text
+OpenFeature SDK/provider
+  -> returned EvaluationDetails<boolean>
+  -> bounded OpenFeature EvaluationDetails artifact JSONL
+  -> assay evidence import openfeature-details
+  -> Assay EvidenceEvent receipt bundle
+  -> evidence verify / trust-basis generate
+```
+
+Assay owns the receipt reduction and bundle semantics. OpenFeature remains the
+decision API context, not the evidence or audit layer.
+
+Harness is intentionally out of scope for P41. Harness may later gate/report
+Trust Basis diffs over these receipts if a Trust Basis claim is added in a
+separate slice.
+
+## 3. Scope
+
+P41 v1 imports exactly one bounded path:
+
+- one JSONL row
+- one `openfeature.evaluation-details.export.v1` artifact
+- one boolean decision result
+- one Assay EvidenceEvent receipt
+
+The importer is boolean-only. String, number, object, and structured flag values
+are follow-up lanes.
+
+## 4. Input surface
+
+P41 consumes the P30 bounded artifact shape, one JSON object per JSONL line:
+
+```json
+{
+  "schema": "openfeature.evaluation-details.export.v1",
+  "framework": "openfeature",
+  "surface": "evaluation_details",
+  "target_kind": "feature_flag",
+  "flag_key": "checkout.new_flow",
+  "result": {
+    "value": true,
+    "variant": "on",
+    "reason": "STATIC",
+    "error_code": null
+  }
+}
+```
+
+This is not a claim that OpenFeature has a single cross-SDK JSON wire shape.
+The JSONL artifact is the downstream, reviewer-safe export shape derived from a
+returned `EvaluationDetails<boolean>` object.
+
+## 5. Receipt v1 thesis
+
+The receipt body is an Assay EvidenceEvent payload:
+
+```json
+{
+  "schema": "assay.receipt.openfeature.evaluation_details.v1",
+  "source_system": "openfeature",
+  "source_surface": "evaluation_details.boolean",
+  "source_artifact_ref": "openfeature-details.jsonl",
+  "source_artifact_digest": "sha256:...",
+  "reducer_version": "assay-openfeature-evaluation-details@0.1.0",
+  "imported_at": "2026-04-27T12:00:00Z",
+  "decision": {
+    "flag_key": "checkout.new_flow",
+    "value_type": "boolean",
+    "value": true,
+    "variant": "on",
+    "reason": "STATIC",
+    "error_code": "FLAG_NOT_FOUND"
+  }
+}
+```
+
+Optional fields are omitted when absent or null. The receipt remains a bounded
+decision receipt. It does not become a flag configuration, targeting, or
+provider truth record.
+
+## 6. Field rules
+
+`decision.flag_key` names the evaluated flag key only. It is not provider
+identity, user identity, or rollout truth.
+
+`decision.value` is the boolean value returned by detailed evaluation. It is
+not application correctness or provider correctness.
+
+`decision.variant` is optional reviewer support when naturally present.
+
+`decision.reason` is a bounded string. It may contain known OpenFeature reasons
+such as `STATIC`, `DEFAULT`, `TARGETING_MATCH`, or `ERROR`, but Assay does not
+treat it as a closed enum or global ontology.
+
+`decision.error_code` is optional bounded machine support. P41 v1 excludes
+`error_message` because it is free text and can become provider-specific or
+leaky.
+
+## 7. Strict exclusions
+
+P41 v1 rejects:
+
+- evaluation context
+- targeting key or user identifiers
+- targeting rules and segments
+- provider configuration or provider state
+- provider metadata
+- inline flag metadata
+- flag definitions and rollout configuration
+- hooks and telemetry
+- `error_message`
+- bulk flag state or arrays of details
+
+The importer should fail closed rather than silently discard a larger artifact.
+
+## 8. Event type
+
+P41 introduces an experimental Assay Evidence event type:
+
+```text
+assay.receipt.openfeature.evaluation_details.v1
+```
+
+Experimental means explicitly invoked importer only. It must not be emitted by
+default evidence export paths.
+
+## 9. Trust Basis posture
+
+P41 does not add a Trust Basis claim. The first slice proves:
+
+- the importer writes a verifiable evidence bundle
+- the event type is registered
+- the receipt payload is bounded
+- the current Trust Basis compiler can read the bundle
+- OpenFeature decision receipts are not classified as external eval receipts
+
+A future slice may add a decision-receipt Trust Basis claim, but that should be
+a separate compatibility decision.
+
+## 10. Acceptance criteria
+
+- `assay evidence import openfeature-details` exists
+- valid boolean decision JSONL produces a verifiable evidence bundle
+- each JSONL row produces exactly one receipt event
+- non-boolean values fail closed
+- context, metadata, provider, rules, and `error_message` fields fail closed
+- receipt payload excludes raw context, provider, metadata, and free-text error
+  messages
+- CLI docs describe the boundary and Trust Basis posture
+- the Evidence Contract registry lists the experimental event type
+
+## 11. Non-goals
+
+P41 does not:
+
+- add OpenFeature provider support
+- add an official OpenFeature integration
+- parse provider configuration
+- import flag definitions
+- import evaluation context
+- support all value types
+- add a Trust Basis claim
+- add Harness gates or reports
+- claim that a flag decision was correct
+
+## 12. Follow-ups
+
+Possible follow-ups, only after P41 lands cleanly:
+
+- P42 decision receipt Trust Basis claim
+- Harness fixture/recipe over decision receipts
+- string/number EvaluationDetails lanes
+- a short Assay-side note: "From OpenFeature EvaluationDetails to Decision
+  Receipts"

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -53,6 +53,7 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [PLAN — P32 Promptfoo Receipt Trust Basis Readiness (Q2 2026)](./PLAN-P32-PROMPTFOO-RECEIPT-TRUST-BASIS-READINESS-2026q2.md) — execution slice that proves P31 receipt bundles feed the current Trust Basis compiler without adding a Promptfoo-specific claim row or Trust Card schema bump
 - [PLAN — P33 External Eval Receipt Trust Basis Claim (Q2 2026)](./PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) — execution slice that adds one bounded Trust Basis claim for supported external evaluation receipt boundaries, starting with Promptfoo assertion-component receipts
 - [PLAN — P34 Trust Basis Diff Gate (Q2 2026)](./PLAN-P34-TRUST-BASIS-DIFF-GATE-2026q2.md) — execution slice that compares canonical Trust Basis artifacts for claim-level regressions without parsing Promptfoo JSONL or external eval payloads
+- [PLAN — P41 OpenFeature EvaluationDetails Decision Receipt Import (Q2 2026)](./PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md) — execution slice that imports bounded boolean OpenFeature decision details as portable Assay receipts, not provider config, targeting, metadata, or application correctness truth
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 
 ## Active RFCs

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -12,6 +12,67 @@ assay evidence <COMMAND> [OPTIONS]
 
 ---
 
+## OpenFeature Details Import
+
+Import bounded OpenFeature boolean `EvaluationDetails` artifacts into a
+verifiable Assay evidence bundle:
+
+```bash
+assay evidence import openfeature-details \
+  --input openfeature-details.jsonl \
+  --bundle-out openfeature-decision-receipts.tar.gz \
+  --source-artifact-ref openfeature-details.jsonl
+```
+
+The importer is intentionally strict in v1:
+
+- input must be JSONL with one bounded `EvaluationDetails` artifact per row
+- each row must use `openfeature.evaluation-details.export.v1`
+- each row must represent `target_kind = feature_flag`
+- `result.value` must be boolean
+- `result.reason` is a bounded string, not an Assay-owned enum
+- provider config, evaluation context, targeting keys, rules, metadata,
+  `error_message`, and full provider state are excluded
+
+The importer first computes `source_artifact_digest` over the full JSONL file,
+then parses and reduces decision details. Receipts stay small while still
+binding back to the exact source artifact bytes.
+
+The receipt is a decision-boundary artifact. It does not mean the flag decision
+was correct, the application behavior was safe, the provider was correct, or
+the targeting rules were imported as Assay truth.
+
+The output bundle can be verified with:
+
+```bash
+assay evidence verify openfeature-decision-receipts.tar.gz
+```
+
+The same bundle can feed the Trust Basis compiler:
+
+```bash
+assay trust-basis generate openfeature-decision-receipts.tar.gz --out openfeature.trust-basis.json
+```
+
+P41 does not add a Trust Basis claim yet. The first OpenFeature compiler slice
+proves the receipt bundle is bundleable, verifiable, and readable by the Trust
+Basis path. Decision-specific Trust Basis claims are a later compatibility
+decision.
+
+Use `--import-time <RFC3339>` for deterministic fixture generation.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--input <PATH>` | OpenFeature EvaluationDetails JSONL artifact file |
+| `--bundle-out <PATH>` | Output Assay evidence bundle path |
+| `--source-artifact-ref <REF>` | Reviewer-safe source artifact reference stored in receipts |
+| `--run-id <ID>` | Assay import run id used for receipt provenance and event ids |
+| `--import-time <RFC3339>` | Deterministic import timestamp override |
+
+---
+
 ## Promptfoo JSONL Import
 
 Import Promptfoo CLI JSONL assertion component results into a verifiable Assay
@@ -80,6 +141,8 @@ To compare the resulting Trust Basis artifact against another run, use
 
 - [Evidence Contract v1](../../spec/EVIDENCE-CONTRACT-v1.md)
 - [Trust Basis CLI](./trust-basis.md)
+- [OpenFeature EvaluationDetails evidence example](../../../examples/openfeature-evaluation-details-evidence/README.md)
 - [Promptfoo assertion grading-result example](../../../examples/promptfoo-assertion-grading-result-evidence/README.md)
 - [From Promptfoo JSONL to Evidence Receipts](../../notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md)
+- [P41 OpenFeature decision receipt import plan](../../architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md)
 - [P31 Promptfoo receipt import plan](../../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md)

--- a/docs/spec/EVIDENCE-CONTRACT-v1.md
+++ b/docs/spec/EVIDENCE-CONTRACT-v1.md
@@ -95,6 +95,7 @@ This table lists event types for Assay Evidence Spec v1.x (bundle schema_version
 | assay.mandate.revoked.v1 | stable | Mandate revoked lifecycle | SPEC-Mandate-v1 | mandate events tests |
 | assay.sandbox.degraded | stable | Operational integrity | [ADR-006 §3.C](../architecture/ADR-006-Evidence-Contract.md#payload-assay-sandbox-degraded) | verify_strict_test::test_sandbox_degraded_stable_payload_conformance |
 | assay.receipt.promptfoo.assertion_component.v1 | experimental | Promptfoo CLI JSONL assertion component receipt | [PLAN-P31 §5-§6](../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md#5-receipt-v1-thesis) | promptfoo_jsonl::tests::import_writes_verifiable_bundle_without_raw_payloads |
+| assay.receipt.openfeature.evaluation_details.v1 | experimental | OpenFeature boolean EvaluationDetails decision receipt | [PLAN-P41 §5-§6](../architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md#5-receipt-v1-thesis) | openfeature_details::tests::import_writes_verifiable_boolean_decision_bundle |
 
 ## 5. Deprecation policy
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -109,7 +109,7 @@ truth.
 Map a tiny artifact derived from OpenFeature's detailed flag evaluation API
 into Assay-shaped external evidence.
 **Focus**: decision-detail-first surface, bounded flag key, returned value,
-reason, variant, and fallback error fields only, no imported provider config,
+reason, variant, and fallback error code only, no imported provider config,
 targeting, rollout, telemetry, or application correctness truth.
 
 ### [Promptfoo Assertion GradingResult Evidence](./promptfoo-assertion-grading-result-evidence)

--- a/examples/openfeature-evaluation-details-evidence/README.md
+++ b/examples/openfeature-evaluation-details-evidence/README.md
@@ -33,6 +33,10 @@ It is intentionally small:
 - `fixtures/fallback.openfeature.json`: one bounded fallback/error artifact
 - `fixtures/malformed.openfeature.json`: one malformed provider/config import
   case
+- `fixtures/decision-details.openfeature.jsonl`: two P41 importer-ready bounded
+  boolean decision details
+- `fixtures/context-leak.openfeature.jsonl`: one P41 fail-closed case with
+  context plus free-text error message
 - `fixtures/valid.assay.ndjson`: mapped placeholder output with fixed import
   time
 - `fixtures/fallback.assay.ndjson`: mapped placeholder output with fixed import
@@ -150,6 +154,30 @@ python3 examples/openfeature-evaluation-details-evidence/map_to_assay.py \
 This third command is expected to fail because the malformed fixture tries to
 carry provider configuration, evaluation context, inline flag metadata, and
 caller-side defaults into a one-detail v1 lane.
+
+## Import the checked-in JSONL artifact as Assay receipts
+
+P41 turns the sample from placeholder mapping into a real Assay compiler path:
+
+```bash
+assay evidence import openfeature-details \
+  --input examples/openfeature-evaluation-details-evidence/fixtures/decision-details.openfeature.jsonl \
+  --bundle-out /tmp/openfeature-decision-receipts.tar.gz \
+  --source-artifact-ref decision-details.openfeature.jsonl \
+  --run-id p41_openfeature_fixture \
+  --import-time 2026-04-27T12:00:00Z
+
+assay evidence verify /tmp/openfeature-decision-receipts.tar.gz
+```
+
+The importer consumes the bounded `openfeature.evaluation-details.export.v1`
+JSONL shape from this example, not provider configuration or a cross-SDK
+OpenFeature wire-format claim. It writes one
+`assay.receipt.openfeature.evaluation_details.v1` event per JSONL row.
+
+The P41 receipt excludes `error_message`, inline flag metadata, provider state,
+targeting keys, evaluation context, and targeting rules. The
+`context-leak.openfeature.jsonl` fixture is expected to fail closed.
 
 ## Important boundary
 

--- a/examples/openfeature-evaluation-details-evidence/fixtures/context-leak.openfeature.jsonl
+++ b/examples/openfeature-evaluation-details-evidence/fixtures/context-leak.openfeature.jsonl
@@ -1,0 +1,1 @@
+{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.new_flow","evaluation_context":{"targeting_key":"user-123"},"result":{"value":true,"variant":"on","reason":"STATIC","error_message":"Flag leaked runtime context"}}

--- a/examples/openfeature-evaluation-details-evidence/fixtures/decision-details.openfeature.jsonl
+++ b/examples/openfeature-evaluation-details-evidence/fixtures/decision-details.openfeature.jsonl
@@ -1,0 +1,2 @@
+{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.new_flow","result":{"value":true,"variant":"on","reason":"STATIC"}}
+{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.missing","result":{"value":false,"reason":"ERROR","error_code":"FLAG_NOT_FOUND"}}


### PR DESCRIPTION
What changed

Adds the P41 OpenFeature decision receipt compiler lane in Assay core.

This PR includes:

- `assay evidence import openfeature-details`
- strict JSONL ingestion for bounded boolean OpenFeature `EvaluationDetails` artifacts
- one `assay.receipt.openfeature.evaluation_details.v1` EvidenceEvent receipt per JSONL row
- direct BundleWriter output to a verifiable evidence bundle
- rejection of provider config, evaluation context, targeting keys/rules, metadata, non-boolean values, and `error_message`
- P41 architecture plan, CLI docs, example fixtures, and an experimental Evidence Contract registry row

Why

Promptfoo proves eval outcome receipts. OpenFeature proves runtime decision receipts.

P41 opens that second family without turning Assay into an OpenFeature integration or provider audit layer: one bounded boolean decision detail in, one portable Assay receipt bundle out.

Boundary

This does not import provider state, flag definitions, targeting rules, evaluation context, user identifiers, flag metadata, provider metadata, telemetry, or application correctness truth. It also does not add a Trust Basis claim yet; this slice proves bundleability, verification, and current Trust Basis readability first.

Validation

Ran locally:

```bash
cargo fmt --check
cargo test -p assay-cli openfeature_details -- --nocapture
cargo test -p assay-cli test_openfeature_imported_decision_receipts_verify_and_feed_trust_basis_generation -- --nocapture
cargo run -p assay-cli -- evidence import openfeature-details --help
cargo clippy -p assay-cli --all-targets -- -D warnings
git diff --check
# local docs-link check for changed docs
cargo run -p assay-cli -- evidence import openfeature-details --input examples/openfeature-evaluation-details-evidence/fixtures/decision-details.openfeature.jsonl --bundle-out /tmp/p41-openfeature-decision-receipts.tar.gz --source-artifact-ref decision-details.openfeature.jsonl --run-id p41_openfeature_fixture --import-time 2026-04-27T12:00:00Z
cargo run -p assay-cli -- evidence verify /tmp/p41-openfeature-decision-receipts.tar.gz
cargo run -p assay-cli -- trust-basis generate /tmp/p41-openfeature-decision-receipts.tar.gz --out /tmp/p41-openfeature.trust-basis.json
```

The `context-leak.openfeature.jsonl` fixture fails closed as expected.

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.
