### PR TITLE
[codex] split Wave 51 Trust Basis canonical serialization

### DIFF
--- a/crates/assay-evidence/src/trust_basis.rs
+++ b/crates/assay-evidence/src/trust_basis.rs
@@ -1,8 +1,8 @@
 use crate::bundle::VerifyLimits;
 use anyhow::Result;
-use serde::Serialize;
 use std::io::Read;
 
+mod canonical;
 mod classifiers;
 mod diff;
 mod generation;
@@ -25,12 +25,7 @@ pub fn generate_trust_basis<R: Read>(
 }
 
 pub fn to_canonical_json_bytes(trust_basis: &TrustBasis) -> Result<Vec<u8>> {
-    let mut output = Vec::new();
-    let formatter = serde_json::ser::PrettyFormatter::with_indent(b"  ");
-    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
-    trust_basis.serialize(&mut serializer)?;
-    output.push(b'\n');
-    Ok(output)
+    canonical::to_canonical_json_bytes(trust_basis)
 }
 
 #[cfg(test)]

--- a/crates/assay-evidence/src/trust_basis/canonical.rs
+++ b/crates/assay-evidence/src/trust_basis/canonical.rs
@@ -1,0 +1,12 @@
+use super::TrustBasis;
+use anyhow::Result;
+use serde::Serialize;
+
+pub(super) fn to_canonical_json_bytes(trust_basis: &TrustBasis) -> Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(b"  ");
+    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
+    trust_basis.serialize(&mut serializer)?;
+    output.push(b'\n');
+    Ok(output)
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-trust-basis-step11.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave51-hotspot-trust-basis-step11.md
@@ -1,0 +1,45 @@
+# SPLIT CHECKLIST - Wave 51 Trust Basis Step11
+
+## Goal
+
+Mechanically split canonical Trust Basis JSON serialization into a tiny implementation module while preserving the public `to_canonical_json_bytes` facade and frozen canonical output contracts.
+
+## Scope
+
+Included:
+
+- `crates/assay-evidence/src/trust_basis.rs`
+- `crates/assay-evidence/src/trust_basis/canonical.rs`
+- Step 11 SPLIT artifacts and reviewer gate
+
+Excluded:
+
+- canonical JSON formatting changes
+- claim ordering changes
+- generation/classifier/diff behavior changes
+- test relocation
+- CLI, Trust Card, workflow, or generated-file changes
+
+## Boundary Rules
+
+- `trust_basis.rs` remains the public facade and delegates `to_canonical_json_bytes` to `canonical.rs`.
+- `trust_basis/canonical.rs` owns `PrettyFormatter`, `Serializer`, `Serialize`, and the trailing newline behavior.
+- Existing Step 8 canonical JSON contract remains the behavior guard.
+- Step 9/10 ownership remains unchanged for types, diff, generation, and classifiers.
+
+## Validation
+
+```bash
+cargo fmt --check
+cargo check -p assay-evidence
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo test -p assay-evidence --lib trust_basis_contract_
+cargo test -p assay-evidence --lib trust_basis
+bash scripts/ci/review-wave51-hotspot-trust-basis-step11.sh
+```
+
+## Reviewer Focus
+
+- Confirm the canonical serializer body moved 1:1.
+- Confirm the public facade path is unchanged.
+- Confirm the canonical JSON shape contract still runs.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-trust-basis-step11.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave51-hotspot-trust-basis-step11.md
@@ -1,0 +1,22 @@
+# SPLIT MOVE MAP - Wave 51 Trust Basis Step11
+
+Step 11 moves the final production helper body out of the Trust Basis facade.
+
+## Moves
+
+| Before | After | Notes |
+| --- | --- | --- |
+| `trust_basis.rs::to_canonical_json_bytes` body | `trust_basis/canonical.rs::to_canonical_json_bytes` | Pretty formatter, serializer call, and trailing newline preserved. |
+| `serde::Serialize` facade import | `trust_basis/canonical.rs` | Serializer dependency now lives with canonical implementation. |
+
+## Stayed Put
+
+- Public `to_canonical_json_bytes` facade entrypoint
+- Public `generate_trust_basis` facade entrypoint
+- `types.rs`, `diff.rs`, `generation.rs`, `classifiers.rs`
+- all Trust Basis tests
+- crate root re-exports
+
+## Follow-up
+
+The production Trust Basis split can stop here. A future cleanup-only PR may relocate tests into module-focused test files, but that should be separate from production movement.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-trust-basis-step11.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave51-hotspot-trust-basis-step11.md
@@ -1,0 +1,47 @@
+# SPLIT REVIEW PACK - Wave 51 Trust Basis Step11
+
+## Summary
+
+Step 11 moves canonical Trust Basis JSON serialization into `trust_basis/canonical.rs`. The public `to_canonical_json_bytes` facade remains unchanged and the Step 8 canonical JSON contract continues to freeze the output shape.
+
+## LOC Delta
+
+| File | Before | After | Delta |
+| --- | ---: | ---: | ---: |
+| `crates/assay-evidence/src/trust_basis.rs` | 1324 | 1319 | -5 |
+| `crates/assay-evidence/src/trust_basis/canonical.rs` | 0 | 12 | +12 |
+
+Facade non-test LOC: `35 -> 30`.
+
+## Boundary Proof
+
+Facade delegates canonical serialization:
+
+```bash
+rg -n 'mod canonical;|pub fn to_canonical_json_bytes|canonical::to_canonical_json_bytes' crates/assay-evidence/src/trust_basis.rs
+```
+
+Canonical module owns serializer implementation:
+
+```bash
+rg -n 'PrettyFormatter|Serializer::with_formatter|serialize\(&mut serializer\)|output\.push\(b' crates/assay-evidence/src/trust_basis/canonical.rs
+```
+
+Facade no longer owns serializer implementation:
+
+```bash
+! rg -n 'PrettyFormatter|Serializer::with_formatter|serde::Serialize|output\.push\(b' crates/assay-evidence/src/trust_basis.rs
+```
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check -p assay-evidence`
+- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
+- `cargo test -p assay-evidence --lib trust_basis_contract_`
+- `cargo test -p assay-evidence --lib trust_basis`
+- `bash scripts/ci/review-wave51-hotspot-trust-basis-step11.sh`
+
+## Next Step
+
+Stop production splitting for Trust Basis here unless reviewers request test-layout cleanup. The facade is now production-thin; remaining line weight is test code.

--- a/scripts/ci/review-wave51-hotspot-trust-basis-step11.sh
+++ b/scripts/ci/review-wave51-hotspot-trust-basis-step11.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TRUST_BASIS="crates/assay-evidence/src/trust_basis.rs"
+CANONICAL="crates/assay-evidence/src/trust_basis/canonical.rs"
+GENERATION="crates/assay-evidence/src/trust_basis/generation.rs"
+CLASSIFIERS="crates/assay-evidence/src/trust_basis/classifiers.rs"
+TYPES="crates/assay-evidence/src/trust_basis/types.rs"
+DIFF="crates/assay-evidence/src/trust_basis/diff.rs"
+LIB="crates/assay-evidence/src/lib.rs"
+
+assert_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if ! rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+assert_not_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+changed_in_review_scope() {
+  local path="$1"
+  local base_ref
+  local base
+  local candidates=()
+
+  if ! git diff --quiet -- "$path"; then
+    return 0
+  fi
+  if ! git diff --cached --quiet -- "$path"; then
+    return 0
+  fi
+
+  if [ -n "${ASSAY_REVIEW_BASE_REF:-}" ]; then
+    candidates+=("$ASSAY_REVIEW_BASE_REF")
+  fi
+  if [ -n "${GITHUB_BASE_REF:-}" ]; then
+    candidates+=("origin/${GITHUB_BASE_REF}" "$GITHUB_BASE_REF")
+  fi
+  candidates+=("origin/main" "main" "HEAD^1")
+
+  for base_ref in "${candidates[@]}"; do
+    if git rev-parse --verify -q "${base_ref}^{commit}" >/dev/null; then
+      base="$(git merge-base "$base_ref" HEAD 2>/dev/null || true)"
+      if [ -n "$base" ]; then
+        ! git diff --quiet "$base..HEAD" -- "$path"
+        return $?
+      fi
+    fi
+  done
+
+  echo "FAIL: unable to resolve review base for scope guard"
+  exit 1
+}
+
+echo "[review] workflow and generated-file guard"
+if changed_in_review_scope .github/workflows; then
+  echo "FAIL: Wave 51 Trust Basis Step11 must not touch workflows"
+  exit 1
+fi
+if changed_in_review_scope crates/assay-ebpf/src/vmlinux.rs; then
+  echo "FAIL: generated vmlinux.rs must stay out of scope"
+  exit 1
+fi
+
+echo "[review] module boundary"
+test -f "$CANONICAL" || { echo "FAIL: canonical module missing"; exit 1; }
+test -f "$GENERATION" || { echo "FAIL: generation module missing"; exit 1; }
+test -f "$CLASSIFIERS" || { echo "FAIL: classifiers module missing"; exit 1; }
+test -f "$TYPES" || { echo "FAIL: types module missing"; exit 1; }
+test -f "$DIFF" || { echo "FAIL: diff module missing"; exit 1; }
+assert_rg '^mod canonical;' "$TRUST_BASIS" "facade must declare canonical module"
+assert_rg '^pub fn to_canonical_json_bytes' "$TRUST_BASIS" "public canonical facade missing"
+assert_rg 'canonical::to_canonical_json_bytes' "$TRUST_BASIS" "canonical facade must delegate to canonical module"
+assert_rg '^pub fn generate_trust_basis' "$TRUST_BASIS" "public generate facade missing"
+assert_rg 'pub use trust_basis::' "$LIB" "root trust_basis re-export missing"
+
+assert_not_rg 'PrettyFormatter|Serializer::with_formatter|serde::Serialize|output\.push\(b' "$TRUST_BASIS" "canonical serializer body must not remain in facade"
+assert_rg '^pub\(super\) fn to_canonical_json_bytes' "$CANONICAL" "canonical module must own internal canonical implementation"
+assert_rg 'PrettyFormatter' "$CANONICAL" "canonical module must own pretty formatter"
+assert_rg 'Serializer::with_formatter' "$CANONICAL" "canonical module must own serializer"
+assert_rg 'serialize\(&mut serializer\)' "$CANONICAL" "canonical module must serialize trust basis"
+assert_rg "output\.push\(b'\\\\n'\)" "$CANONICAL" "canonical module must preserve trailing newline"
+
+facade_non_test_loc=$(awk '/#\[cfg\(test\)\]/{exit} {count++} END{print count}' "$TRUST_BASIS")
+if [ "$facade_non_test_loc" -gt 35 ]; then
+  echo "FAIL: trust_basis facade non-test LOC drifted above Step11 ceiling ($facade_non_test_loc > 35)"
+  exit 1
+fi
+
+echo "[review] freeze contracts still present"
+assert_rg 'trust_basis_contract_generated_claim_id_order_is_frozen' "$TRUST_BASIS" "claim order contract missing"
+assert_rg 'trust_basis_contract_canonical_json_shape_is_frozen' "$TRUST_BASIS" "canonical JSON contract missing"
+assert_rg 'trust_basis_contract_diff_report_ordering_is_frozen' "$TRUST_BASIS" "diff ordering contract missing"
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo check -p assay-evidence
+cargo clippy -p assay-evidence --all-targets -- -D warnings
+cargo test -p assay-evidence --lib trust_basis_contract_
+cargo test -p assay-evidence --lib trust_basis
+git diff --check
+
+echo "[review] PASS"


### PR DESCRIPTION
## Summary

Performs Wave 51 Trust Basis Step 11: moves canonical JSON serialization into a tiny private module while keeping the public facade stable.

- Keeps public `to_canonical_json_bytes` in `trust_basis.rs` and delegates to `trust_basis/canonical.rs`.
- Moves `serde::Serialize`, `PrettyFormatter`, `Serializer::with_formatter`, and trailing newline behavior into the canonical module.
- Leaves generation, classifiers, types, diff, tests, and root re-exports unchanged.
- Adds Step 11 SPLIT checklist, move-map, review-pack, and reviewer gate.

## Scope

Included:

- `crates/assay-evidence/src/trust_basis.rs`
- `crates/assay-evidence/src/trust_basis/canonical.rs`
- `docs/contributing/SPLIT-*wave51-hotspot-trust-basis-step11.md`
- `scripts/ci/review-wave51-hotspot-trust-basis-step11.sh`

Explicitly excluded:

- canonical JSON formatting changes
- claim ordering changes
- generation/classifier/diff behavior changes
- test relocation
- CLI/Trust Card/workflow changes
- unrelated local architecture/example/token files

## LOC Delta

| File | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `crates/assay-evidence/src/trust_basis.rs` | 1324 | 1319 | -5 |
| `crates/assay-evidence/src/trust_basis/canonical.rs` | 0 | 12 | +12 |

Facade non-test LOC: `35 -> 30`.

## Validation

```bash
bash scripts/ci/review-wave51-hotspot-trust-basis-step11.sh
```

This includes:

- `cargo fmt --check`
- `cargo check -p assay-evidence`
- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
- `cargo test -p assay-evidence --lib trust_basis_contract_`
- `cargo test -p assay-evidence --lib trust_basis`
- `git diff --check`

Pre-push hooks also passed, including workspace clippy and linux compile gate.

## Next

Stop production splitting for Trust Basis here unless reviewers request test-layout cleanup. The facade is now production-thin; remaining line weight is test code.
