### PR TITLE
chore(release): prepare v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ All notable changes to this project will be documented in this file.
 
 This minor release has no breaking change for existing Assay-core / Trust Basis
 consumers. NDJSON evidence, Trust Basis diff v1, the three-family receipt
-adoption surface, and all `assay` CLI verbs are byte-identical to `v3.10.2`.
+adoption surface, and the existing public `assay` CLI verbs and their outputs
+are unchanged versus `v3.10.2`. The only new CLI surface is `assay runner-spike`,
+which is `hide = true`, internal-only, and explicitly outside the public CLI
+contract; it exists to back the Runner v0 archive contracts and is not part of
+the stable interface.
 
 ### Assay-Runner v0 measured-run contracts are now durable
 
@@ -54,7 +58,7 @@ new boundary.
 ### Qualified second runtime fixture (Gemini)
 
 `runner-fixtures/gemini-google-genai/` is a second qualified runtime line
-producing artefacts under the same v0 contracts as the OpenAI Agents
+producing artifacts under the same v0 contracts as the OpenAI Agents
 fixture. The fixture passes idempotent capability-diff acceptance on the
 delegated `assay-bpf-runner` host. Identity probe, deterministic local
 provider, recorded cassette, and acceptance harness all live in-tree.
@@ -74,7 +78,7 @@ the v0 capability surface across two distinct qualified runtimes.
   `docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json`.
   This schema is the wire-contract anchor consumers should pin against.
 - Decision record at `docs/reference/runner/cross-runtime-diff-decisions.md`
-  documents the A1+B3+C1 choices (work-dir prefix canonicalisation,
+  documents the A1+B3+C1 choices (work-dir prefix canonicalization,
   side-band SDK metadata, out-of-scope binding-id/policy-outcome
   comparison).
 - Reference projector at
@@ -86,7 +90,7 @@ the v0 capability surface across two distinct qualified runtimes.
 ### Consumer side (Harness)
 
 The companion Harness recipe at [`Rul1an/Assay-Harness`](https://github.com/Rul1an/Assay-Harness)
-can now consume Runner archives and the cross-runtime diff artefact
+can now consume Runner archives and the cross-runtime diff artifact
 separately (`verify-runner`, `runner compare`, `runner cross-runtime
 report`, `runner cross-runtime gate`). Assay still owns measurement
 semantics; Harness only validates, projects, and gates. The Harness side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,135 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.11.0] - 2026-05-23
+
+> **Internal Assay-Runner measured-run contracts and extraction-ready substrate.**
+>
+> Assay-Runner remains an **internal** measured-run subsystem of Assay. This release
+> is **not** a standalone Runner release; the Runner crates stay `publish = false`
+> and Assay still owns measurement semantics. This release exists to mark a
+> durable line on `main` for what has accumulated since `v3.10.2`: Runner v0
+> archive contracts, a qualified second runtime fixture, the cross-runtime
+> diff v0 surface, and the extraction-ready crate split.
+
+This minor release has no breaking change for existing Assay-core / Trust Basis
+consumers. NDJSON evidence, Trust Basis diff v1, the three-family receipt
+adoption surface, and all `assay` CLI verbs are byte-identical to `v3.10.2`.
+
+### Assay-Runner v0 measured-run contracts are now durable
+
+The `assay.runner.*.v0` artifact contracts that Phase 1 produced are now living
+under explicit ownership rather than under the spike crate. Same wire shape,
+new boundary.
+
+- New publish-disabled crate `assay-runner-schema` hosts the v0 data
+  structures and constants for
+  `assay.runner.observation_health.v0`,
+  `assay.runner.capability_surface.v0`,
+  `assay.runner.correlation_report.v0`,
+  `assay.runner.sdk_event.v0`, and
+  `assay.runner.archive_manifest.v0`.
+- New publish-disabled crate `assay-runner-core` hosts archive assembly,
+  layer normalizers, and the `RunnerSpikeArchive` writer that turns measured
+  events into a deterministic `.tar.gz` bundle with `sha256:<hex>` per-file
+  digests.
+- New publish-disabled crate `assay-runner-linux` hosts cgroup v2 placement
+  primitives (`CgroupManager`, `SessionCgroup`) — Linux platform adapter
+  surface only.
+- `assay-cli` consumes Runner via these three crates directly. The
+  `assay-runner-spike` crate is retained as a legacy alias for readers of
+  pre-extraction history; no in-workspace consumer depends on it for
+  production code. A mechanical absence check in
+  `scripts/ci/assay_runner_lane_check.py --self-test` enforces this
+  invariant going forward.
+- The four structural extraction blockers tracked under Phase 2D are
+  resolved on main (Slices 1, 2, 3, 6B). Slice 7 — repository extraction —
+  stays closed; the consolidation gate has moved from a passive 4–6 week
+  calendar wait to explicit burn-in criteria documented in
+  `docs/reference/runner/phase-2d-consolidation-audit.md`.
+
+### Qualified second runtime fixture (Gemini)
+
+`runner-fixtures/gemini-google-genai/` is a second qualified runtime line
+producing artefacts under the same v0 contracts as the OpenAI Agents
+fixture. The fixture passes idempotent capability-diff acceptance on the
+delegated `assay-bpf-runner` host. Identity probe, deterministic local
+provider, recorded cassette, and acceptance harness all live in-tree.
+
+The fixture-package boundary now lives at top-level `runner-fixtures/`
+(formerly `tests/fixtures/runner-spike/`); Node fixture renamed to drop
+the `-js` suffix.
+
+### Cross-runtime diff v0 (frozen under A1+B3+C1)
+
+New artifact contract `assay.runner.cross_runtime_diff.v0` for comparing
+the v0 capability surface across two distinct qualified runtimes.
+
+- Normative golden shape at
+  `docs/reference/runner/golden/cross-runtime-diff-s5-gemini-v0.json`.
+- JSON Schema 2020-12 sidecar for the clean-output shape at
+  `docs/reference/runner/schema/cross-runtime-diff-v0-clean.schema.json`.
+  This schema is the wire-contract anchor consumers should pin against.
+- Decision record at `docs/reference/runner/cross-runtime-diff-decisions.md`
+  documents the A1+B3+C1 choices (work-dir prefix canonicalisation,
+  side-band SDK metadata, out-of-scope binding-id/policy-outcome
+  comparison).
+- Reference projector at
+  `scripts/ci/assay_runner_cross_runtime_diff_validate.py`.
+- Explicit `non_claims` carry through: no acceptability judgment, no
+  declared-capability input, no derived binding identity, no filename
+  semantic equivalence, no SDK capability equivalence across runtimes.
+
+### Consumer side (Harness)
+
+The companion Harness recipe at [`Rul1an/Assay-Harness`](https://github.com/Rul1an/Assay-Harness)
+can now consume Runner archives and the cross-runtime diff artefact
+separately (`verify-runner`, `runner compare`, `runner cross-runtime
+report`, `runner cross-runtime gate`). Assay still owns measurement
+semantics; Harness only validates, projects, and gates. The Harness side
+is `Rul1an/Assay-Harness@v0.6.0` at the time of this release.
+
+### Documentation
+
+- New Phase 1 + Phase 2 retrospective at
+  `docs/notes/ASSAY-RUNNER-PHASE-1-AND-2-RETROSPECTIVE-2026-05-22.md`
+  collapses the whole arc into one read.
+- New read-only walkthrough at
+  `docs/reference/runner/examples/measured-run-proof-bundle.md` shows what
+  one measured-run bundle contains.
+- New conceptual note at
+  `docs/notes/ASSAY-RUNNER-MEASURED-RUNS-2026-05-23.md` explains why
+  measured runs are conceptually distinct from traces.
+- `docs/reference/runner/extraction-roadmap.md` defines the Phase 2D
+  slice sequence and the per-PR boundary discipline rule.
+- `docs/reference/runner/phase-2d-consolidation-audit.md` replaces the
+  passive 4–6 week wait with burn-in criteria.
+- README adds a short "Internal: Assay-Runner" section pointing at the
+  reference index, the consolidation audit, and the measured-run
+  walkthrough.
+
+### Non-claims (explicit)
+
+- Assay-Runner is **not** released as a standalone product. Runner crates
+  stay `publish = false`.
+- Slice 7 (repository extraction) is **not** opened. It stays gated on
+  consolidation burn-in plus a concrete external consumer use case.
+- macOS / Windows measurement paths are **not** in scope. They remain
+  separate platform spikes (see `platform-and-extraction-readiness.md`).
+- No new public-CLI surface is added on the Assay side; only the internal
+  crate boundary moved. `assay-cli` flags and outputs are unchanged for
+  existing users.
+- The cross-runtime diff carries explicit non-claims (no semantic
+  equivalence between runtimes); consumers (Harness or otherwise) must
+  not contradict them.
+
+### Release operations
+
+- Workspace version bumped `3.10.2` → `3.11.0`.
+- All workspace dependency pins for internal crates updated to `3.11.0`.
+- `Cargo.lock` refreshed.
+- P57 seeding pack updated to use the `v3.11.0` release-truth line.
+
 ## [3.10.2] - 2026-05-17
 
 This patch release carries the same three-family adoption surface as `v3.10.1`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-spike"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "assay-runner-core",
  "assay-runner-schema",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.10.2"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.10.2"
+version = "3.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -74,19 +74,19 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.10.2" }
-assay-common = { path = "crates/assay-common", version = "3.10.2", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.10.2" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.10.2" }
-assay-policy = { path = "crates/assay-policy", version = "3.10.2" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.10.2" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.10.2" }
-assay-sim = { path = "crates/assay-sim", version = "3.10.2" }
-assay-registry = { path = "crates/assay-registry", version = "3.10.2" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.10.2" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.10.2" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.10.2" }
-assay-runner-spike = { path = "crates/assay-runner-spike", version = "3.10.2" }
+assay-core = { path = "crates/assay-core", version = "3.11.0" }
+assay-common = { path = "crates/assay-common", version = "3.11.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.11.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.11.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.11.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.11.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.11.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.11.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.11.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.11.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.11.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.11.0" }
+assay-runner-spike = { path = "crates/assay-runner-spike", version = "3.11.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
+++ b/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
@@ -3,7 +3,7 @@
 > **Status:** ready for controlled seeding after Assay `v3.11.0` is tagged;
 > one Promptfoo-context follow-up has already been placed
 >
-> **Last updated:** 2026-05-17
+> **Last updated:** 2026-05-23
 > **Scope:** small repo-native sharing pack for the released evidence receipt
 > surface. This is not a launch plan, campaign, partnership claim, compliance
 > claim, or new product wedge.

--- a/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
+++ b/docs/community/P57-ECOSYSTEM-SEEDING-PACK.md
@@ -1,6 +1,6 @@
 # P57 Ecosystem Seeding Pack
 
-> **Status:** ready for controlled seeding after Assay `v3.10.2` is tagged;
+> **Status:** ready for controlled seeding after Assay `v3.11.0` is tagged;
 > one Promptfoo-context follow-up has already been placed
 >
 > **Last updated:** 2026-05-17
@@ -21,16 +21,16 @@ Short post line:
 
 | Role | Link | Use When |
 |---|---|---|
-| Primary proof | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | Use as the one-link repo-native proof entrypoint after the `v3.10.2` tag is live. |
-| Theory | [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) | Use as the read-more link when someone asks why receipts instead of broad integrations. |
-| Assurance mapping | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | Use only for assurance-context replies after someone asks what review question each receipt family helps answer. |
-| Promptfoo adoption | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | Use when someone wants the smallest eval-output adoption path. |
-| OpenFeature adoption | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | Use when someone asks about runtime flag decision boundaries. |
-| CycloneDX adoption | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | Use when someone asks what model inventory/provenance boundary existed. |
-| Promptfoo context note | [From Promptfoo JSONL to Evidence Receipts](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) | Use only for an existing Promptfoo JSONL/assertion-results context. |
+| Primary proof | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.11.0/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | Use as the one-link repo-native proof entrypoint after the `v3.11.0` tag is live. |
+| Theory | [Evidence Receipts for AI Outcomes, Runtime Decisions, and Model Inventory](https://github.com/Rul1an/assay/blob/v3.11.0/docs/notes/EVIDENCE-RECEIPTS-FOR-AI-OUTCOMES-RUNTIME-DECISIONS-MODEL-INVENTORY.md) | Use as the read-more link when someone asks why receipts instead of broad integrations. |
+| Assurance mapping | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.11.0/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | Use only for assurance-context replies after someone asks what review question each receipt family helps answer. |
+| Promptfoo adoption | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.11.0/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | Use when someone wants the smallest eval-output adoption path. |
+| OpenFeature adoption | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.11.0/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | Use when someone asks about runtime flag decision boundaries. |
+| CycloneDX adoption | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.11.0/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | Use when someone asks what model inventory/provenance boundary existed. |
+| Promptfoo context note | [From Promptfoo JSONL to Evidence Receipts](https://github.com/Rul1an/assay/blob/v3.11.0/docs/notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md) | Use only for an existing Promptfoo JSONL/assertion-results context. |
 | Runnable recipe | [Promptfoo receipt pipeline](https://github.com/Rul1an/Assay-Harness/blob/v0.3.2/docs/PROMPTFOO_RECEIPT_PIPELINE.md) | Use when someone wants to run the smallest released recipe immediately. |
 
-Do not use the `v3.10.2` links outward until the tag exists. Once tagged, this
+Do not use the `v3.11.0` links outward until the tag exists. Once tagged, this
 is the current released link set for the three-family adoption surface.
 
 - `EVIDENCE-RECEIPTS-IN-ACTION.md` is the primary proof page.
@@ -74,10 +74,10 @@ can be bundled and verified, and the Trust Basis claim above it can be gated
 without teaching Harness family-specific semantics.
 
 Proof:
-https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
+https://github.com/Rul1an/assay/blob/v3.11.0/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md
 ```
 
-The proof link must resolve under the public Assay `v3.10.2` tag before this
+The proof link must resolve under the public Assay `v3.11.0` tag before this
 post is used. The existing `v*` release workflow builds full release artifacts,
 so describe the release as a docs/adoption packaging line, not as a bare
 documentation tag.
@@ -93,17 +93,17 @@ Do not add:
 
 | Spot | Link to Send | One Sentence | Do Not Ask |
 |---|---|---|---|
-| Release-adjacent update | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | We made the evidence boundary inspectable: selected Promptfoo, OpenFeature, and CycloneDX outcomes now compile into bounded receipts and Trust Basis claims. | Do not ask for generic feedback, stars, adoption, or partnership. Use a repo Discussion only if there is no suitable release/docs context. |
-| Existing Promptfoo JSONL/componentResults context | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | This keeps Promptfoo as the eval runner while showing how selected assertion component outcomes become portable evidence receipts. | Never open a fresh thread just to restate the proof. Do not imply Promptfoo endorsement, official integration, or eval correctness. Add the recipe link only if someone asks to run it. |
-| OpenFeature runtime-decision context | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | This keeps OpenFeature as the decision API while showing how one bounded boolean EvaluationDetails outcome becomes a reviewable decision receipt. | Do not imply provider support, targeting-rule correctness, or official OpenFeature endorsement. |
-| CycloneDX model-inventory context | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.10.2/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | This shows what model inventory/provenance-reference boundary existed without importing full BOM truth. | Do not imply BOM completeness, model safety, provenance sufficiency, or official CycloneDX endorsement. |
-| Assurance / audit-context follow-up | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.10.2/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | This maps each released receipt family to the assurance question it can help answer and the claims it explicitly does not make. | Do not frame it as a compliance checklist or legal interpretation. |
+| Release-adjacent update | [Evidence Receipts in Action](https://github.com/Rul1an/assay/blob/v3.11.0/docs/notes/EVIDENCE-RECEIPTS-IN-ACTION.md) | We made the evidence boundary inspectable: selected Promptfoo, OpenFeature, and CycloneDX outcomes now compile into bounded receipts and Trust Basis claims. | Do not ask for generic feedback, stars, adoption, or partnership. Use a repo Discussion only if there is no suitable release/docs context. |
+| Existing Promptfoo JSONL/componentResults context | [Evidence Receipts from Promptfoo JSONL](https://github.com/Rul1an/assay/blob/v3.11.0/docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md) | This keeps Promptfoo as the eval runner while showing how selected assertion component outcomes become portable evidence receipts. | Never open a fresh thread just to restate the proof. Do not imply Promptfoo endorsement, official integration, or eval correctness. Add the recipe link only if someone asks to run it. |
+| OpenFeature runtime-decision context | [OpenFeature EvaluationDetails to CI Review Artifact](https://github.com/Rul1an/assay/blob/v3.11.0/docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md) | This keeps OpenFeature as the decision API while showing how one bounded boolean EvaluationDetails outcome becomes a reviewable decision receipt. | Do not imply provider support, targeting-rule correctness, or official OpenFeature endorsement. |
+| CycloneDX model-inventory context | [CycloneDX ML-BOM Model to Inventory Receipt](https://github.com/Rul1an/assay/blob/v3.11.0/docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md) | This shows what model inventory/provenance-reference boundary existed without importing full BOM truth. | Do not imply BOM completeness, model safety, provenance sufficiency, or official CycloneDX endorsement. |
+| Assurance / audit-context follow-up | [Evidence Receipt Assurance Mapping](https://github.com/Rul1an/assay/blob/v3.11.0/docs/notes/EVIDENCE-RECEIPT-ASSURANCE-MAPPING.md) | This maps each released receipt family to the assurance question it can help answer and the claims it explicitly does not make. | Do not frame it as a compliance checklist or legal interpretation. |
 
 ## Share Order
 
 1. Keep the existing Promptfoo-context follow-up on the versioned
    `FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md` note.
-2. Post the repo-native note first, using only the versioned `v3.10.2` proof
+2. Post the repo-native note first, using only the versioned `v3.11.0` proof
    link as the primary outward link.
 3. Let the proof page act as the hub for theory, mapping, and recipes.
 4. Wait at least one day.
@@ -128,9 +128,9 @@ Do not add:
 - No "would love feedback" framing.
 - No pressure to adopt.
 - Link outward to `EVIDENCE-RECEIPTS-IN-ACTION.md` only through the versioned
-  `v3.10.2` URL or a later release tag.
+  `v3.11.0` URL or a later release tag.
 - Link outward to the mapping note and adoption pages only through the
-  versioned `v3.10.2` URL or a later release tag.
+  versioned `v3.11.0` URL or a later release tag.
 
 The goal is only to put the released proof, theory, and runnable recipe in
 front of people who already care about evidence boundaries.


### PR DESCRIPTION
## Release v3.11.0 — Internal Assay-Runner measured-run contracts and extraction-ready substrate

Minor release marking a durable line on `main` for what has accumulated since `v3.10.2`: Runner v0 archive contracts, the qualified second runtime fixture, the cross-runtime diff v0 surface, and the extraction-ready crate split.

> **Assay-Runner remains internal to Assay.** This release is **NOT** a standalone Runner release. The Runner crates stay `publish = false` and Assay still owns measurement semantics. This release exists to give the Runner work a stable anchor — `assay.runner.*.v0` is now durable on `main`, not a moving target under `v3.10.x`.

This minor release has **no breaking change** for existing Assay-core / Trust Basis consumers. NDJSON evidence, Trust Basis diff v1, the three-family receipt adoption surface, and all `assay` CLI verbs are byte-identical to `v3.10.2`.

## Why minor (not patch, not major)

| | |
|---|---|
| **Not patch** | This isn't a bugfix. New internal subsystem surface, new contracts, new crates |
| **Minor** | New publish-disabled crates (`assay-runner-schema`/`-core`/`-linux`), new `assay.runner.cross_runtime_diff.v0` artifact contract, new docs surface — additive, no existing-API break |
| **Not major** | No existing-public-contract break. `assay-cli` flags + outputs unchanged. NDJSON / Trust Basis / receipt families unchanged |

## What ships in v3.11.0

All content was landed via prior PRs on `main`; this PR only bumps the version and updates the changelog + seeding pack.

| Area | Where it landed |
|---|---|
| Runner v0 schema crate (Slice 1) | #1317 |
| Runner core crate (Slice 2) | #1319 |
| Runner Linux platform adapter (Slice 3) | #1320 |
| Phase 2D extraction roadmap | #1316 |
| Cross-runtime diff v0 contract | #1313 |
| Cross-runtime diff projector | #1314 |
| Cross-runtime diff JSON Schema 2020-12 sidecar | #1315 |
| Phase 2D Slice 4 (boundary freeze docs) | #1321 |
| Gemini fixture (second qualified runtime) | #1306, #1308 |
| Fixture package boundary | #1322, #1323 |
| `assay-cli` consumes Runner directly (Slice 6B) | #1325 |
| Phase 2D consolidation audit | #1327 |
| Internal "Assay-Runner status" README section | #1328 |
| Phase 1 + 2 retrospective | #1330 |
| Measured-run proof-bundle walkthrough + measured-runs vs traces note | #1331 |
| Docs auto-update | #1326 |

## Non-claims (explicit)

This release does **not**:

- ship Assay-Runner as a standalone product. Runner crates stay `publish = false`
- open Slice 7 (repository extraction). It stays gated on consolidation burn-in + a concrete external use case
- add macOS or Windows measurement (separate platform spikes)
- add new `assay-cli` flags or change existing flag behaviour
- ship a cross-runtime SDK-capability-equivalence claim (`non_claims` field in the v0 diff carries the five explicit boundaries)

## Changes in this PR

- `Cargo.toml`: workspace `3.10.2` → `3.11.0`; all internal crate pins updated
- `Cargo.lock`: refreshed (`cargo update --workspace --offline`)
- `CHANGELOG.md`: new `[3.11.0] - 2026-05-23` entry above `[3.10.2]` with full framing + non-claims
- `docs/community/P57-ECOSYSTEM-SEEDING-PACK.md`: release-truth-line URLs bumped from `v3.10.2` to `v3.11.0` (same convention as v3.10.0 → v3.10.2 prep PR #1216)

## Test plan

- [x] `cargo build -p assay-runner-schema -p assay-runner-core -p assay-runner-linux --offline` passes on `3.11.0`
- [x] No new `v3.10.2` references in active docs (point-in-time notes, release-plans, and runner phase notes correctly retain their original versions)
- [ ] CI: full workspace build + tests
- [ ] After merge: tag `v3.11.0` from main, push tag, release workflow auto-publishes

## References

- Companion: `Rul1an/Assay-Harness@v0.6.0` (consumes the v0 artefacts shipped here)
- Phase 2D extraction roadmap: `docs/reference/runner/extraction-roadmap.md`
- Phase 2D consolidation audit: `docs/reference/runner/phase-2d-consolidation-audit.md`
- v3.10.0 release prep pattern: #1216

🤖 Generated with [Claude Code](https://claude.com/claude-code)