### PR TITLE
docs: add cross-runtime diff v0 clean-output JSON Schema sidecar

### DIFF
--- a/docs/reference/runner/cross-runtime-diff-v0.md
+++ b/docs/reference/runner/cross-runtime-diff-v0.md
@@ -465,6 +465,42 @@ CLI, and without a workflow change. The next slice may extend
 validate against this golden, or introduce a separate cross-runtime
 projector. That decision is out of scope here.
 
+## Machine-Readable Schema
+
+A JSON Schema 2020-12 sidecar mirrors the clean-output v0 envelope:
+[`schema/cross-runtime-diff-v0-clean.schema.json`](schema/cross-runtime-diff-v0-clean.schema.json).
+
+The schema is a docs-only artifact. It is the third layer of contract
+defense alongside the prose contract above (review) and the
+[golden output shape](golden/cross-runtime-diff-s5-gemini-v0.json)
+(byte-determinism). Consumers MAY validate diff outputs against the
+schema using any JSON Schema 2020-12 validator. The reference projector
+`scripts/ci/assay_runner_cross_runtime_diff_validate.py` does not
+require the schema at runtime; its hand-written structural validator
+covers the same envelope plus invariants the schema cannot express.
+
+Schema scope:
+
+- v0 *clean* output only — `status=clean`, all preconditions `true`,
+  `unbound` categories empty, `ambiguities` empty, complete
+  `non_claims` and `notes` arrays in lexicographic order
+- `partial:health`, `partial:correlation`, `partial:unbound`, and
+  `failed` output shapes are out of scope for this schema; if a future
+  projector chooses to emit them, add their own sibling schema files
+
+Invariants the schema does **not** enforce (kept in the projector):
+
+- stable lexicographic sort *within* `surface.*` arrays (JSON Schema
+  expresses `uniqueItems` but not ordering)
+- SDK metadata leak-prevention into `surface.*` (cross-field
+  constraint not expressible as schema)
+- run-id consistency between health, surface, and correlation
+  artifacts within each side (cross-document constraint)
+
+The cross-field discipline `base_runtime != head_runtime` is enforced
+by a top-level `not` clause in the schema using the closed v0 runtime
+identifier enum.
+
 ## Notes Vocabulary
 
 `notes` follows the code-prefixed convention from

--- a/docs/reference/runner/golden/index.md
+++ b/docs/reference/runner/golden/index.md
@@ -12,3 +12,8 @@ the artifact contract explicitly defines a field's allowed value vocabulary.
 - [`correlation-report-openai-agents-kernel-policy-v0.json`](correlation-report-openai-agents-kernel-policy-v0.json)
 - [`capability-diff-s5-idempotent-v0.json`](capability-diff-s5-idempotent-v0.json)
 - [`cross-runtime-diff-s5-gemini-v0.json`](cross-runtime-diff-s5-gemini-v0.json)
+
+The machine-readable schema for the v0 clean-output shape lives next to
+the contract document, not in this golden directory:
+
+- [`../schema/cross-runtime-diff-v0-clean.schema.json`](../schema/cross-runtime-diff-v0-clean.schema.json)

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -17,6 +17,7 @@ Phase 2B capability-diff planning slice.
 - [Runner cross-runtime diff Phase 2C plan](cross-runtime-diff-plan.md)
 - [Runner cross-runtime diff Phase 2C decisions (A1+B3+C1)](cross-runtime-diff-decisions.md)
 - [Runner cross-runtime diff v0 contract](cross-runtime-diff-v0.md)
+- [Runner cross-runtime diff v0 clean-output JSON Schema](schema/cross-runtime-diff-v0-clean.schema.json)
 - [Runner second runtime Phase 2B plan](second-runtime-plan.md)
 - [Runner second runtime candidate selection](second-runtime-candidate-selection.md)
 - [Runner Gemini fixture design](gemini-fixture-design.md)

--- a/docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json
+++ b/docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/Rul1an/assay/blob/main/docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json",
   "title": "Assay-Runner cross-runtime diff v0 (clean output)",
   "description": "Machine-readable schema for the clean output shape of assay.runner.cross_runtime_diff.v0. Mirrors the contract at docs/reference/runner/cross-runtime-diff-v0.md. Cross-field invariants that JSON Schema cannot express (stable lexicographic sort within surface arrays, SDK metadata leak-prevention into surface) remain in the projector at scripts/ci/assay_runner_cross_runtime_diff_validate.py. This schema covers clean output only; partial:* and failed status shapes are out of scope for this slice and require their own future schema files if/when they become emit-states.",
   "type": "object",

--- a/docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json
+++ b/docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Rul1an/assay/blob/main/docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json",
+  "title": "Assay-Runner cross-runtime diff v0 (clean output)",
+  "description": "Machine-readable schema for the clean output shape of assay.runner.cross_runtime_diff.v0. Mirrors the contract at docs/reference/runner/cross-runtime-diff-v0.md. Cross-field invariants that JSON Schema cannot express (stable lexicographic sort within surface arrays, SDK metadata leak-prevention into surface) remain in the projector at scripts/ci/assay_runner_cross_runtime_diff_validate.py. This schema covers clean output only; partial:* and failed status shapes are out of scope for this slice and require their own future schema files if/when they become emit-states.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "base_run_id",
+    "head_run_id",
+    "base_runtime",
+    "head_runtime",
+    "status",
+    "preconditions",
+    "scope",
+    "canonicalization",
+    "surface",
+    "binding_ids",
+    "policy_outcomes",
+    "sdk_metadata",
+    "unbound",
+    "non_claims",
+    "ambiguities",
+    "notes"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.runner.cross_runtime_diff.v0"
+    },
+    "base_run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "head_run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "base_runtime": {
+      "$ref": "#/$defs/runtime_identifier"
+    },
+    "head_runtime": {
+      "$ref": "#/$defs/runtime_identifier"
+    },
+    "status": {
+      "const": "clean"
+    },
+    "preconditions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "base_health_clean",
+        "head_health_clean",
+        "base_correlation_clean",
+        "head_correlation_clean",
+        "stable_tool_call_ids_required",
+        "stable_tool_call_ids_present",
+        "runtimes_distinct"
+      ],
+      "properties": {
+        "base_health_clean": { "const": true },
+        "head_health_clean": { "const": true },
+        "base_correlation_clean": { "const": true },
+        "head_correlation_clean": { "const": true },
+        "stable_tool_call_ids_required": { "const": true },
+        "stable_tool_call_ids_present": { "const": true },
+        "runtimes_distinct": { "const": true }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "projection",
+        "uses_raw_telemetry",
+        "uses_proof_pack",
+        "per_binding_capability_values",
+        "cross_runtime"
+      ],
+      "properties": {
+        "projection": { "const": "surface_set" },
+        "uses_raw_telemetry": { "const": false },
+        "uses_proof_pack": { "const": false },
+        "per_binding_capability_values": { "const": false },
+        "cross_runtime": { "const": true }
+      }
+    },
+    "canonicalization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "filesystem_paths",
+        "network_endpoints",
+        "process_execs",
+        "mcp_tools",
+        "policy_decisions"
+      ],
+      "properties": {
+        "filesystem_paths": { "const": "work_dir_prefix_only" },
+        "network_endpoints": { "const": "none" },
+        "process_execs": { "const": "none" },
+        "mcp_tools": { "const": "none" },
+        "policy_decisions": { "const": "none" }
+      }
+    },
+    "surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "filesystem_paths",
+        "network_endpoints",
+        "process_execs",
+        "mcp_tools",
+        "policy_decisions"
+      ],
+      "properties": {
+        "filesystem_paths": { "$ref": "#/$defs/surface_category" },
+        "network_endpoints": { "$ref": "#/$defs/surface_category" },
+        "process_execs": { "$ref": "#/$defs/surface_category" },
+        "mcp_tools": { "$ref": "#/$defs/surface_category" },
+        "policy_decisions": { "$ref": "#/$defs/surface_category" }
+      }
+    },
+    "binding_ids": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["comparison"],
+      "properties": {
+        "comparison": { "const": "out_of_scope_cross_runtime_v0" }
+      }
+    },
+    "policy_outcomes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["comparison"],
+      "properties": {
+        "comparison": { "const": "out_of_scope_cross_runtime_v0" }
+      }
+    },
+    "sdk_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["comparison", "base", "head"],
+      "properties": {
+        "comparison": { "const": "side_band_provenance" },
+        "base": { "$ref": "#/$defs/sdk_side" },
+        "head": { "$ref": "#/$defs/sdk_side" }
+      }
+    },
+    "unbound": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "filesystem_paths",
+        "network_endpoints",
+        "process_execs",
+        "mcp_tools",
+        "policy_decisions"
+      ],
+      "properties": {
+        "filesystem_paths": { "const": [] },
+        "network_endpoints": { "const": [] },
+        "process_execs": { "const": [] },
+        "mcp_tools": { "const": [] },
+        "policy_decisions": { "const": [] }
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "prefixItems": [
+        { "const": "cross_runtime_no_acceptability_judgment" },
+        { "const": "cross_runtime_no_declared_capability_input" },
+        { "const": "cross_runtime_no_derived_binding_identity" },
+        { "const": "cross_runtime_no_filename_semantic_equivalence" },
+        { "const": "cross_runtime_no_sdk_capability_equivalence" }
+      ],
+      "items": false
+    },
+    "ambiguities": {
+      "const": []
+    },
+    "notes": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "prefixItems": [
+        { "const": "cross_runtime_diff_binding_ids_out_of_scope: binding ids are not cross-runtime comparable in v0; required only for within-runtime correlation" },
+        { "const": "cross_runtime_diff_sdk_metadata_side_band: sdk metadata reported as side-band runtime provenance, not capability surface" },
+        { "const": "cross_runtime_diff_work_dir_prefix_canonicalized: filesystem_paths normalized via the A1 work-dir prefix rule" }
+      ],
+      "items": false
+    }
+  },
+  "not": {
+    "anyOf": [
+      {
+        "properties": {
+          "base_runtime": { "const": "s5_openai_agents" },
+          "head_runtime": { "const": "s5_openai_agents" }
+        },
+        "required": ["base_runtime", "head_runtime"]
+      },
+      {
+        "properties": {
+          "base_runtime": { "const": "gemini_google_genai" },
+          "head_runtime": { "const": "gemini_google_genai" }
+        },
+        "required": ["base_runtime", "head_runtime"]
+      }
+    ]
+  },
+  "$defs": {
+    "runtime_identifier": {
+      "type": "string",
+      "enum": [
+        "s5_openai_agents",
+        "gemini_google_genai"
+      ]
+    },
+    "surface_category": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["added", "removed", "unchanged"],
+      "properties": {
+        "added": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "removed": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "unchanged": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        }
+      }
+    },
+    "sdk_side": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sdk_name", "sdk_version"],
+      "properties": {
+        "sdk_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sdk_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2C contract-hardening slice. Adds a machine-readable JSON Schema 2020-12 sidecar for the **clean output** shape of `assay.runner.cross_runtime_diff.v0` alongside the existing prose contract and byte-deterministic golden as a third layer of contract defense.

**This PR is docs-only.** No Python code touched. No projector behaviour change. No new dependency introduced.

Resolves the schema-sidecar slice referenced in the \"What this unlocks\" section of #1314 (the projector slice).

## Discipline split (per review)

This is PR 1 of a planned two-step sequence:

- **PR 1 (this PR)**: schema sidecar as contract artifact — docs-only
- **PR 2 (separate, later)**: optional `--schema-check` flag in the projector with lazy `jsonschema` import — tooling behaviour

Splitting keeps review focused: \"is the schema correct?\" vs \"will this optional dependency path age well?\" are different questions.

## New file

```
docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json
```

Introduces a new `schema/` directory next to `golden/` so the boundary is semantically clear:

- `golden/` = example outputs (byte-deterministic acceptance shapes)
- `schema/` = machine contract (formal validation surface)

## Schema scope — deliberately limited to v0 *clean* output

| Field | Constraint |
|---|---|
| `status` | `const: \"clean\"` |
| all 7 preconditions | each `const: true` |
| `unbound.*` categories | each `const: []` |
| `ambiguities` | `const: []` |
| `non_claims` | literal 5-code array via `prefixItems` + `minItems/maxItems` |
| `notes` | literal 3-string array via `prefixItems` + `minItems/maxItems` |
| `base_runtime`/`head_runtime` | closed v0 enum |
| `scope` | exact per-field consts |
| `canonicalization` | per-category literals (`work_dir_prefix_only` for filesystem_paths, `none` for others) |
| `binding_ids` | only `{comparison: out_of_scope_cross_runtime_v0}` |
| `policy_outcomes` | only `{comparison: out_of_scope_cross_runtime_v0}` |
| `sdk_metadata` | side-band shape with required `comparison`/`base`/`head` |
| `base_runtime != head_runtime` | top-level `not`/`anyOf` over the closed enum |

`additionalProperties: false` is set on every object schema so any envelope drift is rejected.

`partial:health`, `partial:correlation`, `partial:unbound`, and `failed` output shapes are **out of scope for this schema**. If a future projector chooses to emit them, sibling schema files can be added; the current projector raises rather than emitting non-clean outputs (matching the `capability-diff-v0` sibling pattern).

## Invariants this schema does NOT enforce

Kept in the projector at `scripts/ci/assay_runner_cross_runtime_diff_validate.py`:

- Stable lexicographic sort *within* `surface.*` arrays (JSON Schema 2020-12 has no ordering operator)
- SDK metadata leak-prevention into `surface.*` (cross-field constraint not expressible in schema)
- Run-id consistency between `observation-health` / `capability-surface` / `correlation-report` per side (cross-document constraint)

This is the right boundary: **schema = shape, projector = invariants beyond shape**.

## Validation (local, `jsonschema` 4.26.0)

- ✅ Schema validates against Draft 2020-12 meta-schema
- ✅ Committed golden `cross-runtime-diff-s5-gemini-v0.json` validates against the new schema
- ✅ **25 drift scenarios** all rejected by the schema:
  - 3 × status drift (failed / partial:health / invented value)
  - 2 × preconditions drift (runtimes_distinct=false / extra+missing key)
  - 2 × scope drift (uses_raw_telemetry=true / cross_runtime=false)
  - 2 × B3 forbidden keys (binding_ids.added / policy_outcomes.changed)
  - 2 × marker string drift (binding_ids.comparison / sdk_metadata.comparison)
  - 2 × canonicalization drift (filesystem_paths / mcp_tools)
  - 2 × surface array drift (non-string element / duplicate value)
  - 1 × unbound non-empty
  - 2 × non_claims drift (missing code / wrong order)
  - 1 × notes truncated
  - 1 × schema string drift to v1
  - 1 × unknown base_runtime (`anthropic_direct`)
  - 1 × same-runtime diff
  - 1 × top-level extra key
  - 1 × ambiguities non-empty
  - 1 × sdk_metadata.base empty sdk_name
- ✅ `mkdocs build --strict` ok, no new warnings
- ✅ `python3 scripts/ci/assay_runner_lane_check.py --self-test` ok (schema/ path classifies as Gate.NONE via existing `docs/reference/runner/` prefix rule)
- ✅ pre-commit hooks ok (fmt, typos, merge conflicts, trailing whitespace, secret hygiene)
- ✅ pre-push hooks ok (clippy, linux compile gate)

## Cross-link updates (3 small edits)

- `cross-runtime-diff-v0.md`: new \"Machine-Readable Schema\" section documenting the sidecar, what it enforces, what stays in the projector, and the clean-only scope
- `runner/index.md`: link to the schema file
- `golden/index.md`: cross-pointer back to the schema directory so consumers landing in golden/ find the schema

## What this PR explicitly does not do

- modify the cross-runtime-diff v0 contract semantics
- modify the cross-runtime-diff v0 golden
- modify the cross-runtime-diff projector or any other script
- introduce a Python dependency (`jsonschema` was used local-only for verification; no committed script imports it)
- add a `--schema-check` flag or any opt-in validation path (deferred to PR 2)
- modify workflows, CI lanes, or fixtures
- pre-approve schemas for non-clean status output shapes

## Four-layer defense in depth (after this PR)

```
1. Prose contract     →  cross-runtime-diff-v0.md (review layer)
2. Golden JSON        →  cross-runtime-diff-s5-gemini-v0.json (byte-determinism layer)
3. JSON Schema 2020-12 →  cross-runtime-diff-v0-clean.schema.json (machine layer)  ◄── this PR
4. Projector code     →  assay_runner_cross_runtime_diff_validate.py (runtime + invariants beyond shape layer)
```

## What this unlocks (separate future PRs)

- **PR 2**: optional `--schema-check` flag on the projector with lazy `jsonschema` import — second line of defense at projection time, opt-in only
- **PR 3**: read-only CI hook that runs `--self-test` on PRs touching the cross-runtime contract, golden, or schema (drift guard)
- consumers can validate v0 clean-output diffs against a formal schema using any standard JSON Schema 2020-12 validator, without Python

## Related

- Contract: `docs/reference/runner/cross-runtime-diff-v0.md` (#1313, merged)
- Golden: `docs/reference/runner/golden/cross-runtime-diff-s5-gemini-v0.json` (#1313, merged)
- Projector + lane-check: `scripts/ci/assay_runner_cross_runtime_diff_validate.py` (#1314, merged)
- Decisions: `docs/reference/runner/cross-runtime-diff-decisions.md` (#1312, merged)
- Mini-plan: `docs/reference/runner/cross-runtime-diff-plan.md` (#1309, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)