### PR TITLE
[codex] split Wave 51 MCP proxy client loop

### DIFF
--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -189,7 +189,6 @@ impl McpProxy {
 
         // Thread B: client -> server passthrough with Policy Check
         let stdout_b = stdout.clone();
-        let config_b = config.clone();
         let emitter_b = decision_emitter.clone();
         let event_source_b = event_source.clone();
         let t_client_to_server = thread::spawn(move || {
@@ -197,7 +196,7 @@ impl McpProxy {
                 child_stdin,
                 stdout_b,
                 policy,
-                config_b,
+                config,
                 emitter_b,
                 event_source_b,
                 identity_cache_b,

--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -1,19 +1,16 @@
-use super::audit::{AuditEvent, AuditLog};
+mod client;
 mod decisions;
 mod server;
 mod tools;
 
-use self::decisions::{emit_decision, extract_tool_call_id, handle_allow, map_policy_code};
+use self::client::run_client_to_server;
 use self::server::run_server_to_client;
-use super::decision::{
-    reason_codes, Decision, DecisionEmitter, FileDecisionEmitter, NullDecisionEmitter,
-};
-use super::jsonrpc::JsonRpcRequest;
-use super::policy::{make_deny_response, McpPolicy, PolicyDecision, PolicyState};
+use super::decision::{DecisionEmitter, FileDecisionEmitter, NullDecisionEmitter};
+use super::policy::McpPolicy;
 use super::tool_definition::ToolDefinitionBinding;
 use std::{
     collections::HashMap,
-    io::{self, BufRead, Write},
+    io,
     process::{Child, Command, Stdio},
     sync::{Arc, Mutex},
     thread,
@@ -154,7 +151,7 @@ impl McpProxy {
     }
 
     pub fn run(mut self) -> io::Result<i32> {
-        let mut child_stdin = self.child.stdin.take().expect("child stdin");
+        let child_stdin = self.child.stdin.take().expect("child stdin");
         let child_stdout = self.child.stdout.take().expect("child stdout");
 
         let stdout = Arc::new(Mutex::new(io::stdout()));
@@ -192,192 +189,20 @@ impl McpProxy {
 
         // Thread B: client -> server passthrough with Policy Check
         let stdout_b = stdout.clone();
+        let config_b = config.clone();
         let emitter_b = decision_emitter.clone();
         let event_source_b = event_source.clone();
-        let t_client_to_server = thread::spawn(move || -> io::Result<()> {
-            let stdin = io::stdin();
-            let mut reader = stdin.lock();
-            let mut line = String::new();
-
-            let mut state = PolicyState::default();
-            let mut audit_log = AuditLog::new(config.audit_log_path.as_deref());
-
-            while reader.read_line(&mut line)? > 0 {
-                // 1. Try Parse as MCP Request
-                match serde_json::from_str::<JsonRpcRequest>(&line) {
-                    Ok(req) => {
-                        // 2. Check Policy with Identity (Phase 9)
-                        let (runtime_id, tool_definition_binding) = if req.is_tool_call() {
-                            let name = req.tool_params().map(|p| p.name).unwrap_or_default();
-                            let runtime_id = {
-                                let cache = identity_cache_b.lock().unwrap();
-                                cache.get(&name).cloned()
-                            };
-                            let tool_definition_binding = {
-                                let cache = tool_definition_cache_b.lock().unwrap();
-                                cache.get(&name).cloned()
-                            };
-                            (runtime_id, tool_definition_binding)
-                        } else {
-                            (None, None)
-                        };
-
-                        let tool_name = req.tool_params().map(|p| p.name).unwrap_or_default();
-                        let tool_call_id = extract_tool_call_id(&req);
-
-                        let policy_eval = policy.evaluate_with_metadata(
-                            &tool_name,
-                            &req.tool_params()
-                                .map(|p| p.arguments)
-                                .unwrap_or(serde_json::Value::Null),
-                            &mut state,
-                            runtime_id.as_ref(),
-                        );
-
-                        match policy_eval.decision {
-                            PolicyDecision::Allow => {
-                                handle_allow(&req, &mut audit_log, config.verbose);
-                                // Emit decision event (I1: always emit)
-                                if req.is_tool_call() {
-                                    emit_decision(
-                                        &emitter_b,
-                                        &event_source_b,
-                                        &tool_call_id,
-                                        &tool_name,
-                                        Decision::Allow,
-                                        reason_codes::P_POLICY_ALLOW,
-                                        None,
-                                        req.id.clone(),
-                                        &policy_eval.metadata,
-                                        tool_definition_binding.as_ref(),
-                                    );
-                                }
-                            }
-                            PolicyDecision::AllowWithWarning { tool, code, reason } => {
-                                // Log warning about allowing a tool invocation with issues
-                                if config.verbose {
-                                    eprintln!(
-                                        "[assay] WARNING: Allowing tool '{}' with warning (code: {}, reason: {}).",
-                                        tool,
-                                        code,
-                                        reason
-                                    );
-                                }
-                                audit_log.log(&AuditEvent {
-                                    timestamp: chrono::Utc::now().to_rfc3339(),
-                                    decision: "allow_with_warning".to_string(),
-                                    tool: Some(tool.clone()),
-                                    reason: Some(reason.clone()),
-                                    request_id: req.id.clone(),
-                                    agentic: None,
-                                });
-                                // Emit decision event (I1: always emit)
-                                emit_decision(
-                                    &emitter_b,
-                                    &event_source_b,
-                                    &tool_call_id,
-                                    &tool,
-                                    Decision::Allow,
-                                    &code,
-                                    Some(reason),
-                                    req.id.clone(),
-                                    &policy_eval.metadata,
-                                    tool_definition_binding.as_ref(),
-                                );
-                                // Then proceed as a normal allow
-                                handle_allow(&req, &mut audit_log, false);
-                                // false = don't double log ALLOW
-                            }
-                            PolicyDecision::Deny {
-                                tool,
-                                code,
-                                reason,
-                                contract,
-                            } => {
-                                // Log Decision
-                                let decision_str =
-                                    if config.dry_run { "would_deny" } else { "deny" };
-
-                                if config.verbose {
-                                    eprintln!(
-                                        "[assay] {} {} (reason: {})",
-                                        decision_str.to_uppercase(),
-                                        tool,
-                                        reason
-                                    );
-                                }
-
-                                audit_log.log(&AuditEvent {
-                                    timestamp: chrono::Utc::now().to_rfc3339(),
-                                    decision: decision_str.to_string(),
-                                    tool: Some(tool.clone()),
-                                    reason: Some(reason.clone()),
-                                    request_id: req.id.clone(),
-                                    agentic: Some(contract.clone()),
-                                });
-
-                                // Emit decision event (I1: always emit)
-                                let reason_code = map_policy_code(&code);
-                                emit_decision(
-                                    &emitter_b,
-                                    &event_source_b,
-                                    &tool_call_id,
-                                    &tool,
-                                    if config.dry_run {
-                                        Decision::Allow
-                                    } else {
-                                        Decision::Deny
-                                    },
-                                    &reason_code,
-                                    Some(reason),
-                                    req.id.clone(),
-                                    &policy_eval.metadata,
-                                    tool_definition_binding.as_ref(),
-                                );
-
-                                if config.dry_run {
-                                    // DRY RUN: Forward anyway
-                                    // Fallthrough to forward logic below
-                                } else {
-                                    // BLOCK: Send error response
-                                    let id = req.id.unwrap_or(serde_json::Value::Null);
-                                    let response_json = make_deny_response(
-                                        id,
-                                        "Content blocked by policy",
-                                        contract,
-                                    );
-
-                                    let mut out = stdout_b
-                                        .lock()
-                                        .map_err(|e| io::Error::other(e.to_string()))?;
-                                    out.write_all(response_json.as_bytes())?;
-                                    out.flush()?;
-
-                                    line.clear();
-                                    continue; // Skip forwarding
-                                }
-                            }
-                        }
-                    }
-                    Err(_) => {
-                        // Hardening: Suspicious Unparsable JSON
-                        let trimmed = line.trim();
-                        if trimmed.starts_with('{')
-                            && (trimmed.contains("\"method\"")
-                                || trimmed.contains("\"params\"")
-                                || trimmed.contains("\"tool\""))
-                        {
-                            eprintln!("[assay] WARNING: Suspicious unparsable JSON, forwarding anyway (potential bypass attempt?): {:.60}...", trimmed);
-                        }
-                    }
-                }
-
-                // 3. Forward
-                child_stdin.write_all(line.as_bytes())?;
-                child_stdin.flush()?;
-                line.clear();
-            }
-            Ok(())
+        let t_client_to_server = thread::spawn(move || {
+            run_client_to_server(
+                child_stdin,
+                stdout_b,
+                policy,
+                config_b,
+                emitter_b,
+                event_source_b,
+                identity_cache_b,
+                tool_definition_cache_b,
+            )
         });
 
         // Wacht tot client->server eindigt (stdin closed)

--- a/crates/assay-core/src/mcp/proxy/client.rs
+++ b/crates/assay-core/src/mcp/proxy/client.rs
@@ -35,44 +35,51 @@ pub(super) fn run_client_to_server(
         // 1. Try Parse as MCP Request
         match serde_json::from_str::<JsonRpcRequest>(&line) {
             Ok(req) => {
+                let tool_params = req.tool_params();
+                let tool_name = tool_params
+                    .as_ref()
+                    .map(|params| params.name.as_str())
+                    .unwrap_or_default();
+
                 // 2. Check Policy with Identity (Phase 9)
                 let (runtime_id, tool_definition_binding) = if req.is_tool_call() {
-                    let name = req.tool_params().map(|p| p.name).unwrap_or_default();
                     let runtime_id = {
                         let cache = identity_cache.lock().unwrap();
-                        cache.get(&name).cloned()
+                        cache.get(tool_name).cloned()
                     };
                     let tool_definition_binding = {
                         let cache = tool_definition_cache.lock().unwrap();
-                        cache.get(&name).cloned()
+                        cache.get(tool_name).cloned()
                     };
                     (runtime_id, tool_definition_binding)
                 } else {
                     (None, None)
                 };
 
-                let tool_name = req.tool_params().map(|p| p.name).unwrap_or_default();
-                let tool_call_id = extract_tool_call_id(&req);
+                let tool_call_id = extract_tool_call_id(&req, tool_params.as_ref());
+                let null_arguments = serde_json::Value::Null;
+                let tool_arguments = tool_params
+                    .as_ref()
+                    .map(|params| &params.arguments)
+                    .unwrap_or(&null_arguments);
 
                 let policy_eval = policy.evaluate_with_metadata(
-                    &tool_name,
-                    &req.tool_params()
-                        .map(|p| p.arguments)
-                        .unwrap_or(serde_json::Value::Null),
+                    tool_name,
+                    tool_arguments,
                     &mut state,
                     runtime_id.as_ref(),
                 );
 
                 match policy_eval.decision {
                     PolicyDecision::Allow => {
-                        handle_allow(&req, &mut audit_log, config.verbose);
+                        handle_allow(&req, tool_params.as_ref(), &mut audit_log, config.verbose);
                         // Emit decision event (I1: always emit)
                         if req.is_tool_call() {
                             emit_decision(
                                 &emitter,
                                 &event_source,
                                 &tool_call_id,
-                                &tool_name,
+                                tool_name,
                                 Decision::Allow,
                                 reason_codes::P_POLICY_ALLOW,
                                 None,
@@ -112,7 +119,7 @@ pub(super) fn run_client_to_server(
                             tool_definition_binding.as_ref(),
                         );
                         // Then proceed as a normal allow
-                        handle_allow(&req, &mut audit_log, false);
+                        handle_allow(&req, tool_params.as_ref(), &mut audit_log, false);
                         // false = don't double log ALLOW
                     }
                     PolicyDecision::Deny {

--- a/crates/assay-core/src/mcp/proxy/client.rs
+++ b/crates/assay-core/src/mcp/proxy/client.rs
@@ -1,0 +1,219 @@
+use super::decisions::{emit_decision, extract_tool_call_id, handle_allow, map_policy_code};
+use super::ProxyConfig;
+use crate::mcp::audit::{AuditEvent, AuditLog};
+use crate::mcp::decision::{reason_codes, Decision, DecisionEmitter};
+use crate::mcp::identity::ToolIdentity;
+use crate::mcp::jsonrpc::JsonRpcRequest;
+use crate::mcp::policy::{make_deny_response, McpPolicy, PolicyDecision, PolicyState};
+use crate::mcp::tool_definition::ToolDefinitionBinding;
+use std::{
+    collections::HashMap,
+    io::{self, BufRead, Write},
+    process::ChildStdin,
+    sync::{Arc, Mutex},
+};
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_client_to_server(
+    mut child_stdin: ChildStdin,
+    stdout: Arc<Mutex<io::Stdout>>,
+    policy: McpPolicy,
+    config: ProxyConfig,
+    emitter: Arc<dyn DecisionEmitter>,
+    event_source: String,
+    identity_cache: Arc<Mutex<HashMap<String, ToolIdentity>>>,
+    tool_definition_cache: Arc<Mutex<HashMap<String, ToolDefinitionBinding>>>,
+) -> io::Result<()> {
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+    let mut line = String::new();
+
+    let mut state = PolicyState::default();
+    let mut audit_log = AuditLog::new(config.audit_log_path.as_deref());
+
+    while reader.read_line(&mut line)? > 0 {
+        // 1. Try Parse as MCP Request
+        match serde_json::from_str::<JsonRpcRequest>(&line) {
+            Ok(req) => {
+                // 2. Check Policy with Identity (Phase 9)
+                let (runtime_id, tool_definition_binding) = if req.is_tool_call() {
+                    let name = req.tool_params().map(|p| p.name).unwrap_or_default();
+                    let runtime_id = {
+                        let cache = identity_cache.lock().unwrap();
+                        cache.get(&name).cloned()
+                    };
+                    let tool_definition_binding = {
+                        let cache = tool_definition_cache.lock().unwrap();
+                        cache.get(&name).cloned()
+                    };
+                    (runtime_id, tool_definition_binding)
+                } else {
+                    (None, None)
+                };
+
+                let tool_name = req.tool_params().map(|p| p.name).unwrap_or_default();
+                let tool_call_id = extract_tool_call_id(&req);
+
+                let policy_eval = policy.evaluate_with_metadata(
+                    &tool_name,
+                    &req.tool_params()
+                        .map(|p| p.arguments)
+                        .unwrap_or(serde_json::Value::Null),
+                    &mut state,
+                    runtime_id.as_ref(),
+                );
+
+                match policy_eval.decision {
+                    PolicyDecision::Allow => {
+                        handle_allow(&req, &mut audit_log, config.verbose);
+                        // Emit decision event (I1: always emit)
+                        if req.is_tool_call() {
+                            emit_decision(
+                                &emitter,
+                                &event_source,
+                                &tool_call_id,
+                                &tool_name,
+                                Decision::Allow,
+                                reason_codes::P_POLICY_ALLOW,
+                                None,
+                                req.id.clone(),
+                                &policy_eval.metadata,
+                                tool_definition_binding.as_ref(),
+                            );
+                        }
+                    }
+                    PolicyDecision::AllowWithWarning { tool, code, reason } => {
+                        // Log warning about allowing a tool invocation with issues
+                        if config.verbose {
+                            eprintln!(
+                                "[assay] WARNING: Allowing tool '{}' with warning (code: {}, reason: {}).",
+                                tool, code, reason
+                            );
+                        }
+                        audit_log.log(&AuditEvent {
+                            timestamp: chrono::Utc::now().to_rfc3339(),
+                            decision: "allow_with_warning".to_string(),
+                            tool: Some(tool.clone()),
+                            reason: Some(reason.clone()),
+                            request_id: req.id.clone(),
+                            agentic: None,
+                        });
+                        // Emit decision event (I1: always emit)
+                        emit_decision(
+                            &emitter,
+                            &event_source,
+                            &tool_call_id,
+                            &tool,
+                            Decision::Allow,
+                            &code,
+                            Some(reason),
+                            req.id.clone(),
+                            &policy_eval.metadata,
+                            tool_definition_binding.as_ref(),
+                        );
+                        // Then proceed as a normal allow
+                        handle_allow(&req, &mut audit_log, false);
+                        // false = don't double log ALLOW
+                    }
+                    PolicyDecision::Deny {
+                        tool,
+                        code,
+                        reason,
+                        contract,
+                    } => {
+                        // Log Decision
+                        let decision_str = if config.dry_run { "would_deny" } else { "deny" };
+
+                        if config.verbose {
+                            eprintln!(
+                                "[assay] {} {} (reason: {})",
+                                decision_str.to_uppercase(),
+                                tool,
+                                reason
+                            );
+                        }
+
+                        audit_log.log(&AuditEvent {
+                            timestamp: chrono::Utc::now().to_rfc3339(),
+                            decision: decision_str.to_string(),
+                            tool: Some(tool.clone()),
+                            reason: Some(reason.clone()),
+                            request_id: req.id.clone(),
+                            agentic: Some(contract.clone()),
+                        });
+
+                        // Emit decision event (I1: always emit)
+                        let reason_code = map_policy_code(&code);
+                        emit_decision(
+                            &emitter,
+                            &event_source,
+                            &tool_call_id,
+                            &tool,
+                            if config.dry_run {
+                                Decision::Allow
+                            } else {
+                                Decision::Deny
+                            },
+                            &reason_code,
+                            Some(reason),
+                            req.id.clone(),
+                            &policy_eval.metadata,
+                            tool_definition_binding.as_ref(),
+                        );
+
+                        if config.dry_run {
+                            // DRY RUN: Forward anyway
+                            // Fallthrough to forward logic below
+                        } else {
+                            // BLOCK: Send error response
+                            let id = req.id.unwrap_or(serde_json::Value::Null);
+                            let response_json =
+                                make_deny_response(id, "Content blocked by policy", contract);
+
+                            let mut out =
+                                stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
+                            out.write_all(response_json.as_bytes())?;
+                            out.flush()?;
+
+                            line.clear();
+                            continue; // Skip forwarding
+                        }
+                    }
+                }
+            }
+            Err(_) => {
+                // Hardening: Suspicious Unparsable JSON
+                let trimmed = line.trim();
+                if trimmed.starts_with('{')
+                    && (trimmed.contains("\"method\"")
+                        || trimmed.contains("\"params\"")
+                        || trimmed.contains("\"tool\""))
+                {
+                    eprintln!("[assay] WARNING: Suspicious unparsable JSON, forwarding anyway (potential bypass attempt?): {:.60}...", trimmed);
+                }
+            }
+        }
+
+        // 3. Forward
+        child_stdin.write_all(line.as_bytes())?;
+        child_stdin.flush()?;
+        line.clear();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_contract_client_loop_inputs_remain_private() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+
+        assert_send::<Arc<Mutex<HashMap<String, ToolIdentity>>>>();
+        assert_send::<Arc<Mutex<HashMap<String, ToolDefinitionBinding>>>>();
+        assert_sync::<Arc<dyn DecisionEmitter>>();
+    }
+}

--- a/crates/assay-core/src/mcp/proxy/decisions.rs
+++ b/crates/assay-core/src/mcp/proxy/decisions.rs
@@ -2,22 +2,24 @@ use crate::mcp::audit::{AuditEvent, AuditLog};
 use crate::mcp::decision::{
     reason_codes, refresh_contract_projections, Decision, DecisionEmitter, DecisionEvent,
 };
-use crate::mcp::jsonrpc::JsonRpcRequest;
+use crate::mcp::jsonrpc::{CallToolParams, JsonRpcRequest};
 use crate::mcp::policy::PolicyMatchMetadata;
 use crate::mcp::tool_definition::ToolDefinitionBinding;
 use std::sync::Arc;
 
-pub(super) fn handle_allow(req: &JsonRpcRequest, audit_log: &mut AuditLog, verbose: bool) {
+pub(super) fn handle_allow(
+    req: &JsonRpcRequest,
+    tool_params: Option<&CallToolParams>,
+    audit_log: &mut AuditLog,
+    verbose: bool,
+) {
     if verbose && req.is_tool_call() {
-        let tool = req
-            .tool_params()
-            .map(|p| p.name)
-            .unwrap_or_else(|| "unknown".to_string());
+        let tool = tool_params.map(|p| p.name.as_str()).unwrap_or("unknown");
         eprintln!("[assay] ALLOW {}", tool);
     }
 
     if req.is_tool_call() {
-        let tool = req.tool_params().map(|p| p.name);
+        let tool = tool_params.map(|p| p.name.clone());
         audit_log.log(&AuditEvent {
             timestamp: chrono::Utc::now().to_rfc3339(),
             decision: "allow".to_string(),
@@ -30,9 +32,12 @@ pub(super) fn handle_allow(req: &JsonRpcRequest, audit_log: &mut AuditLog, verbo
 }
 
 /// Extract tool_call_id from request (I4: idempotency key).
-pub(super) fn extract_tool_call_id(request: &JsonRpcRequest) -> String {
+pub(super) fn extract_tool_call_id(
+    request: &JsonRpcRequest,
+    tool_params: Option<&CallToolParams>,
+) -> String {
     // Try to get from params._meta.tool_call_id (MCP standard)
-    if let Some(params) = request.tool_params() {
+    if let Some(params) = tool_params {
         if let Some(meta) = params.arguments.get("_meta") {
             if let Some(id) = meta.get("tool_call_id").and_then(|v| v.as_str()) {
                 return id.to_string();
@@ -195,7 +200,10 @@ mod tests {
             }
         }));
 
-        assert_eq!(extract_tool_call_id(&request), "tc_explicit_001");
+        assert_eq!(
+            extract_tool_call_id(&request, request.tool_params().as_ref()),
+            "tc_explicit_001"
+        );
     }
 
     #[test]
@@ -219,8 +227,14 @@ mod tests {
             }
         }));
 
-        assert_eq!(extract_tool_call_id(&string_request), "req_request-a");
-        assert_eq!(extract_tool_call_id(&numeric_request), "req_42");
+        assert_eq!(
+            extract_tool_call_id(&string_request, string_request.tool_params().as_ref()),
+            "req_request-a"
+        );
+        assert_eq!(
+            extract_tool_call_id(&numeric_request, numeric_request.tool_params().as_ref()),
+            "req_42"
+        );
     }
 
     #[test]
@@ -234,7 +248,7 @@ mod tests {
             }
         }));
 
-        let generated = extract_tool_call_id(&request);
+        let generated = extract_tool_call_id(&request, request.tool_params().as_ref());
         assert!(
             generated.starts_with("gen_"),
             "missing request id should produce generated idempotency key"

--- a/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step6.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step6.md
@@ -1,0 +1,45 @@
+# SPLIT CHECKLIST - Wave 51 MCP Proxy Step6
+
+## Scope Lock
+
+- Move only the client-to-server stdin/policy/forwarding loop behind the existing `McpProxy` facade.
+- Keep `McpProxy::spawn` and `McpProxy::run` in `crates/assay-core/src/mcp/proxy.rs`.
+- Keep thread spawning, thread joining, child lifecycle, and facade state in `proxy.rs`.
+- Preserve stdin line reading, JSON-RPC parsing, identity/tool-definition cache reads, policy evaluation, allow/warning/deny handling, dry-run forwarding, deny response writing, suspicious JSON warning, and child stdin forwarding.
+- Do not change policy semantics, JSON-RPC surfaces, audit payloads, decision-event payloads, server-to-client behavior, workflows, or generated files.
+
+## Files
+
+- `crates/assay-core/src/mcp/proxy.rs`
+- `crates/assay-core/src/mcp/proxy/client.rs`
+- `docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step6.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step6.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step6.md`
+- `scripts/ci/review-wave51-hotspot-mcp-proxy-step6.sh`
+
+## Drift Gates
+
+- `proxy.rs` non-test code stays under 260 lines.
+- `proxy.rs` declares `mod client;` and calls `run_client_to_server`.
+- `proxy.rs` retains `pub struct McpProxy`, `pub fn spawn`, `pub fn run`, `thread::spawn`, and child `wait`.
+- `proxy.rs` no longer directly imports/uses `AuditLog`, `PolicyDecision`, `PolicyState`, `JsonRpcRequest`, `make_deny_response`, `stdin.lock`, `read_line`, `write_all`, or direct decision helpers.
+- `proxy/client.rs` owns `run_client_to_server`, `stdin.lock`, `read_line`, `PolicyDecision`, `PolicyState`, `AuditLog`, `make_deny_response`, `emit_decision`, `handle_allow`, `map_policy_code`, and child stdin forwarding.
+- `proxy/client.rs` must not call `observe_tool_definition`; server output enrichment remains in `proxy/server.rs`.
+
+## Validation
+
+```bash
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_
+cargo test -p assay-core --lib mcp::proxy::
+bash scripts/ci/review-wave51-hotspot-mcp-proxy-step6.sh
+```
+
+## Definition of Done
+
+- Step 6 reviewer script passes.
+- Step 3/4/5 proxy contract tests pass after the client-loop move.
+- `proxy.rs` remains the stable public facade and owns only orchestration, not per-line policy forwarding.
+- Step 7 can decide whether to stop Wave 51 MCP proxy here or further split client policy branches into smaller units.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step6.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step6.md
@@ -1,0 +1,31 @@
+# SPLIT MOVE MAP - Wave 51 MCP Proxy Step6
+
+## Intent
+
+Move the second threaded loop after Step 5 moved server output handling. Step 6 moves the client-to-server stdin/policy/forwarding loop into `proxy/client.rs` while keeping the thread spawn and join in `McpProxy::run`.
+
+## Moves
+
+| From | To | Notes |
+| --- | --- | --- |
+| client-to-server `stdin.lock` loop | `proxy/client.rs::run_client_to_server` | Preserves line-by-line stdin read and child stdin forwarding. |
+| JSON-RPC request parsing | `proxy/client.rs::run_client_to_server` | Preserves best-effort parse and suspicious unparsable JSON warning. |
+| identity/tool-definition cache reads | `proxy/client.rs::run_client_to_server` | Preserves name-keyed lookup for tool calls. |
+| policy evaluation and state | `proxy/client.rs::run_client_to_server` | Preserves `PolicyState` ownership inside the client loop. |
+| allow/warning/deny policy branches | `proxy/client.rs::run_client_to_server` | Preserves audit logging, decision emission, dry-run behavior, and deny response handling. |
+| child stdin write/flush | `proxy/client.rs::run_client_to_server` | Preserves forwarding for allowed, warning, dry-run deny, non-tool, and unparsable requests. |
+
+## Data Flow After Step 6
+
+1. `proxy.rs::McpProxy::run` opens child stdin/stdout, creates shared stdout, initializes the decision emitter, then spawns both proxy threads.
+2. The server-to-client thread delegates to `proxy::server::run_server_to_client`.
+3. The client-to-server thread delegates to `proxy::client::run_client_to_server`.
+4. `proxy::client::run_client_to_server` owns the policy path and uses helpers from `proxy::decisions`.
+5. `proxy.rs` remains the public facade and process/thread orchestrator.
+
+## Reviewer Focus
+
+- This should be a mechanical loop move, not a policy rewrite.
+- `proxy/client.rs` is allowed to know policy/audit/decision details; `proxy/server.rs` is not.
+- The deny path must still skip forwarding unless `dry_run` is enabled.
+- The suspicious unparsable JSON warning must remain forwarding-only.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step6.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step6.md
@@ -1,0 +1,45 @@
+# SPLIT REVIEW PACK - Wave 51 MCP Proxy Step6
+
+## Summary
+
+Step 6 moves the MCP proxy client-to-server stdin/policy/forwarding loop into `proxy/client.rs`. The stable facade still owns `McpProxy::spawn`, `McpProxy::run`, thread spawning/joining, child lifecycle, decision-emitter initialization, event-source derivation, and cache wiring.
+
+## LOC Delta
+
+| File | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| `crates/assay-core/src/mcp/proxy.rs` | 506 | 331 | -175 |
+| `crates/assay-core/src/mcp/proxy/client.rs` | 0 | 219 | +219 |
+
+## Boundary Proof
+
+Facade still owns orchestration:
+
+```bash
+rg -n 'pub struct McpProxy|pub fn spawn\(|pub fn run\(|thread::spawn|run_client_to_server|run_server_to_client|self\.child\.wait' crates/assay-core/src/mcp/proxy.rs
+```
+
+Client loop moved:
+
+```bash
+rg -n 'fn run_client_to_server|stdin\.lock|read_line|PolicyDecision|PolicyState|AuditLog|make_deny_response|emit_decision|child_stdin\.write_all' crates/assay-core/src/mcp/proxy/client.rs
+```
+
+Facade no longer owns policy forwarding directly:
+
+```bash
+! rg -n 'stdin\.lock|PolicyDecision|PolicyState|AuditLog|JsonRpcRequest|make_deny_response|child_stdin\.write_all|emit_decision|handle_allow|map_policy_code|extract_tool_call_id' crates/assay-core/src/mcp/proxy.rs
+```
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check -p assay-core`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- `cargo test -p assay-core --lib proxy_contract_`
+- `cargo test -p assay-core --lib mcp::proxy::`
+- `bash scripts/ci/review-wave51-hotspot-mcp-proxy-step6.sh`
+
+## Next Step
+
+Step 7 should either stop the MCP proxy split at a maintainable facade or split `proxy/client.rs` internally by policy branch after adding branch-level behavior contracts for allow, warning, deny, and dry-run deny.

--- a/scripts/ci/review-wave51-hotspot-mcp-proxy-step6.sh
+++ b/scripts/ci/review-wave51-hotspot-mcp-proxy-step6.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+PROXY="crates/assay-core/src/mcp/proxy.rs"
+CLIENT="crates/assay-core/src/mcp/proxy/client.rs"
+SERVER="crates/assay-core/src/mcp/proxy/server.rs"
+DECISIONS="crates/assay-core/src/mcp/proxy/decisions.rs"
+TOOLS="crates/assay-core/src/mcp/proxy/tools.rs"
+
+assert_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if ! rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+assert_not_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+echo "[review] workflow and generated-file guard"
+if ! git diff --quiet -- .github/workflows; then
+  echo "FAIL: Wave 51 MCP Proxy Step6 must not touch workflows"
+  exit 1
+fi
+if ! git diff --quiet -- crates/assay-ebpf/src/vmlinux.rs; then
+  echo "FAIL: generated vmlinux.rs must stay out of scope"
+  exit 1
+fi
+
+echo "[review] facade and client-loop boundary"
+proxy_code_lines="$(
+  awk 'BEGIN{n=0; in_tests=0} /^#\[cfg\(test\)\]/{in_tests=1} !in_tests{n++} END{print n}' "$PROXY"
+)"
+echo "proxy non-test lines: $proxy_code_lines"
+if [ "$proxy_code_lines" -gt 260 ]; then
+  echo "FAIL: proxy facade is too thick after Step6"
+  exit 1
+fi
+assert_rg 'mod client;' "$PROXY" "proxy client module declaration missing"
+assert_rg 'run_client_to_server\(' "$PROXY" "proxy facade does not delegate client loop"
+assert_rg 'run_server_to_client\(' "$PROXY" "server loop delegation missing"
+assert_rg 'pub struct McpProxy' "$PROXY" "McpProxy facade moved out of proxy.rs"
+assert_rg 'pub fn spawn\(' "$PROXY" "McpProxy::spawn moved out of proxy.rs"
+assert_rg 'pub fn run\(' "$PROXY" "McpProxy::run moved out of proxy.rs"
+assert_rg 'thread::spawn' "$PROXY" "thread spawning no longer visible in proxy.rs"
+assert_rg 'self\.child\.wait\(\)' "$PROXY" "child wait moved out of proxy facade"
+assert_not_rg 'stdin\.lock|PolicyDecision|PolicyState|AuditLog|AuditEvent|JsonRpcRequest|make_deny_response|child_stdin\.write_all|emit_decision|handle_allow|map_policy_code|extract_tool_call_id' "$PROXY" "client policy/forwarding detail still lives in proxy facade"
+
+echo "[review] client module ownership"
+assert_rg 'fn run_client_to_server\(' "$CLIENT" "client loop entrypoint missing"
+assert_rg 'stdin\.lock\(\)' "$CLIENT" "client module does not own stdin lock"
+assert_rg 'read_line\(&mut line\)' "$CLIENT" "client module does not own read loop"
+assert_rg 'serde_json::from_str::<JsonRpcRequest>' "$CLIENT" "client module does not parse JSON-RPC requests"
+assert_rg 'PolicyDecision::Allow' "$CLIENT" "allow branch missing from client module"
+assert_rg 'PolicyDecision::AllowWithWarning' "$CLIENT" "allow-with-warning branch missing from client module"
+assert_rg 'PolicyDecision::Deny' "$CLIENT" "deny branch missing from client module"
+assert_rg 'PolicyState::default\(\)' "$CLIENT" "policy state ownership missing from client module"
+assert_rg 'AuditLog::new' "$CLIENT" "audit log ownership missing from client module"
+assert_rg 'make_deny_response' "$CLIENT" "deny response path missing from client module"
+assert_rg 'emit_decision\(' "$CLIENT" "decision emission missing from client module"
+assert_rg 'child_stdin\.write_all' "$CLIENT" "child stdin forwarding missing from client module"
+assert_rg 'Suspicious unparsable JSON' "$CLIENT" "suspicious JSON warning missing from client module"
+assert_not_rg 'observe_tool_definition|BufReader::new\(child_stdout\)' "$CLIENT" "client module leaked server output responsibilities"
+assert_not_rg 'PolicyDecision|make_deny_response|AuditLog|emit_decision' "$SERVER" "server module leaked client policy/audit responsibilities"
+assert_rg 'proxy_contract_client_loop_inputs_remain_private' "$CLIENT" "client module contract test missing"
+assert_rg 'proxy_contract_server_loop_enrichment_inputs_remain_private' "$SERVER" "server module contract test missing"
+assert_rg 'proxy_contract_emit_decision_preserves_core_fields' "$DECISIONS" "decision projection contract test missing"
+assert_rg 'proxy_contract_observe_tool_definition_rejects_empty_names' "$TOOLS" "tools/list observation contract test missing"
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_
+cargo test -p assay-core --lib mcp::proxy::
+git diff --check
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary

Performs Wave 51 MCP proxy Step 6: moves the client-to-server stdin/policy/forwarding loop into a private client module.

- Keeps `McpProxy::spawn` and `McpProxy::run` as the stable proxy facade.
- Moves stdin reading, JSON-RPC parsing, identity/tool-definition cache reads, policy evaluation, audit logging, decision emission, deny response handling, suspicious JSON warning, and child stdin forwarding into `proxy/client.rs`.
- Leaves process lifecycle, thread spawning/joining, decision-emitter initialization, event-source derivation, and cache wiring in `proxy.rs`.
- Adds Step 6 SPLIT checklist, move-map, review-pack, and reviewer gate.

## Scope

Included:

- `crates/assay-core/src/mcp/proxy.rs`
- `crates/assay-core/src/mcp/proxy/client.rs`
- `docs/contributing/SPLIT-*wave51-hotspot-mcp-proxy-step6.md`
- `scripts/ci/review-wave51-hotspot-mcp-proxy-step6.sh`

Explicitly excluded:

- changing policy semantics
- changing dry-run or deny-response behavior
- changing audit/decision-event payloads
- changing server-to-client tools/list behavior
- workflow changes
- unrelated local architecture/example/token files

## LOC Delta

| File | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `crates/assay-core/src/mcp/proxy.rs` | 506 | 331 | -175 |
| `crates/assay-core/src/mcp/proxy/client.rs` | 0 | 219 | +219 |

## Validation

```bash
bash scripts/ci/review-wave51-hotspot-mcp-proxy-step6.sh
```

This includes:

```bash
cargo fmt --check
cargo check -p assay-core
cargo clippy -p assay-core --all-targets -- -D warnings
cargo test -p assay-core --lib proxy_contract_
cargo test -p assay-core --lib mcp::proxy::
git diff --check
```

## Chain

This is stacked on PR #1175 while it waits for final CI/merge. Once #1175 lands, this PR can be rebased onto `main` with no intended scope changes.

## Next

Step 7 should either stop the MCP proxy split at this maintainable facade or split `proxy/client.rs` internally by policy branch after adding branch-level behavior contracts for allow, warning, deny, and dry-run deny.
