### PR TITLE
docs(runner): add internal Assay-Runner status section to README and runner reference index

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,15 @@ These are tool-decision timings, not end-to-end model latency. (See [Research & 
 - [ADR-033: Trust compiler positioning](docs/architecture/ADR-033-OTel-Trust-Compiler-Positioning.md)
 - [RFC-005: Trust compiler MVP & Trust Card](docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md)
 
+## Internal: Assay-Runner
+
+Assay-Runner is an internal measured-run subsystem used by Assay's delegated Linux/eBPF acceptance path. It is **not a standalone product**. As of Phase 2D, the runner candidate is split into extraction-ready crates (`assay-runner-schema`, `assay-runner-core`, `assay-runner-linux`) plus the `runner-fixtures/` package tree, but all of these remain `publish = false` and live inside this repository.
+
+- [Assay-Runner reference index](docs/reference/runner/index.md) — internal contracts, boundary map, slice history
+- [Phase 2D consolidation audit](docs/reference/runner/phase-2d-consolidation-audit.md) — current burn-in criteria; the extraction question is closed until the criteria are observed and at least one concrete external use case appears
+
+No release commitment. No timeline. No external demand has been measured.
+
 ## Research, mappings & experiments
 
 **Bounded context:** numbers below support **mapping and experiments**, not a product “security score.”

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ These are tool-decision timings, not end-to-end model latency. (See [Research & 
 
 ## Internal: Assay-Runner
 
-Assay-Runner is an internal measured-run subsystem used by Assay's delegated Linux/eBPF acceptance path. It is **not a standalone product**. As of Phase 2D, the runner candidate is split into extraction-ready crates (`assay-runner-schema`, `assay-runner-core`, `assay-runner-linux`) plus the `runner-fixtures/` package tree, but all of these remain `publish = false` and live inside this repository.
+Assay-Runner is an internal measured-run subsystem used by Assay's delegated Linux/eBPF acceptance path. It is **not a standalone product**. As of Phase 2D, the runner candidate is split into extraction-ready Rust crates (`assay-runner-schema`, `assay-runner-core`, `assay-runner-linux`) — all `publish = false` — plus the `runner-fixtures/` package tree (Node fixture marked `"private": true`; Python fixture has no distribution surface). Everything stays inside this repository.
 
 - [Assay-Runner reference index](docs/reference/runner/index.md) — internal contracts, boundary map, slice history
 - [Phase 2D consolidation audit](docs/reference/runner/phase-2d-consolidation-audit.md) — current burn-in criteria; the extraction question is closed until the criteria are observed and at least one concrete external use case appears

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -1,11 +1,12 @@
 # Assay-Runner Reference
 
 > **Status:** Assay-Runner is an internal measured-run subsystem of Assay,
-> now split into extraction-ready crates (`assay-runner-schema`,
-> `assay-runner-core`, `assay-runner-linux`) plus the `runner-fixtures/`
-> package tree. All of these are `publish = false` and live inside this
-> repository. Not a standalone product. No release commitment. The
-> extraction question is gated by the
+> now split into extraction-ready Rust crates (`assay-runner-schema`,
+> `assay-runner-core`, `assay-runner-linux`) — all `publish = false` —
+> plus the `runner-fixtures/` package tree (Node fixture marked
+> `"private": true`; Python fixture has no distribution surface).
+> Everything stays inside this repository. Not a standalone product.
+> No release commitment. The extraction question is gated by the
 > [Phase 2D consolidation audit](phase-2d-consolidation-audit.md).
 
 Internal reference material for the Assay-Runner measured-run candidate.

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -1,5 +1,13 @@
 # Assay-Runner Reference
 
+> **Status:** Assay-Runner is an internal measured-run subsystem of Assay,
+> now split into extraction-ready crates (`assay-runner-schema`,
+> `assay-runner-core`, `assay-runner-linux`) plus the `runner-fixtures/`
+> package tree. All of these are `publish = false` and live inside this
+> repository. Not a standalone product. No release commitment. The
+> extraction question is gated by the
+> [Phase 2D consolidation audit](phase-2d-consolidation-audit.md).
+
 Internal reference material for the Assay-Runner measured-run candidate.
 
 Assay-Runner is not a released product surface yet. These references freeze


### PR DESCRIPTION
## Summary

Phase 2D Slices 1-6B landed (PR #1325) and the consolidation audit (PR #1327) replaced the passive 4-6 week wait with explicit burn-in criteria. With the structural blockers resolved, the runner candidate is **extraction-ready but not extracted**. This PR makes that status findable without overclaiming.

The vibe is *internally extraction-ready, seeking real standalone demand* — not a launch, not a product page.

## What this PR adds

**README.md** — new "Internal: Assay-Runner" section between Learn More and Research/experiments:
- States explicitly: not a standalone product, `publish = false`, no release commitment, no measured external demand
- Lists two links: runner reference index, Phase 2D consolidation audit
- No badges, no marketing copy, no hero placement

**docs/reference/runner/index.md** — blockquote status banner at the top:
- Extraction-ready crates (`assay-runner-schema`, `assay-runner-core`, `assay-runner-linux`) + `runner-fixtures/` package tree
- All `publish = false`, all inside this repository
- Extraction gated by the Phase 2D consolidation audit

## Non-claims

This PR does not:
- announce Assay-Runner as a separate product
- promise a release window or repository name
- open Slice 7 (repository split)
- change any acceptance gate, contract, or runner crate
- modify lane-check, S5, delegated, or Gemini gates

Visibility only — no code, no schema, no gates touched.

## Test plan

- [x] Pre-commit hooks pass (fmt, typos, trailing whitespace, merge conflicts)
- [ ] CI: lane-check should classify as `Gate.NONE` (only `README.md` and `docs/reference/runner/index.md` touched; `docs/reference/runner/**` is per-PR-discipline-tracked but lane-check itself does not require delegated proof for docs)
- [ ] mkdocs-strict passes (new blockquote, no new anchors introduced)
- [ ] Reviewer confirms wording does not overclaim ("not a standalone product" framing is intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)