### PR TITLE
[codex] freeze Wave 52 LiveKit tool-action split

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1.md
@@ -1,0 +1,48 @@
+# SPLIT CHECKLIST - Wave 52 LiveKit Tool Action Step1
+
+## Scope
+
+Step1 freezes the LiveKit tool-action importer before any production split.
+
+Allowed files:
+
+- `docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1.md`
+- `scripts/ci/review-wave52-livekit-tool-action-step1.sh`
+- `docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md`
+- `docs/security/OWASP-MCP-TOP10-TEST-MAP.md`
+- `scripts/ci/optional-public-api-drift.sh`
+- `scripts/ci/mutation-smoke-pure-modules.sh`
+- `scripts/ci/review-week8-sota-gates.sh`
+
+Forbidden in Step1:
+
+- edits under `crates/assay-cli/src/cli/commands/evidence/**`
+- edits under `crates/assay-cli/tests/**`
+- workflow edits
+- generated file edits
+- schema, hash, timestamp, pairing, or Trust Basis behavior changes
+
+## Frozen Contracts
+
+- CLI route and argument shape remain stable.
+- `assay.receipt.livekit.tool_action.v1` event type remains stable.
+- `assay.receipt.livekit.tool-action.v1` receipt schema remains stable.
+- Reduced input schema remains `livekit.function-tools-executed.export.v1`.
+- Raw transcript/audio/user/model/session/trace/telemetry imports remain rejected.
+- Call/output pairing by `call_id` remains preferred over list order.
+- JSONL multi-row import remains accepted.
+- Raw argument/output values remain hashed or referenced, not embedded.
+- LiveKit receipts remain importer-only and do not mutate Trust Basis external eval/decision/inventory claims.
+
+## Reviewer Gate
+
+Run:
+
+```bash
+bash scripts/ci/review-wave52-livekit-tool-action-step1.sh
+```
+
+The gate enforces docs+gate-only scope and runs the current LiveKit importer tests.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1.md
@@ -1,0 +1,35 @@
+# SPLIT MOVE MAP - Wave 52 LiveKit Tool Action Step1
+
+## Step1 Movement
+
+No production code moves in Step1.
+
+## Source Hotspot
+
+- `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs` (`1104` LOC on `origin/main @ 057151c5`)
+
+## Current Internal Regions
+
+- CLI args and command facade: `LiveKitToolActionArgs`, `cmd_livekit_tool_action`
+- input loading and JSON/JSONL parsing: `read_livekit_tool_actions`, `parse_input_documents`
+- receipt reduction: `reduce_tool_action_event`, `build_receipt`, `paired_call_outputs`
+- schema/key validation: `validate_top_level`, `validate_call_keys`, `validate_output_keys`
+- bounded value/timestamp validation: string, bool, timestamp helpers
+- hashing/canonicalization: `hash_or_ref`, `sha256_json_value`, `canonical_json`, `sha256_file`
+- importer tests: inline `mod tests`
+
+## Step2 Candidate Moves
+
+- `input.rs`: input document parsing and file digest helpers
+- `reduce.rs`: event reduction, receipt construction, and call/output pairing
+- `validate.rs`: key allowlists, forbidden-key checks, bounded strings, booleans, timestamps
+- `canonical.rs`: canonical JSON and hash/ref helpers
+- `bundle.rs`: command orchestration from events to `BundleWriter`
+- `tests.rs`: existing importer tests after behavior stays frozen
+
+## Non-Moves
+
+- Do not alter CLI argument names or aliases.
+- Do not change event or receipt schema strings.
+- Do not alter Trust Basis classifier behavior.
+- Do not import raw LiveKit session, transcript, trace, telemetry, or model/user payloads.

--- a/docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action.md
+++ b/docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action.md
@@ -1,0 +1,82 @@
+# SPLIT PLAN - Wave 52 LiveKit Tool Action Importer
+
+## Goal
+
+Reduce `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs` behind a stable CLI/importer facade without changing LiveKit acted-family receipt semantics.
+
+Current hotspot baseline on `origin/main @ 057151c5`:
+
+- `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs`: `1104` LOC
+- public CLI entrypoint: `cmd_livekit_tool_action(LiveKitToolActionArgs)`
+- companion integration test: `crates/assay-cli/tests/evidence_test.rs::test_livekit_imported_tool_action_receipts_verify_and_do_not_mutate_trust_basis_claims`
+
+## Why This Is Next
+
+Wave51 retired the runner, sandbox, MCP proxy, and Trust Basis hotspots. A fresh `origin/main` LOC snapshot now shows the LiveKit tool-action importer as the largest handwritten production Rust file. It is also a fresh protocol-facing importer, so the safe next move is a freeze-only step before any module extraction.
+
+## Frozen Behavior
+
+Wave52 freezes these importer contracts before moving code:
+
+- CLI arguments and command routing for `evidence import livekit-tool-action`
+- event type/source/schema constants
+- accepted reduced input shape and required/optional top-level keys
+- forbidden raw payload/session/trace/telemetry keys
+- call/output pairing by `call_id` before list order
+- JSONL multi-document input behavior
+- bounded reviewer-safe string validation
+- raw argument/output hashing without raw value leakage
+- timestamp normalization and deterministic import-time handling
+- malformed missing-output rejection
+- non-integer raw float rejection
+- Trust Basis non-mutation for LiveKit acted-family receipts
+
+## Step1 - Freeze and Gate
+
+Branch: `codex/wave52-livekit-tool-action-freeze-step1` (base: `main`)
+
+Step1 is docs+gate only. It must not edit production importer code or tests.
+
+Deliverables:
+
+- `docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1.md`
+- `scripts/ci/review-wave52-livekit-tool-action-step1.sh`
+- `docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md`
+- `docs/security/OWASP-MCP-TOP10-TEST-MAP.md`
+- `scripts/ci/optional-public-api-drift.sh`
+- `scripts/ci/mutation-smoke-pure-modules.sh`
+- `scripts/ci/review-week8-sota-gates.sh`
+
+## Step2 - Mechanical Split Preview
+
+Only after Step1 lands, split behind the existing command facade.
+
+Suggested target layout:
+
+```text
+crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs
+crates/assay-cli/src/cli/commands/evidence/livekit_tool_action/
+  input.rs
+  reduce.rs
+  validate.rs
+  canonical.rs
+  bundle.rs
+  tests.rs
+```
+
+Step2 principles:
+
+- keep `cmd_livekit_tool_action` and `LiveKitToolActionArgs` in the facade
+- move function bodies 1:1 where possible
+- no schema/key allowlist drift
+- no hash/canonical JSON drift
+- no timestamp or source-artifact-ref drift
+- no trust-basis classifier drift
+- preserve existing tests, moving them only if the split needs it
+
+## Stop Rule
+
+If Step2 reduces the facade below roughly 150 LOC and keeps protocol helpers isolated, stop. Do not keep splitting a fresh importer without concrete review pain.

--- a/docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md
+++ b/docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md
@@ -1,0 +1,81 @@
+# SPLIT PLAN - Week 8 SOTA Gates 2026q2
+
+## Intent
+
+Add optional, high-signal gates for refactor waves after the Wave51 hotspot split. These gates are intentionally opt-in or documentation-backed first, because the required tools are not guaranteed to be installed on every contributor machine.
+
+## Source Baseline
+
+- Cargo's SemVer compatibility guide classifies renaming, moving, or removing public items as a major compatibility change: <https://doc.rust-lang.org/cargo/reference/semver.html>
+- `cargo-semver-checks` scans Rust crates for SemVer violations: <https://github.com/obi1kenobi/cargo-semver-checks>
+- `cargo-public-api` lists and diffs public APIs from rustdoc JSON and can be used in CI: <https://github.com/cargo-public-api/cargo-public-api>
+- OWASP MCP Top 10 v0.1 names the MCP security categories that map to Assay proxy, sandbox, and Trust Basis tests: <https://owasp.org/www-project-mcp-top-10/>
+- `cargo-mutants` supports workspace/package mutation testing with timeouts and package selection: <https://mutants.rs/workspaces.html>
+
+## Gate 1 - Public API Drift
+
+Script:
+
+```bash
+bash scripts/ci/optional-public-api-drift.sh
+```
+
+Behavior:
+
+- Runs `cargo semver-checks check-release` for library crates when `cargo-semver-checks` is installed.
+- Runs `cargo public-api` diff checks when `cargo-public-api` is installed and supports package-scoped diffs.
+- Skips with an explicit notice when tools are unavailable.
+
+Initial package set:
+
+- `assay-core`
+- `assay-evidence`
+- `assay-registry`
+- `assay-policy`
+- `assay-metrics`
+
+Rule:
+
+- Required for release candidates and public facade refactors.
+- Optional/non-blocking for early mechanical split PRs until CI has the tool cache.
+
+## Gate 2 - Mutation Smoke on Pure Modules
+
+Script:
+
+```bash
+ASSAY_RUN_MUTATION_SMOKE=1 bash scripts/ci/mutation-smoke-pure-modules.sh
+```
+
+Initial target modules:
+
+- `crates/assay-evidence/src/trust_basis/diff.rs`
+- `crates/assay-evidence/src/trust_basis/classifiers.rs`
+- `crates/assay-cli/src/cli/commands/sandbox/degradation.rs`
+
+Rule:
+
+- Keep mutation smoke targeted to pure or near-pure modules.
+- Do not run full-workspace mutation testing in PR CI.
+- Use this to catch weak assertions after module extraction, especially where branch logic was moved mechanically.
+
+## Gate 3 - OWASP MCP Test Mapping
+
+Mapping:
+
+- `docs/security/OWASP-MCP-TOP10-TEST-MAP.md`
+
+Required focus categories for the current MCP/security refactor lineage:
+
+- MCP01 token/secret exposure
+- MCP02 scope creep
+- MCP03 tool poisoning
+- MCP05 command injection/execution
+- MCP06 prompt/context/intent injection
+- MCP08 audit and telemetry gaps
+- MCP10 context over-sharing
+
+Rule:
+
+- New proxy, sandbox, or Trust Basis tests should name which MCP risk they cover or explicitly state that they are not security coverage tests.
+- Coverage claims should reference concrete tests, not just product capabilities.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1.md
@@ -1,0 +1,50 @@
+# SPLIT REVIEW PACK - Wave 52 LiveKit Tool Action Step1
+
+## Summary
+
+Step1 starts Wave52 with a freeze-only slice for the LiveKit tool-action importer hotspot. The importer is now the largest handwritten production Rust file after Wave51, but it is also a fresh protocol-facing surface, so this PR intentionally adds no production changes.
+
+## Included
+
+- Wave52 split plan
+- Step1 checklist
+- Step1 move map
+- Step1 review pack
+- Step1 reviewer gate script
+- Week 8 SOTA gate plan and optional scripts
+- OWASP MCP Top 10 test coverage map
+
+## Excluded
+
+- production importer edits
+- test edits
+- schema/key allowlist changes
+- hash/canonical JSON changes
+- timestamp normalization changes
+- Trust Basis behavior changes
+- workflow changes
+
+## Validation
+
+Run:
+
+```bash
+bash scripts/ci/review-wave52-livekit-tool-action-step1.sh
+```
+
+The script checks:
+
+- allowlist-only diff
+- no workflow/generated-file changes
+- no edits under LiveKit importer source or CLI tests
+- `cargo fmt --check`
+- `cargo check -p assay-cli`
+- `cargo clippy -p assay-cli --all-targets -- -D warnings`
+- `cargo test -q -p assay-cli livekit_tool_action`
+- `cargo test -q -p assay-cli --test evidence_test test_livekit_imported_tool_action_receipts_verify_and_do_not_mutate_trust_basis_claims -- --exact`
+- `bash scripts/ci/review-week8-sota-gates.sh`
+- `git diff --check`
+
+## Next Step
+
+After Step1 lands, perform the mechanical split behind `cmd_livekit_tool_action` and keep the receipt protocol contracts unchanged.

--- a/docs/security/OWASP-MCP-TOP10-TEST-MAP.md
+++ b/docs/security/OWASP-MCP-TOP10-TEST-MAP.md
@@ -1,0 +1,24 @@
+# OWASP MCP Top 10 Test Map
+
+This map connects concrete Assay tests to the OWASP MCP Top 10 risk categories. It complements the product-level coverage summary in `docs/security/OWASP-MCP-TOP10-MAPPING.md`.
+
+Source taxonomy: <https://owasp.org/www-project-mcp-top-10/>
+
+## Current Security-Coverage Map
+
+| OWASP MCP risk | Assay area | Representative tests | Current posture |
+| --- | --- | --- | --- |
+| MCP01 Token Mismanagement & Secret Exposure | MCP tool-call handling, Trust Basis auth projection | `crates/assay-core/src/mcp/tool_call_handler/tests/redaction.rs::redact_args_contract_sets_additive_fields`; `crates/assay-evidence/src/trust_basis/tests.rs::trust_basis_g3_absent_when_auth_issuer_jws_shaped_or_principal_bearer` | Covered for redaction/auth-projection leak prevention; still needs broader end-to-end token-log regression coverage. |
+| MCP02 Privilege Escalation via Scope Creep | MCP policy engine and tool-call handler | `crates/assay-core/src/mcp/tool_call_handler/tests/scope.rs`; `crates/assay-core/tests/policy_engine_test.rs` deny/restrict-scope cases | Covered for restrict-scope enforcement and deny precedence. |
+| MCP03 Tool Poisoning | MCP proxy/tool identity and decision emission | `cargo test -p assay-core --lib proxy_contract_`; `crates/assay-core/src/mcp/tool_call_handler/tests/emission.rs::test_tool_drift_deny_emits_alert_obligation_outcome` | Covered for tool drift/identity decision evidence; keep metadata poisoning fixtures in future proxy tests. |
+| MCP05 Command Injection & Execution | Sandbox and MCP policy deny paths | `crates/assay-cli/src/cli/commands/sandbox.rs` conflict/degradation tests; `crates/assay-cli/tests/e2e_mcp_wrap_assert_cmd.rs` deny command fixtures | Covered for deny/degrade behavior; mutation smoke should focus on sandbox degradation helpers. |
+| MCP06 Intent Flow Subversion / Prompt Injection via Contextual Payloads | MCP delegation/context contracts and Trust Basis delegation claims | `crates/assay-core/src/mcp/policy/engine.rs` delegation-context tests; `crates/assay-core/src/mcp/tool_call_handler/tests/delegation.rs`; `trust_basis_detects_supported_delegation_and_degradation` | Covered for explicit context/delegation projection; add prompt-context fixture coverage when proxy surfaces new context inputs. |
+| MCP08 Lack of Audit and Telemetry | MCP proxy decisions, sandbox degradation evidence, Trust Basis diff | `cargo test -p assay-core --lib mcp::proxy::`; `crates/assay-cli/tests/evidence_test.rs::test_evidence_export_includes_sandbox_degraded_event_when_profile_contains_degradation`; `trust_basis_contract_diff_report_ordering_is_frozen` | Strong coverage; preserve event emission and degradation payload contracts during splits. |
+| MCP10 Context Injection & Over-Sharing | Redaction, Trust Basis external receipt guards | `crates/assay-core/src/mcp/tool_call_handler/tests/redaction.rs`; `trust_basis_rejects_decision_receipt_boundary_when_context_or_metadata_leaks_in` | Covered for redaction and external receipt boundary guards. |
+
+## Gap Backlog
+
+- Add an end-to-end token-in-log fixture that proves secret-bearing tool args do not leak through audit/decision output.
+- Add a proxy metadata poisoning fixture that mutates tool descriptions mid-session and expects a deny or warning decision path.
+- Add a sandbox command-injection fixture tied directly to MCP05 terminology.
+- Keep Trust Basis external receipt guards mutation-smoke eligible after classifier refactors.

--- a/scripts/ci/mutation-smoke-pure-modules.sh
+++ b/scripts/ci/mutation-smoke-pure-modules.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${ASSAY_RUN_MUTATION_SMOKE:-0}" != "1" ]; then
+  echo "[mutation-smoke] skipped: set ASSAY_RUN_MUTATION_SMOKE=1 to run targeted mutation smoke"
+  exit 0
+fi
+
+if ! cargo mutants --version >/dev/null 2>&1; then
+  echo "[mutation-smoke] skipped: cargo-mutants is not installed"
+  exit 0
+fi
+
+COMMON=(--timeout 60 --minimum-test-timeout 20 --jobs "${ASSAY_MUTATION_JOBS:-2}")
+
+echo "[mutation-smoke] trust_basis diff.rs"
+cargo mutants --package assay-evidence --file crates/assay-evidence/src/trust_basis/diff.rs "${COMMON[@]}" -- trust_basis
+
+echo "[mutation-smoke] trust_basis classifiers.rs"
+cargo mutants --package assay-evidence --file crates/assay-evidence/src/trust_basis/classifiers.rs "${COMMON[@]}" -- trust_basis
+
+echo "[mutation-smoke] sandbox degradation.rs"
+cargo mutants --package assay-cli --file crates/assay-cli/src/cli/commands/sandbox/degradation.rs "${COMMON[@]}" -- sandbox

--- a/scripts/ci/mutation-smoke-pure-modules.sh
+++ b/scripts/ci/mutation-smoke-pure-modules.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
 if [ "${ASSAY_RUN_MUTATION_SMOKE:-0}" != "1" ]; then
   echo "[mutation-smoke] skipped: set ASSAY_RUN_MUTATION_SMOKE=1 to run targeted mutation smoke"
   exit 0

--- a/scripts/ci/optional-public-api-drift.sh
+++ b/scripts/ci/optional-public-api-drift.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
 BASE_REV="${BASE_REV:-origin/main}"
 PACKAGES=(assay-core assay-evidence assay-registry assay-policy assay-metrics)
+
+if ! git rev-parse --verify --quiet "${BASE_REV}^{commit}" >/dev/null; then
+  echo "[api-drift] skip: BASE_REV ${BASE_REV} is not available locally"
+  exit 0
+fi
 
 ran_any=0
 

--- a/scripts/ci/optional-public-api-drift.sh
+++ b/scripts/ci/optional-public-api-drift.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REV="${BASE_REV:-origin/main}"
+PACKAGES=(assay-core assay-evidence assay-registry assay-policy assay-metrics)
+
+ran_any=0
+
+if cargo semver-checks --version >/dev/null 2>&1; then
+  ran_any=1
+  echo "[api-drift] cargo-semver-checks vs ${BASE_REV}"
+  for package in "${PACKAGES[@]}"; do
+    echo "[api-drift] semver-checks package=${package}"
+    cargo semver-checks check-release -p "${package}" --baseline-rev "${BASE_REV}"
+  done
+else
+  echo "[api-drift] skip cargo-semver-checks: cargo subcommand not installed"
+fi
+
+if cargo public-api --version >/dev/null 2>&1; then
+  ran_any=1
+  echo "[api-drift] cargo-public-api diff vs ${BASE_REV}"
+  for package in "${PACKAGES[@]}"; do
+    echo "[api-drift] public-api package=${package}"
+    if cargo public-api diff --help 2>/dev/null | rg -- '--package|-p' >/dev/null; then
+      cargo public-api diff --package "${package}" "${BASE_REV}..HEAD" -sss
+    elif cargo public-api --help 2>/dev/null | rg -- '--package|-p' >/dev/null; then
+      cargo public-api --package "${package}" diff "${BASE_REV}..HEAD" -sss
+    else
+      echo "[api-drift] skip package-scoped public-api diff for ${package}: installed cargo-public-api does not advertise --package"
+    fi
+  done
+else
+  echo "[api-drift] skip cargo-public-api: cargo subcommand not installed"
+fi
+
+if [ "${ran_any}" -eq 0 ]; then
+  echo "[api-drift] no optional public API drift tools installed; install cargo-semver-checks and/or cargo-public-api to enable this gate"
+fi

--- a/scripts/ci/review-wave52-livekit-tool-action-step1.sh
+++ b/scripts/ci/review-wave52-livekit-tool-action-step1.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+
+allowed_pattern='^(docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action\.md|docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1\.md|docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1\.md|docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1\.md|scripts/ci/review-wave52-livekit-tool-action-step1\.sh|docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2\.md|docs/security/OWASP-MCP-TOP10-TEST-MAP\.md|scripts/ci/optional-public-api-drift\.sh|scripts/ci/mutation-smoke-pure-modules\.sh|scripts/ci/review-week8-sota-gates\.sh)$'
+
+collect_changed() {
+  {
+    git diff --name-only "$BASE_REF"...HEAD || true
+    git diff --name-only || true
+    git diff --cached --name-only || true
+    git ls-files --others --exclude-standard || true
+  } | sed '/^$/d' | sort -u
+}
+
+echo "[review] allowlist-only diff vs $BASE_REF + workflow/source/test bans"
+changed="$(collect_changed)"
+if [ -n "$changed" ]; then
+  non_allowed="$(printf '%s\n' "$changed" | rg -v "$allowed_pattern" || true)"
+  if [ -n "$non_allowed" ]; then
+    echo "FAIL: non-allowlisted files changed:"
+    printf '%s\n' "$non_allowed"
+    exit 1
+  fi
+fi
+
+if printf '%s\n' "$changed" | rg '^\.github/workflows/' >/dev/null; then
+  echo "FAIL: Step1 must not touch workflows"
+  exit 1
+fi
+if printf '%s\n' "$changed" | rg '^crates/assay-ebpf/src/vmlinux\.rs$' >/dev/null; then
+  echo "FAIL: generated vmlinux.rs must stay out of scope"
+  exit 1
+fi
+if printf '%s\n' "$changed" | rg '^crates/assay-cli/src/cli/commands/evidence/' >/dev/null; then
+  echo "FAIL: Step1 must not edit evidence importer source"
+  exit 1
+fi
+if printf '%s\n' "$changed" | rg '^crates/assay-cli/tests/' >/dev/null; then
+  echo "FAIL: Step1 must not edit CLI tests"
+  exit 1
+fi
+
+echo "[review] frozen surface markers"
+rg 'cmd_livekit_tool_action' crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs >/dev/null
+rg 'assay\.receipt\.livekit\.tool_action\.v1' crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs >/dev/null
+rg 'livekit\.function-tools-executed\.export\.v1' crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs >/dev/null
+rg 'test_livekit_imported_tool_action_receipts_verify_and_do_not_mutate_trust_basis_claims' crates/assay-cli/tests/evidence_test.rs >/dev/null
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo check -p assay-cli
+cargo clippy -p assay-cli --all-targets -- -D warnings
+cargo test -q -p assay-cli livekit_tool_action
+cargo test -q -p assay-cli --test evidence_test test_livekit_imported_tool_action_receipts_verify_and_do_not_mutate_trust_basis_claims -- --exact
+bash scripts/ci/review-week8-sota-gates.sh
+git diff --check
+
+echo "[review] PASS"

--- a/scripts/ci/review-wave52-livekit-tool-action-step1.sh
+++ b/scripts/ci/review-wave52-livekit-tool-action-step1.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
 BASE_REF="${BASE_REF:-origin/main}"
 
 allowed_pattern='^(docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action\.md|docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1\.md|docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1\.md|docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1\.md|scripts/ci/review-wave52-livekit-tool-action-step1\.sh|docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2\.md|docs/security/OWASP-MCP-TOP10-TEST-MAP\.md|scripts/ci/optional-public-api-drift\.sh|scripts/ci/mutation-smoke-pure-modules\.sh|scripts/ci/review-week8-sota-gates\.sh)$'
 
+if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+  echo "FAIL: BASE_REF ${BASE_REF} is not available; fetch it or set BASE_REF to a local commit"
+  exit 1
+fi
+
 collect_changed() {
   {
-    git diff --name-only "$BASE_REF"...HEAD || true
+    git diff --name-only "$BASE_REF"...HEAD
     git diff --name-only || true
     git diff --cached --name-only || true
     git ls-files --others --exclude-standard || true

--- a/scripts/ci/review-week8-sota-gates.sh
+++ b/scripts/ci/review-week8-sota-gates.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[review] Week8 SOTA gate scripts syntax"
+bash -n scripts/ci/optional-public-api-drift.sh
+bash -n scripts/ci/mutation-smoke-pure-modules.sh
+
+echo "[review] Week8 docs anchors"
+rg 'cargo-semver-checks' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md >/dev/null
+rg 'cargo-public-api' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md >/dev/null
+rg 'cargo-mutants' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md >/dev/null
+rg 'OWASP MCP Top 10' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md docs/security/OWASP-MCP-TOP10-TEST-MAP.md >/dev/null
+
+for risk in MCP01 MCP02 MCP03 MCP05 MCP06 MCP08 MCP10; do
+  rg "$risk" docs/security/OWASP-MCP-TOP10-TEST-MAP.md >/dev/null
+ done
+
+rg 'trust_basis/diff.rs' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md scripts/ci/mutation-smoke-pure-modules.sh >/dev/null
+rg 'trust_basis/classifiers.rs' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md scripts/ci/mutation-smoke-pure-modules.sh >/dev/null
+rg 'sandbox/degradation.rs' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md scripts/ci/mutation-smoke-pure-modules.sh >/dev/null
+
+echo "[review] optional scripts dry-run behavior without tool assumptions"
+bash scripts/ci/optional-public-api-drift.sh
+bash scripts/ci/mutation-smoke-pure-modules.sh
+
+echo "[review] PASS"

--- a/scripts/ci/review-week8-sota-gates.sh
+++ b/scripts/ci/review-week8-sota-gates.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
 echo "[review] Week8 SOTA gate scripts syntax"
 bash -n scripts/ci/optional-public-api-drift.sh
 bash -n scripts/ci/mutation-smoke-pure-modules.sh


### PR DESCRIPTION
Summary

Starts the next refactor step after Wave51 with a freeze-only Wave52 slice for the current largest production Rust hotspot: the LiveKit tool-action importer.

- Identifies `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs` as the next hotspot after the Wave51 merges (`1104` LOC on `origin/main`).
- Adds a Wave52 plan, Step1 checklist, move-map, review-pack, and reviewer gate.
- Keeps Step1 docs+gate-only: no importer source, CLI tests, schema, hash, timestamp, pairing, or Trust Basis behavior changes.
- Incorporates the Week 8 SOTA gate direction: optional public API drift checks, opt-in mutation smoke for pure modules, and OWASP MCP Top 10 test mapping.

Scope

Included:

- `docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action.md`
- `docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1.md`
- `docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1.md`
- `docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1.md`
- `docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md`
- `docs/security/OWASP-MCP-TOP10-TEST-MAP.md`
- `scripts/ci/review-wave52-livekit-tool-action-step1.sh`
- `scripts/ci/review-week8-sota-gates.sh`
- `scripts/ci/optional-public-api-drift.sh`
- `scripts/ci/mutation-smoke-pure-modules.sh`

Explicitly excluded:

- production importer code changes
- CLI test changes
- workflow changes
- generated file changes
- LiveKit receipt schema/key allowlist drift
- Trust Basis classifier behavior changes

Validation

`bash scripts/ci/review-wave52-livekit-tool-action-step1.sh`

This includes:

- allowlist-only diff
- no workflow/generated/source/test edits
- frozen LiveKit surface marker checks
- `cargo fmt --check`
- `cargo check -p assay-cli`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `cargo test -q -p assay-cli livekit_tool_action`
- `cargo test -q -p assay-cli --test evidence_test test_livekit_imported_tool_action_receipts_verify_and_do_not_mutate_trust_basis_claims -- --exact`
- `bash scripts/ci/review-week8-sota-gates.sh`
- `git diff --check`

Notes

- Local `cargo-semver-checks`, `cargo-public-api`, and `cargo-mutants` are not installed, so the new Week 8 scripts currently skip with explicit notices unless enabled/tooling is present.
- Pre-push hooks passed, including workspace clippy and linux compile gate.

Next

After this lands, Step2 should mechanically split `livekit_tool_action.rs` behind the stable `cmd_livekit_tool_action` facade.
