### PR TITLE
[codex] add runner sdk mismatch gate

### DIFF
--- a/.github/workflows/runner-spike-sdk.yml
+++ b/.github/workflows/runner-spike-sdk.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   sdk-policy-determinism:
-    name: SDK+policy determinism
+    name: S5 contract and determinism
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -62,3 +62,10 @@ jobs:
           set -euo pipefail
           ASSAY_BIN="$PWD/target/debug/assay" \
             scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
+
+      - name: SDK+policy mismatch three-run determinism
+        shell: bash
+        run: |
+          set -euo pipefail
+          ASSAY_BIN="$PWD/target/debug/assay" \
+            scripts/ci/runner-spike-sdk-policy-mismatch-three-run-determinism.sh

--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -366,12 +366,16 @@ policy layer:
 tests/fixtures/runner-spike/sdk-policy-agent.sh
 scripts/ci/runner-spike-sdk-policy-correlation.sh
 scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
+scripts/ci/runner-spike-sdk-policy-mismatch.sh
+scripts/ci/runner-spike-sdk-policy-mismatch-three-run-determinism.sh
 ```
 
 When a policy layer is present, every SDK tool-call id must match an existing
 policy correlation binding. A missing binding marks the correlation report
 partial with `sdk_tool_call_without_policy_binding:<tool_call_id>`. SDK events
 still do not create bindings or promote kernel/policy claims by themselves.
+The mismatch verifier intentionally emits a distinct SDK tool-call id and must
+observe that partial-correlation ambiguity across three deterministic runs.
 
 Keep it thin:
 

--- a/scripts/ci/runner-spike-sdk-policy-correlation.sh
+++ b/scripts/ci/runner-spike-sdk-policy-correlation.sh
@@ -34,10 +34,13 @@ BUNDLE="$TMP_ROOT/runner-sdk-policy.tar.gz"
 SDK_LOG="$TMP_ROOT/sdk-events.ndjson"
 DECISION_LOG="$TMP_ROOT/policy-decisions.ndjson"
 RUN_ID="${ASSAY_RUNNER_ACCEPTANCE_RUN_ID:-run_sdk_policy_correlation}"
+SDK_TOOL_CALL_ID="${ASSAY_RUNNER_ACCEPTANCE_SDK_TOOL_CALL_ID:-tc_runner_policy_001}"
+EXPECT_SDK_POLICY_MISMATCH="${ASSAY_RUNNER_ACCEPTANCE_EXPECT_SDK_POLICY_MISMATCH:-0}"
 
 export ASSAY_BIN
 export ASSAY_RUNNER_POLICY_DECISION_LOG="$DECISION_LOG"
 export ASSAY_RUNNER_RUN_ID="$RUN_ID"
+export ASSAY_RUNNER_SDK_TOOL_CALL_ID="$SDK_TOOL_CALL_ID"
 
 "$ASSAY_BIN" runner-spike run \
   --agent-shim openai-agents \
@@ -50,7 +53,7 @@ export ASSAY_RUNNER_RUN_ID="$RUN_ID"
 mkdir -p "$EXTRACT_DIR"
 tar -xzf "$BUNDLE" -C "$EXTRACT_DIR"
 
-python3 - "$EXTRACT_DIR" "$RUN_ID" <<'PY'
+python3 - "$EXTRACT_DIR" "$RUN_ID" "$SDK_TOOL_CALL_ID" "$EXPECT_SDK_POLICY_MISMATCH" <<'PY'
 import hashlib
 import json
 import sys
@@ -58,6 +61,9 @@ from pathlib import Path
 
 extract_dir = Path(sys.argv[1])
 run_id = sys.argv[2]
+sdk_tool_call_id = sys.argv[3]
+expect_sdk_policy_mismatch = sys.argv[4] == "1"
+policy_tool_call_id = "tc_runner_policy_001"
 
 
 def fail(message: str) -> None:
@@ -101,19 +107,27 @@ expect(len(policy_events) == 1, f"expected one policy event, got {len(policy_eve
 
 sdk_tool_calls = {event.get("tool_call_id") for event in sdk_events if event.get("tool_call_id")}
 policy_tool_calls = {event.get("tool_call_id") for event in policy_events}
-expect(sdk_tool_calls == {"tc_runner_policy_001"}, f"sdk tool_call_id mismatch: {sdk_tool_calls!r}")
-expect(policy_tool_calls == {"tc_runner_policy_001"}, f"policy tool_call_id mismatch: {policy_tool_calls!r}")
+expect(sdk_tool_calls == {sdk_tool_call_id}, f"sdk tool_call_id mismatch: {sdk_tool_calls!r}")
+expect(policy_tool_calls == {policy_tool_call_id}, f"policy tool_call_id mismatch: {policy_tool_calls!r}")
 
 expect("read_file" in set(surface.get("mcp_tools", [])), "read_file MCP tool missing")
 expect("allow:read_file" in set(surface.get("policy_decisions", [])), "allow:read_file policy decision missing")
 
 bindings = correlation.get("bindings", [])
 expect(len(bindings) == 1, f"expected one policy correlation binding, got {len(bindings)}")
-expect(bindings[0]["tool_call_id"] == "tc_runner_policy_001", "binding tool_call_id mismatch")
-expect(
-    not any(item.startswith("sdk_tool_call_without_policy_binding:") for item in correlation.get("ambiguities", [])),
-    f"sdk/policy mismatch ambiguity present: {correlation.get('ambiguities', [])!r}",
-)
+expect(bindings[0]["tool_call_id"] == policy_tool_call_id, "binding tool_call_id mismatch")
+ambiguities = correlation.get("ambiguities", [])
+expected_ambiguity = f"sdk_tool_call_without_policy_binding:{sdk_tool_call_id}"
+if expect_sdk_policy_mismatch:
+    expect(sdk_tool_call_id != policy_tool_call_id, "mismatch mode must use a distinct SDK tool_call_id")
+    expect(correlation["status"] == "partial", f"correlation status must be partial, got {correlation['status']!r}")
+    expect(expected_ambiguity in ambiguities, f"expected mismatch ambiguity missing: {ambiguities!r}")
+else:
+    expect(sdk_tool_call_id == policy_tool_call_id, "match mode must use the policy tool_call_id")
+    expect(
+        not any(item.startswith("sdk_tool_call_without_policy_binding:") for item in ambiguities),
+        f"sdk/policy mismatch ambiguity present: {ambiguities!r}",
+    )
 
 print("runner-spike SDK+policy correlation verified")
 PY

--- a/scripts/ci/runner-spike-sdk-policy-mismatch-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-sdk-policy-mismatch-three-run-determinism.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+export ASSAY_RUNNER_ACCEPTANCE_CORRELATION_SCRIPT="$ROOT/scripts/ci/runner-spike-sdk-policy-mismatch.sh"
+export ASSAY_RUNNER_ACCEPTANCE_LABEL="SDK+policy mismatch"
+export ASSAY_RUNNER_ACCEPTANCE_RUN_ID="${ASSAY_RUNNER_ACCEPTANCE_RUN_ID:-run_sdk_policy_mismatch_determinism}"
+
+exec "$ROOT/scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh"

--- a/scripts/ci/runner-spike-sdk-policy-mismatch.sh
+++ b/scripts/ci/runner-spike-sdk-policy-mismatch.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+ASSAY_RUNNER_ACCEPTANCE_SDK_TOOL_CALL_ID="${ASSAY_RUNNER_ACCEPTANCE_SDK_TOOL_CALL_ID:-tc_runner_sdk_only_001}" \
+  ASSAY_RUNNER_ACCEPTANCE_EXPECT_SDK_POLICY_MISMATCH=1 \
+  "$ROOT/scripts/ci/runner-spike-sdk-policy-correlation.sh"

--- a/scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
@@ -11,22 +11,25 @@ cleanup() {
 trap cleanup EXIT
 
 WORK_DIR="$TMP_ROOT/work"
-RUN_ID="run_sdk_policy_determinism"
+RUN_ID="${ASSAY_RUNNER_ACCEPTANCE_RUN_ID:-run_sdk_policy_determinism}"
+CORRELATION_SCRIPT="${ASSAY_RUNNER_ACCEPTANCE_CORRELATION_SCRIPT:-$ROOT/scripts/ci/runner-spike-sdk-policy-correlation.sh}"
+LABEL="${ASSAY_RUNNER_ACCEPTANCE_LABEL:-SDK+policy}"
 
 for run in 1 2 3; do
-  echo "=== runner-spike SDK+policy determinism run $run/3 ==="
+  echo "=== runner-spike $LABEL determinism run $run/3 ==="
   ASSAY_RUNNER_ACCEPTANCE_ARTIFACT_DIR="$TMP_ROOT/run-$run" \
     ASSAY_RUNNER_ACCEPTANCE_WORK_DIR="$WORK_DIR" \
     ASSAY_RUNNER_ACCEPTANCE_RUN_ID="$RUN_ID" \
-    "$ROOT/scripts/ci/runner-spike-sdk-policy-correlation.sh"
+    "$CORRELATION_SCRIPT"
 done
 
-python3 - "$TMP_ROOT" <<'PY'
+python3 - "$TMP_ROOT" "$LABEL" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 tmp_root = Path(sys.argv[1])
+label = sys.argv[2]
 
 
 def fail(message: str) -> None:
@@ -75,7 +78,7 @@ for run in (2, 3):
             "the deterministic MCP policy fixture should emit byte-stable policy events."
         )
 
-print("runner-spike SDK+policy three-run determinism verified")
+print(f"runner-spike {label} three-run determinism verified")
 PY
 
-echo "PASS: runner-spike SDK+policy three-run determinism"
+echo "PASS: runner-spike $LABEL three-run determinism"

--- a/tests/fixtures/runner-spike/sdk-policy-agent.sh
+++ b/tests/fixtures/runner-spike/sdk-policy-agent.sh
@@ -8,8 +8,9 @@ fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 work_dir=$1
+sdk_tool_call_id="${ASSAY_RUNNER_SDK_TOOL_CALL_ID:-tc_runner_policy_001}"
 
-ASSAY_RUNNER_SDK_TOOL_CALL_ID=tc_runner_policy_001 \
+ASSAY_RUNNER_SDK_TOOL_CALL_ID="$sdk_tool_call_id" \
   "$ROOT/tests/fixtures/runner-spike/sdk-event-wrapper.sh" "$work_dir"
 
 "$ROOT/tests/fixtures/runner-spike/mcp-policy-agent.sh" "$work_dir"


### PR DESCRIPTION
Summary
- add a runner-spike SDK+policy mismatch acceptance path that emits an SDK tool_call_id without a matching policy binding
- parameterize the existing SDK+policy correlation verifier instead of duplicating archive validation semantics
- add a three-run determinism wrapper for the mismatch path and wire it into the Runner Spike SDK workflow
- record the negative-path verifier in the Phase 1 spike plan

Validation
- actionlint .github/workflows/runner-spike-sdk.yml
- shellcheck scripts/ci/runner-spike-sdk-policy-correlation.sh scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh scripts/ci/runner-spike-sdk-policy-mismatch.sh scripts/ci/runner-spike-sdk-policy-mismatch-three-run-determinism.sh tests/fixtures/runner-spike/sdk-policy-agent.sh
- git diff --check
- cargo fmt --check
- cargo build -p assay-cli --no-default-features (passes with existing unrelated warnings in assay-cli::cli::args::sim)
- ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-contract-acceptance.sh
- ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-correlation.sh
- ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-mismatch.sh
- ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh
- ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-mismatch-three-run-determinism.sh
- commit hooks: merge-conflict check, yaml, token hygiene, typos, actionlint, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes
- The positive SDK+policy path intentionally does not assert correlation.status=clean because policy-without-kernel may already mark the report partial. It only asserts absence of sdk_tool_call_without_policy_binding ambiguity.
- The mismatch path requires the exact sdk_tool_call_without_policy_binding:<tool_call_id> ambiguity and verifies it is byte-stable across three runs.
