### PR TITLE
P56b: surface tool definition digest binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ All notable changes to this project will be documented in this file.
   cluster is produced atomically. This is a review binding only; it does not
   claim the policy is correct, sufficient, safe, approved, complete,
   retrievable, exportable, or embedded.
+- **Tool definition digest visibility**: supported MCP `tools/list` to
+  `tools/call` decision paths can now project an atomic `tool_definition_*`
+  field cluster onto `assay.tool.decision` events. The digest is computed over
+  the bounded observed tool-definition surface using
+  `jcs:mcp_tool_definition.v1` and excludes `x-assay-sig`, top-level
+  vendor/provider metadata, annotations, display hints, raw registry bodies,
+  runtime results, and inferred `tools/call` fields. This is review visibility
+  only; it does not claim tool safety, signature validity, signer trust,
+  registry truth, or implementation truth.
 
 ## [3.8.0] - 2026-04-29
 

--- a/crates/assay-core/src/mcp/decision.rs
+++ b/crates/assay-core/src/mcp/decision.rs
@@ -42,6 +42,11 @@ pub use replay_diff::{
 mod tests {
     use super::*;
     use crate::mcp::policy::{ApprovalArtifact, ApprovalFreshness};
+    use crate::mcp::tool_definition::{
+        ToolDefinitionBinding, TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1,
+        TOOL_DEFINITION_DIGEST_ALG_SHA256, TOOL_DEFINITION_SCHEMA_V1,
+        TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST,
+    };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -334,6 +339,28 @@ mod tests {
     }
 
     #[test]
+    fn test_decision_event_omits_tool_definition_fields_when_binding_absent() {
+        let event = DecisionEvent::new(
+            "assay://test".to_string(),
+            "tc_no_tool_definition".to_string(),
+            "deploy_service".to_string(),
+        )
+        .allow(reason_codes::P_POLICY_ALLOW);
+
+        let value = serde_json::to_value(event).expect("decision event should serialize");
+        let data = value
+            .get("data")
+            .and_then(serde_json::Value::as_object)
+            .expect("decision event data should be an object");
+
+        assert!(!data.contains_key("tool_definition_digest"));
+        assert!(!data.contains_key("tool_definition_digest_alg"));
+        assert!(!data.contains_key("tool_definition_canonicalization"));
+        assert!(!data.contains_key("tool_definition_schema"));
+        assert!(!data.contains_key("tool_definition_source"));
+    }
+
+    #[test]
     fn test_with_policy_context_projects_policy_snapshot_digest() {
         let context = PolicyDecisionEventContext {
             policy_digest: Some("sha256:policy123".to_string()),
@@ -387,6 +414,50 @@ mod tests {
         assert!(event.data.policy_snapshot_digest_alg.is_some());
         assert!(event.data.policy_snapshot_canonicalization.is_some());
         assert!(event.data.policy_snapshot_schema.is_some());
+    }
+
+    #[test]
+    fn test_with_policy_context_projects_tool_definition_binding() {
+        let binding = ToolDefinitionBinding {
+            digest: "sha256:tooldef123".to_string(),
+            digest_alg: TOOL_DEFINITION_DIGEST_ALG_SHA256.to_string(),
+            canonicalization: TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1
+                .to_string(),
+            schema: TOOL_DEFINITION_SCHEMA_V1.to_string(),
+            source: TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST.to_string(),
+        };
+
+        let event = DecisionEvent::new(
+            "assay://test".to_string(),
+            "tc_tool_definition".to_string(),
+            "deploy_service".to_string(),
+        )
+        .allow(reason_codes::P_POLICY_ALLOW)
+        .with_policy_context(PolicyDecisionEventContext {
+            tool_definition_binding: Some(binding),
+            ..PolicyDecisionEventContext::default()
+        });
+
+        assert_eq!(
+            event.data.tool_definition_digest.as_deref(),
+            Some("sha256:tooldef123")
+        );
+        assert_eq!(
+            event.data.tool_definition_digest_alg.as_deref(),
+            Some(TOOL_DEFINITION_DIGEST_ALG_SHA256)
+        );
+        assert_eq!(
+            event.data.tool_definition_canonicalization.as_deref(),
+            Some(TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1)
+        );
+        assert_eq!(
+            event.data.tool_definition_schema.as_deref(),
+            Some(TOOL_DEFINITION_SCHEMA_V1)
+        );
+        assert_eq!(
+            event.data.tool_definition_source.as_deref(),
+            Some(TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST)
+        );
     }
 
     #[test]

--- a/crates/assay-core/src/mcp/decision_next/builder.rs
+++ b/crates/assay-core/src/mcp/decision_next/builder.rs
@@ -26,6 +26,11 @@ impl DecisionEvent {
                 policy_snapshot_digest_alg: None,
                 policy_snapshot_canonicalization: None,
                 policy_snapshot_schema: None,
+                tool_definition_digest: None,
+                tool_definition_digest_alg: None,
+                tool_definition_canonicalization: None,
+                tool_definition_schema: None,
+                tool_definition_source: None,
                 obligations: Vec::new(),
                 obligation_outcomes: Vec::new(),
                 approval_state: None,
@@ -228,12 +233,15 @@ impl DecisionEvent {
             auth_issuer,
             delegated_from,
             delegation_depth,
+            tool_definition_binding,
         } = context;
 
         self.data.typed_decision = typed_decision;
         self.data.policy_version = policy_version;
         self.data.policy_digest = policy_digest;
         self.data.apply_policy_snapshot_projection();
+        self.data
+            .apply_tool_definition_binding(tool_definition_binding.as_ref());
         self.data.obligations = obligations;
         self.data.obligation_outcomes = obligation_outcomes;
         self.data.approval_state = approval_state;

--- a/crates/assay-core/src/mcp/decision_next/event_types.rs
+++ b/crates/assay-core/src/mcp/decision_next/event_types.rs
@@ -9,6 +9,7 @@ use crate::mcp::policy::{
     ApprovalArtifact, ApprovalFreshness, FailClosedContext, PolicyObligation, RedactArgsContract,
     RestrictScopeContract, TypedPolicyDecision,
 };
+use crate::mcp::tool_definition::ToolDefinitionBinding;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -140,6 +141,7 @@ pub struct PolicyDecisionEventContext {
     pub auth_issuer: Option<String>,
     pub delegated_from: Option<String>,
     pub delegation_depth: Option<u32>,
+    pub tool_definition_binding: Option<ToolDefinitionBinding>,
 }
 
 /// A tool decision event (CloudEvents compliant).
@@ -198,6 +200,21 @@ pub struct DecisionData {
     /// P56a: bounded schema tag for the snapshot surface being digested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy_snapshot_schema: Option<String>,
+    /// P56b: digest of the bounded MCP tool definition observed from `tools/list`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_definition_digest: Option<String>,
+    /// P56b: digest algorithm for `tool_definition_digest`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_definition_digest_alg: Option<String>,
+    /// P56b: canonicalization used before digesting the tool definition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_definition_canonicalization: Option<String>,
+    /// P56b: bounded schema tag for the tool-definition surface being digested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_definition_schema: Option<String>,
+    /// P56b: observed source surface for the tool-definition digest.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_definition_source: Option<String>,
     /// Obligations attached to an allow/deny decision
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub obligations: Vec<PolicyObligation>,
@@ -456,6 +473,29 @@ impl DecisionData {
             self.policy_snapshot_digest_alg = None;
             self.policy_snapshot_canonicalization = None;
             self.policy_snapshot_schema = None;
+        }
+    }
+
+    /// Project a P56b tool-definition binding into the decision payload.
+    ///
+    /// This is digest visibility only. The field cluster is emitted atomically
+    /// and is omitted when no bounded `tools/list` definition was observed.
+    pub(crate) fn apply_tool_definition_binding(
+        &mut self,
+        binding: Option<&ToolDefinitionBinding>,
+    ) {
+        if let Some(binding) = binding {
+            self.tool_definition_digest = Some(binding.digest.clone());
+            self.tool_definition_digest_alg = Some(binding.digest_alg.clone());
+            self.tool_definition_canonicalization = Some(binding.canonicalization.clone());
+            self.tool_definition_schema = Some(binding.schema.clone());
+            self.tool_definition_source = Some(binding.source.clone());
+        } else {
+            self.tool_definition_digest = None;
+            self.tool_definition_digest_alg = None;
+            self.tool_definition_canonicalization = None;
+            self.tool_definition_schema = None;
+            self.tool_definition_source = None;
         }
     }
 }

--- a/crates/assay-core/src/mcp/decision_next/guard.rs
+++ b/crates/assay-core/src/mcp/decision_next/guard.rs
@@ -133,12 +133,16 @@ impl DecisionEmitterGuard {
                 auth_issuer,
                 delegated_from,
                 delegation_depth,
+                tool_definition_binding,
             } = context;
 
             event.data.typed_decision = typed_decision;
             event.data.policy_version = policy_version;
             event.data.policy_digest = policy_digest;
             event.data.apply_policy_snapshot_projection();
+            event
+                .data
+                .apply_tool_definition_binding(tool_definition_binding.as_ref());
             event.data.obligations = obligations;
             event.data.obligation_outcomes = obligation_outcomes;
             event.data.approval_state = approval_state;

--- a/crates/assay-core/src/mcp/mod.rs
+++ b/crates/assay-core/src/mcp/mod.rs
@@ -15,6 +15,7 @@ pub mod proxy;
 pub mod runtime_features;
 pub mod signing;
 pub mod tool_call_handler;
+pub mod tool_definition;
 pub mod tool_match;
 pub mod tool_taxonomy;
 pub mod trust_policy;

--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -7,6 +7,7 @@ use super::jsonrpc::JsonRpcRequest;
 use super::policy::{
     make_deny_response, McpPolicy, PolicyDecision, PolicyMatchMetadata, PolicyState,
 };
+use super::tool_definition::{binding_from_tools_list_tool, ToolDefinitionBinding};
 use std::{
     collections::HashMap,
     io::{self, BufRead, BufReader, Write},
@@ -115,6 +116,8 @@ pub struct McpProxy {
     config: ProxyConfig,
     /// Cache of tool identities discovered during tools/list
     identity_cache: Arc<Mutex<HashMap<String, super::identity::ToolIdentity>>>,
+    /// Cache of bounded tool-definition bindings discovered during tools/list
+    tool_definition_cache: Arc<Mutex<HashMap<String, ToolDefinitionBinding>>>,
 }
 
 impl Drop for McpProxy {
@@ -143,6 +146,7 @@ impl McpProxy {
             policy,
             config,
             identity_cache: Arc::new(Mutex::new(HashMap::new())),
+            tool_definition_cache: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -155,6 +159,8 @@ impl McpProxy {
         let config = self.config.clone();
         let identity_cache_a = self.identity_cache.clone();
         let identity_cache_b = self.identity_cache.clone();
+        let tool_definition_cache_a = self.tool_definition_cache.clone();
+        let tool_definition_cache_b = self.tool_definition_cache.clone();
 
         // Initialize decision emitter (I1: always emit decision)
         let decision_emitter: Arc<dyn DecisionEmitter> =
@@ -183,37 +189,22 @@ impl McpProxy {
                         if let Some(tools) = result.get_mut("tools").and_then(|t| t.as_array_mut())
                         {
                             for tool in tools {
-                                let name = tool
-                                    .get("name")
-                                    .and_then(|n| n.as_str())
-                                    .unwrap_or("unknown");
-                                let description = tool
-                                    .get("description")
-                                    .and_then(|d| d.as_str())
-                                    .map(|s| s.to_string());
-                                let input_schema = tool
-                                    .get("inputSchema")
-                                    .or_else(|| tool.get("input_schema"))
-                                    .cloned();
+                                if let Some(observation) =
+                                    Self::observe_tool_definition(tool, &config.server_id)
+                                {
+                                    let mut identity_cache = identity_cache_a.lock().unwrap();
+                                    identity_cache.insert(
+                                        observation.name.clone(),
+                                        observation.identity.clone(),
+                                    );
+                                    drop(identity_cache);
 
-                                let identity = super::identity::ToolIdentity::new(
-                                    &config.server_id,
-                                    name,
-                                    &input_schema,
-                                    &description,
-                                );
-
-                                // Cache for runtime verification
-                                let mut cache = identity_cache_a.lock().unwrap();
-                                cache.insert(name.to_string(), identity.clone());
-
-                                // Augment the response with the computed identity for downstream/logging
-                                tool.as_object_mut().and_then(|m| {
-                                    m.insert(
-                                        "tool_identity".to_string(),
-                                        serde_json::to_value(&identity).unwrap(),
-                                    )
-                                });
+                                    if let Some(binding) = observation.binding {
+                                        let mut binding_cache =
+                                            tool_definition_cache_a.lock().unwrap();
+                                        binding_cache.insert(observation.name, binding);
+                                    }
+                                }
                             }
                             processed_line =
                                 serde_json::to_string(&v).unwrap_or(line.clone()) + "\n";
@@ -248,12 +239,19 @@ impl McpProxy {
                 match serde_json::from_str::<JsonRpcRequest>(&line) {
                     Ok(req) => {
                         // 2. Check Policy with Identity (Phase 9)
-                        let runtime_id = if req.is_tool_call() {
+                        let (runtime_id, tool_definition_binding) = if req.is_tool_call() {
                             let name = req.tool_params().map(|p| p.name).unwrap_or_default();
-                            let cache = identity_cache_b.lock().unwrap();
-                            cache.get(&name).cloned()
+                            let runtime_id = {
+                                let cache = identity_cache_b.lock().unwrap();
+                                cache.get(&name).cloned()
+                            };
+                            let tool_definition_binding = {
+                                let cache = tool_definition_cache_b.lock().unwrap();
+                                cache.get(&name).cloned()
+                            };
+                            (runtime_id, tool_definition_binding)
                         } else {
-                            None
+                            (None, None)
                         };
 
                         let tool_name = req.tool_params().map(|p| p.name).unwrap_or_default();
@@ -283,6 +281,7 @@ impl McpProxy {
                                         None,
                                         req.id.clone(),
                                         &policy_eval.metadata,
+                                        tool_definition_binding.as_ref(),
                                     );
                                 }
                             }
@@ -315,6 +314,7 @@ impl McpProxy {
                                     Some(reason),
                                     req.id.clone(),
                                     &policy_eval.metadata,
+                                    tool_definition_binding.as_ref(),
                                 );
                                 // Then proceed as a normal allow
                                 Self::handle_allow(&req, &mut audit_log, false);
@@ -364,6 +364,7 @@ impl McpProxy {
                                     Some(reason),
                                     req.id.clone(),
                                     &policy_eval.metadata,
+                                    tool_definition_binding.as_ref(),
                                 );
 
                                 if config.dry_run {
@@ -495,6 +496,7 @@ impl McpProxy {
         reason: Option<String>,
         request_id: Option<serde_json::Value>,
         metadata: &PolicyMatchMetadata,
+        tool_definition_binding: Option<&ToolDefinitionBinding>,
     ) {
         let mut event = DecisionEvent::new(
             source.to_string(),
@@ -513,6 +515,9 @@ impl McpProxy {
         event.data.policy_version = metadata.policy_version.clone();
         event.data.policy_digest = metadata.policy_digest.clone();
         event.data.apply_policy_snapshot_projection();
+        event
+            .data
+            .apply_tool_definition_binding(tool_definition_binding);
         event.data.obligations = metadata.obligations.clone();
         event.data.obligation_outcomes =
             super::obligations::execute_log_only(&metadata.obligations, tool);
@@ -559,11 +564,80 @@ impl McpProxy {
         refresh_contract_projections(&mut event.data);
         emitter.emit(&event);
     }
+
+    fn observe_tool_definition(
+        tool: &mut serde_json::Value,
+        server_id: &str,
+    ) -> Option<ToolDefinitionObservation> {
+        let name = tool.get("name").and_then(|n| n.as_str())?;
+        if name.trim().is_empty() {
+            return None;
+        }
+        let name = name.to_string();
+        let description = tool
+            .get("description")
+            .and_then(|d| d.as_str())
+            .map(|s| s.to_string());
+        let input_schema = tool
+            .get("inputSchema")
+            .or_else(|| tool.get("input_schema"))
+            .cloned();
+
+        let identity =
+            super::identity::ToolIdentity::new(server_id, &name, &input_schema, &description);
+        let binding = binding_from_tools_list_tool(tool, Some(server_id))
+            .ok()
+            .flatten();
+
+        // Augment the response with the computed identity for downstream/logging.
+        tool.as_object_mut().and_then(|m| {
+            m.insert(
+                "tool_identity".to_string(),
+                serde_json::to_value(&identity).unwrap(),
+            )
+        });
+
+        Some(ToolDefinitionObservation {
+            name,
+            identity,
+            binding,
+        })
+    }
+}
+
+struct ToolDefinitionObservation {
+    name: String,
+    identity: super::identity::ToolIdentity,
+    binding: Option<ToolDefinitionBinding>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::tool_definition::{
+        TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1,
+        TOOL_DEFINITION_DIGEST_ALG_SHA256, TOOL_DEFINITION_SCHEMA_V1,
+        TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST,
+    };
+    use std::sync::Mutex as StdMutex;
+
+    struct CapturingEmitter {
+        events: StdMutex<Vec<DecisionEvent>>,
+    }
+
+    impl CapturingEmitter {
+        fn new() -> Self {
+            Self {
+                events: StdMutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl DecisionEmitter for CapturingEmitter {
+        fn emit(&self, event: &DecisionEvent) {
+            self.events.lock().unwrap().push(event.clone());
+        }
+    }
 
     #[test]
     fn event_source_accepts_assay_uri() {
@@ -669,5 +743,71 @@ mod tests {
         };
 
         assert!(ProxyConfig::try_from_raw(raw).is_err());
+    }
+
+    #[test]
+    fn observe_tool_definition_computes_identity_and_binding() {
+        let mut tool = serde_json::json!({
+            "name": "read_file",
+            "description": " Read files ",
+            "inputSchema": {"type": "object"},
+            "annotations": {"title": "Read"},
+            "x-assay-sig": {"signature": "opaque"}
+        });
+
+        let observation = McpProxy::observe_tool_definition(&mut tool, "server-a")
+            .expect("supported tool definition should be observed");
+
+        assert_eq!(observation.name, "read_file");
+        assert_eq!(observation.identity.server_id, "server-a");
+        assert!(observation.binding.is_some());
+        assert!(tool.get("tool_identity").is_some());
+    }
+
+    #[test]
+    fn emit_decision_projects_tool_definition_binding_atomically() {
+        let mut tool = serde_json::json!({
+            "name": "read_file",
+            "description": "Read files",
+            "inputSchema": {"type": "object"}
+        });
+        let observation = McpProxy::observe_tool_definition(&mut tool, "server-a")
+            .expect("supported tool definition should be observed");
+        let binding = observation.binding.expect("binding should be visible");
+        let emitter = Arc::new(CapturingEmitter::new());
+        let emitter_trait: Arc<dyn DecisionEmitter> = emitter.clone();
+
+        McpProxy::emit_decision(
+            &emitter_trait,
+            "assay://test",
+            "tc_tool_definition",
+            "read_file",
+            Decision::Allow,
+            reason_codes::P_POLICY_ALLOW,
+            None,
+            None,
+            &PolicyMatchMetadata::default(),
+            Some(&binding),
+        );
+
+        let events = emitter.events.lock().unwrap();
+        let data = &events[0].data;
+        assert!(data.tool_definition_digest.is_some());
+        assert_eq!(
+            data.tool_definition_digest_alg.as_deref(),
+            Some(TOOL_DEFINITION_DIGEST_ALG_SHA256)
+        );
+        assert_eq!(
+            data.tool_definition_canonicalization.as_deref(),
+            Some(TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1)
+        );
+        assert_eq!(
+            data.tool_definition_schema.as_deref(),
+            Some(TOOL_DEFINITION_SCHEMA_V1)
+        );
+        assert_eq!(
+            data.tool_definition_source.as_deref(),
+            Some(TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST)
+        );
     }
 }

--- a/crates/assay-core/src/mcp/tool_call_handler/emit.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/emit.rs
@@ -1,5 +1,6 @@
 use super::super::decision::{reason_codes, DecisionEvent, PolicyDecisionEventContext};
 use super::super::policy::PolicyMatchMetadata;
+use super::super::tool_definition::ToolDefinitionBinding;
 use super::types::HandleResult;
 use crate::runtime::AuthzReceipt;
 
@@ -42,6 +43,7 @@ pub(super) struct ToolMatchMetadata {
     pub(super) auth_issuer: Option<String>,
     pub(super) delegated_from: Option<String>,
     pub(super) delegation_depth: Option<u32>,
+    pub(super) tool_definition_binding: Option<ToolDefinitionBinding>,
 }
 
 impl ToolMatchMetadata {
@@ -110,6 +112,7 @@ impl ToolMatchMetadata {
             auth_issuer: metadata.auth_issuer.clone(),
             delegated_from: metadata.delegated_from.clone(),
             delegation_depth: metadata.delegation_depth,
+            tool_definition_binding: None,
         }
     }
 
@@ -148,6 +151,7 @@ impl ToolMatchMetadata {
             auth_issuer: self.auth_issuer.clone(),
             delegated_from: self.delegated_from.clone(),
             delegation_depth: self.delegation_depth,
+            tool_definition_binding: self.tool_definition_binding.clone(),
         }
     }
 }

--- a/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/evaluate.rs
@@ -4,6 +4,7 @@ use super::super::jsonrpc::JsonRpcRequest;
 use super::super::lifecycle::mandate_used_event;
 use super::super::obligations;
 use super::super::policy::{FailClosedTrigger, PolicyDecision, PolicyState};
+use super::super::tool_definition::ToolDefinitionBinding;
 use super::emit;
 use super::evaluate_next::{
     approval::validate_approval_required,
@@ -21,6 +22,7 @@ pub(super) fn handle_tool_call(
     request: &JsonRpcRequest,
     state: &mut PolicyState,
     runtime_identity: Option<&ToolIdentity>,
+    tool_definition_binding: Option<&ToolDefinitionBinding>,
     mandate: Option<&MandateData>,
     transaction_object: Option<&Value>,
 ) -> HandleResult {
@@ -71,6 +73,7 @@ pub(super) fn handle_tool_call(
         proj.merge_into_metadata(&mut policy_eval.metadata);
     }
     let mut tool_match = emit::ToolMatchMetadata::from_policy_metadata(&policy_eval.metadata);
+    tool_match.tool_definition_binding = tool_definition_binding.cloned();
     tool_match.obligation_outcomes =
         obligations::execute_log_only(&tool_match.obligations, &tool_name);
     seed_fail_closed_context(

--- a/crates/assay-core/src/mcp/tool_call_handler/mod.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/mod.rs
@@ -16,6 +16,7 @@ use super::identity::ToolIdentity;
 use super::jsonrpc::JsonRpcRequest;
 use super::lifecycle::LifecycleEmitter;
 use super::policy::{McpPolicy, PolicyState};
+use super::tool_definition::ToolDefinitionBinding;
 use crate::runtime::{Authorizer, MandateData};
 use serde_json::Value;
 use std::sync::Arc;
@@ -53,6 +54,32 @@ impl ToolCallHandler {
             request,
             state,
             runtime_identity,
+            None,
+            mandate,
+            transaction_object,
+        )
+    }
+
+    /// Handle a tool call with an observed bounded tool-definition binding.
+    ///
+    /// This preserves the existing runtime identity/pin surface while allowing
+    /// supported `tools/list` observations to be projected onto decision
+    /// evidence as P56b digest visibility.
+    pub fn handle_tool_call_with_tool_definition_binding(
+        &self,
+        request: &JsonRpcRequest,
+        state: &mut PolicyState,
+        runtime_identity: Option<&ToolIdentity>,
+        tool_definition_binding: Option<&ToolDefinitionBinding>,
+        mandate: Option<&MandateData>,
+        transaction_object: Option<&Value>,
+    ) -> HandleResult {
+        evaluate::handle_tool_call(
+            self,
+            request,
+            state,
+            runtime_identity,
+            tool_definition_binding,
             mandate,
             transaction_object,
         )

--- a/crates/assay-core/src/mcp/tool_call_handler/tests/emission.rs
+++ b/crates/assay-core/src/mcp/tool_call_handler/tests/emission.rs
@@ -3,6 +3,11 @@ use super::fixtures::{assert_fail_closed_defaults, make_tool_call_request, Count
 use crate::mcp::decision::{reason_codes, FulfillmentDecisionPath, ObligationOutcomeStatus};
 use crate::mcp::identity::ToolIdentity;
 use crate::mcp::policy::{McpPolicy, PolicyState, ToolPolicy, TypedPolicyDecision};
+use crate::mcp::tool_definition::{
+    binding_from_tools_list_tool, TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1,
+    TOOL_DEFINITION_DIGEST_ALG_SHA256, TOOL_DEFINITION_SCHEMA_V1,
+    TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST,
+};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
@@ -176,4 +181,63 @@ fn test_tool_drift_deny_emits_alert_obligation_outcome() {
 #[test]
 fn test_alert_obligation_outcome_emitted() {
     test_tool_drift_deny_emits_alert_obligation_outcome();
+}
+
+#[test]
+fn test_handler_projects_tool_definition_binding_when_supplied() {
+    let emitter = Arc::new(CountingEmitter(AtomicUsize::new(0)));
+    let policy = McpPolicy::default();
+    let handler = ToolCallHandler::new(
+        policy,
+        None,
+        emitter.clone(),
+        ToolCallHandlerConfig::default(),
+    );
+    let binding = binding_from_tools_list_tool(
+        &serde_json::json!({
+            "name": "safe_tool",
+            "description": " Safe read ",
+            "inputSchema": {"type": "object"}
+        }),
+        Some("server-a"),
+    )
+    .unwrap()
+    .unwrap();
+
+    let request = make_tool_call_request("safe_tool", serde_json::json!({}));
+    let mut state = PolicyState::default();
+    let result = handler.handle_tool_call_with_tool_definition_binding(
+        &request,
+        &mut state,
+        None,
+        Some(&binding),
+        None,
+        None,
+    );
+
+    match result {
+        HandleResult::Allow { decision_event, .. } => {
+            assert!(decision_event.data.tool_definition_digest.is_some());
+            assert_eq!(
+                decision_event.data.tool_definition_digest_alg.as_deref(),
+                Some(TOOL_DEFINITION_DIGEST_ALG_SHA256)
+            );
+            assert_eq!(
+                decision_event
+                    .data
+                    .tool_definition_canonicalization
+                    .as_deref(),
+                Some(TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1)
+            );
+            assert_eq!(
+                decision_event.data.tool_definition_schema.as_deref(),
+                Some(TOOL_DEFINITION_SCHEMA_V1)
+            );
+            assert_eq!(
+                decision_event.data.tool_definition_source.as_deref(),
+                Some(TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST)
+            );
+        }
+        other => panic!("expected allow result, got {:?}", other),
+    }
 }

--- a/crates/assay-core/src/mcp/tool_definition.rs
+++ b/crates/assay-core/src/mcp/tool_definition.rs
@@ -40,9 +40,11 @@ impl ToolDefinitionBinding {
 
 /// Compute a P56b binding from an observed `tools/list` tool definition.
 ///
-/// Returns `Ok(None)` when the observed value is not a supported bounded v1
-/// tool definition. This function never reconstructs a definition from
-/// `tools/call` data and never imports unsupported top-level fields.
+/// Returns `Ok(None)` when the observed value is well-formed but is not a
+/// supported bounded v1 tool definition. Malformed or otherwise invalid tool
+/// definitions may return `Err` during normalization or projection. This
+/// function never reconstructs a definition from `tools/call` data and never
+/// imports unsupported top-level fields.
 pub fn binding_from_tools_list_tool(
     tool: &Value,
     server_id: Option<&str>,

--- a/crates/assay-core/src/mcp/tool_definition.rs
+++ b/crates/assay-core/src/mcp/tool_definition.rs
@@ -1,0 +1,297 @@
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use super::jcs;
+
+/// Digest algorithm used by P56b tool-definition bindings.
+pub const TOOL_DEFINITION_DIGEST_ALG_SHA256: &str = "sha256";
+/// Canonicalization applied before computing `tool_definition_digest`.
+pub const TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1: &str =
+    "jcs:mcp_tool_definition.v1";
+/// Bounded schema tag for the supported MCP tool-definition snapshot projection.
+pub const TOOL_DEFINITION_SCHEMA_V1: &str = "assay.mcp.tool-definition.snapshot.v1";
+/// Supported source surface for P56b v1 tool-definition bindings.
+pub const TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST: &str = "mcp.tools/list";
+
+/// Self-describing digest over a bounded MCP tool-definition projection.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolDefinitionBinding {
+    pub digest: String,
+    pub digest_alg: String,
+    pub canonicalization: String,
+    pub schema: String,
+    pub source: String,
+}
+
+impl ToolDefinitionBinding {
+    fn from_digest(digest: String) -> Self {
+        Self {
+            digest,
+            digest_alg: TOOL_DEFINITION_DIGEST_ALG_SHA256.to_string(),
+            canonicalization: TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1
+                .to_string(),
+            schema: TOOL_DEFINITION_SCHEMA_V1.to_string(),
+            source: TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST.to_string(),
+        }
+    }
+}
+
+/// Compute a P56b binding from an observed `tools/list` tool definition.
+///
+/// Returns `Ok(None)` when the observed value is not a supported bounded v1
+/// tool definition. This function never reconstructs a definition from
+/// `tools/call` data and never imports unsupported top-level fields.
+pub fn binding_from_tools_list_tool(
+    tool: &Value,
+    server_id: Option<&str>,
+) -> Result<Option<ToolDefinitionBinding>> {
+    let Some(projection) = canonical_tool_definition_projection(tool, server_id)? else {
+        return Ok(None);
+    };
+    let canonical = jcs::to_vec(&projection)?;
+    let hash = Sha256::digest(&canonical);
+    Ok(Some(ToolDefinitionBinding::from_digest(format!(
+        "sha256:{}",
+        hex::encode(hash)
+    ))))
+}
+
+/// Build the bounded canonical P56b v1 projection.
+pub fn canonical_tool_definition_projection(
+    tool: &Value,
+    server_id: Option<&str>,
+) -> Result<Option<Value>> {
+    let Some(tool_object) = tool.as_object() else {
+        return Ok(None);
+    };
+
+    let Some(name) = tool_object.get("name").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    if name.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let mut projection = Map::new();
+    projection.insert("name".to_string(), Value::String(name.to_string()));
+
+    if let Some(description) = tool_object.get("description").and_then(Value::as_str) {
+        let trimmed = description.trim();
+        if !trimmed.is_empty() {
+            projection.insert(
+                "description".to_string(),
+                Value::String(trimmed.to_string()),
+            );
+        }
+    }
+
+    if let Some(input_schema) = normalized_input_schema(tool_object)? {
+        projection.insert("input_schema".to_string(), input_schema);
+    }
+
+    if let Some(server_id) = normalized_server_id(server_id) {
+        projection.insert(
+            "server_id".to_string(),
+            Value::String(server_id.to_string()),
+        );
+    }
+
+    Ok(Some(Value::Object(projection)))
+}
+
+fn normalized_input_schema(tool_object: &Map<String, Value>) -> Result<Option<Value>> {
+    let schema = tool_object
+        .get("inputSchema")
+        .or_else(|| tool_object.get("input_schema"));
+
+    match schema {
+        Some(value) if value.is_object() => Ok(Some(value.clone())),
+        Some(_) => bail!("unsupported MCP tool definition: input schema must be a JSON object"),
+        None => Ok(None),
+    }
+}
+
+fn normalized_server_id(server_id: Option<&str>) -> Option<&str> {
+    server_id.map(str::trim).filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::signing::SIG_FIELD;
+    use super::*;
+    use serde_json::json;
+
+    fn binding(tool: Value) -> ToolDefinitionBinding {
+        binding_from_tools_list_tool(&tool, Some("server-a"))
+            .expect("binding should compute")
+            .expect("tool should be supported")
+    }
+
+    #[test]
+    fn projection_allowlist_excludes_unknown_top_level_fields() {
+        let tool = json!({
+            "name": "read_file",
+            "description": "Read a file",
+            "inputSchema": {"type": "object"},
+            "annotations": {"title": "Read"},
+            "display_hint": "danger",
+            "provider_metadata": {"opaque": true}
+        });
+
+        let projection = canonical_tool_definition_projection(&tool, Some("server-a"))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            projection,
+            json!({
+                "name": "read_file",
+                "description": "Read a file",
+                "input_schema": {"type": "object"},
+                "server_id": "server-a"
+            })
+        );
+    }
+
+    #[test]
+    fn digest_is_stable_across_top_level_key_order() {
+        let first = binding(json!({
+            "name": "read_file",
+            "description": "Read a file",
+            "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}}}
+        }));
+        let second = binding(json!({
+            "inputSchema": {"properties": {"path": {"type": "string"}}, "type": "object"},
+            "description": "Read a file",
+            "name": "read_file"
+        }));
+
+        assert_eq!(first.digest, second.digest);
+    }
+
+    #[test]
+    fn input_schema_spelling_normalizes_to_same_digest() {
+        let camel = binding(json!({
+            "name": "read_file",
+            "inputSchema": {"type": "object"}
+        }));
+        let snake = binding(json!({
+            "name": "read_file",
+            "input_schema": {"type": "object"}
+        }));
+
+        assert_eq!(camel.digest, snake.digest);
+    }
+
+    #[test]
+    fn description_is_trimmed_and_whitespace_only_is_absent() {
+        let trimmed = binding(json!({
+            "name": "read_file",
+            "description": "  Read a file  ",
+            "inputSchema": {"type": "object"}
+        }));
+        let clean = binding(json!({
+            "name": "read_file",
+            "description": "Read a file",
+            "inputSchema": {"type": "object"}
+        }));
+        let whitespace = canonical_tool_definition_projection(
+            &json!({
+                "name": "read_file",
+                "description": "   \t\n ",
+                "inputSchema": {"type": "object"}
+            }),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(trimmed.digest, clean.digest);
+        assert!(whitespace.get("description").is_none());
+    }
+
+    #[test]
+    fn server_id_is_only_included_when_supplied() {
+        let tool = json!({
+            "name": "read_file",
+            "inputSchema": {"type": "object"}
+        });
+
+        let unscoped = canonical_tool_definition_projection(&tool, None)
+            .unwrap()
+            .unwrap();
+        let empty_scoped = canonical_tool_definition_projection(&tool, Some("   "))
+            .unwrap()
+            .unwrap();
+        let scoped = canonical_tool_definition_projection(&tool, Some("server-a"))
+            .unwrap()
+            .unwrap();
+
+        assert!(unscoped.get("server_id").is_none());
+        assert!(empty_scoped.get("server_id").is_none());
+        assert_eq!(scoped["server_id"], "server-a");
+    }
+
+    #[test]
+    fn signature_field_does_not_affect_digest() {
+        let unsigned = binding(json!({
+            "name": "read_file",
+            "description": "Read",
+            "inputSchema": {"type": "object"}
+        }));
+        let signed = binding(json!({
+            "name": "read_file",
+            "description": "Read",
+            "inputSchema": {"type": "object"},
+            SIG_FIELD: {"signature": "opaque"}
+        }));
+
+        assert_eq!(unsigned.digest, signed.digest);
+    }
+
+    #[test]
+    fn vendor_schema_keywords_inside_input_schema_are_preserved() {
+        let projection = canonical_tool_definition_projection(
+            &json!({
+                "name": "read_file",
+                "inputSchema": {
+                    "type": "object",
+                    "x-vendor-keyword": {"opaque": true}
+                },
+                "x-vendor-top-level": "excluded"
+            }),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            projection["input_schema"]["x-vendor-keyword"],
+            json!({"opaque": true})
+        );
+        assert!(projection.get("x-vendor-top-level").is_none());
+    }
+
+    #[test]
+    fn invalid_or_missing_name_does_not_invent_binding() {
+        assert!(
+            binding_from_tools_list_tool(&json!({"inputSchema": {"type": "object"}}), None)
+                .unwrap()
+                .is_none()
+        );
+        assert!(binding_from_tools_list_tool(&json!({"name": "   "}), None)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn non_object_input_schema_is_not_supported() {
+        assert!(binding_from_tools_list_tool(
+            &json!({"name": "read_file", "inputSchema": true}),
+            None
+        )
+        .is_err());
+    }
+}

--- a/crates/assay-evidence/src/types.rs
+++ b/crates/assay-evidence/src/types.rs
@@ -240,6 +240,7 @@ impl EvidenceEvent {
 // -- Strongly Typed Payload Helpers --
 
 /// Typed payload variants (for convenience, not enforced by contract)
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "payload")]
 pub enum Payload {
@@ -284,6 +285,16 @@ pub struct PayloadToolDecision {
     pub policy_snapshot_canonicalization: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_snapshot_schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_definition_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_definition_digest_alg: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_definition_canonicalization: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_definition_schema: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_definition_source: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delegated_from: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -424,6 +435,11 @@ mod tests {
         assert_eq!(without_payload.policy_snapshot_digest_alg, None);
         assert_eq!(without_payload.policy_snapshot_canonicalization, None);
         assert_eq!(without_payload.policy_snapshot_schema, None);
+        assert_eq!(without_payload.tool_definition_digest, None);
+        assert_eq!(without_payload.tool_definition_digest_alg, None);
+        assert_eq!(without_payload.tool_definition_canonicalization, None);
+        assert_eq!(without_payload.tool_definition_schema, None);
+        assert_eq!(without_payload.tool_definition_source, None);
 
         let with = serde_json::json!({
             "tool": "deploy_service",
@@ -434,7 +450,12 @@ mod tests {
             "policy_snapshot_digest": "sha256:abc123",
             "policy_snapshot_digest_alg": "sha256",
             "policy_snapshot_canonicalization": "jcs:mcp_policy",
-            "policy_snapshot_schema": "assay.mcp.policy.snapshot.v1"
+            "policy_snapshot_schema": "assay.mcp.policy.snapshot.v1",
+            "tool_definition_digest": "sha256:def456",
+            "tool_definition_digest_alg": "sha256",
+            "tool_definition_canonicalization": "jcs:mcp_tool_definition.v1",
+            "tool_definition_schema": "assay.mcp.tool-definition.snapshot.v1",
+            "tool_definition_source": "mcp.tools/list"
         });
         let with_payload: PayloadToolDecision =
             serde_json::from_value(with).expect("policy snapshot payload should deserialize");
@@ -454,6 +475,26 @@ mod tests {
         assert_eq!(
             with_payload.policy_snapshot_schema.as_deref(),
             Some("assay.mcp.policy.snapshot.v1")
+        );
+        assert_eq!(
+            with_payload.tool_definition_digest.as_deref(),
+            Some("sha256:def456")
+        );
+        assert_eq!(
+            with_payload.tool_definition_digest_alg.as_deref(),
+            Some("sha256")
+        );
+        assert_eq!(
+            with_payload.tool_definition_canonicalization.as_deref(),
+            Some("jcs:mcp_tool_definition.v1")
+        );
+        assert_eq!(
+            with_payload.tool_definition_schema.as_deref(),
+            Some("assay.mcp.tool-definition.snapshot.v1")
+        );
+        assert_eq!(
+            with_payload.tool_definition_source.as_deref(),
+            Some("mcp.tools/list")
         );
     }
 

--- a/crates/assay-evidence/tests/verify_strict_test.rs
+++ b/crates/assay-evidence/tests/verify_strict_test.rs
@@ -147,6 +147,11 @@ fn test_tool_decision_stable_payload_conformance() {
         "policy_snapshot_digest_alg": "sha256",
         "policy_snapshot_canonicalization": "jcs:mcp_policy",
         "policy_snapshot_schema": "assay.mcp.policy.snapshot.v1",
+        "tool_definition_digest": "sha256:tooldef123",
+        "tool_definition_digest_alg": "sha256",
+        "tool_definition_canonicalization": "jcs:mcp_tool_definition.v1",
+        "tool_definition_schema": "assay.mcp.tool-definition.snapshot.v1",
+        "tool_definition_source": "mcp.tools/list",
         "delegated_from": "agent:planner",
         "delegation_depth": 1
     });
@@ -160,6 +165,14 @@ fn test_tool_decision_stable_payload_conformance() {
     assert_eq!(
         typed.policy_snapshot_digest.as_deref(),
         Some("sha256:policy123")
+    );
+    assert_eq!(
+        typed.tool_definition_digest.as_deref(),
+        Some("sha256:tooldef123")
+    );
+    assert_eq!(
+        typed.tool_definition_source.as_deref(),
+        Some("mcp.tools/list")
     );
     assert_eq!(typed.delegation_depth, Some(1));
     verify_single_event(EvidenceEvent::new(

--- a/docs/architecture/ADR-006-Evidence-Contract.md
+++ b/docs/architecture/ADR-006-Evidence-Contract.md
@@ -96,6 +96,11 @@ Records authorization decisions (HITL-ready, protocol-based).
   "policy_snapshot_digest_alg": "sha256",
   "policy_snapshot_canonicalization": "jcs:mcp_policy",
   "policy_snapshot_schema": "assay.mcp.policy.snapshot.v1",
+  "tool_definition_digest": "sha256:...",
+  "tool_definition_digest_alg": "sha256",
+  "tool_definition_canonicalization": "jcs:mcp_tool_definition.v1",
+  "tool_definition_schema": "assay.mcp.tool-definition.snapshot.v1",
+  "tool_definition_source": "mcp.tools/list",
   "delegated_from": "agent:planner",
   "delegation_depth": 1
 }
@@ -121,6 +126,29 @@ reconstruct policy snapshots after the fact, and it does not make policy
 snapshots retrievable, exportable, or embedded. Absence of
 `policy_snapshot_digest` means the policy snapshot boundary is not visible, not
 that the decision is safe.
+
+`tool_definition_digest`, `tool_definition_digest_alg`,
+`tool_definition_canonicalization`, `tool_definition_schema`, and
+`tool_definition_source` are additive optional P56b fields. They make the
+bounded MCP `tools/list` tool-definition digest visible when a supported
+decision path observed that definition before the tool call. The field cluster
+is atomic: if `tool_definition_digest` is present, the algorithm,
+canonicalization, schema, and source fields MUST also be present.
+
+For P56b v1, `tool_definition_digest_alg` is `"sha256"`,
+`tool_definition_canonicalization` is `"jcs:mcp_tool_definition.v1"`,
+`tool_definition_schema` is `"assay.mcp.tool-definition.snapshot.v1"`, and
+`tool_definition_source` is `"mcp.tools/list"`. The digest is computed over a
+bounded JCS projection of the observed tool definition: `name`, optional
+trimmed `description`, optional full normalized `input_schema`, and optional
+`server_id` only when the observed definition is server-scoped. Top-level
+vendor/provider metadata, annotations, display hints, runtime result payloads,
+registry bodies, and `x-assay-sig` are excluded before digesting. Schema
+keywords inside `input_schema` remain part of the reviewed schema surface.
+P56b does not claim tool safety, implementation truth, signature validity,
+signer trust, registry trust, or that the tool definition is retrievable or
+embedded. Absence of `tool_definition_digest` means the tool-definition
+boundary is not visible, not that the tool is safe.
 
 `delegated_from` and `delegation_depth` are additive optional fields. They are
 surfaced only when a supported decision flow carries explicit

--- a/docs/architecture/PLAN-P56B-TOOL-DEFINITION-DIGEST-BINDING-2026q2.md
+++ b/docs/architecture/PLAN-P56B-TOOL-DEFINITION-DIGEST-BINDING-2026q2.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-04-29
 - **Owner:** Evidence / MCP Security
-- **Status:** Plan
+- **Status:** Implemented
 - **Scope:** Bind supported `assay.tool.decision` evidence to a bounded MCP tool
   definition digest when a reviewed tool definition surface is available,
   without claiming tool safety, signature validity, or registry truth.

--- a/docs/architecture/SPEC-Tool-Signing-v1.md
+++ b/docs/architecture/SPEC-Tool-Signing-v1.md
@@ -47,6 +47,21 @@ Signing Input = JCS(tool_object - {"x-assay-sig"})
 | `inputSchema` | Yes |
 | `x-assay-sig` | **No** (removed before canonicalization) |
 
+### 2.2.1 Relation to P56b Decision Evidence Digests
+
+P56b `tool_definition_digest` is a separate decision-evidence review surface.
+It is computed over a bounded MCP `tools/list` projection (`name`, optional
+trimmed `description`, optional normalized `input_schema`, and conditional
+`server_id`) and excludes `x-assay-sig` plus unsupported top-level metadata
+before JCS canonicalization.
+
+The v1 local signing input above remains the full JCS-canonicalized tool object
+with `x-assay-sig` removed. Therefore, `x-assay-sig.payload_digest` and P56b
+`tool_definition_digest` are not required to be the same digest in this spec.
+If a future signing version adopts the same bounded projection as P56b, any
+divergence between signing input and decision-visible digest input MUST be a
+deliberate versioned contract change, not an implementation detail.
+
 ### 2.3 Payload Type Binding
 
 To prevent type confusion attacks, the signature binds to a payload type using DSSE Pre-Authentication Encoding (PAE):

--- a/docs/spec/EVIDENCE-CONTRACT-v1.md
+++ b/docs/spec/EVIDENCE-CONTRACT-v1.md
@@ -154,6 +154,7 @@ These IDs are stable; if a test is renamed, maintain a compatibility alias (e.g.
 | 1                        | 2026-02| New event types policy (§4.1): no new type without registry + schema + conformance test; Event types (v1) registry table (§4.2); §2 normative rule clarified (schema_version 1 + v1.0 baseline; verify MAY v1.x, pack MAY exact 1.0). |
 | 1                        | 2026-04| Tightened version-axis naming (`CE_SPECVERSION` vs `ASSAY_EVIDENCE_SPEC_VERSION`), stable event registry anchors, canonical-writer determinism language, content-hash input scope, and experimental receipt-type emission posture. |
 | 1                        | 2026-04| Added optional `policy_snapshot_*` fields on stable `assay.tool.decision` payloads for P56a policy snapshot digest visibility; this is additive, visibility-only, and projects the existing `policy_digest` without adding policy truth. |
+| 1                        | 2026-04| Added optional atomic `tool_definition_*` fields on stable `assay.tool.decision` payloads for P56b bounded MCP `tools/list` tool-definition digest visibility; this is additive, visibility-only, and does not add tool safety, signature, signer, registry, or implementation-truth claims. |
 
 ## 8. Normative checklist (summary)
 


### PR DESCRIPTION
What changed

Adds P56b: bounded MCP tool-definition digest visibility on supported `assay.tool.decision` evidence.

This PR includes:

- a `ToolDefinitionBinding` helper that computes `sha256:` digests over the bounded v1 MCP `tools/list` projection
- v1 projection rules for `name`, trimmed optional `description`, full normalized `input_schema`, conditional `server_id`, and exclusion of unsupported top-level fields plus `x-assay-sig`
- optional atomic `tool_definition_*` fields on decision events and typed evidence payload helpers
- proxy support that caches tool-definition bindings beside existing `ToolIdentity` from `tools/list` and projects the binding on later `tools/call` decisions
- additive ToolCallHandler support for callers that already have an observed binding
- ADR/Evidence Contract/changelog docs that distinguish ToolIdentity, P56b review digests, and `x-assay-sig` signing semantics

Why

P56a made policy snapshot digest visibility explicit. P56b adds the companion reviewed tool-definition boundary so decision evidence can show which bounded tool surface was observed for the decision without claiming tool trust.

Boundary

This is digest visibility only. It does not add a Trust Basis claim, Trust Card schema bump, signature-verification claim, transparency-log claim, registry-trust claim, tool safety claim, or implementation-truth claim. Current local tool signing still signs the full JCS tool object minus `x-assay-sig`; P56b uses a separate bounded decision-evidence projection.

Validation

Ran locally:

- cargo fmt --check
- git diff --check
- local changed-docs markdown link check
- cargo test -p assay-core tool_definition -- --nocapture
- cargo test -p assay-core --test decision_emit_invariant -- --nocapture
- cargo test -p assay-core --test replay_diff_contract -- --nocapture
- cargo test -p assay-core --test tool_taxonomy_policy_match -- --nocapture
- cargo test -p assay-evidence --test verify_strict_test test_tool_decision_stable_payload_conformance -- --nocapture
- cargo clippy -p assay-core --all-targets -- -D warnings
- cargo clippy -p assay-evidence --all-targets -- -D warnings

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.
