### PR TITLE
P55: add receipt schema CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file.
   `--require <claim-id>=<level>` predicates. The command is claim-id based,
   emits text or `assay.trust-basis.assert.v1` JSON, exits `0` on pass, exits
   `1` on policy mismatch, and keeps input/config/runtime failures on `2+`.
+- **Receipt schema CLI**: `assay evidence schema list/show/validate` exposes
+  the v3.8.0 receipt schema registry as a command-line surface. It lists
+  receipt payload and importer-input schemas, shows schema metadata before raw
+  JSON Schema content, validates JSON or JSONL artifacts, and keeps Mastra
+  marked as importer-only rather than a public Trust Basis claim family.
 
 ## [3.8.0] - 2026-04-29
 

--- a/crates/assay-cli/receipt-schemas/inputs/cyclonedx-mlbom-model-component-input.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/inputs/cyclonedx-mlbom-model-component-input.v1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/v3.8.0/docs/reference/receipt-schemas/inputs/cyclonedx-mlbom-model-component-input.v1.schema.json",
+  "title": "Assay-supported CycloneDX ML-BOM Model Component Input v1",
+  "type": "object",
+  "required": ["bomFormat", "components"],
+  "properties": {
+    "bomFormat": { "const": "CycloneDX" },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "contains": {
+        "type": "object",
+        "required": ["type", "bom-ref", "name"],
+        "properties": {
+          "type": { "const": "machine-learning-model" },
+          "bom-ref": { "$ref": "#/$defs/boundedString" },
+          "name": { "$ref": "#/$defs/boundedString" }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string" },
+          "bom-ref": { "$ref": "#/$defs/boundedString" },
+          "name": { "$ref": "#/$defs/boundedString" },
+          "version": { "$ref": "#/$defs/boundedString" },
+          "publisher": { "$ref": "#/$defs/boundedString" },
+          "purl": { "$ref": "#/$defs/boundedString" },
+          "modelCard": { "type": "object" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "boundedString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    }
+  }
+}

--- a/crates/assay-cli/receipt-schemas/inputs/mastra-score-event-export.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/inputs/mastra-score-event-export.v1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/v3.8.0/docs/reference/receipt-schemas/inputs/mastra-score-event-export.v1.schema.json",
+  "title": "Assay-supported Mastra Reduced ScoreEvent Export Row v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "framework", "surface", "timestamp", "score", "target_ref"],
+  "anyOf": [
+    { "required": ["scorer_id"] },
+    { "required": ["scorer_name"] }
+  ],
+  "properties": {
+    "schema": { "const": "mastra.score-event.export.v1" },
+    "framework": { "const": "mastra" },
+    "surface": { "const": "observability.score_event" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "score": { "type": "number" },
+    "target_ref": { "$ref": "#/$defs/boundedString" },
+    "score_id_ref": { "$ref": "#/$defs/boundedString" },
+    "scorer_id": { "$ref": "#/$defs/boundedString" },
+    "scorer_name": { "$ref": "#/$defs/boundedString" },
+    "scorer_version": { "$ref": "#/$defs/boundedString" },
+    "score_source": { "$ref": "#/$defs/boundedString" },
+    "reason": { "$ref": "#/$defs/reasonString" },
+    "trace_id_ref": { "$ref": "#/$defs/boundedString" },
+    "span_id_ref": { "$ref": "#/$defs/boundedString" },
+    "score_trace_id_ref": { "$ref": "#/$defs/boundedString" },
+    "target_entity_type": { "$ref": "#/$defs/boundedString" },
+    "metadata_ref": { "$ref": "#/$defs/boundedString" }
+  },
+  "$defs": {
+    "boundedString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    },
+    "reasonString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    }
+  }
+}

--- a/crates/assay-cli/receipt-schemas/inputs/openfeature-evaluation-details-export.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/inputs/openfeature-evaluation-details-export.v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/v3.8.0/docs/reference/receipt-schemas/inputs/openfeature-evaluation-details-export.v1.schema.json",
+  "title": "Assay-supported OpenFeature EvaluationDetails Export Row v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "framework", "surface", "target_kind", "flag_key", "result"],
+  "properties": {
+    "schema": { "const": "openfeature.evaluation-details.export.v1" },
+    "framework": { "const": "openfeature" },
+    "surface": { "const": "evaluation_details" },
+    "target_kind": { "const": "feature_flag" },
+    "flag_key": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": { "type": "boolean" },
+        "variant": { "$ref": "#/$defs/boundedString" },
+        "reason": { "$ref": "#/$defs/boundedString" },
+        "error_code": { "$ref": "#/$defs/boundedString" }
+      }
+    }
+  },
+  "$defs": {
+    "boundedString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    }
+  }
+}

--- a/crates/assay-cli/receipt-schemas/inputs/promptfoo-cli-jsonl-component-result.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/inputs/promptfoo-cli-jsonl-component-result.v1.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/v3.8.0/docs/reference/receipt-schemas/inputs/promptfoo-cli-jsonl-component-result.v1.schema.json",
+  "title": "Assay-supported Promptfoo CLI JSONL Row v1",
+  "type": "object",
+  "required": ["gradingResult"],
+  "properties": {
+    "gradingResult": {
+      "type": "object",
+      "required": ["componentResults"],
+      "properties": {
+        "componentResults": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["pass", "score"],
+            "properties": {
+              "pass": { "type": "boolean" },
+              "score": { "enum": [0, 1] },
+              "reason": { "type": "string" },
+              "assertion": {
+                "type": "object",
+                "properties": {
+                  "type": { "const": "equals" }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/crates/assay-cli/receipt-schemas/receipts/cyclonedx.mlbom-model-component.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/receipts/cyclonedx.mlbom-model-component.v1.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/v3.8.0/docs/reference/receipt-schemas/receipts/cyclonedx.mlbom-model-component.v1.schema.json",
+  "title": "Assay CycloneDX ML-BOM Model Component Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "source_system",
+    "source_surface",
+    "source_artifact_ref",
+    "source_artifact_digest",
+    "reducer_version",
+    "imported_at",
+    "model_component"
+  ],
+  "properties": {
+    "schema": { "const": "assay.receipt.cyclonedx.mlbom-model-component.v1" },
+    "source_system": { "const": "cyclonedx" },
+    "source_surface": { "const": "bom.components[type=machine-learning-model]" },
+    "source_artifact_ref": { "$ref": "#/$defs/boundedRef" },
+    "source_artifact_digest": { "$ref": "#/$defs/sha256Digest" },
+    "reducer_version": { "const": "assay-cyclonedx-mlbom-model-component@0.1.0" },
+    "imported_at": { "type": "string", "format": "date-time" },
+    "model_component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bom_ref", "name"],
+      "properties": {
+        "bom_ref": { "$ref": "#/$defs/boundedString" },
+        "name": { "$ref": "#/$defs/boundedString" },
+        "version": { "$ref": "#/$defs/boundedString" },
+        "publisher": { "$ref": "#/$defs/boundedString" },
+        "purl": { "$ref": "#/$defs/boundedString" },
+        "dataset_refs": { "$ref": "#/$defs/refArray" },
+        "model_card_refs": { "$ref": "#/$defs/refArray" }
+      }
+    }
+  },
+  "$defs": {
+    "boundedRef": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "boundedString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    },
+    "refArray": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": { "$ref": "#/$defs/boundedString" }
+    },
+    "sha256Digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    }
+  }
+}

--- a/crates/assay-cli/receipt-schemas/receipts/mastra.score-event.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/receipts/mastra.score-event.v1.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/v3.8.0/docs/reference/receipt-schemas/receipts/mastra.score-event.v1.schema.json",
+  "title": "Assay Mastra ScoreEvent Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "source_system",
+    "source_surface",
+    "source_artifact_ref",
+    "source_artifact_digest",
+    "reducer_version",
+    "imported_at",
+    "score_event"
+  ],
+  "properties": {
+    "schema": { "const": "assay.receipt.mastra.score_event.v1" },
+    "source_system": { "const": "mastra" },
+    "source_surface": { "const": "observability.score_event" },
+    "source_artifact_ref": { "$ref": "#/$defs/boundedRef" },
+    "source_artifact_digest": { "$ref": "#/$defs/sha256Digest" },
+    "reducer_version": { "const": "assay-mastra-score-event@0.1.0" },
+    "imported_at": { "type": "string", "format": "date-time" },
+    "score_event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "target_ref", "timestamp"],
+      "anyOf": [
+        { "required": ["scorer_id"] },
+        { "required": ["scorer_name"] }
+      ],
+      "properties": {
+        "score": { "type": "number" },
+        "target_ref": { "$ref": "#/$defs/boundedString" },
+        "timestamp": { "type": "string", "format": "date-time" },
+        "score_id_ref": { "$ref": "#/$defs/boundedString" },
+        "scorer_id": { "$ref": "#/$defs/boundedString" },
+        "scorer_name": { "$ref": "#/$defs/boundedString" },
+        "scorer_version": { "$ref": "#/$defs/boundedString" },
+        "score_source": { "$ref": "#/$defs/boundedString" },
+        "trace_id_ref": { "$ref": "#/$defs/boundedString" },
+        "span_id_ref": { "$ref": "#/$defs/boundedString" },
+        "score_trace_id_ref": { "$ref": "#/$defs/boundedString" },
+        "target_entity_type": { "$ref": "#/$defs/boundedString" },
+        "metadata_ref": { "$ref": "#/$defs/boundedString" },
+        "reason": { "$ref": "#/$defs/reasonString" }
+      }
+    }
+  },
+  "$defs": {
+    "boundedRef": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "boundedString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    },
+    "reasonString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    },
+    "sha256Digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    }
+  }
+}

--- a/crates/assay-cli/receipt-schemas/receipts/openfeature.evaluation-details.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/receipts/openfeature.evaluation-details.v1.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/v3.8.0/docs/reference/receipt-schemas/receipts/openfeature.evaluation-details.v1.schema.json",
+  "title": "Assay OpenFeature EvaluationDetails Decision Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "source_system",
+    "source_surface",
+    "source_artifact_ref",
+    "source_artifact_digest",
+    "reducer_version",
+    "imported_at",
+    "decision"
+  ],
+  "properties": {
+    "schema": { "const": "assay.receipt.openfeature.evaluation_details.v1" },
+    "source_system": { "const": "openfeature" },
+    "source_surface": { "const": "evaluation_details.boolean" },
+    "source_artifact_ref": { "$ref": "#/$defs/boundedRef" },
+    "source_artifact_digest": { "$ref": "#/$defs/sha256Digest" },
+    "reducer_version": { "const": "assay-openfeature-evaluation-details@0.1.0" },
+    "imported_at": { "type": "string", "format": "date-time" },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["flag_key", "value_type", "value"],
+      "properties": {
+        "flag_key": { "$ref": "#/$defs/flagKey" },
+        "value_type": { "const": "boolean" },
+        "value": { "type": "boolean" },
+        "variant": { "$ref": "#/$defs/boundedString" },
+        "reason": { "$ref": "#/$defs/boundedString" },
+        "error_code": { "$ref": "#/$defs/boundedString" }
+      }
+    }
+  },
+  "$defs": {
+    "boundedRef": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "boundedString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    },
+    "flagKey": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "pattern": "^[^\\r\\n\\\"`{}]+$"
+    },
+    "sha256Digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    }
+  }
+}

--- a/crates/assay-cli/receipt-schemas/receipts/promptfoo.assertion-component.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/receipts/promptfoo.assertion-component.v1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/v3.8.0/docs/reference/receipt-schemas/receipts/promptfoo.assertion-component.v1.schema.json",
+  "title": "Assay Promptfoo Assertion Component Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "source_system",
+    "source_surface",
+    "source_artifact_ref",
+    "source_artifact_digest",
+    "reducer_version",
+    "imported_at",
+    "assertion_type",
+    "result"
+  ],
+  "properties": {
+    "schema": { "const": "assay.receipt.promptfoo.assertion-component.v1" },
+    "source_system": { "const": "promptfoo" },
+    "source_surface": { "const": "cli-jsonl.gradingResult.componentResults" },
+    "source_artifact_ref": { "$ref": "#/$defs/boundedRef" },
+    "source_artifact_digest": { "$ref": "#/$defs/sha256Digest" },
+    "reducer_version": { "const": "assay-promptfoo-jsonl-component-result@0.1.0" },
+    "imported_at": { "type": "string", "format": "date-time" },
+    "assertion_type": { "const": "equals" },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pass", "score"],
+      "properties": {
+        "pass": { "type": "boolean" },
+        "score": { "enum": [0, 1] },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160,
+          "pattern": "^[^\\r\\n\\\"`{}]+$"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "boundedRef": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "sha256Digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    }
+  }
+}

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -8,6 +8,7 @@ pub mod openfeature_details;
 pub mod promptfoo_jsonl;
 pub mod pull;
 pub mod push;
+pub mod schema;
 pub mod store_status;
 
 use anyhow::{Context, Result};
@@ -27,6 +28,8 @@ pub enum EvidenceCmd {
     Show(EvidenceShowArgs),
     /// Import external evidence into an Assay evidence bundle
     Import(EvidenceImportArgs),
+    /// Inspect and validate supported receipt/input schemas
+    Schema(schema::SchemaArgs),
     /// Lint a bundle for quality and security issues
     Lint(lint::LintArgs),
     /// Diff two bundles and report changes
@@ -109,6 +112,7 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
         EvidenceCmd::Verify(a) => cmd_verify(a),
         EvidenceCmd::Show(a) => cmd_show(a),
         EvidenceCmd::Import(a) => cmd_import(a),
+        EvidenceCmd::Schema(a) => schema::cmd_schema(a),
         EvidenceCmd::Lint(a) => lint::cmd_lint(a),
         EvidenceCmd::Diff(a) => diff::cmd_diff(a),
         EvidenceCmd::Push(a) => push::cmd_push(a).await,

--- a/crates/assay-cli/src/cli/commands/evidence/schema.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/schema.rs
@@ -1,5 +1,5 @@
 use crate::cli::args::OutputFormat;
-use crate::exit_codes::{EXIT_SUCCESS, EXIT_TEST_FAILURE};
+use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_SUCCESS, EXIT_TEST_FAILURE};
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand};
 use jsonschema::Draft;
@@ -12,38 +12,32 @@ const SCHEMA_LIST_REPORT: &str = "assay.evidence.schema.list.v1";
 const SCHEMA_SHOW_REPORT: &str = "assay.evidence.schema.show.v1";
 const SCHEMA_VALIDATION_REPORT: &str = "assay.evidence.schema.validation.v1";
 
-const PROMPTFOO_RECEIPT_SCHEMA: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../docs/reference/receipt-schemas/receipts/promptfoo.assertion-component.v1.schema.json"
-));
-const OPENFEATURE_RECEIPT_SCHEMA: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../docs/reference/receipt-schemas/receipts/openfeature.evaluation-details.v1.schema.json"
-));
-const CYCLONEDX_RECEIPT_SCHEMA: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../docs/reference/receipt-schemas/receipts/cyclonedx.mlbom-model-component.v1.schema.json"
-));
-const MASTRA_RECEIPT_SCHEMA: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../docs/reference/receipt-schemas/receipts/mastra.score-event.v1.schema.json"
-));
-const PROMPTFOO_INPUT_SCHEMA: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../docs/reference/receipt-schemas/inputs/promptfoo-cli-jsonl-component-result.v1.schema.json"
-));
-const OPENFEATURE_INPUT_SCHEMA: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../docs/reference/receipt-schemas/inputs/openfeature-evaluation-details-export.v1.schema.json"
-));
-const CYCLONEDX_INPUT_SCHEMA: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../docs/reference/receipt-schemas/inputs/cyclonedx-mlbom-model-component-input.v1.schema.json"
-));
-const MASTRA_INPUT_SCHEMA: &str = include_str!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../docs/reference/receipt-schemas/inputs/mastra-score-event-export.v1.schema.json"
-));
+macro_rules! include_packaged_schema {
+    ($relative_path:literal) => {
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/receipt-schemas/",
+            $relative_path
+        ))
+    };
+}
+
+const PROMPTFOO_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/promptfoo.assertion-component.v1.schema.json");
+const OPENFEATURE_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/openfeature.evaluation-details.v1.schema.json");
+const CYCLONEDX_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/cyclonedx.mlbom-model-component.v1.schema.json");
+const MASTRA_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/mastra.score-event.v1.schema.json");
+const PROMPTFOO_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/promptfoo-cli-jsonl-component-result.v1.schema.json");
+const OPENFEATURE_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/openfeature-evaluation-details-export.v1.schema.json");
+const CYCLONEDX_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/cyclonedx-mlbom-model-component-input.v1.schema.json");
+const MASTRA_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/mastra-score-event-export.v1.schema.json");
 
 /// Inspect and validate supported receipt schema contracts.
 #[derive(Debug, Args, Clone)]
@@ -296,8 +290,28 @@ struct SchemaValidationReport {
 #[derive(Debug, Serialize)]
 struct SchemaValidationError {
     document: usize,
+    kind: SchemaValidationErrorKind,
     instance_path: String,
     message: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SchemaValidationErrorKind {
+    Parse,
+    EmptyInput,
+    Schema,
+}
+
+impl SchemaValidationReport {
+    fn has_input_errors(&self) -> bool {
+        self.errors.iter().any(|error| {
+            matches!(
+                error.kind,
+                SchemaValidationErrorKind::Parse | SchemaValidationErrorKind::EmptyInput
+            )
+        })
+    }
 }
 
 pub fn cmd_schema(args: SchemaArgs) -> Result<i32> {
@@ -364,6 +378,8 @@ fn cmd_validate(args: SchemaValidateArgs) -> Result<i32> {
 
     if report.valid {
         Ok(EXIT_SUCCESS)
+    } else if report.has_input_errors() {
+        Ok(EXIT_CONFIG_ERROR)
     } else {
         Ok(EXIT_TEST_FAILURE)
     }
@@ -381,9 +397,7 @@ fn find_schema(raw: &str) -> Result<&'static SchemaDescriptor> {
         }
     }
 
-    bail!(
-        "unknown receipt schema {needle:?}; run `assay evidence schema list` for supported schemas"
-    );
+    bail!("unknown schema {needle:?}; run `assay evidence schema list` for supported schemas");
 }
 
 fn schema_metadata(descriptor: &SchemaDescriptor) -> Result<SchemaMetadata> {
@@ -426,6 +440,7 @@ fn validate_input(
                 Ok(value) => collect_validation_errors(line_number, &value, validator, &mut errors),
                 Err(err) => errors.push(SchemaValidationError {
                     document: line_number,
+                    kind: SchemaValidationErrorKind::Parse,
                     instance_path: "$".to_string(),
                     message: format!("invalid JSON: {err}"),
                 }),
@@ -437,6 +452,7 @@ fn validate_input(
             Ok(value) => collect_validation_errors(1, &value, validator, &mut errors),
             Err(err) => errors.push(SchemaValidationError {
                 document: 1,
+                kind: SchemaValidationErrorKind::Parse,
                 instance_path: "$".to_string(),
                 message: format!("invalid JSON: {err}"),
             }),
@@ -446,6 +462,7 @@ fn validate_input(
     if documents == 0 {
         errors.push(SchemaValidationError {
             document: 0,
+            kind: SchemaValidationErrorKind::EmptyInput,
             instance_path: "$".to_string(),
             message: "no JSON documents found".to_string(),
         });
@@ -474,6 +491,7 @@ fn collect_validation_errors(
             .iter_errors(value)
             .map(|err| SchemaValidationError {
                 document,
+                kind: SchemaValidationErrorKind::Schema,
                 instance_path: err.instance_path().to_string(),
                 message: err.to_string(),
             }),
@@ -481,7 +499,7 @@ fn collect_validation_errors(
 }
 
 fn write_list_text(report: &SchemaListReport) -> Result<i32> {
-    println!("Assay Receipt Schema Registry");
+    println!("Assay Evidence Schema Registry");
     println!("Schema: {}", report.schema);
     for schema in &report.schemas {
         println!(

--- a/crates/assay-cli/src/cli/commands/evidence/schema.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/schema.rs
@@ -1,0 +1,553 @@
+use crate::cli::args::OutputFormat;
+use crate::exit_codes::{EXIT_SUCCESS, EXIT_TEST_FAILURE};
+use anyhow::{bail, Context, Result};
+use clap::{Args, Subcommand};
+use jsonschema::Draft;
+use serde::Serialize;
+use serde_json::Value;
+use std::fmt;
+use std::path::PathBuf;
+
+const SCHEMA_LIST_REPORT: &str = "assay.evidence.schema.list.v1";
+const SCHEMA_SHOW_REPORT: &str = "assay.evidence.schema.show.v1";
+const SCHEMA_VALIDATION_REPORT: &str = "assay.evidence.schema.validation.v1";
+
+const PROMPTFOO_RECEIPT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/reference/receipt-schemas/receipts/promptfoo.assertion-component.v1.schema.json"
+));
+const OPENFEATURE_RECEIPT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/reference/receipt-schemas/receipts/openfeature.evaluation-details.v1.schema.json"
+));
+const CYCLONEDX_RECEIPT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/reference/receipt-schemas/receipts/cyclonedx.mlbom-model-component.v1.schema.json"
+));
+const MASTRA_RECEIPT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/reference/receipt-schemas/receipts/mastra.score-event.v1.schema.json"
+));
+const PROMPTFOO_INPUT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/reference/receipt-schemas/inputs/promptfoo-cli-jsonl-component-result.v1.schema.json"
+));
+const OPENFEATURE_INPUT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/reference/receipt-schemas/inputs/openfeature-evaluation-details-export.v1.schema.json"
+));
+const CYCLONEDX_INPUT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/reference/receipt-schemas/inputs/cyclonedx-mlbom-model-component-input.v1.schema.json"
+));
+const MASTRA_INPUT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/reference/receipt-schemas/inputs/mastra-score-event-export.v1.schema.json"
+));
+
+/// Inspect and validate supported receipt schema contracts.
+#[derive(Debug, Args, Clone)]
+pub struct SchemaArgs {
+    #[command(subcommand)]
+    pub cmd: SchemaCmd,
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub enum SchemaCmd {
+    /// List supported receipt and importer-input schemas
+    List(SchemaListArgs),
+    /// Show schema metadata, or the raw JSON Schema with --raw
+    Show(SchemaShowArgs),
+    /// Validate a JSON or JSONL artifact against a supported schema
+    Validate(SchemaValidateArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct SchemaListArgs {
+    /// Output format
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct SchemaShowArgs {
+    /// Schema name, alias, source path, or JSON Schema $id
+    #[arg(value_name = "SCHEMA")]
+    pub schema: String,
+
+    /// Output format for metadata
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+
+    /// Print the raw JSON Schema instead of metadata
+    #[arg(long)]
+    pub raw: bool,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct SchemaValidateArgs {
+    /// Schema name, alias, source path, or JSON Schema $id
+    #[arg(long)]
+    pub schema: String,
+
+    /// JSON or JSONL artifact to validate
+    #[arg(long)]
+    pub input: PathBuf,
+
+    /// Treat input as JSONL and validate each non-empty row
+    #[arg(long)]
+    pub jsonl: bool,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SchemaKind {
+    Receipt,
+    Input,
+}
+
+impl fmt::Display for SchemaKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Receipt => f.write_str("receipt"),
+            Self::Input => f.write_str("input"),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SchemaDescriptor {
+    name: &'static str,
+    aliases: &'static [&'static str],
+    kind: SchemaKind,
+    status: &'static str,
+    family: &'static str,
+    source_path: &'static str,
+    description: &'static str,
+    trust_basis_claim: Option<&'static str>,
+    importer_only: bool,
+    schema_json: &'static str,
+}
+
+impl SchemaDescriptor {
+    fn json_schema_value(&self) -> Result<Value> {
+        serde_json::from_str(self.schema_json)
+            .with_context(|| format!("failed to parse embedded schema {}", self.name))
+    }
+
+    fn json_schema_id(&self) -> Result<String> {
+        Ok(self
+            .json_schema_value()?
+            .get("$id")
+            .and_then(Value::as_str)
+            .unwrap_or(self.name)
+            .to_string())
+    }
+
+    fn matches(&self, needle: &str) -> Result<bool> {
+        if self.name == needle || self.source_path == needle || self.aliases.contains(&needle) {
+            return Ok(true);
+        }
+        Ok(self.json_schema_id()? == needle)
+    }
+}
+
+const SCHEMAS: &[SchemaDescriptor] = &[
+    SchemaDescriptor {
+        name: "promptfoo.assertion-component.v1",
+        aliases: &["assay.receipt.promptfoo.assertion-component.v1"],
+        kind: SchemaKind::Receipt,
+        status: "stable",
+        family: "external_eval_receipts",
+        source_path: "docs/reference/receipt-schemas/receipts/promptfoo.assertion-component.v1.schema.json",
+        description: "Assay receipt payload for one selected Promptfoo assertion component result.",
+        trust_basis_claim: Some("external_eval_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: PROMPTFOO_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "openfeature.evaluation-details.v1",
+        aliases: &["assay.receipt.openfeature.evaluation_details.v1"],
+        kind: SchemaKind::Receipt,
+        status: "stable",
+        family: "external_decision_receipts",
+        source_path: "docs/reference/receipt-schemas/receipts/openfeature.evaluation-details.v1.schema.json",
+        description: "Assay receipt payload for one bounded OpenFeature boolean EvaluationDetails decision.",
+        trust_basis_claim: Some("external_decision_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: OPENFEATURE_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "cyclonedx.mlbom-model-component.v1",
+        aliases: &["assay.receipt.cyclonedx.mlbom-model-component.v1"],
+        kind: SchemaKind::Receipt,
+        status: "stable",
+        family: "external_inventory_receipts",
+        source_path: "docs/reference/receipt-schemas/receipts/cyclonedx.mlbom-model-component.v1.schema.json",
+        description: "Assay receipt payload for one selected CycloneDX ML-BOM machine-learning-model component.",
+        trust_basis_claim: Some("external_inventory_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: CYCLONEDX_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "mastra.score-event.v1",
+        aliases: &["assay.receipt.mastra.score_event.v1"],
+        kind: SchemaKind::Receipt,
+        status: "experimental",
+        family: "score_receipts",
+        source_path: "docs/reference/receipt-schemas/receipts/mastra.score-event.v1.schema.json",
+        description: "Assay receipt payload for one bounded Mastra ScoreEvent-derived score artifact.",
+        trust_basis_claim: None,
+        importer_only: true,
+        schema_json: MASTRA_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "promptfoo-cli-jsonl-component-result.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "stable",
+        family: "external_eval_receipts",
+        source_path: "docs/reference/receipt-schemas/inputs/promptfoo-cli-jsonl-component-result.v1.schema.json",
+        description: "Supported Promptfoo CLI JSONL row shape containing assertion component results.",
+        trust_basis_claim: Some("external_eval_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: PROMPTFOO_INPUT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "openfeature-evaluation-details-export.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "stable",
+        family: "external_decision_receipts",
+        source_path: "docs/reference/receipt-schemas/inputs/openfeature-evaluation-details-export.v1.schema.json",
+        description: "Supported reduced OpenFeature boolean EvaluationDetails JSONL row shape.",
+        trust_basis_claim: Some("external_decision_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: OPENFEATURE_INPUT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "cyclonedx-mlbom-model-component-input.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "stable",
+        family: "external_inventory_receipts",
+        source_path: "docs/reference/receipt-schemas/inputs/cyclonedx-mlbom-model-component-input.v1.schema.json",
+        description: "Supported CycloneDX ML-BOM input shape for selecting one machine-learning-model component.",
+        trust_basis_claim: Some("external_inventory_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: CYCLONEDX_INPUT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "mastra-score-event-export.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "experimental",
+        family: "score_receipts",
+        source_path: "docs/reference/receipt-schemas/inputs/mastra-score-event-export.v1.schema.json",
+        description: "Supported reduced Mastra ScoreEvent JSONL row shape.",
+        trust_basis_claim: None,
+        importer_only: true,
+        schema_json: MASTRA_INPUT_SCHEMA,
+    },
+];
+
+#[derive(Debug, Serialize)]
+struct SchemaListReport {
+    schema: &'static str,
+    schemas: Vec<SchemaMetadata>,
+}
+
+#[derive(Debug, Serialize)]
+struct SchemaShowReport {
+    schema: &'static str,
+    metadata: SchemaMetadata,
+}
+
+#[derive(Debug, Serialize)]
+struct SchemaMetadata {
+    name: String,
+    kind: SchemaKind,
+    status: String,
+    family: String,
+    json_schema_id: String,
+    source_path: String,
+    description: String,
+    trust_basis_claim: Option<String>,
+    importer_only: bool,
+    aliases: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SchemaValidationReport {
+    schema: &'static str,
+    schema_name: String,
+    schema_kind: SchemaKind,
+    input: String,
+    jsonl: bool,
+    valid: bool,
+    documents: usize,
+    errors: Vec<SchemaValidationError>,
+}
+
+#[derive(Debug, Serialize)]
+struct SchemaValidationError {
+    document: usize,
+    instance_path: String,
+    message: String,
+}
+
+pub fn cmd_schema(args: SchemaArgs) -> Result<i32> {
+    match args.cmd {
+        SchemaCmd::List(args) => cmd_list(args),
+        SchemaCmd::Show(args) => cmd_show(args),
+        SchemaCmd::Validate(args) => cmd_validate(args),
+    }
+}
+
+fn cmd_list(args: SchemaListArgs) -> Result<i32> {
+    let report = SchemaListReport {
+        schema: SCHEMA_LIST_REPORT,
+        schemas: SCHEMAS
+            .iter()
+            .map(schema_metadata)
+            .collect::<Result<Vec<_>>>()?,
+    };
+
+    match args.format {
+        OutputFormat::Text => write_list_text(&report),
+        OutputFormat::Json => write_json(&report),
+    }
+}
+
+fn cmd_show(args: SchemaShowArgs) -> Result<i32> {
+    let descriptor = find_schema(&args.schema)?;
+    if args.raw {
+        let raw = descriptor.json_schema_value()?;
+        println!("{}", serde_json::to_string_pretty(&raw)?);
+        return Ok(EXIT_SUCCESS);
+    }
+
+    let report = SchemaShowReport {
+        schema: SCHEMA_SHOW_REPORT,
+        metadata: schema_metadata(descriptor)?,
+    };
+
+    match args.format {
+        OutputFormat::Text => write_show_text(&report),
+        OutputFormat::Json => write_json(&report),
+    }
+}
+
+fn cmd_validate(args: SchemaValidateArgs) -> Result<i32> {
+    let descriptor = find_schema(&args.schema)?;
+    let input = std::fs::read_to_string(&args.input).with_context(|| {
+        format!(
+            "failed to read schema validation input {}",
+            args.input.display()
+        )
+    })?;
+    let schema_value = descriptor.json_schema_value()?;
+    let validator = jsonschema::options()
+        .with_draft(Draft::Draft202012)
+        .build(&schema_value)
+        .with_context(|| format!("failed to compile schema {}", descriptor.name))?;
+    let report = validate_input(descriptor, &args.input, args.jsonl, &input, &validator);
+
+    match args.format {
+        OutputFormat::Text => write_validation_text(&report),
+        OutputFormat::Json => write_json(&report),
+    }?;
+
+    if report.valid {
+        Ok(EXIT_SUCCESS)
+    } else {
+        Ok(EXIT_TEST_FAILURE)
+    }
+}
+
+fn find_schema(raw: &str) -> Result<&'static SchemaDescriptor> {
+    let needle = raw.trim();
+    if needle.is_empty() {
+        bail!("schema name is empty");
+    }
+
+    for descriptor in SCHEMAS {
+        if descriptor.matches(needle)? {
+            return Ok(descriptor);
+        }
+    }
+
+    bail!(
+        "unknown receipt schema {needle:?}; run `assay evidence schema list` for supported schemas"
+    );
+}
+
+fn schema_metadata(descriptor: &SchemaDescriptor) -> Result<SchemaMetadata> {
+    Ok(SchemaMetadata {
+        name: descriptor.name.to_string(),
+        kind: descriptor.kind,
+        status: descriptor.status.to_string(),
+        family: descriptor.family.to_string(),
+        json_schema_id: descriptor.json_schema_id()?,
+        source_path: descriptor.source_path.to_string(),
+        description: descriptor.description.to_string(),
+        trust_basis_claim: descriptor.trust_basis_claim.map(str::to_string),
+        importer_only: descriptor.importer_only,
+        aliases: descriptor
+            .aliases
+            .iter()
+            .map(|alias| (*alias).to_string())
+            .collect(),
+    })
+}
+
+fn validate_input(
+    descriptor: &SchemaDescriptor,
+    input_path: &std::path::Path,
+    jsonl: bool,
+    input: &str,
+    validator: &jsonschema::Validator,
+) -> SchemaValidationReport {
+    let mut errors = Vec::new();
+    let mut documents = 0usize;
+
+    if jsonl {
+        for (idx, line) in input.lines().enumerate() {
+            let line_number = idx + 1;
+            if line.trim().is_empty() {
+                continue;
+            }
+            documents += 1;
+            match serde_json::from_str::<Value>(line) {
+                Ok(value) => collect_validation_errors(line_number, &value, validator, &mut errors),
+                Err(err) => errors.push(SchemaValidationError {
+                    document: line_number,
+                    instance_path: "$".to_string(),
+                    message: format!("invalid JSON: {err}"),
+                }),
+            }
+        }
+    } else {
+        documents = 1;
+        match serde_json::from_str::<Value>(input) {
+            Ok(value) => collect_validation_errors(1, &value, validator, &mut errors),
+            Err(err) => errors.push(SchemaValidationError {
+                document: 1,
+                instance_path: "$".to_string(),
+                message: format!("invalid JSON: {err}"),
+            }),
+        }
+    }
+
+    if documents == 0 {
+        errors.push(SchemaValidationError {
+            document: 0,
+            instance_path: "$".to_string(),
+            message: "no JSON documents found".to_string(),
+        });
+    }
+
+    SchemaValidationReport {
+        schema: SCHEMA_VALIDATION_REPORT,
+        schema_name: descriptor.name.to_string(),
+        schema_kind: descriptor.kind,
+        input: input_path.display().to_string(),
+        jsonl,
+        valid: errors.is_empty(),
+        documents,
+        errors,
+    }
+}
+
+fn collect_validation_errors(
+    document: usize,
+    value: &Value,
+    validator: &jsonschema::Validator,
+    errors: &mut Vec<SchemaValidationError>,
+) {
+    errors.extend(
+        validator
+            .iter_errors(value)
+            .map(|err| SchemaValidationError {
+                document,
+                instance_path: err.instance_path().to_string(),
+                message: err.to_string(),
+            }),
+    );
+}
+
+fn write_list_text(report: &SchemaListReport) -> Result<i32> {
+    println!("Assay Receipt Schema Registry");
+    println!("Schema: {}", report.schema);
+    for schema in &report.schemas {
+        println!(
+            "- {} [{}; {}; family: {}]",
+            schema.name, schema.kind, schema.status, schema.family
+        );
+        println!("  id: {}", schema.json_schema_id);
+        println!("  source: {}", schema.source_path);
+        println!("  description: {}", schema.description);
+        if let Some(claim) = &schema.trust_basis_claim {
+            println!("  trust_basis_claim: {claim}");
+        } else if schema.importer_only {
+            println!("  trust_basis_claim: none (importer-only)");
+        }
+    }
+    Ok(EXIT_SUCCESS)
+}
+
+fn write_show_text(report: &SchemaShowReport) -> Result<i32> {
+    let schema = &report.metadata;
+    println!("Schema: {}", schema.name);
+    println!("Kind: {}", schema.kind);
+    println!("Status: {}", schema.status);
+    println!("Family: {}", schema.family);
+    println!("JSON Schema $id: {}", schema.json_schema_id);
+    println!("Source: {}", schema.source_path);
+    println!("Description: {}", schema.description);
+    if let Some(claim) = &schema.trust_basis_claim {
+        println!("Trust Basis claim: {claim}");
+    } else if schema.importer_only {
+        println!("Trust Basis claim: none (importer-only)");
+    } else {
+        println!("Trust Basis claim: none");
+    }
+    if !schema.aliases.is_empty() {
+        println!("Aliases:");
+        for alias in &schema.aliases {
+            println!("- {alias}");
+        }
+    }
+    Ok(EXIT_SUCCESS)
+}
+
+fn write_validation_text(report: &SchemaValidationReport) -> Result<i32> {
+    if report.valid {
+        println!(
+            "Schema validation passed: {} matches {} ({} document(s))",
+            report.input, report.schema_name, report.documents
+        );
+        return Ok(EXIT_SUCCESS);
+    }
+
+    println!(
+        "Schema validation failed: {} does not match {}",
+        report.input, report.schema_name
+    );
+    for error in &report.errors {
+        println!(
+            "- document {} at {}: {}",
+            error.document, error.instance_path, error.message
+        );
+    }
+    Ok(EXIT_SUCCESS)
+}
+
+fn write_json<T: Serialize>(value: &T) -> Result<i32> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(EXIT_SUCCESS)
+}

--- a/crates/assay-cli/tests/receipt_schema_registry_test.rs
+++ b/crates/assay-cli/tests/receipt_schema_registry_test.rs
@@ -16,6 +16,11 @@ fn schema_path(relative: &str) -> PathBuf {
         .join(relative)
 }
 
+fn receipt_family_matrix() -> Value {
+    let path = repo_root().join("docs/reference/receipt-family-matrix.json");
+    serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+}
+
 fn compile_schema(relative: &str) -> Validator {
     let path = schema_path(relative);
     let schema: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
@@ -38,6 +43,12 @@ fn assert_valid(schema_relative: &str, instance: &Value) {
     panic!("{schema_relative} validation failed:\n{errors}\ninstance: {instance}");
 }
 
+fn assay_schema_command() -> Command {
+    let mut cmd = Command::cargo_bin("assay").unwrap();
+    cmd.arg("evidence").arg("schema");
+    cmd
+}
+
 fn jsonl_values(path: &Path) -> Vec<Value> {
     fs::read_to_string(path)
         .unwrap()
@@ -53,6 +64,185 @@ fn bundle_payloads(path: &Path) -> Vec<Value> {
         .events()
         .map(|event| event.unwrap().payload)
         .collect()
+}
+
+#[test]
+fn schema_cli_lists_receipt_and_input_schemas() {
+    let output = assay_schema_command()
+        .arg("list")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["schema"], "assay.evidence.schema.list.v1");
+    let schemas = report["schemas"].as_array().unwrap();
+    assert_eq!(schemas.len(), 8);
+
+    let names = schemas
+        .iter()
+        .map(|schema| schema["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"promptfoo.assertion-component.v1"));
+    assert!(names.contains(&"openfeature.evaluation-details.v1"));
+    assert!(names.contains(&"cyclonedx.mlbom-model-component.v1"));
+    assert!(names.contains(&"mastra.score-event.v1"));
+    assert!(names.contains(&"promptfoo-cli-jsonl-component-result.v1"));
+    assert!(names.contains(&"openfeature-evaluation-details-export.v1"));
+    assert!(names.contains(&"cyclonedx-mlbom-model-component-input.v1"));
+    assert!(names.contains(&"mastra-score-event-export.v1"));
+
+    let mastra = schemas
+        .iter()
+        .find(|schema| schema["name"] == "mastra.score-event.v1")
+        .unwrap();
+    assert_eq!(mastra["importer_only"], true);
+    assert!(mastra["trust_basis_claim"].is_null());
+}
+
+#[test]
+fn schema_cli_paths_match_receipt_family_matrix() {
+    let output = assay_schema_command()
+        .arg("list")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    let cli_paths = report["schemas"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|schema| schema["source_path"].as_str().unwrap())
+        .collect::<Vec<_>>();
+
+    let matrix = receipt_family_matrix();
+    let families = matrix["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .chain(matrix["importer_only_receipts"].as_array().unwrap().iter());
+
+    for family in families {
+        for key in ["receipt_schema_path", "input_schema_path"] {
+            let path = format!("docs/reference/{}", family[key].as_str().unwrap());
+            assert!(
+                cli_paths.contains(&path.as_str()),
+                "schema CLI list should expose matrix path {path}"
+            );
+        }
+    }
+}
+
+#[test]
+fn schema_cli_shows_metadata_and_raw_schema() {
+    let output = assay_schema_command()
+        .arg("show")
+        .arg("assay.receipt.promptfoo.assertion-component.v1")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["schema"], "assay.evidence.schema.show.v1");
+    assert_eq!(
+        report["metadata"]["name"],
+        "promptfoo.assertion-component.v1"
+    );
+    assert_eq!(report["metadata"]["kind"], "receipt");
+    assert_eq!(
+        report["metadata"]["trust_basis_claim"],
+        "external_eval_receipt_boundary_visible"
+    );
+
+    let raw_output = assay_schema_command()
+        .arg("show")
+        .arg("promptfoo.assertion-component.v1")
+        .arg("--raw")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let raw_schema: Value = serde_json::from_slice(&raw_output).unwrap();
+    assert_eq!(
+        raw_schema["$id"],
+        "https://raw.githubusercontent.com/Rul1an/assay/v3.8.0/docs/reference/receipt-schemas/receipts/promptfoo.assertion-component.v1.schema.json"
+    );
+}
+
+#[test]
+fn schema_cli_validates_jsonl_inputs() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("results.jsonl");
+    fs::write(
+        &input,
+        concat!(
+            r#"{"gradingResult":{"componentResults":[{"pass":true,"score":1,"reason":"Assertion passed","assertion":{"type":"equals","value":"Hello world"}}]}}"#,
+            "\n"
+        ),
+    )
+    .unwrap();
+
+    let output = assay_schema_command()
+        .arg("validate")
+        .arg("--schema")
+        .arg("promptfoo-cli-jsonl-component-result.v1")
+        .arg("--input")
+        .arg(&input)
+        .arg("--jsonl")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["schema"], "assay.evidence.schema.validation.v1");
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["documents"], 1);
+}
+
+#[test]
+fn schema_cli_returns_exit_one_for_schema_mismatch() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("receipt.json");
+    fs::write(
+        &input,
+        json!({
+            "schema": "assay.receipt.promptfoo.assertion-component.v1",
+            "source_system": "promptfoo"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let output = assay_schema_command()
+        .arg("validate")
+        .arg("--schema")
+        .arg("promptfoo.assertion-component.v1")
+        .arg("--input")
+        .arg(&input)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["valid"], false);
+    assert!(!report["errors"].as_array().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/assay-cli/tests/receipt_schema_registry_test.rs
+++ b/crates/assay-cli/tests/receipt_schema_registry_test.rs
@@ -16,6 +16,12 @@ fn schema_path(relative: &str) -> PathBuf {
         .join(relative)
 }
 
+fn packaged_schema_path(relative: &str) -> PathBuf {
+    repo_root()
+        .join("crates/assay-cli/receipt-schemas")
+        .join(relative)
+}
+
 fn receipt_family_matrix() -> Value {
     let path = repo_root().join("docs/reference/receipt-family-matrix.json");
     serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
@@ -141,6 +147,31 @@ fn schema_cli_paths_match_receipt_family_matrix() {
 }
 
 #[test]
+fn packaged_schema_assets_match_docs_registry() {
+    let matrix = receipt_family_matrix();
+    let families = matrix["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .chain(matrix["importer_only_receipts"].as_array().unwrap().iter());
+
+    for family in families {
+        for key in ["receipt_schema_path", "input_schema_path"] {
+            let relative = family[key]
+                .as_str()
+                .unwrap()
+                .strip_prefix("receipt-schemas/")
+                .unwrap();
+            assert_eq!(
+                fs::read(schema_path(relative)).unwrap(),
+                fs::read(packaged_schema_path(relative)).unwrap(),
+                "packaged schema asset should match docs registry for {relative}"
+            );
+        }
+    }
+}
+
+#[test]
 fn schema_cli_shows_metadata_and_raw_schema() {
     let output = assay_schema_command()
         .arg("show")
@@ -243,6 +274,59 @@ fn schema_cli_returns_exit_one_for_schema_mismatch() {
     let report: Value = serde_json::from_slice(&output).unwrap();
     assert_eq!(report["valid"], false);
     assert!(!report["errors"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn schema_cli_returns_exit_two_for_invalid_json_input() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("receipt.json");
+    fs::write(
+        &input,
+        r#"{"schema":"assay.receipt.promptfoo.assertion-component.v1""#,
+    )
+    .unwrap();
+
+    let output = assay_schema_command()
+        .arg("validate")
+        .arg("--schema")
+        .arg("promptfoo.assertion-component.v1")
+        .arg("--input")
+        .arg(&input)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .code(2)
+        .get_output()
+        .stdout
+        .clone();
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["valid"], false);
+    assert_eq!(report["errors"][0]["kind"], "parse");
+}
+
+#[test]
+fn schema_cli_returns_exit_two_for_empty_jsonl_input() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("results.jsonl");
+    fs::write(&input, "\n\n").unwrap();
+
+    let output = assay_schema_command()
+        .arg("validate")
+        .arg("--schema")
+        .arg("promptfoo-cli-jsonl-component-result.v1")
+        .arg("--input")
+        .arg(&input)
+        .arg("--jsonl")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .code(2)
+        .get_output()
+        .stdout
+        .clone();
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["valid"], false);
+    assert_eq!(report["errors"][0]["kind"], "empty_input");
 }
 
 #[test]

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -12,6 +12,58 @@ assay evidence <COMMAND> [OPTIONS]
 
 ---
 
+## Receipt Schema Registry
+
+Inspect and validate the machine-readable receipt schema registry:
+
+```bash
+assay evidence schema list
+assay evidence schema show promptfoo.assertion-component.v1
+assay evidence schema show promptfoo.assertion-component.v1 --raw
+assay evidence schema validate \
+  --schema promptfoo.assertion-component.v1 \
+  --input receipt.json
+```
+
+For JSONL importer inputs, validate each non-empty row with `--jsonl`:
+
+```bash
+assay evidence schema validate \
+  --schema promptfoo-cli-jsonl-component-result.v1 \
+  --input results.jsonl \
+  --jsonl
+```
+
+The schema CLI covers the v3.8.0 registry:
+
+- receipt payload schemas for Promptfoo, OpenFeature, CycloneDX ML-BOM, and
+  Mastra receipts
+- importer input schemas where the reduced input artifact differs from the
+  receipt payload
+- metadata such as schema `$id`, family, status, source path, short
+  description, and Trust Basis claim when one exists
+
+Mastra remains importer-only in this registry. It has input and receipt schemas,
+but no public Trust Basis score receipt claim yet.
+
+`validate` exits `0` when the artifact matches the selected schema and exits
+`1` when the artifact is valid JSON/JSONL but fails schema validation. Unknown
+schema names, unreadable files, and runtime/configuration errors remain
+input/config errors (`2+` via the top-level CLI error handling).
+
+### Options
+
+| Command | Description |
+|---------|-------------|
+| `assay evidence schema list [--format text|json]` | List all supported schema entries |
+| `assay evidence schema show <SCHEMA> [--format text|json] [--raw]` | Show schema metadata or raw JSON Schema |
+| `assay evidence schema validate --schema <SCHEMA> --input <PATH> [--jsonl] [--format text|json]` | Validate a JSON or JSONL artifact |
+
+Schema names can be the registry name, known alias, source path, or JSON Schema
+`$id`. Use `list` to discover supported names.
+
+---
+
 ## CycloneDX ML-BOM Model Import
 
 Import one selected CycloneDX ML-BOM `machine-learning-model` component into a

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -47,9 +47,9 @@ Mastra remains importer-only in this registry. It has input and receipt schemas,
 but no public Trust Basis score receipt claim yet.
 
 `validate` exits `0` when the artifact matches the selected schema and exits
-`1` when the artifact is valid JSON/JSONL but fails schema validation. Unknown
-schema names, unreadable files, and runtime/configuration errors remain
-input/config errors (`2+` via the top-level CLI error handling).
+`1` when the artifact is valid JSON/JSONL but fails schema validation. Invalid
+JSON, invalid JSONL rows, empty JSONL input, unknown schema names, unreadable
+files, and runtime/configuration errors remain input/config errors (`2+`).
 
 ### Options
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -30,7 +30,7 @@ assay --version
 | [`assay explain`](explain.md) | Explain why trace steps were allowed/blocked |
 | [`assay bundle`](bundle.md) | Create/verify replay bundles |
 | [`assay replay`](replay.md) | Replay from a replay bundle |
-| [`assay evidence`](evidence.md) | Manage evidence bundles and external evidence imports |
+| [`assay evidence`](evidence.md) | Manage evidence bundles, external evidence imports, and receipt schemas |
 | [`assay trust-basis`](trust-basis.md) | Generate, compare, and assert canonical Trust Basis artifacts |
 | [`assay import`](import.md) | Import sessions from MCP Inspector, etc. |
 | [`assay migrate`](migrate.md) | Upgrade config from v0 to v1 |

--- a/docs/reference/receipt-schemas/README.md
+++ b/docs/reference/receipt-schemas/README.md
@@ -14,6 +14,18 @@ not full Promptfoo, OpenFeature, CycloneDX, or Mastra schemas.
 - `inputs/`: supported importer input artifact schemas where the import shape
   differs from the receipt payload.
 
+## CLI
+
+The registry is also available through the Assay CLI:
+
+```bash
+assay evidence schema list
+assay evidence schema show promptfoo.assertion-component.v1
+assay evidence schema validate --schema promptfoo.assertion-component.v1 --input receipt.json
+```
+
+Use `--jsonl` with `validate` for JSONL importer inputs.
+
 ## Boundary
 
 The schemas do not make integration, endorsement, correctness, safety,


### PR DESCRIPTION
What changed

Adds P55: a small CLI surface over the v3.8.0 receipt schema registry.

This PR includes:

- `assay evidence schema list`
- `assay evidence schema show <schema>` with metadata-first output and `--raw` JSON Schema output
- `assay evidence schema validate --schema <schema> --input <path>` with optional `--jsonl`
- text and JSON output for list/show/validate
- registry descriptors for Promptfoo, OpenFeature, CycloneDX ML-BOM, and Mastra receipt/input schemas
- tests that validate CLI output, mismatch exit behavior, JSONL validation, importer-generated receipts, and drift against `docs/reference/receipt-family-matrix.json`
- CLI docs, schema registry README notes, and changelog entry

Why

P49 made the receipt contracts machine-readable in docs. P55 makes that registry discoverable and directly usable from the CLI, so producers and reviewers can inspect or validate supported receipt/input artifacts without reverse-reading the docs tree.

Boundary

This does not add new schemas, receipt families, Trust Basis claims, Harness behavior, or domain-specific policy. Mastra remains schema-covered and importer-only; it is not promoted into the public three-family Trust Basis claim surface.

Validation

Ran locally:

- `cargo fmt --check`
- `cargo test -p assay-cli --test receipt_schema_registry_test -- --nocapture`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `git diff --check`
- local changed-docs markdown link check
- `cargo run -q -p assay-cli -- evidence schema --help`
- `cargo run -q -p assay-cli -- evidence schema list --format json`
- `cargo run -q -p assay-cli -- evidence schema show mastra.score-event.v1 --format text`

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.
