### PR TITLE
[codex] reuse CLI artifacts in action contract tests

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -9,18 +9,68 @@ on:
 permissions: {}
 
 jobs:
-  # ===========================================================================
-  # Test 1: Pack lint with eu-ai-act-baseline
-  # ===========================================================================
-  pack_lint_baseline:
+  build_cli:
+    name: Build CLI Artifact
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Build CLI
+      - name: Build CLI once
         run: cargo build --release --workspace --exclude assay-ebpf
+
+      - name: Package CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/action-contract-cli
+          cp target/release/assay dist/action-contract-cli/assay
+          chmod 0755 dist/action-contract-cli/assay
+          dist/action-contract-cli/assay --version | tee dist/action-contract-cli/assay.version
+          (
+            cd dist/action-contract-cli
+            sha256sum assay | tee assay.sha256
+            tar -czf ../assay-action-contract-cli-linux-x64.tar.gz assay assay.sha256 assay.version
+          )
+          echo "Packaged artifact:"
+          sha256sum dist/assay-action-contract-cli-linux-x64.tar.gz
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: assay-action-contract-cli-linux-x64-${{ github.sha }}
+          path: dist/assay-action-contract-cli-linux-x64.tar.gz
+          if-no-files-found: error
+
+  # ===========================================================================
+  # Test 1: Pack lint with eu-ai-act-baseline
+  # ===========================================================================
+  pack_lint_baseline:
+    runs-on: ubuntu-latest
+    needs: build_cli
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download CLI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: assay-action-contract-cli-linux-x64-${{ github.sha }}
+          path: dist
+
+      - name: Install CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release
+          tar -xzf dist/assay-action-contract-cli-linux-x64.tar.gz -C target/release
+          (
+            cd target/release
+            sha256sum -c assay.sha256
+            ./assay --version
+          )
 
       - name: Verify test bundle exists
         run: |
@@ -339,8 +389,27 @@ jobs:
   # ===========================================================================
   smoke_monorepo_workdir:
     runs-on: ubuntu-latest
+    needs: build_cli
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download CLI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: assay-action-contract-cli-linux-x64-${{ github.sha }}
+          path: dist
+
+      - name: Install CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release
+          tar -xzf dist/assay-action-contract-cli-linux-x64.tar.gz -C target/release
+          (
+            cd target/release
+            sha256sum -c assay.sha256
+            ./assay --version
+          )
 
       # Minimal fake config + trace in a subdir
       - name: Prepare fixtures
@@ -363,9 +432,6 @@ jobs:
           {"schema_version":1,"type":"assay.trace","request_id":"1","prompt":"p1","response":"hello world","model":"trace","provider":"trace","meta":{}}
           JSONL
 
-      - name: Build Verdict (Current Commit)
-        run: cargo build --release --workspace --exclude assay-ebpf
-
       - name: Run action (workdir)
         env:
           ASSAY_BIN: ${{ github.workspace }}/target/release/assay
@@ -386,10 +452,29 @@ jobs:
 
   export_baseline_artifact:
     runs-on: ubuntu-latest
+    needs: build_cli
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download CLI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: assay-action-contract-cli-linux-x64-${{ github.sha }}
+          path: dist
+
+      - name: Install CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release
+          tar -xzf dist/assay-action-contract-cli-linux-x64.tar.gz -C target/release
+          (
+            cd target/release
+            sha256sum -c assay.sha256
+            ./assay --version
+          )
 
       - name: Prepare fixtures
         run: |
@@ -410,9 +495,6 @@ jobs:
           cat > fixtures/export/traces/ok.jsonl <<'JSONL'
           {"schema_version":1,"type":"assay.trace","request_id":"1","prompt":"p1","response":"hello world","model":"trace","provider":"trace","meta":{}}
           JSONL
-
-      - name: Build Verdict (Current Commit)
-        run: cargo build --release --workspace --exclude assay-ebpf
 
       - name: Export baseline
         env:

--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -390,6 +390,8 @@ jobs:
   smoke_monorepo_workdir:
     runs-on: ubuntu-latest
     needs: build_cli
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/action-v2-test.yml
+++ b/.github/workflows/action-v2-test.yml
@@ -13,14 +13,62 @@ permissions:
   security-events: write
 
 jobs:
-  test-no-bundles:
-    name: Test (no bundles - soft exit)
+  build-assay-cli:
+    name: Build Assay CLI Artifact
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Build Assay CLI
+      - name: Build Assay CLI once
         run: cargo build --release -p assay-cli
+
+      - name: Package CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/action-v2-cli
+          cp target/release/assay dist/action-v2-cli/assay
+          chmod 0755 dist/action-v2-cli/assay
+          dist/action-v2-cli/assay --version | tee dist/action-v2-cli/assay.version
+          (
+            cd dist/action-v2-cli
+            sha256sum assay | tee assay.sha256
+            tar -czf ../assay-action-v2-cli-linux-x64.tar.gz assay assay.sha256 assay.version
+          )
+          echo "Packaged artifact:"
+          sha256sum dist/assay-action-v2-cli-linux-x64.tar.gz
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: assay-action-v2-cli-linux-x64-${{ github.sha }}
+          path: dist/assay-action-v2-cli-linux-x64.tar.gz
+          if-no-files-found: error
+
+  test-no-bundles:
+    name: Test (no bundles - soft exit)
+    runs-on: ubuntu-latest
+    needs: build-assay-cli
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download CLI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: assay-action-v2-cli-linux-x64-${{ github.sha }}
+          path: dist
+
+      - name: Install CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release
+          tar -xzf dist/assay-action-v2-cli-linux-x64.tar.gz -C target/release
+          (
+            cd target/release
+            sha256sum -c assay.sha256
+            ./assay --version
+          )
 
       - name: Add CLI to PATH
         run: echo "${{ github.workspace }}/target/release" >> "$GITHUB_PATH"
@@ -31,11 +79,27 @@ jobs:
   test-with-bundle:
     name: Test (with valid bundle)
     runs-on: ubuntu-latest
+    needs: build-assay-cli
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Build Assay CLI
-        run: cargo build --release -p assay-cli
+      - name: Download CLI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: assay-action-v2-cli-linux-x64-${{ github.sha }}
+          path: dist
+
+      - name: Install CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release
+          tar -xzf dist/assay-action-v2-cli-linux-x64.tar.gz -C target/release
+          (
+            cd target/release
+            sha256sum -c assay.sha256
+            ./assay --version
+          )
 
       - name: Setup evidence directory with fixture
         run: |
@@ -83,11 +147,27 @@ jobs:
   test-with-pack:
     name: Test (with compliance pack)
     runs-on: ubuntu-latest
+    needs: build-assay-cli
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Build Assay CLI
-        run: cargo build --release -p assay-cli
+      - name: Download CLI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: assay-action-v2-cli-linux-x64-${{ github.sha }}
+          path: dist
+
+      - name: Install CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release
+          tar -xzf dist/assay-action-v2-cli-linux-x64.tar.gz -C target/release
+          (
+            cd target/release
+            sha256sum -c assay.sha256
+            ./assay --version
+          )
 
       - name: Setup evidence directory with fixture
         run: |
@@ -124,11 +204,27 @@ jobs:
   test-missing-pack-fails-cleanly:
     name: Test (missing compliance pack failure mode)
     runs-on: ubuntu-latest
+    needs: build-assay-cli
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Build Assay CLI
-        run: cargo build --release -p assay-cli
+      - name: Download CLI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: assay-action-v2-cli-linux-x64-${{ github.sha }}
+          path: dist
+
+      - name: Install CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release
+          tar -xzf dist/assay-action-v2-cli-linux-x64.tar.gz -C target/release
+          (
+            cd target/release
+            sha256sum -c assay.sha256
+            ./assay --version
+          )
 
       - name: Setup evidence directory with fixture
         run: |
@@ -171,11 +267,27 @@ jobs:
   test-invalid-pack-fails-cleanly:
     name: Test (invalid compliance pack failure mode)
     runs-on: ubuntu-latest
+    needs: build-assay-cli
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Build Assay CLI
-        run: cargo build --release -p assay-cli
+      - name: Download CLI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: assay-action-v2-cli-linux-x64-${{ github.sha }}
+          path: dist
+
+      - name: Install CLI artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/release
+          tar -xzf dist/assay-action-v2-cli-linux-x64.tar.gz -C target/release
+          (
+            cd target/release
+            sha256sum -c assay.sha256
+            ./assay --version
+          )
 
       - name: Setup evidence directory with fixture
         run: |


### PR DESCRIPTION
Summary

Implements PR C from the CI/CD sweep: remove duplicate action-contract release builds by building one explicit CLI artifact per workflow run and reusing it in downstream action contract jobs.

Changes:

- Adds `build_cli` to `assay-action-contract-tests` as a single producer using the existing build command: `cargo build --release --workspace --exclude assay-ebpf`.
- Replaces the three duplicate release workspace builds in `action-tests.yml` with artifact download/install/sha256 verification.
- Adds `build-assay-cli` to `Action v2 Test` as a single producer using the existing build command: `cargo build --release -p assay-cli`.
- Replaces the five duplicate CLI builds in `action-v2-test.yml` with artifact download/install/sha256 verification.
- Packages the binary as a tarball so executable permissions survive artifact upload/download.
- Logs `assay --version` and sha256 in producer and verifies sha256 in every consumer.

Before/after build count

- `.github/workflows/action-tests.yml`: 3 release workspace builds -> 1 release workspace build.
- `.github/workflows/action-v2-test.yml`: 5 release CLI builds -> 1 release CLI build.
- Cross-workflow reuse is intentionally not used: GitHub artifacts are reliable inside one workflow run; cross-workflow artifact reuse would add API/token/state coupling and make the test less deterministic.

Scope

Included:

- `.github/workflows/action-tests.yml`
- `.github/workflows/action-v2-test.yml`

Explicitly excluded:

- reusable workflow/composite-action refactors
- larger runner experiments
- cache strategy changes
- dependency/tool install caching
- Kernel Matrix skip logic
- workflow security scanners such as zizmor/Scorecard
- changing action behavior or action inputs

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/action-tests.yml .github/workflows/action-v2-test.yml`
- `git diff --check -- .github/workflows/action-tests.yml .github/workflows/action-v2-test.yml`
- pre-commit during commit, including YAML checks and GitHub Actions workflow lint
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, continue with PR D: add a bounded workflow-security scanner lane, starting with zizmor as non-blocking/high-signal workflow hygiene.
