### PR TITLE
[codex] scope runner health issue auto-close

### DIFF
--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -54,13 +54,20 @@ jobs:
           set -euo pipefail
           TITLE="🚨 Self-hosted runner health needs attention"
 
-          # Check if issue already exists. Some repos may not have the
-          # runner-health label yet, so fall back to a title match.
-          if EXISTING="$(gh issue list --repo "$REPO" --state open --label "runner-health" --json number --jq 'length' 2>/dev/null)"; then
-            :
+          # Only the exact alert issue participates in auto-create/auto-close.
+          # The runner-health label is also used by follow-up design issues, and
+          # those must never block or be closed by this scheduled monitor.
+          if ISSUES_JSON="$(gh issue list --repo "$REPO" --state open --label "runner-health" --limit 100 --json number,title 2>/dev/null)"; then
+            EXISTING="$(printf '%s' "$ISSUES_JSON" | jq --arg title "$TITLE" '[.[] | select(.title == $title)] | length')"
           else
             echo "::warning::Issue lookup by label failed; falling back to title-based lookup."
-            EXISTING="$(gh issue list --repo "$REPO" --state open --search "$TITLE in:title" --json number --jq 'length' 2>/dev/null || echo 0)"
+            if EXISTING="$(gh issue list --repo "$REPO" --state open --search "$TITLE in:title" --limit 100 --json number,title 2>/dev/null \
+              | jq --arg title "$TITLE" '[.[] | select(.title == $title)] | length')"; then
+              :
+            else
+              echo "::warning::Issue lookup by title failed; defaulting to no existing alert issue."
+              EXISTING=0
+            fi
           fi
 
           if [[ "$EXISTING" -eq 0 ]]; then
@@ -137,11 +144,13 @@ jobs:
           set -euo pipefail
           TITLE="🚨 Self-hosted runner health needs attention"
 
-          # Find and close any open runner-health issues. Fall back to title
-          # search when label is absent.
-          ISSUES="$(gh issue list --repo "$REPO" --state open --label "runner-health" --json number --jq '.[].number' 2>/dev/null || true)"
+          # Close only the exact auto-created alert issue. Other runner-health
+          # labeled issues can be design or follow-up work and must remain open.
+          ISSUES="$(gh issue list --repo "$REPO" --state open --label "runner-health" --limit 100 --json number,title 2>/dev/null \
+            | jq -r --arg title "$TITLE" '.[] | select(.title == $title) | .number' || true)"
           if [[ -z "$ISSUES" ]]; then
-            ISSUES="$(gh issue list --repo "$REPO" --state open --search "$TITLE in:title" --json number --jq '.[].number' 2>/dev/null || true)"
+            ISSUES="$(gh issue list --repo "$REPO" --state open --search "$TITLE in:title" --limit 100 --json number,title \
+              | jq -r --arg title "$TITLE" '.[] | select(.title == $title) | .number' || true)"
           fi
 
           for ISSUE in $ISSUES; do


### PR DESCRIPTION
Summary

- prevent the scheduled Runner Health workflow from auto-closing every open issue with the `runner-health` label
- restrict auto-create/auto-close behavior to the exact auto-generated alert title: `🚨 Self-hosted runner health needs attention`
- keep follow-up/design issues safe even if they use runner-health-adjacent labeling later

Validation

- git diff --check
- actionlint .github/workflows/runner-health.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/runner-health.yml"); puts "yaml ok"'\n- commit hooks: merge-conflict, yaml, EOF, whitespace, token hygiene, typos, actionlint, cargo fmt\n- pre-push hooks: merge-conflict, whitespace, typos, actionlint, cargo fmt, workspace clippy, linux compile gate\n\nNotes\n\n#1271 was reopened and had the `runner-health` label removed because it is a Phase 2 follow-up/design issue, not an active runner-health alert.