### PR TITLE
[codex] remove persisted checkout credentials from publish workflows

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Checkout target ref
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref }}
 
       - name: Install VHS runtime dependencies (pinned)
@@ -123,6 +124,7 @@ jobs:
       - name: Checkout target ref
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref }}
 
       - name: Download generated assets
@@ -142,10 +144,12 @@ jobs:
         shell: bash
         env:
           TARGET_REF: ${{ inputs.ref }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
 
           git add -A demo/output
           if git diff --cached --quiet; then
@@ -156,9 +160,11 @@ jobs:
           git commit -m "chore: regenerate demo assets [skip ci]"
           TARGET_BRANCH="${TARGET_REF#refs/heads/}"
 
-          if ! git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null 2>&1; then
+          if ! git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
+            ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null 2>&1; then
             echo "Ref '${TARGET_REF}' is not a pushable remote branch."
             exit 1
           fi
 
-          git push origin "HEAD:${TARGET_BRANCH}"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${AUTH_HEADER}" \
+            push origin "HEAD:${TARGET_BRANCH}"

--- a/.github/workflows/docs-auto-update.yml
+++ b/.github/workflows/docs-auto-update.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0 # Full history for changelog
 
       - name: Setup Rust

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - name: Configure Git Credentials
+      - name: Configure Git Identity
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
@@ -32,4 +34,11 @@ jobs:
           pip install --requirement docs/requirements-ci.txt
 
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${AUTH_HEADER}"
+          trap 'git config --local --unset-all http.https://github.com/.extraheader || true' EXIT
+          mkdocs gh-deploy --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -215,6 +217,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -326,6 +330,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -600,6 +606,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -642,6 +650,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -680,6 +690,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'


### PR DESCRIPTION
Summary

Completes the checkout credential hardening sweep by handling the remaining publish/push/deploy workflows without keeping checkout credentials persisted.

Changes:

- Adds `persist-credentials: false` to the remaining checkout steps in `release.yml`, `demo.yml`, `docs.yml`, and `docs-auto-update.yml`.
- Keeps release publishing auth on existing explicit mechanisms: `gh` with `GH_TOKEN`, OIDC/trusted publishing, and artifact attestation permissions.
- Updates the demo asset push path to use explicit temporary git auth only for `ls-remote` and `push`.
- Updates the docs deploy path to configure a temporary git extraheader only around `mkdocs gh-deploy`, then unset it via `trap`.
- Leaves `docs-auto-update.yml` on explicit token inputs / `gh` commands, with checkout credentials disabled.

Scope

Included:

- `.github/workflows/release.yml`
- `.github/workflows/demo.yml`
- `.github/workflows/docs.yml`
- `.github/workflows/docs-auto-update.yml`

Explicitly excluded:

- Release asset layout changes
- Publishing behavior changes
- Reusable workflow refactors
- Low-confidence template-injection cleanup
- Action version upgrades

Zizmor delta

- Repo-wide `artipacked`: 10 -> 0.
- Repo-wide medium+ findings: 0.
- Remaining findings are low-confidence `template-injection` infos and intentionally out of scope.

Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml .github/workflows/demo.yml .github/workflows/docs.yml .github/workflows/docs-auto-update.yml`
- `git diff --check -- .github/workflows/release.yml .github/workflows/demo.yml .github/workflows/docs.yml .github/workflows/docs-auto-update.yml`
- Repo-wide `uvx zizmor==1.24.1 --no-progress --format=json .github/workflows .github/dependabot.yml assay-action/action.yml`
- Repo-wide `uvx zizmor==1.24.1 --no-progress --min-severity medium --format=json .github/workflows .github/dependabot.yml assay-action/action.yml`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, the checkout credential/artipacked sweep is complete. The remaining workflow-security backlog is low-confidence template-injection cleanup, best handled in small workflow-family slices.
