### PR TITLE
[codex] scope hosted eBPF smoke to eBPF changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       lightweight_only: ${{ steps.detect.outputs.lightweight_only }}
       changed_file_count: ${{ steps.detect.outputs.changed_file_count }}
       mcp_registry_touched: ${{ steps.detect.outputs.mcp_registry_touched }}
+      ebpf_smoke_required: ${{ steps.detect.outputs.ebpf_smoke_required }}
       self_hosted_ebpf_required: ${{ steps.detect.outputs.self_hosted_ebpf_required }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -34,6 +35,7 @@ jobs:
             : > "$changed_file"
             lightweight_only=false
             mcp_registry_touched=false
+            ebpf_smoke_required=true
             self_hosted_ebpf_required=true
           else
             if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
@@ -65,8 +67,10 @@ jobs:
             fi
 
             if grep -E '^(crates/assay-ebpf/|crates/assay-monitor/|infra/bpf-runner/|scripts/verify_lsm_docker\.sh$|scripts/ci/(apt_ports_failover|lsm_deny_smoke)\.sh$)' "$changed_file" >/dev/null; then
+              ebpf_smoke_required=true
               self_hosted_ebpf_required=true
             else
+              ebpf_smoke_required=false
               self_hosted_ebpf_required=false
             fi
           fi
@@ -75,6 +79,7 @@ jobs:
             echo "lightweight_only=${lightweight_only}"
             echo "changed_file_count=$(wc -l < "$changed_file" | tr -d ' ')"
             echo "mcp_registry_touched=${mcp_registry_touched}"
+            echo "ebpf_smoke_required=${ebpf_smoke_required}"
             echo "self_hosted_ebpf_required=${self_hosted_ebpf_required}"
           } >> "$GITHUB_OUTPUT"
 
@@ -84,6 +89,7 @@ jobs:
             echo "- lightweight_only: ${lightweight_only}"
             echo "- changed_file_count: $(wc -l < "$changed_file" | tr -d ' ')"
             echo "- mcp_registry_touched: ${mcp_registry_touched}"
+            echo "- ebpf_smoke_required: ${ebpf_smoke_required}"
             echo "- self_hosted_ebpf_required: ${self_hosted_ebpf_required}"
             if [[ -s "$changed_file" ]]; then
               echo ""
@@ -366,7 +372,8 @@ jobs:
   ebpf-smoke-ubuntu:
     name: eBPF monitor smoke (Linux - Ubuntu)
     needs: [scope, test]
-    if: needs.scope.outputs.lightweight_only != 'true'
+    if: needs.scope.outputs.ebpf_smoke_required == 'true'
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-ebpf-smoke-ubuntu
@@ -614,6 +621,7 @@ jobs:
           MCP_REGISTRY_FOUNDATION_RESULT: ${{ needs.mcp-registry-foundation.result }}
           PERF_RESULT: ${{ needs.perf.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          EBPF_SMOKE_REQUIRED: ${{ needs.scope.outputs.ebpf_smoke_required }}
           EBPF_SMOKE_UBUNTU_RESULT: ${{ needs.ebpf-smoke-ubuntu.result }}
         shell: bash
         run: |
@@ -643,4 +651,5 @@ jobs:
           done
 
           echo "lightweight_only=${LIGHTWEIGHT_ONLY}"
+          echo "ebpf_smoke_required=${EBPF_SMOKE_REQUIRED}"
           echo "All required CI jobs passed or were intentionally skipped."


### PR DESCRIPTION
Summary

Reduces the repeated CI long-tail from hosted Ubuntu eBPF smoke on pure workflow/config PRs.

Changes:

- Adds explicit `ebpf_smoke_required` to CI scope detection.
- Keeps the existing eBPF path set:
  - `crates/assay-ebpf/**`
  - `crates/assay-monitor/**`
  - `infra/bpf-runner/**`
  - `scripts/verify_lsm_docker.sh`
  - `scripts/ci/apt_ports_failover.sh`
  - `scripts/ci/lsm_deny_smoke.sh`
- Runs `eBPF monitor smoke (Linux - Ubuntu)` only when `ebpf_smoke_required=true`.
- Keeps `workflow_dispatch` forcing eBPF smoke coverage.
- Adds `timeout-minutes: 15` to the hosted Ubuntu eBPF smoke job.
- Reports `ebpf_smoke_required` in the scope summary and required CI aggregator output.

Why

PRs #1197 and #1198 were pure workflow/config changes but still waited on the hosted Ubuntu eBPF smoke long tail (~7m each). That job should protect eBPF/monitor/LSM surfaces, not every non-lightweight config PR.

Scope

Included:

- `.github/workflows/ci.yml`

Explicitly excluded:

- changing self-hosted eBPF runner behavior
- changing eBPF smoke scripts
- changing branch protection / required check names
- broad CI workflow refactors
- cache/tool install changes

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yml`
- `git diff --check -- .github/workflows/ci.yml`
- local regex sanity checks:
  - `.github/workflows/action-v2-test.yml` -> `ebpf_smoke_required=false`
  - `.github/dependabot.yml` -> `ebpf_smoke_required=false`
  - `crates/assay-ebpf/src/lib.rs` -> `true`
  - `crates/assay-monitor/src/lib.rs` -> `true`
  - `scripts/verify_lsm_docker.sh` -> `true`
- pre-commit during commit, including GitHub Actions workflow lint
- pre-push hooks during push, including workspace clippy and linux compile gate

Acceptance

- Pure workflow/config PRs no longer run the hosted Ubuntu eBPF smoke.
- eBPF/monitor/LSM PRs still run the hosted Ubuntu eBPF smoke.
- Required `CI` aggregator remains stable because it already accepts skipped dependency jobs.
