### PR TITLE
[codex] enforce public crate release truth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -682,6 +682,9 @@ jobs:
       - name: Debug Cargo Version
         run: cargo --version
 
+      - name: Check public crate policy
+        run: bash scripts/ci/check-public-crate-policy.sh
+
       - name: Authenticate with crates.io
         id: auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1

--- a/assay-python-sdk/Cargo.toml
+++ b/assay-python-sdk/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "Python bindings for Assay trace capture, policy coverage, and explanation helpers."
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/assay-adapter-a2a/Cargo.toml
+++ b/crates/assay-adapter-a2a/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 authors.workspace = true
 description = "A2A protocol adapter for Assay evidence translation."
 readme.workspace = true
+publish = false
 
 [dependencies]
 assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }

--- a/crates/assay-adapter-acp/Cargo.toml
+++ b/crates/assay-adapter-acp/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 authors.workspace = true
 description = "ACP protocol adapter for Assay evidence translation."
 readme.workspace = true
+publish = false
 
 [dependencies]
 assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }

--- a/crates/assay-adapter-api/Cargo.toml
+++ b/crates/assay-adapter-api/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 authors.workspace = true
 description = "Protocol adapter API contracts for Assay evidence translation."
 readme.workspace = true
+publish = false
 
 [dependencies]
 assay-evidence = { path = "../assay-evidence", version = "3.0.0" }

--- a/crates/assay-adapter-ucp/Cargo.toml
+++ b/crates/assay-adapter-ucp/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 authors.workspace = true
 description = "UCP protocol adapter for Assay evidence translation."
 readme.workspace = true
+publish = false
 
 [dependencies]
 assay-adapter-api = { path = "../assay-adapter-api", version = "3.0.0" }

--- a/docs/architecture/ADR-026-Adapter-Distribution-Policy.md
+++ b/docs/architecture/ADR-026-Adapter-Distribution-Policy.md
@@ -19,6 +19,12 @@ The release workflow can publish crates to crates.io through:
 
 At the moment, that publish list does **not** include the adapter crates.
 
+Historical note: `assay-adapter-api` has already appeared on crates.io
+through `3.2.3`. That historical publication does not define the current
+release-line contract. Current `main` treats every ADR-026 adapter crate,
+including `assay-adapter-api`, as source/workspace-internal until a future
+distribution freeze explicitly changes that.
+
 ## Decision
 For the current ADR-026 line, the adapter crates remain **workspace-internal open-core crates**.
 
@@ -42,7 +48,7 @@ This means:
 
 ## Distribution Contract (v1)
 Until a new freeze slice says otherwise:
-- `assay-adapter-api` is not published to crates.io
+- `assay-adapter-api` is not published to crates.io by current release automation; historical crates.io versions may exist
 - `assay-adapter-acp` is not published to crates.io
 - `assay-adapter-a2a` is not published to crates.io
 - `assay-adapter-ucp` is not published to crates.io

--- a/docs/contributing/WAVE0-GATES.md
+++ b/docs/contributing/WAVE0-GATES.md
@@ -39,7 +39,8 @@ If budget is exceeded:
 
 ## Semver allowlist (public crates)
 
-Wave 0 semver gate runs on this allowlist:
+Wave 0 semver gate runs on the library-API subset of the current public
+crates.io contract:
 
 - `assay-common`
 - `assay-policy`
@@ -49,6 +50,13 @@ Wave 0 semver gate runs on this allowlist:
 - `assay-evidence`
 
 Checks are still conditional on touched/global change detection.
+
+The full current crates.io publish contract is enforced separately by
+`scripts/ci/check-public-crate-policy.sh` and `scripts/ci/publish_idempotent.sh`.
+Binary- or operational-facing crates such as `assay-cli`, `assay-monitor`,
+`assay-mcp-server`, and `assay-sim` are published, but are not part of this
+Wave 0 library semver allowlist unless a future gate slice adds stable library
+API coverage for them.
 
 ## Nightly safety lane (Wave 0.1)
 

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -14,17 +14,26 @@ This document outlines the canonical checklist for releasing new versions of Ass
 - [ ] **Lints**: Run `cargo clippy --workspace --all-targets` to ensure no new warnings.
 
 ### 2. Permissions Check (Crucial)
-- [ ] **Trusted Publishing**: Ensure GitHub Actions OIDC is enabled for the new version tag.
-- [ ] **Crate Ownership**: Verify `crates.io` ownership for *all* workspace members:
-  - `assay-core`
-  - `assay-cli`
+- [ ] **Trusted Publishing**: Ensure GitHub Actions OIDC is enabled for the release tag on every current crates.io crate:
   - `assay-common`
-  - `assay-monitor`
-  - `assay-ebpf` (if published separately)
-  - `assay-mcp-server`
+  - `assay-registry`
+  - `assay-evidence`
+  - `assay-core`
   - `assay-metrics`
   - `assay-policy`
+  - `assay-mcp-server`
+  - `assay-monitor`
+  - `assay-sim`
+  - `assay-cli`
+- [ ] **Non-crates.io workspace members**: Confirm these remain `publish = false` unless a dedicated distribution freeze changes the contract:
+  - `assay-adapter-api` (historical crates.io versions exist, but the current release line does not publish it)
+  - `assay-adapter-acp`
+  - `assay-adapter-a2a`
+  - `assay-adapter-ucp`
+  - `assay-it` (distributed through PyPI wheels, not crates.io)
+  - `assay-ebpf`
   - `assay-xtask`
+- [ ] **Public Crate Policy Check**: Run `bash scripts/ci/check-public-crate-policy.sh`.
 - [ ] **Token Scopes**: If using a token fallback, ensure it has `publish-update` scope.
 
 ### 3. Execution
@@ -60,6 +69,10 @@ This document outlines the canonical checklist for releasing new versions of Ass
 ### HTTP 403 Forbidden
 *   **Cause**: Missing ownership or Trusted Publishing not configured for a specific crate.
 *   **Fix**: Go to crates.io settings for the failing crate and add the GitHub repository as a Trusted Publisher.
+
+### Token not valid for crate
+*   **Cause**: A crate in the current public release contract is missing a Trusted Publishing grant.
+*   **Fix**: Configure crates.io Trusted Publishing for that crate. The release intentionally fails instead of silently skipping a public crate and creating release drift.
 
 ### "Crate already uploaded"
 *   **Cause**: Partial failure in a previous run.

--- a/scripts/ci/check-public-crate-policy.sh
+++ b/scripts/ci/check-public-crate-policy.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+public_crates=(
+  assay-common
+  assay-registry
+  assay-evidence
+  assay-core
+  assay-metrics
+  assay-policy
+  assay-mcp-server
+  assay-monitor
+  assay-sim
+  assay-cli
+)
+
+non_crates_io_crates=(
+  assay-adapter-api
+  assay-adapter-acp
+  assay-adapter-a2a
+  assay-adapter-ucp
+  assay-it
+  assay-ebpf
+  assay-xtask
+)
+
+command -v cargo >/dev/null 2>&1 || { echo "cargo missing" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq missing" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "python3 missing" >&2; exit 1; }
+
+join_lines() {
+  printf '%s\n' "$@" | sort
+}
+
+expected_public="$(join_lines "${public_crates[@]}")"
+metadata_json="$(cargo metadata --no-deps --format-version 1)"
+
+metadata_public="$(
+  printf '%s\n' "$metadata_json" |
+    jq -r '.packages[] | select((.publish // ["default"]) != []) | .name' |
+    sort
+)"
+
+if [[ "$metadata_public" != "$expected_public" ]]; then
+  echo "FAIL: Cargo.toml publish policy does not match public crate contract." >&2
+  echo "Expected public crates:" >&2
+  printf '%s\n' "$expected_public" >&2
+  echo "Metadata-publishable crates:" >&2
+  printf '%s\n' "$metadata_public" >&2
+  exit 1
+fi
+
+for crate in "${non_crates_io_crates[@]}"; do
+  publish_value="$(
+    printf '%s\n' "$metadata_json" |
+      jq -r --arg crate "$crate" '.packages[] | select(.name == $crate) | (.publish // ["default"]) | @json'
+  )"
+  if [[ "$publish_value" != "[]" ]]; then
+    echo "FAIL: ${crate} must set publish = false." >&2
+    exit 1
+  fi
+done
+
+publish_script_crates="$(
+  python3 - <<'PY'
+from pathlib import Path
+import re
+
+text = Path("scripts/ci/publish_idempotent.sh").read_text(encoding="utf-8")
+match = re.search(r"(?ms)^CRATES=\(\n(?P<body>.*?)^\)", text)
+if not match:
+    raise SystemExit("CRATES array not found")
+for line in match.group("body").splitlines():
+    line = line.strip()
+    if not line or line.startswith("#"):
+        continue
+    m = re.match(r'"([^"]+)"$', line)
+    if not m:
+        raise SystemExit(f"unexpected CRATES entry: {line}")
+    print(m.group(1))
+PY
+)"
+
+if [[ "$(printf '%s\n' "$publish_script_crates" | sort)" != "$expected_public" ]]; then
+  echo "FAIL: publish_idempotent.sh CRATES must match public crate contract." >&2
+  echo "Expected public crates:" >&2
+  printf '%s\n' "$expected_public" >&2
+  echo "publish_idempotent.sh crates:" >&2
+  printf '%s\n' "$publish_script_crates" | sort >&2
+  exit 1
+fi
+
+echo "Public crate policy is consistent."

--- a/scripts/ci/publish_idempotent.sh
+++ b/scripts/ci/publish_idempotent.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 echo "📦 Starting Idempotent Publisher..."
 
 # Crates published in dependency order
-# assay-adapter-api: excluded — Trusted Publishing not configured; assay-core uses path dep 3.0.0
+# Adapter crates are intentionally source/workspace-internal for this release
+# line. assay-adapter-api has historical crates.io versions, but no current
+# release-line publishing until ADR-026 gets a dedicated distribution freeze.
 CRATES=(
   "assay-common"
   "assay-registry"
@@ -141,13 +143,14 @@ try_publish() {
     return 0
   fi
 
-  # During Trusted Publishing rollouts, some crates might not yet have tokens enabled.
-  # Treat this as a skip (yellow warning) rather than a pipeline failure.
+  # Public crate publishing is a release-truth contract. A missing Trusted
+  # Publishing grant must fail the release instead of silently creating
+  # crates.io drift.
   # Error: "The provided access token is not valid for crate `name`"
   if grep -qiE "token.*not valid for crate|provided access token.*not valid" "$log"; then
-    echo "⚠️  Token not valid for ${crate} (Trusted Publishing restriction?) — skipping."
+    echo "❌ Token not valid for ${crate}; configure crates.io Trusted Publishing before releasing."
     rm -f "$log"
-    return 0
+    return 1
   fi
 
   echo "❌ cargo publish failed for ${crate} (see log above)."


### PR DESCRIPTION
Summary

Implements the public crate publishing-truth step after the Node24 workflow sweep.

Changes:

- Adds explicit `publish = false` to workspace crates that are not part of the current crates.io release contract:
  - `assay-adapter-api`, `assay-adapter-acp`, `assay-adapter-a2a`, `assay-adapter-ucp`
  - `assay-it` (PyPI wheel distribution, not crates.io)
- Adds `scripts/ci/check-public-crate-policy.sh` to machine-check the contract:
  - exactly 10 crates are publishable/current public crates
  - all non-crates.io workspace members set `publish = false`
  - `scripts/ci/publish_idempotent.sh` publishes exactly the current public crate set
- Wires the policy check into the release publish job before crates.io authentication/publish.
- Changes token-not-valid handling in `publish_idempotent.sh` from silent skip to release failure, so missing Trusted Publishing cannot create release drift.
- Updates release docs, Wave 0 semver docs, and ADR-026 adapter distribution policy to distinguish current public crates from source/workspace-internal adapter crates.

Crates.io audit snapshot

- Current public/current-line crates: `assay-common`, `assay-registry`, `assay-evidence`, `assay-core`, `assay-metrics`, `assay-policy`, `assay-mcp-server`, `assay-monitor`, `assay-sim`, `assay-cli`.
- `assay-adapter-api` has historical crates.io versions through `3.2.3`, but is not part of the current release-line publish contract.
- `assay-adapter-acp`, `assay-adapter-a2a`, `assay-adapter-ucp`, `assay-it`, `assay-ebpf`, and `assay-xtask` are not current crates.io publish targets.

Scope

Included:

- Cargo publish flags for non-crates.io workspace crates
- release publish policy check
- release-script failure behavior for missing Trusted Publishing
- release/policy docs

Explicitly excluded:

- publishing any crate
- changing crate versions
- changing adapter APIs or adapter distribution status beyond enforcing the existing ADR-026 policy
- expanding Wave 0 semver checks
- release asset preflight work
- dependency convergence work

Validation

- bash scripts/ci/check-public-crate-policy.sh
- bash -n scripts/ci/check-public-crate-policy.sh scripts/ci/publish_idempotent.sh
- shellcheck scripts/ci/check-public-crate-policy.sh scripts/ci/publish_idempotent.sh
- actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml .github/workflows/split-wave0-gates.yml
- cargo package -p <current public crate> --allow-dirty --no-verify for all 10 public crates
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --workspace --exclude assay-ebpf
- cargo fmt --check
- git diff --check
- commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Note

A plain local `cargo check --workspace --exclude assay-ebpf` fails on this machine because Python 3.14 is newer than PyO3 0.24.2's default supported maximum. The same check passes with `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`, matching the existing release-doc workaround.

Next

After this lands, continue with release preflight / rehearsal so asset shape and publication contract are verified before tag/publication.
