### PR TITLE
P43: import CycloneDX ML-BOM model receipts

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/cyclonedx_mlbom_model.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/cyclonedx_mlbom_model.rs
@@ -1,0 +1,607 @@
+use crate::exit_codes;
+use anyhow::{bail, Context, Result};
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::types::{EvidenceEvent, ProducerMeta};
+use chrono::{DateTime, SecondsFormat, Utc};
+use clap::Args;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+
+const EVENT_TYPE: &str = "assay.receipt.cyclonedx.mlbom_model_component.v1";
+const EVENT_SOURCE: &str = "urn:assay:external:cyclonedx:mlbom-model-component";
+const RECEIPT_SCHEMA: &str = "assay.receipt.cyclonedx.mlbom-model-component.v1";
+const SOURCE_SYSTEM: &str = "cyclonedx";
+const SOURCE_SURFACE: &str = "bom.components[type=machine-learning-model]";
+const REDUCER_VERSION: &str = "assay-cyclonedx-mlbom-model-component@0.1.0";
+const DEFAULT_RUN_ID: &str = "import-cyclonedx-mlbom-model";
+const MAX_BOUNDARY_STRING_CHARS: usize = 240;
+const MAX_REF_COUNT: usize = 32;
+
+#[derive(Debug, Args, Clone)]
+pub struct CycloneDxMlBomModelArgs {
+    /// CycloneDX JSON BOM artifact file
+    #[arg(long, value_name = "PATH")]
+    pub input: PathBuf,
+
+    /// Output Assay evidence bundle path (.tar.gz)
+    #[arg(long, alias = "out", value_name = "PATH")]
+    pub bundle_out: PathBuf,
+
+    /// Select a machine-learning-model component by bom-ref
+    #[arg(long)]
+    pub bom_ref: Option<String>,
+
+    /// Reviewer-safe source artifact reference stored in receipts
+    #[arg(long)]
+    pub source_artifact_ref: Option<String>,
+
+    /// Assay import run id used for receipt provenance and event ids
+    #[arg(long, default_value = DEFAULT_RUN_ID)]
+    pub run_id: String,
+
+    /// Import timestamp for deterministic fixtures (RFC3339 UTC recommended)
+    #[arg(long)]
+    pub import_time: Option<String>,
+}
+
+pub fn cmd_cyclonedx_mlbom_model(args: CycloneDxMlBomModelArgs) -> Result<i32> {
+    let import_time = parse_import_time(args.import_time.as_deref())?;
+    let source_artifact_ref = args
+        .source_artifact_ref
+        .unwrap_or_else(|| default_source_artifact_ref(&args.input));
+    // The receipt reduces one selected model component, while provenance binds
+    // back to the exact BOM bytes that carried the richer inventory.
+    let source_artifact_digest = sha256_file(&args.input)
+        .with_context(|| format!("failed to digest input {}", args.input.display()))?;
+    let producer = ProducerMeta {
+        name: "assay-cli".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        git: option_env!("ASSAY_GIT_SHA").map(str::to_string),
+    };
+
+    let event = read_cyclonedx_model_event(
+        &args.input,
+        args.bom_ref.as_deref(),
+        &source_artifact_ref,
+        &source_artifact_digest,
+        &args.run_id,
+        import_time,
+        &producer,
+    )?;
+
+    let out_file = File::create(&args.bundle_out)
+        .with_context(|| format!("failed to create bundle {}", args.bundle_out.display()))?;
+    let mut writer = BundleWriter::new(out_file).with_producer(producer);
+    writer.add_event(event);
+    writer
+        .finish()
+        .with_context(|| format!("failed to write bundle {}", args.bundle_out.display()))?;
+
+    eprintln!(
+        "Imported CycloneDX ML-BOM model component receipt to {}",
+        args.bundle_out.display()
+    );
+
+    Ok(exit_codes::OK)
+}
+
+fn read_cyclonedx_model_event(
+    input: &Path,
+    bom_ref: Option<&str>,
+    source_artifact_ref: &str,
+    source_artifact_digest: &str,
+    run_id: &str,
+    import_time: DateTime<Utc>,
+    producer: &ProducerMeta,
+) -> Result<EvidenceEvent> {
+    if run_id.contains(':') {
+        bail!("run_id cannot contain ':' because event ids use run_id:seq");
+    }
+
+    let bom = read_json_file(input)?;
+    let payload = reduce_model_component(
+        &bom,
+        bom_ref,
+        source_artifact_ref,
+        source_artifact_digest,
+        import_time,
+    )?;
+
+    Ok(
+        EvidenceEvent::new(EVENT_TYPE, EVENT_SOURCE, run_id, 0, payload)
+            .with_time(import_time)
+            .with_producer(producer),
+    )
+}
+
+fn reduce_model_component(
+    bom: &Value,
+    bom_ref: Option<&str>,
+    source_artifact_ref: &str,
+    source_artifact_digest: &str,
+    import_time: DateTime<Utc>,
+) -> Result<Value> {
+    let bom_obj = bom
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("CycloneDX input must be a JSON object"))?;
+    string_equals(bom_obj, "bomFormat", "CycloneDX")?;
+
+    let components = bom_obj
+        .get("components")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("CycloneDX input must contain components[]"))?;
+
+    let candidates = components
+        .iter()
+        .filter(|component| {
+            component
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value == "machine-learning-model")
+        })
+        .collect::<Vec<_>>();
+
+    if candidates.is_empty() {
+        bail!("CycloneDX input contains no components[] entries with type machine-learning-model");
+    }
+
+    let selected = select_component(&candidates, bom_ref)?;
+    let selected_obj = selected
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("selected CycloneDX component must be an object"))?;
+
+    let bom_ref = bounded_string(
+        selected_obj.get("bom-ref"),
+        "component.bom-ref",
+        MAX_BOUNDARY_STRING_CHARS,
+    )?;
+    let name = bounded_string(
+        selected_obj.get("name"),
+        "component.name",
+        MAX_BOUNDARY_STRING_CHARS,
+    )?;
+
+    let mut model_component = Map::new();
+    model_component.insert("bom_ref".to_string(), Value::String(bom_ref));
+    model_component.insert("name".to_string(), Value::String(name));
+    insert_optional_string(
+        &mut model_component,
+        selected_obj,
+        "version",
+        "component.version",
+    )?;
+    insert_optional_string(
+        &mut model_component,
+        selected_obj,
+        "publisher",
+        "component.publisher",
+    )?;
+    insert_optional_string(&mut model_component, selected_obj, "purl", "component.purl")?;
+
+    let dataset_refs = dataset_refs(selected_obj)?;
+    if !dataset_refs.is_empty() {
+        model_component.insert("dataset_refs".to_string(), strings_value(dataset_refs));
+    }
+    let model_card_refs = model_card_refs(selected_obj)?;
+    if !model_card_refs.is_empty() {
+        model_component.insert(
+            "model_card_refs".to_string(),
+            strings_value(model_card_refs),
+        );
+    }
+
+    Ok(json!({
+        "schema": RECEIPT_SCHEMA,
+        "source_system": SOURCE_SYSTEM,
+        "source_surface": SOURCE_SURFACE,
+        "source_artifact_ref": source_artifact_ref,
+        "source_artifact_digest": source_artifact_digest,
+        "reducer_version": REDUCER_VERSION,
+        "imported_at": import_time.to_rfc3339_opts(SecondsFormat::Secs, true),
+        "model_component": Value::Object(model_component),
+    }))
+}
+
+fn select_component<'a>(candidates: &'a [&'a Value], bom_ref: Option<&str>) -> Result<&'a Value> {
+    if let Some(bom_ref) = bom_ref {
+        let matches = candidates
+            .iter()
+            .copied()
+            .filter(|component| {
+                component
+                    .get("bom-ref")
+                    .and_then(Value::as_str)
+                    .is_some_and(|actual| actual == bom_ref)
+            })
+            .collect::<Vec<_>>();
+        return match matches.as_slice() {
+            [selected] => Ok(*selected),
+            [] => bail!(
+                "--bom-ref {bom_ref:?} did not match a components[] machine-learning-model entry"
+            ),
+            _ => bail!("--bom-ref {bom_ref:?} matched multiple model components"),
+        };
+    }
+
+    match candidates {
+        [selected] => Ok(*selected),
+        _ => bail!(
+            "CycloneDX input contains multiple machine-learning-model components; pass --bom-ref to select one"
+        ),
+    }
+}
+
+fn dataset_refs(component: &Map<String, Value>) -> Result<Vec<String>> {
+    let mut refs = Vec::new();
+    let Some(datasets) = component
+        .get("modelCard")
+        .and_then(|model_card| model_card.get("modelParameters"))
+        .and_then(|model_parameters| model_parameters.get("datasets"))
+        .and_then(Value::as_array)
+    else {
+        return Ok(refs);
+    };
+
+    for (index, dataset) in datasets.iter().enumerate() {
+        let Some(reference) = dataset.get("ref").and_then(Value::as_str) else {
+            continue;
+        };
+        refs.push(validate_bounded_string(
+            reference,
+            &format!("modelCard.modelParameters.datasets[{index}].ref"),
+            MAX_BOUNDARY_STRING_CHARS,
+        )?);
+        if refs.len() > MAX_REF_COUNT {
+            bail!("modelCard.modelParameters.datasets has more than {MAX_REF_COUNT} refs");
+        }
+    }
+
+    Ok(refs)
+}
+
+fn model_card_refs(component: &Map<String, Value>) -> Result<Vec<String>> {
+    let mut refs = Vec::new();
+    if let Some(reference) = component
+        .get("modelCard")
+        .and_then(|model_card| model_card.get("bom-ref"))
+        .and_then(Value::as_str)
+    {
+        refs.push(validate_bounded_string(
+            reference,
+            "modelCard.bom-ref",
+            MAX_BOUNDARY_STRING_CHARS,
+        )?);
+    }
+    Ok(refs)
+}
+
+fn insert_optional_string(
+    output: &mut Map<String, Value>,
+    component: &Map<String, Value>,
+    key: &str,
+    field_name: &str,
+) -> Result<()> {
+    if let Some(value) =
+        optional_bounded_string(component.get(key), field_name, MAX_BOUNDARY_STRING_CHARS)?
+    {
+        output.insert(key.to_string(), Value::String(value));
+    }
+    Ok(())
+}
+
+fn strings_value(values: Vec<String>) -> Value {
+    Value::Array(values.into_iter().map(Value::String).collect())
+}
+
+fn string_equals(record: &Map<String, Value>, key: &str, expected: &str) -> Result<()> {
+    match record.get(key).and_then(Value::as_str) {
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => bail!("{key} must be {expected:?}, got {actual:?}"),
+        None => bail!("missing string {key}"),
+    }
+}
+
+fn bounded_string(value: Option<&Value>, field_name: &str, max_chars: usize) -> Result<String> {
+    let value = value
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("{field_name} must be a string"))?;
+    validate_bounded_string(value, field_name, max_chars)
+}
+
+fn optional_bounded_string(
+    value: Option<&Value>,
+    field_name: &str,
+    max_chars: usize,
+) -> Result<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    Ok(Some(validate_bounded_string(
+        value
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("{field_name} must be a string or null"))?,
+        field_name,
+        max_chars,
+    )?))
+}
+
+fn validate_bounded_string(value: &str, field_name: &str, max_chars: usize) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("{field_name} must not be empty");
+    }
+    if trimmed.chars().count() > max_chars {
+        bail!("{field_name} must be at most {max_chars} characters");
+    }
+    if trimmed.contains('\n')
+        || trimmed.contains('\r')
+        || trimmed.contains('"')
+        || trimmed.contains('`')
+        || trimmed.contains('{')
+        || trimmed.contains('}')
+    {
+        bail!("{field_name} is not reviewer-safe for v1");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn parse_import_time(value: Option<&str>) -> Result<DateTime<Utc>> {
+    match value {
+        Some(value) => Ok(DateTime::parse_from_rfc3339(value)
+            .with_context(|| format!("invalid --import-time {value:?}; expected RFC3339"))?
+            .with_timezone(&Utc)),
+        None => Ok(Utc::now()),
+    }
+}
+
+fn default_source_artifact_ref(input: &Path) -> String {
+    input
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("bom.cdx.json")
+        .to_string()
+}
+
+fn read_json_file(path: &Path) -> Result<Value> {
+    let file =
+        File::open(path).with_context(|| format!("failed to open input {}", path.display()))?;
+    serde_json::from_reader(BufReader::new(file))
+        .with_context(|| format!("invalid JSON input {}", path.display()))
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_evidence::bundle::BundleReader;
+    use std::fs;
+
+    #[test]
+    fn import_writes_verifiable_model_component_bundle_without_bodies() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("bom.cdx.json");
+        let output = dir.path().join("cyclonedx-model.tar.gz");
+        fs::write(&input, fixture_with_one_model()).unwrap();
+
+        let code = cmd_cyclonedx_mlbom_model(CycloneDxMlBomModelArgs {
+            input: input.clone(),
+            bundle_out: output.clone(),
+            bom_ref: None,
+            source_artifact_ref: Some("bom.cdx.json".to_string()),
+            run_id: "cyclonedx_test".to_string(),
+            import_time: Some("2026-04-28T12:00:00Z".to_string()),
+        })
+        .unwrap();
+        assert_eq!(code, exit_codes::OK);
+
+        let reader = BundleReader::open(File::open(output).unwrap()).unwrap();
+        assert_eq!(reader.manifest().event_count, 1);
+        let events = reader.events().collect::<Result<Vec<_>>>().unwrap();
+        let payload = &events[0].payload;
+        assert_eq!(events[0].type_, EVENT_TYPE);
+        assert_eq!(events[0].source, EVENT_SOURCE);
+        assert_eq!(payload["source_system"], SOURCE_SYSTEM);
+        assert_eq!(payload["source_surface"], SOURCE_SURFACE);
+        assert_eq!(
+            payload["model_component"]["bom_ref"],
+            "pkg:huggingface/example/model@abc123"
+        );
+        assert_eq!(payload["model_component"]["name"], "example-model");
+        assert_eq!(payload["model_component"]["version"], "1.0.0");
+        assert_eq!(payload["model_component"]["publisher"], "Example Inc.");
+        assert_eq!(
+            payload["model_component"]["purl"],
+            "pkg:huggingface/example/model@abc123"
+        );
+        assert_eq!(
+            payload["model_component"]["dataset_refs"][0],
+            "component-training-data"
+        );
+        assert_eq!(
+            payload["model_component"]["model_card_refs"][0],
+            "model-card-example-model"
+        );
+
+        let serialized = serde_json::to_string(payload).unwrap();
+        assert!(!serialized.contains("quantitativeAnalysis"));
+        assert!(!serialized.contains("ethicalConsiderations"));
+        assert!(!serialized.contains("Speech Training Data"));
+        assert!(!serialized.contains("licenses"));
+        assert!(!serialized.contains("vulnerabilities"));
+        assert!(!serialized.contains("pedigree"));
+    }
+
+    #[test]
+    fn import_requires_bom_ref_when_multiple_model_components_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("bom.cdx.json");
+        let output = dir.path().join("cyclonedx-model.tar.gz");
+        fs::write(&input, fixture_with_two_models()).unwrap();
+
+        let err = cmd_cyclonedx_mlbom_model(CycloneDxMlBomModelArgs {
+            input,
+            bundle_out: output,
+            bom_ref: None,
+            source_artifact_ref: None,
+            run_id: "cyclonedx_test".to_string(),
+            import_time: Some("2026-04-28T12:00:00Z".to_string()),
+        })
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("multiple machine-learning-model components"));
+    }
+
+    #[test]
+    fn import_selects_model_component_by_bom_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("bom.cdx.json");
+        let output = dir.path().join("cyclonedx-model.tar.gz");
+        fs::write(&input, fixture_with_two_models()).unwrap();
+
+        cmd_cyclonedx_mlbom_model(CycloneDxMlBomModelArgs {
+            input,
+            bundle_out: output.clone(),
+            bom_ref: Some("component-secondary-model".to_string()),
+            source_artifact_ref: None,
+            run_id: "cyclonedx_test".to_string(),
+            import_time: Some("2026-04-28T12:00:00Z".to_string()),
+        })
+        .unwrap();
+
+        let reader = BundleReader::open(File::open(output).unwrap()).unwrap();
+        let events = reader.events().collect::<Result<Vec<_>>>().unwrap();
+        assert_eq!(
+            events[0].payload["model_component"]["bom_ref"],
+            "component-secondary-model"
+        );
+        assert_eq!(
+            events[0].payload["model_component"]["name"],
+            "secondary-model"
+        );
+    }
+
+    #[test]
+    fn import_rejects_missing_or_non_model_bom_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("bom.cdx.json");
+        let output = dir.path().join("cyclonedx-model.tar.gz");
+        fs::write(&input, fixture_with_one_model()).unwrap();
+
+        let err = cmd_cyclonedx_mlbom_model(CycloneDxMlBomModelArgs {
+            input,
+            bundle_out: output,
+            bom_ref: Some("component-training-data".to_string()),
+            source_artifact_ref: None,
+            run_id: "cyclonedx_test".to_string(),
+            import_time: Some("2026-04-28T12:00:00Z".to_string()),
+        })
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("did not match a components[] machine-learning-model entry"));
+    }
+
+    #[test]
+    fn import_rejects_bom_without_model_components() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("bom.cdx.json");
+        let output = dir.path().join("cyclonedx-model.tar.gz");
+        fs::write(
+            &input,
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.7","components":[{"bom-ref":"app","type":"application","name":"app"}]}"#,
+        )
+        .unwrap();
+
+        let err = cmd_cyclonedx_mlbom_model(CycloneDxMlBomModelArgs {
+            input,
+            bundle_out: output,
+            bom_ref: None,
+            source_artifact_ref: None,
+            run_id: "cyclonedx_test".to_string(),
+            import_time: Some("2026-04-28T12:00:00Z".to_string()),
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("no components[] entries"));
+    }
+
+    fn fixture_with_one_model() -> &'static str {
+        r#"{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "components": [
+    {
+      "bom-ref": "pkg:huggingface/example/model@abc123",
+      "type": "machine-learning-model",
+      "publisher": "Example Inc.",
+      "name": "example-model",
+      "version": "1.0.0",
+      "purl": "pkg:huggingface/example/model@abc123",
+      "description": "This long description is intentionally not imported.",
+      "pedigree": { "ancestors": [{ "name": "base-model" }] },
+      "licenses": [{ "license": { "id": "Apache-2.0" } }],
+      "modelCard": {
+        "bom-ref": "model-card-example-model",
+        "modelParameters": {
+          "datasets": [{ "ref": "component-training-data" }]
+        },
+        "quantitativeAnalysis": {
+          "performanceMetrics": [{ "type": "accuracy", "value": "0.9" }]
+        },
+        "considerations": {
+          "ethicalConsiderations": [{ "name": "not imported" }]
+        }
+      }
+    },
+    {
+      "bom-ref": "component-training-data",
+      "type": "data",
+      "publisher": "Example Inc.",
+      "name": "Speech Training Data",
+      "data": [{ "type": "dataset", "classification": "public" }]
+    }
+  ],
+  "vulnerabilities": [{ "id": "CVE-0000-0000" }]
+}"#
+    }
+
+    fn fixture_with_two_models() -> &'static str {
+        r#"{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "components": [
+    {
+      "bom-ref": "component-primary-model",
+      "type": "machine-learning-model",
+      "name": "primary-model"
+    },
+    {
+      "bom-ref": "component-secondary-model",
+      "type": "machine-learning-model",
+      "name": "secondary-model"
+    }
+  ]
+}"#
+    }
+}

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -1,3 +1,4 @@
+pub mod cyclonedx_mlbom_model;
 pub mod diff;
 pub mod lint;
 pub mod list;
@@ -87,6 +88,9 @@ pub struct EvidenceImportArgs {
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum EvidenceImportCmd {
+    /// Import one CycloneDX ML-BOM machine-learning-model component receipt
+    #[command(name = "cyclonedx-mlbom-model")]
+    CycloneDxMlBomModel(cyclonedx_mlbom_model::CycloneDxMlBomModelArgs),
     /// Import bounded OpenFeature boolean EvaluationDetails decision artifacts
     #[command(name = "openfeature-details")]
     OpenFeatureDetails(openfeature_details::OpenFeatureDetailsArgs),
@@ -114,6 +118,9 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
 
 fn cmd_import(args: EvidenceImportArgs) -> Result<i32> {
     match args.cmd {
+        EvidenceImportCmd::CycloneDxMlBomModel(a) => {
+            cyclonedx_mlbom_model::cmd_cyclonedx_mlbom_model(a)
+        }
         EvidenceImportCmd::OpenFeatureDetails(a) => openfeature_details::cmd_openfeature_details(a),
         EvidenceImportCmd::PromptfooJsonl(a) => promptfoo_jsonl::cmd_promptfoo_jsonl(a),
     }

--- a/crates/assay-cli/tests/evidence_test.rs
+++ b/crates/assay-cli/tests/evidence_test.rs
@@ -221,6 +221,95 @@ fn test_openfeature_imported_decision_receipts_verify_and_feed_trust_basis_gener
 }
 
 #[test]
+fn test_cyclonedx_mlbom_model_receipts_verify_and_feed_trust_basis_generation() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("bom.cdx.json");
+    let bundle = dir.path().join("cyclonedx-model-receipts.tar.gz");
+    fs::write(
+        &input,
+        r#"{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "components": [
+    {
+      "bom-ref": "pkg:huggingface/example/model@abc123",
+      "type": "machine-learning-model",
+      "publisher": "Example Inc.",
+      "name": "example-model",
+      "version": "1.0.0",
+      "purl": "pkg:huggingface/example/model@abc123",
+      "modelCard": {
+        "bom-ref": "model-card-example-model",
+        "modelParameters": {
+          "datasets": [{ "ref": "component-training-data" }]
+        }
+      }
+    },
+    {
+      "bom-ref": "component-training-data",
+      "type": "data",
+      "name": "Training Data"
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("import")
+        .arg("cyclonedx-mlbom-model")
+        .arg("--input")
+        .arg(&input)
+        .arg("--bundle-out")
+        .arg(&bundle)
+        .arg("--source-artifact-ref")
+        .arg("bom.cdx.json")
+        .arg("--run-id")
+        .arg("cyclonedx_trust_basis")
+        .arg("--import-time")
+        .arg("2026-04-28T12:00:00Z")
+        .assert()
+        .success();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("verify")
+        .arg(&bundle)
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("generate")
+        .arg(&bundle)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claims = json["claims"].as_array().unwrap();
+    assert_eq!(
+        claims.len(),
+        8,
+        "P43 does not add an inventory-specific Trust Basis claim yet"
+    );
+    assert_eq!(claim(claims, "bundle_verified")["level"], "verified");
+    assert_eq!(
+        claim(claims, "external_eval_receipt_boundary_visible")["level"],
+        "absent",
+        "CycloneDX ML-BOM model receipts are inventory receipts, not external eval receipts"
+    );
+}
+
+#[test]
 fn test_evidence_export_deterministic() {
     let dir = tempdir().unwrap();
     let profile_path = dir.path().join("profile.yaml");

--- a/docs/architecture/PLAN-P43-CYCLONEDX-MLBOM-MODEL-COMPONENT-RECEIPT-IMPORT-2026q2.md
+++ b/docs/architecture/PLAN-P43-CYCLONEDX-MLBOM-MODEL-COMPONENT-RECEIPT-IMPORT-2026q2.md
@@ -1,0 +1,201 @@
+# PLAN — P43 CycloneDX ML-BOM Model Component Receipt Import
+
+- **Date:** 2026-04-28
+- **Owner:** Assay maintainers
+- **Status:** execution slice
+- **Scope:** Turn one selected CycloneDX ML-BOM `machine-learning-model`
+  component into one portable Assay inventory receipt, without importing full
+  BOM, model-card, dataset, graph, vulnerability, license, or compliance truth.
+- **Target repo:** `Rul1an/assay`
+- **Depends on:** P31-P34, P41
+
+## One-line goal
+
+Turn one selected CycloneDX ML-BOM `machine-learning-model` component into one
+portable Assay inventory receipt.
+
+## 1. Why this slice exists
+
+P31 proved eval outcome receipts with Promptfoo. P41 proved runtime decision
+receipts with OpenFeature. P43 opens the third family: inventory and
+provenance-adjacent receipts.
+
+CycloneDX ML-BOM is a strong next seam because it already names AI/ML inventory
+surfaces: models, datasets, dependencies, model cards, and provenance. That
+surface is intentionally rich. P43 deliberately does not become a BOM viewer or
+compliance layer. It imports one model-component boundary and preserves a digest
+link to the richer source BOM.
+
+This is not CycloneDX support in the broad sense. It is an Assay-side compiler
+lane over one bounded model-component inventory surface.
+
+## 2. Layering
+
+The stack boundary is:
+
+```text
+CycloneDX ML-BOM JSON
+  -> selected components[] machine-learning-model entry
+  -> assay evidence import cyclonedx-mlbom-model
+  -> Assay EvidenceEvent receipt bundle
+  -> evidence verify / trust-basis generate
+```
+
+Assay owns receipt reduction and bundle semantics. CycloneDX remains the BOM
+standard and source artifact context, not the Assay evidence contract.
+
+Harness is intentionally out of scope for P43. Harness may later provide a
+recipe over Trust Basis artifacts, but it must not parse CycloneDX, inspect
+receipt payloads, or define inventory drift semantics.
+
+## 3. Scope
+
+P43 v1 imports exactly one bounded path:
+
+- one CycloneDX JSON BOM
+- one selected `components[]` entry
+- `component.type = "machine-learning-model"`
+- one Assay EvidenceEvent receipt
+
+If the BOM has exactly one model component, the importer may select it. If the
+BOM has multiple model components, `--bom-ref` is required. If `--bom-ref` does
+not match a model component, the importer fails closed.
+
+## 4. Input surface
+
+P43 consumes CycloneDX JSON BOM files where the selected model is a component:
+
+```json
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "components": [
+    {
+      "bom-ref": "pkg:huggingface/example/model@abc123",
+      "type": "machine-learning-model",
+      "publisher": "Example Inc.",
+      "name": "example-model",
+      "version": "1.0.0",
+      "purl": "pkg:huggingface/example/model@abc123",
+      "modelCard": {
+        "bom-ref": "model-card-example-model",
+        "modelParameters": {
+          "datasets": [{ "ref": "component-training-data" }]
+        }
+      }
+    }
+  ]
+}
+```
+
+The importer does not claim that all CycloneDX ML-BOM authoring patterns are in
+scope. In particular, P43 v1 does not import `metadata.component` subject BOMs
+or expand BOM graphs. Those may become separate lanes if there is a clear small
+surface.
+
+## 5. Receipt v1 thesis
+
+The receipt body is an Assay EvidenceEvent payload:
+
+```json
+{
+  "schema": "assay.receipt.cyclonedx.mlbom-model-component.v1",
+  "source_system": "cyclonedx",
+  "source_surface": "bom.components[type=machine-learning-model]",
+  "source_artifact_ref": "bom.cdx.json",
+  "source_artifact_digest": "sha256:...",
+  "reducer_version": "assay-cyclonedx-mlbom-model-component@0.1.0",
+  "imported_at": "2026-04-28T12:00:00Z",
+  "model_component": {
+    "bom_ref": "pkg:huggingface/example/model@abc123",
+    "name": "example-model",
+    "version": "1.0.0",
+    "publisher": "Example Inc.",
+    "purl": "pkg:huggingface/example/model@abc123",
+    "dataset_refs": ["component-training-data"],
+    "model_card_refs": ["model-card-example-model"]
+  }
+}
+```
+
+Optional fields are omitted when absent or null. The receipt remains an
+inventory receipt. It does not become a model card, dataset card, full BOM, or
+AI governance declaration.
+
+## 6. Field rules
+
+`model_component.bom_ref` is required. It identifies the selected component
+inside the BOM only. It is not proof that the referenced package, model, or
+repository exists.
+
+`model_component.name` is required. It is the component name carried by the BOM.
+
+`model_component.version`, `publisher`, and `purl` are optional bounded strings
+when naturally present on the selected component. The importer must not invent
+or resolve identity from external systems.
+
+`model_component.dataset_refs` are optional bounded refs taken from
+`modelCard.modelParameters.datasets[].ref`. They are refs only. The importer
+does not expand dataset components or import dataset bodies.
+
+`model_component.model_card_refs` are optional bounded refs taken from
+`modelCard.bom-ref`. They are refs only. The importer does not import the
+`modelCard` body.
+
+## 7. Strict exclusions
+
+P43 v1 excludes:
+
+- full BOM contents
+- `metadata.component` subject import
+- dependency graphs, compositions, and BOM-Link traversal
+- vulnerabilities, VEX, licenses, and legal conclusions
+- pedigree, ancestors, and lineage graph expansion
+- full `modelCard` bodies
+- dataset component bodies and dataset contents
+- performance metrics and quantitative analysis
+- ethical, fairness, limitation, and environmental sections
+- network dereferencing or URL resolution
+- compliance, approval, safety, security, or model-correctness claims
+
+Those fields may be important in a CycloneDX ML-BOM. P43 leaves them in the
+source artifact and binds to that artifact by digest.
+
+## 8. Trust Basis posture
+
+P43 does not add an inventory-specific Trust Basis claim.
+
+The first slice proves that CycloneDX model-component receipts are:
+
+- bundleable
+- verifiable
+- source-digest-bound
+- readable by the Trust Basis path
+
+A later slice may add a claim such as
+`external_inventory_receipt_boundary_visible`, but only after the receipt
+contract has landed and the claim semantics are narrow enough to avoid
+compliance or model-truth overclaiming.
+
+## 9. Acceptance criteria
+
+- `assay evidence import cyclonedx-mlbom-model` writes a verifiable bundle.
+- Exactly one selected model component becomes exactly one receipt event.
+- Multiple model components without `--bom-ref` fail closed.
+- A missing or non-model `--bom-ref` fails closed.
+- Full `modelCard`, dataset body, vulnerability, license, and pedigree content
+  do not appear in the receipt payload.
+- The receipt type is registered as experimental in Evidence Contract v1.
+- CLI docs and an example fixture explain the boundary.
+
+## 10. Follow-ups
+
+P44 should live in Assay Harness as a recipe over existing contracts:
+
+```text
+CycloneDX ML-BOM -> Assay model receipt bundle -> Trust Basis -> diff -> Harness gate/report
+```
+
+P44 must not define model-version or dataset-ref drift by parsing receipts in
+Harness. If inventory drift becomes product-critical, Assay should first define
+an inventory diff or inventory Trust Basis claim contract.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -54,6 +54,7 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [PLAN — P33 External Eval Receipt Trust Basis Claim (Q2 2026)](./PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) — execution slice that adds one bounded Trust Basis claim for supported external evaluation receipt boundaries, starting with Promptfoo assertion-component receipts
 - [PLAN — P34 Trust Basis Diff Gate (Q2 2026)](./PLAN-P34-TRUST-BASIS-DIFF-GATE-2026q2.md) — execution slice that compares canonical Trust Basis artifacts for claim-level regressions without parsing Promptfoo JSONL or external eval payloads
 - [PLAN — P41 OpenFeature EvaluationDetails Decision Receipt Import (Q2 2026)](./PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md) — execution slice that imports bounded boolean OpenFeature decision details as portable Assay receipts, not provider config, targeting, metadata, or application correctness truth
+- [PLAN — P43 CycloneDX ML-BOM Model Component Receipt Import (Q2 2026)](./PLAN-P43-CYCLONEDX-MLBOM-MODEL-COMPONENT-RECEIPT-IMPORT-2026q2.md) — execution slice that imports one selected CycloneDX `machine-learning-model` component as a portable inventory receipt, not full BOM, model-card, dataset, graph, or compliance truth
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 
 ## Active RFCs

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -12,6 +12,68 @@ assay evidence <COMMAND> [OPTIONS]
 
 ---
 
+## CycloneDX ML-BOM Model Import
+
+Import one selected CycloneDX ML-BOM `machine-learning-model` component into a
+verifiable Assay evidence bundle:
+
+```bash
+assay evidence import cyclonedx-mlbom-model \
+  --input bom.cdx.json \
+  --bundle-out cyclonedx-model-receipt.tar.gz \
+  --source-artifact-ref bom.cdx.json
+```
+
+The importer is intentionally strict in v1:
+
+- input must be CycloneDX JSON with `bomFormat = CycloneDX`
+- model components must live in `components[]`
+- the selected component must have `type = machine-learning-model`
+- the selected component must have bounded `bom-ref` and `name`
+- if multiple model components exist, `--bom-ref` is required
+- full BOM graphs, `modelCard` bodies, dataset bodies, vulnerabilities,
+  licenses, pedigree, metrics, and fairness/ethics sections are excluded
+
+The importer first computes `source_artifact_digest` over the full BOM file,
+then reduces the selected model component. Receipts stay small while still
+binding back to the exact source artifact bytes.
+
+The receipt is an inventory-boundary artifact. It does not mean the model is
+safe, approved, licensed, compliant, vulnerable or non-vulnerable, fair, or
+correct. It also does not import full CycloneDX BOM truth into Assay.
+
+The output bundle can be verified with:
+
+```bash
+assay evidence verify cyclonedx-model-receipt.tar.gz
+```
+
+The same bundle can feed the Trust Basis compiler:
+
+```bash
+assay trust-basis generate cyclonedx-model-receipt.tar.gz --out cyclonedx-model.trust-basis.json
+```
+
+P43 does not add an inventory-specific Trust Basis claim yet. The first
+CycloneDX compiler slice proves the receipt bundle is bundleable, verifiable,
+and readable by the Trust Basis path.
+
+Use `--bom-ref <REF>` when the BOM has multiple `machine-learning-model`
+components. Use `--import-time <RFC3339>` for deterministic fixture generation.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--input <PATH>` | CycloneDX JSON BOM artifact file |
+| `--bundle-out <PATH>` | Output Assay evidence bundle path |
+| `--bom-ref <REF>` | Select a `machine-learning-model` component by `bom-ref` |
+| `--source-artifact-ref <REF>` | Reviewer-safe source artifact reference stored in receipts |
+| `--run-id <ID>` | Assay import run id used for receipt provenance and event ids |
+| `--import-time <RFC3339>` | Deterministic import timestamp override |
+
+---
+
 ## OpenFeature Details Import
 
 Import bounded OpenFeature boolean `EvaluationDetails` artifacts into a
@@ -141,8 +203,10 @@ To compare the resulting Trust Basis artifact against another run, use
 
 - [Evidence Contract v1](../../spec/EVIDENCE-CONTRACT-v1.md)
 - [Trust Basis CLI](./trust-basis.md)
+- [CycloneDX ML-BOM Model Component evidence example](../../../examples/cyclonedx-mlbom-model-component-evidence/README.md)
 - [OpenFeature EvaluationDetails evidence example](../../../examples/openfeature-evaluation-details-evidence/README.md)
 - [Promptfoo assertion grading-result example](../../../examples/promptfoo-assertion-grading-result-evidence/README.md)
 - [From Promptfoo JSONL to Evidence Receipts](../../notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md)
+- [P43 CycloneDX ML-BOM model component receipt import plan](../../architecture/PLAN-P43-CYCLONEDX-MLBOM-MODEL-COMPONENT-RECEIPT-IMPORT-2026q2.md)
 - [P41 OpenFeature decision receipt import plan](../../architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md)
 - [P31 Promptfoo receipt import plan](../../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md)

--- a/docs/spec/EVIDENCE-CONTRACT-v1.md
+++ b/docs/spec/EVIDENCE-CONTRACT-v1.md
@@ -96,6 +96,7 @@ This table lists event types for Assay Evidence Spec v1.x (bundle schema_version
 | assay.sandbox.degraded | stable | Operational integrity | [ADR-006 §3.C](../architecture/ADR-006-Evidence-Contract.md#payload-assay-sandbox-degraded) | verify_strict_test::test_sandbox_degraded_stable_payload_conformance |
 | assay.receipt.promptfoo.assertion_component.v1 | experimental | Promptfoo CLI JSONL assertion component receipt | [PLAN-P31 §5-§6](../architecture/PLAN-P31-PROMPTFOO-JSONL-COMPONENT-RESULT-RECEIPT-IMPORT-2026q2.md#5-receipt-v1-thesis) | promptfoo_jsonl::tests::import_writes_verifiable_bundle_without_raw_payloads |
 | assay.receipt.openfeature.evaluation_details.v1 | experimental | OpenFeature boolean EvaluationDetails decision receipt | [PLAN-P41 §5-§6](../architecture/PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md#5-receipt-v1-thesis) | openfeature_details::tests::import_writes_verifiable_boolean_decision_bundle |
+| assay.receipt.cyclonedx.mlbom_model_component.v1 | experimental | CycloneDX ML-BOM model component inventory receipt | [PLAN-P43 §5-§6](../architecture/PLAN-P43-CYCLONEDX-MLBOM-MODEL-COMPONENT-RECEIPT-IMPORT-2026q2.md#5-receipt-v1-thesis) | cyclonedx_mlbom_model::tests::import_writes_verifiable_model_component_bundle_without_bodies |
 
 ## 5. Deprecation policy
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,15 @@ Ready-to-use examples to get started with Assay.
 Wrap an MCP server with policy enforcement in under 2 minutes.
 See ALLOW/DENY decisions for every tool call.
 
+## Inventory examples
+
+### [CycloneDX ML-BOM Model Component Evidence](./cyclonedx-mlbom-model-component-evidence)
+Import one selected CycloneDX `machine-learning-model` component into a
+verifiable Assay inventory receipt bundle.
+**Focus**: model-component-first seam, bounded model identity and refs only,
+no imported full BOM graph, modelCard body, dataset body, vulnerabilities, or
+compliance truth.
+
 ## Evaluation examples
 
 ### [Phoenix Span Annotation Evidence](./phoenix-span-annotation-evidence)

--- a/examples/cyclonedx-mlbom-model-component-evidence/README.md
+++ b/examples/cyclonedx-mlbom-model-component-evidence/README.md
@@ -1,0 +1,67 @@
+# CycloneDX ML-BOM Model Component Evidence
+
+This example shows the P43 inventory receipt lane:
+
+```text
+CycloneDX ML-BOM JSON
+  -> assay evidence import cyclonedx-mlbom-model
+  -> Assay model-component inventory receipt bundle
+  -> assay evidence verify
+  -> assay trust-basis generate
+```
+
+The example is intentionally small. It treats one selected CycloneDX
+`machine-learning-model` component as a bounded inventory surface, not as full
+BOM truth.
+
+## Run
+
+```bash
+assay evidence import cyclonedx-mlbom-model \
+  --input examples/cyclonedx-mlbom-model-component-evidence/fixtures/model.cdx.json \
+  --bundle-out /tmp/cyclonedx-model-receipt.tar.gz \
+  --source-artifact-ref model.cdx.json \
+  --import-time 2026-04-28T12:00:00Z \
+  --run-id cyclonedx_model_example
+
+assay evidence verify /tmp/cyclonedx-model-receipt.tar.gz
+assay trust-basis generate /tmp/cyclonedx-model-receipt.tar.gz
+```
+
+## Boundary
+
+P43 v1 imports one `components[]` entry with
+`type = "machine-learning-model"`.
+
+If the BOM has exactly one model component, the importer can select it. If the
+BOM has more than one model component, pass `--bom-ref` so the receipt does not
+silently guess which model matters.
+
+The receipt may include compact model identity fields plus bounded refs:
+
+- `bom_ref`
+- `name`
+- optional `version`
+- optional `publisher`
+- optional `purl`
+- optional `dataset_refs`
+- optional `model_card_refs`
+
+The importer does not dereference refs, resolve network URLs, expand dataset
+components, or import full `modelCard` bodies.
+
+## Not Imported
+
+The v1 receipt excludes:
+
+- full BOM contents
+- dependency graphs and composition
+- vulnerabilities and licenses
+- pedigree and ancestors
+- full `modelCard` bodies
+- dataset component bodies
+- model metrics
+- ethical, fairness, and limitation sections
+
+Those fields are important in CycloneDX ML-BOMs. P43 simply keeps the Assay
+receipt unit small enough to review and portable enough to bundle.

--- a/examples/cyclonedx-mlbom-model-component-evidence/fixtures/model.cdx.json
+++ b/examples/cyclonedx-mlbom-model-component-evidence/fixtures/model.cdx.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "serialNumber": "urn:uuid:11111111-2222-3333-4444-555555555555",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "pkg:huggingface/example/checkout-risk-model@abc123",
+      "type": "machine-learning-model",
+      "publisher": "Example Inc.",
+      "name": "checkout-risk-model",
+      "version": "1.0.0",
+      "purl": "pkg:huggingface/example/checkout-risk-model@abc123",
+      "description": "Description stays in the source BOM and is not imported into the receipt.",
+      "modelCard": {
+        "bom-ref": "model-card-checkout-risk-model",
+        "modelParameters": {
+          "datasets": [
+            {
+              "ref": "component-checkout-risk-training-data"
+            }
+          ]
+        },
+        "quantitativeAnalysis": {
+          "performanceMetrics": [
+            {
+              "type": "accuracy",
+              "value": "0.91"
+            }
+          ]
+        },
+        "considerations": {
+          "ethicalConsiderations": [
+            {
+              "name": "Example consideration retained only in the source BOM."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "bom-ref": "component-checkout-risk-training-data",
+      "type": "data",
+      "publisher": "Example Inc.",
+      "name": "Checkout Risk Training Data",
+      "version": "2026-04-28",
+      "data": [
+        {
+          "type": "dataset",
+          "classification": "internal"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/cyclonedx-mlbom-model-component-evidence/fixtures/multiple-models.cdx.json
+++ b/examples/cyclonedx-mlbom-model-component-evidence/fixtures/multiple-models.cdx.json
@@ -1,0 +1,16 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "components": [
+    {
+      "bom-ref": "component-primary-model",
+      "type": "machine-learning-model",
+      "name": "primary-model"
+    },
+    {
+      "bom-ref": "component-secondary-model",
+      "type": "machine-learning-model",
+      "name": "secondary-model"
+    }
+  ]
+}

--- a/examples/cyclonedx-mlbom-model-component-evidence/fixtures/no-model.cdx.json
+++ b/examples/cyclonedx-mlbom-model-component-evidence/fixtures/no-model.cdx.json
@@ -1,0 +1,11 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "components": [
+    {
+      "bom-ref": "component-application",
+      "type": "application",
+      "name": "example-application"
+    }
+  ]
+}


### PR DESCRIPTION
What changed

Adds P43: a bounded CycloneDX ML-BOM model-component inventory receipt importer in Assay core.

This PR includes:

- `assay evidence import cyclonedx-mlbom-model`
- one selected `components[]` entry with `type = "machine-learning-model"` -> one Assay EvidenceEvent receipt
- `--bom-ref` selection, required when a BOM contains multiple model components
- full-source `source_artifact_digest` binding before reduction
- refs-only handling for dataset/model-card refs; no dereferencing or component expansion
- fail-closed tests for ambiguous selection, missing/non-model `--bom-ref`, and no model components
- docs, examples, and an experimental Evidence Contract registry row

Why

Promptfoo proved eval outcome receipts. OpenFeature proved runtime decision receipts. CycloneDX ML-BOM gives Assay a third evidence family: inventory/provenance receipts.

The boundary stays deliberately small. This is not broad CycloneDX support, an AI-BOM integration, a model-card importer, or a compliance claim. It is one selected model component in, one portable inventory receipt out.

Boundary

This does not import full BOM contents, `metadata.component` subject BOMs, dependency graphs, BOM-Link traversal, vulnerabilities, licenses, pedigree, full `modelCard` bodies, dataset bodies, metrics, fairness/ethics sections, or any model safety/compliance truth.

P43 also does not add an inventory-specific Trust Basis claim yet. It proves bundleability, verification, source-digest binding, and Trust Basis readability first.

Validation

Ran locally:

```bash
cargo fmt --check
git diff --check
cargo test -p assay-cli cyclonedx_mlbom_model -- --nocapture
cargo clippy -p assay-cli --all-targets -- -D warnings
target/debug/assay evidence import cyclonedx-mlbom-model --input examples/cyclonedx-mlbom-model-component-evidence/fixtures/model.cdx.json --bundle-out /tmp/p43-cyclonedx-model-receipt.tar.gz --source-artifact-ref model.cdx.json --import-time 2026-04-28T12:00:00Z --run-id p43_cyclonedx_fixture
target/debug/assay evidence verify /tmp/p43-cyclonedx-model-receipt.tar.gz
target/debug/assay trust-basis generate /tmp/p43-cyclonedx-model-receipt.tar.gz --out /tmp/p43-cyclonedx-model.trust-basis.json
target/debug/assay evidence import cyclonedx-mlbom-model --input examples/cyclonedx-mlbom-model-component-evidence/fixtures/multiple-models.cdx.json --bundle-out /tmp/p43-ambiguous.tar.gz --import-time 2026-04-28T12:00:00Z
```

The ambiguous multiple-model fixture fails closed as expected.

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.
