### PR TITLE
feat: align LiveKit tool-action importer with SDK pairing

### DIFF
--- a/crates/assay-cli/receipt-schemas/inputs/livekit-function-tools-executed-export.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/inputs/livekit-function-tools-executed-export.v1.schema.json
@@ -30,7 +30,12 @@
     "function_call_outputs": {
       "type": "array",
       "minItems": 1,
-      "items": { "$ref": "#/$defs/functionCallOutput" }
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/functionCallOutput" },
+          { "type": "null" }
+        ]
+      }
     },
     "has_tool_reply": { "type": "boolean" },
     "has_agent_handoff": { "type": "boolean" }

--- a/crates/assay-cli/receipt-schemas/receipts/livekit.tool-action.v1.schema.json
+++ b/crates/assay-cli/receipt-schemas/receipts/livekit.tool-action.v1.schema.json
@@ -43,9 +43,9 @@
     "outcome": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["completed", "is_error"],
+      "required": ["completed"],
       "properties": {
-        "completed": { "const": true },
+        "completed": { "type": "boolean" },
         "is_error": { "type": "boolean" },
         "received_at": { "type": "string", "format": "date-time" },
         "output_hash": { "$ref": "#/$defs/sha256Digest" },

--- a/crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, SecondsFormat, Utc};
 use clap::Args;
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -330,11 +330,7 @@ fn reduce_tool_action_event(
                 "document {document_number} function_calls[{call_index}] must be a JSON object"
             )
         })?;
-        let output = outputs[output_index].as_object().ok_or_else(|| {
-            anyhow::anyhow!(
-                "document {document_number} function_call_outputs[{output_index}] must be a JSON object"
-            )
-        })?;
+        let output = outputs[output_index].as_object();
         let payload = build_receipt(&context, call_index, output_index, call, output)?;
         payloads.push(payload);
     }
@@ -347,10 +343,9 @@ fn build_receipt(
     call_index: usize,
     output_index: usize,
     call: &Map<String, Value>,
-    output: &Map<String, Value>,
+    output: Option<&Map<String, Value>>,
 ) -> Result<Value> {
     validate_call_keys(call, context.document_number, call_index)?;
-    validate_output_keys(output, context.document_number, output_index)?;
 
     let call_name = bounded_string(
         call.get("name"),
@@ -358,18 +353,6 @@ fn build_receipt(
         MAX_NAME_CHARS,
         context.document_number,
     )?;
-    let output_name = bounded_string(
-        output.get("name"),
-        "function_call_outputs[].name",
-        MAX_NAME_CHARS,
-        context.document_number,
-    )?;
-    if call_name != output_name {
-        bail!(
-            "document {} paired call/output names differ at call index {call_index}",
-            context.document_number
-        );
-    }
 
     let mut function = Map::new();
     function.insert(
@@ -380,7 +363,7 @@ fn build_receipt(
         "call_index".to_string(),
         Value::Number((call_index as u64).into()),
     );
-    function.insert("name".to_string(), Value::String(call_name));
+    function.insert("name".to_string(), Value::String(call_name.clone()));
 
     if let Some(call_id) = optional_nullable_bounded_string(
         call.get("call_id"),
@@ -422,36 +405,54 @@ fn build_receipt(
     }
 
     let mut outcome = Map::new();
-    outcome.insert("completed".to_string(), Value::Bool(true));
-    outcome.insert(
-        "is_error".to_string(),
-        Value::Bool(required_bool(
-            output.get("is_error"),
-            "function_call_outputs[].is_error",
+    if let Some(output) = output {
+        validate_output_keys(output, context.document_number, output_index)?;
+        let output_name = bounded_string(
+            output.get("name"),
+            "function_call_outputs[].name",
+            MAX_NAME_CHARS,
             context.document_number,
-        )?),
-    );
-    if let Some(received_at) = optional_timestamp(
-        output.get("created_at"),
-        "function_call_outputs[].created_at",
-        context.document_number,
-    )? {
-        outcome.insert("received_at".to_string(), Value::String(received_at));
-    }
-    match hash_or_ref(
-        output,
-        "output",
-        "output_ref",
-        "function_call_outputs[]",
-        context.document_number,
-    )? {
-        HashOrRef::Hash(value) => {
-            outcome.insert("output_hash".to_string(), Value::String(value));
+        )?;
+        if call_name != output_name {
+            bail!(
+                "document {} paired call/output names differ at call index {call_index}",
+                context.document_number
+            );
         }
-        HashOrRef::Ref(value) => {
-            outcome.insert("output_ref".to_string(), Value::String(value));
+
+        outcome.insert("completed".to_string(), Value::Bool(true));
+        outcome.insert(
+            "is_error".to_string(),
+            Value::Bool(required_bool(
+                output.get("is_error"),
+                "function_call_outputs[].is_error",
+                context.document_number,
+            )?),
+        );
+        if let Some(received_at) = optional_timestamp(
+            output.get("created_at"),
+            "function_call_outputs[].created_at",
+            context.document_number,
+        )? {
+            outcome.insert("received_at".to_string(), Value::String(received_at));
         }
-        HashOrRef::Absent => {}
+        match hash_or_ref(
+            output,
+            "output",
+            "output_ref",
+            "function_call_outputs[]",
+            context.document_number,
+        )? {
+            HashOrRef::Hash(value) => {
+                outcome.insert("output_hash".to_string(), Value::String(value));
+            }
+            HashOrRef::Ref(value) => {
+                outcome.insert("output_ref".to_string(), Value::String(value));
+            }
+            HashOrRef::Absent => {}
+        }
+    } else {
+        outcome.insert("completed".to_string(), Value::Bool(false));
     }
 
     let mut event_context = Map::new();
@@ -485,92 +486,54 @@ fn paired_call_outputs(
     outputs: &[Value],
     document_number: usize,
 ) -> Result<Vec<(usize, usize)>> {
-    let mut calls_all_have_ids = true;
-    let mut calls_any_have_ids = false;
-    for (index, call) in calls.iter().enumerate() {
+    let mut all_pairs_have_call_ids = true;
+    let mut pair_call_ids = Vec::with_capacity(calls.len());
+
+    for (index, (call, output)) in calls.iter().zip(outputs.iter()).enumerate() {
         let call = call.as_object().ok_or_else(|| {
             anyhow::anyhow!(
                 "document {document_number} function_calls[{index}] must be a JSON object"
             )
         })?;
         validate_call_keys(call, document_number, index)?;
-        let has_id = optional_nullable_bounded_string(
+        let call_id = optional_nullable_bounded_string(
             call.get("call_id"),
             "function_calls[].call_id",
             MAX_REF_CHARS,
             document_number,
-        )?
-        .is_some();
-        calls_all_have_ids &= has_id;
-        calls_any_have_ids |= has_id;
-    }
+        )?;
 
-    let mut outputs_all_have_ids = true;
-    let mut outputs_any_have_ids = false;
-    for (index, output) in outputs.iter().enumerate() {
-        if output.is_null() {
-            bail!(
-                "document {document_number} function_call_outputs[{index}] is null; missing output is malformed in LiveKit tool-action v1"
-            );
-        }
-        let output = output.as_object().ok_or_else(|| {
-            anyhow::anyhow!(
-                "document {document_number} function_call_outputs[{index}] must be a JSON object"
-            )
-        })?;
-        validate_output_keys(output, document_number, index)?;
-        let has_id = optional_nullable_bounded_string(
-            output.get("call_id"),
-            "function_call_outputs[].call_id",
-            MAX_REF_CHARS,
-            document_number,
-        )?
-        .is_some();
-        outputs_all_have_ids &= has_id;
-        outputs_any_have_ids |= has_id;
-    }
-
-    if calls_any_have_ids || outputs_any_have_ids {
-        if !calls_all_have_ids || !outputs_all_have_ids {
-            bail!(
-                "document {document_number} call_id pairing requires every call and output to include call_id"
-            );
-        }
-        let mut output_by_id = BTreeMap::new();
-        for (index, output) in outputs.iter().enumerate() {
-            let output = output.as_object().unwrap();
-            let call_id = optional_nullable_bounded_string(
+        let output_id = if output.is_null() {
+            None
+        } else {
+            let output = output.as_object().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "document {document_number} function_call_outputs[{index}] must be a JSON object or null"
+                )
+            })?;
+            validate_output_keys(output, document_number, index)?;
+            optional_nullable_bounded_string(
                 output.get("call_id"),
                 "function_call_outputs[].call_id",
                 MAX_REF_CHARS,
                 document_number,
             )?
-            .unwrap();
-            if output_by_id.insert(call_id.clone(), index).is_some() {
-                bail!("document {document_number} duplicate output call_id {call_id:?}");
-            }
-        }
+        };
 
-        let mut seen_call_ids = BTreeSet::new();
-        let mut pairs = Vec::with_capacity(calls.len());
-        for (call_index, call) in calls.iter().enumerate() {
-            let call = call.as_object().unwrap();
-            let call_id = optional_nullable_bounded_string(
-                call.get("call_id"),
-                "function_calls[].call_id",
-                MAX_REF_CHARS,
-                document_number,
-            )?
-            .unwrap();
-            if !seen_call_ids.insert(call_id.clone()) {
-                bail!("document {document_number} duplicate call_id {call_id:?}");
+        all_pairs_have_call_ids &= call_id.is_some() && output_id.is_some();
+        pair_call_ids.push((call_id, output_id));
+    }
+
+    if all_pairs_have_call_ids {
+        for (index, (call_id, output_id)) in pair_call_ids.iter().enumerate() {
+            if call_id != output_id {
+                bail!(
+                    "document {document_number} call_id mismatch at index {index}: call has {:?}, output has {:?}",
+                    call_id.as_deref(),
+                    output_id.as_deref()
+                );
             }
-            let Some(output_index) = output_by_id.get(&call_id).copied() else {
-                bail!("document {document_number} missing output for call_id {call_id:?}");
-            };
-            pairs.push((call_index, output_index));
         }
-        return Ok(pairs);
     }
 
     Ok((0..calls.len()).map(|index| (index, index)).collect())
@@ -979,7 +942,7 @@ mod tests {
     }
 
     #[test]
-    fn import_pairs_by_call_id_before_list_order() {
+    fn import_pairs_by_list_order_and_rejects_call_id_mismatch_when_complete() {
         let dir = tempfile::tempdir().unwrap();
         let input = dir.path().join("livekit-tool-action.json");
         let output = dir.path().join("livekit-tool-action.tar.gz");
@@ -989,11 +952,33 @@ mod tests {
         )
         .unwrap();
 
+        let err = cmd_livekit_tool_action(LiveKitToolActionArgs {
+            input,
+            bundle_out: output,
+            source_artifact_ref: None,
+            run_id: "livekit_pairing_test".to_string(),
+            import_time: Some("2026-05-09T10:05:02Z".to_string()),
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("call_id mismatch"));
+    }
+
+    #[test]
+    fn import_accepts_partial_call_ids_using_list_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("livekit-tool-action.json");
+        let output = dir.path().join("livekit-tool-action.tar.gz");
+        fs::write(
+            &input,
+            r#"{"schema":"livekit.function-tools-executed.export.v1","framework":"livekit_agents","surface":"function_tools_executed","runtime_mode":"agent_session","event_ref":"turn-45:function_tools_executed:0","created_at":"2026-05-09T10:05:00Z","function_calls":[{"call_id":"call_a","name":"lookup_a","arguments_ref":"arg:a"},{"name":"lookup_b","arguments_ref":"arg:b"}],"function_call_outputs":[{"name":"lookup_a","is_error":false,"output_ref":"out:a"},{"call_id":"call_b","name":"lookup_b","is_error":false,"output_ref":"out:b"}]}"#,
+        )
+        .unwrap();
+
         cmd_livekit_tool_action(LiveKitToolActionArgs {
             input,
             bundle_out: output.clone(),
             source_artifact_ref: None,
-            run_id: "livekit_pairing_test".to_string(),
+            run_id: "livekit_partial_id_test".to_string(),
             import_time: Some("2026-05-09T10:05:02Z".to_string()),
         })
         .unwrap();
@@ -1003,7 +988,7 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].payload["function"]["call_id"], "call_a");
         assert_eq!(events[0].payload["outcome"]["output_ref"], "out:a");
-        assert_eq!(events[1].payload["function"]["call_id"], "call_b");
+        assert!(events[1].payload["function"].get("call_id").is_none());
         assert_eq!(events[1].payload["outcome"]["output_ref"], "out:b");
     }
 
@@ -1037,7 +1022,7 @@ mod tests {
     }
 
     #[test]
-    fn import_rejects_missing_output_none() {
+    fn import_preserves_missing_output_none_without_inferring_error() {
         let dir = tempfile::tempdir().unwrap();
         let input = dir.path().join("livekit-tool-action.json");
         let output = dir.path().join("livekit-tool-action.tar.gz");
@@ -1047,15 +1032,21 @@ mod tests {
         )
         .unwrap();
 
-        let err = cmd_livekit_tool_action(LiveKitToolActionArgs {
+        cmd_livekit_tool_action(LiveKitToolActionArgs {
             input,
-            bundle_out: output,
+            bundle_out: output.clone(),
             source_artifact_ref: None,
             run_id: "livekit_missing_output_test".to_string(),
             import_time: Some("2026-05-09T10:02:02Z".to_string()),
         })
-        .unwrap_err();
-        assert!(err.to_string().contains("missing output is malformed"));
+        .unwrap();
+
+        let reader = BundleReader::open(File::open(output).unwrap()).unwrap();
+        let events = reader.events().collect::<Result<Vec<_>>>().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].payload["outcome"]["completed"], false);
+        assert!(events[0].payload["outcome"].get("is_error").is_none());
+        assert!(events[0].payload["outcome"].get("output_hash").is_none());
     }
 
     #[test]

--- a/docs/architecture/PLAN-P47-LIVEKIT-ACTED-FAMILY-TOOL-ACTION-RECEIPTS-2026q2.md
+++ b/docs/architecture/PLAN-P47-LIVEKIT-ACTED-FAMILY-TOOL-ACTION-RECEIPTS-2026q2.md
@@ -86,10 +86,10 @@ Reduction unit:
 one function call + function call output pair
 ```
 
-The importer may mirror LiveKit's conceptual `zipped()` pairing, but v1 receipt
-generation is defined by the observed call/output lists and the pairing rules
-below. It must not depend on helper methods from one SDK surface as the
-semantic contract.
+The importer mirrors LiveKit's `zipped()` pairing semantics: calls and outputs
+are paired by list order. `call_id` is treated as an optional audit consistency
+check when every paired call/output entry carries one, not as the primary
+framework contract.
 
 ## 5. Frozen input shape
 
@@ -284,11 +284,13 @@ Timestamp boundary:
 1. Require `type == "function_tools_executed"` when present.
 2. Require a non-empty `function_calls` list.
 3. Require `function_call_outputs` to pair cleanly with calls.
-4. Prefer pairing by `call_id` when present on both sides.
-5. Fall back to list order only when `call_id` is absent.
+4. Pair calls and outputs by list order, matching LiveKit's `zipped()`
+   behavior.
+5. If every paired call/output entry has `call_id`, require the ids to match
+   at each index.
 6. Reject mismatched call/output counts in v1.
-7. Treat a missing output for any included call as malformed in Stage 1.
-8. Do not introduce a `missing_output` status yet.
+7. Preserve a missing or `null` output as `completed=false`.
+8. Do not infer `is_error` from a missing or `null` output.
 9. Require stable non-empty function names.
 10. Derive the receipt's `outcome.completed` and `outcome.is_error` fields from
     the paired output.
@@ -298,11 +300,9 @@ Timestamp boundary:
     not as proof that a reply or handoff was correct.
 14. Reject transcript/audio/usage fields if they appear in the reduced input.
 
-LiveKit Python permits `FunctionCallOutput | None`. P47 keeps those cases
-malformed in the first importer-only slice to avoid inventing `missing_output`
-semantics too early. A future production reducer may model this as
-`completed=false`, but that should happen only after a real captured input
-requires the richer status.
+LiveKit Python permits `FunctionCallOutput | None`. P47 preserves those cases
+as observed by setting `completed=false` and omitting `is_error`, rather than
+inventing success/failure semantics for an unknown output.
 
 ## 11. Non-claims
 
@@ -355,9 +355,8 @@ slice.
    acted-family distinction more visible?
 4. Should `has_tool_reply` and `has_agent_handoff` be copied to every receipt,
    or emitted once as event-level context in a batch receipt?
-5. Are `outcome.completed` and `outcome.is_error` enough for v1, with missing
-   output treated as malformed in this importer-only slice, or do we need richer
-   outcome values immediately?
+5. Are `outcome.completed=false` plus omitted `is_error` enough for missing
+   outputs, or do we need richer outcome values immediately?
 
 ## 14. Defaults
 
@@ -366,8 +365,8 @@ slice.
 3. Leave P16 alone for now, but document P47 as the acted-family execution
    successor.
 4. Copy event context into each receipt for review simplicity.
-5. Start with completed/error only; add richer statuses only after a real
-   fixture needs them.
+5. Start with `completed` and optional `is_error`; add richer statuses only
+   after a real fixture needs them.
 
 ## References
 

--- a/docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1.md
@@ -2,40 +2,45 @@
 
 ## Scope
 
-Step1 freezes the LiveKit tool-action importer before any production split.
+Step1 aligns and freezes the LiveKit tool-action importer before any production
+split.
 
-Allowed files:
+Allowed change areas:
 
-- `docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action.md`
-- `docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1.md`
-- `docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1.md`
-- `docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1.md`
-- `scripts/ci/review-wave52-livekit-tool-action-step1.sh`
-- `docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md`
-- `docs/security/OWASP-MCP-TOP10-TEST-MAP.md`
-- `scripts/ci/optional-public-api-drift.sh`
-- `scripts/ci/mutation-smoke-pure-modules.sh`
-- `scripts/ci/review-week8-sota-gates.sh`
+- `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs`
+- LiveKit input/receipt schemas under `crates/assay-cli/receipt-schemas/`
+- mirrored LiveKit schema docs under `docs/reference/receipt-schemas/`
+- LiveKit CLI/reference docs under `docs/reference/cli/evidence.md`
+- P47 architecture docs
+- `examples/livekit-tool-action-evidence/`
+- Wave52 docs and reviewer gate
+- Week 8 SOTA gate docs/scripts
+- OWASP MCP Top 10 test coverage map
 
 Forbidden in Step1:
 
-- edits under `crates/assay-cli/src/cli/commands/evidence/**`
-- edits under `crates/assay-cli/tests/**`
+- module extraction or file moves
 - workflow edits
 - generated file edits
-- schema, hash, timestamp, pairing, or Trust Basis behavior changes
+- Trust Basis classifier changes
+- public receipt-family matrix entries
+- LiveKit endorsement or stable wire-contract claims
 
 ## Frozen Contracts
 
 - CLI route and argument shape remain stable.
 - `assay.receipt.livekit.tool_action.v1` event type remains stable.
-- `assay.receipt.livekit.tool-action.v1` receipt schema remains stable.
+- `assay.receipt.livekit.tool-action.v1` receipt schema remains importer-only.
 - Reduced input schema remains `livekit.function-tools-executed.export.v1`.
 - Raw transcript/audio/user/model/session/trace/telemetry imports remain rejected.
-- Call/output pairing by `call_id` remains preferred over list order.
+- Calls and outputs pair by LiveKit SDK list order.
+- Complete per-index `call_id` pairs are checked for consistency.
+- Partial `call_id` presence remains list-order paired.
+- `null` outputs produce `completed=false` and no inferred `is_error`.
 - JSONL multi-row import remains accepted.
 - Raw argument/output values remain hashed or referenced, not embedded.
-- LiveKit receipts remain importer-only and do not mutate Trust Basis external eval/decision/inventory claims.
+- LiveKit receipts remain importer-only and do not mutate Trust Basis external
+  eval/decision/inventory claims.
 
 ## Reviewer Gate
 
@@ -45,4 +50,4 @@ Run:
 bash scripts/ci/review-wave52-livekit-tool-action-step1.sh
 ```
 
-The gate enforces docs+gate-only scope and runs the current LiveKit importer tests.
+The gate enforces Step1 scope and runs the current LiveKit importer contracts.

--- a/docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1.md
@@ -2,27 +2,34 @@
 
 ## Step1 Movement
 
-No production code moves in Step1.
+No production modules move in Step1.
 
 ## Source Hotspot
 
-- `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs` (`1104` LOC on `origin/main @ 057151c5`)
+- `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs`
+  (`1104` LOC on `origin/main @ 057151c5`)
 
 ## Current Internal Regions
 
-- CLI args and command facade: `LiveKitToolActionArgs`, `cmd_livekit_tool_action`
-- input loading and JSON/JSONL parsing: `read_livekit_tool_actions`, `parse_input_documents`
-- receipt reduction: `reduce_tool_action_event`, `build_receipt`, `paired_call_outputs`
-- schema/key validation: `validate_top_level`, `validate_call_keys`, `validate_output_keys`
+- CLI args and command facade: `LiveKitToolActionArgs`,
+  `cmd_livekit_tool_action`
+- input loading and JSON/JSONL parsing: `read_livekit_tool_actions`,
+  `parse_input_documents`
+- receipt reduction: `reduce_tool_action_event`, `build_receipt`,
+  `paired_call_outputs`
+- schema/key validation: `validate_top_level`, `validate_call_keys`,
+  `validate_output_keys`
 - bounded value/timestamp validation: string, bool, timestamp helpers
-- hashing/canonicalization: `hash_or_ref`, `sha256_json_value`, `canonical_json`, `sha256_file`
+- hashing/canonicalization: `hash_or_ref`, `sha256_json_value`,
+  `canonical_json`, `sha256_file`
 - importer tests: inline `mod tests`
 
 ## Step2 Candidate Moves
 
 - `input.rs`: input document parsing and file digest helpers
-- `reduce.rs`: event reduction, receipt construction, and call/output pairing
-- `validate.rs`: key allowlists, forbidden-key checks, bounded strings, booleans, timestamps
+- `reduce.rs`: event reduction, receipt construction, and list-order pairing
+- `validate.rs`: key allowlists, forbidden-key checks, bounded strings,
+  booleans, timestamps
 - `canonical.rs`: canonical JSON and hash/ref helpers
 - `bundle.rs`: command orchestration from events to `BundleWriter`
 - `tests.rs`: existing importer tests after behavior stays frozen
@@ -32,4 +39,5 @@ No production code moves in Step1.
 - Do not alter CLI argument names or aliases.
 - Do not change event or receipt schema strings.
 - Do not alter Trust Basis classifier behavior.
-- Do not import raw LiveKit session, transcript, trace, telemetry, or model/user payloads.
+- Do not import raw LiveKit session, transcript, trace, telemetry, or
+  model/user payloads.

--- a/docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action.md
+++ b/docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action.md
@@ -2,19 +2,26 @@
 
 ## Goal
 
-Reduce `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs` behind a stable CLI/importer facade without changing LiveKit acted-family receipt semantics.
+Reduce `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs`
+behind a stable CLI/importer facade without changing LiveKit acted-family
+receipt semantics.
 
 Current hotspot baseline on `origin/main @ 057151c5`:
 
 - `crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs`: `1104` LOC
 - public CLI entrypoint: `cmd_livekit_tool_action(LiveKitToolActionArgs)`
-- companion integration test: `crates/assay-cli/tests/evidence_test.rs::test_livekit_imported_tool_action_receipts_verify_and_do_not_mutate_trust_basis_claims`
+- companion integration test:
+  `crates/assay-cli/tests/evidence_test.rs::test_livekit_imported_tool_action_receipts_verify_and_do_not_mutate_trust_basis_claims`
 
 ## Why This Is Next
 
-Wave51 retired the runner, sandbox, MCP proxy, and Trust Basis hotspots. A fresh `origin/main` LOC snapshot now shows the LiveKit tool-action importer as the largest handwritten production Rust file. It is also a fresh protocol-facing importer, so the safe next move is a freeze-only step before any module extraction.
+After Wave51, the LiveKit tool-action importer became the largest handwritten
+production Rust file in `assay-cli`. It is also a fresh protocol-facing
+surface, so the safe next move is not a blind module split. First align the
+behavior with upstream LiveKit feedback, then freeze it, then split
+mechanically.
 
-## Frozen Behavior
+## Frozen Behavior After Alignment
 
 Wave52 freezes these importer contracts before moving code:
 
@@ -22,39 +29,37 @@ Wave52 freezes these importer contracts before moving code:
 - event type/source/schema constants
 - accepted reduced input shape and required/optional top-level keys
 - forbidden raw payload/session/trace/telemetry keys
-- call/output pairing by `call_id` before list order
+- call/output pairing by LiveKit SDK list order
+- optional `call_id` consistency checking when every paired entry has one
+- partial `call_id` presence remains list-order paired
+- `FunctionCallOutput | None` is preserved as `completed=false`
 - JSONL multi-document input behavior
 - bounded reviewer-safe string validation
 - raw argument/output hashing without raw value leakage
 - timestamp normalization and deterministic import-time handling
-- malformed missing-output rejection
 - non-integer raw float rejection
 - Trust Basis non-mutation for LiveKit acted-family receipts
 
-## Step1 - Freeze and Gate
+## Step1 - Upstream Alignment And Freeze
 
-Branch: `codex/wave52-livekit-tool-action-freeze-step1` (base: `main`)
-
-Step1 is docs+gate only. It must not edit production importer code or tests.
+Step1 aligns the importer with LiveKit's source-level
+`FunctionToolsExecutedEvent` semantics and keeps module extraction out of
+scope.
 
 Deliverables:
 
-- `docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action.md`
-- `docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1.md`
-- `docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1.md`
-- `docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1.md`
-- `scripts/ci/review-wave52-livekit-tool-action-step1.sh`
-- `docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md`
-- `docs/security/OWASP-MCP-TOP10-TEST-MAP.md`
-- `scripts/ci/optional-public-api-drift.sh`
-- `scripts/ci/mutation-smoke-pure-modules.sh`
-- `scripts/ci/review-week8-sota-gates.sh`
+- importer list-order pairing alignment
+- null-output receipt behavior
+- fixture, schema, and docs updates
+- Wave52 split plan/checklist/move map/review pack
+- reviewer gate for the aligned surface
+- Week 8 SOTA gate plan and optional scripts
+- OWASP MCP Top 10 test coverage map
 
-## Step2 - Mechanical Split Preview
+## Step2 - Mechanical Split
 
-Only after Step1 lands, split behind the existing command facade.
-
-Suggested target layout:
+Only after Step1 lands, split behind the existing command facade. Suggested
+target layout:
 
 ```text
 crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs
@@ -72,11 +77,13 @@ Step2 principles:
 - keep `cmd_livekit_tool_action` and `LiveKitToolActionArgs` in the facade
 - move function bodies 1:1 where possible
 - no schema/key allowlist drift
-- no hash/canonical JSON drift
+- no pairing, null-output, hash, or canonical JSON drift
 - no timestamp or source-artifact-ref drift
 - no trust-basis classifier drift
 - preserve existing tests, moving them only if the split needs it
 
 ## Stop Rule
 
-If Step2 reduces the facade below roughly 150 LOC and keeps protocol helpers isolated, stop. Do not keep splitting a fresh importer without concrete review pain.
+If Step2 reduces the facade below roughly 150 LOC and keeps protocol helpers
+isolated, stop. Do not keep splitting a fresh importer without concrete review
+pain.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1.md
@@ -2,27 +2,27 @@
 
 ## Summary
 
-Step1 starts Wave52 with a freeze-only slice for the LiveKit tool-action importer hotspot. The importer is now the largest handwritten production Rust file after Wave51, but it is also a fresh protocol-facing surface, so this PR intentionally adds no production changes.
+Step1 aligns the LiveKit tool-action importer with LiveKit's source-level
+`FunctionToolsExecutedEvent` behavior and freezes it before Wave52 module
+splitting.
 
 ## Included
 
-- Wave52 split plan
-- Step1 checklist
-- Step1 move map
-- Step1 review pack
-- Step1 reviewer gate script
+- list-order call/output pairing alignment
+- optional `call_id` consistency checking
+- `null` output preservation as `completed=false`
+- schema, docs, and fixture updates
+- Wave52 split plan, checklist, move map, and reviewer gate
 - Week 8 SOTA gate plan and optional scripts
 - OWASP MCP Top 10 test coverage map
 
 ## Excluded
 
-- production importer edits
-- test edits
-- schema/key allowlist changes
-- hash/canonical JSON changes
-- timestamp normalization changes
-- Trust Basis behavior changes
+- production module moves
 - workflow changes
+- Trust Basis classifier changes
+- public family-matrix entry
+- LiveKit endorsement claim
 
 ## Validation
 
@@ -34,9 +34,8 @@ bash scripts/ci/review-wave52-livekit-tool-action-step1.sh
 
 The script checks:
 
-- allowlist-only diff
-- no workflow/generated-file changes
-- no edits under LiveKit importer source or CLI tests
+- Step1 allowlist
+- no module extraction yet
 - `cargo fmt --check`
 - `cargo check -p assay-cli`
 - `cargo clippy -p assay-cli --all-targets -- -D warnings`
@@ -47,4 +46,5 @@ The script checks:
 
 ## Next Step
 
-After Step1 lands, perform the mechanical split behind `cmd_livekit_tool_action` and keep the receipt protocol contracts unchanged.
+After Step1 lands, perform the mechanical split behind
+`cmd_livekit_tool_action` and keep the receipt protocol contracts unchanged.

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -220,10 +220,12 @@ The importer is intentionally strict in v1:
 - each artifact must use `runtime_mode = agent_session`
 - optional `type` must be `function_tools_executed` when present
 - one receipt is emitted per function call / output pair
-- calls and outputs are paired by `call_id` only when every call and every
-  output entry has one; if neither side uses `call_id`, pairing falls back to
-  list order; partial `call_id` presence is malformed in v1
-- missing `FunctionCallOutput` / `null` output entries are malformed in v1
+- calls and outputs are paired by LiveKit SDK list order
+- if every paired call/output entry has `call_id`, mismatches fail the import
+  as an audit consistency check
+- partial `call_id` presence is accepted and still uses list-order pairing
+- missing `FunctionCallOutput` / `null` output entries are preserved as
+  `completed=false` without inferring `is_error`
 - raw tool arguments and outputs are accepted only as fixture input for hashing;
   receipts store `arguments_hash` / `output_hash` or explicit reviewer-safe
   refs

--- a/docs/reference/receipt-schemas/inputs/livekit-function-tools-executed-export.v1.schema.json
+++ b/docs/reference/receipt-schemas/inputs/livekit-function-tools-executed-export.v1.schema.json
@@ -30,7 +30,12 @@
     "function_call_outputs": {
       "type": "array",
       "minItems": 1,
-      "items": { "$ref": "#/$defs/functionCallOutput" }
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/functionCallOutput" },
+          { "type": "null" }
+        ]
+      }
     },
     "has_tool_reply": { "type": "boolean" },
     "has_agent_handoff": { "type": "boolean" }

--- a/docs/reference/receipt-schemas/receipts/livekit.tool-action.v1.schema.json
+++ b/docs/reference/receipt-schemas/receipts/livekit.tool-action.v1.schema.json
@@ -43,9 +43,9 @@
     "outcome": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["completed", "is_error"],
+      "required": ["completed"],
       "properties": {
-        "completed": { "const": true },
+        "completed": { "type": "boolean" },
         "is_error": { "type": "boolean" },
         "received_at": { "type": "string", "format": "date-time" },
         "output_hash": { "$ref": "#/$defs/sha256Digest" },

--- a/examples/livekit-tool-action-evidence/README.md
+++ b/examples/livekit-tool-action-evidence/README.md
@@ -8,7 +8,9 @@ It is intentionally small:
 - start with one Assay-side frozen export shape derived from one
   `function_tools_executed` event
 - emit one receipt per function call / output pair
-- pair calls and outputs by `call_id` when present
+- pair calls and outputs by LiveKit SDK list order
+- use `call_id` only as an optional consistency check when every paired call
+  and output carries one
 - hash raw arguments and outputs instead of copying them into Assay output
 - keep transcripts, audio, room state, usage telemetry, and full traces out of
   the evidence boundary
@@ -20,6 +22,8 @@ It is intentionally small:
 - `fixtures/valid.livekit.json`: one successful function tool execution event
 - `fixtures/failure.livekit.json`: one function tool execution event whose
   output reports an error
+- `fixtures/missing-output.livekit.json`: one event with a `null`
+  `FunctionCallOutput`
 - `fixtures/malformed.livekit.json`: one malformed import case
 - `fixtures/valid.assay.ndjson`: pre-Stage-1 placeholder output with a fixed
   import time
@@ -69,7 +73,22 @@ assay evidence import livekit-tool-action \
 assay evidence verify /tmp/livekit-tool-action-failure.tar.gz
 ```
 
-## Check the malformed case
+## Import the missing-output artifact
+
+```bash
+assay evidence import livekit-tool-action \
+  --input examples/livekit-tool-action-evidence/fixtures/missing-output.livekit.json \
+  --bundle-out /tmp/livekit-tool-action-missing-output.tar.gz \
+  --import-time 2026-05-09T10:02:02Z \
+  --run-id livekit_tool_action_missing_output
+
+assay evidence verify /tmp/livekit-tool-action-missing-output.tar.gz
+```
+
+LiveKit's Python type allows `FunctionCallOutput | None`. The importer
+preserves that as `completed=false` and does not infer `is_error`.
+
+## Check a malformed call-id consistency case
 
 ```bash
 assay evidence import livekit-tool-action \
@@ -79,10 +98,9 @@ assay evidence import livekit-tool-action \
   --run-id livekit_tool_action_malformed
 ```
 
-This third command is expected to fail because Stage 1 treats a missing
-function-call output as malformed. LiveKit's Python type allows
-`FunctionCallOutput | None`; a future production reducer may model that as
-`completed=false`, but this importer keeps the first acted-family slice strict.
+This command is expected to fail because LiveKit pairs calls and outputs by
+list order, and the fixture has complete `call_id` values that disagree at the
+paired index.
 
 ## Important boundary
 
@@ -110,7 +128,9 @@ hashing behavior. They are fixture inputs, not receipt payload fields.
   `is_error=false`
 - `fixtures/failure.livekit.json`: bounded function-tool execution event with
   `is_error=true`
-- `fixtures/malformed.livekit.json`: malformed missing-output import case
+- `fixtures/missing-output.livekit.json`: import case with a `null`
+  `FunctionCallOutput`
+- `fixtures/malformed.livekit.json`: malformed call-id consistency case
 - `fixtures/valid.assay.ndjson`: mapped placeholder output with fixed import
   time and deterministic SHA-256 hashes
 - `fixtures/failure.assay.ndjson`: mapped placeholder output with fixed import

--- a/examples/livekit-tool-action-evidence/fixtures/missing-output.livekit.json
+++ b/examples/livekit-tool-action-evidence/fixtures/missing-output.livekit.json
@@ -4,21 +4,19 @@
   "surface": "function_tools_executed",
   "runtime_mode": "agent_session",
   "type": "function_tools_executed",
-  "event_ref": "turn-45:function_tools_executed:0",
-  "created_at": 1778320981.5,
+  "event_ref": "turn-44:function_tools_executed:0",
+  "created_at": 1778320921.5,
   "function_calls": [
     {
-      "call_id": "call_lookup_a",
+      "call_id": "call_missing_output_01",
       "name": "lookup_customer_order",
-      "arguments_ref": "arg:lookup-a"
+      "arguments": {
+        "order_id": "ord_404"
+      },
+      "created_at": 1778320921.234
     }
   ],
   "function_call_outputs": [
-    {
-      "call_id": "call_lookup_b",
-      "name": "lookup_customer_order",
-      "is_error": false,
-      "output_ref": "out:lookup-b"
-    }
+    null
   ]
 }

--- a/examples/livekit-tool-action-evidence/map_to_assay.py
+++ b/examples/livekit-tool-action-evidence/map_to_assay.py
@@ -200,10 +200,10 @@ def _validate_call(value: Any, index: int) -> dict[str, Any]:
     return normalized
 
 
-def _validate_output(value: Any, index: int) -> dict[str, Any]:
+def _validate_output(value: Any, index: int) -> dict[str, Any] | None:
     label = f"function_call_outputs[{index}]"
     if value is None:
-        raise ValueError(f"artifact: {label} is missing; missing outputs are malformed in this sample")
+        return None
     if not isinstance(value, dict):
         raise ValueError(f"artifact: {label} must be an object")
     unknown = set(value) - OUTPUT_KEYS
@@ -285,36 +285,21 @@ def _normalize_record(record: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
-def _pair_calls_outputs(normalized: dict[str, Any]) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+def _pair_calls_outputs(normalized: dict[str, Any]) -> list[tuple[dict[str, Any], dict[str, Any] | None]]:
     calls = normalized["function_calls"]
     outputs = normalized["function_call_outputs"]
-    calls_have_ids = all("call_id" in call for call in calls)
-    outputs_have_ids = all("call_id" in output for output in outputs)
-
-    if calls_have_ids and outputs_have_ids:
-        seen_outputs: dict[str, dict[str, Any]] = {}
-        for output in outputs:
-            call_id = output["call_id"]
-            if call_id in seen_outputs:
-                raise ValueError(f"artifact: duplicate output call_id: {call_id}")
-            seen_outputs[call_id] = output
-
-        paired = []
-        seen_calls: set[str] = set()
-        for call in calls:
-            call_id = call["call_id"]
-            if call_id in seen_calls:
-                raise ValueError(f"artifact: duplicate call call_id: {call_id}")
-            seen_calls.add(call_id)
-            if call_id not in seen_outputs:
-                raise ValueError(f"artifact: missing output for call_id: {call_id}")
-            paired.append((call, seen_outputs[call_id]))
-        return paired
-
-    if calls_have_ids != outputs_have_ids:
-        raise ValueError("artifact: call_id must be present on both calls and outputs, or absent on both")
-
-    return list(zip(calls, outputs))
+    paired = list(zip(calls, outputs))
+    if all(
+        "call_id" in call and output is not None and "call_id" in output
+        for call, output in paired
+    ):
+        for index, (call, output) in enumerate(paired):
+            if call["call_id"] != output["call_id"]:
+                raise ValueError(
+                    "artifact: call_id mismatch at index "
+                    f"{index}: call has {call['call_id']!r}, output has {output['call_id']!r}"
+                )
+    return paired
 
 
 def _hash_or_ref(record: dict[str, Any], raw_key: str, ref_key: str) -> tuple[str | None, str | None]:
@@ -330,15 +315,12 @@ def _hash_or_ref(record: dict[str, Any], raw_key: str, ref_key: str) -> tuple[st
 def _build_receipt(
     normalized: dict[str, Any],
     call: dict[str, Any],
-    output: dict[str, Any],
+    output: dict[str, Any] | None,
     call_index: int,
     source_artifact_ref: str,
     source_artifact_digest: str,
     import_time: str,
 ) -> dict[str, Any]:
-    if call["name"] != output["name"]:
-        raise ValueError(f"artifact: paired call/output names differ at index {call_index}")
-
     function: dict[str, Any] = {
         "event_ref": normalized["event_ref"],
         "call_index": call_index,
@@ -353,17 +335,22 @@ def _build_receipt(
     if arguments_ref is not None:
         function["arguments_ref"] = arguments_ref
 
-    outcome: dict[str, Any] = {
-        "completed": True,
-        "is_error": output.get("is_error", False),
-    }
-    output_hash, output_ref = _hash_or_ref(output, "output", "output_ref")
-    if output_hash is not None:
-        outcome["output_hash"] = output_hash
-    if output_ref is not None:
-        outcome["output_ref"] = output_ref
-    if "created_at" in output:
-        outcome["received_at"] = output["created_at"]
+    if output is None:
+        outcome: dict[str, Any] = {"completed": False}
+    else:
+        if call["name"] != output["name"]:
+            raise ValueError(f"artifact: paired call/output names differ at index {call_index}")
+        outcome = {
+            "completed": True,
+            "is_error": output.get("is_error", False),
+        }
+        output_hash, output_ref = _hash_or_ref(output, "output", "output_ref")
+        if output_hash is not None:
+            outcome["output_hash"] = output_hash
+        if output_ref is not None:
+            outcome["output_ref"] = output_ref
+        if "created_at" in output:
+            outcome["received_at"] = output["created_at"]
 
     event_context: dict[str, Any] = {
         "event_created_at": normalized["created_at"],

--- a/scripts/ci/review-wave52-livekit-tool-action-step1.sh
+++ b/scripts/ci/review-wave52-livekit-tool-action-step1.sh
@@ -6,7 +6,7 @@ cd "$ROOT"
 
 BASE_REF="${BASE_REF:-origin/main}"
 
-allowed_pattern='^(docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action\.md|docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1\.md|docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1\.md|docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1\.md|scripts/ci/review-wave52-livekit-tool-action-step1\.sh|docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2\.md|docs/security/OWASP-MCP-TOP10-TEST-MAP\.md|scripts/ci/optional-public-api-drift\.sh|scripts/ci/mutation-smoke-pure-modules\.sh|scripts/ci/review-week8-sota-gates\.sh)$'
+allowed_pattern='^(crates/assay-cli/src/cli/commands/evidence/livekit_tool_action\.rs|crates/assay-cli/receipt-schemas/(inputs/livekit-function-tools-executed-export\.v1\.schema\.json|receipts/livekit\.tool-action\.v1\.schema\.json)|docs/reference/receipt-schemas/(inputs/livekit-function-tools-executed-export\.v1\.schema\.json|receipts/livekit\.tool-action\.v1\.schema\.json)|docs/reference/cli/evidence\.md|docs/architecture/PLAN-P47-LIVEKIT-ACTED-FAMILY-TOOL-ACTION-RECEIPTS-2026q2\.md|examples/livekit-tool-action-evidence/.*|docs/contributing/SPLIT-PLAN-wave52-livekit-tool-action\.md|docs/contributing/SPLIT-CHECKLIST-wave52-livekit-tool-action-step1\.md|docs/contributing/SPLIT-MOVE-MAP-wave52-livekit-tool-action-step1\.md|docs/contributing/SPLIT-REVIEW-PACK-wave52-livekit-tool-action-step1\.md|scripts/ci/review-wave52-livekit-tool-action-step1\.sh|docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2\.md|docs/security/OWASP-MCP-TOP10-TEST-MAP\.md|scripts/ci/optional-public-api-drift\.sh|scripts/ci/mutation-smoke-pure-modules\.sh|scripts/ci/review-week8-sota-gates\.sh)$'
 
 if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
   echo "FAIL: BASE_REF ${BASE_REF} is not available; fetch it or set BASE_REF to a local commit"
@@ -22,7 +22,7 @@ collect_changed() {
   } | sed '/^$/d' | sort -u
 }
 
-echo "[review] allowlist-only diff vs $BASE_REF + workflow/source/test bans"
+echo "[review] Step1 allowlist vs $BASE_REF + local changes"
 changed="$(collect_changed)"
 if [ -n "$changed" ]; then
   non_allowed="$(printf '%s\n' "$changed" | rg -v "$allowed_pattern" || true)"
@@ -37,16 +37,14 @@ if printf '%s\n' "$changed" | rg '^\.github/workflows/' >/dev/null; then
   echo "FAIL: Step1 must not touch workflows"
   exit 1
 fi
+
 if printf '%s\n' "$changed" | rg '^crates/assay-ebpf/src/vmlinux\.rs$' >/dev/null; then
   echo "FAIL: generated vmlinux.rs must stay out of scope"
   exit 1
 fi
-if printf '%s\n' "$changed" | rg '^crates/assay-cli/src/cli/commands/evidence/' >/dev/null; then
-  echo "FAIL: Step1 must not edit evidence importer source"
-  exit 1
-fi
-if printf '%s\n' "$changed" | rg '^crates/assay-cli/tests/' >/dev/null; then
-  echo "FAIL: Step1 must not edit CLI tests"
+
+if printf '%s\n' "$changed" | rg '^crates/assay-cli/src/cli/commands/evidence/livekit_tool_action/' >/dev/null; then
+  echo "FAIL: Step1 must not split livekit_tool_action into modules yet"
   exit 1
 fi
 
@@ -54,6 +52,8 @@ echo "[review] frozen surface markers"
 rg 'cmd_livekit_tool_action' crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs >/dev/null
 rg 'assay\.receipt\.livekit\.tool_action\.v1' crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs >/dev/null
 rg 'livekit\.function-tools-executed\.export\.v1' crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs >/dev/null
+rg 'call_id mismatch' crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs >/dev/null
+rg 'completed.*false' crates/assay-cli/src/cli/commands/evidence/livekit_tool_action.rs >/dev/null
 rg 'test_livekit_imported_tool_action_receipts_verify_and_do_not_mutate_trust_basis_claims' crates/assay-cli/tests/evidence_test.rs >/dev/null
 
 echo "[review] repo checks"


### PR DESCRIPTION
Summary

Aligns P47 Stage 1.1 with the source-level LiveKit `FunctionToolsExecutedEvent` behavior surfaced in the community thread.

What changed:

- pairs calls/outputs by LiveKit SDK list order
- treats `call_id` as an optional per-index audit consistency check, not the primary pairing contract
- accepts partial `call_id` presence while keeping list-order pairing
- preserves `FunctionCallOutput | None` as `completed=false` without inferring `is_error`
- updates input/receipt schemas, fixtures, docs, and the P47/Wave52 freeze notes

Boundary

This PR is stacked on #1183. It does not split `livekit_tool_action.rs`, add a public family-matrix entry, add a Trust Basis claim, or claim LiveKit endorsement/stable wire contract.

Validation

Ran locally:

```bash
cargo check -p assay-cli
cargo test -p assay-cli livekit_tool_action -- --nocapture
cargo test -p assay-cli --test evidence_test test_livekit_imported_tool_action_receipts_verify_and_do_not_mutate_trust_basis_claims -- --exact --nocapture
bash scripts/ci/review-wave52-livekit-tool-action-step1.sh
```

The review gate includes `cargo fmt --check`, `cargo check -p assay-cli`, workspace clippy for assay-cli, LiveKit importer tests, the Trust Basis non-mutation test, Week8 SOTA gate script checks, and `git diff --check`.

Merge order

1. Merge #1183.
2. Merge this PR.
3. Then start Wave52 Step2 mechanical module split.
