### PR TITLE
P54: add static Trust Card HTML projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project will be documented in this file.
   receipt payload and importer-input schemas, shows schema metadata before raw
   JSON Schema content, validates JSON or JSONL artifacts, and keeps Mastra
   marked as importer-only rather than a public Trust Basis claim family.
+- **Static Trust Card HTML**: `assay trustcard generate` now writes
+  `trustcard.html` beside `trustcard.json` and `trustcard.md`. JSON remains the
+  canonical Trust Card artifact; Markdown and single-file HTML are deterministic
+  reviewer projections with no remote assets, JavaScript requirement, scores,
+  badges, or second classifier.
 
 ## [3.8.0] - 2026-04-29
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Your MCP agent calls `read_file`, `exec`, `web_search` — but should it, and wh
 |---|---|
 | **Enforce** | Intercept MCP tool calls, apply policy, **ALLOW** / **DENY** deterministically. |
 | **Compile** | Turn traces, decisions, and bundles into **canonical evidence** — not raw OTel or ad hoc logs as truth. |
-| **Prove** | Export **tamper-evident bundles**, **Trust Basis** (`trust-basis.json`), **Trust Card** (`trustcard.json` / `trustcard.md`), SARIF, and CI gates. |
+| **Prove** | Export **tamper-evident bundles**, **Trust Basis** (`trust-basis.json`), **Trust Card** (`trustcard.json` / `trustcard.md` / `trustcard.html`), SARIF, and CI gates. |
 
 No hosted backend. No API keys for core flows. **Deterministic** — same input, same decision, every time.
 
@@ -89,10 +89,10 @@ assay trust-basis generate demo/fixtures/bundle.tar.gz > trust-basis.json
 
 # Human + machine Trust Card (schema v5 — ten trust claims; key by `id`, not row count)
 assay trustcard generate demo/fixtures/bundle.tar.gz --out-dir ./trust-out
-# → trust-out/trustcard.json , trust-out/trustcard.md
+# → trust-out/trustcard.json , trust-out/trustcard.md , trust-out/trustcard.html
 ```
 
-`trust-basis.json` emits claims from a bounded, versioned vocabulary for this schema (examples: `bundle_verified`, `delegation_context_visible`, `authorization_context_visible`, `containment_degradation_observed`, `external_eval_receipt_boundary_visible`, `external_decision_receipt_boundary_visible`, `external_inventory_receipt_boundary_visible`, …). Claim `id` values are stable across runs, but consumers **must not** rely on row count or ordering; always key by `id`. It is **not** a scalar trust score. The Trust Card is a deterministic render of the same claim rows plus frozen non-goals. **Contract versions, pack floors, and release checklist:** [docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md](docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md), [docs/reference/receipt-family-matrix.json](docs/reference/receipt-family-matrix.json).
+`trust-basis.json` emits claims from a bounded, versioned vocabulary for this schema (examples: `bundle_verified`, `delegation_context_visible`, `authorization_context_visible`, `containment_degradation_observed`, `external_eval_receipt_boundary_visible`, `external_decision_receipt_boundary_visible`, `external_inventory_receipt_boundary_visible`, …). Claim `id` values are stable across runs, but consumers **must not** rely on row count or ordering; always key by `id`. It is **not** a scalar trust score. The Trust Card is a deterministic render of the same claim rows plus frozen non-goals; `trustcard.json` is canonical, while Markdown and static HTML are reviewer projections. **Contract versions, pack floors, and release checklist:** [docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md](docs/architecture/MIGRATION-TRUST-COMPILER-3.2.md), [docs/reference/receipt-family-matrix.json](docs/reference/receipt-family-matrix.json).
 
 In the `v3.8.0` line, supported external eval outcomes, runtime decision details, and model inventory/provenance surfaces can enter this compiler path as bounded receipts rather than full upstream truth, with machine-readable JSON Schema contracts for the supported receipt/import surfaces. The first three claim-visible families are Promptfoo assertion-component results, OpenFeature boolean `EvaluationDetails`, and CycloneDX ML-BOM model components; [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](docs/notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) explains the three-family surface.
 
@@ -104,7 +104,7 @@ In the `v3.8.0` line, supported external eval outcomes, runtime decision details
 | **Evidence bundle** | Offline-verifiable, tamper-evident archive for audit and replay. |
 | **External receipts** | `v3.8.0` line: selected eval outcomes, runtime decision details, and inventory/provenance surfaces as bounded evidence receipts with JSON Schema contracts. |
 | **Trust Basis** | Canonical `trust-basis.json` — bounded claim classification from verified bundles. |
-| **Trust Card** | `trustcard.json` / `trustcard.md` — same claims, review-friendly artifact. |
+| **Trust Card** | `trustcard.json` / `trustcard.md` / `trustcard.html` — same claims, review-friendly artifacts. |
 | **SARIF / CI** | GitHub Action, Security tab integration, policy gates on PRs. |
 
 ## Evidence levels (trust vocabulary)

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -96,7 +96,7 @@ pub enum Command {
     /// Generate canonical trust-basis artifacts from verified evidence bundles
     #[command(name = "trust-basis")]
     TrustBasis(TrustBasisArgs),
-    /// Generate trust card artifacts (trustcard.json + trustcard.md) from verified bundles
+    /// Generate trust card artifacts (JSON, Markdown, and static HTML) from verified bundles
     #[command(name = "trustcard")]
     TrustCard(TrustCardArgs),
 }

--- a/crates/assay-cli/src/cli/args/trust_card.rs
+++ b/crates/assay-cli/src/cli/args/trust_card.rs
@@ -9,7 +9,7 @@ pub struct TrustCardArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum TrustCardSub {
-    /// Generate trustcard.json and trustcard.md from a verified evidence bundle
+    /// Generate trustcard.json, trustcard.md, and trustcard.html from a verified evidence bundle
     Generate(TrustCardGenerateArgs),
 }
 
@@ -19,7 +19,7 @@ pub struct TrustCardGenerateArgs {
     #[arg(value_name = "BUNDLE")]
     pub bundle: PathBuf,
 
-    /// Output directory for trustcard.json and trustcard.md
+    /// Output directory for trustcard.json, trustcard.md, and trustcard.html
     #[arg(long = "out-dir", value_name = "DIR")]
     pub out_dir: PathBuf,
 

--- a/crates/assay-cli/src/cli/commands/trust_card.rs
+++ b/crates/assay-cli/src/cli/commands/trust_card.rs
@@ -5,7 +5,7 @@ use assay_evidence::lint::engine::LintOptions;
 use assay_evidence::lint::packs::load_packs;
 use assay_evidence::{
     generate_trust_basis, trust_basis_to_trust_card, trust_card_to_canonical_json_bytes,
-    trust_card_to_markdown, TrustBasisOptions, VerifyLimits,
+    trust_card_to_html, trust_card_to_markdown, TrustBasisOptions, VerifyLimits,
 };
 use std::fs::File;
 
@@ -39,6 +39,7 @@ fn cmd_generate(args: TrustCardGenerateArgs) -> Result<i32> {
     let json =
         trust_card_to_canonical_json_bytes(&card).context("failed to serialize trust card json")?;
     let md = trust_card_to_markdown(&card);
+    let html = trust_card_to_html(&card);
 
     std::fs::create_dir_all(&args.out_dir).with_context(|| {
         format!(
@@ -49,16 +50,20 @@ fn cmd_generate(args: TrustCardGenerateArgs) -> Result<i32> {
 
     let json_path = args.out_dir.join("trustcard.json");
     let md_path = args.out_dir.join("trustcard.md");
+    let html_path = args.out_dir.join("trustcard.html");
 
     std::fs::write(&json_path, json)
         .with_context(|| format!("failed to write {}", json_path.display()))?;
     std::fs::write(&md_path, md)
         .with_context(|| format!("failed to write {}", md_path.display()))?;
+    std::fs::write(&html_path, html)
+        .with_context(|| format!("failed to write {}", html_path.display()))?;
 
     eprintln!(
-        "Wrote trust card to {} and {}",
+        "Wrote trust card to {}, {}, and {}",
         json_path.display(),
-        md_path.display()
+        md_path.display(),
+        html_path.display()
     );
 
     Ok(EXIT_SUCCESS)

--- a/crates/assay-cli/tests/trustcard_test.rs
+++ b/crates/assay-cli/tests/trustcard_test.rs
@@ -139,6 +139,13 @@ fn trustcard_generate_writes_json_and_md_matching_trust_basis_claims() {
         "HTML must keep JSON canonical"
     );
     assert!(
+        html.contains("Content-Security-Policy")
+            && html.contains("script-src 'none'")
+            && html.contains("prefers-color-scheme: dark")
+            && html.contains("forced-colors: active"),
+        "trustcard.html must carry static-page security and accessibility polish"
+    );
+    assert!(
         !html.contains("<script") && !html.contains("https://") && !html.contains("http://"),
         "trustcard.html must be a static no-network projection"
     );

--- a/crates/assay-cli/tests/trustcard_test.rs
+++ b/crates/assay-cli/tests/trustcard_test.rs
@@ -117,6 +117,31 @@ fn trustcard_generate_writes_json_and_md_matching_trust_basis_claims() {
         assert!(md.contains(&format!("- {line}")));
     }
     assert!(md.contains("| id | level | source | boundary | note |"));
+
+    let html = String::from_utf8(fs::read(out_dir.join("trustcard.html")).unwrap()).unwrap();
+    assert!(html.starts_with("<!doctype html>\n"));
+    assert_eq!(
+        html.matches("data-claim-id=").count(),
+        claims.len(),
+        "trustcard.html must render the same claim rows as trustcard.json"
+    );
+    for id in expected_ids {
+        assert!(
+            html.contains(&format!("data-claim-id=\"{id}\"")),
+            "missing html claim row for {id}"
+        );
+    }
+    for line in TRUST_CARD_NON_GOALS {
+        assert!(html.contains(&format!("<li>{line}</li>")));
+    }
+    assert!(
+        html.contains("Canonical source of truth: trustcard.json"),
+        "HTML must keep JSON canonical"
+    );
+    assert!(
+        !html.contains("<script") && !html.contains("https://") && !html.contains("http://"),
+        "trustcard.html must be a static no-network projection"
+    );
 }
 
 #[test]

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -32,8 +32,9 @@ pub use trust_basis::{
     TrustClaimId, TrustClaimLevel, TrustClaimSource, TRUST_BASIS_DIFF_SCHEMA,
 };
 pub use trust_card::{
-    trust_basis_to_trust_card, trust_card_to_canonical_json_bytes, trust_card_to_markdown,
-    TrustCard, TRUST_CARD_NON_GOALS, TRUST_CARD_NOTE_EMPTY_PLACEHOLDER, TRUST_CARD_SCHEMA_VERSION,
+    trust_basis_to_trust_card, trust_card_to_canonical_json_bytes, trust_card_to_html,
+    trust_card_to_markdown, TrustCard, TRUST_CARD_NON_GOALS, TRUST_CARD_NOTE_EMPTY_PLACEHOLDER,
+    TRUST_CARD_SCHEMA_VERSION,
 };
 pub use types::{
     Envelope, EvidenceEvent, ProducerMeta, ASSAY_EVIDENCE_SPEC_VERSION, CE_SPECVERSION,

--- a/crates/assay-evidence/src/trust_card.rs
+++ b/crates/assay-evidence/src/trust_card.rs
@@ -65,9 +65,13 @@ fn md_cell(raw: &str) -> String {
 }
 
 fn note_markdown(note: &Option<String>) -> String {
+    md_cell(&note_text(note))
+}
+
+fn note_text(note: &Option<String>) -> String {
     let trimmed = note.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty());
     match trimmed {
-        Some(s) => md_cell(s),
+        Some(s) => s.to_string(),
         None => TRUST_CARD_NOTE_EMPTY_PLACEHOLDER.to_string(),
     }
 }
@@ -95,6 +99,90 @@ pub fn trust_card_to_markdown(card: &TrustCard) -> String {
         out.push_str(line);
         out.push('\n');
     }
+    out
+}
+
+fn html_escape(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            '\r' | '\n' => out.push(' '),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Secondary single-file human view. JSON remains canonical; HTML adds no claim semantics.
+pub fn trust_card_to_html(card: &TrustCard) -> String {
+    let mut out = String::new();
+    out.push_str("<!doctype html>\n");
+    out.push_str("<html lang=\"en\">\n");
+    out.push_str("<head>\n");
+    out.push_str("<meta charset=\"utf-8\">\n");
+    out.push_str("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    out.push_str("<title>Assay Trust Card</title>\n");
+    out.push_str("<style>\n");
+    out.push_str(":root{color-scheme:light;--ink:#18211f;--muted:#5e6b66;--line:#d8dfdc;--paper:#fbfaf5;--panel:#ffffff;--accent:#2f6f62;--soft:#edf4f1;}\n");
+    out.push_str("*{box-sizing:border-box}body{margin:0;background:linear-gradient(135deg,#fbfaf5 0%,#eef5f1 100%);color:var(--ink);font-family:Georgia,'Times New Roman',serif;line-height:1.5}main{max-width:1120px;margin:0 auto;padding:48px 24px}section{background:var(--panel);border:1px solid var(--line);border-radius:18px;box-shadow:0 18px 50px rgba(24,33,31,.08);padding:28px;margin:24px 0}h1{font-size:40px;line-height:1.05;margin:0 0 10px}h2{font-size:22px;margin:0 0 16px}.lede{color:var(--muted);max-width:760px}.meta{display:inline-block;background:var(--soft);border:1px solid var(--line);border-radius:999px;padding:6px 12px;color:var(--accent);font:600 13px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}table{width:100%;border-collapse:collapse;font-size:14px;background:#fff}th,td{border-bottom:1px solid var(--line);padding:12px;text-align:left;vertical-align:top}th{font:700 12px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);background:#f6f8f6}td code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px}.level{font-weight:700;color:var(--accent)}ul{margin:0;padding-left:22px}.footnote{color:var(--muted);font-size:13px}@media(max-width:760px){main{padding:28px 14px}section{padding:18px;border-radius:14px}table{display:block;overflow-x:auto;white-space:nowrap}h1{font-size:32px}}\n");
+    out.push_str("</style>\n");
+    out.push_str("</head>\n");
+    out.push_str("<body>\n");
+    out.push_str("<main>\n");
+    out.push_str("<header>\n");
+    out.push_str("<p class=\"meta\">Trust Card schema ");
+    out.push_str(&card.schema_version.to_string());
+    out.push_str("</p>\n");
+    out.push_str("<h1>Trust card</h1>\n");
+    out.push_str("<p class=\"lede\">Static projection of the canonical trustcard.json artifact. This page renders the same claim rows and non-goals for review; it does not add scores, badges, or a second classifier.</p>\n");
+    out.push_str("</header>\n");
+    out.push_str("<section aria-labelledby=\"claims-heading\">\n");
+    out.push_str("<h2 id=\"claims-heading\">Claims</h2>\n");
+    out.push_str("<table>\n");
+    out.push_str("<thead><tr><th>id</th><th>level</th><th>source</th><th>boundary</th><th>note</th></tr></thead>\n");
+    out.push_str("<tbody>\n");
+    for claim in &card.claims {
+        let id = serde_cell_string(&claim.id);
+        let level = serde_cell_string(&claim.level);
+        let source = serde_cell_string(&claim.source);
+        let boundary = serde_cell_string(&claim.boundary);
+        let note = note_text(&claim.note);
+        out.push_str("<tr data-claim-id=\"");
+        out.push_str(&html_escape(&id));
+        out.push_str("\"><td><code>");
+        out.push_str(&html_escape(&id));
+        out.push_str("</code></td><td class=\"level\">");
+        out.push_str(&html_escape(&level));
+        out.push_str("</td><td><code>");
+        out.push_str(&html_escape(&source));
+        out.push_str("</code></td><td><code>");
+        out.push_str(&html_escape(&boundary));
+        out.push_str("</code></td><td>");
+        out.push_str(&html_escape(&note));
+        out.push_str("</td></tr>\n");
+    }
+    out.push_str("</tbody>\n");
+    out.push_str("</table>\n");
+    out.push_str("</section>\n");
+    out.push_str("<section aria-labelledby=\"non-goals-heading\">\n");
+    out.push_str("<h2 id=\"non-goals-heading\">Non-goals</h2>\n");
+    out.push_str("<ul>\n");
+    for line in &card.non_goals {
+        out.push_str("<li>");
+        out.push_str(&html_escape(line));
+        out.push_str("</li>\n");
+    }
+    out.push_str("</ul>\n");
+    out.push_str("</section>\n");
+    out.push_str("<p class=\"footnote\">Canonical source of truth: trustcard.json. Markdown and HTML are deterministic projections.</p>\n");
+    out.push_str("</main>\n");
+    out.push_str("</body>\n");
+    out.push_str("</html>\n");
     out
 }
 
@@ -168,6 +256,14 @@ mod tests {
             }
         }
         out
+    }
+
+    fn html_table_claim_ids(html: &str) -> Vec<String> {
+        html.split("data-claim-id=\"")
+            .skip(1)
+            .map(|tail| tail.split_once('"').expect("claim id attribute").0)
+            .map(str::to_string)
+            .collect()
     }
 
     fn make_event(
@@ -310,6 +406,103 @@ mod tests {
             col, expected,
             "table rows must follow TrustBasis order, not alphabetical or regrouped"
         );
+    }
+
+    #[test]
+    fn trust_card_html_table_rows_follow_claim_id_order_not_sorted() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_html_order",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        let html = trust_card_to_html(&card);
+        let ids = html_table_claim_ids(&html);
+        let expected: Vec<String> = FROZEN_TRUST_BASIS_CLAIM_ID_ORDER
+            .iter()
+            .map(super::serde_cell_string)
+            .collect();
+        assert_eq!(
+            ids, expected,
+            "html rows must follow TrustBasis order, not alphabetical or regrouped"
+        );
+    }
+
+    #[test]
+    fn trust_card_html_is_static_projection_without_remote_assets_or_script() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_html_static",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+        let basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis");
+        let card = trust_basis_to_trust_card(&basis);
+        let html = trust_card_to_html(&card);
+        assert!(html.starts_with("<!doctype html>\n"));
+        assert_eq!(html.matches("data-claim-id=").count(), 10);
+        assert!(
+            !html.contains("<script"),
+            "static Trust Card HTML must not require script"
+        );
+        assert!(
+            !html.contains("<link"),
+            "static Trust Card HTML must not load remote stylesheets"
+        );
+        assert!(
+            !html.contains("http://") && !html.contains("https://"),
+            "static Trust Card HTML must not contain remote asset URLs"
+        );
+        assert!(
+            html.contains("Canonical source of truth: trustcard.json"),
+            "HTML must name JSON as the canonical source"
+        );
+        assert!(
+            html.contains("does not add scores, badges, or a second classifier"),
+            "HTML must keep the no-score/no-badge/no-second-classifier boundary visible"
+        );
+    }
+
+    #[test]
+    fn trust_card_html_escapes_notes_and_keeps_non_goals_literal() {
+        let card = TrustCard {
+            schema_version: TRUST_CARD_SCHEMA_VERSION,
+            claims: vec![TrustBasisClaim {
+                id: TrustClaimId::BundleVerified,
+                level: TrustClaimLevel::Verified,
+                source: TrustClaimSource::BundleVerification,
+                boundary: TrustClaimBoundary::BundleWide,
+                note: Some("<script>alert(\"x\")</script> & ok\r\nnext".to_string()),
+            }],
+            non_goals: TRUST_CARD_NON_GOALS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        };
+        let html = trust_card_to_html(&card);
+        assert!(
+            !html.contains("<script"),
+            "HTML must escape note content, not render raw markup"
+        );
+        assert!(html.contains("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; ok  next"));
+        for goal in TRUST_CARD_NON_GOALS {
+            assert!(
+                html.contains(&format!("<li>{goal}</li>")),
+                "missing frozen non-goal: {goal}"
+            );
+        }
     }
 
     #[test]

--- a/crates/assay-evidence/src/trust_card.rs
+++ b/crates/assay-evidence/src/trust_card.rs
@@ -118,6 +118,83 @@ fn html_escape(raw: &str) -> String {
     out
 }
 
+const TRUST_CARD_HTML_CSP: &str = concat!(
+    "default-src 'none'; ",
+    "style-src 'unsafe-inline'; ",
+    "script-src 'none'; ",
+    "connect-src 'none'; ",
+    "img-src 'none'; ",
+    "font-src 'none'; ",
+    "object-src 'none'; ",
+    "base-uri 'none'; ",
+    "form-action 'none'"
+);
+
+const TRUST_CARD_HTML_CSS: &str = r#":root{
+  color-scheme:light dark;
+  --ink:#18211f;
+  --muted:#5e6b66;
+  --line:#d8dfdc;
+  --paper:#fbfaf5;
+  --panel:#ffffff;
+  --accent:#2f6f62;
+  --soft:#edf4f1;
+  --shadow:0 18px 50px rgba(24,33,31,.08);
+}
+*{box-sizing:border-box}
+body{
+  margin:0;
+  background:
+    radial-gradient(circle at 10% 0%,rgba(47,111,98,.12),transparent 32rem),
+    linear-gradient(135deg,#fbfaf5 0%,#eef5f1 100%);
+  color:var(--ink);
+  font-family:Georgia,"Iowan Old Style","New York",serif;
+  line-height:1.5;
+}
+main{max-width:1120px;margin:0 auto;padding:48px 24px}
+section{background:var(--panel);border:1px solid var(--line);border-radius:18px;box-shadow:var(--shadow);padding:28px;margin:24px 0}
+h1{font-size:clamp(2rem,6vw,3rem);line-height:1.02;margin:0 0 10px;letter-spacing:-.03em}
+h2{font-size:1.375rem;margin:0 0 16px}
+.lede{color:var(--muted);max-width:760px}
+.meta{display:inline-block;background:var(--soft);border:1px solid var(--line);border-radius:999px;padding:6px 12px;color:var(--accent);font:600 .8125rem ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.skip-link{position:absolute;left:1rem;top:1rem;transform:translateY(-200%);background:var(--panel);border:2px solid var(--accent);border-radius:999px;color:var(--ink);padding:.5rem .875rem;text-decoration:none}
+.skip-link:focus-visible{transform:none;outline:3px solid var(--accent);outline-offset:3px}
+.table-wrap{overflow-x:auto;border:1px solid var(--line);border-radius:14px;background:var(--panel);scrollbar-gutter:stable}
+.table-wrap:focus-visible{outline:3px solid var(--accent);outline-offset:4px}
+table{width:100%;border-collapse:collapse;font-size:.875rem;background:var(--panel)}
+caption{padding:14px 12px;text-align:left;color:var(--muted);font-size:.875rem;border-bottom:1px solid var(--line)}
+th,td{border-bottom:1px solid var(--line);padding:12px;text-align:left;vertical-align:top}
+th{font:700 .75rem ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);background:var(--soft)}
+td code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:.8125rem;word-break:break-word}
+.level{font-weight:700;color:var(--accent)}
+ul{margin:0;padding-left:22px}
+.footnote{color:var(--muted);font-size:.8125rem}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+@media (prefers-color-scheme: dark){
+  :root{--ink:#edf5f1;--muted:#a8bbb3;--line:#344943;--paper:#111917;--panel:#17211e;--accent:#8ed8c4;--soft:#21322d;--shadow:0 18px 50px rgba(0,0,0,.35)}
+  body{background:radial-gradient(circle at 10% 0%,rgba(142,216,196,.14),transparent 32rem),linear-gradient(135deg,#101816 0%,#182622 100%)}
+}
+@media (forced-colors: active){
+  body{background:Canvas;color:CanvasText}
+  section,.table-wrap,.meta{border:1px solid CanvasText;box-shadow:none}
+  .skip-link,.table-wrap:focus-visible{outline:3px solid Highlight}
+  th{background:Canvas;color:CanvasText}
+  .level,.meta{color:CanvasText}
+}
+@media (max-width:760px){
+  main{padding:28px 14px}
+  section{padding:18px;border-radius:14px}
+  th,td{padding:10px}
+}
+@media print{
+  body{background:#fff;color:#000}
+  main{max-width:none;padding:0}
+  section{box-shadow:none;border-color:#999;break-inside:avoid}
+  .skip-link{display:none}
+  .table-wrap{overflow:visible}
+}
+"#;
+
 /// Secondary single-file human view. JSON remains canonical; HTML adds no claim semantics.
 pub fn trust_card_to_html(card: &TrustCard) -> String {
     let mut out = String::new();
@@ -126,13 +203,18 @@ pub fn trust_card_to_html(card: &TrustCard) -> String {
     out.push_str("<head>\n");
     out.push_str("<meta charset=\"utf-8\">\n");
     out.push_str("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    out.push_str("<meta name=\"color-scheme\" content=\"light dark\">\n");
+    out.push_str("<meta name=\"referrer\" content=\"no-referrer\">\n");
+    out.push_str("<meta http-equiv=\"Content-Security-Policy\" content=\"");
+    out.push_str(TRUST_CARD_HTML_CSP);
+    out.push_str("\">\n");
     out.push_str("<title>Assay Trust Card</title>\n");
     out.push_str("<style>\n");
-    out.push_str(":root{color-scheme:light;--ink:#18211f;--muted:#5e6b66;--line:#d8dfdc;--paper:#fbfaf5;--panel:#ffffff;--accent:#2f6f62;--soft:#edf4f1;}\n");
-    out.push_str("*{box-sizing:border-box}body{margin:0;background:linear-gradient(135deg,#fbfaf5 0%,#eef5f1 100%);color:var(--ink);font-family:Georgia,'Times New Roman',serif;line-height:1.5}main{max-width:1120px;margin:0 auto;padding:48px 24px}section{background:var(--panel);border:1px solid var(--line);border-radius:18px;box-shadow:0 18px 50px rgba(24,33,31,.08);padding:28px;margin:24px 0}h1{font-size:40px;line-height:1.05;margin:0 0 10px}h2{font-size:22px;margin:0 0 16px}.lede{color:var(--muted);max-width:760px}.meta{display:inline-block;background:var(--soft);border:1px solid var(--line);border-radius:999px;padding:6px 12px;color:var(--accent);font:600 13px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}table{width:100%;border-collapse:collapse;font-size:14px;background:#fff}th,td{border-bottom:1px solid var(--line);padding:12px;text-align:left;vertical-align:top}th{font:700 12px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);background:#f6f8f6}td code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px}.level{font-weight:700;color:var(--accent)}ul{margin:0;padding-left:22px}.footnote{color:var(--muted);font-size:13px}@media(max-width:760px){main{padding:28px 14px}section{padding:18px;border-radius:14px}table{display:block;overflow-x:auto;white-space:nowrap}h1{font-size:32px}}\n");
+    out.push_str(TRUST_CARD_HTML_CSS);
     out.push_str("</style>\n");
     out.push_str("</head>\n");
     out.push_str("<body>\n");
+    out.push_str("<a class=\"skip-link\" href=\"#claims-heading\">Skip to claims</a>\n");
     out.push_str("<main>\n");
     out.push_str("<header>\n");
     out.push_str("<p class=\"meta\">Trust Card schema ");
@@ -141,10 +223,15 @@ pub fn trust_card_to_html(card: &TrustCard) -> String {
     out.push_str("<h1>Trust card</h1>\n");
     out.push_str("<p class=\"lede\">Static projection of the canonical trustcard.json artifact. This page renders the same claim rows and non-goals for review; it does not add scores, badges, or a second classifier.</p>\n");
     out.push_str("</header>\n");
-    out.push_str("<section aria-labelledby=\"claims-heading\">\n");
+    out.push_str(
+        "<section aria-labelledby=\"claims-heading\" aria-describedby=\"claims-description\">\n",
+    );
     out.push_str("<h2 id=\"claims-heading\">Claims</h2>\n");
+    out.push_str("<p id=\"claims-description\" class=\"lede\">Rows are rendered from the canonical Trust Card claim list. Reviewers should key by stable claim id, not row position.</p>\n");
+    out.push_str("<div class=\"table-wrap\" role=\"region\" aria-label=\"Scrollable Trust Card claims table\" tabindex=\"0\">\n");
     out.push_str("<table>\n");
-    out.push_str("<thead><tr><th>id</th><th>level</th><th>source</th><th>boundary</th><th>note</th></tr></thead>\n");
+    out.push_str("<caption>Trust Basis claim rows from trustcard.json</caption>\n");
+    out.push_str("<thead><tr><th scope=\"col\">id</th><th scope=\"col\">level</th><th scope=\"col\">source</th><th scope=\"col\">boundary</th><th scope=\"col\">note</th></tr></thead>\n");
     out.push_str("<tbody>\n");
     for claim in &card.claims {
         let id = serde_cell_string(&claim.id);
@@ -154,20 +241,21 @@ pub fn trust_card_to_html(card: &TrustCard) -> String {
         let note = note_text(&claim.note);
         out.push_str("<tr data-claim-id=\"");
         out.push_str(&html_escape(&id));
-        out.push_str("\"><td><code>");
+        out.push_str("\"><td data-label=\"id\"><code>");
         out.push_str(&html_escape(&id));
-        out.push_str("</code></td><td class=\"level\">");
+        out.push_str("</code></td><td data-label=\"level\" class=\"level\">");
         out.push_str(&html_escape(&level));
-        out.push_str("</td><td><code>");
+        out.push_str("</td><td data-label=\"source\"><code>");
         out.push_str(&html_escape(&source));
-        out.push_str("</code></td><td><code>");
+        out.push_str("</code></td><td data-label=\"boundary\"><code>");
         out.push_str(&html_escape(&boundary));
-        out.push_str("</code></td><td>");
+        out.push_str("</code></td><td data-label=\"note\">");
         out.push_str(&html_escape(&note));
         out.push_str("</td></tr>\n");
     }
     out.push_str("</tbody>\n");
     out.push_str("</table>\n");
+    out.push_str("</div>\n");
     out.push_str("</section>\n");
     out.push_str("<section aria-labelledby=\"non-goals-heading\">\n");
     out.push_str("<h2 id=\"non-goals-heading\">Non-goals</h2>\n");
@@ -458,12 +546,38 @@ mod tests {
             "static Trust Card HTML must not require script"
         );
         assert!(
-            !html.contains("<link"),
-            "static Trust Card HTML must not load remote stylesheets"
+            !html.contains(r#"<link rel="stylesheet""#) && !html.contains(r#" rel="stylesheet""#),
+            "static Trust Card HTML must not load external stylesheets"
         );
         assert!(
             !html.contains("http://") && !html.contains("https://"),
             "static Trust Card HTML must not contain remote asset URLs"
+        );
+        assert!(
+            html.contains("Content-Security-Policy")
+                && html.contains("script-src 'none'")
+                && html.contains("connect-src 'none'")
+                && html.contains("object-src 'none'")
+                && html.contains("base-uri 'none'")
+                && html.contains("form-action 'none'"),
+            "HTML should carry a static-page CSP boundary"
+        );
+        assert!(
+            html.contains(r#"<meta name="referrer" content="no-referrer">"#),
+            "HTML should avoid leaking local artifact paths as referrers"
+        );
+        assert!(
+            html.contains("prefers-color-scheme: dark")
+                && html.contains("forced-colors: active")
+                && html.contains("@media print"),
+            "HTML should respect color-scheme, high-contrast, and print review modes"
+        );
+        assert!(
+            html.contains("<caption>Trust Basis claim rows from trustcard.json</caption>")
+                && html.contains(r#"<th scope="col">id</th>"#)
+                && html.contains(r#"role="region""#)
+                && html.contains(r#"aria-label="Scrollable Trust Card claims table""#),
+            "HTML table should expose accessible labels and scroll context"
         );
         assert!(
             html.contains("Canonical source of truth: trustcard.json"),

--- a/crates/assay-evidence/src/trust_card.rs
+++ b/crates/assay-evidence/src/trust_card.rs
@@ -540,7 +540,7 @@ mod tests {
         let card = trust_basis_to_trust_card(&basis);
         let html = trust_card_to_html(&card);
         assert!(html.starts_with("<!doctype html>\n"));
-        assert_eq!(html.matches("data-claim-id=").count(), 10);
+        assert_eq!(html.matches("data-claim-id=").count(), card.claims.len());
         assert!(
             !html.contains("<script"),
             "static Trust Card HTML must not require script"

--- a/docs/AIcontext/quick-reference.md
+++ b/docs/AIcontext/quick-reference.md
@@ -28,6 +28,7 @@ assay ci --config eval.yaml --trace-file traces.jsonl
 assay evidence verify bundle.tar.gz
 assay trust-basis generate bundle.tar.gz --out trust-basis.json
 assay trustcard generate bundle.tar.gz --out-dir trustcard
+# writes trustcard.json, trustcard.md, and static trustcard.html
 
 # Debug failures
 assay doctor                  # Diagnose common issues

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -213,7 +213,7 @@ The substrate that was on `main` after `P1` was strong enough to shift from "mor
 | Order | Lane | Why now | Boundary |
 |-------|------|---------|----------|
 | **1** | `T1a` OTel-native Trust Compiler MVP | ✅ Merged on `main`: verified bundle -> deterministic `trust-basis.json` with bounded claim classification. | Kept small: no Trust Card rendering, no new signals, no packs, no score-first surface. |
-| **2** | `T1b` Trust Card MVP | ✅ Merged on `main`: deterministic `trustcard.json` + `trustcard.md` from verified bundles (`assay trustcard generate --out-dir`), derived from T1a only. | Evidence-classified output; signed/attestation later; no generic risk score. |
+| **2** | `T1b` Trust Card MVP | ✅ Merged on `main`: deterministic Trust Card artifacts from verified bundles (`trustcard.json`, `trustcard.md`, and static `trustcard.html` via `assay trustcard generate --out-dir`), derived from Trust Basis only. | Evidence-classified output; signed/attestation later; no generic risk score. |
 | **3** | `G3` Authorization Evidence Signal | ✅ Merged on `main`: bounded `auth_scheme` / `auth_issuer` / `principal` on policy-projected MCP decision evidence; Trust Basis + Trust Card schema `2` / seven claims (see [PLAN-G3](architecture/PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md)). | Supported flows only; no auth validation, issuer trust proof, scope checks, or temporal correctness. Optional follow-up: reduce core ↔ evidence drift (normalization vs classification). |
 | **4** | `P2` Protocol Claim Packs | Historical next lane at that point — protocol-aware claim packs as honest product surfaces once auth context became visible in evidence. | Small MCP/A2A claim packs, not broad compliance theater. |
 | **Later** | Reference/temporal/capability attestation | These semantics are valuable but heavier. | Ship only after the claim product line is stable. |
@@ -261,7 +261,7 @@ March 2026 evidence and signal waves change the ordering inside Q3. `T1a`, `T1b`
 | Priority | Capability | Why now | MVP boundary |
 |----------|------------|---------|--------------|
 | **P0** | `T1a` OTel-native Trust Compiler MVP | ✅ Shipped on `main`: verified bundle → `trust-basis.json` / bounded claim classification. | Compiler inputs/outputs, claim basis export; no dashboard-first surface. |
-| **P0** | `T1b` Trust Card MVP | ✅ Shipped on `main`: portable `trustcard.json` + `trustcard.md` for review and diff. | Evidence-level rows + frozen non-goals; no opaque global score. |
+| **P0** | `T1b` Trust Card MVP | ✅ Shipped on `main`: portable `trustcard.json`, `trustcard.md`, and static `trustcard.html` for review and diff. | Evidence-level rows + frozen non-goals; no opaque global score. |
 | **P1** | `G3` Authorization Evidence Signal | ✅ Shipped on `main`: authorization context fields on supported MCP decision evidence; Trust Card schema `2` / seven trust-basis claims. | Supported flows only; no cryptographic or temporal auth-validation semantics. |
 | **P1** | `P2a` MCP companion pack | ✅ Shipped on `main`: built-in `mcp-signal-followup` (MCP-001..003). | G3-aligned lint; see [PLAN-P2a](architecture/PLAN-P2a-MCP-SIGNAL-FOLLOWUP-CLAIM-PACK.md). |
 | **P1** | `H1` Trust kernel alignment & release hardening | ✅ Shipped on `main`: migration SSOT, alignment tests, docs; no new signals. | [PLAN-H1](architecture/PLAN-H1-TRUST-KERNEL-ALIGNMENT-RELEASE-HARDENING.md), [MIGRATION-TRUST-COMPILER-3.2.md](architecture/MIGRATION-TRUST-COMPILER-3.2.md). |

--- a/docs/architecture/PLAN-P52-P56-CONSOLIDATION-PROGRAM-2026q2.md
+++ b/docs/architecture/PLAN-P52-P56-CONSOLIDATION-PROGRAM-2026q2.md
@@ -199,13 +199,8 @@ source of truth.
 - Add HTML projection support to Trust Card generation.
 - Produce a deterministic single-file artifact.
 - Render the same claim rows as `trustcard.json` and `trustcard.md`.
-- Show claim id, level, source, boundary, note, and evidence posture.
-- Show receipt-family context where present:
-  - event type,
-  - included fields,
-  - excluded fields,
-  - `does_not_claim`.
-- Link to raw Trust Basis and evidence artifacts when the caller supplies paths.
+- Show claim id, level, source, boundary, and note.
+- Keep `trustcard.json` canonical; Markdown and HTML are projections.
 
 ### Non-goals
 
@@ -214,6 +209,7 @@ source of truth.
 - No JavaScript requirement to understand the artifact.
 - No scores, badges, or second classifier.
 - No claim semantics added in HTML.
+- No receipt-family context expansion or raw evidence links in this slice.
 
 ### Acceptance
 

--- a/docs/community/DISCUSSIONS.md
+++ b/docs/community/DISCUSSIONS.md
@@ -25,7 +25,7 @@ Pin **931–933** (and optionally **934**) in the GitHub UI: Discussions → ope
 
 **Suggested body:**
 
-**Assay is** a **trust compiler for agent systems**: it turns runtime signals (MCP tool decisions, traces, bundle contents) into **enforceable policy outcomes** and **reviewable trust artifacts** — verifiable evidence bundles, Trust Basis (`trust-basis.json`), Trust Card (`trustcard.json` / `trustcard.md`), SARIF, CI gates.
+**Assay is** a **trust compiler for agent systems**: it turns runtime signals (MCP tool decisions, traces, bundle contents) into **enforceable policy outcomes** and **reviewable trust artifacts** — verifiable evidence bundles, Trust Basis (`trust-basis.json`), Trust Card (`trustcard.json` / `trustcard.md` / `trustcard.html`), SARIF, CI gates.
 
 **The wedge** many people meet first is **deterministic MCP policy enforcement** (`assay mcp wrap`): allow/deny before tools run, with an audit trail. That is the control plane, not the whole category. The `mcp` command group is **hidden** from top-level `assay --help` while the surface stabilizes; run `assay mcp --help` or follow the [MCP Quickstart](https://github.com/Rul1an/assay/tree/main/examples/mcp-quickstart).
 
@@ -51,7 +51,7 @@ High-level sequence (see [RFC-005](https://github.com/Rul1an/assay/blob/main/doc
 | Wave | What shipped (intent) |
 |------|------------------------|
 | **T1a** | Canonical **Trust Basis** compiler output from verified bundles (`assay trust-basis generate`). |
-| **T1b** | **Trust Card** — `trustcard.json` + `trustcard.md` from the same basis (`assay trustcard generate`). |
+| **T1b** | **Trust Card** — `trustcard.json` + `trustcard.md` + static `trustcard.html` from the same basis (`assay trustcard generate`). |
 | **G3** | Bounded **authorization context** on supported MCP decision evidence (`auth_scheme`, `auth_issuer`, `principal`) — visibility, not auth-validation. Trust Card schema bumped; **seven** trust claims — consumers key by **`id`**, not fixed row count. |
 | **P2** | Protocol-oriented claim packs (next). |
 
@@ -69,7 +69,7 @@ Ask questions about sequencing and boundaries here; keep feature requests in Iss
 
 1. Produce or use a **verified** evidence bundle (`.tar.gz`).
 2. `assay trust-basis generate bundle.tar.gz` → `trust-basis.json` (deterministic claim rows).
-3. `assay trustcard generate bundle.tar.gz --out-dir ./out` → `out/trustcard.json`, `out/trustcard.md`.
+3. `assay trustcard generate bundle.tar.gz --out-dir ./out` → `out/trustcard.json`, `out/trustcard.md`, `out/trustcard.html`.
 
 **What to look for:**
 

--- a/docs/concepts/scope.md
+++ b/docs/concepts/scope.md
@@ -32,7 +32,7 @@ verified, what was merely visible, and what should not be claimed.
 | Protocol policy | Deterministic allow/deny/approval decisions over supported MCP tool-call surfaces. |
 | Evidence bundles | Offline-verifiable evidence artifacts with canonical event envelopes and content binding. |
 | Trust Basis | Bounded claim classification from verified bundles, keyed by stable `claim.id`. |
-| Trust Card | Human-readable JSON/Markdown projection of the Trust Basis claim set. |
+| Trust Card | Canonical JSON plus Markdown/HTML projections of the Trust Basis claim set. |
 | External receipts | Narrow compiler lanes for selected upstream seams such as Promptfoo assertion components, OpenFeature boolean `EvaluationDetails`, and CycloneDX ML-BOM model components. |
 | CI projections | SARIF/JUnit/Markdown outputs where appropriate, with raw canonical artifacts kept separate. |
 | Packs | Optional evidence linting and policy packs that structure findings; packs do not prove legal compliance by themselves. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,10 @@ assay trust-basis generate bundle.tar.gz --out trust-basis.json
 assay trustcard generate bundle.tar.gz --out-dir trustcard
 ```
 
+`trustcard.json` is the canonical Trust Card artifact. `trustcard.md` and
+`trustcard.html` are deterministic reviewer projections of the same claim rows
+and frozen non-goals.
+
 ### 5. Optional: Lint with a Pack
 
 ```bash

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -32,6 +32,7 @@ assay --version
 | [`assay replay`](replay.md) | Replay from a replay bundle |
 | [`assay evidence`](evidence.md) | Manage evidence bundles, external evidence imports, and receipt schemas |
 | [`assay trust-basis`](trust-basis.md) | Generate, compare, and assert canonical Trust Basis artifacts |
+| [`assay trustcard`](trustcard.md) | Generate Trust Card JSON, Markdown, and static HTML projections |
 | [`assay import`](import.md) | Import sessions from MCP Inspector, etc. |
 | [`assay migrate`](migrate.md) | Upgrade config from v0 to v1 |
 | [`assay doctor`](doctor.md) | Diagnose setup and optionally auto-fix known issues |
@@ -264,6 +265,14 @@ See [Configuration](../config/index.md) for full reference.
     Generate and compare canonical Trust Basis artifacts.
 
     [:octicons-arrow-right-24: Full reference](trust-basis.md)
+
+-   :material-card-account-details-outline:{ .lg .middle } __assay trustcard__
+
+    ---
+
+    Generate Trust Card JSON, Markdown, and static HTML projections.
+
+    [:octicons-arrow-right-24: Full reference](trustcard.md)
 
 -   :material-server:{ .lg .middle } __assay mcp wrap__
 

--- a/docs/reference/cli/trustcard.md
+++ b/docs/reference/cli/trustcard.md
@@ -22,8 +22,10 @@ non-goals:
 - `trustcard.html` is a deterministic single-file static HTML projection for
   browser review.
 
-The HTML artifact has inline styles only. It does not require JavaScript,
-remote assets, a hosted backend, or network access. It does not add claim
+The HTML artifact has inline styles only plus a static-page Content Security
+Policy. It does not require JavaScript, remote assets, a hosted backend, or
+network access. It includes accessible table structure, responsive overflow,
+dark-mode, forced-colors, and print styling, but it does not add claim
 semantics, scores, badges, or a second classifier.
 
 ## Options

--- a/docs/reference/cli/trustcard.md
+++ b/docs/reference/cli/trustcard.md
@@ -2,9 +2,15 @@
 
 Generate Trust Card artifacts from a verified evidence bundle.
 
+---
+
+## Synopsis
+
 ```bash
 assay trustcard <COMMAND> [OPTIONS]
 ```
+
+---
 
 ## Generate
 
@@ -28,6 +34,8 @@ network access. It includes accessible table structure, responsive overflow,
 dark-mode, forced-colors, and print styling, but it does not add claim
 semantics, scores, badges, or a second classifier.
 
+---
+
 ## Options
 
 | Option | Meaning |
@@ -37,8 +45,18 @@ semantics, scores, badges, or a second classifier.
 | `--pack <PACK[,PACK...]>` | Optional pack references to execute while classifying pack findings. |
 | `--max-results <N>` | Maximum lint results considered when pack execution is enabled. Default: `500`. |
 
+---
+
 ## Contract
 
 Trust Card rendering must stay a projection layer. Claim classification happens
 in [`assay trust-basis`](./trust-basis.md), and consumers should key claims by
 stable `claim.id`, not by row position or count.
+
+---
+
+## See Also
+
+- [Trust Basis CLI](./trust-basis.md)
+- [Receipt family matrix](../receipt-family-matrix.json)
+- [P52-P56 consolidation plan](../../architecture/PLAN-P52-P56-CONSOLIDATION-PROGRAM-2026q2.md)

--- a/docs/reference/cli/trustcard.md
+++ b/docs/reference/cli/trustcard.md
@@ -1,0 +1,42 @@
+# assay trustcard
+
+Generate Trust Card artifacts from a verified evidence bundle.
+
+```bash
+assay trustcard <COMMAND> [OPTIONS]
+```
+
+## Generate
+
+Generate `trustcard.json`, `trustcard.md`, and `trustcard.html`:
+
+```bash
+assay trustcard generate evidence.tar.gz --out-dir trustcard
+```
+
+The Trust Card is a one-way projection of Trust Basis claim rows plus frozen
+non-goals:
+
+- `trustcard.json` is the canonical Trust Card artifact.
+- `trustcard.md` is a deterministic Markdown projection for text review.
+- `trustcard.html` is a deterministic single-file static HTML projection for
+  browser review.
+
+The HTML artifact has inline styles only. It does not require JavaScript,
+remote assets, a hosted backend, or network access. It does not add claim
+semantics, scores, badges, or a second classifier.
+
+## Options
+
+| Option | Meaning |
+|---|---|
+| `<BUNDLE>` | Evidence bundle archive (`.tar.gz`). |
+| `--out-dir <DIR>` | Directory that receives `trustcard.json`, `trustcard.md`, and `trustcard.html`. |
+| `--pack <PACK[,PACK...]>` | Optional pack references to execute while classifying pack findings. |
+| `--max-results <N>` | Maximum lint results considered when pack execution is enabled. Default: `500`. |
+
+## Contract
+
+Trust Card rendering must stay a projection layer. Claim classification happens
+in [`assay trust-basis`](./trust-basis.md), and consumers should key claims by
+stable `claim.id`, not by row position or count.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,6 +186,7 @@ nav:
     - assay migrate: reference/cli/migrate.md
     - assay replay: reference/cli/replay.md
     - assay trust-basis: reference/cli/trust-basis.md
+    - assay trustcard: reference/cli/trustcard.md
     - assay mcp-server: reference/cli/mcp-server.md
 
   - Metrics Reference:


### PR DESCRIPTION
What changed

Adds P54: a deterministic static HTML projection for Trust Cards.

This PR includes:

- `assay trustcard generate` now writes `trustcard.html` beside `trustcard.json` and `trustcard.md`
- `trust_card_to_html` in `assay-evidence`, re-exported for CLI use
- HTML escaping, stable claim-row ordering, frozen non-goals, and no-network/no-script regression tests
- CLI tests proving HTML renders the same claim rows as canonical `trustcard.json`
- CLI docs, README/roadmap/community wording, mkdocs nav, AI quick reference, changelog, and P52-P56 plan alignment

Why

P52 made the product surface legible, P53 made Trust Basis directly assertable, and P55 made receipt schemas inspectable. P54 makes Trust Cards easier to review without adding a hosted dashboard or a second semantic layer.

Boundary

`trustcard.json` remains the canonical Trust Card artifact. `trustcard.md` and `trustcard.html` are deterministic projections only. The HTML artifact is single-file and static: no remote assets, no JavaScript requirement, no scores, no badges, no second classifier, no new claim semantics, and no receipt-family context expansion.

Validation

Ran locally:

- `cargo fmt`
- `cargo test -p assay-evidence trust_card -- --nocapture`
- `cargo test -p assay-cli --test trustcard_test -- --nocapture`
- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `cargo fmt --check && git diff --check`
- local changed-docs markdown link check
- `cargo run -q -p assay-cli -- trustcard --help`
- `cargo run -q -p assay-cli -- trustcard generate --help`

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.