### PR TITLE
[codex] extend Dependabot cooldown window

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,10 @@ updates:
       - "ci"
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 7
-      semver-patch-days: 3
+      semver-patch-days: 7
     ignore:
       # Major version bumps need manual review (breaking changes)
       - dependency-name: "*"
@@ -46,10 +46,10 @@ updates:
       - "rust"
     open-pull-requests-limit: 10
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 7
-      semver-patch-days: 3
+      semver-patch-days: 7
     ignore:
       # rand 0.9 requires coordinated updates with ed25519-dalek (crypto RNG trait changes)
       # See: docs/architecture/ADR-020-Dependency-Governance.md
@@ -85,7 +85,7 @@ updates:
       - "python"
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 3
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 7
-      semver-patch-days: 3
+      semver-patch-days: 7


### PR DESCRIPTION
Summary

Addresses the remaining `zizmor` `dependabot-cooldown` findings by extending Dependabot's default and patch cooldown windows from 3 to 7 days.

Changes:

- GitHub Actions updates: `default-days` and `semver-patch-days` now 7.
- Cargo updates: `default-days` and `semver-patch-days` now 7.
- Python SDK pip updates: `default-days` and `semver-patch-days` now 7.
- Major remains 30 days and minor remains 7 days.

Scope

Included:

- `.github/dependabot.yml`

Explicitly excluded:

- Dependabot maintenance workflow changes
- auto-merge policy changes
- dependency ignore rule changes
- open PR limit changes
- broader workflow hardening

Validation

- `uvx zizmor==1.24.1 --no-progress --format=plain .github/dependabot.yml` returns `status=0`
- `git diff --check -- .github/dependabot.yml`
- YAML parse smoke via Ruby
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Operational note

This intentionally trades a little dependency freshness for lower supply-chain exposure to newly published compromised packages and less immediate Dependabot queue churn.

Next

After this lands, continue with the next bounded low-confidence workflow hardening slice: either action-test template-output cleanup or a scoped checkout `persist-credentials: false` pass.
