### PR TITLE
[codex] add zizmor workflow security scan

### DIFF
--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -1,0 +1,41 @@
+name: Workflow Security (zizmor)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/dependabot.yml"
+      - "assay-action/action.yml"
+  push:
+    branches: [ "main" ]
+    paths:
+      - ".github/workflows/**"
+      - ".github/dependabot.yml"
+      - "assay-action/action.yml"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          version: "1.24.1"
+          min-confidence: high
+          inputs: |
+            .github/workflows
+            .github/dependabot.yml
+            assay-action/action.yml

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -20,6 +20,8 @@ jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Summary

Implements PR D from the CI/CD sweep: add a bounded, non-blocking GitHub Actions security scan with zizmor.

Changes:

- Adds `.github/workflows/workflow-security.yml` as a dedicated workflow-security lane.
- Uses pinned `zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e` (`v0.5.3`).
- Pins the scanner version to `zizmor 1.24.1` for reproducible findings.
- Uploads results through GitHub code scanning / SARIF, which keeps the workflow green for findings and fails only on tool/internal errors.
- Scopes triggers to workflow/action/dependabot metadata changes plus `workflow_dispatch`.
- Scopes inputs to `.github/workflows`, `.github/dependabot.yml`, and `assay-action/action.yml`.
- Uses `min-confidence: high` to start with high-signal findings only.
- Uses least-privilege workflow default `permissions: {}` and job-level `actions: read`, `contents: read`, `security-events: write`.
- Checks out with `persist-credentials: false`.

Scope

Included:

- `.github/workflows/workflow-security.yml`

Explicitly excluded:

- fixing existing zizmor findings
- Scorecard
- required-check/ruleset changes
- reusable workflow refactors
- cache/tool install changes
- broad CI cleanup

Local baseline

Local high-confidence scan command:

```bash
uvx zizmor==1.24.1 --no-progress --min-confidence high --format=sarif \
  .github/workflows .github/dependabot.yml assay-action/action.yml > /tmp/zizmor-high.sarif
```

Observed local result:

- SARIF mode exit code: `0`
- SARIF result count: `12`
- Levels: `7 error`, `4 warning`, `1 note`
- Plain mode exit code: `14`, as expected when findings are emitted outside SARIF/non-blocking mode

Representative high-signal findings surfaced for follow-up PRs:

- Dependabot cooldown missing in `.github/dependabot.yml`
- Workflow-level `security-events: write` in `.github/workflows/action-v2-test.yml`
- Template injection findings in release/split/action workflow surfaces
- Release cache-poisoning warnings on runtime artifact paths

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/workflow-security.yml`
- `git diff --cached --check`
- `uvx zizmor==1.24.1 --no-progress --min-confidence high --format=plain .github/workflows .github/dependabot.yml assay-action/action.yml`
- `uvx zizmor==1.24.1 --no-progress --min-confidence high --format=sarif .github/workflows .github/dependabot.yml assay-action/action.yml > /tmp/zizmor-high.sarif`
- pre-commit during commit, including GitHub Actions workflow lint
- pre-push hooks during push, including workspace clippy and linux compile gate

References

- zizmor GitHub Actions integration: https://docs.zizmor.sh/integrations/
- zizmor quickstart/output modes: https://docs.zizmor.sh/quickstart/

Next

After this lands, start a separate workflow-security cleanup slice from the SARIF findings, beginning with the highest-signal items: Dependabot cooldown, action-v2 workflow-level permissions, and high-confidence template-injection findings.
