### PR TITLE
[codex] add runner kernel-only determinism probe

### DIFF
--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -297,6 +297,8 @@ Acceptance:
 - the bundle verifies with `assay evidence verify` or, until runner-spike
   archives are carried by `assay-evidence`, with the temporary
   `scripts/ci/runner-spike-kernel-only-acceptance.sh` verifier
+- three repeated fixture runs verify with
+  `scripts/ci/runner-spike-kernel-only-three-run-determinism.sh`
 
 ### S4: `none + kernel+policy`
 

--- a/scripts/ci/runner-spike-kernel-only-acceptance.sh
+++ b/scripts/ci/runner-spike-kernel-only-acceptance.sh
@@ -16,16 +16,24 @@ if [ ! -f "$ASSAY_EBPF_PATH" ]; then
   exit 40
 fi
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-only.XXXXXX")"
-cleanup() {
-  rm -rf "$TMP_ROOT"
-}
+if [ -n "${ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR:-}" ]; then
+  TMP_ROOT="$ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR"
+  mkdir -p "$TMP_ROOT"
+  cleanup() {
+    :
+  }
+else
+  TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-only.XXXXXX")"
+  cleanup() {
+    rm -rf -- "$TMP_ROOT"
+  }
+fi
 trap cleanup EXIT
 
-WORK_DIR="$TMP_ROOT/work"
+WORK_DIR="${ASSAY_RUNNER_ACCEPTANCE_WORK_DIR:-$TMP_ROOT/work}"
 EXTRACT_DIR="$TMP_ROOT/extract"
 BUNDLE="$TMP_ROOT/runner-kernel-only.tar.gz"
-RUN_ID="run_kernel_only_acceptance"
+RUN_ID="${ASSAY_RUNNER_ACCEPTANCE_RUN_ID:-run_kernel_only_acceptance}"
 
 cargo run -p assay-cli --no-default-features -- \
   runner-spike run \
@@ -46,7 +54,7 @@ import sys
 from pathlib import Path
 
 extract_dir = Path(sys.argv[1])
-work_dir = Path(sys.argv[2])
+work_dir = Path(sys.argv[2]).resolve()
 run_id = sys.argv[3]
 
 
@@ -97,9 +105,23 @@ expect(
     f"cgroup_correlation must be clean, got {health['cgroup_correlation']!r}",
 )
 
-expect((extract_dir / "layers/policy.ndjson").read_text(encoding="utf-8") == "", "policy layer must be empty")
+expect(
+    (extract_dir / "layers/policy.ndjson").read_text(encoding="utf-8") == "",
+    "policy layer must be empty",
+)
 expect((extract_dir / "layers/sdk.ndjson").read_text(encoding="utf-8") == "", "sdk layer must be empty")
-expect((extract_dir / "layers/kernel.ndjson").stat().st_size > 0, "kernel layer must contain events")
+
+kernel_events = (extract_dir / "layers/kernel.ndjson").read_text(encoding="utf-8").splitlines()
+expect(kernel_events, "kernel layer must contain events")
+for line_number, line in enumerate(kernel_events, start=1):
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError as error:
+        fail(f"kernel event {line_number} is not valid JSON: {error}")
+    expect(
+        event.get("schema") == "assay.runner.kernel_event.v0",
+        f"kernel event {line_number} has unexpected schema: {event.get('schema')!r}",
+    )
 
 filesystem = set(surface.get("filesystem_prefixes", []))
 processes = set(surface.get("process_execs", []))

--- a/scripts/ci/runner-spike-kernel-only-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-kernel-only-three-run-determinism.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "SKIP: runner-spike kernel-only three-run determinism requires Linux." >&2
+  exit 40
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-only-determinism.XXXXXX")"
+cleanup() {
+  rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+WORK_DIR="$TMP_ROOT/work"
+RUN_ID="run_kernel_only_determinism"
+
+for run in 1 2 3; do
+  echo "=== runner-spike kernel-only determinism run $run/3 ==="
+  ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR="$TMP_ROOT/run-$run" \
+    ASSAY_RUNNER_ACCEPTANCE_WORK_DIR="$WORK_DIR" \
+    ASSAY_RUNNER_ACCEPTANCE_RUN_ID="$RUN_ID" \
+    "$ROOT/scripts/ci/runner-spike-kernel-only-acceptance.sh"
+done
+
+python3 - "$TMP_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+tmp_root = Path(sys.argv[1])
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+baseline_health = read_json(tmp_root / "run-1" / "extract" / "observation-health.json")
+baseline_surface = read_json(tmp_root / "run-1" / "extract" / "capability-surface.json")
+
+for run in (2, 3):
+    health = read_json(tmp_root / f"run-{run}" / "extract" / "observation-health.json")
+    surface = read_json(tmp_root / f"run-{run}" / "extract" / "capability-surface.json")
+    if health != baseline_health:
+        fail(
+            f"observation-health.json changed between run 1 and run {run}; "
+            "this can indicate event_count drift on a noisy host. "
+            "Phase 1 requires a clean deterministic run."
+        )
+    if surface != baseline_surface:
+        fail(f"capability-surface.json changed between run 1 and run {run}")
+
+print("runner-spike kernel-only three-run determinism verified")
+PY
+
+echo "PASS: runner-spike kernel-only three-run determinism"

--- a/tests/fixtures/runner-spike/kernel-only-agent.sh
+++ b/tests/fixtures/runner-spike/kernel-only-agent.sh
@@ -17,5 +17,3 @@ cat "$input_file" >/dev/null
 printf '%s\n' "assay runner kernel-only fixture output" > "$output_file"
 
 /usr/bin/env ASSAY_RUNNER_KERNEL_ONLY_FIXTURE=1 >/dev/null
-
-printf '%s\n' "$output_file"


### PR DESCRIPTION
Summary
- add `scripts/ci/runner-spike-kernel-only-three-run-determinism.sh` to run the S3 kernel-only acceptance probe three times and compare `observation-health.json` plus `capability-surface.json`
- make the single-run acceptance verifier composable via artifact/work-dir/run-id env overrides so the determinism wrapper reuses the same archive checks instead of duplicating semantics
- harden the single-run verifier with realpath-normalized fixture paths and per-line `assay.runner.kernel_event.v0` schema checks for `layers/kernel.ndjson`
- remove unused stdout from the kernel-only fixture and record the three-run gate in the Phase 1 spike plan

Validation
- `tests/fixtures/runner-spike/kernel-only-agent.sh $(mktemp -d)`
- `scripts/ci/runner-spike-kernel-only-acceptance.sh` on macOS returns exit 40 skip as expected
- `scripts/ci/runner-spike-kernel-only-three-run-determinism.sh` on macOS returns exit 40 skip as expected
- `shellcheck scripts/ci/runner-spike-kernel-only-acceptance.sh scripts/ci/runner-spike-kernel-only-three-run-determinism.sh tests/fixtures/runner-spike/kernel-only-agent.sh`
- `git diff --check`
- `cargo fmt --check`
- `cargo test -p assay-runner-spike`
- `cargo check -p assay-cli --no-default-features` (passes with existing unrelated warnings in `assay-cli::cli::args::sim`)
- pre-commit hooks: merge-conflict check, whitespace hooks, token hygiene, typos, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes
- This remains a manual/delegated-host acceptance probe. It skips with exit 40 when Linux or the eBPF object is unavailable.
- The wrapper compares deterministic health and capability-surface outputs only; it intentionally does not compare raw kernel event ordering.
