### PR TITLE
P14d: guard score receipt claim candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ All notable changes to this project will be documented in this file.
   with `trust_basis_claim: null`; any future
   `external_score_receipt_boundary_visible` claim must first define exact claim
   semantics, Trust Card impact, and Harness posture.
+- Added a Trust Basis CLI regression guard proving
+  `external_score_receipt_boundary_visible` remains a planning-only candidate,
+  not a registered claim id accepted by `assay trust-basis assert`.
 
 ### Docs
 

--- a/crates/assay-cli/tests/trust_basis_test.rs
+++ b/crates/assay-cli/tests/trust_basis_test.rs
@@ -411,6 +411,27 @@ fn trust_basis_assert_rejects_unknown_claim_id_as_input_error() {
 }
 
 #[test]
+fn trust_basis_assert_rejects_planning_only_score_receipt_claim_candidate() {
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("trust-basis.json");
+    write_trust_basis_json(&input, "verified");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("assert")
+        .arg("--input")
+        .arg(&input)
+        .arg("--require")
+        .arg("external_score_receipt_boundary_visible=verified")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "unknown Trust Basis claim id \"external_score_receipt_boundary_visible\"",
+        ));
+}
+
+#[test]
 fn trust_basis_assert_rejects_duplicate_claim_identity() {
     let dir = tempdir().unwrap();
     let input = dir.path().join("trust-basis.json");


### PR DESCRIPTION
What changed

Adds a small P14d follow-up guard proving that the future score-receipt claim candidate is still planning-only.

This PR includes:

- a Trust Basis CLI regression test for `assay trust-basis assert`
- explicit rejection of `external_score_receipt_boundary_visible=verified` as an unknown claim id
- a changelog note recording that the candidate is not currently registered

Why

P14d names `external_score_receipt_boundary_visible` only as a possible future claim. This makes that boundary executable: if the claim id is ever added accidentally before a deliberate P14e slice, this test will fail.

Boundary

Test/changelog only. No new Trust Basis claim, Trust Card row, receipt schema, Harness behavior, Mastra semantics, score threshold, or compatibility expansion.

Validation

Ran locally:

- `cargo fmt --check`
- `cargo test -p assay-cli --test trust_basis_test trust_basis_assert_rejects_planning_only_score_receipt_claim_candidate -- --nocapture`
- `git diff --check`

Push-time hooks also passed, including cargo fmt, workspace clippy, and the linux compile gate.
