### PR TITLE
[codex] tighten second runtime entry plan wording

### DIFF
--- a/docs/reference/runner/second-runtime-plan.md
+++ b/docs/reference/runner/second-runtime-plan.md
@@ -46,9 +46,9 @@ A candidate runtime must satisfy all of these before code is added:
 | Small event shape | The fixture should produce one binding first; multi-tool or branching traces are later work |
 | Evidence boundary fit | The normalizer must not broaden evidence boundaries to make the runtime look comparable |
 
-If stable identity is absent, do not add order-based matching in the second
-runtime PR. That decision belongs in a separate correlation fallback contract,
-not in fixture plumbing.
+If stable identity is absent, do not add order-based or timestamp-based
+matching in the second runtime PR. That decision belongs in a separate
+correlation fallback contract, not in fixture plumbing.
 
 ## Expected Artifact Shape
 
@@ -178,7 +178,7 @@ runtime candidates against the Candidate Requirements table above. It does
 not propose code; it produces the selection note that step 2 of the
 Suggested PR Sequence requires.
 
-The Ring-Buffer drop debug follow-up tracked in
+The ring-buffer drop debug follow-up tracked in
 <https://github.com/Rul1an/assay/issues/1271> remains independent of this
 line. It must not weaken the `ringbuf_drops=0` clean-health bar for any
 second-runtime fixture.


### PR DESCRIPTION
## Summary

Two self-documentation gaps found in post-merge copilot review of #1294. Strict micro-PR with only those two fixes; no other wording polish.

1. **Timestamp-fallback explicit in the plan text.** The plan's fixture-plumbing rule said "do not add order-based matching", but the #1294 PR body and the plan's Kill Criteria forbid both order-based and timestamp-based fallback. A reader of `second-runtime-plan.md` alone (without the PR body) should see the full rule. Fix: `do not add order-based or timestamp-based matching`.

2. **Capitalization consistency.** "Ring-Buffer" with double-capital appeared only in this new file. The rest of the runner doc set uses "Ring-buffer" (start-of-line) or "ring-buffer" (mid-sentence). Mid-sentence here, so lowercase.

## Why now

The document was just anchored as the Phase 2B second-runtime reference. A precision-pass within its first week of existence anchors it cleaner than a later natural-doc-maintenance pass would. The first gap is semantic (a reader could interpret timestamp-based fallback as permitted); the second is editorial. Both belong in the file that defines the entry discipline, not in PR-body residue or a future maintenance pass.

## Validation

- `git diff --check`
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `/tmp/assay-docs-venv/bin/mkdocs build --strict` (exit 0, no warnings/errors)
- commit hooks: merge conflicts, EOF, whitespace, token hygiene, typos, cargo fmt
- pre-push hooks: cargo clippy + linux compile gate

## Notes

Docs-only. Two lines changed (one rule reflowed across three lines after expansion). No other wording polish, no opportunistic edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)