### PR TITLE
[codex] add runner kernel policy determinism probe

### DIFF
--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -323,6 +323,8 @@ Acceptance:
 - correlation report joins policy to kernel by `run_id`, window, and cgroup
 - the fixture verifies with
   `scripts/ci/runner-spike-kernel-policy-acceptance.sh`
+- three repeated fixture runs verify with
+  `scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh`
 
 ### S5: `openai-agents` Shim
 

--- a/scripts/ci/runner-spike-kernel-policy-acceptance.sh
+++ b/scripts/ci/runner-spike-kernel-policy-acceptance.sh
@@ -21,17 +21,25 @@ if [ ! -x "$ASSAY_BIN" ]; then
   cargo build -p assay-cli --no-default-features
 fi
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-policy.XXXXXX")"
-cleanup() {
-  rm -rf -- "$TMP_ROOT"
-}
+if [ -n "${ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR:-}" ]; then
+  TMP_ROOT="$ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR"
+  mkdir -p "$TMP_ROOT"
+  cleanup() {
+    :
+  }
+else
+  TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-policy.XXXXXX")"
+  cleanup() {
+    rm -rf -- "$TMP_ROOT"
+  }
+fi
 trap cleanup EXIT
 
-WORK_DIR="$TMP_ROOT/work"
+WORK_DIR="${ASSAY_RUNNER_ACCEPTANCE_WORK_DIR:-$TMP_ROOT/work}"
 EXTRACT_DIR="$TMP_ROOT/extract"
 BUNDLE="$TMP_ROOT/runner-kernel-policy.tar.gz"
 DECISION_LOG="$TMP_ROOT/policy-decisions.ndjson"
-RUN_ID="run_kernel_policy_acceptance"
+RUN_ID="${ASSAY_RUNNER_ACCEPTANCE_RUN_ID:-run_kernel_policy_acceptance}"
 
 export ASSAY_BIN
 export ASSAY_RUNNER_POLICY_DECISION_LOG="$DECISION_LOG"

--- a/scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "SKIP: runner-spike kernel+policy three-run determinism requires Linux." >&2
+  exit 40
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-policy-determinism.XXXXXX")"
+cleanup() {
+  rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+WORK_DIR="$TMP_ROOT/work"
+RUN_ID="run_kernel_policy_determinism"
+
+for run in 1 2 3; do
+  echo "=== runner-spike kernel+policy determinism run $run/3 ==="
+  ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR="$TMP_ROOT/run-$run" \
+    ASSAY_RUNNER_ACCEPTANCE_WORK_DIR="$WORK_DIR" \
+    ASSAY_RUNNER_ACCEPTANCE_RUN_ID="$RUN_ID" \
+    "$ROOT/scripts/ci/runner-spike-kernel-policy-acceptance.sh"
+done
+
+python3 - "$TMP_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+tmp_root = Path(sys.argv[1])
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+baseline_health = read_json(tmp_root / "run-1" / "extract" / "observation-health.json")
+baseline_surface = read_json(tmp_root / "run-1" / "extract" / "capability-surface.json")
+baseline_correlation = read_json(tmp_root / "run-1" / "extract" / "correlation-report.json")
+baseline_policy = (tmp_root / "run-1" / "extract" / "layers" / "policy.ndjson").read_text(
+    encoding="utf-8"
+)
+
+for run in (2, 3):
+    health = read_json(tmp_root / f"run-{run}" / "extract" / "observation-health.json")
+    surface = read_json(tmp_root / f"run-{run}" / "extract" / "capability-surface.json")
+    correlation = read_json(tmp_root / f"run-{run}" / "extract" / "correlation-report.json")
+    policy = (tmp_root / f"run-{run}" / "extract" / "layers" / "policy.ndjson").read_text(
+        encoding="utf-8"
+    )
+
+    if health != baseline_health:
+        fail(
+            f"observation-health.json changed between run 1 and run {run}; "
+            "this can indicate event_count drift on a noisy host. "
+            "Phase 1 requires a clean deterministic run."
+        )
+    if surface != baseline_surface:
+        fail(f"capability-surface.json changed between run 1 and run {run}")
+    if correlation != baseline_correlation:
+        fail(f"correlation-report.json changed between run 1 and run {run}")
+    if policy != baseline_policy:
+        fail(f"layers/policy.ndjson changed between run 1 and run {run}")
+
+print("runner-spike kernel+policy three-run determinism verified")
+PY
+
+echo "PASS: runner-spike kernel+policy three-run determinism"


### PR DESCRIPTION
Summary

- add scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh to run the S4 kernel+policy acceptance probe three times
- make the kernel+policy acceptance verifier composable via artifact/work-dir/run-id env overrides, matching the S3 kernel-only probe shape
- compare observation-health.json, capability-surface.json, correlation-report.json, and layers/policy.ndjson across runs while intentionally not comparing raw kernel event ordering
- record the three-run S4 gate in the Phase 1 spike plan

Validation

- shellcheck scripts/ci/runner-spike-kernel-policy-acceptance.sh scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh
- scripts/ci/runner-spike-kernel-policy-acceptance.sh on macOS returns exit 40 skip as expected
- scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh on macOS returns exit 40 skip as expected
- git diff --check
- cargo fmt --check
- pre-commit hooks: merge-conflict check, whitespace hooks, token hygiene, typos, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes

This remains a manual/delegated-host acceptance probe. It skips with exit 40 when Linux or the eBPF object is unavailable.

The wrapper compares deterministic health, capability surface, correlation report, and normalized policy-layer output only. It intentionally does not compare raw kernel event ordering.