### PR TITLE
[codex] finish workflow template interpolation cleanup

### DIFF
--- a/.github/workflows/baseline-gate-demo.yml
+++ b/.github/workflows/baseline-gate-demo.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Prove cache hit (job summary)
         if: always()
+        env:
+          CACHE_HIT: ${{ steps.assay-cache.outputs.cache-hit }}
         run: |
-          echo "cache-hit=${{ steps.assay-cache.outputs.cache-hit }}"
-          echo "cache-hit=${{ steps.assay-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "cache-hit=${CACHE_HIT}"
+          echo "cache-hit=${CACHE_HIT}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,9 +251,11 @@ jobs:
           if-no-files-found: ignore
       - name: Prove cache hit (job summary)
         if: always()
+        env:
+          CACHE_HIT: ${{ steps.rust-cache.outputs.cache-hit }}
         run: |
-          echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
-          echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "cache-hit=${CACHE_HIT}"
+          echo "cache-hit=${CACHE_HIT}" >> "$GITHUB_STEP_SUMMARY"
 
   test:
     name: Build + Test (${{ matrix.os }})

--- a/.github/workflows/docs-auto-update.yml
+++ b/.github/workflows/docs-auto-update.yml
@@ -105,8 +105,10 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true' && steps.create_pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          CREATED_PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
         run: |
-          pr_number="${{ steps.create_pr.outputs.pull-request-number }}"
+          pr_number="${CREATED_PR_NUMBER}"
           head_sha="$(gh pr view "$pr_number" --json headRefOid --jq '.headRefOid')"
           payload_file="$(mktemp)"
           jq -n \
@@ -122,7 +124,7 @@ jobs:
                 summary: $summary
               }
             }' > "$payload_file"
-          gh api "repos/${{ github.repository }}/check-runs" \
+          gh api "repos/${REPO}/check-runs" \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             --input "$payload_file"
@@ -132,4 +134,5 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true' && steps.create_pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr merge "${{ steps.create_pr.outputs.pull-request-number }}" --auto --squash
+          CREATED_PR_NUMBER: ${{ steps.create_pr.outputs.pull-request-number }}
+        run: gh pr merge "$CREATED_PR_NUMBER" --auto --squash

--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -120,11 +120,13 @@ jobs:
           retention-days: 90
 
       - name: Trend summary
+        env:
+          FORENSIC_STATUS: ${{ steps.forensic.outputs.forensic_status }}
         run: |
           {
             echo "## Trend Analysis"
             echo ""
-            echo "Status: ${{ steps.forensic.outputs.forensic_status }}"
+            echo "Status: ${FORENSIC_STATUS}"
             echo ""
             echo "View historical artifacts to track trends over time."
             echo ""

--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -130,5 +130,5 @@ jobs:
             echo ""
             echo "View historical artifacts to track trends over time."
             echo ""
-            echo "Bencher dashboard: https://bencher.dev/perf/${{ secrets.BENCHER_PROJECT }}"
+            echo "Bencher dashboard: configured through BENCHER_PROJECT"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Summary

Finishes the bounded workflow template-interpolation cleanup by removing the last low-confidence zizmor template-injection findings from small workflow clusters.

Changes:

- Moves cache-hit outputs into CACHE_HIT env vars before echoing summaries in baseline-gate-demo.yml and ci.yml.
- Moves docs auto-update PR number and repository values into env vars before gh CLI/API usage.
- Moves perf nightly forensic status into FORENSIC_STATUS before writing the trend summary.
- Removes the secret-backed Bencher project slug from the perf nightly summary output.

Scope

Included:

- .github/workflows/baseline-gate-demo.yml
- .github/workflows/ci.yml
- .github/workflows/docs-auto-update.yml
- .github/workflows/perf_nightly.yml

Explicitly excluded:

- trigger or permission changes
- docs auto-update behavior changes
- cache strategy changes
- perf benchmark behavior changes
- broader workflow refactors

Validation

- actionlint -config-file .github/actionlint.yaml .github/workflows/baseline-gate-demo.yml .github/workflows/ci.yml .github/workflows/docs-auto-update.yml .github/workflows/perf_nightly.yml
- git diff --check -- .github/workflows/baseline-gate-demo.yml .github/workflows/ci.yml .github/workflows/docs-auto-update.yml .github/workflows/perf_nightly.yml
- uvx zizmor==1.24.1 --no-progress --format=json .github/workflows .github/dependabot.yml assay-action/action.yml
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Zizmor delta

- repo-wide template-injection: 7 -> 0
- repo-wide total findings: 7 -> 0
- repo-wide medium/high findings: 0 -> 0

Next

After this lands, the bounded workflow-security sweep can be closed with a final posture summary and any separately scoped future hardening work.

