### PR TITLE
[codex] remove stale CLI dead paths

### DIFF
--- a/crates/assay-cli/src/cli/commands/config_path.rs
+++ b/crates/assay-cli/src/cli/commands/config_path.rs
@@ -4,7 +4,7 @@
 //! Supports: Claude Desktop, Cursor, and generic MCP clients.
 
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::json;
 use std::env;
 use std::path::PathBuf;
 
@@ -34,12 +34,9 @@ impl McpClient {
 
 /// Result of config path detection
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct ConfigDetection {
-    pub client: McpClient,
     pub config_path: PathBuf,
     pub exists: bool,
-    pub current_config: Option<Value>,
 }
 
 /// Generated MCP server configuration
@@ -119,19 +116,9 @@ pub fn detect_config(client: McpClient) -> Option<ConfigDetection> {
     let config_path = detect_config_path(client)?;
     let exists = config_path.exists();
 
-    let current_config = if exists {
-        std::fs::read_to_string(&config_path)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-    } else {
-        None
-    };
-
     Some(ConfigDetection {
-        client,
         config_path,
         exists,
-        current_config,
     })
 }
 

--- a/crates/assay-cli/src/cli/commands/config_path.rs
+++ b/crates/assay-cli/src/cli/commands/config_path.rs
@@ -111,7 +111,7 @@ fn detect_cursor_config_path() -> Option<PathBuf> {
     }
 }
 
-/// Full detection with config file reading
+/// Detect the config file path and whether it currently exists.
 pub fn detect_config(client: McpClient) -> Option<ConfigDetection> {
     let config_path = detect_config_path(client)?;
     let exists = config_path.exists();

--- a/crates/assay-cli/src/cli/commands/coverage/schema.rs
+++ b/crates/assay-cli/src/cli/commands/coverage/schema.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::sync::OnceLock;
 
 use anyhow::{anyhow, Result};

--- a/crates/assay-cli/src/cli/commands/heuristics.rs
+++ b/crates/assay-cli/src/cli/commands/heuristics.rs
@@ -1,7 +1,7 @@
 //! Learning Mode Heuristics
 //!
 //! - Entropy detection for suspicious paths
-//! - Network fanout analysis
+//! - Destination risk hints
 //!
 //! # Risk Levels
 //! | Level            | Meaning                              |
@@ -10,10 +10,8 @@
 //! | NeedsReview      | Suspicious, human should verify      |
 //! | DenyRecommended  | Likely malicious                     |
 
-#![allow(dead_code)]
-
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::HashMap;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Risk Classification
@@ -53,15 +51,10 @@ pub struct HeuristicsConfig {
     pub entropy_threshold: f64,
     /// Min segment length to analyze
     pub min_segment_len: usize,
-    /// Fanout thresholds (unique IPs per process)
-    pub fanout_warn: usize,
-    pub fanout_deny: usize,
     /// Safe patterns to skip
     pub allowlist: Vec<&'static str>,
     /// Suspicious ports
     pub suspicious_ports: Vec<u16>,
-    /// Port scan threshold (unique ports per process)
-    pub port_scan_threshold: usize,
 }
 
 impl Default for HeuristicsConfig {
@@ -69,11 +62,8 @@ impl Default for HeuristicsConfig {
         Self {
             entropy_threshold: 3.8,
             min_segment_len: 8,
-            fanout_warn: 10,
-            fanout_deny: 50,
             allowlist: vec!["/proc/", "/sys/", "/run/user/", ".so."],
             suspicious_ports: vec![22, 23, 445, 139, 3389, 1433, 3306, 5432],
-            port_scan_threshold: 20,
         }
     }
 }
@@ -163,74 +153,6 @@ pub fn analyze_dest(dest: &str, cfg: &HeuristicsConfig) -> RiskAssessment {
     r
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Network Fanout Analysis
-// ─────────────────────────────────────────────────────────────────────────────
-
-#[derive(Debug, Default)]
-pub struct ProcNetStats {
-    pub ips: BTreeSet<String>,
-    pub ports: BTreeSet<u16>,
-}
-
-pub struct NetworkAnalyzer {
-    cfg: HeuristicsConfig,
-    per_pid: HashMap<u32, ProcNetStats>,
-    global: BTreeMap<String, u32>,
-}
-
-impl NetworkAnalyzer {
-    pub fn new(cfg: HeuristicsConfig) -> Self {
-        Self {
-            cfg,
-            per_pid: HashMap::new(),
-            global: BTreeMap::new(),
-        }
-    }
-
-    pub fn record(&mut self, pid: u32, dest: &str) {
-        let (ip, port) = parse_dest(dest);
-        let s = self.per_pid.entry(pid).or_default();
-        s.ips.insert(ip);
-        if let Some(p) = port {
-            s.ports.insert(p);
-        }
-        *self.global.entry(dest.to_string()).or_default() += 1;
-    }
-
-    pub fn assess_dest(&self, dest: &str) -> RiskAssessment {
-        let mut r = RiskAssessment::default();
-        if let (_, Some(port)) = parse_dest(dest) {
-            if self.cfg.suspicious_ports.contains(&port) {
-                r.add(RiskLevel::NeedsReview, format!("sensitive port {}", port));
-            }
-        }
-        r
-    }
-
-    pub fn assess_pid(&self, pid: u32) -> RiskAssessment {
-        let mut r = RiskAssessment::default();
-        if let Some(s) = self.per_pid.get(&pid) {
-            let n = s.ips.len();
-            if n >= self.cfg.fanout_deny {
-                r.add(
-                    RiskLevel::DenyRecommended,
-                    format!("{} unique IPs - scanning?", n),
-                );
-            } else if n >= self.cfg.fanout_warn {
-                r.add(RiskLevel::NeedsReview, format!("{} unique IPs", n));
-            }
-            if s.ports.len() > self.cfg.port_scan_threshold {
-                r.add(
-                    RiskLevel::DenyRecommended,
-                    format!("{} ports - port scan?", s.ports.len()),
-                );
-            }
-        }
-        r
-    }
-}
-
 pub fn parse_dest(dest: &str) -> (String, Option<u16>) {
     if dest.starts_with('[') {
         if let Some(i) = dest.find(']') {
@@ -285,20 +207,6 @@ mod tests {
             &HeuristicsConfig::default(),
         );
         assert!(r.level >= RiskLevel::NeedsReview);
-    }
-
-    #[test]
-    fn fanout_warn() {
-        let cfg = HeuristicsConfig {
-            fanout_warn: 3,
-            fanout_deny: 5,
-            ..Default::default()
-        };
-        let mut na = NetworkAnalyzer::new(cfg);
-        for i in 1..=4 {
-            na.record(1, &format!("10.0.0.{}:80", i));
-        }
-        assert!(na.assess_pid(1).level >= RiskLevel::NeedsReview);
     }
 
     #[test]

--- a/crates/assay-cli/src/cli/commands/sim/soak/schema.rs
+++ b/crates/assay-cli/src/cli/commands/sim/soak/schema.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::sync::OnceLock;
 
 use anyhow::{anyhow, Result};

--- a/scripts/ci/review-dead-stale-cleanup-pr3.sh
+++ b/scripts/ci/review-dead-stale-cleanup-pr3.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+echo "[review] stale/dead cleanup guard"
+if rg -q "NetworkAnalyzer|ProcNetStats|fanout_warn|fanout_deny|port_scan_threshold" \
+  crates/assay-cli/src/cli/commands/heuristics.rs; then
+  echo "FAIL: stateful NetworkAnalyzer fanout path should stay removed" >&2
+  exit 1
+fi
+if rg -q "current_config" crates/assay-cli/src/cli/commands/config_path.rs; then
+  echo "FAIL: stale config_path current_config parsing should stay removed" >&2
+  exit 1
+fi
+if rg -q '#!\[allow\(dead_code\)\]' \
+  crates/assay-cli/src/cli/commands/heuristics.rs \
+  crates/assay-cli/src/cli/commands/coverage/schema.rs \
+  crates/assay-cli/src/cli/commands/sim/soak/schema.rs; then
+  echo "FAIL: module-wide dead_code suppressions should stay removed from PR3 targets" >&2
+  exit 1
+fi
+
+echo "[review] format/check/clippy"
+cargo fmt --check
+cargo check -p assay-cli
+cargo clippy -p assay-cli --all-targets -- -D warnings
+
+echo "[review] focused behavior tests"
+cargo test -p assay-cli --bin assay cli::commands::heuristics::tests
+cargo test -p assay-cli --bin assay cli::commands::coverage::schema::tests
+cargo test -p assay-cli --bin assay cli::commands::sim::soak
+
+echo "[review] diff hygiene"
+git diff --check


### PR DESCRIPTION
Summary

Performs PR3 dead/stale cleanup from the repo hygiene memo with a narrow CLI-only scope.

- Removes the unused stateful `NetworkAnalyzer` fanout path from learning heuristics while keeping live stateless destination risk checks.
- Removes stale `config_path` JSON parsing into `current_config`, because the parsed value was not surfaced in text or JSON output.
- Removes module-wide `dead_code` suppressions from heuristic and schema modules once stale code is gone.
- Adds `scripts/ci/review-dead-stale-cleanup-pr3.sh` to keep these paths deleted and validate affected behavior.

Scope

Included:

- `crates/assay-cli/src/cli/commands/heuristics.rs`
- `crates/assay-cli/src/cli/commands/config_path.rs`
- `crates/assay-cli/src/cli/commands/coverage/schema.rs`
- `crates/assay-cli/src/cli/commands/sim/soak/schema.rs`
- `scripts/ci/review-dead-stale-cleanup-pr3.sh`

Explicitly excluded:

- security fixture work
- dependency cleanup
- API/semver/mutation gates
- BPF backend status changes
- broad unwrap hardening outside these stale paths
- unrelated local architecture/example edits

LOC Delta

- Intended staged delta: +38 / -112 across 5 files.
- `heuristics.rs`: removes the dead stateful fanout implementation and test, not the live entropy/destination helpers.

Validation

- `scripts/ci/review-dead-stale-cleanup-pr3.sh`
- `cargo fmt --check`
- `cargo check -p assay-cli`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `cargo test -p assay-cli --bin assay cli::commands::heuristics::tests`
- `cargo test -p assay-cli --bin assay cli::commands::coverage::schema::tests`
- `cargo test -p assay-cli --bin assay cli::commands::sim::soak`
- `bash -n scripts/ci/review-dead-stale-cleanup-pr3.sh`
- `shellcheck scripts/ci/review-dead-stale-cleanup-pr3.sh`
- `git diff --check`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, continue with PR4 dependency/perf hygiene: duplicate dependency snapshot, direct `sha256` cleanup if still unused, stale `deny.toml` noise, and a separate serde_yaml migration note without doing that migration yet.
