### PR TITLE
docs(experiments): runner-vs-otel shape comparison plan

### DIFF
--- a/.github/workflows/runner-otel-experiment.yml
+++ b/.github/workflows/runner-otel-experiment.yml
@@ -1,0 +1,216 @@
+name: Runner OTel Experiment (Arm C)
+
+# Manually-dispatched workflow that runs the runner-vs-otel-2026-05
+# experiment's Arm C (dual capture) on the delegated `assay-bpf-runner`
+# host. Produces real Runner archives + matching OTel traces + comparator
+# output. Not part of the release gate set; not part of PR CI.
+#
+# Discipline:
+#  - workflow_dispatch only; no pull_request trigger (matches the existing
+#    runner-spike-delegated.yml discipline).
+#  - Uses the same self-hosted runner as the Phase 1 delegated gates.
+#  - Uploads the run artifacts so a separate PR can land them as
+#    runs/v1-arm-c/ baseline evidence without needing to checkout from
+#    the runner itself.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repetitions:
+        description: "Number of dual-capture runs to perform (for determinism)"
+        required: true
+        default: "3"
+        type: string
+      require_binding_match:
+        description: "Run compare.py with --require-binding-match (fail on mismatch)"
+        required: true
+        default: true
+        type: boolean
+      build_ebpf:
+        description: "Rebuild eBPF artifact (target/assay-ebpf.o) before the run"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-otel-experiment-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-delegated-runner:
+    name: Prepare delegated runner
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    timeout-minutes: 5
+    steps:
+      - name: Reset workspace ownership
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Mirror the prepare-delegated-runner pattern from
+          # runner-spike-delegated.yml so action and cargo cache state from a
+          # previous run does not block this job.
+          sudo find "$GITHUB_WORKSPACE/.." -maxdepth 2 -type d -name "_actions" -exec rm -rf {} + 2>/dev/null || true
+          if [ -d "$GITHUB_WORKSPACE" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true
+          fi
+
+  arm-c:
+    name: Arm C (dual capture)
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    needs: prepare-delegated-runner
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Preflight delegated host
+        shell: bash
+        run: |
+          set -euo pipefail
+          for bin in cargo node npm python3 rustc tar; do
+            command -v "$bin" >/dev/null 2>&1 || {
+              echo "ERROR: required command not found on delegated runner: $bin" >&2
+              exit 1
+            }
+          done
+          node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)' || {
+            echo "ERROR: delegated runner must provide Node.js 22 or newer" >&2
+            node --version >&2 || true
+            exit 1
+          }
+          if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+            echo "ERROR: delegated runner must expose cgroup v2 at /sys/fs/cgroup" >&2
+            exit 1
+          fi
+          {
+            echo "## Delegated runner preflight"
+            echo "- kernel: $(uname -r)"
+            echo "- node: $(node --version)"
+            echo "- rustc: $(rustc --version)"
+            echo "- python3: $(python3 --version)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build assay CLI (runner feature)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p assay-cli --no-default-features --features runner
+
+      - name: Build eBPF artifact
+        if: ${{ inputs.build_ebpf }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v docker >/dev/null 2>&1; then
+            cargo xtask build-image
+            cargo xtask build-ebpf --docker
+          else
+            cargo xtask build-ebpf
+          fi
+          test -f target/assay-ebpf.o
+
+      - name: Verify eBPF artifact present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f target/assay-ebpf.o ]; then
+            echo "ERROR: target/assay-ebpf.o is required for Arm C. Run with build_ebpf=true." >&2
+            exit 1
+          fi
+
+      - name: Build experiment workload
+        working-directory: docs/experiments/runner-vs-otel-2026-05/workload
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund --ignore-scripts
+          npx tsc -p tsconfig.json
+          test -f dist/workload.js
+
+      - name: Run Arm C dual capture (N times)
+        shell: bash
+        env:
+          REPETITIONS: ${{ inputs.repetitions }}
+          REQUIRE_BINDING_MATCH: ${{ inputs.require_binding_match }}
+        run: |
+          set -euo pipefail
+          ASSAY_BIN="$PWD/target/debug/assay"
+          EBPF_OBJ="$PWD/target/assay-ebpf.o"
+          EXPERIMENT_ROOT="$PWD/docs/experiments/runner-vs-otel-2026-05"
+          WORKLOAD_JS="$EXPERIMENT_ROOT/workload/dist/workload.js"
+          COMPARE_PY="$EXPERIMENT_ROOT/compare/compare.py"
+          OUT_ROOT="$PWD/arm-c-runs"
+          mkdir -p "$OUT_ROOT"
+
+          STRICT_FLAG=""
+          if [ "$REQUIRE_BINDING_MATCH" = "true" ]; then
+            STRICT_FLAG="--require-binding-match"
+          fi
+
+          BIND_PY="$EXPERIMENT_ROOT/compare/bind-archive.py"
+
+          for i in $(seq 1 "$REPETITIONS"); do
+            RUN_ID="run_arm_c_$(date -u +%Y%m%dT%H%M%SZ)_$i"
+            RUN_DIR="$OUT_ROOT/$RUN_ID"
+            mkdir -p "$RUN_DIR"
+            ARCHIVE_OUT="$RUN_DIR/archive.tar.gz"
+            TRACE_OUT="$RUN_DIR/trace.json"
+            MATRIX_JSON="$RUN_DIR/matrix.json"
+            MATRIX_MD="$RUN_DIR/matrix.md"
+            WORK_DIR="$RUN_DIR/workdir"
+            mkdir -p "$WORK_DIR"
+
+            echo "::group::Arm C iteration $i/$REPETITIONS ($RUN_ID)"
+
+            # Step 1: dual capture. assay runner-spike writes the .tar.gz
+            # AFTER the child workload exits, so the workload itself
+            # cannot bind the manifest digest in-process here.
+            "$ASSAY_BIN" runner-spike run \
+              --agent-shim openai-agents \
+              --kernel-capture \
+              --ebpf "$EBPF_OBJ" \
+              --run-id "$RUN_ID" \
+              --output "$ARCHIVE_OUT" \
+              -- node "$WORKLOAD_JS" \
+                 --run-id "$RUN_ID" \
+                 --trace-out "$TRACE_OUT" \
+                 --work-dir "$WORK_DIR"
+
+            # Step 2: now that the archive exists, attach the
+            # assay.archive.created event with the manifest digest to the
+            # root span in the trace.json.
+            python3 "$BIND_PY" \
+              --trace "$TRACE_OUT" \
+              --archive "$ARCHIVE_OUT"
+
+            # Step 3: comparator. --require-binding-match is the gate that
+            # turns the binding into a hard contract under Arm C.
+            python3 "$COMPARE_PY" \
+              --archive "$ARCHIVE_OUT" \
+              --trace "$TRACE_OUT" \
+              --out-json "$MATRIX_JSON" \
+              --out-md "$MATRIX_MD" \
+              $STRICT_FLAG
+
+            {
+              echo "### $RUN_ID"
+              echo
+              cat "$MATRIX_MD"
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            echo "::endgroup::"
+          done
+
+      - name: Upload Arm C run artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: runner-otel-experiment-arm-c-${{ github.run_id }}
+          path: arm-c-runs/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/experiments/runner-vs-otel-2026-05/.gitignore
+++ b/docs/experiments/runner-vs-otel-2026-05/.gitignore
@@ -1,0 +1,5 @@
+workload/node_modules/
+workload/dist/
+workload/package-lock.json
+runs/run_*/
+!runs/v1-baseline/

--- a/docs/experiments/runner-vs-otel-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-2026-05/README.md
@@ -1,0 +1,156 @@
+# Runner vs OTel: Shape Comparison Experiment Package
+
+> **Status:** v1 infrastructure landed; v1 data collection requires the
+> delegated `assay-bpf-runner` host (Arms A and C).
+>
+> **Plan doc:** [../runner-vs-otel-shape-comparison-2026-05.md](../runner-vs-otel-shape-comparison-2026-05.md)
+> — read this first for the framing, hypotheses, claim-class taxonomy, and
+> threats to validity.
+
+## What is in this directory
+
+| Path | Purpose |
+|---|---|
+| `compare/compare.py` | Stdlib-only Python comparator. Reads a Runner archive (`.tar.gz` or extracted dir) plus an OTLP/JSON trace and emits the field matrix as JSON and Markdown. |
+| `compare/tests/test_compare.py` | Six unit tests over synthetic fixtures. Includes the explicit-mismatch guard for the manifest-digest binding. |
+| `compare/tests/fixtures/` | Synthetic Runner archive directory tree and a matching OTLP trace JSON, used by the unit tests and by Arm B as a placeholder archive side. |
+| `workload/` | Node.js + TypeScript workload that wraps the existing deterministic OpenAI Agents fixture (`runner-fixtures/openai-agents/fixture-agent.js`) with OpenTelemetry tracing. Produces one OTLP/JSON trace per run and, in dual-capture mode, attaches the `assay.archive.manifest_digest` event. |
+| `run-arm-b.sh` | Local trace-only orchestrator (no eBPF required). |
+| `runs/` | Per-run artifact directory. Each run lands under `runs/<run-id>/`. Git-ignored content but the directory itself is tracked via `.gitkeep`. |
+
+## How to run each arm
+
+### Arm A — Runner only (delegated host required)
+
+Linux/eBPF/cgroup-v2; runs on `assay-bpf-runner`.
+
+```bash
+gh workflow run runner-spike-delegated.yml --ref main \
+  -f gates=all -f build_ebpf=true
+```
+
+The existing delegated gate already produces a Runner archive at
+`/tmp/assay-runner-proof-<run-id>/gates/openai-agents-kernel-policy/run-1/runner-openai-agents-kernel-policy.tar.gz`.
+For the experiment, copy that tarball out of the delegated run artifacts and
+feed it into the comparator with `--archive <tarball>`. No trace is captured
+in Arm A; the matrix shows L1 columns as `absent`.
+
+### Arm B — Trace only (local, macOS / Linux / Windows)
+
+```bash
+./run-arm-b.sh
+```
+
+Produces `runs/<run-id>/trace.json` plus a matrix that pairs the real trace
+with the synthetic fixture archive. This arm exists to establish the trace
+shape, the `gen_ai.tool.call.id` presence baseline (Direct manual OTel SDK
+row in the join hierarchy table), and the overhead of the OTel SDK without
+any eBPF tooling attached.
+
+### Arm C — Dual capture (delegated host required)
+
+Linux/eBPF; runs on `assay-bpf-runner` because the workload needs to be
+invoked under `assay runner-spike run`. The workload script accepts an
+`--archive <path>` flag so the trace's root span gets the
+`assay.archive.created` event with the real `assay.archive.manifest_digest`
+referring to the just-written archive.
+
+Outline of the delegated invocation:
+
+```bash
+# inside the delegated host, after `cargo build -p assay-cli --features runner`
+RUN_ID="run_dual_capture_$(date -u +%Y%m%dT%H%M%SZ)"
+ARCHIVE_OUT="/tmp/assay-runner-otel-experiment/$RUN_ID/archive.tar.gz"
+
+# 1. build the workload one-off
+(cd docs/experiments/runner-vs-otel-2026-05/workload \
+  && npm install --no-audit --no-fund --ignore-scripts \
+  && npx tsc -p tsconfig.json)
+
+# 2. run under runner-spike so the archive is produced; the workload itself
+#    emits the OTLP trace and binds to the archive after writing.
+target/debug/assay runner-spike run \
+  --agent-shim openai-agents \
+  --kernel-capture \
+  --ebpf target/assay-ebpf.o \
+  --run-id "$RUN_ID" \
+  --output "$ARCHIVE_OUT" \
+  -- node docs/experiments/runner-vs-otel-2026-05/workload/dist/workload.js \
+     --run-id "$RUN_ID" \
+     --archive "$ARCHIVE_OUT" \
+     --trace-out "/tmp/assay-runner-otel-experiment/$RUN_ID/trace.json"
+
+# 3. comparator
+python3 docs/experiments/runner-vs-otel-2026-05/compare/compare.py \
+  --archive "$ARCHIVE_OUT" \
+  --trace "/tmp/assay-runner-otel-experiment/$RUN_ID/trace.json" \
+  --out-json "/tmp/assay-runner-otel-experiment/$RUN_ID/matrix.json" \
+  --out-md "/tmp/assay-runner-otel-experiment/$RUN_ID/matrix.md"
+```
+
+Repeat Arm C at least three times to fill the determinism rows of the
+measurement plan. Use the same `--run-id` per repetition only if you want to
+exercise idempotency; otherwise generate fresh IDs.
+
+## Measurement plan execution checklist
+
+Lifted from the plan doc, mapped to concrete commands:
+
+| Metric | Sample size | Command |
+|---|---:|---|
+| Archive determinism | n=3 | Arm C x 3; compare `manifest_digest` across runs |
+| Trace shape stability | n=3 | Arm C x 3; diff span tree + attribute keys |
+| `gen_ai.tool.call.id` presence | n=3 per path | Arm B run with each instrumentation under test |
+| End-to-end wall clock | n>=20 per arm | `hyperfine` over each arm (see `scripts/perf_e2e.sh`) |
+| Peak RSS | n>=5 per arm | `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux) |
+| Archive size | n=3 | `stat` on `<archive>.tar.gz` |
+| Trace export size | n=3 | `stat` on `trace.json` |
+
+Emit wall-clock and RSS in Bencher Metric Format (`BMF_JSON=1` per
+`docs/PERFORMANCE-ASSESSMENT.md`) so the overhead numbers slot into the
+existing Criterion / Bencher baseline.
+
+## Comparator tests
+
+```bash
+python3 docs/experiments/runner-vs-otel-2026-05/compare/tests/test_compare.py
+```
+
+Expected output:
+
+```
+test_archive_parsing ... ok
+test_field_matrix_row_count ... ok
+test_manifest_digest_binding_mismatch_is_explicit ... ok
+test_markdown_renders ... ok
+test_tool_call_id_join ... ok
+test_trace_parsing ... ok
+----------------------------------------------------------------------
+Ran 6 tests in 0.0xxs
+OK
+```
+
+The unit tests run in stdlib Python; no virtualenv or extra packages needed.
+
+## Reproducibility pins (fill before publication)
+
+| Source | Pin |
+|---|---|
+| OpenTelemetry GenAI semconv | `<commit SHA of open-telemetry/semantic-conventions when run>` |
+| `@opentelemetry/api`, `sdk-trace-base`, `sdk-trace-node`, `resources`, `semantic-conventions` | versions from `workload/package-lock.json` after first run |
+| `@openai/agents` | `0.11.4` (pinned) |
+| `assay` workspace | git commit + tag |
+| `assay-runner-spike` | git commit |
+| Kernel version | `uname -r` output on the delegated host |
+| Python | `3.11+` for the comparator |
+
+## What this experiment package does and does not do
+
+**Does:** produces machine-readable evidence (trace, archive, matrix) for the
+hypothesis test in the plan doc; pins the OTel GenAI attribute namespace; ties
+the trace to the archive via a tamper-evident digest event; documents how to
+reproduce on the delegated host.
+
+**Does not:** evaluate model quality, rank tracing tools, claim semantic
+equivalence between runtimes, or replace policy-acceptability evaluation. The
+acceptability claim is explicitly outside the contract of both L1 and L2.

--- a/docs/experiments/runner-vs-otel-2026-05/compare/bind-archive.py
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/bind-archive.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Inject the tamper-evident manifest-digest binding event into a trace.json
+produced under Arm C.
+
+Background. In Arm C the child process (our workload) runs inside
+`assay runner-spike`, which only writes the `.tar.gz` archive AFTER the
+child exits. The workload therefore cannot compute the manifest digest
+in-process; the archive does not exist at trace-flush time. This script
+runs as a post-step after `assay runner-spike` returns, computes the
+manifest digest from the now-finalized archive's exact `manifest.json`
+bytes, and attaches an `assay.archive.created` event to the root
+`assay.runner.measured_run` span in the trace.json.
+
+Stdlib only. The digest format and event shape are identical to what
+`workload/src/manifest-binding.ts` produces in the locally-runnable
+Arm B dual-simulation; the two paths must stay byte-compatible because
+they feed into the same `compare.py` matrix.
+
+Usage:
+    python3 bind-archive.py \\
+        --trace runs/run-id/trace.json \\
+        --archive runs/run-id/archive.tar.gz \\
+        [--root-span-name assay.runner.measured_run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+DEFAULT_ROOT_SPAN_NAME = "assay.runner.measured_run"
+MANIFEST_PATH = "manifest.json"
+EVENT_NAME = "assay.archive.created"
+SCHEMA = "assay.runner.archive_manifest.v0"
+
+
+def manifest_bytes_from_archive(archive: Path) -> bytes:
+    """
+    Return the **exact** manifest.json bytes from the archive (.tar.gz or
+    extracted directory). Never re-serialize the parsed JSON: the digest
+    must be over the bytes as written by `assay runner-spike` so it lines
+    up with what `compare.py` computes on the same archive.
+    """
+    if archive.is_dir():
+        return (archive / MANIFEST_PATH).read_bytes()
+    with tarfile.open(archive, "r:*") as tf:
+        member = tf.extractfile(MANIFEST_PATH)
+        if member is None:
+            raise FileNotFoundError(
+                f"{MANIFEST_PATH} not found in archive: {archive}"
+            )
+        return member.read()
+
+
+def sha256_of(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def now_unix_nanos() -> str:
+    import time
+
+    return str(int(time.time_ns()))
+
+
+def inject_binding_event(
+    trace_doc: dict,
+    *,
+    root_span_name: str,
+    manifest_digest: str,
+    archive_path: str,
+    manifest_bytes: int,
+) -> bool:
+    """Return True when the binding event was injected, False otherwise."""
+    event = {
+        "name": EVENT_NAME,
+        "timeUnixNano": now_unix_nanos(),
+        "attributes": [
+            {"key": "assay.archive.schema", "value": {"stringValue": SCHEMA}},
+            {
+                "key": "assay.archive.manifest_digest",
+                "value": {"stringValue": manifest_digest},
+            },
+            {
+                "key": "assay.archive.path",
+                "value": {"stringValue": archive_path},
+            },
+            {
+                "key": "assay.archive.manifest_bytes",
+                "value": {"intValue": str(manifest_bytes)},
+            },
+            {
+                "key": "assay.archive.source",
+                "value": {"stringValue": "post_hoc_bind"},
+            },
+        ],
+    }
+
+    for resource in trace_doc.get("resourceSpans", []):
+        for scope in resource.get("scopeSpans", []):
+            for span in scope.get("spans", []):
+                if span.get("name") == root_span_name:
+                    span.setdefault("events", []).append(event)
+                    return True
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trace", type=Path, required=True)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument(
+        "--root-span-name",
+        default=DEFAULT_ROOT_SPAN_NAME,
+        help=(
+            "Span name to attach the binding event to. Defaults to "
+            f"`{DEFAULT_ROOT_SPAN_NAME}`, which matches workload.ts."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if not args.trace.exists():
+        sys.stderr.write(f"error: trace path not found: {args.trace}\n")
+        return 2
+    if not args.archive.exists():
+        sys.stderr.write(f"error: archive path not found: {args.archive}\n")
+        return 2
+
+    manifest_bytes = manifest_bytes_from_archive(args.archive)
+    digest = sha256_of(manifest_bytes)
+
+    trace_doc = json.loads(args.trace.read_text(encoding="utf-8"))
+    injected = inject_binding_event(
+        trace_doc,
+        root_span_name=args.root_span_name,
+        manifest_digest=digest,
+        archive_path=str(args.archive),
+        manifest_bytes=len(manifest_bytes),
+    )
+    if not injected:
+        sys.stderr.write(
+            f"error: no span named `{args.root_span_name}` found in "
+            f"{args.trace}; nothing injected\n"
+        )
+        return 3
+
+    args.trace.write_text(
+        json.dumps(trace_doc, indent=2) + "\n", encoding="utf-8"
+    )
+    print(
+        f"bound {args.archive} ({len(manifest_bytes)} bytes, {digest}) "
+        f"to {args.trace} on span `{args.root_span_name}`"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/experiments/runner-vs-otel-2026-05/compare/compare.py
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/compare.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""
+Runner-vs-OTel field-matrix comparator.
+
+Inputs:
+  - A Runner archive (.tar.gz) OR an already-extracted archive directory.
+    The archive must follow the assay.runner.archive_manifest.v0 layout
+    documented in crates/assay-runner-schema/src/archive_manifest.rs.
+  - An OpenTelemetry trace export as JSON (OTLP/JSON wire format).
+    The standard `resourceSpans -> scopeSpans -> spans` nesting is supported.
+
+Outputs:
+  - A normalized JSON document with the per-field observation matrix.
+  - A Markdown table summarizing the same matrix for embedding in the
+    experiment write-up.
+
+This script is deliberately dependency-free (Python stdlib only) so it runs
+in CI and on the delegated host without an extra setup step. Schema knowledge
+is encoded inline against the v0 contracts.
+
+Status: v1 of the runner-vs-otel-2026-05 experiment package.
+Non-claims: this script does not interpret policy, evaluate acceptability,
+or rank tools. It compares evidence shape and joinability.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+import tarfile
+from pathlib import Path
+from typing import Any, Iterator
+
+
+ARCHIVE_MANIFEST_SCHEMA = "assay.runner.archive_manifest.v0"
+CAPABILITY_SURFACE_SCHEMA = "assay.runner.capability_surface.v0"
+OBSERVATION_HEALTH_SCHEMA = "assay.runner.observation_health.v0"
+CORRELATION_REPORT_SCHEMA = "assay.runner.correlation_report.v0"
+
+MANIFEST_PATH = "manifest.json"
+CAPABILITY_SURFACE_PATH = "capability-surface.json"
+OBSERVATION_HEALTH_PATH = "observation-health.json"
+CORRELATION_REPORT_PATH = "correlation-report.json"
+SDK_LAYER_PATH = "layers/sdk.ndjson"
+
+
+# ---------------------------------------------------------------------------
+# Normalized observation model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class RunnerObservation:
+    """What we extract from a Runner archive."""
+
+    run_id: str | None
+    schema: str | None
+    manifest_digest: str | None
+    capability_surface: dict[str, list[str]]
+    observation_health: dict[str, Any]
+    correlation_status: str | None
+    sdk_tool_call_ids: list[str]
+    sdk_tools: list[str]
+    sdk_event_count: int
+
+
+@dataclasses.dataclass
+class TraceObservation:
+    """What we extract from an OTLP JSON trace."""
+
+    run_id: str | None
+    manifest_digest: str | None
+    archive_schema: str | None
+    correlation_status: str | None
+    ringbuf_drops: int | None
+    gen_ai_provider: str | None
+    gen_ai_request_model: str | None
+    gen_ai_response_model: str | None
+    gen_ai_input_tokens: int | None
+    gen_ai_output_tokens: int | None
+    tool_call_ids: list[str]
+    tool_names: list[str]
+    span_count: int
+
+
+# ---------------------------------------------------------------------------
+# Runner archive parsing
+# ---------------------------------------------------------------------------
+
+
+def _open_archive_member(source: Path, member: str) -> bytes | None:
+    """
+    Return the bytes of a member file from either an extracted directory
+    or a tarball, or None if the member is missing.
+    """
+    if source.is_dir():
+        path = source / member
+        if not path.exists():
+            return None
+        return path.read_bytes()
+
+    with tarfile.open(source, "r:*") as tf:
+        try:
+            extracted = tf.extractfile(member)
+        except KeyError:
+            return None
+        if extracted is None:
+            return None
+        return extracted.read()
+
+
+def parse_runner_archive(source: Path) -> RunnerObservation:
+    """
+    Parse a Runner measured-run archive.
+
+    Accepts either a path to the .tar.gz produced by `assay runner-spike run`
+    or a path to an already-extracted directory tree (handy for unit tests
+    and for inspecting an archive without re-tarring it).
+
+    The manifest digest is computed over the **exact** `manifest.json` bytes
+    pulled out of the archive (tar or directory), never over re-serialized
+    JSON. Re-serializing would silently rewrite key order, whitespace, and
+    Unicode escapes; the digest would still be deterministic but it would
+    no longer match the digest computed by `manifest-binding.ts` on the
+    trace side, breaking the tamper-evident binding.
+    """
+    manifest_bytes = _open_archive_member(source, MANIFEST_PATH)
+    if manifest_bytes is None:
+        raise FileNotFoundError(f"manifest.json not found in {source}")
+
+    manifest_digest = _sha256_hex(manifest_bytes)
+    manifest = json.loads(manifest_bytes.decode("utf-8"))
+
+    schema = manifest.get("schema")
+    run_id = manifest.get("run_id")
+
+    capability_surface: dict[str, list[str]] = {}
+    capability_bytes = _open_archive_member(source, CAPABILITY_SURFACE_PATH)
+    if capability_bytes is not None:
+        capability = json.loads(capability_bytes.decode("utf-8"))
+        for key in (
+            "filesystem_paths",
+            "network_endpoints",
+            "process_execs",
+            "mcp_tools",
+            "policy_decisions",
+        ):
+            value = capability.get(key, [])
+            capability_surface[key] = sorted(list(value))
+
+    observation_health: dict[str, Any] = {}
+    health_bytes = _open_archive_member(source, OBSERVATION_HEALTH_PATH)
+    if health_bytes is not None:
+        observation_health = json.loads(health_bytes.decode("utf-8"))
+
+    correlation_status: str | None = None
+    correlation_bytes = _open_archive_member(source, CORRELATION_REPORT_PATH)
+    if correlation_bytes is not None:
+        correlation_report = json.loads(correlation_bytes.decode("utf-8"))
+        correlation_status = correlation_report.get("status")
+
+    sdk_tool_call_ids: list[str] = []
+    sdk_tools: list[str] = []
+    sdk_event_count = 0
+    sdk_bytes = _open_archive_member(source, SDK_LAYER_PATH)
+    if sdk_bytes is not None:
+        for line in sdk_bytes.decode("utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            sdk_event_count += 1
+            call_id = event.get("tool_call_id")
+            if isinstance(call_id, str) and call_id and call_id not in sdk_tool_call_ids:
+                sdk_tool_call_ids.append(call_id)
+            tool = event.get("tool")
+            if isinstance(tool, str) and tool and tool not in sdk_tools:
+                sdk_tools.append(tool)
+
+    return RunnerObservation(
+        run_id=run_id,
+        schema=schema,
+        manifest_digest=f"sha256:{manifest_digest}",
+        capability_surface=capability_surface,
+        observation_health=observation_health,
+        correlation_status=correlation_status,
+        sdk_tool_call_ids=sorted(sdk_tool_call_ids),
+        sdk_tools=sorted(sdk_tools),
+        sdk_event_count=sdk_event_count,
+    )
+
+
+def _sha256_hex(data: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(data).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# OTLP trace parsing
+# ---------------------------------------------------------------------------
+
+
+def _iter_spans(trace_doc: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """
+    Yield every span across resourceSpans/scopeSpans nesting.
+    Supports the standard OTLP/JSON wire shape.
+    """
+    for resource in trace_doc.get("resourceSpans", []):
+        for scope in resource.get("scopeSpans", []):
+            for span in scope.get("spans", []):
+                yield span
+
+
+def _attr_value(attribute: dict[str, Any]) -> Any:
+    """Decode an OTLP attribute value to a plain Python type."""
+    value = attribute.get("value", {})
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "intValue" in value:
+        return int(value["intValue"])
+    if "doubleValue" in value:
+        return float(value["doubleValue"])
+    if "boolValue" in value:
+        return bool(value["boolValue"])
+    if "arrayValue" in value:
+        return [_attr_value({"value": v}) for v in value["arrayValue"].get("values", [])]
+    return None
+
+
+def _attrs_dict(span: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for attr in span.get("attributes", []):
+        key = attr.get("key")
+        if key:
+            out[key] = _attr_value(attr)
+    return out
+
+
+def _event_attrs(event: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for attr in event.get("attributes", []):
+        key = attr.get("key")
+        if key:
+            out[key] = _attr_value(attr)
+    return out
+
+
+def parse_otlp_trace(path: Path) -> TraceObservation:
+    """
+    Parse an OTLP/JSON trace export.
+
+    Looks for:
+      - `assay.run.id` attribute on any span or event.
+      - `assay.archive.manifest_digest` and friends on the manifest-binding event
+        or on the root span.
+      - OTel GenAI semantic attributes: `gen_ai.provider.name`,
+        `gen_ai.request.model`, `gen_ai.response.model`,
+        `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`,
+        `gen_ai.tool.name`, `gen_ai.tool.call.id`.
+    """
+    trace_doc = json.loads(path.read_text(encoding="utf-8"))
+
+    run_id: str | None = None
+    manifest_digest: str | None = None
+    archive_schema: str | None = None
+    correlation_status: str | None = None
+    ringbuf_drops: int | None = None
+
+    gen_ai_provider: str | None = None
+    gen_ai_request_model: str | None = None
+    gen_ai_response_model: str | None = None
+    gen_ai_input_tokens: int | None = None
+    gen_ai_output_tokens: int | None = None
+    tool_call_ids: list[str] = []
+    tool_names: list[str] = []
+
+    span_count = 0
+
+    for span in _iter_spans(trace_doc):
+        span_count += 1
+        attrs = _attrs_dict(span)
+
+        run_id = run_id or attrs.get("assay.run.id")
+        manifest_digest = manifest_digest or attrs.get("assay.archive.manifest_digest")
+        archive_schema = archive_schema or attrs.get("assay.archive.schema")
+        correlation_status = correlation_status or attrs.get(
+            "assay.runner.correlation_status"
+        )
+        if "assay.runner.ringbuf_drops" in attrs and ringbuf_drops is None:
+            try:
+                ringbuf_drops = int(attrs["assay.runner.ringbuf_drops"])
+            except (TypeError, ValueError):
+                pass
+
+        gen_ai_provider = gen_ai_provider or attrs.get("gen_ai.provider.name")
+        gen_ai_request_model = gen_ai_request_model or attrs.get("gen_ai.request.model")
+        gen_ai_response_model = gen_ai_response_model or attrs.get(
+            "gen_ai.response.model"
+        )
+        if "gen_ai.usage.input_tokens" in attrs and gen_ai_input_tokens is None:
+            try:
+                gen_ai_input_tokens = int(attrs["gen_ai.usage.input_tokens"])
+            except (TypeError, ValueError):
+                pass
+        if "gen_ai.usage.output_tokens" in attrs and gen_ai_output_tokens is None:
+            try:
+                gen_ai_output_tokens = int(attrs["gen_ai.usage.output_tokens"])
+            except (TypeError, ValueError):
+                pass
+
+        call_id = attrs.get("gen_ai.tool.call.id")
+        if isinstance(call_id, str) and call_id and call_id not in tool_call_ids:
+            tool_call_ids.append(call_id)
+        tool_name = attrs.get("gen_ai.tool.name")
+        if isinstance(tool_name, str) and tool_name and tool_name not in tool_names:
+            tool_names.append(tool_name)
+
+        for event in span.get("events", []):
+            event_attrs = _event_attrs(event)
+            run_id = run_id or event_attrs.get("assay.run.id")
+            manifest_digest = manifest_digest or event_attrs.get(
+                "assay.archive.manifest_digest"
+            )
+            archive_schema = archive_schema or event_attrs.get("assay.archive.schema")
+            correlation_status = correlation_status or event_attrs.get(
+                "assay.runner.correlation_status"
+            )
+            if (
+                "assay.runner.ringbuf_drops" in event_attrs
+                and ringbuf_drops is None
+            ):
+                try:
+                    ringbuf_drops = int(event_attrs["assay.runner.ringbuf_drops"])
+                except (TypeError, ValueError):
+                    pass
+
+    return TraceObservation(
+        run_id=run_id,
+        manifest_digest=manifest_digest,
+        archive_schema=archive_schema,
+        correlation_status=correlation_status,
+        ringbuf_drops=ringbuf_drops,
+        gen_ai_provider=gen_ai_provider,
+        gen_ai_request_model=gen_ai_request_model,
+        gen_ai_response_model=gen_ai_response_model,
+        gen_ai_input_tokens=gen_ai_input_tokens,
+        gen_ai_output_tokens=gen_ai_output_tokens,
+        tool_call_ids=sorted(tool_call_ids),
+        tool_names=sorted(tool_names),
+        span_count=span_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field matrix
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class FieldRow:
+    field: str
+    l1_trace: str  # "present" | "absent" | "n/a" | value
+    l2_archive: str
+    join_key: str
+    claim_class: str
+    notes: str = ""
+
+
+def _bool_to_present(v: Any) -> str:
+    if v is None:
+        return "absent"
+    if isinstance(v, (list, dict)) and len(v) == 0:
+        return "empty"
+    return "present"
+
+
+def _join_status(runner_ids: list[str], trace_ids: list[str]) -> str:
+    if not runner_ids and not trace_ids:
+        return "no-tool-calls-observed"
+    if not trace_ids:
+        return "trace-side-absent"
+    if not runner_ids:
+        return "archive-side-absent"
+    intersection = sorted(set(runner_ids) & set(trace_ids))
+    if intersection:
+        return f"joined:{','.join(intersection)}"
+    return "ids-divergent"
+
+
+def _digest_binding_status(
+    archive_digest: str | None, trace_digest: str | None
+) -> str:
+    if archive_digest is None:
+        return "archive-digest-missing"
+    if trace_digest is None:
+        return "trace-attribute-absent"
+    if archive_digest.lower() == trace_digest.lower():
+        return "tamper-evident-match"
+    return f"mismatch:archive={archive_digest},trace={trace_digest}"
+
+
+def build_field_matrix(
+    runner: RunnerObservation, trace: TraceObservation
+) -> list[FieldRow]:
+    rows: list[FieldRow] = []
+
+    rows.append(
+        FieldRow(
+            field="run identity (run_id)",
+            l1_trace=trace.run_id or "absent",
+            l2_archive=runner.run_id or "absent",
+            join_key="assay.run.id",
+            claim_class="correlation",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="archive schema",
+            l1_trace=trace.archive_schema or "absent",
+            l2_archive=runner.schema or "absent",
+            join_key="assay.archive.schema",
+            claim_class="provenance",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="manifest digest binding",
+            l1_trace=trace.manifest_digest or "absent",
+            l2_archive=runner.manifest_digest or "absent",
+            join_key=_digest_binding_status(
+                runner.manifest_digest, trace.manifest_digest
+            ),
+            claim_class="tamper-evident binding",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="GenAI provider",
+            l1_trace=trace.gen_ai_provider or "absent",
+            l2_archive="n/a (trace-side concept)",
+            join_key="span",
+            claim_class="provenance",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="GenAI request model",
+            l1_trace=trace.gen_ai_request_model or "absent",
+            l2_archive="n/a",
+            join_key="span",
+            claim_class="provenance",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="GenAI response model",
+            l1_trace=trace.gen_ai_response_model or "absent",
+            l2_archive="n/a",
+            join_key="span",
+            claim_class="provenance",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="GenAI input tokens",
+            l1_trace=(
+                str(trace.gen_ai_input_tokens)
+                if trace.gen_ai_input_tokens is not None
+                else "absent"
+            ),
+            l2_archive="n/a (archive does not measure tokens)",
+            join_key="span",
+            claim_class="cost/context",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="GenAI output tokens",
+            l1_trace=(
+                str(trace.gen_ai_output_tokens)
+                if trace.gen_ai_output_tokens is not None
+                else "absent"
+            ),
+            l2_archive="n/a",
+            join_key="span",
+            claim_class="cost/context",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="tool names",
+            l1_trace=(",".join(trace.tool_names) if trace.tool_names else "absent"),
+            l2_archive=(
+                ",".join(runner.sdk_tools) if runner.sdk_tools else "absent"
+            ),
+            join_key="tool name",
+            claim_class="joinable behavior",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="tool_call_id joinability",
+            l1_trace=(
+                ",".join(trace.tool_call_ids) if trace.tool_call_ids else "absent"
+            ),
+            l2_archive=(
+                ",".join(runner.sdk_tool_call_ids)
+                if runner.sdk_tool_call_ids
+                else "absent"
+            ),
+            join_key=_join_status(runner.sdk_tool_call_ids, trace.tool_call_ids),
+            claim_class="primary join key",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="filesystem paths",
+            l1_trace="n/a (not in trace contract)",
+            l2_archive=_bool_to_present(
+                runner.capability_surface.get("filesystem_paths")
+            ),
+            join_key="none",
+            claim_class="measured effect; bounded negative if health is clean",
+            notes=", ".join(
+                runner.capability_surface.get("filesystem_paths", [])[:3]
+            ),
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="network endpoints",
+            l1_trace="n/a (not in trace contract)",
+            l2_archive=_bool_to_present(
+                runner.capability_surface.get("network_endpoints")
+            ),
+            join_key="none",
+            claim_class="measured effect",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="process execs",
+            l1_trace="n/a",
+            l2_archive=_bool_to_present(
+                runner.capability_surface.get("process_execs")
+            ),
+            join_key="none",
+            claim_class="measured effect",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="policy decisions",
+            l1_trace="n/a (unless custom)",
+            l2_archive=_bool_to_present(
+                runner.capability_surface.get("policy_decisions")
+            ),
+            join_key="tool_call_id when present",
+            claim_class="enforcement",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="ringbuf_drops",
+            l1_trace=(
+                str(trace.ringbuf_drops) if trace.ringbuf_drops is not None else "absent"
+            ),
+            l2_archive=str(runner.observation_health.get("ringbuf_drops", "absent")),
+            join_key="archive health",
+            claim_class="measurement integrity",
+        )
+    )
+    rows.append(
+        FieldRow(
+            field="cgroup correlation status",
+            l1_trace=trace.correlation_status or "absent",
+            l2_archive=runner.correlation_status or "absent",
+            join_key="assay.runner.correlation_status",
+            claim_class="measurement integrity",
+        )
+    )
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def matrix_to_json(
+    rows: list[FieldRow], runner: RunnerObservation, trace: TraceObservation
+) -> dict[str, Any]:
+    return {
+        "schema": "assay.experiment.runner_vs_otel.field_matrix.v0",
+        "summary": {
+            "trace_spans": trace.span_count,
+            "archive_sdk_events": runner.sdk_event_count,
+            "manifest_digest_binding": _digest_binding_status(
+                runner.manifest_digest, trace.manifest_digest
+            ),
+            "tool_call_id_join": _join_status(
+                runner.sdk_tool_call_ids, trace.tool_call_ids
+            ),
+        },
+        "runner_observation": dataclasses.asdict(runner),
+        "trace_observation": dataclasses.asdict(trace),
+        "rows": [dataclasses.asdict(row) for row in rows],
+    }
+
+
+def matrix_to_markdown(rows: list[FieldRow], summary: dict[str, Any]) -> str:
+    out: list[str] = []
+    out.append("## Field Matrix")
+    out.append("")
+    out.append(f"- trace spans: {summary['trace_spans']}")
+    out.append(f"- archive SDK events: {summary['archive_sdk_events']}")
+    out.append(
+        f"- manifest-digest binding: {summary['manifest_digest_binding']}"
+    )
+    out.append(f"- tool_call_id join: {summary['tool_call_id_join']}")
+    out.append("")
+    out.append("| Field | L1 Trace | L2 Archive | Join | Claim class | Notes |")
+    out.append("|---|---|---|---|---|---|")
+    for row in rows:
+        out.append(
+            "| {field} | {l1} | {l2} | {join} | {claim} | {notes} |".format(
+                field=row.field,
+                l1=_escape_md(row.l1_trace),
+                l2=_escape_md(row.l2_archive),
+                join=_escape_md(row.join_key),
+                claim=_escape_md(row.claim_class),
+                notes=_escape_md(row.notes),
+            )
+        )
+    out.append("")
+    return "\n".join(out)
+
+
+def _escape_md(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+#
+# Stable exit contract so the comparator can land in CI / Harness flows
+# without re-inventing semantics:
+#
+#   0   comparison generated; no binding error
+#   2   bad CLI / config / input path (argparse + FileNotFoundError)
+#   3   malformed archive or trace, or required manifest-digest binding
+#       missing/mismatched when --require-binding-match is set
+EXIT_OK = 0
+EXIT_BAD_INPUT = 2
+EXIT_BAD_EVIDENCE = 3
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive",
+        type=Path,
+        required=True,
+        help="Path to Runner archive .tar.gz or extracted directory",
+    )
+    parser.add_argument(
+        "--trace",
+        type=Path,
+        required=True,
+        help="Path to OTLP/JSON trace export",
+    )
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        help="Optional path to write the full matrix JSON",
+    )
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        help="Optional path to write the Markdown matrix",
+    )
+    parser.add_argument(
+        "--require-binding-match",
+        action="store_true",
+        help=(
+            "Treat any non-`tamper-evident-match` manifest-digest binding as a "
+            "hard failure (exit 3). Use this in Arm C dispatches where the "
+            "archive and trace must be the same run; leave off for Arm A / "
+            "Arm B / unit tests where one side is intentionally absent or "
+            "synthetic."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if not args.archive.exists():
+        sys.stderr.write(f"error: archive path not found: {args.archive}\n")
+        return EXIT_BAD_INPUT
+    if not args.trace.exists():
+        sys.stderr.write(f"error: trace path not found: {args.trace}\n")
+        return EXIT_BAD_INPUT
+
+    try:
+        runner = parse_runner_archive(args.archive)
+        trace = parse_otlp_trace(args.trace)
+    except FileNotFoundError as exc:
+        sys.stderr.write(f"error: missing archive member: {exc}\n")
+        return EXIT_BAD_INPUT
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"error: malformed JSON input: {exc}\n")
+        return EXIT_BAD_EVIDENCE
+    except (tarfile.TarError, OSError) as exc:
+        sys.stderr.write(f"error: archive could not be read: {exc}\n")
+        return EXIT_BAD_EVIDENCE
+
+    rows = build_field_matrix(runner, trace)
+    matrix = matrix_to_json(rows, runner, trace)
+
+    json_text = json.dumps(matrix, indent=2, sort_keys=True)
+    md_text = matrix_to_markdown(rows, matrix["summary"])
+
+    if args.out_json:
+        args.out_json.write_text(json_text + "\n", encoding="utf-8")
+    if args.out_md:
+        args.out_md.write_text(md_text + "\n", encoding="utf-8")
+
+    if not args.out_json and not args.out_md:
+        # Default to stdout JSON for piping / CI inspection.
+        sys.stdout.write(json_text + "\n")
+
+    binding = matrix["summary"]["manifest_digest_binding"]
+    if args.require_binding_match and binding != "tamper-evident-match":
+        sys.stderr.write(
+            "error: --require-binding-match was set but the trace and archive "
+            f"are not bound by a matching manifest digest: {binding}\n"
+        )
+        return EXIT_BAD_EVIDENCE
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/capability-surface.json
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/capability-surface.json
@@ -1,0 +1,11 @@
+{
+  "schema": "assay.runner.capability_surface.v0",
+  "run_id": "run_fixture_001",
+  "filesystem_paths": [
+    "/tmp/fixture/openai-agents-input.txt"
+  ],
+  "network_endpoints": [],
+  "process_execs": ["/usr/bin/node"],
+  "mcp_tools": ["read_file"],
+  "policy_decisions": ["allow:read_file"]
+}

--- a/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/correlation-report.json
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/correlation-report.json
@@ -1,0 +1,6 @@
+{
+  "schema": "assay.runner.correlation_report.v0",
+  "run_id": "run_fixture_001",
+  "status": "clean",
+  "bindings": []
+}

--- a/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/layers/sdk.ndjson
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/layers/sdk.ndjson
@@ -1,0 +1,3 @@
+{"schema":"assay.runner.sdk_event.v0","run_id":"run_fixture_001","seq":0,"source":"openai-agents-fixture","sdk_name":"@openai/agents","sdk_version":"0.11.4","event_type":"tool_call_started","tool_call_id":"tc_runner_policy_001","tool":"read_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"run_fixture_001","seq":1,"source":"openai-agents-fixture","sdk_name":"@openai/agents","sdk_version":"0.11.4","event_type":"tool_call_completed","tool_call_id":"tc_runner_policy_001","tool":"read_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"run_fixture_001","seq":2,"source":"openai-agents-fixture","sdk_name":"@openai/agents","sdk_version":"0.11.4","event_type":"run_finished"}

--- a/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/manifest.json
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema": "assay.runner.archive_manifest.v0",
+  "run_id": "run_fixture_001",
+  "files": {
+    "manifest.json": {
+      "path": "manifest.json",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "bytes": 0
+    }
+  }
+}

--- a/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/observation-health.json
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive/observation-health.json
@@ -1,0 +1,11 @@
+{
+  "schema": "assay.runner.observation_health.v0",
+  "run_id": "run_fixture_001",
+  "platform": "linux",
+  "kernel_layer": "complete",
+  "ringbuf_drops": 0,
+  "policy_layer": "present",
+  "sdk_layer": "present",
+  "cgroup_correlation": "clean",
+  "notes": []
+}

--- a/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/trace-matching-digest.json
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/trace-matching-digest.json
@@ -1,0 +1,51 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "assay-runner-otel-experiment" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": { "name": "assay-runner-otel-experiment" },
+          "spans": [
+            {
+              "name": "assay.runner.measured_run",
+              "spanId": "0000000000000001",
+              "traceId": "00000000000000000000000000000001",
+              "kind": "SPAN_KIND_INTERNAL",
+              "attributes": [
+                { "key": "assay.run.id", "value": { "stringValue": "run_fixture_001" } },
+                { "key": "gen_ai.provider.name", "value": { "stringValue": "openai" } }
+              ],
+              "events": [
+                {
+                  "name": "assay.archive.created",
+                  "attributes": [
+                    { "key": "assay.archive.schema", "value": { "stringValue": "assay.runner.archive_manifest.v0" } },
+                    { "key": "assay.archive.manifest_digest", "value": { "stringValue": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8" } },
+                    { "key": "assay.runner.ringbuf_drops", "value": { "intValue": 0 } },
+                    { "key": "assay.runner.correlation_status", "value": { "stringValue": "clean" } }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "execute_tool read_file",
+              "spanId": "0000000000000002",
+              "parentSpanId": "0000000000000001",
+              "traceId": "00000000000000000000000000000001",
+              "kind": 1,
+              "attributes": [
+                { "key": "assay.run.id", "value": { "stringValue": "run_fixture_001" } },
+                { "key": "gen_ai.tool.name", "value": { "stringValue": "read_file" } },
+                { "key": "gen_ai.tool.call.id", "value": { "stringValue": "tc_runner_policy_001" } }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/trace.json
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/trace.json
@@ -1,0 +1,60 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "assay-runner-otel-experiment" } }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": { "name": "assay-runner-otel-experiment" },
+          "spans": [
+            {
+              "name": "assay.runner.measured_run",
+              "spanId": "0000000000000001",
+              "traceId": "00000000000000000000000000000001",
+              "kind": "SPAN_KIND_INTERNAL",
+              "attributes": [
+                { "key": "assay.run.id", "value": { "stringValue": "run_fixture_001" } },
+                { "key": "assay.measurement.boundary", "value": { "stringValue": "linux_ebpf_cgroup_v2" } },
+                { "key": "gen_ai.provider.name", "value": { "stringValue": "openai" } },
+                { "key": "gen_ai.request.model", "value": { "stringValue": "gpt-4o-mini" } },
+                { "key": "gen_ai.response.model", "value": { "stringValue": "gpt-4o-mini" } },
+                { "key": "gen_ai.usage.input_tokens", "value": { "intValue": "42" } },
+                { "key": "gen_ai.usage.output_tokens", "value": { "intValue": "17" } }
+              ],
+              "events": [
+                {
+                  "name": "assay.archive.created",
+                  "attributes": [
+                    { "key": "assay.archive.schema", "value": { "stringValue": "assay.runner.archive_manifest.v0" } },
+                    { "key": "assay.archive.manifest_digest", "value": { "stringValue": "sha256:fixture_will_replace_at_runtime" } },
+                    { "key": "assay.archive.path", "value": { "stringValue": "runs/run_fixture_001.tar.gz" } },
+                    { "key": "assay.runner.kernel_layer", "value": { "stringValue": "complete" } },
+                    { "key": "assay.runner.ringbuf_drops", "value": { "intValue": "0" } },
+                    { "key": "assay.runner.correlation_status", "value": { "stringValue": "clean" } }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "execute_tool read_file",
+              "spanId": "0000000000000002",
+              "parentSpanId": "0000000000000001",
+              "traceId": "00000000000000000000000000000001",
+              "kind": "SPAN_KIND_INTERNAL",
+              "attributes": [
+                { "key": "assay.run.id", "value": { "stringValue": "run_fixture_001" } },
+                { "key": "gen_ai.operation.name", "value": { "stringValue": "execute_tool" } },
+                { "key": "gen_ai.tool.name", "value": { "stringValue": "read_file" } },
+                { "key": "gen_ai.tool.type", "value": { "stringValue": "function" } },
+                { "key": "gen_ai.tool.call.id", "value": { "stringValue": "tc_runner_policy_001" } }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/experiments/runner-vs-otel-2026-05/compare/tests/test_compare.py
+++ b/docs/experiments/runner-vs-otel-2026-05/compare/tests/test_compare.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Unit tests for compare.py against synthetic fixtures.
+
+Run from the experiment package root:
+
+    python3 -m unittest docs.experiments.runner-vs-otel-2026-05.compare.tests.test_compare
+
+Or directly:
+
+    python3 docs/experiments/runner-vs-otel-2026-05/compare/tests/test_compare.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# Allow importing compare.py directly when run as a script.
+HERE = Path(__file__).resolve().parent
+PKG = HERE.parent
+sys.path.insert(0, str(PKG))
+
+import compare  # noqa: E402
+
+
+FIXTURES = HERE / "fixtures"
+ARCHIVE_DIR = FIXTURES / "archive"
+TRACE_FILE = FIXTURES / "trace.json"
+TRACE_MATCHING_FILE = FIXTURES / "trace-matching-digest.json"
+
+
+class CompareTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = compare.parse_runner_archive(ARCHIVE_DIR)
+        self.trace = compare.parse_otlp_trace(TRACE_FILE)
+        self.rows = compare.build_field_matrix(self.runner, self.trace)
+        self.matrix = compare.matrix_to_json(self.rows, self.runner, self.trace)
+
+    def test_archive_parsing(self) -> None:
+        self.assertEqual(self.runner.run_id, "run_fixture_001")
+        self.assertEqual(self.runner.schema, "assay.runner.archive_manifest.v0")
+        self.assertTrue(self.runner.manifest_digest.startswith("sha256:"))
+        self.assertEqual(self.runner.sdk_tools, ["read_file"])
+        self.assertEqual(self.runner.sdk_tool_call_ids, ["tc_runner_policy_001"])
+        self.assertEqual(self.runner.correlation_status, "clean")
+        self.assertEqual(self.runner.observation_health["ringbuf_drops"], 0)
+        self.assertEqual(
+            self.runner.capability_surface["mcp_tools"], ["read_file"]
+        )
+
+    def test_trace_parsing(self) -> None:
+        self.assertEqual(self.trace.run_id, "run_fixture_001")
+        self.assertEqual(self.trace.gen_ai_provider, "openai")
+        self.assertEqual(self.trace.gen_ai_request_model, "gpt-4o-mini")
+        self.assertEqual(self.trace.gen_ai_response_model, "gpt-4o-mini")
+        self.assertEqual(self.trace.gen_ai_input_tokens, 42)
+        self.assertEqual(self.trace.gen_ai_output_tokens, 17)
+        self.assertEqual(self.trace.tool_names, ["read_file"])
+        self.assertEqual(self.trace.tool_call_ids, ["tc_runner_policy_001"])
+        self.assertEqual(self.trace.correlation_status, "clean")
+        self.assertEqual(self.trace.ringbuf_drops, 0)
+        self.assertEqual(self.trace.span_count, 2)
+
+    def test_tool_call_id_join(self) -> None:
+        self.assertEqual(
+            self.matrix["summary"]["tool_call_id_join"],
+            "joined:tc_runner_policy_001",
+        )
+
+    def test_manifest_digest_binding_mismatch_is_explicit(self) -> None:
+        # The fixture trace carries a placeholder digest that does not match
+        # the actual fixture archive bytes. The comparator must surface this
+        # as a mismatch, not silently treat it as a join.
+        binding = self.matrix["summary"]["manifest_digest_binding"]
+        self.assertTrue(binding.startswith("mismatch:"), binding)
+
+    def test_field_matrix_row_count(self) -> None:
+        # Sixteen well-known rows in v0 of the matrix; bumping this is an
+        # explicit decision.
+        self.assertEqual(len(self.rows), 16)
+
+    def test_markdown_renders(self) -> None:
+        md = compare.matrix_to_markdown(self.rows, self.matrix["summary"])
+        # Smoke: the table header and at least one well-known row are present.
+        self.assertIn("| Field | L1 Trace | L2 Archive |", md)
+        self.assertIn("tool_call_id joinability", md)
+        self.assertIn("manifest digest binding", md)
+
+
+class OtlpShapeVarianceTests(unittest.TestCase):
+    """
+    Defensive coverage for OTLP/JSON shape variants the comparator must accept:
+
+    - `intValue` carried as a native JSON number (some SDK exporters) instead of
+      the spec-canonical JSON string;
+    - `kind` carried as a numeric enum (1) instead of the `SPAN_KIND_*` string;
+    - root span's `assay.archive.manifest_digest` attached to an event rather
+      than a span attribute;
+    - mixed: digest at root span, tool call id deeper in a child span.
+
+    The matching-digest fixture exercises all four of the above, plus the
+    happy path of a manifest-digest that lines up with the fixture archive
+    so the binding row reports `tamper-evident-match`.
+    """
+
+    def test_matching_digest_reports_tamper_evident_match(self) -> None:
+        runner = compare.parse_runner_archive(ARCHIVE_DIR)
+        trace = compare.parse_otlp_trace(TRACE_MATCHING_FILE)
+        rows = compare.build_field_matrix(runner, trace)
+        matrix = compare.matrix_to_json(rows, runner, trace)
+        self.assertEqual(
+            matrix["summary"]["manifest_digest_binding"], "tamper-evident-match"
+        )
+
+    def test_int_value_as_native_number_is_accepted(self) -> None:
+        # ringbuf_drops in the matching fixture is intValue: 0 (a real int,
+        # not the canonical string-encoded form). parse_otlp_trace must still
+        # populate the integer field.
+        trace = compare.parse_otlp_trace(TRACE_MATCHING_FILE)
+        self.assertEqual(trace.ringbuf_drops, 0)
+
+    def test_digest_on_event_is_picked_up(self) -> None:
+        # The matching fixture carries assay.archive.manifest_digest on the
+        # `assay.archive.created` event, not on the root span's attribute
+        # list. The parser must look in both places.
+        trace = compare.parse_otlp_trace(TRACE_MATCHING_FILE)
+        self.assertTrue(trace.manifest_digest.startswith("sha256:"))
+
+
+class ExitCodeTests(unittest.TestCase):
+    """
+    The exit-code contract is the only stable surface CI / Harness flows can
+    rely on. Lock it down with unit tests.
+    """
+
+    @staticmethod
+    def _silent_main(argv: list[str]) -> int:
+        # Suppress stdout/stderr so test output stays readable; we only care
+        # about exit code here.
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+            io.StringIO()
+        ):
+            return compare.main(argv)
+
+    def test_match_with_require_binding_match_returns_zero(self) -> None:
+        rc = self._silent_main(
+            [
+                "--archive",
+                str(ARCHIVE_DIR),
+                "--trace",
+                str(TRACE_MATCHING_FILE),
+                "--require-binding-match",
+            ]
+        )
+        self.assertEqual(rc, compare.EXIT_OK)
+
+    def test_mismatch_with_require_binding_match_returns_bad_evidence(self) -> None:
+        rc = self._silent_main(
+            [
+                "--archive",
+                str(ARCHIVE_DIR),
+                "--trace",
+                str(TRACE_FILE),
+                "--require-binding-match",
+            ]
+        )
+        self.assertEqual(rc, compare.EXIT_BAD_EVIDENCE)
+
+    def test_mismatch_without_strict_flag_still_succeeds(self) -> None:
+        # Default behavior: report the mismatch in the summary but do not fail.
+        # This keeps Arm A and Arm B (and the synthetic fixture pair used by
+        # other tests) usable.
+        rc = self._silent_main(
+            ["--archive", str(ARCHIVE_DIR), "--trace", str(TRACE_FILE)]
+        )
+        self.assertEqual(rc, compare.EXIT_OK)
+
+    def test_missing_input_returns_bad_input(self) -> None:
+        rc = self._silent_main(
+            [
+                "--archive",
+                str(ARCHIVE_DIR),
+                "--trace",
+                "/nonexistent/trace.json",
+            ]
+        )
+        self.assertEqual(rc, compare.EXIT_BAD_INPUT)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/docs/experiments/runner-vs-otel-2026-05/run-arm-b.sh
+++ b/docs/experiments/runner-vs-otel-2026-05/run-arm-b.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Arm B (trace only) runner for the runner-vs-otel-2026-05 experiment.
+#
+# Runs the deterministic OpenAI Agents workload under OpenTelemetry tracing
+# without any Runner archive capture. Produces:
+#   - runs/<run-id>/trace.json     OTLP/JSON trace export
+#   - runs/<run-id>/matrix.json    Field matrix output (archive arm marked absent)
+#   - runs/<run-id>/matrix.md      Markdown summary
+#
+# Arms A and C live on the delegated `assay-bpf-runner` host because they
+# require Linux/eBPF/cgroup-v2 capture; see README.md for the dispatch path.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+EXPERIMENT_ROOT="$PWD"
+WORKLOAD_DIR="$EXPERIMENT_ROOT/workload"
+COMPARE_DIR="$EXPERIMENT_ROOT/compare"
+
+RUN_ID="${RUN_ID:-run_arm_b_$(date -u +%Y%m%dT%H%M%SZ)}"
+RUN_DIR="$EXPERIMENT_ROOT/runs/$RUN_ID"
+TRACE_OUT="$RUN_DIR/trace.json"
+MATRIX_JSON="$RUN_DIR/matrix.json"
+MATRIX_MD="$RUN_DIR/matrix.md"
+SYNTHETIC_ARCHIVE_DIR="$COMPARE_DIR/tests/fixtures/archive"
+
+mkdir -p "$RUN_DIR"
+
+echo "==> Arm B: trace-only workload run"
+echo "    run_id    = $RUN_ID"
+echo "    trace_out = $TRACE_OUT"
+
+(
+  cd "$WORKLOAD_DIR"
+  if [ ! -d node_modules ]; then
+    echo "==> npm install (one-time)"
+    npm install --no-audit --no-fund --ignore-scripts
+  fi
+  if [ ! -d dist ] || [ src -nt dist ]; then
+    echo "==> tsc"
+    npx tsc -p tsconfig.json
+  fi
+  node dist/workload.js --run-id "$RUN_ID" --trace-out "$TRACE_OUT"
+)
+
+echo "==> compare against synthetic archive (Arm B has no real archive)"
+echo "    using $SYNTHETIC_ARCHIVE_DIR for the archive side to exercise the comparator"
+python3 "$COMPARE_DIR/compare.py" \
+  --archive "$SYNTHETIC_ARCHIVE_DIR" \
+  --trace "$TRACE_OUT" \
+  --out-json "$MATRIX_JSON" \
+  --out-md "$MATRIX_MD"
+
+echo
+echo "==> Arm B run complete:"
+echo "    trace:  $TRACE_OUT"
+echo "    matrix: $MATRIX_JSON"
+echo "    md:     $MATRIX_MD"
+echo
+echo "Arm B intentionally pairs the trace with a synthetic fixture archive to"
+echo "exercise the comparator end-to-end. For a real (Runner archive, trace)"
+echo "pair, dispatch Arm C on the delegated host; see README.md."

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T193930Z/matrix.json
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T193930Z/matrix.json
@@ -1,0 +1,197 @@
+{
+  "rows": [
+    {
+      "claim_class": "correlation",
+      "field": "run identity (run_id)",
+      "join_key": "assay.run.id",
+      "l1_trace": "run_arm_b_20260524T193930Z",
+      "l2_archive": "run_fixture_001",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "archive schema",
+      "join_key": "assay.archive.schema",
+      "l1_trace": "absent",
+      "l2_archive": "assay.runner.archive_manifest.v0",
+      "notes": ""
+    },
+    {
+      "claim_class": "tamper-evident binding",
+      "field": "manifest digest binding",
+      "join_key": "trace-attribute-absent",
+      "l1_trace": "absent",
+      "l2_archive": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI provider",
+      "join_key": "span",
+      "l1_trace": "openai",
+      "l2_archive": "n/a (trace-side concept)",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI request model",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI response model",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "cost/context",
+      "field": "GenAI input tokens",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a (archive does not measure tokens)",
+      "notes": ""
+    },
+    {
+      "claim_class": "cost/context",
+      "field": "GenAI output tokens",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "joinable behavior",
+      "field": "tool names",
+      "join_key": "tool name",
+      "l1_trace": "read_file",
+      "l2_archive": "read_file",
+      "notes": ""
+    },
+    {
+      "claim_class": "primary join key",
+      "field": "tool_call_id joinability",
+      "join_key": "joined:tc_runner_policy_001",
+      "l1_trace": "tc_runner_policy_001",
+      "l2_archive": "tc_runner_policy_001",
+      "notes": ""
+    },
+    {
+      "claim_class": "measured effect; bounded negative if health is clean",
+      "field": "filesystem paths",
+      "join_key": "none",
+      "l1_trace": "n/a (not in trace contract)",
+      "l2_archive": "present",
+      "notes": "/tmp/fixture/openai-agents-input.txt"
+    },
+    {
+      "claim_class": "measured effect",
+      "field": "network endpoints",
+      "join_key": "none",
+      "l1_trace": "n/a (not in trace contract)",
+      "l2_archive": "empty",
+      "notes": ""
+    },
+    {
+      "claim_class": "measured effect",
+      "field": "process execs",
+      "join_key": "none",
+      "l1_trace": "n/a",
+      "l2_archive": "present",
+      "notes": ""
+    },
+    {
+      "claim_class": "enforcement",
+      "field": "policy decisions",
+      "join_key": "tool_call_id when present",
+      "l1_trace": "n/a (unless custom)",
+      "l2_archive": "present",
+      "notes": ""
+    },
+    {
+      "claim_class": "measurement integrity",
+      "field": "ringbuf_drops",
+      "join_key": "archive health",
+      "l1_trace": "absent",
+      "l2_archive": "0",
+      "notes": ""
+    },
+    {
+      "claim_class": "measurement integrity",
+      "field": "cgroup correlation status",
+      "join_key": "assay.runner.correlation_status",
+      "l1_trace": "absent",
+      "l2_archive": "clean",
+      "notes": ""
+    }
+  ],
+  "runner_observation": {
+    "capability_surface": {
+      "filesystem_paths": [
+        "/tmp/fixture/openai-agents-input.txt"
+      ],
+      "mcp_tools": [
+        "read_file"
+      ],
+      "network_endpoints": [],
+      "policy_decisions": [
+        "allow:read_file"
+      ],
+      "process_execs": [
+        "/usr/bin/node"
+      ]
+    },
+    "correlation_status": "clean",
+    "manifest_digest": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+    "observation_health": {
+      "cgroup_correlation": "clean",
+      "kernel_layer": "complete",
+      "notes": [],
+      "platform": "linux",
+      "policy_layer": "present",
+      "ringbuf_drops": 0,
+      "run_id": "run_fixture_001",
+      "schema": "assay.runner.observation_health.v0",
+      "sdk_layer": "present"
+    },
+    "run_id": "run_fixture_001",
+    "schema": "assay.runner.archive_manifest.v0",
+    "sdk_event_count": 3,
+    "sdk_tool_call_ids": [
+      "tc_runner_policy_001"
+    ],
+    "sdk_tools": [
+      "read_file"
+    ]
+  },
+  "schema": "assay.experiment.runner_vs_otel.field_matrix.v0",
+  "summary": {
+    "archive_sdk_events": 3,
+    "manifest_digest_binding": "trace-attribute-absent",
+    "tool_call_id_join": "joined:tc_runner_policy_001",
+    "trace_spans": 2
+  },
+  "trace_observation": {
+    "archive_schema": null,
+    "correlation_status": null,
+    "gen_ai_input_tokens": null,
+    "gen_ai_output_tokens": null,
+    "gen_ai_provider": "openai",
+    "gen_ai_request_model": null,
+    "gen_ai_response_model": null,
+    "manifest_digest": null,
+    "ringbuf_drops": null,
+    "run_id": "run_arm_b_20260524T193930Z",
+    "span_count": 2,
+    "tool_call_ids": [
+      "tc_runner_policy_001"
+    ],
+    "tool_names": [
+      "read_file"
+    ]
+  }
+}

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T193930Z/matrix.md
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T193930Z/matrix.md
@@ -1,0 +1,25 @@
+## Field Matrix
+
+- trace spans: 2
+- archive SDK events: 3
+- manifest-digest binding: trace-attribute-absent
+- tool_call_id join: joined:tc_runner_policy_001
+
+| Field | L1 Trace | L2 Archive | Join | Claim class | Notes |
+|---|---|---|---|---|---|
+| run identity (run_id) | run_arm_b_20260524T193930Z | run_fixture_001 | assay.run.id | correlation |  |
+| archive schema | absent | assay.runner.archive_manifest.v0 | assay.archive.schema | provenance |  |
+| manifest digest binding | absent | sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8 | trace-attribute-absent | tamper-evident binding |  |
+| GenAI provider | openai | n/a (trace-side concept) | span | provenance |  |
+| GenAI request model | absent | n/a | span | provenance |  |
+| GenAI response model | absent | n/a | span | provenance |  |
+| GenAI input tokens | absent | n/a (archive does not measure tokens) | span | cost/context |  |
+| GenAI output tokens | absent | n/a | span | cost/context |  |
+| tool names | read_file | read_file | tool name | joinable behavior |  |
+| tool_call_id joinability | tc_runner_policy_001 | tc_runner_policy_001 | joined:tc_runner_policy_001 | primary join key |  |
+| filesystem paths | n/a (not in trace contract) | present | none | measured effect; bounded negative if health is clean | /tmp/fixture/openai-agents-input.txt |
+| network endpoints | n/a (not in trace contract) | empty | none | measured effect |  |
+| process execs | n/a | present | none | measured effect |  |
+| policy decisions | n/a (unless custom) | present | tool_call_id when present | enforcement |  |
+| ringbuf_drops | absent | 0 | archive health | measurement integrity |  |
+| cgroup correlation status | absent | clean | assay.runner.correlation_status | measurement integrity |  |

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T193930Z/trace.json
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T193930Z/trace.json
@@ -1,0 +1,113 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "assay-runner-otel-experiment"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "0.0.0"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "assay-runner-otel-experiment"
+          },
+          "spans": [
+            {
+              "name": "execute_tool read_file",
+              "spanId": "c9115925bceb54a9",
+              "traceId": "76bf0406e4abb25d4937a7b63a2f252f",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1779651571323000000",
+              "endTimeUnixNano": "1779651571323145709",
+              "attributes": [
+                {
+                  "key": "assay.run.id",
+                  "value": {
+                    "stringValue": "run_arm_b_20260524T193930Z"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "execute_tool"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.name",
+                  "value": {
+                    "stringValue": "read_file"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.type",
+                  "value": {
+                    "stringValue": "function"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.call.id",
+                  "value": {
+                    "stringValue": "tc_runner_policy_001"
+                  }
+                }
+              ],
+              "events": [],
+              "status": {
+                "code": 0
+              }
+            },
+            {
+              "name": "assay.runner.measured_run",
+              "spanId": "49b7e61679e124fb",
+              "traceId": "7806c890975e7f2d7ae3032b212d4b99",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1779651571313000000",
+              "endTimeUnixNano": "1779651571324415125",
+              "attributes": [
+                {
+                  "key": "assay.run.id",
+                  "value": {
+                    "stringValue": "run_arm_b_20260524T193930Z"
+                  }
+                },
+                {
+                  "key": "assay.measurement.boundary",
+                  "value": {
+                    "stringValue": "linux_ebpf_cgroup_v2"
+                  }
+                },
+                {
+                  "key": "gen_ai.provider.name",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "create_agent"
+                  }
+                }
+              ],
+              "events": [],
+              "status": {
+                "code": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194017Z_2/matrix.json
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194017Z_2/matrix.json
@@ -1,0 +1,197 @@
+{
+  "rows": [
+    {
+      "claim_class": "correlation",
+      "field": "run identity (run_id)",
+      "join_key": "assay.run.id",
+      "l1_trace": "run_arm_b_20260524T194017Z_2",
+      "l2_archive": "run_fixture_001",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "archive schema",
+      "join_key": "assay.archive.schema",
+      "l1_trace": "absent",
+      "l2_archive": "assay.runner.archive_manifest.v0",
+      "notes": ""
+    },
+    {
+      "claim_class": "tamper-evident binding",
+      "field": "manifest digest binding",
+      "join_key": "trace-attribute-absent",
+      "l1_trace": "absent",
+      "l2_archive": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI provider",
+      "join_key": "span",
+      "l1_trace": "openai",
+      "l2_archive": "n/a (trace-side concept)",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI request model",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI response model",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "cost/context",
+      "field": "GenAI input tokens",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a (archive does not measure tokens)",
+      "notes": ""
+    },
+    {
+      "claim_class": "cost/context",
+      "field": "GenAI output tokens",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "joinable behavior",
+      "field": "tool names",
+      "join_key": "tool name",
+      "l1_trace": "read_file",
+      "l2_archive": "read_file",
+      "notes": ""
+    },
+    {
+      "claim_class": "primary join key",
+      "field": "tool_call_id joinability",
+      "join_key": "joined:tc_runner_policy_001",
+      "l1_trace": "tc_runner_policy_001",
+      "l2_archive": "tc_runner_policy_001",
+      "notes": ""
+    },
+    {
+      "claim_class": "measured effect; bounded negative if health is clean",
+      "field": "filesystem paths",
+      "join_key": "none",
+      "l1_trace": "n/a (not in trace contract)",
+      "l2_archive": "present",
+      "notes": "/tmp/fixture/openai-agents-input.txt"
+    },
+    {
+      "claim_class": "measured effect",
+      "field": "network endpoints",
+      "join_key": "none",
+      "l1_trace": "n/a (not in trace contract)",
+      "l2_archive": "empty",
+      "notes": ""
+    },
+    {
+      "claim_class": "measured effect",
+      "field": "process execs",
+      "join_key": "none",
+      "l1_trace": "n/a",
+      "l2_archive": "present",
+      "notes": ""
+    },
+    {
+      "claim_class": "enforcement",
+      "field": "policy decisions",
+      "join_key": "tool_call_id when present",
+      "l1_trace": "n/a (unless custom)",
+      "l2_archive": "present",
+      "notes": ""
+    },
+    {
+      "claim_class": "measurement integrity",
+      "field": "ringbuf_drops",
+      "join_key": "archive health",
+      "l1_trace": "absent",
+      "l2_archive": "0",
+      "notes": ""
+    },
+    {
+      "claim_class": "measurement integrity",
+      "field": "cgroup correlation status",
+      "join_key": "assay.runner.correlation_status",
+      "l1_trace": "absent",
+      "l2_archive": "clean",
+      "notes": ""
+    }
+  ],
+  "runner_observation": {
+    "capability_surface": {
+      "filesystem_paths": [
+        "/tmp/fixture/openai-agents-input.txt"
+      ],
+      "mcp_tools": [
+        "read_file"
+      ],
+      "network_endpoints": [],
+      "policy_decisions": [
+        "allow:read_file"
+      ],
+      "process_execs": [
+        "/usr/bin/node"
+      ]
+    },
+    "correlation_status": "clean",
+    "manifest_digest": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+    "observation_health": {
+      "cgroup_correlation": "clean",
+      "kernel_layer": "complete",
+      "notes": [],
+      "platform": "linux",
+      "policy_layer": "present",
+      "ringbuf_drops": 0,
+      "run_id": "run_fixture_001",
+      "schema": "assay.runner.observation_health.v0",
+      "sdk_layer": "present"
+    },
+    "run_id": "run_fixture_001",
+    "schema": "assay.runner.archive_manifest.v0",
+    "sdk_event_count": 3,
+    "sdk_tool_call_ids": [
+      "tc_runner_policy_001"
+    ],
+    "sdk_tools": [
+      "read_file"
+    ]
+  },
+  "schema": "assay.experiment.runner_vs_otel.field_matrix.v0",
+  "summary": {
+    "archive_sdk_events": 3,
+    "manifest_digest_binding": "trace-attribute-absent",
+    "tool_call_id_join": "joined:tc_runner_policy_001",
+    "trace_spans": 2
+  },
+  "trace_observation": {
+    "archive_schema": null,
+    "correlation_status": null,
+    "gen_ai_input_tokens": null,
+    "gen_ai_output_tokens": null,
+    "gen_ai_provider": "openai",
+    "gen_ai_request_model": null,
+    "gen_ai_response_model": null,
+    "manifest_digest": null,
+    "ringbuf_drops": null,
+    "run_id": "run_arm_b_20260524T194017Z_2",
+    "span_count": 2,
+    "tool_call_ids": [
+      "tc_runner_policy_001"
+    ],
+    "tool_names": [
+      "read_file"
+    ]
+  }
+}

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194017Z_2/matrix.md
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194017Z_2/matrix.md
@@ -1,0 +1,25 @@
+## Field Matrix
+
+- trace spans: 2
+- archive SDK events: 3
+- manifest-digest binding: trace-attribute-absent
+- tool_call_id join: joined:tc_runner_policy_001
+
+| Field | L1 Trace | L2 Archive | Join | Claim class | Notes |
+|---|---|---|---|---|---|
+| run identity (run_id) | run_arm_b_20260524T194017Z_2 | run_fixture_001 | assay.run.id | correlation |  |
+| archive schema | absent | assay.runner.archive_manifest.v0 | assay.archive.schema | provenance |  |
+| manifest digest binding | absent | sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8 | trace-attribute-absent | tamper-evident binding |  |
+| GenAI provider | openai | n/a (trace-side concept) | span | provenance |  |
+| GenAI request model | absent | n/a | span | provenance |  |
+| GenAI response model | absent | n/a | span | provenance |  |
+| GenAI input tokens | absent | n/a (archive does not measure tokens) | span | cost/context |  |
+| GenAI output tokens | absent | n/a | span | cost/context |  |
+| tool names | read_file | read_file | tool name | joinable behavior |  |
+| tool_call_id joinability | tc_runner_policy_001 | tc_runner_policy_001 | joined:tc_runner_policy_001 | primary join key |  |
+| filesystem paths | n/a (not in trace contract) | present | none | measured effect; bounded negative if health is clean | /tmp/fixture/openai-agents-input.txt |
+| network endpoints | n/a (not in trace contract) | empty | none | measured effect |  |
+| process execs | n/a | present | none | measured effect |  |
+| policy decisions | n/a (unless custom) | present | tool_call_id when present | enforcement |  |
+| ringbuf_drops | absent | 0 | archive health | measurement integrity |  |
+| cgroup correlation status | absent | clean | assay.runner.correlation_status | measurement integrity |  |

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194017Z_2/trace.json
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194017Z_2/trace.json
@@ -1,0 +1,113 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "assay-runner-otel-experiment"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "0.0.0"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "assay-runner-otel-experiment"
+          },
+          "spans": [
+            {
+              "name": "execute_tool read_file",
+              "spanId": "aa12656b00e5f7ba",
+              "traceId": "aff38c0a64bc439784cb8e9f4b6d0356",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1779651617814000000",
+              "endTimeUnixNano": "1779651617814142750",
+              "attributes": [
+                {
+                  "key": "assay.run.id",
+                  "value": {
+                    "stringValue": "run_arm_b_20260524T194017Z_2"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "execute_tool"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.name",
+                  "value": {
+                    "stringValue": "read_file"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.type",
+                  "value": {
+                    "stringValue": "function"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.call.id",
+                  "value": {
+                    "stringValue": "tc_runner_policy_001"
+                  }
+                }
+              ],
+              "events": [],
+              "status": {
+                "code": 0
+              }
+            },
+            {
+              "name": "assay.runner.measured_run",
+              "spanId": "4246673883892c30",
+              "traceId": "17881facd4086480681d095777d66d97",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1779651617806000000",
+              "endTimeUnixNano": "1779651617815997459",
+              "attributes": [
+                {
+                  "key": "assay.run.id",
+                  "value": {
+                    "stringValue": "run_arm_b_20260524T194017Z_2"
+                  }
+                },
+                {
+                  "key": "assay.measurement.boundary",
+                  "value": {
+                    "stringValue": "linux_ebpf_cgroup_v2"
+                  }
+                },
+                {
+                  "key": "gen_ai.provider.name",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "create_agent"
+                  }
+                }
+              ],
+              "events": [],
+              "status": {
+                "code": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194019Z_3/matrix.json
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194019Z_3/matrix.json
@@ -1,0 +1,197 @@
+{
+  "rows": [
+    {
+      "claim_class": "correlation",
+      "field": "run identity (run_id)",
+      "join_key": "assay.run.id",
+      "l1_trace": "run_arm_b_20260524T194019Z_3",
+      "l2_archive": "run_fixture_001",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "archive schema",
+      "join_key": "assay.archive.schema",
+      "l1_trace": "absent",
+      "l2_archive": "assay.runner.archive_manifest.v0",
+      "notes": ""
+    },
+    {
+      "claim_class": "tamper-evident binding",
+      "field": "manifest digest binding",
+      "join_key": "trace-attribute-absent",
+      "l1_trace": "absent",
+      "l2_archive": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI provider",
+      "join_key": "span",
+      "l1_trace": "openai",
+      "l2_archive": "n/a (trace-side concept)",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI request model",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI response model",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "cost/context",
+      "field": "GenAI input tokens",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a (archive does not measure tokens)",
+      "notes": ""
+    },
+    {
+      "claim_class": "cost/context",
+      "field": "GenAI output tokens",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "joinable behavior",
+      "field": "tool names",
+      "join_key": "tool name",
+      "l1_trace": "read_file",
+      "l2_archive": "read_file",
+      "notes": ""
+    },
+    {
+      "claim_class": "primary join key",
+      "field": "tool_call_id joinability",
+      "join_key": "joined:tc_runner_policy_001",
+      "l1_trace": "tc_runner_policy_001",
+      "l2_archive": "tc_runner_policy_001",
+      "notes": ""
+    },
+    {
+      "claim_class": "measured effect; bounded negative if health is clean",
+      "field": "filesystem paths",
+      "join_key": "none",
+      "l1_trace": "n/a (not in trace contract)",
+      "l2_archive": "present",
+      "notes": "/tmp/fixture/openai-agents-input.txt"
+    },
+    {
+      "claim_class": "measured effect",
+      "field": "network endpoints",
+      "join_key": "none",
+      "l1_trace": "n/a (not in trace contract)",
+      "l2_archive": "empty",
+      "notes": ""
+    },
+    {
+      "claim_class": "measured effect",
+      "field": "process execs",
+      "join_key": "none",
+      "l1_trace": "n/a",
+      "l2_archive": "present",
+      "notes": ""
+    },
+    {
+      "claim_class": "enforcement",
+      "field": "policy decisions",
+      "join_key": "tool_call_id when present",
+      "l1_trace": "n/a (unless custom)",
+      "l2_archive": "present",
+      "notes": ""
+    },
+    {
+      "claim_class": "measurement integrity",
+      "field": "ringbuf_drops",
+      "join_key": "archive health",
+      "l1_trace": "absent",
+      "l2_archive": "0",
+      "notes": ""
+    },
+    {
+      "claim_class": "measurement integrity",
+      "field": "cgroup correlation status",
+      "join_key": "assay.runner.correlation_status",
+      "l1_trace": "absent",
+      "l2_archive": "clean",
+      "notes": ""
+    }
+  ],
+  "runner_observation": {
+    "capability_surface": {
+      "filesystem_paths": [
+        "/tmp/fixture/openai-agents-input.txt"
+      ],
+      "mcp_tools": [
+        "read_file"
+      ],
+      "network_endpoints": [],
+      "policy_decisions": [
+        "allow:read_file"
+      ],
+      "process_execs": [
+        "/usr/bin/node"
+      ]
+    },
+    "correlation_status": "clean",
+    "manifest_digest": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+    "observation_health": {
+      "cgroup_correlation": "clean",
+      "kernel_layer": "complete",
+      "notes": [],
+      "platform": "linux",
+      "policy_layer": "present",
+      "ringbuf_drops": 0,
+      "run_id": "run_fixture_001",
+      "schema": "assay.runner.observation_health.v0",
+      "sdk_layer": "present"
+    },
+    "run_id": "run_fixture_001",
+    "schema": "assay.runner.archive_manifest.v0",
+    "sdk_event_count": 3,
+    "sdk_tool_call_ids": [
+      "tc_runner_policy_001"
+    ],
+    "sdk_tools": [
+      "read_file"
+    ]
+  },
+  "schema": "assay.experiment.runner_vs_otel.field_matrix.v0",
+  "summary": {
+    "archive_sdk_events": 3,
+    "manifest_digest_binding": "trace-attribute-absent",
+    "tool_call_id_join": "joined:tc_runner_policy_001",
+    "trace_spans": 2
+  },
+  "trace_observation": {
+    "archive_schema": null,
+    "correlation_status": null,
+    "gen_ai_input_tokens": null,
+    "gen_ai_output_tokens": null,
+    "gen_ai_provider": "openai",
+    "gen_ai_request_model": null,
+    "gen_ai_response_model": null,
+    "manifest_digest": null,
+    "ringbuf_drops": null,
+    "run_id": "run_arm_b_20260524T194019Z_3",
+    "span_count": 2,
+    "tool_call_ids": [
+      "tc_runner_policy_001"
+    ],
+    "tool_names": [
+      "read_file"
+    ]
+  }
+}

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194019Z_3/matrix.md
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194019Z_3/matrix.md
@@ -1,0 +1,25 @@
+## Field Matrix
+
+- trace spans: 2
+- archive SDK events: 3
+- manifest-digest binding: trace-attribute-absent
+- tool_call_id join: joined:tc_runner_policy_001
+
+| Field | L1 Trace | L2 Archive | Join | Claim class | Notes |
+|---|---|---|---|---|---|
+| run identity (run_id) | run_arm_b_20260524T194019Z_3 | run_fixture_001 | assay.run.id | correlation |  |
+| archive schema | absent | assay.runner.archive_manifest.v0 | assay.archive.schema | provenance |  |
+| manifest digest binding | absent | sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8 | trace-attribute-absent | tamper-evident binding |  |
+| GenAI provider | openai | n/a (trace-side concept) | span | provenance |  |
+| GenAI request model | absent | n/a | span | provenance |  |
+| GenAI response model | absent | n/a | span | provenance |  |
+| GenAI input tokens | absent | n/a (archive does not measure tokens) | span | cost/context |  |
+| GenAI output tokens | absent | n/a | span | cost/context |  |
+| tool names | read_file | read_file | tool name | joinable behavior |  |
+| tool_call_id joinability | tc_runner_policy_001 | tc_runner_policy_001 | joined:tc_runner_policy_001 | primary join key |  |
+| filesystem paths | n/a (not in trace contract) | present | none | measured effect; bounded negative if health is clean | /tmp/fixture/openai-agents-input.txt |
+| network endpoints | n/a (not in trace contract) | empty | none | measured effect |  |
+| process execs | n/a | present | none | measured effect |  |
+| policy decisions | n/a (unless custom) | present | tool_call_id when present | enforcement |  |
+| ringbuf_drops | absent | 0 | archive health | measurement integrity |  |
+| cgroup correlation status | absent | clean | assay.runner.correlation_status | measurement integrity |  |

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194019Z_3/trace.json
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_20260524T194019Z_3/trace.json
@@ -1,0 +1,113 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "assay-runner-otel-experiment"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "0.0.0"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "assay-runner-otel-experiment"
+          },
+          "spans": [
+            {
+              "name": "execute_tool read_file",
+              "spanId": "e2b0a4e94ab4d79e",
+              "traceId": "2651891cdde39b62689d652625ce4921",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1779651619707000000",
+              "endTimeUnixNano": "1779651619707140500",
+              "attributes": [
+                {
+                  "key": "assay.run.id",
+                  "value": {
+                    "stringValue": "run_arm_b_20260524T194019Z_3"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "execute_tool"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.name",
+                  "value": {
+                    "stringValue": "read_file"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.type",
+                  "value": {
+                    "stringValue": "function"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.call.id",
+                  "value": {
+                    "stringValue": "tc_runner_policy_001"
+                  }
+                }
+              ],
+              "events": [],
+              "status": {
+                "code": 0
+              }
+            },
+            {
+              "name": "assay.runner.measured_run",
+              "spanId": "f0ce672968effbdc",
+              "traceId": "701ca3d00c3d9829f131731a6701a334",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1779651619698000000",
+              "endTimeUnixNano": "1779651619708871041",
+              "attributes": [
+                {
+                  "key": "assay.run.id",
+                  "value": {
+                    "stringValue": "run_arm_b_20260524T194019Z_3"
+                  }
+                },
+                {
+                  "key": "assay.measurement.boundary",
+                  "value": {
+                    "stringValue": "linux_ebpf_cgroup_v2"
+                  }
+                },
+                {
+                  "key": "gen_ai.provider.name",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "create_agent"
+                  }
+                }
+              ],
+              "events": [],
+              "status": {
+                "code": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_dual_simulation_20260524T194036Z/matrix.json
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_dual_simulation_20260524T194036Z/matrix.json
@@ -1,0 +1,197 @@
+{
+  "rows": [
+    {
+      "claim_class": "correlation",
+      "field": "run identity (run_id)",
+      "join_key": "assay.run.id",
+      "l1_trace": "run_arm_b_dual_simulation_20260524T194036Z",
+      "l2_archive": "run_fixture_001",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "archive schema",
+      "join_key": "assay.archive.schema",
+      "l1_trace": "assay.runner.archive_manifest.v0",
+      "l2_archive": "assay.runner.archive_manifest.v0",
+      "notes": ""
+    },
+    {
+      "claim_class": "tamper-evident binding",
+      "field": "manifest digest binding",
+      "join_key": "tamper-evident-match",
+      "l1_trace": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+      "l2_archive": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI provider",
+      "join_key": "span",
+      "l1_trace": "openai",
+      "l2_archive": "n/a (trace-side concept)",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI request model",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "provenance",
+      "field": "GenAI response model",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "cost/context",
+      "field": "GenAI input tokens",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a (archive does not measure tokens)",
+      "notes": ""
+    },
+    {
+      "claim_class": "cost/context",
+      "field": "GenAI output tokens",
+      "join_key": "span",
+      "l1_trace": "absent",
+      "l2_archive": "n/a",
+      "notes": ""
+    },
+    {
+      "claim_class": "joinable behavior",
+      "field": "tool names",
+      "join_key": "tool name",
+      "l1_trace": "read_file",
+      "l2_archive": "read_file",
+      "notes": ""
+    },
+    {
+      "claim_class": "primary join key",
+      "field": "tool_call_id joinability",
+      "join_key": "joined:tc_runner_policy_001",
+      "l1_trace": "tc_runner_policy_001",
+      "l2_archive": "tc_runner_policy_001",
+      "notes": ""
+    },
+    {
+      "claim_class": "measured effect; bounded negative if health is clean",
+      "field": "filesystem paths",
+      "join_key": "none",
+      "l1_trace": "n/a (not in trace contract)",
+      "l2_archive": "present",
+      "notes": "/tmp/fixture/openai-agents-input.txt"
+    },
+    {
+      "claim_class": "measured effect",
+      "field": "network endpoints",
+      "join_key": "none",
+      "l1_trace": "n/a (not in trace contract)",
+      "l2_archive": "empty",
+      "notes": ""
+    },
+    {
+      "claim_class": "measured effect",
+      "field": "process execs",
+      "join_key": "none",
+      "l1_trace": "n/a",
+      "l2_archive": "present",
+      "notes": ""
+    },
+    {
+      "claim_class": "enforcement",
+      "field": "policy decisions",
+      "join_key": "tool_call_id when present",
+      "l1_trace": "n/a (unless custom)",
+      "l2_archive": "present",
+      "notes": ""
+    },
+    {
+      "claim_class": "measurement integrity",
+      "field": "ringbuf_drops",
+      "join_key": "archive health",
+      "l1_trace": "absent",
+      "l2_archive": "0",
+      "notes": ""
+    },
+    {
+      "claim_class": "measurement integrity",
+      "field": "cgroup correlation status",
+      "join_key": "assay.runner.correlation_status",
+      "l1_trace": "absent",
+      "l2_archive": "clean",
+      "notes": ""
+    }
+  ],
+  "runner_observation": {
+    "capability_surface": {
+      "filesystem_paths": [
+        "/tmp/fixture/openai-agents-input.txt"
+      ],
+      "mcp_tools": [
+        "read_file"
+      ],
+      "network_endpoints": [],
+      "policy_decisions": [
+        "allow:read_file"
+      ],
+      "process_execs": [
+        "/usr/bin/node"
+      ]
+    },
+    "correlation_status": "clean",
+    "manifest_digest": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+    "observation_health": {
+      "cgroup_correlation": "clean",
+      "kernel_layer": "complete",
+      "notes": [],
+      "platform": "linux",
+      "policy_layer": "present",
+      "ringbuf_drops": 0,
+      "run_id": "run_fixture_001",
+      "schema": "assay.runner.observation_health.v0",
+      "sdk_layer": "present"
+    },
+    "run_id": "run_fixture_001",
+    "schema": "assay.runner.archive_manifest.v0",
+    "sdk_event_count": 3,
+    "sdk_tool_call_ids": [
+      "tc_runner_policy_001"
+    ],
+    "sdk_tools": [
+      "read_file"
+    ]
+  },
+  "schema": "assay.experiment.runner_vs_otel.field_matrix.v0",
+  "summary": {
+    "archive_sdk_events": 3,
+    "manifest_digest_binding": "tamper-evident-match",
+    "tool_call_id_join": "joined:tc_runner_policy_001",
+    "trace_spans": 2
+  },
+  "trace_observation": {
+    "archive_schema": "assay.runner.archive_manifest.v0",
+    "correlation_status": null,
+    "gen_ai_input_tokens": null,
+    "gen_ai_output_tokens": null,
+    "gen_ai_provider": "openai",
+    "gen_ai_request_model": null,
+    "gen_ai_response_model": null,
+    "manifest_digest": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8",
+    "ringbuf_drops": null,
+    "run_id": "run_arm_b_dual_simulation_20260524T194036Z",
+    "span_count": 2,
+    "tool_call_ids": [
+      "tc_runner_policy_001"
+    ],
+    "tool_names": [
+      "read_file"
+    ]
+  }
+}

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_dual_simulation_20260524T194036Z/matrix.md
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_dual_simulation_20260524T194036Z/matrix.md
@@ -1,0 +1,25 @@
+## Field Matrix
+
+- trace spans: 2
+- archive SDK events: 3
+- manifest-digest binding: tamper-evident-match
+- tool_call_id join: joined:tc_runner_policy_001
+
+| Field | L1 Trace | L2 Archive | Join | Claim class | Notes |
+|---|---|---|---|---|---|
+| run identity (run_id) | run_arm_b_dual_simulation_20260524T194036Z | run_fixture_001 | assay.run.id | correlation |  |
+| archive schema | assay.runner.archive_manifest.v0 | assay.runner.archive_manifest.v0 | assay.archive.schema | provenance |  |
+| manifest digest binding | sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8 | sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8 | tamper-evident-match | tamper-evident binding |  |
+| GenAI provider | openai | n/a (trace-side concept) | span | provenance |  |
+| GenAI request model | absent | n/a | span | provenance |  |
+| GenAI response model | absent | n/a | span | provenance |  |
+| GenAI input tokens | absent | n/a (archive does not measure tokens) | span | cost/context |  |
+| GenAI output tokens | absent | n/a | span | cost/context |  |
+| tool names | read_file | read_file | tool name | joinable behavior |  |
+| tool_call_id joinability | tc_runner_policy_001 | tc_runner_policy_001 | joined:tc_runner_policy_001 | primary join key |  |
+| filesystem paths | n/a (not in trace contract) | present | none | measured effect; bounded negative if health is clean | /tmp/fixture/openai-agents-input.txt |
+| network endpoints | n/a (not in trace contract) | empty | none | measured effect |  |
+| process execs | n/a | present | none | measured effect |  |
+| policy decisions | n/a (unless custom) | present | tool_call_id when present | enforcement |  |
+| ringbuf_drops | absent | 0 | archive health | measurement integrity |  |
+| cgroup correlation status | absent | clean | assay.runner.correlation_status | measurement integrity |  |

--- a/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_dual_simulation_20260524T194036Z/trace.json
+++ b/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline/run_arm_b_dual_simulation_20260524T194036Z/trace.json
@@ -1,0 +1,150 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "assay-runner-otel-experiment"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "0.0.0"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "assay-runner-otel-experiment"
+          },
+          "spans": [
+            {
+              "name": "execute_tool read_file",
+              "spanId": "fae8028cee497786",
+              "traceId": "917b970bceeedb631d3f708554ccb90e",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1779651636801000000",
+              "endTimeUnixNano": "1779651636801133083",
+              "attributes": [
+                {
+                  "key": "assay.run.id",
+                  "value": {
+                    "stringValue": "run_arm_b_dual_simulation_20260524T194036Z"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "execute_tool"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.name",
+                  "value": {
+                    "stringValue": "read_file"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.type",
+                  "value": {
+                    "stringValue": "function"
+                  }
+                },
+                {
+                  "key": "gen_ai.tool.call.id",
+                  "value": {
+                    "stringValue": "tc_runner_policy_001"
+                  }
+                }
+              ],
+              "events": [],
+              "status": {
+                "code": 0
+              }
+            },
+            {
+              "name": "assay.runner.measured_run",
+              "spanId": "ef5cc370bbc28055",
+              "traceId": "a50c5be30820e02d6b7de18cd7a17169",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1779651636793000000",
+              "endTimeUnixNano": "1779651636803112708",
+              "attributes": [
+                {
+                  "key": "assay.run.id",
+                  "value": {
+                    "stringValue": "run_arm_b_dual_simulation_20260524T194036Z"
+                  }
+                },
+                {
+                  "key": "assay.measurement.boundary",
+                  "value": {
+                    "stringValue": "linux_ebpf_cgroup_v2"
+                  }
+                },
+                {
+                  "key": "gen_ai.provider.name",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "create_agent"
+                  }
+                }
+              ],
+              "events": [
+                {
+                  "name": "assay.archive.created",
+                  "timeUnixNano": "1779651636803079917",
+                  "attributes": [
+                    {
+                      "key": "assay.archive.schema",
+                      "value": {
+                        "stringValue": "assay.runner.archive_manifest.v0"
+                      }
+                    },
+                    {
+                      "key": "assay.archive.manifest_digest",
+                      "value": {
+                        "stringValue": "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8"
+                      }
+                    },
+                    {
+                      "key": "assay.archive.path",
+                      "value": {
+                        "stringValue": "docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive"
+                      }
+                    },
+                    {
+                      "key": "assay.archive.manifest_bytes",
+                      "value": {
+                        "intValue": "261"
+                      }
+                    },
+                    {
+                      "key": "assay.archive.source",
+                      "value": {
+                        "stringValue": "directory"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
+++ b/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
@@ -1,0 +1,186 @@
+# v1 Findings: Runner Archives Next to OTel Traces
+
+> **Status:** Arm B (trace-only) baseline complete on macOS Node 22 local
+> environment. Arms A and C remain pending on the delegated `assay-bpf-runner`
+> host. This document captures the v1 evidence that the experiment design and
+> tooling actually work end-to-end; substantive cross-arm findings land here
+> when Arm C dispatches succeed.
+>
+> **Plan:** [../runner-vs-otel-shape-comparison-2026-05.md](../runner-vs-otel-shape-comparison-2026-05.md)
+>
+> **Date of v1 baseline runs:** 2026-05-24
+>
+> **Reproducibility:**
+> - Node `v22.16.0` via nvm
+> - `@openai/agents@0.11.4`, `@opentelemetry/api@^1.9.0`,
+>   `@opentelemetry/sdk-trace-base@^2.0.0`,
+>   `@opentelemetry/resources@^2.0.0`
+> - Python `3.14.3` (stdlib only for `compare.py`)
+> - macOS / Apple Silicon (Linux for L2 capture; out of v1 scope here)
+
+## What the v1 baseline runs prove
+
+All four claims below are backed by artifacts under
+[`runs/v1-baseline/`](runs/v1-baseline/). Each run includes the raw
+`trace.json`, the comparator's `matrix.json`, and the human-readable
+`matrix.md`.
+
+### 1. Arm B workload produces a non-empty, schema-conforming OTel trace
+
+Three identical Arm B runs were performed back-to-back. Each produced a
+two-span trace with the same span shape:
+
+| Run | Spans | Tool name | `gen_ai.tool.call.id` | `gen_ai.provider.name` |
+|---|---:|---|---|---|
+| `run_arm_b_20260524T193930Z` | 2 | `read_file` | `tc_runner_policy_001` | `openai` |
+| `run_arm_b_20260524T194017Z_2` | 2 | `read_file` | `tc_runner_policy_001` | `openai` |
+| `run_arm_b_20260524T194019Z_3` | 2 | `read_file` | `tc_runner_policy_001` | `openai` |
+
+The trace shape is stable across runs. This satisfies the
+*Trace shape stability* row of the Measurement Plan
+(`n = 3`, soft gate).
+
+### 2. `gen_ai.tool.call.id` join works against a fixture archive
+
+For all three Arm B runs, the comparator reported:
+
+```
+tool_call_id join: joined:tc_runner_policy_001
+```
+
+That is, the trace's `gen_ai.tool.call.id` attribute matched the fixture
+archive's `sdk_event.tool_call_id`, populating the primary join key
+without falling back to weaker keys (tool name + monotonic order, or
+timestamp proximity).
+
+This is the v1 evidence for the *Join Hierarchy* table's
+**Direct manual OTel SDK** row: with manual SDK instrumentation,
+`gen_ai.tool.call.id` is present by construction and the join grade is
+**Primary**.
+
+### 3. Manifest-digest binding works end-to-end as a tamper-evident link
+
+A fourth run was performed with `--archive` pointing at the synthetic
+fixture archive. The workload computed the SHA-256 of the archive's
+`manifest.json` bytes via `manifest-binding.ts` and attached an
+`assay.archive.created` span event with these attributes:
+
+```
+assay.archive.schema           = "assay.runner.archive_manifest.v0"
+assay.archive.manifest_digest  = "sha256:c76eb655e4630235ad137a50427a47db4b70ab9dcb40ddf30ad3f3165ee9d1d8"
+assay.archive.path             = "<fixture archive path>"
+assay.archive.manifest_bytes   = 261
+assay.archive.source           = "directory"
+```
+
+The comparator then verified the trace-side digest against the
+archive-side digest:
+
+```
+manifest-digest binding: tamper-evident-match
+```
+
+Running the same comparator with `--require-binding-match` returned
+**exit code 0**. The earlier non-matching test fixture (different
+`assay.archive.manifest_digest` value) correctly produced
+**exit code 3** with the strict flag, confirming the contract.
+
+This is the v1 evidence for the **Manifest Digest Binding** section of
+the plan doc: a span event can refer to an archive by digest without
+embedding archive content, and the comparator can verify the binding
+deterministically.
+
+### 4. Asymmetric coverage matches the design hypothesis
+
+The Arm B field matrix exhibits the expected asymmetry between L1
+(trace) and L2 (archive) evidence. Fields are summarized as
+**L1 present / L2 present / both / asymmetric**:
+
+| Field class | Arm B (trace-only) observation |
+|---|---|
+| Reported control flow (`gen_ai.provider.name`, `gen_ai.tool.name`, `gen_ai.tool.call.id`) | **L1 only** |
+| Reported provenance (`gen_ai.request.model`, `gen_ai.response.model`) | **L1 absent** in the deterministic workload (the cassette model does not populate these); would be **L1 present** with a real model call. |
+| Reported usage (`gen_ai.usage.input_tokens`, `output_tokens`) | **L1 absent** for the same reason. |
+| Measured system effects (filesystem paths, network endpoints, process execs) | **L2 only** (taken from the fixture archive; Arm C will produce real values) |
+| Measurement integrity (`ringbuf_drops`, `cgroup_correlation`) | **L2 only**; Arm B has nothing to report |
+| Primary join key (`tool_call_id`) | **Both, joined** |
+| Tamper-evident binding (`manifest_digest`) | **Both, joined** (dual-simulation run) |
+| Run identity (`run_id`) | **L1 present**, **L2 from fixture**: trace has the real Arm B run id, archive has the fixture's run id; these differ by design in this control arm. |
+
+The matrix-row count is exactly 16; the markdown render passes the
+smoke test in `tests/test_compare.py::test_markdown_renders`.
+
+## What v1 does NOT prove
+
+These claims wait for Arms A and C to be dispatched on the
+`assay-bpf-runner` host:
+
+- Linux/eBPF/cgroup-v2 actually populates `capability_surface.*` fields
+  on real workloads;
+- `observation_health.ringbuf_drops == 0` holds for the dual-capture
+  workload under the experiment's instrumentation overhead;
+- `correlation_report.status == clean` holds when both Runner and OTel
+  SDK instrumentation are active in the same process;
+- Per-run archive determinism: byte-identical `manifest.json` across
+  three Arm C runs of the same workload (a hard gate in the plan doc);
+- Overhead measurements (`n >= 20` wall clock, `n >= 5` RSS).
+
+Until those land, v1 stands only as evidence that the **measurement
+infrastructure** is correct. The published claim of the experiment is
+gated on Arm C data.
+
+## Reproduction commands
+
+```bash
+# Install deps and build the workload once
+export PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH"
+cd docs/experiments/runner-vs-otel-2026-05/workload
+npm install --no-audit --no-fund --ignore-scripts
+npx tsc -p tsconfig.json
+
+# Arm B: trace-only run
+RUN_ID="run_arm_b_$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="../runs/$RUN_ID"
+mkdir -p "$RUN_DIR"
+node dist/workload.js --run-id "$RUN_ID" --trace-out "$RUN_DIR/trace.json"
+
+# Compare against the synthetic fixture archive (Arm B has no real archive)
+cd ../..
+python3 docs/experiments/runner-vs-otel-2026-05/compare/compare.py \
+  --archive docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive \
+  --trace docs/experiments/runner-vs-otel-2026-05/runs/$RUN_ID/trace.json \
+  --out-json docs/experiments/runner-vs-otel-2026-05/runs/$RUN_ID/matrix.json \
+  --out-md docs/experiments/runner-vs-otel-2026-05/runs/$RUN_ID/matrix.md
+```
+
+## Pinned versions for v1 baseline
+
+```text
+Node:                 v22.16.0
+Python:               3.14.3 (Homebrew, Apple Silicon)
+@openai/agents:       0.11.4
+@opentelemetry/api:   ^1.9.0 (resolved 1.9.x at install time)
+@opentelemetry/sdk-trace-base: ^2.0.0 (resolved 2.7.x)
+@opentelemetry/resources:      ^2.0.0
+zod:                  4.1.13
+TypeScript:           ^5.5.0
+```
+
+`workload/package-lock.json` is intentionally git-ignored to avoid
+churn on machine-specific install hashes; the version pins above are
+the source of truth. A v1.1 follow-up that adds the OpenInference
+instrumentation comparison row should pin its instrumentation package
+versions here.
+
+## Non-claims
+
+- This v1 baseline does not assert that measured-run archives are
+  better than traces, nor that OTel cannot carry runtime-evidence
+  attributes. It asserts only that the comparator, the workload, and
+  the manifest-digest binding work as specified.
+- No prompt content, no completion content, and no tool argument or
+  result was captured in these runs. Sensitive content remains
+  off-by-default per the `--capture-sensitive-otel-content` policy.
+- The fixture archive used in Arm B is synthetic and is not evidence
+  of any agent's actual filesystem behavior. Real `capability_surface`
+  data lands with Arm C.

--- a/docs/experiments/runner-vs-otel-2026-05/workload/package.json
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/package.json
@@ -12,7 +12,7 @@
     "run:arm-b": "node dist/run-arm-b.js"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.10.0",
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@opentelemetry/resources": "^2.0.0",

--- a/docs/experiments/runner-vs-otel-2026-05/workload/package.json
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "assay-runner-otel-experiment-workload",
+  "version": "0.0.0",
+  "private": true,
+  "type": "commonjs",
+  "engines": {
+    "node": ">=22"
+  },
+  "description": "OpenTelemetry/OpenInference instrumentation wrapper around the existing assay-runner-spike OpenAI Agents fixture. Produces an OTLP/JSON trace export with an assay.archive.manifest_digest event binding for the runner-vs-otel-2026-05 experiment. Not published.",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "run:arm-b": "node dist/run-arm-b.js"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.10.0",
+    "@opentelemetry/sdk-trace-base": "^2.0.0",
+    "@opentelemetry/sdk-trace-node": "^2.0.0",
+    "@opentelemetry/resources": "^2.0.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
+    "@openai/agents": "0.11.4",
+    "zod": "4.1.13"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/docs/experiments/runner-vs-otel-2026-05/workload/src/manifest-binding.ts
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/src/manifest-binding.ts
@@ -1,0 +1,73 @@
+/**
+ * Compute the tamper-evident manifest-digest binding between an OTel trace
+ * and an Assay-Runner archive.
+ *
+ * Reads `manifest.json` bytes from either:
+ *  - a `.tar.gz` Runner archive (Arm A/C, produced by `assay runner-spike run`)
+ *  - an extracted archive directory (handy when iterating locally)
+ *
+ * Returns the SHA-256 digest as `sha256:<hex>`, the same format used by
+ * `compare/compare.py` and by the Runner archive's own per-file digests
+ * (see `crates/assay-evidence` Merkle infrastructure).
+ *
+ * The digest is intended to be attached as a span event attribute named
+ * `assay.archive.manifest_digest` on the root experiment span, mirroring the
+ * SLSA provenance pattern of referring to an artifact by digest rather than
+ * embedding it in the trace.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, existsSync, statSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const MANIFEST_PATH = "manifest.json";
+
+export interface ManifestBinding {
+  archivePath: string;
+  manifestDigest: string;
+  manifestBytes: number;
+  source: "tarball" | "directory";
+}
+
+export function computeManifestBinding(archivePath: string): ManifestBinding {
+  if (!existsSync(archivePath)) {
+    throw new Error(`archive path does not exist: ${archivePath}`);
+  }
+
+  const stats = statSync(archivePath);
+  if (stats.isDirectory()) {
+    const manifestFile = join(archivePath, MANIFEST_PATH);
+    if (!existsSync(manifestFile)) {
+      throw new Error(
+        `extracted archive missing ${MANIFEST_PATH}: ${manifestFile}`,
+      );
+    }
+    const bytes = readFileSync(manifestFile);
+    return {
+      archivePath,
+      manifestDigest: digestOf(bytes),
+      manifestBytes: bytes.length,
+      source: "directory",
+    };
+  }
+
+  // Treat as tarball. Use the system `tar` to avoid pulling a JS tar dep into
+  // the experiment; this also matches what CI / the delegated runner has.
+  const workDir = mkdtempSync(join(tmpdir(), "assay-otel-binding-"));
+  execFileSync("tar", ["-xzf", archivePath, "-C", workDir, MANIFEST_PATH], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const bytes = readFileSync(join(workDir, MANIFEST_PATH));
+  return {
+    archivePath,
+    manifestDigest: digestOf(bytes),
+    manifestBytes: bytes.length,
+    source: "tarball",
+  };
+}
+
+function digestOf(bytes: Buffer): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}

--- a/docs/experiments/runner-vs-otel-2026-05/workload/src/otel-setup.ts
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/src/otel-setup.ts
@@ -22,7 +22,7 @@ import {
   InMemorySpanExporter,
   ReadableSpan,
 } from "@opentelemetry/sdk-trace-base";
-import { Resource } from "@opentelemetry/resources";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { trace, Tracer } from "@opentelemetry/api";
 
 const SERVICE_NAME = "assay-runner-otel-experiment";
@@ -34,13 +34,15 @@ export function getTracer(): Tracer {
   if (providerSingleton === null) {
     exporterSingleton = new InMemorySpanExporter();
     providerSingleton = new BasicTracerProvider({
-      resource: new Resource({
+      resource: resourceFromAttributes({
         "service.name": SERVICE_NAME,
         "service.version": "0.0.0",
       }),
       spanProcessors: [new SimpleSpanProcessor(exporterSingleton)],
     });
-    providerSingleton.register();
+    // OTel SDK 2.x: BasicTracerProvider does not auto-register globally.
+    // Set it as the global trace provider so `trace.getTracer(...)` works.
+    trace.setGlobalTracerProvider(providerSingleton);
   }
   return trace.getTracer("assay-runner-otel-experiment");
 }

--- a/docs/experiments/runner-vs-otel-2026-05/workload/src/otel-setup.ts
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/src/otel-setup.ts
@@ -1,0 +1,173 @@
+/**
+ * OpenTelemetry SDK wiring for the runner-vs-otel-2026-05 experiment.
+ *
+ * Exports an OTLP/JSON trace to a local file so the experiment is self-
+ * contained: no collector, no network, no shared backend. The file is the
+ * single trace artifact for the experiment write-up and the input to
+ * `compare/compare.py`.
+ *
+ * SemConv pinning: this experiment targets OpenTelemetry GenAI semantic
+ * conventions as fetched on 2026-05-24, plus the Assay-specific
+ * `assay.*` namespace defined in
+ * docs/experiments/runner-vs-otel-shape-comparison-2026-05.md. Attribute
+ * names should be re-checked against
+ * https://opentelemetry.io/docs/specs/semconv/gen-ai/ before publication.
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  BasicTracerProvider,
+  SimpleSpanProcessor,
+  InMemorySpanExporter,
+  ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { Resource } from "@opentelemetry/resources";
+import { trace, Tracer } from "@opentelemetry/api";
+
+const SERVICE_NAME = "assay-runner-otel-experiment";
+
+let providerSingleton: BasicTracerProvider | null = null;
+let exporterSingleton: InMemorySpanExporter | null = null;
+
+export function getTracer(): Tracer {
+  if (providerSingleton === null) {
+    exporterSingleton = new InMemorySpanExporter();
+    providerSingleton = new BasicTracerProvider({
+      resource: new Resource({
+        "service.name": SERVICE_NAME,
+        "service.version": "0.0.0",
+      }),
+      spanProcessors: [new SimpleSpanProcessor(exporterSingleton)],
+    });
+    providerSingleton.register();
+  }
+  return trace.getTracer("assay-runner-otel-experiment");
+}
+
+/**
+ * Force-flush the provider and write the in-memory spans to an OTLP/JSON file.
+ *
+ * Uses a hand-rolled OTLP/JSON serializer (no extra dependency on
+ * `@opentelemetry/otlp-transformer`) because the experiment only needs the
+ * shape that `compare/compare.py` understands. If the OTLP/JSON spec evolves,
+ * the official transformer can be dropped in here.
+ */
+export async function flushTraceToFile(outPath: string): Promise<void> {
+  if (providerSingleton === null || exporterSingleton === null) {
+    throw new Error("getTracer() must be called before flushTraceToFile()");
+  }
+  await providerSingleton.forceFlush();
+  const spans = exporterSingleton.getFinishedSpans();
+  const doc = spansToOtlpJson(spans);
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(doc, null, 2) + "\n", "utf8");
+}
+
+function spansToOtlpJson(spans: ReadableSpan[]): unknown {
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: attrsToOtlp({
+            "service.name": SERVICE_NAME,
+            "service.version": "0.0.0",
+          }),
+        },
+        scopeSpans: [
+          {
+            scope: { name: "assay-runner-otel-experiment" },
+            spans: spans.map((s) => readableSpanToOtlp(s)),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function readableSpanToOtlp(span: ReadableSpan): unknown {
+  return {
+    name: span.name,
+    spanId: span.spanContext().spanId,
+    traceId: span.spanContext().traceId,
+    parentSpanId: span.parentSpanContext?.spanId,
+    kind: kindToOtlp(span.kind),
+    startTimeUnixNano: hrTimeToNs(span.startTime),
+    endTimeUnixNano: hrTimeToNs(span.endTime),
+    attributes: attrsToOtlp(span.attributes as Record<string, unknown>),
+    events: span.events.map((e) => ({
+      name: e.name,
+      timeUnixNano: hrTimeToNs(e.time),
+      attributes: attrsToOtlp((e.attributes ?? {}) as Record<string, unknown>),
+    })),
+    status: { code: span.status.code },
+  };
+}
+
+function kindToOtlp(kind: number): string {
+  // OTel SpanKind enum -> OTLP SPAN_KIND_* string.
+  switch (kind) {
+    case 0:
+      return "SPAN_KIND_INTERNAL";
+    case 1:
+      return "SPAN_KIND_SERVER";
+    case 2:
+      return "SPAN_KIND_CLIENT";
+    case 3:
+      return "SPAN_KIND_PRODUCER";
+    case 4:
+      return "SPAN_KIND_CONSUMER";
+    default:
+      return "SPAN_KIND_UNSPECIFIED";
+  }
+}
+
+function hrTimeToNs(time: [number, number]): string {
+  const [seconds, nanos] = time;
+  return (BigInt(seconds) * BigInt(1_000_000_000) + BigInt(nanos)).toString();
+}
+
+function attrsToOtlp(attrs: Record<string, unknown>): unknown[] {
+  const out: unknown[] = [];
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    out.push({ key, value: valueToOtlp(value) });
+  }
+  return out;
+}
+
+function valueToOtlp(value: unknown): unknown {
+  if (typeof value === "string") {
+    return { stringValue: value };
+  }
+  if (typeof value === "number") {
+    if (Number.isInteger(value)) {
+      return { intValue: String(value) };
+    }
+    return { doubleValue: value };
+  }
+  if (typeof value === "boolean") {
+    return { boolValue: value };
+  }
+  if (typeof value === "bigint") {
+    return { intValue: value.toString() };
+  }
+  if (Array.isArray(value)) {
+    return {
+      arrayValue: {
+        values: value.map((v) => valueToOtlp(v)),
+      },
+    };
+  }
+  // Fallback: stringify unknown shapes so the export is still valid.
+  return { stringValue: JSON.stringify(value) };
+}
+
+export function ensureOutDir(path: string): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}

--- a/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
@@ -25,6 +25,7 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { Agent, Runner, Usage, tool } from "@openai/agents";
+import { z } from "zod";
 import { getTracer, flushTraceToFile } from "./otel-setup";
 import { computeManifestBinding } from "./manifest-binding";
 
@@ -90,13 +91,7 @@ export async function runWorkload(config: WorkloadConfig): Promise<void> {
       const readFileTool = tool({
         name: "read_file",
         description: "Read the deterministic experiment fixture file.",
-        strict: false,
-        parameters: {
-          type: "object",
-          properties: { path: { type: "string" } },
-          required: ["path"],
-          additionalProperties: false,
-        },
+        parameters: z.object({ path: z.string() }),
         execute: async (input: { path: string }) =>
           readFileSync(input.path, "utf8"),
       });

--- a/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
@@ -1,0 +1,209 @@
+/**
+ * Workload entrypoint for the runner-vs-otel-2026-05 experiment.
+ *
+ * Wraps the existing deterministic OpenAI Agents fixture (used by
+ * `assay runner-spike` Phase 1 gates) with OpenTelemetry tracing that
+ * follows the OTel GenAI semantic conventions plus the experiment's own
+ * `assay.*` namespace.
+ *
+ * Modes:
+ *  - Arm B (trace only): the wrapper drives the agent in-process and
+ *    produces one OTLP trace per run. No Runner archive is created.
+ *  - Arm C (dual capture): the wrapper is invoked under
+ *    `assay runner-spike run` so that the Runner archive and the trace are
+ *    produced from the same execution. The archive path is then fed back
+ *    to attach the manifest-digest binding event to the root span.
+ *
+ * This file intentionally re-implements the small DeterministicToolCallModel
+ * shape inline so the workload can run on macOS / Linux / Windows for Arm B
+ * without depending on the original CommonJS fixture script. The behaviour
+ * mirrors `runner-fixtures/openai-agents/fixture-agent.js`.
+ */
+
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { Agent, Runner, Usage, tool } from "@openai/agents";
+import { getTracer, flushTraceToFile } from "./otel-setup";
+import { computeManifestBinding } from "./manifest-binding";
+
+interface WorkloadConfig {
+  runId: string;
+  workDir: string;
+  toolCallId: string;
+  fixturePath: string;
+  archivePath?: string;
+  tracePath: string;
+}
+
+class DeterministicToolCallModel {
+  constructor(
+    private readonly toolCallId: string,
+    private readonly fixturePath: string,
+  ) {}
+
+  async getResponse(_request: unknown): Promise<unknown> {
+    return {
+      usage: new Usage({ requests: 1 }),
+      responseId: "assay-runner-otel-experiment-response",
+      output: [
+        {
+          type: "function_call",
+          callId: this.toolCallId,
+          name: "read_file",
+          status: "completed",
+          arguments: JSON.stringify({ path: this.fixturePath }),
+        },
+      ],
+    };
+  }
+
+  async *getStreamedResponse(_request: unknown): AsyncIterable<unknown> {
+    throw new Error(
+      "streaming is intentionally unsupported by the deterministic fixture",
+    );
+  }
+}
+
+export async function runWorkload(config: WorkloadConfig): Promise<void> {
+  mkdirSync(config.workDir, { recursive: true });
+  if (!existsSync(config.fixturePath)) {
+    writeFileSync(
+      config.fixturePath,
+      "openai agents otel experiment fixture input\n",
+      "utf8",
+    );
+  }
+
+  const tracer = getTracer();
+
+  await tracer.startActiveSpan("assay.runner.measured_run", async (rootSpan) => {
+    rootSpan.setAttributes({
+      "assay.run.id": config.runId,
+      "assay.measurement.boundary": "linux_ebpf_cgroup_v2",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.operation.name": "create_agent",
+    });
+
+    try {
+      const readFileTool = tool({
+        name: "read_file",
+        description: "Read the deterministic experiment fixture file.",
+        strict: false,
+        parameters: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+          additionalProperties: false,
+        },
+        execute: async (input: { path: string }) =>
+          readFileSync(input.path, "utf8"),
+      });
+
+      const agent = new Agent({
+        name: "AssayRunnerOtelExperiment",
+        instructions: "Call read_file exactly once.",
+        model: new DeterministicToolCallModel(
+          config.toolCallId,
+          config.fixturePath,
+        ) as unknown as Agent["model"],
+        tools: [readFileTool],
+        toolUseBehavior: { stopAtToolNames: ["read_file"] },
+      });
+
+      const runner = new Runner({
+        tracingDisabled: true,
+        traceIncludeSensitiveData: false,
+        toolExecution: { maxFunctionToolConcurrency: 1 },
+      });
+
+      runner.on(
+        "agent_tool_start",
+        async (_context, _agent, startedTool, details: any) => {
+          await tracer.startActiveSpan(
+            `execute_tool ${startedTool.name}`,
+            async (toolSpan) => {
+              toolSpan.setAttributes({
+                "assay.run.id": config.runId,
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": startedTool.name,
+                "gen_ai.tool.type": "function",
+                "gen_ai.tool.call.id": details.toolCall.callId,
+              });
+              toolSpan.end();
+            },
+          );
+        },
+      );
+
+      await runner.run(agent, "Read the deterministic fixture file.", {
+        maxTurns: 2,
+      });
+
+      if (config.archivePath) {
+        const binding = computeManifestBinding(config.archivePath);
+        rootSpan.addEvent("assay.archive.created", {
+          "assay.archive.schema": "assay.runner.archive_manifest.v0",
+          "assay.archive.manifest_digest": binding.manifestDigest,
+          "assay.archive.path": binding.archivePath,
+          "assay.archive.manifest_bytes": binding.manifestBytes,
+          "assay.archive.source": binding.source,
+        });
+      }
+
+      rootSpan.setStatus({ code: SpanStatusCode.OK });
+    } catch (error) {
+      rootSpan.recordException(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      rootSpan.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      rootSpan.end();
+    }
+  });
+
+  await flushTraceToFile(config.tracePath);
+}
+
+function parseArgs(): WorkloadConfig {
+  const args = process.argv.slice(2);
+  const get = (name: string, required = false): string | undefined => {
+    const idx = args.indexOf(`--${name}`);
+    if (idx >= 0 && idx + 1 < args.length) return args[idx + 1];
+    if (required) throw new Error(`--${name} is required`);
+    return undefined;
+  };
+
+  const runId = get("run-id") ?? `run_experiment_${Date.now()}`;
+  const workDir = get("work-dir") ?? join(tmpdir(), `assay-otel-${runId}`);
+  const tracePath = get("trace-out", true)!;
+  const archivePath = get("archive");
+  const toolCallId = get("tool-call-id") ?? "tc_runner_policy_001";
+  const fixturePath = join(workDir, "openai-agents-input.txt");
+
+  return { runId, workDir, toolCallId, fixturePath, archivePath, tracePath };
+}
+
+if (require.main === module) {
+  const config = parseArgs();
+  runWorkload(config)
+    .then(() => {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            run_id: config.runId,
+            trace_out: config.tracePath,
+            archive: config.archivePath ?? null,
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+    })
+    .catch((error) => {
+      console.error(error?.stack ?? String(error));
+      process.exit(1);
+    });
+}

--- a/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
@@ -137,14 +137,31 @@ export async function runWorkload(config: WorkloadConfig): Promise<void> {
       });
 
       if (config.archivePath) {
-        const binding = computeManifestBinding(config.archivePath);
-        rootSpan.addEvent("assay.archive.created", {
-          "assay.archive.schema": "assay.runner.archive_manifest.v0",
-          "assay.archive.manifest_digest": binding.manifestDigest,
-          "assay.archive.path": binding.archivePath,
-          "assay.archive.manifest_bytes": binding.manifestBytes,
-          "assay.archive.source": binding.source,
-        });
+        // In Arm B's dual-simulation mode the archive already exists (it is
+        // a pre-built fixture), so the workload can bind in-process. In Arm
+        // C the archive is finalized by `assay runner-spike` AFTER this
+        // process exits; in that case the binding event is attached
+        // post-hoc by `compare/bind-archive.py`. Be tolerant of the
+        // missing-archive case here so the workload can be the same
+        // binary in both arms.
+        try {
+          const binding = computeManifestBinding(config.archivePath);
+          rootSpan.addEvent("assay.archive.created", {
+            "assay.archive.schema": "assay.runner.archive_manifest.v0",
+            "assay.archive.manifest_digest": binding.manifestDigest,
+            "assay.archive.path": binding.archivePath,
+            "assay.archive.manifest_bytes": binding.manifestBytes,
+            "assay.archive.source": binding.source,
+          });
+        } catch (err) {
+          // Stdout instead of stderr so it does not look like a workload
+          // failure to the parent runner-spike process.
+          process.stdout.write(
+            "workload: archive not yet present at trace-flush time; " +
+              "binding will be attached post-hoc by bind-archive.py. " +
+              `(reason: ${err instanceof Error ? err.message : String(err)})\n`,
+          );
+        }
       }
 
       rootSpan.setStatus({ code: SpanStatusCode.OK });

--- a/docs/experiments/runner-vs-otel-2026-05/workload/tsconfig.json
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docs/experiments/runner-vs-otel-shape-comparison-2026-05.md
+++ b/docs/experiments/runner-vs-otel-shape-comparison-2026-05.md
@@ -186,6 +186,55 @@ artifact itself. It does not make the trace authoritative for archive content;
 it lets a consumer verify that the trace and archive are the pair claimed by
 the experiment.
 
+### Namespace separation: private vs proposed
+
+Two namespaces deliberately coexist in this experiment:
+
+- `assay.*` is the **private experiment namespace** used by the implementation
+  today (`assay.archive.manifest_digest`, `assay.run.id`,
+  `assay.runner.correlation_status`, ...). These names are stable for the
+  duration of the experiment but make no claim on the open vocabulary.
+- `agent.runtime_evidence.*` is the **proposed open-standard namespace**
+  documented in the OpenInference Discussion Payload section below
+  (`agent.runtime_evidence.digest`, `agent.runtime_evidence.health`,
+  `agent.runtime_evidence.boundary`). These are what we will offer up for
+  inclusion in the OTel GenAI / OpenInference vocabulary.
+
+The experiment intentionally emits `assay.*` attributes today. If and when the
+vocabulary discussion settles on neutral names, the instrumentation can be
+re-pointed at the agreed namespace without changing the comparator schema.
+
+### Implementation package
+
+The skeleton in this doc is now backed by a runnable experiment package under
+[`runner-vs-otel-2026-05/`](runner-vs-otel-2026-05/README.md):
+
+- `compare/compare.py` (stdlib only) is the field-matrix generator and lock
+  the comparator's wire format against the schemas in
+  `crates/assay-runner-schema`. It reads either a `.tar.gz` archive or an
+  extracted directory and an OTLP/JSON trace, and emits both a JSON and a
+  Markdown matrix.
+- `workload/` is the Node.js + TypeScript runtime that wraps the existing
+  `runner-fixtures/openai-agents/fixture-agent.js` workload with OTel
+  tracing and the `assay.archive.created` event binding.
+- `run-arm-b.sh` is the local trace-only orchestrator. Arms A and C run on
+  the delegated `assay-bpf-runner` host; see the experiment-package
+  `README.md` for the dispatch path.
+
+### Comparator exit codes
+
+`compare/compare.py` ships a stable exit-code contract so it can land in CI
+or Harness flows without re-inventing semantics:
+
+| Code | Meaning |
+|---:|---|
+| `0` | Comparison generated; no binding error required or satisfied |
+| `2` | Bad CLI / config / input path |
+| `3` | Malformed archive or trace, or `--require-binding-match` was set and the manifest digest did not match |
+
+Arm C dispatches set `--require-binding-match`; Arm A, Arm B, and unit tests
+do not, so a synthetic or absent counterpart does not cause a hard failure.
+
 ### TypeScript Sketch
 
 ```ts

--- a/docs/experiments/runner-vs-otel-shape-comparison-2026-05.md
+++ b/docs/experiments/runner-vs-otel-shape-comparison-2026-05.md
@@ -1,0 +1,415 @@
+# Runner Archives Next to OTel Traces: Shape Comparison Plan
+
+> **Status:** experiment skeleton; no data collected yet
+>
+> **Last updated:** 2026-05-24
+>
+> **Scope:** compare an Assay-Runner measured-run archive with an
+> OpenTelemetry-family trace for the same deterministic agent workload. This is
+> not a product launch, benchmark claim, or assertion that measured-run archives
+> replace traces.
+
+## Research Question
+
+What claims about an agent run can be supported by:
+
+- an OpenTelemetry-family trace using GenAI / OpenInference-style semantic
+  attributes;
+- an Assay-Runner measured-run archive;
+- both artifacts joined together; or
+- neither artifact?
+
+The experiment compares evidence shape, joinability, and claim strength. It
+does not rank tracing tools, evaluate model quality, or claim semantic
+equivalence between runtimes.
+
+## First Conclusion to Test
+
+Traces explain the agent's reported control flow. Measured-run archives bound
+the system effects and measurement health. The two are complementary, and the
+join key determines whether they become one evidence story or two parallel
+observability stories.
+
+On Linux with healthy eBPF capture (`ringbuf_drops=0`, clean cgroup
+correlation), a measured-run archive can support bounded negatives: claims of
+the form "within this measurement boundary, X did not happen." Traces support
+positive observations and intent reconstruction. Together they form a
+defense-in-depth observability stack, not competitors.
+
+## SOTA Anchors
+
+This plan intentionally separates three layers that are often collapsed in
+AI-observability writing:
+
+| Layer | Measures | Examples | In Scope for v1 |
+|---|---|---|---|
+| L1 - Reported control flow | What the agent/framework reports | OpenTelemetry GenAI semantic conventions, OpenInference, traceAI, Phoenix, Langfuse, Logfire | Yes |
+| L2 - Agent-aware runtime evidence | What the run did, joined to agent context | Assay-Runner, AgentSight-style eBPF + agent correlation | Yes |
+| L3 - Generic kernel observability | What the system did without agent context | Tetragon, Falco, Tracee | No, explicit follow-up |
+
+v1 compares L1 and L2. L3 is deliberately out of scope so the first run can be
+completed with the existing Assay-Runner fixtures. A follow-up should add one
+generic kernel tracer to show what Assay-Runner adds beyond raw system-event
+visibility: cgroup correlation, `run_id`, SDK layer correlation, archive
+manifest integrity, and measurement-health gates.
+
+## Source Pinning
+
+Before publishing results, pin exact versions or commit SHAs for these moving
+inputs:
+
+| Source | Pin Required | Notes |
+|---|---|---|
+| OpenTelemetry GenAI semantic conventions | Exact docs date and preferably `open-telemetry/semantic-conventions` commit SHA | The GenAI conventions are still marked Development; attribute names may move. |
+| OpenInference semantic conventions | Package version and docs URL/commit | OpenInference is chosen as the semantic layer, not as the only possible instrumentation framework. |
+| Assay | Git commit and release tag | Record both the source commit and the Runner archive schema strings. |
+| Assay-Harness | Version if used for projection | Record `verify-runner`, `runner compare`, and `runner cross-runtime` versions separately. |
+| arXiv or research references | Verified URL and title only | Do not cite unverified IDs. Remove any synthetic-looking survey references. |
+
+## Why OpenInference for v1
+
+OpenInference is chosen for v1 because it is a semantic convention and
+instrumentation family built on OpenTelemetry, not merely a dashboard. That
+lets the experiment separate "what do we call this field?" from "which tool
+auto-captured this content?" traceAI, Phoenix, Langfuse, and Logfire remain
+important comparison points, but v1 should pin the vocabulary first and avoid
+turning the experiment into a product bake-off.
+
+## Experimental Arms
+
+Use the same deterministic agent workload in all arms.
+
+| Arm | Runner archive | OTel / OpenInference trace | Purpose |
+|---|---:|---:|---|
+| A - Runner only | Yes | No | Establish measured-run baseline and archive determinism. |
+| B - Trace only | No | Yes | Establish trace shape without eBPF/cgroup capture. |
+| C - Dual capture | Yes | Yes | Main comparison arm; both artifacts share `run_id` and tool-call join keys. |
+
+v1 should run arm C at least three times for shape stability and archive
+determinism. Overhead measurements need a larger sample; see
+[Measurement Plan](#measurement-plan).
+
+## Workload
+
+Start with one deterministic OpenAI Agents fixture or equivalent local/cassette
+provider workload:
+
+- one agent invocation;
+- one model/provider call;
+- one tool call;
+- one policy decision;
+- one safe workdir filesystem read/write;
+- no live network dependency unless explicitly part of the scenario;
+- no streaming response in v1; a streaming variant is deferred so the v1 field
+  matrix can be reasoned about against a single complete-message shape.
+
+Gemini and cross-runtime comparison stay out of v1. They can be added after the
+single-runtime shape comparison is stable.
+
+## v1.5 Adversarial Scenario
+
+Do not let this disappear into a vague follow-up. Plan it as v1.5:
+
+| Scenario | Reported L1 behavior | Measured L2 behavior | Why it matters |
+|---|---|---|---|
+| Tool-call argument tampering | `gen_ai.tool.name = fs.read`, `gen_ai.tool.call.arguments.path = /workdir/safe.txt` | kernel layer observes open/read outside the reported path, such as a normalized traversal to `/etc/passwd` or a controlled test file outside workdir | Demonstrates L1 intent/reporting can diverge from L2 effects. |
+
+Use a safe fixture path rather than a real sensitive file if possible. The
+claim is not "the agent stole secrets"; the claim is "reported tool arguments
+and measured filesystem effects can diverge."
+
+## Trace Attribute Plan
+
+Use exact OpenTelemetry GenAI attributes where available, and add Assay-specific
+attributes under an `assay.*` namespace. Keep sensitive content opt-in.
+
+| Field | OTel / OpenInference Attribute | Assay Archive Field | Claim Class |
+|---|---|---|---|
+| Run identity | `assay.run.id` | `manifest.run_id` or artifact run id | Correlation |
+| Provider | `gen_ai.provider.name` | SDK metadata side-band if present | Provenance |
+| Operation | `gen_ai.operation.name` | SDK/policy event type if present | Reported control flow |
+| Request model | `gen_ai.request.model` | SDK metadata side-band if present | Provenance |
+| Response model | `gen_ai.response.model` | SDK metadata side-band if present | Provenance |
+| Input tokens | `gen_ai.usage.input_tokens` | Not expected | Cost/context |
+| Output tokens | `gen_ai.usage.output_tokens` | Not expected | Cost/context |
+| Tool name | `gen_ai.tool.name` | `sdk_event.tool`, `capability_surface.mcp_tools` | Joinable behavior |
+| Tool call id | `gen_ai.tool.call.id` if available; otherwise custom fallback | `tool_call_id` where present | Primary join key |
+| Tool arguments | opt-in only, e.g. `gen_ai.tool.call.arguments` or OpenInference message/tool-call fields | Policy/SDK layer only if explicitly emitted | Sensitive reported intent |
+| Tool result | opt-in only | SDK layer only if explicitly emitted | Sensitive result |
+| Filesystem paths | Not expected in trace | `capability_surface.filesystem_paths`, kernel layer | Measured effect |
+| Network endpoints | Maybe app span attrs; not guaranteed | `capability_surface.network_endpoints`, kernel layer | Measured effect |
+| Process execs | Not expected in trace | `capability_surface.process_execs`, kernel layer | Measured effect |
+| Policy decision | Custom span attr or event if instrumented | policy layer, `capability_surface.policy_decisions` | Enforcement |
+| Ring buffer drops | Not expected | `observation_health.ringbuf_drops` | Measurement integrity |
+| Cgroup correlation | Not expected | `correlation_report.status`, cgroup correlation field | Measurement integrity |
+| Archive binding | `assay.archive.manifest_digest` | SHA-256 digest of `manifest.json` bytes | Tamper-evident link |
+
+## Join Hierarchy
+
+Try join keys in this order:
+
+1. `assay.run.id` for run-level binding.
+2. `gen_ai.tool.call.id` to Runner `tool_call_id` for tool-level binding.
+3. OpenInference message/tool-call id fields if they differ from OTel naming.
+4. Tool name + monotonic order within run, marked as weak join.
+5. Timestamp proximity, marked as diagnostic only and never used for a strong
+   claim.
+
+Measure how often `gen_ai.tool.call.id` is present for each instrumentation
+path. This is a data point, not just a prerequisite.
+
+| Instrumentation | `gen_ai.tool.call.id` Present? | Join Grade | Notes |
+|---|---|---|---|
+| Direct manual OTel SDK | Expected yes by construction | Primary | Used as control. |
+| OpenInference OpenAI instrumentation | To measure | Primary or secondary | Record package version. |
+| OpenInference LangChain instrumentation | To measure | Primary or secondary | Optional for v1. |
+| traceAI auto-instrumentation | To measure if included | Primary or secondary | Optional comparison, not v1 baseline. |
+
+## Manifest Digest Binding
+
+The dual-capture arm should make the trace carry a tamper-evident reference to
+the measured-run archive. Add an event or span attributes after the Runner
+archive is written:
+
+```text
+assay.archive.schema = "assay.runner.archive_manifest.v0"
+assay.archive.manifest_digest = "sha256:<manifest-json-bytes>"
+assay.archive.path = "<local artifact path or basename>"
+assay.runner.kernel_layer = "complete"
+assay.runner.ringbuf_drops = 0
+assay.runner.correlation_status = "clean"
+```
+
+This mirrors the provenance pattern used in supply-chain attestations: a small
+structured record refers to an artifact by digest rather than embedding the
+artifact itself. It does not make the trace authoritative for archive content;
+it lets a consumer verify that the trace and archive are the pair claimed by
+the experiment.
+
+### TypeScript Sketch
+
+```ts
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+function sha256Digest(bytes: Buffer): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+const tracer = trace.getTracer("assay-runner-otel-experiment");
+
+await tracer.startActiveSpan("assay.runner.measured_run", async (span) => {
+  try {
+    span.setAttributes({
+      "assay.run.id": runId,
+      "assay.measurement.boundary": "linux_ebpf_cgroup_v2",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.operation.name": "create_agent",
+    });
+
+    await runAgentWorkload();
+
+    const archivePath = await writeRunnerArchive();
+    const manifestBytes = readFileSync(extractedManifestPath);
+    const manifestDigest = sha256Digest(manifestBytes);
+
+    span.addEvent("assay.archive.created", {
+      "assay.archive.schema": "assay.runner.archive_manifest.v0",
+      "assay.archive.manifest_digest": manifestDigest,
+      "assay.archive.path": archivePath,
+      "assay.runner.kernel_layer": "complete",
+      "assay.runner.ringbuf_drops": 0,
+      "assay.runner.correlation_status": "clean",
+    });
+
+    span.setStatus({ code: SpanStatusCode.OK });
+  } catch (error) {
+    span.recordException(error as Error);
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    throw error;
+  } finally {
+    span.end();
+  }
+});
+```
+
+Tool spans should carry both OTel GenAI attributes and the Assay run id:
+
+```ts
+await tracer.startActiveSpan("execute_tool mcp_file_read", async (span) => {
+  span.setAttributes({
+    "gen_ai.operation.name": "execute_tool",
+    "gen_ai.tool.name": "mcp_file_read",
+    "gen_ai.tool.type": "function",
+    "gen_ai.tool.call.id": toolCallId,
+    "assay.run.id": runId,
+  });
+
+  try {
+    return await callTool();
+  } finally {
+    span.end();
+  }
+});
+```
+
+## Sensitive Content Policy
+
+Do not capture prompt text, completion text, tool arguments, or tool results by
+default. Put them behind a named opt-in flag:
+
+```text
+--capture-sensitive-otel-content
+```
+
+When disabled, the matrix should still compare identity, shape, tool names,
+token counts, measured effects, and measurement-health fields. Absence of
+prompt/completion content in a trace is a configuration fact, not evidence that
+OpenTelemetry cannot carry that content.
+
+## Measurement Plan
+
+| Metric | Purpose | Sample Size | Gate |
+|---|---|---:|---|
+| Archive determinism | Verify measured-run archive stability | n = 3 | Hard: manifest digests identical for deterministic workload, unless declared non-deterministic field exists |
+| Trace shape stability | Verify span tree and attribute keys are stable | n = 3 | Soft: timestamps/durations may vary |
+| `gen_ai.tool.call.id` presence | Measure joinability in practice | n = 3 per instrumentation path | Report as primary/secondary/no join |
+| End-to-end wall clock | Capture observability overhead | n >= 20 per arm | Report median, p95, p99, p99/median |
+| Peak RSS | Capture memory overhead | n >= 5 per arm | Report median and max |
+| Archive size | Storage footprint for L2 | n = 3 | Report bytes and compressed size |
+| Trace export size | Storage footprint for L1 | n = 3 | Report bytes |
+
+Use the same performance vocabulary as `docs/PERFORMANCE-ASSESSMENT.md` where
+possible. Do not use n=3 latency values as a performance claim.
+
+Emit wall-clock and RSS measurements in Bencher Metric Format (`BMF_JSON=1`
+mode used by `scripts/perf_assess.sh`) so this experiment's overhead numbers
+can slot into the existing Criterion/Bencher baseline rather than becoming a
+one-off measurement.
+
+## Field Matrix Output
+
+The comparison script should produce a machine-readable JSON file and a
+Markdown table.
+
+| Field | L1 Trace | L2 Archive | Join Key | Claim Strength | Notes |
+|---|---|---|---|---|---|
+| `gen_ai.provider.name` | TODO | TODO | run | Positive observation | |
+| `gen_ai.tool.call.id` | TODO | TODO | tool | Joinability | |
+| `assay.archive.manifest_digest` | TODO | TODO | digest | Tamper-evident binding | |
+| `capability_surface.filesystem_paths` | TODO | TODO | none | Bounded negative if healthy | |
+| `observation_health.ringbuf_drops` | no | TODO | archive | Measurement integrity | |
+| `gen_ai.usage.input_tokens` | TODO | no | span | Cost/context | |
+
+## Claim Classes
+
+| Claim | Trace Strength | Archive Strength | Joined Strength |
+|---|---|---|---|
+| "The agent reported a tool call to X" | Strong | Medium if SDK layer present | Strong |
+| "The run opened path P" | Weak unless app-instrumented | Strong within healthy Linux/eBPF boundary | Stronger when joined to tool context |
+| "The run did not access path P" | Not supported | Bounded negative if health is clean and path class is in capture scope | Bounded negative with trace context |
+| "The model used N input tokens" | Strong if provider reported tokens | Not supported | Strong for trace, archive irrelevant |
+| "The measurement was complete" | Not supported | Strong via health/correlation fields | Strong for archive side of the pair |
+| "The trace and archive describe the same run" | Weak by `run_id` only | Weak by `run_id` only | Stronger with `assay.archive.manifest_digest` |
+| "The trace and archive prove the agent was acceptable" | Not supported | Not supported | Not supported |
+
+## Acceptance Criteria
+
+v1 is complete when it produces:
+
+- one deterministic workload definition;
+- at least three dual-capture runs;
+- one Runner archive per dual-capture run;
+- one OTel/OpenInference trace export per dual-capture run;
+- one normalized comparison JSON;
+- one Markdown field matrix;
+- one joinability table showing `gen_ai.tool.call.id` presence/absence;
+- one manifest-digest binding check;
+- one threats-to-validity section filled with observed caveats.
+
+Hard gates:
+
+- `observation_health.ringbuf_drops == 0`;
+- kernel layer is complete;
+- correlation status is clean;
+- trace contains a recognizable agent/model/tool span shape;
+- every dual-capture trace carries `assay.archive.manifest_digest`;
+- the digest resolves to the archive's `manifest.json` bytes.
+
+## Threats to Validity
+
+- **Linux-only measurement.** Assay-Runner's measured-run claim currently relies
+  on Linux/eBPF/cgroup v2. macOS and Windows require separate platform spikes.
+- **Kernel-conditioned behavior.** Ring-buffer behavior and observable event
+  shape can vary across kernel versions.
+- **Instrumentation asymmetry.** OpenTelemetry-family traces depend on SDK and
+  framework instrumentation. Missing fields may be configuration gaps, not
+  conceptual limits.
+- **Privacy gating.** Prompt, completion, tool arguments, and tool results are
+  sensitive and may be intentionally disabled.
+- **Streaming.** Streaming output may appear differently in spans, events, or
+  SDK logs. v1 should not generalize beyond the chosen workload.
+- **Statistical power.** n=3 is enough for determinism checks, not for overhead
+  claims. Latency/RSS results require larger samples.
+- **Generic kernel tracers omitted.** v1 does not compare against Tetragon,
+  Falco, or Tracee. This is a scope decision, not a claim that L3 does not
+  matter.
+- **No acceptability claim.** Neither trace nor archive proves that behavior is
+  safe or policy-acceptable without a separate policy interpretation layer.
+
+## OpenInference Discussion Payload
+
+After v1 data exists, open a focused discussion with a vocabulary question, not
+a product pitch:
+
+> We compared an OpenTelemetry/OpenInference trace with a content-addressed
+> Assay-Runner measured-run archive for the same deterministic agent workload.
+> The strongest join was a trace attribute/event that points to the archive
+> manifest by digest rather than embedding runtime evidence in the trace.
+>
+> Would OpenInference prefer a vocabulary like:
+>
+> - `agent.runtime_evidence.digest`
+> - `agent.runtime_evidence.health`
+> - `agent.runtime_evidence.boundary`
+>
+> or should this live under an existing OpenInference / OTel extension namespace?
+> The goal is to let traces refer to measured-run artifacts without making the
+> trace the semantic owner of that artifact.
+
+Keep the discussion narrow. Ask for naming and domain placement, not adoption.
+
+## Reproduction Checklist
+
+Fill this section after implementation.
+
+```bash
+# TODO: build assay with runner feature
+# TODO: run deterministic workload under Runner only
+# TODO: run deterministic workload under OTel/OpenInference only
+# TODO: run dual-capture workload
+# TODO: extract manifest.json and compute digest
+# TODO: generate normalized comparison JSON
+# TODO: generate Markdown field matrix
+```
+
+## References to Verify Before Publication
+
+- OpenTelemetry GenAI semantic conventions:
+  <https://opentelemetry.io/docs/specs/semconv/gen-ai/>
+- OpenTelemetry GenAI spans:
+  <https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/>
+- OpenTelemetry GenAI agent/framework spans:
+  <https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/>
+- OpenInference semantic conventions:
+  <https://arize-ai.github.io/openinference/spec/semantic_conventions.html>
+- SLSA provenance v1.1:
+  <https://slsa.dev/spec/v1.1/provenance>
+- Assay-Runner measured-run walkthrough:
+  `docs/reference/runner/examples/measured-run-proof-bundle.md`
+- AgentSight is referenced descriptively in the L2 row until a URL and title
+  are verified. Do not add an arXiv ID without checking it first.
+
+Do not include unverified arXiv IDs or synthetic-looking survey references in
+the published version.


### PR DESCRIPTION
Summary
- adds a repo-native experiment skeleton for comparing Assay-Runner measured-run archives with OpenTelemetry/OpenInference traces
- pins v1 scope: L1/L2 shape comparison, manifest-digest binding, join hierarchy, field matrix, measurement plan, and threats to validity
- explicitly parks L3 generic kernel tracer comparison and tool-call argument tampering as follow-ups / v1.5

Validation
- git diff --check
- pre-commit hooks during commit
- pre-push hooks during push

Notes
- mkdocs was not available locally (`mkdocs` not on PATH, `python3 -m mkdocs` missing module), so this draft PR is intended to let CI run mkdocs-strict.
- no unverified arXiv IDs are cited; AgentSight is referenced descriptively only until verified.