### PR TITLE
docs(runner): add explainable measured-run walkthrough + measured-runs vs traces note

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ These are tool-decision timings, not end-to-end model latency. (See [Research & 
 Assay-Runner is an internal measured-run subsystem used by Assay's delegated Linux/eBPF acceptance path. It is **not a standalone product**. As of Phase 2D, the runner candidate is split into extraction-ready Rust crates (`assay-runner-schema`, `assay-runner-core`, `assay-runner-linux`) — all `publish = false` — plus the `runner-fixtures/` package tree (Node fixture marked `"private": true`; Python fixture has no distribution surface). Everything stays inside this repository.
 
 - [Assay-Runner reference index](docs/reference/runner/index.md) — internal contracts, boundary map, slice history
+- [Measured-run proof-bundle walkthrough](docs/reference/runner/examples/measured-run-proof-bundle.md) — read-only walkthrough for maintainers evaluating standalone use cases
 - [Phase 2D consolidation audit](docs/reference/runner/phase-2d-consolidation-audit.md) — current burn-in criteria; the extraction question is closed until the criteria are observed and at least one concrete external use case appears
 
 No release commitment. No timeline. No external demand has been measured.

--- a/docs/notes/ASSAY-RUNNER-MEASURED-RUNS-2026-05-23.md
+++ b/docs/notes/ASSAY-RUNNER-MEASURED-RUNS-2026-05-23.md
@@ -1,0 +1,184 @@
+# Measured Runs Are Not Traces
+
+> **Status:** internal engineering note, not a release announcement.
+> **Date:** 2026-05-23
+> **Scope:** the conceptual distinction between traces/observability and a
+> deterministic measured-run proof bundle; companion to the
+> [read-only walkthrough](../reference/runner/examples/measured-run-proof-bundle.md)
+> and the [Phase 1 + 2 retrospective](./ASSAY-RUNNER-PHASE-1-AND-2-RETROSPECTIVE-2026-05-22.md).
+
+This note exists because two questions keep coming back from people who
+look at Assay-Runner for the first time:
+
+> "Is this a tracing tool?"
+
+and
+
+> "Is this an observability dashboard?"
+
+Both reasonable, both no. This is an attempt to explain *why* no, in
+plain terms, without pitching a product.
+
+## The Gap Traces Don't Cover
+
+Traces tell you what the application *thought* happened. Span hierarchies,
+attributes, status codes, sometimes events. That is genuinely useful and
+not something Assay-Runner is trying to replace.
+
+But traces sit at the application layer. They tell you what the agent
+*said* it did. They do not tell you what the process *actually* did at
+the kernel boundary — which files it opened, which sockets it touched,
+which child processes it spawned, whether the policy decision the agent
+believed in was the same decision the host system saw.
+
+For most production observability work, that gap is fine. You look at
+spans, you fix what's slow, you ship. Nobody needs kernel-grounded
+evidence to debug a latency regression.
+
+For agent systems in CI, release-gate, or audit contexts, the gap
+matters more. The question shifts from *"is the agent fast"* to *"is
+the agent doing what the policy said it was allowed to do, and can I
+prove it deterministically two weeks from now when this release ships"*.
+Traces don't carry that proof.
+
+## What A Measured Run Adds
+
+A measured run is one execution of one agent fixture, observed at three
+layers simultaneously and bound together by a stable `tool_call_id`:
+
+- **Kernel layer.** cgroup-scoped eBPF events: file opens, network
+  endpoints, process execs. What the host actually saw.
+- **Policy layer.** MCP allow/deny decisions: what the policy gate
+  decided about each tool call.
+- **SDK layer.** Normalized agent tool-call events: what the SDK
+  claimed it did.
+
+The run produces one archive containing five canonical JSON artifacts
+plus two ndjson layer streams. Schemas are frozen as
+`assay.runner.*.v0`. The archive verifies through the existing Assay
+evidence path; runner bundles do not have their own verifier.
+
+The most load-bearing artifact is **observation health**. It is the
+contract that the bundle is *not lying about gaps*. If the kernel
+ring-buffer dropped events, the bundle has to say so and degrade. If
+policy capture was missing, the bundle has to say so. If the SDK layer
+was self-reported only and not kernel-corroborated, it is recorded as
+`self_reported` — never as if the SDK had been independently verified.
+
+The [walkthrough](../reference/runner/examples/measured-run-proof-bundle.md)
+shows what each artifact looks like in practice, using existing
+checked-in golden artifacts from the OpenAI Agents and Gemini
+fixtures.
+
+## How This Differs From An Observability Dashboard
+
+An observability dashboard answers:
+
+> What is happening across many runs, right now?
+
+It optimizes for live signal, aggregation, drill-down, and human eyes
+in the loop. The system gets faster and louder; the user notices.
+
+A measured-run proof bundle answers:
+
+> For this one run, exactly what did the kernel/policy/SDK layers
+> observe, and do those layers correlate cleanly under a frozen
+> contract?
+
+It optimizes for byte-stable artifacts, no inferred ordering, explicit
+honesty about degraded layers, and CI gates in the loop. The artifact
+is the deliverable; it has to survive being diffed two months from now
+against today's baseline.
+
+Both are useful. They are not substitutes. A team running an
+observability stack might still want a measured-run bundle for the
+narrow case where they need to *prove* what one specific release did
+under a specific policy. The reverse — running measured-run bundles
+where you actually want live monitoring — would be the wrong shape.
+
+## Why Standalone Extraction Is Not Decided
+
+The four structural blockers that would have prevented Assay-Runner
+from leaving the Assay repository have been resolved as of Phase 2D
+Slice 6B. The schemas live in their own crate, archive assembly lives
+in its own crate, cgroup placement lives in its own crate, and Assay
+itself consumes the runner via those crates rather than through the
+spike wrapper.
+
+That makes extraction *possible*. It does not make extraction *right*.
+
+The honest version is that no concrete external consumer has appeared.
+We did not build this because someone asked for a deterministic
+proof-bundle subsystem; we built it because Assay needed measured-run
+evidence and the boundary work was good engineering hygiene. The
+question of whether it should ever leave the Assay repo is downstream
+of "would anyone use it standalone", and that is not a question we can
+answer from inside the repo.
+
+The
+[Phase 2D consolidation audit](../reference/runner/phase-2d-consolidation-audit.md)
+replaces the original "wait 4–6 weeks" rule with explicit burn-in
+criteria: at least two normal PRs through the new boundary, at least
+one Runner-impacting maintenance PR through the per-PR discipline, no
+re-introduction of the spike crate, no public API widening for routine
+fixes. None of these criteria are observed yet at the time of writing
+because the audit just landed.
+
+So: extraction is technically unblocked, evidentially unproven, and
+externally unmotivated. The right answer in that situation is "wait
+and look", not "split".
+
+## The Honest Question To External Maintainers
+
+If you are maintaining an agent-observability project — system-level
+or application-level — the question this work is trying to answer is
+narrower than "would you use Assay-Runner?". It is:
+
+> Would a deterministic measured-run proof-bundle layer be useful as a
+> CI or release companion next to what you already do?
+
+Three answers all give us useful signal:
+
+- **Yes, this would slot in next to our live monitoring as a CI
+  evidence artifact.** That is a real external use case; the audit
+  page would treat it as one of the triggers for opening the
+  extraction question.
+- **No, our users want streaming/live signal, not bundles.** That is a
+  clean shape-mismatch verdict; it goes into the consolidation audit
+  as evidence that the abstraction is wrong for that audience, and
+  the extraction question stays closed.
+- **Maybe, if it emitted OTel-shaped output.** That is a bridge
+  question, not a Slice 7 trigger, but it tells us where the future
+  contract surface might need to grow.
+
+The places that question is currently being asked, passively:
+
+- [Discussion #1329](https://github.com/Rul1an/assay/discussions/1329)
+  on this repo.
+- [Issue #44](https://github.com/eunomia-bpf/agentsight/issues/44) at
+  AgentSight, as a maintainer-level sanity check.
+
+No pings, no cross-posts, no @-mentions. The probe is intentionally
+low-pressure.
+
+## Short Form
+
+- Traces tell you what the agent thought it did.
+- A measured run tells you what the kernel saw, what the policy
+  decided, and what the SDK claimed — bound together by one stable
+  `tool_call_id`.
+- One archive per run, five frozen JSON artifacts, two ndjson layer
+  streams, verifiable through the existing Assay evidence path.
+- This is not an observability dashboard. It is a deterministic
+  evidence layer for CI/release/audit contexts.
+- Whether it should ever leave the Assay repo depends on someone
+  outside the repo saying it would help them. Until then, it stays in.
+
+## References
+
+- [Measured-run proof-bundle walkthrough](../reference/runner/examples/measured-run-proof-bundle.md)
+- [Phase 1 + 2 retrospective](./ASSAY-RUNNER-PHASE-1-AND-2-RETROSPECTIVE-2026-05-22.md)
+- [Assay-Runner reference index](../reference/runner/index.md)
+- [Phase 2D consolidation audit](../reference/runner/phase-2d-consolidation-audit.md)
+- [Runner artifact v0 contracts](../reference/runner/artifacts-v0.md)
+- [Runner cross-runtime diff v0 contract](../reference/runner/cross-runtime-diff-v0.md)

--- a/docs/notes/ASSAY-RUNNER-MEASURED-RUNS-2026-05-23.md
+++ b/docs/notes/ASSAY-RUNNER-MEASURED-RUNS-2026-05-23.md
@@ -53,10 +53,15 @@ layers simultaneously and bound together by a stable `tool_call_id`:
 - **SDK layer.** Normalized agent tool-call events: what the SDK
   claimed it did.
 
-The run produces one archive containing five canonical JSON artifacts
-plus two ndjson layer streams. Schemas are frozen as
-`assay.runner.*.v0`. The archive verifies through the existing Assay
-evidence path; runner bundles do not have their own verifier.
+The run produces one deterministic `.tar.gz` archive containing three
+load-bearing v0 JSON artifacts (`observation-health.json`,
+`capability-surface.json`, `correlation-report.json`), an archive
+manifest (`manifest.json` with file digests), a whole-archive event
+stream (`events.ndjson`), and three per-layer event streams
+(`layers/kernel.ndjson`, `layers/policy.ndjson`, `layers/sdk.ndjson`).
+Schemas are frozen as `assay.runner.*.v0`. The archive verifies through
+the existing Assay evidence path; runner bundles do not have their own
+verifier.
 
 The most load-bearing artifact is **observation health**. It is the
 contract that the bundle is *not lying about gaps*. If the kernel

--- a/docs/reference/runner/examples/measured-run-proof-bundle.md
+++ b/docs/reference/runner/examples/measured-run-proof-bundle.md
@@ -1,0 +1,332 @@
+# Measured-Run Proof Bundle — Read-Only Walkthrough
+
+> **Status:** explainable demo, not a runnable quickstart. Uses existing
+> committed golden artifacts from the Phase 1 and Phase 2 acceptance
+> fixtures. No install instructions, no eBPF setup, no claim that this is
+> a standalone product.
+
+This page walks through what one Assay-Runner measured run produces, using
+the canonical golden artifacts already checked into the repo. The goal is
+not to teach you how to run a measured run yourself — that requires a
+delegated Linux/eBPF host class (`assay-bpf-runner`) — but to make it
+concrete what comes *out* of one. If you are evaluating whether a
+deterministic proof-bundle layer would be useful next to your existing
+observability or testing setup, this is the document that answers "what
+am I actually looking at?".
+
+If you arrived here from
+[GitHub Discussion #1329](https://github.com/Rul1an/assay/discussions/1329)
+or the AgentSight
+[Issue #44](https://github.com/eunomia-bpf/agentsight/issues/44),
+this is the conceptual companion to the
+[Phase 1 + 2 retrospective](../../notes/ASSAY-RUNNER-PHASE-1-AND-2-RETROSPECTIVE-2026-05-22.md).
+
+## What This Is Not
+
+- Not an install guide. There is no `cargo install assay-runner`.
+- Not a live monitor. Nothing in this document streams.
+- Not an instrumentation library. There is no SDK for the user to import.
+- Not a comparison against any specific observability product. The point
+  is to explain the *shape* of the artifact, not to position it against
+  alternatives.
+
+## What One Measured Run Produces
+
+A measured run produces one archive (tar) containing five canonical
+artifacts plus two ndjson layer streams. All five JSON artifacts are
+content-addressed and verifiable through the existing Assay evidence
+path. The schemas are frozen as `assay.runner.*.v0`.
+
+```text
+run-archive.tar
+├── manifest.json                 # archive manifest with file digests
+├── observation-health.json       # honest health-of-observation report
+├── capability-surface.json       # what the run touched (paths/tools/decisions)
+├── correlation-report.json       # SDK/policy/kernel correlation by tool_call_id
+└── layers/
+    ├── kernel.ndjson             # cgroup-scoped normalized kernel events
+    ├── policy.ndjson             # MCP allow/deny decisions
+    └── sdk.ndjson                # normalized SDK tool-call events
+```
+
+The five JSON files are what reviewers, CI gates, and cross-runtime diff
+projections actually read. The ndjson streams are the layer-level evidence
+the JSON files are computed from.
+
+## Observation Health — Honesty About Gaps
+
+This is the most important artifact. It says *what was observed cleanly
+and what was not*. A measured run that lost kernel events, missed a
+policy decision, or had a degraded SDK capture is required to say so
+here.
+
+Canonical golden, from
+[`golden/observation-health-openai-agents-kernel-policy-v0.json`](../golden/observation-health-openai-agents-kernel-policy-v0.json):
+
+```json
+{
+  "schema": "assay.runner.observation_health.v0",
+  "run_id": "run_openai_agents_kernel_policy_determinism",
+  "platform": "linux",
+  "kernel_layer": "complete",
+  "ringbuf_drops": 0,
+  "policy_layer": "present",
+  "sdk_layer": "self_reported",
+  "cgroup_correlation": "clean",
+  "notes": [
+    "s2_kernel_capture: monitor_events=4 ringbuf_drops=0",
+    "s4_policy_capture: policy_events=1",
+    "s5_sdk_capture: sdk_events=3 sdk_tool_calls=1"
+  ]
+}
+```
+
+How to read this:
+
+- `kernel_layer: complete` plus `ringbuf_drops: 0` means the kernel did
+  not lose any events the eBPF ring buffer handed us. If it had, this
+  would say `degraded` and the count would be non-zero, and the rest of
+  the bundle would have to be interpreted in that light.
+- `policy_layer: present` means MCP policy decisions were captured.
+- `sdk_layer: self_reported` is the honest framing: SDK events come from
+  the SDK itself, so we record them but never call them
+  kernel-corroborated.
+- `cgroup_correlation: clean` means the child process landed in the
+  measured cgroup *before* it spawned, so the kernel observation window
+  matches the process's actual lifetime.
+
+If any of these degrade, the v0 contract requires the bundle to say so.
+A measured run does not pretend to be cleaner than it is.
+
+## Capability Surface — What The Run Touched
+
+A normalized, set-shaped view of what the run did at the policy and
+kernel layers. Deterministic across runs that do the same thing.
+
+Canonical golden, from
+[`golden/capability-surface-openai-agents-kernel-policy-v0.json`](../golden/capability-surface-openai-agents-kernel-policy-v0.json):
+
+```json
+{
+  "schema": "assay.runner.capability_surface.v0",
+  "run_id": "run_openai_agents_kernel_policy_determinism",
+  "filesystem_paths": [
+    "/tmp/assay-runner-openai-agents-kernel-policy/work/openai-agents-input.txt",
+    "/tmp/assay-runner-openai-agents-kernel-policy/work/policy-input.txt"
+  ],
+  "network_endpoints": [],
+  "process_execs": [],
+  "mcp_tools": [
+    "read_file"
+  ],
+  "policy_decisions": [
+    "allow:read_file"
+  ]
+}
+```
+
+How to read this:
+
+- The fixture used one MCP tool (`read_file`), policy allowed it once,
+  and two filesystem paths were touched. No network, no extra process
+  execs.
+- Sets are sorted and deduplicated. Two runs of the same fixture produce
+  byte-identical surfaces. Two runs that diverge in observed behaviour
+  produce a non-empty diff on this artifact, which is exactly the
+  regression signal CI gates can read.
+
+This is the artifact a release gate would diff against a baseline. Not
+"did the eval pass" — "did the surface change in a way we did not
+expect".
+
+## Correlation Report — Cross-Layer Binding
+
+This is the artifact that makes the SDK / policy / kernel layers
+*comparable* rather than three separate streams. It binds tool-calls
+across layers by `tool_call_id`.
+
+Canonical golden, from
+[`golden/correlation-report-openai-agents-kernel-policy-v0.json`](../golden/correlation-report-openai-agents-kernel-policy-v0.json):
+
+```json
+{
+  "schema": "assay.runner.correlation_report.v0",
+  "run_id": "run_openai_agents_kernel_policy_determinism",
+  "status": "clean",
+  "bindings": [
+    {
+      "tool_call_id": "tc_runner_policy_001",
+      "policy_decision": "allow",
+      "kernel_event_count": 2,
+      "window": {
+        "start": "run_started",
+        "end": "run_finished"
+      }
+    }
+  ],
+  "ambiguities": []
+}
+```
+
+How to read this:
+
+- The SDK declared a tool call with id `tc_runner_policy_001`. The
+  policy layer recorded an `allow` decision under the same id. The
+  kernel layer recorded two normalized events inside the binding
+  window.
+- `status: clean` means every SDK tool-call binding had a stable
+  `tool_call_id` and a matching policy decision. If a runtime omitted
+  `tool_call_id`, the v0 contract requires this to degrade to `partial`
+  or `failed` with the ambiguity recorded — we do not invent ordering
+  to paper over the gap.
+- `window.start`/`window.end` are runner-defined phase markers from one
+  canonical runner clock. SDK timestamps are informational only.
+
+## SDK And Policy Layer Streams
+
+The ndjson layers are not golden-checked-in (they are produced by the
+fixture at acceptance time), but their shape is contract-frozen.
+Illustrative slices from a clean run look like this.
+
+SDK layer, one event per line, `assay.runner.sdk_event.v0`:
+
+```ndjson
+{"schema":"assay.runner.sdk_event.v0","run_id":"run_openai_agents_kernel_policy_determinism","seq":0,"event_type":"run_started","source":"openai-agents-fixture","sdk_name":"@openai/agents","sdk_version":"0.11.4"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"run_openai_agents_kernel_policy_determinism","seq":1,"event_type":"tool_call_started","source":"openai-agents-fixture","sdk_name":"@openai/agents","sdk_version":"0.11.4","tool_call_id":"tc_runner_policy_001","tool":"read_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"run_openai_agents_kernel_policy_determinism","seq":2,"event_type":"tool_call_completed","source":"openai-agents-fixture","sdk_name":"@openai/agents","sdk_version":"0.11.4","tool_call_id":"tc_runner_policy_001","tool":"read_file"}
+```
+
+Policy layer (also ndjson, MCP decision records). One illustrative entry:
+
+```json
+{
+  "tool_call_id": "tc_runner_policy_001",
+  "tool": "read_file",
+  "decision": "allow",
+  "reason": "policy:tools.allow",
+  "ts_runner": "policy_layer_captured"
+}
+```
+
+`tool_call_id` is the join key across all three layers. That is the
+whole v0 correlation contract: one stable id, one window, three layers,
+no inferred ordering.
+
+## Cross-Runtime Diff — Comparing Two Runtimes
+
+A cross-runtime diff projects the capability surface across two
+different runtime fixtures (here `@openai/agents` vs `google-genai`),
+applies the canonicalization rules from
+[`cross-runtime-diff-decisions.md`](../cross-runtime-diff-decisions.md),
+and produces a diff with explicit non-claims.
+
+Excerpt from
+[`golden/cross-runtime-diff-s5-gemini-v0.json`](../golden/cross-runtime-diff-s5-gemini-v0.json):
+
+```json
+{
+  "schema": "assay.runner.cross_runtime_diff.v0",
+  "base_runtime": "s5_openai_agents",
+  "head_runtime": "gemini_google_genai",
+  "status": "clean",
+  "preconditions": {
+    "base_health_clean": true,
+    "head_health_clean": true,
+    "stable_tool_call_ids_required": true,
+    "stable_tool_call_ids_present": true,
+    "runtimes_distinct": true
+  },
+  "surface": {
+    "filesystem_paths": {
+      "added":     ["<work>/gemini-input.txt"],
+      "removed":   ["<work>/openai-agents-input.txt"],
+      "unchanged": ["<work>/policy-input.txt"]
+    },
+    "mcp_tools": { "added": [], "removed": [], "unchanged": ["read_file"] },
+    "policy_decisions": { "added": [], "removed": [], "unchanged": ["allow:read_file"] }
+  },
+  "sdk_metadata": {
+    "comparison": "side_band_provenance",
+    "base": { "sdk_name": "@openai/agents", "sdk_version": "0.11.4" },
+    "head": { "sdk_name": "google-genai", "sdk_version": "2.6.0" }
+  },
+  "non_claims": [
+    "cross_runtime_no_acceptability_judgment",
+    "cross_runtime_no_declared_capability_input",
+    "cross_runtime_no_derived_binding_identity",
+    "cross_runtime_no_filename_semantic_equivalence",
+    "cross_runtime_no_sdk_capability_equivalence"
+  ]
+}
+```
+
+How to read this:
+
+- The two runtimes touched different per-fixture filename prefixes
+  (`openai-agents-input.txt` vs `gemini-input.txt`) but reached the same
+  policy decision on the same MCP tool (`read_file`, `allow`). That
+  difference is in the surface diff, surfaced explicitly, not silently
+  normalized away.
+- The `<work>/` prefix is the A1 work-dir canonicalization rule:
+  per-fixture work directories are normalized to a stable prefix so the
+  diff is meaningful across runtimes without losing per-fixture
+  filenames.
+- `non_claims` is the heart of v0 honesty: the diff *does not* claim
+  that two runtimes touching `read_file` means they have semantically
+  equivalent capabilities, and it does not pretend to derive binding
+  identity across runtimes. Cross-runtime equivalence is a separate,
+  not-yet-opened, contract question.
+
+If a schema change made these two runtimes diverge unexpectedly, the
+diff catches it before it ships. That is the regression surface, and
+it's the thing CI can read.
+
+## What This Bundle Is Useful For
+
+- **Release gating.** Diff today's surface against last release's
+  baseline; non-empty diff blocks the release unless explicitly
+  approved.
+- **Regression testing.** Run the same agent fixture before and after
+  a change; the surface should be byte-identical or the diff has to
+  explain itself.
+- **Cross-runtime comparison.** When the same prompt runs under two
+  different agent runtimes, the cross-runtime diff says where they
+  agree and where they don't, without making semantic-equivalence
+  claims.
+- **Honest evidence under load.** The observation health is the
+  contract that the bundle is not lying about gaps. Degradation is
+  recorded, not hidden.
+
+What it is **not** useful for:
+
+- "What is my agent doing right now" — Assay-Runner is not a live
+  monitor. Use a system-level observability tool for that.
+- Production traffic analysis — the contract is per-run, not per-fleet.
+- Live LLM call observability — the supported path uses deterministic
+  local providers; live LLM observability is a different problem.
+
+## Where Each Artifact Comes From
+
+If you want to read the code:
+
+- Schemas and manifest types: `crates/assay-runner-schema/`
+- Archive assembly and layer normalizers: `crates/assay-runner-core/`
+- Cgroup placement primitives: `crates/assay-runner-linux/`
+- Cross-runtime diff projection: `scripts/ci/` (currently script-hosted)
+- Fixtures producing the goldens above: `runner-fixtures/openai-agents/`
+  and `runner-fixtures/gemini-google-genai/`
+
+All four runner crates are `publish = false`. The fixtures require a
+delegated Linux/eBPF host class (`assay-bpf-runner`) to produce real
+acceptance runs. The golden JSON artifacts referenced from this page
+are checked-in snapshots so reviewers can read the contract without
+running anything.
+
+## Further Reading
+
+- [Phase 1 + 2 retrospective](../../notes/ASSAY-RUNNER-PHASE-1-AND-2-RETROSPECTIVE-2026-05-22.md) — the long-form story
+- [Assay-Runner reference index](../index.md) — all internal contracts
+- [Runner artifact v0 contracts](../artifacts-v0.md) — full schema specs
+- [Runner cross-runtime diff v0 contract](../cross-runtime-diff-v0.md)
+- [Runner cross-runtime diff decisions (A1+B3+C1)](../cross-runtime-diff-decisions.md)
+- [Phase 2D consolidation audit](../phase-2d-consolidation-audit.md) — extraction-readiness gating

--- a/docs/reference/runner/examples/measured-run-proof-bundle.md
+++ b/docs/reference/runner/examples/measured-run-proof-bundle.md
@@ -19,7 +19,7 @@ If you arrived here from
 or the AgentSight
 [Issue #44](https://github.com/eunomia-bpf/agentsight/issues/44),
 this is the conceptual companion to the
-[Phase 1 + 2 retrospective](../../notes/ASSAY-RUNNER-PHASE-1-AND-2-RETROSPECTIVE-2026-05-22.md).
+[Phase 1 + 2 retrospective](../../../notes/ASSAY-RUNNER-PHASE-1-AND-2-RETROSPECTIVE-2026-05-22.md).
 
 ## What This Is Not
 
@@ -32,26 +32,41 @@ this is the conceptual companion to the
 
 ## What One Measured Run Produces
 
-A measured run produces one archive (tar) containing five canonical
-artifacts plus two ndjson layer streams. All five JSON artifacts are
-content-addressed and verifiable through the existing Assay evidence
-path. The schemas are frozen as `assay.runner.*.v0`.
+A measured run produces one deterministic `.tar.gz` archive. The archive
+contains, per the
+[`assay.runner.archive_manifest.v0`](../boundary-map.md) layout (see also
+the schema constants in `crates/assay-runner-schema/src/archive_manifest.rs`):
+
+- **Three load-bearing v0 JSON artifacts** that reviewers and CI gates
+  read: `observation-health.json`, `capability-surface.json`,
+  `correlation-report.json`. Each carries an `assay.runner.*.v0` schema
+  string.
+- **One archive manifest**: `manifest.json` (schema
+  `assay.runner.archive_manifest.v0`) listing every file in the archive
+  with its SHA-256 and byte count.
+- **One whole-archive event stream**: `events.ndjson`.
+- **Three per-layer event streams**: `layers/kernel.ndjson`,
+  `layers/policy.ndjson`, `layers/sdk.ndjson`.
 
 ```text
-run-archive.tar
-├── manifest.json                 # archive manifest with file digests
+run-archive.tar.gz
+├── manifest.json                 # archive manifest (schema, run_id, files[])
 ├── observation-health.json       # honest health-of-observation report
 ├── capability-surface.json       # what the run touched (paths/tools/decisions)
 ├── correlation-report.json       # SDK/policy/kernel correlation by tool_call_id
+├── events.ndjson                 # whole-archive event stream
 └── layers/
     ├── kernel.ndjson             # cgroup-scoped normalized kernel events
     ├── policy.ndjson             # MCP allow/deny decisions
     └── sdk.ndjson                # normalized SDK tool-call events
 ```
 
-The five JSON files are what reviewers, CI gates, and cross-runtime diff
-projections actually read. The ndjson streams are the layer-level evidence
-the JSON files are computed from.
+The three load-bearing JSON files are what reviewers, CI gates, and
+cross-runtime diff projections actually read. The ndjson streams are the
+layer-level evidence the JSON files are computed from. The archive
+verifies through the existing Assay evidence path: every file is hashed
+and recorded in `manifest.json`, and the runner does not ship its own
+verifier.
 
 ## Observation Health — Honesty About Gaps
 

--- a/docs/reference/runner/examples/measured-run-proof-bundle.md
+++ b/docs/reference/runner/examples/measured-run-proof-bundle.md
@@ -339,7 +339,7 @@ running anything.
 
 ## Further Reading
 
-- [Phase 1 + 2 retrospective](../../notes/ASSAY-RUNNER-PHASE-1-AND-2-RETROSPECTIVE-2026-05-22.md) — the long-form story
+- [Phase 1 + 2 retrospective](../../../notes/ASSAY-RUNNER-PHASE-1-AND-2-RETROSPECTIVE-2026-05-22.md) — the long-form story
 - [Assay-Runner reference index](../index.md) — all internal contracts
 - [Runner artifact v0 contracts](../artifacts-v0.md) — full schema specs
 - [Runner cross-runtime diff v0 contract](../cross-runtime-diff-v0.md)

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -35,4 +35,5 @@ Phase 2B capability-diff planning slice.
 - [Assay-Runner extraction roadmap (Phase 2D slice sequence)](extraction-roadmap.md)
 - [Assay consumes Runner as external — Slice 6A design note](assay-consumes-runner-external.md)
 - [Phase 2D consolidation audit (burn-in criteria, not calendar wait)](phase-2d-consolidation-audit.md)
+- [Measured-run proof-bundle walkthrough (read-only, explainable demo)](examples/measured-run-proof-bundle.md)
 - [Phase 1 delegated proof pack](proof-packs/phase1-delegated-2026-05-21.md)


### PR DESCRIPTION
## Summary

Adds an **explainable demo** (read-only walkthrough using existing checked-in golden artifacts) and a **companion conceptual note** framing measured-run bundles as distinct from traces and observability dashboards. Plus one-line cross-links from the README "Internal: Assay-Runner" section and the runner reference index.

This is the conceptual tier *before* any runnable demo. It exists so that maintainers evaluating Assay-Runner as a possible standalone component ([Discussion #1329](https://github.com/Rul1an/assay/discussions/1329), [AgentSight Issue #44](https://github.com/eunomia-bpf/agentsight/issues/44)) can see what one measured-run bundle actually contains without being asked to spin up a delegated Linux/eBPF host class.

## What this PR adds

### 1. Read-only walkthrough — `docs/reference/runner/examples/measured-run-proof-bundle.md`

- Walks through each canonical artifact using the checked-in golden JSON:
  - `assay.runner.observation_health.v0`
  - `assay.runner.capability_surface.v0`
  - `assay.runner.correlation_report.v0`
  - `assay.runner.cross_runtime_diff.v0`
- Illustrative SDK ndjson + policy ndjson shapes from the v0 schema and the fixture v0 contract
- Explicit non-claims at the top: not an install guide, not a live monitor, not an instrumentation library, not a product comparison
- "What this bundle is useful for" (CI gating, regression testing, cross-runtime comparison, honest evidence under load) plus explicit "what it is not useful for" (live monitoring, production traffic, live LLM observability)
- Pointers to source code (`crates/assay-runner-*`, `runner-fixtures/`) so reviewers can read the implementations cold

### 2. Conceptual note — `docs/notes/ASSAY-RUNNER-MEASURED-RUNS-2026-05-23.md`

- Maintainer-voice engineering note explaining why measured runs are conceptually distinct from traces and observability dashboards
- "The gap traces don't cover" framing for agent CI/release/audit contexts
- Honest section on why standalone extraction is not yet decided (technically unblocked, evidentially unproven, externally unmotivated)
- The narrow question being asked passively at Discussion #1329 and AgentSight Issue #44, with three useful-signal answers (yes / no, wrong shape / maybe, if OTel-shaped)

### 3. Cross-links

- `README.md`: one-line addition under the existing "Internal: Assay-Runner" section pointing to the walkthrough
- `docs/reference/runner/index.md`: one-line addition to the reference list

## Non-claims

This PR does not:

- claim Assay-Runner is a standalone product
- claim external demand has been measured
- announce a release
- add a runnable quickstart, install instructions, or any "try it now" path
- add new fixtures, new schemas, new code, or new gates
- supersede any existing v0 contract or boundary doc
- weaken any acceptance gate (lane-check, delegated, Gemini, S5)
- cross-link the walkthrough from the AgentSight Issue or pin it in Discussion #1329 (would convert a passive probe into outreach)

The walkthrough uses only checked-in golden artifacts; nothing new is fabricated for it.

## Test plan

- [x] Pre-commit hooks pass (fmt, typos, trailing whitespace, merge conflicts, clippy, linux compile gate)
- [x] All inter-doc links use relative paths within `docs/`; the walkthrough cross-links to the Phase 1 + 2 retrospective (PR #1330) via the same relative path that will resolve once both land on main
- [ ] CI: lane-check should classify as `Gate.NONE` (only `docs/` and `README.md` touched)
- [ ] mkdocs strict build passes
- [ ] Reviewer reads the walkthrough and the note cold and confirms the tone is engineering retrospective, not launch

## Sequencing

This PR can land before or after #1330 (Phase 1 + 2 retrospective). The walkthrough references the retrospective by relative path; if this PR lands first, the link will be live as soon as #1330 merges. No cross-PR ordering constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)