### PR TITLE
docs(phase-2d): replace passive 4-6 week wait with consolidation burn-in criteria

### DIFF
--- a/docs/reference/runner/boundary-map.md
+++ b/docs/reference/runner/boundary-map.md
@@ -172,11 +172,14 @@ window, treat that as evidence that extraction is premature. Do not force a
 repository split while the ownership line is still moving.
 
 The consolidation window is an evidence requirement, not a calendar
-requirement. After Phase 2D Slices 1-6B landed, the passive 4-6 week wait is
-satisfied by the burn-in criteria recorded in
-[`phase-2d-consolidation-audit.md`](phase-2d-consolidation-audit.md). Counting
-weeks without observing repo behavior is weak evidence; the audit page makes
-the evidence concrete.
+requirement. After Phase 2D Slices 1-6B landed, the passive 4-6 week wait
+is replaced by the burn-in criteria defined in
+[`phase-2d-consolidation-audit.md`](phase-2d-consolidation-audit.md). The
+burn-in criteria are the new satisfaction condition for this consolidation
+gate; they are not necessarily satisfied yet — the audit page tracks which
+criteria are observed and which are still pending. Counting weeks without
+observing repo behavior is weak evidence; the audit page makes the
+evidence concrete.
 
 ## Extraction Blocking Conditions
 

--- a/docs/reference/runner/boundary-map.md
+++ b/docs/reference/runner/boundary-map.md
@@ -171,6 +171,13 @@ If the boundary map remains materially unstable after a 4-6 week consolidation
 window, treat that as evidence that extraction is premature. Do not force a
 repository split while the ownership line is still moving.
 
+The consolidation window is an evidence requirement, not a calendar
+requirement. After Phase 2D Slices 1-6B landed, the passive 4-6 week wait is
+satisfied by the burn-in criteria recorded in
+[`phase-2d-consolidation-audit.md`](phase-2d-consolidation-audit.md). Counting
+weeks without observing repo behavior is weak evidence; the audit page makes
+the evidence concrete.
+
 ## Extraction Blocking Conditions
 
 Extraction is blocked if any of these are true:

--- a/docs/reference/runner/extraction-roadmap.md
+++ b/docs/reference/runner/extraction-roadmap.md
@@ -435,9 +435,13 @@ product docs, and the consumer side of runner evidence.
    in the boundary map are green.
 2. Zero of the 11 [`Extraction Blocking Conditions`](boundary-map.md#extraction-blocking-conditions)
    are true.
-3. Slices 1-6 have all landed and have passed at least one consolidation
-   window (4-6 weeks) without semantic churn on the boundaries they
-   touched.
+3. Slices 1-6 have all landed and have passed the consolidation
+   burn-in recorded in
+   [`phase-2d-consolidation-audit.md`](phase-2d-consolidation-audit.md)
+   without semantic churn on the boundaries they touched. The
+   consolidation window is an evidence requirement, not a calendar
+   requirement; 4-6 weeks of idle calendar time alone does not
+   satisfy this gate.
 4. A concrete external use case exists (per the trigger in
    [`platform-and-extraction-readiness.md`](platform-and-extraction-readiness.md#extraction-readiness)).
    "We could split now" is not a trigger.
@@ -599,7 +603,7 @@ readiness hold simultaneously, not just the technical one:
 | Readiness type | What it covers |
 |---|---|
 | **Technical** | Slices 1-6 landed: schema crate, core crate, cgroup/platform boundary, fixture package boundary, archive verification without copying Assay internals |
-| **Process** | CI lane classification stable, delegated proof recording stable, ringbuf diagnostics explicitly decided per [`#1271`](https://github.com/Rul1an/assay/issues/1271), 4-6 weeks without contract churn, maintainers can explain the boundary without archaeology |
+| **Process** | CI lane classification stable, delegated proof recording stable, ringbuf diagnostics explicitly decided per [`#1271`](https://github.com/Rul1an/assay/issues/1271), consolidation burn-in satisfied per [`phase-2d-consolidation-audit.md`](phase-2d-consolidation-audit.md) (not 4-6 weeks of idle calendar time), maintainers can explain the boundary without archaeology |
 | **Product** | Assay consumes Runner as an external dependency (Slice 6), at least one real non-spike external consumer or use case exists, the split is justified because someone needs Runner standalone — not because the split is technically possible |
 
 The hardest gate is the **product** one. Slices 1-6 are work the

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -25,4 +25,5 @@ Phase 2B capability-diff planning slice.
 - [Runner platform and extraction readiness](platform-and-extraction-readiness.md)
 - [Assay-Runner extraction roadmap (Phase 2D slice sequence)](extraction-roadmap.md)
 - [Assay consumes Runner as external — Slice 6A design note](assay-consumes-runner-external.md)
+- [Phase 2D consolidation audit (burn-in criteria, not calendar wait)](phase-2d-consolidation-audit.md)
 - [Phase 1 delegated proof pack](proof-packs/phase1-delegated-2026-05-21.md)

--- a/docs/reference/runner/phase-2d-consolidation-audit.md
+++ b/docs/reference/runner/phase-2d-consolidation-audit.md
@@ -1,0 +1,189 @@
+# Phase 2D Consolidation Audit
+
+> Snapshot, not roadmap. Records the current verdict after Phase 2D
+> Slices 1-6B landed (commit `132c7011`, 2026-05-22): the four named
+> structural extraction blockers are resolved, and Slice 7 (repository
+> extraction) is still closed. This page replaces the passive 4-6 week
+> calendar wait with explicit burn-in criteria.
+
+**The consolidation window is an evidence requirement, not a calendar
+requirement.**
+
+Phase 2D Slice 7 may not open until either the burn-in criteria below
+are satisfied, or this document is updated to explain why a different
+form of evidence is sufficient. Counting weeks is not evidence.
+
+## Status
+
+| Item | Verdict |
+|---|---|
+| Phase 2D structural blocker #1 (schema crate) | **resolved** (Slice 1, `assay-runner-schema`) |
+| Phase 2D structural blocker #2 (archive boundary) | **resolved** (Slices 1 + 2, `assay-runner-core`) |
+| Phase 2D structural blocker #3 (cgroup API) | **resolved** (Slice 3, `assay-runner-linux`) |
+| Phase 2D structural blocker #4 (`assay-cli` no longer consumes spike) | **resolved** (Slice 6B) |
+| Slice 4 (platform composition boundary) | **landed re-scoped** as docs-only freeze; `PlatformAdapter` trait deferred |
+| Slice 5A/5B (fixture package boundary) | **landed** under `runner-fixtures/` |
+| Slice 6A (external-consumer design note) | **landed** ([`assay-consumes-runner-external.md`](assay-consumes-runner-external.md)) |
+| Slice 7 (repository extraction) | **still closed**; see hard gates in [`extraction-roadmap.md` § Slice 7](extraction-roadmap.md#slice-7-repository-split-gated) |
+| External consumer demand | **none proven**; no party has asked to consume `assay.runner.*.v0` without depending on Assay |
+
+The 15 [`Extraction Readiness Criteria`](boundary-map.md#extraction-readiness-criteria)
+and the 11 [`Extraction Blocking Conditions`](boundary-map.md#extraction-blocking-conditions)
+remain the authoritative checklist. This document does not replace
+them. It records the current verdict per category.
+
+## Why Not A Passive 4-6 Week Wait
+
+The original boundary-map rule says: if the boundary remains materially
+unstable after a 4-6 week consolidation window, treat that as evidence
+that extraction is premature. That rule was written assuming the repo
+would see normal churn during the window, and that the window would
+surface boundary stress through actual maintenance.
+
+Without an external consumer and without organic Runner-impacting
+maintenance, calendar time produces no signal. Sitting on a stable
+boundary for six idle weeks is not the same as proving the boundary
+under load. Passive calendar wait is weak evidence by itself.
+
+The correction is not to weaken the discipline; it is to make the
+evidence concrete.
+
+## Burn-In Criteria (Replace The Calendar Window)
+
+Slice 7 may not open until **all** of the following are observed in
+the existing monorepo. Each is a verifiable repo-behavior check, not a
+time check.
+
+1. **At least two normal (non-Runner) PRs land** that do not require
+   any edits to `crates/assay-runner-schema/`,
+   `crates/assay-runner-core/`, `crates/assay-runner-linux/`, the
+   `assay-runner-spike` wrapper, or the `runner-fixtures/` package
+   tree. This proves the new boundary does not leak into unrelated
+   work.
+2. **At least one Runner-impacting maintenance PR lands** through the
+   per-PR discipline rule in
+   [`extraction-roadmap.md` § Per-PR Discipline Rule](extraction-roadmap.md#per-pr-discipline-rule),
+   without reintroducing `assay-runner-spike` as a dependency of
+   `crates/assay-cli/` and without adding a new public API to the
+   three runner crates solely to make the maintenance possible.
+3. **All existing gates remain green on that maintenance PR.** That
+   means: `assay_runner_lane_check.py` classifier and self-test,
+   delegated `gates=all` proof on `assay-bpf-runner`, S5
+   mcp-policy-agent acceptance, and the Gemini second-runtime
+   fixture.
+4. **No new public API is added to `assay-runner-schema`,
+   `assay-runner-core`, or `assay-runner-linux` to absorb a normal
+   bug fix.** If a normal fix requires widening the public surface,
+   that is a churn signal and resets the burn-in.
+5. **No reintroduction of `assay-runner-spike` as a non-internal
+   consumer.** The wrapper stays as a legacy alias; nothing new
+   imports through it. The lane-check mechanical absence check
+   continues to enforce this.
+6. **The boundary-map ownership table is not amended during the
+   burn-in** except to record evidence (e.g. marking a row as
+   exercised by a specific PR). Structural amendments reset the
+   burn-in.
+
+A burn-in clock does not run. There is no minimum number of weeks. If
+two normal PRs and one maintenance PR all satisfy criteria 3-6 within
+two weeks, the burn-in is satisfied. If they take three months because
+no such PRs naturally arise, the burn-in is still incomplete and Slice
+7 stays closed.
+
+## Allowed Work During Burn-In
+
+The burn-in window is not a freeze. The following work is explicitly
+allowed, and counts toward the burn-in evidence when it occurs:
+
+- [`#1271`](https://github.com/Rul1an/assay/issues/1271) — non-canonical
+  ring-buffer diagnostic projection. A natural Type A or Type B
+  candidate that exercises `assay-runner-schema` and/or
+  `assay-runner-core` boundaries on a real feature.
+- Docs hygiene PRs: anchor fixes, mkdocs strict warnings, dead-link
+  cleanup, typo fixes in the runner reference.
+- CI guardrails: new lane-check self-test scenarios, tighter regexes,
+  encoding pinning, additional mechanical absence checks.
+- Bug fixes inside any existing runner crate that do not widen the
+  public API.
+- Acceptance-gate maintenance: re-recording delegated proof on a
+  newer self-hosted host, refreshing Gemini fixture trace bytes, S5
+  policy-agent maintenance.
+
+These do not require the audit document to be re-opened. They count
+as ordinary work.
+
+## Forbidden Work During Burn-In
+
+The following must not be opened during the burn-in window. Each is
+forbidden because it either pre-empts Slice 7, makes a product claim
+that has no evidence behind it, or relitigates a closed decision.
+
+- Repository split, repository name selection, new repo skeleton, or
+  any extraction-side scaffolding under a different `git remote`.
+- Publication: `publish = true` on any of the three runner crates,
+  crates.io reservation, npm/PyPI reservation, or registry presence.
+- macOS or Windows measurement work. These are governed exclusively
+  by [`platform-and-extraction-readiness.md`](platform-and-extraction-readiness.md#macos-proof-readiness)
+  and require their own spike plan.
+- A third runtime spike beyond the Linux + Gemini second-runtime
+  scope already accepted in
+  [`second-runtime-plan.md`](second-runtime-plan.md).
+- Reopening the `PlatformAdapter` trait or any platform-composition
+  façade before one of the three reopen triggers in
+  [`extraction-roadmap.md` § Slice 4](extraction-roadmap.md#slice-4-platform-composition-boundary-landed-re-scoped)
+  fires.
+- New `assay.runner.*.v1` contract work. The v0 contracts are still
+  under churn observation.
+- Public marketing of Assay-Runner as a standalone product (homepage
+  hero, "available now", external announcement, conference talk
+  framing it as a separate release).
+
+## Decision Checkpoint
+
+After the burn-in criteria are satisfied, this document is updated
+with one of three verdicts:
+
+1. **Keep in monorepo, publish-disabled.** Default outcome if no
+   external use case has been articulated. The three runner crates
+   stay `publish = false`; the spike wrapper stays as legacy alias;
+   the boundary discipline stays in force. Slice 7 stays closed and
+   this document is re-issued for the next burn-in cycle.
+2. **Open Slice 7 planning issue.** Only if (a) burn-in is satisfied
+   *and* (b) at least one concrete external consumer use case is
+   documented in a GitHub Discussion or issue. The Slice 7 planning
+   issue then names the repository, license, branch protection, CI
+   surface, and publication target.
+3. **Reset consolidation due to churn.** If burn-in criterion 4, 5,
+   or 6 is violated during the window, the burn-in is reset and the
+   reason is recorded here. This is not a failure; it is the
+   document doing its job.
+
+The decision belongs in a docs-only update to this page. It does not
+open implementation work by itself.
+
+## Non-Claims
+
+This document does not:
+
+- claim Assay-Runner is a standalone product
+- claim external demand exists or is being measured
+- claim a release window for Slice 7
+- announce a repository name or layout
+- replace any of the 15 readiness criteria or the 11 blocking
+  conditions
+- weaken any existing acceptance gate (lane-check, delegated,
+  Gemini, S5)
+- authorize any of the work listed under Forbidden Work
+- supersede [`boundary-map.md`](boundary-map.md),
+  [`extraction-roadmap.md`](extraction-roadmap.md), or
+  [`platform-and-extraction-readiness.md`](platform-and-extraction-readiness.md);
+  it sits next to them as the consolidation-evidence page
+
+## References
+
+- [Assay-Runner boundary and extraction map](boundary-map.md)
+- [Assay-Runner extraction roadmap (Phase 2D slice sequence)](extraction-roadmap.md)
+- [Runner platform and extraction readiness](platform-and-extraction-readiness.md)
+- [Assay consumes Runner as external — Slice 6A design note](assay-consumes-runner-external.md)
+- [Runner CI lane contract](ci-lanes.md)
+- [Runner second runtime Phase 2B plan](second-runtime-plan.md)

--- a/docs/reference/runner/platform-and-extraction-readiness.md
+++ b/docs/reference/runner/platform-and-extraction-readiness.md
@@ -96,8 +96,11 @@ Triggers for reopening extraction readiness review:
   without depending on Assay internals. This creates the missing external
   consumer and creates a real reason to move schemas to a shared crate.
 - The four structural blockers above are independently resolved.
-- The `assay.runner.*.v0` contracts pass a stable window of at least four to
-  six weeks without semantic churn.
+- The `assay.runner.*.v0` contracts pass the consolidation burn-in recorded
+  in [`phase-2d-consolidation-audit.md`](phase-2d-consolidation-audit.md)
+  without semantic churn. The consolidation window is an evidence
+  requirement, not a calendar requirement; 4-6 weeks of idle calendar time
+  does not by itself satisfy this trigger.
 
 Until those triggers fire, extraction stays closed by default. "We could
 extract now" is not a trigger.


### PR DESCRIPTION
## Summary

After Phase 2D Slices 1-6B landed (commit `132c7011`), the four named structural extraction blockers are resolved and Slice 7 (repository split) is still closed. The original boundary-map rule said: if the boundary remains materially unstable after a 4-6 week consolidation window, treat that as evidence that extraction is premature. That rule was written assuming the repo would see normal churn during the window. Without an external consumer and without organic Runner-impacting maintenance, calendar time produces no signal.

> The consolidation window is an evidence requirement, not a calendar requirement.

This PR is docs-only. It does not open Slice 7, does not weaken any acceptance gate, and does not replace any of the 15 readiness criteria or the 11 blocking conditions in `boundary-map.md`.

## What this PR adds

- `docs/reference/runner/phase-2d-consolidation-audit.md` (new):
  - Snapshot of current status: blockers 1-4 resolved, Slice 7 closed
  - Why a passive 4-6 week wait is weak evidence without users
  - Burn-in criteria that replace the calendar window (6 verifiable repo-behavior checks)
  - Allowed work during burn-in: #1271 diagnostic projection, docs hygiene, CI guardrails, bug fixes, acceptance-gate maintenance
  - Forbidden work during burn-in: repo split, publication, macOS/Windows, third runtime, PlatformAdapter trait reopen without trigger, v1 contract work, standalone product marketing
  - Decision checkpoint: keep in monorepo / open Slice 7 planning issue / reset consolidation due to churn
  - Explicit non-claims: no standalone product, no external demand proven, no release claim

## Cross-link edits

- `boundary-map.md`: clarifies that after Slices 1-6B the 4-6 week window is satisfied by the burn-in criteria in the new audit page
- `extraction-roadmap.md`: Slice 7 gate #3 and the Process readiness row both reference the burn-in instead of raw calendar time
- `platform-and-extraction-readiness.md`: extraction reopen trigger about the 4-6 week stable window now references the audit page
- `index.md`: adds the new page to the runner reference list

## Non-claims

This PR does not:
- open Slice 7 or any extraction work
- pick a repository name, license, branch protection, CI surface, or publication target
- claim Assay-Runner is a standalone product
- claim external demand has been measured
- weaken any acceptance gate (lane-check, delegated, Gemini, S5)
- supersede `boundary-map.md`, `extraction-roadmap.md`, or `platform-and-extraction-readiness.md`; the new page sits next to them as the consolidation-evidence page

## Test plan

- [x] Pre-commit hooks pass (fmt, typos, trailing whitespace, merge conflicts, clippy, linux compile gate)
- [x] All anchor targets in the new page resolve against verified headings (Slice 4 anchor pattern used as reference)
- [ ] mkdocs strict build (not run locally; relies on CI docs job if present)
- [ ] CI: lane-check passes (this PR touches only `docs/reference/runner/`, classifier should mark as `Gate.NONE`)
- [ ] Reviewer reads the new audit page end-to-end and confirms the "evidence not calendar" framing matches intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)