### PR TITLE
[codex] split Wave 51 MCP proxy helpers

### DIFF
--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -1,13 +1,15 @@
 use super::audit::{AuditEvent, AuditLog};
+mod decisions;
+mod tools;
+
+use self::decisions::{emit_decision, extract_tool_call_id, handle_allow, map_policy_code};
+use self::tools::observe_tool_definition;
 use super::decision::{
-    reason_codes, refresh_contract_projections, Decision, DecisionEmitter, DecisionEvent,
-    FileDecisionEmitter, NullDecisionEmitter,
+    reason_codes, Decision, DecisionEmitter, FileDecisionEmitter, NullDecisionEmitter,
 };
 use super::jsonrpc::JsonRpcRequest;
-use super::policy::{
-    make_deny_response, McpPolicy, PolicyDecision, PolicyMatchMetadata, PolicyState,
-};
-use super::tool_definition::{binding_from_tools_list_tool, ToolDefinitionBinding};
+use super::policy::{make_deny_response, McpPolicy, PolicyDecision, PolicyState};
+use super::tool_definition::ToolDefinitionBinding;
 use std::{
     collections::HashMap,
     io::{self, BufRead, BufReader, Write},
@@ -190,7 +192,7 @@ impl McpProxy {
                         {
                             for tool in tools {
                                 if let Some(observation) =
-                                    Self::observe_tool_definition(tool, &config.server_id)
+                                    observe_tool_definition(tool, &config.server_id)
                                 {
                                     let mut identity_cache = identity_cache_a.lock().unwrap();
                                     identity_cache.insert(
@@ -255,7 +257,7 @@ impl McpProxy {
                         };
 
                         let tool_name = req.tool_params().map(|p| p.name).unwrap_or_default();
-                        let tool_call_id = Self::extract_tool_call_id(&req);
+                        let tool_call_id = extract_tool_call_id(&req);
 
                         let policy_eval = policy.evaluate_with_metadata(
                             &tool_name,
@@ -268,10 +270,10 @@ impl McpProxy {
 
                         match policy_eval.decision {
                             PolicyDecision::Allow => {
-                                Self::handle_allow(&req, &mut audit_log, config.verbose);
+                                handle_allow(&req, &mut audit_log, config.verbose);
                                 // Emit decision event (I1: always emit)
                                 if req.is_tool_call() {
-                                    Self::emit_decision(
+                                    emit_decision(
                                         &emitter_b,
                                         &event_source_b,
                                         &tool_call_id,
@@ -304,7 +306,7 @@ impl McpProxy {
                                     agentic: None,
                                 });
                                 // Emit decision event (I1: always emit)
-                                Self::emit_decision(
+                                emit_decision(
                                     &emitter_b,
                                     &event_source_b,
                                     &tool_call_id,
@@ -317,7 +319,7 @@ impl McpProxy {
                                     tool_definition_binding.as_ref(),
                                 );
                                 // Then proceed as a normal allow
-                                Self::handle_allow(&req, &mut audit_log, false);
+                                handle_allow(&req, &mut audit_log, false);
                                 // false = don't double log ALLOW
                             }
                             PolicyDecision::Deny {
@@ -349,8 +351,8 @@ impl McpProxy {
                                 });
 
                                 // Emit decision event (I1: always emit)
-                                let reason_code = Self::map_policy_code(&code);
-                                Self::emit_decision(
+                                let reason_code = map_policy_code(&code);
+                                emit_decision(
                                     &emitter_b,
                                     &event_source_b,
                                     &tool_call_id,
@@ -424,224 +426,11 @@ impl McpProxy {
         let status = self.child.wait()?;
         Ok(status.code().unwrap_or(1))
     }
-
-    fn handle_allow(req: &JsonRpcRequest, audit_log: &mut AuditLog, verbose: bool) {
-        if verbose && req.is_tool_call() {
-            let tool = req
-                .tool_params()
-                .map(|p| p.name)
-                .unwrap_or_else(|| "unknown".to_string());
-            eprintln!("[assay] ALLOW {}", tool);
-        }
-
-        if req.is_tool_call() {
-            let tool = req.tool_params().map(|p| p.name);
-            audit_log.log(&AuditEvent {
-                timestamp: chrono::Utc::now().to_rfc3339(),
-                decision: "allow".to_string(),
-                tool,
-                reason: None,
-                request_id: req.id.clone(),
-                agentic: None,
-            });
-        }
-    }
-
-    /// Extract tool_call_id from request (I4: idempotency key).
-    fn extract_tool_call_id(request: &JsonRpcRequest) -> String {
-        // Try to get from params._meta.tool_call_id (MCP standard)
-        if let Some(params) = request.tool_params() {
-            if let Some(meta) = params.arguments.get("_meta") {
-                if let Some(id) = meta.get("tool_call_id").and_then(|v| v.as_str()) {
-                    return id.to_string();
-                }
-            }
-        }
-
-        // Fall back to request.id if present
-        if let Some(id) = &request.id {
-            if let Some(s) = id.as_str() {
-                return format!("req_{}", s);
-            }
-            if let Some(n) = id.as_i64() {
-                return format!("req_{}", n);
-            }
-        }
-
-        // Generate one if none found
-        format!("gen_{}", uuid::Uuid::new_v4())
-    }
-
-    /// Map policy error code to reason code.
-    fn map_policy_code(code: &str) -> String {
-        match code {
-            "E_TOOL_DENIED" => reason_codes::P_TOOL_DENIED.to_string(),
-            "E_TOOL_NOT_ALLOWED" => reason_codes::P_TOOL_NOT_ALLOWED.to_string(),
-            "E_ARG_SCHEMA" => reason_codes::P_ARG_SCHEMA.to_string(),
-            "E_RATE_LIMIT" => reason_codes::P_RATE_LIMIT.to_string(),
-            "E_TOOL_DRIFT" => reason_codes::P_TOOL_DRIFT.to_string(),
-            _ => reason_codes::P_POLICY_DENY.to_string(),
-        }
-    }
-
-    /// Emit a decision event (I1: always emit).
-    #[allow(clippy::too_many_arguments)]
-    fn emit_decision(
-        emitter: &Arc<dyn DecisionEmitter>,
-        source: &str,
-        tool_call_id: &str,
-        tool: &str,
-        decision: Decision,
-        reason_code: &str,
-        reason: Option<String>,
-        request_id: Option<serde_json::Value>,
-        metadata: &PolicyMatchMetadata,
-        tool_definition_binding: Option<&ToolDefinitionBinding>,
-    ) {
-        let mut event = DecisionEvent::new(
-            source.to_string(),
-            tool_call_id.to_string(),
-            tool.to_string(),
-        );
-        event.data.decision = decision;
-        event.data.reason_code = reason_code.to_string();
-        event.data.reason = reason;
-        event.data.request_id = request_id;
-        event.data.tool_classes = metadata.tool_classes.clone();
-        event.data.matched_tool_classes = metadata.matched_tool_classes.clone();
-        event.data.match_basis = metadata.match_basis.as_str().map(ToString::to_string);
-        event.data.matched_rule = metadata.matched_rule.clone();
-        event.data.typed_decision = metadata.typed_decision;
-        event.data.policy_version = metadata.policy_version.clone();
-        event.data.policy_digest = metadata.policy_digest.clone();
-        event.data.apply_policy_snapshot_projection();
-        event
-            .data
-            .apply_tool_definition_binding(tool_definition_binding);
-        event.data.obligations = metadata.obligations.clone();
-        event.data.obligation_outcomes =
-            super::obligations::execute_log_only(&metadata.obligations, tool);
-        event.data.approval_state = metadata.approval_state.clone();
-        if let Some(artifact) = &metadata.approval_artifact {
-            event.data.approval_id = Some(artifact.approval_id.clone());
-            event.data.approver = Some(artifact.approver.clone());
-            event.data.issued_at = Some(artifact.issued_at.clone());
-            event.data.expires_at = Some(artifact.expires_at.clone());
-            event.data.scope = Some(artifact.scope.clone());
-            event.data.approval_bound_tool = Some(artifact.bound_tool.clone());
-            event.data.approval_bound_resource = Some(artifact.bound_resource.clone());
-        }
-        event.data.approval_freshness = metadata.approval_freshness;
-        event.data.approval_failure_reason = metadata.approval_failure_reason.clone();
-        event.data.scope_type = metadata.scope_type.clone();
-        event.data.scope_value = metadata.scope_value.clone();
-        event.data.scope_match_mode = metadata.scope_match_mode.clone();
-        event.data.scope_evaluation_state = metadata.scope_evaluation_state.clone();
-        event.data.scope_failure_reason = metadata.scope_failure_reason.clone();
-        event.data.restrict_scope_present = metadata.restrict_scope_present;
-        event.data.restrict_scope_target = metadata.restrict_scope_target.clone();
-        event.data.restrict_scope_match = metadata.restrict_scope_match;
-        event.data.restrict_scope_reason = metadata.restrict_scope_reason.clone();
-        event.data.redaction_target = metadata.redaction_target.clone();
-        event.data.redaction_mode = metadata.redaction_mode.clone();
-        event.data.redaction_scope = metadata.redaction_scope.clone();
-        event.data.redaction_applied_state = metadata.redaction_applied_state.clone();
-        event.data.redaction_reason = metadata.redaction_reason.clone();
-        event.data.redaction_failure_reason = metadata.redaction_failure_reason.clone();
-        event.data.redact_args_present = metadata.redact_args_present;
-        event.data.redact_args_target = metadata.redact_args_target.clone();
-        event.data.redact_args_mode = metadata.redact_args_mode.clone();
-        event.data.redact_args_result = metadata.redact_args_result.clone();
-        event.data.redact_args_reason = metadata.redact_args_reason.clone();
-        event.data.fail_closed = metadata.fail_closed.clone();
-        event.data.lane = metadata.lane.clone();
-        event.data.principal = metadata.principal.clone();
-        event.data.auth_context_summary = metadata.auth_context_summary.clone();
-        event.data.auth_scheme = metadata.auth_scheme.clone();
-        event.data.auth_issuer = metadata.auth_issuer.clone();
-        event.data.delegated_from = metadata.delegated_from.clone();
-        event.data.delegation_depth = metadata.delegation_depth;
-        refresh_contract_projections(&mut event.data);
-        emitter.emit(&event);
-    }
-
-    fn observe_tool_definition(
-        tool: &mut serde_json::Value,
-        server_id: &str,
-    ) -> Option<ToolDefinitionObservation> {
-        let name = tool.get("name").and_then(|n| n.as_str())?;
-        if name.trim().is_empty() {
-            return None;
-        }
-        let name = name.to_string();
-        let description = tool
-            .get("description")
-            .and_then(|d| d.as_str())
-            .map(|s| s.to_string());
-        let input_schema = tool
-            .get("inputSchema")
-            .or_else(|| tool.get("input_schema"))
-            .cloned();
-
-        let identity =
-            super::identity::ToolIdentity::new(server_id, &name, &input_schema, &description);
-        let binding = binding_from_tools_list_tool(tool, Some(server_id))
-            .ok()
-            .flatten();
-
-        // Augment the response with the computed identity for downstream/logging.
-        tool.as_object_mut().and_then(|m| {
-            m.insert(
-                "tool_identity".to_string(),
-                serde_json::to_value(&identity).unwrap(),
-            )
-        });
-
-        Some(ToolDefinitionObservation {
-            name,
-            identity,
-            binding,
-        })
-    }
-}
-
-struct ToolDefinitionObservation {
-    name: String,
-    identity: super::identity::ToolIdentity,
-    binding: Option<ToolDefinitionBinding>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mcp::tool_definition::{
-        TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1,
-        TOOL_DEFINITION_DIGEST_ALG_SHA256, TOOL_DEFINITION_SCHEMA_V1,
-        TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST,
-    };
-    use std::sync::Mutex as StdMutex;
-
-    struct CapturingEmitter {
-        events: StdMutex<Vec<DecisionEvent>>,
-    }
-
-    impl CapturingEmitter {
-        fn new() -> Self {
-            Self {
-                events: StdMutex::new(Vec::new()),
-            }
-        }
-    }
-
-    impl DecisionEmitter for CapturingEmitter {
-        fn emit(&self, event: &DecisionEvent) {
-            self.events.lock().unwrap().push(event.clone());
-        }
-    }
-
-    fn proxy_contract_request(value: serde_json::Value) -> JsonRpcRequest {
-        serde_json::from_value(value).expect("test JSON-RPC request should deserialize")
-    }
 
     #[test]
     fn event_source_accepts_assay_uri() {
@@ -747,233 +536,5 @@ mod tests {
         };
 
         assert!(ProxyConfig::try_from_raw(raw).is_err());
-    }
-
-    #[test]
-    fn observe_tool_definition_computes_identity_and_binding() {
-        let mut tool = serde_json::json!({
-            "name": "read_file",
-            "description": " Read files ",
-            "inputSchema": {"type": "object"},
-            "annotations": {"title": "Read"},
-            "x-assay-sig": {"signature": "opaque"}
-        });
-
-        let observation = McpProxy::observe_tool_definition(&mut tool, "server-a")
-            .expect("supported tool definition should be observed");
-
-        assert_eq!(observation.name, "read_file");
-        assert_eq!(observation.identity.server_id, "server-a");
-        assert!(observation.binding.is_some());
-        assert!(tool.get("tool_identity").is_some());
-    }
-
-    #[test]
-    fn proxy_contract_tool_call_id_prefers_meta() {
-        let request = proxy_contract_request(serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": "request-a",
-            "method": "tools/call",
-            "params": {
-                "name": "read_file",
-                "arguments": {
-                    "_meta": {
-                        "tool_call_id": "tc_explicit_001"
-                    }
-                }
-            }
-        }));
-
-        assert_eq!(McpProxy::extract_tool_call_id(&request), "tc_explicit_001");
-    }
-
-    #[test]
-    fn proxy_contract_tool_call_id_uses_request_id() {
-        let string_request = proxy_contract_request(serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": "request-a",
-            "method": "tools/call",
-            "params": {
-                "name": "read_file",
-                "arguments": {}
-            }
-        }));
-        let numeric_request = proxy_contract_request(serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 42,
-            "method": "tools/call",
-            "params": {
-                "name": "read_file",
-                "arguments": {}
-            }
-        }));
-
-        assert_eq!(
-            McpProxy::extract_tool_call_id(&string_request),
-            "req_request-a"
-        );
-        assert_eq!(McpProxy::extract_tool_call_id(&numeric_request), "req_42");
-    }
-
-    #[test]
-    fn proxy_contract_unknown_tool_call_id_is_generated() {
-        let request = proxy_contract_request(serde_json::json!({
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "params": {
-                "name": "read_file",
-                "arguments": {}
-            }
-        }));
-
-        let generated = McpProxy::extract_tool_call_id(&request);
-        assert!(
-            generated.starts_with("gen_"),
-            "missing request id should produce generated idempotency key"
-        );
-    }
-
-    #[test]
-    fn proxy_contract_policy_code_mapping_is_stable() {
-        assert_eq!(
-            McpProxy::map_policy_code("E_TOOL_DENIED"),
-            reason_codes::P_TOOL_DENIED
-        );
-        assert_eq!(
-            McpProxy::map_policy_code("E_TOOL_NOT_ALLOWED"),
-            reason_codes::P_TOOL_NOT_ALLOWED
-        );
-        assert_eq!(
-            McpProxy::map_policy_code("E_ARG_SCHEMA"),
-            reason_codes::P_ARG_SCHEMA
-        );
-        assert_eq!(
-            McpProxy::map_policy_code("E_RATE_LIMIT"),
-            reason_codes::P_RATE_LIMIT
-        );
-        assert_eq!(
-            McpProxy::map_policy_code("E_TOOL_DRIFT"),
-            reason_codes::P_TOOL_DRIFT
-        );
-        assert_eq!(
-            McpProxy::map_policy_code("E_UNKNOWN_NEW_CODE"),
-            reason_codes::P_POLICY_DENY
-        );
-    }
-
-    #[test]
-    fn proxy_contract_observe_tool_definition_rejects_empty_names() {
-        let mut tool = serde_json::json!({
-            "name": "   ",
-            "description": "invalid",
-            "inputSchema": {"type": "object"}
-        });
-
-        let observation = McpProxy::observe_tool_definition(&mut tool, "server-a");
-
-        assert!(observation.is_none());
-        assert!(tool.get("tool_identity").is_none());
-    }
-
-    #[test]
-    fn proxy_contract_emit_decision_preserves_core_fields() {
-        let emitter = Arc::new(CapturingEmitter::new());
-        let emitter_trait: Arc<dyn DecisionEmitter> = emitter.clone();
-        let metadata = PolicyMatchMetadata {
-            tool_classes: vec!["fs.read".to_string()],
-            matched_tool_classes: vec!["fs.read".to_string()],
-            match_basis: crate::mcp::tool_match::MatchBasis::NameAndClass,
-            matched_rule: Some("allow-read-file".to_string()),
-            policy_version: Some("2026-05".to_string()),
-            policy_digest: Some("sha256:policy".to_string()),
-            lane: Some("local-dev".to_string()),
-            principal: Some("user:alice".to_string()),
-            auth_context_summary: Some("local session".to_string()),
-            ..PolicyMatchMetadata::default()
-        };
-
-        McpProxy::emit_decision(
-            &emitter_trait,
-            "assay://test",
-            "tc_core_fields",
-            "read_file",
-            Decision::Deny,
-            reason_codes::P_TOOL_DENIED,
-            Some("blocked by test policy".to_string()),
-            Some(serde_json::json!("request-a")),
-            &metadata,
-            None,
-        );
-
-        let events = emitter.events.lock().unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].source, "assay://test");
-        let data = &events[0].data;
-        assert_eq!(data.tool, "read_file");
-        assert_eq!(data.tool_call_id, "tc_core_fields");
-        assert_eq!(data.decision, Decision::Deny);
-        assert_eq!(data.reason_code, reason_codes::P_TOOL_DENIED);
-        assert_eq!(data.reason.as_deref(), Some("blocked by test policy"));
-        assert_eq!(data.request_id, Some(serde_json::json!("request-a")));
-        assert_eq!(data.tool_classes, vec!["fs.read".to_string()]);
-        assert_eq!(data.matched_tool_classes, vec!["fs.read".to_string()]);
-        assert_eq!(data.match_basis.as_deref(), Some("name+class"));
-        assert_eq!(data.matched_rule.as_deref(), Some("allow-read-file"));
-        assert_eq!(data.policy_version.as_deref(), Some("2026-05"));
-        assert_eq!(data.policy_digest.as_deref(), Some("sha256:policy"));
-        assert_eq!(
-            data.policy_snapshot_digest.as_deref(),
-            Some("sha256:policy")
-        );
-        assert_eq!(data.lane.as_deref(), Some("local-dev"));
-        assert_eq!(data.principal.as_deref(), Some("user:alice"));
-        assert_eq!(data.auth_context_summary.as_deref(), Some("local session"));
-    }
-
-    #[test]
-    fn emit_decision_projects_tool_definition_binding_atomically() {
-        let mut tool = serde_json::json!({
-            "name": "read_file",
-            "description": "Read files",
-            "inputSchema": {"type": "object"}
-        });
-        let observation = McpProxy::observe_tool_definition(&mut tool, "server-a")
-            .expect("supported tool definition should be observed");
-        let binding = observation.binding.expect("binding should be visible");
-        let emitter = Arc::new(CapturingEmitter::new());
-        let emitter_trait: Arc<dyn DecisionEmitter> = emitter.clone();
-
-        McpProxy::emit_decision(
-            &emitter_trait,
-            "assay://test",
-            "tc_tool_definition",
-            "read_file",
-            Decision::Allow,
-            reason_codes::P_POLICY_ALLOW,
-            None,
-            None,
-            &PolicyMatchMetadata::default(),
-            Some(&binding),
-        );
-
-        let events = emitter.events.lock().unwrap();
-        let data = &events[0].data;
-        assert!(data.tool_definition_digest.is_some());
-        assert_eq!(
-            data.tool_definition_digest_alg.as_deref(),
-            Some(TOOL_DEFINITION_DIGEST_ALG_SHA256)
-        );
-        assert_eq!(
-            data.tool_definition_canonicalization.as_deref(),
-            Some(TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1)
-        );
-        assert_eq!(
-            data.tool_definition_schema.as_deref(),
-            Some(TOOL_DEFINITION_SCHEMA_V1)
-        );
-        assert_eq!(
-            data.tool_definition_source.as_deref(),
-            Some(TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST)
-        );
     }
 }

--- a/crates/assay-core/src/mcp/proxy/decisions.rs
+++ b/crates/assay-core/src/mcp/proxy/decisions.rs
@@ -1,0 +1,364 @@
+use crate::mcp::audit::{AuditEvent, AuditLog};
+use crate::mcp::decision::{
+    reason_codes, refresh_contract_projections, Decision, DecisionEmitter, DecisionEvent,
+};
+use crate::mcp::jsonrpc::JsonRpcRequest;
+use crate::mcp::policy::PolicyMatchMetadata;
+use crate::mcp::tool_definition::ToolDefinitionBinding;
+use std::sync::Arc;
+
+pub(super) fn handle_allow(req: &JsonRpcRequest, audit_log: &mut AuditLog, verbose: bool) {
+    if verbose && req.is_tool_call() {
+        let tool = req
+            .tool_params()
+            .map(|p| p.name)
+            .unwrap_or_else(|| "unknown".to_string());
+        eprintln!("[assay] ALLOW {}", tool);
+    }
+
+    if req.is_tool_call() {
+        let tool = req.tool_params().map(|p| p.name);
+        audit_log.log(&AuditEvent {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            decision: "allow".to_string(),
+            tool,
+            reason: None,
+            request_id: req.id.clone(),
+            agentic: None,
+        });
+    }
+}
+
+/// Extract tool_call_id from request (I4: idempotency key).
+pub(super) fn extract_tool_call_id(request: &JsonRpcRequest) -> String {
+    // Try to get from params._meta.tool_call_id (MCP standard)
+    if let Some(params) = request.tool_params() {
+        if let Some(meta) = params.arguments.get("_meta") {
+            if let Some(id) = meta.get("tool_call_id").and_then(|v| v.as_str()) {
+                return id.to_string();
+            }
+        }
+    }
+
+    // Fall back to request.id if present
+    if let Some(id) = &request.id {
+        if let Some(s) = id.as_str() {
+            return format!("req_{}", s);
+        }
+        if let Some(n) = id.as_i64() {
+            return format!("req_{}", n);
+        }
+    }
+
+    // Generate one if none found
+    format!("gen_{}", uuid::Uuid::new_v4())
+}
+
+/// Map policy error code to reason code.
+pub(super) fn map_policy_code(code: &str) -> String {
+    match code {
+        "E_TOOL_DENIED" => reason_codes::P_TOOL_DENIED.to_string(),
+        "E_TOOL_NOT_ALLOWED" => reason_codes::P_TOOL_NOT_ALLOWED.to_string(),
+        "E_ARG_SCHEMA" => reason_codes::P_ARG_SCHEMA.to_string(),
+        "E_RATE_LIMIT" => reason_codes::P_RATE_LIMIT.to_string(),
+        "E_TOOL_DRIFT" => reason_codes::P_TOOL_DRIFT.to_string(),
+        _ => reason_codes::P_POLICY_DENY.to_string(),
+    }
+}
+
+/// Emit a decision event (I1: always emit).
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit_decision(
+    emitter: &Arc<dyn DecisionEmitter>,
+    source: &str,
+    tool_call_id: &str,
+    tool: &str,
+    decision: Decision,
+    reason_code: &str,
+    reason: Option<String>,
+    request_id: Option<serde_json::Value>,
+    metadata: &PolicyMatchMetadata,
+    tool_definition_binding: Option<&ToolDefinitionBinding>,
+) {
+    let mut event = DecisionEvent::new(
+        source.to_string(),
+        tool_call_id.to_string(),
+        tool.to_string(),
+    );
+    event.data.decision = decision;
+    event.data.reason_code = reason_code.to_string();
+    event.data.reason = reason;
+    event.data.request_id = request_id;
+    event.data.tool_classes = metadata.tool_classes.clone();
+    event.data.matched_tool_classes = metadata.matched_tool_classes.clone();
+    event.data.match_basis = metadata.match_basis.as_str().map(ToString::to_string);
+    event.data.matched_rule = metadata.matched_rule.clone();
+    event.data.typed_decision = metadata.typed_decision;
+    event.data.policy_version = metadata.policy_version.clone();
+    event.data.policy_digest = metadata.policy_digest.clone();
+    event.data.apply_policy_snapshot_projection();
+    event
+        .data
+        .apply_tool_definition_binding(tool_definition_binding);
+    event.data.obligations = metadata.obligations.clone();
+    event.data.obligation_outcomes =
+        crate::mcp::obligations::execute_log_only(&metadata.obligations, tool);
+    event.data.approval_state = metadata.approval_state.clone();
+    if let Some(artifact) = &metadata.approval_artifact {
+        event.data.approval_id = Some(artifact.approval_id.clone());
+        event.data.approver = Some(artifact.approver.clone());
+        event.data.issued_at = Some(artifact.issued_at.clone());
+        event.data.expires_at = Some(artifact.expires_at.clone());
+        event.data.scope = Some(artifact.scope.clone());
+        event.data.approval_bound_tool = Some(artifact.bound_tool.clone());
+        event.data.approval_bound_resource = Some(artifact.bound_resource.clone());
+    }
+    event.data.approval_freshness = metadata.approval_freshness;
+    event.data.approval_failure_reason = metadata.approval_failure_reason.clone();
+    event.data.scope_type = metadata.scope_type.clone();
+    event.data.scope_value = metadata.scope_value.clone();
+    event.data.scope_match_mode = metadata.scope_match_mode.clone();
+    event.data.scope_evaluation_state = metadata.scope_evaluation_state.clone();
+    event.data.scope_failure_reason = metadata.scope_failure_reason.clone();
+    event.data.restrict_scope_present = metadata.restrict_scope_present;
+    event.data.restrict_scope_target = metadata.restrict_scope_target.clone();
+    event.data.restrict_scope_match = metadata.restrict_scope_match;
+    event.data.restrict_scope_reason = metadata.restrict_scope_reason.clone();
+    event.data.redaction_target = metadata.redaction_target.clone();
+    event.data.redaction_mode = metadata.redaction_mode.clone();
+    event.data.redaction_scope = metadata.redaction_scope.clone();
+    event.data.redaction_applied_state = metadata.redaction_applied_state.clone();
+    event.data.redaction_reason = metadata.redaction_reason.clone();
+    event.data.redaction_failure_reason = metadata.redaction_failure_reason.clone();
+    event.data.redact_args_present = metadata.redact_args_present;
+    event.data.redact_args_target = metadata.redact_args_target.clone();
+    event.data.redact_args_mode = metadata.redact_args_mode.clone();
+    event.data.redact_args_result = metadata.redact_args_result.clone();
+    event.data.redact_args_reason = metadata.redact_args_reason.clone();
+    event.data.fail_closed = metadata.fail_closed.clone();
+    event.data.lane = metadata.lane.clone();
+    event.data.principal = metadata.principal.clone();
+    event.data.auth_context_summary = metadata.auth_context_summary.clone();
+    event.data.auth_scheme = metadata.auth_scheme.clone();
+    event.data.auth_issuer = metadata.auth_issuer.clone();
+    event.data.delegated_from = metadata.delegated_from.clone();
+    event.data.delegation_depth = metadata.delegation_depth;
+    refresh_contract_projections(&mut event.data);
+    emitter.emit(&event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::tool_definition::{
+        TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1,
+        TOOL_DEFINITION_DIGEST_ALG_SHA256, TOOL_DEFINITION_SCHEMA_V1,
+        TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST,
+    };
+    use std::sync::Mutex as StdMutex;
+
+    struct CapturingEmitter {
+        events: StdMutex<Vec<DecisionEvent>>,
+    }
+
+    impl CapturingEmitter {
+        fn new() -> Self {
+            Self {
+                events: StdMutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl DecisionEmitter for CapturingEmitter {
+        fn emit(&self, event: &DecisionEvent) {
+            self.events.lock().unwrap().push(event.clone());
+        }
+    }
+
+    fn proxy_contract_request(value: serde_json::Value) -> JsonRpcRequest {
+        serde_json::from_value(value).expect("test JSON-RPC request should deserialize")
+    }
+
+    #[test]
+    fn proxy_contract_tool_call_id_prefers_meta() {
+        let request = proxy_contract_request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "request-a",
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {
+                    "_meta": {
+                        "tool_call_id": "tc_explicit_001"
+                    }
+                }
+            }
+        }));
+
+        assert_eq!(extract_tool_call_id(&request), "tc_explicit_001");
+    }
+
+    #[test]
+    fn proxy_contract_tool_call_id_uses_request_id() {
+        let string_request = proxy_contract_request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "request-a",
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {}
+            }
+        }));
+        let numeric_request = proxy_contract_request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {}
+            }
+        }));
+
+        assert_eq!(extract_tool_call_id(&string_request), "req_request-a");
+        assert_eq!(extract_tool_call_id(&numeric_request), "req_42");
+    }
+
+    #[test]
+    fn proxy_contract_unknown_tool_call_id_is_generated() {
+        let request = proxy_contract_request(serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {}
+            }
+        }));
+
+        let generated = extract_tool_call_id(&request);
+        assert!(
+            generated.starts_with("gen_"),
+            "missing request id should produce generated idempotency key"
+        );
+    }
+
+    #[test]
+    fn proxy_contract_policy_code_mapping_is_stable() {
+        assert_eq!(
+            map_policy_code("E_TOOL_DENIED"),
+            reason_codes::P_TOOL_DENIED
+        );
+        assert_eq!(
+            map_policy_code("E_TOOL_NOT_ALLOWED"),
+            reason_codes::P_TOOL_NOT_ALLOWED
+        );
+        assert_eq!(map_policy_code("E_ARG_SCHEMA"), reason_codes::P_ARG_SCHEMA);
+        assert_eq!(map_policy_code("E_RATE_LIMIT"), reason_codes::P_RATE_LIMIT);
+        assert_eq!(map_policy_code("E_TOOL_DRIFT"), reason_codes::P_TOOL_DRIFT);
+        assert_eq!(
+            map_policy_code("E_UNKNOWN_NEW_CODE"),
+            reason_codes::P_POLICY_DENY
+        );
+    }
+
+    #[test]
+    fn proxy_contract_emit_decision_preserves_core_fields() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let emitter_trait: Arc<dyn DecisionEmitter> = emitter.clone();
+        let metadata = PolicyMatchMetadata {
+            tool_classes: vec!["fs.read".to_string()],
+            matched_tool_classes: vec!["fs.read".to_string()],
+            match_basis: crate::mcp::tool_match::MatchBasis::NameAndClass,
+            matched_rule: Some("allow-read-file".to_string()),
+            policy_version: Some("2026-05".to_string()),
+            policy_digest: Some("sha256:policy".to_string()),
+            lane: Some("local-dev".to_string()),
+            principal: Some("user:alice".to_string()),
+            auth_context_summary: Some("local session".to_string()),
+            ..PolicyMatchMetadata::default()
+        };
+
+        emit_decision(
+            &emitter_trait,
+            "assay://test",
+            "tc_core_fields",
+            "read_file",
+            Decision::Deny,
+            reason_codes::P_TOOL_DENIED,
+            Some("blocked by test policy".to_string()),
+            Some(serde_json::json!("request-a")),
+            &metadata,
+            None,
+        );
+
+        let events = emitter.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].source, "assay://test");
+        let data = &events[0].data;
+        assert_eq!(data.tool, "read_file");
+        assert_eq!(data.tool_call_id, "tc_core_fields");
+        assert_eq!(data.decision, Decision::Deny);
+        assert_eq!(data.reason_code, reason_codes::P_TOOL_DENIED);
+        assert_eq!(data.reason.as_deref(), Some("blocked by test policy"));
+        assert_eq!(data.request_id, Some(serde_json::json!("request-a")));
+        assert_eq!(data.tool_classes, vec!["fs.read".to_string()]);
+        assert_eq!(data.matched_tool_classes, vec!["fs.read".to_string()]);
+        assert_eq!(data.match_basis.as_deref(), Some("name+class"));
+        assert_eq!(data.matched_rule.as_deref(), Some("allow-read-file"));
+        assert_eq!(data.policy_version.as_deref(), Some("2026-05"));
+        assert_eq!(data.policy_digest.as_deref(), Some("sha256:policy"));
+        assert_eq!(
+            data.policy_snapshot_digest.as_deref(),
+            Some("sha256:policy")
+        );
+        assert_eq!(data.lane.as_deref(), Some("local-dev"));
+        assert_eq!(data.principal.as_deref(), Some("user:alice"));
+        assert_eq!(data.auth_context_summary.as_deref(), Some("local session"));
+    }
+
+    #[test]
+    fn emit_decision_projects_tool_definition_binding_atomically() {
+        let mut tool = serde_json::json!({
+            "name": "read_file",
+            "description": "Read files",
+            "inputSchema": {"type": "object"}
+        });
+        let observation = super::super::tools::observe_tool_definition(&mut tool, "server-a")
+            .expect("supported tool definition should be observed");
+        let binding = observation.binding.expect("binding should be visible");
+        let emitter = Arc::new(CapturingEmitter::new());
+        let emitter_trait: Arc<dyn DecisionEmitter> = emitter.clone();
+
+        emit_decision(
+            &emitter_trait,
+            "assay://test",
+            "tc_tool_definition",
+            "read_file",
+            Decision::Allow,
+            reason_codes::P_POLICY_ALLOW,
+            None,
+            None,
+            &PolicyMatchMetadata::default(),
+            Some(&binding),
+        );
+
+        let events = emitter.events.lock().unwrap();
+        let data = &events[0].data;
+        assert!(data.tool_definition_digest.is_some());
+        assert_eq!(
+            data.tool_definition_digest_alg.as_deref(),
+            Some(TOOL_DEFINITION_DIGEST_ALG_SHA256)
+        );
+        assert_eq!(
+            data.tool_definition_canonicalization.as_deref(),
+            Some(TOOL_DEFINITION_CANONICALIZATION_JCS_MCP_TOOL_DEFINITION_V1)
+        );
+        assert_eq!(
+            data.tool_definition_schema.as_deref(),
+            Some(TOOL_DEFINITION_SCHEMA_V1)
+        );
+        assert_eq!(
+            data.tool_definition_source.as_deref(),
+            Some(TOOL_DEFINITION_SOURCE_MCP_TOOLS_LIST)
+        );
+    }
+}

--- a/crates/assay-core/src/mcp/proxy/tools.rs
+++ b/crates/assay-core/src/mcp/proxy/tools.rs
@@ -1,0 +1,84 @@
+use crate::mcp::identity::ToolIdentity;
+use crate::mcp::tool_definition::{binding_from_tools_list_tool, ToolDefinitionBinding};
+
+pub(super) struct ToolDefinitionObservation {
+    pub(super) name: String,
+    pub(super) identity: ToolIdentity,
+    pub(super) binding: Option<ToolDefinitionBinding>,
+}
+
+pub(super) fn observe_tool_definition(
+    tool: &mut serde_json::Value,
+    server_id: &str,
+) -> Option<ToolDefinitionObservation> {
+    let name = tool.get("name").and_then(|n| n.as_str())?;
+    if name.trim().is_empty() {
+        return None;
+    }
+    let name = name.to_string();
+    let description = tool
+        .get("description")
+        .and_then(|d| d.as_str())
+        .map(|s| s.to_string());
+    let input_schema = tool
+        .get("inputSchema")
+        .or_else(|| tool.get("input_schema"))
+        .cloned();
+
+    let identity = ToolIdentity::new(server_id, &name, &input_schema, &description);
+    let binding = binding_from_tools_list_tool(tool, Some(server_id))
+        .ok()
+        .flatten();
+
+    // Augment the response with the computed identity for downstream/logging.
+    tool.as_object_mut().and_then(|m| {
+        m.insert(
+            "tool_identity".to_string(),
+            serde_json::to_value(&identity).unwrap(),
+        )
+    });
+
+    Some(ToolDefinitionObservation {
+        name,
+        identity,
+        binding,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_tool_definition_computes_identity_and_binding() {
+        let mut tool = serde_json::json!({
+            "name": "read_file",
+            "description": " Read files ",
+            "inputSchema": {"type": "object"},
+            "annotations": {"title": "Read"},
+            "x-assay-sig": {"signature": "opaque"}
+        });
+
+        let observation = observe_tool_definition(&mut tool, "server-a")
+            .expect("supported tool definition should be observed");
+
+        assert_eq!(observation.name, "read_file");
+        assert_eq!(observation.identity.server_id, "server-a");
+        assert!(observation.binding.is_some());
+        assert!(tool.get("tool_identity").is_some());
+    }
+
+    #[test]
+    fn proxy_contract_observe_tool_definition_rejects_empty_names() {
+        let mut tool = serde_json::json!({
+            "name": "   ",
+            "description": "invalid",
+            "inputSchema": {"type": "object"}
+        });
+
+        let observation = observe_tool_definition(&mut tool, "server-a");
+
+        assert!(observation.is_none());
+        assert!(tool.get("tool_identity").is_none());
+    }
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step4.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step4.md
@@ -1,0 +1,48 @@
+# SPLIT CHECKLIST - Wave 51 MCP Proxy Step4
+
+## Scope Lock
+
+- Split pure MCP proxy helpers behind the existing `McpProxy` facade.
+- Keep `McpProxy::spawn` and `McpProxy::run` in `crates/assay-core/src/mcp/proxy.rs`.
+- Keep threaded stdio passthrough and child lifecycle in `proxy.rs` for this step.
+- Move decision/idempotency/audit-allow helpers into `proxy/decisions.rs`.
+- Move tools/list observation and tool-definition binding into `proxy/tools.rs`.
+- Preserve Step 3 `proxy_contract_*` behavior.
+- Do not change policy semantics, JSON-RPC surfaces, event payload shape, workflows, or generated files.
+
+## Files
+
+- `crates/assay-core/src/mcp/proxy.rs`
+- `crates/assay-core/src/mcp/proxy/decisions.rs`
+- `crates/assay-core/src/mcp/proxy/tools.rs`
+- `docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step4.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step4.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step4.md`
+- `scripts/ci/review-wave51-hotspot-mcp-proxy-step4.sh`
+
+## Drift Gates
+
+- `proxy.rs` non-test code stays under 450 lines.
+- `proxy.rs` declares `mod decisions;` and `mod tools;`.
+- `proxy.rs` retains `pub struct McpProxy`, `pub fn spawn`, `pub fn run`, `thread::spawn`, and `make_deny_response`.
+- `proxy.rs` no longer owns helper definitions for `extract_tool_call_id`, `map_policy_code`, `emit_decision`, or `observe_tool_definition`.
+- `proxy/decisions.rs` owns `handle_allow`, `extract_tool_call_id`, `map_policy_code`, and `emit_decision`.
+- `proxy/tools.rs` owns `observe_tool_definition` and `ToolDefinitionObservation`.
+
+## Validation
+
+```bash
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_
+cargo test -p assay-core --lib mcp::proxy::
+bash scripts/ci/review-wave51-hotspot-mcp-proxy-step4.sh
+```
+
+## Definition of Done
+
+- Step 4 reviewer script passes.
+- Step 3 contract tests pass from their new module homes.
+- `proxy.rs` remains the stable facade for process/thread behavior.
+- Step 5 can move the server-to-client tools/list loop or client-to-server policy loop behind these module seams.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step4.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step4.md
@@ -1,0 +1,31 @@
+# SPLIT MOVE MAP - Wave 51 MCP Proxy Step4
+
+## Intent
+
+Make the first mechanical MCP proxy split without touching the stdio threading loop. This moves pure helpers and their characterization tests into private proxy submodules while preserving `McpProxy` as the public facade.
+
+## Moves
+
+| From | To | Notes |
+| --- | --- | --- |
+| `McpProxy::handle_allow` | `proxy/decisions.rs::handle_allow` | Preserves audit allow logging and verbose allow message behavior. |
+| `McpProxy::extract_tool_call_id` | `proxy/decisions.rs::extract_tool_call_id` | Preserves `_meta.tool_call_id`, request id fallback, and generated id fallback. |
+| `McpProxy::map_policy_code` | `proxy/decisions.rs::map_policy_code` | Preserves legacy `E_*` to `P_*` mapping and fail-closed unknown-code mapping. |
+| `McpProxy::emit_decision` | `proxy/decisions.rs::emit_decision` | Preserves decision event field projection, policy snapshot projection, obligations, and tool-definition binding projection. |
+| `McpProxy::observe_tool_definition` | `proxy/tools.rs::observe_tool_definition` | Preserves tools/list identity computation, bounded tool-definition binding, and outbound `tool_identity` augmentation. |
+| `ToolDefinitionObservation` | `proxy/tools.rs::ToolDefinitionObservation` | Keeps observation shape private to the proxy implementation. |
+| Step 3 helper tests | `proxy/decisions.rs` / `proxy/tools.rs` | Keeps behavior contracts adjacent to moved code. |
+
+## Data Flow After Step 4
+
+1. `proxy.rs::McpProxy::run` still owns both stdio threads and child lifecycle.
+2. The server-to-client loop delegates each tools/list item to `proxy::tools::observe_tool_definition`.
+3. The client-to-server loop delegates idempotency, allow logging, reason-code mapping, and decision event projection to `proxy::decisions`.
+4. The existing identity and tool-definition caches stay in `McpProxy` for now.
+
+## Reviewer Focus
+
+- This PR should read as mostly moved code plus call-site rewiring.
+- No JSON-RPC parse/forward behavior should change.
+- No decision-event field should disappear or change meaning.
+- No public proxy API should be introduced from the new submodules.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step4.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step4.md
@@ -1,0 +1,46 @@
+# SPLIT REVIEW PACK - Wave 51 MCP Proxy Step4
+
+## Summary
+
+Step 4 performs the first MCP proxy module split by moving pure helper responsibilities into private `proxy/*` modules. `McpProxy::run` remains the stable facade for child process lifecycle and threaded stdio passthrough.
+
+## LOC Delta
+
+| File | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| `crates/assay-core/src/mcp/proxy.rs` | 979 | 540 | -439 |
+| `crates/assay-core/src/mcp/proxy/decisions.rs` | 0 | 364 | +364 |
+| `crates/assay-core/src/mcp/proxy/tools.rs` | 0 | 84 | +84 |
+
+## Boundary Proof
+
+Facade stays in place:
+
+```bash
+rg -n 'pub struct McpProxy|pub fn spawn\(|pub fn run\(|thread::spawn|make_deny_response' crates/assay-core/src/mcp/proxy.rs
+```
+
+Moved decision helpers:
+
+```bash
+rg -n 'fn handle_allow|fn extract_tool_call_id|fn map_policy_code|fn emit_decision' crates/assay-core/src/mcp/proxy/decisions.rs
+```
+
+Moved tools/list helper:
+
+```bash
+rg -n 'struct ToolDefinitionObservation|fn observe_tool_definition' crates/assay-core/src/mcp/proxy/tools.rs
+```
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check -p assay-core`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- `cargo test -p assay-core --lib proxy_contract_`
+- `cargo test -p assay-core --lib mcp::proxy::`
+- `bash scripts/ci/review-wave51-hotspot-mcp-proxy-step4.sh`
+
+## Next Step
+
+Step 5 should move one threaded loop at a time. The lower-risk next candidate is the server-to-client tools/list enrichment loop, because Step 4 already isolates tools/list observation and keeps the forwarding contract visible.

--- a/scripts/ci/review-wave51-hotspot-mcp-proxy-step4.sh
+++ b/scripts/ci/review-wave51-hotspot-mcp-proxy-step4.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+PROXY="crates/assay-core/src/mcp/proxy.rs"
+DECISIONS="crates/assay-core/src/mcp/proxy/decisions.rs"
+TOOLS="crates/assay-core/src/mcp/proxy/tools.rs"
+
+assert_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if ! rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+assert_not_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+echo "[review] workflow and generated-file guard"
+if ! git diff --quiet -- .github/workflows; then
+  echo "FAIL: Wave 51 MCP Proxy Step4 must not touch workflows"
+  exit 1
+fi
+if ! git diff --quiet -- crates/assay-ebpf/src/vmlinux.rs; then
+  echo "FAIL: generated vmlinux.rs must stay out of scope"
+  exit 1
+fi
+
+echo "[review] facade thinness and split boundary"
+proxy_code_lines="$(
+  awk 'BEGIN{n=0; in_tests=0} /^#\[cfg\(test\)\]/{in_tests=1} !in_tests{n++} END{print n}' "$PROXY"
+)"
+echo "proxy non-test lines: $proxy_code_lines"
+if [ "$proxy_code_lines" -gt 450 ]; then
+  echo "FAIL: proxy facade is too thick after Step4"
+  exit 1
+fi
+assert_rg 'mod decisions;' "$PROXY" "proxy decisions module declaration missing"
+assert_rg 'mod tools;' "$PROXY" "proxy tools module declaration missing"
+assert_rg 'pub struct McpProxy' "$PROXY" "McpProxy facade moved out of proxy.rs"
+assert_rg 'pub fn spawn\(' "$PROXY" "McpProxy::spawn moved out of proxy.rs"
+assert_rg 'pub fn run\(' "$PROXY" "McpProxy::run moved out of proxy.rs"
+assert_rg 'thread::spawn' "$PROXY" "threaded proxy loops no longer visible in proxy.rs"
+assert_rg 'make_deny_response' "$PROXY" "deny response path marker missing"
+assert_not_rg '^    fn (handle_allow|extract_tool_call_id|map_policy_code|emit_decision|observe_tool_definition)\(' "$PROXY" "helper definition still lives in proxy facade"
+
+echo "[review] moved helper ownership"
+assert_rg 'fn handle_allow\(' "$DECISIONS" "handle_allow helper missing from decisions module"
+assert_rg 'fn extract_tool_call_id\(' "$DECISIONS" "idempotency helper missing from decisions module"
+assert_rg 'fn map_policy_code\(' "$DECISIONS" "policy code mapper missing from decisions module"
+assert_rg 'fn emit_decision\(' "$DECISIONS" "decision event projector missing from decisions module"
+assert_rg 'struct ToolDefinitionObservation' "$TOOLS" "tool observation type missing from tools module"
+assert_rg 'fn observe_tool_definition\(' "$TOOLS" "tools/list observation helper missing from tools module"
+assert_rg 'proxy_contract_tool_call_id_prefers_meta' "$DECISIONS" "explicit tool_call_id contract test missing"
+assert_rg 'proxy_contract_policy_code_mapping_is_stable' "$DECISIONS" "policy code mapping contract test missing"
+assert_rg 'proxy_contract_emit_decision_preserves_core_fields' "$DECISIONS" "decision projection contract test missing"
+assert_rg 'proxy_contract_observe_tool_definition_rejects_empty_names' "$TOOLS" "empty tool definition contract test missing"
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_
+cargo test -p assay-core --lib mcp::proxy::
+git diff --check
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary

Performs Wave 51 MCP proxy Step 4: the first mechanical split after the Step 3 characterization PR landed.

- Keeps `McpProxy::spawn` and `McpProxy::run` as the stable proxy facade.
- Moves idempotency, policy reason-code mapping, allow audit logging, and decision-event projection into `proxy/decisions.rs`.
- Moves tools/list observation, tool identity enrichment, and bounded tool-definition binding into `proxy/tools.rs`.
- Moves the Step 3 contract tests next to the split helper modules.
- Adds Step 4 SPLIT checklist, move-map, review-pack, and reviewer gate.

## Scope

Included:

- `crates/assay-core/src/mcp/proxy.rs`
- `crates/assay-core/src/mcp/proxy/decisions.rs`
- `crates/assay-core/src/mcp/proxy/tools.rs`
- `docs/contributing/SPLIT-*wave51-hotspot-mcp-proxy-step4.md`
- `scripts/ci/review-wave51-hotspot-mcp-proxy-step4.sh`

Explicitly excluded:

- moving threaded stdio loops
- moving child lifecycle/spawn handling
- policy semantic changes
- JSON-RPC surface changes
- workflow changes
- unrelated local architecture/example/token files

## LOC Delta

| File | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `crates/assay-core/src/mcp/proxy.rs` | 979 | 540 | -439 |
| `crates/assay-core/src/mcp/proxy/decisions.rs` | 0 | 364 | +364 |
| `crates/assay-core/src/mcp/proxy/tools.rs` | 0 | 84 | +84 |

## Validation

```bash
bash scripts/ci/review-wave51-hotspot-mcp-proxy-step4.sh
```

This includes:

```bash
cargo fmt --check
cargo check -p assay-core
cargo clippy -p assay-core --all-targets -- -D warnings
cargo test -p assay-core --lib proxy_contract_
cargo test -p assay-core --lib mcp::proxy::
git diff --check
```

## Chain

PR #1173 has landed, so this PR targets `main` directly.

## Next

Step 5 should move one threaded loop at a time. Recommended first candidate: server-to-client tools/list enrichment, since Step 4 has isolated the tools/list observation helper.
