### PR TITLE
docs: record MCP registry discovery freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Docs / Distribution
+
+- Added an MCP Registry discovery audit and tightened MCP Registry publish
+  docs around the canonical `io.github.Rul1an/assay-mcp-server` identity,
+  release-attached `server.json`, stale legacy registry entry handling, and
+  third-party directory freshness checks.
+
 ## [3.9.2] - 2026-05-04
 
 This patch release prepares the post-canonicalization evidence receipt surface

--- a/docs/DISTRIBUTION-SUBMISSION-GUIDE.md
+++ b/docs/DISTRIBUTION-SUBMISSION-GUIDE.md
@@ -213,8 +213,14 @@ De scan zoekt in de repo naar: `@modelcontextprotocol/sdk` (of `mcp`, `fastmcp`)
 - **Registry:** https://registry.modelcontextprotocol.io
 - **Schema:** https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json
 
-### Huidige status (2026-04)
-Dit is de primaire registry-route voor Assay, maar nog steeds **preview**. Gebruik hem alleen met een **gegenereerde** `release/server.json` uit een echte release asset set. Zie het als een publish-stap na een release, niet als iets dat al live is omdat de repo packaging klaar heeft.
+### Huidige status (2026-05)
+Dit is de primaire registry-route voor Assay, maar nog steeds **preview**.
+Gebruik hem alleen met een **gegenereerde** `release/server.json` uit een
+echte release asset set. De canonieke Assay identity is
+`io.github.Rul1an/assay-mcp-server`; oudere `io.github.Rul1an/assay`
+registry-resultaten zijn stale legacy discovery en horen deprecated te blijven,
+niet current. Zie ook de
+[MCP Registry Discovery Audit](ops/MCP-REGISTRY-DISCOVERY-AUDIT.md).
 
 ### Stappen
 
@@ -241,6 +247,10 @@ chmod +x scripts/publish-mcp-registry.sh
    ```bash
    mcp-publisher publish release/server.json
    ```
+6. Controleer de publieke registry:
+   ```bash
+   curl -fsSL 'https://registry.modelcontextprotocol.io/v0/servers?search=assay'
+   ```
 
 ### Exact invullen
 Gebruik **`release/server.json`**, niet een handmatig onderhouden rootbestand. Die metadata hoort gegenereerd te worden uit de echte MCPB release asset plus SHA-256, zodat versie, URL en package type blijven kloppen.
@@ -252,7 +262,7 @@ Gebruik **`release/server.json`**, niet een handmatig onderhouden rootbestand. D
 
 ### Troubleshooting
 - **Validate faalt** — Controleer eerst of `release/server.json` en de onderliggende `.mcpb` uit dezelfde release komen.
-- **Login faalt** — Auth opnieuw met `mcp-publisher login github`.
+- **Login faalt of token is verlopen** — Auth opnieuw met `mcp-publisher login github`.
 - **Publish faalt op namespace** — Controleer of de GitHub login overeenkomt met de `io.github.*` namespace in `release/server.json`.
 - **Preview drift** — De registry is nog preview; herlees de quickstart als de publish-flow veranderd is.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ and [community discussion seeds](community/DISCUSSIONS.md).
 
 **Evidence portability notes:** [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) explains the released `v3.8.0` receipt/schema surface and the first three claim-visible receipt families. [Evidence Receipts in Action](notes/EVIDENCE-RECEIPTS-IN-ACTION.md) shows the same three-family path with small checked-in artifacts generated from released Assay/Harness versions. The [receipt family matrix](reference/receipt-family-matrix.json) and [receipt schema registry](reference/receipt-schemas/README.md) are the machine-readable receipt-family references. The `v3.9.0` line adds assertion, schema CLI, Trust Card HTML, and MCP policy/tool digest review surfaces without adding new receipt families or Trust Basis claims. [From Promptfoo JSONL to Evidence Receipts](notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) explains the first Promptfoo assertion-component receipt path as a downstream evidence-portability recipe, not a Promptfoo integration or partnership claim.
 
+**Registry/discovery note:** [MCP Registry Discovery Audit](ops/MCP-REGISTRY-DISCOVERY-AUDIT.md) tracks the canonical `io.github.Rul1an/assay-mcp-server` release metadata, stale registry duplicates, and third-party directory freshness without treating any directory listing as the source of truth.
+
 ## 5-Minute Quickstart
 
 ### 1. Install

--- a/docs/ops/MCP-REGISTRY-DISCOVERY-AUDIT.md
+++ b/docs/ops/MCP-REGISTRY-DISCOVERY-AUDIT.md
@@ -1,0 +1,102 @@
+# MCP Registry Discovery Audit
+
+Date: 2026-05-06
+
+Status: Operational discovery note.
+
+This note tracks where the released Assay MCP server package can be found, where
+registry metadata is stale, and where third-party discovery surfaces still need
+follow-up. It is not a launch page, partnership claim, hosted-service claim, or
+new product surface.
+
+## Source Of Truth
+
+Assay registry metadata is release-attached, not hand-maintained from `main`.
+The canonical file for the current line is:
+
+- GitHub release: [`v3.9.2`](https://github.com/Rul1an/assay/releases/tag/v3.9.2)
+- Registry metadata:
+  [`server.json`](https://github.com/Rul1an/assay/releases/download/v3.9.2/server.json)
+- Canonical registry name: `io.github.Rul1an/assay-mcp-server`
+- Package type: `mcpb`
+- Transport: `stdio`
+- Compatibility: Linux MCPB package for this line
+
+The generated `server.json` for `v3.9.2` validates with:
+
+```bash
+mcp-publisher validate release/server.json
+```
+
+## Official Registry State
+
+Checked on 2026-05-06.
+
+| Surface | Observed state | Action |
+| --- | --- | --- |
+| Official MCP Registry search for `assay` | Canonical `io.github.Rul1an/assay-mcp-server` is active at `3.9.2` and marked latest. The older canonical `3.5.1` row remains active but not latest. | Keep publishing the canonical entry from release-attached `server.json` after each release. |
+| Legacy official registry identity | Stale `io.github.Rul1an/assay` at `3.1.0` is deprecated with a pointer to the canonical `io.github.Rul1an/assay-mcp-server` identity. | Leave deprecated, not deleted, so older discovery links have a safe migration signal. |
+| `v3.9.2` release metadata | `server.json` exists as a release asset, validates against the registry schema, and has been published to the canonical official registry identity. | Use this file for publish. Do not create a root-level static `server.json`. |
+| GitHub repo homepage | Updated to `https://getassay.dev` because the previous `http://www.getassay.dev` value did not resolve reliably. | Keep repo metadata aligned with the canonical site URL. |
+
+Publication command:
+
+```bash
+gh release download v3.9.2 --repo Rul1an/assay --pattern server.json --dir release
+mcp-publisher validate release/server.json
+mcp-publisher login github
+mcp-publisher publish release/server.json
+curl -fsSL 'https://registry.modelcontextprotocol.io/v0/servers?search=assay'
+```
+
+If `mcp-publisher publish` reports an expired registry token, rerun
+`mcp-publisher login github` and repeat the publish step. Boring on purpose,
+but it keeps release truth honest.
+
+If a stale legacy identity needs to remain discoverable but should no longer be
+presented as current, use the non-destructive status flow:
+
+```bash
+mcp-publisher status --status deprecated \
+  --message 'Canonical registry identity is io.github.Rul1an/assay-mcp-server; use the latest version there.' \
+  io.github.Rul1an/assay 3.1.0
+```
+
+## Third-Party Discovery State
+
+Checked on 2026-05-06. These directories are external indexes. Presence there
+does not imply endorsement, official integration, hosted availability, or
+registry truth.
+
+| Surface | Observed state | Action |
+| --- | --- | --- |
+| [MCPBench](https://mcpbench.ai/servers/io.github.Rul1an/assay) | Page returns `200`. | Recheck after the official registry refresh. If the page still tracks the legacy `io.github.Rul1an/assay` identity, prefer correcting the official registry first. |
+| [mcpservers.org](https://mcpservers.org/th/servers/rul1an/assay) | Page returns `200`. | Recheck after the official registry refresh. Do not claim freshness unless the listing shows the current release line. |
+| [mcp.so](https://mcp.so/server/assay) | Page returns `200`. | Recheck after the official registry refresh. Treat as third-party discovery only. |
+| [PulseMCP](https://www.pulsemcp.com/servers/gh-rul1an-assay) | Search previously found a listing, but direct `curl` is blocked by Cloudflare with `403`. | Verify manually in a browser before making any freshness claim. |
+| [Glama MCP directory](https://glama.ai/api/mcp/v1/servers?query=assay) | API search returns zero Assay results. | Candidate follow-up after official registry is current. Keep the submission factual: local MCPB package, no hosted server claim. |
+| [Smithery](https://api.smithery.ai/servers?q=assay) | API search returns unrelated results for `assay`, `Rul1an/assay`, and `assay-mcp-server`. | Candidate follow-up only if Smithery can represent a local stdio MCPB package honestly. Do not imply a remote deployment. |
+| [mcp.directory](https://mcp.directory/server/assay) | Exact page returns `404`. | Candidate follow-up after official registry is current. |
+
+## Guardrails
+
+This audit must not be used to claim:
+
+- official partnership or upstream endorsement;
+- hosted Assay MCP service availability;
+- cross-platform MCPB availability beyond the release asset set;
+- Trust Basis or evidence-receipt semantics changes;
+- freshness in third-party indexes that have not been rechecked;
+- that a third-party directory listing is the source of truth.
+
+## Release Cadence
+
+After each Assay release that includes an MCPB package:
+
+1. Confirm the release includes `assay-mcp-server-<version>-linux.mcpb`.
+2. Confirm the release includes generated `server.json`.
+3. Run `mcp-publisher validate` against that exact `server.json`.
+4. Publish the canonical `io.github.Rul1an/assay-mcp-server` entry.
+5. Recheck the official registry search result.
+6. Recheck third-party directories and update this audit only with observed
+   facts.

--- a/packaging/mcp-registry/README.md
+++ b/packaging/mcp-registry/README.md
@@ -7,9 +7,27 @@ release workflow.
 
 Current v1 registry direction:
 - canonical surface: `assay-mcp-server`
+- canonical registry name: `io.github.Rul1an/assay-mcp-server`
 - package type: `mcpb`
 - transport: `stdio`
 - compatibility: Linux only for the first honest release line
+
+Current release-truth check:
+
+```bash
+gh release download v3.9.2 --repo Rul1an/assay --pattern server.json --dir release
+mcp-publisher validate release/server.json
+mcp-publisher login github
+mcp-publisher publish release/server.json
+curl -fsSL 'https://registry.modelcontextprotocol.io/v0/servers?search=assay'
+```
+
+Use this generated release asset, not a hand-maintained root `server.json`.
+The stale legacy `io.github.Rul1an/assay` identity has been deprecated rather
+than deleted, so old discovery links have a safe migration signal while the
+canonical `assay-mcp-server` line stays current. The registry/discovery audit
+lives at
+[`../../docs/ops/MCP-REGISTRY-DISCOVERY-AUDIT.md`](../../docs/ops/MCP-REGISTRY-DISCOVERY-AUDIT.md).
 
 Supporting files:
 - `../mcpb/manifest.assay-mcp-server.template.json`


### PR DESCRIPTION
What changed

Records the registry/discovery freshness work for the current Assay MCP server release line.

This PR includes:

- new MCP Registry Discovery Audit under docs/ops
- MCP Registry packaging README updates for the canonical io.github.Rul1an/assay-mcp-server identity
- distribution guide updates for v3.9.2 publish verification and expired-token recovery
- docs index and changelog links

Why

Visibility for Assay is currently more registry-native than social-channel-native. The official MCP Registry entry was stale, third-party directories are uneven, and the repo homepage metadata pointed at a non-resolving www URL. This records the release-truth path without turning directory listings into endorsement, partnership, hosted-service, or product-semantics claims.

Operational work already performed

- published the v3.9.2 release server.json to the official MCP Registry
- confirmed io.github.Rul1an/assay-mcp-server is active at 3.9.2 and marked latest
- deprecated stale legacy io.github.Rul1an/assay 3.1.0 rather than deleting it
- updated the GitHub repo homepage to https://getassay.dev

Boundary

Docs/discovery only. No runtime behavior, MCPB packaging behavior, evidence semantics, Trust Basis claims, Harness semantics, hosted service, third-party partnership claim, or official integration claim.

Validation

Ran locally:

- mcp-publisher validate v3.9.2 server.json
- mcp-publisher publish v3.9.2 server.json
- mcp-publisher status --status deprecated for the stale legacy registry identity
- official MCP Registry search verification
- GitHub repo homepage verification
- local changed-docs markdown link check
- git diff --cached --check
- pre-commit hooks on commit
- push-time hooks, including cargo fmt, workspace clippy, and linux compile gate

Note: mkdocs build --strict was not run locally because mkdocs is not installed in this worktree environment; the PR docs workflow should cover it.
