### PR TITLE
P45: add inventory receipt Trust Basis claim

### DIFF
--- a/crates/assay-cli/tests/evidence_test.rs
+++ b/crates/assay-cli/tests/evidence_test.rs
@@ -139,14 +139,19 @@ fn test_promptfoo_imported_receipts_feed_trust_basis_generation() {
     let claims = json["claims"].as_array().unwrap();
     assert_eq!(
         claims.len(),
-        8,
-        "P33 adds one bounded external receipt boundary claim"
+        9,
+        "P45 keeps all frozen Trust Basis claims present"
     );
     assert_eq!(claim(claims, "bundle_verified")["level"], "verified");
     assert_eq!(
         claim(claims, "external_eval_receipt_boundary_visible")["level"],
         "verified",
         "Promptfoo receipts should now surface the bounded external receipt boundary claim"
+    );
+    assert_eq!(
+        claim(claims, "external_inventory_receipt_boundary_visible")["level"],
+        "absent",
+        "Promptfoo receipts are eval receipts, not inventory receipts"
     );
 }
 
@@ -209,14 +214,19 @@ fn test_openfeature_imported_decision_receipts_verify_and_feed_trust_basis_gener
     let claims = json["claims"].as_array().unwrap();
     assert_eq!(
         claims.len(),
-        8,
-        "P41 does not add a Trust Basis claim yet; it proves bundle/readability first"
+        9,
+        "P45 keeps all frozen Trust Basis claims present"
     );
     assert_eq!(claim(claims, "bundle_verified")["level"], "verified");
     assert_eq!(
         claim(claims, "external_eval_receipt_boundary_visible")["level"],
         "absent",
         "OpenFeature decision receipts are not external eval receipts"
+    );
+    assert_eq!(
+        claim(claims, "external_inventory_receipt_boundary_visible")["level"],
+        "absent",
+        "OpenFeature decision receipts are not inventory receipts"
     );
 }
 
@@ -298,14 +308,19 @@ fn test_cyclonedx_mlbom_model_receipts_verify_and_feed_trust_basis_generation() 
     let claims = json["claims"].as_array().unwrap();
     assert_eq!(
         claims.len(),
-        8,
-        "P43 does not add an inventory-specific Trust Basis claim yet"
+        9,
+        "P45 adds one bounded external inventory receipt boundary claim"
     );
     assert_eq!(claim(claims, "bundle_verified")["level"], "verified");
     assert_eq!(
         claim(claims, "external_eval_receipt_boundary_visible")["level"],
         "absent",
         "CycloneDX ML-BOM model receipts are inventory receipts, not external eval receipts"
+    );
+    assert_eq!(
+        claim(claims, "external_inventory_receipt_boundary_visible")["level"],
+        "verified",
+        "CycloneDX ML-BOM model receipts should surface the bounded inventory receipt boundary claim"
     );
 }
 

--- a/crates/assay-cli/tests/trust_basis_test.rs
+++ b/crates/assay-cli/tests/trust_basis_test.rs
@@ -117,7 +117,7 @@ fn trust_basis_generate_stdout_emits_all_frozen_claims() {
     let claims = json["claims"].as_array().unwrap();
     assert_eq!(
         claims.len(),
-        8,
+        9,
         "all frozen claims should always be present"
     );
 
@@ -145,6 +145,10 @@ fn trust_basis_generate_stdout_emits_all_frozen_claims() {
     );
     assert_eq!(
         claim(claims, "external_eval_receipt_boundary_visible")["level"],
+        "absent"
+    );
+    assert_eq!(
+        claim(claims, "external_inventory_receipt_boundary_visible")["level"],
         "absent"
     );
 }

--- a/crates/assay-cli/tests/trustcard_test.rs
+++ b/crates/assay-cli/tests/trustcard_test.rs
@@ -66,14 +66,14 @@ fn trustcard_generate_writes_json_and_md_matching_trust_basis_claims() {
     let card_json: serde_json::Value =
         serde_json::from_slice(&fs::read(out_dir.join("trustcard.json")).unwrap()).unwrap();
 
-    assert_eq!(card_json["schema_version"], json!(3));
+    assert_eq!(card_json["schema_version"], json!(4));
     assert_eq!(card_json["claims"], basis_json["claims"]);
 
     let claims = card_json["claims"].as_array().expect("claims array");
     assert_eq!(
         claims.len(),
-        8,
-        "trustcard must carry exactly eight frozen claims"
+        9,
+        "trustcard must carry exactly nine frozen claims"
     );
     let expected_ids = [
         "bundle_verified",
@@ -83,6 +83,7 @@ fn trustcard_generate_writes_json_and_md_matching_trust_basis_claims() {
         "authorization_context_visible",
         "containment_degradation_observed",
         "external_eval_receipt_boundary_visible",
+        "external_inventory_receipt_boundary_visible",
         "applied_pack_findings_present",
     ];
     let ids: Vec<_> = claims

--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -19,6 +19,7 @@ pub enum TrustClaimId {
     AuthorizationContextVisible,
     ContainmentDegradationObserved,
     ExternalEvalReceiptBoundaryVisible,
+    ExternalInventoryReceiptBoundaryVisible,
     AppliedPackFindingsPresent,
 }
 
@@ -39,6 +40,7 @@ pub enum TrustClaimSource {
     CanonicalDecisionEvidence,
     CanonicalEventPresence,
     ExternalEvidenceReceipt,
+    ExternalInventoryReceipt,
     PackExecutionResults,
 }
 
@@ -51,6 +53,7 @@ pub enum TrustClaimBoundary {
     SupportedAuthProjectedFlowsOnly,
     SupportedContainmentFallbackPathsOnly,
     SupportedExternalEvalReceiptEventsOnly,
+    SupportedExternalInventoryReceiptEventsOnly,
     ProofSurfacesOnly,
     PackExecutionOnly,
 }
@@ -411,6 +414,13 @@ pub fn generate_trust_basis<R: Read>(
                 note: None,
             },
             TrustBasisClaim {
+                id: TrustClaimId::ExternalInventoryReceiptBoundaryVisible,
+                level: classify_external_inventory_receipt_boundary(&events),
+                source: TrustClaimSource::ExternalInventoryReceipt,
+                boundary: TrustClaimBoundary::SupportedExternalInventoryReceiptEventsOnly,
+                note: None,
+            },
+            TrustBasisClaim {
                 id: TrustClaimId::AppliedPackFindingsPresent,
                 level: classify_pack_findings(lint_result.as_ref()),
                 source: TrustClaimSource::PackExecutionResults,
@@ -485,6 +495,17 @@ const PROMPTFOO_RECEIPT_SOURCE_SYSTEM: &str = "promptfoo";
 const PROMPTFOO_RECEIPT_SOURCE_SURFACE: &str = "cli-jsonl.gradingResult.componentResults";
 const PROMPTFOO_RECEIPT_REDUCER_PREFIX: &str = "assay-promptfoo-jsonl-component-result@";
 const PROMPTFOO_MAX_REASON_CHARS: usize = 160;
+const SOURCE_ARTIFACT_REF_MAX_CHARS: usize = 240;
+const CYCLONEDX_MLBOM_MODEL_RECEIPT_EVENT_TYPE: &str =
+    "assay.receipt.cyclonedx.mlbom_model_component.v1";
+const CYCLONEDX_MLBOM_MODEL_RECEIPT_SCHEMA: &str =
+    "assay.receipt.cyclonedx.mlbom-model-component.v1";
+const CYCLONEDX_MLBOM_MODEL_RECEIPT_SOURCE_SYSTEM: &str = "cyclonedx";
+const CYCLONEDX_MLBOM_MODEL_RECEIPT_SOURCE_SURFACE: &str =
+    "bom.components[type=machine-learning-model]";
+const CYCLONEDX_MLBOM_MODEL_RECEIPT_REDUCER_PREFIX: &str = "assay-cyclonedx-mlbom-model-component@";
+const INVENTORY_BOUNDARY_STRING_MAX_CHARS: usize = 240;
+const INVENTORY_REF_MAX_COUNT: usize = 32;
 
 fn classify_external_eval_receipt_boundary(events: &[EvidenceEvent]) -> TrustClaimLevel {
     if events.iter().any(is_supported_promptfoo_receipt) {
@@ -523,7 +544,9 @@ fn is_supported_promptfoo_receipt(event: &EvidenceEvent) -> bool {
     string_field(payload, "schema") == Some(PROMPTFOO_RECEIPT_SCHEMA)
         && string_field(payload, "source_system") == Some(PROMPTFOO_RECEIPT_SOURCE_SYSTEM)
         && string_field(payload, "source_surface") == Some(PROMPTFOO_RECEIPT_SOURCE_SURFACE)
-        && non_empty_string_field(payload, "source_artifact_ref")
+        && string_field(payload, "source_artifact_ref")
+            .map(is_bounded_source_artifact_ref)
+            .unwrap_or(false)
         && string_field(payload, "source_artifact_digest")
             .map(is_sha256_digest)
             .unwrap_or(false)
@@ -541,17 +564,71 @@ fn is_supported_promptfoo_receipt(event: &EvidenceEvent) -> bool {
             .unwrap_or(false)
 }
 
+fn classify_external_inventory_receipt_boundary(events: &[EvidenceEvent]) -> TrustClaimLevel {
+    if events
+        .iter()
+        .any(is_supported_cyclonedx_mlbom_model_receipt)
+    {
+        TrustClaimLevel::Verified
+    } else {
+        TrustClaimLevel::Absent
+    }
+}
+
+fn is_supported_cyclonedx_mlbom_model_receipt(event: &EvidenceEvent) -> bool {
+    if event.type_ != CYCLONEDX_MLBOM_MODEL_RECEIPT_EVENT_TYPE {
+        return false;
+    }
+
+    let Some(payload) = event.payload.as_object() else {
+        return false;
+    };
+    let allowed_fields = [
+        "schema",
+        "source_system",
+        "source_surface",
+        "source_artifact_ref",
+        "source_artifact_digest",
+        "reducer_version",
+        "imported_at",
+        "model_component",
+    ];
+    if payload
+        .keys()
+        .any(|key| !allowed_fields.contains(&key.as_str()))
+    {
+        return false;
+    }
+
+    string_field(payload, "schema") == Some(CYCLONEDX_MLBOM_MODEL_RECEIPT_SCHEMA)
+        && string_field(payload, "source_system")
+            == Some(CYCLONEDX_MLBOM_MODEL_RECEIPT_SOURCE_SYSTEM)
+        && string_field(payload, "source_surface")
+            == Some(CYCLONEDX_MLBOM_MODEL_RECEIPT_SOURCE_SURFACE)
+        && string_field(payload, "source_artifact_ref")
+            .map(is_bounded_source_artifact_ref)
+            .unwrap_or(false)
+        && string_field(payload, "source_artifact_digest")
+            .map(is_sha256_digest)
+            .unwrap_or(false)
+        && string_field(payload, "reducer_version")
+            .map(|value| value.starts_with(CYCLONEDX_MLBOM_MODEL_RECEIPT_REDUCER_PREFIX))
+            .unwrap_or(false)
+        && string_field(payload, "imported_at")
+            .map(is_utc_rfc3339)
+            .unwrap_or(false)
+        && payload
+            .get("model_component")
+            .and_then(|value| value.as_object())
+            .map(is_supported_cyclonedx_model_component)
+            .unwrap_or(false)
+}
+
 fn string_field<'a>(
     payload: &'a serde_json::Map<String, serde_json::Value>,
     key: &str,
 ) -> Option<&'a str> {
     payload.get(key).and_then(|value| value.as_str())
-}
-
-fn non_empty_string_field(payload: &serde_json::Map<String, serde_json::Value>, key: &str) -> bool {
-    string_field(payload, key)
-        .map(|value| !value.trim().is_empty())
-        .unwrap_or(false)
 }
 
 fn is_sha256_digest(value: &str) -> bool {
@@ -608,6 +685,86 @@ fn is_bounded_reason(reason: &str) -> bool {
         && !trimmed.contains('`')
         && !trimmed.contains('{')
         && !trimmed.contains('}')
+}
+
+fn is_supported_cyclonedx_model_component(
+    component: &serde_json::Map<String, serde_json::Value>,
+) -> bool {
+    let allowed_fields = [
+        "bom_ref",
+        "name",
+        "version",
+        "publisher",
+        "purl",
+        "dataset_refs",
+        "model_card_refs",
+    ];
+    if component
+        .keys()
+        .any(|key| !allowed_fields.contains(&key.as_str()))
+    {
+        return false;
+    }
+
+    string_field(component, "bom_ref")
+        .map(is_bounded_inventory_string)
+        .unwrap_or(false)
+        && string_field(component, "name")
+            .map(is_bounded_inventory_string)
+            .unwrap_or(false)
+        && optional_bounded_inventory_string_field(component, "version")
+        && optional_bounded_inventory_string_field(component, "publisher")
+        && optional_bounded_inventory_string_field(component, "purl")
+        && optional_inventory_ref_array_field(component, "dataset_refs")
+        && optional_inventory_ref_array_field(component, "model_card_refs")
+}
+
+fn optional_bounded_inventory_string_field(
+    payload: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> bool {
+    match payload.get(key) {
+        Some(value) => value
+            .as_str()
+            .map(is_bounded_inventory_string)
+            .unwrap_or(false),
+        None => true,
+    }
+}
+
+fn optional_inventory_ref_array_field(
+    payload: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> bool {
+    match payload.get(key) {
+        Some(serde_json::Value::Array(values)) => {
+            values.len() <= INVENTORY_REF_MAX_COUNT
+                && values.iter().all(|value| {
+                    value
+                        .as_str()
+                        .map(is_bounded_inventory_string)
+                        .unwrap_or(false)
+                })
+        }
+        Some(_) => false,
+        None => true,
+    }
+}
+
+fn is_bounded_inventory_string(value: &str) -> bool {
+    is_bounded_reviewer_string(value, INVENTORY_BOUNDARY_STRING_MAX_CHARS)
+}
+
+fn is_bounded_source_artifact_ref(value: &str) -> bool {
+    is_bounded_reviewer_string(value, SOURCE_ARTIFACT_REF_MAX_CHARS)
+}
+
+fn is_bounded_reviewer_string(value: &str, max_chars: usize) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && trimmed == value
+        && value.chars().count() <= max_chars
+        && !value.chars().any(char::is_control)
 }
 
 fn classify_pack_findings(lint_result: Option<&LintReportWithPacks>) -> TrustClaimLevel {
@@ -715,6 +872,34 @@ mod tests {
         payload
     }
 
+    fn cyclonedx_mlbom_model_receipt_payload(extra: serde_json::Value) -> serde_json::Value {
+        let mut payload = json!({
+            "schema": "assay.receipt.cyclonedx.mlbom-model-component.v1",
+            "source_system": "cyclonedx",
+            "source_surface": "bom.components[type=machine-learning-model]",
+            "source_artifact_ref": "bom.cdx.json",
+            "source_artifact_digest": format!("sha256:{}", "b".repeat(64)),
+            "reducer_version": "assay-cyclonedx-mlbom-model-component@0.1.0",
+            "imported_at": "2026-04-28T12:00:00Z",
+            "model_component": {
+                "bom_ref": "pkg:huggingface/example/model@abc123",
+                "name": "example-model",
+                "version": "1.0.0",
+                "publisher": "Example Inc.",
+                "purl": "pkg:huggingface/example/model@abc123",
+                "dataset_refs": ["component-training-data"],
+                "model_card_refs": ["model-card-example-model"]
+            }
+        });
+        if let Some(extra) = extra.as_object() {
+            let obj = payload.as_object_mut().expect("payload object");
+            for (key, value) in extra {
+                obj.insert(key.clone(), value.clone());
+            }
+        }
+        payload
+    }
+
     #[test]
     fn g3_authorization_claim_is_after_delegation_before_containment() {
         let bundle = make_bundle(vec![make_event(
@@ -731,7 +916,7 @@ mod tests {
         .expect("trust basis");
         let ids: Vec<_> = trust_basis.claims.iter().map(|c| c.id).collect();
         let pos = |id| ids.iter().position(|&x| x == id).expect("claim id");
-        assert_eq!(ids.len(), 8);
+        assert_eq!(ids.len(), 9);
         assert!(
             pos(TrustClaimId::DelegationContextVisible)
                 < pos(TrustClaimId::AuthorizationContextVisible)
@@ -801,6 +986,11 @@ mod tests {
                     TrustClaimBoundary::SupportedExternalEvalReceiptEventsOnly,
                 ),
                 (
+                    TrustClaimId::ExternalInventoryReceiptBoundaryVisible,
+                    TrustClaimSource::ExternalInventoryReceipt,
+                    TrustClaimBoundary::SupportedExternalInventoryReceiptEventsOnly,
+                ),
+                (
                     TrustClaimId::AppliedPackFindingsPresent,
                     TrustClaimSource::PackExecutionResults,
                     TrustClaimBoundary::PackExecutionOnly,
@@ -815,6 +1005,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 TrustClaimLevel::Verified,
+                TrustClaimLevel::Absent,
                 TrustClaimLevel::Absent,
                 TrustClaimLevel::Absent,
                 TrustClaimLevel::Absent,
@@ -980,6 +1171,169 @@ mod tests {
             claim(
                 &trust_basis,
                 TrustClaimId::ExternalEvalReceiptBoundaryVisible
+            )
+            .level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_detects_supported_external_inventory_receipt_boundary() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.receipt.cyclonedx.mlbom_model_component.v1",
+            "run_cyclonedx_receipt",
+            0,
+            cyclonedx_mlbom_model_receipt_payload(json!({})),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(
+                &trust_basis,
+                TrustClaimId::ExternalInventoryReceiptBoundaryVisible
+            )
+            .level,
+            TrustClaimLevel::Verified
+        );
+        assert_eq!(
+            claim(
+                &trust_basis,
+                TrustClaimId::ExternalEvalReceiptBoundaryVisible
+            )
+            .level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_rejects_inventory_receipt_boundary_when_model_card_body_leaks_in() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.receipt.cyclonedx.mlbom_model_component.v1",
+            "run_cyclonedx_raw_model_card",
+            0,
+            cyclonedx_mlbom_model_receipt_payload(json!({
+                "model_component": {
+                    "bom_ref": "pkg:huggingface/example/model@abc123",
+                    "name": "example-model",
+                    "modelCard": {
+                        "modelParameters": {
+                            "datasets": [{ "ref": "component-training-data" }]
+                        }
+                    }
+                }
+            })),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(
+                &trust_basis,
+                TrustClaimId::ExternalInventoryReceiptBoundaryVisible
+            )
+            .level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_rejects_inventory_receipt_boundary_when_digest_is_missing_or_bad() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.receipt.cyclonedx.mlbom_model_component.v1",
+            "run_cyclonedx_bad_digest",
+            0,
+            cyclonedx_mlbom_model_receipt_payload(json!({
+                "source_artifact_digest": "sha256:not-a-real-digest"
+            })),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(
+                &trust_basis,
+                TrustClaimId::ExternalInventoryReceiptBoundaryVisible
+            )
+            .level,
+            TrustClaimLevel::Absent
+        );
+    }
+
+    #[test]
+    fn trust_basis_rejects_inventory_receipt_boundary_when_source_ref_is_unbounded() {
+        for (case_name, source_artifact_ref) in [
+            ("control_char", "bom.cdx.json\nnext-line".to_string()),
+            ("too_long", "x".repeat(SOURCE_ARTIFACT_REF_MAX_CHARS + 1)),
+        ] {
+            let bundle = make_bundle(vec![make_event(
+                "assay.receipt.cyclonedx.mlbom_model_component.v1",
+                case_name,
+                0,
+                cyclonedx_mlbom_model_receipt_payload(json!({
+                    "source_artifact_ref": source_artifact_ref
+                })),
+            )]);
+
+            let trust_basis = generate_trust_basis(
+                Cursor::new(bundle),
+                VerifyLimits::default(),
+                TrustBasisOptions::default(),
+            )
+            .expect("trust basis should generate");
+
+            assert_eq!(
+                claim(
+                    &trust_basis,
+                    TrustClaimId::ExternalInventoryReceiptBoundaryVisible
+                )
+                .level,
+                TrustClaimLevel::Absent
+            );
+        }
+    }
+
+    #[test]
+    fn trust_basis_rejects_inventory_receipt_boundary_when_refs_are_expanded_objects() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.receipt.cyclonedx.mlbom_model_component.v1",
+            "run_cyclonedx_expanded_dataset",
+            0,
+            cyclonedx_mlbom_model_receipt_payload(json!({
+                "model_component": {
+                    "bom_ref": "pkg:huggingface/example/model@abc123",
+                    "name": "example-model",
+                    "dataset_refs": [{ "ref": "component-training-data", "name": "raw dataset body" }]
+                }
+            })),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        assert_eq!(
+            claim(
+                &trust_basis,
+                TrustClaimId::ExternalInventoryReceiptBoundaryVisible
             )
             .level,
             TrustClaimLevel::Absent

--- a/crates/assay-evidence/src/trust_card.rs
+++ b/crates/assay-evidence/src/trust_card.rs
@@ -6,8 +6,8 @@ use crate::trust_basis::{TrustBasis, TrustBasisClaim};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-/// Trust Card schema: `3` adds `external_eval_receipt_boundary_visible`.
-pub const TRUST_CARD_SCHEMA_VERSION: u32 = 3;
+/// Trust Card schema: `4` adds `external_inventory_receipt_boundary_visible`.
+pub const TRUST_CARD_SCHEMA_VERSION: u32 = 4;
 
 /// Markdown table cell when T1a leaves `note` empty (`None` or blank). Do not vary by test/renderer.
 pub const TRUST_CARD_NOTE_EMPTY_PLACEHOLDER: &str = "-";
@@ -120,7 +120,7 @@ mod tests {
     use std::io::Cursor;
 
     /// Must match `TrustBasis::claims` order from [`crate::trust_basis::generate_trust_basis`].
-    const FROZEN_TRUST_BASIS_CLAIM_ID_ORDER: [TrustClaimId; 8] = [
+    const FROZEN_TRUST_BASIS_CLAIM_ID_ORDER: [TrustClaimId; 9] = [
         TrustClaimId::BundleVerified,
         TrustClaimId::SigningEvidencePresent,
         TrustClaimId::ProvenanceBackedClaimsPresent,
@@ -128,6 +128,7 @@ mod tests {
         TrustClaimId::AuthorizationContextVisible,
         TrustClaimId::ContainmentDegradationObserved,
         TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+        TrustClaimId::ExternalInventoryReceiptBoundaryVisible,
         TrustClaimId::AppliedPackFindingsPresent,
     ];
 
@@ -234,7 +235,7 @@ mod tests {
     }
 
     #[test]
-    fn trust_card_json_always_exactly_eight_frozen_claim_ids_once_in_trust_basis_order() {
+    fn trust_card_json_always_exactly_nine_frozen_claim_ids_once_in_trust_basis_order() {
         let bundle = make_bundle(vec![make_event(
             "assay.process.exec",
             "run_seven",
@@ -249,7 +250,7 @@ mod tests {
         .expect("trust basis");
         let card = trust_basis_to_trust_card(&basis);
 
-        assert_eq!(card.claims.len(), 8);
+        assert_eq!(card.claims.len(), 9);
         let ids: Vec<TrustClaimId> = card.claims.iter().map(|c| c.id).collect();
         assert_eq!(ids, FROZEN_TRUST_BASIS_CLAIM_ID_ORDER);
     }
@@ -374,13 +375,13 @@ mod tests {
             .filter(|l| !l.contains("| --- |"))
             .count();
         assert_eq!(
-            table_rows, 8,
-            "schema 3 adds one external receipt row; no extra markdown table blocks"
+            table_rows, 9,
+            "schema 4 adds one external inventory receipt row; no extra markdown table blocks"
         );
     }
 
     #[test]
-    fn trust_card_schema_version_is_three() {
+    fn trust_card_schema_version_is_four() {
         let bundle = make_bundle(vec![make_event(
             "assay.process.exec",
             "run_schema",
@@ -394,11 +395,11 @@ mod tests {
         )
         .expect("trust basis");
         let card = trust_basis_to_trust_card(&basis);
-        assert_eq!(card.schema_version, 3);
+        assert_eq!(card.schema_version, 4);
         let v: serde_json::Value =
             serde_json::from_slice(&trust_card_to_canonical_json_bytes(&card).expect("json"))
                 .expect("parse");
-        assert_eq!(v["schema_version"], json!(3));
+        assert_eq!(v["schema_version"], json!(4));
     }
 
     #[test]

--- a/crates/assay-evidence/tests/h1_trust_kernel_alignment.rs
+++ b/crates/assay-evidence/tests/h1_trust_kernel_alignment.rs
@@ -88,7 +88,7 @@ fn h1_trust_card_matches_trust_basis_claims_and_frozen_top_level() {
     let card = trust_basis_to_trust_card(&tb);
 
     assert_eq!(card.schema_version, TRUST_CARD_SCHEMA_VERSION);
-    assert_eq!(card.claims.len(), 8);
+    assert_eq!(card.claims.len(), 9);
     assert_eq!(
         card.claims, tb.claims,
         "Trust Card must not reclassify claims"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -235,6 +235,7 @@ Closed lines on `main`:
 - **Supply chain and governance surfaces**: BYOS Phase 1, tool signing, GitHub Action v2/v2.1, mandate evidence, and starter/baseline pack infrastructure are shipped
 - **Evidence-as-a-product**: soak, closure, completeness, and the OTel bridge slices from ADR-025 are shipped
 - **External eval receipts**: P31-P39 are merged on `main` as the first evidence-portability lane for selected external eval outcomes, starting with Promptfoo assertion components and ending in Trust Basis diff / Harness reporting without importing full eval-run truth
+- **Inventory receipts**: P43/P45 add the first inventory/provenance receipt lane, starting with CycloneDX ML-BOM model components and a bounded Trust Basis boundary-visibility claim without importing full BOM, model-card, dataset, graph, or compliance truth
 - **Bounded claim waves**: `E1`, `G1`, `G2`, `P1`, `T1a`, `T1b`, `G3`, and the `3.2.3` release-line truth fix are shipped
 
 For detailed historical delivery records, see the relevant ADRs and companion docs:

--- a/docs/architecture/PLAN-P45-INVENTORY-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md
+++ b/docs/architecture/PLAN-P45-INVENTORY-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md
@@ -1,0 +1,156 @@
+# PLAN — P45 Inventory Receipt Trust Basis Claim (Q2 2026)
+
+- **Date:** 2026-04-28
+- **Owner:** Evidence / Trust Compiler
+- **Status:** Execution slice
+- **Scope:** Add one bounded Trust Basis claim for supported external inventory
+  receipt evidence, starting with the P43 CycloneDX ML-BOM model-component
+  receipt event.
+
+## 1. Why this exists
+
+P43 made the CycloneDX ML-BOM model-component compiler path real:
+
+```text
+CycloneDX ML-BOM model component
+  -> assay evidence import cyclonedx-mlbom-model
+  -> Assay EvidenceEvent receipt bundle
+  -> assay evidence verify
+  -> assay trust-basis generate
+```
+
+That proves inventory receipts are bundleable and readable. P45 is the next
+compatibility step: make the supported inventory receipt boundary visible as a
+named Trust Basis claim without importing BOM truth, model-card truth, dataset
+truth, or compliance posture.
+
+## 2. What P45 is
+
+P45 adds:
+
+- `external_inventory_receipt_boundary_visible`
+- `source = external_inventory_receipt`
+- `boundary = supported-external-inventory-receipt-events-only`
+- Trust Card schema `4`, because the visible claim table changes
+
+The claim is `verified` only when the bundle contains at least one supported
+inventory receipt event whose payload matches the bounded v1 receipt predicate
+exactly.
+
+For the first slice, the only supported event is:
+
+```text
+assay.receipt.cyclonedx.mlbom_model_component.v1
+```
+
+with:
+
+- `schema = "assay.receipt.cyclonedx.mlbom-model-component.v1"`
+- `source_system = "cyclonedx"`
+- `source_surface = "bom.components[type=machine-learning-model]"`
+- bounded, reviewer-safe source artifact ref and digest
+- `reducer_version` starting with
+  `assay-cyclonedx-mlbom-model-component@`
+- `imported_at` that parses as RFC3339 and has zero UTC offset
+- bounded `model_component.bom_ref`
+- bounded `model_component.name`
+- optional bounded `version`, `publisher`, and `purl`
+- optional bounded `dataset_refs[]` and `model_card_refs[]` as refs only
+
+The CloudEvents `type` and the receipt payload `schema` are separate exact
+identifiers. The event type uses the established event-name segment style
+(`mlbom_model_component`), while the payload schema uses the receipt schema slug
+(`mlbom-model-component`). P45 accepts only the exact strings above.
+
+## 3. What P45 is not
+
+P45 does not claim:
+
+- the BOM is complete
+- the model is safe, approved, licensed, compliant, vulnerable, or
+  non-vulnerable
+- the model card is correct
+- the dataset refs are approved or sufficient
+- the full CycloneDX graph was imported
+- vulnerability, license, pedigree, metric, fairness, ethics, or compliance
+  truth
+- Harness inventory-drift semantics
+
+The claim means only:
+
+```text
+the verified bundle contains at least one supported bounded inventory receipt
+```
+
+It does not mean:
+
+```text
+the upstream inventory statement is complete, correct, or sufficient
+```
+
+## 4. Predicate rule
+
+The Trust Basis predicate must stay stricter than generic event presence.
+Trust Basis claim support is narrower than generic EvidenceEvent acceptance:
+future or wider inventory receipt events may verify as evidence, but they do
+not satisfy this claim until the predicate is deliberately expanded.
+
+`external_inventory_receipt_boundary_visible = verified` requires:
+
+- supported inventory receipt event type
+- exact supported source system and source surface
+- bounded, reviewer-safe `source_artifact_ref`
+- digest-shaped source artifact binding
+- `imported_at` parseable as RFC3339 with zero UTC offset; serialized receipts
+  should use `Z` form, and naive/local timestamps do not satisfy the predicate
+- `reducer_version` starting with
+  `assay-cyclonedx-mlbom-model-component@`
+- bounded model-component object
+- `dataset_refs[]` and `model_card_refs[]` as arrays of bounded string refs
+  only
+- no raw `modelCard` body, dataset body, BOM graph, vulnerability, license,
+  pedigree, metrics, or other expanded inventory bodies in the receipt payload
+
+In v1, bounded inventory strings are non-empty after trimming, serialized
+without leading or trailing whitespace, no longer than 240 Unicode scalar
+values, and contain no control characters. This applies to the source artifact
+ref, model-component identity fields, and refs-only arrays.
+
+Malformed, wider, or future-shaped inventory receipt payloads remain accepted by
+evidence verify if the bundle contract allows them, but this Trust Basis claim
+should stay `absent` until the predicate is deliberately widened.
+
+## 5. Trust Card impact
+
+Adding a claim row changes the Trust Card visible surface. P45 therefore bumps:
+
+```text
+TRUST_CARD_SCHEMA_VERSION = 4
+```
+
+The Trust Card remains a deterministic render of Trust Basis. It does not add a
+second classifier, summary prose, aggregate score, compliance badge, or
+inventory-specific interpretation layer.
+
+## 6. Acceptance criteria
+
+- Trust Basis always emits the new claim row.
+- Ordinary bundles keep the claim `absent`.
+- Supported P43 CycloneDX ML-BOM model-component receipt bundles classify it as
+  `verified`.
+- Receipt-like events that include model-card bodies, dataset bodies, expanded
+  refs, or invalid provenance fields classify it as `absent`.
+- Trust Card schema is bumped to `4`.
+- Trust Card JSON and Markdown still render only the same claim rows plus frozen
+  non-goals.
+- CLI docs explain the claim boundary without describing BOM completeness,
+  model safety, dataset approval, or compliance truth.
+
+## 7. Sequencing
+
+P45 comes after P43 and P44. It prepares the inventory family for generic
+Trust Basis diff/gate/report flows.
+
+The next likely slice is Harness-side validation that the existing generic
+Trust Basis gate/report layer can carry this new claim family without learning
+CycloneDX, BOM, model, dataset, or inventory semantics.

--- a/docs/architecture/PLAN-T1b-TRUST-CARD-2026q2.md
+++ b/docs/architecture/PLAN-T1b-TRUST-CARD-2026q2.md
@@ -8,12 +8,16 @@
 
 Ship `trustcard.json` (canonical) and `trustcard.md` (secondary) derived **only** from `generate_trust_basis` → `trust_basis_to_trust_card`. No second classification pass, no aggregate score, no badge semantics, no `trust_basis_sha256` in v1.
 
-## 2) Frozen contract (T1b baseline; extended by G3 and P33)
+## 2) Frozen contract (T1b baseline; extended by G3, P33, and P45)
+
+This table records the current effective T1b surface as extended by later
+accepted slices; it is not a claim that all of these properties shipped in the
+original March 2026 cut.
 
 | Item | Rule |
 |------|------|
-| `schema_version` | `3` after [P33](./PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) (`TRUST_CARD_SCHEMA_VERSION`); was `2` after [G3](./PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md) and `1` for the original T1b-only ship. |
-| `claims[]` | `Vec<TrustBasisClaim>` — same serde as trust basis; **eight** frozen ids after P33, same order as `TrustBasis::claims` (was seven after G3 and six for T1a-only). |
+| `schema_version` | `4` after [P45](./PLAN-P45-INVENTORY-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) (`TRUST_CARD_SCHEMA_VERSION`); was `3` after [P33](./PLAN-P33-EXTERNAL-EVAL-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md), `2` after [G3](./PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md), and `1` for the original T1b-only ship. |
+| `claims[]` | `Vec<TrustBasisClaim>` — same serde as trust basis; **nine** frozen ids after P45, same order as `TrustBasis::claims` (was eight after P33, seven after G3, and six for T1a-only). |
 | `non_goals` | Three fixed strings in fixed order (`TRUST_CARD_NON_GOALS` in code); identical in JSON and Markdown. |
 | Markdown `note` column | Empty T1a `note` renders as placeholder `-` (`TRUST_CARD_NOTE_EMPTY_PLACEHOLDER`); no multiline cells. |
 | Markdown shape | Title + fixed five-column table + `## Non-goals` with literal bullets. |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -55,6 +55,7 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [PLAN — P34 Trust Basis Diff Gate (Q2 2026)](./PLAN-P34-TRUST-BASIS-DIFF-GATE-2026q2.md) — execution slice that compares canonical Trust Basis artifacts for claim-level regressions without parsing Promptfoo JSONL or external eval payloads
 - [PLAN — P41 OpenFeature EvaluationDetails Decision Receipt Import (Q2 2026)](./PLAN-P41-OPENFEATURE-EVALUATION-DETAILS-DECISION-RECEIPT-IMPORT-2026q2.md) — execution slice that imports bounded boolean OpenFeature decision details as portable Assay receipts, not provider config, targeting, metadata, or application correctness truth
 - [PLAN — P43 CycloneDX ML-BOM Model Component Receipt Import (Q2 2026)](./PLAN-P43-CYCLONEDX-MLBOM-MODEL-COMPONENT-RECEIPT-IMPORT-2026q2.md) — execution slice that imports one selected CycloneDX `machine-learning-model` component as a portable inventory receipt, not full BOM, model-card, dataset, graph, or compliance truth
+- [PLAN — P45 Inventory Receipt Trust Basis Claim (Q2 2026)](./PLAN-P45-INVENTORY-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) — execution slice that adds one bounded Trust Basis claim for supported inventory receipt boundaries, starting with CycloneDX ML-BOM model-component receipts
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 
 ## Active RFCs

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -54,9 +54,11 @@ The same bundle can feed the Trust Basis compiler:
 assay trust-basis generate cyclonedx-model-receipt.tar.gz --out cyclonedx-model.trust-basis.json
 ```
 
-P43 does not add an inventory-specific Trust Basis claim yet. The first
-CycloneDX compiler slice proves the receipt bundle is bundleable, verifiable,
-and readable by the Trust Basis path.
+Trust Basis emits `external_inventory_receipt_boundary_visible` when the
+supported CycloneDX ML-BOM model-component receipt shape is present. That claim
+means the bounded inventory receipt boundary is visible; it does not mean the
+BOM is complete, the model is safe, the model card is correct, the datasets are
+approved, or the CycloneDX artifact is imported as Assay truth.
 
 Use `--bom-ref <REF>` when the BOM has multiple `machine-learning-model`
 components. Use `--import-time <RFC3339>` for deterministic fixture generation.

--- a/docs/reference/cli/trust-basis.md
+++ b/docs/reference/cli/trust-basis.md
@@ -57,7 +57,12 @@ assay trust-basis diff \
 ```
 
 The diff compares Trust Basis claim presence and levels only. It does not parse
-Promptfoo JSONL, inspect external eval payloads, or infer model correctness.
+Promptfoo JSONL, CycloneDX BOMs, external receipt payloads, or infer model,
+decision, inventory, or upstream-tool correctness.
+
+Claim identity is determined solely by `claim.id`. Source, boundary, and note
+differences do not create a different claim identity; they are reported
+separately as metadata changes.
 
 Claim levels are ordered as:
 
@@ -86,6 +91,10 @@ JSON output uses the stable machine-readable schema
 - `unchanged_claim_count`
 
 Diff arrays are sorted deterministically by `claim.id`.
+
+P34/P35/P36 consumers should treat `assay.trust-basis.diff.v1` JSON as the
+canonical machine contract and must not infer regressions from ad hoc text
+output.
 
 Exit codes are:
 


### PR DESCRIPTION
What changed

Adds the P45 Trust Basis claim for bounded external inventory receipts.

This PR includes:

- external_inventory_receipt_boundary_visible in Trust Basis
- source external_inventory_receipt and boundary supported-external-inventory-receipt-events-only
- strict predicate support for the P43 CycloneDX ML-BOM model-component receipt event
- Trust Card schema_version bump to 4 because the visible claim table changes
- CLI tests proving Promptfoo/OpenFeature remain non-inventory while CycloneDX receipts verify the new claim
- docs and a P45 plan that keep the claim as boundary/provenance visibility only

Why

P43 made the CycloneDX model-component receipt compiler path real. P44 proved Harness can run that family through the existing gate/report stack. P45 makes the inventory receipt boundary visible at the Trust Basis claim layer without importing BOM, model-card, dataset, graph, vulnerability, license, safety, or compliance truth.

Boundary

This claim only means a supported bounded inventory receipt is present with visible source surface, digest, reducer, import time, and refs-only model-component boundary. It does not mean the BOM is complete, the model is safe, the model card is correct, the dataset refs are approved, or the CycloneDX artifact is true.

This PR does not add Harness inventory semantics, model-version diffing, dataset-ref policy, SARIF projection, or a three-family public note.

Validation

Ran locally:

cargo fmt --check
cargo test -p assay-evidence trust_basis -- --nocapture
cargo test -p assay-evidence trust_basis_detects_supported_external_inventory_receipt_boundary -- --nocapture
cargo test -p assay-cli test_cyclonedx_mlbom_model_receipts_verify_and_feed_trust_basis_generation -- --nocapture
cargo test -p assay-cli test_promptfoo_imported_receipts_feed_trust_basis_generation -- --nocapture
cargo test -p assay-cli test_openfeature_imported_decision_receipts_verify_and_feed_trust_basis_generation -- --nocapture
cargo test -p assay-cli trust_basis_generate_stdout_emits_all_frozen_claims -- --nocapture
cargo test -p assay-cli trustcard_generate_writes_json_and_md_matching_trust_basis_claims -- --nocapture
cargo clippy -p assay-evidence --all-targets -- -D warnings
cargo clippy -p assay-cli --all-targets -- -D warnings
git diff --check
local docs link check for changed docs

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.