### PR TITLE
[codex] characterize Wave 51 MCP proxy before split

### DIFF
--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -639,6 +639,10 @@ mod tests {
         }
     }
 
+    fn proxy_contract_request(value: serde_json::Value) -> JsonRpcRequest {
+        serde_json::from_value(value).expect("test JSON-RPC request should deserialize")
+    }
+
     #[test]
     fn event_source_accepts_assay_uri() {
         validate_event_source("assay://myorg/myapp").unwrap();
@@ -762,6 +766,168 @@ mod tests {
         assert_eq!(observation.identity.server_id, "server-a");
         assert!(observation.binding.is_some());
         assert!(tool.get("tool_identity").is_some());
+    }
+
+    #[test]
+    fn proxy_contract_tool_call_id_prefers_meta() {
+        let request = proxy_contract_request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "request-a",
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {
+                    "_meta": {
+                        "tool_call_id": "tc_explicit_001"
+                    }
+                }
+            }
+        }));
+
+        assert_eq!(McpProxy::extract_tool_call_id(&request), "tc_explicit_001");
+    }
+
+    #[test]
+    fn proxy_contract_tool_call_id_uses_request_id() {
+        let string_request = proxy_contract_request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "request-a",
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {}
+            }
+        }));
+        let numeric_request = proxy_contract_request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {}
+            }
+        }));
+
+        assert_eq!(
+            McpProxy::extract_tool_call_id(&string_request),
+            "req_request-a"
+        );
+        assert_eq!(McpProxy::extract_tool_call_id(&numeric_request), "req_42");
+    }
+
+    #[test]
+    fn proxy_contract_unknown_tool_call_id_is_generated() {
+        let request = proxy_contract_request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {}
+            }
+        }));
+
+        let generated = McpProxy::extract_tool_call_id(&request);
+        assert!(
+            generated.starts_with("gen_"),
+            "missing request id should produce generated idempotency key"
+        );
+    }
+
+    #[test]
+    fn proxy_contract_policy_code_mapping_is_stable() {
+        assert_eq!(
+            McpProxy::map_policy_code("E_TOOL_DENIED"),
+            reason_codes::P_TOOL_DENIED
+        );
+        assert_eq!(
+            McpProxy::map_policy_code("E_TOOL_NOT_ALLOWED"),
+            reason_codes::P_TOOL_NOT_ALLOWED
+        );
+        assert_eq!(
+            McpProxy::map_policy_code("E_ARG_SCHEMA"),
+            reason_codes::P_ARG_SCHEMA
+        );
+        assert_eq!(
+            McpProxy::map_policy_code("E_RATE_LIMIT"),
+            reason_codes::P_RATE_LIMIT
+        );
+        assert_eq!(
+            McpProxy::map_policy_code("E_TOOL_DRIFT"),
+            reason_codes::P_TOOL_DRIFT
+        );
+        assert_eq!(
+            McpProxy::map_policy_code("E_UNKNOWN_NEW_CODE"),
+            reason_codes::P_POLICY_DENY
+        );
+    }
+
+    #[test]
+    fn proxy_contract_observe_tool_definition_rejects_empty_names() {
+        let mut tool = serde_json::json!({
+            "name": "   ",
+            "description": "invalid",
+            "inputSchema": {"type": "object"}
+        });
+
+        let observation = McpProxy::observe_tool_definition(&mut tool, "server-a");
+
+        assert!(observation.is_none());
+        assert!(tool.get("tool_identity").is_none());
+    }
+
+    #[test]
+    fn proxy_contract_emit_decision_preserves_core_fields() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let emitter_trait: Arc<dyn DecisionEmitter> = emitter.clone();
+        let metadata = PolicyMatchMetadata {
+            tool_classes: vec!["fs.read".to_string()],
+            matched_tool_classes: vec!["fs.read".to_string()],
+            match_basis: crate::mcp::tool_match::MatchBasis::NameAndClass,
+            matched_rule: Some("allow-read-file".to_string()),
+            policy_version: Some("2026-05".to_string()),
+            policy_digest: Some("sha256:policy".to_string()),
+            lane: Some("local-dev".to_string()),
+            principal: Some("user:alice".to_string()),
+            auth_context_summary: Some("local session".to_string()),
+            ..PolicyMatchMetadata::default()
+        };
+
+        McpProxy::emit_decision(
+            &emitter_trait,
+            "assay://test",
+            "tc_core_fields",
+            "read_file",
+            Decision::Deny,
+            reason_codes::P_TOOL_DENIED,
+            Some("blocked by test policy".to_string()),
+            Some(serde_json::json!("request-a")),
+            &metadata,
+            None,
+        );
+
+        let events = emitter.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source, "assay://test");
+        let data = &events[0].data;
+        assert_eq!(data.tool, "read_file");
+        assert_eq!(data.tool_call_id, "tc_core_fields");
+        assert_eq!(data.decision, Decision::Deny);
+        assert_eq!(data.reason_code, reason_codes::P_TOOL_DENIED);
+        assert_eq!(data.reason.as_deref(), Some("blocked by test policy"));
+        assert_eq!(data.request_id, Some(serde_json::json!("request-a")));
+        assert_eq!(data.tool_classes, vec!["fs.read".to_string()]);
+        assert_eq!(data.matched_tool_classes, vec!["fs.read".to_string()]);
+        assert_eq!(data.match_basis.as_deref(), Some("name+class"));
+        assert_eq!(data.matched_rule.as_deref(), Some("allow-read-file"));
+        assert_eq!(data.policy_version.as_deref(), Some("2026-05"));
+        assert_eq!(data.policy_digest.as_deref(), Some("sha256:policy"));
+        assert_eq!(
+            data.policy_snapshot_digest.as_deref(),
+            Some("sha256:policy")
+        );
+        assert_eq!(data.lane.as_deref(), Some("local-dev"));
+        assert_eq!(data.principal.as_deref(), Some("user:alice"));
+        assert_eq!(data.auth_context_summary.as_deref(), Some("local session"));
     }
 
     #[test]

--- a/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step3.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step3.md
@@ -1,0 +1,45 @@
+# SPLIT CHECKLIST - Wave 51 MCP Proxy Step3
+
+## Scope Lock
+
+- Characterize `crates/assay-core/src/mcp/proxy.rs` before any module split.
+- Preserve `McpProxy` as the stable facade for spawn/run behavior.
+- Add focused contract tests around JSON-RPC tool-call idempotency, policy reason-code mapping, tool-definition observation, and decision-event field projection.
+- Do not move proxy code yet.
+- Do not change policy semantics, stdio passthrough behavior, audit logging, decision emission, workflows, or generated files.
+
+## Files
+
+- `crates/assay-core/src/mcp/proxy.rs`
+- `docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step3.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step3.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step3.md`
+- `scripts/ci/review-wave51-hotspot-mcp-proxy-step3.sh`
+
+## Drift Gates
+
+- `McpProxy` remains in `mcp/proxy.rs`.
+- `McpProxy::run` remains in `mcp/proxy.rs`.
+- server-to-client and client-to-server thread boundaries remain visible in `mcp/proxy.rs`.
+- deny responses still use `make_deny_response`.
+- decision event emission still flows through `emit_decision`.
+- tool-definition enrichment still flows through `observe_tool_definition`.
+- idempotency keys still flow through `extract_tool_call_id`.
+- no `crates/assay-core/src/mcp/proxy/` submodule directory is introduced in Step 3.
+
+## Validation
+
+```bash
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_
+bash scripts/ci/review-wave51-hotspot-mcp-proxy-step3.sh
+```
+
+## Definition of Done
+
+- Step 3 reviewer script passes.
+- `proxy_contract_*` tests pass.
+- No proxy code is moved yet.
+- Step 4 can split proxy internals using these tests as a behavioral safety net.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step3.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step3.md
@@ -1,0 +1,36 @@
+# SPLIT MOVE MAP - Wave 51 MCP Proxy Step3
+
+## Intent
+
+Freeze behavior in `crates/assay-core/src/mcp/proxy.rs` before splitting the proxy hotspot. Step 3 intentionally adds characterization coverage only; it is the safety rail for the later mechanical move.
+
+## Moves
+
+| From | To | Notes |
+| --- | --- | --- |
+| none | none | Step 3 is characterization only. No proxy code moves in this step. |
+
+## Characterized Seams
+
+| Seam | Contract |
+| --- | --- |
+| JSON-RPC idempotency key extraction | `_meta.tool_call_id` wins over request id; string and numeric request ids map to `req_*`; missing ids generate `gen_*`. |
+| Policy reason-code mapping | known legacy policy codes map to stable `P_*` reason codes; unknown codes fail closed to `P_POLICY_DENY`. |
+| Tool-definition observation | empty tool names are ignored and do not mutate outbound tool JSON with `tool_identity`. |
+| Decision event projection | source, tool, tool_call_id, decision, reason, request id, match metadata, policy digest snapshot, lane, principal, and auth summary stay projected. |
+
+## Step 4 Candidate Moves
+
+| Candidate responsibility | Target shape | Review risk |
+| --- | --- | --- |
+| server-to-client tools/list enrichment | `mcp/proxy/server.rs` or `mcp/proxy/tools_list.rs` | Preserve stdout passthrough and per-line processing. |
+| client-to-server policy loop | `mcp/proxy/client.rs` or `mcp/proxy/policy_loop.rs` | Preserve exactly-one decision event per tool call attempt. |
+| idempotency and reason-code helpers | `mcp/proxy/decision.rs` | Keep fallback behavior stable. |
+| tool-definition observation/cache update | `mcp/proxy/tool_observation.rs` | Preserve identity and bounded binding atomicity. |
+| spawn/facade state | `mcp/proxy/mod.rs` | Keep `McpProxy::spawn` and `McpProxy::run` as the public facade. |
+
+## Reviewer Focus
+
+- Treat this as behavior-freeze, not architecture movement.
+- Prefer additive tests over helper extraction in this step.
+- The next PR should be allowed to move code only if these contracts stay green.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step3.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step3.md
@@ -1,0 +1,36 @@
+# SPLIT REVIEW PACK - Wave 51 MCP Proxy Step3
+
+## Summary
+
+Step 3 prepares the MCP proxy hotspot for a later module split by adding contract tests and a review gate. No proxy implementation blocks are moved in this step.
+
+## Behavioral Contracts Added
+
+- explicit MCP `_meta.tool_call_id` remains the preferred idempotency key.
+- string and numeric JSON-RPC request ids remain deterministic fallback keys.
+- missing request ids still generate `gen_*` fallback keys.
+- legacy policy error codes still map to stable decision-event reason codes.
+- unknown policy error codes still normalize to `P_POLICY_DENY`.
+- empty tool names are not observed and do not gain `tool_identity`.
+- decision event projection preserves the core request, policy, match, and auth-context fields used downstream.
+
+## Boundary Proof
+
+```bash
+rg -n 'pub struct McpProxy|pub fn run\(|thread::spawn|make_deny_response|emit_decision|observe_tool_definition|extract_tool_call_id' crates/assay-core/src/mcp/proxy.rs
+find crates/assay-core/src/mcp -maxdepth 2 -type f | sort | rg 'mcp/proxy/'
+```
+
+The second command should return no files for Step 3.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check -p assay-core`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- `cargo test -p assay-core --lib proxy_contract_`
+- `bash scripts/ci/review-wave51-hotspot-mcp-proxy-step3.sh`
+
+## Next Step
+
+Step 4 can perform the actual proxy split with the Step 3 tests acting as the no-regression harness. Recommended first split target: tool-call idempotency, policy-code mapping, and decision emission helpers, because those are pure and easiest to verify before moving the threaded stdio loops.

--- a/scripts/ci/review-wave51-hotspot-mcp-proxy-step3.sh
+++ b/scripts/ci/review-wave51-hotspot-mcp-proxy-step3.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+PROXY="crates/assay-core/src/mcp/proxy.rs"
+
+assert_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if ! rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+echo "[review] workflow and generated-file guard"
+if ! git diff --quiet -- .github/workflows; then
+  echo "FAIL: Wave 51 MCP Proxy Step3 must not touch workflows"
+  exit 1
+fi
+if ! git diff --quiet -- crates/assay-ebpf/src/vmlinux.rs; then
+  echo "FAIL: generated vmlinux.rs must stay out of scope"
+  exit 1
+fi
+
+echo "[review] characterization-only boundary"
+if [ -d crates/assay-core/src/mcp/proxy ]; then
+  echo "FAIL: Step3 must not introduce proxy submodules yet"
+  exit 1
+fi
+assert_rg 'pub struct McpProxy' "$PROXY" "McpProxy facade moved out of proxy.rs"
+assert_rg 'pub fn run\(' "$PROXY" "McpProxy::run moved out of proxy.rs"
+assert_rg 'thread::spawn' "$PROXY" "threaded proxy loops no longer visible in proxy.rs"
+assert_rg 'make_deny_response' "$PROXY" "deny response path marker missing"
+assert_rg 'fn emit_decision\(' "$PROXY" "decision event projection marker missing"
+assert_rg 'fn observe_tool_definition\(' "$PROXY" "tool-definition observation marker missing"
+assert_rg 'fn extract_tool_call_id\(' "$PROXY" "idempotency helper marker missing"
+
+echo "[review] proxy contract tests"
+assert_rg 'proxy_contract_tool_call_id_prefers_meta' "$PROXY" "explicit tool_call_id contract test missing"
+assert_rg 'proxy_contract_tool_call_id_uses_request_id' "$PROXY" "request id fallback contract test missing"
+assert_rg 'proxy_contract_unknown_tool_call_id_is_generated' "$PROXY" "generated id contract test missing"
+assert_rg 'proxy_contract_policy_code_mapping_is_stable' "$PROXY" "policy code mapping contract test missing"
+assert_rg 'proxy_contract_observe_tool_definition_rejects_empty_names' "$PROXY" "empty tool definition contract test missing"
+assert_rg 'proxy_contract_emit_decision_preserves_core_fields' "$PROXY" "decision projection contract test missing"
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_
+git diff --check
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary

Characterizes the Wave 51 MCP proxy hotspot before any proxy module split.

- Adds `proxy_contract_*` tests for JSON-RPC tool-call idempotency keys, policy reason-code mapping, tool-definition observation, and decision-event field projection.
- Adds Step 3 SPLIT checklist, move-map, review-pack, and reviewer gate.
- Keeps `crates/assay-core/src/mcp/proxy.rs` as-is structurally: no proxy code moved yet.

## Scope

Included:

- `crates/assay-core/src/mcp/proxy.rs`
- `docs/contributing/SPLIT-*wave51-hotspot-mcp-proxy-step3.md`
- `scripts/ci/review-wave51-hotspot-mcp-proxy-step3.sh`

Explicitly excluded:

- any proxy module split
- policy semantic changes
- stdio passthrough changes
- workflow changes
- unrelated local architecture/example/token files

## Validation

```bash
bash scripts/ci/review-wave51-hotspot-mcp-proxy-step3.sh
```

This includes:

```bash
cargo fmt --check
cargo check -p assay-core
cargo clippy -p assay-core --all-targets -- -D warnings
cargo test -p assay-core --lib proxy_contract_
git diff --check
```

## Chain

PR #1172 has landed, so this PR targets `main` directly.

## Next

After this lands, Step 4 can mechanically split MCP proxy internals while keeping these characterization contracts green.
