### PR TITLE
[codex] Tolerate CRLF release checksums

### DIFF
--- a/scripts/ci/check-release-assets.sh
+++ b/scripts/ci/check-release-assets.sh
@@ -28,6 +28,7 @@ basename_from_checksum_line() {
   line="${line#* }"
   line="${line#"${line%%[![:space:]]*}"}"
   line="${line#\\*}"
+  line="${line//$'\r'/}"
   basename "$line"
 }
 

--- a/scripts/ci/test-release-assets.sh
+++ b/scripts/ci/test-release-assets.sh
@@ -98,6 +98,14 @@ valid_dir="${tmp_root}/valid"
 build_valid_assets "$valid_dir"
 expect_pass "$valid_dir"
 
+crlf_checksum_dir="${tmp_root}/crlf-checksum"
+cp -R "$valid_dir" "$crlf_checksum_dir"
+crlf_target="assay-${VERSION}-x86_64-pc-windows-msvc.zip"
+printf '%s  %s\r\n' \
+  "$(compute_sha256 "${crlf_checksum_dir}/${crlf_target}")" \
+  "$crlf_target" >"${crlf_checksum_dir}/${crlf_target}.sha256"
+expect_pass "$crlf_checksum_dir"
+
 missing_checksum_dir="${tmp_root}/missing-checksum"
 cp -R "$valid_dir" "$missing_checksum_dir"
 rm "${missing_checksum_dir}/assay-${VERSION}-x86_64-unknown-linux-gnu.tar.gz.sha256"


### PR DESCRIPTION
Summary

- tolerate CRLF line endings in release checksum target parsing
- add a regression test that mirrors the Windows .zip.sha256 output shape
- keep release asset preflight strict on names, hashes, and server.json linkage

Validation

- bash scripts/ci/test-release-assets.sh
- git diff --check
- pre-commit hooks during commit/push: merge-conflict check, whitespace, typos, shellcheck, cargo fmt, clippy, linux compile gate

Release note

The v3.10.1 tag exists, but the GitHub Release was not created because the release workflow failed in asset preflight before publishing. The failure was caused by CRLF in the Windows checksum file target line, not by a bad artifact hash. After this lands, rerun release on a fresh tag or explicitly decide whether to recreate v3.10.1.