### PR TITLE
[codex] add runner sdk subprocess fixture

### DIFF
--- a/crates/assay-cli/src/cli/commands/runner_spike.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike.rs
@@ -1,4 +1,4 @@
-use assay_runner_spike::RunSpec;
+use assay_runner_spike::{RunSpec, SDK_EVENT_SCHEMA};
 use clap::{Args, Subcommand};
 use std::fs::File;
 use std::path::PathBuf;
@@ -80,6 +80,13 @@ fn build_spec(args: &RunnerSpikeRunArgs) -> RunSpec {
     let mut spec = RunSpec::new(args.command.clone()).with_agent_shim(args.agent_shim.clone());
     if let Some(run_id) = &args.run_id {
         spec = spec.with_run_id(run_id.clone());
+    }
+    if let Some(path) = &args.sdk_event_log {
+        let run_id = spec.run_id.clone();
+        spec = spec
+            .with_env("ASSAY_RUNNER_SDK_EVENT_LOG", path.display().to_string())
+            .with_env("ASSAY_RUNNER_RUN_ID", run_id)
+            .with_env("ASSAY_RUNNER_SDK_EVENT_SCHEMA", SDK_EVENT_SCHEMA);
     }
     spec
 }
@@ -253,6 +260,7 @@ fn spawn_child_in_cgroup(
     let procs_path = CString::new(cgroup.procs_path().as_os_str().as_bytes())?;
     let mut command = tokio::process::Command::new(&spec.command[0]);
     command.args(&spec.command[1..]);
+    command.envs(&spec.env);
 
     unsafe {
         command.pre_exec(move || write_self_to_cgroup(&procs_path));

--- a/crates/assay-runner-spike/src/run.rs
+++ b/crates/assay-runner-spike/src/run.rs
@@ -1,6 +1,7 @@
 use crate::{CgroupCorrelationStatus, KernelLayerStatus, RunnerSpikeArchive};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::process::{Command, ExitStatus};
 use std::time::{Duration, Instant};
 use thiserror::Error;
@@ -14,6 +15,7 @@ pub struct RunSpec {
     pub platform: String,
     pub agent_shim: String,
     pub command: Vec<String>,
+    pub env: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -65,6 +67,7 @@ impl RunSpec {
             platform: std::env::consts::OS.to_string(),
             agent_shim: "none".to_string(),
             command,
+            env: BTreeMap::new(),
         }
     }
 
@@ -80,6 +83,11 @@ impl RunSpec {
 
     pub fn with_agent_shim(mut self, agent_shim: impl Into<String>) -> Self {
         self.agent_shim = agent_shim.into();
+        self
+    }
+
+    pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(key.into(), value.into());
         self
     }
 
@@ -125,6 +133,7 @@ impl RunSpec {
 
         let mut child = Command::new(&self.command[0])
             .args(&self.command[1..])
+            .envs(&self.env)
             .spawn()
             .map_err(|source| RunExecutionError::Spawn {
                 command: self.command[0].clone(),
@@ -163,6 +172,7 @@ impl RunSpec {
                 "type": "run_started",
                 "agent_shim": &self.agent_shim,
                 "command": &self.command,
+                "env_keys": self.env.keys().collect::<Vec<_>>(),
                 "window_elapsed_ms": window_elapsed.as_millis() as u64
             }),
         )?;

--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -346,6 +346,19 @@ event log through the same hidden runner boundary. That only freezes the
 `openai-agents` shim has passed until the subprocess transport and
 deterministic fixture are wired.
 
+The next S5 implementation slice proves the transport boundary with a
+deterministic SDK fixture:
+
+```text
+tests/fixtures/runner-spike/sdk-event-wrapper.sh
+scripts/ci/runner-spike-sdk-contract-acceptance.sh
+```
+
+Runner supplies `ASSAY_RUNNER_SDK_EVENT_LOG`, `ASSAY_RUNNER_RUN_ID`, and
+`ASSAY_RUNNER_SDK_EVENT_SCHEMA` to the measured subprocess. The subprocess
+writes normalized SDK NDJSON to that path; stdout and stderr remain
+diagnostic only.
+
 Keep it thin:
 
 - emit normalized SDK events

--- a/scripts/ci/runner-spike-sdk-contract-acceptance.sh
+++ b/scripts/ci/runner-spike-sdk-contract-acceptance.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [ -n "${ASSAY_BIN:-}" ]; then
+  if [ ! -x "$ASSAY_BIN" ]; then
+    echo "ERROR: ASSAY_BIN is not executable: $ASSAY_BIN" >&2
+    exit 2
+  fi
+else
+  cargo build -p assay-cli --no-default-features
+  ASSAY_BIN="$ROOT/target/debug/assay"
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-sdk-contract.XXXXXX")"
+cleanup() {
+  rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+WORK_DIR="$TMP_ROOT/work"
+EXTRACT_DIR="$TMP_ROOT/extract"
+BUNDLE="$TMP_ROOT/runner-sdk-contract.tar.gz"
+SDK_LOG="$TMP_ROOT/sdk-events.ndjson"
+RUN_ID="run_sdk_contract_acceptance"
+
+"$ASSAY_BIN" runner-spike run \
+  --agent-shim openai-agents \
+  --sdk-event-log "$SDK_LOG" \
+  --run-id "$RUN_ID" \
+  --output "$BUNDLE" \
+  -- "$ROOT/tests/fixtures/runner-spike/sdk-event-wrapper.sh" "$WORK_DIR"
+
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$BUNDLE" -C "$EXTRACT_DIR"
+
+python3 - "$EXTRACT_DIR" "$WORK_DIR" "$RUN_ID" "$SDK_LOG" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+extract_dir = Path(sys.argv[1])
+work_dir = Path(sys.argv[2]).resolve()
+run_id = sys.argv[3]
+sdk_log = Path(sys.argv[4])
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def read_json(path: str):
+    return json.loads((extract_dir / path).read_text(encoding="utf-8"))
+
+
+manifest = read_json("manifest.json")
+health = read_json("observation-health.json")
+surface = read_json("capability-surface.json")
+correlation = read_json("correlation-report.json")
+
+expect(manifest["schema"] == "assay.runner.archive_manifest.v0", "unexpected manifest schema")
+expect(health["schema"] == "assay.runner.observation_health.v0", "unexpected health schema")
+expect(surface["schema"] == "assay.runner.capability_surface.v0", "unexpected surface schema")
+expect(correlation["schema"] == "assay.runner.correlation_report.v0", "unexpected correlation schema")
+
+for name, document in {
+    "manifest": manifest,
+    "observation-health": health,
+    "capability-surface": surface,
+    "correlation-report": correlation,
+}.items():
+    expect(document["run_id"] == run_id, f"{name} run_id mismatch: {document['run_id']!r}")
+
+for relative_path, entry in manifest["files"].items():
+    payload = (extract_dir / relative_path).read_bytes()
+    digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+    expect(entry["path"] == relative_path, f"manifest path mismatch for {relative_path}")
+    expect(entry["bytes"] == len(payload), f"manifest byte count mismatch for {relative_path}")
+    expect(entry["sha256"] == digest, f"manifest sha256 mismatch for {relative_path}")
+
+expect(health["kernel_layer"] == "absent", f"kernel_layer must be absent, got {health['kernel_layer']!r}")
+expect(health["ringbuf_drops"] == 0, f"ringbuf_drops must be 0, got {health['ringbuf_drops']!r}")
+expect(health["policy_layer"] == "absent", f"policy_layer must be absent, got {health['policy_layer']!r}")
+expect(health["sdk_layer"] == "self_reported", f"sdk_layer must be self_reported, got {health['sdk_layer']!r}")
+expect(
+    health["cgroup_correlation"] == "partial",
+    f"cgroup_correlation must remain partial without kernel capture, got {health['cgroup_correlation']!r}",
+)
+
+expect((extract_dir / "layers/kernel.ndjson").read_text(encoding="utf-8") == "", "kernel layer must be empty")
+expect((extract_dir / "layers/policy.ndjson").read_text(encoding="utf-8") == "", "policy layer must be empty")
+
+sdk_events = (extract_dir / "layers/sdk.ndjson").read_text(encoding="utf-8").splitlines()
+source_events = sdk_log.read_text(encoding="utf-8").splitlines()
+expect(len(sdk_events) == 3, f"expected three sdk events, got {len(sdk_events)}")
+expect(len(source_events) == 3, f"expected three source sdk events, got {len(source_events)}")
+
+for seq, line in enumerate(sdk_events):
+    event = json.loads(line)
+    source_event = json.loads(source_events[seq])
+    expect(event["schema"] == "assay.runner.sdk_event.v0", f"sdk event {seq} schema mismatch")
+    expect(event["run_id"] == run_id, f"sdk event {seq} run_id mismatch")
+    expect(event["seq"] == seq, f"sdk event {seq} seq mismatch")
+    for field in ("event_type", "source", "sdk_name", "sdk_version"):
+        expect(event.get(field) == source_event.get(field), f"sdk event {seq} {field} mismatch")
+    if event["event_type"] in {"tool_call_started", "tool_call_completed"}:
+        expect(event["tool_call_id"] == "tc_runner_sdk_001", f"sdk event {seq} tool_call_id mismatch")
+        expect(event["tool"] == "read_file", f"sdk event {seq} tool mismatch")
+
+expect((work_dir / "sdk-wrapper-ran.txt").read_text(encoding="utf-8").strip() == "sdk wrapper fixture ran", "sdk wrapper fixture did not run")
+expect(surface.get("filesystem_prefixes", []) == [], "sdk-only fixture must not add filesystem capabilities")
+expect(correlation.get("bindings", []) == [], "sdk-only fixture must not add correlation bindings")
+
+print("runner-spike SDK contract archive verified")
+PY
+
+echo "PASS: runner-spike SDK contract acceptance"

--- a/tests/fixtures/runner-spike/sdk-event-wrapper.sh
+++ b/tests/fixtures/runner-spike/sdk-event-wrapper.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <work-dir>" >&2
+  exit 64
+fi
+
+: "${ASSAY_RUNNER_SDK_EVENT_LOG:?ASSAY_RUNNER_SDK_EVENT_LOG must be set}"
+: "${ASSAY_RUNNER_RUN_ID:?ASSAY_RUNNER_RUN_ID must be set}"
+: "${ASSAY_RUNNER_SDK_EVENT_SCHEMA:?ASSAY_RUNNER_SDK_EVENT_SCHEMA must be set}"
+
+work_dir=$1
+mkdir -p "$work_dir"
+printf '%s\n' "sdk wrapper fixture ran" > "$work_dir/sdk-wrapper-ran.txt"
+
+python3 - "$ASSAY_RUNNER_SDK_EVENT_LOG" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+run_id = os.environ["ASSAY_RUNNER_RUN_ID"]
+schema = os.environ["ASSAY_RUNNER_SDK_EVENT_SCHEMA"]
+
+events = [
+    {
+        "schema": schema,
+        "run_id": run_id,
+        "seq": 0,
+        "event_type": "tool_call_started",
+        "source": "deterministic-sdk-fixture",
+        "sdk_name": "@openai/agents",
+        "sdk_version": "0.0.0-fixture",
+        "tool_call_id": "tc_runner_sdk_001",
+        "tool": "read_file",
+    },
+    {
+        "schema": schema,
+        "run_id": run_id,
+        "seq": 1,
+        "event_type": "tool_call_completed",
+        "source": "deterministic-sdk-fixture",
+        "sdk_name": "@openai/agents",
+        "sdk_version": "0.0.0-fixture",
+        "tool_call_id": "tc_runner_sdk_001",
+        "tool": "read_file",
+    },
+    {
+        "schema": schema,
+        "run_id": run_id,
+        "seq": 2,
+        "event_type": "run_finished",
+        "source": "deterministic-sdk-fixture",
+        "sdk_name": "@openai/agents",
+        "sdk_version": "0.0.0-fixture",
+    },
+]
+
+path.write_text(
+    "".join(json.dumps(event, separators=(",", ":")) + "\n" for event in events),
+    encoding="utf-8",
+)
+PY


### PR DESCRIPTION
Summary

- pass `ASSAY_RUNNER_SDK_EVENT_LOG`, `ASSAY_RUNNER_RUN_ID`, and `ASSAY_RUNNER_SDK_EVENT_SCHEMA` into runner-spike child processes when `--sdk-event-log` is set
- add a deterministic SDK wrapper fixture that writes normalized `assay.runner.sdk_event.v0` NDJSON through that runner-supplied path
- add `scripts/ci/runner-spike-sdk-contract-acceptance.sh` to verify the SDK subprocess transport boundary without live LLM calls or Node/OpenAI SDK wiring
- keep SDK-only evidence bounded: the acceptance verifier requires `sdk_layer=self_reported`, `kernel_layer=absent`, `policy_layer=absent`, no capability surface additions, and no correlation bindings
- record the S5 transport fixture in the Phase 1 spike plan

Validation

- cargo fmt --check
- cargo test -p assay-runner-spike
- cargo clippy -p assay-runner-spike -- -D warnings
- cargo check -p assay-cli --no-default-features (passes with existing unrelated warnings in assay-cli::cli::args::sim)
- shellcheck scripts/ci/runner-spike-sdk-contract-acceptance.sh tests/fixtures/runner-spike/sdk-event-wrapper.sh
- scripts/ci/runner-spike-sdk-contract-acceptance.sh
- git diff --check
- pre-commit hooks: merge-conflict check, whitespace hooks, token hygiene, typos, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes

This is still a deterministic SDK fixture, not the completed `@openai/agents` shim. It proves the runner-owned subprocess transport path: stdout/stderr remain diagnostic, and normalized SDK events are passed through the explicit runner-supplied event file.