### PR TITLE
[codex] wire runner live kernel capture

### DIFF
--- a/crates/assay-cli/src/cli/commands/runner_spike.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike.rs
@@ -29,6 +29,18 @@ pub struct RunnerSpikeRunArgs {
     #[arg(long, short = 'o')]
     pub output: Option<PathBuf>,
 
+    /// Hidden S3 spike path: capture live kernel events with assay-monitor.
+    #[arg(long, hide = true)]
+    pub kernel_capture: bool,
+
+    /// eBPF object path for hidden kernel capture mode.
+    #[arg(long, hide = true)]
+    pub ebpf: Option<PathBuf>,
+
+    /// Milliseconds to drain kernel events after the child exits.
+    #[arg(long, hide = true, default_value_t = 100)]
+    pub kernel_drain_ms: u64,
+
     /// Command to run.
     #[arg(allow_hyphen_values = true, required = true, trailing_var_arg = true)]
     pub command: Vec<String>,
@@ -36,19 +48,35 @@ pub struct RunnerSpikeRunArgs {
 
 pub async fn run(args: RunnerSpikeArgs) -> anyhow::Result<i32> {
     match args.cmd {
-        RunnerSpikeCommand::Run(args) => cmd_run(args),
+        RunnerSpikeCommand::Run(args) => cmd_run(args).await,
     }
 }
 
-fn cmd_run(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
-    let mut spec = RunSpec::new(args.command).with_agent_shim(args.agent_shim);
-    if let Some(run_id) = args.run_id {
-        spec = spec.with_run_id(run_id);
+async fn cmd_run(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
+    if args.kernel_capture {
+        return cmd_run_with_kernel_capture(args).await;
     }
 
-    let output = args
-        .output
-        .unwrap_or_else(|| PathBuf::from(format!("assay-runner-spike-{}.tar.gz", spec.run_id)));
+    cmd_run_contract_only(args)
+}
+
+fn build_spec(args: &RunnerSpikeRunArgs) -> RunSpec {
+    let mut spec = RunSpec::new(args.command.clone()).with_agent_shim(args.agent_shim.clone());
+    if let Some(run_id) = &args.run_id {
+        spec = spec.with_run_id(run_id.clone());
+    }
+    spec
+}
+
+fn bundle_output_path(args: &RunnerSpikeRunArgs, run_id: &str) -> PathBuf {
+    args.output
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(format!("assay-runner-spike-{run_id}.tar.gz")))
+}
+
+fn cmd_run_contract_only(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
+    let spec = build_spec(&args);
+    let output = bundle_output_path(&args, &spec.run_id);
 
     let outcome = spec.run_contract_only()?;
     let mut file = File::create(&output)?;
@@ -63,6 +91,186 @@ fn cmd_run(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
     );
 
     Ok(exit_status_code(outcome.exit_code, outcome.signal))
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn cmd_run_with_kernel_capture(_args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
+    eprintln!("Error: runner-spike --kernel-capture is only supported on Linux.");
+    Ok(40)
+}
+
+#[cfg(target_os = "linux")]
+async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
+    use assay_monitor::Monitor;
+    use assay_runner_spike::{CgroupCorrelationStatus, KernelLayerBuilder};
+    use std::time::{Duration, Instant};
+    use tokio_stream::StreamExt;
+
+    let spec = build_spec(&args);
+    spec.validate()?;
+    let output = bundle_output_path(&args, &spec.run_id);
+    let ebpf_path = args
+        .ebpf
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("target/assay-ebpf.o"));
+
+    if !ebpf_path.exists() {
+        eprintln!(
+            "Error: eBPF object not found at {}. Build it with 'cargo xtask build-ebpf' or provide --ebpf <path>.",
+            ebpf_path.display()
+        );
+        return Ok(40);
+    }
+
+    let mut monitor = match Monitor::load_file(&ebpf_path) {
+        Ok(monitor) => monitor,
+        Err(error) => {
+            eprintln!("Failed to load eBPF: {error}");
+            return Ok(40);
+        }
+    };
+    if let Err(error) = monitor.configure_defaults() {
+        eprintln!("Failed to configure eBPF defaults: {error}");
+        return Ok(40);
+    }
+    if let Err(error) = monitor.attach() {
+        eprintln!("Failed to attach eBPF probes: {error}");
+        return Ok(40);
+    }
+
+    let before_stats = monitor.snapshot_stats()?;
+    // Safe before arming: assay-ebpf default-denies events when
+    // MONITORED_CGROUPS is empty and KEY_MONITOR_ALL is unset, so this window
+    // loses early child events rather than contaminating the bundle.
+    let mut stream = monitor.listen()?;
+    let mut builder = KernelLayerBuilder::new(&spec.run_id)?;
+    let mut archive = spec.skeleton_archive()?;
+    let clock = Instant::now();
+    spec.append_run_started(&mut archive, 0, Duration::ZERO)?;
+
+    let mut child = tokio::process::Command::new(&spec.command[0])
+        .args(&spec.command[1..])
+        .spawn()?;
+    if let Some(pid) = child.id() {
+        arm_monitor_for_pid(&mut monitor, pid);
+    } else {
+        eprintln!("Warning: child pid unavailable; kernel capture will be attribution-partial.");
+    }
+
+    let status = loop {
+        tokio::select! {
+            status = child.wait() => break status?,
+            event = stream.next() => {
+                match event {
+                    Some(Ok(event)) => builder.push_monitor_event(&event)?,
+                    Some(Err(error)) => eprintln!("Warning: failed to parse kernel event: {error}"),
+                    None => {
+                        eprintln!("Warning: kernel event stream closed before child exit.");
+                        break child.wait().await?;
+                    }
+                }
+            }
+        }
+    };
+
+    drain_kernel_events(
+        &mut stream,
+        &mut builder,
+        Duration::from_millis(args.kernel_drain_ms),
+    )
+    .await?;
+    let after_stats = monitor.snapshot_stats()?;
+    let capture = builder.finish(&before_stats, &after_stats);
+    capture.apply_to_archive(&mut archive, CgroupCorrelationStatus::Partial)?;
+    spec.append_run_finished(&mut archive, 1, &status, clock.elapsed())?;
+
+    let mut file = File::create(&output)?;
+    archive.write(&mut file)?;
+    let exit_code = status.code();
+    let signal = exit_signal(&status);
+    let exit_status = exit_status_label(exit_code, signal);
+
+    println!(
+        "wrote runner-spike bundle: {} (run_id={}, status={}, kernel_capture=partial)",
+        output.display(),
+        spec.run_id,
+        exit_status
+    );
+
+    Ok(exit_status_code(exit_code, signal))
+}
+
+#[cfg(target_os = "linux")]
+fn arm_monitor_for_pid(monitor: &mut assay_monitor::Monitor, pid: u32) {
+    if let Err(error) = monitor.set_monitored_pids(&[pid]) {
+        eprintln!("Warning: failed to populate runner PID map for {pid}: {error}");
+    }
+
+    match resolve_cgroup_id(pid) {
+        Ok(cgroup_id) => {
+            if let Err(error) = monitor.set_monitored_cgroups(&[cgroup_id]) {
+                eprintln!("Warning: failed to populate runner cgroup map for {pid}: {error}");
+            }
+        }
+        Err(error) => {
+            eprintln!("Warning: failed to resolve runner cgroup for {pid}: {error}");
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn drain_kernel_events(
+    stream: &mut assay_monitor::EventStream,
+    builder: &mut assay_runner_spike::KernelLayerBuilder,
+    duration: std::time::Duration,
+) -> anyhow::Result<()> {
+    use tokio_stream::StreamExt;
+
+    let deadline = tokio::time::sleep(duration);
+    tokio::pin!(deadline);
+    loop {
+        tokio::select! {
+            _ = &mut deadline => break,
+            event = stream.next() => {
+                match event {
+                    Some(Ok(event)) => builder.push_monitor_event(&event)?,
+                    Some(Err(error)) => eprintln!("Warning: failed to parse kernel event while draining: {error}"),
+                    None => break,
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_cgroup_id(pid: u32) -> anyhow::Result<u64> {
+    use std::io::BufRead;
+    use std::os::linux::fs::MetadataExt;
+
+    let cgroup_path = format!("/proc/{pid}/cgroup");
+    let file = std::fs::File::open(&cgroup_path)?;
+    let reader = std::io::BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.starts_with("0::") {
+            let path = line.trim_start_matches("0::");
+            let path = if path.is_empty() { "/" } else { path };
+            let full_path = format!("/sys/fs/cgroup{path}");
+            let metadata = std::fs::metadata(&full_path)
+                .map_err(|error| anyhow::anyhow!("failed to stat {full_path}: {error}"))?;
+            return Ok(metadata.st_ino());
+        }
+    }
+
+    anyhow::bail!("no cgroup v2 entry found in {cgroup_path}")
+}
+
+#[cfg(target_os = "linux")]
+fn exit_signal(status: &std::process::ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt;
+    status.signal()
 }
 
 fn exit_status_label(exit_code: Option<i32>, signal: Option<i32>) -> String {

--- a/crates/assay-runner-spike/src/lib.rs
+++ b/crates/assay-runner-spike/src/lib.rs
@@ -24,5 +24,5 @@ pub use health::{
     SdkLayerStatus, OBSERVATION_HEALTH_SCHEMA,
 };
 pub use kernel::{KernelLayerBuilder, KernelLayerCapture, KernelLayerError, KERNEL_EVENT_SCHEMA};
-pub use run::{RunExecutionError, RunOutcome, RunSpec, RunSpecError};
+pub use run::{RunExecutionError, RunOutcome, RunSpec, RunSpecError, RUN_EVENT_SCHEMA};
 pub use surface::{CapabilitySurface, CapabilitySurfaceError, CAPABILITY_SURFACE_SCHEMA};

--- a/crates/assay-runner-spike/src/run.rs
+++ b/crates/assay-runner-spike/src/run.rs
@@ -1,10 +1,12 @@
 use crate::{CgroupCorrelationStatus, KernelLayerStatus, RunnerSpikeArchive};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::process::Command;
-use std::time::Instant;
+use std::process::{Command, ExitStatus};
+use std::time::{Duration, Instant};
 use thiserror::Error;
 use uuid::Uuid;
+
+pub const RUN_EVENT_SCHEMA: &str = "assay.runner.event.v0";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RunSpec {
@@ -119,18 +121,7 @@ impl RunSpec {
         let mut archive = self.skeleton_archive()?;
         let clock = Instant::now();
 
-        append_event(
-            &mut archive,
-            json!({
-                "schema": "assay.runner.event.v0",
-                "run_id": self.run_id,
-                "seq": 0_u64,
-                "type": "run_started",
-                "agent_shim": self.agent_shim,
-                "command": self.command,
-                "window_elapsed_ms": 0_u64
-            }),
-        )?;
+        self.append_run_started(&mut archive, 0, Duration::ZERO)?;
 
         let mut child = Command::new(&self.command[0])
             .args(&self.command[1..])
@@ -147,19 +138,7 @@ impl RunSpec {
         let exit_code = status.code();
         let signal = exit_signal(&status);
         let success = status.success();
-        append_event(
-            &mut archive,
-            json!({
-                "schema": "assay.runner.event.v0",
-                "run_id": self.run_id,
-                "seq": 1_u64,
-                "type": "run_finished",
-                "exit_code": exit_code,
-                "signal": signal,
-                "success": success,
-                "window_elapsed_ms": clock.elapsed().as_millis() as u64
-            }),
-        )?;
+        self.append_run_finished(&mut archive, 1, &status, clock.elapsed())?;
 
         Ok(RunOutcome {
             archive,
@@ -167,6 +146,50 @@ impl RunSpec {
             signal,
             success,
         })
+    }
+
+    pub fn append_run_started(
+        &self,
+        archive: &mut RunnerSpikeArchive,
+        seq: u64,
+        window_elapsed: Duration,
+    ) -> Result<(), RunExecutionError> {
+        append_event(
+            archive,
+            json!({
+                "schema": RUN_EVENT_SCHEMA,
+                "run_id": &self.run_id,
+                "seq": seq,
+                "type": "run_started",
+                "agent_shim": &self.agent_shim,
+                "command": &self.command,
+                "window_elapsed_ms": window_elapsed.as_millis() as u64
+            }),
+        )?;
+        Ok(())
+    }
+
+    pub fn append_run_finished(
+        &self,
+        archive: &mut RunnerSpikeArchive,
+        seq: u64,
+        status: &ExitStatus,
+        window_elapsed: Duration,
+    ) -> Result<(), RunExecutionError> {
+        append_event(
+            archive,
+            json!({
+                "schema": RUN_EVENT_SCHEMA,
+                "run_id": &self.run_id,
+                "seq": seq,
+                "type": "run_finished",
+                "exit_code": status.code(),
+                "signal": exit_signal(status),
+                "success": status.success(),
+                "window_elapsed_ms": window_elapsed.as_millis() as u64
+            }),
+        )?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Summary
- add a hidden runner-spike --kernel-capture path that loads assay-monitor, listens for live MonitorEvent values, and feeds them through the S2 KernelLayerBuilder
- reuse RunSpec lifecycle event helpers so contract-only and live-capture runs emit the same runner event schema
- keep live capture honesty-bounded: post-spawn PID/cgroup arming is best-effort and bundles are marked with partial cgroup correlation rather than complete attribution

Validation
- cargo fmt --check
- cargo test -p assay-runner-spike
- cargo clippy -p assay-runner-spike -- -D warnings
- cargo check -p assay-cli --no-default-features
- git diff --check
- cargo run -p assay-cli --no-default-features -- runner-spike run --run-id run_contract_live_pr --output /tmp/assay-runner-spike-live-pr-contract.tar.gz -- true
- cargo run -p assay-cli --no-default-features -- runner-spike run --run-id run_live_fallback_pr --kernel-capture -- true (macOS fallback returned exit 40 as expected)
- pre-push hooks: workspace clippy and linux compile gate passed

Notes
- This is the live-capture wiring slice after S2. It intentionally does not create a clean cgroup before child start, so the capture path still reports partial cgroup correlation.
- The hidden --kernel-capture path is Linux-only; non-Linux exits cleanly with code 40.
- Local x86_64-unknown-linux-gnu cargo check was blocked earlier by missing x86_64-linux-gnu-gcc, but the repository pre-push linux compile gate passed after commit.