### PR TITLE
chore(release): public-crate-policy update for runner substrate (v3.11.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,30 @@ jobs:
         shell: bash
         run: ./scripts/ci/check_assay_cli_publish_shape.sh
 
+  public-crate-policy:
+    # Guardrail: catch v3.11.2-style regressions where a workspace member
+    # flips between `publish = true` and `publish = false`, or the
+    # `publish_idempotent.sh` CRATES array drifts from the public crate
+    # contract, without the policy script's allow-list being updated in
+    # the same PR.
+    #
+    # `check-public-crate-policy.sh` previously only ran inside the release
+    # workflow, so a divergence between the policy allow-list and the
+    # actual workspace shape only surfaced at tag time after merge. This
+    # PR-CI mirror runs the same script on every PR so the gate fires
+    # before tag, not after.
+    name: Public crate policy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Verify public crate contract is consistent
+        run: bash scripts/ci/check-public-crate-policy.sh
+
   vendored-packs:
     name: Vendored Pack Sync
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,85 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.11.3] - 2026-05-23
+
+> **Public crate contract update for Assay-Runner substrate.**
+>
+> `v3.11.0`, `v3.11.1`, and `v3.11.2` are all partial-publish lines on
+> crates.io: `assay-cli` did not publish on any of them. This release
+> registers the four `assay-runner-*` crates in the explicit public-crate
+> allow-list — a deliberate policy decision, not a manifest hot-fix —
+> and is the first complete crates.io publish line since `v3.10.2`.
+
+### Why `v3.11.2`'s manifest flip alone wasn't enough
+
+`v3.11.2` removed `publish = false` from the four runner crates so cargo
+could resolve them at publish time, but it did not update
+`scripts/ci/check-public-crate-policy.sh`. That script enforces an
+explicit allow-list of public crates as a release-truth-line contract
+against both `Cargo.toml` metadata and `publish_idempotent.sh`'s `CRATES`
+array. Because the script runs inside the release workflow on tag push
+(not in PR CI), the divergence between "manifest says publishable" and
+"policy allow-list says not allowed" only surfaced after merge, when the
+release workflow's policy check blocked the publish chain before any
+`cargo publish` ran.
+
+The gate worked as intended. The fix is to acknowledge the policy
+decision in the allow-list itself, not to soften the gate.
+
+### Resolution
+
+- `scripts/ci/check-public-crate-policy.sh`: add the four runner crates to
+  the `public_crates` array. The comment block now documents the framing:
+  these crates are published because `assay-cli` depends on them, with
+  explicit internal/experimental wording in their package descriptions;
+  adding any new public crate here is a deliberate public-surface
+  decision.
+- `.github/workflows/ci.yml`: new `Public crate policy` PR-CI job runs
+  `check-public-crate-policy.sh` on every PR, so the gate fires before
+  tag, not at release time. This is the same defense-in-depth pattern as
+  the `Publish-shape guardrail (assay-cli)` job added in `v3.11.1`.
+- `docs/contributing/WAVE0-GATES.md`: document the runner crates as
+  published-but-not-semver-checked, and note the new PR-CI guardrail.
+
+### What this changes for consumers
+
+- `cargo install assay-cli` works again at `3.11.3` (first complete CLI
+  publish since `3.10.2`). Default features include `runner`; CLI ships
+  with the hidden internal `runner-spike` command. Users who want a
+  runner-free CLI can install with
+  `--no-default-features --features tui,sim`.
+- `assay-runner-{schema,core,linux,spike}` are visible on crates.io at
+  `3.11.3` for the first time. Their package descriptions explicitly
+  state: *"Internal/experimental substrate for Assay measured-run
+  workflows … No standalone product guarantee; API surface remains narrow
+  and intentionally undocumented for third-party use; semver tracks the
+  Assay workspace."* They are **not** in the Wave 0 library semver
+  allowlist.
+
+### Known issue with the `v3.11.0`, `v3.11.1`, and `v3.11.2` lines
+
+All three earlier `v3.11.x` releases on crates.io are partial-publish:
+
+- `assay-cli` was not published; the published CLI line remains at
+  `3.10.2` for those tags.
+- `v3.11.0` and `v3.11.1` also did not publish the runner crates.
+- `v3.11.2` published the 8 non-runner workspace crates at `3.11.2` but
+  blocked at the policy gate before publishing the runner crates or
+  `assay-cli`.
+
+The corresponding GitHub Releases stay in place as a record of what
+shipped on the binary-tarball side and what the policy gate caught. Use
+`v3.11.3` for the first complete crates.io publish line.
+
+### Non-change
+
+- No behavioural change to Assay-core / Trust Basis consumers, NDJSON
+  evidence, Trust Basis diff v1, Runner v0 archive contracts, or the
+  cross-runtime diff v0 surface.
+- The `Publish-shape guardrail (assay-cli)` PR-CI job from `v3.11.1`
+  stays in place alongside the new `Public crate policy` job.
+
 ## [3.11.2] - 2026-05-23
 
 > **Corrected publish line.** `v3.11.0` and `v3.11.1` are partial-publish lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,12 +85,18 @@ shipped on the binary-tarball side and what the policy gate caught. Use
 
 ## [3.11.2] - 2026-05-23
 
-> **Corrected publish line.** `v3.11.0` and `v3.11.1` are partial-publish lines
-> on crates.io: 8 of the 9 workspace crates published, but `assay-cli` did not
-> (it remained pinned at `3.10.2` on crates.io). `v3.11.2` is the first
-> complete CLI publish since `v3.10.2`. The four Assay-Runner crates now ship
-> alongside the rest of the workspace, with internal/experimental framing in
-> their package descriptions.
+> **Intended as the corrected publish line; in practice a third partial-publish
+> line.** `v3.11.2` flipped the four Assay-Runner crates from `publish = false`
+> to publishable with internal/experimental framing, so cargo could resolve
+> them at publish time. The release-workflow policy gate
+> (`scripts/ci/check-public-crate-policy.sh`) then correctly blocked the
+> publish chain because the policy allow-list still listed only the original
+> 10 public crates. No runner crate and no `assay-cli` was published from this
+> tag; `assay-cli` remained at `3.10.2` on crates.io. See `[3.11.3]` for the
+> follow-up policy PR that registers the runner crates in the allow-list and
+> mirrors the policy check to PR CI. The framing of the runner crates as
+> internal/experimental substrate stays unchanged from what landed in this
+> release.
 
 ### Why `v3.11.1`'s `optional = true` was not enough
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-spike"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assay-runner-core",
  "assay-runner-schema",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.11.2"
+version = "3.11.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -74,19 +74,19 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.11.2" }
-assay-common = { path = "crates/assay-common", version = "3.11.2", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.11.2" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.11.2" }
-assay-policy = { path = "crates/assay-policy", version = "3.11.2" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.11.2" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.11.2" }
-assay-sim = { path = "crates/assay-sim", version = "3.11.2" }
-assay-registry = { path = "crates/assay-registry", version = "3.11.2" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.11.2" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.11.2" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.11.2" }
-assay-runner-spike = { path = "crates/assay-runner-spike", version = "3.11.2" }
+assay-core = { path = "crates/assay-core", version = "3.11.3" }
+assay-common = { path = "crates/assay-common", version = "3.11.3", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.11.3" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.11.3" }
+assay-policy = { path = "crates/assay-policy", version = "3.11.3" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.11.3" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.11.3" }
+assay-sim = { path = "crates/assay-sim", version = "3.11.3" }
+assay-registry = { path = "crates/assay-registry", version = "3.11.3" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.11.3" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.11.3" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.11.3" }
+assay-runner-spike = { path = "crates/assay-runner-spike", version = "3.11.3" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/contributing/WAVE0-GATES.md
+++ b/docs/contributing/WAVE0-GATES.md
@@ -58,6 +58,20 @@ Binary- or operational-facing crates such as `assay-cli`, `assay-monitor`,
 Wave 0 library semver allowlist unless a future gate slice adds stable library
 API coverage for them.
 
+The four Assay-Runner substrate crates — `assay-runner-schema`,
+`assay-runner-core`, `assay-runner-linux`, and `assay-runner-spike` — are
+also published as of `v3.11.3`, but their package descriptions explicitly
+frame them as internal/experimental substrate (no standalone product
+guarantee, intentionally undocumented for third-party use, semver tracks
+the Assay workspace). They are intentionally **not** in the Wave 0 library
+semver allowlist; they exist on crates.io only because `assay-cli` depends
+on them and cargo publish requires every declared dep to be resolvable
+from crates.io.
+
+As of `v3.11.3`, `check-public-crate-policy.sh` also runs as a PR-CI
+guardrail (job `Public crate policy` in `ci.yml`), so the policy gate
+fires before tag, not at release time.
+
 ## Nightly safety lane (Wave 0.1)
 
 - Current status: non-blocking stub job in Wave 0 workflow (`continue-on-error: true`).

--- a/scripts/ci/check-public-crate-policy.sh
+++ b/scripts/ci/check-public-crate-policy.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Public crate contract: every workspace member whose package metadata
+# allows publishing must appear here, and vice versa. This is the
+# release-truth-line allow-list; the policy script enforces it against
+# both `Cargo.toml` metadata and the publish_idempotent.sh `CRATES`
+# array.
+#
+# The four `assay-runner-*` crates are registered here as of v3.11.3,
+# with their package descriptions explicitly framing them as
+# internal/experimental substrate (no standalone product guarantee,
+# semver follows the Assay workspace, intentionally undocumented for
+# third-party use). They are published because `assay-cli` depends on
+# them; cargo publish requires every dep in `[dependencies]` to be
+# resolvable from crates.io regardless of feature activation, so
+# keeping them publish = false made `assay-cli` itself unpublishable
+# (see CHANGELOG entries for v3.11.0, v3.11.1, v3.11.2, v3.11.3).
+#
+# Adding any new public crate here is a deliberate public-surface
+# decision; the PR that does so must update package descriptions and
+# (when relevant) docs/contributing/WAVE0-GATES.md.
 public_crates=(
   assay-common
   assay-registry
@@ -10,6 +29,10 @@ public_crates=(
   assay-policy
   assay-mcp-server
   assay-monitor
+  assay-runner-schema
+  assay-runner-linux
+  assay-runner-core
+  assay-runner-spike
   assay-sim
   assay-cli
 )


### PR DESCRIPTION
## Summary

This is a **policy PR**, not a manifest hot-fix. `v3.11.0`, `v3.11.1`, and `v3.11.2` are all partial-publish lines on crates.io: `assay-cli` did not publish on any of them. `v3.11.2` specifically blocked at the release-workflow policy gate (`scripts/ci/check-public-crate-policy.sh`) because the policy allow-list still listed only the original 10 public crates, while the manifest flip in `v3.11.2` had made the four runner crates `publish = true`.

The gate worked as intended. Making the runner crates publicly available on crates.io is a real public-surface decision, not a one-line manifest fix. This PR lands that decision deliberately, with all the matching policy, doc, and PR-CI guardrail wiring in one place.

## What changes

- **`scripts/ci/check-public-crate-policy.sh`**: extend `public_crates` to include `assay-runner-schema`, `assay-runner-core`, `assay-runner-linux`, `assay-runner-spike`. Comment block documents the framing — published because `assay-cli` depends on them; package descriptions explicitly say *"Internal/experimental substrate for Assay measured-run workflows … No standalone product guarantee; API surface remains narrow and intentionally undocumented for third-party use; semver tracks the Assay workspace."*; intentionally **not** in the Wave 0 library semver allowlist; adding any new public crate here is a deliberate public-surface decision.
- **`.github/workflows/ci.yml`**: new `Public crate policy` PR-CI job that runs `check-public-crate-policy.sh` on every PR. Until now the script only ran inside the release workflow on tag push, so a divergence between manifest and allow-list only surfaced after merge. This is the same defense-in-depth pattern as the `Publish-shape guardrail (assay-cli)` job added in `v3.11.1`.
- **`docs/contributing/WAVE0-GATES.md`**: document the runner crates as published-but-not-Wave-0-semver-checked; note the new PR-CI guardrail.
- **`CHANGELOG [3.11.3]`**: full reasoning, known-issue note covering the `v3.11.0/1/2` partial-publish lines, and "what changes for consumers" section.
- Workspace pins 3.11.2 → 3.11.3.

## Test plan

- [x] Local `bash scripts/ci/check-public-crate-policy.sh` — passes
- [x] Local `bash scripts/ci/check_assay_cli_publish_shape.sh` — passes (defense-in-depth)
- [ ] PR CI green incl. new `Public crate policy` job
- [ ] Delegated `Runner Spike Delegated gates=all` proof on PR head SHA
- [ ] Post-merge: tag `v3.11.3` from main → release workflow runs the full publish chain → 13 crates published (`assay-{common,registry,evidence,core,metrics,policy,mcp-server,monitor,sim,cli}` + `assay-runner-{schema,linux,core,spike}`) → `assay-cli@3.11.3` lands on crates.io for the first time since `3.10.2`

## After this lands

I'll annotate GitHub Releases `v3.11.0`, `v3.11.1`, and `v3.11.2` with a known-issue note: *"`assay-cli` was not published for this line; use `v3.11.3`."* The GitHub Releases themselves stay in place as a record of what shipped on the binary-tarball side and what the policy gate caught.

## Non-claims

- No behavioural change to Assay-core / Trust Basis consumers, NDJSON evidence, Trust Basis diff v1, Runner v0 archive contracts, or the cross-runtime diff v0 surface.
- The runner crates' package descriptions stay explicit about internal/experimental scope. Their presence on crates.io is mechanical (cargo publish requires resolvable deps), not a product commitment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)