### PR TITLE
[codex] split Wave 51 MCP proxy server loop

### DIFF
--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -1,9 +1,10 @@
 use super::audit::{AuditEvent, AuditLog};
 mod decisions;
+mod server;
 mod tools;
 
 use self::decisions::{emit_decision, extract_tool_call_id, handle_allow, map_policy_code};
-use self::tools::observe_tool_definition;
+use self::server::run_server_to_client;
 use super::decision::{
     reason_codes, Decision, DecisionEmitter, FileDecisionEmitter, NullDecisionEmitter,
 };
@@ -12,7 +13,7 @@ use super::policy::{make_deny_response, McpPolicy, PolicyDecision, PolicyState};
 use super::tool_definition::ToolDefinitionBinding;
 use std::{
     collections::HashMap,
-    io::{self, BufRead, BufReader, Write},
+    io::{self, BufRead, Write},
     process::{Child, Command, Stdio},
     sync::{Arc, Mutex},
     thread,
@@ -178,50 +179,15 @@ impl McpProxy {
 
         // Thread A: server -> client passthrough
         let stdout_a = stdout.clone();
-        let t_server_to_client = thread::spawn(move || -> io::Result<()> {
-            let mut reader = BufReader::new(child_stdout);
-            let mut line = String::new();
-
-            while reader.read_line(&mut line)? > 0 {
-                let mut processed_line = line.clone();
-
-                // Phase 9: Compute Identities on tools/list response
-                if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(&line) {
-                    if let Some(result) = v.get_mut("result") {
-                        if let Some(tools) = result.get_mut("tools").and_then(|t| t.as_array_mut())
-                        {
-                            for tool in tools {
-                                if let Some(observation) =
-                                    observe_tool_definition(tool, &config.server_id)
-                                {
-                                    let mut identity_cache = identity_cache_a.lock().unwrap();
-                                    identity_cache.insert(
-                                        observation.name.clone(),
-                                        observation.identity.clone(),
-                                    );
-                                    drop(identity_cache);
-
-                                    if let Some(binding) = observation.binding {
-                                        let mut binding_cache =
-                                            tool_definition_cache_a.lock().unwrap();
-                                        binding_cache.insert(observation.name, binding);
-                                    }
-                                }
-                            }
-                            processed_line =
-                                serde_json::to_string(&v).unwrap_or(line.clone()) + "\n";
-                        }
-                    }
-                }
-
-                let mut out = stdout_a
-                    .lock()
-                    .map_err(|e| io::Error::other(e.to_string()))?;
-                out.write_all(processed_line.as_bytes())?;
-                out.flush()?;
-                line.clear();
-            }
-            Ok(())
+        let server_id_a = config.server_id.clone();
+        let t_server_to_client = thread::spawn(move || {
+            run_server_to_client(
+                child_stdout,
+                stdout_a,
+                server_id_a,
+                identity_cache_a,
+                tool_definition_cache_a,
+            )
         });
 
         // Thread B: client -> server passthrough with Policy Check

--- a/crates/assay-core/src/mcp/proxy/server.rs
+++ b/crates/assay-core/src/mcp/proxy/server.rs
@@ -1,0 +1,65 @@
+use super::tools::observe_tool_definition;
+use crate::mcp::identity::ToolIdentity;
+use crate::mcp::tool_definition::ToolDefinitionBinding;
+use std::{
+    collections::HashMap,
+    io::{self, BufRead, BufReader, Write},
+    process::ChildStdout,
+    sync::{Arc, Mutex},
+};
+
+pub(super) fn run_server_to_client(
+    child_stdout: ChildStdout,
+    stdout: Arc<Mutex<io::Stdout>>,
+    server_id: String,
+    identity_cache: Arc<Mutex<HashMap<String, ToolIdentity>>>,
+    tool_definition_cache: Arc<Mutex<HashMap<String, ToolDefinitionBinding>>>,
+) -> io::Result<()> {
+    let mut reader = BufReader::new(child_stdout);
+    let mut line = String::new();
+
+    while reader.read_line(&mut line)? > 0 {
+        let mut processed_line = line.clone();
+
+        // Phase 9: Compute Identities on tools/list response
+        if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(&line) {
+            if let Some(result) = v.get_mut("result") {
+                if let Some(tools) = result.get_mut("tools").and_then(|t| t.as_array_mut()) {
+                    for tool in tools {
+                        if let Some(observation) = observe_tool_definition(tool, &server_id) {
+                            let mut identities = identity_cache.lock().unwrap();
+                            identities.insert(observation.name.clone(), observation.identity);
+                            drop(identities);
+
+                            if let Some(binding) = observation.binding {
+                                let mut bindings = tool_definition_cache.lock().unwrap();
+                                bindings.insert(observation.name, binding);
+                            }
+                        }
+                    }
+                    processed_line = serde_json::to_string(&v).unwrap_or(line.clone()) + "\n";
+                }
+            }
+        }
+
+        let mut out = stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
+        out.write_all(processed_line.as_bytes())?;
+        out.flush()?;
+        line.clear();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_contract_server_loop_enrichment_inputs_remain_private() {
+        fn assert_send<T: Send>() {}
+
+        assert_send::<Arc<Mutex<HashMap<String, ToolIdentity>>>>();
+        assert_send::<Arc<Mutex<HashMap<String, ToolDefinitionBinding>>>>();
+    }
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step5.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step5.md
@@ -1,0 +1,45 @@
+# SPLIT CHECKLIST - Wave 51 MCP Proxy Step5
+
+## Scope Lock
+
+- Move only the server-to-client child stdout loop behind the existing `McpProxy` facade.
+- Keep `McpProxy::spawn` and `McpProxy::run` in `crates/assay-core/src/mcp/proxy.rs`.
+- Keep the client-to-server policy loop in `proxy.rs` for this step.
+- Preserve stdout passthrough, per-line processing, tools/list enrichment, identity cache updates, and tool-definition cache updates.
+- Do not change policy semantics, JSON-RPC parsing, deny responses, audit logging, decision-event payloads, workflows, or generated files.
+
+## Files
+
+- `crates/assay-core/src/mcp/proxy.rs`
+- `crates/assay-core/src/mcp/proxy/server.rs`
+- `docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step5.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step5.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step5.md`
+- `scripts/ci/review-wave51-hotspot-mcp-proxy-step5.sh`
+
+## Drift Gates
+
+- `proxy.rs` non-test code stays under 420 lines.
+- `proxy.rs` declares `mod server;` and calls `run_server_to_client`.
+- `proxy.rs` retains `pub struct McpProxy`, `pub fn spawn`, `pub fn run`, `thread::spawn`, `make_deny_response`, and the client-to-server `stdin.lock()` loop.
+- `proxy.rs` no longer imports or uses `BufReader`.
+- `proxy.rs` no longer directly calls `observe_tool_definition`.
+- `proxy/server.rs` owns `run_server_to_client`, `BufReader`, `read_line`, `observe_tool_definition`, identity cache insertion, and tool-definition cache insertion.
+
+## Validation
+
+```bash
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_
+cargo test -p assay-core --lib mcp::proxy::
+bash scripts/ci/review-wave51-hotspot-mcp-proxy-step5.sh
+```
+
+## Definition of Done
+
+- Step 5 reviewer script passes.
+- Step 3/4 proxy contract tests pass after the server-loop move.
+- `proxy.rs` remains the stable public facade and still owns the client-to-server policy loop.
+- Step 6 can move the client-to-server policy loop once deny/allow forwarding seams are characterized enough.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step5.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step5.md
@@ -1,0 +1,29 @@
+# SPLIT MOVE MAP - Wave 51 MCP Proxy Step5
+
+## Intent
+
+Move one threaded loop at a time. Step 5 moves the server-to-client child stdout loop into `proxy/server.rs` while keeping the thread spawn and join in `McpProxy::run`.
+
+## Moves
+
+| From | To | Notes |
+| --- | --- | --- |
+| server-to-client `BufReader` loop | `proxy/server.rs::run_server_to_client` | Preserves line-by-line child stdout passthrough. |
+| tools/list JSON response parsing | `proxy/server.rs::run_server_to_client` | Preserves enrichment only when `result.tools` is an array. |
+| identity cache insertion | `proxy/server.rs::run_server_to_client` | Preserves name-keyed runtime identity cache behavior. |
+| tool-definition cache insertion | `proxy/server.rs::run_server_to_client` | Preserves name-keyed bounded binding cache behavior. |
+| stdout lock/write/flush for server output | `proxy/server.rs::run_server_to_client` | Preserves serialized writes to shared stdout. |
+
+## Data Flow After Step 5
+
+1. `proxy.rs::McpProxy::run` opens child stdin/stdout, creates shared stdout, and spawns both proxy threads.
+2. The server-to-client thread delegates to `proxy::server::run_server_to_client`.
+3. `proxy::server::run_server_to_client` reads child stdout, enriches tools/list responses via `proxy::tools::observe_tool_definition`, updates caches, then writes the processed line to stdout.
+4. The client-to-server policy loop remains in `proxy.rs` and continues to use the same identity/tool-definition caches.
+
+## Reviewer Focus
+
+- This should be a mechanical loop move, not a behavior rewrite.
+- The shared stdout lock remains the same synchronization point.
+- The client-to-server policy path is intentionally not split here.
+- `proxy/server.rs` should not know policy decisions or audit semantics.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step5.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step5.md
@@ -1,0 +1,45 @@
+# SPLIT REVIEW PACK - Wave 51 MCP Proxy Step5
+
+## Summary
+
+Step 5 moves the MCP proxy server-to-client child stdout loop into `proxy/server.rs`. The stable facade still owns `McpProxy::spawn`, `McpProxy::run`, thread spawning, child lifecycle, deny responses, and the client-to-server policy loop.
+
+## LOC Delta
+
+| File | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| `crates/assay-core/src/mcp/proxy.rs` | 540 | 506 | -34 |
+| `crates/assay-core/src/mcp/proxy/server.rs` | 0 | 65 | +65 |
+
+## Boundary Proof
+
+Facade still owns process/thread shape:
+
+```bash
+rg -n 'pub struct McpProxy|pub fn spawn\(|pub fn run\(|thread::spawn|make_deny_response|stdin\.lock' crates/assay-core/src/mcp/proxy.rs
+```
+
+Server loop moved:
+
+```bash
+rg -n 'fn run_server_to_client|BufReader|read_line|observe_tool_definition|identity_cache|tool_definition_cache' crates/assay-core/src/mcp/proxy/server.rs
+```
+
+Facade no longer parses server output directly:
+
+```bash
+! rg -n 'BufReader|observe_tool_definition' crates/assay-core/src/mcp/proxy.rs
+```
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check -p assay-core`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- `cargo test -p assay-core --lib proxy_contract_`
+- `cargo test -p assay-core --lib mcp::proxy::`
+- `bash scripts/ci/review-wave51-hotspot-mcp-proxy-step5.sh`
+
+## Next Step
+
+Step 6 should characterize and then move the client-to-server policy loop. That split is riskier because it owns forwarding, deny responses, dry-run behavior, audit logging, and decision emission.

--- a/scripts/ci/review-wave51-hotspot-mcp-proxy-step5.sh
+++ b/scripts/ci/review-wave51-hotspot-mcp-proxy-step5.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+PROXY="crates/assay-core/src/mcp/proxy.rs"
+SERVER="crates/assay-core/src/mcp/proxy/server.rs"
+DECISIONS="crates/assay-core/src/mcp/proxy/decisions.rs"
+TOOLS="crates/assay-core/src/mcp/proxy/tools.rs"
+
+assert_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if ! rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+assert_not_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+echo "[review] workflow and generated-file guard"
+if ! git diff --quiet -- .github/workflows; then
+  echo "FAIL: Wave 51 MCP Proxy Step5 must not touch workflows"
+  exit 1
+fi
+if ! git diff --quiet -- crates/assay-ebpf/src/vmlinux.rs; then
+  echo "FAIL: generated vmlinux.rs must stay out of scope"
+  exit 1
+fi
+
+echo "[review] facade and server-loop boundary"
+proxy_code_lines="$(
+  awk 'BEGIN{n=0; in_tests=0} /^#\[cfg\(test\)\]/{in_tests=1} !in_tests{n++} END{print n}' "$PROXY"
+)"
+echo "proxy non-test lines: $proxy_code_lines"
+if [ "$proxy_code_lines" -gt 420 ]; then
+  echo "FAIL: proxy facade is too thick after Step5"
+  exit 1
+fi
+assert_rg 'mod server;' "$PROXY" "proxy server module declaration missing"
+assert_rg 'run_server_to_client\(' "$PROXY" "proxy facade does not delegate server loop"
+assert_rg 'pub struct McpProxy' "$PROXY" "McpProxy facade moved out of proxy.rs"
+assert_rg 'pub fn spawn\(' "$PROXY" "McpProxy::spawn moved out of proxy.rs"
+assert_rg 'pub fn run\(' "$PROXY" "McpProxy::run moved out of proxy.rs"
+assert_rg 'thread::spawn' "$PROXY" "thread spawning no longer visible in proxy.rs"
+assert_rg 'stdin\.lock\(' "$PROXY" "client-to-server policy loop moved too early"
+assert_rg 'make_deny_response' "$PROXY" "deny response path marker missing"
+assert_not_rg 'BufReader' "$PROXY" "server output reader still lives in proxy facade"
+assert_not_rg 'observe_tool_definition' "$PROXY" "tools/list observation still called directly by proxy facade"
+
+echo "[review] server module ownership"
+assert_rg 'fn run_server_to_client\(' "$SERVER" "server loop entrypoint missing"
+assert_rg 'BufReader::new\(child_stdout\)' "$SERVER" "server module does not own child stdout reader"
+assert_rg 'read_line\(&mut line\)' "$SERVER" "server module does not own read loop"
+assert_rg 'observe_tool_definition\(' "$SERVER" "server module does not enrich tools/list responses"
+assert_rg 'identity_cache\.lock\(\)' "$SERVER" "server module does not update identity cache"
+assert_rg 'tool_definition_cache\.lock\(\)' "$SERVER" "server module does not update tool-definition cache"
+assert_not_rg 'PolicyDecision|make_deny_response|AuditLog|emit_decision' "$SERVER" "server module leaked client policy/audit responsibilities"
+assert_rg 'proxy_contract_server_loop_enrichment_inputs_remain_private' "$SERVER" "server module contract test missing"
+assert_rg 'proxy_contract_emit_decision_preserves_core_fields' "$DECISIONS" "decision projection contract test missing"
+assert_rg 'proxy_contract_observe_tool_definition_rejects_empty_names' "$TOOLS" "tools/list observation contract test missing"
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_
+cargo test -p assay-core --lib mcp::proxy::
+git diff --check
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary

Performs Wave 51 MCP proxy Step 5: moves the server-to-client child stdout loop into a private server module.

- Keeps `McpProxy::spawn` and `McpProxy::run` as the stable proxy facade.
- Moves the child stdout `BufReader` loop, tools/list enrichment, identity cache updates, tool-definition cache updates, and stdout write/flush into `proxy/server.rs`.
- Leaves the client-to-server policy loop in `proxy.rs` for a later, separately characterized split.
- Adds Step 5 SPLIT checklist, move-map, review-pack, and reviewer gate.

## Scope

Included:

- `crates/assay-core/src/mcp/proxy.rs`
- `crates/assay-core/src/mcp/proxy/server.rs`
- `docs/contributing/SPLIT-*wave51-hotspot-mcp-proxy-step5.md`
- `scripts/ci/review-wave51-hotspot-mcp-proxy-step5.sh`

Explicitly excluded:

- moving the client-to-server policy loop
- policy semantic changes
- deny-response or dry-run behavior changes
- audit/decision-event payload changes
- workflow changes
- unrelated local architecture/example/token files

## LOC Delta

| File | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `crates/assay-core/src/mcp/proxy.rs` | 540 | 506 | -34 |
| `crates/assay-core/src/mcp/proxy/server.rs` | 0 | 65 | +65 |

## Validation

```bash
bash scripts/ci/review-wave51-hotspot-mcp-proxy-step5.sh
```

This includes:

```bash
cargo fmt --check
cargo check -p assay-core
cargo clippy -p assay-core --all-targets -- -D warnings
cargo test -p assay-core --lib proxy_contract_
cargo test -p assay-core --lib mcp::proxy::
git diff --check
```

## Chain

PR #1174 has landed, so this PR targets `main` directly.

## Next

Step 6 should characterize and then move the client-to-server policy loop. That split is riskier because it owns forwarding, deny responses, dry-run behavior, audit logging, and decision emission.
