### PR TITLE
[codex] Align evidence receipt seeding pack

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -12,6 +12,21 @@ permissions:
   contents: read
 
 jobs:
+  mkdocs-strict:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.x"
+
+      - name: Install docs dependencies
+        run: pip install --requirement docs/requirements-ci.txt
+
+      - name: Build docs strictly
+        run: mkdocs build --strict
+
   local-links:
     runs-on: ubuntu-latest
     steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,18 @@
 # Assay
 
-**Deterministic testing for AI agents.** Record traces, replay in CI, validate against policies. No API calls, no flakiness.
+**Assay compiles selected external outcomes and agent runtime signals into
+portable evidence receipts, verifiable bundles, and bounded Trust Basis
+claims.**
 
-**Product story (repo root):** Assay is positioned as a **trust compiler for agent systems** — MCP policy enforcement as the wedge, plus verifiable evidence bundles, Trust Basis, Trust Card, and CI/SARIF. See the [main README](../README.md), [ADR-033](architecture/ADR-033-OTel-Trust-Compiler-Positioning.md), and [community discussion seeds](community/DISCUSSIONS.md).
+Assay is positioned as a **trust compiler for agent systems**: MCP policy
+enforcement is the wedge, while the product surface is canonical evidence,
+portable receipts, Trust Basis, Trust Card, and reviewable CI projections.
+It is not an eval runner, hosted dashboard, generic MCP/policy tool, or
+upstream truth oracle. See the [main README](../README.md), [What Assay is and
+is not](concepts/scope.md), [ADR-033](architecture/ADR-033-OTel-Trust-Compiler-Positioning.md),
+and [community discussion seeds](community/DISCUSSIONS.md).
 
-**Evidence portability notes:** [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) explains the released `v3.8.0` receipt/schema surface and the first three claim-visible receipt families. [Evidence Receipts in Action](notes/EVIDENCE-RECEIPTS-IN-ACTION.md) shows the same three-family path with small checked-in artifacts generated from released Assay/Harness versions. The `v3.9.0` line adds assertion, schema CLI, Trust Card HTML, and MCP policy/tool digest review surfaces without adding new receipt families or Trust Basis claims. [From Promptfoo JSONL to Evidence Receipts](notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) explains the first Promptfoo assertion-component receipt path as a downstream evidence-portability recipe, not a Promptfoo integration or partnership claim.
+**Evidence portability notes:** [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) explains the released `v3.8.0` receipt/schema surface and the first three claim-visible receipt families. [Evidence Receipts in Action](notes/EVIDENCE-RECEIPTS-IN-ACTION.md) shows the same three-family path with small checked-in artifacts generated from released Assay/Harness versions. The [receipt family matrix](reference/receipt-family-matrix.json) and [receipt schema registry](reference/receipt-schemas/README.md) are the machine-readable receipt-family references. The `v3.9.0` line adds assertion, schema CLI, Trust Card HTML, and MCP policy/tool digest review surfaces without adding new receipt families or Trust Basis claims. [From Promptfoo JSONL to Evidence Receipts](notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) explains the first Promptfoo assertion-component receipt path as a downstream evidence-portability recipe, not a Promptfoo integration or partnership claim.
 
 ## 5-Minute Quickstart
 

--- a/docs/community/DISCUSSIONS.md
+++ b/docs/community/DISCUSSIONS.md
@@ -2,6 +2,10 @@
 
 Assay uses [GitHub Discussions](https://github.com/Rul1an/assay/discussions) for category clarity and roadmap Q&A. Maintainers should **pin** the threads below so newcomers see the north star without scrolling the README.
 
+For the current evidence-receipts seeding slice, use the
+[P57 Ecosystem Seeding Pack](P57-ECOSYSTEM-SEEDING-PACK.md). It is a small
+proof/theory/recipe sharing pack, not a launch plan or partnership ask.
+
 ## Live discussions (March 2026)
 
 | Topic | URL |

--- a/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
+++ b/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
@@ -1,0 +1,138 @@
+# P57 Ecosystem Seeding Pack
+
+> **Status:** paused after one Promptfoo-context follow-up; ready for broader
+> controlled seeding only after a docs tag contains the primary proof page
+>
+> **Last updated:** 2026-05-04
+> **Scope:** small repo-native sharing pack for the released evidence receipt
+> surface. This is not a launch plan, campaign, partnership claim, compliance
+> claim, or new product wedge.
+
+## Core Line
+
+Assay compiles selected external outcomes into portable evidence receipts and
+bounded Trust Basis claims.
+
+Short post line:
+
+> We made the evidence boundary inspectable.
+
+## Released Link Set
+
+| Role | Link | Use When |
+|---|---|---|
+| Promptfoo context note | [From Promptfoo JSONL to Evidence Receipts](https://github.com/Rul1an/assay/blob/v3.9.1/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) | Use only for an existing Promptfoo JSONL/assertion-results context. This note is present in the `v3.9.1` tag. |
+| Theory | [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](https://github.com/Rul1an/assay/blob/v3.9.1/docs/notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) | Use as the read-more link when someone asks why receipts instead of broad integrations. |
+| Runnable recipe | [Promptfoo receipt pipeline](https://github.com/Rul1an/Assay-Harness/blob/v0.3.2/docs/PROMPTFOO_RECEIPT_PIPELINE.md) | Use when someone wants to run the smallest released recipe immediately. |
+
+Held until a later Assay tag:
+
+- `EVIDENCE-RECEIPTS-IN-ACTION.md` is the intended primary proof page, but it
+  is not present in the public Assay `v3.9.1` tag. Do not use it in outward
+  messages until a later Assay tag, expected as docs-only `v3.9.2`, contains
+  the page.
+
+Main-only second-layer note:
+
+- [Evidence Receipt Assurance Mapping](../notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md)
+  is useful for assurance-context replies, but it is not part of the released
+  `v3.9.1` truth line yet. Do not include it in the public one-link post until
+  a later Assay tag contains it.
+
+Current allowed package:
+
+- Promptfoo context: From Promptfoo JSONL to Evidence Receipts
+- theory: Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory
+- recipe: Promptfoo receipt pipeline
+
+Post-`v3.9.2` intended package:
+
+- proof: Evidence Receipts in Action
+- theory: Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory
+- recipe: Promptfoo receipt pipeline
+
+## Repo-Native Post
+
+Title:
+
+```text
+Evidence Receipts in Action
+```
+
+Body:
+
+```markdown
+We made the evidence boundary inspectable.
+
+Assay now compiles selected external outcomes into portable evidence receipts,
+verifiable bundles, and bounded Trust Basis claims.
+
+The first released receipt families are intentionally small:
+
+- Promptfoo assertion component results -> eval outcome receipts
+- OpenFeature boolean EvaluationDetails -> runtime decision receipts
+- CycloneDX ML-BOM machine-learning-model components -> inventory receipts
+
+The useful part is not that Assay imports everything. It does not. The useful
+part is that a small upstream outcome can become a bounded receipt, the receipt
+can be bundled and verified, and the Trust Basis claim above it can be gated
+without teaching Harness family-specific semantics.
+
+Proof:
+<VERSIONED_EVIDENCE_RECEIPTS_IN_ACTION_LINK>
+```
+
+Do not publish this post until `<VERSIONED_EVIDENCE_RECEIPTS_IN_ACTION_LINK>`
+resolves under a public Assay tag. The expected next clean line is a small
+docs-only `v3.9.2` Assay release.
+
+Do not add:
+
+- partnership language,
+- compliance language,
+- a request for general feedback,
+- claims that Assay replaces Promptfoo, OpenFeature, CycloneDX, or Harness.
+
+## Landing Spots
+
+| Spot | Link to Send | One Sentence | Do Not Ask |
+|---|---|---|---|
+| Release-adjacent update | Hold until `EVIDENCE-RECEIPTS-IN-ACTION.md` is present in a public Assay tag. | We made the evidence boundary inspectable: selected Promptfoo, OpenFeature, and CycloneDX outcomes now compile into bounded receipts and Trust Basis claims. | Do not ask for generic feedback, stars, adoption, or partnership. Use a repo Discussion only if there is no suitable release/docs context. |
+| Existing Promptfoo JSONL/componentResults context | [From Promptfoo JSONL to Evidence Receipts](https://github.com/Rul1an/assay/blob/v3.9.1/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) | This keeps Promptfoo as the eval runner while showing how selected assertion component outcomes become portable evidence receipts. | Never open a fresh thread just to restate the proof. Do not imply Promptfoo endorsement, official integration, or eval correctness. Add the recipe link only if someone asks to run it. |
+| Assurance / audit-context follow-up | [Evidence Receipt Assurance Mapping](../notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | This maps each released receipt family to the assurance question it can help answer and the claims it explicitly does not make. | Do not frame it as a compliance checklist or legal interpretation. Keep this internal/main-only until the mapping note is tagged. |
+
+## Share Order
+
+1. Keep the existing Promptfoo-context follow-up on the versioned
+   `FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md` note.
+2. Do not post the general repo-native note until the intended primary proof
+   page is present in a public Assay tag.
+3. After that tag exists, post the repo-native note first.
+4. Wait at least one day.
+5. Do at most one or two contextual follow-ups where there is already relevant
+   conversation.
+6. Prefer Promptfoo context first because the recipe is the smallest and most
+   directly runnable.
+7. Use OpenFeature or CycloneDX context later only when there is existing
+   discussion about runtime decisions or model inventory boundaries.
+8. Stop after those follow-ups unless someone asks for a concrete artifact,
+   recipe, or boundary explanation.
+9. If there is no reply or no natural continuation, stop. Do not open a new
+   thread to restate the same proof.
+
+## Guardrails
+
+- No new receipt families.
+- No new Harness behavior.
+- No compliance claims.
+- No partnership language.
+- No broad campaign language.
+- No "would love feedback" framing.
+- No pressure to adopt.
+- No outward link to `EVIDENCE-RECEIPTS-IN-ACTION.md` until it is included in
+  a tagged Assay release.
+- Do not promote the mapping note in any outward message until it is included
+  in a tagged Assay release.
+
+The goal is only to put the released proof, theory, and runnable recipe in
+front of people who already care about evidence boundaries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,10 @@ sudo assay monitor --policy policy.yaml --pid <agent-pid>
 
 - [**Getting Started**](getting-started/index.md)
 - [**Scope & Boundaries**](concepts/scope.md)
-- [**Evidence Receipts in Action**](notes/EVIDENCE-RECEIPTS-IN-ACTION.md)
+- [**Evidence Receipts Technical Note**](notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md)
+- [**Evidence Receipt Assurance Mapping**](notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md)
+- [**Receipt Family Matrix**](reference/receipt-family-matrix.json)
+- [**Receipt Schema Registry**](reference/receipt-schemas/README.md)
 - [**Operator Proof Flow**](guides/operator-proof-flow.md)
 - [**Python SDK**](getting-started/python-quickstart.md)
 - [**OpenTelemetry & Langfuse**](guides/otel-langfuse.md)

--- a/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md
+++ b/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md
@@ -1,0 +1,143 @@
+# Evidence Receipt Assurance Mapping
+
+> **Status:** mapping note
+> **Last updated:** 2026-05-03
+> **Scope:** maps the released three-family receipt surface to common
+> assurance questions. This note adds no new receipt family, Trust Basis claim,
+> Harness behavior, compliance claim, or upstream integration claim.
+
+Assay compiles selected external outcomes into portable evidence receipts and
+bounded Trust Basis claims.
+
+This note maps the released receipt families to the assurance questions they
+can help answer. It does not turn Assay into a compliance oracle or make
+upstream systems true. It only maps the current receipt boundaries to the
+questions they can help answer.
+
+## How to Read This
+
+This is an assurance-oriented mapping note, not a compliance checklist or legal
+interpretation.
+
+| Column | Meaning |
+|---|---|
+| Assurance question | The kind of review question a team may be trying to answer. |
+| Receipt family | The released Assay receipt family that can make the boundary visible. |
+| What Assay makes visible | The bounded receipt boundary and Trust Basis claim Assay can compile from a verified bundle. |
+| What Assay does not claim | The upstream, semantic, legal, or operational truth that remains outside Assay. |
+
+The source of truth for paths, schemas, included fields, excluded fields, and
+non-claims remains the [receipt family matrix](../reference/receipt-family-matrix.json).
+For artifact proof, use [Evidence Receipts in Action](EVIDENCE-RECEIPTS-IN-ACTION.md).
+
+## Mapping
+
+| Assurance question | Receipt family | What Assay makes visible | What Assay does not claim |
+|---|---|---|---|
+| What was tested? | Promptfoo eval outcome receipts | A selected Promptfoo assertion component result was reduced into a bounded receipt, bundled, verified, and compiled into `external_eval_receipt_boundary_visible`. | The eval run passed, the model output was correct, Promptfoo is complete truth, or raw prompts/outputs/vars were imported. |
+| What was decided at runtime? | OpenFeature runtime decision receipts | A boolean OpenFeature `EvaluationDetails` outcome was reduced into a bounded decision receipt, bundled, verified, and compiled into `external_decision_receipt_boundary_visible`. | The flag decision was correct, targeting rules were correct, provider behavior was safe, or evaluation context/config was imported. |
+| What was the system built with? | CycloneDX ML-BOM inventory/provenance receipts | A selected CycloneDX `machine-learning-model` component was reduced into a bounded inventory receipt, bundled, verified, and compiled into `external_inventory_receipt_boundary_visible`. | The BOM is complete, the model is safe, licenses/vulnerabilities are covered, or full dependency/model-card/dataset truth was imported. |
+
+## Family Detail
+
+### Promptfoo
+
+Promptfoo remains the eval runner. Assay only consumes selected assertion
+component outcomes as receipt input.
+
+Useful assurance framing:
+
+- A reviewer can see that a supported eval outcome boundary exists in the
+  evidence bundle.
+- A reviewer can inspect the assertion type, pass/score fields, bounded reason
+  when present, source artifact reference, source artifact digest, reducer
+  version, and import timestamp.
+- A CI gate can block if the Trust Basis claim boundary regresses or disappears.
+
+Non-claims:
+
+- Assay does not decide whether the model answer was correct.
+- Assay does not import the full Promptfoo JSONL row, raw prompt, raw output,
+  expected-value expansion, vars, provider payload, or run-level truth.
+- Assay does not create an official Promptfoo integration claim.
+
+### OpenFeature
+
+OpenFeature remains the feature-flag evaluation surface. Assay only consumes
+one bounded boolean `EvaluationDetails` export shape as receipt input.
+
+Useful assurance framing:
+
+- A reviewer can see that a supported runtime decision boundary exists in the
+  evidence bundle.
+- A reviewer can inspect the flag key, boolean value, value type, and, when
+  present, the variant, reason, error code, source artifact reference, source
+  artifact digest, reducer version, and import timestamp.
+- A CI gate can block if the Trust Basis claim boundary regresses or disappears.
+
+Non-claims:
+
+- Assay does not decide whether the flag value was correct.
+- Assay does not import targeting context, targeting key, rules, provider
+  config, provider metadata, user identifiers, application state, or
+  `error_message`.
+- Assay does not create an official OpenFeature integration claim.
+
+### CycloneDX ML-BOM
+
+CycloneDX remains the inventory/BOM format. Assay only consumes selected
+`machine-learning-model` component data as receipt input.
+
+Useful assurance framing:
+
+- A reviewer can see that a supported model inventory /
+  provenance-reference boundary exists in the evidence bundle.
+- A reviewer can inspect selected model component refs, bounded model/dataset
+  and model-card refs, source artifact reference, source artifact digest,
+  reducer version, and import timestamp.
+- A CI gate can block if the Trust Basis claim boundary regresses or disappears.
+
+Non-claims:
+
+- Assay does not decide whether the model is safe or whether provenance is
+  sufficient.
+- Assay does not import the full BOM graph, vulnerabilities, licenses, pedigree,
+  ancestors, full model-card body, dataset bodies, fairness/ethics sections, or
+  compliance truth.
+- Assay does not create an official CycloneDX integration claim.
+
+## Harness Boundary
+
+Assay Harness is deliberately generic in this layer.
+
+Harness may:
+
+- call Assay recipes or commands,
+- preserve raw `assay.trust-basis.diff.v1` JSON,
+- map Trust Basis regressions to CI exit codes,
+- project raw diffs into Markdown and JUnit.
+
+Harness must not:
+
+- parse Promptfoo JSONL, OpenFeature JSONL, CycloneDX BOMs, or Assay receipt
+  payloads,
+- compare assertion values, flag decisions, model versions, dataset refs, or
+  family-specific metadata,
+- add its own Trust Basis claim logic.
+
+## Importer-Only Lanes
+
+Mastra score events and Pydantic case results are importer-only receipt lanes
+in the current line. They are useful for importer boundary work, but they are
+not public claim-visible families in this mapping.
+
+They should stay out of assurance-facing family tables until a later accepted
+claim slice explicitly changes the receipt family matrix and release notes.
+
+## References
+
+- [Evidence Receipts in Action](EVIDENCE-RECEIPTS-IN-ACTION.md)
+- [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md)
+- [Receipt families](../reference/receipt-families.md)
+- [Receipt family matrix](../reference/receipt-family-matrix.json)
+- [Receipt schema registry](../reference/receipt-schemas/README.md)

--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -1,0 +1,21 @@
+# Notes
+
+These notes are canonical narrative entries for the current evidence-receipt
+line. They should describe the released surfaces without opening new receipt
+families or new Harness semantics.
+
+- [Evidence Receipts in Action](EVIDENCE-RECEIPTS-IN-ACTION.md) is the static
+  proof page generated from the released Assay `v3.9.1` binary and Assay
+  Harness `v0.3.2` three-family path.
+- [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md)
+  is the longform technical note for the same bounded receipt surface.
+- [Evidence Receipt Assurance Mapping](EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md)
+  maps the three released receipt families to assurance questions without
+  adding compliance claims or new receipt semantics.
+- [From Promptfoo JSONL to Evidence Receipts](FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md)
+  explains the first Promptfoo assertion-component receipt path as a downstream
+  evidence-portability recipe.
+
+For machine-readable receipt-family truth, use the
+[receipt family matrix](../reference/receipt-family-matrix.json) and
+[receipt schema registry](../reference/receipt-schemas/README.md).

--- a/docs/reference/receipt-families.md
+++ b/docs/reference/receipt-families.md
@@ -1,0 +1,24 @@
+# Receipt Families
+
+Assay compiles selected external outcomes into portable evidence receipts and
+bounded Trust Basis claims.
+
+The current public claim-visible families are:
+
+| Source surface | Receipt family | Trust Basis claim |
+|---|---|---|
+| Promptfoo assertion component result | eval outcome receipt | `external_eval_receipt_boundary_visible` |
+| OpenFeature boolean `EvaluationDetails` | runtime decision receipt | `external_decision_receipt_boundary_visible` |
+| CycloneDX ML-BOM `machine-learning-model` component | inventory / provenance receipt | `external_inventory_receipt_boundary_visible` |
+
+Mastra score events and Pydantic case results are importer-only receipt lanes in
+this line. They do not expose public Trust Basis claims.
+
+Use the machine-readable [receipt family matrix](receipt-family-matrix.json) for
+the source-of-truth family paths, schema names, included fields, excluded
+fields, non-claims, and importer-only status.
+
+Use the [receipt schema registry](receipt-schemas/README.md) for the bounded
+JSON Schema contracts exposed through `assay evidence schema`.
+
+For artifact-first proof, see [Evidence Receipts in Action](../notes/EVIDENCE-RECEIPTS-IN-ACTION.md).

--- a/docs/reference/receipt-schemas/README.md
+++ b/docs/reference/receipt-schemas/README.md
@@ -32,6 +32,7 @@ The schemas do not make integration, endorsement, correctness, safety,
 compliance, or full-platform truth claims. They only make the selected receipt
 boundary inspectable and testable.
 
-Schema `$id` values use release-tagged `raw.githubusercontent.com` URLs. In this
-branch they point at the intended `v3.8.0` contract line and become
-dereferenceable once the release tag is cut.
+Schema `$id` values use release-tagged `raw.githubusercontent.com` URLs. They
+point at the released `v3.8.0` contract line; later compatible releases carry
+the same bounded receipt/import schemas forward unless release notes say
+otherwise.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ site_name: Assay
 site_url: https://docs.assay.dev
 site_description: "CI-native evidence compiler and Trust Basis artifacts for agent systems"
 site_author: Assay Team
+exclude_docs: /README.md
 
 repo_name: Rul1an/assay
 repo_url: https://github.com/Rul1an/assay
@@ -109,6 +110,15 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.tilde
 
+validation:
+  links:
+    # Many architecture/archive notes intentionally link to repo-root source,
+    # scripts, fixtures, and historical files outside the generated docs site.
+    # The dedicated docs link-check workflow validates changed Markdown links
+    # against the repository filesystem; this setting lets the public site build
+    # run in strict mode without treating those repo-crosslinks as site pages.
+    not_found: ignore
+
 extra:
   social:
     - icon: fontawesome/brands/github
@@ -148,6 +158,11 @@ nav:
     - Replay Engine: concepts/replay.md
     - Cache & Fingerprints: concepts/cache.md
     - Scope & Boundaries: concepts/scope.md
+    - Evidence Receipt Notes:
+      - notes/index.md
+      - Evidence Receipts Technical Note: notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md
+      - Evidence Receipt Assurance Mapping: notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md
+      - Promptfoo Receipt Note: notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md
     - Fail-Safe Config: concepts/fail-safe.md
     - Pack Registry: concepts/pack-registry.md
 
@@ -163,6 +178,8 @@ nav:
 
   - Configuration:
     - reference/config/index.md
+    - Receipt Families: reference/receipt-families.md
+    - Receipt Schema Registry: reference/receipt-schemas/README.md
     - mcp-eval.yaml: reference/config/eval-yaml.md
     - Policy Files: reference/config/policies.md
     - Sandbox Policies: reference/sandbox-policies.md


### PR DESCRIPTION
## Summary

- align the docs entrypoints around the three released receipt families and the Assay/Harness boundary
- add the P57 ecosystem seeding pack with release-truth guardrails after the Promptfoo follow-up
- add the assurance mapping note, receipt-family wrapper, notes index, and docs nav entries
- add a reproducible `mkdocs build --strict` CI job while keeping repo-crosslink checks in the existing link checker

## Release Truth

- Assay `v3.9.1` and Assay Harness `v0.3.2` remain the current released binaries referenced by the docs.
- `FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md` is present in the public `v3.9.1` tag and is the only current outward Promptfoo-context link in P57.
- `EVIDENCE-RECEIPTS-IN-ACTION.md` is intentionally held for broader seeding until it is included in a future tagged Assay release, expected as a docs-only `v3.9.2` line.
- The mapping note remains main-only until tagged; P57 says not to promote it outward before that.

## Validation

- `git diff --check`
- `mkdocs build --strict`
- pre-commit hooks during commit: merge-conflict check, YAML check, EOF/whitespace, typos, actionlint, cargo fmt, clippy, linux compile gate
