### PR TITLE
[codex] add Dependabot cooldown windows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
       - "dependencies"
       - "ci"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     ignore:
       # Major version bumps need manual review (breaking changes)
       - dependency-name: "*"
@@ -40,6 +45,11 @@ updates:
       - "dependencies"
       - "rust"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     ignore:
       # rand 0.9 requires coordinated updates with ed25519-dalek (crypto RNG trait changes)
       # See: docs/architecture/ADR-020-Dependency-Governance.md
@@ -74,3 +84,8 @@ updates:
       - "dependencies"
       - "python"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
Summary

Starts the post-zizmor cleanup with one small high-confidence finding: Dependabot update cooldowns.

Changes:

- Adds `cooldown` to the `github-actions`, `cargo`, and `pip` Dependabot ecosystems.
- Uses the same bounded cadence for each ecosystem:
  - patch: 3 days
  - minor: 7 days
  - major: 30 days
  - default: 3 days
- Leaves all existing ignore rules, grouping, labels, schedules, and open PR limits unchanged.

Why

- `zizmor 1.24.1` reported `dependabot-cooldown` as a high-confidence finding for all three Dependabot ecosystems.
- GitHub documents `cooldown` as applying to version updates, not security updates, so this reduces version-update churn without delaying Dependabot security updates.
- This also reduces supply-chain race risk by not immediately adopting freshly-published dependency releases.

Scope

Included:

- `.github/dependabot.yml`

Explicitly excluded:

- action-v2 permission cleanup
- template-injection cleanup
- release cache-poisoning changes
- Dependabot schedule/group/ignore rewrites
- workflow refactors

Validation

- `uvx zizmor==1.24.1 --no-progress --min-confidence high --format=plain .github/dependabot.yml`
  - Result: `No findings to report. Good job! (3 ignored)`
- `git diff --check -- .github/dependabot.yml`
- pre-commit during commit, including YAML checks
- pre-push hooks during push, including workspace clippy and linux compile gate

References

- GitHub Dependabot `cooldown` option: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown

Next

Continue with a separate workflow-security cleanup PR for `action-v2-test.yml` workflow-level permissions or high-confidence template-injection findings.
