### PR TITLE
[codex] add runner sdk layer contract

### DIFF
--- a/crates/assay-cli/src/cli/commands/runner_spike.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike.rs
@@ -45,6 +45,10 @@ pub struct RunnerSpikeRunArgs {
     #[arg(long, hide = true)]
     pub policy_decision_log: Option<PathBuf>,
 
+    /// Hidden S5 spike path: ingest normalized SDK event NDJSON.
+    #[arg(long, hide = true)]
+    pub sdk_event_log: Option<PathBuf>,
+
     /// Command to run.
     #[arg(allow_hyphen_values = true, required = true, trailing_var_arg = true)]
     pub command: Vec<String>,
@@ -57,11 +61,19 @@ pub async fn run(args: RunnerSpikeArgs) -> anyhow::Result<i32> {
 }
 
 async fn cmd_run(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
+    validate_runner_spike_args(&args)?;
     if args.kernel_capture {
         return cmd_run_with_kernel_capture(args).await;
     }
 
     cmd_run_contract_only(args)
+}
+
+fn validate_runner_spike_args(args: &RunnerSpikeRunArgs) -> anyhow::Result<()> {
+    if args.sdk_event_log.is_some() && args.agent_shim == "none" {
+        anyhow::bail!("runner-spike --sdk-event-log requires an SDK agent shim");
+    }
+    Ok(())
 }
 
 fn build_spec(args: &RunnerSpikeRunArgs) -> RunSpec {
@@ -84,6 +96,7 @@ fn cmd_run_contract_only(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
 
     let mut outcome = spec.run_contract_only()?;
     apply_policy_decision_log_if_requested(&spec, &args, &mut outcome.archive)?;
+    apply_sdk_event_log_if_requested(&spec, &args, &mut outcome.archive)?;
     let mut file = File::create(&output)?;
     outcome.archive.write(&mut file)?;
     let exit_status = exit_status_label(outcome.exit_code, outcome.signal);
@@ -209,6 +222,7 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
     let capture = builder.finish(&before_stats, &after_stats);
     capture.apply_to_archive(&mut archive, cgroup_correlation)?;
     apply_policy_decision_log_if_requested(&spec, &args, &mut archive)?;
+    apply_sdk_event_log_if_requested(&spec, &args, &mut archive)?;
     spec.append_run_finished(&mut archive, 1, &status, clock.elapsed())?;
 
     let mut file = File::create(&output)?;
@@ -369,6 +383,27 @@ fn apply_policy_decision_log_if_requested(
     })?;
     let capture =
         assay_runner_spike::PolicyLayerCapture::from_decision_ndjson(spec.run_id.clone(), &bytes)?;
+    capture.apply_to_archive(archive)?;
+    Ok(())
+}
+
+fn apply_sdk_event_log_if_requested(
+    spec: &RunSpec,
+    args: &RunnerSpikeRunArgs,
+    archive: &mut assay_runner_spike::RunnerSpikeArchive,
+) -> anyhow::Result<()> {
+    let Some(path) = args.sdk_event_log.as_ref() else {
+        return Ok(());
+    };
+
+    let bytes = std::fs::read(path).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to read runner-spike SDK event log {}: {error}",
+            path.display()
+        )
+    })?;
+    let capture =
+        assay_runner_spike::SdkLayerCapture::from_sdk_ndjson(spec.run_id.clone(), &bytes)?;
     capture.apply_to_archive(archive)?;
     Ok(())
 }

--- a/crates/assay-runner-spike/src/lib.rs
+++ b/crates/assay-runner-spike/src/lib.rs
@@ -9,6 +9,7 @@ mod health;
 mod kernel;
 mod policy;
 mod run;
+mod sdk;
 mod surface;
 
 pub use archive::{
@@ -27,4 +28,5 @@ pub use health::{
 pub use kernel::{KernelLayerBuilder, KernelLayerCapture, KernelLayerError, KERNEL_EVENT_SCHEMA};
 pub use policy::{PolicyLayerCapture, PolicyLayerError, PolicyLayerEvent, POLICY_EVENT_SCHEMA};
 pub use run::{RunExecutionError, RunOutcome, RunSpec, RunSpecError, RUN_EVENT_SCHEMA};
+pub use sdk::{SdkLayerCapture, SdkLayerError, SdkLayerEvent, SDK_EVENT_SCHEMA};
 pub use surface::{CapabilitySurface, CapabilitySurfaceError, CAPABILITY_SURFACE_SCHEMA};

--- a/crates/assay-runner-spike/src/sdk.rs
+++ b/crates/assay-runner-spike/src/sdk.rs
@@ -1,0 +1,431 @@
+use crate::{run::is_safe_run_id, RunnerSpikeArchive, SdkLayerStatus};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+pub const SDK_EVENT_SCHEMA: &str = "assay.runner.sdk_event.v0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SdkLayerEvent {
+    pub schema: String,
+    pub run_id: String,
+    pub seq: u64,
+    pub event_type: String,
+    pub source: String,
+    pub sdk_name: Option<String>,
+    pub sdk_version: Option<String>,
+    pub tool_call_id: Option<String>,
+    pub tool: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SdkLayerCapture {
+    pub run_id: String,
+    pub sdk_layer_ndjson: Vec<u8>,
+    pub events: Vec<SdkLayerEvent>,
+}
+
+#[derive(Debug, Error)]
+pub enum SdkLayerError {
+    #[error("sdk layer run_id must not be empty")]
+    EmptyRunId,
+    #[error("sdk layer run_id may only contain ASCII letters, digits, '_' and '-'")]
+    UnsafeRunId,
+    #[error("sdk layer run_id mismatch: expected {expected}, found {actual}")]
+    RunIdMismatch { expected: String, actual: String },
+    #[error("sdk event log did not contain events")]
+    EmptySdkLog,
+    #[error("invalid sdk event json at line {line}: {source}")]
+    InvalidJson {
+        line: usize,
+        source: serde_json::Error,
+    },
+    #[error(
+        "sdk event line {line} must have schema {SDK_EVENT_SCHEMA}, found {observed_schema:?}"
+    )]
+    UnexpectedSchema {
+        line: usize,
+        observed_schema: Option<String>,
+    },
+    #[error("sdk event line {line} run_id mismatch: expected {expected}, found {actual}")]
+    EventRunIdMismatch {
+        line: usize,
+        expected: String,
+        actual: String,
+    },
+    #[error("sdk event line {line} missing required field {field}")]
+    MissingRequiredField { line: usize, field: String },
+    #[error("sdk event line {line} event_type {event_type} requires {field}")]
+    MissingToolCallField {
+        line: usize,
+        event_type: String,
+        field: &'static str,
+    },
+    #[error("sdk event line {line} has unsupported event_type {event_type}")]
+    UnsupportedEventType { line: usize, event_type: String },
+    #[error("sdk event line {line} seq mismatch: expected {expected}, found {actual}")]
+    SeqMismatch {
+        line: usize,
+        expected: u64,
+        actual: u64,
+    },
+    #[error("sdk event serialization failed: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl SdkLayerCapture {
+    pub fn from_sdk_ndjson(
+        run_id: impl Into<String>,
+        ndjson: &[u8],
+    ) -> Result<Self, SdkLayerError> {
+        let run_id = run_id.into();
+        if run_id.is_empty() {
+            return Err(SdkLayerError::EmptyRunId);
+        }
+        if !is_safe_run_id(&run_id) {
+            return Err(SdkLayerError::UnsafeRunId);
+        }
+
+        let input = String::from_utf8_lossy(ndjson);
+        let mut sdk_layer_ndjson = Vec::new();
+        let mut events = Vec::new();
+
+        for (idx, raw) in input.lines().enumerate() {
+            let line = idx + 1;
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let value: Value = serde_json::from_str(trimmed)
+                .map_err(|source| SdkLayerError::InvalidJson { line, source })?;
+            let observed_schema = observed_schema(&value);
+            if observed_schema.as_deref() != Some(SDK_EVENT_SCHEMA) {
+                return Err(SdkLayerError::UnexpectedSchema {
+                    line,
+                    observed_schema,
+                });
+            }
+
+            let event_run_id = required_string(&value, "run_id", line)?;
+            if event_run_id != run_id {
+                return Err(SdkLayerError::EventRunIdMismatch {
+                    line,
+                    expected: run_id.clone(),
+                    actual: event_run_id,
+                });
+            }
+
+            let seq = required_u64(&value, "seq", line)?;
+            let expected_seq = events.len() as u64;
+            if seq != expected_seq {
+                return Err(SdkLayerError::SeqMismatch {
+                    line,
+                    expected: expected_seq,
+                    actual: seq,
+                });
+            }
+
+            let event_type = required_string(&value, "event_type", line)?;
+            if !is_supported_event_type(&event_type) {
+                return Err(SdkLayerError::UnsupportedEventType { line, event_type });
+            }
+            let tool_call_id = optional_string(&value, "tool_call_id");
+            let tool = optional_string(&value, "tool");
+            validate_tool_call_fields(line, &event_type, &tool_call_id, &tool)?;
+
+            let event = SdkLayerEvent {
+                schema: SDK_EVENT_SCHEMA.to_string(),
+                run_id: run_id.clone(),
+                seq,
+                event_type,
+                source: required_string(&value, "source", line)?,
+                sdk_name: optional_string(&value, "sdk_name"),
+                sdk_version: optional_string(&value, "sdk_version"),
+                tool_call_id,
+                tool,
+            };
+            serde_json::to_writer(&mut sdk_layer_ndjson, &event)?;
+            sdk_layer_ndjson.push(b'\n');
+            events.push(event);
+        }
+
+        if events.is_empty() {
+            return Err(SdkLayerError::EmptySdkLog);
+        }
+
+        Ok(Self {
+            run_id,
+            sdk_layer_ndjson,
+            events,
+        })
+    }
+
+    /// Apply this SDK capture to the archive.
+    ///
+    /// SDK-layer events are self-reported runtime observations. Applying them
+    /// may set `sdk_layer=self_reported`, but it must not promote kernel or
+    /// policy claims: side-effect evidence remains owned by those layers.
+    pub fn apply_to_archive(self, archive: &mut RunnerSpikeArchive) -> Result<(), SdkLayerError> {
+        let SdkLayerCapture {
+            run_id,
+            sdk_layer_ndjson,
+            events,
+        } = self;
+
+        if archive.run_id != run_id {
+            return Err(SdkLayerError::RunIdMismatch {
+                expected: archive.run_id.clone(),
+                actual: run_id,
+            });
+        }
+
+        archive.sdk_layer_ndjson = sdk_layer_ndjson;
+        archive.observation_health.sdk_layer = SdkLayerStatus::SelfReported;
+        archive
+            .observation_health
+            .notes
+            .retain(|note| !note.starts_with("s5_sdk_capture:"));
+        archive
+            .observation_health
+            .notes
+            .push(format!("s5_sdk_capture: sdk_events={}", events.len()));
+        Ok(())
+    }
+}
+
+fn required_string(
+    value: &Value,
+    field: &'static str,
+    line: usize,
+) -> Result<String, SdkLayerError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| SdkLayerError::MissingRequiredField {
+            line,
+            field: field.to_string(),
+        })
+}
+
+fn required_u64(value: &Value, field: &'static str, line: usize) -> Result<u64, SdkLayerError> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| SdkLayerError::MissingRequiredField {
+            line,
+            field: field.to_string(),
+        })
+}
+
+fn optional_string(value: &Value, field: &'static str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn observed_schema(value: &Value) -> Option<String> {
+    value.get("schema").map(|schema| match schema {
+        Value::String(schema) => schema.clone(),
+        other => other.to_string(),
+    })
+}
+
+fn is_supported_event_type(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "tool_call_started" | "tool_call_completed" | "run_finished" | "run_failed"
+    )
+}
+
+fn validate_tool_call_fields(
+    line: usize,
+    event_type: &str,
+    tool_call_id: &Option<String>,
+    tool: &Option<String>,
+) -> Result<(), SdkLayerError> {
+    if !matches!(event_type, "tool_call_started" | "tool_call_completed") {
+        return Ok(());
+    }
+    if tool_call_id.is_none() {
+        return Err(SdkLayerError::MissingToolCallField {
+            line,
+            event_type: event_type.to_string(),
+            field: "tool_call_id",
+        });
+    }
+    if tool.is_none() {
+        return Err(SdkLayerError::MissingToolCallField {
+            line,
+            event_type: event_type.to_string(),
+            field: "tool",
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{KernelLayerStatus, PolicyLayerStatus};
+
+    const SDK_EVENTS: &[u8] = br#"{"schema":"assay.runner.sdk_event.v0","run_id":"run_001","seq":0,"event_type":"tool_call_started","source":"openai-agents","sdk_name":"@openai/agents","sdk_version":"0.0.0-fixture","tool_call_id":"tc_runner_policy_001","tool":"read_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"run_001","seq":1,"event_type":"tool_call_completed","source":"openai-agents","sdk_name":"@openai/agents","sdk_version":"0.0.0-fixture","tool_call_id":"tc_runner_policy_001","tool":"read_file"}
+"#;
+
+    #[test]
+    fn sdk_log_records_self_reported_layer() {
+        let capture = SdkLayerCapture::from_sdk_ndjson("run_001", SDK_EVENTS).unwrap();
+        let sdk = String::from_utf8(capture.sdk_layer_ndjson.clone()).unwrap();
+
+        assert!(sdk.contains(SDK_EVENT_SCHEMA));
+        assert!(sdk.contains("tc_runner_policy_001"));
+        assert_eq!(capture.events.len(), 2);
+    }
+
+    #[test]
+    fn apply_marks_sdk_self_reported_without_promoting_other_layers() {
+        let capture = SdkLayerCapture::from_sdk_ndjson("run_001", SDK_EVENTS).unwrap();
+        let mut archive = RunnerSpikeArchive::empty("run_001", "linux");
+
+        capture.apply_to_archive(&mut archive).unwrap();
+
+        assert_eq!(
+            archive.observation_health.sdk_layer,
+            SdkLayerStatus::SelfReported
+        );
+        assert_eq!(
+            archive.observation_health.kernel_layer,
+            KernelLayerStatus::Absent
+        );
+        assert_eq!(
+            archive.observation_health.policy_layer,
+            PolicyLayerStatus::Absent
+        );
+        assert!(archive
+            .observation_health
+            .notes
+            .iter()
+            .any(|note| note == "s5_sdk_capture: sdk_events=2"));
+    }
+
+    #[test]
+    fn empty_sdk_log_is_rejected() {
+        assert!(matches!(
+            SdkLayerCapture::from_sdk_ndjson("run_001", b"\n\n"),
+            Err(SdkLayerError::EmptySdkLog)
+        ));
+    }
+
+    #[test]
+    fn unsupported_event_type_is_rejected() {
+        let err = SdkLayerCapture::from_sdk_ndjson(
+            "run_001",
+            br#"{"schema":"assay.runner.sdk_event.v0","run_id":"run_001","seq":0,"event_type":"unknown","source":"fixture"}
+"#,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SdkLayerError::UnsupportedEventType {
+                line: 1,
+                ref event_type
+            } if event_type == "unknown"
+        ));
+    }
+
+    #[test]
+    fn tool_call_events_require_tool_call_id() {
+        let err = SdkLayerCapture::from_sdk_ndjson(
+            "run_001",
+            br#"{"schema":"assay.runner.sdk_event.v0","run_id":"run_001","seq":0,"event_type":"tool_call_started","source":"fixture","tool":"read_file"}
+"#,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SdkLayerError::MissingToolCallField {
+                line: 1,
+                ref event_type,
+                field: "tool_call_id"
+            } if event_type == "tool_call_started"
+        ));
+    }
+
+    #[test]
+    fn tool_call_events_require_tool_name() {
+        let err = SdkLayerCapture::from_sdk_ndjson(
+            "run_001",
+            br#"{"schema":"assay.runner.sdk_event.v0","run_id":"run_001","seq":0,"event_type":"tool_call_completed","source":"fixture","tool_call_id":"tc_runner_sdk_001"}
+"#,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SdkLayerError::MissingToolCallField {
+                line: 1,
+                ref event_type,
+                field: "tool"
+            } if event_type == "tool_call_completed"
+        ));
+    }
+
+    #[test]
+    fn run_finished_does_not_require_tool_call_fields() {
+        let capture = SdkLayerCapture::from_sdk_ndjson(
+            "run_001",
+            br#"{"schema":"assay.runner.sdk_event.v0","run_id":"run_001","seq":0,"event_type":"run_finished","source":"fixture"}
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(capture.events[0].tool_call_id, None);
+        assert_eq!(capture.events[0].tool, None);
+    }
+
+    #[test]
+    fn seq_must_be_contiguous() {
+        let err = SdkLayerCapture::from_sdk_ndjson(
+            "run_001",
+            br#"{"schema":"assay.runner.sdk_event.v0","run_id":"run_001","seq":1,"event_type":"run_finished","source":"fixture"}
+"#,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SdkLayerError::SeqMismatch {
+                line: 1,
+                expected: 0,
+                actual: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn event_run_id_must_match_capture_run_id() {
+        let err = SdkLayerCapture::from_sdk_ndjson(
+            "run_001",
+            br#"{"schema":"assay.runner.sdk_event.v0","run_id":"run_002","seq":0,"event_type":"run_finished","source":"fixture"}
+"#,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            SdkLayerError::EventRunIdMismatch {
+                line: 1,
+                ref expected,
+                ref actual
+            } if expected == "run_001" && actual == "run_002"
+        ));
+    }
+}

--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -340,6 +340,12 @@ Transport is fixed for the spike:
 - stdout/stderr remain diagnostic channels; they are not the canonical SDK
   event stream
 
+The first S5 implementation slice may ingest a prewritten normalized SDK
+event log through the same hidden runner boundary. That only freezes the
+`assay.runner.sdk_event.v0` contract; it is not enough to claim the
+`openai-agents` shim has passed until the subprocess transport and
+deterministic fixture are wired.
+
 Keep it thin:
 
 - emit normalized SDK events


### PR DESCRIPTION
Summary

- add an internal S5 SDK-layer adapter for normalized `assay.runner.sdk_event.v0` NDJSON
- set `sdk_layer=self_reported` only when SDK events are ingested, without promoting kernel or policy claims
- add hidden `assay runner-spike run --sdk-event-log <path>` wiring for the next subprocess shim slice
- reject `--sdk-event-log` with `--agent-shim none` so the `none` mode continues to force `sdk_layer=absent`
- record in the Phase 1 spike plan that this is only the SDK event contract slice, not the completed `openai-agents` shim

Validation

- cargo fmt --check
- cargo test -p assay-runner-spike
- cargo clippy -p assay-runner-spike -- -D warnings
- cargo check -p assay-cli --no-default-features (passes with existing unrelated warnings in assay-cli::cli::args::sim)
- git diff --check
- runner-spike SDK contract smoke: `--agent-shim openai-agents --sdk-event-log <fixture>` produced `sdk_layer=self_reported`, `kernel_layer=absent`, and two `assay.runner.sdk_event.v0` records
- pre-commit hooks: merge-conflict check, whitespace hooks, token hygiene, typos, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes

This intentionally does not launch `node` or invoke `@openai/agents` yet. It freezes the normalized SDK event stream and bundle application rules first, so the upcoming subprocess/VCR slice has a narrow contract to target.