### PR TITLE
[codex] add platform and extraction readiness checkpoint

### DIFF
--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -16,4 +16,5 @@ Phase 2B capability-diff planning slice.
 - [Runner capability-diff v0 contract](capability-diff-v0.md)
 - [Runner second runtime Phase 2B plan](second-runtime-plan.md)
 - [Assay-Runner boundary and extraction map](boundary-map.md)
+- [Runner platform and extraction readiness](platform-and-extraction-readiness.md)
 - [Phase 1 delegated proof pack](proof-packs/phase1-delegated-2026-05-21.md)

--- a/docs/reference/runner/platform-and-extraction-readiness.md
+++ b/docs/reference/runner/platform-and-extraction-readiness.md
@@ -1,0 +1,149 @@
+# Assay-Runner Platform And Extraction Readiness
+
+> Internal Phase 2B readiness checkpoint. This page records the current
+> verdict on three deferred ambitions: repository extraction, macOS proof,
+> and Windows proof. It is not a roadmap, not a schedule, and not a decision
+> to open any of these lines.
+
+The Phase 2B consolidation and the second-runtime entry plan deferred three
+distinct ambitions:
+
+- **Extraction**: moving the Assay-Runner candidate to its own repository
+- **macOS proof**: producing measured-run acceptance on macOS hosts
+- **Windows proof**: producing measured-run acceptance on Windows hosts
+
+This page exists so "not now" cannot later be misread as "never discussed"
+or as "apparently allowed now". Each line stays closed until a documented
+readiness checkpoint passes.
+
+## Status Overview
+
+| Ambition | Current verdict | Documented in |
+|---|---|---|
+| Extraction (new repo) | **not ready** | [`boundary-map.md` § Extraction Readiness Criteria](boundary-map.md#extraction-readiness-criteria) |
+| macOS proof | **not ready** | [`second-runtime-plan.md` § Out Of Phase 2B Scope](second-runtime-plan.md#out-of-phase-2b-scope), and several Non-Goals tables across Phase 2A docs |
+| Windows proof | **not ready** | same as macOS, with the additional condition that macOS proof exists first |
+
+Cross-runtime capability-diff is a separate Phase 2C question and is tracked
+through the capability-diff documents, not here.
+
+## Extraction Readiness
+
+Authoritative checklist: [`boundary-map.md` § Extraction Readiness Criteria](boundary-map.md#extraction-readiness-criteria)
+and [`boundary-map.md` § Extraction Blocking Conditions](boundary-map.md#extraction-blocking-conditions).
+This page does not duplicate the 15 criteria. It only summarises the current
+shape of the gap.
+
+Current structural blockers, in priority order:
+
+1. `assay.runner.*.v0` schemas still live in `crates/assay-runner-spike/src/`.
+   They must move to an Assay-owned shared crate before extraction.
+2. Archive verification still crosses an unresolved boundary conflict between
+   runner assembly and Assay artifact semantics (`archive.rs`).
+3. Cgroup placement still depends on `crates/assay-cli/src/cgroup.rs`. A
+   stable cgroup API is required before extraction.
+4. There is no non-spike external consumer of the runner bundle format. The
+   capability-diff projection helper is an internal consumer.
+
+Triggers for reopening extraction readiness review:
+
+- An external party concretely asks to consume the runner bundle format
+  without depending on Assay internals. This creates the missing external
+  consumer and creates a real reason to move schemas to a shared crate.
+- The four structural blockers above are independently resolved.
+- The `assay.runner.*.v0` contracts pass a stable window of at least four to
+  six weeks without semantic churn.
+
+Until those triggers fire, extraction stays closed by default. "We could
+extract now" is not a trigger.
+
+## macOS Proof Readiness
+
+macOS is a separate platform spike, not a port of Linux. The Phase 1 spike
+established the discipline for proving one platform end to end; the same
+discipline applies to macOS independently.
+
+Current blockers, in summary form:
+
+- No proven Phase 2B second-runtime line yet. macOS work cannot ride on
+  Phase 1 alone; we need at least one second-runtime fixture passing the
+  capability-diff idempotent acceptance on Linux first.
+- No `macos-measurement-spike-plan.md` analog of
+  [`ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md`](../../notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md).
+  macOS needs its own kill criteria and acceptance criteria because the
+  measurement technology is different.
+- No documented measurement-technology decision. macOS measurement
+  candidates differ from eBPF in capability, signing requirements, and
+  evidence boundary. The decision belongs in the macOS spike plan, not in
+  the existing Linux artifact contracts.
+- No dedicated host class equivalent to the `assay-bpf-runner` for macOS.
+
+Triggers for opening macOS proof readiness review:
+
+- A second-runtime fixture has reached `qualifies` and produced a clean
+  idempotent capability-diff on Linux.
+- The Linux runner-boundary has passed a stable window of at least four to
+  six weeks.
+- A concrete use case requires macOS measurement (not "we could", but
+  "we need this for X").
+- Resources are available to provision a dedicated macOS host class.
+
+Until those triggers fire, macOS work is not a port question and not a
+small extension. It is a separate spike with its own entry plan.
+
+## Windows Proof Readiness
+
+Windows is downstream of macOS in two senses:
+
+- The measurement-technology question is broader (ETW, eBPF-for-Windows,
+  Sysmon, and others each carry different trade-offs).
+- Cross-platform `assay.runner.*.v0` schemas should first survive Linux plus
+  macOS before they are stress-tested against a third platform.
+
+Triggers for opening Windows proof readiness review:
+
+- macOS proof has reached clean acceptance with its own spike plan and host
+  class.
+- A concrete use case requires Windows measurement.
+
+No technology decision is made by this page.
+
+## Non-Goals
+
+This page does not:
+
+- open extraction, macOS, or Windows work
+- propose a schedule, quarter, or calendar window
+- choose a macOS measurement technology
+- choose a Windows measurement technology
+- propose a new repository name or layout
+- open issues for any of the three ambitions
+- weaken the Linux/eBPF acceptance bar
+- replace the authoritative criteria in `boundary-map.md`
+
+Each of those decisions belongs in its own dedicated planning slice, only
+after the relevant triggers above fire.
+
+## How To Use This Page
+
+When a maintainer or reviewer is tempted to start extraction, macOS, or
+Windows work:
+
+1. Read the relevant Triggers section above.
+2. If no trigger applies, do not open the line. Reference this page.
+3. If a trigger applies, open a dedicated planning slice analogous to
+   `second-runtime-plan.md`, with kill criteria, acceptance criteria, and
+   non-goals specific to that ambition. Do not start implementation work
+   from this page.
+
+This page is updated only when a verdict changes, when a structural blocker
+is resolved, or when a trigger fires.
+
+## References
+
+- [Assay-Runner boundary and extraction map](boundary-map.md)
+- [Runner second runtime Phase 2B plan](second-runtime-plan.md)
+- [Runner capability-diff v0 contract](capability-diff-v0.md)
+- [Runner CI lane contract](ci-lanes.md)
+- [Assay-Runner Phase 1 spike plan (template for future platform spikes)](../../notes/ASSAY-RUNNER-PHASE1-SPIKE-PLAN-2026-05-20.md)
+- [Assay-Runner Phase 1 acceptance](../../notes/ASSAY-RUNNER-PHASE1-ACCEPTANCE-2026-05-21.md)


### PR DESCRIPTION
## Summary

Add a docs-only readiness checkpoint for three deferred ambitions:

- repository extraction (new Assay-Runner repo)
- macOS proof
- Windows proof

Each line has a current verdict (all three: **not ready**), structural blockers in summary form, and explicit triggers for reopening readiness review. The note exists so "not now" cannot later be misread as "never discussed" or as "apparently allowed now".

## Scope discipline

- This is a **checkpoint**, not a roadmap. No schedule, no quarter, no calendar window.
- Authoritative criteria for extraction stay in [`boundary-map.md`](../blob/main/docs/reference/runner/boundary-map.md). This note summarises the current shape of the gap rather than duplicating 15 readiness criteria.
- Each ambition lists triggers that must fire before readiness review reopens. Until then the line stays closed by default.
- "We could extract/measure macOS/measure Windows now" is explicitly not a trigger.

## What this PR explicitly does not do

- open extraction, macOS, or Windows work
- propose a schedule, quarter, or calendar window
- choose a macOS measurement technology
- choose a Windows measurement technology
- propose a new repository name or layout
- open issues for any of the three ambitions
- weaken the Linux/eBPF acceptance bar
- replace the authoritative criteria in `boundary-map.md`

## How To Use This Page section

When a reviewer or maintainer is tempted to start one of the three lines:

1. Read the Triggers section for that ambition.
2. If no trigger applies, decline and reference this page.
3. If a trigger applies, open a dedicated planning slice analogous to `second-runtime-plan.md`. Do not start implementation work from this page.

Updates to this page are restricted to verdict changes, structural blocker resolution, or trigger firing.

## Validation

- `git diff --check`
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `/tmp/assay-docs-venv/bin/mkdocs build --strict` (exit 0, no warnings/errors)
- commit hooks: merge conflicts, EOF, whitespace, token hygiene, typos, cargo fmt
- pre-push hooks: cargo clippy + linux compile gate

## Notes

Docs-only readiness slice. It does not change runner behavior, fixture behavior, workflow triggers, delegated acceptance semantics, or branch protection. The lane-check classifier correctly treats this PR as no-delegated-proof-required.

Independent of stacked PR #1297 (candidate selection skeleton). Both add a single line to the runner reference index in different positions; no merge conflict expected.

## Test plan

- [x] mkdocs build --strict
- [x] lane-check self-test
- [x] git diff --check
- [x] pre-commit hooks
- [x] pre-push hooks (clippy + linux compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)