### PR TITLE
[codex] disable persisted checkout credentials in action contracts

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Build CLI once
         run: cargo build --release --workspace --exclude assay-ebpf
@@ -53,6 +55,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download CLI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -153,6 +157,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Test fork detection logic
         env:
@@ -208,6 +214,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Test store URL provider detection
         run: |
@@ -254,6 +262,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Test attestation gating logic
         run: |
@@ -342,6 +352,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Test coverage formula
         run: |
@@ -394,6 +406,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download CLI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -459,6 +473,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download CLI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/action-v2-test.yml
+++ b/.github/workflows/action-v2-test.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Build Assay CLI once
         run: cargo build --release -p assay-cli
@@ -53,6 +55,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download CLI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -87,6 +91,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download CLI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -158,6 +164,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download CLI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -218,6 +226,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download CLI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -284,6 +294,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download CLI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
Summary

Performs the first bounded `persist-credentials: false` sweep on action contract workflows.

Changes:

- Adds `persist-credentials: false` to all `actions/checkout` steps in `action-tests.yml`.
- Adds `persist-credentials: false` to all `actions/checkout` steps in `action-v2-test.yml`.
- Keeps all action contract behavior, artifact reuse, permissions, and test semantics unchanged.

Scope

Included:

- `.github/workflows/action-tests.yml`
- `.github/workflows/action-v2-test.yml`

Explicitly excluded:

- Workflows with commit/push/deploy semantics
- Broad read-only workflow sweep
- Low-confidence template-injection cleanup
- Reusable workflow refactors
- Checkout/action version changes

Zizmor delta

- Repo-wide `artipacked`: 64 -> 50.
- Touched workflows `artipacked`: 14 -> 0.
- Remaining findings in touched workflows are `template-injection` infos and intentionally out of scope for this PR.

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/action-tests.yml .github/workflows/action-v2-test.yml`
- `git diff --check -- .github/workflows/action-tests.yml .github/workflows/action-v2-test.yml`
- `uvx zizmor==1.24.1 --no-progress --format=json .github/workflows/action-tests.yml .github/workflows/action-v2-test.yml`
- repo-wide `uvx zizmor==1.24.1 --no-progress --format=json .github/workflows .github/dependabot.yml assay-action/action.yml` for delta measurement
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, continue with the broad read-only checkout sweep across CI, kernel matrix, split gates, docs-link, smoke, security, perf, and runner-health workflows. Keep demo/docs deploy exceptions separate.
