### PR TITLE
[codex] upload assay runner delegated proof packs

### DIFF
--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -72,6 +72,8 @@ jobs:
       contents: read
     env:
       CARGO_INCREMENTAL: 0
+      ASSAY_RUNNER_DELEGATED_PROOF_ROOT: /tmp/assay-runner-proof-${{ github.run_id }}
+      ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD: ${{ github.workspace }}/assay-runner-proof-upload
 
     steps:
       - name: Prepend Rust to PATH
@@ -175,38 +177,55 @@ jobs:
           set -euo pipefail
           assay_bin="$PWD/target/debug/assay"
           ebpf_path="$PWD/target/assay-ebpf.o"
+          rm -rf "$ASSAY_RUNNER_DELEGATED_PROOF_ROOT" "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD"
+          mkdir -p "$ASSAY_RUNNER_DELEGATED_PROOF_ROOT/gates"
 
           run_gate() {
-            local label="$1"
-            local script="$2"
+            local key="$1"
+            local label="$2"
+            local script="$3"
+            local gate_dir="$ASSAY_RUNNER_DELEGATED_PROOF_ROOT/gates/$key"
             echo "=== runner-spike delegated gate: ${label} ==="
+            rm -rf "$gate_dir"
+            mkdir -p "$gate_dir"
+            set +e
             sudo -E env \
               "PATH=$PATH" \
               "ASSAY_BIN=$assay_bin" \
               "ASSAY_EBPF_PATH=$ebpf_path" \
-              bash "$script"
+              "ASSAY_RUNNER_DELEGATED_PROOF_GATE_DIR=$gate_dir" \
+              bash "$script" 2>&1 | tee "$gate_dir/gate.log"
+            local status="${PIPESTATUS[0]}"
+            sudo chown -R "$(id -u):$(id -g)" "$gate_dir" 2>/dev/null || true
+            set -e
+            if [ "$status" -eq 0 ]; then
+              echo "passed" > "$gate_dir/status.txt"
+            else
+              echo "failed" > "$gate_dir/status.txt"
+              return "$status"
+            fi
             echo "- ${label}: passed" >> "$GITHUB_STEP_SUMMARY"
           }
 
           case "$GATES" in
             all)
-              run_gate "kernel-only three-run determinism" \
+              run_gate "kernel-only" "kernel-only three-run determinism" \
                 "$PWD/scripts/ci/runner-spike-kernel-only-three-run-determinism.sh"
-              run_gate "kernel+policy three-run determinism" \
+              run_gate "kernel-policy" "kernel+policy three-run determinism" \
                 "$PWD/scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh"
-              run_gate "OpenAI Agents kernel+policy+SDK three-run determinism" \
+              run_gate "openai-agents-kernel-policy" "OpenAI Agents kernel+policy+SDK three-run determinism" \
                 "$PWD/scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh"
               ;;
             kernel-only)
-              run_gate "kernel-only three-run determinism" \
+              run_gate "kernel-only" "kernel-only three-run determinism" \
                 "$PWD/scripts/ci/runner-spike-kernel-only-three-run-determinism.sh"
               ;;
             kernel-policy)
-              run_gate "kernel+policy three-run determinism" \
+              run_gate "kernel-policy" "kernel+policy three-run determinism" \
                 "$PWD/scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh"
               ;;
             openai-agents-kernel-policy)
-              run_gate "OpenAI Agents kernel+policy+SDK three-run determinism" \
+              run_gate "openai-agents-kernel-policy" "OpenAI Agents kernel+policy+SDK three-run determinism" \
                 "$PWD/scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh"
               ;;
             *)
@@ -214,6 +233,42 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Build delegated proof pack
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          workflow_sha="${GITHUB_WORKFLOW_SHA:-$GITHUB_SHA}"
+          python3 scripts/ci/assay_runner_delegated_proof_pack.py \
+            --proof-root "$ASSAY_RUNNER_DELEGATED_PROOF_ROOT" \
+            --output-dir "$ASSAY_RUNNER_DELEGATED_PROOF_UPLOAD" \
+            --gates "${{ inputs.gates }}" \
+            --build-ebpf "${{ inputs.build_ebpf }}" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --run-url "$run_url" \
+            --ref "$GITHUB_REF" \
+            --head-sha "$GITHUB_SHA" \
+            --workflow-sha "$workflow_sha" \
+            --workflow-name "$GITHUB_WORKFLOW" \
+            --retention-days 365
+          {
+            echo "### Delegated proof pack"
+            echo "- artifact: assay-runner-delegated-proof-pack-${GITHUB_RUN_ID}"
+            echo "- manifest: assay-runner-proof-upload/manifest.json"
+            echo "- retention-days: 365"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload delegated proof pack
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: assay-runner-delegated-proof-pack-${{ github.run_id }}
+          path: assay-runner-proof-upload
+          if-no-files-found: warn
+          retention-days: 365
 
       - name: Cleanup delegated runner
         if: always()

--- a/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
+++ b/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
@@ -90,6 +90,7 @@ as a small runbook or workflow edit.
    - commit SHA
    - selected `gates`
    - pass/fail result
+   - uploaded proof-pack artifact name, when present
    - relevant PASS lines or failure diagnostics
 
 Recommended progression during diagnosis:
@@ -115,6 +116,28 @@ artifact restore or copy step.
 On a fresh host, the Docker-based eBPF image/artifact build can take a few
 minutes. That is expected; do not cancel the run just because the build step is
 quiet for the first minute or two.
+
+## Delegated Proof Pack
+
+Future delegated runs upload a first-class proof-pack artifact named
+`assay-runner-delegated-proof-pack-<run_id>`. The upload happens before
+delegated-runner cleanup and uses `if: always()` semantics, so failed runs
+retain whatever archives, selected JSON artifacts, PASS lines, and gate status
+metadata were produced before failure.
+
+The proof pack is operational evidence, not normalized runner evidence. It
+remains separate from the runner archive schema unless a future artifact
+contract explicitly says otherwise. Its manifest distinguishes historical
+verification from current-state verification:
+
+- historical verification: the proof pack is sufficient to review what happened
+  for the recorded run, commit, inputs, and retained artifacts
+- current-state verification: a fresh delegated dispatch is still required for
+  a new commit, host state, dependency set, or workflow version
+
+Artifact retention is configured to 365 days. The manifest records the
+configured retention, total pack size, archive digests, selected JSON digests,
+and any gates that were missing, failed, skipped, or incomplete.
 
 ## Skip Semantics
 

--- a/docs/reference/runner/proof-packs/phase1-delegated-2026-05-21.md
+++ b/docs/reference/runner/proof-packs/phase1-delegated-2026-05-21.md
@@ -69,5 +69,6 @@ review requires fresh delegated proof.
 
 Future delegated acceptance workflows should upload a first-class proof-pack
 artifact during the run so archive digests and selected extracted JSON
-artifacts are retained at the time of execution. That workflow follow-up is
-tracked in <https://github.com/Rul1an/assay/issues/1287>.
+artifacts are retained at the time of execution. The current delegated workflow
+does this for new runs; this historical pack remains limited because the
+original run cleaned its temporary archive paths before any upload step existed.

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Build a delegated Assay-Runner proof-pack upload directory.
+
+The delegated workflow runs on a self-hosted Linux/eBPF host and writes runner
+archives under temporary gate directories. This helper copies the durable
+forensic subset into a separate upload directory before workflow cleanup removes
+those temporary paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "assay.runner.delegated_proof_pack.v0"
+KIND = "delegated_runner_proof_pack"
+GATE_SELECTIONS = {
+    "all": ("kernel-only", "kernel-policy", "openai-agents-kernel-policy"),
+    "kernel-only": ("kernel-only",),
+    "kernel-policy": ("kernel-policy",),
+    "openai-agents-kernel-policy": ("openai-agents-kernel-policy",),
+}
+SELECTED_JSON = {
+    "manifest.json",
+    "observation-health.json",
+    "capability-surface.json",
+    "correlation-report.json",
+}
+
+
+class ProofPackError(Exception):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def copy_payload_file(source: Path, output_root: Path, relative: Path) -> dict[str, Any]:
+    target = output_root / "payload" / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    return {
+        "path": str(Path("payload") / relative),
+        "bytes": target.stat().st_size,
+        "sha256": sha256_file(target),
+    }
+
+
+def pass_lines(log_path: Path) -> list[str]:
+    if not log_path.exists():
+        return []
+    lines = []
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith("PASS:"):
+            lines.append(line)
+    return lines
+
+
+def gate_status(gate_dir: Path) -> str:
+    status_path = gate_dir / "status.txt"
+    if not gate_dir.exists():
+        return "missing"
+    if not status_path.exists():
+        return "incomplete"
+    value = status_path.read_text(encoding="utf-8").strip()
+    if value in {"passed", "failed", "skipped", "incomplete"}:
+        return value
+    return "incomplete"
+
+
+def collect_gate(gate: str, proof_root: Path, output_root: Path) -> dict[str, Any]:
+    gate_dir = proof_root / "gates" / gate
+    status = gate_status(gate_dir)
+    entry: dict[str, Any] = {
+        "gate": gate,
+        "status": status,
+        "archives": [],
+        "selected_json": [],
+        "pass_lines": [],
+    }
+
+    if not gate_dir.exists():
+        return entry
+
+    log_path = gate_dir / "gate.log"
+    if log_path.exists():
+        copied = copy_payload_file(log_path, output_root, Path("gates") / gate / "gate.log")
+        entry["gate_log"] = copied
+        entry["pass_lines"] = pass_lines(log_path)
+
+    for archive in sorted(gate_dir.rglob("runner-*.tar.gz")):
+        relative = Path("gates") / gate / archive.relative_to(gate_dir)
+        entry["archives"].append(copy_payload_file(archive, output_root, relative))
+
+    for json_path in sorted(gate_dir.rglob("*.json")):
+        if json_path.name not in SELECTED_JSON:
+            continue
+        relative = Path("gates") / gate / json_path.relative_to(gate_dir)
+        entry["selected_json"].append(copy_payload_file(json_path, output_root, relative))
+
+    if status == "passed" and not entry["archives"]:
+        entry["status"] = "incomplete"
+        entry.setdefault("notes", []).append("passed gate did not leave runner archive tarballs")
+
+    return entry
+
+
+def payload_files(output_root: Path) -> list[dict[str, Any]]:
+    payload_root = output_root / "payload"
+    if not payload_root.exists():
+        return []
+    files = []
+    for path in sorted(item for item in payload_root.rglob("*") if item.is_file()):
+        relative = path.relative_to(output_root)
+        files.append(
+            {
+                "path": str(relative),
+                "bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+        )
+    return files
+
+
+def total_size(output_root: Path) -> int:
+    return sum(path.stat().st_size for path in output_root.rglob("*") if path.is_file())
+
+
+def write_manifest(output_root: Path, manifest: dict[str, Any]) -> None:
+    manifest_path = output_root / "manifest.json"
+    for _ in range(10):
+        manifest["pack_size_bytes"] = total_size(output_root)
+        text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+        manifest_path.write_text(text, encoding="utf-8")
+        new_size = total_size(output_root)
+        if new_size == manifest["pack_size_bytes"]:
+            return
+    raise ProofPackError("manifest pack_size_bytes did not stabilize")
+
+
+def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
+    selected_gates = GATE_SELECTIONS.get(args.gates)
+    if selected_gates is None:
+        allowed = ", ".join(sorted(GATE_SELECTIONS))
+        raise ProofPackError(f"unsupported gates value {args.gates!r}; expected one of {allowed}")
+
+    proof_root = args.proof_root
+    output_root = args.output_dir
+    if output_root.exists():
+        shutil.rmtree(output_root)
+    output_root.mkdir(parents=True)
+
+    gates = [collect_gate(gate, proof_root, output_root) for gate in selected_gates]
+    manifest = {
+        "schema": SCHEMA,
+        "kind": KIND,
+        "created_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "workflow": {
+            "name": args.workflow_name,
+            "run_id": args.run_id,
+            "run_attempt": args.run_attempt,
+            "run_url": args.run_url,
+            "ref": args.ref,
+            "head_sha": args.head_sha,
+            "workflow_sha": args.workflow_sha,
+            "inputs": {
+                "gates": args.gates,
+                "build_ebpf": args.build_ebpf,
+            },
+        },
+        "verification_modes": {
+            "historical": "proof_pack_sufficient_for_recorded_run",
+            "current_state": "fresh_delegated_dispatch_required",
+        },
+        "retention_days": args.retention_days,
+        "expected_size_policy": {
+            "soft_cap_bytes": args.soft_cap_bytes,
+            "action": "revisit retention and quota impact before expanding delegated matrices",
+        },
+        "evidence_boundary": {
+            "separate_from_normalized_runner_evidence": True,
+            "not_a_runner_emitted_artifact": True,
+        },
+        "gates": gates,
+        "payload_files": [],
+        "pack_size_bytes": 0,
+    }
+    manifest["payload_files"] = payload_files(output_root)
+    write_manifest(output_root, manifest)
+    return manifest
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="run a local collector self-test")
+    parser.add_argument("--proof-root", type=Path, help="delegated proof work root")
+    parser.add_argument("--output-dir", type=Path, help="directory to upload as the proof-pack artifact")
+    parser.add_argument("--gates", default="all", help="delegated gates input")
+    parser.add_argument("--build-ebpf", default="true", help="delegated build_ebpf input")
+    parser.add_argument("--run-id", default="", help="GitHub workflow run id")
+    parser.add_argument("--run-attempt", default="", help="GitHub workflow run attempt")
+    parser.add_argument("--run-url", default="", help="GitHub workflow run URL")
+    parser.add_argument("--ref", default="", help="Git ref for the workflow run")
+    parser.add_argument("--head-sha", default="", help="workflow head SHA")
+    parser.add_argument("--workflow-sha", default="", help="workflow definition SHA")
+    parser.add_argument("--workflow-name", default="Runner Spike Delegated")
+    parser.add_argument("--retention-days", type=int, default=365)
+    parser.add_argument("--soft-cap-bytes", type=int, default=50 * 1024 * 1024)
+    return parser.parse_args(argv)
+
+
+def self_test() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        proof_root = root / "proof"
+        gate_dir = proof_root / "gates" / "kernel-only" / "run-1" / "extract"
+        gate_dir.mkdir(parents=True)
+        (proof_root / "gates" / "kernel-only" / "status.txt").write_text("passed\n", encoding="utf-8")
+        (proof_root / "gates" / "kernel-only" / "gate.log").write_text(
+            "noise\nPASS: runner-spike kernel-only acceptance\n",
+            encoding="utf-8",
+        )
+        (proof_root / "gates" / "kernel-only" / "run-1" / "runner-kernel-only.tar.gz").write_bytes(b"tar")
+        (gate_dir / "observation-health.json").write_text('{"schema":"x"}\n', encoding="utf-8")
+
+        args = argparse.Namespace(
+            proof_root=proof_root,
+            output_dir=root / "upload",
+            gates="all",
+            build_ebpf="true",
+            run_id="123",
+            run_attempt="1",
+            run_url="https://github.example/run/123",
+            ref="refs/heads/test",
+            head_sha="abc",
+            workflow_sha="def",
+            workflow_name="Runner Spike Delegated",
+            retention_days=365,
+            soft_cap_bytes=50 * 1024 * 1024,
+        )
+        manifest = build_manifest(args)
+        if manifest["schema"] != SCHEMA:
+            raise ProofPackError("self-test manifest schema mismatch")
+        if manifest["verification_modes"]["current_state"] != "fresh_delegated_dispatch_required":
+            raise ProofPackError("self-test verification mode mismatch")
+        statuses = {gate["gate"]: gate["status"] for gate in manifest["gates"]}
+        if statuses != {
+            "kernel-only": "passed",
+            "kernel-policy": "missing",
+            "openai-agents-kernel-policy": "missing",
+        }:
+            raise ProofPackError(f"self-test gate status mismatch: {statuses}")
+        if not manifest["gates"][0]["archives"]:
+            raise ProofPackError("self-test did not collect archive digest")
+        if not (args.output_dir / "manifest.json").exists():
+            raise ProofPackError("self-test did not write manifest")
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        if args.self_test:
+            self_test()
+            print("delegated proof-pack self-test ok")
+            return 0
+        if args.proof_root is None or args.output_dir is None:
+            raise ProofPackError("--proof-root and --output-dir are required")
+        manifest = build_manifest(args)
+        print(
+            "delegated proof-pack manifest written: "
+            f"{args.output_dir / 'manifest.json'} ({manifest['pack_size_bytes']} bytes)"
+        )
+    except ProofPackError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/ci/runner-spike-kernel-only-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-kernel-only-three-run-determinism.sh
@@ -9,10 +9,18 @@ if [ "$(uname -s)" != "Linux" ]; then
   exit 40
 fi
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-only-determinism.XXXXXX")"
-cleanup() {
-  rm -rf -- "$TMP_ROOT"
-}
+if [ -n "${ASSAY_RUNNER_DELEGATED_PROOF_GATE_DIR:-}" ]; then
+  TMP_ROOT="$ASSAY_RUNNER_DELEGATED_PROOF_GATE_DIR"
+  mkdir -p "$TMP_ROOT"
+  cleanup() {
+    :
+  }
+else
+  TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-only-determinism.XXXXXX")"
+  cleanup() {
+    rm -rf -- "$TMP_ROOT"
+  }
+fi
 trap cleanup EXIT
 
 WORK_DIR="$TMP_ROOT/work"

--- a/scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh
@@ -9,10 +9,18 @@ if [ "$(uname -s)" != "Linux" ]; then
   exit 40
 fi
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-policy-determinism.XXXXXX")"
-cleanup() {
-  rm -rf -- "$TMP_ROOT"
-}
+if [ -n "${ASSAY_RUNNER_DELEGATED_PROOF_GATE_DIR:-}" ]; then
+  TMP_ROOT="$ASSAY_RUNNER_DELEGATED_PROOF_GATE_DIR"
+  mkdir -p "$TMP_ROOT"
+  cleanup() {
+    :
+  }
+else
+  TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-kernel-policy-determinism.XXXXXX")"
+  cleanup() {
+    rm -rf -- "$TMP_ROOT"
+  }
+fi
 trap cleanup EXIT
 
 WORK_DIR="$TMP_ROOT/work"

--- a/scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh
@@ -9,10 +9,18 @@ if [ "$(uname -s)" != "Linux" ]; then
   exit 40
 fi
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-openai-agents-kernel-policy-determinism.XXXXXX")"
-cleanup() {
-  rm -rf -- "$TMP_ROOT"
-}
+if [ -n "${ASSAY_RUNNER_DELEGATED_PROOF_GATE_DIR:-}" ]; then
+  TMP_ROOT="$ASSAY_RUNNER_DELEGATED_PROOF_GATE_DIR"
+  mkdir -p "$TMP_ROOT"
+  cleanup() {
+    :
+  }
+else
+  TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/assay-runner-openai-agents-kernel-policy-determinism.XXXXXX")"
+  cleanup() {
+    rm -rf -- "$TMP_ROOT"
+  }
+fi
 trap cleanup EXIT
 
 WORK_DIR="$TMP_ROOT/work"


### PR DESCRIPTION
Summary

- teach `Runner Spike Delegated` to retain per-gate temporary artifacts under a proof-pack work root and upload a first-class proof-pack artifact before cleanup
- add `scripts/ci/assay_runner_delegated_proof_pack.py` to collect archive digests, selected extracted JSON artifacts, PASS lines, gate status, workflow metadata, retention, and historical/current verification semantics
- update the delegated runbook and historical Phase 1 proof-pack note to document the new future-run proof-pack behavior

Validation

- `python3 -m py_compile scripts/ci/assay_runner_delegated_proof_pack.py`
- `python3 scripts/ci/assay_runner_delegated_proof_pack.py --self-test`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/runner-spike-delegated.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/runner-spike-delegated.yml`
- `bash -n` on the touched runner-spike determinism scripts
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `git diff --check`
- local docs markdown link check matching `.github/workflows/docs-link-check.yml`
- `/tmp/assay-docs-venv/bin/mkdocs build --strict`
- commit hooks and pre-push hooks, including actionlint, shellcheck, workspace clippy, and linux compile gate

Delegated proof

This PR changes the delegated workflow and runner-spike determinism wrappers. Assay-Runner Lane Check should require a fresh `Runner Spike Delegated` dispatch with `gates=all`, `build_ebpf=true`, and head SHA `12072c09` before merge.

Closes #1287.
