### PR TITLE
[codex] add release asset preflight contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,6 +383,7 @@ jobs:
 
           tar -czf "release/assay-${VERSION}-sbom-cyclonedx.tar.gz" -C release/sbom .
           shasum -a 256 "release/assay-${VERSION}-sbom-cyclonedx.tar.gz" > "release/assay-${VERSION}-sbom-cyclonedx.tar.gz.sha256"
+          rm -rf release/sbom
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -520,6 +521,16 @@ jobs:
           set -euo pipefail
           bash scripts/ci/release_proof_kit_build.sh
           shasum -a 256 "${OUT_ARCHIVE}" > "${OUT_ARCHIVE}.sha256"
+
+      - name: Check release asset preflight
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          ASSETS_DIR: release
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/check-release-assets.sh
 
       - name: Upload release provenance evidence
         if: always()

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -50,6 +50,8 @@ This document outlines the canonical checklist for releasing new versions of Ass
   - Step: `Generate CycloneDX SBOM bundle` (produces `release/assay-${VERSION}-sbom-cyclonedx.tar.gz` plus `.sha256`).
   - Step: `Enforce release attestation policy` (produces `release/assay-${VERSION}-release-provenance.json` plus `.sha256` and uploads raw attestation verification evidence as a workflow artifact).
   - Step: `Build release proof kit` (produces `release/assay-${VERSION}-release-proof-kit.tar.gz` plus `.sha256`).
+  - Step: `Check release asset preflight` (fails before publication unless the `release/` directory exactly matches the expected asset contract, every `.sha256` verifies, and `server.json` points at the generated MCPB checksum).
+  - Step: `Create GitHub Release` (uploads only the preflighted files from `release/`).
 
 ### 4. Verification
 - [ ] **Install Check**: `cargo install assay-cli --version X.Y.Z`
@@ -59,6 +61,7 @@ This document outlines the canonical checklist for releasing new versions of Ass
 - [ ] **Registry Metadata Check**: Confirm the GitHub release includes `server.json` generated from the MCPB asset and matching SHA-256.
 - [ ] **Provenance Asset Check**: Confirm the GitHub release includes `assay-${VERSION}-release-provenance.json` and `assay-${VERSION}-release-provenance.json.sha256`.
 - [ ] **Proof Kit Asset Check**: Confirm the GitHub release includes `assay-${VERSION}-release-proof-kit.tar.gz` and `assay-${VERSION}-release-proof-kit.tar.gz.sha256`.
+- [ ] **Release Asset Preflight Check**: Confirm `Check release asset preflight` passed before `Create GitHub Release`; this is the machine-readable asset contract for GitHub release publication.
 - [ ] **Workflow Evidence Check**: Confirm the workflow artifacts include `release-provenance-evidence` with the raw `gh attestation verify --format json` results for each release archive.
 - [ ] **Offline Verification Check**: Unpack the proof kit and run `verify-offline.sh --assets-dir /path/to/release-assets` against the downloaded release archives. See [Release Proof Kit](../security/RELEASE-PROOF-KIT.md).
 - [ ] **Operator Flow Check**: For the compact end-to-end story that connects transcript ingest, shipped `C2` pack evaluation, and proof-kit verification, see [Operator Proof Flow](../guides/operator-proof-flow.md).

--- a/scripts/ci/check-release-assets.sh
+++ b/scripts/ci/check-release-assets.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${VERSION:?VERSION is required, for example v3.10.0}"
+ASSETS_DIR="${ASSETS_DIR:-release}"
+JQ_BIN="${JQ_BIN:-jq}"
+REPO="${REPO:-Rul1an/assay}"
+
+require_bin() {
+  local bin="$1"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "missing required binary: $bin" >&2
+    exit 1
+  fi
+}
+
+compute_sha256() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi
+}
+
+basename_from_checksum_line() {
+  local line="$1"
+  line="${line#* }"
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line#\\*}"
+  basename "$line"
+}
+
+require_bin "$JQ_BIN"
+
+if [[ ! "$VERSION" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "release VERSION must be a v-prefixed semver tag: $VERSION" >&2
+  exit 1
+fi
+
+if [[ ! -d "$ASSETS_DIR" ]]; then
+  echo "release assets directory not found: $ASSETS_DIR" >&2
+  exit 1
+fi
+
+non_files="$(find "$ASSETS_DIR" -mindepth 1 -maxdepth 1 ! -type f -print | sort)"
+if [[ -n "$non_files" ]]; then
+  echo "release assets directory must contain only regular files" >&2
+  printf '%s\n' "$non_files" | sed 's/^/  - /' >&2
+  exit 1
+fi
+
+checksum_targets=(
+  "assay-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+  "assay-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+  "assay-${VERSION}-x86_64-apple-darwin.tar.gz"
+  "assay-${VERSION}-aarch64-apple-darwin.tar.gz"
+  "assay-${VERSION}-x86_64-pc-windows-msvc.zip"
+  "assay-mcp-server-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+  "assay-mcp-server-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+  "assay-mcp-server-${VERSION}-linux.mcpb"
+  "assay-${VERSION}-sbom-cyclonedx.tar.gz"
+  "assay-${VERSION}-release-provenance.json"
+  "assay-${VERSION}-release-proof-kit.tar.gz"
+)
+
+plain_assets=(
+  "server.json"
+)
+
+scratch_dir="$(mktemp -d)"
+trap 'rm -rf "$scratch_dir"' EXIT
+expected_files="$scratch_dir/expected-files.txt"
+actual_files="$scratch_dir/actual-files.txt"
+
+: >"$expected_files"
+for asset in "${checksum_targets[@]}"; do
+  printf '%s\n' "$asset" >>"$expected_files"
+  printf '%s.sha256\n' "$asset" >>"$expected_files"
+done
+for asset in "${plain_assets[@]}"; do
+  printf '%s\n' "$asset" >>"$expected_files"
+done
+sort -o "$expected_files" "$expected_files"
+
+find "$ASSETS_DIR" -mindepth 1 -maxdepth 1 -type f -exec basename {} \; | sort >"$actual_files"
+if ! diff -u "$expected_files" "$actual_files"; then
+  echo "release asset set does not match the expected contract" >&2
+  echo "expected exactly $(wc -l <"$expected_files" | tr -d ' ') files in $ASSETS_DIR" >&2
+  exit 1
+fi
+
+for asset in "${checksum_targets[@]}"; do
+  asset_path="$ASSETS_DIR/$asset"
+  checksum_path="${asset_path}.sha256"
+
+  if [[ ! -s "$asset_path" ]]; then
+    echo "release asset is missing or empty: $asset" >&2
+    exit 1
+  fi
+  if [[ ! -s "$checksum_path" ]]; then
+    echo "release checksum is missing or empty: $(basename "$checksum_path")" >&2
+    exit 1
+  fi
+
+  checksum_line="$(head -n 1 "$checksum_path")"
+  expected_hash="$(awk '{print $1}' <<<"$checksum_line")"
+  checksum_target="$(basename_from_checksum_line "$checksum_line")"
+  actual_hash="$(compute_sha256 "$asset_path")"
+
+  if [[ ! "$expected_hash" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "release checksum has invalid sha256 format: $(basename "$checksum_path")" >&2
+    exit 1
+  fi
+  if [[ "$checksum_target" != "$asset" ]]; then
+    echo "release checksum target mismatch in $(basename "$checksum_path"): expected $asset, got $checksum_target" >&2
+    exit 1
+  fi
+  if [[ "$expected_hash" != "$actual_hash" ]]; then
+    echo "release checksum mismatch for $asset" >&2
+    exit 1
+  fi
+done
+
+mcpb_asset="assay-mcp-server-${VERSION}-linux.mcpb"
+mcpb_sha="$(awk '{print $1}' "$ASSETS_DIR/${mcpb_asset}.sha256")"
+semver="${VERSION#v}"
+mcpb_url="https://github.com/${REPO}/releases/download/${VERSION}/${mcpb_asset}"
+# shellcheck disable=SC2016
+if ! "$JQ_BIN" -e \
+  --arg version "$semver" \
+  --arg mcpb_asset "$mcpb_asset" \
+  --arg mcpb_sha "$mcpb_sha" \
+  --arg mcpb_url "$mcpb_url" \
+  '
+  .version == $version
+  and .name == "io.github.Rul1an/assay-mcp-server"
+  and .title == "Assay MCP Server"
+  and .repository.url == "https://github.com/Rul1an/assay"
+  and .repository.source == "github"
+  and (.packages | length == 1)
+  and .packages[0].version == $version
+  and .packages[0].registryType == "mcpb"
+  and .packages[0].identifier == $mcpb_url
+  and .packages[0].fileSha256 == $mcpb_sha
+  ' "$ASSETS_DIR/server.json" >/dev/null; then
+  echo "release server.json does not match the generated MCPB asset contract" >&2
+  exit 1
+fi
+
+{
+  echo "## Release Asset Preflight"
+  echo
+  echo "- version: \`$VERSION\`"
+  echo "- assets_dir: \`$ASSETS_DIR\`"
+  echo "- file_count: \`$(wc -l <"$actual_files" | tr -d ' ')\`"
+  echo
+  echo "Validated exact release asset set, sha256 files, and MCP Registry server.json linkage."
+} >>"${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+echo "release asset preflight passed for $VERSION ($(wc -l <"$actual_files" | tr -d ' ') files)"

--- a/scripts/ci/test-release-assets.sh
+++ b/scripts/ci/test-release-assets.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CHECK_SCRIPT="${REPO_ROOT}/scripts/ci/check-release-assets.sh"
+VERSION="v9.9.9"
+SEMVER="${VERSION#v}"
+
+compute_sha256() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi
+}
+
+write_asset() {
+  local assets_dir="$1"
+  local name="$2"
+  printf 'fixture payload for %s\n' "$name" >"${assets_dir}/${name}"
+  printf '%s  %s\n' "$(compute_sha256 "${assets_dir}/${name}")" "$name" >"${assets_dir}/${name}.sha256"
+}
+
+write_server_json() {
+  local assets_dir="$1"
+  local sha="$2"
+  cat >"${assets_dir}/server.json" <<EOF
+{
+  "\$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Rul1an/assay-mcp-server",
+  "title": "Assay MCP Server",
+  "repository": {
+    "url": "https://github.com/Rul1an/assay",
+    "source": "github"
+  },
+  "version": "${SEMVER}",
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/Rul1an/assay/releases/download/${VERSION}/assay-mcp-server-${VERSION}-linux.mcpb",
+      "version": "${SEMVER}",
+      "fileSha256": "${sha}",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}
+EOF
+}
+
+build_valid_assets() {
+  local assets_dir="$1"
+  mkdir -p "$assets_dir"
+  local targets=(
+    "assay-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+    "assay-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+    "assay-${VERSION}-x86_64-apple-darwin.tar.gz"
+    "assay-${VERSION}-aarch64-apple-darwin.tar.gz"
+    "assay-${VERSION}-x86_64-pc-windows-msvc.zip"
+    "assay-mcp-server-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+    "assay-mcp-server-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+    "assay-mcp-server-${VERSION}-linux.mcpb"
+    "assay-${VERSION}-sbom-cyclonedx.tar.gz"
+    "assay-${VERSION}-release-provenance.json"
+    "assay-${VERSION}-release-proof-kit.tar.gz"
+  )
+  for target in "${targets[@]}"; do
+    write_asset "$assets_dir" "$target"
+  done
+  write_server_json "$assets_dir" "$(compute_sha256 "${assets_dir}/assay-mcp-server-${VERSION}-linux.mcpb")"
+}
+
+expect_pass() {
+  local assets_dir="$1"
+  VERSION="$VERSION" ASSETS_DIR="$assets_dir" bash "$CHECK_SCRIPT" >/dev/null
+}
+
+expect_fail() {
+  local name="$1"
+  local assets_dir="$2"
+  local safe_name
+  safe_name="$(printf '%s' "$name" | tr -c 'A-Za-z0-9_.-' '_')"
+  local out_file="${tmp_root}/${safe_name}.out"
+  local err_file="${tmp_root}/${safe_name}.err"
+  if VERSION="$VERSION" ASSETS_DIR="$assets_dir" bash "$CHECK_SCRIPT" >"$out_file" 2>"$err_file"; then
+    echo "expected failure for ${name}, but preflight passed" >&2
+    exit 1
+  fi
+}
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+valid_dir="${tmp_root}/valid"
+build_valid_assets "$valid_dir"
+expect_pass "$valid_dir"
+
+missing_checksum_dir="${tmp_root}/missing-checksum"
+cp -R "$valid_dir" "$missing_checksum_dir"
+rm "${missing_checksum_dir}/assay-${VERSION}-x86_64-unknown-linux-gnu.tar.gz.sha256"
+expect_fail "missing checksum" "$missing_checksum_dir"
+
+empty_checksum_dir="${tmp_root}/empty-checksum"
+cp -R "$valid_dir" "$empty_checksum_dir"
+: >"${empty_checksum_dir}/assay-${VERSION}-x86_64-unknown-linux-gnu.tar.gz.sha256"
+expect_fail "empty checksum" "$empty_checksum_dir"
+
+checksum_mismatch_dir="${tmp_root}/checksum-mismatch"
+cp -R "$valid_dir" "$checksum_mismatch_dir"
+printf 'tampered\n' >>"${checksum_mismatch_dir}/assay-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+expect_fail "checksum mismatch" "$checksum_mismatch_dir"
+
+unexpected_file_dir="${tmp_root}/unexpected-file"
+cp -R "$valid_dir" "$unexpected_file_dir"
+printf 'surprise\n' >"${unexpected_file_dir}/assay-${VERSION}-extra.tar.gz"
+expect_fail "unexpected file" "$unexpected_file_dir"
+
+server_mismatch_dir="${tmp_root}/server-mismatch"
+cp -R "$valid_dir" "$server_mismatch_dir"
+write_server_json "$server_mismatch_dir" "0000000000000000000000000000000000000000000000000000000000000000"
+expect_fail "server.json sha mismatch" "$server_mismatch_dir"
+
+echo "release asset preflight tests passed"


### PR DESCRIPTION
Summary

Adds a release asset preflight gate before GitHub Release publication so the release job fails closed unless the `release/` directory exactly matches the expected asset contract.

Changes:

- Adds `scripts/ci/check-release-assets.sh` to validate:
  - exact top-level release asset set for the current version
  - only regular files in `release/`
  - every `.sha256` file points at and matches its sibling asset
  - `server.json` version/package metadata points at the generated MCPB and matching SHA-256
- Adds `scripts/ci/test-release-assets.sh` covering success plus missing checksum, checksum mismatch, unexpected file, and `server.json` SHA mismatch failures.
- Wires `Check release asset preflight` into `.github/workflows/release.yml` after proof-kit generation and before release publication.
- Removes the temporary `release/sbom/` staging directory after SBOM archive generation so `release/` only contains publishable files.
- Documents the new preflight step in the release runbook.

Scope

Included:

- `.github/workflows/release.yml`
- `docs/reference/release.md`
- `scripts/ci/check-release-assets.sh`
- `scripts/ci/test-release-assets.sh`

Explicitly excluded:

- release asset layout changes
- attestation/provenance policy changes
- proof-kit schema changes
- crate publishing changes
- broader release workflow refactors
- dependency/cache/security scanner work

Validation

- `bash scripts/ci/test-release-assets.sh`
- `bash -n scripts/ci/check-release-assets.sh scripts/ci/test-release-assets.sh`
- `shellcheck scripts/ci/check-release-assets.sh scripts/ci/test-release-assets.sh`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml`
- `git diff --check -- scripts/ci/check-release-assets.sh scripts/ci/test-release-assets.sh .github/workflows/release.yml docs/reference/release.md`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Next

After this lands, continue with scanner intentionality/security-tab cleanup or the dependency convergence memo, depending on whether we want governance noise or dependency drift next.
