### PR TITLE
[codex] Prepare v3.10.2 release truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.10.2] - 2026-05-17
+
+This patch release carries the same three-family adoption surface as `v3.10.1`
+and fixes the release asset preflight so Windows `.sha256` files with CRLF line
+endings are accepted when the checksum target and hash are otherwise correct.
+It does **not** add runtime behavior, a new claim-visible receipt family,
+Harness semantics, or a new external claim.
+
+### Release Operations
+
+- Tolerated CRLF line endings when parsing release checksum target filenames.
+- Added a regression test for the Windows `.zip.sha256` shape that blocked the
+  `v3.10.1` GitHub Release creation after the build matrix had succeeded.
+- Updated the P57 seeding pack to use the `v3.10.2` release-truth line for
+  outward proof, theory, mapping, and adoption links.
+
 ## [3.10.1] - 2026-05-17
 
 This patch release packages the post-`v3.10.0` three-family adoption surface

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "aya",
  "chrono",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1435,7 +1435,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1613,7 +1613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2884,7 +2884,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4182,7 +4182,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4240,7 +4240,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4661,7 +4661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4825,7 +4825,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5646,7 +5646,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.10.1"
+version = "3.10.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -70,15 +70,15 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.10.1" }
-assay-common = { path = "crates/assay-common", version = "3.10.1", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.10.1" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.10.1" }
-assay-policy = { path = "crates/assay-policy", version = "3.10.1" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.10.1" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.10.1" }
-assay-sim = { path = "crates/assay-sim", version = "3.10.1" }
-assay-registry = { path = "crates/assay-registry", version = "3.10.1" }
+assay-core = { path = "crates/assay-core", version = "3.10.2" }
+assay-common = { path = "crates/assay-common", version = "3.10.2", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.10.2" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.10.2" }
+assay-policy = { path = "crates/assay-policy", version = "3.10.2" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.10.2" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.10.2" }
+assay-sim = { path = "crates/assay-sim", version = "3.10.2" }
+assay-registry = { path = "crates/assay-registry", version = "3.10.2" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
+++ b/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
@@ -1,6 +1,6 @@
 # P57 Ecosystem Seeding Pack
 
-> **Status:** ready for controlled seeding after Assay `v3.10.1` is tagged;
+> **Status:** ready for controlled seeding after Assay `v3.10.2` is tagged;
 > one Promptfoo-context follow-up has already been placed
 >
 > **Last updated:** 2026-05-17
@@ -21,16 +21,16 @@ Short post line:
 
 | Role | Link | Use When |
 |---|---|---|
-| Primary proof | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | Use as the one-link repo-native proof entrypoint after the `v3.10.1` tag is live. |
-| Theory | [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) | Use as the read-more link when someone asks why receipts instead of broad integrations. |
-| Assurance mapping | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | Use only for assurance-context replies after someone asks what review question each receipt family helps answer. |
-| Promptfoo adoption | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | Use when someone wants the smallest eval-output adoption path. |
-| OpenFeature adoption | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | Use when someone asks about runtime flag decision boundaries. |
-| CycloneDX adoption | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | Use when someone asks what model inventory/provenance boundary existed. |
-| Promptfoo context note | [From Promptfoo JSONL to Evidence Receipts](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) | Use only for an existing Promptfoo JSONL/assertion-results context. |
+| Primary proof | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | Use as the one-link repo-native proof entrypoint after the `v3.10.2` tag is live. |
+| Theory | [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) | Use as the read-more link when someone asks why receipts instead of broad integrations. |
+| Assurance mapping | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | Use only for assurance-context replies after someone asks what review question each receipt family helps answer. |
+| Promptfoo adoption | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | Use when someone wants the smallest eval-output adoption path. |
+| OpenFeature adoption | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | Use when someone asks about runtime flag decision boundaries. |
+| CycloneDX adoption | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | Use when someone asks what model inventory/provenance boundary existed. |
+| Promptfoo context note | [From Promptfoo JSONL to Evidence Receipts](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) | Use only for an existing Promptfoo JSONL/assertion-results context. |
 | Runnable recipe | [Promptfoo receipt pipeline](https://github.com/Rul1an/Assay-Harness/blob/v0.3.2/docs/PROMPTFOO_RECEIPT_PIPELINE.md) | Use when someone wants to run the smallest released recipe immediately. |
 
-Do not use the `v3.10.1` links outward until the tag exists. Once tagged, this
+Do not use the `v3.10.2` links outward until the tag exists. Once tagged, this
 is the current released link set for the three-family adoption surface.
 
 - `EVIDENCE-RECEIPTS-IN-ACTION.md` is the primary proof page.
@@ -74,10 +74,10 @@ can be bundled and verified, and the Trust Basis claim above it can be gated
 without teaching Harness family-specific semantics.
 
 Proof:
-https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
+https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
 ```
 
-The proof link must resolve under the public Assay `v3.10.1` tag before this
+The proof link must resolve under the public Assay `v3.10.2` tag before this
 post is used. The existing `v*` release workflow builds full release artifacts,
 so describe the release as a docs/adoption packaging line, not as a bare
 documentation tag.
@@ -93,17 +93,17 @@ Do not add:
 
 | Spot | Link to Send | One Sentence | Do Not Ask |
 |---|---|---|---|
-| Release-adjacent update | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | We made the evidence boundary inspectable: selected Promptfoo, OpenFeature, and CycloneDX outcomes now compile into bounded receipts and Trust Basis claims. | Do not ask for generic feedback, stars, adoption, or partnership. Use a repo Discussion only if there is no suitable release/docs context. |
-| Existing Promptfoo JSONL/componentResults context | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | This keeps Promptfoo as the eval runner while showing how selected assertion component outcomes become portable evidence receipts. | Never open a fresh thread just to restate the proof. Do not imply Promptfoo endorsement, official integration, or eval correctness. Add the recipe link only if someone asks to run it. |
-| OpenFeature runtime-decision context | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | This keeps OpenFeature as the decision API while showing how one bounded boolean EvaluationDetails outcome becomes a reviewable decision receipt. | Do not imply provider support, targeting-rule correctness, or official OpenFeature endorsement. |
-| CycloneDX model-inventory context | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.10.1/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | This shows what model inventory/provenance-reference boundary existed without importing full BOM truth. | Do not imply BOM completeness, model safety, provenance sufficiency, or official CycloneDX endorsement. |
-| Assurance / audit-context follow-up | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.10.1/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | This maps each released receipt family to the assurance question it can help answer and the claims it explicitly does not make. | Do not frame it as a compliance checklist or legal interpretation. |
+| Release-adjacent update | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | We made the evidence boundary inspectable: selected Promptfoo, OpenFeature, and CycloneDX outcomes now compile into bounded receipts and Trust Basis claims. | Do not ask for generic feedback, stars, adoption, or partnership. Use a repo Discussion only if there is no suitable release/docs context. |
+| Existing Promptfoo JSONL/componentResults context | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | This keeps Promptfoo as the eval runner while showing how selected assertion component outcomes become portable evidence receipts. | Never open a fresh thread just to restate the proof. Do not imply Promptfoo endorsement, official integration, or eval correctness. Add the recipe link only if someone asks to run it. |
+| OpenFeature runtime-decision context | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | This keeps OpenFeature as the decision API while showing how one bounded boolean EvaluationDetails outcome becomes a reviewable decision receipt. | Do not imply provider support, targeting-rule correctness, or official OpenFeature endorsement. |
+| CycloneDX model-inventory context | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | This shows what model inventory/provenance-reference boundary existed without importing full BOM truth. | Do not imply BOM completeness, model safety, provenance sufficiency, or official CycloneDX endorsement. |
+| Assurance / audit-context follow-up | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | This maps each released receipt family to the assurance question it can help answer and the claims it explicitly does not make. | Do not frame it as a compliance checklist or legal interpretation. |
 
 ## Share Order
 
 1. Keep the existing Promptfoo-context follow-up on the versioned
    `FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md` note.
-2. Post the repo-native note first, using only the versioned `v3.10.1` proof
+2. Post the repo-native note first, using only the versioned `v3.10.2` proof
    link as the primary outward link.
 3. Let the proof page act as the hub for theory, mapping, and recipes.
 4. Wait at least one day.
@@ -128,9 +128,9 @@ Do not add:
 - No "would love feedback" framing.
 - No pressure to adopt.
 - Link outward to `EVIDENCE-RECEIPTS-IN-ACTION.md` only through the versioned
-  `v3.10.1` URL or a later release tag.
+  `v3.10.2` URL or a later release tag.
 - Link outward to the mapping note and adoption pages only through the
-  versioned `v3.10.1` URL or a later release tag.
+  versioned `v3.10.2` URL or a later release tag.
 
 The goal is only to put the released proof, theory, and runnable recipe in
 front of people who already care about evidence boundaries.


### PR DESCRIPTION
Summary

- bump the workspace release line from 3.10.1 to 3.10.2 without adding new runtime semantics
- keep the three-family adoption surface as the released truth target
- update P57 outward links from v3.10.1 to v3.10.2
- document that v3.10.2 carries the CRLF release-checksum preflight fix after the v3.10.1 release creation failed before publishing

Release Truth

- v3.10.1 exists as a tag, but there is no GitHub Release for it.
- The v3.10.1 release workflow failed in Create Release asset preflight after the build matrix succeeded.
- v3.10.2 is the clean next release line; no tag rewriting is needed.

Validation

- git diff --check
- cargo metadata --locked --no-deps --format-version 1
- bash scripts/ci/test-release-assets.sh
- mkdocs build --strict via a fresh temp venv using docs/requirements-ci.txt
- pre-commit hooks during commit and push: merge-conflict check, TOML check, EOF/whitespace, typos, cargo fmt, cargo deny/audit, clippy, linux compile gate