### PR TITLE
[codex] evaluate openai typescript sdk direct as second runtime candidate

### DIFF
--- a/docs/reference/runner/second-runtime-candidate-selection.md
+++ b/docs/reference/runner/second-runtime-candidate-selection.md
@@ -340,6 +340,57 @@ for SDK-level uniqueness guarantees, not for provider ID uniqueness in
 general; underlying provider IDs may still satisfy `run-window unique` under
 the right configuration even when the wrapper SDK does not guarantee it.
 
+### Candidate: OpenAI TypeScript SDK direct
+
+The OpenAI TypeScript SDK direct path means using
+[`openai-node`](https://github.com/openai/openai-node) (the `openai` npm
+package) against the Chat Completions API with a custom client tool, not
+through `@openai/agents-js` and not through Assistants/Responses higher-level
+surfaces. This isolates the smallest possible second-runtime surface using
+OpenAI as the underlying provider, paralleling the Anthropic SDK direct and
+OpenAI Python SDK direct evaluations above.
+
+| # | Requirement | Outcome | Evidence |
+|---|---|---|---|
+| 1 | Offline execution | qualifies | Cassette-replay via `nock` or MSW (TypeScript) at the HTTPS layer against `api.openai.com`. Live API key is required only during one-time cassette recording (curation step), never during delegated acceptance. Restrictions: non-streaming `client.chat.completions.create()` only (streaming cassettes complicate determinism); `openai` SDK version pinned via `package.json`/lockfile; cassette request/response shape stable across compatible SDK patch versions; re-recording is maintainer-controlled, analogous to the [`@openai/agents` bump flow in `fixtures-v0.md`](fixtures-v0.md#dependency-upgrade-contract). |
+| 2 | Stable identity | insufficient evidence | One of three level-3 sub-conditions passes via public TypeScript SDK JSDoc; two are gaps. See Stable identity detail below. |
+| 3 | Comparable surface | not yet evaluated | Row 2 blocks overall outcome; remaining rows recorded as `not yet evaluated` to avoid speculative claims. Re-evaluate when row 2 is unblocked. |
+| 4 | Deterministic dependency lock | not yet evaluated | Row 2 blocks overall outcome. |
+| 5 | Linux/eBPF fit | not yet evaluated | Row 2 blocks overall outcome. |
+| 6 | Small event shape | not yet evaluated | Row 2 blocks overall outcome. |
+| 7 | Evidence boundary fit | not yet evaluated | Row 2 blocks overall outcome. |
+
+**Stable identity detail (row 2):**
+
+The candidate identity field is the `id` field on `ChatCompletionMessageFunctionToolCall`
+in the [openai-node TypeScript SDK](https://github.com/openai/openai-node/blob/master/src/resources/chat/completions/completions.ts).
+The interface is declared with the interface-level JSDoc *"A call to a function tool created by the model."*
+
+- Field name: `ChatCompletionMessageFunctionToolCall.id`
+- Source: `tool_calls` array on the assistant message of a Chat Completions API response, accessed via the TypeScript SDK type
+- **runtime-generated evidence:** `insufficient evidence`. The TypeScript JSDoc for the field reads literally *"The ID of the tool call."* — identical wording to the Python SDK docstring. The enclosing interface comment *"A call to a function tool created by the model."* is suggestive of model-side creation, but it documents the object as a whole rather than the `id` field specifically. The example value's `call_` prefix matches OpenAI's other server-issued identifier conventions, and the SDK has no documented client-side generation path. However, no public docs sentence or typed SDK annotation explicitly states that the OpenAI API server generates the `id` field. Per the level-3 strict reading codified in the [Stable Identity Checklist](#stable-identity--level-3-checklist), implicit chain-of-reasoning evidence does not satisfy `runtime-generated`.
+- **binding-intended evidence:** `qualifies`. The TypeScript JSDoc for [`ChatCompletionToolMessageParam.tool_call_id`](https://github.com/openai/openai-node/blob/master/src/resources/chat/completions/completions.ts) reads literally *"Tool call that this message is responding to."* — identical wording to the Python SDK. The official Function Calling guide demonstrates the binding mechanism in code using the SDK type.
+- **run-window unique evidence:** `insufficient evidence`. The TypeScript JSDoc for the `id` field reads only *"The ID of the tool call."* — no "unique" claim, identical to the Python SDK gap. The official Function Calling guide does not provide an explicit uniqueness guarantee for parallel tool calls within a single response. Per the level-3 strict reading, an implicit uniqueness expectation does not satisfy `run-window unique`.
+
+**Expected delegated gate for first fixture PR (only filled if overall outcome is `qualifies`):**
+Not applicable. Overall outcome below is `insufficient evidence`, so no first fixture PR may be opened from this evaluation.
+
+**Overall outcome:** `insufficient evidence`
+
+Per the lowest-row-wins rule in [Evaluation Discipline](#evaluation-discipline),
+row 2's `insufficient evidence` determines the candidate's overall outcome.
+Rows 3-7 remain `not yet evaluated` because evaluating them would not change
+the overall outcome and would invite optimistic interpretation. They become
+relevant only if both `runtime-generated` and `run-window unique` evidence
+improves.
+
+**Notes:** Two OpenAI direct-SDK evaluations now show the same level-3
+identity profile: Python (#1301) and TypeScript (this PR) both document
+binding intent, but neither provides explicit public evidence for
+`runtime-generated` or `run-window unique`. This observation is scoped to
+OpenAI direct SDKs and the public documentation reviewed here; it does not
+claim anything about other providers.
+
 ## Selection Outcome
 
 **No candidate currently qualifies.**
@@ -352,6 +403,7 @@ Evaluated candidates and their overall outcomes:
 | PydanticAI | `does not qualify` |
 | OpenAI Python SDK direct | `insufficient evidence` |
 | Vercel AI SDK | `does not qualify as independent runtime` (path A); provider-wrapper path (B) is `insufficient evidence` and not a selection path |
+| OpenAI TypeScript SDK direct | `insufficient evidence` |
 
 The selection issue
 [`#1295`](https://github.com/Rul1an/assay/issues/1295) remains open until a

--- a/docs/reference/runner/second-runtime-candidate-selection.md
+++ b/docs/reference/runner/second-runtime-candidate-selection.md
@@ -363,13 +363,13 @@ OpenAI Python SDK direct evaluations above.
 **Stable identity detail (row 2):**
 
 The candidate identity field is the `id` field on `ChatCompletionMessageFunctionToolCall`
-in the [openai-node TypeScript SDK](https://github.com/openai/openai-node/blob/master/src/resources/chat/completions/completions.ts).
+in the [openai-node TypeScript SDK](https://github.com/openai/openai-node/blob/200211197931763ed43b7ff41839b53e4dbfdf6e/src/resources/chat/completions/completions.ts).
 The interface is declared with the interface-level JSDoc *"A call to a function tool created by the model."*
 
 - Field name: `ChatCompletionMessageFunctionToolCall.id`
 - Source: `tool_calls` array on the assistant message of a Chat Completions API response, accessed via the TypeScript SDK type
 - **runtime-generated evidence:** `insufficient evidence`. The TypeScript JSDoc for the field reads literally *"The ID of the tool call."* — identical wording to the Python SDK docstring. The enclosing interface comment *"A call to a function tool created by the model."* is suggestive of model-side creation, but it documents the object as a whole rather than the `id` field specifically. The example value's `call_` prefix matches OpenAI's other server-issued identifier conventions, and the SDK has no documented client-side generation path. However, no public docs sentence or typed SDK annotation explicitly states that the OpenAI API server generates the `id` field. Per the level-3 strict reading codified in the [Stable Identity Checklist](#stable-identity--level-3-checklist), implicit chain-of-reasoning evidence does not satisfy `runtime-generated`.
-- **binding-intended evidence:** `qualifies`. The TypeScript JSDoc for [`ChatCompletionToolMessageParam.tool_call_id`](https://github.com/openai/openai-node/blob/master/src/resources/chat/completions/completions.ts) reads literally *"Tool call that this message is responding to."* — identical wording to the Python SDK. The official Function Calling guide demonstrates the binding mechanism in code using the SDK type.
+- **binding-intended evidence:** `qualifies`. The TypeScript JSDoc for [`ChatCompletionToolMessageParam.tool_call_id`](https://github.com/openai/openai-node/blob/200211197931763ed43b7ff41839b53e4dbfdf6e/src/resources/chat/completions/completions.ts) reads literally *"Tool call that this message is responding to."* — identical wording to the Python SDK. The official Function Calling guide demonstrates the binding mechanism in code using the SDK type.
 - **run-window unique evidence:** `insufficient evidence`. The TypeScript JSDoc for the `id` field reads only *"The ID of the tool call."* — no "unique" claim, identical to the Python SDK gap. The official Function Calling guide does not provide an explicit uniqueness guarantee for parallel tool calls within a single response. Per the level-3 strict reading, an implicit uniqueness expectation does not satisfy `run-window unique`.
 
 **Expected delegated gate for first fixture PR (only filled if overall outcome is `qualifies`):**


### PR DESCRIPTION
## Summary

Fifth concrete candidate evaluation under the skeleton landed in #1297. Evaluates **OpenAI TypeScript SDK direct** against the seven Candidate Requirements.

**Overall outcome: `insufficient evidence`.** Identical two-gap profile to OpenAI Python SDK direct (#1301).

## Central finding — identical JSDocs as Python SDK

OpenAI's TypeScript SDK uses identical field-level documentation as the Python SDK for the tool-call binding fields:

```typescript
/**
 * A call to a function tool created by the model.
 */
export interface ChatCompletionMessageFunctionToolCall {
  /**
   * The ID of the tool call.
   */
  id: string;
  // ...
}
```

```typescript
/**
 * Tool call that this message is responding to.
 */
tool_call_id: string;
```

## Row 2 sub-condition comparison (Python vs TypeScript)

| Sub-condition | Python SDK | TypeScript SDK | Outcome |
|---|---|---|---|
| `runtime-generated` | "The ID of the tool call." | "The ID of the tool call." (within "A call to a function tool created by the model." interface comment) | both `insufficient evidence` |
| `binding-intended` | "Tool call that this message is responding to." | "Tool call that this message is responding to." | both `qualifies` |
| `run-window unique` | no "unique" word | no "unique" word | both `insufficient evidence` |

The interface-level JSDoc *"A call to a function tool created by the model"* is **slightly more explicit** than the Python equivalent, but it describes the object as a whole rather than the `id` field specifically. For strict level-3 reading, this remains `insufficient evidence`.

## Scoped observation in Notes section

Added carefully:

> *Two OpenAI direct-SDK evaluations now show the same level-3 identity profile: Python (#1301) and TypeScript (this PR) both document binding intent, but neither provides explicit public evidence for `runtime-generated` or `run-window unique`. This observation is scoped to OpenAI direct SDKs and the public documentation reviewed here; it does not claim anything about other providers.*

Important constraints on this note:
- Scoped to **OpenAI direct SDKs** — explicitly does not claim anything about other providers
- Scoped to **public documentation reviewed here** — not a claim about provider behavior in general
- No mention of OpenAPI source-of-truth (plausible inference, not directly demonstrable from repo metadata)
- No Selection Outcome roadmap claim (e.g. "do not evaluate other OpenAI SDKs"); that is a separate research-economy decision

## What this PR explicitly does not do

- propose OpenAI TypeScript SDK direct as the selected second runtime
- claim OpenAI's documentation gap originates at the OpenAPI source-of-truth level (plausible but not directly demonstrated)
- claim other providers have similar gaps (only two OpenAI SDKs evaluated)
- propose fixture code, dependencies, or a cassette implementation
- modify the Evaluation Discipline, Outcome Vocabulary, Stable Identity checklist, or Candidate Evaluation Form sections
- reinterpret implicit evidence as `qualifies`
- propose roadmap decisions about which candidates to evaluate next

Per the "How To Add A Candidate" procedure, only `## Candidates` and `## Selection Outcome` are modified.

## Selection Outcome status after merge

| Candidate | Overall outcome |
|---|---|
| Anthropic SDK direct | `insufficient evidence` |
| PydanticAI | `does not qualify` |
| OpenAI Python SDK direct | `insufficient evidence` |
| Vercel AI SDK | `does not qualify as independent runtime` (path A); provider-wrapper path (B) is `insufficient evidence` and not a selection path |
| OpenAI TypeScript SDK direct | `insufficient evidence` |

No candidate currently qualifies. Selection issue #1295 remains open.

## Validation

- `git diff --check`
- `python3 scripts/ci/assay_runner_lane_check.py --self-test`
- `/tmp/assay-docs-venv/bin/mkdocs build --strict` (exit 0, no warnings/errors)
- commit hooks: merge conflicts, EOF, whitespace, token hygiene, typos, cargo fmt
- pre-push hooks: cargo clippy + linux compile gate

## Notes

Docs-only Phase 2B candidate evaluation slice. It does not change runner behavior, fixture behavior, workflow triggers, delegated acceptance semantics, or branch protection. The lane-check classifier correctly treats this PR as no-delegated-proof-required.

## Test plan

- [x] mkdocs build --strict
- [x] lane-check self-test
- [x] git diff --check
- [x] pre-commit hooks
- [x] pre-push hooks (clippy + linux compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)