### PR TITLE
[codex] Prepare v3.10.1 release-truth packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.10.1] - 2026-05-17
+
+This patch release packages the post-`v3.10.0` three-family adoption surface
+under one versioned Assay line. It focuses on release-truth and shareability:
+the proof page, longform receipt note, assurance mapping note, and three
+search-intent adoption pages now travel together under the same tag. It does
+**not** add runtime behavior, a new claim-visible receipt family, Harness
+semantics, a compliance claim, a partnership claim, or a hosted surface.
+
+### Docs / Adoption
+
+- Added three compact adoption paths for the released claim-visible receipt
+  families:
+  - [Evidence Receipts from Promptfoo JSONL](docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md)
+    for selected eval outcome receipts.
+  - [OpenFeature EvaluationDetails to CI Review Artifact](docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md)
+    for bounded runtime decision receipts.
+  - [CycloneDX ML-BOM Model to Inventory Receipt](docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md)
+    for selected model inventory/provenance-reference receipts.
+- Updated README, docs homepage, use-cases index, and MkDocs navigation so the
+  three adoption routes appear in the intended order: Promptfoo first,
+  OpenFeature second, CycloneDX third.
+- Tightened the P57 ecosystem seeding pack around one release-truth line:
+  outward links for proof, theory, mapping, and adoption surfaces should use
+  this tag or a later release tag rather than `main`.
+
 ## [3.10.0] - 2026-05-11
 
 This minor release turns the post-`v3.9.2` audit/refactor sweep into a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "aya",
  "chrono",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.10.0"
+version = "3.10.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -70,15 +70,15 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.10.0" }
-assay-common = { path = "crates/assay-common", version = "3.10.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.10.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.10.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.10.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.10.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.10.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.10.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.10.0" }
+assay-core = { path = "crates/assay-core", version = "3.10.1" }
+assay-common = { path = "crates/assay-common", version = "3.10.1", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.10.1" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.10.1" }
+assay-policy = { path = "crates/assay-policy", version = "3.10.1" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.10.1" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.10.1" }
+assay-sim = { path = "crates/assay-sim", version = "3.10.1" }
+assay-registry = { path = "crates/assay-registry", version = "3.10.1" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
+++ b/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
@@ -1,9 +1,9 @@
 # P57 Ecosystem Seeding Pack
 
-> **Status:** ready for controlled seeding after Assay `v3.9.2`; one
-> Promptfoo-context follow-up has already been placed
+> **Status:** ready for controlled seeding after Assay `v3.10.1` is tagged;
+> one Promptfoo-context follow-up has already been placed
 >
-> **Last updated:** 2026-05-04
+> **Last updated:** 2026-05-17
 > **Scope:** small repo-native sharing pack for the released evidence receipt
 > surface. This is not a launch plan, campaign, partnership claim, compliance
 > claim, or new product wedge.
@@ -21,22 +21,29 @@ Short post line:
 
 | Role | Link | Use When |
 |---|---|---|
-| Primary proof | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.9.2/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | Use as the one-link repo-native proof entrypoint. This page is present in the `v3.9.2` tag. |
-| Assurance mapping | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.9.2/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | Use only for assurance-context replies after someone asks what review question each receipt family helps answer. |
-| Promptfoo context note | [From Promptfoo JSONL to Evidence Receipts](https://github.com/Rul1an/assay/blob/v3.9.1/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) | Use only for an existing Promptfoo JSONL/assertion-results context. This note is present in the `v3.9.1` tag. |
-| Theory | [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](https://github.com/Rul1an/assay/blob/v3.9.1/docs/notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) | Use as the read-more link when someone asks why receipts instead of broad integrations. |
+| Primary proof | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | Use as the one-link repo-native proof entrypoint after the `v3.10.1` tag is live. |
+| Theory | [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) | Use as the read-more link when someone asks why receipts instead of broad integrations. |
+| Assurance mapping | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | Use only for assurance-context replies after someone asks what review question each receipt family helps answer. |
+| Promptfoo adoption | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | Use when someone wants the smallest eval-output adoption path. |
+| OpenFeature adoption | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | Use when someone asks about runtime flag decision boundaries. |
+| CycloneDX adoption | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | Use when someone asks what model inventory/provenance boundary existed. |
+| Promptfoo context note | [From Promptfoo JSONL to Evidence Receipts](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) | Use only for an existing Promptfoo JSONL/assertion-results context. |
 | Runnable recipe | [Promptfoo receipt pipeline](https://github.com/Rul1an/Assay-Harness/blob/v0.3.2/docs/PROMPTFOO_RECEIPT_PIPELINE.md) | Use when someone wants to run the smallest released recipe immediately. |
 
-Now tagged in Assay `v3.9.2`:
+Do not use the `v3.10.1` links outward until the tag exists. Once tagged, this
+is the current released link set for the three-family adoption surface.
 
 - `EVIDENCE-RECEIPTS-IN-ACTION.md` is the primary proof page.
 - `EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md` is the second-layer assurance note.
+- the three use-case pages are the adoption surfaces for Promptfoo,
+  OpenFeature, and CycloneDX.
 
 Current allowed package:
 
 - proof: Evidence Receipts in Action
 - Promptfoo context: From Promptfoo JSONL to Evidence Receipts
 - theory: Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory
+- adoption: Promptfoo, OpenFeature, and CycloneDX use-case pages
 - recipe: Promptfoo receipt pipeline
 
 ## Repo-Native Post
@@ -67,12 +74,13 @@ can be bundled and verified, and the Trust Basis claim above it can be gated
 without teaching Harness family-specific semantics.
 
 Proof:
-https://github.com/Rul1an/assay/blob/v3.9.2/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
+https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
 ```
 
-The proof link resolves under the public Assay `v3.9.2` tag. The existing `v*`
-release workflow builds full release artifacts, so do not describe `v3.9.2` as
-docs-only.
+The proof link must resolve under the public Assay `v3.10.1` tag before this
+post is used. The existing `v*` release workflow builds full release artifacts,
+so describe the release as a docs/adoption packaging line, not as a bare
+documentation tag.
 
 Do not add:
 
@@ -85,15 +93,17 @@ Do not add:
 
 | Spot | Link to Send | One Sentence | Do Not Ask |
 |---|---|---|---|
-| Release-adjacent update | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.9.2/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | We made the evidence boundary inspectable: selected Promptfoo, OpenFeature, and CycloneDX outcomes now compile into bounded receipts and Trust Basis claims. | Do not ask for generic feedback, stars, adoption, or partnership. Use a repo Discussion only if there is no suitable release/docs context. |
-| Existing Promptfoo JSONL/componentResults context | [From Promptfoo JSONL to Evidence Receipts](https://github.com/Rul1an/assay/blob/v3.9.1/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) | This keeps Promptfoo as the eval runner while showing how selected assertion component outcomes become portable evidence receipts. | Never open a fresh thread just to restate the proof. Do not imply Promptfoo endorsement, official integration, or eval correctness. Add the recipe link only if someone asks to run it. |
-| Assurance / audit-context follow-up | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.9.2/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | This maps each released receipt family to the assurance question it can help answer and the claims it explicitly does not make. | Do not frame it as a compliance checklist or legal interpretation. |
+| Release-adjacent update | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | We made the evidence boundary inspectable: selected Promptfoo, OpenFeature, and CycloneDX outcomes now compile into bounded receipts and Trust Basis claims. | Do not ask for generic feedback, stars, adoption, or partnership. Use a repo Discussion only if there is no suitable release/docs context. |
+| Existing Promptfoo JSONL/componentResults context | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | This keeps Promptfoo as the eval runner while showing how selected assertion component outcomes become portable evidence receipts. | Never open a fresh thread just to restate the proof. Do not imply Promptfoo endorsement, official integration, or eval correctness. Add the recipe link only if someone asks to run it. |
+| OpenFeature runtime-decision context | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | This keeps OpenFeature as the decision API while showing how one bounded boolean EvaluationDetails outcome becomes a reviewable decision receipt. | Do not imply provider support, targeting-rule correctness, or official OpenFeature endorsement. |
+| CycloneDX model-inventory context | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | This shows what model inventory/provenance-reference boundary existed without importing full BOM truth. | Do not imply BOM completeness, model safety, provenance sufficiency, or official CycloneDX endorsement. |
+| Assurance / audit-context follow-up | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | This maps each released receipt family to the assurance question it can help answer and the claims it explicitly does not make. | Do not frame it as a compliance checklist or legal interpretation. |
 
 ## Share Order
 
 1. Keep the existing Promptfoo-context follow-up on the versioned
    `FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md` note.
-2. Post the repo-native note first, using only the versioned `v3.9.2` proof
+2. Post the repo-native note first, using only the versioned `v3.10.1` proof
    link as the primary outward link.
 3. Let the proof page act as the hub for theory, mapping, and recipes.
 4. Wait at least one day.
@@ -118,9 +128,9 @@ Do not add:
 - No "would love feedback" framing.
 - No pressure to adopt.
 - Link outward to `EVIDENCE-RECEIPTS-IN-ACTION.md` only through the versioned
-  `v3.9.2` URL or a later release tag.
-- Link outward to the mapping note only through the versioned `v3.9.2` URL or a
-  later release tag.
+  `v3.10.1` URL or a later release tag.
+- Link outward to the mapping note and adoption pages only through the
+  versioned `v3.10.1` URL or a later release tag.
 
 The goal is only to put the released proof, theory, and runnable recipe in
 front of people who already care about evidence boundaries.


### PR DESCRIPTION
Summary
- prepare Assay v3.10.1 as the smallest correct release line for the three-family adoption surface
- bump workspace/package metadata from 3.10.0 to 3.10.1 so a future v3.10.1 tag has matching binary/crate metadata
- add changelog release notes for proof, longform, mapping, and three adoption pages under one versioned line
- update P57 seeding pack so outward links target v3.10.1 and no longer claim missing v3.9.2 pages

Release Truth
- Latest released tag remains v3.10.0 until this PR is merged and v3.10.1 is tagged.
- v3.9.2 and v3.10.0 do not contain the current proof/mapping/adoption page set.
- Do not use the P57 v3.10.1 outward links until the tag exists.
- Harness recipe links remain on Assay-Harness v0.3.2 where the proof recipes are unchanged.

Validation
- git diff --check
- mkdocs build --strict
- cargo metadata --locked --no-deps --format-version 1
- pre-commit hooks during commit: merge-conflict check, TOML check, EOF/whitespace, typos, cargo fmt, cargo deny