### PR TITLE
docs: freeze cross-runtime diff v0 semantics (A1+B3+C1)

### DIFF
--- a/docs/reference/runner/capability-diff-v0.md
+++ b/docs/reference/runner/capability-diff-v0.md
@@ -275,7 +275,9 @@ v0 does not include:
   separate Phase 2C+ slice
 - per-binding path/process/endpoint attribution
 - call-id-less order fallback
-- second runtime support
+- second runtime support; cross-runtime semantics are contracted
+  separately in
+  [`cross-runtime-diff-v0.md`](cross-runtime-diff-v0.md)
 - macOS runner support
 - raw telemetry diffing
 - proof-pack ingestion as a required input

--- a/docs/reference/runner/cross-runtime-diff-decisions.md
+++ b/docs/reference/runner/cross-runtime-diff-decisions.md
@@ -131,22 +131,36 @@ This decision note does not:
 
 ## What This Unlocks
 
-The next discoverable step is the Phase 2C contract slice PR
-(step 4 in `cross-runtime-diff-plan.md` § Suggested Slice Sequence).
-That PR may proceed under this decision combination. It must:
+> **Contract slice landed.** The decision combination resolved here was
+> frozen as the v0 contract in
+> [`cross-runtime-diff-v0.md`](cross-runtime-diff-v0.md), with golden
+> shape at
+> [`golden/cross-runtime-diff-s5-gemini-v0.json`](golden/cross-runtime-diff-s5-gemini-v0.json).
+> The next discoverable step is the cross-runtime projector
+> implementation slice (described below as the "later implementation
+> slice").
 
-- freeze `cross-runtime-diff-v0` either as a new section in
-  `capability-diff-v0.md` or as a sibling document, whichever the
-  contract author judges cleaner
-- include a golden shape for the cross-runtime `S5 ↔ Gemini` case
-- implement A1 path canonicalization as a syntactic prefix rule with
-  no per-runtime knowledge
-- treat binding ids per B3 — out of cross-runtime comparison entirely
-- treat SDK metadata per C1 — side-band, not added/removed/unchanged
-- preserve all `capability-diff-v0` preconditions (clean health,
-  within-runtime stable binding identity, idempotent `diff(X, X)`)
-- not introduce a new fixture, new delegated gate, or new lane-check
-  rule
+The contract slice PR landed under this decision combination. It:
+
+- froze `cross-runtime-diff-v0` as a sibling document next to
+  `capability-diff-v0.md`
+- includes a golden shape for the cross-runtime `S5 ↔ Gemini` case
+- defines A1 path canonicalization as a declared syntactic prefix rule
+  with no per-runtime knowledge
+- treats binding ids per B3 — out of cross-runtime comparison entirely
+- treats SDK metadata per C1 — side-band, not added/removed/unchanged
+- preserves all `capability-diff-v0` preconditions on each side (clean
+  health, within-runtime stable binding identity)
+- did not introduce a new fixture, new delegated gate, or new
+  lane-check rule
+
+### Later implementation slice
+
+A future projector implementation PR may extend or wrap
+`scripts/ci/assay_runner_capability_diff_validate.py` (or introduce a
+separate cross-runtime projector) to produce and validate the golden
+shape from the S5 and Gemini accepted fixture evidence sets. That PR
+remains separate; it is **not** part of the contract slice.
 
 ## What Remains Forbidden In The Contract Slice PR
 

--- a/docs/reference/runner/cross-runtime-diff-plan.md
+++ b/docs/reference/runner/cross-runtime-diff-plan.md
@@ -4,11 +4,14 @@
 > small. It does not freeze a schema, propose code, propose a CI lane change,
 > or pre-approve a Phase 2C implementation PR.
 >
-> **Decision resolved.** The central open question recorded below has been
-> answered in [`cross-runtime-diff-decisions.md`](cross-runtime-diff-decisions.md)
-> with combination **A1 + B3 + C1**. The Phase 2C contract slice PR may now
-> proceed under that combination; this mini-plan remains the scope and
-> non-goal record.
+> **Decision resolved and contract frozen.** The central open question
+> recorded below has been answered in
+> [`cross-runtime-diff-decisions.md`](cross-runtime-diff-decisions.md)
+> with combination **A1 + B3 + C1**, and the Phase 2C contract slice is
+> frozen in [`cross-runtime-diff-v0.md`](cross-runtime-diff-v0.md) with a
+> golden shape at
+> [`golden/cross-runtime-diff-s5-gemini-v0.json`](golden/cross-runtime-diff-s5-gemini-v0.json).
+> This mini-plan remains the scope and non-goal record.
 
 Phase 2B closed with two qualifying runtime fixtures landed under delegated
 `gates=all`:
@@ -283,6 +286,8 @@ them:
 ## References
 
 - [Cross-runtime diff Phase 2C decisions (A1+B3+C1)](cross-runtime-diff-decisions.md)
+- [Cross-runtime diff v0 contract](cross-runtime-diff-v0.md)
+- [Cross-runtime diff v0 golden shape (S5 ↔ Gemini)](golden/cross-runtime-diff-s5-gemini-v0.json)
 - [Runner capability-diff Phase 2B plan](capability-diff-plan.md)
 - [Runner capability-diff v0 contract](capability-diff-v0.md)
 - [Runner second runtime Phase 2B plan](second-runtime-plan.md)

--- a/docs/reference/runner/cross-runtime-diff-v0.md
+++ b/docs/reference/runner/cross-runtime-diff-v0.md
@@ -45,9 +45,15 @@ The kernzin:
 ## Inputs
 
 A v0 cross-runtime diff compares two evidence sets, named `base` and
-`head`, **each recorded from a different runtime fixture**. Each set
-must provide the same normalized artifacts required by
-[`capability-diff-v0`](capability-diff-v0.md):
+`head`, **each recorded from a different runtime fixture**. Each side
+provides two kinds of input plus one declared projector configuration
+value.
+
+### Primary capability-surface inputs
+
+Each side must provide the same normalized artifacts required by
+[`capability-diff-v0`](capability-diff-v0.md). These artifacts are the
+exclusive source for `surface.*` set comparisons:
 
 | Artifact | Role |
 |---|---|
@@ -55,15 +61,44 @@ must provide the same normalized artifacts required by
 | `capability-surface.json` | Provides the observed capability sets to compare across runtimes |
 | `correlation-report.json` | Provides stable within-runtime binding identity through `tool_call_id` |
 
-Raw kernel telemetry, workflow logs, proof-pack metadata, and normalized
-layer streams are diagnostic context only. They are not primary v0
+### Required side-band provenance input
+
+`sdk_metadata` is reported as side-band runtime provenance per C1, so
+v0 cross-runtime diff extends the input set with one required side-band
+provenance artifact per side:
+
+| Artifact | Role |
+|---|---|
+| `layers/sdk.ndjson` | Source of `sdk_name` and `sdk_version` for the [side-band `sdk_metadata` block](#sdk-metadata-side-band-provenance) |
+
+`layers/sdk.ndjson` is **not** a capability-surface input. The
+projector MUST consult it exclusively to populate the side-band
+`sdk_metadata` block. Set comparisons in `surface.*` MUST NOT consume
+`layers/*` streams. This preserves the
+[`capability-diff-v0` boundary](capability-diff-v0.md#inputs) that
+layer streams are diagnostic for capability projection, while making
+the SDK-metadata sourcing for cross-runtime explicit and reproducible.
+
+### Declared per-side projector configuration
+
+Per A1, exactly one canonicalization rule applies to `filesystem_paths`:
+the work-dir prefix is replaced with `<work>/`. The prefix MUST be
+declared per side; the projector MUST NOT infer it from input path
+values, mktemp templates, or runtime-name heuristics. See
+[Per-Side Prefix Declaration](#per-side-prefix-declaration).
+
+### Excluded inputs
+
+Raw kernel telemetry, workflow logs, proof-pack metadata, and
+`layers/policy.ndjson` are diagnostic context only. They are not v0
 cross-runtime diff inputs.
 
-The v0 cross-runtime diff is a pure projection over normalized evidence.
-Workflow run URLs, commit SHAs, generation timestamps, and cassette
-provenance are intentionally not part of this schema. Consumers that
-need forensic anchoring should pair the diff with proof-pack manifests
-from both sides.
+The v0 cross-runtime diff is a pure projection over normalized evidence
+plus one declared per-side configuration value. Workflow run URLs,
+commit SHAs, generation timestamps, and cassette provenance are
+intentionally not part of this schema. Consumers that need forensic
+anchoring should pair the diff with proof-pack manifests from both
+sides.
 
 ## Contract Principles
 
@@ -108,9 +143,9 @@ Fields:
 | `scope` | object | yes | Declares what evidence domain this diff used; includes the `cross_runtime` flag |
 | `canonicalization` | object | yes | Declares which canonicalization rule was applied per surface category |
 | `surface` | object | yes | Added, removed, and unchanged capability-surface values by category, after canonicalization |
-| `binding_ids` | object | yes | Out-of-scope marker; see [Binding Ids — Out Of Scope](#binding-ids--out-of-scope) |
-| `policy_outcomes` | object | yes | Out-of-scope marker; see [Policy Outcomes — Out Of Scope](#policy-outcomes--out-of-scope) |
-| `sdk_metadata` | object | yes | Side-band runtime provenance; see [SDK Metadata — Side-Band Provenance](#sdk-metadata--side-band-provenance) |
+| `binding_ids` | object | yes | Out-of-scope marker; see [Binding Ids — Out Of Scope](#binding-ids-out-of-scope) |
+| `policy_outcomes` | object | yes | Out-of-scope marker; see [Policy Outcomes — Out Of Scope](#policy-outcomes-out-of-scope) |
+| `sdk_metadata` | object | yes | Side-band runtime provenance; see [SDK Metadata — Side-Band Provenance](#sdk-metadata-side-band-provenance) |
 | `unbound` | object | yes | Evidence buckets that could not be safely compared in v0 |
 | `non_claims` | array[string] | yes | Stable code-prefixed non-claim assertions; see [Non-Claims](#non-claims) |
 | `ambiguities` | array[string] | yes | Stable code-prefixed ambiguity strings |
@@ -189,7 +224,7 @@ rule:
 
 | Rule | Applies to | Operational definition |
 |---|---|---|
-| `work_dir_prefix_only` | `filesystem_paths` | Match any path beginning with an acceptance-script work-directory prefix and replace that prefix with the canonical placeholder `<work>/`. The prefix set is the set of `mktemp -d` templates declared by the v0-accepted acceptance scripts; see [Configured Prefixes](#configured-prefixes) |
+| `work_dir_prefix_only` | `filesystem_paths` | For each side independently, strip the side's declared work-dir prefix from any path that begins with that prefix and replace it with the canonical placeholder `<work>/`. The prefix is a per-side declared input; see [Per-Side Prefix Declaration](#per-side-prefix-declaration) |
 
 For every category v0 declares a canonicalization key:
 
@@ -206,21 +241,48 @@ without updating this contract. Implementations MUST NOT apply a rule
 implicitly: the `canonicalization` block declares what was applied; the
 projector emits exactly that.
 
-### Configured Prefixes
+### Per-Side Prefix Declaration
 
-The work-dir prefix set is declared, not inferred. v0 accepts these
-acceptance-script prefixes:
+The work-dir prefix used to canonicalize `filesystem_paths` is **not**
+a global, contract-frozen set of strings. The acceptance and
+three-run-determinism wrappers create work directories with
+`mktemp -d` (including randomized suffixes and platform-dependent
+`TMPDIR` resolution), and may be further overridden by
+`ASSAY_RUNNER_ACCEPTANCE_WORK_DIR`. A static prefix list cannot match
+real run paths and would silently fail to canonicalize.
 
-- `/tmp/assay-runner-openai-agents-kernel-policy/work/`
-- `/tmp/assay-runner-gemini-google-genai-kernel-policy/work/`
+Instead, the projector accepts the prefix as a declared, required,
+per-side configuration value:
 
-Adding a new prefix requires updating this contract together with the
-acceptance script that produces it. The projector MUST NOT discover
-prefixes heuristically from input values.
+| Configuration value | Required | Shape |
+|---|---:|---|
+| `base_work_dir_prefix` | yes | Absolute filesystem path, non-empty, ending with `/`. The exact prefix used by the base side's wrapper for `WORK_DIR` |
+| `head_work_dir_prefix` | yes | Absolute filesystem path, non-empty, ending with `/`. The exact prefix used by the head side's wrapper for `WORK_DIR` |
 
-A path that matches none of the configured prefixes is emitted
-unchanged. A non-matching path is not an error; it simply means the
-canonicalization rule did not apply.
+Operational rules:
+
+- The two prefixes MUST be declared by the side that produced the
+  evidence (e.g. wrapper-emitted manifest, environment variable, or
+  CLI flag). The projector MUST NOT infer them from input path values,
+  mktemp templates, or runtime-name heuristics.
+- The projector MUST treat the prefixes as opaque syntactic strings.
+  It MUST NOT decode them for runtime intent, fixture name, or
+  determinism-vs-acceptance variant.
+- Absent, empty, or non-absolute prefix on either side → `status=failed`.
+- A path that does not begin with its side's declared prefix is emitted
+  unchanged. Non-matching paths are not an error; they simply mean the
+  side's evidence contains paths outside the work directory (these
+  remain rare under the existing telemetry-versus-evidence filter, but
+  are not forbidden by v0).
+- The wiring mechanism (manifest file, env var, CLI flag, or future
+  declared-input artifact) is implementation detail and out of scope
+  for this contract. v0 freezes the *shape and discipline* of the
+  declaration, not the transport.
+- Prefix values MUST NOT appear in the output. The `canonicalization`
+  block records only the *rule* that was applied per category. This
+  keeps the golden shape stable across runs whose mktemp suffixes
+  differ. Forensic reproduction of the prefix value, if needed, lives
+  in the proof-pack manifest, not the diff output.
 
 ## Surface Diff
 
@@ -294,14 +356,25 @@ capability-surface added/removed/unchanged.
 }
 ```
 
-`sdk_name` and `sdk_version` are sourced from each side's normalized
-SDK layer or fixture metadata in the same way as the runner's existing
-fixture acceptance. They are visible for diagnostics; they MUST NOT
-participate in any `surface.added`/`removed`/`unchanged` projection.
+`sdk_name` and `sdk_version` are sourced exclusively from each side's
+`layers/sdk.ndjson` file, declared as a [required side-band provenance
+input](#required-side-band-provenance-input) above. They are read from
+SDK events whose schema is `assay.runner.sdk_event.v0`. When the layer
+stream contains multiple events with consistent `sdk_name` and
+`sdk_version` values (the v0 expected case for the accepted fixtures),
+the projector emits those values; when the layer stream contains
+inconsistent values within a single side, the projector MUST emit
+`status=failed` rather than picking one silently.
+
+These values are visible for diagnostics; they MUST NOT participate in
+any `surface.added`/`removed`/`unchanged` projection.
 
 Adding further `sdk_metadata` fields (e.g. SDK feature flags) requires
 a separate contract update. v0 accepts exactly `sdk_name` and
-`sdk_version` under `base` and `head`.
+`sdk_version` under `base` and `head`. Sourcing `sdk_metadata` from
+anywhere other than `layers/sdk.ndjson` (for example from fixture
+filenames, environment variables, or proof-pack metadata) is
+explicitly forbidden in v0.
 
 ## Unbound Evidence
 
@@ -345,7 +418,7 @@ contract conformance check.
 | `partial:health` | At least one evidence set can be parsed but has incomplete health (e.g. ring-buffer drops, incomplete cgroup correlation) |
 | `partial:correlation` | Health is sufficient to parse, but at least one within-runtime correlation report is partial, ambiguous, or lacks stable binding identity |
 | `partial:unbound` | Reserved for a future per-binding capability artifact; v0 producers MUST NOT emit this status from run-global capability-surface values |
-| `failed` | Required artifacts are missing, schema strings are unsupported, run ids are internally inconsistent, deterministic parsing fails, `base_runtime == head_runtime`, or `base_runtime`/`head_runtime` is not in the [runtime identifier table](#runtime-identifiers) |
+| `failed` | Required artifacts are missing (including `layers/sdk.ndjson` on either side), schema strings are unsupported, run ids are internally inconsistent, deterministic parsing fails, `base_runtime == head_runtime`, `base_runtime`/`head_runtime` is not in the [runtime identifier table](#runtime-identifiers), `base_work_dir_prefix` or `head_work_dir_prefix` is absent, empty, or not an absolute path ending with `/`, or `layers/sdk.ndjson` on a single side contains inconsistent `sdk_name`/`sdk_version` values |
 
 `partial:*` diffs may be useful for triage, but they are not clean
 evidence for any further claim. `ringbuf_drops > 0` always prevents
@@ -360,11 +433,12 @@ meaning-preserving:
   MUST produce the same output as applying them once. Formally, for the
   projector `P`: `P(P(x)) == P(x)` for any valid input `x`.
 - **Meaning-preserving.** The rules MUST only remove explicitly
-  declared fixture plumbing as listed in
-  [Configured Prefixes](#configured-prefixes). They MUST NOT infer
-  semantic equivalence, synthesize binding identity, rewrite tool
-  names, rewrite policy decision summaries, or alter capability values
-  beyond the A1 prefix rule.
+  declared fixture plumbing as defined by the per-side prefix
+  declaration in
+  [Per-Side Prefix Declaration](#per-side-prefix-declaration). They
+  MUST NOT infer semantic equivalence, synthesize binding identity,
+  rewrite tool names, rewrite policy decision summaries, or alter
+  capability values beyond the A1 prefix rule.
 
 Intra-runtime idempotence (`diff(X, X)` where both sides come from the
 same runtime fixture) is **not** an acceptance check for this contract.

--- a/docs/reference/runner/cross-runtime-diff-v0.md
+++ b/docs/reference/runner/cross-runtime-diff-v0.md
@@ -1,0 +1,462 @@
+# Assay-Runner Cross-Runtime Diff v0 Contract
+
+> Internal Phase 2C contract slice. This page defines the first
+> Assay-Runner cross-runtime capability-diff projection over normalized
+> runner evidence sets recorded from *different* runtime fixtures. It is
+> not a runner-emitted archive artifact, not a CLI surface, and not a
+> product release contract.
+
+The v0 cross-runtime diff answers one narrow question:
+
+```text
+Given two clean normalized runner evidence sets recorded from different
+runtimes, what observed capability surface differs after explicit
+fixture plumbing normalization?
+```
+
+The diff is descriptive. It reports added, removed, and unchanged
+normalized capability values across runtimes, after exactly one
+declared canonicalization rule has stripped run/work-dir prefixes. It
+must not decide whether a difference is acceptable, must not infer
+semantic equivalence beyond the declared rule, and must not synthesize
+cross-runtime binding identity. Acceptability remains policy, reviewer,
+or Harness responsibility.
+
+## Decision Lineage
+
+This contract freezes the combination resolved by the Phase 2C decision
+gate at <https://github.com/Rul1an/assay/issues/1310> and recorded in
+[`cross-runtime-diff-decisions.md`](cross-runtime-diff-decisions.md):
+
+| Dimension | Choice | Meaning |
+|---|---|---|
+| Paths | **A1** | Work-dir prefix canonicalization only (replace with `<work>/`); fixture-local filenames remain observed surface values |
+| Binding ids | **B3** | Binding ids are out of scope for cross-runtime comparability in v0; required only for within-runtime correlation |
+| SDK metadata | **C1** | SDK metadata reported as side-band runtime provenance, not capability-surface |
+
+The kernzin:
+
+> v0 cross-runtime diff removes obvious fixture plumbing, preserves
+> observed capability-surface differences, and avoids derived
+> cross-runtime identity semantics. Binding ids remain required for
+> within-runtime correlation, but are not themselves cross-runtime
+> comparable in v0.
+
+## Inputs
+
+A v0 cross-runtime diff compares two evidence sets, named `base` and
+`head`, **each recorded from a different runtime fixture**. Each set
+must provide the same normalized artifacts required by
+[`capability-diff-v0`](capability-diff-v0.md):
+
+| Artifact | Role |
+|---|---|
+| `observation-health.json` | Determines whether the evidence set is clean enough for a clean cross-runtime diff |
+| `capability-surface.json` | Provides the observed capability sets to compare across runtimes |
+| `correlation-report.json` | Provides stable within-runtime binding identity through `tool_call_id` |
+
+Raw kernel telemetry, workflow logs, proof-pack metadata, and normalized
+layer streams are diagnostic context only. They are not primary v0
+cross-runtime diff inputs.
+
+The v0 cross-runtime diff is a pure projection over normalized evidence.
+Workflow run URLs, commit SHAs, generation timestamps, and cassette
+provenance are intentionally not part of this schema. Consumers that
+need forensic anchoring should pair the diff with proof-pack manifests
+from both sides.
+
+## Contract Principles
+
+This contract inherits all six `capability-diff-v0`
+[contract principles](capability-diff-v0.md#contract-principles), and
+adds three cross-runtime-specific principles:
+
+7. **Idempotent and meaning-preserving canonicalization.**
+   Cross-runtime canonicalization MUST be idempotent and
+   meaning-preserving: applying it more than once produces the same
+   output as applying it once, and it may remove only explicitly
+   declared fixture plumbing. It MUST NOT infer semantic equivalence,
+   synthesize binding identity, rewrite tool names, or rewrite policy
+   decision summaries.
+8. **Within-runtime identity remains required; cross-runtime identity
+   is intentionally not modeled.** Each side must independently meet
+   the `capability-diff-v0` within-runtime binding-identity rule.
+   Cross-runtime binding-id comparability is explicitly out of scope.
+9. **No adapter knowledge in the projector.** The canonicalization rule
+   set MUST be syntactic and runtime-agnostic. The projector MUST NOT
+   carry per-runtime case logic.
+
+## Schema
+
+Schema string:
+
+```text
+assay.runner.cross_runtime_diff.v0
+```
+
+Fields:
+
+| Field | Type | Required | Semantics |
+|---|---|---:|---|
+| `schema` | string | yes | Must equal `assay.runner.cross_runtime_diff.v0` |
+| `base_run_id` | string | yes | `run_id` from the base evidence set |
+| `head_run_id` | string | yes | `run_id` from the head evidence set |
+| `base_runtime` | string | yes | Runtime identifier for the base side; v0 accepts only the values in the [runtime identifier table](#runtime-identifiers) |
+| `head_runtime` | string | yes | Runtime identifier for the head side; v0 accepts only the values in the [runtime identifier table](#runtime-identifiers) and MUST differ from `base_runtime` |
+| `status` | enum | yes | `clean`, `partial:health`, `partial:correlation`, `partial:unbound`, or `failed` |
+| `preconditions` | object | yes | Machine-readable checks that determine whether the diff can be clean |
+| `scope` | object | yes | Declares what evidence domain this diff used; includes the `cross_runtime` flag |
+| `canonicalization` | object | yes | Declares which canonicalization rule was applied per surface category |
+| `surface` | object | yes | Added, removed, and unchanged capability-surface values by category, after canonicalization |
+| `binding_ids` | object | yes | Out-of-scope marker; see [Binding Ids — Out Of Scope](#binding-ids--out-of-scope) |
+| `policy_outcomes` | object | yes | Out-of-scope marker; see [Policy Outcomes — Out Of Scope](#policy-outcomes--out-of-scope) |
+| `sdk_metadata` | object | yes | Side-band runtime provenance; see [SDK Metadata — Side-Band Provenance](#sdk-metadata--side-band-provenance) |
+| `unbound` | object | yes | Evidence buckets that could not be safely compared in v0 |
+| `non_claims` | array[string] | yes | Stable code-prefixed non-claim assertions; see [Non-Claims](#non-claims) |
+| `ambiguities` | array[string] | yes | Stable code-prefixed ambiguity strings |
+| `notes` | array[string] | yes | Stable code-prefixed human-readable notes |
+
+All arrays MUST serialize in stable lexicographic order. All object keys
+follow the order shown in this table for byte-determinism.
+
+## Runtime Identifiers
+
+`base_runtime` and `head_runtime` accept only the following values in
+v0:
+
+| Value | Maps to fixture |
+|---|---|
+| `s5_openai_agents` | S5 OpenAI Agents (`@openai/agents`) fixture |
+| `gemini_google_genai` | Gemini Python `google-genai` direct fixture |
+
+Adding a third runtime identifier requires a separate Phase 2C+
+contract slice and re-opening
+[`second-runtime-candidate-selection.md`](second-runtime-candidate-selection.md).
+v0 implementations MUST reject any other value with `status=failed`.
+
+`base_runtime == head_runtime` MUST yield `status=failed`. Same-runtime
+diffs are covered by [`capability-diff-v0`](capability-diff-v0.md); the
+cross-runtime contract does not duplicate intra-runtime semantics.
+
+## Preconditions
+
+`preconditions` records why a diff is or is not clean. v0 cross-runtime
+preconditions extend the `capability-diff-v0` preconditions with one
+cross-runtime-specific check:
+
+| Field | Type | Required | Clean value |
+|---|---|---:|---|
+| `base_health_clean` | boolean | yes | `true` |
+| `head_health_clean` | boolean | yes | `true` |
+| `base_correlation_clean` | boolean | yes | `true` |
+| `head_correlation_clean` | boolean | yes | `true` |
+| `stable_tool_call_ids_required` | boolean | yes | `true` (within each side) |
+| `stable_tool_call_ids_present` | boolean | yes | `true` (within each side) |
+| `runtimes_distinct` | boolean | yes | `true` |
+
+A health set is clean only when:
+
+- `kernel_layer=complete`
+- `ringbuf_drops=0`
+- `policy_layer=present`
+- `sdk_layer=self_reported`
+- `cgroup_correlation=clean`
+
+`stable_tool_call_ids_*` apply *within each side*, not across them.
+Per B3, cross-runtime binding-id stability is not modeled.
+
+## Scope
+
+`scope` separates preconditions from projection scope.
+
+| Field | Type | Required | v0 value |
+|---|---|---:|---|
+| `projection` | string | yes | `surface_set` |
+| `uses_raw_telemetry` | boolean | yes | `false` |
+| `uses_proof_pack` | boolean | yes | `false` |
+| `per_binding_capability_values` | boolean | yes | `false` |
+| `cross_runtime` | boolean | yes | `true` |
+
+`cross_runtime=true` is load-bearing. A `false` value here means the
+diff is intra-runtime and the consumer must use
+`capability-diff-v0` instead.
+
+## Canonicalization
+
+The `canonicalization` object declares which canonicalization rule was
+applied to each `capability-surface` category. v0 defines exactly one
+rule:
+
+| Rule | Applies to | Operational definition |
+|---|---|---|
+| `work_dir_prefix_only` | `filesystem_paths` | Match any path beginning with an acceptance-script work-directory prefix and replace that prefix with the canonical placeholder `<work>/`. The prefix set is the set of `mktemp -d` templates declared by the v0-accepted acceptance scripts; see [Configured Prefixes](#configured-prefixes) |
+
+For every category v0 declares a canonicalization key:
+
+| Field | Type | Required | v0 value |
+|---|---|---:|---|
+| `filesystem_paths` | string | yes | `work_dir_prefix_only` |
+| `network_endpoints` | string | yes | `none` |
+| `process_execs` | string | yes | `none` |
+| `mcp_tools` | string | yes | `none` |
+| `policy_decisions` | string | yes | `none` |
+
+Implementations MUST NOT introduce a new canonicalization rule string
+without updating this contract. Implementations MUST NOT apply a rule
+implicitly: the `canonicalization` block declares what was applied; the
+projector emits exactly that.
+
+### Configured Prefixes
+
+The work-dir prefix set is declared, not inferred. v0 accepts these
+acceptance-script prefixes:
+
+- `/tmp/assay-runner-openai-agents-kernel-policy/work/`
+- `/tmp/assay-runner-gemini-google-genai-kernel-policy/work/`
+
+Adding a new prefix requires updating this contract together with the
+acceptance script that produces it. The projector MUST NOT discover
+prefixes heuristically from input values.
+
+A path that matches none of the configured prefixes is emitted
+unchanged. A non-matching path is not an error; it simply means the
+canonicalization rule did not apply.
+
+## Surface Diff
+
+`surface` contains one object per `capability-surface.v0` category:
+
+- `filesystem_paths`
+- `network_endpoints`
+- `process_execs`
+- `mcp_tools`
+- `policy_decisions`
+
+Each category object has the same fields as
+[`capability-diff-v0`](capability-diff-v0.md#surface-diff):
+
+| Field | Type | Required | Semantics |
+|---|---|---:|---|
+| `added` | array[string] | yes | Values present in head (after canonicalization) and absent from base |
+| `removed` | array[string] | yes | Values present in base (after canonicalization) and absent from head |
+| `unchanged` | array[string] | yes | Values present in both base and head (after canonicalization) |
+
+All arrays serialize in stable lexicographic order. The presence of a
+fixture-local filename in `unchanged` is a syntactic equality after the
+declared canonicalization rule. It is **not** a semantic-equivalence
+claim across runtimes; see [Non-Claims](#non-claims).
+
+## Binding Ids — Out Of Scope
+
+Per B3, binding-id comparability is not modeled in v0 cross-runtime
+diffs. The `binding_ids` field retains its schema slot for envelope
+parity with `capability-diff-v0`, but its only valid v0 shape is:
+
+```json
+"binding_ids": {
+  "comparison": "out_of_scope_cross_runtime_v0"
+}
+```
+
+v0 implementations MUST NOT emit `added`, `removed`, `changed`, or
+`unchanged` keys inside `binding_ids` in a cross-runtime diff.
+Within-runtime binding-id stability is still required as a precondition
+on each side; it just does not produce a cross-runtime comparison.
+
+## Policy Outcomes — Out Of Scope
+
+`capability-diff-v0` reports `policy_outcomes.changed` per stable
+binding id. Per B3, stable binding ids are not comparable across
+runtimes, so v0 also marks `policy_outcomes` out of scope. The only
+valid v0 shape is:
+
+```json
+"policy_outcomes": {
+  "comparison": "out_of_scope_cross_runtime_v0"
+}
+```
+
+Set-level policy comparison remains available through
+`surface.policy_decisions`, which compares decision-summary strings
+(e.g. `allow:read_file`) as a set. Per-binding attribution is the part
+that v0 does not model cross-runtime.
+
+## SDK Metadata — Side-Band Provenance
+
+Per C1, SDK metadata is reported as runtime provenance, not as
+capability-surface added/removed/unchanged.
+
+```json
+"sdk_metadata": {
+  "comparison": "side_band_provenance",
+  "base": {"sdk_name": "@openai/agents", "sdk_version": "0.11.4"},
+  "head": {"sdk_name": "google-genai", "sdk_version": "2.6.0"}
+}
+```
+
+`sdk_name` and `sdk_version` are sourced from each side's normalized
+SDK layer or fixture metadata in the same way as the runner's existing
+fixture acceptance. They are visible for diagnostics; they MUST NOT
+participate in any `surface.added`/`removed`/`unchanged` projection.
+
+Adding further `sdk_metadata` fields (e.g. SDK feature flags) requires
+a separate contract update. v0 accepts exactly `sdk_name` and
+`sdk_version` under `base` and `head`.
+
+## Unbound Evidence
+
+`unbound` uses the same category names as `surface`, each as a stable
+`array[string]`. For a clean v0 cross-runtime diff, every `unbound`
+category MUST be empty.
+
+`partial:unbound` is reserved for a future per-binding capability
+artifact, identical to `capability-diff-v0`. v0 implementations MUST
+keep `unbound` arrays empty; inputs that suggest per-value unbinding
+without an explicit versioned source must produce `status=failed`, not
+an invented `partial:unbound` projection.
+
+## Non-Claims
+
+`non_claims` is a stable array of code-prefixed non-claim assertions.
+Every v0 cross-runtime diff with `status=clean` MUST include all of
+these entries:
+
+| Code | Asserts |
+|---|---|
+| `cross_runtime_no_filename_semantic_equivalence` | An `unchanged` filesystem path after work-dir prefix canonicalization is a syntactic equality, not a semantic equivalence of capability across runtimes |
+| `cross_runtime_no_derived_binding_identity` | The diff does not derive or report a cross-runtime binding identifier; binding ids remain out of scope |
+| `cross_runtime_no_sdk_capability_equivalence` | SDK metadata is provenance, not a capability-equivalence claim |
+| `cross_runtime_no_declared_capability_input` | The diff is over observed capability evidence only; a declared-capability comparison requires a separate contract |
+| `cross_runtime_no_acceptability_judgment` | The diff does not decide whether any difference is acceptable for a project |
+
+`partial:*` and `failed` diffs MUST still include the
+`cross_runtime_no_*` non-claims that apply to the projection that was
+produced.
+
+Implementations MUST NOT introduce new non-claim codes without updating
+this contract. Consumers MAY assert presence of these codes as a
+contract conformance check.
+
+## Status Semantics
+
+| Status | Semantics |
+|---|---|
+| `clean` | All preconditions true (including `runtimes_distinct=true`), all required artifacts validate, within-runtime correlation clean on both sides, declared canonicalization applied per the rules above, `unbound` arrays empty, and `non_claims` complete |
+| `partial:health` | At least one evidence set can be parsed but has incomplete health (e.g. ring-buffer drops, incomplete cgroup correlation) |
+| `partial:correlation` | Health is sufficient to parse, but at least one within-runtime correlation report is partial, ambiguous, or lacks stable binding identity |
+| `partial:unbound` | Reserved for a future per-binding capability artifact; v0 producers MUST NOT emit this status from run-global capability-surface values |
+| `failed` | Required artifacts are missing, schema strings are unsupported, run ids are internally inconsistent, deterministic parsing fails, `base_runtime == head_runtime`, or `base_runtime`/`head_runtime` is not in the [runtime identifier table](#runtime-identifiers) |
+
+`partial:*` diffs may be useful for triage, but they are not clean
+evidence for any further claim. `ringbuf_drops > 0` always prevents
+`status=clean`.
+
+## Idempotence And Meaning-Preservation
+
+Cross-runtime canonicalization MUST be idempotent and
+meaning-preserving:
+
+- **Idempotent.** Applying the declared canonicalization rules twice
+  MUST produce the same output as applying them once. Formally, for the
+  projector `P`: `P(P(x)) == P(x)` for any valid input `x`.
+- **Meaning-preserving.** The rules MUST only remove explicitly
+  declared fixture plumbing as listed in
+  [Configured Prefixes](#configured-prefixes). They MUST NOT infer
+  semantic equivalence, synthesize binding identity, rewrite tool
+  names, rewrite policy decision summaries, or alter capability values
+  beyond the A1 prefix rule.
+
+Intra-runtime idempotence (`diff(X, X)` where both sides come from the
+same runtime fixture) is **not** an acceptance check for this contract.
+It is the acceptance check for
+[`capability-diff-v0`](capability-diff-v0.md#idempotence) and remains
+there. The cross-runtime contract is acceptance-checked by the
+S5 ↔ Gemini golden shape below.
+
+## Golden Shape
+
+The frozen v0 cross-runtime golden shape for the S5 ↔ Gemini case is
+[`golden/cross-runtime-diff-s5-gemini-v0.json`](golden/cross-runtime-diff-s5-gemini-v0.json).
+
+This file is a normative shape example. Each field, key order, and
+non-claim entry follows the contract above. Implementations of a future
+cross-runtime projector MUST be able to produce this exact output (up
+to deterministic serialization) when given the S5 and Gemini accepted
+fixture evidence sets.
+
+The golden does not pre-commit to any future projector implementation:
+this contract slice intentionally lands without a validator, without a
+CLI, and without a workflow change. The next slice may extend
+`scripts/ci/assay_runner_capability_diff_validate.py` to project and
+validate against this golden, or introduce a separate cross-runtime
+projector. That decision is out of scope here.
+
+## Notes Vocabulary
+
+`notes` follows the code-prefixed convention from
+`capability-diff-v0`. v0 reserves the `cross_runtime_diff_` prefix.
+First note codes:
+
+- `cross_runtime_diff_work_dir_prefix_canonicalized` — work-dir prefix
+  canonicalization was applied to `filesystem_paths` per the A1 rule
+- `cross_runtime_diff_binding_ids_out_of_scope` — emitted on every
+  clean diff to reinforce B3 at consumption time
+- `cross_runtime_diff_sdk_metadata_side_band` — emitted on every clean
+  diff to reinforce C1 at consumption time
+
+Implementations MUST NOT introduce new note codes without updating this
+contract.
+
+## Forward Compatibility
+
+This contract freezes A1 + B3 + C1. A future revision may relax B3 only
+if a cross-runtime binding-identity projection is contracted separately
+under its own schema slice and lineage. A future revision may broaden
+A1 only if a filename-layer canonicalization is contracted separately.
+A future revision may extend C1 only if SDK metadata gains
+capability-bearing fields and is contracted separately.
+
+v0 consumers MUST treat any output emitted under a `cross_runtime_diff`
+schema string other than `assay.runner.cross_runtime_diff.v0` as
+unsupported. v0 producers MUST NOT downgrade a `v1+` evidence input
+into a v0 output silently.
+
+## Non-Goals
+
+v0 does not include:
+
+- declared-capability input; declared-capability is a separate Phase 2C+
+  slice
+- per-binding path/process/endpoint attribution across runtimes
+- third-runtime support; third-runtime evaluation reopens
+  [`second-runtime-candidate-selection.md`](second-runtime-candidate-selection.md)
+- derived cross-runtime identity scheme
+- filename-layer canonicalization
+- promotion of SDK metadata into capability-surface comparison
+- call-id-less order fallback
+- macOS or Windows runner support
+- raw telemetry diffing
+- proof-pack ingestion as a required input
+- OTel or GenAI semantic-convention mapping of cross-runtime output
+- acceptability or policy judgment
+- delegated `gates=all` requirement for cross-runtime diff; the diff is
+  a projection over existing evidence, not a runtime gate
+
+## Implementation Placement
+
+The [boundary map](boundary-map.md) places capability-diff projection
+semantics on the Trust Basis / Harness side while Runner delivers clean
+measured-run input bundles. Cross-runtime diff inherits the same
+placement. A future implementation may start as an Assay-side reference
+projector, but it MUST NOT silently move artifact meaning into the
+runner candidate.
+
+## References
+
+- [Runner capability-diff v0 contract](capability-diff-v0.md)
+- [Runner cross-runtime diff Phase 2C mini-plan](cross-runtime-diff-plan.md)
+- [Runner cross-runtime diff Phase 2C decisions (A1+B3+C1)](cross-runtime-diff-decisions.md)
+- [Runner artifact v0 contracts](artifacts-v0.md)
+- [Runner acceptance fixture v0 contract](fixtures-v0.md)
+- [Runner second runtime candidate selection](second-runtime-candidate-selection.md)
+- Decision gate (resolved): <https://github.com/Rul1an/assay/issues/1310>

--- a/docs/reference/runner/golden/cross-runtime-diff-s5-gemini-v0.json
+++ b/docs/reference/runner/golden/cross-runtime-diff-s5-gemini-v0.json
@@ -1,0 +1,105 @@
+{
+  "schema": "assay.runner.cross_runtime_diff.v0",
+  "base_run_id": "run_openai_agents_kernel_policy_determinism",
+  "head_run_id": "run_gemini_google_genai_kernel_policy_determinism",
+  "base_runtime": "s5_openai_agents",
+  "head_runtime": "gemini_google_genai",
+  "status": "clean",
+  "preconditions": {
+    "base_health_clean": true,
+    "head_health_clean": true,
+    "base_correlation_clean": true,
+    "head_correlation_clean": true,
+    "stable_tool_call_ids_required": true,
+    "stable_tool_call_ids_present": true,
+    "runtimes_distinct": true
+  },
+  "scope": {
+    "projection": "surface_set",
+    "uses_raw_telemetry": false,
+    "uses_proof_pack": false,
+    "per_binding_capability_values": false,
+    "cross_runtime": true
+  },
+  "canonicalization": {
+    "filesystem_paths": "work_dir_prefix_only",
+    "network_endpoints": "none",
+    "process_execs": "none",
+    "mcp_tools": "none",
+    "policy_decisions": "none"
+  },
+  "surface": {
+    "filesystem_paths": {
+      "added": [
+        "<work>/gemini-input.txt"
+      ],
+      "removed": [
+        "<work>/openai-agents-input.txt"
+      ],
+      "unchanged": [
+        "<work>/policy-input.txt"
+      ]
+    },
+    "network_endpoints": {
+      "added": [],
+      "removed": [],
+      "unchanged": []
+    },
+    "process_execs": {
+      "added": [],
+      "removed": [],
+      "unchanged": []
+    },
+    "mcp_tools": {
+      "added": [],
+      "removed": [],
+      "unchanged": [
+        "read_file"
+      ]
+    },
+    "policy_decisions": {
+      "added": [],
+      "removed": [],
+      "unchanged": [
+        "allow:read_file"
+      ]
+    }
+  },
+  "binding_ids": {
+    "comparison": "out_of_scope_cross_runtime_v0"
+  },
+  "policy_outcomes": {
+    "comparison": "out_of_scope_cross_runtime_v0"
+  },
+  "sdk_metadata": {
+    "comparison": "side_band_provenance",
+    "base": {
+      "sdk_name": "@openai/agents",
+      "sdk_version": "0.11.4"
+    },
+    "head": {
+      "sdk_name": "google-genai",
+      "sdk_version": "2.6.0"
+    }
+  },
+  "unbound": {
+    "filesystem_paths": [],
+    "network_endpoints": [],
+    "process_execs": [],
+    "mcp_tools": [],
+    "policy_decisions": []
+  },
+  "non_claims": [
+    "cross_runtime_no_acceptability_judgment",
+    "cross_runtime_no_declared_capability_input",
+    "cross_runtime_no_derived_binding_identity",
+    "cross_runtime_no_filename_semantic_equivalence",
+    "cross_runtime_no_sdk_capability_equivalence"
+  ],
+  "ambiguities": [],
+  "notes": [
+    "cross_runtime_diff_binding_ids_out_of_scope: binding ids are not cross-runtime comparable in v0; required only for within-runtime correlation",
+    "cross_runtime_diff_sdk_metadata_side_band: sdk metadata reported as side-band runtime provenance, not capability surface",
+    "cross_runtime_diff_work_dir_prefix_canonicalized: filesystem_paths normalized via the A1 work-dir prefix rule"
+  ]
+}

--- a/docs/reference/runner/golden/index.md
+++ b/docs/reference/runner/golden/index.md
@@ -11,3 +11,4 @@ the artifact contract explicitly defines a field's allowed value vocabulary.
 - [`capability-surface-openai-agents-kernel-policy-v0.json`](capability-surface-openai-agents-kernel-policy-v0.json)
 - [`correlation-report-openai-agents-kernel-policy-v0.json`](correlation-report-openai-agents-kernel-policy-v0.json)
 - [`capability-diff-s5-idempotent-v0.json`](capability-diff-s5-idempotent-v0.json)
+- [`cross-runtime-diff-s5-gemini-v0.json`](cross-runtime-diff-s5-gemini-v0.json)

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -16,6 +16,7 @@ Phase 2B capability-diff planning slice.
 - [Runner capability-diff v0 contract](capability-diff-v0.md)
 - [Runner cross-runtime diff Phase 2C plan](cross-runtime-diff-plan.md)
 - [Runner cross-runtime diff Phase 2C decisions (A1+B3+C1)](cross-runtime-diff-decisions.md)
+- [Runner cross-runtime diff v0 contract](cross-runtime-diff-v0.md)
 - [Runner second runtime Phase 2B plan](second-runtime-plan.md)
 - [Runner second runtime candidate selection](second-runtime-candidate-selection.md)
 - [Runner Gemini fixture design](gemini-fixture-design.md)


### PR DESCRIPTION
## Summary

Phase 2C contract slice that freezes cross-runtime capability-diff semantics for the S5 OpenAI Agents and Gemini Python google-genai fixtures.

This PR is **docs-only**. It adds the v0 contract document and a normative golden shape, with no code, no projector, no validator, no fixture, no CI lane change, and no change to existing v0 contracts.

Resolves the contract-slice step (step 4) of `cross-runtime-diff-plan.md` § Suggested Slice Sequence under the combination chosen in [#1310](https://github.com/Rul1an/assay/issues/1310) and recorded in [cross-runtime-diff-decisions.md](https://github.com/Rul1an/assay/blob/main/docs/reference/runner/cross-runtime-diff-decisions.md).

## Contract scope

- **A1** — work-dir prefix canonicalization to `<work>/`; fixture-local filenames remain observed surface values
- **B3** — binding ids carry the comparison marker `out_of_scope_cross_runtime_v0` (no `added`/`removed`/`changed`/`unchanged`)
- **C1** — SDK metadata reported as side-band runtime provenance with `base` and `head` sub-objects; never in `surface.added`/`removed`/`unchanged`

Kernzin (in the contract):

> v0 cross-runtime diff removes obvious fixture plumbing, preserves observed capability-surface differences, and avoids derived cross-runtime identity semantics. Binding ids remain required for within-runtime correlation, but are not themselves cross-runtime comparable in v0.

## What is new

### `docs/reference/runner/cross-runtime-diff-v0.md`

The contract freezes schema string `assay.runner.cross_runtime_diff.v0` and:

- mirrors the `capability-diff-v0` envelope (`base`/`head`, `status`, `preconditions`, `scope`, `surface` categories, `unbound`, `ambiguities`, `notes`)
- adds cross-runtime extensions: `base_runtime`/`head_runtime` from a closed v0 runtime identifier table, `runtimes_distinct` precondition, `cross_runtime` scope flag, an explicit `canonicalization` declaration block per surface category, out-of-scope markers for `binding_ids` and `policy_outcomes`, and side-band `sdk_metadata`
- adds a first-class `non_claims` array with five mandatory codes (no filename semantic equivalence, no derived binding identity, no SDK capability equivalence, no declared capability input, no acceptability judgment)
- declares the configured work-dir prefix set explicitly so the canonicalization rule remains syntactic and runtime-agnostic
- includes an explicit idempotence + meaning-preservation rule with formal statement `P(P(x)) == P(x)`
- includes a forward-compatibility clause: v0 consumers MUST reject `v1+` outputs; v0 producers MUST NOT silently downgrade

### `docs/reference/runner/golden/cross-runtime-diff-s5-gemini-v0.json`

Normative golden shape for the S5 → Gemini case. Shows:

- `filesystem_paths`: `added=[<work>/gemini-input.txt]`, `removed=[<work>/openai-agents-input.txt]`, `unchanged=[<work>/policy-input.txt]`
- `mcp_tools.unchanged = [read_file]`
- `policy_decisions.unchanged = [allow:read_file]`
- `binding_ids = {comparison: out_of_scope_cross_runtime_v0}`
- `policy_outcomes = {comparison: out_of_scope_cross_runtime_v0}`
- `sdk_metadata` side-band with `@openai/agents 0.11.4` (base) and `google-genai 2.6.0` (head)
- all five `non_claims` codes, all three reserved `cross_runtime_diff_*` notes

The golden is the acceptance shape against which a future projector PR can validate.

### Cross-link updates

- `cross-runtime-diff-plan.md`: top callout records contract frozen
- `cross-runtime-diff-decisions.md`: "What This Unlocks" updated to record contract slice landed; names later projector implementation slice as next discoverable step
- `capability-diff-v0.md`: "second runtime support" non-goal now cross-references the sibling cross-runtime contract
- `golden/index.md` and `runner/index.md`: new entries

## What this PR explicitly does not do

- introduce code, a projector, a CLI, or workflow changes
- modify v0 artifact contracts, fixture v0 contract, `capability-diff-v0` semantics, ci-lane contract, or boundary map
- add a delegated gate, lane-check rule, or new fixture
- pre-approve a third runtime, derived cross-runtime identity scheme, filename-layer canonicalization, or cassette regeneration semantics

## Acceptance criteria (self-check)

- [x] A1+B3+C1 explicit in the contract
- [x] golden shape for S5 ↔ Gemini present and normative
- [x] binding ids explicit out-of-scope marker (no added/removed/changed/unchanged keys)
- [x] SDK metadata explicit side-band (with own `comparison` marker)
- [x] idempotence + meaning-preservation rule explicit
- [x] decision lineage cross-link to #1310 and decisions doc
- [x] no derived identity scheme anywhere
- [x] configured prefix set declared, not inferred
- [x] `non_claims` mechanically detectable as array

## Validation (local)

- `python3 -m json.tool` on the golden ✓
- `non_claims` and `notes` arrays sorted lexicographically ✓
- key order in golden matches the field-table order in the contract ✓
- `mkdocs build --strict` ✓ exit 0, no new warnings
- pre-commit hooks ✓ (fmt, typos, merge conflicts, trailing whitespace, secret hygiene)
- pre-push hooks ✓ (clippy, linux compile gate)

## What this unlocks

A future cross-runtime projector implementation slice may extend or wrap `scripts/ci/assay_runner_capability_diff_validate.py` to produce and validate this golden from the S5 and Gemini accepted fixture evidence sets. That PR is separate and not part of this contract slice.

## Related

- Decision gate (resolved): #1310 (closed by #1312)
- Decisions doc: `docs/reference/runner/cross-runtime-diff-decisions.md`
- Mini-plan: `docs/reference/runner/cross-runtime-diff-plan.md`
- Sibling contract: `docs/reference/runner/capability-diff-v0.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)