### PR TITLE
[codex] tighten assay runner contract precision

### DIFF
--- a/crates/assay-runner-spike/src/kernel.rs
+++ b/crates/assay-runner-spike/src/kernel.rs
@@ -126,7 +126,7 @@ impl KernelLayerBuilder {
 
         match (decoded.kind.as_str(), decoded.value.as_deref()) {
             ("openat", Some(path)) | ("file_blocked", Some(path)) => {
-                self.capability_surface.add_filesystem_prefix(path);
+                self.capability_surface.add_filesystem_path(path);
             }
             ("connect", Some(endpoint)) | ("connect_blocked", Some(endpoint)) => {
                 self.capability_surface.add_network_endpoint(endpoint);
@@ -542,7 +542,7 @@ mod tests {
             .contains("\"kind\":\"openat\""));
         assert!(capture
             .capability_surface
-            .filesystem_prefixes
+            .filesystem_paths
             .contains("/tmp/assay-known-file"));
         assert_eq!(capture.ringbuf_drops, 0);
     }
@@ -583,7 +583,7 @@ mod tests {
 
         assert_eq!(capture.event_count, 0);
         assert!(capture.kernel_layer_ndjson.is_empty());
-        assert!(capture.capability_surface.filesystem_prefixes.is_empty());
+        assert!(capture.capability_surface.filesystem_paths.is_empty());
     }
 
     #[test]
@@ -604,7 +604,7 @@ mod tests {
         assert_eq!(capture.event_count, 1);
         assert!(capture
             .capability_surface
-            .filesystem_prefixes
+            .filesystem_paths
             .contains("/lib/aarch64-linux-gnu/libc.so.6"));
     }
 
@@ -648,7 +648,7 @@ mod tests {
 
         assert!(capture
             .capability_surface
-            .filesystem_prefixes
+            .filesystem_paths
             .contains("/etc/passwd"));
     }
 
@@ -815,7 +815,7 @@ mod tests {
 
         assert_eq!(capture.event_count, 0);
         assert!(capture.kernel_layer_ndjson.is_empty());
-        assert!(capture.capability_surface.filesystem_prefixes.is_empty());
+        assert!(capture.capability_surface.filesystem_paths.is_empty());
         assert!(capture.capability_surface.network_endpoints.is_empty());
         assert!(capture.capability_surface.process_execs.is_empty());
     }

--- a/crates/assay-runner-spike/src/surface.rs
+++ b/crates/assay-runner-spike/src/surface.rs
@@ -11,9 +11,8 @@ pub struct CapabilitySurface {
     /// Set of filesystem paths the agent touched.
     ///
     /// v0 stores full paths from observed file events. Projection onto
-    /// directory prefixes for capability-diff is a later transformation; the
-    /// field name is kept stable for the v0 schema.
-    pub filesystem_prefixes: BTreeSet<String>,
+    /// directory prefixes for capability-diff is a later transformation.
+    pub filesystem_paths: BTreeSet<String>,
     pub network_endpoints: BTreeSet<String>,
     pub process_execs: BTreeSet<String>,
     pub mcp_tools: BTreeSet<String>,
@@ -35,7 +34,7 @@ impl CapabilitySurface {
         Self {
             schema: CAPABILITY_SURFACE_SCHEMA.to_string(),
             run_id: run_id.into(),
-            filesystem_prefixes: BTreeSet::new(),
+            filesystem_paths: BTreeSet::new(),
             network_endpoints: BTreeSet::new(),
             process_execs: BTreeSet::new(),
             mcp_tools: BTreeSet::new(),
@@ -43,8 +42,8 @@ impl CapabilitySurface {
         }
     }
 
-    pub fn add_filesystem_prefix(&mut self, prefix: impl Into<String>) {
-        self.filesystem_prefixes.insert(prefix.into());
+    pub fn add_filesystem_path(&mut self, path: impl Into<String>) {
+        self.filesystem_paths.insert(path.into());
     }
 
     pub fn add_network_endpoint(&mut self, endpoint: impl Into<String>) {
@@ -73,8 +72,8 @@ impl CapabilitySurface {
             });
         }
 
-        self.filesystem_prefixes
-            .extend(other.filesystem_prefixes.iter().cloned());
+        self.filesystem_paths
+            .extend(other.filesystem_paths.iter().cloned());
         self.network_endpoints
             .extend(other.network_endpoints.iter().cloned());
         self.process_execs
@@ -104,16 +103,16 @@ mod tests {
     #[test]
     fn capability_surface_serializes_sets_deterministically() {
         let mut surface = CapabilitySurface::new("run_001");
-        surface.add_filesystem_prefix("/tmp/z");
-        surface.add_filesystem_prefix("/tmp/a");
+        surface.add_filesystem_path("/tmp/z");
+        surface.add_filesystem_path("/tmp/a");
         surface.add_network_endpoint("b.example:443");
         surface.add_network_endpoint("a.example:443");
         surface.add_process_exec("/usr/bin/z");
         surface.add_process_exec("/usr/bin/a");
-        surface.add_mcp_tool("filesystem.write_file");
-        surface.add_mcp_tool("filesystem.read_file");
-        surface.add_policy_decision("deny:filesystem.write_file");
-        surface.add_policy_decision("allow:filesystem.read_file");
+        surface.add_mcp_tool("write_file");
+        surface.add_mcp_tool("read_file");
+        surface.add_policy_decision("deny:write_file");
+        surface.add_policy_decision("allow:read_file");
 
         let value = serde_json::to_value(&surface).expect("surface serializes");
 
@@ -122,11 +121,11 @@ mod tests {
             json!({
                 "schema": CAPABILITY_SURFACE_SCHEMA,
                 "run_id": "run_001",
-                "filesystem_prefixes": ["/tmp/a", "/tmp/z"],
+                "filesystem_paths": ["/tmp/a", "/tmp/z"],
                 "network_endpoints": ["a.example:443", "b.example:443"],
                 "process_execs": ["/usr/bin/a", "/usr/bin/z"],
-                "mcp_tools": ["filesystem.read_file", "filesystem.write_file"],
-                "policy_decisions": ["allow:filesystem.read_file", "deny:filesystem.write_file"]
+                "mcp_tools": ["read_file", "write_file"],
+                "policy_decisions": ["allow:read_file", "deny:write_file"]
             })
         );
     }
@@ -145,15 +144,15 @@ mod tests {
     #[test]
     fn merge_from_preserves_deterministic_sets() {
         let mut first = CapabilitySurface::new("run_001");
-        first.add_filesystem_prefix("/tmp/b");
+        first.add_filesystem_path("/tmp/b");
         let mut second = CapabilitySurface::new("run_001");
-        second.add_filesystem_prefix("/tmp/a");
+        second.add_filesystem_path("/tmp/a");
         second.add_process_exec("/usr/bin/true");
 
         first.merge_from(&second).unwrap();
 
         assert_eq!(
-            first.filesystem_prefixes.into_iter().collect::<Vec<_>>(),
+            first.filesystem_paths.into_iter().collect::<Vec<_>>(),
             vec!["/tmp/a", "/tmp/b"]
         );
         assert_eq!(

--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -86,7 +86,19 @@ Fields:
 | `policy_layer` | enum | yes | `present` or `absent` |
 | `sdk_layer` | enum | yes | `present`, `self_reported`, or `absent` |
 | `cgroup_correlation` | enum | yes | `clean`, `partial`, or `failed` |
-| `notes` | array[string] | yes | Stable human-readable capture notes used by delegated determinism |
+| `notes` | array[string] | yes | Stable code-prefixed capture notes used by delegated determinism |
+
+`sdk_layer=self_reported` is the accepted v0 value for the OpenAI Agents SDK
+fixture because SDK events are emitted by the fixture/runtime path itself.
+`sdk_layer=present` remains in the v0 enum vocabulary for a future directly
+corroborated SDK layer, but the accepted S5 fixture does not use it.
+
+`notes` are strings in v0, but they are not arbitrary prose. The token before
+the first colon is the machine-readable note code, for example
+`s2_kernel_capture`, `s4_policy_capture`, or `s5_sdk_capture`. Text after the
+colon is a stable deterministic message for reviewers and diffs. A future v1
+may split these into `{code, message}` objects, but v0 consumers should parse
+the code prefix when they need machine-readable note identity.
 
 Validation rules:
 
@@ -105,7 +117,7 @@ Passing Linux/eBPF example:
   "kernel_layer": "complete",
   "ringbuf_drops": 0,
   "policy_layer": "present",
-  "sdk_layer": "present",
+  "sdk_layer": "self_reported",
   "cgroup_correlation": "clean",
   "notes": [
     "s2_kernel_capture: monitor_events=4 ringbuf_drops=0",
@@ -129,15 +141,17 @@ Fields:
 |---|---|---:|---|
 | `schema` | string | yes | Must equal `assay.runner.capability_surface.v0` |
 | `run_id` | string | yes | Non-empty run identifier shared by all archive artifacts |
-| `filesystem_prefixes` | array[string] | yes | Stable sorted set of observed filesystem evidence values |
+| `filesystem_paths` | array[string] | yes | Stable sorted set of observed filesystem evidence values |
 | `network_endpoints` | array[string] | yes | Stable sorted set of observed network endpoints |
 | `process_execs` | array[string] | yes | Stable sorted set of observed process execution values |
 | `mcp_tools` | array[string] | yes | Stable sorted set of observed MCP/tool names |
 | `policy_decisions` | array[string] | yes | Stable sorted set of policy decision summaries |
 
-`filesystem_prefixes` stores full observed v0 path values despite the legacy
-field name. Projection onto directory prefixes is a later capability-diff
-transformation, not part of this artifact contract.
+`filesystem_paths` stores full observed v0 path values, not directory-prefix
+projections. During Phase 2A consolidation this field was renamed from the
+earlier internal `filesystem_prefixes` label because the old name implied a
+projection the artifact never provided. Prefix projection remains a later
+capability-diff transformation, not part of this artifact contract.
 
 Example:
 
@@ -145,7 +159,7 @@ Example:
 {
   "schema": "assay.runner.capability_surface.v0",
   "run_id": "run_kernel_policy_determinism",
-  "filesystem_prefixes": [
+  "filesystem_paths": [
     "/tmp/assay-runner-kernel-policy/work/input.txt",
     "/tmp/assay-runner-kernel-policy/work/output.txt"
   ],
@@ -154,10 +168,10 @@ Example:
     "/usr/bin/cat"
   ],
   "mcp_tools": [
-    "filesystem.read_file"
+    "read_file"
   ],
   "policy_decisions": [
-    "allow:filesystem.read_file"
+    "allow:read_file"
   ]
 }
 ```
@@ -191,8 +205,9 @@ Binding fields:
 | `window.end` | string | yes | Inclusive window end marker |
 
 Correlation windows use runner-defined phase markers from one canonical runner
-clock. SDK-provided timestamps are informational only and are not the primary
-join key for v0 correlation.
+clock. SDK-provided timestamps are informational only and MUST NOT be used as
+primary join keys for v0 correlation. They also MUST NOT be used as an ordering
+fallback to disambiguate call-id-less tool bindings.
 
 Clean v0 correlation requires a stable `tool_call_id` for every tool-call
 binding. The first Phase 2B capability-diff contract inherits this rule: it may

--- a/docs/reference/runner/boundary-map.md
+++ b/docs/reference/runner/boundary-map.md
@@ -64,6 +64,14 @@ must not depend on a publishable runner crate for artifact interpretation. If a
 core crate needs a helper currently living in runner-spike code, move the
 helper to the appropriate core module first and cover that move with tests.
 
+Additional extraction rule:
+
+1. If a runner candidate module contains artifact schema or data-structure
+   definitions needed by both Assay and a future runner repository, those
+   definitions must migrate to an Assay-owned shared contract before
+   extraction. The runner may fill those structures, but it may not be the sole
+   owner of their meaning across a repository boundary.
+
 ## Current In-Repo Ownership
 
 The current spike surfaces remain in `Rul1an/assay`:
@@ -146,9 +154,9 @@ true:
 | Drop diagnostics | the ring-buffer debug follow-up in
    <https://github.com/Rul1an/assay/issues/1271> is either implemented or
    explicitly accepted as post-extraction operational work |
-| CI enforcement path | the CI-lane enforcement follow-up in
-   <https://github.com/Rul1an/assay/issues/1274> has a chosen implementation
-   path, even if full enforcement is deferred |
+| CI enforcement path | the Assay-Runner lane-check required status and
+   reviewer workflow are active; future refinements are tracked separately
+   rather than blocking the v0 boundary |
 | Maintainer explainability | a maintainer can explain which crate owns each boundary row above without reading the Phase 1 history |
 
 If the boundary map remains materially unstable after a 4-6 week consolidation

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -48,7 +48,7 @@ changed layer:
 | Kernel fixture control path or kernel-only acceptance assertion | `kernel-only` |
 | Policy capture or policy-to-kernel coherence | `kernel-policy` |
 | OpenAI Agents SDK fixture, SDK event schema, SDK version assertion, or `tool_call_id` binding | `openai-agents-kernel-policy` |
-| `crates/assay-monitor/**`, `crates/assay-ebpf/**`, eBPF build/attach path, cgroup placement, telemetry filter, cross-layer archive, artifact schema, correlation report, workflow/security model, runner scripts, BPF/runtime dependency bump, or final release/acceptance proof | `all` |
+| `crates/assay-monitor/**`, `crates/assay-ebpf/**`, `crates/assay-xtask/**`, eBPF build/attach path, cgroup placement, telemetry filter, cross-layer archive, artifact schema, correlation report, workflow/security model, runner scripts, BPF/runtime dependency bump, or final release/acceptance proof | `all` |
 
 If a change touches multiple surfaces, run the highest required gate. If the
 right gate is ambiguous, default to `all`.

--- a/docs/reference/runner/fixtures-v0.md
+++ b/docs/reference/runner/fixtures-v0.md
@@ -57,9 +57,10 @@ kernel plus policy plus SDK fixture shape deliberately:
 | Correlation report | `status=clean`, `ambiguities=[]`, one binding | delegated acceptance fails with status, ambiguity, or binding-count mismatch |
 | Correlation window | `{"start":"run_started","end":"run_finished"}` | delegated acceptance fails with `binding window mismatch` |
 
-These counts and values are part of the accepted v0 S5 fixture instance.
-Changing them is not a copy-edit; it changes the deterministic instance that
-proved Phase 1 and requires an explicit fixture-instance review.
+These counts and values are part of the accepted v0 S5 fixture instance: the
+historical/proven fixture shape, not the general fixture law. Changing them is
+not a copy-edit; it changes the deterministic instance that proved Phase 1 and
+requires an explicit fixture-instance review.
 
 ## Contract Principles
 
@@ -242,8 +243,10 @@ Passing delegated determinism requires:
 
 Kernel, policy, and SDK correlation windows use runner-defined phase markers
 derived from the measured run lifecycle, not SDK-provided wall-clock timestamps.
-SDK timestamps are informational only and are never the primary join key for v0
-correlation. Choosing a concrete runtime clock source such as
+SDK timestamps are informational only and MUST NOT be used as primary join keys
+for v0 correlation. They also MUST NOT be used as an ordering fallback to
+disambiguate call-id-less tool bindings. Choosing a concrete runtime clock
+source such as
 `CLOCK_MONOTONIC` is runner-side mechanics and belongs in the boundary map
 before it becomes a v0 artifact contract requirement.
 
@@ -310,5 +313,5 @@ The v0 fixture contract does not define:
 - production-load or long-running process behavior
 - external plugin or third-party SDK fixture authoring
 
-Each of those requires a separate contract decision before it can become part
+Each non-goal requires a separate contract decision before it can become part
 of Assay-Runner.

--- a/docs/reference/runner/golden/capability-surface-openai-agents-kernel-policy-v0.json
+++ b/docs/reference/runner/golden/capability-surface-openai-agents-kernel-policy-v0.json
@@ -1,7 +1,7 @@
 {
   "schema": "assay.runner.capability_surface.v0",
   "run_id": "run_openai_agents_kernel_policy_determinism",
-  "filesystem_prefixes": [
+  "filesystem_paths": [
     "/tmp/assay-runner-openai-agents-kernel-policy/work/openai-agents-input.txt",
     "/tmp/assay-runner-openai-agents-kernel-policy/work/policy-input.txt"
   ],

--- a/docs/reference/runner/proof-packs/phase1-delegated-2026-05-21.manifest.json
+++ b/docs/reference/runner/proof-packs/phase1-delegated-2026-05-21.manifest.json
@@ -63,7 +63,7 @@
       },
       {
         "path": "../golden/capability-surface-openai-agents-kernel-policy-v0.json",
-        "sha256": "sha256:f24c1483b46375ef4d21ee0e000acdc1b5123fe9f01f9c908d6426907a8fa21a"
+        "sha256": "sha256:f11e0e9673154d44e751e9409cc6686f791adc804373de201a8be6e69af38692"
       },
       {
         "path": "../golden/correlation-report-openai-agents-kernel-policy-v0.json",

--- a/docs/reference/runner/proof-packs/phase1-delegated-2026-05-21.md
+++ b/docs/reference/runner/proof-packs/phase1-delegated-2026-05-21.md
@@ -55,6 +55,12 @@ The manifest records SHA-256 digests for the fetched workflow metadata,
 gzipped workflow log, raw workflow log content, log excerpt, and v0
 golden-shape JSON files.
 
+The retained capability-surface golden shape follows the Phase 2A precision
+rename from `filesystem_prefixes` to `filesystem_paths`. Because the historical
+run did not retain raw runner archives, this proof pack preserves the delegated
+run proof plus the current v0 contract anchors; it does not claim a byte replay
+of the pre-rename raw capability-surface archive.
+
 ## Limits
 
 This pack does not claim to contain the original `runner-*.tar.gz` archives

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -138,9 +138,10 @@ def classify_file(path: str) -> tuple[Gate, str | None]:
         "crates/assay-runner-spike/",
         "crates/assay-monitor/",
         "crates/assay-ebpf/",
+        "crates/assay-xtask/",
     )
     if any(starts(path, prefix) for prefix in all_prefixes):
-        return Gate.ALL, f"{path}: shared runner/eBPF/monitor code requires gates=all"
+        return Gate.ALL, f"{path}: shared runner/eBPF/monitor/xtask code requires gates=all"
 
     if path in {
         ".github/workflows/runner-spike-delegated.yml",
@@ -460,6 +461,7 @@ def self_test() -> None:
         (["tests/fixtures/runner-spike/mcp-policy-agent.sh"], Gate.KERNEL_POLICY),
         (["tests/fixtures/runner-spike/openai-agents-js/package-lock.json"], Gate.OPENAI_AGENTS_KERNEL_POLICY),
         (["crates/assay-monitor/src/lib.rs"], Gate.ALL),
+        (["crates/assay-xtask/src/main.rs"], Gate.ALL),
         (["scripts/ci/runner-spike-sdk-policy-correlation.sh"], Gate.ALL),
         (["tests/fixtures/runner-spike/kernel-only-agent.sh", "crates/assay-ebpf/src/main.rs"], Gate.ALL),
     ]

--- a/scripts/ci/runner-spike-kernel-only-acceptance.sh
+++ b/scripts/ci/runner-spike-kernel-only-acceptance.sh
@@ -155,7 +155,7 @@ for line_number, event in enumerate(kernel_events, start=1):
         f"kernel event {line_number} has unexpected schema: {event.get('schema')!r}",
     )
 
-filesystem = set(surface.get("filesystem_prefixes", []))
+filesystem = set(surface.get("filesystem_paths", []))
 expect(str(work_dir / "input.txt") in filesystem, "fixture input read was not recorded")
 
 print("runner-spike kernel-only archive verified")

--- a/scripts/ci/runner-spike-kernel-policy-acceptance.sh
+++ b/scripts/ci/runner-spike-kernel-policy-acceptance.sh
@@ -198,7 +198,7 @@ expect(
     "source decision tool_call_id mismatch",
 )
 
-filesystem = set(surface.get("filesystem_prefixes", []))
+filesystem = set(surface.get("filesystem_paths", []))
 expect(str(work_dir / "policy-input.txt") in filesystem, "fixture policy input read was not recorded")
 expect("read_file" in set(surface.get("mcp_tools", [])), "read_file MCP tool was not recorded")
 expect(

--- a/scripts/ci/runner-spike-openai-agents-kernel-policy-acceptance.sh
+++ b/scripts/ci/runner-spike-openai-agents-kernel-policy-acceptance.sh
@@ -263,7 +263,7 @@ expect(
     "sdk event sequence mismatch",
 )
 
-filesystem = set(surface.get("filesystem_prefixes", []))
+filesystem = set(surface.get("filesystem_paths", []))
 expect(str(work_dir / "openai-agents-input.txt") in filesystem, "OpenAI Agents fixture input read was not recorded")
 expect(str(work_dir / "policy-input.txt") in filesystem, "policy fixture input read was not recorded")
 expect("read_file" in set(surface.get("mcp_tools", [])), "read_file MCP tool was not recorded")

--- a/scripts/ci/runner-spike-sdk-contract-acceptance.sh
+++ b/scripts/ci/runner-spike-sdk-contract-acceptance.sh
@@ -116,7 +116,7 @@ for seq, line in enumerate(sdk_events):
         expect(event["tool"] == "read_file", f"sdk event {seq} tool mismatch")
 
 expect((work_dir / "sdk-wrapper-ran.txt").read_text(encoding="utf-8").strip() == "sdk wrapper fixture ran", "sdk wrapper fixture did not run")
-expect(surface.get("filesystem_prefixes", []) == [], "sdk-only fixture must not add filesystem capabilities")
+expect(surface.get("filesystem_paths", []) == [], "sdk-only fixture must not add filesystem capabilities")
 expect(correlation.get("bindings", []) == [], "sdk-only fixture must not add correlation bindings")
 
 print("runner-spike SDK contract archive verified")


### PR DESCRIPTION
Summary

- rename the runner capability-surface field from `filesystem_prefixes` to `filesystem_paths` across the Rust schema, kernel capture, acceptance scripts, docs, and golden shape
- tighten Phase 2A contract language for observation-health notes, `sdk_layer` semantics, SDK timestamp usage, and shared schema extraction ownership
- align runner reference examples with the accepted S5 fixture shape and add `crates/assay-xtask/**` to the lane-check `gates=all` classifier
- update the Phase 1 proof-pack manifest digest for the renamed capability-surface golden shape and document the historical archive limitation

Validation

- python3 scripts/ci/assay_runner_lane_check.py --self-test
- python3 -m py_compile scripts/ci/assay_runner_lane_check.py
- python3 -m json.tool on the updated capability-surface golden shape and proof-pack manifest
- cargo fmt --check
- cargo test -p assay-runner-spike
- cargo test -p assay-runner-spike surface::tests::capability_surface_serializes_sets_deterministically
- bash -n on the touched runner-spike acceptance scripts
- git diff --check
- local docs markdown link check matching .github/workflows/docs-link-check.yml
- /tmp/assay-docs-venv/bin/mkdocs build --strict
- commit hooks and pre-push hooks, including workspace clippy and linux compile gate

Delegated proof

Assay-Runner delegated proof:
- gate: all
- run: https://github.com/Rul1an/assay/actions/runs/26229555655
- sha: 2a4ae69d675775940112531dec665a1284c5fe52
