### PR TITLE
feat(runner-core): extract runner mechanics into assay-runner-core crate (Phase 2D Slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,16 +440,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "assay-runner-schema"
-version = "3.10.2"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "assay-runner-spike"
+name = "assay-runner-core"
 version = "3.10.2"
 dependencies = [
  "assay-common",
@@ -463,6 +454,23 @@ dependencies = [
  "tar",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "assay-runner-schema"
+version = "3.10.2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "assay-runner-spike"
+version = "3.10.2"
+dependencies = [
+ "assay-runner-core",
+ "assay-runner-schema",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "assay-python-sdk", "crates/assay-policy", "crates/assay-evidence", "crates/assay-sim",
   "crates/assay-registry",
   "crates/assay-runner-schema",
+  "crates/assay-runner-core",
   "crates/assay-runner-spike",
 ]
 default-members = [
@@ -82,6 +83,7 @@ assay-evidence = { path = "crates/assay-evidence", version = "3.10.2" }
 assay-sim = { path = "crates/assay-sim", version = "3.10.2" }
 assay-registry = { path = "crates/assay-registry", version = "3.10.2" }
 assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.10.2" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.10.2" }
 assay-runner-spike = { path = "crates/assay-runner-spike", version = "3.10.2" }
 
 # Common dependencies

--- a/crates/assay-runner-core/Cargo.toml
+++ b/crates/assay-runner-core/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "assay-runner-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Runner orchestration, archive assembly, and layer normalizers for the Assay-Runner candidate (Phase 2D Slice 2)."
+readme.workspace = true
+publish = false
+
+[dependencies]
+assay-common = { workspace = true, features = ["std"] }
+assay-monitor = { workspace = true }
+assay-runner-schema = { workspace = true }
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true, features = ["std"] }
+sha2 = { workspace = true }
+hex = { workspace = true }
+thiserror = { workspace = true }
+flate2 = { workspace = true }
+tar = { workspace = true }
+uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/assay-runner-core/src/archive.rs
+++ b/crates/assay-runner-core/src/archive.rs
@@ -309,7 +309,7 @@ mod tests {
     fn write_rejects_invalid_observation_health() {
         let mut archive = RunnerSpikeArchive::empty("run_001", "linux");
         archive.observation_health.ringbuf_drops = 1;
-        archive.observation_health.kernel_layer = crate::KernelLayerStatus::Complete;
+        archive.observation_health.kernel_layer = assay_runner_schema::KernelLayerStatus::Complete;
         let mut bytes = Vec::new();
 
         let err = archive.write(&mut bytes).unwrap_err();

--- a/crates/assay-runner-core/src/kernel.rs
+++ b/crates/assay-runner-core/src/kernel.rs
@@ -1,12 +1,10 @@
-use crate::{
-    run::is_safe_run_id, CapabilitySurface, CgroupCorrelationStatus, KernelLayerStatus,
-    RunnerSpikeArchive,
-};
+use crate::{run::is_safe_run_id, RunnerSpikeArchive};
 use assay_common::{
     MonitorEvent, EVENT_CONNECT, EVENT_CONNECT_BLOCKED, EVENT_EXEC, EVENT_FILE_BLOCKED,
     EVENT_INODE_RESOLVED, EVENT_OPENAT,
 };
 use assay_monitor::MonitorStatsSnapshot;
+use assay_runner_schema::{CapabilitySurface, CgroupCorrelationStatus, KernelLayerStatus};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/crates/assay-runner-core/src/lib.rs
+++ b/crates/assay-runner-core/src/lib.rs
@@ -1,0 +1,26 @@
+//! Runner orchestration, archive assembly, and layer normalizers for the
+//! Assay-Runner candidate.
+//!
+//! This crate is the Phase 2D Slice 2 result of the Assay-Runner extraction
+//! roadmap (see `docs/reference/runner/extraction-roadmap.md`). It hosts the
+//! mechanics half of the Phase 1 measured-run path: `RunSpec` orchestration,
+//! archive assembly and writing, and the kernel/policy/SDK layer normalizers.
+//! The data-structure half lives in [`assay_runner_schema`] since Slice 1.
+//!
+//! The crate is `publish = false` until Slice 7 (repository extraction). It
+//! does not depend on `assay-cli` (the cgroup placement extraction is a
+//! separate Slice 3 boundary move), does not depend on `assay-evidence`,
+//! and does not embed Assay-side artifact-verification semantics; runner
+//! archives remain consumable through the existing Assay evidence path.
+
+mod archive;
+mod kernel;
+mod policy;
+mod run;
+mod sdk;
+
+pub use archive::{RunnerSpikeArchive, RunnerSpikeArchiveError};
+pub use kernel::{KernelLayerBuilder, KernelLayerCapture, KernelLayerError, KERNEL_EVENT_SCHEMA};
+pub use policy::{PolicyLayerCapture, PolicyLayerError, PolicyLayerEvent, POLICY_EVENT_SCHEMA};
+pub use run::{RunExecutionError, RunOutcome, RunSpec, RunSpecError, RUN_EVENT_SCHEMA};
+pub use sdk::{SdkLayerCapture, SdkLayerError};

--- a/crates/assay-runner-core/src/policy.rs
+++ b/crates/assay-runner-core/src/policy.rs
@@ -1,6 +1,6 @@
-use crate::{
-    run::is_safe_run_id, BindingWindow, CapabilitySurface, CorrelationBinding, PolicyLayerStatus,
-    RunnerSpikeArchive,
+use crate::{run::is_safe_run_id, RunnerSpikeArchive};
+use assay_runner_schema::{
+    BindingWindow, CapabilitySurface, CorrelationBinding, PolicyLayerStatus,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -237,7 +237,7 @@ fn observed_type(value: &Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CgroupCorrelationStatus, KernelLayerStatus};
+    use assay_runner_schema::{CgroupCorrelationStatus, KernelLayerStatus};
 
     const DECISION: &[u8] = br#"{"specversion":"1.0","id":"evt_decision_001","type":"assay.tool.decision","source":"assay://runner-spike/run_001","time":"2026-05-20T00:00:00Z","data":{"tool":"read_file","decision":"allow","reason_code":"P_TOOL_ALLOWED","tool_call_id":"tc_runner_policy_001"}}
 "#;
@@ -334,7 +334,7 @@ mod tests {
 
         assert_eq!(
             archive.correlation_report.status,
-            crate::CorrelationStatus::Partial
+            assay_runner_schema::CorrelationStatus::Partial
         );
         assert!(archive
             .correlation_report

--- a/crates/assay-runner-core/src/run.rs
+++ b/crates/assay-runner-core/src/run.rs
@@ -1,4 +1,5 @@
-use crate::{CgroupCorrelationStatus, KernelLayerStatus, RunnerSpikeArchive};
+use crate::RunnerSpikeArchive;
+use assay_runner_schema::{CgroupCorrelationStatus, KernelLayerStatus};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -239,7 +240,7 @@ fn exit_signal(_status: &std::process::ExitStatus) -> Option<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::SdkLayerStatus;
+    use assay_runner_schema::SdkLayerStatus;
 
     #[test]
     fn generated_run_id_is_stream_safe() {

--- a/crates/assay-runner-core/src/sdk.rs
+++ b/crates/assay-runner-core/src/sdk.rs
@@ -1,5 +1,5 @@
-use crate::{run::is_safe_run_id, RunnerSpikeArchive, SdkLayerStatus};
-use assay_runner_schema::{SdkLayerEvent, SDK_EVENT_SCHEMA};
+use crate::{run::is_safe_run_id, RunnerSpikeArchive};
+use assay_runner_schema::{SdkLayerEvent, SdkLayerStatus, SDK_EVENT_SCHEMA};
 use serde_json::Value;
 use std::collections::BTreeSet;
 use thiserror::Error;
@@ -292,7 +292,7 @@ fn mark_sdk_policy_mismatches(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{KernelLayerStatus, PolicyLayerStatus};
+    use assay_runner_schema::{KernelLayerStatus, PolicyLayerStatus};
 
     const SDK_EVENTS: &[u8] = br#"{"schema":"assay.runner.sdk_event.v0","run_id":"run_001","seq":0,"event_type":"tool_call_started","source":"openai-agents","sdk_name":"@openai/agents","sdk_version":"0.0.0-fixture","tool_call_id":"tc_runner_policy_001","tool":"read_file"}
 {"schema":"assay.runner.sdk_event.v0","run_id":"run_001","seq":1,"event_type":"tool_call_completed","source":"openai-agents","sdk_name":"@openai/agents","sdk_version":"0.0.0-fixture","tool_call_id":"tc_runner_policy_001","tool":"read_file"}
@@ -341,11 +341,11 @@ mod tests {
         archive.policy_layer_ndjson = b"{\"schema\":\"assay.runner.policy_event.v0\"}\n".to_vec();
         archive
             .correlation_report
-            .add_binding(crate::CorrelationBinding {
+            .add_binding(assay_runner_schema::CorrelationBinding {
                 tool_call_id: "tc_runner_policy_001".to_string(),
                 policy_decision: Some("allow".to_string()),
                 kernel_event_count: 1,
-                window: crate::BindingWindow {
+                window: assay_runner_schema::BindingWindow {
                     start: "run_started".to_string(),
                     end: "run_finished".to_string(),
                 },
@@ -355,7 +355,7 @@ mod tests {
 
         assert_eq!(
             archive.correlation_report.status,
-            crate::CorrelationStatus::Clean
+            assay_runner_schema::CorrelationStatus::Clean
         );
         assert!(archive.correlation_report.ambiguities.is_empty());
     }
@@ -367,11 +367,11 @@ mod tests {
         archive.policy_layer_ndjson = b"{\"schema\":\"assay.runner.policy_event.v0\"}\n".to_vec();
         archive
             .correlation_report
-            .add_binding(crate::CorrelationBinding {
+            .add_binding(assay_runner_schema::CorrelationBinding {
                 tool_call_id: "tc_different_policy_call".to_string(),
                 policy_decision: Some("allow".to_string()),
                 kernel_event_count: 1,
-                window: crate::BindingWindow {
+                window: assay_runner_schema::BindingWindow {
                     start: "run_started".to_string(),
                     end: "run_finished".to_string(),
                 },
@@ -381,7 +381,7 @@ mod tests {
 
         assert_eq!(
             archive.correlation_report.status,
-            crate::CorrelationStatus::Partial
+            assay_runner_schema::CorrelationStatus::Partial
         );
         assert!(archive
             .correlation_report

--- a/crates/assay-runner-spike/Cargo.toml
+++ b/crates/assay-runner-spike/Cargo.toml
@@ -5,22 +5,13 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "Internal spike contracts for measured Assay runner experiments."
+description = "Compatibility wrapper crate that re-exports the Assay-Runner candidate surface from assay-runner-schema (Slice 1) and assay-runner-core (Slice 2)."
 readme.workspace = true
 publish = false
 
 [dependencies]
-assay-common = { workspace = true, features = ["std"] }
-assay-monitor = { workspace = true }
+assay-runner-core = { workspace = true }
 assay-runner-schema = { workspace = true }
-serde = { workspace = true, features = ["derive", "std"] }
-serde_json = { workspace = true, features = ["std"] }
-sha2 = { workspace = true }
-hex = { workspace = true }
-thiserror = { workspace = true }
-flate2 = { workspace = true }
-tar = { workspace = true }
-uuid = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/assay-runner-spike/src/lib.rs
+++ b/crates/assay-runner-spike/src/lib.rs
@@ -1,24 +1,23 @@
 //! Internal contracts for the Assay-Runner Phase 1 spike.
 //!
-//! This crate is deliberately publish-disabled. It freezes the v0 measured-run
-//! contract shapes before orchestration, eBPF capture, or SDK shims are wired.
+//! This crate is deliberately publish-disabled. It is a thin compatibility
+//! wrapper after the Phase 2D extraction work:
 //!
-//! Phase 2D Slice 1 moved the data-structure half of the v0 schemas to the
-//! sibling crate [`assay_runner_schema`]. This crate re-exports those types
-//! so existing call sites continue to compile unchanged. The runner archive
-//! assembly, layer parsing, kernel/policy/SDK capture orchestration, and
-//! run-spec semantics remain here until Phase 2D Slice 2 splits them into
-//! `assay-runner-core`.
+//! - Phase 2D Slice 1 moved the data-structure half of the v0 schemas to
+//!   [`assay_runner_schema`].
+//! - Phase 2D Slice 2 moved orchestration, archive assembly, and layer
+//!   normalizers to [`assay_runner_core`].
+//!
+//! Both moves are surfaced here through `pub use` so existing call sites
+//! (notably `assay-cli`, fixture wrappers under `tests/fixtures/runner-spike/`,
+//! and acceptance scripts under `scripts/ci/runner-spike-*.sh`) continue to
+//! import via `assay_runner_spike::{Type}` unchanged.
+//!
+//! Future extraction slices may redirect those consumers to depend on the
+//! schema and core crates directly; this wrapper exists only so the
+//! relocation can happen incrementally without breaking the active
+//! delegated proof path.
 
-mod archive;
-mod kernel;
-mod policy;
-mod run;
-mod sdk;
-
-// Re-exports of the v0 schema layer hosted by `assay-runner-schema`. The set
-// of names re-exported here is the same set this crate exposed before Slice 1,
-// so external consumers can continue to import every name unchanged.
 pub use assay_runner_schema::{
     ArchiveFile, ArchiveManifest, BindingWindow, CapabilitySurface, CapabilitySurfaceError,
     CgroupCorrelationStatus, CorrelationBinding, CorrelationReport, CorrelationReportError,
@@ -29,9 +28,9 @@ pub use assay_runner_schema::{
     SDK_EVENT_SCHEMA, SDK_LAYER_PATH,
 };
 
-// Assembly-side runner spike contracts that still live in this crate.
-pub use archive::{RunnerSpikeArchive, RunnerSpikeArchiveError};
-pub use kernel::{KernelLayerBuilder, KernelLayerCapture, KernelLayerError, KERNEL_EVENT_SCHEMA};
-pub use policy::{PolicyLayerCapture, PolicyLayerError, PolicyLayerEvent, POLICY_EVENT_SCHEMA};
-pub use run::{RunExecutionError, RunOutcome, RunSpec, RunSpecError, RUN_EVENT_SCHEMA};
-pub use sdk::{SdkLayerCapture, SdkLayerError};
+pub use assay_runner_core::{
+    KernelLayerBuilder, KernelLayerCapture, KernelLayerError, PolicyLayerCapture, PolicyLayerError,
+    PolicyLayerEvent, RunExecutionError, RunOutcome, RunSpec, RunSpecError, RunnerSpikeArchive,
+    RunnerSpikeArchiveError, SdkLayerCapture, SdkLayerError, KERNEL_EVENT_SCHEMA,
+    POLICY_EVENT_SCHEMA, RUN_EVENT_SCHEMA,
+};

--- a/docs/reference/runner/boundary-map.md
+++ b/docs/reference/runner/boundary-map.md
@@ -84,13 +84,14 @@ The current spike surfaces remain in `Rul1an/assay`:
 | `crates/assay-runner-schema/src/correlation.rs` | correlation-report data structures and validation | shared contract; hosted by the schema crate since Slice 1 |
 | `crates/assay-runner-schema/src/sdk_event.rs` | SDK event schema string and `SdkLayerEvent` shape | shared contract; hosted by the schema crate since Slice 1 |
 | `crates/assay-runner-schema/src/archive_manifest.rs` | archive manifest schema string, archive file path constants, `ArchiveFile`, `ArchiveManifest` | shared contract (manifest semantics half of the archive boundary conflict); hosted by the schema crate since Slice 1 |
-| `crates/assay-runner-spike/` | publish-disabled measured-run spike crate | candidate runner orchestration, not extractable yet |
-| `crates/assay-runner-spike/src/run.rs` | measured command execution, run id, archive handoff | runner candidate orchestration |
-| `crates/assay-runner-spike/src/kernel.rs` | kernel capture normalization and health application | runner candidate mechanics using Assay monitor semantics |
-| `crates/assay-runner-spike/src/policy.rs` | policy log normalization and binding into the archive | runner candidate mechanics using Assay policy semantics |
-| `crates/assay-runner-spike/src/sdk.rs` | SDK ndjson parsing and SDK/policy mismatch marking (event types now live in `assay-runner-schema`) | runner candidate mechanics consuming shared SDK event semantics from the schema crate |
-| `crates/assay-runner-spike/src/archive.rs` | runner archive assembly (manifest semantics now live in `assay-runner-schema`) | runner candidate mechanics; the assembly half of the archive boundary conflict — Slice 2 of [`extraction-roadmap.md`](extraction-roadmap.md#slice-2--cratesassay-runner-core) moves this into `assay-runner-core` |
-| `crates/assay-runner-spike/src/lib.rs` | re-export surface for the spike crate, including `pub use assay_runner_schema::*` for the moved types | temporary in-repo facade, not a stable external API |
+| `crates/assay-runner-core/` | publish-disabled runner mechanics crate (Phase 2D Slice 2) | runner candidate orchestration, archive assembly, and layer normalizers; consumes `assay-runner-schema` for v0 types; the mechanics half of the runner v0 contract layer |
+| `crates/assay-runner-core/src/run.rs` | measured command execution, run id, archive handoff | runner candidate orchestration; hosted by the core crate since Slice 2 |
+| `crates/assay-runner-core/src/kernel.rs` | kernel capture normalization and health application | runner candidate mechanics using Assay monitor semantics; hosted by the core crate since Slice 2 |
+| `crates/assay-runner-core/src/policy.rs` | policy log normalization and binding into the archive | runner candidate mechanics using Assay policy semantics; hosted by the core crate since Slice 2 |
+| `crates/assay-runner-core/src/sdk.rs` | SDK ndjson parsing and SDK/policy mismatch marking | runner candidate mechanics; consumes `SdkLayerEvent`/`SDK_EVENT_SCHEMA` from the schema crate; hosted by the core crate since Slice 2 |
+| `crates/assay-runner-core/src/archive.rs` | runner archive assembly and writing | runner candidate mechanics; consumes manifest types from the schema crate; hosted by the core crate since Slice 2 |
+| `crates/assay-runner-spike/` | publish-disabled compatibility wrapper crate | thin re-export wrapper around `assay-runner-schema` and `assay-runner-core` so existing `assay_runner_spike::Type` call sites continue to compile during the staged extraction |
+| `crates/assay-runner-spike/src/lib.rs` | `pub use` re-exports of every name previously hosted by this crate | only file in the crate; assay-cli and fixture wrappers import through this re-export surface until a later slice redirects them to depend on `assay-runner-core` and `assay-runner-schema` directly |
 | `crates/assay-monitor/` | monitor reader, stats, event decoding | Assay core monitor substrate |
 | `crates/assay-ebpf/` | eBPF programs | Assay core monitor substrate |
 | `crates/assay-cli/src/cli/commands/runner_spike.rs` | hidden CLI command | candidate runner CLI surface |
@@ -110,7 +111,7 @@ explaining the ownership later.
 
 | Conflict | Why it is hard | Current rule |
 |---|---|---|
-| `archive.rs` | the runner assembles archives, but manifest shape, digest meaning, and verification are artifact semantics | Partially resolved by Phase 2D Slice 1: manifest schema constants, `ArchiveFile`, and `ArchiveManifest` moved to `assay-runner-schema`. Assembly (`RunnerSpikeArchive`, `RunnerSpikeArchiveError`, `write`) still lives in `assay-runner-spike` and moves into `assay-runner-core` at [Slice 2](extraction-roadmap.md#slice-2--cratesassay-runner-core) |
+| `archive.rs` | the runner assembles archives, but manifest shape, digest meaning, and verification are artifact semantics | Fully resolved by Phase 2D Slices 1 + 2: manifest schema constants, `ArchiveFile`, and `ArchiveManifest` moved to `assay-runner-schema` in Slice 1; assembly (`RunnerSpikeArchive`, `RunnerSpikeArchiveError`, `write`) moved to `assay-runner-core` in Slice 2. Archive verification continues to use the existing Assay evidence path; the runner side no longer mixes assembly mechanics with manifest semantics ownership |
 | `health.rs` and `observation-health.json` | the runner measures drops and cgroup health, but `kernel_layer=complete` and related status meanings are Assay claims | Assay owns the status definitions; runner computes whether a measured run satisfies them |
 | telemetry-versus-evidence filters | the runner implements event-type and path filters, but deciding what counts as evidence is artifact semantics | Assay owns the evidence taxonomy and rationale; runner owns the implementation and diagnostics |
 | `tool_call_id` fallback semantics | fallback would change correlation mechanics and `correlation-report.json` ambiguity semantics at the same time | v0 clean correlation and the first Phase 2B capability-diff contract require stable tool-call ids; call-id-less support is out of scope until a separate fallback contract exists |

--- a/docs/reference/runner/extraction-roadmap.md
+++ b/docs/reference/runner/extraction-roadmap.md
@@ -171,7 +171,10 @@ Compatibility:
 Resolves: blocker #1 fully; partial progress on blocker #2 (manifest
 semantics half).
 
-### Slice 2 — `crates/assay-runner-core`
+### Slice 2 — `crates/assay-runner-core` ✅ LANDED
+
+> Resolves blocker #2 fully (archive boundary conflict completely
+> resolved together with Slice 1's manifest semantics move).
 
 **Scope.** Move runner orchestration and archive assembly into a new
 `crates/assay-runner-core` crate that depends on

--- a/docs/reference/runner/platform-and-extraction-readiness.md
+++ b/docs/reference/runner/platform-and-extraction-readiness.md
@@ -43,12 +43,14 @@ Current structural blockers, in priority order:
    unchanged. See
    [`extraction-roadmap.md` § Slice 1](extraction-roadmap.md#slice-1--cratesassay-runner-schema)
    and the updated boundary-map ownership table.
-2. **Partially resolved by Phase 2D Slice 1.** Archive manifest
-   semantics (schema constants, `ArchiveFile`, `ArchiveManifest`)
-   moved to `assay-runner-schema`. Archive assembly mechanics
-   (`RunnerSpikeArchive`, `write`, normalizers) still live in
-   `assay-runner-spike` and move to `assay-runner-core` at
-   [Slice 2](extraction-roadmap.md#slice-2--cratesassay-runner-core).
+2. **Resolved by Phase 2D Slices 1 + 2.** Archive manifest semantics
+   (schema constants, `ArchiveFile`, `ArchiveManifest`) moved to
+   `assay-runner-schema` in Slice 1. Archive assembly mechanics
+   (`RunnerSpikeArchive`, `write`, normalizers, `RunSpec`
+   orchestration) moved to `assay-runner-core` in Slice 2. The
+   archive boundary conflict is now fully resolved on the runner
+   side; verification continues through the existing Assay evidence
+   path.
 3. Cgroup placement still depends on `crates/assay-cli/src/cgroup.rs`. A
    stable cgroup API is required before extraction.
 4. There is no non-spike external consumer of the runner bundle format. The

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -137,6 +137,7 @@ def classify_file(path: str) -> tuple[Gate, str | None]:
     all_prefixes = (
         "crates/assay-runner-spike/",
         "crates/assay-runner-schema/",
+        "crates/assay-runner-core/",
         "crates/assay-monitor/",
         "crates/assay-ebpf/",
         "crates/assay-xtask/",
@@ -500,6 +501,13 @@ def self_test() -> None:
         # runner-impacting and require gates=all just like the spike crate.
         (["crates/assay-runner-schema/src/lib.rs"], Gate.ALL),
         (["crates/assay-runner-schema/Cargo.toml"], Gate.ALL),
+        # Phase 2D Slice 2 extracted runner orchestration, archive
+        # assembly, and layer normalizers from crates/assay-runner-spike/
+        # into crates/assay-runner-core/. Core hosts the mechanics half
+        # of the measured-run path and must be classified the same as
+        # the spike crate for delegated proof requirements.
+        (["crates/assay-runner-core/src/lib.rs"], Gate.ALL),
+        (["crates/assay-runner-core/Cargo.toml"], Gate.ALL),
     ]
     for files, expected in cases:
         got = classify_files(files).gate


### PR DESCRIPTION
## Summary

**Phase 2D Slice 2** of the [Assay-Runner extraction roadmap](https://github.com/Rul1an/assay/blob/main/docs/reference/runner/extraction-roadmap.md). Move runner orchestration, archive assembly, and kernel/policy/SDK layer normalizers out of `crates/assay-runner-spike/` into a new publish-disabled crate `crates/assay-runner-core/`. The spike crate becomes a thin compatibility wrapper that re-exports the public surface from `assay-runner-core` (mechanics, this slice) and `assay-runner-schema` (data, Slice 1).

## Delegated proof recorded

- gate: `all`
- run: <https://github.com/Rul1an/assay/actions/runs/26297323350>
- head SHA: `fb73550c7fc562ce15c1d2a40cce063def1306e3`
- short SHA: `fb73550c`
- proof-pack artifact: `assay-runner-delegated-proof-pack-26297323350`
- jobs: Prepare delegated runner (success) + Phase 1 delegated gates (all) (success)
- host class: `assay-bpf-runner` self-hosted Linux runner
- first dispatch attempt (`26294732689`) failed with infrastructure cancellation during eBPF build (no Slice 2 code involvement); retry succeeded cleanly

## Extraction boundary impact

This PR is **Type A** per the [per-PR discipline rule](https://github.com/Rul1an/assay/blob/main/docs/reference/runner/extraction-roadmap.md#per-pr-discipline-rule): it resolves a named structural blocker.

| Blocker | Before this PR | After this PR |
|---|---|---|
| **#2** Archive verification crosses an unresolved boundary conflict in `archive.rs` | partially resolved (manifest semantics moved in Slice 1) | **RESOLVED FULLY** — assembly mechanics moved to `assay-runner-core`; runner side no longer mixes assembly with manifest semantics ownership |

Remaining structural blockers (per [`platform-and-extraction-readiness.md`](https://github.com/Rul1an/assay/blob/main/docs/reference/runner/platform-and-extraction-readiness.md#extraction-readiness)):

- **#3** Cgroup placement at `crates/assay-cli/src/cgroup.rs` — Slice 3 territory, untouched in this PR
- **#4** No non-spike external consumer of the runner bundle format — Slice 6 territory

## What moved (git-tracked renames spike → core)

Five files, 2502 lines, **all detected as renames** by git with 96-99% similarity:

| File | Lines | Contents |
|---|---:|---|
| `run.rs` | 375 | `RunSpec`, execution orchestration, run_id validation, contract-only-bundle |
| `archive.rs` | 375 (after Slice 1 trim) | `RunnerSpikeArchive` assembly, write/manifest helpers, deterministic tar/gzip |
| `kernel.rs` | 864 | `KernelLayerBuilder`, `KernelLayerCapture`, monitor stats normalization, cgroup-correlation, telemetry filters |
| `policy.rs` | 345 | `PolicyLayerCapture` parsing, capability-surface derivation from decision events |
| `sdk.rs` | 506 (after Slice 1 trim) | `SdkLayerCapture` parsing, SDK/policy mismatch marking |

## New crate dependencies for `assay-runner-core`

Carried over from the previous `assay-runner-spike` Cargo.toml plus the schema crate added in Slice 1:

- `assay-common` (workspace, std)
- `assay-monitor` (workspace) — `kernel.rs` uses `MonitorStatsSnapshot`
- `assay-runner-schema` (workspace) — all v0 types consumed from here
- `serde` + `serde_json` (workspace, std)
- `sha2` + `hex` (workspace) — archive manifest digests
- `thiserror` (workspace) — error enums
- `flate2` + `tar` (workspace) — archive assembly
- `uuid` (workspace) — run id generation

**Explicitly forbidden per roadmap (verified absent):**
- `assay-cli` (would re-introduce blocker #3 dependency; cgroup extraction is Slice 3)
- `assay-evidence` direct usage (runner archives stay consumable through the existing Assay evidence path; no copy of verification logic)

`publish = false` until Slice 7.

## Compatibility — `assay-runner-spike` thin wrapper

`crates/assay-runner-spike/src/lib.rs` now contains only `pub use` re-exports:
- `pub use assay_runner_schema::{...}` (data structures from Slice 1)
- `pub use assay_runner_core::{...}` (mechanics from this slice)

`crates/assay-runner-spike/Cargo.toml` dependencies reduced to just `assay-runner-schema` and `assay-runner-core`. No `serde`, `thiserror`, `sha2`, `hex`, `flate2`, `tar`, `uuid`, `assay-common`, or `assay-monitor` — all those moved with the implementation into the core crate.

External consumers (`assay-cli`, `scripts/ci/runner-spike-*.sh`, `tests/fixtures/runner-spike/`) continue to import via `assay_runner_spike::Type` unchanged.

## Lane-check classifier updated

`scripts/ci/assay_runner_lane_check.py`:
- `crates/assay-runner-core/` added to `all_prefixes` list
- Two defensive self-test cases pin the new crate to `Gate.ALL`:
  - `crates/assay-runner-core/src/lib.rs`
  - `crates/assay-runner-core/Cargo.toml`

## Docs updated to reflect the boundary move

- `boundary-map.md` § "Current In-Repo Ownership" — new `crates/assay-runner-core/` rows + collapsed spike rows (now just wrapper + single lib.rs)
- `boundary-map.md` § "Active Boundary Conflicts" — `archive.rs` conflict marked **"Fully resolved by Phase 2D Slices 1 + 2"**
- `platform-and-extraction-readiness.md` § "Extraction Readiness" — blocker #2 marked resolved fully
- `extraction-roadmap.md` § Slice 2 — marked `✅ LANDED`

## What this PR explicitly does NOT do

- modify any v0 schema string value, field set, or value vocabulary
- modify any v0 contract document semantically (only ownership-table updates)
- introduce new fixtures, workflows, or CI lane rules
- introduce new external dependencies
- redirect assay-cli call sites to depend on assay-runner-core directly (spike wrapper keeps existing imports working; redirect is a later cleanup)
- touch the cgroup dependency from `crates/assay-cli/src/cgroup.rs` (Slice 3)
- open Slice 3 or any later slice

## Validation (local)

| Check | Result |
|---|---|
| `cargo build -p assay-runner-core` | ✅ |
| `cargo test -p assay-runner-core --lib` | ✅ **49 passed** (every test that ran in the previous assay-runner-spike now runs in assay-runner-core; 14 schema tests run in assay-runner-schema per Slice 1) |
| `cargo build -p assay-runner-spike` | ✅ (wrapper compiles) |
| `cargo test -p assay-runner-spike --lib` | ✅ 0 tests (correct — wrapper has no behaviour) |
| `cargo build -p assay-cli` | ✅ (external consumer compiles unchanged through the wrapper) |
| `cargo clippy -p assay-runner-core -p assay-runner-spike -p assay-runner-schema -p assay-cli --all-targets -- -D warnings` | ✅ |
| `cargo fmt --check` | ✅ |
| `python3 scripts/ci/assay_runner_lane_check.py --self-test` | ✅ |
| `mkdocs build --strict` | ✅ no new warnings |
| pre-commit hooks | ✅ (fmt, typos, merge conflicts, trailing whitespace, cargo deny, secret hygiene) |
| pre-push hooks | ✅ (clippy on changed crates, linux compile gate) |

## Delegated proof requirement

This PR requires a delegated `gates=all` run per the lane-check classifier:
- `Cargo.toml` change → `Gate.ALL`
- `crates/assay-runner-spike/` changes → `Gate.ALL`
- `crates/assay-runner-core/` changes → `Gate.ALL` (new rule)

Delegated run URL + head SHA + proof-pack artifact reference will be added to this PR body before Ready/merge.

## Related

- Roadmap: `docs/reference/runner/extraction-roadmap.md` (#1316, merged)
- Slice 1: `crates/assay-runner-schema/` (#1317, merged)
- Boundary: `docs/reference/runner/boundary-map.md`
- Readiness: `docs/reference/runner/platform-and-extraction-readiness.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)