### PR TITLE
[codex] tighten low-risk workflow permissions

### DIFF
--- a/.github/workflows/codespaces-prebuild.yml
+++ b/.github/workflows/codespaces-prebuild.yml
@@ -12,6 +12,8 @@ on:
     - cron: '0 6 * * 1'  # Monday 6:00 UTC
   workflow_dispatch:
 
+permissions: {}
+
 # GitHub builds the prebuild image automatically based on
 # .devcontainer/devcontainer.json — you only need to configure the trigger.
 # Go to: Settings → Codespaces → Set up prebuild

--- a/.github/workflows/perf_pr_closed.yml
+++ b/.github/workflows/perf_pr_closed.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   archive_pr_branch:
     name: Archive closed PR branch with Bencher
@@ -13,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: bencherdev/bencher@0f8f620172ccd6225d40a7590598eb7b41718af8 # v0.6.2
       - name: Archive closed PR branch with Bencher
         env:


### PR DESCRIPTION
Summary

Removes the remaining `zizmor` excessive-permissions findings from two low-risk workflows and hardens the Bencher archive checkout credential handling.

Changes:

- Adds `permissions: {}` to `codespaces-prebuild.yml`, which only emits a trigger echo and does not need a token.
- Adds top-level `contents: read` to `perf_pr_closed.yml`.
- Sets `persist-credentials: false` on the Bencher archive workflow checkout.

Scope

Included:

- `.github/workflows/codespaces-prebuild.yml`
- `.github/workflows/perf_pr_closed.yml`

Explicitly excluded:

- broader checkout hardening across all workflows
- cache-poisoning hardening
- action composite `GITHUB_PATH` behavior changes
- Bencher archive behavior changes
- required-check or trigger changes

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/codespaces-prebuild.yml .github/workflows/perf_pr_closed.yml`
- `git diff --check -- .github/workflows/codespaces-prebuild.yml .github/workflows/perf_pr_closed.yml`
- `uvx zizmor==1.24.1 --no-progress --format=plain .github/workflows/codespaces-prebuild.yml .github/workflows/perf_pr_closed.yml` returns `status=0`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, the remaining meaningful `zizmor` classes are cache-poisoning in release/cache paths, the composite action `GITHUB_PATH` write, broad checkout credential persistence, and low-confidence template-output cleanup.
