### PR TITLE
P56a: surface policy snapshot digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to this project will be documented in this file.
   canonical Trust Card artifact; Markdown and single-file HTML are deterministic
   reviewer projections with no remote assets, JavaScript requirement, scores,
   badges, or second classifier.
+- **Policy snapshot digest visibility**: supported MCP `assay.tool.decision`
+  events now project `policy_snapshot_digest`,
+  `policy_snapshot_digest_alg`, `policy_snapshot_canonicalization`, and
+  `policy_snapshot_schema` from the canonical policy digest when available.
+  This is a review binding only; it does not claim the policy is correct,
+  sufficient, safe, approved, or complete.
 
 ## [3.8.0] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ All notable changes to this project will be documented in this file.
 - **Policy snapshot digest visibility**: supported MCP `assay.tool.decision`
   events now project `policy_snapshot_digest`,
   `policy_snapshot_digest_alg`, `policy_snapshot_canonicalization`, and
-  `policy_snapshot_schema` from the canonical policy digest when available.
-  This is a review binding only; it does not claim the policy is correct,
-  sufficient, safe, approved, or complete.
+  `policy_snapshot_schema` from the existing `policy_digest` when available.
+  `policy_snapshot_digest` is the self-describing reviewer projection of
+  `policy_digest`; the values match on supported paths, and the snapshot field
+  cluster is produced atomically. This is a review binding only; it does not
+  claim the policy is correct, sufficient, safe, approved, complete,
+  retrievable, exportable, or embedded.
 
 ## [3.8.0] - 2026-04-29
 

--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -354,7 +354,7 @@ mod tests {
         );
         assert_eq!(
             event.data.policy_snapshot_digest.as_deref(),
-            Some("sha256:policy123")
+            event.data.policy_digest.as_deref()
         );
         assert_eq!(
             event.data.policy_snapshot_digest_alg.as_deref(),
@@ -368,6 +368,25 @@ mod tests {
             event.data.policy_snapshot_schema.as_deref(),
             Some(POLICY_SNAPSHOT_SCHEMA_V1)
         );
+    }
+
+    #[test]
+    fn test_policy_snapshot_projection_is_atomic() {
+        let event = DecisionEvent::new(
+            "assay://test".to_string(),
+            "tc_policy_snapshot_atomic".to_string(),
+            "deploy_service".to_string(),
+        )
+        .allow(reason_codes::P_POLICY_ALLOW)
+        .with_policy_context(PolicyDecisionEventContext {
+            policy_digest: Some("sha256:policy456".to_string()),
+            ..PolicyDecisionEventContext::default()
+        });
+
+        assert!(event.data.policy_snapshot_digest.is_some());
+        assert!(event.data.policy_snapshot_digest_alg.is_some());
+        assert!(event.data.policy_snapshot_canonicalization.is_some());
+        assert!(event.data.policy_snapshot_schema.is_some());
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -19,6 +19,8 @@ pub use self::decision_next::emitters::{
 pub use self::decision_next::event_types::{
     reason_codes, Decision, DecisionData, DecisionEvent, FulfillmentDecisionPath,
     ObligationOutcome, ObligationOutcomeStatus, PolicyDecisionEventContext,
+    POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY, POLICY_SNAPSHOT_DIGEST_ALG_SHA256,
+    POLICY_SNAPSHOT_SCHEMA_V1,
 };
 pub use self::decision_next::guard::DecisionEmitterGuard;
 pub(crate) use self::decision_next::normalization::refresh_contract_projections;
@@ -308,6 +310,64 @@ mod tests {
 
         assert!(!data.contains_key("delegated_from"));
         assert!(!data.contains_key("delegation_depth"));
+    }
+
+    #[test]
+    fn test_decision_event_omits_policy_snapshot_fields_when_digest_absent() {
+        let event = DecisionEvent::new(
+            "assay://test".to_string(),
+            "tc_no_policy_snapshot".to_string(),
+            "deploy_service".to_string(),
+        )
+        .allow(reason_codes::P_POLICY_ALLOW);
+
+        let value = serde_json::to_value(event).expect("decision event should serialize");
+        let data = value
+            .get("data")
+            .and_then(serde_json::Value::as_object)
+            .expect("decision event data should be an object");
+
+        assert!(!data.contains_key("policy_snapshot_digest"));
+        assert!(!data.contains_key("policy_snapshot_digest_alg"));
+        assert!(!data.contains_key("policy_snapshot_canonicalization"));
+        assert!(!data.contains_key("policy_snapshot_schema"));
+    }
+
+    #[test]
+    fn test_with_policy_context_projects_policy_snapshot_digest() {
+        let context = PolicyDecisionEventContext {
+            policy_digest: Some("sha256:policy123".to_string()),
+            ..PolicyDecisionEventContext::default()
+        };
+
+        let event = DecisionEvent::new(
+            "assay://test".to_string(),
+            "tc_policy_snapshot".to_string(),
+            "deploy_service".to_string(),
+        )
+        .allow(reason_codes::P_POLICY_ALLOW)
+        .with_policy_context(context);
+
+        assert_eq!(
+            event.data.policy_digest.as_deref(),
+            Some("sha256:policy123")
+        );
+        assert_eq!(
+            event.data.policy_snapshot_digest.as_deref(),
+            Some("sha256:policy123")
+        );
+        assert_eq!(
+            event.data.policy_snapshot_digest_alg.as_deref(),
+            Some(POLICY_SNAPSHOT_DIGEST_ALG_SHA256)
+        );
+        assert_eq!(
+            event.data.policy_snapshot_canonicalization.as_deref(),
+            Some(POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY)
+        );
+        assert_eq!(
+            event.data.policy_snapshot_schema.as_deref(),
+            Some(POLICY_SNAPSHOT_SCHEMA_V1)
+        );
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/decision_next/builder.rs
+++ b/crates/assay-core/src/mcp/decision_next/builder.rs
@@ -198,10 +198,6 @@ impl DecisionEvent {
             typed_decision,
             policy_version,
             policy_digest,
-            policy_snapshot_digest,
-            policy_snapshot_digest_alg,
-            policy_snapshot_canonicalization,
-            policy_snapshot_schema,
             obligations,
             obligation_outcomes,
             approval_state,
@@ -237,12 +233,7 @@ impl DecisionEvent {
         self.data.typed_decision = typed_decision;
         self.data.policy_version = policy_version;
         self.data.policy_digest = policy_digest;
-        self.data.apply_policy_snapshot_projection(
-            policy_snapshot_digest,
-            policy_snapshot_digest_alg,
-            policy_snapshot_canonicalization,
-            policy_snapshot_schema,
-        );
+        self.data.apply_policy_snapshot_projection();
         self.data.obligations = obligations;
         self.data.obligation_outcomes = obligation_outcomes;
         self.data.approval_state = approval_state;

--- a/crates/assay-core/src/mcp/decision_next/builder.rs
+++ b/crates/assay-core/src/mcp/decision_next/builder.rs
@@ -22,6 +22,10 @@ impl DecisionEvent {
                 typed_decision: None,
                 policy_version: None,
                 policy_digest: None,
+                policy_snapshot_digest: None,
+                policy_snapshot_digest_alg: None,
+                policy_snapshot_canonicalization: None,
+                policy_snapshot_schema: None,
                 obligations: Vec::new(),
                 obligation_outcomes: Vec::new(),
                 approval_state: None,
@@ -194,6 +198,10 @@ impl DecisionEvent {
             typed_decision,
             policy_version,
             policy_digest,
+            policy_snapshot_digest,
+            policy_snapshot_digest_alg,
+            policy_snapshot_canonicalization,
+            policy_snapshot_schema,
             obligations,
             obligation_outcomes,
             approval_state,
@@ -229,6 +237,12 @@ impl DecisionEvent {
         self.data.typed_decision = typed_decision;
         self.data.policy_version = policy_version;
         self.data.policy_digest = policy_digest;
+        self.data.apply_policy_snapshot_projection(
+            policy_snapshot_digest,
+            policy_snapshot_digest_alg,
+            policy_snapshot_canonicalization,
+            policy_snapshot_schema,
+        );
         self.data.obligations = obligations;
         self.data.obligation_outcomes = obligation_outcomes;
         self.data.approval_state = approval_state;

--- a/crates/assay-core/src/mcp/decision_next/event_types.rs
+++ b/crates/assay-core/src/mcp/decision_next/event_types.rs
@@ -12,6 +12,13 @@ use crate::mcp::policy::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Policy snapshot digest algorithm used by supported decision events.
+pub const POLICY_SNAPSHOT_DIGEST_ALG_SHA256: &str = "sha256";
+/// Canonicalization applied before computing `policy_snapshot_digest`.
+pub const POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY: &str = "jcs:mcp_policy";
+/// Bounded schema tag for the supported MCP policy snapshot projection.
+pub const POLICY_SNAPSHOT_SCHEMA_V1: &str = "assay.mcp.policy.snapshot.v1";
+
 /// Reason codes for tool decisions (SPEC-Mandate-v1.0.4 §7.10).
 pub mod reason_codes {
     // Policy decisions (P_*)
@@ -101,6 +108,10 @@ pub struct PolicyDecisionEventContext {
     pub typed_decision: Option<TypedPolicyDecision>,
     pub policy_version: Option<String>,
     pub policy_digest: Option<String>,
+    pub policy_snapshot_digest: Option<String>,
+    pub policy_snapshot_digest_alg: Option<String>,
+    pub policy_snapshot_canonicalization: Option<String>,
+    pub policy_snapshot_schema: Option<String>,
     pub obligations: Vec<PolicyObligation>,
     pub obligation_outcomes: Vec<ObligationOutcome>,
     pub approval_state: Option<String>,
@@ -179,6 +190,18 @@ pub struct DecisionData {
     /// Policy bundle digest used for evaluation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy_digest: Option<String>,
+    /// P56a: digest of the canonical policy snapshot used for this evaluation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_snapshot_digest: Option<String>,
+    /// P56a: digest algorithm for `policy_snapshot_digest`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_snapshot_digest_alg: Option<String>,
+    /// P56a: canonicalization used before digesting the policy snapshot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_snapshot_canonicalization: Option<String>,
+    /// P56a: bounded schema tag for the snapshot surface being digested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_snapshot_schema: Option<String>,
     /// Obligations attached to an allow/deny decision
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub obligations: Vec<PolicyObligation>,
@@ -419,4 +442,29 @@ pub struct DecisionData {
     /// Store latency in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub store_latency_ms: Option<u64>,
+}
+
+impl DecisionData {
+    pub(crate) fn apply_policy_snapshot_projection(
+        &mut self,
+        digest: Option<String>,
+        digest_alg: Option<String>,
+        canonicalization: Option<String>,
+        schema: Option<String>,
+    ) {
+        self.policy_snapshot_digest = digest.or_else(|| self.policy_digest.clone());
+
+        if self.policy_snapshot_digest.is_some() {
+            self.policy_snapshot_digest_alg =
+                digest_alg.or_else(|| Some(POLICY_SNAPSHOT_DIGEST_ALG_SHA256.to_string()));
+            self.policy_snapshot_canonicalization = canonicalization
+                .or_else(|| Some(POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY.to_string()));
+            self.policy_snapshot_schema =
+                schema.or_else(|| Some(POLICY_SNAPSHOT_SCHEMA_V1.to_string()));
+        } else {
+            self.policy_snapshot_digest_alg = None;
+            self.policy_snapshot_canonicalization = None;
+            self.policy_snapshot_schema = None;
+        }
+    }
 }

--- a/crates/assay-core/src/mcp/decision_next/event_types.rs
+++ b/crates/assay-core/src/mcp/decision_next/event_types.rs
@@ -108,10 +108,6 @@ pub struct PolicyDecisionEventContext {
     pub typed_decision: Option<TypedPolicyDecision>,
     pub policy_version: Option<String>,
     pub policy_digest: Option<String>,
-    pub policy_snapshot_digest: Option<String>,
-    pub policy_snapshot_digest_alg: Option<String>,
-    pub policy_snapshot_canonicalization: Option<String>,
-    pub policy_snapshot_schema: Option<String>,
     pub obligations: Vec<PolicyObligation>,
     pub obligation_outcomes: Vec<ObligationOutcome>,
     pub approval_state: Option<String>,
@@ -445,22 +441,17 @@ pub struct DecisionData {
 }
 
 impl DecisionData {
-    pub(crate) fn apply_policy_snapshot_projection(
-        &mut self,
-        digest: Option<String>,
-        digest_alg: Option<String>,
-        canonicalization: Option<String>,
-        schema: Option<String>,
-    ) {
-        self.policy_snapshot_digest = digest.or_else(|| self.policy_digest.clone());
+    /// Project the legacy-compatible `policy_digest` into the explicit P56a
+    /// review surface. This is a pure projection: never reconstruct a digest,
+    /// and never let the snapshot fields represent a different value.
+    pub(crate) fn apply_policy_snapshot_projection(&mut self) {
+        self.policy_snapshot_digest = self.policy_digest.clone();
 
         if self.policy_snapshot_digest.is_some() {
-            self.policy_snapshot_digest_alg =
-                digest_alg.or_else(|| Some(POLICY_SNAPSHOT_DIGEST_ALG_SHA256.to_string()));
-            self.policy_snapshot_canonicalization = canonicalization
-                .or_else(|| Some(POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY.to_string()));
-            self.policy_snapshot_schema =
-                schema.or_else(|| Some(POLICY_SNAPSHOT_SCHEMA_V1.to_string()));
+            self.policy_snapshot_digest_alg = Some(POLICY_SNAPSHOT_DIGEST_ALG_SHA256.to_string());
+            self.policy_snapshot_canonicalization =
+                Some(POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY.to_string());
+            self.policy_snapshot_schema = Some(POLICY_SNAPSHOT_SCHEMA_V1.to_string());
         } else {
             self.policy_snapshot_digest_alg = None;
             self.policy_snapshot_canonicalization = None;

--- a/crates/assay-core/src/mcp/decision_next/guard.rs
+++ b/crates/assay-core/src/mcp/decision_next/guard.rs
@@ -103,6 +103,10 @@ impl DecisionEmitterGuard {
                 typed_decision,
                 policy_version,
                 policy_digest,
+                policy_snapshot_digest,
+                policy_snapshot_digest_alg,
+                policy_snapshot_canonicalization,
+                policy_snapshot_schema,
                 obligations,
                 obligation_outcomes,
                 approval_state,
@@ -138,6 +142,12 @@ impl DecisionEmitterGuard {
             event.data.typed_decision = typed_decision;
             event.data.policy_version = policy_version;
             event.data.policy_digest = policy_digest;
+            event.data.apply_policy_snapshot_projection(
+                policy_snapshot_digest,
+                policy_snapshot_digest_alg,
+                policy_snapshot_canonicalization,
+                policy_snapshot_schema,
+            );
             event.data.obligations = obligations;
             event.data.obligation_outcomes = obligation_outcomes;
             event.data.approval_state = approval_state;

--- a/crates/assay-core/src/mcp/decision_next/guard.rs
+++ b/crates/assay-core/src/mcp/decision_next/guard.rs
@@ -103,10 +103,6 @@ impl DecisionEmitterGuard {
                 typed_decision,
                 policy_version,
                 policy_digest,
-                policy_snapshot_digest,
-                policy_snapshot_digest_alg,
-                policy_snapshot_canonicalization,
-                policy_snapshot_schema,
                 obligations,
                 obligation_outcomes,
                 approval_state,
@@ -142,12 +138,7 @@ impl DecisionEmitterGuard {
             event.data.typed_decision = typed_decision;
             event.data.policy_version = policy_version;
             event.data.policy_digest = policy_digest;
-            event.data.apply_policy_snapshot_projection(
-                policy_snapshot_digest,
-                policy_snapshot_digest_alg,
-                policy_snapshot_canonicalization,
-                policy_snapshot_schema,
-            );
+            event.data.apply_policy_snapshot_projection();
             event.data.obligations = obligations;
             event.data.obligation_outcomes = obligation_outcomes;
             event.data.approval_state = approval_state;

--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -512,9 +512,7 @@ impl McpProxy {
         event.data.typed_decision = metadata.typed_decision;
         event.data.policy_version = metadata.policy_version.clone();
         event.data.policy_digest = metadata.policy_digest.clone();
-        event
-            .data
-            .apply_policy_snapshot_projection(None, None, None, None);
+        event.data.apply_policy_snapshot_projection();
         event.data.obligations = metadata.obligations.clone();
         event.data.obligation_outcomes =
             super::obligations::execute_log_only(&metadata.obligations, tool);

--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -512,6 +512,9 @@ impl McpProxy {
         event.data.typed_decision = metadata.typed_decision;
         event.data.policy_version = metadata.policy_version.clone();
         event.data.policy_digest = metadata.policy_digest.clone();
+        event
+            .data
+            .apply_policy_snapshot_projection(None, None, None, None);
         event.data.obligations = metadata.obligations.clone();
         event.data.obligation_outcomes =
             super::obligations::execute_log_only(&metadata.obligations, tool);

--- a/crates/assay-core/src/mcp/tool_call_handler/emit.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/emit.rs
@@ -1,8 +1,4 @@
-use super::super::decision::{
-    reason_codes, DecisionEvent, PolicyDecisionEventContext,
-    POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY, POLICY_SNAPSHOT_DIGEST_ALG_SHA256,
-    POLICY_SNAPSHOT_SCHEMA_V1,
-};
+use super::super::decision::{reason_codes, DecisionEvent, PolicyDecisionEventContext};
 use super::super::policy::PolicyMatchMetadata;
 use super::types::HandleResult;
 use crate::runtime::AuthzReceipt;
@@ -118,18 +114,10 @@ impl ToolMatchMetadata {
     }
 
     pub(super) fn policy_context(&self) -> PolicyDecisionEventContext {
-        let has_policy_digest = self.policy_digest.is_some();
         PolicyDecisionEventContext {
             typed_decision: self.typed_decision,
             policy_version: self.policy_version.clone(),
             policy_digest: self.policy_digest.clone(),
-            policy_snapshot_digest: self.policy_digest.clone(),
-            policy_snapshot_digest_alg: has_policy_digest
-                .then(|| POLICY_SNAPSHOT_DIGEST_ALG_SHA256.to_string()),
-            policy_snapshot_canonicalization: has_policy_digest
-                .then(|| POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY.to_string()),
-            policy_snapshot_schema: has_policy_digest
-                .then(|| POLICY_SNAPSHOT_SCHEMA_V1.to_string()),
             obligations: self.obligations.clone(),
             obligation_outcomes: self.obligation_outcomes.clone(),
             approval_state: self.approval_state.clone(),

--- a/crates/assay-core/src/mcp/tool_call_handler/emit.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/emit.rs
@@ -1,4 +1,8 @@
-use super::super::decision::{reason_codes, DecisionEvent, PolicyDecisionEventContext};
+use super::super::decision::{
+    reason_codes, DecisionEvent, PolicyDecisionEventContext,
+    POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY, POLICY_SNAPSHOT_DIGEST_ALG_SHA256,
+    POLICY_SNAPSHOT_SCHEMA_V1,
+};
 use super::super::policy::PolicyMatchMetadata;
 use super::types::HandleResult;
 use crate::runtime::AuthzReceipt;
@@ -114,10 +118,18 @@ impl ToolMatchMetadata {
     }
 
     pub(super) fn policy_context(&self) -> PolicyDecisionEventContext {
+        let has_policy_digest = self.policy_digest.is_some();
         PolicyDecisionEventContext {
             typed_decision: self.typed_decision,
             policy_version: self.policy_version.clone(),
             policy_digest: self.policy_digest.clone(),
+            policy_snapshot_digest: self.policy_digest.clone(),
+            policy_snapshot_digest_alg: has_policy_digest
+                .then(|| POLICY_SNAPSHOT_DIGEST_ALG_SHA256.to_string()),
+            policy_snapshot_canonicalization: has_policy_digest
+                .then(|| POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY.to_string()),
+            policy_snapshot_schema: has_policy_digest
+                .then(|| POLICY_SNAPSHOT_SCHEMA_V1.to_string()),
             obligations: self.obligations.clone(),
             obligation_outcomes: self.obligation_outcomes.clone(),
             approval_state: self.approval_state.clone(),

--- a/crates/assay-core/tests/decision_emit_invariant/emission.rs
+++ b/crates/assay-core/tests/decision_emit_invariant/emission.rs
@@ -5,6 +5,8 @@ use assay_core::mcp::decision::{
     ObligationOutcomeStatus, OutcomeCompatState, ReplayClassificationSource,
     DECISION_BASIS_VERSION_V1, DECISION_CONSUMER_CONTRACT_VERSION_V1,
     DECISION_CONTEXT_CONTRACT_VERSION_V1, DENY_PRECEDENCE_VERSION_V1,
+    POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY, POLICY_SNAPSHOT_DIGEST_ALG_SHA256,
+    POLICY_SNAPSHOT_SCHEMA_V1,
 };
 use assay_core::mcp::policy::{McpPolicy, PolicyState, ToolPolicy, TypedPolicyDecision};
 use assay_core::mcp::tool_call_handler::{HandleResult, ToolCallHandler, ToolCallHandlerConfig};
@@ -286,7 +288,27 @@ fn test_event_contains_required_fields() {
     assert!(!event.data.tool_call_id.is_empty());
     assert!(!event.data.reason_code.is_empty());
     assert!(event.data.policy_version.is_some());
-    assert!(event.data.policy_digest.is_some());
+    let policy_digest = event
+        .data
+        .policy_digest
+        .as_deref()
+        .expect("policy digest should be visible");
+    assert_eq!(
+        event.data.policy_snapshot_digest.as_deref(),
+        Some(policy_digest)
+    );
+    assert_eq!(
+        event.data.policy_snapshot_digest_alg.as_deref(),
+        Some(POLICY_SNAPSHOT_DIGEST_ALG_SHA256)
+    );
+    assert_eq!(
+        event.data.policy_snapshot_canonicalization.as_deref(),
+        Some(POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY)
+    );
+    assert_eq!(
+        event.data.policy_snapshot_schema.as_deref(),
+        Some(POLICY_SNAPSHOT_SCHEMA_V1)
+    );
     assert_eq!(
         event.data.typed_decision,
         Some(TypedPolicyDecision::AllowWithObligations)

--- a/crates/assay-core/tests/tool_taxonomy_policy_match.rs
+++ b/crates/assay-core/tests/tool_taxonomy_policy_match.rs
@@ -1,4 +1,7 @@
-use assay_core::mcp::decision::{Decision, NullDecisionEmitter};
+use assay_core::mcp::decision::{
+    Decision, NullDecisionEmitter, POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY,
+    POLICY_SNAPSHOT_DIGEST_ALG_SHA256, POLICY_SNAPSHOT_SCHEMA_V1,
+};
 use assay_core::mcp::jsonrpc::JsonRpcRequest;
 use assay_core::mcp::policy::{McpPolicy, PolicyDecision, PolicyState, TypedPolicyDecision};
 use assay_core::mcp::tool_call_handler::{HandleResult, ToolCallHandler, ToolCallHandlerConfig};
@@ -126,7 +129,30 @@ fn tool_taxonomy_policy_match_handler_decision_event_records_classes() {
                 Some(TypedPolicyDecision::Deny)
             );
             assert!(decision_event.data.policy_version.is_some());
-            assert!(decision_event.data.policy_digest.is_some());
+            let policy_digest = decision_event
+                .data
+                .policy_digest
+                .as_deref()
+                .expect("policy digest should be visible");
+            assert_eq!(
+                decision_event.data.policy_snapshot_digest.as_deref(),
+                Some(policy_digest)
+            );
+            assert_eq!(
+                decision_event.data.policy_snapshot_digest_alg.as_deref(),
+                Some(POLICY_SNAPSHOT_DIGEST_ALG_SHA256)
+            );
+            assert_eq!(
+                decision_event
+                    .data
+                    .policy_snapshot_canonicalization
+                    .as_deref(),
+                Some(POLICY_SNAPSHOT_CANONICALIZATION_JCS_MCP_POLICY)
+            );
+            assert_eq!(
+                decision_event.data.policy_snapshot_schema.as_deref(),
+                Some(POLICY_SNAPSHOT_SCHEMA_V1)
+            );
         }
         other => panic!("expected deny result, got {:?}", other),
     }

--- a/crates/assay-evidence/src/types.rs
+++ b/crates/assay-evidence/src/types.rs
@@ -275,6 +275,8 @@ pub struct PayloadToolDecision {
     pub reason_code: Option<String>,
     pub args_schema_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_snapshot_digest: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_snapshot_digest_alg: Option<String>,
@@ -417,6 +419,7 @@ mod tests {
         });
         let without_payload: PayloadToolDecision =
             serde_json::from_value(without).expect("legacy payload should deserialize");
+        assert_eq!(without_payload.policy_digest, None);
         assert_eq!(without_payload.policy_snapshot_digest, None);
         assert_eq!(without_payload.policy_snapshot_digest_alg, None);
         assert_eq!(without_payload.policy_snapshot_canonicalization, None);
@@ -427,6 +430,7 @@ mod tests {
             "decision": "allow",
             "reason_code": "P_POLICY_ALLOW",
             "args_schema_hash": null,
+            "policy_digest": "sha256:abc123",
             "policy_snapshot_digest": "sha256:abc123",
             "policy_snapshot_digest_alg": "sha256",
             "policy_snapshot_canonicalization": "jcs:mcp_policy",
@@ -434,6 +438,7 @@ mod tests {
         });
         let with_payload: PayloadToolDecision =
             serde_json::from_value(with).expect("policy snapshot payload should deserialize");
+        assert_eq!(with_payload.policy_digest.as_deref(), Some("sha256:abc123"));
         assert_eq!(
             with_payload.policy_snapshot_digest.as_deref(),
             Some("sha256:abc123")

--- a/crates/assay-evidence/src/types.rs
+++ b/crates/assay-evidence/src/types.rs
@@ -275,6 +275,14 @@ pub struct PayloadToolDecision {
     pub reason_code: Option<String>,
     pub args_schema_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_snapshot_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_snapshot_digest_alg: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_snapshot_canonicalization: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_snapshot_schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delegated_from: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delegation_depth: Option<u32>,
@@ -397,6 +405,51 @@ mod tests {
             Some("agent:planner")
         );
         assert_eq!(with_payload.delegation_depth, Some(1));
+    }
+
+    #[test]
+    fn tool_decision_payload_policy_snapshot_fields_are_additive() {
+        let without = serde_json::json!({
+            "tool": "deploy_service",
+            "decision": "allow",
+            "reason_code": "P_POLICY_ALLOW",
+            "args_schema_hash": null
+        });
+        let without_payload: PayloadToolDecision =
+            serde_json::from_value(without).expect("legacy payload should deserialize");
+        assert_eq!(without_payload.policy_snapshot_digest, None);
+        assert_eq!(without_payload.policy_snapshot_digest_alg, None);
+        assert_eq!(without_payload.policy_snapshot_canonicalization, None);
+        assert_eq!(without_payload.policy_snapshot_schema, None);
+
+        let with = serde_json::json!({
+            "tool": "deploy_service",
+            "decision": "allow",
+            "reason_code": "P_POLICY_ALLOW",
+            "args_schema_hash": null,
+            "policy_snapshot_digest": "sha256:abc123",
+            "policy_snapshot_digest_alg": "sha256",
+            "policy_snapshot_canonicalization": "jcs:mcp_policy",
+            "policy_snapshot_schema": "assay.mcp.policy.snapshot.v1"
+        });
+        let with_payload: PayloadToolDecision =
+            serde_json::from_value(with).expect("policy snapshot payload should deserialize");
+        assert_eq!(
+            with_payload.policy_snapshot_digest.as_deref(),
+            Some("sha256:abc123")
+        );
+        assert_eq!(
+            with_payload.policy_snapshot_digest_alg.as_deref(),
+            Some("sha256")
+        );
+        assert_eq!(
+            with_payload.policy_snapshot_canonicalization.as_deref(),
+            Some("jcs:mcp_policy")
+        );
+        assert_eq!(
+            with_payload.policy_snapshot_schema.as_deref(),
+            Some("assay.mcp.policy.snapshot.v1")
+        );
     }
 
     #[test]

--- a/crates/assay-evidence/tests/verify_strict_test.rs
+++ b/crates/assay-evidence/tests/verify_strict_test.rs
@@ -142,12 +142,20 @@ fn test_tool_decision_stable_payload_conformance() {
         "decision": "allow",
         "reason_code": "P_POLICY_ALLOW",
         "args_schema_hash": "sha256:abc",
+        "policy_snapshot_digest": "sha256:policy123",
+        "policy_snapshot_digest_alg": "sha256",
+        "policy_snapshot_canonicalization": "jcs:mcp_policy",
+        "policy_snapshot_schema": "assay.mcp.policy.snapshot.v1",
         "delegated_from": "agent:planner",
         "delegation_depth": 1
     });
     let typed: PayloadToolDecision = serde_json::from_value(payload.clone())
         .expect("tool decision payload contract should parse");
     assert_eq!(typed.tool, "read_file");
+    assert_eq!(
+        typed.policy_snapshot_digest.as_deref(),
+        Some("sha256:policy123")
+    );
     assert_eq!(typed.delegation_depth, Some(1));
     verify_single_event(EvidenceEvent::new(
         "assay.tool.decision",

--- a/crates/assay-evidence/tests/verify_strict_test.rs
+++ b/crates/assay-evidence/tests/verify_strict_test.rs
@@ -142,6 +142,7 @@ fn test_tool_decision_stable_payload_conformance() {
         "decision": "allow",
         "reason_code": "P_POLICY_ALLOW",
         "args_schema_hash": "sha256:abc",
+        "policy_digest": "sha256:policy123",
         "policy_snapshot_digest": "sha256:policy123",
         "policy_snapshot_digest_alg": "sha256",
         "policy_snapshot_canonicalization": "jcs:mcp_policy",
@@ -152,6 +153,10 @@ fn test_tool_decision_stable_payload_conformance() {
     let typed: PayloadToolDecision = serde_json::from_value(payload.clone())
         .expect("tool decision payload contract should parse");
     assert_eq!(typed.tool, "read_file");
+    assert_eq!(
+        typed.policy_digest.as_deref(),
+        typed.policy_snapshot_digest.as_deref()
+    );
     assert_eq!(
         typed.policy_snapshot_digest.as_deref(),
         Some("sha256:policy123")

--- a/docs/architecture/ADR-006-Evidence-Contract.md
+++ b/docs/architecture/ADR-006-Evidence-Contract.md
@@ -91,6 +91,7 @@ Records authorization decisions (HITL-ready, protocol-based).
   "decision": "allow|deny|requires_approval",
   "reason_code": "E_POLICY_DENY",
   "args_schema_hash": "sha256:...",
+  "policy_digest": "sha256:...",
   "policy_snapshot_digest": "sha256:...",
   "policy_snapshot_digest_alg": "sha256",
   "policy_snapshot_canonicalization": "jcs:mcp_policy",
@@ -106,7 +107,20 @@ optional P56a fields. They make the canonical MCP policy snapshot digest
 visible when supported runtime decision paths already have a policy digest.
 They do not imply that the policy is correct, sufficient, safe, approved, or
 complete. Existing `policy_digest` remains a compatibility field;
-`policy_snapshot_digest` is the explicit reviewer surface.
+`policy_snapshot_digest` is the explicit reviewer surface. On supported paths,
+`policy_snapshot_digest` is the self-describing projection of `policy_digest`
+and MUST carry the same digest value. If `policy_snapshot_digest` is present,
+then `policy_snapshot_digest_alg`, `policy_snapshot_canonicalization`, and
+`policy_snapshot_schema` MUST also be present.
+
+`policy_snapshot_canonicalization: "jcs:mcp_policy"` means the digest is
+computed over the existing canonical serialization of the `McpPolicy` object
+using JCS before SHA-256 hashing, matching the `McpPolicy::policy_digest()`
+implementation. P56a projects this existing digest only; it does not infer or
+reconstruct policy snapshots after the fact, and it does not make policy
+snapshots retrievable, exportable, or embedded. Absence of
+`policy_snapshot_digest` means the policy snapshot boundary is not visible, not
+that the decision is safe.
 
 `delegated_from` and `delegation_depth` are additive optional fields. They are
 surfaced only when a supported decision flow carries explicit

--- a/docs/architecture/ADR-006-Evidence-Contract.md
+++ b/docs/architecture/ADR-006-Evidence-Contract.md
@@ -91,10 +91,22 @@ Records authorization decisions (HITL-ready, protocol-based).
   "decision": "allow|deny|requires_approval",
   "reason_code": "E_POLICY_DENY",
   "args_schema_hash": "sha256:...",
+  "policy_snapshot_digest": "sha256:...",
+  "policy_snapshot_digest_alg": "sha256",
+  "policy_snapshot_canonicalization": "jcs:mcp_policy",
+  "policy_snapshot_schema": "assay.mcp.policy.snapshot.v1",
   "delegated_from": "agent:planner",
   "delegation_depth": 1
 }
 ```
+
+`policy_snapshot_digest`, `policy_snapshot_digest_alg`,
+`policy_snapshot_canonicalization`, and `policy_snapshot_schema` are additive
+optional P56a fields. They make the canonical MCP policy snapshot digest
+visible when supported runtime decision paths already have a policy digest.
+They do not imply that the policy is correct, sufficient, safe, approved, or
+complete. Existing `policy_digest` remains a compatibility field;
+`policy_snapshot_digest` is the explicit reviewer surface.
 
 `delegated_from` and `delegation_depth` are additive optional fields. They are
 surfaced only when a supported decision flow carries explicit

--- a/docs/architecture/PLAN-P52-P56-CONSOLIDATION-PROGRAM-2026q2.md
+++ b/docs/architecture/PLAN-P52-P56-CONSOLIDATION-PROGRAM-2026q2.md
@@ -220,6 +220,9 @@ source of truth.
 
 ## 7. P56a — Policy Snapshot Digest Visibility
 
+Status: execution slice tracked in
+[PLAN-P56a](./PLAN-P56A-POLICY-SNAPSHOT-DIGEST-VISIBILITY-2026q2.md).
+
 ### Goal
 
 Make the policy snapshot that governed a decision visibly digest-bound in

--- a/docs/architecture/PLAN-P56A-POLICY-SNAPSHOT-DIGEST-VISIBILITY-2026q2.md
+++ b/docs/architecture/PLAN-P56A-POLICY-SNAPSHOT-DIGEST-VISIBILITY-2026q2.md
@@ -5,6 +5,10 @@
 Make supported MCP decision evidence explicitly show which canonical policy
 snapshot governed the decision, using a digest-bound review surface.
 
+P56a makes the existing policy digest boundary self-describing on supported
+`assay.tool.decision` events. It does not add policy truth, policy approval,
+policy retrieval, or tool-definition binding.
+
 The slice is deliberately small:
 
 - keep the existing `policy_digest` compatibility field;
@@ -24,12 +28,25 @@ The supported projection is:
 
 ```json
 {
+  "policy_digest": "sha256:...",
   "policy_snapshot_digest": "sha256:...",
   "policy_snapshot_digest_alg": "sha256",
   "policy_snapshot_canonicalization": "jcs:mcp_policy",
   "policy_snapshot_schema": "assay.mcp.policy.snapshot.v1"
 }
 ```
+
+`policy_snapshot_digest` is the self-describing projection of the existing
+`policy_digest`. In supported decision paths, both fields MUST represent the
+same digest value while the compatibility field remains present.
+
+The `jcs:mcp_policy` canonicalization identifier means the digest is computed
+over the existing canonical serialization of the `McpPolicy` object using JCS
+before SHA-256 hashing, matching the `McpPolicy::policy_digest()` code path.
+
+If `policy_snapshot_digest` is present, the whole cluster is atomic:
+`policy_snapshot_digest_alg`, `policy_snapshot_canonicalization`, and
+`policy_snapshot_schema` MUST also be present.
 
 ## 3. Boundary
 
@@ -41,14 +58,16 @@ P56a does not mean:
 - the policy is complete;
 - the policy is safe;
 - the policy was approved by a reviewer;
+- the policy snapshot is retrievable, exportable, or embedded;
 - the tool definition was bound to the same snapshot.
 
 P56b covers tool definition digest binding separately.
 
 ## 4. Implementation Shape
 
-- Project the snapshot fields from supported decision-context paths that already
-  carry `policy_digest`.
+- Project the snapshot fields from supported `assay.tool.decision` paths that
+  already carry `policy_digest`.
+- Project only; never infer or reconstruct a policy snapshot after the fact.
 - Preserve `policy_digest` for compatibility.
 - Keep all fields optional and additive under Evidence Contract v1.
 - Keep missing policy digest explicit by omitting `policy_snapshot_digest`; do
@@ -58,7 +77,12 @@ P56b covers tool definition digest binding separately.
 
 - Supported MCP decision events with a policy digest also include the
   `policy_snapshot_*` fields.
+- Tests prove `policy_digest == policy_snapshot_digest` when both are present.
+- Tests prove the `policy_snapshot_*` cluster is produced atomically, and is
+  absent when no policy digest is visible.
 - Stable payload parsing accepts the new fields as additive optional data.
 - ADR-006 and Evidence Contract v1 document the fields and the non-goal.
+- Canonicalization and schema identifiers are defined as code constants and
+  documented as spec strings.
 - No new Trust Basis claim, Trust Card schema bump, or policy-quality assertion
   is introduced.

--- a/docs/architecture/PLAN-P56A-POLICY-SNAPSHOT-DIGEST-VISIBILITY-2026q2.md
+++ b/docs/architecture/PLAN-P56A-POLICY-SNAPSHOT-DIGEST-VISIBILITY-2026q2.md
@@ -1,5 +1,12 @@
 # PLAN — P56a Policy Snapshot Digest Visibility (Q2 2026)
 
+- **Date:** 2026-04-29
+- **Owner:** Evidence / MCP Security
+- **Status:** Execution slice
+- **Scope:** Surface the existing canonical policy digest as an explicit,
+  self-describing policy snapshot review boundary on supported
+  `assay.tool.decision` evidence.
+
 ## 1. Goal
 
 Make supported MCP decision evidence explicitly show which canonical policy

--- a/docs/architecture/PLAN-P56A-POLICY-SNAPSHOT-DIGEST-VISIBILITY-2026q2.md
+++ b/docs/architecture/PLAN-P56A-POLICY-SNAPSHOT-DIGEST-VISIBILITY-2026q2.md
@@ -1,0 +1,64 @@
+# PLAN — P56a Policy Snapshot Digest Visibility (Q2 2026)
+
+## 1. Goal
+
+Make supported MCP decision evidence explicitly show which canonical policy
+snapshot governed the decision, using a digest-bound review surface.
+
+The slice is deliberately small:
+
+- keep the existing `policy_digest` compatibility field;
+- add explicit `policy_snapshot_*` projection fields on `assay.tool.decision`;
+- document the digest algorithm, canonicalization, and bounded snapshot schema;
+- avoid any claim that the policy itself is correct, sufficient, safe, approved,
+  or complete.
+
+## 2. Current Seam
+
+Supported MCP policy paths already compute a deterministic policy digest from
+the canonical serialized `McpPolicy` object. P56a makes that digest
+self-describing for reviewers and downstream tools rather than leaving it as a
+single generic policy field.
+
+The supported projection is:
+
+```json
+{
+  "policy_snapshot_digest": "sha256:...",
+  "policy_snapshot_digest_alg": "sha256",
+  "policy_snapshot_canonicalization": "jcs:mcp_policy",
+  "policy_snapshot_schema": "assay.mcp.policy.snapshot.v1"
+}
+```
+
+## 3. Boundary
+
+This is digest visibility, not policy truth.
+
+P56a does not mean:
+
+- the policy is correct;
+- the policy is complete;
+- the policy is safe;
+- the policy was approved by a reviewer;
+- the tool definition was bound to the same snapshot.
+
+P56b covers tool definition digest binding separately.
+
+## 4. Implementation Shape
+
+- Project the snapshot fields from supported decision-context paths that already
+  carry `policy_digest`.
+- Preserve `policy_digest` for compatibility.
+- Keep all fields optional and additive under Evidence Contract v1.
+- Keep missing policy digest explicit by omitting `policy_snapshot_digest`; do
+  not treat absence as safe.
+
+## 5. Acceptance
+
+- Supported MCP decision events with a policy digest also include the
+  `policy_snapshot_*` fields.
+- Stable payload parsing accepts the new fields as additive optional data.
+- ADR-006 and Evidence Contract v1 document the fields and the non-goal.
+- No new Trust Basis claim, Trust Card schema bump, or policy-quality assertion
+  is introduced.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -60,6 +60,7 @@ Assay is a CI-native evidence and trust compiler for agent systems, built as a R
 - [PLAN — P45 Inventory Receipt Trust Basis Claim (Q2 2026)](./PLAN-P45-INVENTORY-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) — execution slice that adds one bounded Trust Basis claim for supported inventory receipt boundaries, starting with CycloneDX ML-BOM model-component receipts
 - [PLAN — P45b Decision Receipt Trust Basis Claim (Q2 2026)](./PLAN-P45B-DECISION-RECEIPT-TRUST-BASIS-CLAIM-2026q2.md) — execution slice that adds one bounded Trust Basis claim for supported decision receipt boundaries, starting with OpenFeature boolean EvaluationDetails receipts
 - [PLAN — P52-P56 Assay Product Surface Consolidation Program (Q2 2026)](./PLAN-P52-P56-CONSOLIDATION-PROGRAM-2026q2.md) — post-v3.8.0 consolidation program for product truth sync, Trust Basis assertions, receipt schema CLI, static Trust Card HTML, and policy/tool digest binding
+- [PLAN — P56a Policy Snapshot Digest Visibility (Q2 2026)](./PLAN-P56A-POLICY-SNAPSHOT-DIGEST-VISIBILITY-2026q2.md) — execution slice that projects canonical policy snapshot digest metadata onto supported MCP decision evidence without claiming policy correctness
 - [Assay Architecture & Roadmap Gap Analysis (Q2 2026)](./GAP-ASSAY-ARCHITECTURE-ROADMAP-2026q2.md) — repo-wide truth sync and next-step ordering
 
 ## Active RFCs

--- a/docs/spec/EVIDENCE-CONTRACT-v1.md
+++ b/docs/spec/EVIDENCE-CONTRACT-v1.md
@@ -153,6 +153,7 @@ These IDs are stable; if a test is renamed, maintain a compatibility alias (e.g.
 | 1                        | 2026-02| Contract freeze: this spec (compat matrix, evolution rules, deprecation, golden fixtures). |
 | 1                        | 2026-02| New event types policy (§4.1): no new type without registry + schema + conformance test; Event types (v1) registry table (§4.2); §2 normative rule clarified (schema_version 1 + v1.0 baseline; verify MAY v1.x, pack MAY exact 1.0). |
 | 1                        | 2026-04| Tightened version-axis naming (`CE_SPECVERSION` vs `ASSAY_EVIDENCE_SPEC_VERSION`), stable event registry anchors, canonical-writer determinism language, content-hash input scope, and experimental receipt-type emission posture. |
+| 1                        | 2026-04| Added optional `policy_snapshot_*` fields on stable `assay.tool.decision` payloads for P56a policy snapshot digest visibility; this is additive and visibility-only. |
 
 ## 8. Normative checklist (summary)
 

--- a/docs/spec/EVIDENCE-CONTRACT-v1.md
+++ b/docs/spec/EVIDENCE-CONTRACT-v1.md
@@ -153,7 +153,7 @@ These IDs are stable; if a test is renamed, maintain a compatibility alias (e.g.
 | 1                        | 2026-02| Contract freeze: this spec (compat matrix, evolution rules, deprecation, golden fixtures). |
 | 1                        | 2026-02| New event types policy (§4.1): no new type without registry + schema + conformance test; Event types (v1) registry table (§4.2); §2 normative rule clarified (schema_version 1 + v1.0 baseline; verify MAY v1.x, pack MAY exact 1.0). |
 | 1                        | 2026-04| Tightened version-axis naming (`CE_SPECVERSION` vs `ASSAY_EVIDENCE_SPEC_VERSION`), stable event registry anchors, canonical-writer determinism language, content-hash input scope, and experimental receipt-type emission posture. |
-| 1                        | 2026-04| Added optional `policy_snapshot_*` fields on stable `assay.tool.decision` payloads for P56a policy snapshot digest visibility; this is additive and visibility-only. |
+| 1                        | 2026-04| Added optional `policy_snapshot_*` fields on stable `assay.tool.decision` payloads for P56a policy snapshot digest visibility; this is additive, visibility-only, and projects the existing `policy_digest` without adding policy truth. |
 
 ## 8. Normative checklist (summary)
 


### PR DESCRIPTION
What changed

Adds P56a: explicit policy snapshot digest visibility on supported MCP decision evidence.

This PR includes:

- additive `policy_snapshot_digest`, `policy_snapshot_digest_alg`, `policy_snapshot_canonicalization`, and `policy_snapshot_schema` fields on `assay.tool.decision`
- projection from existing canonical policy digests across builder, guard, and proxy decision paths
- stable payload parsing/tests for the new optional fields
- decision invariant and taxonomy tests proving supported decision events carry the snapshot projection when a policy digest exists
- ADR-006, Evidence Contract v1, changelog, architecture index, and a focused P56a plan note

Why

P52-P55 made the product surface legible, assertable, inspectable, and reviewable. P56a starts the binding layer by making the policy snapshot that governed a supported decision explicit and self-describing, while preserving the existing `policy_digest` compatibility field.

Boundary

This is digest visibility only. It does not add a Trust Basis claim, Trust Card schema bump, policy authoring redesign, policy approval workflow, Sigstore/keyless layer, or tool definition binding. `policy_snapshot_digest` does not mean the policy is correct, sufficient, safe, approved, or complete. P56b remains the separate tool-definition digest binding slice.

Validation

Ran locally:

- `cargo fmt --check`
- `cargo test -p assay-core --test decision_emit_invariant -- --nocapture`
- `cargo test -p assay-core --test tool_taxonomy_policy_match -- --nocapture`
- `cargo test -p assay-core --test replay_diff_contract -- --nocapture`
- `cargo test -p assay-core policy_snapshot -- --nocapture`
- `cargo test -p assay-evidence tool_decision_payload -- --nocapture`
- `cargo test -p assay-evidence --test verify_strict_test -- --nocapture`
- `cargo clippy -p assay-core --all-targets -- -D warnings`
- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
- local changed-docs markdown link check
- `git diff --check`

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.