### PR TITLE
[codex] sharpen assay runner fixture contract precision

### DIFF
--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -16,6 +16,11 @@ layer streams in the archive. It is not a claim that raw kernel telemetry, raw
 ring-buffer delivery, dynamic loader behavior, or the eBPF object are
 byte-identical across runs.
 
+Machine-readable golden-shape examples are listed in
+[`golden/index.md`](golden/index.md). They are not substitutes for delegated
+acceptance runs; they freeze the v0 field set, value vocabulary, and
+serialization shape that docs and tests should preserve.
+
 ## Contract Principles
 
 1. **Monitor observes broadly.** Kernel, policy, and SDK monitors may observe
@@ -175,6 +180,10 @@ Binding fields:
 | `kernel_event_count` | integer | yes | Count of normalized kernel events in the binding window |
 | `window.start` | string | yes | Inclusive window start marker |
 | `window.end` | string | yes | Inclusive window end marker |
+
+Correlation windows use runner-defined phase markers from one canonical runner
+clock. SDK-provided timestamps are informational only and are not the primary
+join key for v0 correlation.
 
 Example:
 

--- a/docs/reference/runner/fixtures-v0.md
+++ b/docs/reference/runner/fixtures-v0.md
@@ -21,7 +21,23 @@ policy, and SDK correlation without introducing accidental host noise.
 The three delegated determinism wrappers run the relevant acceptance path
 three times and compare normalized artifacts byte-for-byte.
 
-## Proven Full S5 Fixture Shape
+## Fixture Contract Versus Accepted Instances
+
+This page separates two layers:
+
+- **Fixture contract:** rules that every runner acceptance fixture must follow:
+  deterministic invocation, stable identifiers, no live secrets, normalized
+  artifact determinism, and explicit telemetry-versus-evidence boundaries.
+- **Accepted fixture instance:** the exact shape proven by the current Phase 1
+  full S5 fixture, including SDK version, event counts, tool name, tool-call id,
+  and health-note text.
+
+Changing the general fixture discipline is a contract change. Updating a
+single accepted instance, for example during an `@openai/agents` dependency
+bump, is still reviewable but should be handled as an instance update as long
+as the general contract remains intact.
+
+## Accepted Full S5 Fixture Instance
 
 The Phase 1 `openai-agents-kernel-policy` acceptance path fixes the full
 kernel plus policy plus SDK fixture shape deliberately:
@@ -41,9 +57,9 @@ kernel plus policy plus SDK fixture shape deliberately:
 | Correlation report | `status=clean`, `ambiguities=[]`, one binding | delegated acceptance fails with status, ambiguity, or binding-count mismatch |
 | Correlation window | `{"start":"run_started","end":"run_finished"}` | delegated acceptance fails with `binding window mismatch` |
 
-These counts and values are part of the v0 fixture contract. Changing them is
-not a copy-edit; it changes the accepted deterministic fixture shape and
-requires an explicit contract review.
+These counts and values are part of the accepted v0 S5 fixture instance.
+Changing them is not a copy-edit; it changes the deterministic instance that
+proved Phase 1 and requires an explicit fixture-instance review.
 
 ## Contract Principles
 
@@ -107,6 +123,21 @@ validate required variables before doing measured work.
 
 The OpenAI Agents fixture also sets `OPENAI_AGENTS_DISABLE_TRACING=1`. The
 runner bundle does not claim OpenAI tracing export behavior in Phase 2A.
+
+Environment values that can affect fixture output or normalized evidence are
+part of fixture review. New fixture wrappers should pin or explicitly justify:
+
+- `TZ=UTC`
+- `LANG=C` and `LC_ALL=C`, unless locale behavior is the evidence under test
+- a stable `TMPDIR` root for control files
+- a stable `HOME` when SDK or package tooling reads user configuration
+- a fixed Node major/minor line for JavaScript fixtures
+- a stable current working directory before measured work begins
+- a stable `umask` when file modes can enter evidence or golden artifacts
+
+The accepted v0 fixture does not claim general locale, timezone, or user-home
+coverage. It claims deterministic normalized artifacts for the delegated Linux
+host and the fixture environment asserted by the acceptance wrappers.
 
 ## Filesystem Evidence Contract
 
@@ -188,6 +219,11 @@ The full S5 determinism wrapper compares exactly:
 Wrappers should print self-describing diffs when these artifacts drift. The
 diff is diagnostic only; it must not loosen the pass condition.
 
+The v0 machine-readable golden shapes for these artifacts are listed in
+[`golden/index.md`](golden/index.md). They are canonical examples for field
+presence, serialization shape, and status vocabulary. The delegated three-run
+comparison remains the executable determinism check for real fixture instances.
+
 Passing delegated determinism requires:
 
 - `kernel_layer=complete` when kernel capture is in scope
@@ -195,6 +231,12 @@ Passing delegated determinism requires:
 - `cgroup_correlation=clean`
 - stable normalized evidence across all three runs
 - no delegated skip treated as success
+
+## Correlation Clock Rule
+
+Kernel, policy, and SDK correlation windows use one canonical runner clock and
+runner-defined phase markers. SDK-provided timestamps are informational only
+and are never the primary join key for v0 correlation.
 
 ## Dependency Upgrade Contract
 
@@ -220,6 +262,14 @@ ids into `assay.runner.sdk_event.v0`.
 
 Dependency bumps must not relax event-schema validation, sequence validation,
 or three-run determinism.
+
+## Second-Order Fixtures
+
+Negative, adversarial, or S7-style fixtures are second-order contract tests.
+They are useful before widening the runner claim, but they must not silently
+complicate the happy-path S5 acceptance fixture. The happy path remains the
+small deterministic proof that kernel, policy, and SDK evidence can be
+captured, correlated, and reproduced byte-for-byte.
 
 ## Adding Or Changing A Fixture
 

--- a/docs/reference/runner/golden/capability-surface-openai-agents-kernel-policy-v0.json
+++ b/docs/reference/runner/golden/capability-surface-openai-agents-kernel-policy-v0.json
@@ -1,0 +1,16 @@
+{
+  "schema": "assay.runner.capability_surface.v0",
+  "run_id": "run_openai_agents_kernel_policy_determinism",
+  "filesystem_prefixes": [
+    "/tmp/assay-runner-openai-agents-kernel-policy/work/openai-agents-input.txt",
+    "/tmp/assay-runner-openai-agents-kernel-policy/work/policy-input.txt"
+  ],
+  "network_endpoints": [],
+  "process_execs": [],
+  "mcp_tools": [
+    "read_file"
+  ],
+  "policy_decisions": [
+    "allow:read_file"
+  ]
+}

--- a/docs/reference/runner/golden/correlation-report-openai-agents-kernel-policy-v0.json
+++ b/docs/reference/runner/golden/correlation-report-openai-agents-kernel-policy-v0.json
@@ -1,0 +1,17 @@
+{
+  "schema": "assay.runner.correlation_report.v0",
+  "run_id": "run_openai_agents_kernel_policy_determinism",
+  "status": "clean",
+  "bindings": [
+    {
+      "tool_call_id": "tc_runner_policy_001",
+      "policy_decision": "allow",
+      "kernel_event_count": 2,
+      "window": {
+        "start": "run_started",
+        "end": "run_finished"
+      }
+    }
+  ],
+  "ambiguities": []
+}

--- a/docs/reference/runner/golden/index.md
+++ b/docs/reference/runner/golden/index.md
@@ -1,0 +1,11 @@
+# Runner Artifact Golden Shapes
+
+Internal golden-shape examples for Assay-Runner v0 artifacts.
+
+These files are examples of canonical field sets, value vocabulary, and stable
+serialization shape. They are not delegated proof artifacts and do not replace
+the Linux/eBPF three-run determinism gates.
+
+- [`observation-health-openai-agents-kernel-policy-v0.json`](observation-health-openai-agents-kernel-policy-v0.json)
+- [`capability-surface-openai-agents-kernel-policy-v0.json`](capability-surface-openai-agents-kernel-policy-v0.json)
+- [`correlation-report-openai-agents-kernel-policy-v0.json`](correlation-report-openai-agents-kernel-policy-v0.json)

--- a/docs/reference/runner/golden/observation-health-openai-agents-kernel-policy-v0.json
+++ b/docs/reference/runner/golden/observation-health-openai-agents-kernel-policy-v0.json
@@ -1,0 +1,15 @@
+{
+  "schema": "assay.runner.observation_health.v0",
+  "run_id": "run_openai_agents_kernel_policy_determinism",
+  "platform": "linux",
+  "kernel_layer": "complete",
+  "ringbuf_drops": 0,
+  "policy_layer": "present",
+  "sdk_layer": "self_reported",
+  "cgroup_correlation": "clean",
+  "notes": [
+    "s2_kernel_capture: monitor_events=4 ringbuf_drops=0",
+    "s4_policy_capture: policy_events=1",
+    "s5_sdk_capture: sdk_events=3 sdk_tool_calls=1"
+  ]
+}

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -7,6 +7,7 @@ the Phase 2A internal contracts needed to keep the delegated Linux/eBPF proof
 reviewable while the runner boundary is consolidated.
 
 - [Runner artifact v0 contracts](artifacts-v0.md)
+- [Runner artifact golden shapes](golden/index.md)
 - [Runner acceptance fixture v0 contract](fixtures-v0.md)
 - [Runner CI lane contract](ci-lanes.md)
 - [Assay-Runner boundary and extraction map](boundary-map.md)


### PR DESCRIPTION
Summary
- split the runner fixture contract from the accepted full S5 fixture instance so dependency bumps are instance reviews, not accidental contract rewrites
- add explicit environment-stability review points for timezone, locale, temp roots, HOME, Node line, working directory, and umask
- add machine-readable golden-shape JSON examples for observation-health, capability-surface, and correlation-report v0 artifacts
- document the canonical runner clock rule for correlation windows and keep SDK timestamps informational only
- mark negative/adversarial/S7-style fixtures as second-order so they do not complicate the happy-path S5 acceptance fixture

Validation
- git diff --check
- python3 -m json.tool on all new golden JSON files
- local docs markdown link check matching .github/workflows/docs-link-check.yml
- /tmp/assay-docs-venv/bin/mkdocs build --strict
- commit hooks: merge-conflict, EOF, whitespace, token hygiene, typos, cargo fmt
- pre-push hooks: merge-conflict, whitespace, typos, actionlint, shellcheck, cargo fmt, workspace clippy, linux compile gate

Notes
- docs-only follow-up to the Phase 2A fixture contract review
- does not change runner behavior, fixture behavior, workflow triggers, or delegated acceptance semantics