### PR TITLE
[codex] add runner kernel-only acceptance fixture

### DIFF
--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -294,7 +294,9 @@ Acceptance:
 - `policy_layer=absent`
 - `kernel_layer=complete` on Linux when no drops occur
 - `cgroup_correlation=clean`
-- `assay evidence verify` succeeds
+- the bundle verifies with `assay evidence verify` or, until runner-spike
+  archives are carried by `assay-evidence`, with the temporary
+  `scripts/ci/runner-spike-kernel-only-acceptance.sh` verifier
 
 ### S4: `none + kernel+policy`
 

--- a/scripts/ci/runner-spike-kernel-only-acceptance.sh
+++ b/scripts/ci/runner-spike-kernel-only-acceptance.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "SKIP: runner-spike kernel-only acceptance requires Linux." >&2
+  exit 40
+fi
+
+ASSAY_EBPF_PATH="${ASSAY_EBPF_PATH:-$ROOT/target/assay-ebpf.o}"
+if [ ! -f "$ASSAY_EBPF_PATH" ]; then
+  echo "SKIP: eBPF object not found: $ASSAY_EBPF_PATH" >&2
+  echo "Hint: build it first, for example with: cargo xtask build-ebpf" >&2
+  exit 40
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-only.XXXXXX")"
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+WORK_DIR="$TMP_ROOT/work"
+EXTRACT_DIR="$TMP_ROOT/extract"
+BUNDLE="$TMP_ROOT/runner-kernel-only.tar.gz"
+RUN_ID="run_kernel_only_acceptance"
+
+cargo run -p assay-cli --no-default-features -- \
+  runner-spike run \
+  --agent-shim none \
+  --kernel-capture \
+  --ebpf "$ASSAY_EBPF_PATH" \
+  --run-id "$RUN_ID" \
+  --output "$BUNDLE" \
+  -- "$ROOT/tests/fixtures/runner-spike/kernel-only-agent.sh" "$WORK_DIR"
+
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$BUNDLE" -C "$EXTRACT_DIR"
+
+python3 - "$EXTRACT_DIR" "$WORK_DIR" "$RUN_ID" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+extract_dir = Path(sys.argv[1])
+work_dir = Path(sys.argv[2])
+run_id = sys.argv[3]
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def read_json(path: str):
+    return json.loads((extract_dir / path).read_text(encoding="utf-8"))
+
+
+manifest = read_json("manifest.json")
+health = read_json("observation-health.json")
+surface = read_json("capability-surface.json")
+correlation = read_json("correlation-report.json")
+
+expect(manifest["schema"] == "assay.runner.archive_manifest.v0", "unexpected manifest schema")
+expect(health["schema"] == "assay.runner.observation_health.v0", "unexpected health schema")
+expect(surface["schema"] == "assay.runner.capability_surface.v0", "unexpected surface schema")
+expect(correlation["schema"] == "assay.runner.correlation_report.v0", "unexpected correlation schema")
+
+for name, document in {
+    "manifest": manifest,
+    "observation-health": health,
+    "capability-surface": surface,
+    "correlation-report": correlation,
+}.items():
+    expect(document["run_id"] == run_id, f"{name} run_id mismatch: {document['run_id']!r}")
+
+for relative_path, entry in manifest["files"].items():
+    payload = (extract_dir / relative_path).read_bytes()
+    digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+    expect(entry["path"] == relative_path, f"manifest path mismatch for {relative_path}")
+    expect(entry["bytes"] == len(payload), f"manifest byte count mismatch for {relative_path}")
+    expect(entry["sha256"] == digest, f"manifest sha256 mismatch for {relative_path}")
+
+expect(health["kernel_layer"] == "complete", f"kernel_layer must be complete, got {health['kernel_layer']!r}")
+expect(health["ringbuf_drops"] == 0, f"ringbuf_drops must be 0, got {health['ringbuf_drops']!r}")
+expect(health["policy_layer"] == "absent", f"policy_layer must be absent, got {health['policy_layer']!r}")
+expect(health["sdk_layer"] == "absent", f"sdk_layer must be absent, got {health['sdk_layer']!r}")
+expect(
+    health["cgroup_correlation"] == "clean",
+    f"cgroup_correlation must be clean, got {health['cgroup_correlation']!r}",
+)
+
+expect((extract_dir / "layers/policy.ndjson").read_text(encoding="utf-8") == "", "policy layer must be empty")
+expect((extract_dir / "layers/sdk.ndjson").read_text(encoding="utf-8") == "", "sdk layer must be empty")
+expect((extract_dir / "layers/kernel.ndjson").stat().st_size > 0, "kernel layer must contain events")
+
+filesystem = set(surface.get("filesystem_prefixes", []))
+processes = set(surface.get("process_execs", []))
+expect(str(work_dir / "input.txt") in filesystem, "fixture input read was not recorded")
+expect("/usr/bin/env" in processes, "fixture /usr/bin/env exec was not recorded")
+
+print("runner-spike kernel-only archive verified")
+PY
+
+echo "PASS: runner-spike kernel-only acceptance"

--- a/tests/fixtures/runner-spike/kernel-only-agent.sh
+++ b/tests/fixtures/runner-spike/kernel-only-agent.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <work-dir>" >&2
+  exit 64
+fi
+
+work_dir=$1
+mkdir -p "$work_dir"
+
+input_file="$work_dir/input.txt"
+output_file="$work_dir/output.txt"
+
+printf '%s\n' "assay runner kernel-only fixture input" > "$input_file"
+cat "$input_file" >/dev/null
+printf '%s\n' "assay runner kernel-only fixture output" > "$output_file"
+
+/usr/bin/env ASSAY_RUNNER_KERNEL_ONLY_FIXTURE=1 >/dev/null
+
+printf '%s\n' "$output_file"


### PR DESCRIPTION
Summary
- add the S3 runner-spike kernel-only fixture at `tests/fixtures/runner-spike/kernel-only-agent.sh`
- add a Linux-only acceptance verifier that runs `assay runner-spike run --kernel-capture`, extracts the runner archive, checks manifest hashes, health fields, empty SDK/policy layers, and expected kernel-derived capability surface entries
- update the Phase 1 spike plan to record the temporary verifier path until runner-spike archives are carried by `assay evidence verify`

Validation
- `tests/fixtures/runner-spike/kernel-only-agent.sh $(mktemp -d)`
- `scripts/ci/runner-spike-kernel-only-acceptance.sh` on macOS returns exit 40 skip as expected
- `shellcheck tests/fixtures/runner-spike/kernel-only-agent.sh scripts/ci/runner-spike-kernel-only-acceptance.sh`
- `git diff --check`
- `cargo fmt --check`
- `cargo test -p assay-runner-spike`
- `cargo check -p assay-cli --no-default-features` (passes with existing unrelated warnings in `assay-cli::cli::args::sim`)
- pre-commit hooks: merge-conflict check, whitespace hooks, token hygiene, typos, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes
- This is the S3 acceptance fixture/probe only. It does not add policy ingest, SDK shims, or a privileged CI job.
- The verifier intentionally skips with exit 40 outside Linux or when `target/assay-ebpf.o` is missing.
