### PR TITLE
[codex] prune dependency hygiene drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,6 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha2 0.11.0",
- "sha256",
  "spki 0.8.0",
  "strsim",
  "sysinfo",
@@ -4545,19 +4544,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
-]
-
-[[package]]
-name = "sha256"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f880fc8562bdeb709793f00eb42a2ad0e672c4f883bbe59122b926eca935c8f6"
-dependencies = [
- "async-trait",
- "bytes",
- "hex",
- "sha2 0.10.9",
- "tokio",
 ]
 
 [[package]]

--- a/crates/assay-core/Cargo.toml
+++ b/crates/assay-core/Cargo.toml
@@ -65,7 +65,6 @@ schemars = "1.2.1"
 
 # SQLite: always use bundled to avoid cross-platform/cross-compilation issues
 rusqlite = { version = "0.31", features = ["bundled"] }
-sha256 = "1.6.0"
 url = "2.5.8"
 
 # Unix-specifics for Kill Switch P0

--- a/deny.toml
+++ b/deny.toml
@@ -27,11 +27,6 @@ ignore = [
     # rsa: transitive via jsonwebtoken (assay-mcp-server). No safe upgrade; timing sidechannel.
     # JWT verification is server-side; accept risk for MCP auth until jsonwebtoken/rsa offer a fix.
     "RUSTSEC-2023-0071",
-    # rand 0.8.5 is present broadly in the current workspace and transitively via jsonwebtoken/rsa.
-    # This advisory is conditional on a custom logger calling ThreadRng during reseed; the repo does
-    # not implement a custom logger path. Accept temporarily until the workspace and transitive stack
-    # can move to rand >=0.9.3 / >=0.10.1 in a dedicated dependency update.
-    "RUSTSEC-2026-0097",
 ]
 
 # =============================================================================
@@ -92,5 +87,3 @@ private = { ignore = true }
 unknown-registry = "deny"
 unknown-git = "warn"  # Git deps need review but don't block CI
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# Explicitly allow git dependencies (aya-rs for eBPF, pinned by tag)
-allow-git = ["https://github.com/aya-rs/aya"]

--- a/docs/architecture/PLAN-DEPENDENCY-PERF-HYGIENE-PR4-2026q2.md
+++ b/docs/architecture/PLAN-DEPENDENCY-PERF-HYGIENE-PR4-2026q2.md
@@ -1,0 +1,71 @@
+# PR4 Dependency and Perf Hygiene - 2026 Q2
+
+## Scope
+
+This note records the intentionally small PR4 cleanup slice from the repo hygiene memo.
+It avoids functional parser migrations, API gates, mutation gates, security fixtures, and stale-code refactors.
+
+Included:
+
+- Remove the direct `sha256` crate dependency from `assay-core`; production hashing already uses the workspace `sha2` crate.
+- Prune stale `deny.toml` entries that no longer match the resolved dependency graph.
+- Capture the dependency snapshot so the review can see what changed and what remains intentionally out of scope.
+- Create an explicit `serde_yaml` retirement plan without changing parser behavior in this PR.
+
+Excluded:
+
+- Migrating YAML parsing away from `serde_yaml`.
+- Resolving ecosystem-wide duplicate transitive stacks such as `reqwest`, `rand`, `digest`, `getrandom`, and Windows target crates.
+- Public API or semver gate changes.
+- Security fixture changes.
+
+## Before Snapshot
+
+Command: `cargo tree -d`
+
+Relevant findings before this PR:
+
+- `assay-core` directly depended on `sha256 v1.6.0`.
+- That direct dependency pulled an additional edge into `sha2 v0.10.9`, while the workspace already standardizes direct hashing on `sha2 v0.11.0`.
+- `deny.toml` contained `RUSTSEC-2026-0097`, but `cargo deny check advisories bans sources` reported it as `advisory-not-detected`.
+- `deny.toml` contained `https://github.com/aya-rs/aya` in `allow-git`, but `cargo deny` reported that exact source exception as unmatched. The lockfile still contains pinned `aya-rs/aya` git sources; they are covered by the repository's `unknown-git = "warn"` policy until a precise source allowlist is reintroduced.
+
+## After Snapshot
+
+Expected review outcomes after this PR:
+
+- `Cargo.lock` no longer contains a `sha256` package entry.
+- `crates/assay-core/Cargo.toml` no longer has a direct `sha256` dependency.
+- `cargo tree -p assay-core -i sha256` no longer finds `sha256` in the resolved graph.
+- `cargo deny check advisories bans sources` no longer reports the stale `RUSTSEC-2026-0097` ignore or the stale `aya-rs/aya` source allowlist.
+
+Remaining duplicate dependency families are deliberately not changed in PR4 because they are transitive ecosystem transitions rather than a local direct dependency mistake:
+
+- `sha2`/`digest` split between crypto dependencies using 0.10 and workspace code using 0.11.
+- `rand`/`getrandom` split across older crypto stacks and newer storage/runtime stacks.
+- `reqwest` split through `jsonschema` and direct HTTP clients.
+- Windows target crate splits from platform-specific transitive dependencies.
+
+## serde_yaml Retirement Plan
+
+`serde_yaml` remains in place for PR4. It is deprecated upstream and should be retired in a dedicated compatibility migration, not as a drive-by dependency cleanup.
+
+Candidate replacement direction:
+
+- Evaluate `serde_yaml_ng` or another maintained YAML parser with compatible serde data-model behavior.
+- Keep parsing behavior stable for lint packs, lockfiles, registry manifests, and user-authored config documents.
+- Avoid parser replacement until golden compatibility tests exist.
+
+Required migration evidence:
+
+- Golden fixtures for representative pack YAML, lockfile YAML, config YAML, anchors/aliases if supported, duplicate-key behavior, scalar coercions, nulls, comments tolerance, and error messages that users see.
+- Before/after parser behavior matrix documenting accepted input, rejected input, normalized values, and diagnostic drift.
+- Explicit security review for entity expansion, alias abuse, deep nesting, resource limits, duplicate keys, and unexpected tag handling.
+- Rollout plan that can either keep a compatibility fallback or intentionally reject ambiguous legacy YAML with clear migration guidance.
+
+Exit criteria for a future parser migration PR:
+
+- Existing golden vectors pass or intentional deltas are documented.
+- User-facing diagnostics are at least as actionable as today.
+- `cargo deny`/audit posture improves or stays neutral.
+- The migration does not change Trust Basis, registry, or lint-pack semantics without a separate reviewed ADR.

--- a/docs/architecture/PLAN-DEPENDENCY-PERF-HYGIENE-PR4-2026q2.md
+++ b/docs/architecture/PLAN-DEPENDENCY-PERF-HYGIENE-PR4-2026q2.md
@@ -1,6 +1,13 @@
-# PR4 Dependency and Perf Hygiene - 2026 Q2
+# PLAN — Dependency and Perf Hygiene PR4 (2026 Q2)
 
-## Scope
+- **Date:** 2026-05-10
+- **Owner:** Core / Maintenance
+- **Status:** Review lane
+- **Scope (current repo state):** Execute the dependency/perf hygiene PR4
+  slice without parser migrations, API gates, mutation gates, security
+  fixtures, or stale-code refactors.
+
+## 1. Scope
 
 This note records the intentionally small PR4 cleanup slice from the repo hygiene memo.
 It avoids functional parser migrations, API gates, mutation gates, security fixtures, and stale-code refactors.
@@ -19,7 +26,7 @@ Excluded:
 - Public API or semver gate changes.
 - Security fixture changes.
 
-## Before Snapshot
+## 2. Before Snapshot
 
 Command: `cargo tree -d`
 
@@ -30,7 +37,7 @@ Relevant findings before this PR:
 - `deny.toml` contained `RUSTSEC-2026-0097`, but `cargo deny check advisories bans sources` reported it as `advisory-not-detected`.
 - `deny.toml` contained `https://github.com/aya-rs/aya` in `allow-git`, but `cargo deny` reported that exact source exception as unmatched. The lockfile still contains pinned `aya-rs/aya` git sources; they are covered by the repository's `unknown-git = "warn"` policy until a precise source allowlist is reintroduced.
 
-## After Snapshot
+## 3. After Snapshot
 
 Expected review outcomes after this PR:
 
@@ -46,7 +53,7 @@ Remaining duplicate dependency families are deliberately not changed in PR4 beca
 - `reqwest` split through `jsonschema` and direct HTTP clients.
 - Windows target crate splits from platform-specific transitive dependencies.
 
-## serde_yaml Retirement Plan
+## 4. serde_yaml Retirement Plan
 
 `serde_yaml` remains in place for PR4. It is deprecated upstream and should be retired in a dedicated compatibility migration, not as a drive-by dependency cleanup.
 

--- a/scripts/ci/review-dependency-perf-hygiene-pr4.sh
+++ b/scripts/ci/review-dependency-perf-hygiene-pr4.sh
@@ -2,13 +2,17 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
+base_ref="${BASE_REF:-${GITHUB_BASE_REF:+origin/${GITHUB_BASE_REF}}}"
+if [[ -z "$base_ref" ]]; then
+  base_ref="origin/main"
+fi
 
 echo "[review] dependency hygiene guards"
 if rg -q '(^|[[:space:]])sha256[[:space:]]*=' crates/assay-core/Cargo.toml Cargo.toml; then
   echo "FAIL: direct sha256 crate dependency should stay removed; use workspace sha2 helpers instead" >&2
   exit 1
 fi
-if rg -q '^name = "sha256"$|"sha256"' Cargo.lock; then
+if rg -q '^name = "sha256"$' Cargo.lock; then
   echo "FAIL: Cargo.lock should not contain the sha256 crate after PR4 cleanup" >&2
   exit 1
 fi
@@ -37,4 +41,9 @@ cargo check -p assay-core
 cargo clippy -p assay-core --all-targets -- -D warnings
 
 echo "[review] diff hygiene"
-git diff --check
+if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  git diff --check "$base_ref"...HEAD
+else
+  echo "WARN: BASE_REF not found ($base_ref); checking working-tree diff only" >&2
+  git diff --check
+fi

--- a/scripts/ci/review-dependency-perf-hygiene-pr4.sh
+++ b/scripts/ci/review-dependency-perf-hygiene-pr4.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+echo "[review] dependency hygiene guards"
+if rg -q '(^|[[:space:]])sha256[[:space:]]*=' crates/assay-core/Cargo.toml Cargo.toml; then
+  echo "FAIL: direct sha256 crate dependency should stay removed; use workspace sha2 helpers instead" >&2
+  exit 1
+fi
+if rg -q '^name = "sha256"$|"sha256"' Cargo.lock; then
+  echo "FAIL: Cargo.lock should not contain the sha256 crate after PR4 cleanup" >&2
+  exit 1
+fi
+if cargo tree -p assay-core -i sha256 >/tmp/assay-pr4-sha256-tree.txt 2>&1; then
+  cat /tmp/assay-pr4-sha256-tree.txt >&2
+  echo "FAIL: sha256 crate is still reachable from assay-core" >&2
+  exit 1
+fi
+
+if rg -q 'RUSTSEC-2026-0097|github\.com/aya-rs/aya' deny.toml; then
+  echo "FAIL: stale deny.toml advisory/source exceptions should stay removed" >&2
+  exit 1
+fi
+
+if ! rg -q 'serde_yaml' docs/architecture/PLAN-DEPENDENCY-PERF-HYGIENE-PR4-2026q2.md; then
+  echo "FAIL: PR4 must keep an explicit serde_yaml retirement note without migrating it" >&2
+  exit 1
+fi
+
+echo "[review] cargo deny scope"
+cargo deny check advisories bans sources
+
+echo "[review] format/check/clippy"
+cargo fmt --check
+cargo check -p assay-core
+cargo clippy -p assay-core --all-targets -- -D warnings
+
+echo "[review] diff hygiene"
+git diff --check


### PR DESCRIPTION
Summary

Performs PR4 from the repo hygiene memo: dependency/perf hygiene without functional behavior changes.

- Removes the unused direct `sha256` crate dependency from `assay-core`; hashing code already uses the workspace `sha2` crate.
- Updates `Cargo.lock` so the standalone `sha256` package is no longer resolved.
- Removes stale `deny.toml` entries reported by `cargo deny`: unmatched `RUSTSEC-2026-0097` advisory ignore and unmatched `aya-rs/aya` exact source allowlist.
- Adds a dependency/perf hygiene note with before/after snapshot and an explicit `serde_yaml` retirement plan for a later compatibility migration.
- Adds a PR4 reviewer gate to keep the scope narrow and catch regression drift.

Scope

Included:

- `Cargo.lock`
- `crates/assay-core/Cargo.toml`
- `deny.toml`
- `docs/architecture/PLAN-DEPENDENCY-PERF-HYGIENE-PR4-2026q2.md`
- `scripts/ci/review-dependency-perf-hygiene-pr4.sh`

Explicitly excluded:

- `serde_yaml` parser migration
- public API or semver gates
- mutation gates
- security fixtures
- stale/dead code cleanup
- unrelated local architecture/example edits

Dependency delta

- Before: `assay-core` directly depended on `sha256 v1.6.0`, which pulled an extra local edge into `sha2 v0.10.9` alongside the workspace `sha2 v0.11.0` usage.
- After: `sha256` is absent from `Cargo.lock`, and `cargo tree -p assay-core -i sha256` no longer resolves.
- Remaining duplicate dependency families are documented as transitive ecosystem transitions and intentionally left out of PR4.

Validation

- `scripts/ci/review-dependency-perf-hygiene-pr4.sh`
- `bash -n scripts/ci/review-dependency-perf-hygiene-pr4.sh`
- `shellcheck scripts/ci/review-dependency-perf-hygiene-pr4.sh`
- `cargo deny check advisories bans sources`
- `cargo fmt --check`
- `cargo check -p assay-core`
- `cargo clippy -p assay-core --all-targets -- -D warnings`
- `git diff --check`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

PR5 should add API and mutation gate coverage after this smaller dependency hygiene slice lands.
