### PR TITLE
[codex] add assay runner lane check

### DIFF
--- a/.github/workflows/assay-runner-lane-check.yml
+++ b/.github/workflows/assay-runner-lane-check.yml
@@ -1,0 +1,57 @@
+name: Assay-Runner Lane Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to classify"
+        required: true
+        type: number
+
+permissions: {}
+
+jobs:
+  lane-check:
+    name: lane-check
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Checkout base helper
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+
+      - name: Bootstrap helper for first same-repo rollout
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f scripts/ci/assay_runner_lane_check.py ]; then
+            exit 0
+          fi
+          echo "::warning::Base helper is missing; bootstrapping lane-check helper from same-repo PR head."
+          git fetch --depth=1 origin "${{ github.event.pull_request.head.sha }}"
+          git checkout FETCH_HEAD -- scripts/ci/assay_runner_lane_check.py
+
+      - name: Verify lane-check helper exists
+        shell: bash
+        run: test -f scripts/ci/assay_runner_lane_check.py
+
+      - name: Self-test lane classifier
+        shell: bash
+        run: python3 scripts/ci/assay_runner_lane_check.py --self-test
+
+      - name: Check PR delegated lane proof
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr_number }}
+        run: python3 scripts/ci/assay_runner_lane_check.py --comment

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -72,10 +72,18 @@ If a runner-impacting PR cannot get a delegated run because the host is
 unavailable, leave the PR open. Merge only docs-only or clearly
 non-runner-impacting changes without delegated proof.
 
-This page is advisory until enforcement is added. The follow-up for path-aware
-review or status-check pressure is tracked in
-<https://github.com/Rul1an/assay/issues/1274>. Ring-buffer drop diagnostics
-remain a separate follow-up tracked in
+The `Assay-Runner Lane Check / lane-check` workflow provides the
+machine-visible path classification and delegated proof check for this
+contract. To make the contract hard-blocking, repository branch protection must
+mark that check as required.
+
+The executable path mapping lives in
+`scripts/ci/assay_runner_lane_check.py` and must mirror the decision table on
+this page. Changes to this contract and changes to the classifier must land in
+the same PR; the helper's `--self-test` is the drift canary for the known
+runner-impacting surfaces.
+
+Ring-buffer drop diagnostics remain a separate follow-up tracked in
 <https://github.com/Rul1an/assay/issues/1271>; that issue must not weaken the
 `ringbuf_drops=0` delegated acceptance rule.
 

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Enforce the Assay-Runner delegated CI lane contract for pull requests.
+
+The script is intentionally stdlib-only so the GitHub workflow can run it from
+the base branch without installing repository dependencies or executing PR code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Iterable
+
+
+CONTRACT_DOC = "docs/reference/runner/ci-lanes.md"
+DELEGATED_WORKFLOW_NAME = "Runner Spike Delegated"
+COMMENT_MARKER = "<!-- assay-runner-lane-check -->"
+
+
+class Gate(IntEnum):
+    NONE = 0
+    KERNEL_ONLY = 1
+    KERNEL_POLICY = 2
+    OPENAI_AGENTS_KERNEL_POLICY = 3
+    ALL = 4
+
+    @property
+    def label(self) -> str:
+        return {
+            Gate.NONE: "none",
+            Gate.KERNEL_ONLY: "kernel-only",
+            Gate.KERNEL_POLICY: "kernel-policy",
+            Gate.OPENAI_AGENTS_KERNEL_POLICY: "openai-agents-kernel-policy",
+            Gate.ALL: "all",
+        }[self]
+
+
+@dataclass(frozen=True)
+class Classification:
+    gate: Gate
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    number: int
+    title: str
+    body: str
+    head_sha: str
+    files: tuple[str, ...]
+
+
+class GitHubApi:
+    def __init__(self, repo: str, token: str) -> None:
+        self.repo = repo
+        self.base_url = f"https://api.github.com/repos/{repo}"
+        self.token = token
+
+    def request(self, method: str, path: str, payload: object | None = None) -> object:
+        url = path if path.startswith("https://") else f"{self.base_url}{path}"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Authorization": f"Bearer {self.token}",
+        }
+        data = None
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode("utf-8")
+            return json.loads(body) if body else {}
+
+    def paginated(self, path: str) -> list[object]:
+        separator = "&" if "?" in path else "?"
+        url = f"{self.base_url}{path}{separator}per_page=100"
+        results: list[object] = []
+        while url:
+            request = urllib.request.Request(
+                url,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                    "Authorization": f"Bearer {self.token}",
+                },
+            )
+            with urllib.request.urlopen(request, timeout=30) as response:
+                page = json.loads(response.read().decode("utf-8"))
+                if not isinstance(page, list):
+                    raise TypeError(f"Expected list response from {url}")
+                results.extend(page)
+                url = next_link(response.headers.get("Link", ""))
+        return results
+
+
+def next_link(header: str) -> str | None:
+    for part in header.split(","):
+        section = part.strip()
+        if 'rel="next"' not in section:
+            continue
+        match = re.match(r"<([^>]+)>", section)
+        if match:
+            return match.group(1)
+    return None
+
+
+def starts(path: str, prefix: str) -> bool:
+    return path == prefix.rstrip("/") or path.startswith(prefix.rstrip("/") + "/")
+
+
+def classify_file(path: str) -> tuple[Gate, str | None]:
+    docs_runner_prefixes = (
+        "docs/reference/runner/",
+        "docs/notes/ASSAY-RUNNER-",
+        "docs/ops/ASSAY-RUNNER-",
+    )
+    if any(path.startswith(prefix) for prefix in docs_runner_prefixes):
+        return Gate.NONE, None
+
+    if path in {
+        ".github/workflows/assay-runner-lane-check.yml",
+        "scripts/ci/assay_runner_lane_check.py",
+    }:
+        return Gate.NONE, None
+
+    all_prefixes = (
+        "crates/assay-runner-spike/",
+        "crates/assay-monitor/",
+        "crates/assay-ebpf/",
+    )
+    if any(starts(path, prefix) for prefix in all_prefixes):
+        return Gate.ALL, f"{path}: shared runner/eBPF/monitor code requires gates=all"
+
+    if path in {
+        ".github/workflows/runner-spike-delegated.yml",
+        ".github/workflows/runner-spike-sdk.yml",
+        "crates/assay-cli/src/cli/commands/runner_spike.rs",
+        "crates/assay-cli/src/cgroup.rs",
+        "Cargo.toml",
+        "Cargo.lock",
+    }:
+        return Gate.ALL, f"{path}: runner workflow, CLI, cgroup, or workspace dependency surface requires gates=all"
+
+    if path.startswith("scripts/ci/runner-spike-kernel-only-"):
+        return Gate.KERNEL_ONLY, f"{path}: kernel-only acceptance surface requires gates=kernel-only"
+
+    if path.startswith("scripts/ci/runner-spike-kernel-policy-"):
+        return Gate.KERNEL_POLICY, f"{path}: kernel+policy acceptance surface requires gates=kernel-policy"
+
+    if path.startswith("scripts/ci/runner-spike-openai-agents-kernel-policy-"):
+        return (
+            Gate.OPENAI_AGENTS_KERNEL_POLICY,
+            f"{path}: OpenAI Agents kernel+policy acceptance surface requires gates=openai-agents-kernel-policy",
+        )
+
+    if path.startswith("scripts/ci/runner-spike-"):
+        return Gate.ALL, f"{path}: shared runner-spike script requires gates=all"
+
+    if path == "tests/fixtures/runner-spike/kernel-only-agent.sh":
+        return Gate.KERNEL_ONLY, f"{path}: kernel-only fixture requires gates=kernel-only"
+
+    if path in {
+        "tests/fixtures/runner-spike/mcp-policy-agent.sh",
+        "tests/fixtures/runner-spike/mcp_file_server.py",
+    }:
+        return Gate.KERNEL_POLICY, f"{path}: policy fixture requires gates=kernel-policy"
+
+    if path.startswith("tests/fixtures/runner-spike/openai-agents-js/") or path == (
+        "tests/fixtures/runner-spike/openai-agents-sdk-policy-agent.sh"
+    ):
+        return (
+            Gate.OPENAI_AGENTS_KERNEL_POLICY,
+            f"{path}: OpenAI Agents fixture requires gates=openai-agents-kernel-policy",
+        )
+
+    if path.startswith("tests/fixtures/runner-spike/"):
+        return Gate.ALL, f"{path}: ambiguous runner fixture surface defaults to gates=all"
+
+    return Gate.NONE, None
+
+
+def classify_files(files: Iterable[str]) -> Classification:
+    gate = Gate.NONE
+    reasons: list[str] = []
+    for path in files:
+        file_gate, reason = classify_file(path)
+        if file_gate > gate:
+            gate = file_gate
+        if reason:
+            reasons.append(reason)
+    return Classification(gate=gate, reasons=tuple(reasons))
+
+
+def accepted_gates(expected: Gate) -> set[str]:
+    if expected == Gate.KERNEL_ONLY:
+        return {"kernel-only", "all"}
+    if expected == Gate.KERNEL_POLICY:
+        return {"kernel-policy", "all"}
+    if expected == Gate.OPENAI_AGENTS_KERNEL_POLICY:
+        return {"openai-agents-kernel-policy", "all"}
+    if expected == Gate.ALL:
+        return {"all"}
+    return set()
+
+
+def load_pr(api: GitHubApi, number: int) -> PullRequest:
+    pr = api.request("GET", f"/pulls/{number}")
+    files = api.paginated(f"/pulls/{number}/files")
+    return PullRequest(
+        number=number,
+        title=str(pr.get("title") or ""),
+        body=str(pr.get("body") or ""),
+        head_sha=str(pr["head"]["sha"]),
+        files=tuple(str(item["filename"]) for item in files),
+    )
+
+
+def load_issue_comments(api: GitHubApi, number: int) -> list[dict[str, object]]:
+    return [dict(item) for item in api.paginated(f"/issues/{number}/comments")]
+
+
+def combined_evidence_text(pr: PullRequest, comments: Iterable[dict[str, object]]) -> str:
+    chunks = [pr.body]
+    chunks.extend(str(comment.get("body") or "") for comment in comments)
+    return "\n\n".join(chunks)
+
+
+def run_ids_from_text(repo: str, text: str) -> list[str]:
+    escaped = re.escape(repo)
+    pattern = re.compile(rf"https://github\.com/{escaped}/actions/runs/([0-9]+)")
+    seen: set[str] = set()
+    run_ids: list[str] = []
+    for run_id in pattern.findall(text):
+        if run_id not in seen:
+            seen.add(run_id)
+            run_ids.append(run_id)
+    return run_ids
+
+
+def text_mentions_head_sha(text: str, sha: str) -> bool:
+    return sha in text or sha[:12] in text
+
+
+def find_valid_delegated_run(
+    api: GitHubApi,
+    run_ids: Iterable[str],
+    head_sha: str,
+) -> tuple[dict[str, object] | None, list[str]]:
+    diagnostics: list[str] = []
+    for run_id in run_ids:
+        try:
+            run = dict(api.request("GET", f"/actions/runs/{run_id}"))
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as exc:
+            diagnostics.append(f"run {run_id}: could not read workflow run ({exc})")
+            continue
+        diagnostic = delegated_run_diagnostic(run, run_id, head_sha)
+        if diagnostic is not None:
+            diagnostics.append(diagnostic)
+            continue
+        return run, diagnostics
+    return None, diagnostics
+
+
+def delegated_run_diagnostic(run: dict[str, object], run_id: str, head_sha: str) -> str | None:
+    name = str(run.get("name") or "")
+    event = str(run.get("event") or "")
+    conclusion = str(run.get("conclusion") or "")
+    run_head = str(run.get("head_sha") or "")
+    if name != DELEGATED_WORKFLOW_NAME:
+        return f"run {run_id}: workflow name is {name!r}, expected {DELEGATED_WORKFLOW_NAME!r}"
+    if event != "workflow_dispatch":
+        return f"run {run_id}: event is {event!r}, expected 'workflow_dispatch'"
+    if run_head != head_sha:
+        return f"run {run_id}: head_sha {run_head} does not match PR head {head_sha}"
+    if conclusion != "success":
+        return f"run {run_id}: conclusion is {conclusion!r}, expected 'success'"
+    return None
+
+
+def recorded_gate_ok(text: str, expected: Gate) -> bool:
+    gates = accepted_gates(expected)
+    if not gates:
+        return True
+    for gate in gates:
+        if re.search(rf"\b(?:gate|gates)\s*[:=]\s*`?{re.escape(gate)}`?\b", text, re.IGNORECASE):
+            return True
+    return False
+
+
+def comment_body(classification: Classification, pr: PullRequest, passed: bool, detail: str) -> str:
+    if classification.gate == Gate.NONE:
+        status = "PASS: no delegated runner proof required for this PR."
+        proof = ""
+    else:
+        status = (
+            "PASS: delegated runner proof recorded and matched this PR head."
+            if passed
+            else "FAIL: delegated runner proof is required before merge."
+        )
+        proof = f"""
+
+Expected delegated gate: `{classification.gate.label}`
+
+Record proof in the PR body or a PR comment using:
+
+```text
+Assay-Runner delegated proof:
+- gate: {classification.gate.label}
+- run: https://github.com/Rul1an/assay/actions/runs/<run_id>
+- sha: {pr.head_sha}
+```
+"""
+    reasons = "\n".join(f"- {reason}" for reason in classification.reasons[:12])
+    if not reasons:
+        reasons = "- No runner-impacting paths detected."
+    return f"""{COMMENT_MARKER}
+### Assay-Runner Lane Check
+
+{status}
+
+{detail}
+{proof}
+Changed-path classification:
+{reasons}
+
+Contract: [`{CONTRACT_DOC}`](https://github.com/Rul1an/assay/blob/main/{CONTRACT_DOC})
+"""
+
+
+def post_or_update_comment(
+    api: GitHubApi,
+    pr_number: int,
+    comments: Iterable[dict[str, object]],
+    body: str,
+) -> None:
+    existing_id: int | None = None
+    for comment in comments:
+        if COMMENT_MARKER in str(comment.get("body") or ""):
+            existing_id = int(comment["id"])
+            break
+    if existing_id is not None:
+        api.request("PATCH", f"/issues/comments/{existing_id}", {"body": body})
+    else:
+        api.request("POST", f"/issues/{pr_number}/comments", {"body": body})
+
+
+def run_check(api: GitHubApi, pr_number: int, *, comment: bool) -> int:
+    pr = load_pr(api, pr_number)
+    comments = load_issue_comments(api, pr.number)
+    classification = classify_files(pr.files)
+    text = combined_evidence_text(pr, comments)
+
+    print(f"Assay-Runner lane check for PR #{pr.number}")
+    print(f"Head SHA: {pr.head_sha}")
+    print(f"Changed files: {len(pr.files)}")
+    print(f"Expected delegated gate: {classification.gate.label}")
+    for reason in classification.reasons:
+        print(f"- {reason}")
+
+    if classification.gate == Gate.NONE:
+        body = comment_body(classification, pr, True, "No runner-impacting paths were detected.")
+        maybe_comment(api, pr.number, comments, body, comment=comment and existing_lane_comment(comments))
+        return 0
+
+    run_ids = run_ids_from_text(api.repo, text)
+    valid_run, run_diagnostics = find_valid_delegated_run(api, run_ids, pr.head_sha)
+    sha_ok = text_mentions_head_sha(text, pr.head_sha)
+    gate_ok = recorded_gate_ok(text, classification.gate)
+    passed = valid_run is not None and sha_ok and gate_ok
+
+    details: list[str] = []
+    if valid_run is None:
+        details.append("No successful `Runner Spike Delegated` workflow_dispatch run URL matched the PR head SHA.")
+    if not sha_ok:
+        details.append("The PR body/comments do not record the current PR head SHA or its 12-character prefix.")
+    if not gate_ok:
+        details.append(
+            f"The PR body/comments do not record `gate: {classification.gate.label}`"
+            + (" or `gate: all`." if classification.gate != Gate.ALL else ".")
+        )
+    if run_diagnostics:
+        details.append("Run diagnostics:\n" + "\n".join(f"- {line}" for line in run_diagnostics[:8]))
+    if passed:
+        details.append(f"Matched delegated run: {valid_run.get('html_url')}")
+
+    detail = "\n\n".join(details)
+    body = comment_body(classification, pr, passed, detail)
+    maybe_comment(api, pr.number, comments, body, comment=comment)
+
+    if passed:
+        return 0
+    print(detail, file=sys.stderr)
+    return 1
+
+
+def existing_lane_comment(comments: Iterable[dict[str, object]]) -> bool:
+    return any(COMMENT_MARKER in str(comment.get("body") or "") for comment in comments)
+
+
+def maybe_comment(
+    api: GitHubApi,
+    pr_number: int,
+    comments: Iterable[dict[str, object]],
+    body: str,
+    *,
+    comment: bool,
+) -> None:
+    if not comment:
+        return
+    try:
+        post_or_update_comment(api, pr_number, comments, body)
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as exc:
+        print(f"warning: could not post/update PR comment: {exc}", file=sys.stderr)
+
+
+def self_test() -> None:
+    cases = [
+        (["docs/reference/runner/ci-lanes.md"], Gate.NONE),
+        (["tests/fixtures/runner-spike/kernel-only-agent.sh"], Gate.KERNEL_ONLY),
+        (["tests/fixtures/runner-spike/mcp-policy-agent.sh"], Gate.KERNEL_POLICY),
+        (["tests/fixtures/runner-spike/openai-agents-js/package-lock.json"], Gate.OPENAI_AGENTS_KERNEL_POLICY),
+        (["crates/assay-monitor/src/lib.rs"], Gate.ALL),
+        (["scripts/ci/runner-spike-sdk-policy-correlation.sh"], Gate.ALL),
+        (["tests/fixtures/runner-spike/kernel-only-agent.sh", "crates/assay-ebpf/src/main.rs"], Gate.ALL),
+    ]
+    for files, expected in cases:
+        got = classify_files(files).gate
+        if got != expected:
+            raise AssertionError(f"{files}: expected {expected.label}, got {got.label}")
+    text = """
+    Assay-Runner delegated proof:
+    - gate: all
+    - run: https://github.com/Rul1an/assay/actions/runs/26202770332
+    - sha: abcdef1234567890
+    """
+    assert run_ids_from_text("Rul1an/assay", text) == ["26202770332"]
+    assert text_mentions_head_sha(text, "abcdef1234567890ffffffffffffffffffffffff")
+    assert recorded_gate_ok(text, Gate.KERNEL_ONLY)
+    assert recorded_gate_ok("- gates=all", Gate.OPENAI_AGENTS_KERNEL_POLICY)
+    assert not recorded_gate_ok("- gate: kernel-only", Gate.ALL)
+    assert not recorded_gate_ok("- gate: kernel-only", Gate.OPENAI_AGENTS_KERNEL_POLICY)
+
+    valid_run = {
+        "name": DELEGATED_WORKFLOW_NAME,
+        "event": "workflow_dispatch",
+        "head_sha": "abc123",
+        "conclusion": "success",
+    }
+    assert delegated_run_diagnostic(valid_run, "1", "abc123") is None
+    assert "head_sha" in delegated_run_diagnostic({**valid_run, "head_sha": "def456"}, "1", "abc123")
+    assert "conclusion" in delegated_run_diagnostic({**valid_run, "conclusion": "failure"}, "1", "abc123")
+    assert "workflow name" in delegated_run_diagnostic({**valid_run, "name": "CI"}, "1", "abc123")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--pr-number", type=int, default=int(os.environ.get("PR_NUMBER", "0") or "0"))
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--comment", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        print("self-test ok")
+        return 0
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("GITHUB_TOKEN is required", file=sys.stderr)
+        return 2
+    if not args.repo:
+        print("--repo or GITHUB_REPOSITORY is required", file=sys.stderr)
+        return 2
+    if args.pr_number <= 0:
+        print("--pr-number or PR_NUMBER is required", file=sys.stderr)
+        return 2
+
+    return run_check(GitHubApi(args.repo, token), args.pr_number, comment=args.comment)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary
- add a lightweight Assay-Runner Lane Check workflow for the Phase 2A CI-lane contract
- classify changed PR paths against `docs/reference/runner/ci-lanes.md` and compute the minimum delegated gate
- require runner-impacting PRs to record a successful `Runner Spike Delegated` workflow_dispatch URL, matching head SHA, and gate before the check passes
- keep the delegated self-hosted workflow manual-only; this does not add pull_request triggers to Runner Spike Delegated
- run the helper from the base checkout so normal PRs do not execute PR-supplied helper code with comment permissions
- include a same-repo-only first-rollout bootstrap when the base helper is not present yet; fork PRs still fail closed if the base helper is missing
- update the CI-lane docs to note that branch protection must mark `Assay-Runner Lane Check / lane-check` as required for hard-blocking behavior

Validation
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `python3 -m py_compile scripts/ci/assay_runner_lane_check.py`
- `actionlint .github/workflows/assay-runner-lane-check.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/assay-runner-lane-check.yml"); puts "yaml ok"'`
- `git diff --check`
- `/tmp/assay-docs-venv/bin/mkdocs build --strict`
- commit hooks and pre-push hooks

Notes
- Refs #1274. This implements the machine-visible lane proof check; repository branch-protection settings still need to require this check before it becomes hard-blocking.
- Follow-up #1283 tracks the Dependabot-specific maintainer flow for dependency PRs that require delegated proof.
- This PR intentionally classifies the new lane-check workflow/helper as not requiring delegated proof, to avoid bootstrap deadlock for the enforcement mechanism itself.
