### PR TITLE
docs: add copyable evidence receipts proof snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project will be documented in this file.
   page shows the three released receipt families, their exact Trust Basis claim
   IDs, and the raw diff JSON to Markdown/JUnit projection split without adding
   a new product surface or integration claim.
+- Added a copyable GitHub Actions proof snippet to the D1 page. The snippet
+  verifies the checked-in proof bundles with the released Assay `v3.9.1`
+  binary, writes a small job summary, and uploads canonical/projection
+  artifacts without adding a required workflow or new runtime semantics.
 
 ### CI / Release
 

--- a/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
+++ b/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
@@ -318,6 +318,77 @@ Harness manual compatibility workflow can also be used as an example proof
 run, but it is not the primary source of truth because workflow artifacts are
 run-scoped and retention-bound.
 
+## Copyable GitHub Actions Proof
+
+If you want the smallest workflow-native version, use this as a repo-local
+proof over the checked-in D1 assets. It does not call upstream APIs and does
+not regenerate the recipes. It verifies the released proof bundles, writes a
+small job summary, and uploads the canonical/projection artifacts for review.
+
+```yaml
+name: evidence-receipts-proof
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  proof:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Assay v3.9.1
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="https://github.com/Rul1an/assay/releases/download/v3.9.1"
+          curl -fsSLO "$base/assay-v3.9.1-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSLO "$base/assay-v3.9.1-x86_64-unknown-linux-gnu.tar.gz.sha256"
+          sha256sum -c assay-v3.9.1-x86_64-unknown-linux-gnu.tar.gz.sha256
+          tar -xzf assay-v3.9.1-x86_64-unknown-linux-gnu.tar.gz
+          ./assay-v3.9.1-x86_64-unknown-linux-gnu/assay --version
+
+      - name: Verify checked-in proof bundles
+        shell: bash
+        run: |
+          set -euo pipefail
+          ASSAY="./assay-v3.9.1-x86_64-unknown-linux-gnu/assay"
+          for family in promptfoo openfeature cyclonedx; do
+            "$ASSAY" evidence verify "docs/assets/evidence-receipts-in-action/$family/evidence.tar.gz"
+          done
+
+      - name: Write proof summary
+        shell: bash
+        run: |
+          {
+            echo "## Evidence Receipts Proof"
+            echo
+            echo "| Family | Trust Basis claim | Canonical artifacts | Projections |"
+            echo "| --- | --- | --- | --- |"
+            echo "| Promptfoo | \`external_eval_receipt_boundary_visible\` | bundle, trust-basis.json, diff JSON | Markdown, JUnit |"
+            echo "| OpenFeature | \`external_decision_receipt_boundary_visible\` | bundle, trust-basis.json, diff JSON | Markdown, JUnit |"
+            echo "| CycloneDX ML-BOM | \`external_inventory_receipt_boundary_visible\` | bundle, trust-basis.json, diff JSON | Markdown, JUnit |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload proof artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-receipts-proof
+          path: |
+            docs/assets/evidence-receipts-in-action/manifest.json
+            docs/assets/evidence-receipts-in-action/**/evidence.tar.gz
+            docs/assets/evidence-receipts-in-action/**/trust-basis.json
+            docs/assets/evidence-receipts-in-action/**/trust-basis.diff.json
+            docs/assets/evidence-receipts-in-action/**/trust-basis-summary.md
+            docs/assets/evidence-receipts-in-action/**/junit-trust-basis.xml
+```
+
+This is a proof wrapper, not a required integration path. The full runnable
+family recipes stay in Assay Harness.
+
 ## Boundary
 
 This is a downstream evidence pattern, not an upstream integration claim.


### PR DESCRIPTION
What changed

Adds a small copyable GitHub Actions proof snippet to `Evidence Receipts in Action`.

The snippet:

- downloads the released Assay `v3.9.1` Linux binary
- verifies the release checksum before use
- verifies the checked-in D1 proof bundles
- writes a compact GitHub job summary
- uploads the canonical/projection proof artifacts as a workflow artifact

Why

The D1 page is already a static proof. This makes it more copyable for engineers who want to see the same proof in a workflow-native shape without creating a new required workflow, hosted demo, upstream integration, or runtime surface.

Boundary

Docs only. No new workflow is added to this repository, no CI cost is added, and no Assay/Harness behavior changes. The snippet is a proof wrapper over checked-in D1 assets; the full runnable family recipes stay in Assay Harness.

Validation

Ran locally:

- local changed-docs link check
- fenced YAML parse through Ruby YAML
- checked the Assay `v3.9.1` Linux tarball contains `assay-v3.9.1-x86_64-unknown-linux-gnu/assay`
- `git diff --check`

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.
