### PR TITLE
[codex] add runner sdk policy correlation

### DIFF
--- a/crates/assay-runner-spike/src/sdk.rs
+++ b/crates/assay-runner-spike/src/sdk.rs
@@ -1,6 +1,7 @@
 use crate::{run::is_safe_run_id, RunnerSpikeArchive, SdkLayerStatus};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeSet;
 use thiserror::Error;
 
 pub const SDK_EVENT_SCHEMA: &str = "assay.runner.sdk_event.v0";
@@ -185,10 +186,13 @@ impl SdkLayerCapture {
             .observation_health
             .notes
             .retain(|note| !note.starts_with("s5_sdk_capture:"));
-        archive
-            .observation_health
-            .notes
-            .push(format!("s5_sdk_capture: sdk_events={}", events.len()));
+        let sdk_tool_call_ids = sdk_tool_call_ids(&events);
+        mark_sdk_policy_mismatches(archive, &sdk_tool_call_ids);
+        archive.observation_health.notes.push(format!(
+            "s5_sdk_capture: sdk_events={} sdk_tool_calls={}",
+            events.len(),
+            sdk_tool_call_ids.len()
+        ));
         Ok(())
     }
 }
@@ -269,6 +273,37 @@ fn validate_tool_call_fields(
     Ok(())
 }
 
+fn sdk_tool_call_ids(events: &[SdkLayerEvent]) -> BTreeSet<String> {
+    events
+        .iter()
+        .filter_map(|event| event.tool_call_id.clone())
+        .collect()
+}
+
+fn mark_sdk_policy_mismatches(
+    archive: &mut RunnerSpikeArchive,
+    sdk_tool_call_ids: &BTreeSet<String>,
+) {
+    if archive.policy_layer_ndjson.is_empty() {
+        return;
+    }
+
+    let policy_binding_ids = archive
+        .correlation_report
+        .bindings
+        .iter()
+        .map(|binding| binding.tool_call_id.clone())
+        .collect::<BTreeSet<_>>();
+
+    for tool_call_id in sdk_tool_call_ids {
+        if !policy_binding_ids.contains(tool_call_id) {
+            archive.correlation_report.mark_partial(format!(
+                "sdk_tool_call_without_policy_binding:{tool_call_id}"
+            ));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -311,7 +346,62 @@ mod tests {
             .observation_health
             .notes
             .iter()
-            .any(|note| note == "s5_sdk_capture: sdk_events=2"));
+            .any(|note| note == "s5_sdk_capture: sdk_events=2 sdk_tool_calls=1"));
+    }
+
+    #[test]
+    fn sdk_policy_matching_tool_call_keeps_existing_correlation_status() {
+        let capture = SdkLayerCapture::from_sdk_ndjson("run_001", SDK_EVENTS).unwrap();
+        let mut archive = RunnerSpikeArchive::empty("run_001", "linux");
+        archive.policy_layer_ndjson = b"{\"schema\":\"assay.runner.policy_event.v0\"}\n".to_vec();
+        archive
+            .correlation_report
+            .add_binding(crate::CorrelationBinding {
+                tool_call_id: "tc_runner_policy_001".to_string(),
+                policy_decision: Some("allow".to_string()),
+                kernel_event_count: 1,
+                window: crate::BindingWindow {
+                    start: "run_started".to_string(),
+                    end: "run_finished".to_string(),
+                },
+            });
+
+        capture.apply_to_archive(&mut archive).unwrap();
+
+        assert_eq!(
+            archive.correlation_report.status,
+            crate::CorrelationStatus::Clean
+        );
+        assert!(archive.correlation_report.ambiguities.is_empty());
+    }
+
+    #[test]
+    fn sdk_policy_mismatched_tool_call_marks_correlation_partial() {
+        let capture = SdkLayerCapture::from_sdk_ndjson("run_001", SDK_EVENTS).unwrap();
+        let mut archive = RunnerSpikeArchive::empty("run_001", "linux");
+        archive.policy_layer_ndjson = b"{\"schema\":\"assay.runner.policy_event.v0\"}\n".to_vec();
+        archive
+            .correlation_report
+            .add_binding(crate::CorrelationBinding {
+                tool_call_id: "tc_different_policy_call".to_string(),
+                policy_decision: Some("allow".to_string()),
+                kernel_event_count: 1,
+                window: crate::BindingWindow {
+                    start: "run_started".to_string(),
+                    end: "run_finished".to_string(),
+                },
+            });
+
+        capture.apply_to_archive(&mut archive).unwrap();
+
+        assert_eq!(
+            archive.correlation_report.status,
+            crate::CorrelationStatus::Partial
+        );
+        assert!(archive
+            .correlation_report
+            .ambiguities
+            .contains(&"sdk_tool_call_without_policy_binding:tc_runner_policy_001".to_string()));
     }
 
     #[test]

--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -359,6 +359,19 @@ Runner supplies `ASSAY_RUNNER_SDK_EVENT_LOG`, `ASSAY_RUNNER_RUN_ID`, and
 writes normalized SDK NDJSON to that path; stdout and stderr remain
 diagnostic only.
 
+The following S5 slice cross-checks SDK self-report against the existing
+policy layer:
+
+```text
+tests/fixtures/runner-spike/sdk-policy-agent.sh
+scripts/ci/runner-spike-sdk-policy-correlation.sh
+```
+
+When a policy layer is present, every SDK tool-call id must match an existing
+policy correlation binding. A missing binding marks the correlation report
+partial with `sdk_tool_call_without_policy_binding:<tool_call_id>`. SDK events
+still do not create bindings or promote kernel/policy claims by themselves.
+
 Keep it thin:
 
 - emit normalized SDK events

--- a/scripts/ci/runner-spike-sdk-policy-correlation.sh
+++ b/scripts/ci/runner-spike-sdk-policy-correlation.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [ -n "${ASSAY_BIN:-}" ]; then
+  if [ ! -x "$ASSAY_BIN" ]; then
+    echo "ERROR: ASSAY_BIN is not executable: $ASSAY_BIN" >&2
+    exit 2
+  fi
+else
+  cargo build -p assay-cli --no-default-features
+  ASSAY_BIN="$ROOT/target/debug/assay"
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-sdk-policy.XXXXXX")"
+cleanup() {
+  rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+WORK_DIR="$TMP_ROOT/work"
+EXTRACT_DIR="$TMP_ROOT/extract"
+BUNDLE="$TMP_ROOT/runner-sdk-policy.tar.gz"
+SDK_LOG="$TMP_ROOT/sdk-events.ndjson"
+DECISION_LOG="$TMP_ROOT/policy-decisions.ndjson"
+RUN_ID="run_sdk_policy_correlation"
+
+export ASSAY_BIN
+export ASSAY_RUNNER_POLICY_DECISION_LOG="$DECISION_LOG"
+export ASSAY_RUNNER_RUN_ID="$RUN_ID"
+
+"$ASSAY_BIN" runner-spike run \
+  --agent-shim openai-agents \
+  --sdk-event-log "$SDK_LOG" \
+  --policy-decision-log "$DECISION_LOG" \
+  --run-id "$RUN_ID" \
+  --output "$BUNDLE" \
+  -- "$ROOT/tests/fixtures/runner-spike/sdk-policy-agent.sh" "$WORK_DIR"
+
+mkdir -p "$EXTRACT_DIR"
+tar -xzf "$BUNDLE" -C "$EXTRACT_DIR"
+
+python3 - "$EXTRACT_DIR" "$RUN_ID" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+extract_dir = Path(sys.argv[1])
+run_id = sys.argv[2]
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def read_json(path: str):
+    return json.loads((extract_dir / path).read_text(encoding="utf-8"))
+
+
+manifest = read_json("manifest.json")
+health = read_json("observation-health.json")
+surface = read_json("capability-surface.json")
+correlation = read_json("correlation-report.json")
+
+for relative_path, entry in manifest["files"].items():
+    payload = (extract_dir / relative_path).read_bytes()
+    digest = "sha256:" + hashlib.sha256(payload).hexdigest()
+    expect(entry["path"] == relative_path, f"manifest path mismatch for {relative_path}")
+    expect(entry["bytes"] == len(payload), f"manifest byte count mismatch for {relative_path}")
+    expect(entry["sha256"] == digest, f"manifest sha256 mismatch for {relative_path}")
+
+expect(health["run_id"] == run_id, "health run_id mismatch")
+expect(health["sdk_layer"] == "self_reported", f"sdk_layer mismatch: {health['sdk_layer']!r}")
+expect(health["policy_layer"] == "present", f"policy_layer mismatch: {health['policy_layer']!r}")
+expect(health["kernel_layer"] == "absent", f"kernel_layer mismatch: {health['kernel_layer']!r}")
+expect(
+    any(note == "s5_sdk_capture: sdk_events=3 sdk_tool_calls=1" for note in health["notes"]),
+    "sdk capture note missing",
+)
+
+sdk_events = [json.loads(line) for line in (extract_dir / "layers/sdk.ndjson").read_text(encoding="utf-8").splitlines()]
+policy_events = [json.loads(line) for line in (extract_dir / "layers/policy.ndjson").read_text(encoding="utf-8").splitlines()]
+expect(len(sdk_events) == 3, f"expected three sdk events, got {len(sdk_events)}")
+expect(len(policy_events) == 1, f"expected one policy event, got {len(policy_events)}")
+
+sdk_tool_calls = {event.get("tool_call_id") for event in sdk_events if event.get("tool_call_id")}
+policy_tool_calls = {event.get("tool_call_id") for event in policy_events}
+expect(sdk_tool_calls == {"tc_runner_policy_001"}, f"sdk tool_call_id mismatch: {sdk_tool_calls!r}")
+expect(policy_tool_calls == {"tc_runner_policy_001"}, f"policy tool_call_id mismatch: {policy_tool_calls!r}")
+
+expect("read_file" in set(surface.get("mcp_tools", [])), "read_file MCP tool missing")
+expect("allow:read_file" in set(surface.get("policy_decisions", [])), "allow:read_file policy decision missing")
+
+bindings = correlation.get("bindings", [])
+expect(len(bindings) == 1, f"expected one policy correlation binding, got {len(bindings)}")
+expect(bindings[0]["tool_call_id"] == "tc_runner_policy_001", "binding tool_call_id mismatch")
+expect(
+    not any(item.startswith("sdk_tool_call_without_policy_binding:") for item in correlation.get("ambiguities", [])),
+    f"sdk/policy mismatch ambiguity present: {correlation.get('ambiguities', [])!r}",
+)
+
+print("runner-spike SDK+policy correlation verified")
+PY
+
+echo "PASS: runner-spike SDK+policy correlation"

--- a/tests/fixtures/runner-spike/sdk-event-wrapper.sh
+++ b/tests/fixtures/runner-spike/sdk-event-wrapper.sh
@@ -14,13 +14,16 @@ work_dir=$1
 mkdir -p "$work_dir"
 printf '%s\n' "sdk wrapper fixture ran" > "$work_dir/sdk-wrapper-ran.txt"
 
-python3 - "$ASSAY_RUNNER_SDK_EVENT_LOG" <<'PY'
+tool_call_id="${ASSAY_RUNNER_SDK_TOOL_CALL_ID:-tc_runner_sdk_001}"
+
+python3 - "$ASSAY_RUNNER_SDK_EVENT_LOG" "$tool_call_id" <<'PY'
 import json
 import os
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
+tool_call_id = sys.argv[2]
 run_id = os.environ["ASSAY_RUNNER_RUN_ID"]
 schema = os.environ["ASSAY_RUNNER_SDK_EVENT_SCHEMA"]
 
@@ -33,7 +36,7 @@ events = [
         "source": "deterministic-sdk-fixture",
         "sdk_name": "@openai/agents",
         "sdk_version": "0.0.0-fixture",
-        "tool_call_id": "tc_runner_sdk_001",
+        "tool_call_id": tool_call_id,
         "tool": "read_file",
     },
     {
@@ -44,7 +47,7 @@ events = [
         "source": "deterministic-sdk-fixture",
         "sdk_name": "@openai/agents",
         "sdk_version": "0.0.0-fixture",
-        "tool_call_id": "tc_runner_sdk_001",
+        "tool_call_id": tool_call_id,
         "tool": "read_file",
     },
     {

--- a/tests/fixtures/runner-spike/sdk-policy-agent.sh
+++ b/tests/fixtures/runner-spike/sdk-policy-agent.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <work-dir>" >&2
+  exit 64
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+work_dir=$1
+
+ASSAY_RUNNER_SDK_TOOL_CALL_ID=tc_runner_policy_001 \
+  "$ROOT/tests/fixtures/runner-spike/sdk-event-wrapper.sh" "$work_dir"
+
+"$ROOT/tests/fixtures/runner-spike/mcp-policy-agent.sh" "$work_dir"


### PR DESCRIPTION
Summary

- cross-check SDK self-reported tool_call_id values against existing policy correlation bindings when a policy layer is present
- mark the correlation report partial with `sdk_tool_call_without_policy_binding:<tool_call_id>` when an SDK tool call has no matching policy binding
- keep SDK isolation intact: SDK events do not create bindings or promote kernel/policy claims
- add a deterministic SDK+policy fixture that emits SDK events with the same tool_call_id used by the MCP policy fixture
- add `scripts/ci/runner-spike-sdk-policy-correlation.sh` to verify SDK ↔ policy matching without eBPF or live LLM calls
- record the S5 SDK-policy cross-check in the Phase 1 spike plan

Validation

- cargo fmt --check
- cargo test -p assay-runner-spike
- cargo clippy -p assay-runner-spike -- -D warnings
- cargo check -p assay-cli --no-default-features (passes with existing unrelated warnings in assay-cli::cli::args::sim)
- shellcheck scripts/ci/runner-spike-sdk-policy-correlation.sh tests/fixtures/runner-spike/sdk-policy-agent.sh tests/fixtures/runner-spike/sdk-event-wrapper.sh
- scripts/ci/runner-spike-sdk-policy-correlation.sh
- git diff --check
- pre-commit hooks: merge-conflict check, whitespace hooks, token hygiene, typos, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes

This is still deterministic fixture work, not the final `@openai/agents` shim. It proves the first cross-layer S5 rule: SDK tool-call self-reports must be joinable to policy evidence when policy evidence is present.