### PR TITLE
[codex] add runner kernel policy acceptance

### DIFF
--- a/crates/assay-cli/src/cli/commands/runner_spike.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike.rs
@@ -41,6 +41,10 @@ pub struct RunnerSpikeRunArgs {
     #[arg(long, hide = true, default_value_t = 100)]
     pub kernel_drain_ms: u64,
 
+    /// Hidden S4 spike path: ingest assay mcp wrap --decision-log output.
+    #[arg(long, hide = true)]
+    pub policy_decision_log: Option<PathBuf>,
+
     /// Command to run.
     #[arg(allow_hyphen_values = true, required = true, trailing_var_arg = true)]
     pub command: Vec<String>,
@@ -78,7 +82,8 @@ fn cmd_run_contract_only(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
     let spec = build_spec(&args);
     let output = bundle_output_path(&args, &spec.run_id);
 
-    let outcome = spec.run_contract_only()?;
+    let mut outcome = spec.run_contract_only()?;
+    apply_policy_decision_log_if_requested(&spec, &args, &mut outcome.archive)?;
     let mut file = File::create(&output)?;
     outcome.archive.write(&mut file)?;
     let exit_status = exit_status_label(outcome.exit_code, outcome.signal);
@@ -203,6 +208,7 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
     let after_stats = monitor.snapshot_stats()?;
     let capture = builder.finish(&before_stats, &after_stats);
     capture.apply_to_archive(&mut archive, cgroup_correlation)?;
+    apply_policy_decision_log_if_requested(&spec, &args, &mut archive)?;
     spec.append_run_finished(&mut archive, 1, &status, clock.elapsed())?;
 
     let mut file = File::create(&output)?;
@@ -344,6 +350,27 @@ fn write_u32_decimal(value: u32, buf: &mut [u8; 32]) -> usize {
         buf[idx] = scratch[len - idx - 1];
     }
     len
+}
+
+fn apply_policy_decision_log_if_requested(
+    spec: &RunSpec,
+    args: &RunnerSpikeRunArgs,
+    archive: &mut assay_runner_spike::RunnerSpikeArchive,
+) -> anyhow::Result<()> {
+    let Some(path) = args.policy_decision_log.as_ref() else {
+        return Ok(());
+    };
+
+    let bytes = std::fs::read(path).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to read runner-spike policy decision log {}: {error}",
+            path.display()
+        )
+    })?;
+    let capture =
+        assay_runner_spike::PolicyLayerCapture::from_decision_ndjson(spec.run_id.clone(), &bytes)?;
+    capture.apply_to_archive(archive)?;
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/assay-runner-spike/src/lib.rs
+++ b/crates/assay-runner-spike/src/lib.rs
@@ -7,6 +7,7 @@ mod archive;
 mod correlation;
 mod health;
 mod kernel;
+mod policy;
 mod run;
 mod surface;
 
@@ -24,5 +25,6 @@ pub use health::{
     SdkLayerStatus, OBSERVATION_HEALTH_SCHEMA,
 };
 pub use kernel::{KernelLayerBuilder, KernelLayerCapture, KernelLayerError, KERNEL_EVENT_SCHEMA};
+pub use policy::{PolicyLayerCapture, PolicyLayerError, PolicyLayerEvent, POLICY_EVENT_SCHEMA};
 pub use run::{RunExecutionError, RunOutcome, RunSpec, RunSpecError, RUN_EVENT_SCHEMA};
 pub use surface::{CapabilitySurface, CapabilitySurfaceError, CAPABILITY_SURFACE_SCHEMA};

--- a/crates/assay-runner-spike/src/policy.rs
+++ b/crates/assay-runner-spike/src/policy.rs
@@ -1,0 +1,345 @@
+use crate::{
+    run::is_safe_run_id, BindingWindow, CapabilitySurface, CorrelationBinding, PolicyLayerStatus,
+    RunnerSpikeArchive,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+pub const POLICY_EVENT_SCHEMA: &str = "assay.runner.policy_event.v0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyLayerEvent {
+    pub schema: String,
+    pub run_id: String,
+    pub seq: u64,
+    pub source_event_type: String,
+    pub source: String,
+    pub tool_call_id: String,
+    pub tool: String,
+    pub decision: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyLayerCapture {
+    pub run_id: String,
+    pub policy_layer_ndjson: Vec<u8>,
+    pub capability_surface: CapabilitySurface,
+    pub events: Vec<PolicyLayerEvent>,
+}
+
+#[derive(Debug, Error)]
+pub enum PolicyLayerError {
+    #[error("policy layer run_id must not be empty")]
+    EmptyRunId,
+    #[error("policy layer run_id may only contain ASCII letters, digits, '_' and '-'")]
+    UnsafeRunId,
+    #[error("policy layer run_id mismatch: expected {expected}, found {actual}")]
+    RunIdMismatch { expected: String, actual: String },
+    #[error("policy decision log did not contain decision events")]
+    EmptyDecisionLog,
+    #[error("invalid policy decision json at line {line}: {source}")]
+    InvalidJson {
+        line: usize,
+        source: serde_json::Error,
+    },
+    #[error(
+        "policy decision line {line} must have type assay.tool.decision, found {observed_type:?}"
+    )]
+    UnexpectedEventType {
+        line: usize,
+        observed_type: Option<String>,
+    },
+    #[error("policy decision line {line} missing required field {field}")]
+    MissingRequiredField { line: usize, field: String },
+    #[error("invalid capability surface: {0}")]
+    CapabilitySurface(#[from] crate::surface::CapabilitySurfaceError),
+    #[error("policy event serialization failed: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl PolicyLayerCapture {
+    pub fn from_decision_ndjson(
+        run_id: impl Into<String>,
+        ndjson: &[u8],
+    ) -> Result<Self, PolicyLayerError> {
+        let run_id = run_id.into();
+        if run_id.is_empty() {
+            return Err(PolicyLayerError::EmptyRunId);
+        }
+        if !is_safe_run_id(&run_id) {
+            return Err(PolicyLayerError::UnsafeRunId);
+        }
+
+        let input = String::from_utf8_lossy(ndjson);
+        let mut policy_layer_ndjson = Vec::new();
+        let mut capability_surface = CapabilitySurface::new(run_id.clone());
+        let mut events = Vec::new();
+
+        for (idx, raw) in input.lines().enumerate() {
+            let line = idx + 1;
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let value: Value = serde_json::from_str(trimmed)
+                .map_err(|source| PolicyLayerError::InvalidJson { line, source })?;
+            let observed_type = observed_type(&value);
+            if observed_type.as_deref() != Some("assay.tool.decision") {
+                return Err(PolicyLayerError::UnexpectedEventType {
+                    line,
+                    observed_type,
+                });
+            }
+            let data = value
+                .get("data")
+                .ok_or_else(|| PolicyLayerError::MissingRequiredField {
+                    line,
+                    field: "data".to_string(),
+                })?;
+            let source = required_string(&value, "source", line)?;
+            let tool = required_data_string(data, "tool", line)?;
+            let tool_call_id = required_data_string(data, "tool_call_id", line)?;
+            let decision = required_data_string(data, "decision", line)?;
+
+            capability_surface.add_mcp_tool(tool.clone());
+            capability_surface.add_policy_decision(format!("{decision}:{tool}"));
+
+            let event = PolicyLayerEvent {
+                schema: POLICY_EVENT_SCHEMA.to_string(),
+                run_id: run_id.clone(),
+                seq: events.len() as u64,
+                source_event_type: "assay.tool.decision".to_string(),
+                source,
+                tool_call_id,
+                tool,
+                decision,
+            };
+            serde_json::to_writer(&mut policy_layer_ndjson, &event)?;
+            policy_layer_ndjson.push(b'\n');
+            events.push(event);
+        }
+
+        if events.is_empty() {
+            return Err(PolicyLayerError::EmptyDecisionLog);
+        }
+
+        Ok(Self {
+            run_id,
+            policy_layer_ndjson,
+            capability_surface,
+            events,
+        })
+    }
+
+    /// Apply this policy capture to the archive.
+    ///
+    /// Must be called after any kernel-layer capture has been applied:
+    /// `kernel_event_count` is read from `archive.kernel_layer_ndjson` at apply
+    /// time. Calling this on an archive with no kernel events marks the
+    /// correlation report partial with `policy_events_without_kernel_events`.
+    pub fn apply_to_archive(
+        self,
+        archive: &mut RunnerSpikeArchive,
+    ) -> Result<(), PolicyLayerError> {
+        let PolicyLayerCapture {
+            run_id,
+            policy_layer_ndjson,
+            capability_surface,
+            events,
+        } = self;
+
+        if archive.run_id != run_id {
+            return Err(PolicyLayerError::RunIdMismatch {
+                expected: archive.run_id.clone(),
+                actual: run_id,
+            });
+        }
+
+        archive.policy_layer_ndjson = policy_layer_ndjson;
+        archive.capability_surface.merge_from(&capability_surface)?;
+        archive.observation_health.policy_layer = PolicyLayerStatus::Present;
+        archive
+            .observation_health
+            .notes
+            .retain(|note| !note.starts_with("s4_policy_capture:"));
+        archive.observation_health.notes.push(format!(
+            "s4_policy_capture: decision_events={}",
+            events.len()
+        ));
+
+        let kernel_event_count = archive
+            .kernel_layer_ndjson
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .count() as u64;
+        if kernel_event_count == 0 {
+            archive
+                .correlation_report
+                .mark_partial("policy_events_without_kernel_events");
+        }
+
+        for event in events {
+            archive.correlation_report.add_binding(CorrelationBinding {
+                tool_call_id: event.tool_call_id,
+                policy_decision: Some(event.decision),
+                kernel_event_count,
+                window: BindingWindow {
+                    start: "run_started".to_string(),
+                    end: "run_finished".to_string(),
+                },
+            });
+        }
+        Ok(())
+    }
+}
+
+fn required_string(
+    value: &Value,
+    field: &'static str,
+    line: usize,
+) -> Result<String, PolicyLayerError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| PolicyLayerError::MissingRequiredField {
+            line,
+            field: field.to_string(),
+        })
+}
+
+fn required_data_string(
+    data: &Value,
+    field: &'static str,
+    line: usize,
+) -> Result<String, PolicyLayerError> {
+    data.get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| PolicyLayerError::MissingRequiredField {
+            line,
+            field: format!("data.{field}"),
+        })
+}
+
+fn observed_type(value: &Value) -> Option<String> {
+    value.get("type").map(|event_type| match event_type {
+        Value::String(event_type) => event_type.clone(),
+        other => other.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CgroupCorrelationStatus, KernelLayerStatus};
+
+    const DECISION: &[u8] = br#"{"specversion":"1.0","id":"evt_decision_001","type":"assay.tool.decision","source":"assay://runner-spike/run_001","time":"2026-05-20T00:00:00Z","data":{"tool":"read_file","decision":"allow","reason_code":"P_TOOL_ALLOWED","tool_call_id":"tc_runner_policy_001"}}
+"#;
+
+    #[test]
+    fn decision_log_records_policy_layer_and_surface() {
+        let capture = PolicyLayerCapture::from_decision_ndjson("run_001", DECISION).unwrap();
+        let policy = String::from_utf8(capture.policy_layer_ndjson.clone()).unwrap();
+
+        assert!(policy.contains(POLICY_EVENT_SCHEMA));
+        assert!(policy.contains("tc_runner_policy_001"));
+        assert!(capture.capability_surface.mcp_tools.contains("read_file"));
+        assert!(capture
+            .capability_surface
+            .policy_decisions
+            .contains("allow:read_file"));
+    }
+
+    #[test]
+    fn apply_marks_policy_present_and_adds_binding() {
+        let capture = PolicyLayerCapture::from_decision_ndjson("run_001", DECISION).unwrap();
+        let mut archive = RunnerSpikeArchive::empty("run_001", "linux");
+        archive.observation_health.kernel_layer = KernelLayerStatus::Complete;
+        archive.observation_health.cgroup_correlation = CgroupCorrelationStatus::Clean;
+        archive.kernel_layer_ndjson = b"{\"schema\":\"assay.runner.kernel_event.v0\"}\n".to_vec();
+
+        capture.apply_to_archive(&mut archive).unwrap();
+
+        assert_eq!(
+            archive.observation_health.policy_layer,
+            PolicyLayerStatus::Present
+        );
+        assert_eq!(archive.correlation_report.bindings.len(), 1);
+        assert_eq!(
+            archive.correlation_report.bindings[0].tool_call_id,
+            "tc_runner_policy_001"
+        );
+        assert_eq!(archive.correlation_report.bindings[0].kernel_event_count, 1);
+    }
+
+    #[test]
+    fn empty_decision_log_is_rejected() {
+        assert!(matches!(
+            PolicyLayerCapture::from_decision_ndjson("run_001", b"\n"),
+            Err(PolicyLayerError::EmptyDecisionLog)
+        ));
+    }
+
+    #[test]
+    fn unexpected_event_type_reports_observed_type() {
+        let err = PolicyLayerCapture::from_decision_ndjson(
+            "run_001",
+            br#"{"type":"assay.other.event","source":"assay://test","data":{}}
+"#,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            PolicyLayerError::UnexpectedEventType {
+                line: 1,
+                observed_type: Some(ref observed)
+            } if observed == "assay.other.event"
+        ));
+        assert!(err.to_string().contains("assay.other.event"));
+    }
+
+    #[test]
+    fn missing_top_level_source_is_not_reported_as_data_source() {
+        let err = PolicyLayerCapture::from_decision_ndjson(
+            "run_001",
+            br#"{"type":"assay.tool.decision","data":{"tool":"read_file","decision":"allow","tool_call_id":"tc_runner_policy_001"}}
+"#,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            PolicyLayerError::MissingRequiredField {
+                line: 1,
+                ref field
+            } if field == "source"
+        ));
+        assert!(err.to_string().contains("missing required field source"));
+        assert!(!err.to_string().contains("data.source"));
+    }
+
+    #[test]
+    fn policy_without_kernel_events_marks_correlation_partial() {
+        let capture = PolicyLayerCapture::from_decision_ndjson("run_001", DECISION).unwrap();
+        let mut archive = RunnerSpikeArchive::empty("run_001", "linux");
+
+        capture.apply_to_archive(&mut archive).unwrap();
+
+        assert_eq!(
+            archive.correlation_report.status,
+            crate::CorrelationStatus::Partial
+        );
+        assert!(archive
+            .correlation_report
+            .ambiguities
+            .iter()
+            .any(|ambiguity| ambiguity == "policy_events_without_kernel_events"));
+    }
+}

--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -321,6 +321,8 @@ Acceptance:
 - policy event includes a stable `tool_call_id`
 - kernel capability set is congruent with the allowed tool call
 - correlation report joins policy to kernel by `run_id`, window, and cgroup
+- the fixture verifies with
+  `scripts/ci/runner-spike-kernel-policy-acceptance.sh`
 
 ### S5: `openai-agents` Shim
 

--- a/scripts/ci/runner-spike-kernel-policy-acceptance.sh
+++ b/scripts/ci/runner-spike-kernel-policy-acceptance.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "SKIP: runner-spike kernel+policy acceptance requires Linux." >&2
+  exit 40
+fi
+
+ASSAY_EBPF_PATH="${ASSAY_EBPF_PATH:-$ROOT/target/assay-ebpf.o}"
+if [ ! -f "$ASSAY_EBPF_PATH" ]; then
+  echo "SKIP: eBPF object not found: $ASSAY_EBPF_PATH" >&2
+  echo "Hint: build it first, for example with: cargo xtask build-ebpf" >&2
+  exit 40
+fi
+
+ASSAY_BIN="${ASSAY_BIN:-$ROOT/target/debug/assay}"
+if [ ! -x "$ASSAY_BIN" ]; then
+  cargo build -p assay-cli --no-default-features
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-policy.XXXXXX")"
+cleanup() {
+  rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+WORK_DIR="$TMP_ROOT/work"
+EXTRACT_DIR="$TMP_ROOT/extract"
+BUNDLE="$TMP_ROOT/runner-kernel-policy.tar.gz"
+DECISION_LOG="$TMP_ROOT/policy-decisions.ndjson"
+RUN_ID="run_kernel_policy_acceptance"
+
+export ASSAY_BIN
+export ASSAY_RUNNER_POLICY_DECISION_LOG="$DECISION_LOG"
+export ASSAY_RUNNER_RUN_ID="$RUN_ID"
+
+"$ASSAY_BIN" runner-spike run \
+  --agent-shim none \
+  --kernel-capture \
+  --ebpf "$ASSAY_EBPF_PATH" \
+  --policy-decision-log "$DECISION_LOG" \
+  --run-id "$RUN_ID" \
+  --output "$BUNDLE" \
+  -- "$ROOT/tests/fixtures/runner-spike/mcp-policy-agent.sh" "$WORK_DIR"
+
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$BUNDLE" -C "$EXTRACT_DIR"
+
+python3 - "$EXTRACT_DIR" "$WORK_DIR" "$RUN_ID" "$DECISION_LOG" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+extract_dir = Path(sys.argv[1])
+work_dir = Path(sys.argv[2]).resolve()
+run_id = sys.argv[3]
+decision_log = Path(sys.argv[4])
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def read_json(path: str):
+    return json.loads((extract_dir / path).read_text(encoding="utf-8"))
+
+
+manifest = read_json("manifest.json")
+health = read_json("observation-health.json")
+surface = read_json("capability-surface.json")
+correlation = read_json("correlation-report.json")
+
+expect(manifest["schema"] == "assay.runner.archive_manifest.v0", "unexpected manifest schema")
+expect(health["schema"] == "assay.runner.observation_health.v0", "unexpected health schema")
+expect(surface["schema"] == "assay.runner.capability_surface.v0", "unexpected surface schema")
+expect(correlation["schema"] == "assay.runner.correlation_report.v0", "unexpected correlation schema")
+
+for name, document in {
+    "manifest": manifest,
+    "observation-health": health,
+    "capability-surface": surface,
+    "correlation-report": correlation,
+}.items():
+    expect(document["run_id"] == run_id, f"{name} run_id mismatch: {document['run_id']!r}")
+
+for relative_path, entry in manifest["files"].items():
+    payload = (extract_dir / relative_path).read_bytes()
+    digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+    expect(entry["path"] == relative_path, f"manifest path mismatch for {relative_path}")
+    expect(entry["bytes"] == len(payload), f"manifest byte count mismatch for {relative_path}")
+    expect(entry["sha256"] == digest, f"manifest sha256 mismatch for {relative_path}")
+
+expect(health["kernel_layer"] == "complete", f"kernel_layer must be complete, got {health['kernel_layer']!r}")
+expect(health["ringbuf_drops"] == 0, f"ringbuf_drops must be 0, got {health['ringbuf_drops']!r}")
+expect(health["policy_layer"] == "present", f"policy_layer must be present, got {health['policy_layer']!r}")
+expect(health["sdk_layer"] == "absent", f"sdk_layer must be absent, got {health['sdk_layer']!r}")
+expect(
+    health["cgroup_correlation"] == "clean",
+    f"cgroup_correlation must be clean, got {health['cgroup_correlation']!r}",
+)
+
+expect((extract_dir / "layers/sdk.ndjson").read_text(encoding="utf-8") == "", "sdk layer must be empty")
+kernel_events = (extract_dir / "layers/kernel.ndjson").read_text(encoding="utf-8").splitlines()
+expect(kernel_events, "kernel layer must contain events")
+for line_number, line in enumerate(kernel_events, start=1):
+    event = json.loads(line)
+    expect(
+        event.get("schema") == "assay.runner.kernel_event.v0",
+        f"kernel event {line_number} has unexpected schema: {event.get('schema')!r}",
+    )
+
+policy_events = (extract_dir / "layers/policy.ndjson").read_text(encoding="utf-8").splitlines()
+expect(len(policy_events) == 1, f"expected one policy event, got {len(policy_events)}")
+policy_event = json.loads(policy_events[0])
+expect(policy_event["schema"] == "assay.runner.policy_event.v0", "unexpected policy event schema")
+expect(policy_event["run_id"] == run_id, "policy event run_id mismatch")
+expect(policy_event["tool_call_id"] == "tc_runner_policy_001", "policy event tool_call_id mismatch")
+expect(policy_event["tool"] == "read_file", "policy event tool mismatch")
+expect(policy_event["decision"] == "allow", "policy event decision mismatch")
+
+source_events = [json.loads(line) for line in decision_log.read_text(encoding="utf-8").splitlines() if line.strip()]
+expect(len(source_events) == 1, f"expected one source decision event, got {len(source_events)}")
+expect(source_events[0]["type"] == "assay.tool.decision", "source decision event type mismatch")
+expect(
+    source_events[0]["data"]["tool_call_id"] == "tc_runner_policy_001",
+    "source decision tool_call_id mismatch",
+)
+
+filesystem = set(surface.get("filesystem_prefixes", []))
+expect(str(work_dir / "policy-input.txt") in filesystem, "fixture policy input read was not recorded")
+expect("read_file" in set(surface.get("mcp_tools", [])), "read_file MCP tool was not recorded")
+expect(
+    "allow:read_file" in set(surface.get("policy_decisions", [])),
+    "allow:read_file policy decision was not recorded",
+)
+
+bindings = correlation.get("bindings", [])
+expect(len(bindings) == 1, f"expected one correlation binding, got {len(bindings)}")
+binding = bindings[0]
+expect(binding["tool_call_id"] == "tc_runner_policy_001", "binding tool_call_id mismatch")
+expect(binding["policy_decision"] == "allow", "binding policy_decision mismatch")
+expect(binding["kernel_event_count"] > 0, "binding must include kernel events")
+expect(binding["window"] == {"start": "run_started", "end": "run_finished"}, "binding window mismatch")
+
+print("runner-spike kernel+policy archive verified")
+PY
+
+echo "PASS: runner-spike kernel+policy acceptance"

--- a/tests/fixtures/runner-spike/mcp-policy-agent.sh
+++ b/tests/fixtures/runner-spike/mcp-policy-agent.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <work-dir>" >&2
+  exit 64
+fi
+
+: "${ASSAY_BIN:?ASSAY_BIN must point to the assay CLI binary}"
+: "${ASSAY_RUNNER_POLICY_DECISION_LOG:?ASSAY_RUNNER_POLICY_DECISION_LOG must be set}"
+: "${ASSAY_RUNNER_RUN_ID:?ASSAY_RUNNER_RUN_ID must be set}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+work_dir=$1
+mkdir -p "$work_dir"
+
+input_file="$work_dir/policy-input.txt"
+policy_file="$work_dir/policy.yaml"
+request_file="$work_dir/request.jsonl"
+response_file="$work_dir/response.jsonl"
+
+printf '%s\n' "assay runner policy fixture input" > "$input_file"
+cat > "$policy_file" <<'YAML'
+tools:
+  allow:
+    - read_file
+YAML
+
+python3 - "$input_file" > "$request_file" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+print(
+    json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": "runner-policy-request-001",
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": {
+                    "path": path,
+                    "_meta": {"tool_call_id": "tc_runner_policy_001"},
+                },
+            },
+        },
+        separators=(",", ":"),
+    )
+)
+PY
+
+"$ASSAY_BIN" mcp wrap \
+  --policy "$policy_file" \
+  --decision-log "$ASSAY_RUNNER_POLICY_DECISION_LOG" \
+  --event-source "assay://runner-spike/$ASSAY_RUNNER_RUN_ID" \
+  --label runner-spike-policy-fixture \
+  -- python3 "$ROOT/tests/fixtures/runner-spike/mcp_file_server.py" \
+  < "$request_file" > "$response_file"
+
+python3 - "$response_file" <<'PY'
+import json
+import sys
+
+line = open(sys.argv[1], encoding="utf-8").readline()
+response = json.loads(line)
+content = response["result"]["content"][0]["text"]
+if "assay runner policy fixture input" not in content:
+    raise SystemExit("wrapped MCP response did not include fixture input")
+PY

--- a/tests/fixtures/runner-spike/mcp_file_server.py
+++ b/tests/fixtures/runner-spike/mcp_file_server.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+
+def respond(message):
+    print(json.dumps(message, separators=(",", ":")), flush=True)
+
+
+for line in sys.stdin:
+    request = json.loads(line)
+    request_id = request.get("id")
+    params = request.get("params") or {}
+    arguments = params.get("arguments") or {}
+
+    if request.get("method") != "tools/call" or params.get("name") != "read_file":
+        respond(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32601, "message": "Method not found"},
+            }
+        )
+        continue
+
+    path = Path(arguments["path"])
+    text = path.read_text(encoding="utf-8")
+    respond(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"content": [{"type": "text", "text": text}]},
+        }
+    )


### PR DESCRIPTION
Summary
- add a runner-spike policy-layer adapter that ingests existing `assay mcp wrap --decision-log` CloudEvents into `layers/policy.ndjson`
- derive `mcp_tools`, `policy_decisions`, `policy_layer=present`, and correlation bindings from stable `tool_call_id` values
- add hidden `assay runner-spike run --policy-decision-log <path>` wiring for S4 fixture runs
- add `tests/fixtures/runner-spike/mcp-policy-agent.sh` plus a tiny MCP file server that performs one allowed `read_file` tool call with `tc_runner_policy_001`
- add `scripts/ci/runner-spike-kernel-policy-acceptance.sh` to verify the kernel+policy archive shape on a delegated Linux/eBPF host
- record the S4 verifier in the Phase 1 spike plan

Validation
- `cargo fmt --check`
- `cargo test -p assay-runner-spike`
- `cargo check -p assay-cli --no-default-features` (passes with existing unrelated warnings in `assay-cli::cli::args::sim`)
- `cargo test -p assay-cli --no-default-features runner_spike -- --nocapture`
- `cargo clippy -p assay-runner-spike -- -D warnings`
- `shellcheck scripts/ci/runner-spike-kernel-policy-acceptance.sh tests/fixtures/runner-spike/mcp-policy-agent.sh`
- `python3 -m py_compile tests/fixtures/runner-spike/mcp_file_server.py`
- MCP fixture smoke with `target/debug/assay mcp wrap` produced one `assay.tool.decision` carrying `tc_runner_policy_001`
- runner-spike contract-only smoke with `--policy-decision-log` produced `policy_layer=present`, `assay.runner.policy_event.v0`, `mcp_tools=[read_file]`, `policy_decisions=[allow:read_file]`, and a correlation binding
- `scripts/ci/runner-spike-kernel-policy-acceptance.sh` on macOS returns exit 40 skip as expected
- `git diff --check`
- pre-commit hooks: merge-conflict check, whitespace hooks, token hygiene, typos, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes
- This is the S4 `none + kernel+policy` fixture/probe slice. It reuses the existing MCP decision log surface rather than adding a new policy runtime.
- The acceptance script remains manual/delegated-host only and skips with exit 40 when Linux or the eBPF object is unavailable.
- The correlation binding is set-based/window-based (`run_started` to `run_finished`), not a causal syscall sequence claim.
