### PR TITLE
chore(release): prepare v3.11.2 (flip runner crates to publish = true)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,10 +70,13 @@ repo extraction) stays closed; the burn-in criteria in
   evidence, Trust Basis diff v1, Runner v0 archive contracts, or the
   cross-runtime diff v0 surface.
 - The `Publish-shape guardrail (assay-cli)` PR-CI job added in `v3.11.1`
-  stays in place as defense-in-depth: it will not fire today (no workspace
-  crate is `publish = false` any more), but will catch a future regression
-  if a new `publish = false` workspace crate is added back and reaches
-  `assay-cli`'s non-optional dep set.
+  stays in place as defense-in-depth: it will not fire today (none of
+  `assay-cli`'s non-optional workspace deps are `publish = false`; other
+  workspace crates such as `assay-ebpf`, `assay-xtask`, and the adapter
+  crates remain `publish = false` by design, outside `assay-cli`'s dep
+  surface), but will catch a future regression if a new `publish = false`
+  workspace crate is added back and reaches `assay-cli`'s non-optional
+  dep set.
 
 ## [3.11.1] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,77 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.11.2] - 2026-05-23
+
+> **Corrected publish line.** `v3.11.0` and `v3.11.1` are partial-publish lines
+> on crates.io: 8 of the 9 workspace crates published, but `assay-cli` did not
+> (it remained pinned at `3.10.2` on crates.io). `v3.11.2` is the first
+> complete CLI publish since `v3.10.2`. The four Assay-Runner crates now ship
+> alongside the rest of the workspace, with internal/experimental framing in
+> their package descriptions.
+
+### Why `v3.11.1`'s `optional = true` was not enough
+
+`v3.11.1` attempted to make `assay-cli` publishable by marking its
+`assay-runner-{schema,core,linux}` deps as `optional = true` and passing
+`--no-default-features --features tui,sim` at publish. That was a wrong
+mental model of `cargo publish`. Cargo verifies **every** dep listed in the
+crate manifest at publish time, regardless of which features are active:
+optional deps must still have a `version` pin **and** that version must be
+resolvable from crates.io. Path-only deps without versions are rejected with
+`all dependencies must have a version requirement specified`. There is no
+combination of feature flags that lets a published crate keep deps on
+internal `publish = false` workspace siblings.
+
+### Resolution: flip the four Assay-Runner crates to `publish = true`
+
+The four runner crates ship to crates.io as of `v3.11.2`:
+
+- `assay-runner-schema`
+- `assay-runner-core`
+- `assay-runner-linux`
+- `assay-runner-spike`
+
+Each package description now opens with
+*"Internal/experimental substrate for Assay measured-run workflows… No
+standalone product guarantee; API surface remains narrow and intentionally
+undocumented for third-party use; semver tracks the Assay workspace."*
+
+This is a deliberate reframing, not an extraction. The crates were already
+*extraction-ready* per the Phase 2D Slice 6B work that landed for `v3.11.0`;
+making them resolvable on crates.io is the smallest step that restores
+`cargo install assay-cli` without splitting the repo. Slice 7 (separate
+repo extraction) stays closed; the burn-in criteria in
+`docs/reference/runner/phase-2d-consolidation-audit.md` continue to apply.
+
+### What this changes for consumers
+
+- `cargo install assay-cli` works again at `3.11.2`, with the `runner`
+  feature on by default (binary includes `assay runner-spike` per workspace
+  parity).
+- `cargo install assay-cli --no-default-features --features tui,sim`
+  still works and produces a `runner-spike`-free CLI for consumers who want
+  the publishing-minimal surface.
+- The four runner crates are visible on crates.io but **not** part of the
+  public Assay API contract. Third parties using them do so at their own
+  risk; their semver is the workspace's semver.
+- `scripts/ci/publish_idempotent.sh` now publishes the four runner crates
+  in dependency order (`assay-runner-schema → assay-runner-linux →
+  assay-runner-core → assay-runner-spike`) between `assay-monitor` and
+  `assay-sim`. The per-crate `--no-default-features --features tui,sim`
+  override for `assay-cli` is removed; default features are sufficient now.
+
+### Non-change
+
+- No behavioural change to Assay-core / Trust Basis consumers, NDJSON
+  evidence, Trust Basis diff v1, Runner v0 archive contracts, or the
+  cross-runtime diff v0 surface.
+- The `Publish-shape guardrail (assay-cli)` PR-CI job added in `v3.11.1`
+  stays in place as defense-in-depth: it will not fire today (no workspace
+  crate is `publish = false` any more), but will catch a future regression
+  if a new `publish = false` workspace crate is added back and reaches
+  `assay-cli`'s non-optional dep set.
+
 ## [3.11.1] - 2026-05-23
 
 > **Publish-path hot-fix for `assay-cli`.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-spike"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assay-runner-core",
  "assay-runner-schema",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.11.1"
+version = "3.11.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -74,19 +74,19 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.11.1" }
-assay-common = { path = "crates/assay-common", version = "3.11.1", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.11.1" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.11.1" }
-assay-policy = { path = "crates/assay-policy", version = "3.11.1" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.11.1" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.11.1" }
-assay-sim = { path = "crates/assay-sim", version = "3.11.1" }
-assay-registry = { path = "crates/assay-registry", version = "3.11.1" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.11.1" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.11.1" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.11.1" }
-assay-runner-spike = { path = "crates/assay-runner-spike", version = "3.11.1" }
+assay-core = { path = "crates/assay-core", version = "3.11.2" }
+assay-common = { path = "crates/assay-common", version = "3.11.2", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.11.2" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.11.2" }
+assay-policy = { path = "crates/assay-policy", version = "3.11.2" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.11.2" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.11.2" }
+assay-sim = { path = "crates/assay-sim", version = "3.11.2" }
+assay-registry = { path = "crates/assay-registry", version = "3.11.2" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.11.2" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.11.2" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.11.2" }
+assay-runner-spike = { path = "crates/assay-runner-spike", version = "3.11.2" }
 
 # Common dependencies
 anyhow = "1"

--- a/crates/assay-runner-core/Cargo.toml
+++ b/crates/assay-runner-core/Cargo.toml
@@ -5,9 +5,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "Runner orchestration, archive assembly, and layer normalizers for the Assay-Runner candidate (Phase 2D Slice 2)."
+description = "Internal/experimental substrate for Assay measured-run workflows. Runner orchestration, archive assembly, and layer normalizers for the Assay-Runner candidate (Phase 2D Slice 2). No standalone product guarantee; API surface remains narrow and intentionally undocumented for third-party use; semver tracks the Assay workspace."
 readme.workspace = true
-publish = false
 
 [dependencies]
 assay-common = { workspace = true, features = ["std"] }

--- a/crates/assay-runner-linux/Cargo.toml
+++ b/crates/assay-runner-linux/Cargo.toml
@@ -5,9 +5,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "Linux-only platform adapter for the Assay-Runner candidate. Hosts cgroup placement primitives (Phase 2D Slice 3)."
+description = "Internal/experimental substrate for Assay measured-run workflows. Linux-only platform adapter for the Assay-Runner candidate; hosts cgroup placement primitives (Phase 2D Slice 3). No standalone product guarantee; API surface remains narrow and intentionally undocumented for third-party use; semver tracks the Assay workspace."
 readme.workspace = true
-publish = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/assay-runner-schema/Cargo.toml
+++ b/crates/assay-runner-schema/Cargo.toml
@@ -5,9 +5,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "Versioned schema types and constants for the Assay-Runner v0 contracts (Phase 2D Slice 1)."
+description = "Internal/experimental substrate for Assay measured-run workflows. Versioned schema types and constants for the Assay-Runner v0 contracts (Phase 2D Slice 1). No standalone product guarantee; API surface remains narrow and intentionally undocumented for third-party use; semver tracks the Assay workspace."
 readme.workspace = true
-publish = false
 
 [dependencies]
 serde = { workspace = true, features = ["derive", "std"] }

--- a/crates/assay-runner-spike/Cargo.toml
+++ b/crates/assay-runner-spike/Cargo.toml
@@ -5,9 +5,8 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "Compatibility wrapper crate that re-exports the Assay-Runner candidate surface from assay-runner-schema (Slice 1) and assay-runner-core (Slice 2)."
+description = "Internal/experimental substrate for Assay measured-run workflows. Compatibility wrapper crate that re-exports the Assay-Runner candidate surface from assay-runner-schema (Slice 1) and assay-runner-core (Slice 2). No standalone product guarantee; legacy alias retained for readers of pre-extraction history; semver tracks the Assay workspace."
 readme.workspace = true
-publish = false
 
 [dependencies]
 assay-runner-core = { workspace = true }

--- a/scripts/ci/publish_idempotent.sh
+++ b/scripts/ci/publish_idempotent.sh
@@ -3,10 +3,18 @@ set -euo pipefail
 
 echo "📦 Starting Idempotent Publisher..."
 
-# Crates published in dependency order
+# Crates published in dependency order.
+#
 # Adapter crates are intentionally source/workspace-internal for this release
 # line. assay-adapter-api has historical crates.io versions, but no current
 # release-line publishing until ADR-026 gets a dedicated distribution freeze.
+#
+# As of v3.11.2 the four Assay-Runner crates publish too. They are marked as
+# internal/experimental substrate in their package descriptions; they exist on
+# crates.io so that `assay-cli` (which depends on them when the `runner`
+# feature is enabled, the default) can resolve them at publish time. Their
+# semver tracks the Assay workspace and they are not guaranteed standalone
+# product crates.
 CRATES=(
   "assay-common"
   "assay-registry"
@@ -16,6 +24,10 @@ CRATES=(
   "assay-policy"
   "assay-mcp-server"
   "assay-monitor"
+  "assay-runner-schema"
+  "assay-runner-linux"
+  "assay-runner-core"
+  "assay-runner-spike"
   "assay-sim"
   "assay-cli"
 )
@@ -119,30 +131,12 @@ try_publish() {
   local crate="$1"
   local ver="$2"
 
-  # Per-crate feature overrides for publish.
-  #
-  # `assay-cli` directly depends on `assay-runner-{schema,core,linux}`, which
-  # are `publish = false` internal crates. To keep cargo publish resolvable
-  # without changing repo/binary-build behaviour, those runner deps are
-  # `optional = true` behind the `runner` feature (in default for workspace
-  # consumers). cargo publish must therefore exclude `runner` from the active
-  # feature set: pass `--no-default-features --features tui,sim`.
-  local -a extra_args=()
-  case "$crate" in
-    assay-cli)
-      # `tui,sim` is a single cargo argument (comma-separated feature list),
-      # not three shell array elements.
-      # shellcheck disable=SC2054
-      extra_args=(--no-default-features --features tui,sim)
-      ;;
-  esac
-
   # Attempt publish; treat "already exists" as success for idempotency.
   # Using mktemp avoids pipefail issues with tee + grep.
   local log
   log="$(mktemp)"
   set +e
-  cargo publish --package "$crate" "${extra_args[@]}" --verbose 2>&1 | tee "$log"
+  cargo publish --package "$crate" --verbose 2>&1 | tee "$log"
   local rc="${PIPESTATUS[0]}"
   set -e
 


### PR DESCRIPTION
## Summary

Corrected publish line. v3.11.0 and v3.11.1 are partial-publish lines on crates.io — 8 of 9 workspace crates landed, `assay-cli` did not. This PR cuts v3.11.2 as the first complete CLI publish since v3.10.2 by flipping the four Assay-Runner crates to `publish = true` with explicit internal/experimental framing.

## Why `v3.11.1`'s `optional = true` was insufficient

`cargo publish` verifies **every** dep listed in the crate manifest at publish time, regardless of which features are active. Optional deps must still have a `version` pin **and** that version must be resolvable from crates.io. Path-only deps without versions are rejected outright. There is no combination of feature flags that keeps `assay-cli` publishable while its runner deps remain `publish = false`.

This was confirmed locally:

```
$ cargo publish --package assay-cli --no-default-features --features tui,sim --dry-run
error: failed to prepare local package for uploading
Caused by:
  no matching package named \`assay-runner-core\` found
  location searched: crates.io index
  required by package \`assay-cli v3.11.1\`
```

Same error on `path = "../assay-runner-core"` (no version):

```
error: failed to verify manifest at \`crates/assay-cli/Cargo.toml\`
Caused by:
  all dependencies must have a version requirement specified when publishing.
```

## What changes

- `crates/assay-runner-{schema,core,linux,spike}/Cargo.toml`: remove `publish = false`. Each description now opens with the internal/experimental framing: *"Internal/experimental substrate for Assay measured-run workflows… No standalone product guarantee; API surface remains narrow and intentionally undocumented for third-party use; semver tracks the Assay workspace."*
- `scripts/ci/publish_idempotent.sh`: add the four runner crates to `CRATES` in dependency order between `assay-monitor` and `assay-sim`. Drop the per-crate `--no-default-features --features tui,sim` override for `assay-cli` — default features are sufficient now.
- Workspace pins bump 3.11.1 → 3.11.2.
- CHANGELOG `[3.11.2]` documents the reframe in full and explains why v3.11.1's approach didn't work.

## What stays

- `assay-cli/Cargo.toml`: runner deps remain `optional = true` behind the `runner` feature, in defaults. `#[cfg(feature = "runner")]` gating on the `runner-spike` command stays. Users who do `cargo install assay-cli --no-default-features --features tui,sim` still get a runner-spike-free CLI.
- Runner workflow `--features runner` flags stay (paired with `--no-default-features` they keep the minimal-but-runnable build).
- Publish-shape guardrail PR-CI job stays as defense-in-depth.
- Phase 2D Slice 7 (separate-repo extraction) stays closed; burn-in criteria in `docs/reference/runner/phase-2d-consolidation-audit.md` continue to apply.

## Test plan

- [x] Local `cargo publish --dry-run` for `assay-runner-schema` and `assay-runner-linux`: clean
- [x] Local `cargo publish --dry-run` for `assay-runner-core` and `assay-cli`: structurally clean; only fail-mode left is "assay-common@3.11.2 not on crates.io yet" — expected pre-publish and resolved by the publish chain at release time
- [ ] PR CI green incl. `Publish-shape guardrail (assay-cli)`
- [ ] Delegated `Runner Spike Delegated gates=all` proof on PR head SHA
- [ ] Post-merge: tag `v3.11.2` from main → release workflow runs the full publish chain → 12 crates published (4 runner crates + 8 existing) → `assay-cli@3.11.2` lands on crates.io for the first time since `3.10.2`

## Non-claims

- No behavioural change to Assay-core / Trust Basis consumers, NDJSON evidence, Trust Basis diff v1, Runner v0 archive contracts, or the cross-runtime diff v0 surface.
- This is a reframe of the runner crates from "internal only" to "internal/experimental but on crates.io", not an extraction. Slice 7 stays closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)