### PR TITLE
[codex] split Wave 51 MCP proxy client policy branches

### DIFF
--- a/crates/assay-core/src/mcp/proxy/client.rs
+++ b/crates/assay-core/src/mcp/proxy/client.rs
@@ -1,10 +1,13 @@
-use super::decisions::{emit_decision, extract_tool_call_id, handle_allow, map_policy_code};
+mod branches;
+
+use self::branches::{handle_policy_decision, BranchOutcome, PolicyBranchContext};
+use super::decisions::extract_tool_call_id;
 use super::ProxyConfig;
-use crate::mcp::audit::{AuditEvent, AuditLog};
-use crate::mcp::decision::{reason_codes, Decision, DecisionEmitter};
+use crate::mcp::audit::AuditLog;
+use crate::mcp::decision::DecisionEmitter;
 use crate::mcp::identity::ToolIdentity;
 use crate::mcp::jsonrpc::JsonRpcRequest;
-use crate::mcp::policy::{make_deny_response, McpPolicy, PolicyDecision, PolicyState};
+use crate::mcp::policy::{McpPolicy, PolicyState};
 use crate::mcp::tool_definition::ToolDefinitionBinding;
 use std::{
     collections::HashMap,
@@ -70,122 +73,30 @@ pub(super) fn run_client_to_server(
                     runtime_id.as_ref(),
                 );
 
-                match policy_eval.decision {
-                    PolicyDecision::Allow => {
-                        handle_allow(&req, tool_params.as_ref(), &mut audit_log, config.verbose);
-                        // Emit decision event (I1: always emit)
-                        if req.is_tool_call() {
-                            emit_decision(
-                                &emitter,
-                                &event_source,
-                                &tool_call_id,
-                                tool_name,
-                                Decision::Allow,
-                                reason_codes::P_POLICY_ALLOW,
-                                None,
-                                req.id.clone(),
-                                &policy_eval.metadata,
-                                tool_definition_binding.as_ref(),
-                            );
-                        }
-                    }
-                    PolicyDecision::AllowWithWarning { tool, code, reason } => {
-                        // Log warning about allowing a tool invocation with issues
-                        if config.verbose {
-                            eprintln!(
-                                "[assay] WARNING: Allowing tool '{}' with warning (code: {}, reason: {}).",
-                                tool, code, reason
-                            );
-                        }
-                        audit_log.log(&AuditEvent {
-                            timestamp: chrono::Utc::now().to_rfc3339(),
-                            decision: "allow_with_warning".to_string(),
-                            tool: Some(tool.clone()),
-                            reason: Some(reason.clone()),
-                            request_id: req.id.clone(),
-                            agentic: None,
-                        });
-                        // Emit decision event (I1: always emit)
-                        emit_decision(
-                            &emitter,
-                            &event_source,
-                            &tool_call_id,
-                            &tool,
-                            Decision::Allow,
-                            &code,
-                            Some(reason),
-                            req.id.clone(),
-                            &policy_eval.metadata,
-                            tool_definition_binding.as_ref(),
-                        );
-                        // Then proceed as a normal allow
-                        handle_allow(&req, tool_params.as_ref(), &mut audit_log, false);
-                        // false = don't double log ALLOW
-                    }
-                    PolicyDecision::Deny {
-                        tool,
-                        code,
-                        reason,
-                        contract,
-                    } => {
-                        // Log Decision
-                        let decision_str = if config.dry_run { "would_deny" } else { "deny" };
+                let branch_outcome = handle_policy_decision(
+                    policy_eval.decision,
+                    PolicyBranchContext {
+                        req: &req,
+                        tool_params: tool_params.as_ref(),
+                        tool_name,
+                        tool_call_id: &tool_call_id,
+                        metadata: &policy_eval.metadata,
+                        tool_definition_binding: tool_definition_binding.as_ref(),
+                        config: &config,
+                        emitter: &emitter,
+                        event_source: &event_source,
+                        audit_log: &mut audit_log,
+                    },
+                    |response_json| {
+                        let mut out = stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
+                        out.write_all(response_json.as_bytes())?;
+                        out.flush()
+                    },
+                )?;
 
-                        if config.verbose {
-                            eprintln!(
-                                "[assay] {} {} (reason: {})",
-                                decision_str.to_uppercase(),
-                                tool,
-                                reason
-                            );
-                        }
-
-                        audit_log.log(&AuditEvent {
-                            timestamp: chrono::Utc::now().to_rfc3339(),
-                            decision: decision_str.to_string(),
-                            tool: Some(tool.clone()),
-                            reason: Some(reason.clone()),
-                            request_id: req.id.clone(),
-                            agentic: Some(contract.clone()),
-                        });
-
-                        // Emit decision event (I1: always emit)
-                        let reason_code = map_policy_code(&code);
-                        emit_decision(
-                            &emitter,
-                            &event_source,
-                            &tool_call_id,
-                            &tool,
-                            if config.dry_run {
-                                Decision::Allow
-                            } else {
-                                Decision::Deny
-                            },
-                            &reason_code,
-                            Some(reason),
-                            req.id.clone(),
-                            &policy_eval.metadata,
-                            tool_definition_binding.as_ref(),
-                        );
-
-                        if config.dry_run {
-                            // DRY RUN: Forward anyway
-                            // Fallthrough to forward logic below
-                        } else {
-                            // BLOCK: Send error response
-                            let id = req.id.unwrap_or(serde_json::Value::Null);
-                            let response_json =
-                                make_deny_response(id, "Content blocked by policy", contract);
-
-                            let mut out =
-                                stdout.lock().map_err(|e| io::Error::other(e.to_string()))?;
-                            out.write_all(response_json.as_bytes())?;
-                            out.flush()?;
-
-                            line.clear();
-                            continue; // Skip forwarding
-                        }
-                    }
+                if branch_outcome == BranchOutcome::Blocked {
+                    line.clear();
+                    continue;
                 }
             }
             Err(_) => {

--- a/crates/assay-core/src/mcp/proxy/client/branches.rs
+++ b/crates/assay-core/src/mcp/proxy/client/branches.rs
@@ -1,0 +1,356 @@
+use super::super::decisions::{emit_decision, handle_allow, map_policy_code};
+use super::super::ProxyConfig;
+use crate::mcp::audit::{AuditEvent, AuditLog};
+use crate::mcp::decision::{reason_codes, Decision, DecisionEmitter};
+use crate::mcp::jsonrpc::{CallToolParams, JsonRpcRequest};
+use crate::mcp::policy::{make_deny_response, PolicyDecision, PolicyMatchMetadata};
+use crate::mcp::tool_definition::ToolDefinitionBinding;
+use std::{io, sync::Arc};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BranchOutcome {
+    Forward,
+    Blocked,
+}
+
+pub(super) struct PolicyBranchContext<'a> {
+    pub(super) req: &'a JsonRpcRequest,
+    pub(super) tool_params: Option<&'a CallToolParams>,
+    pub(super) tool_name: &'a str,
+    pub(super) tool_call_id: &'a str,
+    pub(super) metadata: &'a PolicyMatchMetadata,
+    pub(super) tool_definition_binding: Option<&'a ToolDefinitionBinding>,
+    pub(super) config: &'a ProxyConfig,
+    pub(super) emitter: &'a Arc<dyn DecisionEmitter>,
+    pub(super) event_source: &'a str,
+    pub(super) audit_log: &'a mut AuditLog,
+}
+
+pub(super) fn handle_policy_decision<F>(
+    decision: PolicyDecision,
+    ctx: PolicyBranchContext<'_>,
+    write_deny_response: F,
+) -> io::Result<BranchOutcome>
+where
+    F: FnOnce(&str) -> io::Result<()>,
+{
+    match decision {
+        PolicyDecision::Allow => handle_allow_branch(ctx),
+        PolicyDecision::AllowWithWarning { tool, code, reason } => {
+            handle_allow_with_warning_branch(ctx, tool, code, reason)
+        }
+        PolicyDecision::Deny {
+            tool,
+            code,
+            reason,
+            contract,
+        } => handle_deny_branch(ctx, tool, code, reason, contract, write_deny_response),
+    }
+}
+
+fn handle_allow_branch(ctx: PolicyBranchContext<'_>) -> io::Result<BranchOutcome> {
+    handle_allow(ctx.req, ctx.tool_params, ctx.audit_log, ctx.config.verbose);
+    if ctx.req.is_tool_call() {
+        emit_decision(
+            ctx.emitter,
+            ctx.event_source,
+            ctx.tool_call_id,
+            ctx.tool_name,
+            Decision::Allow,
+            reason_codes::P_POLICY_ALLOW,
+            None,
+            ctx.req.id.clone(),
+            ctx.metadata,
+            ctx.tool_definition_binding,
+        );
+    }
+    Ok(BranchOutcome::Forward)
+}
+
+fn handle_allow_with_warning_branch(
+    ctx: PolicyBranchContext<'_>,
+    tool: String,
+    code: String,
+    reason: String,
+) -> io::Result<BranchOutcome> {
+    if ctx.config.verbose {
+        eprintln!(
+            "[assay] WARNING: Allowing tool '{}' with warning (code: {}, reason: {}).",
+            tool, code, reason
+        );
+    }
+    ctx.audit_log.log(&AuditEvent {
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        decision: "allow_with_warning".to_string(),
+        tool: Some(tool.clone()),
+        reason: Some(reason.clone()),
+        request_id: ctx.req.id.clone(),
+        agentic: None,
+    });
+    emit_decision(
+        ctx.emitter,
+        ctx.event_source,
+        ctx.tool_call_id,
+        &tool,
+        Decision::Allow,
+        &code,
+        Some(reason),
+        ctx.req.id.clone(),
+        ctx.metadata,
+        ctx.tool_definition_binding,
+    );
+    handle_allow(ctx.req, ctx.tool_params, ctx.audit_log, false);
+    Ok(BranchOutcome::Forward)
+}
+
+fn handle_deny_branch<F>(
+    ctx: PolicyBranchContext<'_>,
+    tool: String,
+    code: String,
+    reason: String,
+    contract: serde_json::Value,
+    write_deny_response: F,
+) -> io::Result<BranchOutcome>
+where
+    F: FnOnce(&str) -> io::Result<()>,
+{
+    let decision_str = if ctx.config.dry_run {
+        "would_deny"
+    } else {
+        "deny"
+    };
+
+    if ctx.config.verbose {
+        eprintln!(
+            "[assay] {} {} (reason: {})",
+            decision_str.to_uppercase(),
+            tool,
+            reason
+        );
+    }
+
+    ctx.audit_log.log(&AuditEvent {
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        decision: decision_str.to_string(),
+        tool: Some(tool.clone()),
+        reason: Some(reason.clone()),
+        request_id: ctx.req.id.clone(),
+        agentic: Some(contract.clone()),
+    });
+
+    let reason_code = map_policy_code(&code);
+    emit_decision(
+        ctx.emitter,
+        ctx.event_source,
+        ctx.tool_call_id,
+        &tool,
+        if ctx.config.dry_run {
+            Decision::Allow
+        } else {
+            Decision::Deny
+        },
+        &reason_code,
+        Some(reason),
+        ctx.req.id.clone(),
+        ctx.metadata,
+        ctx.tool_definition_binding,
+    );
+
+    if ctx.config.dry_run {
+        return Ok(BranchOutcome::Forward);
+    }
+
+    let id = ctx.req.id.clone().unwrap_or(serde_json::Value::Null);
+    let response_json = make_deny_response(id, "Content blocked by policy", contract);
+    write_deny_response(&response_json)?;
+    Ok(BranchOutcome::Blocked)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::decision::DecisionEvent;
+    use serde_json::json;
+    use std::sync::Mutex as StdMutex;
+
+    struct CapturingEmitter {
+        events: StdMutex<Vec<DecisionEvent>>,
+    }
+
+    impl CapturingEmitter {
+        fn new() -> Self {
+            Self {
+                events: StdMutex::new(Vec::new()),
+            }
+        }
+
+        fn events(&self) -> Vec<DecisionEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl DecisionEmitter for CapturingEmitter {
+        fn emit(&self, event: &DecisionEvent) {
+            self.events.lock().unwrap().push(event.clone());
+        }
+    }
+
+    fn proxy_contract_request() -> JsonRpcRequest {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": "request-a",
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {
+                    "_meta": {
+                        "tool_call_id": "tc_step7_001"
+                    }
+                }
+            }
+        }))
+        .expect("test request should deserialize")
+    }
+
+    fn proxy_config(dry_run: bool) -> ProxyConfig {
+        ProxyConfig {
+            dry_run,
+            verbose: false,
+            audit_log_path: None,
+            server_id: "test-server".to_string(),
+            decision_log_path: None,
+            event_source: Some("assay://test/client-branches".to_string()),
+        }
+    }
+
+    fn with_branch_context<R>(
+        dry_run: bool,
+        f: impl FnOnce(PolicyBranchContext<'_>, Arc<CapturingEmitter>, &mut String) -> io::Result<R>,
+    ) -> io::Result<R> {
+        let request = proxy_contract_request();
+        let params = request.tool_params();
+        let emitter = Arc::new(CapturingEmitter::new());
+        let emitter_dyn: Arc<dyn DecisionEmitter> = emitter.clone();
+        let config = proxy_config(dry_run);
+        let metadata = PolicyMatchMetadata::default();
+        let mut audit_log = AuditLog::new(None);
+        let mut deny_response = String::new();
+        let context = PolicyBranchContext {
+            req: &request,
+            tool_params: params.as_ref(),
+            tool_name: "read_file",
+            tool_call_id: "tc_step7_001",
+            metadata: &metadata,
+            tool_definition_binding: None,
+            config: &config,
+            emitter: &emitter_dyn,
+            event_source: "assay://test/client-branches",
+            audit_log: &mut audit_log,
+        };
+
+        f(context, emitter, &mut deny_response)
+    }
+
+    #[test]
+    fn proxy_contract_client_branch_allow_emits_allow_and_forwards() {
+        with_branch_context(false, |context, emitter, deny_response| {
+            let outcome = handle_policy_decision(PolicyDecision::Allow, context, |response| {
+                deny_response.push_str(response);
+                Ok(())
+            })?;
+
+            assert_eq!(outcome, BranchOutcome::Forward);
+            assert!(deny_response.is_empty());
+            let events = emitter.events();
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].data.decision, Decision::Allow);
+            assert_eq!(events[0].data.tool, "read_file");
+            assert_eq!(events[0].data.reason_code, reason_codes::P_POLICY_ALLOW);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn proxy_contract_client_branch_warning_emits_allow_and_forwards() {
+        with_branch_context(false, |context, emitter, deny_response| {
+            let outcome = handle_policy_decision(
+                PolicyDecision::AllowWithWarning {
+                    tool: "read_file".to_string(),
+                    code: "W_UNCONSTRAINED".to_string(),
+                    reason: "missing schema".to_string(),
+                },
+                context,
+                |response| {
+                    deny_response.push_str(response);
+                    Ok(())
+                },
+            )?;
+
+            assert_eq!(outcome, BranchOutcome::Forward);
+            assert!(deny_response.is_empty());
+            let events = emitter.events();
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].data.decision, Decision::Allow);
+            assert_eq!(events[0].data.reason_code, "W_UNCONSTRAINED");
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn proxy_contract_client_branch_deny_emits_deny_and_blocks() {
+        with_branch_context(false, |context, emitter, deny_response| {
+            let outcome = handle_policy_decision(
+                PolicyDecision::Deny {
+                    tool: "read_file".to_string(),
+                    code: "E_TOOL_DENIED".to_string(),
+                    reason: "tool denied".to_string(),
+                    contract: json!({"policy": "test"}),
+                },
+                context,
+                |response| {
+                    deny_response.push_str(response);
+                    Ok(())
+                },
+            )?;
+
+            assert_eq!(outcome, BranchOutcome::Blocked);
+            assert!(deny_response.contains("Content blocked by policy"));
+            let events = emitter.events();
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].data.decision, Decision::Deny);
+            assert_eq!(events[0].data.reason_code, reason_codes::P_TOOL_DENIED);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn proxy_contract_client_branch_dry_run_deny_emits_allow_and_forwards() {
+        with_branch_context(true, |context, emitter, deny_response| {
+            let outcome = handle_policy_decision(
+                PolicyDecision::Deny {
+                    tool: "read_file".to_string(),
+                    code: "E_TOOL_DENIED".to_string(),
+                    reason: "tool denied".to_string(),
+                    contract: json!({"policy": "test"}),
+                },
+                context,
+                |response| {
+                    deny_response.push_str(response);
+                    Ok(())
+                },
+            )?;
+
+            assert_eq!(outcome, BranchOutcome::Forward);
+            assert!(deny_response.is_empty());
+            let events = emitter.events();
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].data.decision, Decision::Allow);
+            assert_eq!(events[0].data.reason_code, reason_codes::P_TOOL_DENIED);
+            Ok(())
+        })
+        .unwrap();
+    }
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step7.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step7.md
@@ -1,0 +1,46 @@
+# SPLIT CHECKLIST - Wave 51 MCP Proxy Step7
+
+## Scope Lock
+
+- Split only the MCP proxy client policy-decision branch handling out of `proxy/client.rs`.
+- Keep `proxy/client.rs::run_client_to_server` as the stdin/read/parse/cache/evaluate/forward loop.
+- Move allow, allow-with-warning, deny, and dry-run-deny response decisions into `proxy/client/branches.rs`.
+- Add branch-level behavior contracts for allow, warning, deny, and dry-run deny before relying on the split.
+- Do not change policy semantics, JSON-RPC surfaces, audit payloads, decision-event payloads, server-to-client behavior, workflows, or generated files.
+
+## Files
+
+- `crates/assay-core/src/mcp/proxy/client.rs`
+- `crates/assay-core/src/mcp/proxy/client/branches.rs`
+- `docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-mcp-proxy-step7.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step7.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step7.md`
+- `scripts/ci/review-wave51-hotspot-mcp-proxy-step7.sh`
+
+## Drift Gates
+
+- `proxy.rs` remains the stable public facade and keeps orchestration only.
+- `proxy/client.rs` owns stdin locking, line reads, JSON-RPC parsing, identity/tool-definition cache lookup, policy evaluation, suspicious JSON warning, and child stdin forwarding.
+- `proxy/client.rs` delegates policy branch handling through `handle_policy_decision` and `PolicyBranchContext`.
+- `proxy/client.rs` must not directly match `PolicyDecision::{Allow, AllowWithWarning, Deny}` or own deny-response construction.
+- `proxy/client/branches.rs` owns `PolicyDecision` branch matching, allow/warning/deny audit decisions, decision emission, reason-code mapping, deny response generation, and branch outcomes.
+- `proxy/client/branches.rs` must not own stdin reading, child stdin forwarding, server-output enrichment, or tools/list observation.
+
+## Validation
+
+```bash
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_client_branch_
+cargo test -p assay-core --lib proxy_contract_
+cargo test -p assay-core --lib mcp::proxy::
+bash scripts/ci/review-wave51-hotspot-mcp-proxy-step7.sh
+```
+
+## Definition of Done
+
+- Step 7 reviewer script passes.
+- Four branch-level contracts pass: allow, warning, deny, and dry-run deny.
+- `proxy/client.rs` is a loop/coordinator, not a policy branch implementation file.
+- `proxy/client/branches.rs` is private to the client module and does not broaden public API surface.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step7.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-mcp-proxy-step7.md
@@ -1,0 +1,31 @@
+# SPLIT MOVE MAP - Wave 51 MCP Proxy Step7
+
+## Intent
+
+After Step 6 moved the full client-to-server loop into `proxy/client.rs`, Step 7 narrows that file by extracting policy-decision branch mechanics. The loop remains responsible for reading, parsing, evaluating policy, and forwarding. The new branch module owns the behavior that differs across allow, allow-with-warning, deny, and dry-run deny.
+
+## Moves
+
+| From | To | Notes |
+| --- | --- | --- |
+| `PolicyDecision::Allow` handling | `proxy/client/branches.rs::handle_allow_branch` | Preserves allow audit logging and always-emit allow decision event for tool calls. |
+| `PolicyDecision::AllowWithWarning` handling | `proxy/client/branches.rs::handle_allow_with_warning_branch` | Preserves warning log shape, audit entry, allow decision event, and non-double-logged allow continuation. |
+| `PolicyDecision::Deny` handling | `proxy/client/branches.rs::handle_deny_branch` | Preserves deny/would-deny audit entry, mapped reason code, decision event, dry-run forwarding, and blocking deny response. |
+| forwarding vs blocking decision | `proxy/client/branches.rs::BranchOutcome` | Makes the loop branch-neutral: forward unless the branch returns `Blocked`. |
+| branch inputs | `proxy/client/branches.rs::PolicyBranchContext` | Passes existing request, cached tool params, metadata, binding, config, emitter, event source, and audit log without broadening visibility. |
+
+## Data Flow After Step 7
+
+1. `proxy.rs::McpProxy::run` still spawns and joins the proxy threads.
+2. `proxy/client.rs::run_client_to_server` reads stdin lines, parses JSON-RPC, looks up caches, evaluates policy, and builds a `PolicyBranchContext`.
+3. `proxy/client/branches.rs::handle_policy_decision` handles allow, warning, deny, and dry-run deny outcomes.
+4. `proxy/client.rs` forwards the original line unless the branch outcome is `Blocked`.
+5. Deny response writing remains injected by closure so tests can capture the response without running the stdio proxy loop.
+
+## Reviewer Focus
+
+- This should be a mechanical branch split, not a policy rewrite.
+- `client.rs` should not regain direct `PolicyDecision` branch arms.
+- `branches.rs` should not learn about stdin, child stdin, server stdout parsing, or tools/list enrichment.
+- Dry-run deny must continue to emit `Decision::Allow` and forward the original request.
+- Non-dry-run deny must continue to emit `Decision::Deny`, write a deny response, and skip forwarding.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step7.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-mcp-proxy-step7.md
@@ -1,0 +1,46 @@
+# SPLIT REVIEW PACK - Wave 51 MCP Proxy Step7
+
+## Summary
+
+Step 7 extracts MCP proxy client policy-decision branch handling from `proxy/client.rs` into private module `proxy/client/branches.rs`. This keeps the client loop focused on read/parse/cache/evaluate/forward orchestration and gives allow, warning, deny, and dry-run deny their own branch-level contracts.
+
+## LOC Delta
+
+| File | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| `crates/assay-core/src/mcp/proxy/client.rs` | 226 | 137 | -89 |
+| `crates/assay-core/src/mcp/proxy/client/branches.rs` | 0 | 356 | +356 |
+
+## Boundary Proof
+
+Client loop remains the loop/coordinator:
+
+```bash
+rg -n 'fn run_client_to_server|stdin\.lock|read_line|serde_json::from_str::<JsonRpcRequest>|handle_policy_decision|child_stdin\.write_all' crates/assay-core/src/mcp/proxy/client.rs
+```
+
+Branch module owns policy branches:
+
+```bash
+rg -n 'fn handle_policy_decision|PolicyDecision::Allow|PolicyDecision::AllowWithWarning|PolicyDecision::Deny|make_deny_response|BranchOutcome::Blocked' crates/assay-core/src/mcp/proxy/client/branches.rs
+```
+
+Client loop no longer owns policy branch mechanics:
+
+```bash
+! rg -n 'PolicyDecision::Allow|PolicyDecision::AllowWithWarning|PolicyDecision::Deny|make_deny_response|map_policy_code|AuditEvent' crates/assay-core/src/mcp/proxy/client.rs
+```
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check -p assay-core`
+- `cargo clippy -p assay-core --all-targets -- -D warnings`
+- `cargo test -p assay-core --lib proxy_contract_client_branch_`
+- `cargo test -p assay-core --lib proxy_contract_`
+- `cargo test -p assay-core --lib mcp::proxy::`
+- `bash scripts/ci/review-wave51-hotspot-mcp-proxy-step7.sh`
+
+## Next Step
+
+After Step 7 lands, stop the MCP proxy split unless a concrete reviewer concern or new hotspot analysis shows `proxy/client/branches.rs` needs a second internal split. The facade and loop boundaries are now small enough for routine review.

--- a/scripts/ci/review-wave51-hotspot-mcp-proxy-step7.sh
+++ b/scripts/ci/review-wave51-hotspot-mcp-proxy-step7.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+PROXY="crates/assay-core/src/mcp/proxy.rs"
+CLIENT="crates/assay-core/src/mcp/proxy/client.rs"
+BRANCHES="crates/assay-core/src/mcp/proxy/client/branches.rs"
+SERVER="crates/assay-core/src/mcp/proxy/server.rs"
+DECISIONS="crates/assay-core/src/mcp/proxy/decisions.rs"
+TOOLS="crates/assay-core/src/mcp/proxy/tools.rs"
+
+assert_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if ! rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+assert_not_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+non_test_lines() {
+  awk 'BEGIN{n=0; in_tests=0} /^#\[cfg\(test\)\]/{in_tests=1} !in_tests{n++} END{print n}' "$1"
+}
+
+echo "[review] workflow and generated-file guard"
+if ! git diff --quiet -- .github/workflows; then
+  echo "FAIL: Wave 51 MCP Proxy Step7 must not touch workflows"
+  exit 1
+fi
+if ! git diff --quiet -- crates/assay-ebpf/src/vmlinux.rs; then
+  echo "FAIL: generated vmlinux.rs must stay out of scope"
+  exit 1
+fi
+
+echo "[review] facade boundary"
+proxy_code_lines="$(non_test_lines "$PROXY")"
+echo "proxy non-test lines: $proxy_code_lines"
+if [ "$proxy_code_lines" -gt 260 ]; then
+  echo "FAIL: proxy facade is too thick after Step7"
+  exit 1
+fi
+assert_rg 'mod client;' "$PROXY" "proxy client module declaration missing"
+assert_rg 'run_client_to_server\(' "$PROXY" "proxy facade does not delegate client loop"
+assert_rg 'run_server_to_client\(' "$PROXY" "server loop delegation missing"
+assert_rg 'pub struct McpProxy' "$PROXY" "McpProxy facade moved out of proxy.rs"
+assert_rg 'pub fn spawn\(' "$PROXY" "McpProxy::spawn moved out of proxy.rs"
+assert_rg 'pub fn run\(' "$PROXY" "McpProxy::run moved out of proxy.rs"
+assert_rg 'thread::spawn' "$PROXY" "thread spawning no longer visible in proxy.rs"
+assert_rg 'self\.child\.wait\(\)' "$PROXY" "child wait moved out of proxy facade"
+assert_not_rg 'stdin\.lock|PolicyDecision|PolicyState|AuditLog|AuditEvent|JsonRpcRequest|make_deny_response|child_stdin\.write_all|emit_decision|handle_allow|map_policy_code|extract_tool_call_id' "$PROXY" "client policy/forwarding detail still lives in proxy facade"
+
+echo "[review] client loop boundary"
+client_code_lines="$(non_test_lines "$CLIENT")"
+echo "client non-test lines: $client_code_lines"
+if [ "$client_code_lines" -gt 130 ]; then
+  echo "FAIL: client loop is too thick after Step7"
+  exit 1
+fi
+assert_rg 'mod branches;' "$CLIENT" "client branches module declaration missing"
+assert_rg 'fn run_client_to_server\(' "$CLIENT" "client loop entrypoint missing"
+assert_rg 'stdin\.lock\(\)' "$CLIENT" "client module does not own stdin lock"
+assert_rg 'read_line\(&mut line\)' "$CLIENT" "client module does not own read loop"
+assert_rg 'serde_json::from_str::<JsonRpcRequest>' "$CLIENT" "client module does not parse JSON-RPC requests"
+assert_rg 'PolicyState::default\(\)' "$CLIENT" "policy state ownership missing from client loop"
+assert_rg 'AuditLog::new' "$CLIENT" "audit log ownership missing from client loop"
+assert_rg 'handle_policy_decision\(' "$CLIENT" "client loop does not delegate policy branches"
+assert_rg 'PolicyBranchContext' "$CLIENT" "client loop does not pass explicit branch context"
+assert_rg 'BranchOutcome::Blocked' "$CLIENT" "client loop does not honor blocking branch outcomes"
+assert_rg 'child_stdin\.write_all' "$CLIENT" "child stdin forwarding missing from client loop"
+assert_rg 'Suspicious unparsable JSON' "$CLIENT" "suspicious JSON warning missing from client loop"
+assert_not_rg 'PolicyDecision::Allow|PolicyDecision::AllowWithWarning|PolicyDecision::Deny|make_deny_response|map_policy_code|AuditEvent|reason_codes::P_POLICY_ALLOW|decision_str = ' "$CLIENT" "policy branch detail still lives in client loop"
+assert_not_rg 'observe_tool_definition|BufReader::new\(child_stdout\)' "$CLIENT" "client module leaked server output responsibilities"
+
+echo "[review] branch module ownership"
+assert_rg 'fn handle_policy_decision' "$BRANCHES" "branch dispatcher missing"
+assert_rg 'fn handle_allow_branch\(' "$BRANCHES" "allow branch handler missing"
+assert_rg 'fn handle_allow_with_warning_branch\(' "$BRANCHES" "warning branch handler missing"
+assert_rg 'fn handle_deny_branch' "$BRANCHES" "deny branch handler missing"
+assert_rg 'PolicyDecision::Allow' "$BRANCHES" "allow branch match missing"
+assert_rg 'PolicyDecision::AllowWithWarning' "$BRANCHES" "allow-with-warning branch match missing"
+assert_rg 'PolicyDecision::Deny' "$BRANCHES" "deny branch match missing"
+assert_rg 'make_deny_response' "$BRANCHES" "deny response construction missing from branch module"
+assert_rg 'map_policy_code' "$BRANCHES" "deny reason-code mapping missing from branch module"
+assert_rg 'emit_decision\(' "$BRANCHES" "decision emission missing from branch module"
+assert_rg 'AuditEvent' "$BRANCHES" "audit event ownership missing from branch module"
+assert_rg 'BranchOutcome::Blocked' "$BRANCHES" "blocking outcome missing from branch module"
+assert_not_rg 'stdin\.lock|read_line\(&mut line\)|serde_json::from_str::<JsonRpcRequest>|child_stdin\.write_all|observe_tool_definition|BufReader::new\(child_stdout\)' "$BRANCHES" "branch module leaked loop/server responsibilities"
+assert_not_rg 'PolicyDecision|make_deny_response|AuditLog|emit_decision' "$SERVER" "server module leaked client policy/audit responsibilities"
+
+ echo "[review] branch contracts"
+assert_rg 'proxy_contract_client_branch_allow_emits_allow_and_forwards' "$BRANCHES" "allow branch contract missing"
+assert_rg 'proxy_contract_client_branch_warning_emits_allow_and_forwards' "$BRANCHES" "warning branch contract missing"
+assert_rg 'proxy_contract_client_branch_deny_emits_deny_and_blocks' "$BRANCHES" "deny branch contract missing"
+assert_rg 'proxy_contract_client_branch_dry_run_deny_emits_allow_and_forwards' "$BRANCHES" "dry-run deny branch contract missing"
+assert_rg 'proxy_contract_client_loop_inputs_remain_private' "$CLIENT" "client loop contract test missing"
+assert_rg 'proxy_contract_server_loop_enrichment_inputs_remain_private' "$SERVER" "server module contract test missing"
+assert_rg 'proxy_contract_emit_decision_preserves_core_fields' "$DECISIONS" "decision projection contract test missing"
+assert_rg 'proxy_contract_observe_tool_definition_rejects_empty_names' "$TOOLS" "tools/list observation contract test missing"
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo test -p assay-core --lib proxy_contract_client_branch_
+cargo test -p assay-core --lib proxy_contract_
+cargo test -p assay-core --lib mcp::proxy::
+git diff --check
+
+echo "[review] PASS"


### PR DESCRIPTION
Summary
- Performs Wave 51 MCP proxy Step 7: splits client policy-decision branch handling into a private branch module.
- Keeps `proxy/client.rs::run_client_to_server` focused on stdin read, JSON-RPC parse, cache lookup, policy evaluation, suspicious JSON warning, and child stdin forwarding.
- Moves allow, allow-with-warning, deny, and dry-run-deny branch mechanics into `proxy/client/branches.rs`.
- Adds branch-level behavior contracts for allow, warning, deny, and dry-run deny.

Scope
Included:
- `crates/assay-core/src/mcp/proxy/client.rs`
- `crates/assay-core/src/mcp/proxy/client/branches.rs`
- `docs/contributing/SPLIT-*wave51-hotspot-mcp-proxy-step7.md`
- `scripts/ci/review-wave51-hotspot-mcp-proxy-step7.sh`

Explicitly excluded:
- changing policy semantics
- changing dry-run or deny-response behavior
- changing audit/decision-event payloads
- changing server-to-client tools/list behavior
- changing `McpProxy` facade/orchestration
- workflow changes
- unrelated local architecture/example/token files

LOC Delta
| File | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `crates/assay-core/src/mcp/proxy/client.rs` | 226 | 137 | -89 |
| `crates/assay-core/src/mcp/proxy/client/branches.rs` | 0 | 356 | +356 |

Validation
- `bash scripts/ci/review-wave51-hotspot-mcp-proxy-step7.sh`

This includes:
- `cargo fmt --check`
- `cargo check -p assay-core`
- `cargo clippy -p assay-core --all-targets -- -D warnings`
- `cargo test -p assay-core --lib proxy_contract_client_branch_`
- `cargo test -p assay-core --lib proxy_contract_`
- `cargo test -p assay-core --lib mcp::proxy::`
- `git diff --check`

Chain
- Stacked on PR #1176 while it waits for final CI/merge.
- Once #1176 lands, this PR can be rebased onto `main` with no intended scope changes.

Next
- After this lands, stop the MCP proxy split unless review feedback or fresh hotspot analysis shows `proxy/client/branches.rs` needs another internal split.
