### PR TITLE
[codex] harden self-hosted runner health classification

### DIFF
--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -204,6 +204,9 @@ jobs:
       needs.check-ebpf-changes.outputs.ebpf_changed == 'true'
     runs-on: [self-hosted, linux, assay-bpf-runner]
     timeout-minutes: 5
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-cleanup-runner
+      cancel-in-progress: true
     steps:
       - name: Nuke _actions cache (force fresh download for next job)
         shell: bash

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -18,91 +18,23 @@ jobs:
     name: Check Self-Hosted Runner
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Check runner status
         id: check
         env:
-          # GITHUB_TOKEN can read queued workflow runs. Repository runner listing
-          # may require a broader token, so keep that optional token scoped to the
-          # runner-status lookup instead of reusing it for queue visibility.
+          # Repository runner listing may require a broader token, so keep that
+          # optional token scoped to runner-status lookup instead of reusing it
+          # for queue visibility.
           RUNNER_STATUS_TOKEN: ${{ secrets.RUNNER_HEALTH_TOKEN || github.token }}
           QUEUE_TOKEN: ${{ github.token }}
+          RUNNER_NAME: assay-bpf-runner
+          REQUIRED_RUNNER_LABEL: assay-bpf-runner
         run: |
-          set -euo pipefail
-
-          REPO="${{ github.repository }}"
-          RUNNER_NAME="assay-bpf-runner"
-
-          echo "Checking runner status for $RUNNER_NAME..."
-
-          # Get runner status. Do not collapse API/auth failures into
-          # not_found; those are monitor-health problems, not runner-health
-          # facts.
-          RUNNER_STATUS_ERROR=""
-          RUNNER_STATUS_STDERR="$(mktemp)"
-          if STATUS=$(GH_TOKEN="$RUNNER_STATUS_TOKEN" gh api "repos/$REPO/actions/runners" \
-            --jq ".runners[] | select(.name == \"$RUNNER_NAME\") | .status" \
-            2>"$RUNNER_STATUS_STDERR"); then
-            if [[ -z "$STATUS" ]]; then
-              STATUS="not_found"
-            fi
-          else
-            STATUS="unknown"
-            RUNNER_STATUS_ERROR=$(tr '\n' ' ' < "$RUNNER_STATUS_STDERR" | sed 's/[[:space:]]\+/ /g')
-            echo "::warning::Unable to query self-hosted runner status: ${RUNNER_STATUS_ERROR}"
-          fi
-          rm -f "$RUNNER_STATUS_STDERR"
-
-          echo "runner_status=$STATUS" >> "$GITHUB_OUTPUT"
-          echo "runner_status_error=$RUNNER_STATUS_ERROR" >> "$GITHUB_OUTPUT"
-          echo "Runner status: $STATUS"
-
-          # Get queued jobs count
-          QUEUE_STATUS_ERROR=""
-          QUEUE_STATUS_STDERR="$(mktemp)"
-          if QUEUED=$(GH_TOKEN="$QUEUE_TOKEN" gh api "repos/$REPO/actions/runs?status=queued" \
-            --jq '.workflow_runs | length' \
-            2>"$QUEUE_STATUS_STDERR"); then
-            if [[ -z "$QUEUED" ]]; then
-              QUEUED="0"
-            fi
-          else
-            QUEUED="unknown"
-            QUEUE_STATUS_ERROR=$(tr '\n' ' ' < "$QUEUE_STATUS_STDERR" | sed 's/[[:space:]]\+/ /g')
-            echo "::warning::Unable to query queued workflow runs: ${QUEUE_STATUS_ERROR}"
-          fi
-          rm -f "$QUEUE_STATUS_STDERR"
-
-          echo "queued_jobs=$QUEUED" >> "$GITHUB_OUTPUT"
-          echo "queued_jobs_error=$QUEUE_STATUS_ERROR" >> "$GITHUB_OUTPUT"
-          echo "Queued jobs: $QUEUED"
-
-          # Determine health
-          QUEUE_IS_NUMERIC=false
-          if [[ "$QUEUED" =~ ^[0-9]+$ ]]; then
-            QUEUE_IS_NUMERIC=true
-          fi
-
-          if [[ "$STATUS" == "online" ]]; then
-            echo "healthy=true" >> "$GITHUB_OUTPUT"
-            echo "✅ Runner is healthy"
-          elif [[ "$QUEUE_IS_NUMERIC" == "true" ]] && [[ "$QUEUED" -gt 0 ]]; then
-            echo "healthy=false" >> "$GITHUB_OUTPUT"
-            echo "❌ Runner is $STATUS with $QUEUED queued jobs!"
-            exit 1
-          elif [[ "$QUEUED" == "unknown" ]]; then
-            echo "healthy=false" >> "$GITHUB_OUTPUT"
-            echo "❌ Runner is $STATUS and queue state is unknown!"
-            exit 1
-          elif [[ "$STATUS" == "unknown" ]]; then
-            echo "healthy=true" >> "$GITHUB_OUTPUT"
-            echo "⚠️ Runner health is unknown but no queued jobs"
-          else
-            echo "healthy=true" >> "$GITHUB_OUTPUT"
-            echo "⚠️ Runner is $STATUS but no queued jobs"
-          fi
+          bash scripts/ci/check-runner-health.sh
 
       - name: Create issue if unhealthy
-        if: failure()
+        if: steps.check.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -122,14 +54,20 @@ jobs:
           if [[ "$EXISTING" -eq 0 ]]; then
             ISSUE_BODY="## Runner Health Alert
 
-          The self-hosted runner \`assay-bpf-runner\` is **offline or unknown** while queued jobs may be waiting, or the monitor could not verify queue state.
+          The self-hosted runner \`assay-bpf-runner\` needs attention for label-specific queue health.
 
           ### Details
           - **Runner:** assay-bpf-runner
           - **Status:** ${{ steps.check.outputs.runner_status }}
           - **Status Error:** ${{ steps.check.outputs.runner_status_error }}
-          - **Queued Jobs:** ${{ steps.check.outputs.queued_jobs }}
-          - **Queued Jobs Error:** ${{ steps.check.outputs.queued_jobs_error }}
+          - **Busy:** ${{ steps.check.outputs.runner_busy }}
+          - **Runner Labels:** ${{ steps.check.outputs.runner_labels }}
+          - **Required Label:** ${{ steps.check.outputs.required_runner_label }}
+          - **General Queued Workflow Runs:** ${{ steps.check.outputs.general_queued_runs }}
+          - **Inspected Workflow Runs:** ${{ steps.check.outputs.inspected_workflow_runs }}
+          - **Matching Queued Jobs:** ${{ steps.check.outputs.matching_queued_jobs }}
+          - **Queue Classification Error:** ${{ steps.check.outputs.queue_status_error }}
+          - **Health Reason:** ${{ steps.check.outputs.health_reason }}
           - **Detected:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
           ### Recovery Steps
@@ -155,7 +93,7 @@ jobs:
           - Runner token expired
           - Network issues
 
-          This issue will auto-close when the runner comes back online."
+          This issue will auto-close when the label-specific health alert condition clears."
 
             if gh issue create --repo "$REPO" \
               --title "$TITLE" \
@@ -192,6 +130,6 @@ jobs:
 
           for ISSUE in $ISSUES; do
             gh issue close "$ISSUE" --repo "$REPO" \
-              --comment "✅ Runner is back online. Auto-closing this alert."
+              --comment "✅ Runner health alert condition cleared. Auto-closing this alert."
             echo "Closed issue #$ISSUE"
           done

--- a/infra/bpf-runner/README.md
+++ b/infra/bpf-runner/README.md
@@ -44,7 +44,7 @@ The `health_check.sh` script monitors the runner and auto-recovers from common f
 - Configure only the custom labels: `bpf-lsm,assay-bpf-runner`
 - GitHub adds read-only labels such as `self-hosted`, `Linux`, and the current architecture automatically
 
-**GitHub Actions backup:** A workflow (`runner-health.yml`) runs every 15 minutes and creates a GitHub issue if the runner is offline with queued jobs.
+**GitHub Actions backup:** A workflow (`runner-health.yml`) runs every 15 minutes and creates a GitHub issue only when the runner is unavailable with queued jobs that require the `assay-bpf-runner` label, or when the monitor cannot classify that label-specific queue. Kernel Matrix cleanup jobs also use per-ref concurrency so stale self-hosted cleanup work does not keep piling up while the runner is offline.
 
 ## "No space left on device" (Kernel Matrix CI)
 

--- a/scripts/ci/check-runner-health.sh
+++ b/scripts/ci/check-runner-health.sh
@@ -8,6 +8,12 @@ runner_status_token="${RUNNER_STATUS_TOKEN:-${GH_TOKEN:-}}"
 queue_token="${QUEUE_TOKEN:-${GH_TOKEN:-}}"
 output_file="${GITHUB_OUTPUT:-/dev/null}"
 summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
 
 if [[ -z "$repo" ]]; then
   echo "ERROR: GITHUB_REPOSITORY or REPO is required" >&2
@@ -38,10 +44,10 @@ runner_status_error=""
 runner_busy="unknown"
 runner_labels=""
 
-runner_status_stderr="$(mktemp)"
-runner_json="$(mktemp)"
-if GH_TOKEN="$runner_status_token" gh api "repos/$repo/actions/runners?per_page=100" >"$runner_json" 2>"$runner_status_stderr"; then
-  selected_runner="$(jq -c --arg name "$runner_name" '.runners[]? | select(.name == $name)' "$runner_json")"
+runner_status_stderr="$tmpdir/runner-status.stderr"
+runner_json="$tmpdir/runners.json"
+if GH_TOKEN="$runner_status_token" gh api --paginate "repos/$repo/actions/runners?per_page=100" >"$runner_json" 2>"$runner_status_stderr"; then
+  selected_runner="$(jq -sc --arg name "$runner_name" '[.[].runners[]? | select(.name == $name)] | .[0] // empty' "$runner_json")"
   if [[ -z "$selected_runner" ]]; then
     runner_status="not_found"
   else
@@ -53,28 +59,27 @@ else
   runner_status_error="$(sanitize_error <"$runner_status_stderr")"
   echo "::warning::Unable to query self-hosted runner status: ${runner_status_error}" >&2
 fi
-rm -f "$runner_status_stderr" "$runner_json"
 
-matching_jobs="$(mktemp)"
-queue_stderr="$(mktemp)"
+matching_jobs="$tmpdir/matching-jobs.tsv"
+queue_stderr="$tmpdir/queue.stderr"
 queue_status_error=""
 general_queued_runs=0
 inspected_workflow_runs=0
 
 for run_status in queued in_progress; do
-  runs_json="$(mktemp)"
-  if GH_TOKEN="$queue_token" gh api "repos/$repo/actions/runs?status=${run_status}&per_page=50" >"$runs_json" 2>>"$queue_stderr"; then
+  runs_json="$tmpdir/runs-${run_status}.json"
+  if GH_TOKEN="$queue_token" gh api --paginate "repos/$repo/actions/runs?status=${run_status}&per_page=100" >"$runs_json" 2>>"$queue_stderr"; then
     run_rows="$(jq -r '.workflow_runs[]? | [.id, .name, .status, .html_url] | @tsv' "$runs_json")"
     if [[ "$run_status" == "queued" ]]; then
-      general_queued_runs="$(printf '%s\n' "$run_rows" | count_nonempty_lines)"
+      general_queued_runs="$(jq -r '.workflow_runs[]?.id' "$runs_json" | count_nonempty_lines)"
     fi
 
     while IFS=$'\t' read -r run_id run_name _status run_url; do
       [[ -n "${run_id:-}" ]] || continue
       inspected_workflow_runs=$((inspected_workflow_runs + 1))
 
-      jobs_json="$(mktemp)"
-      if GH_TOKEN="$queue_token" gh api "repos/$repo/actions/runs/${run_id}/jobs?filter=latest&per_page=100" >"$jobs_json" 2>>"$queue_stderr"; then
+      jobs_json="$tmpdir/jobs-${run_id}.json"
+      if GH_TOKEN="$queue_token" gh api --paginate "repos/$repo/actions/runs/${run_id}/jobs?filter=latest&per_page=100" >"$jobs_json" 2>>"$queue_stderr"; then
         jq -r \
           --arg label "$required_runner_label" \
           --arg run_name "$run_name" \
@@ -89,17 +94,14 @@ for run_status in queued in_progress; do
       else
         echo "Unable to query jobs for run ${run_id}" >>"$queue_stderr"
       fi
-      rm -f "$jobs_json"
     done <<<"$run_rows"
   fi
-  rm -f "$runs_json"
 done
 
 if [[ -s "$queue_stderr" ]]; then
   queue_status_error="$(sanitize_error <"$queue_stderr")"
   echo "::warning::Unable to fully classify queued jobs: ${queue_status_error}" >&2
 fi
-rm -f "$queue_stderr"
 
 matching_queued_jobs="$(count_nonempty_lines <"$matching_jobs")"
 health_reason="clear"
@@ -155,8 +157,6 @@ write_output "health_reason" "$health_reason"
     echo '```'
   fi
 } >>"$summary_file"
-
-rm -f "$matching_jobs"
 
 if [[ "$healthy" != "true" ]]; then
   echo "Runner health alert: ${health_reason}" >&2

--- a/scripts/ci/check-runner-health.sh
+++ b/scripts/ci/check-runner-health.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:-${REPO:-}}"
+runner_name="${RUNNER_NAME:-assay-bpf-runner}"
+required_runner_label="${REQUIRED_RUNNER_LABEL:-assay-bpf-runner}"
+runner_status_token="${RUNNER_STATUS_TOKEN:-${GH_TOKEN:-}}"
+queue_token="${QUEUE_TOKEN:-${GH_TOKEN:-}}"
+output_file="${GITHUB_OUTPUT:-/dev/null}"
+summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+if [[ -z "$repo" ]]; then
+  echo "ERROR: GITHUB_REPOSITORY or REPO is required" >&2
+  exit 2
+fi
+
+if [[ -z "$runner_status_token" || -z "$queue_token" ]]; then
+  echo "ERROR: RUNNER_STATUS_TOKEN/QUEUE_TOKEN or GH_TOKEN is required" >&2
+  exit 2
+fi
+
+write_output() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%s\n' "$key" "$value" >> "$output_file"
+}
+
+sanitize_error() {
+  tr '\n' ' ' | sed 's/[[:space:]]\+/ /g'
+}
+
+count_nonempty_lines() {
+  sed '/^[[:space:]]*$/d' | wc -l | tr -d ' '
+}
+
+runner_status="unknown"
+runner_status_error=""
+runner_busy="unknown"
+runner_labels=""
+
+runner_status_stderr="$(mktemp)"
+runner_json="$(mktemp)"
+if GH_TOKEN="$runner_status_token" gh api "repos/$repo/actions/runners?per_page=100" >"$runner_json" 2>"$runner_status_stderr"; then
+  selected_runner="$(jq -c --arg name "$runner_name" '.runners[]? | select(.name == $name)' "$runner_json")"
+  if [[ -z "$selected_runner" ]]; then
+    runner_status="not_found"
+  else
+    runner_status="$(jq -r '.status // "unknown"' <<<"$selected_runner")"
+    runner_busy="$(jq -r 'if has("busy") then (.busy | tostring) else "unknown" end' <<<"$selected_runner")"
+    runner_labels="$(jq -r '[.labels[]?.name] | join(",")' <<<"$selected_runner")"
+  fi
+else
+  runner_status_error="$(sanitize_error <"$runner_status_stderr")"
+  echo "::warning::Unable to query self-hosted runner status: ${runner_status_error}" >&2
+fi
+rm -f "$runner_status_stderr" "$runner_json"
+
+matching_jobs="$(mktemp)"
+queue_stderr="$(mktemp)"
+queue_status_error=""
+general_queued_runs=0
+inspected_workflow_runs=0
+
+for run_status in queued in_progress; do
+  runs_json="$(mktemp)"
+  if GH_TOKEN="$queue_token" gh api "repos/$repo/actions/runs?status=${run_status}&per_page=50" >"$runs_json" 2>>"$queue_stderr"; then
+    run_rows="$(jq -r '.workflow_runs[]? | [.id, .name, .status, .html_url] | @tsv' "$runs_json")"
+    if [[ "$run_status" == "queued" ]]; then
+      general_queued_runs="$(printf '%s\n' "$run_rows" | count_nonempty_lines)"
+    fi
+
+    while IFS=$'\t' read -r run_id run_name _status run_url; do
+      [[ -n "${run_id:-}" ]] || continue
+      inspected_workflow_runs=$((inspected_workflow_runs + 1))
+
+      jobs_json="$(mktemp)"
+      if GH_TOKEN="$queue_token" gh api "repos/$repo/actions/runs/${run_id}/jobs?filter=latest&per_page=100" >"$jobs_json" 2>>"$queue_stderr"; then
+        jq -r \
+          --arg label "$required_runner_label" \
+          --arg run_name "$run_name" \
+          --arg run_url "$run_url" \
+          '
+          .jobs[]?
+          | select((.status == "queued" or .status == "waiting" or .status == "pending" or .status == "requested")
+              and ((.labels // []) | index($label)))
+          | [$run_name, .name, .status, ((.labels // []) | join(",")), (.html_url // $run_url)]
+          | @tsv
+          ' "$jobs_json" >>"$matching_jobs"
+      else
+        echo "Unable to query jobs for run ${run_id}" >>"$queue_stderr"
+      fi
+      rm -f "$jobs_json"
+    done <<<"$run_rows"
+  fi
+  rm -f "$runs_json"
+done
+
+if [[ -s "$queue_stderr" ]]; then
+  queue_status_error="$(sanitize_error <"$queue_stderr")"
+  echo "::warning::Unable to fully classify queued jobs: ${queue_status_error}" >&2
+fi
+rm -f "$queue_stderr"
+
+matching_queued_jobs="$(count_nonempty_lines <"$matching_jobs")"
+health_reason="clear"
+healthy="true"
+
+if [[ "$runner_status" == "online" ]]; then
+  health_reason="runner_online"
+elif [[ "$matching_queued_jobs" =~ ^[0-9]+$ && "$matching_queued_jobs" -gt 0 ]]; then
+  healthy="false"
+  health_reason="runner_${runner_status}_with_matching_backlog"
+elif [[ -n "$queue_status_error" && "$runner_status" != "online" ]]; then
+  healthy="false"
+  health_reason="runner_${runner_status}_queue_classification_unknown"
+elif [[ "$runner_status" == "offline" || "$runner_status" == "not_found" || "$runner_status" == "unknown" ]]; then
+  health_reason="runner_${runner_status}_without_matching_backlog"
+fi
+
+write_output "runner_status" "$runner_status"
+write_output "runner_status_error" "$runner_status_error"
+write_output "runner_busy" "$runner_busy"
+write_output "runner_labels" "$runner_labels"
+write_output "required_runner_label" "$required_runner_label"
+write_output "general_queued_runs" "$general_queued_runs"
+write_output "inspected_workflow_runs" "$inspected_workflow_runs"
+write_output "matching_queued_jobs" "$matching_queued_jobs"
+write_output "queue_status_error" "$queue_status_error"
+write_output "healthy" "$healthy"
+write_output "health_reason" "$health_reason"
+
+{
+  echo "## Runner Health"
+  echo "- runner: ${runner_name}"
+  echo "- runner_status: ${runner_status}"
+  echo "- runner_busy: ${runner_busy}"
+  echo "- runner_labels: ${runner_labels:-unknown}"
+  echo "- required_runner_label: ${required_runner_label}"
+  echo "- general_queued_workflow_runs: ${general_queued_runs}"
+  echo "- inspected_workflow_runs: ${inspected_workflow_runs}"
+  echo "- matching_queued_jobs: ${matching_queued_jobs}"
+  echo "- healthy: ${healthy}"
+  echo "- health_reason: ${health_reason}"
+  if [[ -n "$runner_status_error" ]]; then
+    echo "- runner_status_error: ${runner_status_error}"
+  fi
+  if [[ -n "$queue_status_error" ]]; then
+    echo "- queue_status_error: ${queue_status_error}"
+  fi
+  if [[ -s "$matching_jobs" ]]; then
+    echo ""
+    echo "### Matching queued jobs"
+    echo '```text'
+    cat "$matching_jobs"
+    echo '```'
+  fi
+} >>"$summary_file"
+
+rm -f "$matching_jobs"
+
+if [[ "$healthy" != "true" ]]; then
+  echo "Runner health alert: ${health_reason}" >&2
+  exit 1
+fi
+
+echo "Runner health clear: ${health_reason}"


### PR DESCRIPTION
Summary

Hardens the P0 self-hosted runner health monitor so it reports label-specific runner incidents instead of treating all queued workflow runs as self-hosted runner backlog.

Changes:
- Moves runner health API logic into scripts/ci/check-runner-health.sh so it is shellcheckable and easier to review.
- Keeps runner status lookup separate from queue classification.
- Inspects queued and in-progress workflow jobs and counts only queued/waiting jobs with the assay-bpf-runner label.
- Reports general queued workflow runs separately from matching self-hosted queued jobs.
- Updates the health issue payload with runner labels, busy state, matching queue count, inspected run count, and health reason.
- Adds per-ref concurrency to Kernel Matrix cleanup-runner so stale self-hosted cleanup jobs stop piling up while the runner is offline.
- Documents the new label-specific behavior in infra/bpf-runner/README.md.

Scope

Included:
- .github/workflows/runner-health.yml
- .github/workflows/kernel-matrix.yml
- scripts/ci/check-runner-health.sh
- infra/bpf-runner/README.md

Explicitly excluded:
- broader CI refactors
- action contract build artifact reuse
- Kernel Matrix skip-before-build restructuring
- zizmor/Scorecard workflow security scanning
- cancelling existing queued runs
- unrelated local docs/example edits

Validation

- bash -n scripts/ci/check-runner-health.sh
- shellcheck scripts/ci/check-runner-health.sh
- actionlint .github/workflows/runner-health.yml .github/workflows/kernel-matrix.yml
- git diff --check -- .github/workflows/runner-health.yml .github/workflows/kernel-matrix.yml infra/bpf-runner/README.md scripts/ci/check-runner-health.sh
- live API smoke with current repository tokens

Live finding

The live API smoke now reports the real P0 condition precisely:
- runner_status: offline
- runner_labels: self-hosted,Linux,ARM64,bpf-lsm,assay-bpf-runner
- general_queued_runs: 5
- matching_queued_jobs: 5
- health_reason: runner_offline_with_matching_backlog

All matching queued jobs are Kernel Matrix CI / Free disk (before matrix) jobs requiring self-hosted,linux,assay-bpf-runner. This confirms the monitor is now pointing at label-specific backlog rather than generic GitHub queue noise.

Operational follow-up

Existing queued runs were not cancelled in this PR. After merge, either recover assay-bpf-runner or explicitly cancel stale queued Kernel Matrix runs if they are no longer useful.

Next

After P0 lands, continue with Kernel Matrix skip-before-build as the next small CI waste-reduction PR.