### PR TITLE
[codex] Trim only trailing CR in release checksum target

### DIFF
--- a/scripts/ci/check-release-assets.sh
+++ b/scripts/ci/check-release-assets.sh
@@ -28,7 +28,7 @@ basename_from_checksum_line() {
   line="${line#* }"
   line="${line#"${line%%[![:space:]]*}"}"
   line="${line#\\*}"
-  line="${line//$'\r'/}"
+  line="${line%$'\r'}"
   basename "$line"
 }
 

--- a/scripts/ci/test-release-assets.sh
+++ b/scripts/ci/test-release-assets.sh
@@ -106,6 +106,14 @@ printf '%s  %s\r\n' \
   "$crlf_target" >"${crlf_checksum_dir}/${crlf_target}.sha256"
 expect_pass "$crlf_checksum_dir"
 
+embedded_cr_target_dir="${tmp_root}/embedded-cr-target"
+cp -R "$valid_dir" "$embedded_cr_target_dir"
+printf '%s  %s\r%s\n' \
+  "$(compute_sha256 "${embedded_cr_target_dir}/${crlf_target}")" \
+  "assay-${VERSION}-x86_64-pc-windows-msvc" \
+  ".zip" >"${embedded_cr_target_dir}/${crlf_target}.sha256"
+expect_fail "embedded carriage return in checksum target" "$embedded_cr_target_dir"
+
 missing_checksum_dir="${tmp_root}/missing-checksum"
 cp -R "$valid_dir" "$missing_checksum_dir"
 rm "${missing_checksum_dir}/assay-${VERSION}-x86_64-unknown-linux-gnu.tar.gz.sha256"


### PR DESCRIPTION
## Summary
- tighten checksum target parsing to trim only a trailing carriage return ()
- preserve CRLF tolerance for Windows-generated checksum files
- add regression coverage proving embedded  in the checksum target is rejected

## Validation
- release asset preflight tests passed
- pre-commit hooks during commit/push (shellcheck, cargo fmt, clippy, linux compile gate)

## Why
Copilot flagged that global CR removal could normalize malformed target strings more than intended. This follow-up keeps the original CRLF fix while making parsing stricter.