### PR TITLE
[codex] evaluate anthropic sdk direct as second runtime candidate

### DIFF
--- a/docs/reference/runner/second-runtime-candidate-selection.md
+++ b/docs/reference/runner/second-runtime-candidate-selection.md
@@ -114,17 +114,71 @@ side effect of the first fixture PR.
 
 ## Candidates
 
-*Placeholder. No candidate has been added yet. Each candidate evaluation lands
-in its own PR following the Candidate Evaluation Form above.*
+### Candidate: Anthropic SDK direct
+
+The Anthropic SDK direct path means using
+[`anthropic-sdk-python`](https://github.com/anthropics/anthropic-sdk-python)
+or `@anthropic-ai/sdk` against the Messages API with a custom client tool, not
+through `@openai/agents-js` and not through `Anthropic Agent SDK` higher-level
+wrappers. This isolates the smallest possible second-runtime surface.
+
+| # | Requirement | Outcome | Evidence |
+|---|---|---|---|
+| 1 | Offline execution | qualifies | Cassette-replay via [VCR.py](https://vcrpy.readthedocs.io/en/latest/usage.html) (Python) or `nock`/MSW (TypeScript) works at the HTTPS layer against `api.anthropic.com`. Live API key is required only during one-time cassette recording (curation step), never during delegated acceptance. `record_mode='none'` guarantees no network calls during fixture execution. Restrictions: non-streaming `client.messages.create()` only (streaming cassettes complicate determinism); `anthropic-version` header pinned; re-recording is maintainer-controlled, analogous to the [`@openai/agents` bump flow in `fixtures-v0.md`](fixtures-v0.md#dependency-upgrade-contract). |
+| 2 | Stable identity | insufficient evidence | Two of three level-3 conditions pass; one is implicit only. See Stable identity detail below. |
+| 3 | Comparable surface | not yet evaluated | Row 2 blocks overall outcome; remaining rows recorded as `not yet evaluated` to avoid speculative claims. Re-evaluate when row 2 is unblocked. |
+| 4 | Deterministic dependency lock | not yet evaluated | Row 2 blocks overall outcome. |
+| 5 | Linux/eBPF fit | not yet evaluated | Row 2 blocks overall outcome. |
+| 6 | Small event shape | not yet evaluated | Row 2 blocks overall outcome. |
+| 7 | Evidence boundary fit | not yet evaluated | Row 2 blocks overall outcome. |
+
+**Stable identity detail (row 2):**
+
+The candidate identity field is `tool_use.id` in the
+[Messages API tool_use content block](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls).
+Example value from public docs: `"toolu_01A09q90qw90lq917835lq9"`.
+
+- Field name: `tool_use.id`
+- Source: `tool_use` content block in the assistant message of a Messages API response
+- **runtime-generated evidence:** `insufficient evidence`. Public docs describe the `id` as a field on the `tool_use` block contained in the API response, and the SDK has no documented client-side generation path. The example value's `toolu_` prefix matches Anthropic's other server-issued identifier conventions (`msg_`, etc.). However, no public docs sentence explicitly states that the Anthropic API server generates this field. Per the level-3 strict reading codified in the [Stable Identity Checklist](#stable-identity--level-3-checklist), implicit chain-of-reasoning evidence does not satisfy `runtime-generated`. A `qualifies` outcome requires either an explicit docs statement or a typed SDK schema annotation that names the field as server-generated.
+- **binding-intended evidence:** `qualifies`. The [handle-tool-calls docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls) state literally: *"`id`: A unique identifier for this particular tool use block. This will be used to match up the tool results later."* The same docs define `tool_result.tool_use_id` as *"The `id` of the tool use request this is a result for."* A 400-error message documented in the same page (*"tool_use ids were found without tool_result blocks immediately after"*) confirms that the API enforces the binding contract at request validation time.
+- **run-window unique evidence:** `qualifies`. The [handle-tool-calls docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls) state literally: *"A unique identifier for this particular tool use block."*
+
+**Expected delegated gate for first fixture PR (only filled if overall outcome is `qualifies`):**
+Not applicable. Overall outcome below is `insufficient evidence`, so no first fixture PR may be opened from this evaluation.
+
+**Overall outcome:** `insufficient evidence`
+
+Per the lowest-row-wins rule in [Evaluation Discipline](#evaluation-discipline),
+row 2's `insufficient evidence` determines the candidate's overall outcome.
+Rows 3-7 remain `not yet evaluated` because evaluating them would not change
+the overall outcome and would invite optimistic interpretation. They become
+relevant only if `runtime-generated` evidence improves.
+
+**Notes:** Anthropic SDK direct is technically promising on rows 1, 2.b, 2.c.
+The single blocker is the absence of one explicit docs sentence or typed schema
+annotation that names `tool_use.id` as server-generated. This evaluation is
+recorded so the same research does not have to be repeated when the docs or
+SDK schema improve.
 
 ## Selection Outcome
 
-*Filled in only after at least one candidate evaluation reaches `qualifies`.
-A `does not qualify` or `insufficient evidence` outcome for all evaluated
-candidates leaves this section as a placeholder stating "no candidate
-currently qualifies"; the selection issue
+**No candidate currently qualifies.**
+
+Evaluated candidates and their overall outcomes:
+
+| Candidate | Overall outcome |
+|---|---|
+| Anthropic SDK direct | `insufficient evidence` |
+
+The selection issue
 [`#1295`](https://github.com/Rul1an/assay/issues/1295) remains open until a
-qualifying candidate exists.*
+candidate evaluation reaches `qualifies` AND this section is explicitly
+updated to name that candidate as the selected second runtime.
+
+Re-evaluation of an `insufficient evidence` outcome happens in a separate PR
+that cites the new public evidence which closes the previous gap; it does
+not happen by reinterpreting the same evidence more optimistically.
 
 ## Non-Goals For This Note
 


### PR DESCRIPTION
## Summary

First concrete candidate evaluation under the skeleton landed in #1297, following the agreed A → C plan (form first, then one candidate per iteration). This PR evaluates **Anthropic SDK direct** against the seven Candidate Requirements from `second-runtime-plan.md`.

**Overall outcome: `insufficient evidence`.** No candidate currently qualifies. Selection issue #1295 stays open.

## Why this evaluation lands as `insufficient evidence`, not `qualifies`

Per the strict level-3 reading codified by the Stable Identity Checklist in `second-runtime-candidate-selection.md`, row 2 (Stable identity) requires three sub-conditions to each be supported by public docs, typed API contracts, or stable SDK event schemas — not by implicit chain-of-reasoning.

For Anthropic SDK direct:

| Sub-condition | Result | Source |
|---|---|---|
| `binding-intended` | qualifies | docs literal: *"This will be used to match up the tool results later"* + *"`tool_use_id`: The `id` of the tool use request this is a result for"* |
| `run-window unique` | qualifies | docs literal: *"A unique identifier for this particular tool use block"* |
| `runtime-generated` | insufficient evidence | response-field shape + `toolu_` prefix + no documented client-side generation path are strong implicit signals, but no public docs sentence explicitly states the API server generates this field |

Lowest-row-wins → row 2 overall `insufficient evidence` → candidate overall `insufficient evidence`.

This is **not a rejection**. It is a paused line, recorded so the research does not have to be repeated when the docs or typed SDK schema improve.

## Why row 1 passes

Row 1 (Offline execution) qualifies via the checked-in cassette strategy:

- HTTP-layer recording via [VCR.py](https://vcrpy.readthedocs.io/en/latest/usage.html) (Python) or `nock`/MSW (TypeScript) against `api.anthropic.com`
- API key only during one-time recording (curation step)
- `record_mode='none'` in fixture execution → no network calls possible
- Restrictions documented in the evaluation: non-streaming Messages API only, `anthropic-version` header pinned, re-recording maintainer-controlled analogous to the `@openai/agents` bump flow

## Why rows 3-7 are `not yet evaluated`, not speculated

Per `second-runtime-candidate-selection.md` Evaluation Discipline, evaluating rows 3-7 with optimistic claims when overall outcome is already pinned by row 2 would invite scope drift. Rows 3-7 are recorded as `not yet evaluated` and become relevant only when row 2's `runtime-generated` evidence improves.

## What this PR explicitly does not do

- propose Anthropic SDK direct as the selected second runtime
- propose fixture code, dependencies, or a cassette implementation
- introduce call-id-less fallback
- propose a narrower delegated gate
- propose cross-runtime capability-diff against S5
- modify the Evaluation Discipline, Outcome Vocabulary, Stable Identity checklist, or Candidate Evaluation Form sections of the selection note
- reinterpret implicit evidence as `qualifies`

Per the "How To Add A Candidate" procedure in the selection note, only `## Candidates` and `## Selection Outcome` are modified.

## Validation

- `git diff --check`
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `/tmp/assay-docs-venv/bin/mkdocs build --strict` (exit 0, no warnings/errors)
- commit hooks: merge conflicts, EOF, whitespace, token hygiene, typos, cargo fmt
- pre-push hooks: cargo clippy + linux compile gate

## Notes

Docs-only Phase 2B candidate evaluation slice. It does not change runner behavior, fixture behavior, workflow triggers, delegated acceptance semantics, or branch protection. The lane-check classifier correctly treats this PR as no-delegated-proof-required.

The next candidate evaluation (Vercel AI SDK, PydanticAI, or other) follows in its own iteration PR. Re-evaluation of Anthropic SDK direct requires a separate future PR that cites new public evidence closing the `runtime-generated` gap; reinterpreting the same evidence is explicitly disallowed by the selection note.

## Test plan

- [x] mkdocs build --strict
- [x] lane-check self-test
- [x] git diff --check
- [x] pre-commit hooks
- [x] pre-push hooks (clippy + linux compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)