### PR TITLE
docs: clarify evidence receipts proof wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ All notable changes to this project will be documented in this file.
   page shows the three released receipt families, their exact Trust Basis claim
   IDs, and the raw diff JSON to Markdown/JUnit projection split without adding
   a new product surface or integration claim.
-- Added a copyable GitHub Actions proof snippet to the D1 page. The snippet
-  verifies the checked-in proof bundles with the released Assay `v3.9.1`
-  binary, writes a small job summary, and uploads canonical/projection
-  artifacts without adding a required workflow or new runtime semantics.
+- Added a copyable GitHub Actions proof snippet to the Evidence Receipts in
+  Action page. The snippet verifies the checked-in proof bundles with the
+  released Assay `v3.9.1` binary, writes a small job summary, and uploads
+  canonical/projection artifacts without adding a required workflow or new
+  runtime semantics.
 
 ### CI / Release
 

--- a/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
+++ b/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
@@ -321,9 +321,10 @@ run-scoped and retention-bound.
 ## Copyable GitHub Actions Proof
 
 If you want the smallest workflow-native version, use this as a repo-local
-proof over the checked-in D1 assets. It does not call upstream APIs and does
-not regenerate the recipes. It verifies the released proof bundles, writes a
-small job summary, and uploads the canonical/projection artifacts for review.
+proof over the checked-in Evidence Receipts in Action assets. It does not call
+upstream APIs and does not regenerate the recipes. It verifies the checked-in
+proof bundles, writes a small job summary, and uploads the
+canonical/projection artifacts for review.
 
 ```yaml
 name: evidence-receipts-proof


### PR DESCRIPTION
What changed

Small follow-up to the merged copyable Evidence Receipts in Action proof snippet.

This PR:

- replaces the internal D1 shorthand with the public page name
- changes "released proof bundles" to "checked-in proof bundles" so the proof-source hierarchy is precise
- makes the changelog entry self-contained for readers skimming release notes

Why

The copyable snippet is public-facing docs. These wording tweaks keep the page understandable without internal project shorthand and avoid implying that workflow/run-scoped artifacts are the primary source of truth.

Boundary

Docs copy only. No workflow, runtime behavior, schemas, receipts, Trust Basis claims, or Harness semantics change.

Validation

Ran locally / via push hooks:

- rg check for stale D1 / released proof bundles wording
- git diff --check
- push-time hooks, including cargo fmt, workspace clippy, and linux compile gate
