### PR TITLE
[codex] add opt-in API and mutation gates

### DIFF
--- a/.github/workflows/week8-sota-gates.yml
+++ b/.github/workflows/week8-sota-gates.yml
@@ -1,0 +1,90 @@
+name: Week 8 SOTA Gates
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_rev:
+        description: "Git revision to compare public API drift against"
+        required: false
+        default: "origin/main"
+        type: string
+      run_public_api_drift:
+        description: "Run semver/public-api drift checks with tools installed on demand"
+        required: false
+        default: true
+        type: boolean
+      run_mutation_smoke:
+        description: "Run targeted cargo-mutants smoke on pure modules"
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+concurrency:
+  group: week8-sota-gates-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  public-api-drift:
+    name: Public API drift
+    if: inputs.run_public_api_drift == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Swatinem/rust-cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - name: Run optional public API drift gate
+        shell: bash
+        env:
+          ASSAY_INSTALL_API_DRIFT_TOOLS: "1"
+          BASE_REV: ${{ inputs.base_rev }}
+        run: |
+          set -euo pipefail
+          bash scripts/ci/optional-public-api-drift.sh
+          {
+            echo "## Public API drift"
+            echo "- base_rev: ${BASE_REV}"
+            echo "- packages: assay-core assay-evidence assay-registry assay-policy assay-metrics"
+            echo "- tools: cargo-semver-checks, cargo-public-api"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  mutation-smoke:
+    name: Mutation smoke pure modules
+    if: inputs.run_mutation_smoke == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Swatinem/rust-cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      - name: Run targeted mutation smoke
+        shell: bash
+        env:
+          ASSAY_INSTALL_MUTATION_TOOLS: "1"
+          ASSAY_RUN_MUTATION_SMOKE: "1"
+          ASSAY_MUTATION_JOBS: "2"
+        run: |
+          set -euo pipefail
+          bash scripts/ci/mutation-smoke-pure-modules.sh
+          {
+            echo "## Mutation smoke"
+            echo "- targets: trust_basis/diff.rs, trust_basis/classifiers.rs, sandbox/degradation.rs"
+            echo "- jobs: ${ASSAY_MUTATION_JOBS}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/week8-sota-gates.yml
+++ b/.github/workflows/week8-sota-gates.yml
@@ -49,6 +49,7 @@ jobs:
         shell: bash
         env:
           ASSAY_INSTALL_API_DRIFT_TOOLS: "1"
+          ASSAY_API_DRIFT_FAIL_ON_MISSING_BASE: "1"
           BASE_REV: ${{ inputs.base_rev }}
         run: |
           set -euo pipefail

--- a/docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md
+++ b/docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md
@@ -39,6 +39,13 @@ Rule:
 - Required for release candidates and public facade refactors.
 - Optional/non-blocking for early mechanical split PRs until CI has the tool cache.
 
+Workflow:
+
+- `.github/workflows/week8-sota-gates.yml`
+- Manual `workflow_dispatch` lane.
+- Installs `cargo-semver-checks` and `cargo-public-api` on demand with `ASSAY_INSTALL_API_DRIFT_TOOLS=1`.
+- Keeps this out of pull-request required checks until false-positive and cost behavior are understood.
+
 ## Gate 2 - Mutation Smoke on Pure Modules
 
 Script:
@@ -58,6 +65,13 @@ Rule:
 - Keep mutation smoke targeted to pure or near-pure modules.
 - Do not run full-workspace mutation testing in PR CI.
 - Use this to catch weak assertions after module extraction, especially where branch logic was moved mechanically.
+
+Workflow:
+
+- `.github/workflows/week8-sota-gates.yml`
+- Manual `workflow_dispatch` lane behind `run_mutation_smoke=true`.
+- Installs `cargo-mutants` on demand with `ASSAY_INSTALL_MUTATION_TOOLS=1`.
+- Does not run by default because mutation testing is intentionally heavier and should be reviewer-initiated.
 
 ## Gate 3 - OWASP MCP Test Mapping
 

--- a/docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md
+++ b/docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md
@@ -44,6 +44,7 @@ Workflow:
 - `.github/workflows/week8-sota-gates.yml`
 - Manual `workflow_dispatch` lane.
 - Installs `cargo-semver-checks` and `cargo-public-api` on demand with `ASSAY_INSTALL_API_DRIFT_TOOLS=1`.
+- Fails closed in GitHub Actions if `base_rev` cannot be fetched for comparison.
 - Keeps this out of pull-request required checks until false-positive and cost behavior are understood.
 
 ## Gate 2 - Mutation Smoke on Pure Modules

--- a/scripts/ci/mutation-smoke-pure-modules.sh
+++ b/scripts/ci/mutation-smoke-pure-modules.sh
@@ -10,8 +10,13 @@ if [ "${ASSAY_RUN_MUTATION_SMOKE:-0}" != "1" ]; then
 fi
 
 if ! cargo mutants --version >/dev/null 2>&1; then
-  echo "[mutation-smoke] skipped: cargo-mutants is not installed"
-  exit 0
+  if [ "${ASSAY_INSTALL_MUTATION_TOOLS:-0}" = "1" ]; then
+    echo "[mutation-smoke] installing cargo-mutants"
+    cargo install --locked cargo-mutants
+  else
+    echo "[mutation-smoke] skipped: cargo-mutants is not installed"
+    exit 0
+  fi
 fi
 
 COMMON=(--timeout 60 --minimum-test-timeout 20 --jobs "${ASSAY_MUTATION_JOBS:-2}")

--- a/scripts/ci/optional-public-api-drift.sh
+++ b/scripts/ci/optional-public-api-drift.sh
@@ -7,13 +7,34 @@ cd "$ROOT"
 BASE_REV="${BASE_REV:-origin/main}"
 PACKAGES=(assay-core assay-evidence assay-registry assay-policy assay-metrics)
 INSTALL_TOOLS="${ASSAY_INSTALL_API_DRIFT_TOOLS:-0}"
+FAIL_ON_MISSING_BASE="${ASSAY_API_DRIFT_FAIL_ON_MISSING_BASE:-${GITHUB_ACTIONS:-0}}"
 
 if [ -n "${ASSAY_API_DRIFT_PACKAGES:-}" ]; then
   # shellcheck disable=SC2206
   PACKAGES=(${ASSAY_API_DRIFT_PACKAGES})
 fi
 
-if ! git rev-parse --verify --quiet "${BASE_REV}^{commit}" >/dev/null; then
+ensure_base_rev() {
+  if git rev-parse --verify --quiet "${BASE_REV}^{commit}" >/dev/null; then
+    return 0
+  fi
+
+  echo "[api-drift] BASE_REV ${BASE_REV} is not available locally; attempting fetch"
+  if [[ "${BASE_REV}" == origin/* ]]; then
+    local remote_branch="${BASE_REV#origin/}"
+    git fetch --no-tags origin "${remote_branch}:refs/remotes/origin/${remote_branch}" || true
+  else
+    git fetch --no-tags origin "${BASE_REV}" || git fetch --no-tags origin "${BASE_REV}:refs/temp/api-drift-baseline" || true
+  fi
+
+  git rev-parse --verify --quiet "${BASE_REV}^{commit}" >/dev/null
+}
+
+if ! ensure_base_rev; then
+  if [ "${FAIL_ON_MISSING_BASE}" = "1" ] || [ "${FAIL_ON_MISSING_BASE}" = "true" ]; then
+    echo "[api-drift] FAIL: BASE_REV ${BASE_REV} is not available after fetch" >&2
+    exit 1
+  fi
   echo "[api-drift] skip: BASE_REV ${BASE_REV} is not available locally"
   exit 0
 fi

--- a/scripts/ci/optional-public-api-drift.sh
+++ b/scripts/ci/optional-public-api-drift.sh
@@ -6,15 +6,36 @@ cd "$ROOT"
 
 BASE_REV="${BASE_REV:-origin/main}"
 PACKAGES=(assay-core assay-evidence assay-registry assay-policy assay-metrics)
+INSTALL_TOOLS="${ASSAY_INSTALL_API_DRIFT_TOOLS:-0}"
+
+if [ -n "${ASSAY_API_DRIFT_PACKAGES:-}" ]; then
+  # shellcheck disable=SC2206
+  PACKAGES=(${ASSAY_API_DRIFT_PACKAGES})
+fi
 
 if ! git rev-parse --verify --quiet "${BASE_REV}^{commit}" >/dev/null; then
   echo "[api-drift] skip: BASE_REV ${BASE_REV} is not available locally"
   exit 0
 fi
 
+ensure_cargo_subcommand() {
+  local subcommand="$1"
+  local crate="$2"
+  if cargo "${subcommand}" --version >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ "${INSTALL_TOOLS}" = "1" ]; then
+    echo "[api-drift] installing ${crate}"
+    cargo install --locked "${crate}"
+    cargo "${subcommand}" --version >/dev/null
+    return 0
+  fi
+  return 1
+}
+
 ran_any=0
 
-if cargo semver-checks --version >/dev/null 2>&1; then
+if ensure_cargo_subcommand semver-checks cargo-semver-checks; then
   ran_any=1
   echo "[api-drift] cargo-semver-checks vs ${BASE_REV}"
   for package in "${PACKAGES[@]}"; do
@@ -25,7 +46,7 @@ else
   echo "[api-drift] skip cargo-semver-checks: cargo subcommand not installed"
 fi
 
-if cargo public-api --version >/dev/null 2>&1; then
+if ensure_cargo_subcommand public-api cargo-public-api; then
   ran_any=1
   echo "[api-drift] cargo-public-api diff vs ${BASE_REV}"
   for package in "${PACKAGES[@]}"; do

--- a/scripts/ci/optional-public-api-drift.sh
+++ b/scripts/ci/optional-public-api-drift.sh
@@ -51,9 +51,9 @@ if ensure_cargo_subcommand public-api cargo-public-api; then
   echo "[api-drift] cargo-public-api diff vs ${BASE_REV}"
   for package in "${PACKAGES[@]}"; do
     echo "[api-drift] public-api package=${package}"
-    if cargo public-api diff --help 2>/dev/null | rg -- '--package|-p' >/dev/null; then
+    if cargo public-api diff --help 2>/dev/null | grep -qE -- '--package|-p'; then
       cargo public-api diff --package "${package}" "${BASE_REV}..HEAD" -sss
-    elif cargo public-api --help 2>/dev/null | rg -- '--package|-p' >/dev/null; then
+    elif cargo public-api --help 2>/dev/null | grep -qE -- '--package|-p'; then
       cargo public-api --package "${package}" diff "${BASE_REV}..HEAD" -sss
     else
       echo "[api-drift] skip package-scoped public-api diff for ${package}: installed cargo-public-api does not advertise --package"

--- a/scripts/ci/review-week8-sota-gates.sh
+++ b/scripts/ci/review-week8-sota-gates.sh
@@ -7,12 +7,25 @@ cd "$ROOT"
 echo "[review] Week8 SOTA gate scripts syntax"
 bash -n scripts/ci/optional-public-api-drift.sh
 bash -n scripts/ci/mutation-smoke-pure-modules.sh
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/week8-sota-gates.yml")'
 
 echo "[review] Week8 docs anchors"
 rg 'cargo-semver-checks' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md >/dev/null
 rg 'cargo-public-api' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md >/dev/null
 rg 'cargo-mutants' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md >/dev/null
 rg 'OWASP MCP Top 10' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md docs/security/OWASP-MCP-TOP10-TEST-MAP.md >/dev/null
+rg 'week8-sota-gates.yml' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md >/dev/null
+
+echo "[review] Week8 workflow anchors"
+rg '^name: Week 8 SOTA Gates$' .github/workflows/week8-sota-gates.yml >/dev/null
+rg 'workflow_dispatch:' .github/workflows/week8-sota-gates.yml >/dev/null
+rg 'pull_request:' .github/workflows/week8-sota-gates.yml >/dev/null && {
+  echo "FAIL: Week8 SOTA workflow must stay manual/opt-in, not a PR required-check candidate" >&2
+  exit 1
+}
+rg 'ASSAY_INSTALL_API_DRIFT_TOOLS: "1"' .github/workflows/week8-sota-gates.yml >/dev/null
+rg 'ASSAY_RUN_MUTATION_SMOKE: "1"' .github/workflows/week8-sota-gates.yml >/dev/null
+rg 'ASSAY_INSTALL_MUTATION_TOOLS: "1"' .github/workflows/week8-sota-gates.yml >/dev/null
 
 for risk in MCP01 MCP02 MCP03 MCP05 MCP06 MCP08 MCP10; do
   rg "$risk" docs/security/OWASP-MCP-TOP10-TEST-MAP.md >/dev/null

--- a/scripts/ci/review-week8-sota-gates.sh
+++ b/scripts/ci/review-week8-sota-gates.sh
@@ -7,7 +7,10 @@ cd "$ROOT"
 echo "[review] Week8 SOTA gate scripts syntax"
 bash -n scripts/ci/optional-public-api-drift.sh
 bash -n scripts/ci/mutation-smoke-pure-modules.sh
-ruby -e 'require "yaml"; YAML.load_file(".github/workflows/week8-sota-gates.yml")'
+ruby - <<'RUBY'
+require "yaml"
+YAML.load_file(".github/workflows/week8-sota-gates.yml", permitted_classes: [], aliases: true)
+RUBY
 
 echo "[review] Week8 docs anchors"
 rg 'cargo-semver-checks' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md >/dev/null
@@ -19,11 +22,12 @@ rg 'week8-sota-gates.yml' docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.m
 echo "[review] Week8 workflow anchors"
 rg '^name: Week 8 SOTA Gates$' .github/workflows/week8-sota-gates.yml >/dev/null
 rg 'workflow_dispatch:' .github/workflows/week8-sota-gates.yml >/dev/null
-rg 'pull_request:' .github/workflows/week8-sota-gates.yml >/dev/null && {
+rg '^[[:space:]]{2}pull_request:' .github/workflows/week8-sota-gates.yml >/dev/null && {
   echo "FAIL: Week8 SOTA workflow must stay manual/opt-in, not a PR required-check candidate" >&2
   exit 1
 }
 rg 'ASSAY_INSTALL_API_DRIFT_TOOLS: "1"' .github/workflows/week8-sota-gates.yml >/dev/null
+rg 'ASSAY_API_DRIFT_FAIL_ON_MISSING_BASE: "1"' .github/workflows/week8-sota-gates.yml >/dev/null
 rg 'ASSAY_RUN_MUTATION_SMOKE: "1"' .github/workflows/week8-sota-gates.yml >/dev/null
 rg 'ASSAY_INSTALL_MUTATION_TOOLS: "1"' .github/workflows/week8-sota-gates.yml >/dev/null
 


### PR DESCRIPTION
Summary

Implements PR5 from the repo hygiene/security execution memo: an opt-in API and mutation gate layer for high-signal review/release checks without adding noisy required PR checks.

- Adds `.github/workflows/week8-sota-gates.yml` as a manual `workflow_dispatch` gate.
- Wires public API drift checks to install and run `cargo-semver-checks` and `cargo-public-api` on demand.
- Keeps targeted mutation smoke behind explicit `run_mutation_smoke=true`, installing `cargo-mutants` only when requested.
- Extends the Week 8 SOTA gate plan and reviewer script so the workflow remains manual/opt-in and tied to the existing OWASP MCP mapping.

Scope

Included:

- `.github/workflows/week8-sota-gates.yml`
- `scripts/ci/optional-public-api-drift.sh`
- `scripts/ci/mutation-smoke-pure-modules.sh`
- `scripts/ci/review-week8-sota-gates.sh`
- `docs/contributing/SPLIT-PLAN-week8-sota-gates-2026q2.md`

Explicitly excluded:

- making mutation smoke a required PR check
- full-workspace mutation testing
- changing existing Wave 0 required checks
- parser/dependency cleanup
- security fixture changes
- unrelated local architecture/example edits

Gate behavior

Public API drift:

- manual workflow input `run_public_api_drift=true` by default
- compares against `base_rev` input, defaulting to `origin/main`
- installs API drift tools with `ASSAY_INSTALL_API_DRIFT_TOOLS=1`

Mutation smoke:

- manual workflow input `run_mutation_smoke=false` by default
- runs only when explicitly enabled
- targets `trust_basis/diff.rs`, `trust_basis/classifiers.rs`, and `sandbox/degradation.rs`
- installs `cargo-mutants` with `ASSAY_INSTALL_MUTATION_TOOLS=1`

Validation

- `scripts/ci/review-week8-sota-gates.sh`
- `bash -n scripts/ci/optional-public-api-drift.sh scripts/ci/mutation-smoke-pure-modules.sh scripts/ci/review-week8-sota-gates.sh`
- `shellcheck scripts/ci/optional-public-api-drift.sh scripts/ci/mutation-smoke-pure-modules.sh scripts/ci/review-week8-sota-gates.sh`
- `actionlint .github/workflows/week8-sota-gates.yml`
- `git diff --check`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, use the manual Week 8 workflow for release candidates and public facade refactors. Keep mutation smoke reviewer-initiated until cost and false-positive behavior are understood.
