### PR TITLE
[codex] project assay runner capability diffs

### DIFF
--- a/docs/reference/runner/capability-diff-plan.md
+++ b/docs/reference/runner/capability-diff-plan.md
@@ -174,6 +174,7 @@ relocate the boundary.
 5. Revisit second-runtime fixtures after the diff contract has one clean
    consumer.
 
-Step 3 is implemented by `scripts/ci/assay_runner_capability_diff_validate.py`,
-which remains a read-only contract validator over golden artifacts rather than a
-runner execution path.
+Step 3 is implemented by `scripts/ci/assay_runner_capability_diff_validate.py`.
+Step 4 starts by letting the same helper project v0 diffs from explicit
+base/head normalized evidence directories. It remains an Assay-side reference
+projection over normalized artifacts rather than a runner execution path.

--- a/docs/reference/runner/capability-diff-v0.md
+++ b/docs/reference/runner/capability-diff-v0.md
@@ -240,9 +240,24 @@ This must produce:
 
 The golden shape for this case is
 [`golden/capability-diff-s5-idempotent-v0.json`](golden/capability-diff-s5-idempotent-v0.json).
-The read-only validation entry point is
-`scripts/ci/assay_runner_capability_diff_validate.py`; it projects the diff from
-the existing S5 golden artifacts and compares it to that frozen output shape.
+The read-only validation and reference projection entry point is
+`scripts/ci/assay_runner_capability_diff_validate.py`.
+
+Without explicit inputs, the helper projects the diff from the existing S5
+golden artifacts and compares it to that frozen output shape. With explicit
+`--base-dir` and `--head-dir` inputs, or with explicit base/head artifact
+paths, it emits a v0 capability diff over normalized evidence only. Directory
+inputs must contain `observation-health.json`, `capability-surface.json`, and
+`correlation-report.json`.
+
+Example:
+
+```bash
+python3 scripts/ci/assay_runner_capability_diff_validate.py \
+  --base-dir /path/to/base-normalized-evidence \
+  --head-dir /path/to/head-normalized-evidence \
+  --output /tmp/capability-diff.json
+```
 
 ## Notes Vocabulary
 

--- a/scripts/ci/assay_runner_capability_diff_validate.py
+++ b/scripts/ci/assay_runner_capability_diff_validate.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Validate the Assay-Runner capability-diff v0 golden shape.
+"""Validate and project the Assay-Runner capability-diff v0 shape.
 
 This is a read-only contract validator. It consumes normalized runner golden
 artifacts and verifies that the S5 idempotence projection matches the frozen
-capability-diff v0 golden JSON.
+capability-diff v0 golden JSON. It can also project the same v0 diff shape from
+two explicit normalized evidence sets without reading raw telemetry or proof
+packs.
 """
 
 from __future__ import annotations
@@ -36,6 +38,10 @@ DEFAULT_SURFACE = GOLDEN_DIR / "capability-surface-openai-agents-kernel-policy-v
 DEFAULT_CORRELATION = GOLDEN_DIR / "correlation-report-openai-agents-kernel-policy-v0.json"
 DEFAULT_EXPECTED = GOLDEN_DIR / "capability-diff-s5-idempotent-v0.json"
 
+HEALTH_NAME = "observation-health.json"
+SURFACE_NAME = "capability-surface.json"
+CORRELATION_NAME = "correlation-report.json"
+
 
 class ValidationError(Exception):
     pass
@@ -51,6 +57,14 @@ def load_json(path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValidationError(f"{path} must contain a JSON object")
     return data
+
+
+def write_json(data: dict[str, Any], output: Path | None) -> None:
+    text = json.dumps(data, indent=2) + "\n"
+    if output is None:
+        print(text, end="")
+        return
+    output.write_text(text)
 
 
 def stable(values: set[str]) -> list[str]:
@@ -279,6 +293,80 @@ def default_idempotence_diff() -> dict[str, Any]:
     return project_capability_diff(health, surface, correlation, health, surface, correlation)
 
 
+def load_evidence_set(
+    *,
+    directory: Path | None,
+    health_path: Path | None,
+    surface_path: Path | None,
+    correlation_path: Path | None,
+    label: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    if directory is not None:
+        if any(path is not None for path in (health_path, surface_path, correlation_path)):
+            raise ValidationError(f"{label} must use either --{label}-dir or explicit paths, not both")
+        health_path = directory / HEALTH_NAME
+        surface_path = directory / SURFACE_NAME
+        correlation_path = directory / CORRELATION_NAME
+
+    missing = [
+        name
+        for name, path in (
+            ("health", health_path),
+            ("surface", surface_path),
+            ("correlation", correlation_path),
+        )
+        if path is None
+    ]
+    if missing:
+        joined = ", ".join(missing)
+        raise ValidationError(f"{label} evidence is missing required artifact path(s): {joined}")
+
+    assert health_path is not None
+    assert surface_path is not None
+    assert correlation_path is not None
+    return load_json(health_path), load_json(surface_path), load_json(correlation_path)
+
+
+def custom_projection(args: argparse.Namespace) -> dict[str, Any] | None:
+    path_args = (
+        args.base_dir,
+        args.head_dir,
+        args.base_health,
+        args.base_surface,
+        args.base_correlation,
+        args.head_health,
+        args.head_surface,
+        args.head_correlation,
+    )
+    if not any(path_args):
+        return None
+
+    base_health, base_surface, base_correlation = load_evidence_set(
+        directory=args.base_dir,
+        health_path=args.base_health,
+        surface_path=args.base_surface,
+        correlation_path=args.base_correlation,
+        label="base",
+    )
+    head_health, head_surface, head_correlation = load_evidence_set(
+        directory=args.head_dir,
+        health_path=args.head_health,
+        surface_path=args.head_surface,
+        correlation_path=args.head_correlation,
+        label="head",
+    )
+    diff = project_capability_diff(
+        base_health,
+        base_surface,
+        base_correlation,
+        head_health,
+        head_surface,
+        head_correlation,
+    )
+    validate_policy_consistency(diff)
+    return diff
+
+
 def validate_default_golden() -> None:
     actual = default_idempotence_diff()
     expected = load_json(DEFAULT_EXPECTED)
@@ -327,6 +415,10 @@ def self_test() -> None:
     else:
         raise ValidationError("missing tool_call_id must fail validation")
 
+    explicit = project_capability_diff(health, surface, correlation, health, surface, correlation)
+    if explicit != default_idempotence_diff():
+        raise ValidationError("explicit S5 projection must match default idempotence projection")
+
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -336,19 +428,47 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="print the projected S5 idempotence diff JSON after validation",
     )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="write projected capability-diff JSON to this path instead of stdout",
+    )
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        help=f"directory containing base {HEALTH_NAME}, {SURFACE_NAME}, and {CORRELATION_NAME}",
+    )
+    parser.add_argument(
+        "--head-dir",
+        type=Path,
+        help=f"directory containing head {HEALTH_NAME}, {SURFACE_NAME}, and {CORRELATION_NAME}",
+    )
+    parser.add_argument("--base-health", type=Path, help="base observation-health.json path")
+    parser.add_argument("--base-surface", type=Path, help="base capability-surface.json path")
+    parser.add_argument("--base-correlation", type=Path, help="base correlation-report.json path")
+    parser.add_argument("--head-health", type=Path, help="head observation-health.json path")
+    parser.add_argument("--head-surface", type=Path, help="head capability-surface.json path")
+    parser.add_argument("--head-correlation", type=Path, help="head correlation-report.json path")
     return parser.parse_args(argv)
 
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     try:
+        projected = custom_projection(args)
+        if projected is not None:
+            write_json(projected, args.output)
+            return 0
+
         if args.self_test:
             self_test()
         else:
             validate_default_golden()
         if args.print:
-            print(json.dumps(default_idempotence_diff(), indent=2))
+            write_json(default_idempotence_diff(), args.output)
             return 0
+        if args.output is not None:
+            raise ValidationError("--output requires --print or explicit base/head inputs")
     except ValidationError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
Summary

- extend the Assay-Runner capability-diff helper from S5-only validation to a narrow v0 reference projection over explicit normalized evidence inputs
- support `--base-dir`/`--head-dir` directories containing `observation-health.json`, `capability-surface.json`, and `correlation-report.json`, plus explicit artifact-path inputs
- document the projection entry point in the v0 contract and mark Phase 2B step 4 as starting with this Assay-side helper, not a runner execution path

Validation

- `python3 -m py_compile scripts/ci/assay_runner_capability_diff_validate.py`
- `python3 scripts/ci/assay_runner_capability_diff_validate.py --self-test`
- `python3 scripts/ci/assay_runner_capability_diff_validate.py --print > /tmp/capability-diff-default.json && python3 -m json.tool /tmp/capability-diff-default.json >/dev/null`
- explicit base/head artifact path projection matches `docs/reference/runner/golden/capability-diff-s5-idempotent-v0.json`
- `--base-dir`/`--head-dir` projection matches `docs/reference/runner/golden/capability-diff-s5-idempotent-v0.json`
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `git diff --check`
- local docs markdown link check matching `.github/workflows/docs-link-check.yml`
- `/tmp/assay-docs-venv/bin/mkdocs build --strict`
- commit hooks and pre-push hooks, including workspace clippy and linux compile gate

Notes

Docs/script-only Phase 2B step-4 slice. It does not change runner behavior, fixture behavior, workflow triggers, delegated acceptance semantics, or branch protection.
