### PR TITLE
[codex] fix gh release asset selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -595,8 +595,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          assets=(release/*)
+          assets=()
+          while IFS= read -r -d '' asset; do
+            assets+=("$asset")
+          done < <(find release -maxdepth 1 -type f -print0 | sort -z)
           if [[ ${#assets[@]} -eq 0 ]]; then
             echo "::error::No release assets found in release/."
             exit 1


### PR DESCRIPTION
Summary

Fixes the v3.10.0 release workflow failure introduced by the native gh release create path: the release asset glob included the release/sbom directory, so gh attempted to upload a directory as an asset.

Changes:

- Builds the release asset list from top-level files only using find -type f.
- Keeps fail-closed behavior when no release assets are present.
- Leaves release asset layout, provenance, SBOM generation, PyPI, and crates.io behavior unchanged.

Failure being fixed:

- v3.10.0 tag run failed at Create GitHub Release with: read release/sbom: is a directory.
- No GitHub Release was created and publish jobs were skipped.

Validation:

- actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml
- git diff --check -- .github/workflows/release.yml
- uvx zizmor==1.24.1 --no-progress --min-confidence high --format=plain .github/workflows/release.yml

Post-merge:

- Recreate/re-push the v3.10.0 tag on the fixed main commit, because the current pushed tag points at the workflow version that cannot publish.