### PR TITLE
[codex] classify assay runner ci lanes

### DIFF
--- a/docs/notes/ASSAY-RUNNER-PHASE1-ACCEPTANCE-2026-05-21.md
+++ b/docs/notes/ASSAY-RUNNER-PHASE1-ACCEPTANCE-2026-05-21.md
@@ -115,7 +115,8 @@ expansion:
 2. maintain the telemetry-versus-evidence filter contract in that reference
 3. maintain the delegated runner runbook for provisioning and failure triage:
    [`ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md`](../ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md)
-4. classify when delegated CI is required for runner-impacting changes
+4. classify when delegated CI is required for runner-impacting changes:
+   [`Runner CI lane contract`](../reference/runner/ci-lanes.md)
 5. write an acceptance fixture contract for future SDK fixtures
 6. define the Assay-Runner boundary and extraction map
 

--- a/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
+++ b/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
@@ -102,6 +102,10 @@ Recommended progression during diagnosis:
 Use `all` once the narrower failing gate has been fixed. This avoids mixing
 multiple failure signals in the same diagnostic run.
 
+For merge-time gate selection, use the
+[`Runner CI lane contract`](../reference/runner/ci-lanes.md). It classifies
+which runner surfaces require delegated proof and which minimum gate applies.
+
 For acceptance or regression evidence, use `build_ebpf=true`. The prepare and
 workspace cleanup steps remove `target/`, so a previously built
 `target/assay-ebpf.o` will not survive the documented workflow path.

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -1,0 +1,87 @@
+# Assay-Runner CI Lane Contract
+
+> Internal Phase 2A reference. This page classifies when ordinary continuous
+> CI is enough and when the delegated Linux/eBPF runner lane is required.
+
+Assay-Runner has two proof classes:
+
+- **Continuous CI**: hosted or ordinary repository checks that must stay fast,
+  broadly available, and safe for pull requests.
+- **Delegated CI**: the manual `Runner Spike Delegated` workflow on
+  `[self-hosted, linux, assay-bpf-runner]`, used when a change can only be
+  proven on the dedicated Linux/eBPF host.
+
+The delegated lane is intentionally `workflow_dispatch` only. Do not add a
+pull-request, push, or schedule trigger to make the lane automatic. The host is
+dedicated and destructive cleanup is part of the contract.
+
+## Decision Table
+
+| Change type | Continuous CI | Delegated CI | Required before merge? |
+|---|---|---|---|
+| Docs-only change outside runner acceptance, runbook, artifact contracts, or CI lane docs | yes | no | no |
+| Docs-only change to runner acceptance, runbook, artifact contracts, fixture contract, or CI lane docs | yes | no | no, unless it changes acceptance criteria |
+| Non-runner crate change with no monitor, policy, SDK fixture, cgroup, workflow, or evidence artifact impact | yes | no | no |
+| Runner artifact schema, field set, note format, or artifact determinism semantics | yes | yes | yes |
+| Runner telemetry-versus-evidence filter behavior | yes | yes | yes |
+| `assay-monitor` ring-buffer reader, BPF event decode, drop accounting, or capture stats | yes | yes | yes |
+| `crates/assay-monitor/**` or `crates/assay-ebpf/**` | yes | yes | yes |
+| eBPF build image, build command, or loader/attach path | yes | yes | yes |
+| Runner cgroup placement, domain-root resolution, or process spawn discipline | yes | yes | yes |
+| Policy correlation, policy event normalization, or policy-to-kernel coherence rule | yes | yes | yes |
+| OpenAI Agents fixture dependency, SDK event normalization, SDK version assertion, or `tool_call_id` binding | yes | yes | yes |
+| Acceptance fixture behavior or control paths | yes | yes | case-by-case; required when observed evidence can change |
+| Delegated workflow, runner labels, cleanup, checkout, sudo environment, preflight, or `scripts/ci/runner-spike-*.sh` | yes | yes | yes |
+| `@openai/agents`, `zod`, or fixture `package-lock.json` bump | yes | yes | yes |
+| `aya`, `aya-ebpf`, `aya-log-ebpf`, or BPF/runtime dependency bump | yes | yes | yes |
+| Workspace dependency bump that can affect `assay-runner-spike`, `assay-monitor`, `assay-ebpf`, `assay-cli`, policy correlation, or runner fixtures | yes | yes | yes |
+| Delegated runbook wording that only clarifies existing behavior | yes | no | no |
+| Follow-up issue text, planning notes, or extraction-roadmap prose | yes | no | no |
+
+## Required Delegated Gate
+
+When delegated CI is required, choose the narrowest gate that proves the
+changed layer:
+
+| Touched surface | Minimum delegated gate |
+|---|---|
+| Kernel fixture control path or kernel-only acceptance assertion | `kernel-only` |
+| Policy capture or policy-to-kernel coherence | `kernel-policy` |
+| OpenAI Agents SDK fixture, SDK event schema, SDK version assertion, or `tool_call_id` binding | `openai-agents-kernel-policy` |
+| `crates/assay-monitor/**`, `crates/assay-ebpf/**`, eBPF build/attach path, cgroup placement, telemetry filter, cross-layer archive, artifact schema, correlation report, workflow/security model, runner scripts, BPF/runtime dependency bump, or final release/acceptance proof | `all` |
+
+If a change touches multiple surfaces, run the highest required gate. If the
+right gate is ambiguous, default to `all`.
+
+Use `build_ebpf=true` for delegated proof unless the workflow has been
+explicitly extended to restore a deterministic prebuilt eBPF object after
+cleanup and checkout.
+
+## Merge Discipline
+
+1. Run ordinary continuous CI for every PR.
+2. For runner-impacting changes, dispatch the minimum delegated gate after the
+   PR branch contains the final candidate commit.
+3. Record the workflow run URL, commit SHA, selected gate, and result in the
+   PR body or a PR comment.
+4. Do not treat a delegated skip as success. In the delegated lane, exit `40`
+   means the runner contract has drifted.
+5. Do not bypass required repository checks for runner-impacting changes.
+
+If a runner-impacting PR cannot get a delegated run because the host is
+unavailable, leave the PR open. Merge only docs-only or clearly
+non-runner-impacting changes without delegated proof.
+
+This page is advisory until enforcement is added. The follow-up for path-aware
+review or status-check pressure is tracked in
+<https://github.com/Rul1an/assay/issues/1274>. Ring-buffer drop diagnostics
+remain a separate follow-up tracked in
+<https://github.com/Rul1an/assay/issues/1271>; that issue must not weaken the
+`ringbuf_drops=0` delegated acceptance rule.
+
+## Boundary Rule
+
+The delegated lane proves the Linux/eBPF runner boundary, not macOS, Windows,
+live LLM calls, production load, or a distributed runner fleet. Platform
+expansion requires a separate platform spike with its own kill criteria and CI
+lane contract.

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -7,3 +7,4 @@ the Phase 2A internal contracts needed to keep the delegated Linux/eBPF proof
 reviewable while the runner boundary is consolidated.
 
 - [Runner artifact v0 contracts](artifacts-v0.md)
+- [Runner CI lane contract](ci-lanes.md)


### PR DESCRIPTION
Summary

- add an internal Assay-Runner CI lane contract for Phase 2A
- classify which change types require ordinary CI only versus delegated Linux/eBPF proof before merge
- map touched runner surfaces to the minimum delegated gate, with conservative `all` defaults for foundational, ambiguous, or multi-surface changes
- document dependency-bump handling for OpenAI Agents, BPF/runtime dependencies, and workspace bumps that affect runner surfaces
- link the delegated runbook to the CI lane contract and track enforcement as follow-up issue #1274

Validation

- git diff --check
- /tmp/assay-docs-venv/bin/mkdocs build --strict
- local docs markdown link check matching .github/workflows/docs-link-check.yml
- commit hooks: merge-conflict, EOF, whitespace, token hygiene, typos, cargo fmt

Notes

This is a docs-only Phase 2A consolidation slice. It does not change workflow triggers or branch protection; it freezes the merge decision table for runner-impacting changes. Enforcement follow-up: #1274. Ring-buffer debug follow-up remains #1271.