### PR TITLE
[codex] Add Promptfoo receipt adoption surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   </p>
   <p align="center">
     <a href="#see-it-work">See It Work</a> ·
+    <a href="docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md">Promptfoo JSONL</a> ·
     <a href="examples/mcp-quickstart/">Quick Start</a> ·
     <a href="docs/guides/github-action.md">CI Guide</a> ·
     <a href="https://github.com/Rul1an/assay/discussions">Discussions</a>
@@ -22,6 +23,8 @@
 Your MCP agent calls `read_file`, `exec`, `web_search` — but should it, and what can you honestly **prove** about that run afterward?
 
 **Assay turns agent tool/runtime outcomes into reviewable evidence artifacts with explicit evidence levels: `verified`, `self_reported`, `inferred`, or `absent`.** The wedge is familiar: sit between the agent and MCP servers, **allow or deny** tool calls from policy, and record every decision. The broader output is canonical **evidence**, bounded Trust Basis claims, Trust Cards, SARIF, and CI gates you can hand to review without a hosted backend.
+
+Already have machine-readable AI run artifacts? Start with the smallest adoption path: [Promptfoo JSONL to evidence receipts](docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md).
 
 **Positioning:** Assay is a **CI-native evidence compiler for agent governance**. It is **not** a trust-score engine, a generic eval dashboard, or an observability product with a thin security veneer. See [What Assay is and is not](docs/concepts/scope.md) for the current boundary.
 
@@ -271,6 +274,7 @@ CI: [GitHub Action](https://github.com/marketplace/actions/assay-ai-agent-securi
 
 ## Learn More
 
+- [Promptfoo JSONL to Evidence Receipts](docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) — smallest adoption path for existing eval artifacts
 - [MCP Quickstart](examples/mcp-quickstart/) — filesystem server walkthrough
 - [Policy Files](docs/reference/config/policies.md) — YAML schema for `assay mcp wrap`
 - [OpenTelemetry & Langfuse](docs/guides/otel-langfuse.md) — traces → replay and evidence

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ enforcement is the wedge: Assay can sit between an agent and its tools, make
 deterministic allow/deny decisions, and preserve the evidence chain for CI,
 security review, and audit without a hosted backend.
 
+If you already have machine-readable AI run artifacts, start with the smallest
+receipt path: [Promptfoo JSONL to evidence receipts](use-cases/evidence-receipts-from-promptfoo-jsonl.md).
+
 ---
 
 ## Install
@@ -49,6 +52,7 @@ curl -fsSL https://getassay.dev/install.sh | sh
     Compile verified bundles into Trust Basis claims and import bounded external receipt families for eval outcomes, runtime decisions, and model inventory.
 
     [:octicons-arrow-right-24: Receipt Matrix](reference/receipt-family-matrix.json)
+    [:octicons-arrow-right-24: Promptfoo JSONL Receipts](use-cases/evidence-receipts-from-promptfoo-jsonl.md)
 
 -   :material-key:{ .lg .middle } __Tool Signing__
 
@@ -141,6 +145,7 @@ sudo assay monitor --policy policy.yaml --pid <agent-pid>
 - [**Getting Started**](getting-started/index.md)
 - [**Scope & Boundaries**](concepts/scope.md)
 - [**Evidence Receipts Technical Note**](notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md)
+- [**Promptfoo JSONL to Evidence Receipts**](use-cases/evidence-receipts-from-promptfoo-jsonl.md)
 - [**Evidence Receipt Assurance Mapping**](notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md)
 - [**Receipt Family Matrix**](reference/receipt-family-matrix.json)
 - [**Receipt Schema Registry**](reference/receipt-schemas/README.md)

--- a/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md
+++ b/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md
@@ -1,0 +1,168 @@
+# Evidence Receipts from Promptfoo JSONL
+
+Use this if Promptfoo already runs in CI and you want a smaller reviewable
+artifact than a full JSONL row.
+
+Assay does not replace Promptfoo. Promptfoo runs the assertions and writes the
+JSONL output. Assay reduces selected assertion component results into bounded
+evidence receipts, bundles them, verifies the bundle, and lets CI gate the
+Trust Basis diff above that bundle.
+
+## Problem
+
+A Promptfoo CI run can tell you whether an eval passed. Later review often
+needs a smaller question:
+
+```text
+Which eval outcome was selected, what source artifact did it come from, and
+can that boundary be reviewed without importing the full Promptfoo run?
+```
+
+That is the receipt boundary. It is useful for pull request review, incident
+follow-up, and audit trails where the reviewer should not need raw prompts,
+model outputs, vars, provider metadata, or a full eval dashboard.
+
+## One Workflow
+
+First write Promptfoo JSONL:
+
+```bash
+promptfoo eval --output results.jsonl
+```
+
+Then import the supported assertion component results into an Assay evidence
+bundle:
+
+```bash
+assay evidence import promptfoo-jsonl \
+  --input results.jsonl \
+  --bundle-out promptfoo-evidence.tar.gz \
+  --source-artifact-ref results.jsonl
+```
+
+Verify the bundle and compile the claim artifact:
+
+```bash
+assay evidence verify promptfoo-evidence.tar.gz
+assay trust-basis generate promptfoo-evidence.tar.gz \
+  --out promptfoo.trust-basis.json
+```
+
+Compare the candidate Trust Basis against a baseline:
+
+```bash
+assay trust-basis diff \
+  baseline.trust-basis.json \
+  promptfoo.trust-basis.json \
+  --format json \
+  --fail-on-regression
+```
+
+In CI, the baseline Trust Basis artifact usually comes from the default branch
+or a previously approved run.
+
+Harness owns orchestration, exit codes, Markdown, and JUnit projection. The
+released recipe is here:
+
+- [Promptfoo receipt pipeline](https://github.com/Rul1an/Assay-Harness/blob/v0.3.2/docs/PROMPTFOO_RECEIPT_PIPELINE.md)
+
+## Canonical Artifact
+
+The smallest source shape is one Promptfoo CLI JSONL row with
+`gradingResult.componentResults[]`:
+
+```json
+{
+  "gradingResult": {
+    "componentResults": [
+      {
+        "pass": true,
+        "score": 1,
+        "reason": "Assertion passed",
+        "assertion": {
+          "type": "equals",
+          "value": "expected-output-ref:checkout-greeting"
+        }
+      }
+    ]
+  }
+}
+```
+
+The current receipt lane is intentionally strict. It imports selected
+`equals` assertion component results with binary scores only. The receipt
+keeps the bounded result and a digest of the source artifact, not the full
+Promptfoo row.
+
+Proof artifacts are checked in under the Evidence Receipts in Action assets:
+
+| Artifact | Role |
+|---|---|
+| [`candidate.results.jsonl`](../assets/evidence-receipts-in-action/promptfoo/candidate.results.jsonl) | Tiny Promptfoo source artifact |
+| [`evidence.tar.gz`](../assets/evidence-receipts-in-action/promptfoo/evidence.tar.gz) | Verifiable Assay receipt bundle |
+| [`trust-basis.json`](../assets/evidence-receipts-in-action/promptfoo/trust-basis.json) | Canonical claim artifact |
+| [`trust-basis.diff.json`](../assets/evidence-receipts-in-action/promptfoo/trust-basis.diff.json) | Canonical CI diff artifact |
+| [`trust-basis-summary.md`](../assets/evidence-receipts-in-action/promptfoo/trust-basis-summary.md) | Markdown reviewer projection |
+| [`junit-trust-basis.xml`](../assets/evidence-receipts-in-action/promptfoo/junit-trust-basis.xml) | JUnit CI projection |
+
+## Boundary
+
+Assay may claim that a supported external eval receipt boundary is visible:
+
+```json
+{
+  "id": "external_eval_receipt_boundary_visible",
+  "level": "verified",
+  "source": "external_evidence_receipt",
+  "boundary": "supported-external-eval-receipt-events-only"
+}
+```
+
+That claim means the selected Promptfoo outcome was reduced into a supported
+receipt shape, carried through a verifiable bundle, and compiled into a Trust
+Basis artifact.
+
+It does not mean Assay owns Promptfoo semantics.
+
+## Not Claimed
+
+This path does not claim:
+
+- the Promptfoo run passed
+- the model output was correct
+- the assertion was well designed
+- the eval set was complete
+- the application is safe
+- the full Promptfoo export is Assay truth
+
+The claim is about a reviewable evidence boundary, not eval correctness.
+
+## Payoff Preview
+
+The gate projection is intentionally small:
+
+```text
+Trust Basis Gate
+Status: OK
+Regressed claims: 0
+Removed claims: 0
+Unchanged claims: 10
+```
+
+The raw JSON diff remains the canonical CI artifact. Markdown and JUnit are
+review projections only.
+
+## When to Use This
+
+Use this path when:
+
+- Promptfoo already runs in CI
+- reviewers need a portable artifact, not only a pass/fail line
+- you want Trust Basis diffs and Harness gates above selected eval outcomes
+- raw prompts, outputs, vars, and provider responses should stay out of the
+  receipt boundary
+
+For the longer technical explanation, see
+[From Promptfoo JSONL to Evidence Receipts](../notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md).
+For the three-family static proof page, see
+[Evidence Receipts in Action](../notes/EVIDENCE-RECEIPTS-IN-ACTION.md).

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -42,6 +42,15 @@ Assay is designed for teams building production AI agents. Here are the most com
 
     [:octicons-arrow-right-24: Learn more](self-correction.md)
 
+-   :material-receipt-text:{ .lg .middle } __Promptfoo JSONL Receipts__
+
+    ---
+
+    Turn selected Promptfoo assertion component results into bounded evidence
+    receipts for CI review.
+
+    [:octicons-arrow-right-24: Learn more](evidence-receipts-from-promptfoo-jsonl.md)
+
 </div>
 
 ---
@@ -54,6 +63,7 @@ Assay is designed for teams building production AI agents. Here are the most com
 | Trace-Driven Debugging | Fast root cause analysis | On-call Engineer |
 | Air-Gapped Enterprise | Compliance, privacy | Security, FinTech |
 | Agent Self-Correction | Runtime guardrails | Agent Developer |
+| Promptfoo JSONL Receipts | Reviewable eval evidence boundary | Platform, Security |
 
 ---
 
@@ -98,4 +108,5 @@ Assay is designed for teams building production AI agents. Here are the most com
 
 - [Quick Start](../getting-started/quickstart.md)
 - [Core Concepts](../concepts/index.md)
+- [Evidence Receipts from Promptfoo JSONL](evidence-receipts-from-promptfoo-jsonl.md)
 - [MCP Integration](../mcp/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -215,6 +215,7 @@ nav:
 
   - Use Cases:
     - use-cases/index.md
+    - Promptfoo JSONL Receipts: use-cases/evidence-receipts-from-promptfoo-jsonl.md
     - CI Regression Gate: use-cases/ci-gate.md
     - Trace-Driven Debugging: use-cases/debugging.md
     - Air-Gapped Enterprise: use-cases/air-gapped.md


### PR DESCRIPTION
Summary
- add a Promptfoo-first use-case page for turning JSONL assertion component results into bounded Assay receipts
- link that adoption path from README, docs homepage, use-cases index, and docs nav
- keep the path on existing released surfaces: assay evidence import promptfoo-jsonl, Trust Basis diff, and Harness v0.3.2 recipe

Validation
- git diff --check
- mkdocs build --strict
- pre-commit hooks during commit and push
