### PR TITLE
[codex] clarify runner correlation report vocabulary

### DIFF
--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -177,7 +177,7 @@ Binding fields:
 | Field | Type | Required | Semantics |
 |---|---|---:|---|
 | `tool_call_id` | string | yes | Tool-call id used to bind SDK and policy layers |
-| `policy_decision` | string or null | yes | Matched policy decision summary, when present |
+| `policy_decision` | string or null | yes | Matched coarse policy outcome, when present (`allow` or `deny` in v0 accepted fixtures) |
 | `kernel_event_count` | integer | yes | Count of normalized kernel events in the binding window |
 | `window.start` | string | yes | Inclusive window start marker |
 | `window.end` | string | yes | Inclusive window end marker |
@@ -195,7 +195,7 @@ Example:
   "status": "clean",
   "bindings": [
     {
-      "tool_call_id": "tc_read_fixture_input",
+      "tool_call_id": "tc_runner_policy_001",
       "policy_decision": "allow",
       "kernel_event_count": 2,
       "window": {


### PR DESCRIPTION
Summary

- follow up on Copilot feedback from #1279 after the PR merged before the final two-line amendment landed
- clarify that correlation-report `policy_decision` is the coarse policy outcome (`allow`/`deny`) rather than the capability-surface decision summary string
- align the prose `tool_call_id` example with the golden v0 correlation-report example (`tc_runner_policy_001`)

Validation

- git diff --check
- /tmp/assay-docs-venv/bin/mkdocs build --strict
- commit hooks: merge-conflict, EOF, whitespace, token hygiene, typos, cargo fmt
- pre-push hooks: merge-conflict, whitespace, typos, actionlint, shellcheck, cargo fmt, workspace clippy, linux compile gate

Notes

Docs-only micro-follow-up. Does not change runner behavior, fixture behavior, workflow triggers, or delegated acceptance semantics.