### PR TITLE
[codex] add runner sdk policy determinism probe

### DIFF
--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -365,6 +365,7 @@ policy layer:
 ```text
 tests/fixtures/runner-spike/sdk-policy-agent.sh
 scripts/ci/runner-spike-sdk-policy-correlation.sh
+scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
 ```
 
 When a policy layer is present, every SDK tool-call id must match an existing

--- a/scripts/ci/runner-spike-sdk-policy-correlation.sh
+++ b/scripts/ci/runner-spike-sdk-policy-correlation.sh
@@ -14,18 +14,26 @@ else
   ASSAY_BIN="$ROOT/target/debug/assay"
 fi
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-sdk-policy.XXXXXX")"
-cleanup() {
-  rm -rf -- "$TMP_ROOT"
-}
+if [ -n "${ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR:-}" ]; then
+  TMP_ROOT="$ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR"
+  mkdir -p "$TMP_ROOT"
+  cleanup() {
+    :
+  }
+else
+  TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-sdk-policy.XXXXXX")"
+  cleanup() {
+    rm -rf -- "$TMP_ROOT"
+  }
+fi
 trap cleanup EXIT
 
-WORK_DIR="$TMP_ROOT/work"
+WORK_DIR="${ASSAY_RUNNER_ACCEPTANCE_WORK_DIR:-$TMP_ROOT/work}"
 EXTRACT_DIR="$TMP_ROOT/extract"
 BUNDLE="$TMP_ROOT/runner-sdk-policy.tar.gz"
 SDK_LOG="$TMP_ROOT/sdk-events.ndjson"
 DECISION_LOG="$TMP_ROOT/policy-decisions.ndjson"
-RUN_ID="run_sdk_policy_correlation"
+RUN_ID="${ASSAY_RUNNER_ACCEPTANCE_RUN_ID:-run_sdk_policy_correlation}"
 
 export ASSAY_BIN
 export ASSAY_RUNNER_POLICY_DECISION_LOG="$DECISION_LOG"

--- a/scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-sdk-policy-determinism.XXXXXX")"
+cleanup() {
+  rm -rf -- "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+WORK_DIR="$TMP_ROOT/work"
+RUN_ID="run_sdk_policy_determinism"
+
+for run in 1 2 3; do
+  echo "=== runner-spike SDK+policy determinism run $run/3 ==="
+  ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR="$TMP_ROOT/run-$run" \
+    ASSAY_RUNNER_ACCEPTANCE_WORK_DIR="$WORK_DIR" \
+    ASSAY_RUNNER_ACCEPTANCE_RUN_ID="$RUN_ID" \
+    "$ROOT/scripts/ci/runner-spike-sdk-policy-correlation.sh"
+done
+
+python3 - "$TMP_ROOT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+tmp_root = Path(sys.argv[1])
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+baseline_health = read_json(tmp_root / "run-1" / "extract" / "observation-health.json")
+baseline_surface = read_json(tmp_root / "run-1" / "extract" / "capability-surface.json")
+baseline_correlation = read_json(tmp_root / "run-1" / "extract" / "correlation-report.json")
+baseline_sdk = (tmp_root / "run-1" / "extract" / "layers" / "sdk.ndjson").read_text(
+    encoding="utf-8"
+)
+baseline_policy = (tmp_root / "run-1" / "extract" / "layers" / "policy.ndjson").read_text(
+    encoding="utf-8"
+)
+
+for run in (2, 3):
+    health = read_json(tmp_root / f"run-{run}" / "extract" / "observation-health.json")
+    surface = read_json(tmp_root / f"run-{run}" / "extract" / "capability-surface.json")
+    correlation = read_json(tmp_root / f"run-{run}" / "extract" / "correlation-report.json")
+    sdk = (tmp_root / f"run-{run}" / "extract" / "layers" / "sdk.ndjson").read_text(
+        encoding="utf-8"
+    )
+    policy = (tmp_root / f"run-{run}" / "extract" / "layers" / "policy.ndjson").read_text(
+        encoding="utf-8"
+    )
+
+    if health != baseline_health:
+        fail(f"observation-health.json changed between run 1 and run {run}")
+    if surface != baseline_surface:
+        fail(f"capability-surface.json changed between run 1 and run {run}")
+    if correlation != baseline_correlation:
+        fail(f"correlation-report.json changed between run 1 and run {run}")
+    if sdk != baseline_sdk:
+        fail(
+            f"layers/sdk.ndjson changed between run 1 and run {run}; "
+            "the deterministic SDK fixture should emit byte-stable normalized events."
+        )
+    if policy != baseline_policy:
+        fail(
+            f"layers/policy.ndjson changed between run 1 and run {run}; "
+            "the deterministic MCP policy fixture should emit byte-stable policy events."
+        )
+
+print("runner-spike SDK+policy three-run determinism verified")
+PY
+
+echo "PASS: runner-spike SDK+policy three-run determinism"


### PR DESCRIPTION
Summary

- add scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh to run the SDK+policy correlation probe three times
- make the SDK+policy correlation verifier composable through artifact/work-dir/run-id env overrides, matching earlier acceptance probes
- compare observation-health.json, capability-surface.json, correlation-report.json, layers/sdk.ndjson, and layers/policy.ndjson across the three runs
- record the S5 three-run SDK+policy determinism gate in the Phase 1 spike plan

Validation

- shellcheck scripts/ci/runner-spike-sdk-policy-correlation.sh scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
- scripts/ci/runner-spike-sdk-policy-correlation.sh
- scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
- git diff --check
- cargo fmt --check
- pre-commit hooks: merge-conflict check, whitespace hooks, token hygiene, typos, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes

This remains deterministic fixture work. It requires no eBPF host and no live LLM calls; it only proves that the SDK+policy cross-check stays byte-stable over repeated runs.