### PR TITLE
[codex] remove privileged Dependabot PR trigger

### DIFF
--- a/.github/workflows/dependabot-maintenance.yml
+++ b/.github/workflows/dependabot-maintenance.yml
@@ -1,8 +1,6 @@
 name: Dependabot Queue Maintenance
 
 on:
-  pull_request_target:
-    types: [opened, reopened, ready_for_review]
   push:
     branches: [main]
   schedule:
@@ -16,44 +14,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  enable-auto-merge:
-    name: Enable auto-merge for Dependabot PRs
-    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Enable auto-merge
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          already_enabled="$(
-            gh pr view "$PR_NUMBER" --repo "$REPO" --json autoMergeRequest --jq 'if .autoMergeRequest then "true" else "false" end'
-          )"
-
-          if [[ "$already_enabled" == "true" ]]; then
-            echo "Auto-merge already enabled for Dependabot PR #$PR_NUMBER" >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          gh pr merge "$PR_NUMBER" --repo "$REPO" --merge --auto
-          echo "Enabled auto-merge for Dependabot PR #$PR_NUMBER" >> "$GITHUB_STEP_SUMMARY"
-
   refresh-queue:
     name: Refresh dependency queue PR branches
-    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Refresh queue
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Summary

Removes the privileged `pull_request_target` path from Dependabot Queue Maintenance and lets the existing queue maintenance job handle auto-merge/update work from trusted triggers only.

Changes:

- Drops the `pull_request_target` trigger from `.github/workflows/dependabot-maintenance.yml`.
- Removes the dedicated per-PR auto-merge job that depended on `github.actor == 'dependabot[bot]'`.
- Keeps the existing `refresh-queue` job for `push` to `main`, scheduled runs, and manual dispatch.
- Keeps auto-merge/update behavior in `scripts/ci/dependabot-maintenance.sh`, which scans open Dependabot and replacement dependency PRs.
- Sets `persist-credentials: false` on the checkout used by the maintenance job.

Scope

Included:

- `.github/workflows/dependabot-maintenance.yml`

Explicitly excluded:

- dependency queue script changes
- Dependabot cooldown changes
- auto-merge strategy changes beyond removing the privileged PR-event fast path
- broader checkout hardening across other workflows
- branch-protection changes

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/dependabot-maintenance.yml`
- `git diff --check -- .github/workflows/dependabot-maintenance.yml`
- `uvx zizmor==1.24.1 --no-progress --format=plain .github/workflows/dependabot-maintenance.yml` returns `status=0`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Operational note

Dependabot auto-merge is no longer enabled immediately from the PR event. It is handled by the trusted schedule/push/manual maintenance job instead, avoiding a privileged PR-triggered workflow while preserving queue upkeep.
