### PR TITLE
[codex] use gh CLI for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -572,17 +572,29 @@ jobs:
           sed -i "s|__CHANGELOG_URL__|https://github.com/${REPO}/blob/main/CHANGELOG.md|g" release_notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          name: Assay ${{ steps.version.outputs.version }}
-          tag_name: ${{ steps.version.outputs.version }}
-          target_commitish: ${{ github.sha }}
-          body_path: release_notes.md
-          draft: false
-          prerelease: ${{ contains(steps.version.outputs.version, '-rc') || contains(steps.version.outputs.version, '-beta') }}
-          files: release/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=(release/*)
+          if [[ ${#assets[@]} -eq 0 ]]; then
+            echo "::error::No release assets found in release/."
+            exit 1
+          fi
+          release_args=(
+            "$VERSION"
+            "${assets[@]}"
+            --title "Assay $VERSION"
+            --target "$GITHUB_SHA"
+            --notes-file release_notes.md
+          )
+          if [[ "$VERSION" == *-rc* || "$VERSION" == *-beta* ]]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create "${release_args[@]}"
 
   # ============================================================
   # Verify LSM Enforcement (Self-Hosted Gate)


### PR DESCRIPTION
Summary

Removes the remaining high-confidence `zizmor` `superfluous-actions` finding in the release workflow by replacing `softprops/action-gh-release` with the GitHub-hosted runner's native `gh release create` command.

Changes:

- Drops the third-party release creation action from `.github/workflows/release.yml`.
- Creates the release with `gh release create` using the same version, asset glob, title, target commit, and release notes file.
- Preserves prerelease behavior for `-rc` and `-beta` versions.
- Uses `GH_TOKEN` with the existing release job `contents: write` permission.

Scope

Included:

- `.github/workflows/release.yml`

Explicitly excluded:

- release asset layout changes
- attestation/provenance behavior changes
- broader release workflow refactors
- cache hardening or cache cleanup
- reusable workflow extraction

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml`
- `git diff --check -- .github/workflows/release.yml`
- `uvx zizmor==1.24.1 --no-progress --min-confidence high --format=plain .github/workflows/release.yml` returns `status=0`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, rerun high-confidence `zizmor` across workflows/actions to confirm the current bounded CI-security sweep is clean, then decide whether cache-poisoning hardening deserves its own PR.
