### PR TITLE
[codex] disable persisted checkout credentials in read-only workflows

### DIFF
--- a/.github/workflows/adr025-nightly-closure.yml
+++ b/.github/workflows/adr025-nightly-closure.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/adr025-nightly-otel-bridge.yml
+++ b/.github/workflows/adr025-nightly-otel-bridge.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Prepare artifacts dir
         run: |

--- a/.github/workflows/adr025-nightly-readiness.yml
+++ b/.github/workflows/adr025-nightly-readiness.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Prepare dirs
         run: |

--- a/.github/workflows/adr025-nightly-soak.yml
+++ b/.github/workflows/adr025-nightly-soak.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/assay-security.yml
+++ b/.github/workflows/assay-security.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Assay
         shell: bash

--- a/.github/workflows/assay.yml
+++ b/.github/workflows/assay.yml
@@ -7,6 +7,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.1
+        with:
+          persist-credentials: false
       - name: Setup Assay
         uses: ./assay-action
         with:

--- a/.github/workflows/baseline-gate-demo.yml
+++ b/.github/workflows/baseline-gate-demo.yml
@@ -15,6 +15,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Cache Assay store (baseline-gate)
         id: assay-cache
@@ -30,10 +32,13 @@ jobs:
         shell: bash
         env:
           BASE_REF: ${{ github.base_ref }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           BASE="${BASE_REF}"
-          git fetch origin "$BASE" --depth=1 || echo "Base not found"
+          AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
+            fetch origin "$BASE" --depth=1 || echo "Base not found"
 
           # In a real setup we'd fetch baseline from artifact/main
           # For this demo we use local baseline.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - id: detect
@@ -108,6 +109,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Install cargo-deny
         run: cargo install --locked cargo-deny
       - name: Install cargo-audit
@@ -129,6 +132,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Swatinem/rust-cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install Linux deps (for build scripts)
@@ -158,6 +163,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Check open core boundary
         run: ./scripts/ci/check-open-core-boundary.sh
 
@@ -168,6 +175,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Check vendored pack files are in sync
         run: ./scripts/check-vendored-packs.sh
 
@@ -180,6 +189,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -196,6 +207,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Swatinem/rust-cache
         id: rust-cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
@@ -260,6 +273,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -382,6 +397,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -32,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Collect changed docs files

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -34,6 +34,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -80,6 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Check for eBPF-related changes
@@ -206,6 +209,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Dependencies
         shell: bash
@@ -410,6 +415,8 @@ jobs:
           echo "TMPDIR=/dev/shm/assay-tmp-${{ matrix.kernel }}-${{ github.run_id }}" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -91,6 +93,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/perf_main.yml
+++ b/.github/workflows/perf_main.yml
@@ -27,6 +27,8 @@ jobs:
       QUICK: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Swatinem/rust-cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install Linux deps

--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -22,6 +22,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Swatinem/rust-cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2

--- a/.github/workflows/perf_pr.yml
+++ b/.github/workflows/perf_pr.yml
@@ -34,6 +34,8 @@ jobs:
       QUICK: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Swatinem/rust-cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       - name: Install Linux deps

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check runner status
         id: check

--- a/.github/workflows/smoke-install.yml
+++ b/.github/workflows/smoke-install.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - id: detect
@@ -157,6 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Swatinem/rust-cache
@@ -292,6 +294,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Swatinem/rust-cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
@@ -357,6 +361,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Swatinem/rust-cache
@@ -369,13 +374,19 @@ jobs:
 
       - name: Ensure semver baseline commit is available
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if git cat-file -e "${WAVE0_SEMVER_BASELINE_SHA}^{commit}" 2>/dev/null; then
             echo "Baseline commit present: ${WAVE0_SEMVER_BASELINE_SHA}"
           else
             echo "Baseline commit missing locally, fetching explicitly..."
-            git fetch --no-tags origin "${WAVE0_SEMVER_BASELINE_SHA}" || git fetch --no-tags origin "${WAVE0_SEMVER_BASELINE_SHA}:refs/temp/wave0-baseline"
+            AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
+              fetch --no-tags origin "${WAVE0_SEMVER_BASELINE_SHA}" || \
+              git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
+                fetch --no-tags origin "${WAVE0_SEMVER_BASELINE_SHA}:refs/temp/wave0-baseline"
             git cat-file -e "${WAVE0_SEMVER_BASELINE_SHA}^{commit}"
           fi
           # Cleanup fallback ref if created by the alternate fetch path.
@@ -437,6 +448,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Wave 0.1 stub
         shell: bash

--- a/.github/workflows/structurizr-validate.yml
+++ b/.github/workflows/structurizr-validate.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Validate Structurizr workspaces
         run: |

--- a/.github/workflows/wave6-nightly-readiness.yml
+++ b/.github/workflows/wave6-nightly-readiness.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Generate readiness report

--- a/.github/workflows/wave6-nightly-safety.yml
+++ b/.github/workflows/wave6-nightly-safety.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -61,6 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/week8-sota-gates.yml
+++ b/.github/workflows/week8-sota-gates.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Swatinem/rust-cache
@@ -69,6 +70,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Swatinem/rust-cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2


### PR DESCRIPTION
Summary

Performs the broad read-only `persist-credentials: false` sweep after the action-contract pilot PR.

Changes:

- Adds `persist-credentials: false` to checkout steps in read-only CI/test/lint/security/perf/nightly workflows.
- Preserves existing checkout options such as `fetch-depth: 0`.
- Leaves workflows with release/publish/commit/PR/deploy semantics untouched for a separate exception-focused PR.

Scope

Included:

- `ci.yml`
- `kernel-matrix.yml`
- `split-wave0-gates.yml`
- `week8-sota-gates.yml`
- `wave6-nightly-safety.yml`
- `wave6-nightly-readiness.yml`
- `parity.yml`
- `docs-link-check.yml`
- `baseline-gate-demo.yml`
- `assay.yml`
- `assay-security.yml`
- `smoke-install.yml`
- `runner-health.yml`
- `perf_pr.yml`
- `perf_main.yml`
- `perf_nightly.yml`
- `structurizr-validate.yml`
- `adr025-nightly-closure.yml`
- `adr025-nightly-readiness.yml`
- `adr025-nightly-otel-bridge.yml`
- `adr025-nightly-soak.yml`

Explicitly excluded:

- `release.yml` because it creates releases, publishes crates/wheels, and uses release environments.
- `demo.yml` because it has an optional commit/push path.
- `docs.yml` because it deploys GitHub Pages via `mkdocs gh-deploy`.
- `docs-auto-update.yml` because it creates and auto-merges PRs.
- Low-confidence template-injection cleanup.
- Checkout/action version changes.

Zizmor delta

- Repo-wide `artipacked`: 50 -> 10.
- Remaining `artipacked` findings are only in the intentionally excluded workflows:
  - `release.yml`: 6
  - `demo.yml`: 2
  - `docs.yml`: 1
  - `docs-auto-update.yml`: 1

Validation

- `actionlint -config-file .github/actionlint.yaml ...` on all touched workflows.
- `git diff --check -- .github/workflows`
- Repo-wide `uvx zizmor==1.24.1 --no-progress --format=json .github/workflows .github/dependabot.yml assay-action/action.yml` for delta measurement.
- pre-commit hooks during commit.
- pre-push hooks during push, including workspace clippy and linux compile gate.

Next

Handle the remaining 10 findings in a separate exception PR: either add `persist-credentials: false` with explicit token-based push/deploy alternatives, or leave credentials persisted with short comments explaining the contract.
