### PR TITLE
[codex] remove high-confidence workflow template injections

### DIFF
--- a/.github/workflows/baseline-gate-demo.yml
+++ b/.github/workflows/baseline-gate-demo.yml
@@ -28,9 +28,11 @@ jobs:
 
       - name: Fetch baseline from base branch (anti-tamper)
         shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          BASE="${{ github.base_ref }}"
+          BASE="${BASE_REF}"
           git fetch origin "$BASE" --depth=1 || echo "Base not found"
 
           # In a real setup we'd fetch baseline from artifact/main

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -140,6 +140,8 @@ jobs:
 
       - name: Commit and push regenerated assets
         shell: bash
+        env:
+          TARGET_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -152,7 +154,6 @@ jobs:
           fi
 
           git commit -m "chore: regenerate demo assets [skip ci]"
-          TARGET_REF="${{ inputs.ref }}"
           TARGET_BRANCH="${TARGET_REF#refs/heads/}"
 
           if ! git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,13 +156,20 @@ jobs:
       - name: Get version
         id: version
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_VERSION_INPUT: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            V="${{ github.event.inputs.version }}"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            V="${RELEASE_VERSION_INPUT}"
           else
             V="${GITHUB_REF#refs/tags/}"
           fi
-          echo "version=$V" >> "$GITHUB_OUTPUT"
+          if [[ "$V" == *$'\n'* || "$V" == *$'\r'* ]]; then
+            echo "::error::Release version must be a single-line value."
+            exit 1
+          fi
+          printf 'version=%s\n' "$V" >> "$GITHUB_OUTPUT"
 
       - name: Package (Unix)
         if: matrix.archive == 'tar.gz'
@@ -278,13 +285,20 @@ jobs:
       - name: Get version
         id: version
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_VERSION_INPUT: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            V="${{ github.event.inputs.version }}"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            V="${RELEASE_VERSION_INPUT}"
           else
             V="${GITHUB_REF#refs/tags/}"
           fi
-          echo "version=$V" >> "$GITHUB_OUTPUT"
+          if [[ "$V" == *$'\n'* || "$V" == *$'\r'* ]]; then
+            echo "::error::Release version must be a single-line value."
+            exit 1
+          fi
+          printf 'version=%s\n' "$V" >> "$GITHUB_OUTPUT"
 
       - name: Package assay-mcp-server
         shell: bash
@@ -328,13 +342,21 @@ jobs:
 
       - name: Get version
         id: version
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_VERSION_INPUT: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            V="${{ github.event.inputs.version }}"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            V="${RELEASE_VERSION_INPUT}"
           else
             V="${GITHUB_REF#refs/tags/}"
           fi
-          echo "version=$V" >> "$GITHUB_OUTPUT"
+          if [[ "$V" == *$'\n'* || "$V" == *$'\r'* ]]; then
+            echo "::error::Release version must be a single-line value."
+            exit 1
+          fi
+          printf 'version=%s\n' "$V" >> "$GITHUB_OUTPUT"
 
       - name: Install CycloneDX generator
         shell: bash

--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -42,10 +42,12 @@ jobs:
 
       - id: detect
         shell: bash
+        env:
+          SIMULATED_CHANGED_FILES: ${{ inputs.simulated_changed_files }}
         run: |
           set -euo pipefail
           changed_file="$RUNNER_TEMP/changed_files.txt"
-          simulated="${{ inputs.simulated_changed_files }}"
+          simulated="${SIMULATED_CHANGED_FILES}"
 
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             if [[ -n "${simulated}" ]]; then

--- a/assay-action/action.yml
+++ b/assay-action/action.yml
@@ -534,15 +534,21 @@ runs:
       env:
         USER_CATEGORY: ${{ inputs.category }}
         RUNNER_OS: ${{ runner.os }}
+        WORKFLOW_NAME: ${{ github.workflow }}
+        JOB_NAME: ${{ github.job }}
       run: |
         if [ -n "$USER_CATEGORY" ]; then
-          echo "category=$USER_CATEGORY" >> $GITHUB_OUTPUT
+          CATEGORY="$USER_CATEGORY"
         else
           # Auto-generate unique category per job + OS (matrix-safe)
           # Include runner.os to prevent collisions in matrix builds
-          CATEGORY="assay-${{ github.workflow }}-${{ github.job }}-${RUNNER_OS}"
-          echo "category=$CATEGORY" >> $GITHUB_OUTPUT
+          CATEGORY="assay-${WORKFLOW_NAME}-${JOB_NAME}-${RUNNER_OS}"
         fi
+        if [[ "$CATEGORY" == *$'\n'* || "$CATEGORY" == *$'\r'* ]]; then
+          echo "::error::SARIF category must be a single-line value."
+          exit 1
+        fi
+        printf 'category=%s\n' "$CATEGORY" >> "$GITHUB_OUTPUT"
 
     - name: Upload SARIF to GitHub Security
       id: upload-sarif


### PR DESCRIPTION
Summary

Removes the remaining high-confidence `zizmor` template-injection findings from workflow and composite-action shell steps by moving GitHub expression values into environment variables before shell evaluation.

Changes:

- Moves `github.base_ref` in `baseline-gate-demo.yml` into `BASE_REF`.
- Moves `inputs.ref` in `demo.yml` into `TARGET_REF`.
- Moves release version dispatch inputs/event name into env vars in all release `Get version` steps.
- Moves simulated split-gate file input into `SIMULATED_CHANGED_FILES`.
- Moves SARIF category workflow/job context in `assay-action/action.yml` into env vars before category construction.

Scope

Included:

- `.github/workflows/baseline-gate-demo.yml`
- `.github/workflows/demo.yml`
- `.github/workflows/release.yml`
- `.github/workflows/split-wave0-gates.yml`
- `assay-action/action.yml`

Explicitly excluded:

- superfluous `actions/cache` cleanup in release workflow
- cache-poisoning hardening
- broader workflow refactors
- reusable workflow extraction
- CI cost changes

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/baseline-gate-demo.yml .github/workflows/demo.yml .github/workflows/release.yml .github/workflows/split-wave0-gates.yml`
- `git diff --check -- .github/workflows/baseline-gate-demo.yml .github/workflows/demo.yml .github/workflows/release.yml .github/workflows/split-wave0-gates.yml assay-action/action.yml`
- `uvx zizmor==1.24.1 --no-progress --min-confidence high --format=plain ...` on the touched workflows/action: no remaining `error[template-injection]`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, continue with the next bounded CI-security cleanup: decide whether to remove the remaining superfluous release cache action or harden cache-save behavior in a separate PR.
