### PR TITLE
[codex] disable release build caches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,11 +145,6 @@ jobs:
             echo "AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar"
           } >> "$GITHUB_ENV"
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-        with:
-          key: release-${{ matrix.target }}
-
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} --package assay-cli
 
@@ -273,11 +268,6 @@ jobs:
             echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc"
             echo "AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar"
           } >> "$GITHUB_ENV"
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-        with:
-          key: release-mcp-server-${{ matrix.target }}
 
       - name: Build assay-mcp-server binary
         run: cargo build --release --target ${{ matrix.target }} --package assay-mcp-server
@@ -703,7 +693,7 @@ jobs:
           # required inside the manylinux container and harmless on macOS,
           # where setup-python provides the same Python version.
           args: --release --out dist --locked -i python3.12 --compatibility pypi
-          sccache: 'true'
+          sccache: 'false'
           manylinux: auto
 
       - name: Upload wheels


### PR DESCRIPTION
Summary

Hardens the release workflow against `zizmor` cache-poisoning findings by removing release-build cache use from artifact-producing jobs.

Changes:

- Removes `Swatinem/rust-cache` from the assay CLI release build matrix.
- Removes `Swatinem/rust-cache` from the assay MCP server release build matrix.
- Disables `sccache` in the PyO3/maturin wheel build step.

Scope

Included:

- `.github/workflows/release.yml`

Explicitly excluded:

- non-release CI cache strategy changes
- release artifact layout changes
- release trigger changes
- release signing/attestation/provenance changes
- checkout credential persistence cleanup
- low-confidence template-output cleanup

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml`
- `git diff --check -- .github/workflows/release.yml`
- `uvx zizmor==1.24.1 --no-progress --format=plain .github/workflows/release.yml` no longer reports `cache-poisoning`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Trade-off

Release builds may be slower, but published release artifacts no longer depend on mutable build caches. This keeps fast caches available in normal CI while making the release path stricter.
