### PR TITLE
P52: align product truth surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 
 Your MCP agent calls `read_file`, `exec`, `web_search` — but should it, and what can you honestly **prove** about that run afterward?
 
-**Assay compiles agent runtime signals into enforceable decisions and portable evidence artifacts.** The wedge is familiar: sit between the agent and MCP servers, **allow or deny** tool calls from policy, and record every decision. The product story is broader: canonical **evidence**, **bounded trust claims** (what is verified vs merely visible), and outputs you can hand to CI, security review, or audit — without a hosted backend.
+**Assay compiles agent runtime signals and selected external outcomes into verifiable evidence and bounded Trust Basis claims.** The wedge is familiar: sit between the agent and MCP servers, **allow or deny** tool calls from policy, and record every decision. The product story is broader: canonical **evidence**, **bounded trust claims** (what is verified vs merely visible), and outputs you can hand to CI, security review, or audit — without a hosted backend.
 
-**Positioning:** Assay is best understood as a **CI-native protocol-governance layer**: canonical evidence compiler + protocol-aware policy checks. It is **not** a trust-score engine, a generic eval dashboard, or an observability product with a thin security veneer.
+**Positioning:** Assay is best understood as a **CI-native protocol-governance layer**: canonical evidence compiler + protocol-aware policy checks. It is **not** a trust-score engine, a generic eval dashboard, or an observability product with a thin security veneer. See [What Assay is and is not](docs/concepts/scope.md) for the current boundary.
 
 | | |
 |---|---|

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -34,7 +34,7 @@ pub use trust_card::*;
 #[command(
     name = "assay",
     version,
-    about = "Policy-as-Code for AI Agents — deterministic testing, verifiable evidence, and runtime enforcement for MCP"
+    about = "CI-native evidence and trust compiler for agent runtime governance"
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -80,7 +80,7 @@ pub enum Command {
     Profile(super::commands::profile::ProfileArgs),
     /// Secure execution sandbox (v0.1)
     Sandbox(SandboxArgs),
-    /// Evidence Management (Audit/Compliance)
+    /// Evidence bundles, imports, verification, and stores
     Evidence(EvidenceArgs),
     /// Replay bundle management (create/verify)
     Bundle(BundleArgs),

--- a/docs/AIcontext/CLAUDE.md
+++ b/docs/AIcontext/CLAUDE.md
@@ -2,11 +2,15 @@
 
 ## What is Assay?
 
-Assay is a **Policy-as-Code** engine for Model Context Protocol (MCP) that validates AI agent behavior. It provides deterministic testing (trace replay), runtime security (eBPF/LSM kernel enforcement on Linux), and compliance gates (tool argument/sequence validation).
+Assay is a **CI-native evidence and trust compiler** for agent systems. It
+compiles agent runtime signals and selected external outcomes into verifiable
+evidence and bounded Trust Basis claims. MCP policy enforcement remains the
+main runtime wedge: deterministic tool decisions, evidence bundles, Trust Basis,
+Trust Card, and CI projections without a hosted backend.
 
 ## Workspace Structure
 
-Rust monorepo with workspace version `2.15.0`.
+Rust monorepo with workspace version `3.8.0`.
 
 ```
 crates/
@@ -234,7 +238,7 @@ See `docs/PERFORMANCE-ASSESSMENT.md` for full documentation.
 
 ## Conventions
 
-- Workspace version in root `Cargo.toml` (`version = "2.15.0"`)
+- Workspace version in root `Cargo.toml` (`version = "3.8.0"`)
 - Internal crate deps use `workspace = true` with path + version
 - `#[deny(unsafe_code)]` on all crates except assay-ebpf
 - Error handling: `anyhow` for applications, `thiserror` for libraries

--- a/docs/AIcontext/ci-infrastructure.md
+++ b/docs/AIcontext/ci-infrastructure.md
@@ -1,7 +1,7 @@
 # CI Infrastructure
 
 > **Purpose**: Documentation for CI/CD infrastructure, self-hosted runners, health checks, and optimization.
-> **Version**: 2.15.0 (February 2026)
+> **Version**: 3.8.0 (April 2026)
 
 ## Overview
 

--- a/docs/AIcontext/codebase-overview.md
+++ b/docs/AIcontext/codebase-overview.md
@@ -1,17 +1,21 @@
 # Assay Codebase Overview
 
-> **Version**: 2.15.0 (February 2026)
-> **SOTA Status**: Bleeding Edge (Judge Reliability, MCP Auth, OTel GenAI, Replay Bundle)
+> **Version**: 3.8.0 (April 2026)
+> **SOTA Status**: Trust Compiler line (MCP governance, Trust Basis, receipt portability)
 
 ## What is Assay?
 
-**Assay** is a **Policy-as-Code** engine for Model Context Protocol (MCP) that validates AI agent behavior. It provides:
+**Assay** is a CI-native evidence and trust compiler for agent systems. It
+compiles agent runtime signals and selected external outcomes into verifiable
+evidence and bounded Trust Basis claims. It provides:
 
-- **Deterministic testing**: Replay recorded traces without LLM API calls (milliseconds, $0 cost, 0% flakiness)
-- **Runtime security**: Kernel-level enforcement on Linux to block unauthorized tool access
-- **Compliance gates**: Validate tool arguments, sequences, and blocklists before production
+- **Protocol policy enforcement**: Deterministic MCP tool decisions without LLM calls in CI
+- **Evidence bundles**: Offline-verifiable artifacts for audit, review, and replay
+- **Trust compiler artifacts**: Trust Basis and Trust Card outputs with explicit evidence levels
+- **External receipt lanes**: Bounded receipt imports for selected eval, decision, inventory, and score-event surfaces
 
-Assay replaces flaky, network-dependent evals with deterministic replay testing. Record agent behavior once, then validate every PR in milliseconds.
+Policy-as-code remains an important wedge, but the current product surface is
+broader: verified evidence, bounded claims, and portable receipt contracts.
 
 ## High-Level Architecture
 
@@ -207,7 +211,7 @@ Report (console/JSON/JUnit/SARIF; SARIF truncation at 25k results by default, wi
 
 1. **Determinism**: Same input + same policy = same result (zero flakiness)
 2. **Statelessness**: Validation requires only policy file + trace list
-3. **Policy-as-Code**: Uses logic, not LLMs, for evaluation
+3. **Deterministic policy**: Uses explicit logic, not LLMs, for policy decisions
 4. **Separation of Concerns**: CLI handles UX/config, core handles evaluation logic
 5. **Extensibility**: Metrics, providers, and policies are pluggable via traits
 

--- a/docs/AIcontext/decision-trees.md
+++ b/docs/AIcontext/decision-trees.md
@@ -1,7 +1,7 @@
 # Decision Trees
 
 > **Purpose**: Help AI agents decide which command, approach, or pattern to use.
-> **Version**: 2.15.0 (February 2026)
+> **Version**: 3.8.0 (April 2026)
 
 ## Decision Tree 1: Which Command Should I Use?
 

--- a/docs/AIcontext/index.md
+++ b/docs/AIcontext/index.md
@@ -1,10 +1,13 @@
 # AI Context Documentation
 
-> **Version**: 2.18.0 (February 2026, post-RFC-003)
-> **Last Updated**: 2026-02-10
-> **SOTA Status**: Generate decomposition complete (RFC-003); Code health complete (RFC-002); Judge output (PR #159); SARIF limits (PR #160)
+> **Version**: 3.8.0 (April 2026)
+> **Last Updated**: 2026-04-29
+> **SOTA Status**: Trust Compiler line with Trust Basis, receipt portability, and schema registry
 
-This directory contains comprehensive documentation designed specifically for AI agents (LLMs) to understand and work with the Assay codebase. These documents follow best practices for AI context management as of January 2026.
+This directory contains documentation designed specifically for AI agents
+(LLMs) to understand and work with the Assay codebase. The highest-priority
+files now describe Assay as a CI-native evidence and trust compiler, not just
+as the older policy-as-code wedge.
 
 ## Quick Start for AI Agents
 

--- a/docs/AIcontext/interdependencies.md
+++ b/docs/AIcontext/interdependencies.md
@@ -439,7 +439,7 @@ Rul1an/assay/assay-action@v2
 **Workspace Version**: All crates share version from `Cargo.toml` workspace:
 ```toml
 [workspace.package]
-version = "2.15.0"
+version = "3.8.0"
 ```
 
 **Patch Section**: Internal crates are patched to use local paths:

--- a/docs/AIcontext/quick-reference.md
+++ b/docs/AIcontext/quick-reference.md
@@ -1,14 +1,14 @@
 # Quick Reference
 
 > **Purpose**: Fast lookup for AI agents - commands, patterns, exit codes, and common operations.
-> **Version**: 2.15.0 (February 2026)
+> **Version**: 3.8.0 (April 2026)
 
 ## TL;DR - What is Assay?
 
-**Assay** = Policy-as-Code engine for AI agent validation
-- **Input**: Agent traces (JSONL) + Policy (YAML)
-- **Output**: Pass/Fail + SARIF report
-- **Key insight**: Deterministic replay testing (no LLM calls needed in CI)
+**Assay** = CI-native evidence and trust compiler for agent systems
+- **Input**: Agent runtime signals, evidence bundles, and bounded external receipt inputs
+- **Output**: Evidence bundles, Trust Basis, Trust Card, SARIF/JUnit/CI projections
+- **Key insight**: deterministic policy and bounded evidence claims, not trust scores or dashboards
 
 ## Most Common Commands
 
@@ -23,6 +23,11 @@ assay run --config eval.yaml --trace-file traces.jsonl
 
 # CI gate (strict mode)
 assay ci --config eval.yaml --trace-file traces.jsonl
+
+# Trust compiler artifacts
+assay evidence verify bundle.tar.gz
+assay trust-basis generate bundle.tar.gz --out trust-basis.json
+assay trustcard generate bundle.tar.gz --out-dir trustcard
 
 # Debug failures
 assay doctor                  # Diagnose common issues

--- a/docs/AIcontext/run-output.md
+++ b/docs/AIcontext/run-output.md
@@ -1,7 +1,7 @@
 # Run Output Contract (PR Gate)
 
 > **Purpose**: Machine-readable outputs from `assay run` and `assay ci` for CI gates and downstream tooling.
-> **Version**: 2.15.0 (February 2026)
+> **Version**: 3.8.0 (April 2026)
 > **Spec**: [SPEC-PR-Gate-Outputs-v1](../architecture/SPEC-PR-Gate-Outputs-v1.md) — §3.3.1 Seeds, §3.3.2 Judge metrics, §6.3 SARIF truncation.
 > **Implementation**: PR #159 (E7.5, E7.2, E7.3); PR #160 (E2.3 SARIF limits, sarif.omitted).
 

--- a/docs/architecture/PLAN-P52-P56-CONSOLIDATION-PROGRAM-2026q2.md
+++ b/docs/architecture/PLAN-P52-P56-CONSOLIDATION-PROGRAM-2026q2.md
@@ -1,0 +1,339 @@
+# PLAN — P52-P56 Assay Product Surface Consolidation Program (Q2 2026)
+
+- **Date:** 2026-04-29
+- **Owner:** Assay maintainers
+- **Status:** planning program
+- **Scope:** Consolidate the post-v3.8.0 Assay product surface before opening
+  another evidence family or upstream wedge.
+
+## 1. Why this program exists
+
+Assay now has enough strong lanes:
+
+- agent runtime signals and MCP governance evidence,
+- canonical Evidence Bundles,
+- Trust Basis and Trust Card artifacts,
+- three claim-visible external receipt families,
+- a machine-readable receipt schema registry,
+- and Assay Harness compatibility proof against the released v3.8.0 line.
+
+The next risk is not lack of capability. The next risk is product legibility.
+A new reader should not have to reconstruct the difference between
+policy-as-code, evidence bundles, receipt imports, Trust Basis claims, Trust
+Cards, Harness recipes, SARIF projections, and compliance packs from history.
+
+This program turns the existing lanes into one coherent product surface:
+
+```text
+understandable -> assertable -> schema-validatable -> reviewable -> bound to policy/tool identity
+```
+
+It deliberately does not add a new receipt family, external wedge, dashboard,
+or integration claim.
+
+## 2. Program invariants
+
+All slices in this program must preserve these rules:
+
+- Assay remains an evidence and trust compiler, not an eval runner,
+  observability dashboard, BOM viewer, or generic policy platform.
+- Trust Basis JSON remains canonical for claim classification.
+- Trust Card Markdown/HTML and CI outputs are projections only.
+- Consumers key Trust Basis claims by stable `claim.id`, never row position or
+  row count.
+- Receipt-family docs must keep included fields, excluded fields, and
+  `does_not_claim` semantics visible.
+- Harness remains outside Assay receipt payload semantics.
+- No slice may imply official support, partnership, or endorsement from
+  Promptfoo, OpenFeature, CycloneDX, Mastra, or any runtime provider.
+
+## 3. P52 — Product Truth Sync
+
+### Goal
+
+Make the public product surface tell one story everywhere:
+
+```text
+Assay compiles agent runtime signals and selected external outcomes into
+verifiable evidence and bounded Trust Basis claims.
+```
+
+### Work
+
+- Update top-level product language across README, docs index, CLI help, and
+  quickstart surfaces.
+- Demote older "Policy-as-Code for AI Agents" language from the primary
+  product identity to one capability inside the broader trust compiler story.
+- Keep compliance packs visible but not first-positioned as the product wedge.
+- Add or refresh a short "What Assay is / is not" reference page.
+- Separate Assay core from Assay Harness in public docs:
+  - Assay owns evidence, receipts, bundle verification, Trust Basis, Trust Card,
+    schema registry, and claim semantics.
+  - Assay Harness owns orchestration, regression gating, and CI projections over
+    Assay artifacts.
+- Link the receipt family matrix as a first-class public artifact from the
+  docs surfaces that introduce external receipts.
+
+### Non-goals
+
+- No roadmap rewrite from scratch.
+- No new runtime behavior.
+- No new Trust Basis claims.
+- No new receipt families.
+- No new compliance or partnership claims.
+
+### Acceptance
+
+- `assay --help`, README, docs index, and first-run docs use compatible product
+  language.
+- A new reader can identify the canonical chain:
+
+```text
+runtime/import signal -> evidence bundle -> Trust Basis -> Trust Card / diff
+```
+
+- The receipt family matrix remains linked from public receipt docs.
+
+## 4. P53 — Trust Basis Assert
+
+### Goal
+
+Make a single canonical `trust-basis.json` directly assertable in CI without
+requiring Harness or family-specific policy logic.
+
+### Command shape
+
+```bash
+assay trust-basis assert \
+  --input trust-basis.json \
+  --require external_eval_receipt_boundary_visible=verified
+```
+
+### Work
+
+- Add a small `trust-basis assert` command.
+- Accept one or more `--require <claim-id>=<level>` predicates.
+- Key only by `claim.id`.
+- Validate that input is a canonical Trust Basis artifact.
+- Emit machine-readable JSON.
+- Emit a short text summary for humans.
+- Preserve exit codes:
+  - `0`: all requirements satisfied
+  - `1`: at least one requirement mismatch
+  - `2+`: input, config, or runtime error
+
+### Non-goals
+
+- No baseline/candidate comparison.
+- No Trust Basis diff replacement.
+- No Harness behavior.
+- No Promptfoo/OpenFeature/CycloneDX-specific policy.
+- No new Trust Basis claims.
+
+### Acceptance
+
+- Any existing claim can be asserted by stable `claim.id`.
+- Missing claims fail as policy mismatch, not success.
+- Unknown levels or malformed requirements fail as config/input errors.
+- JSON output includes required claim id, expected level, actual level, and
+  pass/fail status.
+
+## 5. P55 — Receipt Schema CLI
+
+### Goal
+
+Turn the v3.8.0 receipt schema registry into a discoverable product surface.
+
+### Command shape
+
+```bash
+assay evidence schema list
+assay evidence schema show promptfoo.assertion-component.v1
+assay evidence schema validate \
+  --schema promptfoo.assertion-component.v1 \
+  --input receipt.json
+```
+
+### Work
+
+- Add schema discovery for:
+  - receipt payload schemas,
+  - importer input schemas where those differ from receipt payloads.
+- Support Promptfoo, OpenFeature, CycloneDX ML-BOM, and Mastra schema entries.
+- Keep Mastra marked as importer-only.
+- Show useful metadata before raw schema content:
+  - schema id,
+  - family,
+  - status,
+  - source file,
+  - short description,
+  - whether the schema is receipt payload or importer input.
+- Validate inputs with JSON pointer style error paths where practical.
+- Keep the schema registry linked to
+  `docs/reference/receipt-family-matrix.json`.
+
+### Non-goals
+
+- No new schemas beyond the existing v3.8.0 family set.
+- No new receipt families.
+- No Trust Basis classification changes.
+- No Harness validation responsibility.
+
+### Acceptance
+
+- `list` returns all v3.8.0 receipt and importer-input schemas.
+- `show` can return metadata plus raw JSON schema.
+- `validate` passes for checked-in fixtures and importer-generated supported
+  receipt payloads.
+- `validate` fails closed for malformed payloads with actionable paths.
+
+## 6. P54 — Static Trust Card HTML
+
+### Goal
+
+Make Trust Cards more reviewable without creating a hosted dashboard or a second
+source of truth.
+
+### Work
+
+- Add HTML projection support to Trust Card generation.
+- Produce a deterministic single-file artifact.
+- Render the same claim rows as `trustcard.json` and `trustcard.md`.
+- Show claim id, level, source, boundary, note, and evidence posture.
+- Show receipt-family context where present:
+  - event type,
+  - included fields,
+  - excluded fields,
+  - `does_not_claim`.
+- Link to raw Trust Basis and evidence artifacts when the caller supplies paths.
+
+### Non-goals
+
+- No hosted dashboard.
+- No remote assets.
+- No JavaScript requirement to understand the artifact.
+- No scores, badges, or second classifier.
+- No claim semantics added in HTML.
+
+### Acceptance
+
+- HTML output is deterministic for the same Trust Basis / Trust Card input.
+- JSON remains canonical; HTML is documented as projection only.
+- HTML renders without network access.
+- Tests prove claim ordering and level rendering match the canonical artifact.
+
+## 7. P56a — Policy Snapshot Digest Visibility
+
+### Goal
+
+Make the policy snapshot that governed a decision visibly digest-bound in
+evidence and review artifacts.
+
+### Work
+
+- Identify the current canonical policy snapshot object for MCP/runtime
+  decisions.
+- Surface a stable policy snapshot digest in evidence where available.
+- Carry digest visibility into Trust Basis metadata or supporting evidence
+  without implying policy quality.
+- Document the boundary:
+
+```text
+policy snapshot digest visible != policy is correct or sufficient
+```
+
+### Non-goals
+
+- No policy authoring redesign.
+- No waiver lifecycle.
+- No proof that policy is safe.
+- No Sigstore/keyless layer yet.
+
+### Acceptance
+
+- A reviewer can see which policy snapshot governed a supported decision path.
+- Digest drift is reviewable.
+- Missing policy digest remains explicit rather than silently treated as safe.
+
+## 8. P56b — Tool Definition Digest Binding
+
+### Goal
+
+Bind supported tool decisions to the tool definition surface that was reviewed,
+without claiming the tool is safe or fully signed.
+
+### Work
+
+- Reuse the existing tool signing / definition canonicalization line where
+  possible.
+- Surface tool definition digest alongside supported decision evidence.
+- Document how this relates to `x-assay-sig`, DSSE, and future transparency-log
+  work.
+- Keep runtime/provider-specific tool surfaces out unless there is a canonical
+  bounded definition object.
+
+### Non-goals
+
+- No full tool signing completion.
+- No transparency log requirement.
+- No claim that the tool is safe.
+- No provider-wide tool registry import.
+
+### Acceptance
+
+- A supported decision can be reviewed with:
+  - policy snapshot digest,
+  - tool definition digest,
+  - decision evidence,
+  - Trust Basis posture.
+- Tool-definition drift is visible as review evidence.
+- The implementation does not invent identity for runtimes that do not expose a
+  bounded tool definition surface.
+
+## 9. Preferred execution order
+
+1. **P52** — product truth sync.
+2. **P53** — Trust Basis assert.
+3. **P55** — receipt schema CLI.
+4. **P54** — static Trust Card HTML.
+5. **P56a** — policy snapshot digest visibility.
+6. **P56b** — tool definition digest binding.
+
+P55 may run in parallel with P53 if write scopes are kept separate. P54 should
+wait until the assert and schema surfaces are stable enough to avoid producing a
+pretty artifact over unstable terminology. P56a and P56b should remain separate
+unless implementation discovery proves the write scope is tiny.
+
+## 10. Program test plan
+
+Per slice:
+
+- `cargo fmt --check`
+- targeted `cargo test -p assay-evidence`
+- targeted `cargo test -p assay-cli`
+- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
+- `cargo clippy -p assay-cli --all-targets -- -D warnings`
+- docs link check for changed docs
+- `git diff --check`
+
+For P54 and later, add deterministic golden tests for projection output.
+
+For P56a/P56b, add regression tests that prove missing or malformed digest
+visibility does not accidentally classify as verified trust.
+
+## 11. External posture
+
+Do not publish a new external wedge from this program until P52, P53, and P55
+are landed. If P54 lands soon after, use the HTML Trust Card as the reviewer
+artifact in demos. P56a/P56b are stronger security follow-ups, not blockers for
+basic external readability.
+
+External language should stay small:
+
+```text
+Assay compiles selected agent/runtime and external evidence surfaces into
+bounded, verifiable claims that can be reviewed in CI.
+```
+
+No call to action, no partnership language, and no claim that upstream systems
+endorse the Assay receipt lanes.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Assay is a governance and evidence platform for AI agents, built as a Rust workspace.
+Assay is a CI-native evidence and trust compiler for agent systems, built as a Rust workspace.
 
 ## Structure
 
@@ -59,6 +59,7 @@ Assay is a governance and evidence platform for AI agents, built as a Rust works
 - [PLAN — P43 CycloneDX ML-BOM Model Component Receipt Import (Q2 2026)](./PLAN-P43-CYCLONEDX-MLBOM-MODEL-COMPONENT-RECEIPT-IMPORT-2026q2.md) — execution slice that imports one selected CycloneDX `machine-learning-model` component as a portable inventory receipt, not full BOM, model-card, dataset, graph, or compliance truth
 - [PLAN — P45 Inventory Receipt Trust Basis Claim (Q2 2026)](./PLAN-P45-INVENTORY-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) — execution slice that adds one bounded Trust Basis claim for supported inventory receipt boundaries, starting with CycloneDX ML-BOM model-component receipts
 - [PLAN — P45b Decision Receipt Trust Basis Claim (Q2 2026)](./PLAN-P45B-DECISION-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) — execution slice that adds one bounded Trust Basis claim for supported decision receipt boundaries, starting with OpenFeature boolean EvaluationDetails receipts
+- [PLAN — P52-P56 Assay Product Surface Consolidation Program (Q2 2026)](./PLAN-P52-P56-CONSOLIDATION-PROGRAM-2026q2.md) — post-v3.8.0 consolidation program for product truth sync, Trust Basis assertions, receipt schema CLI, static Trust Card HTML, and policy/tool digest binding
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 
 ## Active RFCs

--- a/docs/concepts/scope.md
+++ b/docs/concepts/scope.md
@@ -1,167 +1,83 @@
-# What Assay Does (and Doesn't Do)
+# What Assay Is And Is Not
 
-Assay is a **deterministic policy enforcement engine** for AI agents. This page clarifies our scope to help you understand when Assay is the right tool—and when you should look elsewhere.
+Assay compiles agent runtime signals and selected external outcomes into
+verifiable evidence and bounded Trust Basis claims.
 
-## Core Principle
+It is strongest when a team needs deterministic governance over tool calls,
+portable evidence bundles, and reviewable trust artifacts in CI. It is not an
+eval runner, observability dashboard, compliance oracle, or general-purpose
+authorization service.
 
-> **If it needs a classifier, we don't build it. We build gates.**
+## Core Boundary
 
-Assay enforces rules that can be evaluated with 100% determinism. No probability scores. No "maybe". Just Pass or Fail.
+Assay owns this chain:
 
----
-
-## ✅ In Scope: Tool-Call Enforcement
-
-Assay validates **agent actions** (tool calls) against policies you define.
-
-### Argument Validation (`args_valid`)
-
-Enforce that tool arguments match a JSON Schema.
-
-```yaml
-assertions:
-  - type: args_valid
-    tool: ApplyDiscount
-    schema:
-      type: object
-      properties:
-        percent:
-          type: number
-          maximum: 30  # Block discounts > 30%
-        reason:
-          type: string
-          minLength: 10
-      required: [percent, reason]
+```text
+runtime/import signal
+  -> canonical evidence bundle
+  -> bundle verification
+  -> Trust Basis claims
+  -> Trust Card / SARIF / CI projections
 ```
 
-**Use case:** Prevent agents from applying excessive discounts, sending malformed API requests, or passing invalid parameters.
+Policy enforcement is still a key wedge. Assay can sit between an agent and MCP
+tools, evaluate explicit policy, and record the decision. The broader product
+surface is the evidence compiler around those decisions: what happened, what was
+verified, what was merely visible, and what should not be claimed.
 
-### Sequence Enforcement (`sequence_valid`)
+## In Scope
 
-Ensure tools are called in the correct order.
+| Area | What Assay Does |
+|---|---|
+| Protocol policy | Deterministic allow/deny/approval decisions over supported MCP tool-call surfaces. |
+| Evidence bundles | Offline-verifiable evidence artifacts with canonical event envelopes and content binding. |
+| Trust Basis | Bounded claim classification from verified bundles, keyed by stable `claim.id`. |
+| Trust Card | Human-readable JSON/Markdown projection of the Trust Basis claim set. |
+| External receipts | Narrow compiler lanes for selected upstream seams such as Promptfoo assertion components, OpenFeature boolean `EvaluationDetails`, and CycloneDX ML-BOM model components. |
+| CI projections | SARIF/JUnit/Markdown outputs where appropriate, with raw canonical artifacts kept separate. |
+| Packs | Optional evidence linting and policy packs that structure findings; packs do not prove legal compliance by themselves. |
 
-```yaml
-assertions:
-  - type: sequence_valid
-    rules:
-      - type: require
-        tool: VerifyIdentity
-      - type: before
-        first: VerifyIdentity
-        then: DeleteAccount
-```
+The machine-readable receipt family surface is tracked in the
+[receipt family matrix](../reference/receipt-family-matrix.json).
 
-**Use case:** Require verification before destructive actions. Enforce multi-step approval workflows.
+## Out Of Scope
 
-### Tool Blocklists (`tool_blocklist`)
+| Area | Why It Is Not Assay |
+|---|---|
+| Eval running | Promptfoo, DeepEval, Braintrust, LangSmith, Langfuse, Phoenix, and similar tools should run or manage evaluations. Assay imports selected outcomes as bounded receipts when useful. |
+| Observability dashboard | Assay can export or bridge evidence, but it does not replace tracing, metrics, prompt management, or production monitoring platforms. |
+| Trust score | Trust Basis claims use explicit evidence levels. Assay does not collapse trust into a single score, badge, or "safe/unsafe" label. |
+| Compliance certification | Assay can produce evidence and pack findings. It does not certify EU AI Act, SOC 2, or other legal compliance. |
+| Full BOM viewer | CycloneDX ML-BOM receipts preserve selected inventory boundaries. Assay does not import full BOM graphs, vulnerabilities, licenses, or model-card truth. |
+| Semantic safety classifier | Toxicity, jailbreak, hallucination, bias, and content-safety checks require probabilistic or model-based systems. Assay should complement them, not impersonate them. |
 
-Prevent specific tools from being called.
+## Assay Versus Assay Harness
 
-```yaml
-assertions:
-  - type: tool_blocklist
-    blocked:
-      - DeleteDatabase
-      - DropTable
-      - ExecuteRawSQL
-```
+Assay owns artifact semantics:
 
-**Use case:** Hard blocks on dangerous operations. Defense in depth for agent sandboxing.
+- evidence import and reduction,
+- evidence bundle verification,
+- receipt schemas and receipt-family matrix,
+- Trust Basis generation and diff semantics,
+- Trust Card generation.
 
----
+Assay Harness owns operational CI recipes above those artifacts:
 
-## ❌ Out of Scope: Classifier-Based Safety
+- run baseline/candidate recipes,
+- preserve raw Assay diff JSON,
+- map Trust Basis regressions to CI exits,
+- project raw diffs into Markdown or JUnit.
 
-The following capabilities are **explicitly out of scope** for Assay. They require probabilistic classifiers and introduce non-determinism.
+Harness must not parse Promptfoo JSONL, OpenFeature JSONL, CycloneDX BOMs, or
+Assay receipt payloads. Domain semantics stay in Assay.
 
-| Capability | Why Not Assay | Alternative |
-|------------|---------------|-------------|
-| **Toxicity Detection** | Requires language model classifier | [Llama Guard](https://ai.meta.com/llama-guard/), [Perspective API](https://perspectiveapi.com/) |
-| **Jailbreak Detection** | Arms race, adversarial by nature | Prompt gateways, [Rebuff](https://github.com/protectai/rebuff) |
-| **Hallucination Detection** | Requires ground truth comparison | LLM-as-judge pipelines, RAG evaluation tools |
-| **RAG Grounding** | Context-dependent, semantic matching | [RAGAS](https://github.com/explodinggradients/ragas), [TruLens](https://trulens.org/) |
-| **Bias Detection** | Subjective, contested definitions | Academic research tools, human review |
-| **PII Detection** | Pattern matching is incomplete | [Presidio](https://github.com/microsoft/presidio), cloud DLP APIs |
+## Decision Rule
 
-### Why This Boundary Matters
+Use Assay when the answer should come from deterministic policy, verified
+evidence, or a bounded receipt boundary.
 
-1. **Determinism:** Classifiers have variance. The same input can produce different outputs across runs. Assay guarantees: same trace + same policy = same result, always.
+Use another tool first when the answer requires subjective scoring, semantic
+judgment, broad trace exploration, prompt iteration, or legal certification.
 
-2. **Latency:** Classifier-based checks add 100ms-1000ms. Assay's pure-function checks run in <10ms p95.
-
-3. **False Positives:** Classifiers trade off precision vs recall. Assay's rules are explicit—you control exactly what passes and fails.
-
-4. **Auditability:** "The model said it was toxic" is not a compliance answer. "The discount exceeded 30% (schema violation)" is.
-
----
-
-## The Integration Model
-
-Assay is designed to **complement** classifier-based tools, not replace them.
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     YOUR AGENT RUNTIME                       │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐     │
-│  │ Prompt      │    │   ASSAY     │    │  Response   │     │
-│  │ Gateway     │───▶│  Preflight  │───▶│  Filter     │     │
-│  │ (jailbreak) │    │ (tool args) │    │ (toxicity)  │     │
-│  └─────────────┘    └─────────────┘    └─────────────┘     │
-│                                                             │
-│  Classifier-based   DETERMINISTIC     Classifier-based     │
-│  ~200ms             <10ms p95         ~150ms               │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
-```
-
-**Assay owns the middle:** the tool-call decision point where deterministic enforcement is both possible and critical.
-
----
-
-## Decision Framework
-
-Use this to decide if Assay is right for your check:
-
-| Question | If Yes → Assay | If No → Other Tool |
-|----------|----------------|-------------------|
-| Can I express this as a JSON Schema? | ✅ `args_valid` | Use classifier |
-| Can I express this as a tool sequence? | ✅ `sequence_valid` | Use workflow engine |
-| Can I express this as a blocklist? | ✅ `tool_blocklist` | Use allowlist/RBAC |
-| Does "maybe" ever make sense? | ❌ Not Assay | Use probabilistic check |
-| Must the check be <10ms? | ✅ Assay | Async classifier OK |
-
----
-
-## FAQ
-
-### Can Assay detect prompt injection?
-
-No. Prompt injection detection requires semantic understanding of adversarial inputs. Use a dedicated prompt gateway or input sanitization layer.
-
-### Can Assay validate response quality?
-
-No. Quality is subjective and requires LLM-as-judge or human evaluation. Assay validates *actions*, not *content*.
-
-### Can Assay enforce rate limits?
-
-No. Rate limiting is a runtime infrastructure concern. Use your API gateway or agent framework's built-in throttling.
-
-### Can Assay replace my observability stack?
-
-No. Assay produces audit events, but it's not a monitoring platform. Export Assay results to your existing observability tools (Datadog, Grafana, etc.) via the planned OTel integration.
-
----
-
-## Summary
-
-| Assay Is | Assay Is Not |
-|----------|--------------|
-| Deterministic | Probabilistic |
-| Rule-based | Classifier-based |
-| Tool-focused | Content-focused |
-| Fast (<10ms) | Expensive (100ms+) |
-| Auditable | "Trust the model" |
-
-**Tagline:** If you can write it as a rule, Assay enforces it. If you need a model to decide, look elsewhere.
+Assay should make those external results portable when they matter; it should
+not become those systems.

--- a/docs/concepts/scope.md
+++ b/docs/concepts/scope.md
@@ -1,4 +1,4 @@
-# What Assay Is And Is Not
+# What Assay Is and Is Not
 
 Assay compiles agent runtime signals and selected external outcomes into
 verifiable evidence and bounded Trust Basis claims.
@@ -40,7 +40,7 @@ verified, what was merely visible, and what should not be claimed.
 The machine-readable receipt family surface is tracked in the
 [receipt family matrix](../reference/receipt-family-matrix.json).
 
-## Out Of Scope
+## Out of Scope
 
 | Area | Why It Is Not Assay |
 |---|---|

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,13 @@
   <br>
 </h1>
 
-<p class="subtitle">Policy-as-Code for AI Agents</p>
+<p class="subtitle">CI-native evidence compiler for agent governance</p>
 
-Assay is a **Policy-as-Code** engine for the Model Context Protocol (MCP). End-to-end governance pipeline: trace capture → policy generation → deterministic CI replay gating → verifiable evidence bundles → signed compliance packs.
+Assay compiles **agent runtime signals** and selected external outcomes into
+**verifiable evidence** and bounded **Trust Basis claims**. MCP policy
+enforcement is the wedge: Assay can sit between an agent and its tools, make
+deterministic allow/deny decisions, and preserve the evidence chain for CI,
+security review, and audit without a hosted backend.
 
 ---
 
@@ -22,11 +26,11 @@ curl -fsSL https://getassay.dev/install.sh | sh
 
 <div class="grid cards" markdown>
 
--   :material-shield-check:{ .lg .middle } __Policy Enforcement__
+-   :material-shield-check:{ .lg .middle } __Protocol Policy Enforcement__
 
     ---
 
-    Validate tool calls against JSON Schema constraints, sequence rules, and allowlists. No LLM calls in CI.
+    Validate MCP tool calls against JSON Schema constraints, sequence rules, and allowlists. No LLM calls in CI.
 
     [:octicons-arrow-right-24: Policy Reference](reference/config/policies.md)
 
@@ -34,17 +38,17 @@ curl -fsSL https://getassay.dev/install.sh | sh
 
     ---
 
-    Tamper-evident audit trails with content-addressed IDs. CloudEvents v1.0 format. SARIF output for GitHub Security. Combine with BYOS append-only storage for audit-grade completeness.
+    Tamper-evident audit trails with content-addressed IDs. Verify bundles offline and keep canonical evidence separate from projections.
 
     [:octicons-arrow-right-24: Evidence Guide](concepts/traces.md)
 
--   :material-clipboard-check:{ .lg .middle } __Compliance Packs__
+-   :material-clipboard-check:{ .lg .middle } __Trust Basis & Receipts__
 
     ---
 
-    Built-in rule packs that structure engineering evidence for EU AI Act, SOC 2, and custom policies. Article-referenced findings for auditors. Packs do not constitute legal compliance on their own.
+    Compile verified bundles into Trust Basis claims and import bounded external receipt families for eval outcomes, runtime decisions, and model inventory.
 
-    [:octicons-arrow-right-24: Pack Engine](architecture/SPEC-Pack-Engine-v1.md)
+    [:octicons-arrow-right-24: Receipt Matrix](reference/receipt-family-matrix.json)
 
 -   :material-key:{ .lg .middle } __Tool Signing__
 
@@ -78,7 +82,14 @@ assay evidence export --profile assay-profile.yaml --out bundle.tar.gz
 assay evidence verify bundle.tar.gz
 ```
 
-### 4. Lint with Compliance Pack
+### 4. Generate Trust Artifacts
+
+```bash
+assay trust-basis generate bundle.tar.gz --out trust-basis.json
+assay trustcard generate bundle.tar.gz --out-dir trustcard
+```
+
+### 5. Optional: Lint with a Pack
 
 ```bash
 assay evidence lint --pack eu-ai-act-baseline bundle.tar.gz
@@ -119,11 +130,12 @@ sudo assay monitor --policy policy.yaml --pid <agent-pid>
 | CloudEvents v1.0 | Evidence envelope format |
 | W3C Trace Context | `traceparent` correlation |
 | SARIF 2.1.0 | GitHub Code Scanning |
-| EU AI Act Article 12 | Compliance pack mapping |
+| EU AI Act Article 12 | Optional pack mapping |
 
 ## Next Steps
 
 - [**Getting Started**](getting-started/index.md)
+- [**Scope & Boundaries**](concepts/scope.md)
 - [**Operator Proof Flow**](guides/operator-proof-flow.md)
 - [**Python SDK**](getting-started/python-quickstart.md)
 - [**OpenTelemetry & Langfuse**](guides/otel-langfuse.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@
 
 site_name: Assay
 site_url: https://docs.assay.dev
-site_description: "The purity test for AI — Zero-flake CI for AI agents"
+site_description: "CI-native evidence compiler and Trust Basis artifacts for agent systems"
 site_author: Assay Team
 
 repo_name: Rul1an/assay


### PR DESCRIPTION
What changed

Adds the P52 product truth sync and records the P52-P56 consolidation program.

This PR includes:

- one umbrella plan for P52-P56 after the v3.8.0 receipt schema line
- README wording aligned to the current evidence/trust compiler surface
- docs home page rewritten away from the older Policy-as-Code-only framing
- refreshed "What Assay is and is not" scope page with Assay vs Assay Harness boundaries
- CLI help wording updated to evidence/trust compiler language
- AI-context docs bumped to the current v3.8.0 product truth

Why

Assay now has claim-visible eval, decision, and inventory receipt families plus a v3.8.0 schema registry. The next risk is not missing capability; it is product legibility. P52 makes the current public surface consistent without adding runtime behavior or new claims.

Boundary

This is a docs/product-truth slice plus one CLI about-string update. It does not add new Trust Basis claims, receipt families, schema semantics, Harness behavior, release claims, compliance claims, or partnership language.

Validation

Ran locally:

- cargo fmt --check
- git diff --check
- local changed-docs markdown link check
- cargo run -q -p assay-cli -- --help
- cargo run -q -p assay-cli -- evidence --help

Push-time hooks also passed, including workspace clippy and linux compile gate.
