### PR TITLE
[codex] decide assay runner call-id fallback scope

### DIFF
--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -186,6 +186,14 @@ Correlation windows use runner-defined phase markers from one canonical runner
 clock. SDK-provided timestamps are informational only and are not the primary
 join key for v0 correlation.
 
+Clean v0 correlation requires a stable `tool_call_id` for every tool-call
+binding. The first Phase 2B capability-diff contract inherits this rule: it may
+diff clean bindings by `tool_call_id`, but it must not introduce deterministic
+order-fallback for call-id-less agent runtimes. If a runtime cannot provide a
+stable tool-call id, the runner must report a partial or failed correlation
+state until a separate call-id-less fixture and contract explicitly define the
+fallback semantics.
+
 Example:
 
 ```json

--- a/docs/reference/runner/boundary-map.md
+++ b/docs/reference/runner/boundary-map.md
@@ -102,7 +102,7 @@ explaining the ownership later.
 | `archive.rs` | the runner assembles archives, but manifest shape, digest meaning, and verification are artifact semantics | keep assembly in the runner candidate; move or duplicate manifest semantics only through an Assay-owned shared contract |
 | `health.rs` and `observation-health.json` | the runner measures drops and cgroup health, but `kernel_layer=complete` and related status meanings are Assay claims | Assay owns the status definitions; runner computes whether a measured run satisfies them |
 | telemetry-versus-evidence filters | the runner implements event-type and path filters, but deciding what counts as evidence is artifact semantics | Assay owns the evidence taxonomy and rationale; runner owns the implementation and diagnostics |
-| `tool_call_id` fallback semantics | fallback would change correlation mechanics and `correlation-report.json` ambiguity semantics at the same time | v0 clean correlation requires stable tool-call ids; call-id-less support remains blocked on issue #1275 |
+| `tool_call_id` fallback semantics | fallback would change correlation mechanics and `correlation-report.json` ambiguity semantics at the same time | v0 clean correlation and the first Phase 2B capability-diff contract require stable tool-call ids; call-id-less support is out of scope until a separate fallback contract exists |
 
 If a future PR touches one of these conflicts, reviewers should require a
 contract update or an explicit statement that the PR does not change the
@@ -142,9 +142,7 @@ true:
 | Archive verification | runner archives verify through Assay evidence semantics without copying verification logic |
 | Boundary API stability | two consecutive minor releases, or an equivalent internal stabilization window, pass without breaking the boundary API |
 | External consumer | at least one non-spike consumer can read the runner bundle contract without depending on spike implementation details |
-| Call-id decision | the call-id-less correlation decision in
-   <https://github.com/Rul1an/assay/issues/1275> is either resolved or clearly
-   excluded from the extracted v0 scope |
+| Call-id decision | call-id-less correlation is explicitly excluded from the extracted v0 scope unless a later fallback contract replaces that rule |
 | Drop diagnostics | the ring-buffer debug follow-up in
    <https://github.com/Rul1an/assay/issues/1271> is either implemented or
    explicitly accepted as post-extraction operational work |

--- a/docs/reference/runner/dependabot-lane-flow.md
+++ b/docs/reference/runner/dependabot-lane-flow.md
@@ -76,8 +76,9 @@ Dependabot-specific maintainer path for delegated-proof recording.
   broader runner surface that requires `gates=all`;
 - keep live model calls and live credentials out of the fixture.
 
-If the bump changes tool-call identity behavior, stop and use issue #1275 as
-the decision gate before merging a correlation-contract change.
+If the bump changes tool-call identity behavior, stop. The v0 contract requires
+stable `tool_call_id`; supporting call-id-less behavior requires a separate
+fallback contract, fixture, and ambiguity model.
 
 ## BPF or Runtime Dependency Bumps
 

--- a/docs/reference/runner/fixtures-v0.md
+++ b/docs/reference/runner/fixtures-v0.md
@@ -192,11 +192,12 @@ The Rust SDK event parser permits non-tool lifecycle events such as
 acceptance then requires the SDK tool-call id to equal the policy
 `tool_call_id` and the correlation binding id.
 
-For Phase 2A v0, `tool_call_id` is required for clean SDK-to-policy correlation
-of tool-call events. Call-id-less agent support is deliberately undecided and
-tracked in <https://github.com/Rul1an/assay/issues/1275>. Do not merge a
-correlation contract slice that silently chooses an order-based fallback
-without resolving that issue.
+For Phase 2A v0 and the first Phase 2B capability-diff contract,
+`tool_call_id` is required for clean SDK-to-policy correlation of tool-call
+events. Call-id-less agent support is out of scope for this contract. A future
+order-based fallback requires a separate fixture, explicit ambiguity semantics,
+and a new contract decision; it must not be added as a small extension to the
+accepted S5 fixture.
 
 The OpenAI Agents fixture must keep tool concurrency bounded to one. A future
 fixture that exercises parallel tool calls is a new contract test, not a small
@@ -289,7 +290,7 @@ Before merging a fixture change, reviewers should be able to answer:
 - What new evidence value does this fixture intentionally add?
 - Which normalized artifact should change?
 - Which paths are control plumbing and should not become evidence?
-- Is `tool_call_id` stable, or is this blocked on issue #1275?
+- Is `tool_call_id` stable? If not, this is outside the v0 fixture contract.
 - Does the fixture run without network credentials or live LLM calls?
 - Does the narrow delegated gate pass?
 - If the change touches shared capture, cgroup, monitor, normalizer, or
@@ -305,7 +306,7 @@ The v0 fixture contract does not define:
 - macOS or Windows attribution fixtures
 - live LLM/cassette behavior
 - parallel tool-call correlation
-- call-id-less fallback semantics
+- call-id-less fallback semantics and order-based binding identity
 - production-load or long-running process behavior
 - external plugin or third-party SDK fixture authoring
 


### PR DESCRIPTION
Summary

- resolve the Phase 2 call-id decision by keeping stable `tool_call_id` required for clean v0 correlation and the first Phase 2B capability-diff contract
- make call-id-less/order-fallback support explicitly out of scope until a separate fallback fixture, ambiguity model, and contract exist
- update the artifact, fixture, boundary, and Dependabot lane docs so future capability-diff work does not implicitly introduce order-based binding identity

Validation

- git diff --check
- local docs markdown link check matching .github/workflows/docs-link-check.yml
- /tmp/assay-docs-venv/bin/mkdocs build --strict
- commit hooks: merge-conflict, EOF, whitespace, token hygiene, typos, cargo fmt
- pre-push hooks: merge-conflict, whitespace, typos, cargo fmt, workspace clippy, linux compile gate

Notes

- Closes #1275.
- This does not add support for call-id-less agent runtimes; it keeps the first Phase 2B capability-diff input model narrow and deterministic.
