### PR TITLE
[codex] freeze Wave 51 Trust Basis contracts

### DIFF
--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -1182,6 +1182,95 @@ mod tests {
     }
 
     #[test]
+    fn trust_basis_contract_generated_claim_id_order_is_frozen() {
+        let bundle = make_bundle(vec![make_event(
+            "assay.process.exec",
+            "run_contract_claim_order",
+            0,
+            json!({ "hits": 1 }),
+        )]);
+
+        let trust_basis = generate_trust_basis(
+            Cursor::new(bundle),
+            VerifyLimits::default(),
+            TrustBasisOptions::default(),
+        )
+        .expect("trust basis should generate");
+
+        let claim_ids = trust_basis
+            .claims
+            .iter()
+            .map(|claim| serde_json::to_value(claim.id).expect("claim id serializes"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            claim_ids,
+            vec![
+                json!("bundle_verified"),
+                json!("signing_evidence_present"),
+                json!("provenance_backed_claims_present"),
+                json!("delegation_context_visible"),
+                json!("authorization_context_visible"),
+                json!("containment_degradation_observed"),
+                json!("external_eval_receipt_boundary_visible"),
+                json!("external_decision_receipt_boundary_visible"),
+                json!("external_inventory_receipt_boundary_visible"),
+                json!("applied_pack_findings_present"),
+            ]
+        );
+    }
+
+    #[test]
+    fn trust_basis_contract_canonical_json_shape_is_frozen() {
+        let trust_basis = TrustBasis {
+            claims: vec![
+                TrustBasisClaim {
+                    id: TrustClaimId::BundleVerified,
+                    level: TrustClaimLevel::Verified,
+                    source: TrustClaimSource::BundleVerification,
+                    boundary: TrustClaimBoundary::BundleWide,
+                    note: None,
+                },
+                TrustBasisClaim {
+                    id: TrustClaimId::DelegationContextVisible,
+                    level: TrustClaimLevel::Absent,
+                    source: TrustClaimSource::CanonicalDecisionEvidence,
+                    boundary: TrustClaimBoundary::SupportedDelegatedFlowsOnly,
+                    note: Some("contract note".to_string()),
+                },
+            ],
+        };
+
+        let canonical = String::from_utf8(
+            to_canonical_json_bytes(&trust_basis).expect("canonical trust basis json"),
+        )
+        .expect("canonical json is utf8");
+
+        assert_eq!(
+            canonical,
+            r#"{
+  "claims": [
+    {
+      "id": "bundle_verified",
+      "level": "verified",
+      "source": "bundle_verification",
+      "boundary": "bundle-wide",
+      "note": null
+    },
+    {
+      "id": "delegation_context_visible",
+      "level": "absent",
+      "source": "canonical_decision_evidence",
+      "boundary": "supported-delegated-flows-only",
+      "note": "contract note"
+    }
+  ]
+}
+"#
+        );
+    }
+
+    #[test]
     fn trust_basis_regeneration_is_byte_stable() {
         let bundle = make_bundle(vec![make_event(
             "assay.tool.decision",
@@ -1901,6 +1990,119 @@ mod tests {
                 TrustClaimId::AppliedPackFindingsPresent,
                 TrustClaimId::BundleVerified,
             ]
+        );
+    }
+
+    #[test]
+    fn trust_basis_contract_diff_report_ordering_is_frozen() {
+        let baseline = TrustBasis {
+            claims: vec![
+                trust_basis_claim(
+                    TrustClaimId::SigningEvidencePresent,
+                    TrustClaimLevel::Verified,
+                    None,
+                ),
+                trust_basis_claim(
+                    TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+                    TrustClaimLevel::Absent,
+                    None,
+                ),
+                trust_basis_claim(
+                    TrustClaimId::BundleVerified,
+                    TrustClaimLevel::Verified,
+                    Some("baseline note"),
+                ),
+                trust_basis_claim(
+                    TrustClaimId::AuthorizationContextVisible,
+                    TrustClaimLevel::Verified,
+                    None,
+                ),
+            ],
+        };
+        let candidate = TrustBasis {
+            claims: vec![
+                trust_basis_claim(
+                    TrustClaimId::ExternalEvalReceiptBoundaryVisible,
+                    TrustClaimLevel::Verified,
+                    None,
+                ),
+                trust_basis_claim(
+                    TrustClaimId::BundleVerified,
+                    TrustClaimLevel::Verified,
+                    Some("candidate note"),
+                ),
+                trust_basis_claim(
+                    TrustClaimId::AppliedPackFindingsPresent,
+                    TrustClaimLevel::Verified,
+                    None,
+                ),
+                trust_basis_claim(
+                    TrustClaimId::SigningEvidencePresent,
+                    TrustClaimLevel::Absent,
+                    None,
+                ),
+            ],
+        };
+
+        let report = diff_trust_basis(&baseline, &candidate);
+
+        assert_eq!(report.schema, TRUST_BASIS_DIFF_SCHEMA);
+        assert_eq!(report.claim_identity, "claim.id");
+        assert_eq!(
+            report.level_order,
+            vec![
+                TrustClaimLevel::Absent,
+                TrustClaimLevel::Inferred,
+                TrustClaimLevel::SelfReported,
+                TrustClaimLevel::Verified,
+            ]
+        );
+        assert_eq!(report.summary.regressed_claims, 1);
+        assert_eq!(report.summary.improved_claims, 1);
+        assert_eq!(report.summary.removed_claims, 1);
+        assert_eq!(report.summary.added_claims, 1);
+        assert_eq!(report.summary.metadata_changes, 1);
+        assert_eq!(report.summary.unchanged_claim_count, 0);
+        assert!(report.summary.has_regressions);
+        assert_eq!(
+            report
+                .regressed_claims
+                .iter()
+                .map(|diff| diff.claim_id)
+                .collect::<Vec<_>>(),
+            vec![TrustClaimId::SigningEvidencePresent]
+        );
+        assert_eq!(
+            report
+                .improved_claims
+                .iter()
+                .map(|diff| diff.claim_id)
+                .collect::<Vec<_>>(),
+            vec![TrustClaimId::ExternalEvalReceiptBoundaryVisible]
+        );
+        assert_eq!(
+            report
+                .removed_claims
+                .iter()
+                .map(|diff| diff.claim_id)
+                .collect::<Vec<_>>(),
+            vec![TrustClaimId::AuthorizationContextVisible]
+        );
+        assert_eq!(
+            report
+                .added_claims
+                .iter()
+                .map(|diff| diff.claim_id)
+                .collect::<Vec<_>>(),
+            vec![TrustClaimId::AppliedPackFindingsPresent]
+        );
+        assert_eq!(
+            report
+                .metadata_changes
+                .iter()
+                .map(|diff| diff.claim_id)
+                .collect::<Vec<_>>(),
+            vec![TrustClaimId::BundleVerified]
         );
     }
 

--- a/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-trust-basis-step8.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-trust-basis-step8.md
@@ -1,0 +1,46 @@
+# SPLIT CHECKLIST - Wave 51 Trust Basis Step8
+
+## Scope Lock
+
+- Freeze Trust Basis protocol behavior before splitting `crates/assay-evidence/src/trust_basis.rs`.
+- Add contract tests for generated claim order, canonical JSON shape, and diff report ordering/summary.
+- Do not move implementation into modules in Step 8.
+- Do not change public re-exports in `crates/assay-evidence/src/lib.rs`.
+- Do not change CLI command behavior, JSON schema strings, claim IDs, claim levels, sources, boundaries, workflows, or generated files.
+
+## Files
+
+- `crates/assay-evidence/src/trust_basis.rs`
+- `docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-trust-basis-step8.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-trust-basis-step8.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-trust-basis-step8.md`
+- `scripts/ci/review-wave51-hotspot-trust-basis-step8.sh`
+
+## Drift Gates
+
+- `trust_basis.rs` still owns `TrustBasis`, `TrustBasisClaim`, claim enums, diff structs, generation, canonical serialization, classifier helpers, and tests.
+- No `trust_basis/` implementation directory is introduced in Step 8.
+- `generate_trust_basis`, `to_canonical_json_bytes`, `diff_trust_basis`, and `duplicate_trust_basis_claim_ids` remain in `trust_basis.rs`.
+- Contract tests with prefix `trust_basis_contract_` cover:
+  - generated claim-id order
+  - canonical JSON field/claim shape
+  - diff report level order, section ordering, and summary counters
+- Workflow files and generated eBPF bindings remain untouched.
+
+## Validation
+
+```bash
+cargo fmt --check
+cargo check -p assay-evidence
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo test -p assay-evidence --lib trust_basis_contract_
+cargo test -p assay-evidence --lib trust_basis
+bash scripts/ci/review-wave51-hotspot-trust-basis-step8.sh
+```
+
+## Definition of Done
+
+- Step 8 reviewer script passes.
+- Trust Basis contract tests pass.
+- No module split occurs before the frozen behavior contracts exist.
+- Step 9 can mechanically split types/diff/generation/classifiers behind the same public `trust_basis` API.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-trust-basis-step8.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-trust-basis-step8.md
@@ -1,0 +1,29 @@
+# SPLIT MOVE MAP - Wave 51 Trust Basis Step8
+
+## Intent
+
+Step 8 is a freeze-only characterization step for `crates/assay-evidence/src/trust_basis.rs`. The file is the next Wave 51 hotspot after runner, sandbox, and MCP proxy. Before moving code, this step pins the Trust Basis protocol surfaces that reviewers need to protect during future splits.
+
+## Moves
+
+No implementation moves in Step 8.
+
+| Behavior | Frozen By | Notes |
+| --- | --- | --- |
+| generated claim order | `trust_basis_contract_generated_claim_id_order_is_frozen` | Locks the public claim-id sequence emitted by `generate_trust_basis`. |
+| canonical JSON shape | `trust_basis_contract_canonical_json_shape_is_frozen` | Locks pretty JSON field order, enum spellings, null note behavior, and trailing newline. |
+| diff report ordering | `trust_basis_contract_diff_report_ordering_is_frozen` | Locks level order, summary counters, and sorted report sections. |
+
+## Future Split Targets
+
+- `trust_basis/types.rs`: claim enums, claim/diff structs, schema constants.
+- `trust_basis/diff.rs`: diff indexing, ranking, sorting, duplicate handling.
+- `trust_basis/generate.rs`: bundle loading, lint integration, claim vector construction.
+- `trust_basis/classifiers.rs`: signing/provenance/delegation/auth/degradation/receipt/pack classifiers.
+- `trust_basis/canonical.rs`: canonical JSON serialization if it grows beyond a thin helper.
+
+## Reviewer Focus
+
+- This PR should not change behavior.
+- The added tests are deliberately snapshot-like because Trust Basis JSON is a protocol artifact.
+- Step 9 should be mechanical and keep `assay_evidence::trust_basis::*` and root re-exports stable.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-trust-basis-step8.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-trust-basis-step8.md
@@ -1,0 +1,44 @@
+# SPLIT REVIEW PACK - Wave 51 Trust Basis Step8
+
+## Summary
+
+Step 8 starts the Trust Basis hotspot work with behavior-freeze contracts only. It adds tests that pin generated claim order, canonical JSON shape, and diff report ordering before any code is moved out of `trust_basis.rs`.
+
+## LOC Delta
+
+| File | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| `crates/assay-evidence/src/trust_basis.rs` | 2012 | 2214 | +202 |
+
+## Boundary Proof
+
+No implementation split yet:
+
+```bash
+! test -d crates/assay-evidence/src/trust_basis
+```
+
+Trust Basis public entrypoints remain in the same file:
+
+```bash
+rg -n 'pub fn diff_trust_basis|pub fn generate_trust_basis|pub fn to_canonical_json_bytes|pub fn duplicate_trust_basis_claim_ids' crates/assay-evidence/src/trust_basis.rs
+```
+
+Freeze contracts exist:
+
+```bash
+rg -n 'trust_basis_contract_generated_claim_id_order_is_frozen|trust_basis_contract_canonical_json_shape_is_frozen|trust_basis_contract_diff_report_ordering_is_frozen' crates/assay-evidence/src/trust_basis.rs
+```
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check -p assay-evidence`
+- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
+- `cargo test -p assay-evidence --lib trust_basis_contract_`
+- `cargo test -p assay-evidence --lib trust_basis`
+- `bash scripts/ci/review-wave51-hotspot-trust-basis-step8.sh`
+
+## Next Step
+
+Step 9 should mechanically split Trust Basis types and diff helpers first, preserving root crate re-exports and the frozen contract tests added here.

--- a/scripts/ci/review-wave51-hotspot-trust-basis-step8.sh
+++ b/scripts/ci/review-wave51-hotspot-trust-basis-step8.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TRUST_BASIS="crates/assay-evidence/src/trust_basis.rs"
+LIB="crates/assay-evidence/src/lib.rs"
+
+assert_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if ! rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+assert_not_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+echo "[review] workflow and generated-file guard"
+if ! git diff --quiet -- .github/workflows; then
+  echo "FAIL: Wave 51 Trust Basis Step8 must not touch workflows"
+  exit 1
+fi
+if ! git diff --quiet -- crates/assay-ebpf/src/vmlinux.rs; then
+  echo "FAIL: generated vmlinux.rs must stay out of scope"
+  exit 1
+fi
+
+echo "[review] freeze-only boundary"
+if [ -d crates/assay-evidence/src/trust_basis ]; then
+  echo "FAIL: Step8 must not introduce trust_basis implementation modules yet"
+  exit 1
+fi
+assert_rg 'pub enum TrustClaimId' "$TRUST_BASIS" "TrustClaimId moved before freeze split"
+assert_rg 'pub struct TrustBasisClaim' "$TRUST_BASIS" "TrustBasisClaim moved before freeze split"
+assert_rg 'pub struct TrustBasisDiffReport' "$TRUST_BASIS" "TrustBasisDiffReport moved before freeze split"
+assert_rg 'pub fn diff_trust_basis\(' "$TRUST_BASIS" "diff_trust_basis moved before freeze split"
+assert_rg 'pub fn generate_trust_basis' "$TRUST_BASIS" "generate_trust_basis moved before freeze split"
+assert_rg 'pub fn to_canonical_json_bytes' "$TRUST_BASIS" "to_canonical_json_bytes moved before freeze split"
+assert_rg 'pub fn duplicate_trust_basis_claim_ids' "$TRUST_BASIS" "duplicate claim helper moved before freeze split"
+assert_rg 'pub use trust_basis::' "$LIB" "root trust_basis re-export missing"
+assert_not_rg 'mod types;|mod diff;|mod generate;|mod classifiers;|mod canonical;' "$TRUST_BASIS" "Step8 must not start implementation split"
+
+echo "[review] freeze contracts"
+assert_rg 'trust_basis_contract_generated_claim_id_order_is_frozen' "$TRUST_BASIS" "claim order contract missing"
+assert_rg 'trust_basis_contract_canonical_json_shape_is_frozen' "$TRUST_BASIS" "canonical JSON contract missing"
+assert_rg 'trust_basis_contract_diff_report_ordering_is_frozen' "$TRUST_BASIS" "diff ordering contract missing"
+assert_rg 'json!\("bundle_verified"\)' "$TRUST_BASIS" "serialized claim id spelling not locked"
+assert_rg '"boundary": "supported-delegated-flows-only"' "$TRUST_BASIS" "canonical boundary spelling not locked"
+assert_rg 'report\.level_order' "$TRUST_BASIS" "diff level order not locked"
+assert_rg 'report\.summary\.regressed_claims' "$TRUST_BASIS" "diff summary counters not locked"
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo check -p assay-evidence
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo test -p assay-evidence --lib trust_basis_contract_
+cargo test -p assay-evidence --lib trust_basis
+git diff --check
+
+echo "[review] PASS"


### PR DESCRIPTION
Summary
- Starts Wave 51 Trust Basis work with a freeze-only characterization PR before any module split.
- Adds contract tests for generated claim-id order, canonical Trust Basis JSON shape, and diff report ordering/summary.
- Adds Step 8 SPLIT checklist, move-map, review-pack, and reviewer gate.

Scope
Included:
- `crates/assay-evidence/src/trust_basis.rs`
- `docs/contributing/SPLIT-*wave51-hotspot-trust-basis-step8.md`
- `scripts/ci/review-wave51-hotspot-trust-basis-step8.sh`

Explicitly excluded:
- moving Trust Basis implementation into modules
- changing claim IDs, levels, sources, boundaries, or schema strings
- changing public root re-exports
- changing CLI behavior
- workflow changes
- generated files
- unrelated local architecture/example/token files

LOC Delta
| File | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `crates/assay-evidence/src/trust_basis.rs` | 2012 | 2214 | +202 |

Validation
- `bash scripts/ci/review-wave51-hotspot-trust-basis-step8.sh`

This includes:
- `cargo fmt --check`
- `cargo check -p assay-evidence`
- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
- `cargo test -p assay-evidence --lib trust_basis_contract_`
- `cargo test -p assay-evidence --lib trust_basis`
- `git diff --check`

Next
- Step 9 should mechanically split Trust Basis types and diff helpers first, preserving root crate re-exports and the frozen contracts added here.
