### PR TITLE
[codex] Add OpenFeature decision receipt adoption surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <p align="center">
     <a href="#see-it-work">See It Work</a> ·
     <a href="docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md">Promptfoo JSONL</a> ·
+    <a href="docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md">OpenFeature</a> ·
     <a href="examples/mcp-quickstart/">Quick Start</a> ·
     <a href="docs/guides/github-action.md">CI Guide</a> ·
     <a href="https://github.com/Rul1an/assay/discussions">Discussions</a>
@@ -27,6 +28,7 @@ Start with the path that matches what you already have:
 | You have | Use this when | What you get | Next click |
 |---|---|---|---|
 | Promptfoo JSONL from CI evals | You want smaller PR evidence than a full eval export | Eval outcome receipts, verified bundle, Trust Basis diff | [Promptfoo JSONL](docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) |
+| OpenFeature boolean `EvaluationDetails` | You want CI evidence for a runtime flag decision boundary | Decision receipt, verified bundle, Trust Basis diff | [OpenFeature EvaluationDetails](docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) |
 | MCP tool calls | You are ready to put a policy file around tool execution | Allow/deny audit trail and evidence for observed tool behavior | [MCP Quick Start](examples/mcp-quickstart/) |
 | A GitHub PR gate | You want CI to block regressions from checked artifacts | Trust Basis diff, gate status, SARIF/JUnit-ready output | [CI Guide](docs/guides/github-action.md) |
 
@@ -291,6 +293,7 @@ These are tool-decision timings, not end-to-end model latency. (See [Research & 
 ## Learn More
 
 - [Promptfoo JSONL to Evidence Receipts](docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) — smallest adoption path for existing eval artifacts
+- [OpenFeature EvaluationDetails to CI Review Artifact](docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) — runtime decision receipt path
 - [MCP Quickstart](examples/mcp-quickstart/) — filesystem server walkthrough
 - [Policy Files](docs/reference/config/policies.md) — YAML schema for `assay mcp wrap`
 - [OpenTelemetry & Langfuse](docs/guides/otel-langfuse.md) — traces → replay and evidence

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,8 @@ security review, and audit without a hosted backend.
 
 If you already have machine-readable AI run artifacts, start with the smallest
 receipt path: [Promptfoo JSONL to evidence receipts](use-cases/evidence-receipts-from-promptfoo-jsonl.md).
+For runtime flag decisions, use the second adoption path:
+[OpenFeature EvaluationDetails to CI Review Artifact](use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md).
 
 ---
 
@@ -53,6 +55,7 @@ curl -fsSL https://getassay.dev/install.sh | sh
 
     [:octicons-arrow-right-24: Receipt Matrix](reference/receipt-family-matrix.json)
     [:octicons-arrow-right-24: Promptfoo JSONL Receipts](use-cases/evidence-receipts-from-promptfoo-jsonl.md)
+    [:octicons-arrow-right-24: OpenFeature Decision Receipts](use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md)
 
 -   :material-key:{ .lg .middle } __Tool Signing__
 
@@ -146,6 +149,7 @@ sudo assay monitor --policy policy.yaml --pid <agent-pid>
 - [**Scope & Boundaries**](concepts/scope.md)
 - [**Evidence Receipts Technical Note**](notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md)
 - [**Promptfoo JSONL to Evidence Receipts**](use-cases/evidence-receipts-from-promptfoo-jsonl.md)
+- [**OpenFeature EvaluationDetails to CI Review Artifact**](use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md)
 - [**Evidence Receipt Assurance Mapping**](notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md)
 - [**Receipt Family Matrix**](reference/receipt-family-matrix.json)
 - [**Receipt Schema Registry**](reference/receipt-schemas/README.md)

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -51,6 +51,15 @@ Assay is designed for teams building production AI agents. Here are the most com
 
     [:octicons-arrow-right-24: Learn more](evidence-receipts-from-promptfoo-jsonl.md)
 
+-   :material-toggle-switch:{ .lg .middle } __OpenFeature Decision Receipts__
+
+    ---
+
+    Turn bounded boolean OpenFeature EvaluationDetails outcomes into runtime
+    decision receipts for CI review.
+
+    [:octicons-arrow-right-24: Learn more](openfeature-evaluationdetails-to-ci-review-artifact.md)
+
 </div>
 
 ---
@@ -64,6 +73,7 @@ Assay is designed for teams building production AI agents. Here are the most com
 | Air-Gapped Enterprise | Compliance, privacy | Security, FinTech |
 | Agent Self-Correction | Runtime guardrails | Agent Developer |
 | Promptfoo JSONL Receipts | Reviewable eval evidence boundary | Platform, Security |
+| OpenFeature Decision Receipts | Reviewable runtime decision boundary | Platform, Security |
 
 ---
 
@@ -109,4 +119,5 @@ Assay is designed for teams building production AI agents. Here are the most com
 - [Quick Start](../getting-started/quickstart.md)
 - [Core Concepts](../concepts/index.md)
 - [Evidence Receipts from Promptfoo JSONL](evidence-receipts-from-promptfoo-jsonl.md)
+- [OpenFeature EvaluationDetails to CI Review Artifact](openfeature-evaluationdetails-to-ci-review-artifact.md)
 - [MCP Integration](../mcp/index.md)

--- a/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md
+++ b/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md
@@ -1,0 +1,227 @@
+# OpenFeature EvaluationDetails to CI Review Artifact
+
+Use this if your application already emits boolean OpenFeature
+`EvaluationDetails` outcomes and you want a small reviewable CI artifact above
+that decision boundary.
+
+Assay does not replace OpenFeature or inspect provider rules. OpenFeature
+produces the detailed evaluation result. Assay reduces one bounded boolean
+`EvaluationDetails` outcome into a runtime decision receipt, bundles it,
+verifies the bundle, and lets CI gate the Trust Basis diff above that bundle.
+
+## Problem
+
+A runtime flag decision may be operationally important, but the full provider
+context, targeting state, and rule engine internals are often too broad for a
+review artifact.
+
+The smaller review question is:
+
+```text
+Which flag decision was observed, what source artifact did it come from, and
+can that decision boundary be reviewed without importing provider/runtime truth?
+```
+
+That is the receipt boundary. It is useful when reviewers need a CI artifact for
+runtime decision visibility without raw evaluation context, targeting keys,
+provider config, rules, metadata, or full observability traces.
+
+## One Workflow
+
+First write a bounded OpenFeature `EvaluationDetails` export as JSONL:
+
+```json
+{"schema":"openfeature.evaluation-details.export.v1","framework":"openfeature","surface":"evaluation_details","target_kind":"feature_flag","flag_key":"checkout.missing","result":{"value":false,"reason":"ERROR","error_code":"FLAG_NOT_FOUND"}}
+```
+
+Then import the supported boolean decision details into an Assay evidence
+bundle:
+
+```bash
+assay evidence import openfeature-details \
+  --input evaluation-details.jsonl \
+  --bundle-out openfeature-evidence.tar.gz \
+  --source-artifact-ref evaluation-details.jsonl
+```
+
+Verify the bundle and compile the claim artifact:
+
+```bash
+assay evidence verify openfeature-evidence.tar.gz
+assay trust-basis generate openfeature-evidence.tar.gz \
+  --out openfeature.trust-basis.json
+```
+
+Compare the candidate Trust Basis against a baseline:
+
+```bash
+assay trust-basis diff \
+  baseline.trust-basis.json \
+  openfeature.trust-basis.json \
+  --format json \
+  --fail-on-regression
+```
+
+In CI, the baseline Trust Basis artifact usually comes from the default branch
+or a previously approved run.
+
+Harness owns orchestration, exit codes, Markdown, and JUnit projection. The
+released recipe is here:
+
+- [OpenFeature decision receipt pipeline](https://github.com/Rul1an/Assay-Harness/blob/v0.3.2/docs/OPENFEATURE_DECISION_RECEIPT_PIPELINE.md)
+
+## Artifact Chain
+
+```text
+OpenFeature EvaluationDetails JSONL
+  -> assay evidence import openfeature-details
+  -> evidence.tar.gz
+  -> assay trust-basis generate
+  -> trust-basis.json
+  -> assay trust-basis diff
+  -> assay.trust-basis.diff.v1
+  -> assay-harness trust-basis gate/report
+```
+
+## Canonical Artifact
+
+The upstream OpenFeature Evaluation API documents detailed evaluation as a
+result structure with a flag key, value, and optional fields such as reason,
+variant, flag metadata, error code, and error message. Assay consumes a
+narrower exported shape for this receipt lane.
+
+Tiny bounded source excerpt:
+
+```json
+{
+  "schema": "openfeature.evaluation-details.export.v1",
+  "framework": "openfeature",
+  "surface": "evaluation_details",
+  "target_kind": "feature_flag",
+  "flag_key": "checkout.missing",
+  "result": {
+    "value": false,
+    "reason": "ERROR",
+    "error_code": "FLAG_NOT_FOUND"
+  }
+}
+```
+
+The current receipt lane is intentionally strict. It imports a bounded boolean
+value and, when present, bounded `variant`, `reason`, and `error_code` fields.
+Provider config, evaluation context, targeting keys, rules, metadata,
+`error_message`, and full provider state stay outside the receipt boundary.
+
+Proof artifacts are checked in under the Evidence Receipts in Action assets:
+
+| Artifact | Role |
+|---|---|
+| [`candidate.openfeature-details.jsonl`](../assets/evidence-receipts-in-action/openfeature/candidate.openfeature-details.jsonl) | Tiny bounded OpenFeature source artifact |
+| [`evidence.tar.gz`](../assets/evidence-receipts-in-action/openfeature/evidence.tar.gz) | Verifiable Assay decision receipt bundle |
+| [`trust-basis.json`](../assets/evidence-receipts-in-action/openfeature/trust-basis.json) | Canonical claim artifact |
+| [`trust-basis.diff.json`](../assets/evidence-receipts-in-action/openfeature/trust-basis.diff.json) | Canonical CI diff artifact |
+| [`trust-basis-summary.md`](../assets/evidence-receipts-in-action/openfeature/trust-basis-summary.md) | Markdown reviewer projection |
+| [`junit-trust-basis.xml`](../assets/evidence-receipts-in-action/openfeature/junit-trust-basis.xml) | JUnit CI projection |
+
+## Decision Receipt
+
+The reduced receipt keeps the decision boundary and source artifact digest:
+
+```json
+{
+  "schema": "assay.receipt.openfeature.evaluation_details.v1",
+  "source_system": "openfeature",
+  "source_surface": "evaluation_details.boolean",
+  "source_artifact_ref": "candidate.openfeature-details.jsonl",
+  "source_artifact_digest": "sha256:56d1e1a729d93f074044069b376fc54ef4cbef16ac5b7b0576195211ffa93436",
+  "reducer_version": "assay-openfeature-evaluation-details@0.1.0",
+  "imported_at": "2026-04-28T09:01:00Z",
+  "decision": {
+    "flag_key": "checkout.missing",
+    "value": false,
+    "value_type": "boolean",
+    "reason": "ERROR",
+    "error_code": "FLAG_NOT_FOUND"
+  }
+}
+```
+
+## Boundary
+
+Assay may claim that a supported external decision receipt boundary is visible:
+
+```json
+{
+  "id": "external_decision_receipt_boundary_visible",
+  "level": "verified",
+  "source": "external_decision_receipt",
+  "boundary": "supported-external-decision-receipt-events-only"
+}
+```
+
+That claim means one bounded boolean OpenFeature decision outcome was reduced
+into a supported receipt shape, carried through a verifiable bundle, and
+compiled into a Trust Basis artifact.
+
+It does not mean Assay owns OpenFeature semantics.
+
+## Not Claimed
+
+This path does not claim:
+
+- the flag value was correct
+- the targeting rules were correct
+- the provider was correct or safe
+- the evaluation context was imported
+- OpenFeature officially supports Assay
+- Assay understands full provider/runtime semantics
+- application behavior is safe
+
+The claim is about a reviewable decision boundary, not flag correctness.
+
+## Payoff Preview
+
+The raw diff stays the canonical CI artifact:
+
+```json
+{
+  "schema": "assay.trust-basis.diff.v1",
+  "summary": {
+    "regressed_claims": 0,
+    "removed_claims": 0,
+    "unchanged_claim_count": 10,
+    "has_regressions": false
+  }
+}
+```
+
+The Markdown projection is intentionally smaller:
+
+```text
+Trust Basis Gate
+Status: OK
+Regressed claims: 0
+Removed claims: 0
+Unchanged claims: 10
+```
+
+Markdown and JUnit are review projections only. The raw JSON diff remains the
+canonical CI artifact.
+
+## When to Use This
+
+Use this path when:
+
+- OpenFeature detailed evaluation output is already available or easy to export
+- reviewers need a portable artifact for a runtime decision boundary
+- you want Trust Basis diffs and Harness gates above selected flag decisions
+- targeting context, provider state, and rule internals should stay out of the
+  receipt boundary
+
+For the upstream field reference, see the OpenFeature
+[Evaluation API](https://openfeature.dev/docs/reference/concepts/evaluation-api/)
+and [Flag Evaluation API specification](https://openfeature.dev/specification/sections/flag-evaluation).
+For the Assay CLI import reference, see
+[`assay evidence import openfeature-details`](../reference/cli/evidence.md#openfeature-details-import).
+For the three-family static proof page, see
+[Evidence Receipts in Action](../notes/EVIDENCE-RECEIPTS-IN-ACTION.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -216,6 +216,7 @@ nav:
   - Use Cases:
     - use-cases/index.md
     - Promptfoo JSONL Receipts: use-cases/evidence-receipts-from-promptfoo-jsonl.md
+    - OpenFeature Decision Receipts: use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md
     - CI Regression Gate: use-cases/ci-gate.md
     - Trace-Driven Debugging: use-cases/debugging.md
     - Air-Gapped Enterprise: use-cases/air-gapped.md


### PR DESCRIPTION
Summary
- add the P61 OpenFeature EvaluationDetails adoption page for runtime decision receipts
- show the released openfeature-details importer path, checked-in proof artifacts, Trust Basis claim, raw diff, and Markdown projection
- link OpenFeature as the second adoption route from README, docs homepage, use-cases index, and MkDocs nav while keeping Promptfoo first
- keep the language bounded: no OpenFeature integration claim, provider support claim, or new receipt family

Validation
- git diff --check
- mkdocs build --strict
- pre-commit hooks during commit and push

References
- OpenFeature Evaluation API: https://openfeature.dev/docs/reference/concepts/evaluation-api/
- OpenFeature Flag Evaluation API specification: https://openfeature.dev/specification/sections/flag-evaluation
