### PR TITLE
[codex] scope Action v2 security-events permission

### DIFF
--- a/.github/workflows/action-v2-test.yml
+++ b/.github/workflows/action-v2-test.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   build-assay-cli:
@@ -49,6 +48,9 @@ jobs:
     name: Test (no bundles - soft exit)
     runs-on: ubuntu-latest
     needs: build-assay-cli
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -80,6 +82,9 @@ jobs:
     name: Test (with valid bundle)
     runs-on: ubuntu-latest
     needs: build-assay-cli
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -148,6 +153,9 @@ jobs:
     name: Test (with compliance pack)
     runs-on: ubuntu-latest
     needs: build-assay-cli
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -205,6 +213,9 @@ jobs:
     name: Test (missing compliance pack failure mode)
     runs-on: ubuntu-latest
     needs: build-assay-cli
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -268,6 +279,9 @@ jobs:
     name: Test (invalid compliance pack failure mode)
     runs-on: ubuntu-latest
     needs: build-assay-cli
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
Summary

Continues the post-zizmor workflow-security cleanup with one focused finding: remove workflow-level `security-events: write` from `Action v2 Test` and grant it only to jobs that execute `./assay-action`.

Changes:

- Keeps workflow-level permissions at `contents: read` only.
- Adds job-level `contents: read` + `security-events: write` to the five jobs that run `uses: ./assay-action`.
- Leaves the CLI artifact producer job on the inherited read-only workflow permission.
- Leaves action behavior, action inputs, SARIF upload behavior, and test coverage unchanged.

Why

- `zizmor 1.24.1` reported workflow-level `security-events: write` as a high-confidence excessive-permissions finding.
- `assay-action` defaults `sarif: true`, so jobs that execute the local action still need `security-events: write` for same-repo SARIF upload behavior.
- Scoping the permission at job level keeps the intended SARIF test surface while removing broad workflow-level privilege.

Scope

Included:

- `.github/workflows/action-v2-test.yml`

Explicitly excluded:

- template-injection cleanup
- checkout `persist-credentials` cleanup
- changing `assay-action/action.yml`
- changing action-v2 test semantics
- workflow refactors

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/action-v2-test.yml`
- `uvx zizmor==1.24.1 --no-progress --min-confidence high --format=plain .github/workflows/action-v2-test.yml`
  - Result: `No findings to report. Good job! (28 ignored, 11 suppressed)`
- `git diff --check -- .github/workflows/action-v2-test.yml`
- pre-commit during commit, including GitHub Actions workflow lint
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

Continue with a separate template-injection cleanup PR for the remaining high-confidence findings.
