### PR TITLE
[codex] clean online zizmor workflow alerts

### DIFF
--- a/.github/workflows/adr025-nightly-closure.yml
+++ b/.github/workflows/adr025-nightly-closure.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Prepare inputs
         env:

--- a/.github/workflows/adr025-nightly-soak.yml
+++ b/.github/workflows/adr025-nightly-soak.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build (assay-cli)
         run: cargo build -p assay-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install Linux deps (for build scripts)
         if: runner.os == 'Linux'
         shell: bash
@@ -151,7 +151,7 @@ jobs:
               -o Acquire::Languages=none
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
@@ -211,7 +211,7 @@ jobs:
           persist-credentials: false
       - name: Swatinem/rust-cache
         id: rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install Linux deps (for build scripts)
         shell: bash
         run: |
@@ -226,7 +226,7 @@ jobs:
               -o Acquire::Languages=none
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - name: Criterion (store_write_heavy)
@@ -284,7 +284,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
 
@@ -334,7 +334,7 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: |
             . -> target
@@ -403,7 +403,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rust-src
 

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -62,7 +62,7 @@ jobs:
           ffmpeg -version | head -n 1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build assay-cli for tape playback
         run: cargo build --locked -p assay-cli

--- a/.github/workflows/docs-auto-update.yml
+++ b/.github/workflows/docs-auto-update.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0 # Full history for changelog
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install jq
         run: sudo apt-get install -y jq

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -51,7 +51,7 @@ jobs:
             precommit-${{ runner.os }}-
 
       - name: Set up Rust (fmt + clippy)
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
 
@@ -225,7 +225,7 @@ jobs:
             llvm-dev libclang-dev build-essential libbpf-dev pkg-config
 
       - name: Install Rust Toolchain (nightly)
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
 
       - name: Install rust-src for eBPF (explicit for ARM)
         run: |
@@ -238,7 +238,7 @@ jobs:
           }
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
 

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -97,7 +97,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build release binaries
         run: |

--- a/.github/workflows/perf_main.yml
+++ b/.github/workflows/perf_main.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install Linux deps
         shell: bash
         run: |
@@ -39,7 +39,7 @@ jobs:
             sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -o Acquire::Retries=10 -o Acquire::http::Timeout=60 -o Acquire::https::Timeout=60
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - uses: bencherdev/bencher@0f8f620172ccd6225d40a7590598eb7b41718af8 # v0.6.2

--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -26,14 +26,14 @@ jobs:
           persist-credentials: false
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install Linux deps
         run: |
           sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev bc jq
 
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - uses: bencherdev/bencher@0f8f620172ccd6225d40a7590598eb7b41718af8 # v0.6.2
 

--- a/.github/workflows/perf_pr.yml
+++ b/.github/workflows/perf_pr.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install Linux deps
         shell: bash
         run: |
@@ -46,7 +46,7 @@ jobs:
             sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -o Acquire::Retries=10 -o Acquire::http::Timeout=60 -o Acquire::https::Timeout=60
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - uses: bencherdev/bencher@0f8f620172ccd6225d40a7590598eb7b41718af8 # v0.6.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -224,7 +224,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -338,7 +338,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Get version
         id: version
@@ -644,7 +644,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Verify LSM blocking (CI gate)
         run: |
@@ -688,7 +688,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Debug Cargo Version
         run: cargo --version
@@ -698,7 +698,7 @@ jobs:
 
       - name: Authenticate with crates.io
         id: auth
-        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
       - name: Publish Crates (Idempotent)
         run: |
@@ -770,7 +770,7 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist
           skip-existing: true  # Idempotent: skip already-published versions

--- a/.github/workflows/smoke-install.yml
+++ b/.github/workflows/smoke-install.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build and Install Assay (from source)
         run: |

--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -162,7 +162,7 @@ jobs:
           fetch-depth: 0
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install Linux deps
         shell: bash
@@ -179,7 +179,7 @@ jobs:
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
 
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install cargo-nextest and cargo-hack
         shell: bash
@@ -298,7 +298,7 @@ jobs:
           persist-credentials: false
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install Linux deps
         shell: bash
@@ -315,7 +315,7 @@ jobs:
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang libsqlite3-dev
           }
 
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
@@ -365,9 +365,9 @@ jobs:
           fetch-depth: 0
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install cargo-semver-checks
         run: cargo install --locked cargo-semver-checks

--- a/.github/workflows/wave6-nightly-safety.yml
+++ b/.github/workflows/wave6-nightly-safety.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: nightly
           components: miri
@@ -44,7 +44,7 @@ jobs:
           }
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Miri smoke test (verify fail-closed anchor)
         shell: bash
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install Linux deps
         shell: bash
@@ -83,7 +83,7 @@ jobs:
           }
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Proptest smoke anchor
         shell: bash

--- a/.github/workflows/week8-sota-gates.yml
+++ b/.github/workflows/week8-sota-gates.yml
@@ -42,9 +42,9 @@ jobs:
           fetch-depth: 0
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Run optional public API drift gate
         shell: bash
@@ -74,9 +74,9 @@ jobs:
           persist-credentials: false
 
       - name: Swatinem/rust-cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Run targeted mutation smoke
         shell: bash


### PR DESCRIPTION
Summary

Cleans the current online zizmor/Security-tab backlog by refreshing action pins and version comments so the workflow-security SARIF run stops reporting high-confidence online findings on main.

Changes:

- Replaces the incorrect `dtolnay/rust-toolchain` commit pin with the current commit behind the `stable` branch comment.
- Replaces the `dtolnay/rust-toolchain` nightly use with the current commit behind the `nightly` branch comment.
- Updates `Swatinem/rust-cache` comments from `v2` to `v2.9.1`, matching the pinned commit.
- Updates `rust-lang/crates-io-auth-action` comment from `v1` to `v1.0.4`, matching the pinned commit.
- Updates `pypa/gh-action-pypi-publish` from pinned `v1.9.0` to pinned `v1.14.0` to clear the known-vulnerable-actions alert.

Scope

Included:

- GitHub workflow `uses:` pin/comment refreshes only.

Explicitly excluded:

- workflow behavior refactors
- new scanners or rulesets
- checkout credential sweeps
- reusable workflow extraction
- dependency cleanup outside GitHub Actions
- changing Rust toolchain channel semantics beyond correcting the pinned commits for the existing `stable`/`nightly` channels

Validation

- `GH_TOKEN=$(gh auth token) uvx zizmor==1.24.1 --no-progress --persona regular --min-confidence high --format=plain .github/workflows .github/dependabot.yml assay-action/action.yml` -> no findings
- `actionlint -config-file .github/actionlint.yaml .github/workflows/*.yml`
- `git diff --check -- .github/workflows`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate

Security-tab note

Before this PR, the open code scanning alerts were:

- 44 `zizmor` alerts: 28 `impostor-commit`, 15 `ref-version-mismatch`, 1 `known-vulnerable-actions`
- 4 assay evidence lint alerts, intentionally outside this PR

After this PR lands and `Workflow Security (zizmor)` uploads the new SARIF on main, the current zizmor alerts should close or move to the next explicit finding set.

Next

After this lands, re-check open code scanning alerts. Remaining non-zizmor assay evidence-lint alerts should be classified separately because they are product/evidence policy findings, not workflow hardening findings.
