### PR TITLE
[codex] add openai agents determinism gate

### DIFF
--- a/.github/workflows/runner-spike-sdk.yml
+++ b/.github/workflows/runner-spike-sdk.yml
@@ -87,3 +87,10 @@ jobs:
           set -euo pipefail
           ASSAY_BIN="$PWD/target/debug/assay" \
             scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh
+
+      - name: OpenAI Agents SDK+policy three-run determinism
+        shell: bash
+        run: |
+          set -euo pipefail
+          ASSAY_BIN="$PWD/target/debug/assay" \
+            scripts/ci/runner-spike-openai-agents-sdk-policy-three-run-determinism.sh

--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -385,6 +385,7 @@ deterministic model provider to force one `read_file` function-tool call:
 tests/fixtures/runner-spike/openai-agents-js/fixture-agent.js
 tests/fixtures/runner-spike/openai-agents-sdk-policy-agent.sh
 scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh
+scripts/ci/runner-spike-openai-agents-sdk-policy-three-run-determinism.sh
 ```
 
 This proves the `@openai/agents` runtime hook path and the runner-supplied SDK

--- a/scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh
+++ b/scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if ! command -v node >/dev/null 2>&1; then
+  echo "SKIP: runner-spike OpenAI Agents fixture requires Node.js 22 or newer; node was not found on PATH." >&2
+  exit 40
+fi
+
 if ! node -e 'process.exit(Number(process.versions.node.split(".")[0]) >= 22 ? 0 : 1)'; then
   echo "SKIP: runner-spike OpenAI Agents fixture requires Node.js 22 or newer." >&2
   exit 40

--- a/scripts/ci/runner-spike-openai-agents-sdk-policy-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-openai-agents-sdk-policy-three-run-determinism.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export ASSAY_RUNNER_ACCEPTANCE_CORRELATION_SCRIPT="$ROOT/scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh"
+export ASSAY_RUNNER_ACCEPTANCE_LABEL="OpenAI Agents SDK+policy"
+export ASSAY_RUNNER_ACCEPTANCE_RUN_ID="${ASSAY_RUNNER_ACCEPTANCE_RUN_ID:-run_openai_agents_sdk_policy_determinism}"
+
+exec "$ROOT/scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh"

--- a/tests/fixtures/runner-spike/openai-agents-js/fixture-agent.js
+++ b/tests/fixtures/runner-spike/openai-agents-js/fixture-agent.js
@@ -5,8 +5,26 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { Agent, Runner, Usage, tool } = require('@openai/agents');
 
-const SDK_NAME = '@openai/agents';
-const SDK_VERSION = '0.11.4';
+const { name: SDK_NAME, version: SDK_VERSION } = loadSdkMetadata();
+
+function loadSdkMetadata() {
+  let directory = path.dirname(require.resolve('@openai/agents'));
+  for (;;) {
+    const packageJson = path.join(directory, 'package.json');
+    if (fs.existsSync(packageJson)) {
+      const metadata = JSON.parse(fs.readFileSync(packageJson, 'utf8'));
+      if (metadata.name === '@openai/agents') {
+        return metadata;
+      }
+    }
+
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      throw new Error('could not locate @openai/agents package metadata');
+    }
+    directory = parent;
+  }
+}
 
 function requiredEnv(name) {
   const value = process.env[name];
@@ -110,6 +128,8 @@ async function main() {
     toolExecution: { maxFunctionToolConcurrency: 1 },
   });
 
+  // @openai/agents 0.11.x hook names map to assay.runner.sdk_event.v0:
+  // agent_tool_start -> tool_call_started, agent_tool_end -> tool_call_completed.
   runner.on('agent_tool_start', (_context, _agent, startedTool, details) => {
     emit({
       event_type: 'tool_call_started',

--- a/tests/fixtures/runner-spike/openai-agents-sdk-policy-agent.sh
+++ b/tests/fixtures/runner-spike/openai-agents-sdk-policy-agent.sh
@@ -13,5 +13,16 @@ FIXTURE_DIR="$ROOT/tests/fixtures/runner-spike/openai-agents-js"
 export ASSAY_RUNNER_SDK_TOOL_CALL_ID
 export OPENAI_AGENTS_DISABLE_TRACING=1
 
+if ! command -v node >/dev/null 2>&1; then
+  echo "error: node is required to run $FIXTURE_DIR/fixture-agent.js but was not found on PATH" >&2
+  exit 69
+fi
+
+if [ ! -d "$FIXTURE_DIR/node_modules/@openai/agents" ]; then
+  echo "error: missing fixture dependency '@openai/agents' under $FIXTURE_DIR/node_modules" >&2
+  echo "hint: run 'npm ci' in $FIXTURE_DIR before running this script" >&2
+  exit 69
+fi
+
 node "$FIXTURE_DIR/fixture-agent.js" "$1"
 "$ROOT/tests/fixtures/runner-spike/mcp-policy-agent.sh" "$1"


### PR DESCRIPTION
Summary

- add an OpenAI Agents SDK+policy three-run determinism wrapper that reuses the existing parameterized S5 determinism gate
- run that new OpenAI Agents three-run gate from the Runner Spike SDK workflow
- harden the OpenAI Agents correlation preflight so missing `node` skips with exit 40 instead of surfacing a shell 127
- derive emitted SDK name/version from the installed `@openai/agents` package metadata instead of a second hardcoded fixture constant
- add local fixture preflight hints for missing Node or missing `npm ci` dependencies
- document the OpenAI Agents determinism script in the Phase 1 spike plan

Validation

- `node --check tests/fixtures/runner-spike/openai-agents-js/fixture-agent.js`
- `shellcheck scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh scripts/ci/runner-spike-openai-agents-sdk-policy-three-run-determinism.sh tests/fixtures/runner-spike/openai-agents-sdk-policy-agent.sh`
- `PATH=/usr/bin:/bin scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh` returns exit 40 skip for missing Node
- direct OpenAI Agents fixture probe emitted three normalized SDK events with `sdk_name=@openai/agents` and `sdk_version=0.11.4` derived from installed package metadata
- local Node 20 runs of `scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh` and `scripts/ci/runner-spike-openai-agents-sdk-policy-three-run-determinism.sh` return exit 40 skip as expected
- `ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh`
- `ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-mismatch-three-run-determinism.sh`
- `actionlint .github/workflows/runner-spike-sdk.yml`
- `cargo fmt --check`
- `git diff --check`
- pre-commit hooks: merge-conflict check, YAML/actionlint, whitespace hooks, token hygiene, typos, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes

This closes the small follow-up items from #1260: local preflights are clearer, SDK metadata comes from the installed package, and the real `@openai/agents` route now has the same three-run byte-determinism gate as the existing S5 fixture paths. This still does not claim the privileged Linux kernel+policy+SDK acceptance gate is done.
