### PR TITLE
[codex] document runner spike S5 apply ordering

### DIFF
--- a/crates/assay-cli/src/cli/commands/runner_spike.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike.rs
@@ -102,8 +102,7 @@ fn cmd_run_contract_only(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
     let output = bundle_output_path(&args, &spec.run_id);
 
     let mut outcome = spec.run_contract_only()?;
-    apply_policy_decision_log_if_requested(&spec, &args, &mut outcome.archive)?;
-    apply_sdk_event_log_if_requested(&spec, &args, &mut outcome.archive)?;
+    apply_policy_then_sdk_logs_if_requested(&spec, &args, &mut outcome.archive)?;
     let mut file = File::create(&output)?;
     outcome.archive.write(&mut file)?;
     let exit_status = exit_status_label(outcome.exit_code, outcome.signal);
@@ -228,8 +227,7 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
     let after_stats = monitor.snapshot_stats()?;
     let capture = builder.finish(&before_stats, &after_stats);
     capture.apply_to_archive(&mut archive, cgroup_correlation)?;
-    apply_policy_decision_log_if_requested(&spec, &args, &mut archive)?;
-    apply_sdk_event_log_if_requested(&spec, &args, &mut archive)?;
+    apply_policy_then_sdk_logs_if_requested(&spec, &args, &mut archive)?;
     spec.append_run_finished(&mut archive, 1, &status, clock.elapsed())?;
 
     let mut file = File::create(&output)?;
@@ -372,6 +370,19 @@ fn write_u32_decimal(value: u32, buf: &mut [u8; 32]) -> usize {
         buf[idx] = scratch[len - idx - 1];
     }
     len
+}
+
+fn apply_policy_then_sdk_logs_if_requested(
+    spec: &RunSpec,
+    args: &RunnerSpikeRunArgs,
+    archive: &mut assay_runner_spike::RunnerSpikeArchive,
+) -> anyhow::Result<()> {
+    // Policy must be applied before SDK: SDK cross-checks read policy
+    // correlation bindings and the mismatch determinism gate relies on stable
+    // ambiguity ordering.
+    apply_policy_decision_log_if_requested(spec, args, archive)?;
+    apply_sdk_event_log_if_requested(spec, args, archive)?;
+    Ok(())
 }
 
 fn apply_policy_decision_log_if_requested(


### PR DESCRIPTION
Summary
- centralize runner-spike policy+SDK log application in one helper used by both contract-only and kernel-capture paths
- document that policy logs must be applied before SDK logs because SDK cross-checks read policy correlation bindings
- preserve stable ambiguity ordering for the SDK+policy mismatch determinism gate

Validation
- cargo fmt --check
- cargo check -p assay-cli --no-default-features (passes with existing unrelated warnings in assay-cli::cli::args::sim)
- cargo build -p assay-cli --no-default-features (passes with the same existing warnings)
- ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-correlation.sh
- ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-mismatch-three-run-determinism.sh
- git diff --check
- commit hooks: merge-conflict check, token hygiene, typos, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes
- This is only an ordering-invariant/documentation slice. It does not claim S5 is complete.
- S5 still needs the real openai-agents Node subprocess shim plus replay/VCR determinism before the full S5 acceptance path is complete.
