### PR TITLE
[codex] record assay action PATH compatibility

### DIFF
--- a/assay-action/README.md
+++ b/assay-action/README.md
@@ -174,6 +174,16 @@ jobs:
 | `bundle_url` | BYOS URL (if pushed) |
 | `attestation_url` | Attestation URL (if generated) |
 
+## PATH Compatibility
+
+When the action installs the Assay CLI, v2 also adds `~/.assay/bin` to `PATH`
+for later steps in the same job. This lets workflows call `assay` directly after
+`Rul1an/assay-action@v2` runs and is treated as a v2 compatibility guarantee.
+
+A future major version may replace this implicit export with an explicit opt-in
+such as `export_path` plus an `assay_path` output, but v2 must keep the current
+behavior.
+
 ## Permissions
 
 ```yaml

--- a/assay-action/action.yml
+++ b/assay-action/action.yml
@@ -349,8 +349,10 @@ runs:
       id: verify-install
       if: steps.check-existing.outputs.skip_install != 'true'
       shell: bash
-      run: |
-        echo "$HOME/.assay/bin" >> $GITHUB_PATH
+      run: | # zizmor: ignore[github-env] v2 compatibility exports a literal install dir for later caller steps
+        # v2 compatibility: later caller steps may invoke `assay` directly.
+        # Keep exporting this literal install directory until a major-version contract change.
+        printf '%s\n' "$HOME/.assay/bin" >> "$GITHUB_PATH"
         export PATH="$HOME/.assay/bin:$PATH"
 
         if ! ~/.assay/bin/assay --version; then

--- a/docs/architecture/SPEC-GitHub-Action-v2.1.md
+++ b/docs/architecture/SPEC-GitHub-Action-v2.1.md
@@ -196,6 +196,17 @@ MUST match one of:
 
 ## 4. Output Contract
 
+### 4.0 PATH Compatibility (v2)
+
+If the action installs the Assay CLI, it MUST add `~/.assay/bin` to `PATH` for
+subsequent steps in the same job. This is a v2 compatibility contract: workflows
+may call `assay` directly after `Rul1an/assay-action@v2` completes.
+
+This PATH export is intentionally limited to the literal install directory. A
+future major version may replace the implicit export with an explicit opt-in
+input such as `export_path` and an `assay_path` output, but v2 MUST preserve the
+current behavior.
+
 ### 4.1 Existing Outputs (v2.0)
 
 | Output | Type | Description |


### PR DESCRIPTION
Summary

Records the explicit v2 compatibility decision for `assay-action` PATH export instead of treating the remaining `GITHUB_PATH` scanner finding as an accidental implementation detail.

Changes:

- Keeps the current v2 behavior: when the action installs Assay, later caller steps can invoke `assay` directly.
- Switches the `GITHUB_PATH` write from `echo ... >> $GITHUB_PATH` to `printf ... >> "$GITHUB_PATH"` with a literal install directory.
- Adds an inline zizmor ignore with rationale on the exact compatibility step.
- Documents the v2 compatibility guarantee in `assay-action/README.md` and `SPEC-GitHub-Action-v2.1.md`.
- Notes the future major-version migration shape: explicit `export_path` opt-in plus `assay_path` output.

Scope

Included:

- `assay-action/action.yml`
- `assay-action/README.md`
- `docs/architecture/SPEC-GitHub-Action-v2.1.md`

Explicitly excluded:

- Removing `GITHUB_PATH` behavior in v2
- Adding a new action input or output
- Broad workflow `persist-credentials` sweep
- Low-confidence template-injection cleanup
- Workflow refactors

Validation

- `ruby -e 'require "yaml"; YAML.load_file("assay-action/action.yml"); YAML.load_file(".github/workflows/assay.yml"); puts "yaml ok"'`
- `git diff --check -- assay-action/action.yml assay-action/README.md docs/architecture/SPEC-GitHub-Action-v2.1.md`
- `uvx zizmor==1.24.1 --no-progress --format=plain assay-action/action.yml`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, continue with the first mechanical `persist-credentials: false` sweep on `action-tests.yml` and `action-v2-test.yml`.
