### PR TITLE
docs: state of Assay 2026-05-11 + scanner-dismissal ledger

### DIFF
--- a/docs/notes/SCANNER-DISMISSALS.md
+++ b/docs/notes/SCANNER-DISMISSALS.md
@@ -1,0 +1,50 @@
+# Code-scanning dismissal ledger
+
+> **Status:** live ledger
+> **Last updated:** 2026-05-11
+> **Scope:** records intentionally dismissed code-scanning alerts and their
+> revisit triggers; not a general security-debt tracker.
+
+Tracks deliberately-dismissed scanner alerts so a future reviewer can see
+that the dismiss-state is bounded test-analysis context rather than buried
+real debt.
+
+Format: one row per alert, terse. The ledger is *not* a substitute for the
+GitHub Security tab — it is a human-readable trail that survives outside
+the GitHub UI and answers the question:
+
+> *"Why is this alert dismissed and when should it be re-examined?"*
+
+## Ledger
+
+| Date | Alert (tool · rule · ref) | Reason | Revisit trigger |
+|---|---|---|---|
+| 2026-05-11 | `assay-evidence-lint` · `EU12-002` · Security alert #3 (`/tmp/test_non_compliant.tar.gz`) | Stale non-compliant fixture SARIF upload from commit `bc0fe07f`; intentional test-analysis state, not a tracked repo artifact or current workflow output. | Next major Assay release, next evidence-lint audit cycle, or any reappearance on a tracked repo path. |
+| 2026-05-11 | `assay-evidence-lint` · `EU12-003` · Security alert #4 (`/tmp/test_non_compliant.tar.gz`) | Stale non-compliant fixture SARIF upload from commit `bc0fe07f`; intentional test-analysis state, not a tracked repo artifact or current workflow output. | Next major Assay release, next evidence-lint audit cycle, or any reappearance on a tracked repo path. |
+| 2026-05-11 | `assay-evidence-lint` · `EU12-004` · Security alert #5 (`/tmp/test_non_compliant.tar.gz`) | Stale non-compliant fixture SARIF upload from commit `bc0fe07f`; intentional test-analysis state, not a tracked repo artifact or current workflow output. | Next major Assay release, next evidence-lint audit cycle, or any reappearance on a tracked repo path. |
+
+## Conventions
+
+- **Date**: when the dismissal was made.
+- **Alert**: enough context to find it again — tool (CodeQL / zizmor /
+  etc.), rule id, and a stable reference (alert number or location).
+- **Reason**: one sentence on why this is not real debt. Honest. If the
+  reason is "we accept the risk for now", say so explicitly — do not
+  dress it up as "false positive."
+- **Revisit trigger**: a concrete condition or date when this should be
+  re-examined. "Next major release" is acceptable; "later" is not.
+
+## When to remove a row
+
+When the underlying alert is genuinely resolved (code change, tool
+upgrade, framework migration) the row stays for one further audit cycle
+as historical context, then can be pruned. The git history retains
+everything; this ledger is for current-state legibility.
+
+## When NOT to use this ledger
+
+- Real, actionable findings — fix the code; do not log a dismissal.
+- Stale alerts where the underlying file or branch was deleted — those
+  resolve themselves and need no row here.
+- Findings outside the security-tab/code-scanning surface — for those,
+  use the appropriate ADR or design note family.

--- a/docs/notes/STATE-OF-ASSAY-2026-05-11.md
+++ b/docs/notes/STATE-OF-ASSAY-2026-05-11.md
@@ -1,0 +1,115 @@
+# State of Assay — 2026-05-11
+
+> **Status:** operational snapshot
+> **Last updated:** 2026-05-11
+> **Scope:** records the post-`v3.10.0` Assay posture and the remaining
+> maintenance-mode focus areas; not a roadmap or feature plan.
+
+Snapshot of where Assay sits after the spring 2026 hardening sweep. Intended as
+internal reference and as cross-repo handoff context (especially for
+Assay-Harness, which is now the next governance focus).
+
+The previous snapshot is
+[`STATE-OF-ASSAY-2026-03-15.md`](../STATE-OF-ASSAY-2026-03-15.md).
+
+## Headline
+
+Assay has shifted from **hardening target** to **stable base layer**.
+
+The credibility gaps that previously made Assay the bottleneck — release-truth,
+workflow-security, scanner noise, Node 24 deadline-risk — are closed. The
+release tag is `v3.10.0` (2026-05-11). The next priorities live above Assay,
+not in it.
+
+## What is done
+
+These were the things blocking Assay from being treatable as a stable
+compiler-layer dependency. They are now closed:
+
+- **Workflow security** — high-confidence `zizmor` clean on `origin/main`.
+  Permissions tightened, template-injection paths closed,
+  `persist-credentials: false` baseline, trusted-org pinning policy
+  enforced by `.github/workflows/workflow-security.yml`.
+- **Release truth** — semver and publishing pipeline now self-consistent.
+  Release preflight is no longer ad-hoc. Public crate policy enforced via
+  `scripts/ci/check-public-crate-policy.sh`. Release assets validated by
+  `scripts/ci/check-release-assets.sh`.
+- **Security tab** — code-scanning alerts at zero. Deliberately-dismissed
+  test-analysis alerts are tracked in
+  [`SCANNER-DISMISSALS.md`](./SCANNER-DISMISSALS.md) so the dismiss-state
+  remains traceable rather than implicit.
+- **Node 24 readiness** — third-party Action versions on Node 24-compatible
+  major lines. Local test runtime on Node 20 LTS, separate decision.
+- **Trust Basis surface** — diff/report disciplined; sandbox/MCP-proxy
+  hardening landed.
+- **Evidence portability** — the three-family receipt line (tested /
+  decided / inventoried) plus the experimental acted-family scripts are
+  reproducible against released `v3.10.0`.
+
+## What remains, but is second-order
+
+Items that are now follow-up housekeeping rather than blockers. None of
+these prevent treating Assay as a stable dependency.
+
+- **Dependency convergence** — workspace crates and `Cargo.lock` are clean,
+  but periodic upgrade sweeps still produce dozens of dependabot PRs per
+  month. Continue the existing weekly cooldown-protected cadence.
+- **Workflow inventory and TTL** — there are still several CI workflows
+  whose purpose is implicit. An inventory note (one row per workflow:
+  *what it gates, why it exists, when to revisit*) would close that.
+- **Unsafe code atlas** — the repo has explicit `unsafe_code` exceptions
+  outside eBPF as well as the eBPF crate itself (for example CLI/test
+  seams, ring-buffer parsing, tracing/config shims, and MCP tests). A
+  short atlas note listing these bounded exceptions would make the policy
+  legible for future contributors without implying that the current
+  boundary is eBPF-only.
+- **`$GITHUB_PATH` / `persist-credentials` compatibility** — two
+  compatibility decisions are documented in line comments inside specific
+  workflows but not consolidated. A consolidation pass would help, but is
+  not urgent.
+
+## What the next focus actually is
+
+With Assay stable, the next-most-likely-to-rattle surfaces are above and
+beside Assay-core:
+
+1. **Assay-Harness alignment.**
+   Harness `v0.4.0` is release-clean and `zizmor`-clean but still has
+   weaker governance than Assay (no required-status-check ruleset until
+   2026-05-11, dependency freshness on `@openai/agents`, no Node 24 lane).
+   Bringing Harness to Assay-level governance is the most concrete next
+   piece of work.
+2. **Packaging / proof / seeding.**
+   The proof page, longform, and assurance-mapping note can now be
+   surfaced with more confidence because the underlying release-truth
+   and security-tab posture is clean. This is external-visibility work,
+   not core engineering.
+3. **New substantive slices.**
+   Only after (1) and (2) are stable. Adding new functionality while
+   Harness governance is still maturing risks reopening the same gaps
+   on a new surface.
+
+## Discipline rules in maintenance mode
+
+To keep Assay in stable-base-layer shape:
+
+- **No broad cleanup PRs.** Cleanup is now case-by-case. "We were
+  already in here" is not a justification.
+- **Each new follow-up PR cites a concrete trigger.** Either a real
+  dependency upgrade, an audit-found gap, or a decision that needs
+  documenting. No anticipatory polish.
+- **Scanner dismissals are logged.** Every dismissed code-scanning alert
+  has a row in `SCANNER-DISMISSALS.md`. Test-analysis state is bounded,
+  not implicit.
+- **Cross-repo decisions are written down here.** When Harness pulls
+  in something from Assay that needed a compatibility decision, that
+  decision lives in this note family (`STATE-OF-ASSAY-*.md`) rather
+  than scattered in commit messages.
+
+## Cross-references
+
+- [Assay-Harness `v0.4.0` release](https://github.com/Rul1an/Assay-Harness/releases/tag/v0.4.0)
+- [Assay `v3.10.0` release](https://github.com/Rul1an/assay/releases/tag/v3.10.0)
+- [Evidence Receipts in Action](./EVIDENCE-RECEIPTS-IN-ACTION.md)
+- [Evidence Receipt Assurance Mapping](./EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md)
+- [Claim Compilation Below AX](./CLAIM-COMPILATION-BELOW-AX.md)

--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -19,6 +19,15 @@ families or new Harness semantics.
   explains the first Promptfoo assertion-component receipt path as a downstream
   evidence-portability recipe.
 
+Operational status:
+
+- [State of Assay — 2026-05-11](STATE-OF-ASSAY-2026-05-11.md) records the
+  post-`v3.10.0` posture shift from hardening target to stable base layer,
+  and locates the next governance focus in Assay-Harness alignment.
+- [Code-scanning dismissal ledger](SCANNER-DISMISSALS.md) tracks deliberately
+  dismissed Security-tab alerts so the dismiss-state stays traceable rather
+  than implicit.
+
 For machine-readable receipt-family truth, use the
 [receipt family matrix](../reference/receipt-family-matrix.json) and
 [receipt schema registry](../reference/receipt-schemas/README.md).


### PR DESCRIPTION
## Summary

Two operational status artefacts captured at the `v3.10.0` milestone. No code changes; this is documentation that formalises the handoff from hardening target to stable base layer.

## Files

### `docs/notes/STATE-OF-ASSAY-2026-05-11.md`

Snapshot of where Assay sits after the spring 2026 sweep. Follows the format agreed in the post-release status review:

- **What is done** — workflow security, release truth, security tab, Node 24 readiness, Trust Basis, evidence portability
- **What remains, but is second-order** — dependency convergence, workflow inventory/TTL, unsafe atlas, compatibility consolidation
- **What the next focus actually is** — Harness alignment, packaging/proof/seeding, then new substantive slices

Also encodes maintenance-mode discipline rules: no broad cleanup PRs, every follow-up cites a concrete trigger, scanner dismissals are logged, cross-repo decisions are written here.

### `docs/notes/SCANNER-DISMISSALS.md`

Template ledger for deliberately-dismissed code-scanning alerts. One row per alert with date, alert reference, one-sentence honest reason, and concrete revisit trigger. Includes a 'when NOT to use this ledger' section to keep it focused.

### `docs/notes/index.md`

New 'Operational status' subsection surfaces both files alongside the receipt-line notes.

## Why now

Previously the credibility gaps in Assay (release truth, workflow security, scanner noise) made it the bottleneck for cross-repo work. Those are closed. `v3.10.0` is the milestone where Assay can be treated as a stable compiler-layer dependency. The memo records that shift; the dismissal ledger keeps the security-tab honest about which alerts are bounded vs real.

## Cross-references

- Assay-Harness `v0.4.0` (related cycle): https://github.com/Rul1an/Assay-Harness/releases/tag/v0.4.0
- Previous snapshot: `docs/STATE-OF-ASSAY-2026-03-15.md`

## Test plan

- [ ] Render check: both new files render correctly on GitHub
- [ ] Internal links resolve (all verified via file-existence check pre-push)
- [ ] CI passes — this is docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)