### PR TITLE
P53: add Trust Basis assert command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Trust Compiler
+
+- **Trust Basis assertions**: `assay trust-basis assert` can now gate one
+  canonical `trust-basis.json` artifact against generic
+  `--require <claim-id>=<level>` predicates. The command is claim-id based,
+  emits text or `assay.trust-basis.assert.v1` JSON, exits `0` on pass, exits
+  `1` on policy mismatch, and keeps input/config/runtime failures on `2+`.
+
 ## [3.8.0] - 2026-04-29
 
 This minor release turns the v3.7.0 three-family receipt surface into a more

--- a/crates/assay-cli/src/cli/args/trust_basis.rs
+++ b/crates/assay-cli/src/cli/args/trust_basis.rs
@@ -14,6 +14,8 @@ pub enum TrustBasisSub {
     Generate(TrustBasisGenerateArgs),
     /// Compare two canonical trust-basis.json artifacts
     Diff(TrustBasisDiffArgs),
+    /// Assert required claim levels in one canonical trust-basis.json artifact
+    Assert(TrustBasisAssertArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -52,4 +54,19 @@ pub struct TrustBasisDiffArgs {
     /// Exit non-zero when the candidate removes or lowers a baseline claim
     #[arg(long)]
     pub fail_on_regression: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct TrustBasisAssertArgs {
+    /// Trust Basis JSON artifact produced by `assay trust-basis generate`
+    #[arg(long, short = 'i', value_name = "TRUST_BASIS")]
+    pub input: PathBuf,
+
+    /// Required claim level, formatted as <claim-id>=<level>
+    #[arg(long = "require", value_name = "CLAIM=LEVEL", required = true)]
+    pub requirements: Vec<String>,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
 }

--- a/crates/assay-cli/src/cli/commands/trust_basis.rs
+++ b/crates/assay-cli/src/cli/commands/trust_basis.rs
@@ -1,5 +1,6 @@
 use crate::cli::args::{
-    OutputFormat, TrustBasisArgs, TrustBasisDiffArgs, TrustBasisGenerateArgs, TrustBasisSub,
+    OutputFormat, TrustBasisArgs, TrustBasisAssertArgs, TrustBasisDiffArgs, TrustBasisGenerateArgs,
+    TrustBasisSub,
 };
 use crate::exit_codes::{EXIT_SUCCESS, EXIT_TEST_FAILURE};
 use anyhow::{bail, Context, Result};
@@ -11,13 +12,18 @@ use assay_evidence::{
     TrustBasisClaimPresenceDiff, TrustBasisDiffReport, TrustBasisOptions, TrustClaimBoundary,
     TrustClaimId, TrustClaimLevel, TrustClaimSource, VerifyLimits,
 };
+use serde::Serialize;
+use serde_json::Value;
 use std::fs::File;
 use std::io::Write;
+
+const TRUST_BASIS_ASSERT_SCHEMA: &str = "assay.trust-basis.assert.v1";
 
 pub fn run(args: TrustBasisArgs) -> Result<i32> {
     match args.cmd {
         TrustBasisSub::Generate(args) => cmd_generate(args),
         TrustBasisSub::Diff(args) => cmd_diff(args),
+        TrustBasisSub::Assert(args) => cmd_assert(args),
     }
 }
 
@@ -84,6 +90,28 @@ fn cmd_diff(args: TrustBasisDiffArgs) -> Result<i32> {
     Ok(EXIT_SUCCESS)
 }
 
+fn cmd_assert(args: TrustBasisAssertArgs) -> Result<i32> {
+    let trust_basis = read_trust_basis(&args.input)?;
+    ensure_unique_claim_ids("input", &trust_basis)?;
+    let requirements = parse_requirements(&args.requirements)?;
+    let report = assert_trust_basis(&trust_basis, requirements);
+
+    match args.format {
+        OutputFormat::Text => {
+            write_assert_text(&report).context("failed to write assert output")?
+        }
+        OutputFormat::Json => {
+            write_assert_json(&report).context("failed to write assert output")?
+        }
+    }
+
+    if report.summary.failed_requirements > 0 {
+        return Ok(EXIT_TEST_FAILURE);
+    }
+
+    Ok(EXIT_SUCCESS)
+}
+
 fn read_trust_basis(path: &std::path::Path) -> Result<TrustBasis> {
     let file = File::open(path)
         .with_context(|| format!("failed to open trust basis {}", path.display()))?;
@@ -103,6 +131,166 @@ fn ensure_unique_claim_ids(label: &str, trust_basis: &TrustBasis) -> Result<()> 
         .collect::<Vec<_>>()
         .join(", ");
     bail!("{label} Trust Basis contains duplicate claim id(s): {duplicate_labels}");
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TrustBasisRequirement {
+    claim_id: TrustClaimId,
+    expected_level: TrustClaimLevel,
+}
+
+#[derive(Debug, Serialize)]
+struct TrustBasisAssertReport {
+    schema: &'static str,
+    claim_identity: &'static str,
+    summary: TrustBasisAssertSummary,
+    requirements: Vec<TrustBasisAssertRequirementResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct TrustBasisAssertSummary {
+    total_requirements: usize,
+    passed_requirements: usize,
+    failed_requirements: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct TrustBasisAssertRequirementResult {
+    claim_id: TrustClaimId,
+    expected_level: TrustClaimLevel,
+    actual_level: Option<TrustClaimLevel>,
+    status: TrustBasisAssertStatus,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TrustBasisAssertStatus {
+    Passed,
+    Failed,
+}
+
+fn parse_requirements(raw_requirements: &[String]) -> Result<Vec<TrustBasisRequirement>> {
+    raw_requirements
+        .iter()
+        .map(|raw| parse_requirement(raw))
+        .collect()
+}
+
+fn parse_requirement(raw: &str) -> Result<TrustBasisRequirement> {
+    let (claim_id_raw, level_raw) = raw.split_once('=').ok_or_else(|| {
+        anyhow::anyhow!("invalid trust basis requirement {raw:?}: expected <claim-id>=<level>")
+    })?;
+    let claim_id = parse_claim_id(claim_id_raw.trim())?;
+    let expected_level = parse_claim_level(level_raw.trim())?;
+    Ok(TrustBasisRequirement {
+        claim_id,
+        expected_level,
+    })
+}
+
+fn parse_claim_id(raw: &str) -> Result<TrustClaimId> {
+    if raw.is_empty() {
+        bail!("invalid trust basis requirement: claim id is empty");
+    }
+    serde_json::from_value(Value::String(raw.to_string()))
+        .with_context(|| format!("unknown Trust Basis claim id {raw:?}"))
+}
+
+fn parse_claim_level(raw: &str) -> Result<TrustClaimLevel> {
+    if raw.is_empty() {
+        bail!("invalid trust basis requirement: claim level is empty");
+    }
+    serde_json::from_value(Value::String(raw.to_string()))
+        .with_context(|| format!("unknown Trust Basis claim level {raw:?}"))
+}
+
+fn assert_trust_basis(
+    trust_basis: &TrustBasis,
+    requirements: Vec<TrustBasisRequirement>,
+) -> TrustBasisAssertReport {
+    let results: Vec<TrustBasisAssertRequirementResult> = requirements
+        .into_iter()
+        .map(|requirement| {
+            let actual_level = trust_basis
+                .claims
+                .iter()
+                .find(|claim| claim.id == requirement.claim_id)
+                .map(|claim| claim.level);
+            let status = if actual_level == Some(requirement.expected_level) {
+                TrustBasisAssertStatus::Passed
+            } else {
+                TrustBasisAssertStatus::Failed
+            };
+            TrustBasisAssertRequirementResult {
+                claim_id: requirement.claim_id,
+                expected_level: requirement.expected_level,
+                actual_level,
+                status,
+            }
+        })
+        .collect();
+
+    let passed_requirements = results
+        .iter()
+        .filter(|result| matches!(result.status, TrustBasisAssertStatus::Passed))
+        .count();
+    let failed_requirements = results.len().saturating_sub(passed_requirements);
+
+    TrustBasisAssertReport {
+        schema: TRUST_BASIS_ASSERT_SCHEMA,
+        claim_identity: "claim.id",
+        summary: TrustBasisAssertSummary {
+            total_requirements: results.len(),
+            passed_requirements,
+            failed_requirements,
+        },
+        requirements: results,
+    }
+}
+
+fn write_assert_json(report: &TrustBasisAssertReport) -> Result<()> {
+    let mut stdout = std::io::stdout();
+    serde_json::to_writer_pretty(&mut stdout, report)?;
+    stdout.write_all(b"\n")?;
+    Ok(())
+}
+
+fn write_assert_text(report: &TrustBasisAssertReport) -> Result<()> {
+    let mut stdout = std::io::stdout();
+    if report.summary.failed_requirements == 0 {
+        writeln!(
+            stdout,
+            "Trust Basis assertions passed: {}/{} requirement(s)",
+            report.summary.passed_requirements, report.summary.total_requirements
+        )?;
+    } else {
+        writeln!(
+            stdout,
+            "Trust Basis assertions failed: {}/{} requirement(s) failed",
+            report.summary.failed_requirements, report.summary.total_requirements
+        )?;
+    }
+
+    for result in &report.requirements {
+        let marker = match result.status {
+            TrustBasisAssertStatus::Passed => "PASS",
+            TrustBasisAssertStatus::Failed => "FAIL",
+        };
+        writeln!(
+            stdout,
+            "- {marker} {}: expected {}, actual {}",
+            id_label(result.claim_id),
+            level_label(result.expected_level),
+            assert_actual_level_label(result.actual_level)
+        )?;
+    }
+    Ok(())
+}
+
+fn assert_actual_level_label(level: Option<TrustClaimLevel>) -> String {
+    level
+        .map(level_label)
+        .unwrap_or_else(|| "missing".to_string())
 }
 
 fn write_diff_json(report: &TrustBasisDiffReport) -> Result<()> {

--- a/crates/assay-cli/src/cli/commands/trust_basis.rs
+++ b/crates/assay-cli/src/cli/commands/trust_basis.rs
@@ -14,6 +14,7 @@ use assay_evidence::{
 };
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 
@@ -208,14 +209,16 @@ fn assert_trust_basis(
     trust_basis: &TrustBasis,
     requirements: Vec<TrustBasisRequirement>,
 ) -> TrustBasisAssertReport {
+    let claim_levels: HashMap<TrustClaimId, TrustClaimLevel> = trust_basis
+        .claims
+        .iter()
+        .map(|claim| (claim.id, claim.level))
+        .collect();
+
     let results: Vec<TrustBasisAssertRequirementResult> = requirements
         .into_iter()
         .map(|requirement| {
-            let actual_level = trust_basis
-                .claims
-                .iter()
-                .find(|claim| claim.id == requirement.claim_id)
-                .map(|claim| claim.level);
+            let actual_level = claim_levels.get(&requirement.claim_id).copied();
             let status = if actual_level == Some(requirement.expected_level) {
                 TrustBasisAssertStatus::Passed
             } else {

--- a/crates/assay-cli/tests/trust_basis_test.rs
+++ b/crates/assay-cli/tests/trust_basis_test.rs
@@ -74,6 +74,20 @@ fn write_duplicate_claim_trust_basis_json(path: &std::path::Path) {
     fs::write(path, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
 }
 
+fn write_minimal_trust_basis_json(path: &std::path::Path) {
+    let value = json!({
+        "claims": [
+            {
+                "id": "bundle_verified",
+                "level": "verified",
+                "source": "bundle_verification",
+                "boundary": "bundle-wide"
+            }
+        ]
+    });
+    fs::write(path, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
+}
+
 #[test]
 fn trust_basis_generate_stdout_emits_all_frozen_claims() {
     let dir = tempdir().unwrap();
@@ -290,5 +304,129 @@ fn trust_basis_diff_rejects_duplicate_claim_identity() {
         .code(2)
         .stderr(predicate::str::contains(
             "baseline Trust Basis contains duplicate claim id(s): bundle_verified",
+        ));
+}
+
+#[test]
+fn trust_basis_assert_passes_required_claim_level() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("trust-basis.json");
+    write_trust_basis_json(&input, "verified");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("assert")
+        .arg("--input")
+        .arg(&input)
+        .arg("--require")
+        .arg("external_eval_receipt_boundary_visible=verified")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Trust Basis assertions passed"))
+        .stdout(predicate::str::contains(
+            "external_eval_receipt_boundary_visible: expected verified, actual verified",
+        ));
+}
+
+#[test]
+fn trust_basis_assert_exits_one_on_mismatch() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("trust-basis.json");
+    write_trust_basis_json(&input, "absent");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("assert")
+        .arg("--input")
+        .arg(&input)
+        .arg("--require")
+        .arg("external_eval_receipt_boundary_visible=verified")
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("Trust Basis assertions failed"))
+        .stdout(predicate::str::contains(
+            "external_eval_receipt_boundary_visible: expected verified, actual absent",
+        ));
+}
+
+#[test]
+fn trust_basis_assert_json_reports_missing_claim_as_failed_requirement() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("trust-basis.json");
+    write_minimal_trust_basis_json(&input);
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("assert")
+        .arg("--input")
+        .arg(&input)
+        .arg("--require")
+        .arg("external_eval_receipt_boundary_visible=verified")
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(stdout["schema"], "assay.trust-basis.assert.v1");
+    assert_eq!(stdout["claim_identity"], "claim.id");
+    assert_eq!(stdout["summary"]["total_requirements"], 1);
+    assert_eq!(stdout["summary"]["passed_requirements"], 0);
+    assert_eq!(stdout["summary"]["failed_requirements"], 1);
+    assert_eq!(
+        stdout["requirements"][0]["claim_id"],
+        "external_eval_receipt_boundary_visible"
+    );
+    assert_eq!(stdout["requirements"][0]["expected_level"], "verified");
+    assert_eq!(
+        stdout["requirements"][0]["actual_level"],
+        serde_json::Value::Null
+    );
+    assert_eq!(stdout["requirements"][0]["status"], "failed");
+}
+
+#[test]
+fn trust_basis_assert_rejects_unknown_claim_id_as_input_error() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("trust-basis.json");
+    write_trust_basis_json(&input, "verified");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("assert")
+        .arg("--input")
+        .arg(&input)
+        .arg("--require")
+        .arg("not_a_claim=verified")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "unknown Trust Basis claim id \"not_a_claim\"",
+        ));
+}
+
+#[test]
+fn trust_basis_assert_rejects_duplicate_claim_identity() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("trust-basis.json");
+    write_duplicate_claim_trust_basis_json(&input);
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("assert")
+        .arg("--input")
+        .arg(&input)
+        .arg("--require")
+        .arg("bundle_verified=verified")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "input Trust Basis contains duplicate claim id(s): bundle_verified",
         ));
 }

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -31,7 +31,7 @@ assay --version
 | [`assay bundle`](bundle.md) | Create/verify replay bundles |
 | [`assay replay`](replay.md) | Replay from a replay bundle |
 | [`assay evidence`](evidence.md) | Manage evidence bundles and external evidence imports |
-| [`assay trust-basis`](trust-basis.md) | Generate and compare canonical Trust Basis artifacts |
+| [`assay trust-basis`](trust-basis.md) | Generate, compare, and assert canonical Trust Basis artifacts |
 | [`assay import`](import.md) | Import sessions from MCP Inspector, etc. |
 | [`assay migrate`](migrate.md) | Upgrade config from v0 to v1 |
 | [`assay doctor`](doctor.md) | Diagnose setup and optionally auto-fix known issues |

--- a/docs/reference/cli/trust-basis.md
+++ b/docs/reference/cli/trust-basis.md
@@ -104,6 +104,64 @@ Exit codes are:
 
 ---
 
+## Assert
+
+Assert required claim levels in one canonical Trust Basis artifact:
+
+```bash
+assay trust-basis assert \
+  --input trust-basis.json \
+  --require external_eval_receipt_boundary_visible=verified
+```
+
+`assert` is intentionally smaller than `diff`. It reads one
+`trust-basis.json` artifact, keys requirements only by stable `claim.id`, and
+checks that each requested claim has the expected level.
+
+Multiple requirements are allowed:
+
+```bash
+assay trust-basis assert \
+  --input trust-basis.json \
+  --require bundle_verified=verified \
+  --require external_decision_receipt_boundary_visible=verified
+```
+
+Use JSON output for CI consumers:
+
+```bash
+assay trust-basis assert \
+  --input trust-basis.json \
+  --require external_inventory_receipt_boundary_visible=verified \
+  --format json
+```
+
+JSON output uses the stable machine-readable schema
+`assay.trust-basis.assert.v1` and includes:
+
+- `summary`
+- `requirements`
+- `claim_id`
+- `expected_level`
+- `actual_level`
+- `status`
+
+Missing claims are policy mismatches, not successes. Unknown claim IDs, unknown
+levels, malformed requirements, duplicate claim IDs in the input artifact, and
+parse errors are input/config failures.
+
+Exit codes are:
+
+- `0` when all requirements are satisfied.
+- `1` when at least one requirement does not match.
+- Other non-zero codes for input, parse, or validation failures.
+
+`assert` does not compare baseline and candidate artifacts, replace
+`trust-basis diff`, or add Promptfoo/OpenFeature/CycloneDX-specific policy. It
+is a generic claim-id gate over one Trust Basis artifact.
+
+---
+
 ## See Also
 
 - [Evidence imports](./evidence.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,9 +180,12 @@ nav:
     - assay doctor: reference/cli/doctor.md
     - assay watch: reference/cli/watch.md
     - assay sandbox: reference/cli/sandbox.md
+    - assay evidence: reference/cli/evidence.md
+    - assay bundle: reference/cli/bundle.md
     - assay import: reference/cli/import.md
     - assay migrate: reference/cli/migrate.md
     - assay replay: reference/cli/replay.md
+    - assay trust-basis: reference/cli/trust-basis.md
     - assay mcp-server: reference/cli/mcp-server.md
 
   - Metrics Reference:


### PR DESCRIPTION
What changed

Adds P53: a small generic assertion layer over one canonical Trust Basis artifact.

This PR includes:

- `assay trust-basis assert --input trust-basis.json --require <claim-id>=<level>`
- text output for humans and `assay.trust-basis.assert.v1` JSON for machines
- exit-code split: `0` pass, `1` requirement mismatch, `2+` input/config/runtime errors
- duplicate claim-id rejection, unknown claim/level rejection, and missing-claim mismatch handling
- CLI docs, mkdocs nav wiring, changelog entry, and regression tests

Why

P52 made the product surface legible. P53 makes Trust Basis directly usable as a small CI gate without requiring Harness and without turning this command into baseline/candidate diffing.

Boundary

This is a generic claim-id assertion command over one Trust Basis JSON artifact. It does not compare baseline/candidate artifacts, replace `trust-basis diff`, add Harness behavior, add domain-specific Promptfoo/OpenFeature/CycloneDX policy, or add new Trust Basis claims.

Validation

Ran locally:

- cargo fmt --check
- git diff --check
- cargo test -p assay-cli --test trust_basis_test -- --nocapture
- cargo clippy -p assay-cli --all-targets -- -D warnings
- cargo clippy -p assay-evidence --all-targets -- -D warnings
- local changed-docs markdown link check
- cargo run -q -p assay-cli -- trust-basis --help
- cargo run -q -p assay-cli -- trust-basis assert --help

Push-time hooks also passed, including workspace clippy and linux compile gate.
