### PR TITLE
[codex] harden MCP registry secret hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ docs/DISTRIBUTION-CHANNELS.md
 .claude/
 .obsidian/
 .cursor/
+.mcpregistry_*
 _v.txt
 ai-agent-eval-plugin/
 /Assay/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,15 @@ repos:
         stages: [manual]
 
   # --- Tooling hooks (remote) ---
+  - repo: local
+    hooks:
+      - id: mcpregistry-secret-hygiene
+        name: MCP registry local token hygiene
+        entry: scripts/ci/check-mcpregistry-secret-hygiene.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
   # typos (spellcheck)
   - repo: https://github.com/crate-ci/typos
     rev: v1.42.1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,3 +68,15 @@ Assay runs in untrusted environments (CI/CD, agent sandboxes).
 | PyPI | Trusted Publishing |
 | Dependencies | `cargo-deny` audit in CI |
 | Releases | GitHub Actions, no manual tokens |
+
+## Local Credential Hygiene
+
+MCP registry token files named `.mcpregistry_*` are local-only secrets. They are
+ignored by git and must never be committed, copied into logs, or uploaded as CI
+artifacts. If such files may have appeared in shell history, terminal logs, or
+shared artifacts, rotate the underlying credentials before continuing.
+
+Run `scripts/ci/check-mcpregistry-secret-hygiene.sh` before publishing changes
+that touch registry auth or release workflows. Set
+`ASSAY_FAIL_ON_LOCAL_MCPREGISTRY_TOKENS=1` when a hard-fail local preflight is
+preferred.

--- a/scripts/ci/check-mcpregistry-secret-hygiene.sh
+++ b/scripts/ci/check-mcpregistry-secret-hygiene.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pattern='.mcpregistry_*'
+
+fail_with_list() {
+  local title="$1"
+  local entries="$2"
+  echo "FAIL: ${title}" >&2
+  printf '%s\n' "$entries" | sed 's/^/  - /' >&2
+  exit 1
+}
+
+tracked="$(git ls-files -- "$pattern")"
+if [[ -n "$tracked" ]]; then
+  fail_with_list "MCP registry token files must never be tracked" "$tracked"
+fi
+
+commit_risk="$(git ls-files --others --exclude-standard -- "$pattern")"
+if [[ -n "$commit_risk" ]]; then
+  fail_with_list "MCP registry token files are not ignored and could be committed" "$commit_risk"
+fi
+
+local_files="$(find . -maxdepth 1 -type f -name "$pattern" -print | sed 's#^./##' | sort)"
+if [[ -n "$local_files" ]]; then
+  echo "WARN: local MCP registry token files exist in the repo root." >&2
+  printf '%s\n' "$local_files" | sed 's/^/  - /' >&2
+  echo "WARN: keep them local only; rotate credentials if they may have leaked into logs, shell history, or artifacts." >&2
+  if [[ "${ASSAY_FAIL_ON_LOCAL_MCPREGISTRY_TOKENS:-0}" == "1" ]]; then
+    exit 1
+  fi
+fi
+
+echo "MCP registry secret hygiene check passed"

--- a/scripts/ci/check-mcpregistry-secret-hygiene.sh
+++ b/scripts/ci/check-mcpregistry-secret-hygiene.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-pattern='.mcpregistry_*'
+token_file_regex='(^|/)\.mcpregistry_'
 
 fail_with_list() {
   local title="$1"
@@ -14,19 +14,19 @@ fail_with_list() {
   exit 1
 }
 
-tracked="$(git ls-files -- "$pattern")"
+tracked="$(git ls-files | grep -E "$token_file_regex" || true)"
 if [[ -n "$tracked" ]]; then
   fail_with_list "MCP registry token files must never be tracked" "$tracked"
 fi
 
-commit_risk="$(git ls-files --others --exclude-standard -- "$pattern")"
+commit_risk="$(git ls-files --others --exclude-standard | grep -E "$token_file_regex" || true)"
 if [[ -n "$commit_risk" ]]; then
   fail_with_list "MCP registry token files are not ignored and could be committed" "$commit_risk"
 fi
 
-local_files="$(find . -maxdepth 1 -type f -name "$pattern" -print | sed 's#^./##' | sort)"
+local_files="$(git ls-files --others -i --exclude-standard | grep -E "$token_file_regex" || true)"
 if [[ -n "$local_files" ]]; then
-  echo "WARN: local MCP registry token files exist in the repo root." >&2
+  echo "WARN: local MCP registry token files exist in the repo." >&2
   printf '%s\n' "$local_files" | sed 's/^/  - /' >&2
   echo "WARN: keep them local only; rotate credentials if they may have leaked into logs, shell history, or artifacts." >&2
   if [[ "${ASSAY_FAIL_ON_LOCAL_MCPREGISTRY_TOKENS:-0}" == "1" ]]; then


### PR DESCRIPTION
Summary
- Adds `.mcpregistry_*` to `.gitignore` so local MCP registry token files are not accidentally commit-visible.
- Adds `scripts/ci/check-mcpregistry-secret-hygiene.sh` to fail on tracked or unignored MCP registry token files, while warning on intentionally ignored local token files.
- Wires the hygiene check into local pre-commit.
- Documents local credential hygiene and rotation guidance in `SECURITY.md`.

Scope
Included:
- `.gitignore`
- `.pre-commit-config.yaml`
- `SECURITY.md`
- `scripts/ci/check-mcpregistry-secret-hygiene.sh`

Explicitly excluded:
- security fixture work
- dependency cleanup
- dead/stale code cleanup
- workflow changes
- token file contents or token rotation operations

Validation
- `scripts/ci/check-mcpregistry-secret-hygiene.sh`
- `ASSAY_FAIL_ON_LOCAL_MCPREGISTRY_TOKENS=1 scripts/ci/check-mcpregistry-secret-hygiene.sh` returns failure when local token files exist
- `bash -n scripts/ci/check-mcpregistry-secret-hygiene.sh`
- `shellcheck scripts/ci/check-mcpregistry-secret-hygiene.sh`
- `git check-ignore -v .mcpregistry_github_token .mcpregistry_registry_token`
- `git diff --check`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Operational follow-up
- Rotate MCP registry/GitHub registry credentials if these local token values may have appeared in shell history, terminal logs, or artifacts.
