### PR TITLE
[codex] define assay runner dependabot lane flow

### DIFF
--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -83,6 +83,12 @@ this page. Changes to this contract and changes to the classifier must land in
 the same PR; the helper's `--self-test` is the drift canary for the known
 runner-impacting surfaces.
 
+Dependabot PRs follow the same proof rules, but need maintainer action because
+Dependabot cannot dispatch the delegated lane or record proof itself. See the
+[Runner Dependabot lane flow](dependabot-lane-flow.md) for the required
+maintainer steps. Do not auto-dispatch the self-hosted delegated workflow from
+Dependabot PRs without a separate security design review.
+
 Ring-buffer drop diagnostics remain a separate follow-up tracked in
 <https://github.com/Rul1an/assay/issues/1271>; that issue must not weaken the
 `ringbuf_drops=0` delegated acceptance rule.

--- a/docs/reference/runner/dependabot-lane-flow.md
+++ b/docs/reference/runner/dependabot-lane-flow.md
@@ -1,0 +1,105 @@
+# Assay-Runner Dependabot Lane Flow
+
+> Internal Phase 2A reference. This page defines how maintainers handle
+> dependency PRs when the Assay-Runner lane check requires delegated Linux/eBPF
+> proof.
+
+## Scope
+
+The `Assay-Runner Lane Check / lane-check` workflow treats runner-impacting
+dependency bumps the same way it treats maintainer-authored runner changes: the
+PR must record a successful manual `Runner Spike Delegated` run that matches
+the PR head SHA and required gate.
+
+Dependabot cannot perform the manual parts of that flow. It cannot dispatch the
+self-hosted delegated workflow, decide whether fixture assertions need coupled
+updates, or add the final proof comment. A maintainer owns those steps.
+
+This page does not make the delegated workflow automatic. The delegated lane
+remains `workflow_dispatch` only.
+
+## Runner-Impacting Dependency Surfaces
+
+Treat these dependency changes as runner-impacting:
+
+- `tests/fixtures/runner-spike/openai-agents-js/package.json`
+- `tests/fixtures/runner-spike/openai-agents-js/package-lock.json`
+- `@openai/agents`, `zod`, and related OpenAI Agents fixture dependencies
+- `aya`, `aya-ebpf`, `aya-log-ebpf`, and BPF/runtime dependency bumps
+- workspace dependency bumps that can affect `assay-runner-spike`,
+  `assay-monitor`, `assay-ebpf`, `assay-cli`, policy correlation, or runner
+  fixtures
+
+When in doubt, follow the [CI lane contract](ci-lanes.md) and default to the
+highest applicable delegated gate.
+
+## Maintainer Flow
+
+1. Inspect the dependency bump and the lane-check comment.
+2. If the bump requires coupled fixture or assertion updates, push those changes
+   from a maintainer branch or open a replacement PR. Do not ask Dependabot to
+   carry manual runner-contract edits.
+3. Wait until the PR head SHA is final.
+4. Dispatch `Runner Spike Delegated` manually with the gate named by the
+   lane-check comment.
+5. Add a maintainer comment to the PR:
+
+   ```text
+   Assay-Runner delegated proof:
+   - gate: <kernel-only|kernel-policy|openai-agents-kernel-policy|all>
+   - run: https://github.com/Rul1an/assay/actions/runs/<run_id>
+   - sha: <current-pr-head-sha>
+   ```
+
+6. Confirm `Assay-Runner Lane Check / lane-check` passes after the comment is
+   posted.
+7. If Dependabot rebases or force-pushes, repeat the delegated dispatch. Proof
+   for an older head SHA must not satisfy the check.
+
+Grouped Dependabot PRs follow the highest required gate across all bumped
+dependencies. If a grouped PR mixes fixture bumps with workspace or runtime
+bumps, dispatch the broader gate and verify the lane-check comment names the
+same gate.
+
+## Fixture Dependency Bumps
+
+For `@openai/agents` or fixture dependency updates:
+
+See the [fixture dependency upgrade contract](fixtures-v0.md#dependency-upgrade-contract)
+for the full fixture procedure. This section captures only the
+Dependabot-specific maintainer path for delegated-proof recording.
+
+- verify the deterministic fixture still emits the accepted SDK event sequence;
+- update the SDK version assertion only when the dependency bump intentionally
+  changes the accepted fixture instance;
+- dispatch `gates=openai-agents-kernel-policy` unless the change also touches a
+  broader runner surface that requires `gates=all`;
+- keep live model calls and live credentials out of the fixture.
+
+If the bump changes tool-call identity behavior, stop and use issue #1275 as
+the decision gate before merging a correlation-contract change.
+
+## BPF or Runtime Dependency Bumps
+
+For `aya`, `aya-ebpf`, `aya-log-ebpf`, or workspace dependency bumps that can
+change monitor, eBPF, cgroup, or archive behavior:
+
+- dispatch `gates=all`;
+- keep `build_ebpf=true`;
+- require `ringbuf_drops=0`, `kernel_layer=complete`, and
+  `cgroup_correlation=clean` exactly as in the Phase 1 acceptance lane.
+
+## Interaction With Auto-Merge
+
+If Dependabot auto-merge is enabled, runner-impacting bumps stay blocked until
+a maintainer dispatches the delegated gate and records matching proof. This is
+intentional. Auto-merge must not bypass the delegated proof requirement.
+
+## Non-Goals
+
+- Do not add `pull_request`, `push`, or `schedule` triggers to
+  `Runner Spike Delegated`.
+- Do not auto-dispatch the self-hosted delegated runner from Dependabot PRs in
+  Phase 2A.
+- Do not let a Dependabot PR merge with a delegated run from an older head SHA.
+- Do not weaken the delegated acceptance bar for dependency updates.

--- a/docs/reference/runner/fixtures-v0.md
+++ b/docs/reference/runner/fixtures-v0.md
@@ -271,6 +271,9 @@ ids into `assay.runner.sdk_event.v0`.
 Dependency bumps must not relax event-schema validation, sequence validation,
 or three-run determinism.
 
+When the bump arrives as a Dependabot PR, follow the maintainer steps in the
+[Dependabot lane flow](dependabot-lane-flow.md) for delegated-proof recording.
+
 ## Second-Order Fixtures
 
 Negative, adversarial, or S7-style fixtures are second-order contract tests.

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -10,4 +10,5 @@ reviewable while the runner boundary is consolidated.
 - [Runner artifact golden shapes](golden/index.md)
 - [Runner acceptance fixture v0 contract](fixtures-v0.md)
 - [Runner CI lane contract](ci-lanes.md)
+- [Runner Dependabot lane flow](dependabot-lane-flow.md)
 - [Assay-Runner boundary and extraction map](boundary-map.md)

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -21,6 +21,7 @@ from typing import Iterable
 
 
 CONTRACT_DOC = "docs/reference/runner/ci-lanes.md"
+DEPENDABOT_FLOW_DOC = "docs/reference/runner/dependabot-lane-flow.md"
 DELEGATED_WORKFLOW_NAME = "Runner Spike Delegated"
 COMMENT_MARKER = "<!-- assay-runner-lane-check -->"
 
@@ -54,6 +55,7 @@ class PullRequest:
     number: int
     title: str
     body: str
+    author_login: str
     head_sha: str
     files: tuple[str, ...]
 
@@ -219,6 +221,7 @@ def load_pr(api: GitHubApi, number: int) -> PullRequest:
         number=number,
         title=str(pr.get("title") or ""),
         body=str(pr.get("body") or ""),
+        author_login=str((pr.get("user") or {}).get("login") or ""),
         head_sha=str(pr["head"]["sha"]),
         files=tuple(str(item["filename"]) for item in files),
     )
@@ -306,6 +309,7 @@ def comment_body(classification: Classification, pr: PullRequest, passed: bool, 
             if passed
             else "FAIL: delegated runner proof is required before merge."
         )
+        dependabot = dependabot_guidance(pr, classification) if not passed else ""
         proof = f"""
 
 Expected delegated gate: `{classification.gate.label}`
@@ -318,6 +322,7 @@ Assay-Runner delegated proof:
 - run: https://github.com/Rul1an/assay/actions/runs/<run_id>
 - sha: {pr.head_sha}
 ```
+{dependabot}
 """
     reasons = "\n".join(f"- {reason}" for reason in classification.reasons[:12])
     if not reasons:
@@ -333,6 +338,32 @@ Changed-path classification:
 {reasons}
 
 Contract: [`{CONTRACT_DOC}`](https://github.com/Rul1an/assay/blob/main/{CONTRACT_DOC})
+"""
+
+
+def is_dependabot_pr(pr: PullRequest) -> bool:
+    # GitHub normally reports Dependabot as dependabot[bot]; keep the app form
+    # for older API surfaces that expose the GitHub App slug instead.
+    return pr.author_login in {"dependabot[bot]", "app/dependabot"}
+
+
+def dependabot_guidance(pr: PullRequest, classification: Classification) -> str:
+    if not is_dependabot_pr(pr):
+        return ""
+    return f"""
+Dependabot maintainer flow:
+
+1. Review the dependency surface and update any coupled runner fixture
+   assertions on a maintainer branch if needed.
+2. Dispatch `Runner Spike Delegated` manually with `gates={classification.gate.label}`
+   after the PR head SHA is final.
+3. Add a maintainer comment with the run URL, `gate: {classification.gate.label}`,
+   and the current PR head SHA. Dependabot does not need to edit its own PR body.
+4. If Dependabot rebases or force-pushes, rerun the delegated gate because the
+   recorded proof must match the new head SHA.
+
+Flow reference:
+[`{DEPENDABOT_FLOW_DOC}`](https://github.com/Rul1an/assay/blob/main/{DEPENDABOT_FLOW_DOC})
 """
 
 
@@ -459,6 +490,21 @@ def self_test() -> None:
     assert "head_sha" in delegated_run_diagnostic({**valid_run, "head_sha": "def456"}, "1", "abc123")
     assert "conclusion" in delegated_run_diagnostic({**valid_run, "conclusion": "failure"}, "1", "abc123")
     assert "workflow name" in delegated_run_diagnostic({**valid_run, "name": "CI"}, "1", "abc123")
+
+    dependabot_pr = PullRequest(
+        number=1,
+        title="Bump @openai/agents",
+        body="",
+        author_login="dependabot[bot]",
+        head_sha="abc123",
+        files=("tests/fixtures/runner-spike/openai-agents-js/package-lock.json",),
+    )
+    guidance = dependabot_guidance(
+        dependabot_pr,
+        Classification(Gate.OPENAI_AGENTS_KERNEL_POLICY, ()),
+    )
+    assert "Dependabot maintainer flow" in guidance
+    assert "gates=openai-agents-kernel-policy" in guidance
 
 
 def main() -> int:


### PR DESCRIPTION
Summary

- add a maintainer-facing Assay-Runner Dependabot lane flow for delegated-proof dependency bumps
- teach the Assay-Runner lane-check comment to recognize Dependabot PRs and print the exact maintainer steps instead of only a generic red check
- link the flow from the runner reference index and CI lane contract

Validation

- python3 scripts/ci/assay_runner_lane_check.py --self-test
- python3 -m py_compile scripts/ci/assay_runner_lane_check.py
- git diff --check
- local docs markdown link check matching .github/workflows/docs-link-check.yml
- /tmp/assay-docs-venv/bin/mkdocs build --strict
- commit hooks: merge-conflict, EOF, whitespace, token hygiene, typos, cargo fmt
- pre-push hooks: merge-conflict, whitespace, typos, cargo fmt, workspace clippy, linux compile gate

Notes

- Closes #1283.
- This keeps Runner Spike Delegated manual-only; it does not add pull_request, push, or schedule triggers to the self-hosted lane.
