### PR TITLE
[codex] add openai agents mismatch gate

### DIFF
--- a/.github/workflows/runner-spike-sdk.yml
+++ b/.github/workflows/runner-spike-sdk.yml
@@ -94,3 +94,10 @@ jobs:
           set -euo pipefail
           ASSAY_BIN="$PWD/target/debug/assay" \
             scripts/ci/runner-spike-openai-agents-sdk-policy-three-run-determinism.sh
+
+      - name: OpenAI Agents SDK+policy mismatch three-run determinism
+        shell: bash
+        run: |
+          set -euo pipefail
+          ASSAY_BIN="$PWD/target/debug/assay" \
+            scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch-three-run-determinism.sh

--- a/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md
@@ -386,12 +386,18 @@ tests/fixtures/runner-spike/openai-agents-js/fixture-agent.js
 tests/fixtures/runner-spike/openai-agents-sdk-policy-agent.sh
 scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh
 scripts/ci/runner-spike-openai-agents-sdk-policy-three-run-determinism.sh
+scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch.sh
+scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch-three-run-determinism.sh
 ```
 
 This proves the `@openai/agents` runtime hook path and the runner-supplied SDK
 event stream without a live LLM request. It still is not the full delegated
 Linux kernel+policy+SDK acceptance gate: that requires the privileged eBPF host
 to run the kernel capture alongside the JavaScript shim.
+The OpenAI Agents mismatch verifier intentionally emits the SDK tool-call id
+`tc_runner_sdk_only_001` while policy keeps `tc_runner_policy_001`, and must
+observe the same `sdk_tool_call_without_policy_binding:<tool_call_id>`
+ambiguity across three deterministic runs.
 
 Keep it thin:
 

--- a/scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch-three-run-determinism.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+export ASSAY_RUNNER_ACCEPTANCE_CORRELATION_SCRIPT="$ROOT/scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch.sh"
+export ASSAY_RUNNER_ACCEPTANCE_LABEL="OpenAI Agents SDK+policy mismatch"
+export ASSAY_RUNNER_ACCEPTANCE_RUN_ID="${ASSAY_RUNNER_ACCEPTANCE_RUN_ID:-run_openai_agents_sdk_policy_mismatch_determinism}"
+
+exec "$ROOT/scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh"

--- a/scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch.sh
+++ b/scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+ASSAY_RUNNER_ACCEPTANCE_SDK_TOOL_CALL_ID="${ASSAY_RUNNER_ACCEPTANCE_SDK_TOOL_CALL_ID:-tc_runner_sdk_only_001}" \
+  ASSAY_RUNNER_ACCEPTANCE_EXPECT_SDK_POLICY_MISMATCH=1 \
+  "$ROOT/scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh"


### PR DESCRIPTION
Summary

- add an OpenAI Agents SDK+policy mismatch verifier that drives the existing S5 mismatch semantics through the real JS SDK fixture
- add an OpenAI Agents SDK+policy mismatch three-run determinism wrapper by reusing the existing parameterized S5 determinism gate
- run the new mismatch determinism gate from the Runner Spike SDK workflow
- record the OpenAI Agents mismatch gate in the Phase 1 spike plan

Validation

- `shellcheck scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch.sh scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch-three-run-determinism.sh scripts/ci/runner-spike-openai-agents-sdk-policy-correlation.sh`
- `actionlint .github/workflows/runner-spike-sdk.yml`
- `scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch.sh` on local Node 20 returns exit 40 skip as expected
- `scripts/ci/runner-spike-openai-agents-sdk-policy-mismatch-three-run-determinism.sh` on local Node 20 returns exit 40 skip as expected
- `ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-three-run-determinism.sh`
- `ASSAY_BIN="$PWD/target/debug/assay" scripts/ci/runner-spike-sdk-policy-mismatch-three-run-determinism.sh`
- `cargo fmt --check`
- `git diff --check`
- pre-commit hooks: merge-conflict check, YAML/actionlint, whitespace hooks, token hygiene, typos, shellcheck, cargo fmt
- pre-push hooks: workspace clippy and linux compile gate passed

Notes

This closes the cross-platform S5 symmetry gap: the real `@openai/agents` route now has match and mismatch three-run determinism gates in CI. It still does not claim the privileged Linux kernel+policy+SDK acceptance gate is complete.
