### PR TITLE
docs(experiments): Slice 4 — OpenInference discussion + blog publication drafts

### DIFF
--- a/docs/experiments/runner-vs-otel-2026-05/publication/README.md
+++ b/docs/experiments/runner-vs-otel-2026-05/publication/README.md
@@ -1,0 +1,41 @@
+# Publication drafts (Slice 4)
+
+> **Status:** drafts only. Not filed, not published, not announced.
+> Lives in the repo so the framing matches the evidence on disk and
+> so the maintainer (Rul1an) can revise both pieces in one place
+> before either goes out.
+
+## Files
+
+| File | Audience | Channel | When to ship |
+|---|---|---|---|
+| [`openinference-discussion.md`](openinference-discussion.md) | OpenInference / OTel GenAI WG maintainers | Discussion on [`arize-ai/openinference`](https://github.com/Arize-ai/openinference/discussions) (and optionally `open-telemetry/semantic-conventions` if OpenInference routes us there) | After one final read-through; deliberately single narrow question, no @-mentions, no multi-question dump. |
+| [`blog-draft.md`](blog-draft.md) | Engineers working on OTel-family AI observability, eBPF / agent-runtime observability | Personal blog / dev.to / Hashnode. Optional cross-post link from the OpenInference discussion if the conversation goes well. | After the OpenInference discussion has a maintainer response. Posting the blog before the discussion would skip the channel discipline the experiment plan committed to. |
+
+## Sequencing
+
+1. File the OpenInference discussion. One question, one evidence
+   link. Wait for routing signal.
+2. If maintainers route us to `open-telemetry/semantic-conventions`,
+   cross-post the *same* question there — do not double-file
+   without routing.
+3. After at least one maintainer response (positive, negative, or
+   "this lives elsewhere"), publish the blog with the discussion
+   link embedded.
+4. Do not @-mention any individual maintainer. Do not promote on
+   Slack / Discord / X without an explicit signal from the
+   community that they want a broader audience.
+
+## Discipline from the plan doc
+
+These drafts honour:
+
+- The plan doc's "External question packet" section: ask the
+  smallest narrow question, one community at a time, with the
+  full evidence package linked once.
+- The "What we deliberately do NOT ask" list: no adoption ask, no
+  integration ask, no "have you seen this in general?" question,
+  no individual maintainer pings.
+- The Threats to Validity from the plan doc — both drafts repeat
+  the Linux-only / kernel-conditioned / measurement-boundary
+  caveats up front so reviewers don't have to chase them down.

--- a/docs/experiments/runner-vs-otel-2026-05/publication/blog-draft.md
+++ b/docs/experiments/runner-vs-otel-2026-05/publication/blog-draft.md
@@ -19,8 +19,10 @@ leaking sensitive content.
 This post is about a different cut of the same agent run.
 
 Internally we maintain a Linux/eBPF measured-run capture called
-Assay-Runner. It produces a deterministic content-addressed
-archive of an agent execution: cgroup-scoped kernel events,
+Assay-Runner. It produces a content-addressed measured-run
+archive of an agent execution (per-run tamper-evident binding,
+shape stability across runs, not byte-identical determinism):
+cgroup-scoped kernel events,
 normalized policy decisions, and SDK tool-call events bound by
 the same `tool_call_id` an OTel trace would carry. It is internal
 to a sibling project (`Rul1an/assay`), Linux-only, no public users,
@@ -282,10 +284,17 @@ repo at
   the same `tool_call_id`.
 - I'm not claiming Linux-only is a permanent limitation; it is
   the current measurement boundary of the prototype runtime.
-- I'm not running this as a product. The runtime is `publish =
-  false` in the workspace it lives in; the four contract crates
-  that *do* publish to crates.io carry explicit
-  internal/experimental framing in their descriptions.
+- I'm not running this as a product. The four Assay-Runner
+  crates that publish to crates.io
+  (`assay-runner-{schema, core, linux, spike}`) exist there only
+  so `assay-cli` and its workspace dependencies stay resolvable;
+  each crate's description carries explicit
+  internal/experimental framing
+  (`No standalone product guarantee; API surface remains narrow
+  and intentionally undocumented for third-party use; semver
+  tracks the Assay workspace`). See the v3.11.3 CHANGELOG entry
+  for why the crates are publishable and what that does and does
+  not commit us to.
 
 If the four candidate attribute names land in someone else's
 vocabulary, that's a good outcome and we move the experiment's
@@ -304,7 +313,9 @@ cd docs/experiments/runner-vs-otel-2026-05/workload
 npm install --no-audit --no-fund --ignore-scripts
 npx tsc -p tsconfig.json
 node dist/workload.js --run-id "demo" --trace-out "/tmp/trace.json"
-cd ../..
+
+# Comparator + Arm C verification run from the experiment package root
+cd ..
 python3 compare/compare.py \
   --archive compare/tests/fixtures/archive \
   --trace /tmp/trace.json --out-md /tmp/matrix.md

--- a/docs/experiments/runner-vs-otel-2026-05/publication/blog-draft.md
+++ b/docs/experiments/runner-vs-otel-2026-05/publication/blog-draft.md
@@ -1,0 +1,340 @@
+# Replay archives next to live traces: a shape-by-shape comparison of agent observability
+
+> **Status:** draft. Not yet published. Lives in the repo so the
+> framing matches the evidence on disk and so reviewers can
+> verify every number from the committed artefacts.
+>
+> **Date written:** 2026-05-25.
+
+OpenTelemetry GenAI semantic conventions, OpenInference, traceAI,
+Phoenix, Langfuse, Pydantic Logfire — the AI observability world
+in 2026 is rich and converging on a shared idea: capture what the
+agent *reports* doing as structured spans, ship the spans through
+familiar OTel infrastructure, and reason about agent behaviour
+through that lens. The frontier most people are talking about is
+prompt-and-completion semantics, span/event/metric carrier
+distinctions, and how to do tool-call argument capture without
+leaking sensitive content.
+
+This post is about a different cut of the same agent run.
+
+Internally we maintain a Linux/eBPF measured-run capture called
+Assay-Runner. It produces a deterministic content-addressed
+archive of an agent execution: cgroup-scoped kernel events,
+normalized policy decisions, and SDK tool-call events bound by
+the same `tool_call_id` an OTel trace would carry. It is internal
+to a sibling project (`Rul1an/assay`), Linux-only, no public users,
+not a tracing tool, not a competitor to anything OTel covers.
+
+The question that kept coming up: **what happens if you capture the
+*same* agent run both ways and put the artefacts side by side?**
+Not "which is better" — that question is uninteresting. The interesting
+question is which claims each layer can support, where the two
+layers complement each other, and where they say different things
+about the same execution.
+
+So we built the experiment, committed every artifact, and now I
+have something to write up. Everything in this post is verifiable
+from
+[`docs/experiments/runner-vs-otel-2026-05/`](https://github.com/Rul1an/assay/tree/main/docs/experiments/runner-vs-otel-2026-05)
+in the assay repo — including a stdlib-only Python comparator
+(`compare/compare.py`) that takes a trace + an archive and
+produces the field matrix shown below.
+
+## TL;DR for tracing folks
+
+OTel/OpenInference traces do exactly what they say: they capture
+the agent's reported control flow with semantic clarity. They are
+not designed to bound what the system actually did at the kernel
+level. That's fine. The interesting move is to **pair** a trace
+with a content-addressed runtime-evidence artifact that *is*
+designed to bound system effects, and let each layer make the
+claims it was built for.
+
+This experiment shows three things on real Linux/eBPF data, all
+verifiable from the committed artefacts:
+
+1. **Per-run tamper-evident binding works.** An
+   `assay.archive.created` span event carrying
+   `sha256:<manifest-bytes>` lets a consumer cryptographically pair
+   a trace with exactly one runtime-evidence archive.
+2. **Tool-level join works** via shared `tool_call_id` between
+   `gen_ai.tool.call.id` on the trace and the SDK-event
+   `tool_call_id` in the archive.
+3. **Reported intent ≠ measured effect** is *expressible* once
+   binding + tool-level join hold: when the agent reports reading
+   file X and the kernel observes a read of file Y at the same
+   `tool_call_id`, the comparator surfaces the asymmetry as
+   `intent-effect-mismatch:<path>`.
+
+What it does **not** show:
+
+- It does not say OTel is missing anything. The trace is honest
+  about what the agent reported.
+- It does not claim byte-identical determinism across live eBPF
+  runs (run id, timestamps, PIDs, inodes vary; only shape is
+  stable).
+- It does not propose a new tracing stack. It proposes — at most —
+  a small vocabulary addition so existing traces can refer to
+  out-of-band runtime evidence by digest.
+
+## The setup
+
+One deterministic workload: an `@openai/agents` agent with a
+cassette-style local provider that produces a single
+`read_file` tool call with a fixed `tool_call_id`
+(`tc_runner_policy_001`). No network. Cross-platform for the
+trace-only arm; Linux/eBPF for the dual-capture arm.
+
+Three arms:
+
+| Arm | Trace | Archive | Where |
+|---|---|---|---|
+| A — Runner only | no | yes | Linux/eBPF (delegated host) |
+| B — Trace only | yes | no | macOS / Linux / Windows |
+| C — Dual capture | yes | yes | Linux/eBPF (delegated host) |
+
+The comparator (`compare/compare.py`) reads `(archive, trace)` and
+emits a 17-row field matrix and a top-level summary:
+
+```
+trace spans: 2
+archive SDK events: 3
+manifest-digest binding: tamper-evident-match
+tool_call_id join: joined:tc_runner_policy_001
+intent-vs-effect: intent-effect-match | intent-effect-mismatch:<path> | not-applicable
+```
+
+The `intent-vs-effect` field is what makes the experiment
+publishable. It distinguishes "the agent reported what it did"
+from "the kernel agrees with what the agent reported" and reports
+the disagreement when there is one.
+
+## What L1 alone can carry (and what it can't)
+
+In the Arm B baseline (three identical runs, see
+[`runs/v1-baseline/`](https://github.com/Rul1an/assay/tree/main/docs/experiments/runner-vs-otel-2026-05/runs/v1-baseline)):
+
+| Field | OTel/OpenInference trace |
+|---|---|
+| `gen_ai.provider.name` | `openai` |
+| `gen_ai.tool.name` | `read_file` |
+| `gen_ai.tool.call.id` | `tc_runner_policy_001` |
+| `gen_ai.usage.input_tokens` | absent here (cassette model doesn't set it; a real model call would populate) |
+| Filesystem effects | n/a — out of contract |
+| Network effects | n/a — out of contract |
+| Measurement integrity | n/a — out of contract |
+
+A trace cannot bound system effects because it was never asked to.
+That is not a flaw; it is the right separation. Asking a trace to
+prove a negative ("nothing else happened") is the wrong question
+for the abstraction.
+
+## What L2 adds: bounded negatives + measurement health
+
+In the Arm C baseline (three iterations under real Linux/eBPF,
+see
+[`runs/v1-arm-c/`](https://github.com/Rul1an/assay/tree/main/docs/experiments/runner-vs-otel-2026-05/runs/v1-arm-c)):
+
+| Field | Runner archive |
+|---|---|
+| `capability_surface.filesystem_paths` | `workload.js`, `otel-setup.js`, `manifest-binding.js`, `package.json`, fixture file, trace.json write — the actual file opens the Node runtime made |
+| `observation_health.kernel_layer` | `complete` |
+| `observation_health.ringbuf_drops` | `0` (hard gate) |
+| `observation_health.cgroup_correlation` | `clean` |
+| `correlation_report.status` | `clean` |
+| Per-run manifest digest | `sha256:<bytes>` — different bytes each run because timestamps/PIDs vary |
+
+On Linux with healthy capture this lets you say "within this
+measurement boundary, X did not happen" — a *bounded negative*.
+Bounded negatives are the asymmetry that motivates the experiment.
+A trace can say "we did Y"; an archive can say "we did Y, and we
+did *not* do W either."
+
+A subtlety we landed on the honest way: live-eBPF archives are
+not byte-identical across runs. Same workload, same
+`require_binding_match` exit 0, same field shape, same line
+counts — different bytes, because the kernel measures real
+timestamps/PIDs/inodes. The right published claim is
+**per-run** tamper-evident binding plus **shape** stability, not
+cross-run byte determinism.
+
+## The binding
+
+```typescript
+// workload/src/otel-setup.ts (excerpt)
+await tracer.startActiveSpan("assay.runner.measured_run", async (span) => {
+  // ... do the agent run ...
+
+  // Post-run: bind the trace to the just-written archive by digest.
+  const manifestBytes = readFileSync(extractedManifestPath);
+  const digest = `sha256:${createHash("sha256").update(manifestBytes).digest("hex")}`;
+
+  span.addEvent("assay.archive.created", {
+    "assay.archive.schema": "assay.runner.archive_manifest.v0",
+    "assay.archive.manifest_digest": digest,
+    "assay.archive.path": archivePath,
+    "assay.runner.ringbuf_drops": 0,
+    "assay.runner.correlation_status": "clean",
+  });
+});
+```
+
+That's it on the trace side. On the archive side the same
+`manifest.json` bytes hash to the same digest. The comparator
+checks them and reports `tamper-evident-match` (or `mismatch` or
+the various "absent" states). With `--require-binding-match`, exit
+code 3 if the bytes don't line up.
+
+This is the SLSA provenance pattern, applied at runtime. A small
+structured record refers to an artefact by digest rather than
+embedding the artefact itself.
+
+## The tool-level join
+
+OTel GenAI semconv defines `gen_ai.tool.call.id` on tool spans.
+The runner archive's SDK layer stores the same id in its
+`sdk_event.tool_call_id`. When you arrange the workload to write
+both (one to the OTLP file exporter, one to the
+`$ASSAY_RUNNER_SDK_EVENT_LOG` NDJSON that the runner folds into
+the archive's `layers/sdk.ndjson`), the comparator joins them by
+exact id match.
+
+Slice 2 of the experiment series lands this end-to-end. After it,
+the `runs/slice2-arm-c/` baseline reports
+`tool_call_id join: joined:tc_runner_policy_001` on real eBPF
+data — the first proof that the L1 trace and the L2 archive
+agree on which tool call we're talking about.
+
+## The interesting one: intent vs effect
+
+With tool-level join holding and the trace optionally carrying
+`gen_ai.tool.call.arguments` (sensitive content, opt-in), the
+comparator can compare what the agent *reported* doing to what
+the kernel *measured* it doing — at the same `tool_call_id`.
+
+Slice 3 of the experiment series demonstrates this on a
+controlled adversarial scenario. The deterministic model reports
+reading `${workdir}/agent-claimed-fixture.txt`; the workload
+never creates that file; the `read_file` tool implementation
+under `--tampering` mode ignores the reported path and reads
+`${workdir}/tampering-target.txt` instead.
+
+Three Arm C iterations on `assay-bpf-runner` (see
+[`runs/slice3-arm-c/`](https://github.com/Rul1an/assay/tree/main/docs/experiments/runner-vs-otel-2026-05/runs/slice3-arm-c))
+report, identically:
+
+```
+intent_effect_status: intent-effect-mismatch:<workdir>/agent-claimed-fixture.txt
+```
+
+- The trace carries
+  `gen_ai.tool.call.arguments = {"path": "<workdir>/agent-claimed-fixture.txt"}`
+- The archive's `capability_surface.filesystem_paths` includes
+  `tampering-target.txt` (the redirected read) and the workload's
+  own JS file opens.
+- `agent-claimed-fixture.txt` is **nowhere** in
+  `capability_surface` — the kernel never recorded that open, so
+  the agent never executed it.
+- `tool_call_id_join` still works
+  (`joined:tc_runner_policy_001`); both sides agree on which
+  tool call we are talking about.
+- `manifest_digest_binding` still works
+  (`tamper-evident-match`); each trace still cryptographically
+  binds to its own archive.
+
+The reported intent is divorced from the measured effect, the
+divergence is anchored at the same `tool_call_id`, and the
+artefact pair is tamper-evident. **That is the central
+asymmetry claim, demonstrable on real Linux/eBPF data.**
+
+## What I'm asking the OpenInference / OTel community
+
+Not adoption. Not integration. Just a vocabulary question.
+
+The binding event and the intent-vs-effect status feel like they
+could be useful in any setup that pairs an OTel-family trace
+with an out-of-band runtime-evidence artifact, not just ours.
+We've parked them in a private `assay.*` namespace because we
+didn't want to squat on unspecified OTel GenAI / OpenInference
+names.
+
+Four candidate attribute names:
+
+- `agent.runtime_evidence.digest` — content-addressed pointer
+- `agent.runtime_evidence.health` — measurement integrity status
+- `agent.runtime_evidence.boundary` — declared measurement boundary
+- `agent.runtime_evidence.intent_effect_status` — reported vs measured verdict
+
+The discussion draft asking for placement guidance lives in the
+repo at
+[`publication/openinference-discussion.md`](https://github.com/Rul1an/assay/blob/main/docs/experiments/runner-vs-otel-2026-05/publication/openinference-discussion.md).
+
+## Non-claims (in case anyone reading this thinks I'm selling something)
+
+- I'm not claiming OTel traces are missing anything they were
+  supposed to carry.
+- I'm not proposing a new tracing stack or a new vendor.
+- I'm not claiming the runtime-evidence layer is novel — eBPF +
+  agent observability is an active research area (AgentSight et
+  al.). What's new is the per-run cryptographic binding to an
+  OTel-family trace and the intent-vs-effect status expressed at
+  the same `tool_call_id`.
+- I'm not claiming Linux-only is a permanent limitation; it is
+  the current measurement boundary of the prototype runtime.
+- I'm not running this as a product. The runtime is `publish =
+  false` in the workspace it lives in; the four contract crates
+  that *do* publish to crates.io carry explicit
+  internal/experimental framing in their descriptions.
+
+If the four candidate attribute names land in someone else's
+vocabulary, that's a good outcome and we move the experiment's
+implementation to use them. If they don't, the experiment's
+evidence still holds; only the namespace is uncertain.
+
+## Reproduce
+
+```bash
+# Clone
+git clone https://github.com/Rul1an/assay.git
+cd assay
+
+# Local Arm B (trace-only, macOS/Linux/Windows)
+cd docs/experiments/runner-vs-otel-2026-05/workload
+npm install --no-audit --no-fund --ignore-scripts
+npx tsc -p tsconfig.json
+node dist/workload.js --run-id "demo" --trace-out "/tmp/trace.json"
+cd ../..
+python3 compare/compare.py \
+  --archive compare/tests/fixtures/archive \
+  --trace /tmp/trace.json --out-md /tmp/matrix.md
+cat /tmp/matrix.md
+
+# Verify the committed Arm C baselines (Linux/eBPF runs)
+for d in runs/slice3-arm-c/run_arm_c_*; do
+  python3 compare/compare.py \
+    --archive "$d/archive-contents" --trace "$d/trace.json" \
+    --require-binding-match >/dev/null && \
+    echo "$(basename $d) OK"
+done
+
+# All three print OK; matrix.json's
+# summary.intent_effect_status reads
+# intent-effect-mismatch:<workdir>/agent-claimed-fixture.txt
+```
+
+The full experiment package is committed; each per-run artifact
+directory contains the trace, the comparator output, and the
+extracted archive contents (manifest, capability surface,
+observation health, correlation report, ndjson layers). Raw
+`.tar.gz` archives are not tracked because they don't add anything
+verifiable that the extracted form doesn't already give a
+reviewer.
+
+---
+
+*Side note for tracing tool maintainers: if you read this and
+think "this should live as a span attribute X under spec Y", the
+OpenInference discussion linked above is where I'd most like to
+hear that. Single narrow question, one cross-link to here for
+evidence, no follow-up volley.*

--- a/docs/experiments/runner-vs-otel-2026-05/publication/openinference-discussion.md
+++ b/docs/experiments/runner-vs-otel-2026-05/publication/openinference-discussion.md
@@ -1,0 +1,129 @@
+# OpenInference / OTel GenAI semconv — discussion draft
+
+> **Status:** draft, ready to file as a Discussion on
+> [`arize-ai/openinference`](https://github.com/Arize-ai/openinference/discussions)
+> (and optionally cross-linked to
+> [`open-telemetry/semantic-conventions`](https://github.com/open-telemetry/semantic-conventions/discussions)).
+>
+> **Intent:** narrow vocabulary question, *one* discussion, *one*
+> attached evidence link, *no* product pitch. Per the plan doc's
+> "External question packet" discipline.
+>
+> **Not yet filed.** Maintainer is reviewing before posting; revisions
+> live here so the version sent matches what we'll defend.
+
+## Subject line
+
+> Vocabulary question: how should an OTel/OpenInference trace refer
+> to a content-addressed runtime-evidence artifact captured alongside
+> the same agent run?
+
+## Body
+
+Hi OpenInference / OTel GenAI WG,
+
+We ran a controlled experiment (Linux/eBPF, n=3 per arm) that
+captures an agent run twice in the same execution:
+
+- **L1 — reported control flow**: OTel/OpenInference-style trace
+  emitted in-process by the workload using
+  `@opentelemetry/sdk-trace-base` and the OTel GenAI semconv
+  attribute set (`gen_ai.provider.name`, `gen_ai.operation.name`,
+  `gen_ai.tool.name`, `gen_ai.tool.call.id`, optionally
+  `gen_ai.tool.call.arguments`).
+- **L2 — measured runtime evidence**: a content-addressed Runner
+  archive produced by an eBPF + cgroup-v2 capture that records the
+  kernel-observed filesystem paths, network endpoints, process
+  execs, plus measurement-health gates (`ringbuf_drops`,
+  `cgroup_correlation`).
+
+Both streams share the same `tool_call_id`, and a per-run
+`sha256:<manifest-bytes>` digest of the archive's `manifest.json`
+is attached to the trace's root span as an
+`assay.archive.created` event — a tamper-evident binding in the
+SLSA-provenance style. This lets us state per-run claims like
+"this trace and this archive describe the same execution" without
+the trace owning the archive's content.
+
+We've also instrumented a controlled adversarial scenario where
+the agent reports reading file X and the kernel observes a read
+of file Y. With L1 and L2 joined on `tool_call_id`, the
+comparator expresses the asymmetry as "reported intent X !=
+measured effect Y at the same `tool_call_id`".
+
+Today the binding + intent-effect attributes live in a private
+`assay.*` namespace because we did not want to squat on
+unspecified OTel GenAI / OpenInference attribute names. Three of
+them feel like they could be widely useful in any setup that
+pairs a tracing layer with an out-of-band runtime-evidence
+artifact:
+
+- `agent.runtime_evidence.digest` — content-addressed pointer to
+  the artifact (e.g., `sha256:<manifest-bytes>`).
+- `agent.runtime_evidence.health` — short enum/string for
+  measurement integrity (`clean`, `degraded`, `unknown`).
+- `agent.runtime_evidence.boundary` — declared measurement boundary
+  string (e.g., `linux_ebpf_cgroup_v2`).
+
+Plus a fourth that emerged from the adversarial scenario:
+
+- `agent.runtime_evidence.intent_effect_status` — short enum/string
+  reporting how the trace's reported tool arguments compare to the
+  runtime artifact's measured effects (e.g.,
+  `intent-effect-match`, `intent-effect-mismatch:<path>`,
+  `not-applicable`, `inconclusive`).
+
+The narrow question I'd like maintainer input on:
+
+> Where should attributes like these live? Do they fit under the
+> OpenInference spec, under an OTel GenAI extension, in a separate
+> namespace altogether, or is there an existing attribute we should
+> be using and just missed?
+
+The runtime-evidence artifact itself is intentionally out of scope
+for the trace; the trace only needs to refer to it by digest +
+short health + boundary fields. Whatever the right home is, we'd
+like to move our `assay.*` private names there so other consumers
+that pair OTel-family tracing with out-of-band runtime evidence
+can use the same vocabulary.
+
+I've attached the full experiment package in the repo we used to
+develop this (Linux/eBPF only, internal/experimental). The
+v1-findings.md walks through the four slices that produced the
+evidence; the per-run Arm C archives + traces + comparator output
+are committed under `runs/v1-arm-c/`, `runs/slice2-arm-c/`, and
+`runs/slice3-arm-c/`.
+
+- Experiment package: <https://github.com/Rul1an/assay/tree/main/docs/experiments/runner-vs-otel-2026-05>
+- Plan doc with claim-class taxonomy + threats to validity: [`runner-vs-otel-shape-comparison-2026-05.md`](https://github.com/Rul1an/assay/blob/main/docs/experiments/runner-vs-otel-shape-comparison-2026-05.md)
+- v1 findings (with Slice 2 + Slice 3 resolutions): [`v1-findings.md`](https://github.com/Rul1an/assay/blob/main/docs/experiments/runner-vs-otel-2026-05/v1-findings.md)
+- Comparator source (stdlib Python): [`compare/compare.py`](https://github.com/Rul1an/assay/blob/main/docs/experiments/runner-vs-otel-2026-05/compare/compare.py)
+
+Happy to file separate narrower issues if the discussion suggests
+they're better tracked there. Not asking for adoption, not asking
+for integration; just want to know where the vocabulary should
+live so the cross-tool wiring stays clean.
+
+Thanks,
+Roel (Rul1an)
+
+---
+
+## What we deliberately do NOT ask
+
+Per the plan doc's external-outreach discipline:
+
+- We do not ask for OpenInference / OTel to adopt or integrate with
+  Assay-Runner specifically.
+- We do not ask anyone to validate the experiment design or the
+  Linux/eBPF mechanism. That's our problem.
+- We do not multi-question dump.
+- We do not @-mention any individual maintainer.
+
+## Per-community channel discipline
+
+| Repo | When to file |
+|---|---|
+| `arize-ai/openinference` Discussions | Primary. The four attributes naturally live in agent/tool observability space. |
+| `open-telemetry/semantic-conventions` Discussions | Optional cross-link if the OpenInference maintainers route us there. Do not double-file without a routing signal. |
+| `open-telemetry/community` issues | Only if OpenInference + semconv both say "wrong place". |

--- a/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
+++ b/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
@@ -1,17 +1,18 @@
 # v1 Findings: Runner Archives Next to OTel Traces
 
-> **Status:** All four central evidence slices landed on `main`. Arm B
-> baseline (macOS local, n=3 + dual-simulation), Arm C baseline
-> (delegated `assay-bpf-runner`, n=3, real Linux/eBPF), Slice 2
-> (SDK-layer ingestion fix, n=3, tool-level L1↔L2 join working), and
-> Slice 3 (tool-call argument tampering, n=3, `intent_effect_status =
+> **Status:** Slices 1–3 evidence landed on `main`. Arm B baseline
+> (macOS local, n=3 + dual-simulation), Arm C baseline (delegated
+> `assay-bpf-runner`, n=3, real Linux/eBPF), Slice 2 (SDK-layer
+> ingestion fix, n=3, tool-level L1↔L2 join working), and Slice 3
+> (tool-call argument tampering, n=3, `intent_effect_status =
 > intent-effect-mismatch` on the agent's reported fictional path) all
 > have committed per-run evidence. Arm A (Runner-only) is implicitly
 > covered by the archive half of Arm C. **Slice 4 publication drafts**
-> (OpenInference discussion + blog) live under
-> [`publication/`](publication/), not yet filed. Overhead measurement
-> at n≥20 and the L3 (Tetragon/Falco/Tracee) comparison remain open
-> follow-ups.
+> (OpenInference discussion + blog) are prepared under
+> [`publication/`](publication/) but not yet filed and not yet on
+> `main` either; the discipline is to revise both pieces in repo
+> before either goes outward. Overhead measurement at n≥20 and the L3
+> (Tetragon/Falco/Tracee) comparison remain open follow-ups.
 >
 > **Plan:** [../runner-vs-otel-shape-comparison-2026-05.md](../runner-vs-otel-shape-comparison-2026-05.md)
 >
@@ -407,8 +408,11 @@ RUN_DIR="../runs/$RUN_ID"
 mkdir -p "$RUN_DIR"
 node dist/workload.js --run-id "$RUN_ID" --trace-out "$RUN_DIR/trace.json"
 
-# Compare against the synthetic fixture archive (Arm B has no real archive)
-cd ../..
+# Compare against the synthetic fixture archive (Arm B has no real
+# archive). Paths below are repo-root relative, so cd up to the repo
+# root from the workload directory (four levels: workload ->
+# runner-vs-otel-2026-05 -> experiments -> docs -> repo root).
+cd ../../../..
 python3 docs/experiments/runner-vs-otel-2026-05/compare/compare.py \
   --archive docs/experiments/runner-vs-otel-2026-05/compare/tests/fixtures/archive \
   --trace docs/experiments/runner-vs-otel-2026-05/runs/$RUN_ID/trace.json \

--- a/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
+++ b/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
@@ -1,15 +1,17 @@
 # v1 Findings: Runner Archives Next to OTel Traces
 
-> **Status:** Arm B baseline (macOS local, n=3 + dual-simulation), Arm C
-> baseline (delegated `assay-bpf-runner`, n=3 with real Linux/eBPF capture),
-> Slice 2 (SDK-layer ingestion fix) baseline (delegated, n=3 with
-> tool-level L1↔L2 join working), **and Slice 3 (tool-call argument
-> tampering) baseline** (delegated, n=3 with `intent_effect_status =
-> intent-effect-mismatch` on the agent's reported fictional path) are
-> all landed. Arm A (Runner-only) is implicitly covered by the archive
-> half of Arm C. Slice 4 (OpenInference vocabulary discussion + blog),
-> overhead measurement at n≥20, and the L3 (Tetragon/Falco/Tracee)
-> comparison remain open.
+> **Status:** All four central evidence slices landed on `main`. Arm B
+> baseline (macOS local, n=3 + dual-simulation), Arm C baseline
+> (delegated `assay-bpf-runner`, n=3, real Linux/eBPF), Slice 2
+> (SDK-layer ingestion fix, n=3, tool-level L1↔L2 join working), and
+> Slice 3 (tool-call argument tampering, n=3, `intent_effect_status =
+> intent-effect-mismatch` on the agent's reported fictional path) all
+> have committed per-run evidence. Arm A (Runner-only) is implicitly
+> covered by the archive half of Arm C. **Slice 4 publication drafts**
+> (OpenInference discussion + blog) live under
+> [`publication/`](publication/), not yet filed. Overhead measurement
+> at n≥20 and the L3 (Tetragon/Falco/Tracee) comparison remain open
+> follow-ups.
 >
 > **Plan:** [../runner-vs-otel-shape-comparison-2026-05.md](../runner-vs-otel-shape-comparison-2026-05.md)
 >
@@ -349,6 +351,31 @@ experiment can publish a vocabulary discussion on OpenInference / OTel
 GenAI semconv asking for the right place to put a runtime-evidence
 binding attribute and an intent-vs-effect status. That is Slice 4 of
 the experiment plan.
+
+## Slice 4: publication drafts (not yet filed)
+
+Slice 4 produces two drafts, both committed under
+[`publication/`](publication/) so the wording matches the evidence
+on disk before either goes out:
+
+- [`publication/openinference-discussion.md`](publication/openinference-discussion.md)
+  — single narrow vocabulary question for the OpenInference / OTel
+  GenAI WG: where should `agent.runtime_evidence.{digest, health,
+  boundary, intent_effect_status}` live? Channels: file on
+  [`arize-ai/openinference`](https://github.com/Arize-ai/openinference/discussions)
+  first; cross-link to OTel semconv only if routed there. No
+  individual maintainer pings.
+- [`publication/blog-draft.md`](publication/blog-draft.md) — engineer
+  audience write-up covering the four slices, the per-run binding,
+  the tool-level join, and the intent-vs-effect mismatch on real
+  eBPF data. Posts only after the OpenInference discussion has at
+  least one maintainer response, so the blog can embed the
+  discussion link and the back-and-forth.
+
+The publication discipline (one channel at a time, no
+@-mentions, no multi-question dumps, no adoption asks) is
+documented in [`publication/README.md`](publication/README.md).
+Neither artifact is published yet.
 
 ## What still does NOT prove
 


### PR DESCRIPTION
## Summary

Closes the runner-vs-otel-2026-05 experiment's four-slice plan. Adds two **publication drafts** + a sequencing README — but does not file or publish either.

| Slice | Status |
|---|---|
| 1. Arm C baseline (per-run tamper-evident binding) | ✅ on main (#1337, #1338) |
| 2. SDK-layer ingestion (tool-level L1↔L2 join) | ✅ on main (#1339) |
| 3. Tool-call argument tampering (intent != effect) | ✅ on main (#1340) |
| **4. OpenInference discussion + blog drafts** | This PR |

## What lands

- [`publication/openinference-discussion.md`](https://github.com/Rul1an/assay/blob/codex/slice-4-openinference-discussion/docs/experiments/runner-vs-otel-2026-05/publication/openinference-discussion.md) — single narrow vocabulary question for the OpenInference / OTel GenAI WG: where should `agent.runtime_evidence.{digest, health, boundary, intent_effect_status}` live? One evidence link, no @-mentions, no adoption ask. Per the plan doc's "External question packet" discipline.
- [`publication/blog-draft.md`](https://github.com/Rul1an/assay/blob/codex/slice-4-openinference-discussion/docs/experiments/runner-vs-otel-2026-05/publication/blog-draft.md) — engineer-audience write-up covering the four slices, with reproduction commands so any reader can verify every claim from the committed artefacts.
- [`publication/README.md`](https://github.com/Rul1an/assay/blob/codex/slice-4-openinference-discussion/docs/experiments/runner-vs-otel-2026-05/publication/README.md) — sequencing rules: file OpenInference discussion first, wait for routing signal, publish blog after at least one maintainer response so the back-and-forth can be embedded.
- `v1-findings.md` — status block updated; new "Slice 4: publication drafts (not yet filed)" section pointing at the three new files.

## What does NOT land

- The OpenInference discussion is NOT filed.
- The blog is NOT published.
- No third-party announcement, no Slack/Discord/X cross-post.
- No @-mentions of individual maintainers.

Both artefacts live in the repo so the maintainer (Rul1an) can revise them in one place before either goes out. External shipping is a separate, deliberate action gated on this PR landing first.

## Why drafts-in-repo is the right discipline

The four prior slices committed every evidence artifact under `runs/<arm>/` so reviewers can verify the claims from the repo without contacting the maintainer. The publication drafts inherit the same discipline: the text that goes outward should match the evidence on disk, and the wording should survive a separate review pass before it travels.

The plan doc's "External question packet" section in `runner-vs-otel-shape-comparison-2026-05.md` already committed us to:
- one narrow question per community,
- the full evidence package linked once,
- no @-mentions,
- no multi-question dumps,
- no adoption asks.

The drafts honour all five.

## Test plan

- [x] All three publication files render as markdown (no broken links to the rest of the repo)
- [x] v1-findings.md status block now describes all four slices as landed
- [x] No source / workflow / runtime changes; pure docs addition
- [ ] PR CI green

## Non-claims

- This PR does not propose adoption of `agent.runtime_evidence.*` by OpenInference or OTel — only asks the placement question.
- This PR does not assert the blog will be published. The blog text exists so the question and the answer (when it comes) can be embedded in a single readable artefact; whether it lands on a personal blog, dev.to, or stays in the repo is a separate decision.
- This PR does not extend the experiment's central evidence claims; those landed in Slices 1–3.

## After this lands

Per the publication README sequencing:

1. File the OpenInference discussion (single click, the file is the body).
2. Wait for maintainer response.
3. If positive routing signal, publish the blog with the discussion link embedded.
4. No promotion outside the channel the maintainers route us to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)