### PR TITLE
docs(experiments): Slice 1 — cross-runtime drift workload contract + impls

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05.md
+++ b/docs/experiments/cross-runtime-drift-2026-05.md
@@ -1,9 +1,10 @@
 # Cross-Runtime Capability-Surface Drift: Plan
 
-> **Status:** **draft, no code written yet.** Plan-doc only, lives in
-> the repo so it can be sharpened the same way
-> [`runner-vs-otel-shape-comparison-2026-05.md`](runner-vs-otel-shape-comparison-2026-05.md)
-> was iterated before Slice 1 landed. Companion to that experiment;
+> **Status:** Slice 0 (this plan) and Slice 1 (workload contract +
+> two implementations + contract-checker) landed. See
+> [`cross-runtime-drift-2026-05/README.md`](cross-runtime-drift-2026-05/README.md)
+> for the Slice 1 layout. Companion to
+> [`runner-vs-otel-shape-comparison-2026-05.md`](runner-vs-otel-shape-comparison-2026-05.md);
 > reuses the same Runner archive + capability_surface contract, so
 > the L2 capture machinery is already proven on
 > [`assay-bpf-runner`](../../.github/workflows/runner-otel-experiment.yml).
@@ -91,13 +92,15 @@ The drift report is a **new** comparator. It does **not** reuse
 which is a trace-vs-archive comparator. A new
 `compare/drift.py` is the artefact.
 
-## Open Questions (must resolve before Slice 1)
+## Open Questions
 
-These are the framing choices I want sharpened before any code
-lands. Pulling them up front so the plan does not silently bake
-in defaults.
+These were the framing choices pulled up front so the plan did
+not silently bake in defaults. **Q1 and Q3 are resolved by
+Slice 1** (see
+[`cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md`](cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md));
+Q2, Q4, Q5 remain open.
 
-1. **Which second runtime, and in which tool-calling mode?**
+1. **[RESOLVED — Slice 1]** **Which second runtime, and in which tool-calling mode?**
    - **Option A:** Google Gemini via `@google/genai` (unified SDK,
      newest, supports both manual and automatic function calling).
    - **Option B:** Google Gemini via `@google/generative-ai` (older
@@ -134,7 +137,7 @@ in defaults.
      Then the drift is the *runtime overhead* of the same
      contract, not "two different programs."
 
-3. **Determinism?**
+3. **[RESOLVED — Slice 1]** **Determinism?**
    - OpenAI Agents has `temperature: 0` + structured output
      mode; we already exercise this in the runner-vs-otel
      workload's `--deterministic-fixture` path.
@@ -286,14 +289,14 @@ A successful first findings doc:
 
 ## Sequencing (slices)
 
-| Slice | Deliverable | External dependency |
-|---|---|---|
-| 0 | This plan-doc, reviewed and sharpened (Open Questions resolved) | None |
-| 1 | Workload contract written down (including the exact tool-calling mode: manual function-calling loop on both sides). Both runtime implementations of the workload, runnable locally with API keys. Each passes the contract checker. **Blocked on Open Question #1 resolution.** | OpenAI key (already used), second runtime's key |
-| 2 | `compare/drift.py` MVP. **Scope-locked to v0 surface**: touched-path set diff, network host/port/CIDR diff, process exec diff, SDK tool-event diff, MCP tool-surface diff, tool invocation order where SDK events preserve it. Read/write/create classification and kernel-ndjson parsing are deferred. Runs on two synthetic archives derived from existing runner-vs-otel fixtures, no live runs yet. Comparator output schema locked in. | None |
-| 3 | Live Arm A0 + B0 dispatch on `assay-bpf-runner` (workflow extension). n=3 per arm. Baselines committed under `docs/experiments/cross-runtime-drift-2026-05/runs/{a0,b0}/`. | Second runtime API key as workflow secret |
-| 4 | `findings.md`. Drift table, classification, threats-to-validity, reproduction commands. | None |
-| 5 | Publication artefacts (issue + blog draft) following the same discipline as runner-vs-otel Slice 4: one narrow question per channel, no maintainer @-mentions, evidence link once. | OpenInference #3162 triage outcome should inform whether to file under same umbrella or separately |
+| Slice | Status | Deliverable | External dependency |
+|---|---|---|---|
+| 0 | **Done** | This plan-doc, reviewed and sharpened (Open Questions #1 + #3 resolved) | None |
+| 1 | **Done** | Workload contract ([`WORKLOAD_CONTRACT.md`](cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md)), `@openai/agents` workload, `@google/genai` manual-function-calling workload, stdlib contract-checker with 10 unit tests | OpenAI key (already used), Google key for live local testing |
+| 2 | TODO | `compare/drift.py` MVP. **Scope-locked to v0 surface**: touched-path set diff, network host/port/CIDR diff, process exec diff, SDK tool-event diff, MCP tool-surface diff, tool invocation order where SDK events preserve it. Read/write/create classification and kernel-ndjson parsing are deferred. Runs on two synthetic archives derived from existing runner-vs-otel fixtures, no live runs yet. Comparator output schema locked in. | None |
+| 3 | TODO | Live Arm A0 + B0 dispatch on `assay-bpf-runner` (workflow extension). n=3 per arm. Baselines committed under `docs/experiments/cross-runtime-drift-2026-05/runs/{a0,b0}/`. | Second runtime API key as workflow secret |
+| 4 | TODO | `findings.md`. Drift table, classification, threats-to-validity, reproduction commands. | None |
+| 5 | TODO | Publication artefacts (issue + blog draft) following the same discipline as runner-vs-otel Slice 4: one narrow question per channel, no maintainer @-mentions, evidence link once. | OpenInference #3162 triage outcome should inform whether to file under same umbrella or separately |
 
 ## What this experiment deliberately does NOT do
 

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -28,10 +28,18 @@
 Each workload is a self-contained Node 22+ TypeScript project. The
 contract-checker is stdlib Python 3.10+.
 
+All examples below assume `$REPO_ROOT` points at the assay repo
+root, so each block can run independently of where the previous
+one left the shell:
+
+```bash
+export REPO_ROOT="$(git rev-parse --show-toplevel)"
+```
+
 ### workload-openai
 
 ```bash
-cd docs/experiments/cross-runtime-drift-2026-05/workload-openai
+cd "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/workload-openai"
 npm install --no-audit --no-fund --ignore-scripts
 npx tsc -p tsconfig.json
 
@@ -44,7 +52,7 @@ OPENAI_API_KEY="$OPENAI_API_KEY" \
 ### workload-gemini
 
 ```bash
-cd docs/experiments/cross-runtime-drift-2026-05/workload-gemini
+cd "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/workload-gemini"
 npm install --no-audit --no-fund --ignore-scripts
 npx tsc -p tsconfig.json
 
@@ -57,13 +65,14 @@ GOOGLE_API_KEY="$GOOGLE_API_KEY" \
 ### contract-checker
 
 ```bash
-# From the work-dir produced by either workload above:
-python3 docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py \
+# Against the work-dir produced by either workload above. Runs from
+# any cwd thanks to $REPO_ROOT.
+python3 "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py" \
   --work-dir "$WORK"
 
 # Tests (no API keys required):
 python3 -m unittest discover \
-  -s docs/experiments/cross-runtime-drift-2026-05/contract-checker \
+  -s "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/contract-checker" \
   -p 'test_*.py'
 ```
 

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -1,0 +1,98 @@
+# cross-runtime-drift-2026-05
+
+> **Status:** Slice 1 landed. Workload contract written, two runtime
+> implementations runnable locally with API keys, contract-checker
+> validates outputs with 10 stdlib unit tests passing. Slices 2–5
+> still TODO.
+>
+> **Plan-doc:** [`../cross-runtime-drift-2026-05.md`](../cross-runtime-drift-2026-05.md)
+> (research question, drift dimensions, threats to validity, sequencing).
+>
+> **Companion experiment:** [`runner-vs-otel-2026-05/`](../runner-vs-otel-2026-05/)
+> (where the Runner L2 capture + comparator pattern were first proven).
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| [`WORKLOAD_CONTRACT.md`](WORKLOAD_CONTRACT.md) | The rules every workload implementation must satisfy. Slice 1 deliverable. |
+| [`workload-openai/`](workload-openai/) | `@openai/agents` implementation (standard agent loop). |
+| [`workload-gemini/`](workload-gemini/) | `@google/genai` implementation (manual function-calling loop, `automaticFunctionCalling.disable = true`). |
+| [`contract-checker/`](contract-checker/) | Stdlib-only Python validator. Independent of Runner capture. |
+
+`runs/` will appear once Slice 3 dispatches live captures on
+`assay-bpf-runner`. Not present yet.
+
+## Running locally
+
+Each workload is a self-contained Node 22+ TypeScript project. The
+contract-checker is stdlib Python 3.10+.
+
+### workload-openai
+
+```bash
+cd docs/experiments/cross-runtime-drift-2026-05/workload-openai
+npm install --no-audit --no-fund --ignore-scripts
+npx tsc -p tsconfig.json
+
+WORK=$(mktemp -d -t cross-runtime-openai)
+WORKLOAD_WORK_DIR="$WORK" \
+OPENAI_API_KEY="$OPENAI_API_KEY" \
+  node dist/workload.js
+```
+
+### workload-gemini
+
+```bash
+cd docs/experiments/cross-runtime-drift-2026-05/workload-gemini
+npm install --no-audit --no-fund --ignore-scripts
+npx tsc -p tsconfig.json
+
+WORK=$(mktemp -d -t cross-runtime-gemini)
+WORKLOAD_WORK_DIR="$WORK" \
+GOOGLE_API_KEY="$GOOGLE_API_KEY" \
+  node dist/workload.js
+```
+
+### contract-checker
+
+```bash
+# From the work-dir produced by either workload above:
+python3 docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py \
+  --work-dir "$WORK"
+
+# Tests (no API keys required):
+python3 -m unittest discover \
+  -s docs/experiments/cross-runtime-drift-2026-05/contract-checker \
+  -p 'test_*.py'
+```
+
+## What's done in Slice 1
+
+- Open Question #1 resolved: Gemini via `@google/genai`, manual
+  function-calling loop on the Gemini side, `@openai/agents`
+  standard agent loop on the OpenAI side. Asymmetry is part of
+  the runtime drift we want to surface; the workload contract
+  pins it explicitly.
+- Open Question #3 resolved: real model calls (no cassette),
+  `temperature: 0`, tight prompt, contract requires `read_file`
+  then `write_file` and `DONE` reply. Variance in the model's
+  exact terminating string is tolerated; variance in tool-call
+  *sequence* is a contract violation.
+- Both workloads emit `tool-calls.ndjson` and `run-meta.json`
+  per the contract; checker validates without any Runner
+  archive present.
+- 10 contract-checker unit tests cover the happy path for both
+  runtimes plus each individual rule failure mode.
+
+## What's deliberately NOT in Slice 1
+
+- No Runner capture wiring. That arrives in Slice 3 alongside an
+  `assay-bpf-runner` workflow extension.
+- No `compare/drift.py` yet. That is Slice 2 (works against
+  synthetic archives first to lock the output schema).
+- No CI dispatch. `GOOGLE_API_KEY` is local-only until the
+  workload contract is reviewed and Slice 2's comparator schema
+  is stable.
+- No OTel trace emission. The cross-runtime comparison is
+  between two Runner archives; traces are an explicit follow-up.

--- a/docs/experiments/cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md
@@ -118,7 +118,7 @@ the run was captured under Runner.
 |---|---|
 | 0 | Workload completed and (the workload believes) satisfied the contract |
 | 1 | Internal workload error (failed to bootstrap, SDK error, etc.) |
-| 2 | Workload self-detected a contract violation (e.g. agent tried to call an unregistered tool) |
+| 2 | Workload self-detected a contract violation. Fail-fast cases: agent called `read_file` with `path != WORKLOAD_INPUT_PATH`, `write_file` with `path != WORKLOAD_OUTPUT_PATH`, a path outside `WORKLOAD_WORK_DIR`, or an unregistered tool. Both implementations throw a `ContractViolationError` from the tool handler so the side effect never lands on disk. |
 | 3 | Model output rejected (no `DONE` produced within the allowed iterations) |
 
 Contract-checker independently re-verifies; the workload's exit

--- a/docs/experiments/cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md
@@ -1,0 +1,163 @@
+# Workload Contract — cross-runtime-drift-2026-05
+
+> **Purpose:** make "same agent task" *checkable*, not aspirational.
+> Both runtime implementations of the workload must satisfy every
+> rule below. The `contract-checker/check.py` script validates rules
+> 1–6 automatically after a run; rules 7–8 are pinned design
+> decisions enforced by the workload code itself.
+>
+> **Status:** Slice 1 of the
+> [`cross-runtime-drift-2026-05`](../cross-runtime-drift-2026-05.md)
+> experiment. Resolves Open Questions #1 and #3.
+
+## Open Question resolutions baked into this contract
+
+- **Q1 — Second runtime:** Google Gemini via `@google/genai`.
+  Reason: closest semantic parity with `@openai/agents`,
+  single-vendor stack so we are measuring runtime drift not also
+  framework drift.
+- **Q1 sub — Tool-calling mode:** Gemini side uses
+  `automaticFunctionCalling: { disable: true }` and orchestrates
+  the loop in *our* code. OpenAI side uses `@openai/agents` in
+  its standard agent-loop mode. The auto-vs-manual asymmetry
+  **is** part of the runtime drift we want to surface; it is not
+  smuggled in.
+- **Q3 — Determinism:** real model calls with `temperature: 0` +
+  a tight prompt + minimum required tools. We deliberately do
+  *not* use a cassette/fake model here — the whole point is to
+  measure each runtime's actual transport, loader, and SDK
+  machinery against the kernel. Variance in the model's
+  *exact* string output is tolerated; variance in the
+  *tool-call sequence* is a contract violation.
+
+## Inputs
+
+The host (or CI workflow) must provide:
+
+| Env var | Required | Meaning |
+|---|---|---|
+| `WORKLOAD_WORK_DIR` | yes | Absolute path to an empty directory the workload owns for this run |
+| `WORKLOAD_INPUT_PATH` | no, default `$WORKLOAD_WORK_DIR/fixture-input.txt` | File the workload's read tool will be pointed at |
+| `WORKLOAD_OUTPUT_PATH` | no, default `$WORKLOAD_WORK_DIR/fixture-output.txt` | File the workload's write tool must produce |
+| `WORKLOAD_INPUT_CONTENTS` | no, default `cross-runtime drift fixture\n` | Contents written to `WORKLOAD_INPUT_PATH` before the agent runs |
+| `OPENAI_API_KEY` | only for `workload-openai` | OpenAI auth |
+| `GOOGLE_API_KEY` | only for `workload-gemini` | Gemini auth |
+
+The workload **creates `WORKLOAD_INPUT_PATH` itself** with
+`WORKLOAD_INPUT_CONTENTS` before invoking the agent. The
+contract-checker assumes this.
+
+## Tools the workload must register
+
+Both implementations register **exactly these two tools, with
+these names and these signatures**:
+
+```
+read_file(path: string) -> string
+  Returns the UTF-8 contents of `path`.
+  Errors if path is outside WORKLOAD_WORK_DIR or does not exist.
+
+write_file(path: string, contents: string) -> void
+  Writes `contents` (UTF-8) to `path`.
+  Errors if path is outside WORKLOAD_WORK_DIR.
+```
+
+No other tools, no MCP servers, no extra helpers. Any deviation
+is a workload bug, not a drift signal.
+
+## The prompt
+
+Both implementations send **exactly the same user prompt**:
+
+> Read the file at `${WORKLOAD_INPUT_PATH}`, uppercase its
+> contents, then write the result to `${WORKLOAD_OUTPUT_PATH}`.
+> Call `read_file` first and `write_file` second. Do not call
+> any other tool. When done, reply with the single word `DONE`.
+
+`WORKLOAD_INPUT_PATH` and `WORKLOAD_OUTPUT_PATH` are interpolated
+into the prompt as absolute paths before sending.
+
+System / instruction message (also identical):
+
+> You are a deterministic agent. Use the provided tools to do
+> exactly what the user asked. Do not paraphrase the task. Do
+> not add commentary. Reply with the literal word `DONE` when
+> the work is complete.
+
+## Required tool-call sequence
+
+The agent **must** invoke tools in this order:
+
+1. `read_file(path = WORKLOAD_INPUT_PATH)`
+2. `write_file(path = WORKLOAD_OUTPUT_PATH, contents = <uppercase of step-1 result>)`
+
+Any other order, any other tool, any repeated invocation of
+either tool, or any extra invocations counts as a contract
+violation. The contract-checker enforces this by reading a
+`tool-calls.ndjson` file the workload writes (see Outputs).
+
+## Outputs
+
+Each workload run must produce, in `$WORKLOAD_WORK_DIR`:
+
+| File | Required | Format | Used by |
+|---|---|---|---|
+| `fixture-input.txt` (or override) | yes | Pre-seeded by the workload | the read tool |
+| `fixture-output.txt` (or override) | yes | Written by the write tool | contract-checker |
+| `tool-calls.ndjson` | yes | One JSON object per line: `{"seq": int, "tool": string, "args": {...}}` | contract-checker |
+| `run-meta.json` | yes | `{"runtime": "openai-agents" \| "gemini-genai", "model": "...", "sdk_version": "...", "started_at": "...", "ended_at": "...", "exit_code": 0}` | contract-checker + future drift reports |
+
+`tool-calls.ndjson` is written by the workload itself
+(instrumented inside the tool handlers), *not* derived from
+Runner archives. Contract conformance is independent of whether
+the run was captured under Runner.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Workload completed and (the workload believes) satisfied the contract |
+| 1 | Internal workload error (failed to bootstrap, SDK error, etc.) |
+| 2 | Workload self-detected a contract violation (e.g. agent tried to call an unregistered tool) |
+| 3 | Model output rejected (no `DONE` produced within the allowed iterations) |
+
+Contract-checker independently re-verifies; the workload's exit
+code is advisory, not authoritative.
+
+## Validation rules (automatically enforced by `contract-checker/check.py`)
+
+Given `$WORKLOAD_WORK_DIR`, the checker confirms:
+
+1. `fixture-output.txt` exists and is non-empty.
+2. `fixture-output.txt` equals `WORKLOAD_INPUT_CONTENTS` uppercased.
+3. `tool-calls.ndjson` exists, has exactly two lines.
+4. Line 1: `tool == "read_file"`, `args.path == WORKLOAD_INPUT_PATH`.
+5. Line 2: `tool == "write_file"`, `args.path == WORKLOAD_OUTPUT_PATH`,
+   `args.contents == WORKLOAD_INPUT_CONTENTS.upper()`.
+6. `run-meta.json` exists and parses; `exit_code == 0`; `runtime`
+   matches one of the two allowed values.
+7. (Design rule, not auto-checked) Both implementations use the
+   tool-calling mode pinned in this contract: `@openai/agents`
+   standard agent loop on the OpenAI side, `@google/genai` with
+   `automaticFunctionCalling.disable = true` on the Gemini side.
+8. (Design rule, not auto-checked) No additional tools, MCP
+   servers, or external services are invoked from the workload
+   code. Whatever extra surface appears in a Runner capture is
+   runtime-induced, not workload-induced.
+
+## What this contract does NOT specify
+
+- **Latency or token counts.** Out of scope for the drift
+  experiment. Will be measured separately if at all.
+- **Exact model version.** Both workloads pin a model in
+  `run-meta.json`, but the contract does not require both to use
+  the same family. The plan-doc's "single snapshot in time" caveat
+  applies.
+- **Exact text of the model's terminating reply** beyond requiring
+  the literal `DONE`. Models may add or omit punctuation; the
+  contract accepts `DONE`, `DONE.`, `DONE!`, etc.
+- **OTel trace emission.** The runner-vs-otel-2026-05 experiment
+  proved binding + tool-level join with OTel traces. For
+  cross-runtime-drift the comparison is between two Runner
+  archives, not traces. Traces may be added later; they are not
+  part of Slice 1.

--- a/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Validate that a cross-runtime-drift workload run satisfied the contract.
+
+See WORKLOAD_CONTRACT.md for the rules enforced here. This script is
+stdlib-only by policy. Independent of Runner capture — runs against the
+work directory the workload itself produced.
+
+Exit codes:
+  0 - all rules pass
+  2 - one or more rules failed (details on stderr)
+  3 - bad inputs (work-dir missing, unreadable JSON, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+ALLOWED_RUNTIMES = {"openai-agents", "gemini-genai"}
+DEFAULT_INPUT_CONTENTS = "cross-runtime drift fixture\n"
+
+
+@dataclass
+class CheckResult:
+    rule: str
+    passed: bool
+    detail: str
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_ndjson(path: Path) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        out.append(json.loads(line))
+    return out
+
+
+def _result(rule: str, passed: bool, detail: str = "") -> CheckResult:
+    return CheckResult(rule=rule, passed=passed, detail=detail)
+
+
+def check_output_exists(output_path: Path) -> CheckResult:
+    if not output_path.is_file():
+        return _result(
+            "1. fixture-output.txt exists and is non-empty",
+            False,
+            f"missing or not a file: {output_path}",
+        )
+    if output_path.stat().st_size == 0:
+        return _result(
+            "1. fixture-output.txt exists and is non-empty",
+            False,
+            f"file exists but is empty: {output_path}",
+        )
+    return _result("1. fixture-output.txt exists and is non-empty", True)
+
+
+def check_output_uppercased(
+    output_path: Path, expected_contents: str
+) -> CheckResult:
+    actual = output_path.read_text(encoding="utf-8")
+    expected = expected_contents.upper()
+    if actual != expected:
+        return _result(
+            "2. fixture-output.txt equals input uppercased",
+            False,
+            f"expected {expected!r}, got {actual!r}",
+        )
+    return _result("2. fixture-output.txt equals input uppercased", True)
+
+
+def check_tool_calls_two_lines(
+    tool_calls_path: Path,
+) -> tuple[CheckResult, list[dict[str, Any]] | None]:
+    if not tool_calls_path.is_file():
+        return (
+            _result(
+                "3. tool-calls.ndjson exists, has exactly two lines",
+                False,
+                f"missing: {tool_calls_path}",
+            ),
+            None,
+        )
+    calls = _load_ndjson(tool_calls_path)
+    if len(calls) != 2:
+        return (
+            _result(
+                "3. tool-calls.ndjson exists, has exactly two lines",
+                False,
+                f"expected 2 calls, got {len(calls)}",
+            ),
+            calls,
+        )
+    return (
+        _result("3. tool-calls.ndjson exists, has exactly two lines", True),
+        calls,
+    )
+
+
+def check_first_call_read(
+    calls: list[dict[str, Any]], input_path: Path
+) -> CheckResult:
+    call = calls[0]
+    if call.get("tool") != "read_file":
+        return _result(
+            "4. line 1: read_file with correct path",
+            False,
+            f"first tool is {call.get('tool')!r}, expected 'read_file'",
+        )
+    args = call.get("args", {})
+    if str(args.get("path")) != str(input_path):
+        return _result(
+            "4. line 1: read_file with correct path",
+            False,
+            f"expected path {input_path}, got {args.get('path')}",
+        )
+    return _result("4. line 1: read_file with correct path", True)
+
+
+def check_second_call_write(
+    calls: list[dict[str, Any]],
+    output_path: Path,
+    expected_contents: str,
+) -> CheckResult:
+    call = calls[1]
+    if call.get("tool") != "write_file":
+        return _result(
+            "5. line 2: write_file with correct path + contents",
+            False,
+            f"second tool is {call.get('tool')!r}, expected 'write_file'",
+        )
+    args = call.get("args", {})
+    if str(args.get("path")) != str(output_path):
+        return _result(
+            "5. line 2: write_file with correct path + contents",
+            False,
+            f"expected path {output_path}, got {args.get('path')}",
+        )
+    actual = str(args.get("contents", ""))
+    expected = expected_contents.upper()
+    if actual != expected:
+        return _result(
+            "5. line 2: write_file with correct path + contents",
+            False,
+            f"expected contents {expected!r}, got {actual!r}",
+        )
+    return _result(
+        "5. line 2: write_file with correct path + contents", True
+    )
+
+
+def check_run_meta(meta_path: Path) -> CheckResult:
+    if not meta_path.is_file():
+        return _result(
+            "6. run-meta.json exists, exit_code=0, runtime allowed",
+            False,
+            f"missing: {meta_path}",
+        )
+    try:
+        meta = _load_json(meta_path)
+    except json.JSONDecodeError as exc:
+        return _result(
+            "6. run-meta.json exists, exit_code=0, runtime allowed",
+            False,
+            f"invalid JSON: {exc}",
+        )
+    issues: list[str] = []
+    if meta.get("exit_code") != 0:
+        issues.append(f"exit_code={meta.get('exit_code')!r}")
+    if meta.get("runtime") not in ALLOWED_RUNTIMES:
+        issues.append(
+            f"runtime={meta.get('runtime')!r} not in {sorted(ALLOWED_RUNTIMES)}"
+        )
+    if issues:
+        return _result(
+            "6. run-meta.json exists, exit_code=0, runtime allowed",
+            False,
+            "; ".join(issues),
+        )
+    return _result(
+        "6. run-meta.json exists, exit_code=0, runtime allowed", True
+    )
+
+
+def run_checks(
+    work_dir: Path,
+    input_path: Path,
+    output_path: Path,
+    input_contents: str,
+) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    results.append(check_output_exists(output_path))
+    if results[-1].passed:
+        results.append(check_output_uppercased(output_path, input_contents))
+    else:
+        results.append(
+            _result(
+                "2. fixture-output.txt equals input uppercased",
+                False,
+                "skipped (rule 1 failed)",
+            )
+        )
+
+    tool_calls_path = work_dir / "tool-calls.ndjson"
+    r3, calls = check_tool_calls_two_lines(tool_calls_path)
+    results.append(r3)
+    if r3.passed and calls is not None:
+        results.append(check_first_call_read(calls, input_path))
+        results.append(
+            check_second_call_write(calls, output_path, input_contents)
+        )
+    else:
+        results.append(
+            _result(
+                "4. line 1: read_file with correct path",
+                False,
+                "skipped (rule 3 failed)",
+            )
+        )
+        results.append(
+            _result(
+                "5. line 2: write_file with correct path + contents",
+                False,
+                "skipped (rule 3 failed)",
+            )
+        )
+
+    results.append(check_run_meta(work_dir / "run-meta.json"))
+    return results
+
+
+def render_results(results: Iterable[CheckResult]) -> str:
+    lines: list[str] = []
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        detail = f" — {r.detail}" if r.detail else ""
+        lines.append(f"[{status}] {r.rule}{detail}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--work-dir",
+        required=True,
+        type=Path,
+        help="Path to the workload's WORK_DIR (where it wrote outputs).",
+    )
+    parser.add_argument(
+        "--input-path",
+        type=Path,
+        help=(
+            "Override expected input path. Defaults to "
+            "<work-dir>/fixture-input.txt."
+        ),
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        help=(
+            "Override expected output path. Defaults to "
+            "<work-dir>/fixture-output.txt."
+        ),
+    )
+    parser.add_argument(
+        "--input-contents",
+        default=DEFAULT_INPUT_CONTENTS,
+        help=(
+            "Override the expected pre-seeded input contents. Defaults to "
+            f"{DEFAULT_INPUT_CONTENTS!r}."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    work_dir: Path = args.work_dir.resolve()
+    if not work_dir.is_dir():
+        print(f"work-dir is not a directory: {work_dir}", file=sys.stderr)
+        return 3
+
+    input_path = (
+        args.input_path.resolve()
+        if args.input_path
+        else work_dir / "fixture-input.txt"
+    )
+    output_path = (
+        args.output_path.resolve()
+        if args.output_path
+        else work_dir / "fixture-output.txt"
+    )
+
+    results = run_checks(work_dir, input_path, output_path, args.input_contents)
+    print(render_results(results))
+
+    if all(r.passed for r in results):
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py
@@ -5,10 +5,14 @@ See WORKLOAD_CONTRACT.md for the rules enforced here. This script is
 stdlib-only by policy. Independent of Runner capture — runs against the
 work directory the workload itself produced.
 
+Output:
+  Per-rule PASS/FAIL lines are written to stdout. Bad-input messages
+  (exit 3) are written to stderr.
+
 Exit codes:
   0 - all rules pass
-  2 - one or more rules failed (details on stderr)
-  3 - bad inputs (work-dir missing, unreadable JSON, etc.)
+  2 - one or more rules failed (details on stdout)
+  3 - bad inputs (work-dir missing, unreadable JSON, etc.) — message on stderr
 """
 from __future__ import annotations
 

--- a/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py
@@ -23,6 +23,12 @@ ALLOWED_RUNTIMES = {"openai-agents", "gemini-genai"}
 DEFAULT_INPUT_CONTENTS = "cross-runtime drift fixture\n"
 
 
+class BadInputError(Exception):
+    """Raised when an artifact is present but unreadable (corrupt JSON,
+    decode error, etc.). Surfaced as exit code 3 — the contract cannot be
+    evaluated, distinct from a rule failure (exit 2)."""
+
+
 @dataclass
 class CheckResult:
     rule: str
@@ -31,15 +37,29 @@ class CheckResult:
 
 
 def _load_json(path: Path) -> Any:
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise BadInputError(f"{path}: invalid JSON: {exc}") from exc
+    except UnicodeDecodeError as exc:
+        raise BadInputError(f"{path}: invalid UTF-8: {exc}") from exc
 
 
 def _load_ndjson(path: Path) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise BadInputError(f"{path}: invalid UTF-8: {exc}") from exc
+    for lineno, line in enumerate(text.splitlines(), start=1):
         if not line.strip():
             continue
-        out.append(json.loads(line))
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            raise BadInputError(
+                f"{path}:{lineno}: invalid JSON: {exc}"
+            ) from exc
     return out
 
 
@@ -164,14 +184,10 @@ def check_run_meta(meta_path: Path) -> CheckResult:
             False,
             f"missing: {meta_path}",
         )
-    try:
-        meta = _load_json(meta_path)
-    except json.JSONDecodeError as exc:
-        return _result(
-            "6. run-meta.json exists, exit_code=0, runtime allowed",
-            False,
-            f"invalid JSON: {exc}",
-        )
+    # Corrupt JSON bubbles up as BadInputError (exit 3), distinct from
+    # rule-violation (exit 2). The "rule failed" case is reserved for
+    # well-formed-but-wrong content like a non-allowed runtime string.
+    meta = _load_json(meta_path)
     issues: list[str] = []
     if meta.get("exit_code") != 0:
         issues.append(f"exit_code={meta.get('exit_code')!r}")
@@ -280,23 +296,34 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    work_dir: Path = args.work_dir.resolve()
+    # Use .absolute() (not .resolve()) so we do not collapse macOS
+    # /var/... -> /private/var/... symlinks. The Node workloads use
+    # `path.resolve()`, which also stops at filesystem-symlink boundaries.
+    # The two sides must agree, otherwise local mktemp -d runs falsely
+    # fail the path-equality rules.
+    work_dir: Path = args.work_dir.absolute()
     if not work_dir.is_dir():
         print(f"work-dir is not a directory: {work_dir}", file=sys.stderr)
         return 3
 
     input_path = (
-        args.input_path.resolve()
+        args.input_path.absolute()
         if args.input_path
         else work_dir / "fixture-input.txt"
     )
     output_path = (
-        args.output_path.resolve()
+        args.output_path.absolute()
         if args.output_path
         else work_dir / "fixture-output.txt"
     )
 
-    results = run_checks(work_dir, input_path, output_path, args.input_contents)
+    try:
+        results = run_checks(
+            work_dir, input_path, output_path, args.input_contents
+        )
+    except BadInputError as exc:
+        print(f"bad input: {exc}", file=sys.stderr)
+        return 3
     print(render_results(results))
 
     if all(r.passed for r in results):

--- a/docs/experiments/cross-runtime-drift-2026-05/contract-checker/test_check.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/contract-checker/test_check.py
@@ -1,0 +1,180 @@
+"""Unit tests for the workload contract checker.
+
+Stdlib unittest only. Simulates a workload's WORK_DIR layout and exercises
+both the happy path and each individual rule failure mode.
+
+Run: python3 -m unittest contract-checker/test_check.py
+or:  python3 -m unittest discover -s contract-checker -p 'test_*.py'
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+
+import check  # noqa: E402  (after sys.path tweak)
+
+
+def write_valid_workdir(
+    tmpdir: Path,
+    *,
+    runtime: str = "openai-agents",
+    input_contents: str = "cross-runtime drift fixture\n",
+    output_contents: str | None = None,
+    tool_calls: list[dict] | None = None,
+    exit_code: int = 0,
+) -> tuple[Path, Path, Path]:
+    """Materialize a workdir that should pass all checks by default."""
+    input_path = tmpdir / "fixture-input.txt"
+    output_path = tmpdir / "fixture-output.txt"
+    input_path.write_text(input_contents, encoding="utf-8")
+    output_path.write_text(
+        output_contents
+        if output_contents is not None
+        else input_contents.upper(),
+        encoding="utf-8",
+    )
+    if tool_calls is None:
+        tool_calls = [
+            {"seq": 1, "tool": "read_file", "args": {"path": str(input_path)}},
+            {
+                "seq": 2,
+                "tool": "write_file",
+                "args": {
+                    "path": str(output_path),
+                    "contents": input_contents.upper(),
+                },
+            },
+        ]
+    (tmpdir / "tool-calls.ndjson").write_text(
+        "\n".join(json.dumps(c) for c in tool_calls) + "\n",
+        encoding="utf-8",
+    )
+    (tmpdir / "run-meta.json").write_text(
+        json.dumps(
+            {
+                "runtime": runtime,
+                "model": "test-model",
+                "sdk_version": "0.0.0",
+                "started_at": "2026-05-25T00:00:00Z",
+                "ended_at": "2026-05-25T00:00:01Z",
+                "exit_code": exit_code,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return input_path, output_path, tmpdir
+
+
+class HappyPathTests(unittest.TestCase):
+    def test_openai_runtime_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            write_valid_workdir(tmpdir, runtime="openai-agents")
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 0)
+
+    def test_gemini_runtime_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            write_valid_workdir(tmpdir, runtime="gemini-genai")
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 0)
+
+
+class RuleFailureTests(unittest.TestCase):
+    def test_missing_output_file_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            write_valid_workdir(tmpdir)
+            (tmpdir / "fixture-output.txt").unlink()
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 2)
+
+    def test_empty_output_file_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            write_valid_workdir(tmpdir, output_contents="")
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 2)
+
+    def test_wrong_case_output_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            write_valid_workdir(
+                tmpdir, output_contents="not uppercased\n"
+            )
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 2)
+
+    def test_three_tool_calls_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            extra_call = {
+                "seq": 3,
+                "tool": "read_file",
+                "args": {"path": str(tmpdir / "fixture-input.txt")},
+            }
+            write_valid_workdir(tmpdir)
+            # Append an extra call to break rule 3.
+            with (tmpdir / "tool-calls.ndjson").open(
+                "a", encoding="utf-8"
+            ) as f:
+                f.write(json.dumps(extra_call) + "\n")
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 2)
+
+    def test_wrong_first_tool_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            input_path = tmpdir / "fixture-input.txt"
+            output_path = tmpdir / "fixture-output.txt"
+            bad_calls = [
+                {
+                    "seq": 1,
+                    "tool": "write_file",
+                    "args": {
+                        "path": str(output_path),
+                        "contents": "WHATEVER",
+                    },
+                },
+                {
+                    "seq": 2,
+                    "tool": "read_file",
+                    "args": {"path": str(input_path)},
+                },
+            ]
+            write_valid_workdir(tmpdir, tool_calls=bad_calls)
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 2)
+
+    def test_wrong_runtime_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            write_valid_workdir(tmpdir, runtime="anthropic-claude")
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 2)
+
+    def test_nonzero_exit_code_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            write_valid_workdir(tmpdir, exit_code=2)
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 2)
+
+
+class BadInputTests(unittest.TestCase):
+    def test_missing_workdir_returns_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            rc = check.main(["--work-dir", os.path.join(tmp, "nope")])
+            self.assertEqual(rc, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/experiments/cross-runtime-drift-2026-05/contract-checker/test_check.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/contract-checker/test_check.py
@@ -3,8 +3,16 @@
 Stdlib unittest only. Simulates a workload's WORK_DIR layout and exercises
 both the happy path and each individual rule failure mode.
 
-Run: python3 -m unittest contract-checker/test_check.py
-or:  python3 -m unittest discover -s contract-checker -p 'test_*.py'
+Run from repo root:
+  python3 -m unittest discover \
+    -s docs/experiments/cross-runtime-drift-2026-05/contract-checker \
+    -p 'test_*.py'
+Or directly:
+  python3 docs/experiments/cross-runtime-drift-2026-05/contract-checker/test_check.py
+
+(`python3 -m unittest <module>` cannot be used because the
+directory name contains a hyphen, which Python's module
+importer rejects. Use the discover form above instead.)
 """
 from __future__ import annotations
 

--- a/docs/experiments/cross-runtime-drift-2026-05/contract-checker/test_check.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/contract-checker/test_check.py
@@ -175,6 +175,90 @@ class BadInputTests(unittest.TestCase):
             rc = check.main(["--work-dir", os.path.join(tmp, "nope")])
             self.assertEqual(rc, 3)
 
+    def test_malformed_tool_calls_ndjson_returns_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            write_valid_workdir(tmpdir)
+            (tmpdir / "tool-calls.ndjson").write_text(
+                "{bad json}\n", encoding="utf-8"
+            )
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 3)
+
+    def test_malformed_run_meta_json_returns_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            write_valid_workdir(tmpdir)
+            (tmpdir / "run-meta.json").write_text(
+                "{not valid", encoding="utf-8"
+            )
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 3)
+
+
+class PathCanonicalizationTests(unittest.TestCase):
+    """The checker must NOT collapse symlinks via Path.resolve(), because
+    the Node workloads use path.resolve() which stops at filesystem
+    symlinks. On macOS, /var is a symlink to /private/var, so collapsing
+    would falsely fail path-equality rules on local mktemp -d runs."""
+
+    def test_workdir_passed_as_symlink_path_is_not_canonicalized(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_real:
+            real_dir = Path(tmp_real).resolve()
+            # Build a symlink that points at the real workdir under a
+            # different prefix.
+            symlink_dir = real_dir.parent / (real_dir.name + "-symlink")
+            try:
+                symlink_dir.symlink_to(real_dir, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                self.skipTest("filesystem does not support symlinks")
+
+            try:
+                # Record tool-calls with the symlink-prefix path (what a
+                # Node workload's path.resolve() would produce if the
+                # user passed the symlink as WORKLOAD_WORK_DIR).
+                input_path = symlink_dir / "fixture-input.txt"
+                output_path = symlink_dir / "fixture-output.txt"
+                contents = "cross-runtime drift fixture\n"
+                input_path.write_text(contents, encoding="utf-8")
+                output_path.write_text(contents.upper(), encoding="utf-8")
+                tool_calls = [
+                    {
+                        "seq": 1,
+                        "tool": "read_file",
+                        "args": {"path": str(input_path)},
+                    },
+                    {
+                        "seq": 2,
+                        "tool": "write_file",
+                        "args": {
+                            "path": str(output_path),
+                            "contents": contents.upper(),
+                        },
+                    },
+                ]
+                (symlink_dir / "tool-calls.ndjson").write_text(
+                    "\n".join(json.dumps(c) for c in tool_calls) + "\n",
+                    encoding="utf-8",
+                )
+                (symlink_dir / "run-meta.json").write_text(
+                    json.dumps(
+                        {
+                            "runtime": "openai-agents",
+                            "model": "test-model",
+                            "sdk_version": "0.0.0",
+                            "started_at": "2026-05-25T00:00:00Z",
+                            "ended_at": "2026-05-25T00:00:01Z",
+                            "exit_code": 0,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                rc = check.main(["--work-dir", str(symlink_dir)])
+                self.assertEqual(rc, 0)
+            finally:
+                symlink_dir.unlink(missing_ok=True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/package.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "cross-runtime-drift-workload-gemini",
+  "version": "0.0.0",
+  "private": true,
+  "type": "commonjs",
+  "engines": {
+    "node": ">=22"
+  },
+  "description": "Google @google/genai implementation of the cross-runtime-drift-2026-05 workload contract. Manual function-calling loop (automaticFunctionCalling.disable = true). Real Gemini API calls. Not published.",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/workload.js"
+  },
+  "dependencies": {
+    "@google/genai": "2.6.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
@@ -17,7 +17,7 @@ import {
   appendFileSync,
   statSync,
 } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, relative, isAbsolute } from "node:path";
 import {
   GoogleGenAI,
   type Content,
@@ -82,7 +82,15 @@ class ContractViolationError extends Error {
 
 function ensureInsideWorkDir(workDir: string, candidate: string): string {
   const abs = resolve(candidate);
-  if (!abs.startsWith(workDir + "/") && abs !== workDir) {
+  // Use path.relative() instead of a "/" string-prefix check so the
+  // containment test is portable across path separators. A candidate is
+  // inside workDir iff relative(workDir, abs) is empty (same path),
+  // does not start with "..", and is not absolute (different drive on
+  // Windows).
+  const rel = relative(workDir, abs);
+  const insideOrSame =
+    rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  if (!insideOrSame) {
     throw new ContractViolationError(
       `Path ${candidate} is outside WORKLOAD_WORK_DIR (${workDir})`,
     );

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
@@ -67,14 +67,39 @@ function loadEnv(): WorkloadEnv {
   };
 }
 
+/**
+ * Contract violation: the model asked for an action the workload contract
+ * does not allow (path outside WORK_DIR, wrong path for tool, etc.). The
+ * outer try/catch turns this into exit code 2. Distinct from generic
+ * Errors which become exit code 1.
+ */
+class ContractViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContractViolationError";
+  }
+}
+
 function ensureInsideWorkDir(workDir: string, candidate: string): string {
   const abs = resolve(candidate);
   if (!abs.startsWith(workDir + "/") && abs !== workDir) {
-    throw new Error(
+    throw new ContractViolationError(
       `Path ${candidate} is outside WORKLOAD_WORK_DIR (${workDir})`,
     );
   }
   return abs;
+}
+
+function assertPathEquals(
+  toolName: string,
+  expected: string,
+  candidate: string,
+): void {
+  if (candidate !== expected) {
+    throw new ContractViolationError(
+      `${toolName}: path mismatch — expected ${expected}, got ${candidate}`,
+    );
+  }
 }
 
 function appendToolCall(
@@ -192,6 +217,7 @@ async function runManualLoop(
           env.workDir,
           String(args.path ?? ""),
         );
+        assertPathEquals("read_file", env.inputPath, path);
         appendToolCall(toolCallsPath, seq, "read_file", { path });
         const data = readFileSync(path, "utf-8");
         responseParts.push({
@@ -205,6 +231,7 @@ async function runManualLoop(
           env.workDir,
           String(args.path ?? ""),
         );
+        assertPathEquals("write_file", env.outputPath, path);
         const fileContents = String(args.contents ?? "");
         appendToolCall(toolCallsPath, seq, "write_file", {
           path,
@@ -255,7 +282,11 @@ async function main(): Promise<number> {
     outcome = await runManualLoop(ai, env, toolCallsPath, seq);
   } catch (err) {
     process.stderr.write(`workload-gemini error: ${(err as Error).message}\n`);
-    outcome = { exitCode: 1, modelReply: "" };
+    if (err instanceof ContractViolationError) {
+      outcome = { exitCode: 2, modelReply: (err as Error).message };
+    } else {
+      outcome = { exitCode: 1, modelReply: "" };
+    }
   }
   const endedAt = new Date().toISOString();
 

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
@@ -1,0 +1,304 @@
+/**
+ * cross-runtime-drift-2026-05 — workload-gemini
+ *
+ * Implements the workload contract using @google/genai with manual
+ * function-calling (automaticFunctionCalling.disable = true). The
+ * dispatch loop is OUR code so the wrapper is visible/deterministic
+ * and SDK auto-dispatch does not silently add drift.
+ *
+ * See WORKLOAD_CONTRACT.md for the rules every workload implementation
+ * must satisfy.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  appendFileSync,
+  statSync,
+} from "node:fs";
+import { resolve, dirname } from "node:path";
+import {
+  GoogleGenAI,
+  type Content,
+  type FunctionCall,
+  type FunctionDeclaration,
+  type Part,
+} from "@google/genai";
+
+interface WorkloadEnv {
+  workDir: string;
+  inputPath: string;
+  outputPath: string;
+  inputContents: string;
+  model: string;
+  apiKey: string;
+}
+
+function loadEnv(): WorkloadEnv {
+  const workDir = process.env.WORKLOAD_WORK_DIR;
+  if (!workDir) {
+    throw new Error("WORKLOAD_WORK_DIR is required");
+  }
+  const apiKey = process.env.GOOGLE_API_KEY;
+  if (!apiKey) {
+    throw new Error("GOOGLE_API_KEY is required");
+  }
+  const absWorkDir = resolve(workDir);
+  mkdirSync(absWorkDir, { recursive: true });
+
+  const inputPath = resolve(
+    process.env.WORKLOAD_INPUT_PATH ?? `${absWorkDir}/fixture-input.txt`,
+  );
+  const outputPath = resolve(
+    process.env.WORKLOAD_OUTPUT_PATH ?? `${absWorkDir}/fixture-output.txt`,
+  );
+  const inputContents =
+    process.env.WORKLOAD_INPUT_CONTENTS ?? "cross-runtime drift fixture\n";
+  const model = process.env.WORKLOAD_MODEL ?? "gemini-2.0-flash";
+
+  return {
+    workDir: absWorkDir,
+    inputPath,
+    outputPath,
+    inputContents,
+    model,
+    apiKey,
+  };
+}
+
+function ensureInsideWorkDir(workDir: string, candidate: string): string {
+  const abs = resolve(candidate);
+  if (!abs.startsWith(workDir + "/") && abs !== workDir) {
+    throw new Error(
+      `Path ${candidate} is outside WORKLOAD_WORK_DIR (${workDir})`,
+    );
+  }
+  return abs;
+}
+
+function appendToolCall(
+  toolCallsPath: string,
+  seqRef: { value: number },
+  tool: string,
+  args: Record<string, unknown>,
+): void {
+  seqRef.value += 1;
+  const line = JSON.stringify({ seq: seqRef.value, tool, args }) + "\n";
+  appendFileSync(toolCallsPath, line, { encoding: "utf-8" });
+}
+
+const readFileDecl: FunctionDeclaration = {
+  name: "read_file",
+  description: "Read a UTF-8 file from the workload work directory.",
+  parametersJsonSchema: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "Absolute path to the file to read.",
+      },
+    },
+    required: ["path"],
+  },
+};
+
+const writeFileDecl: FunctionDeclaration = {
+  name: "write_file",
+  description: "Write UTF-8 contents to a file inside the work directory.",
+  parametersJsonSchema: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "Absolute path to the file to write.",
+      },
+      contents: {
+        type: "string",
+        description: "UTF-8 contents to write.",
+      },
+    },
+    required: ["path", "contents"],
+  },
+};
+
+const SYSTEM_INSTRUCTION =
+  "You are a deterministic agent. Use the provided tools to do exactly " +
+  "what the user asked. Do not paraphrase the task. Do not add " +
+  "commentary. Reply with the literal word `DONE` when the work is " +
+  "complete.";
+
+const MAX_LOOP_ITERATIONS = 6;
+
+interface DispatchOutcome {
+  exitCode: number;
+  modelReply: string;
+}
+
+async function runManualLoop(
+  ai: GoogleGenAI,
+  env: WorkloadEnv,
+  toolCallsPath: string,
+  seq: { value: number },
+): Promise<DispatchOutcome> {
+  const prompt =
+    `Read the file at \`${env.inputPath}\`, uppercase its contents, then ` +
+    `write the result to \`${env.outputPath}\`. Call \`read_file\` first ` +
+    `and \`write_file\` second. Do not call any other tool. When done, ` +
+    `reply with the single word \`DONE\`.`;
+
+  const contents: Content[] = [
+    { role: "user", parts: [{ text: prompt }] },
+  ];
+
+  for (let iter = 0; iter < MAX_LOOP_ITERATIONS; iter += 1) {
+    const response = await ai.models.generateContent({
+      model: env.model,
+      contents,
+      config: {
+        temperature: 0,
+        systemInstruction: SYSTEM_INSTRUCTION,
+        tools: [
+          { functionDeclarations: [readFileDecl, writeFileDecl] },
+        ],
+        automaticFunctionCalling: { disable: true },
+      },
+    });
+
+    const calls: FunctionCall[] | undefined = response.functionCalls;
+
+    if (!calls || calls.length === 0) {
+      const text = String(response.text ?? "").trim();
+      if (/^DONE[.!]?$/i.test(text)) {
+        return { exitCode: 0, modelReply: text };
+      }
+      return { exitCode: 3, modelReply: text };
+    }
+
+    // Echo the model's function-call turn into history so the SDK keeps
+    // the conversation coherent. parts must be { functionCall: ... }.
+    contents.push({
+      role: "model",
+      parts: calls.map((c) => ({ functionCall: c }) as Part),
+    });
+
+    const responseParts: Part[] = [];
+    for (const call of calls) {
+      const name = call.name ?? "";
+      const args = (call.args ?? {}) as Record<string, unknown>;
+
+      if (name === "read_file") {
+        const path = ensureInsideWorkDir(
+          env.workDir,
+          String(args.path ?? ""),
+        );
+        appendToolCall(toolCallsPath, seq, "read_file", { path });
+        const data = readFileSync(path, "utf-8");
+        responseParts.push({
+          functionResponse: {
+            name,
+            response: { output: data },
+          },
+        });
+      } else if (name === "write_file") {
+        const path = ensureInsideWorkDir(
+          env.workDir,
+          String(args.path ?? ""),
+        );
+        const fileContents = String(args.contents ?? "");
+        appendToolCall(toolCallsPath, seq, "write_file", {
+          path,
+          contents: fileContents,
+        });
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, fileContents, { encoding: "utf-8" });
+        responseParts.push({
+          functionResponse: {
+            name,
+            response: { output: "ok" },
+          },
+        });
+      } else {
+        // Unregistered tool — contract violation. Surface upstream.
+        return {
+          exitCode: 2,
+          modelReply: `model invoked unknown tool: ${name}`,
+        };
+      }
+    }
+
+    contents.push({ role: "user", parts: responseParts });
+  }
+
+  return {
+    exitCode: 3,
+    modelReply: `loop exceeded ${MAX_LOOP_ITERATIONS} iterations without DONE`,
+  };
+}
+
+async function main(): Promise<number> {
+  const env = loadEnv();
+  const toolCallsPath = `${env.workDir}/tool-calls.ndjson`;
+  const metaPath = `${env.workDir}/run-meta.json`;
+
+  writeFileSync(toolCallsPath, "", { encoding: "utf-8" });
+
+  mkdirSync(dirname(env.inputPath), { recursive: true });
+  writeFileSync(env.inputPath, env.inputContents, { encoding: "utf-8" });
+
+  const seq = { value: 0 };
+  const ai = new GoogleGenAI({ apiKey: env.apiKey });
+
+  const startedAt = new Date().toISOString();
+  let outcome: DispatchOutcome = { exitCode: 1, modelReply: "" };
+  try {
+    outcome = await runManualLoop(ai, env, toolCallsPath, seq);
+  } catch (err) {
+    process.stderr.write(`workload-gemini error: ${(err as Error).message}\n`);
+    outcome = { exitCode: 1, modelReply: "" };
+  }
+  const endedAt = new Date().toISOString();
+
+  if (outcome.exitCode === 0) {
+    try {
+      const st = statSync(env.outputPath);
+      if (!st.isFile() || st.size === 0) {
+        outcome.exitCode = 2;
+      }
+    } catch {
+      outcome.exitCode = 2;
+    }
+  }
+
+  const sdkVersion: string = (() => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const pkg = require("@google/genai/package.json") as { version: string };
+      return pkg.version;
+    } catch {
+      return "unknown";
+    }
+  })();
+
+  const meta = {
+    runtime: "gemini-genai",
+    model: env.model,
+    sdk_version: sdkVersion,
+    started_at: startedAt,
+    ended_at: endedAt,
+    exit_code: outcome.exitCode,
+    model_reply: outcome.modelReply,
+  };
+  writeFileSync(metaPath, JSON.stringify(meta, null, 2) + "\n", {
+    encoding: "utf-8",
+  });
+
+  return outcome.exitCode;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    process.stderr.write(`workload-gemini fatal: ${(err as Error).stack ?? err}\n`);
+    process.exit(1);
+  });

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/tsconfig.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-openai/package.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-openai/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cross-runtime-drift-workload-openai",
+  "version": "0.0.0",
+  "private": true,
+  "type": "commonjs",
+  "engines": {
+    "node": ">=22"
+  },
+  "description": "OpenAI Agents SDK implementation of the cross-runtime-drift-2026-05 workload contract. Real OpenAI API calls (no cassette). Not published.",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/workload.js"
+  },
+  "dependencies": {
+    "@openai/agents": "0.11.4",
+    "zod": "4.1.13"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
@@ -1,0 +1,195 @@
+/**
+ * cross-runtime-drift-2026-05 — workload-openai
+ *
+ * Implements the workload contract using @openai/agents (real OpenAI API).
+ * Mode: standard agent loop (the SDK orchestrates dispatch). This is the
+ * runtime under measurement on the OpenAI arm.
+ *
+ * See WORKLOAD_CONTRACT.md for the rules every workload implementation
+ * must satisfy.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, appendFileSync, statSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { Agent, Runner, tool } from "@openai/agents";
+import { z } from "zod";
+
+interface WorkloadEnv {
+  workDir: string;
+  inputPath: string;
+  outputPath: string;
+  inputContents: string;
+  model: string;
+}
+
+function loadEnv(): WorkloadEnv {
+  const workDir = process.env.WORKLOAD_WORK_DIR;
+  if (!workDir) {
+    throw new Error("WORKLOAD_WORK_DIR is required");
+  }
+  const absWorkDir = resolve(workDir);
+  mkdirSync(absWorkDir, { recursive: true });
+
+  const inputPath = resolve(
+    process.env.WORKLOAD_INPUT_PATH ?? `${absWorkDir}/fixture-input.txt`,
+  );
+  const outputPath = resolve(
+    process.env.WORKLOAD_OUTPUT_PATH ?? `${absWorkDir}/fixture-output.txt`,
+  );
+  const inputContents =
+    process.env.WORKLOAD_INPUT_CONTENTS ?? "cross-runtime drift fixture\n";
+  const model = process.env.WORKLOAD_MODEL ?? "gpt-4o-mini";
+
+  return { workDir: absWorkDir, inputPath, outputPath, inputContents, model };
+}
+
+function ensureInsideWorkDir(workDir: string, candidate: string): string {
+  const abs = resolve(candidate);
+  if (!abs.startsWith(workDir + "/") && abs !== workDir) {
+    throw new Error(
+      `Path ${candidate} is outside WORKLOAD_WORK_DIR (${workDir})`,
+    );
+  }
+  return abs;
+}
+
+function appendToolCall(
+  toolCallsPath: string,
+  seqRef: { value: number },
+  tool: string,
+  args: Record<string, unknown>,
+): void {
+  seqRef.value += 1;
+  const line = JSON.stringify({ seq: seqRef.value, tool, args }) + "\n";
+  appendFileSync(toolCallsPath, line, { encoding: "utf-8" });
+}
+
+async function main(): Promise<number> {
+  const env = loadEnv();
+  const toolCallsPath = `${env.workDir}/tool-calls.ndjson`;
+  const metaPath = `${env.workDir}/run-meta.json`;
+
+  // Reset per-run artefacts. Re-running into the same WORK_DIR must be
+  // idempotent at the contract level.
+  writeFileSync(toolCallsPath, "", { encoding: "utf-8" });
+
+  // Seed the input fixture. The contract requires the workload to do this
+  // itself so the contract-checker can verify against a known input.
+  mkdirSync(dirname(env.inputPath), { recursive: true });
+  writeFileSync(env.inputPath, env.inputContents, { encoding: "utf-8" });
+
+  const seq = { value: 0 };
+
+  const readFileTool = tool({
+    name: "read_file",
+    description: "Read a UTF-8 file from the workload work directory.",
+    parameters: z.object({
+      path: z.string().describe("Absolute path to the file to read."),
+    }),
+    execute: async ({ path }) => {
+      const abs = ensureInsideWorkDir(env.workDir, path);
+      appendToolCall(toolCallsPath, seq, "read_file", { path: abs });
+      return readFileSync(abs, "utf-8");
+    },
+  });
+
+  const writeFileTool = tool({
+    name: "write_file",
+    description: "Write UTF-8 contents to a file inside the work directory.",
+    parameters: z.object({
+      path: z.string().describe("Absolute path to the file to write."),
+      contents: z.string().describe("UTF-8 contents to write."),
+    }),
+    execute: async ({ path, contents }) => {
+      const abs = ensureInsideWorkDir(env.workDir, path);
+      appendToolCall(toolCallsPath, seq, "write_file", {
+        path: abs,
+        contents,
+      });
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, contents, { encoding: "utf-8" });
+      return "ok";
+    },
+  });
+
+  const agent = new Agent({
+    name: "cross-runtime-drift-openai",
+    instructions:
+      "You are a deterministic agent. Use the provided tools to do exactly " +
+      "what the user asked. Do not paraphrase the task. Do not add " +
+      "commentary. Reply with the literal word `DONE` when the work is " +
+      "complete.",
+    model: env.model,
+    tools: [readFileTool, writeFileTool],
+    modelSettings: {
+      temperature: 0,
+    },
+  });
+
+  const startedAt = new Date().toISOString();
+  const runner = new Runner();
+  const prompt =
+    `Read the file at \`${env.inputPath}\`, uppercase its contents, then ` +
+    `write the result to \`${env.outputPath}\`. Call \`read_file\` first ` +
+    `and \`write_file\` second. Do not call any other tool. When done, ` +
+    `reply with the single word \`DONE\`.`;
+
+  let exitCode = 0;
+  let modelReply = "";
+  try {
+    const result = await runner.run(agent, prompt);
+    modelReply = String(result.finalOutput ?? "").trim();
+    if (!/^DONE[.!]?$/i.test(modelReply)) {
+      exitCode = 3;
+    }
+  } catch (err) {
+    process.stderr.write(`workload-openai error: ${(err as Error).message}\n`);
+    exitCode = 1;
+  }
+  const endedAt = new Date().toISOString();
+
+  // Self-check: if exit_code is still 0, also confirm the agent at least
+  // produced the output file. If it didn't, demote to contract-violation 2.
+  if (exitCode === 0) {
+    try {
+      const st = statSync(env.outputPath);
+      if (!st.isFile() || st.size === 0) {
+        exitCode = 2;
+      }
+    } catch {
+      exitCode = 2;
+    }
+  }
+
+  const sdkVersion: string = (() => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const pkg = require("@openai/agents/package.json") as { version: string };
+      return pkg.version;
+    } catch {
+      return "unknown";
+    }
+  })();
+
+  const meta = {
+    runtime: "openai-agents",
+    model: env.model,
+    sdk_version: sdkVersion,
+    started_at: startedAt,
+    ended_at: endedAt,
+    exit_code: exitCode,
+    model_reply: modelReply,
+  };
+  writeFileSync(metaPath, JSON.stringify(meta, null, 2) + "\n", {
+    encoding: "utf-8",
+  });
+
+  return exitCode;
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    process.stderr.write(`workload-openai fatal: ${(err as Error).stack ?? err}\n`);
+    process.exit(1);
+  });

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
@@ -43,14 +43,39 @@ function loadEnv(): WorkloadEnv {
   return { workDir: absWorkDir, inputPath, outputPath, inputContents, model };
 }
 
+/**
+ * Contract violation: the model asked for an action the workload contract
+ * does not allow (path outside WORK_DIR, wrong path for tool, etc.). The
+ * outer try/catch turns this into exit code 2. Distinct from generic
+ * Errors which become exit code 1.
+ */
+class ContractViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContractViolationError";
+  }
+}
+
 function ensureInsideWorkDir(workDir: string, candidate: string): string {
   const abs = resolve(candidate);
   if (!abs.startsWith(workDir + "/") && abs !== workDir) {
-    throw new Error(
+    throw new ContractViolationError(
       `Path ${candidate} is outside WORKLOAD_WORK_DIR (${workDir})`,
     );
   }
   return abs;
+}
+
+function assertPathEquals(
+  toolName: string,
+  expected: string,
+  candidate: string,
+): void {
+  if (candidate !== expected) {
+    throw new ContractViolationError(
+      `${toolName}: path mismatch — expected ${expected}, got ${candidate}`,
+    );
+  }
 }
 
 function appendToolCall(
@@ -88,6 +113,7 @@ async function main(): Promise<number> {
     }),
     execute: async ({ path }) => {
       const abs = ensureInsideWorkDir(env.workDir, path);
+      assertPathEquals("read_file", env.inputPath, abs);
       appendToolCall(toolCallsPath, seq, "read_file", { path: abs });
       return readFileSync(abs, "utf-8");
     },
@@ -102,6 +128,7 @@ async function main(): Promise<number> {
     }),
     execute: async ({ path, contents }) => {
       const abs = ensureInsideWorkDir(env.workDir, path);
+      assertPathEquals("write_file", env.outputPath, abs);
       appendToolCall(toolCallsPath, seq, "write_file", {
         path: abs,
         contents,
@@ -144,7 +171,20 @@ async function main(): Promise<number> {
     }
   } catch (err) {
     process.stderr.write(`workload-openai error: ${(err as Error).message}\n`);
-    exitCode = 1;
+    if (err instanceof ContractViolationError) {
+      exitCode = 2;
+    } else {
+      // @openai/agents wraps tool execute errors in its own error type.
+      // Detect by name as a fallback so contract violations bubble up
+      // even if the SDK rewraps them.
+      const name = (err as Error)?.name ?? "";
+      const msg = (err as Error)?.message ?? "";
+      if (name === "ContractViolationError" || msg.includes("ContractViolationError")) {
+        exitCode = 2;
+      } else {
+        exitCode = 1;
+      }
+    }
   }
   const endedAt = new Date().toISOString();
 

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
@@ -10,7 +10,7 @@
  */
 
 import { mkdirSync, readFileSync, writeFileSync, appendFileSync, statSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, relative, isAbsolute } from "node:path";
 import { Agent, Runner, tool } from "@openai/agents";
 import { z } from "zod";
 
@@ -58,7 +58,15 @@ class ContractViolationError extends Error {
 
 function ensureInsideWorkDir(workDir: string, candidate: string): string {
   const abs = resolve(candidate);
-  if (!abs.startsWith(workDir + "/") && abs !== workDir) {
+  // Use path.relative() instead of a "/" string-prefix check so the
+  // containment test is portable across path separators. A candidate is
+  // inside workDir iff relative(workDir, abs) is empty (same path),
+  // does not start with "..", and is not absolute (different drive on
+  // Windows).
+  const rel = relative(workDir, abs);
+  const insideOrSame =
+    rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  if (!insideOrSame) {
     throw new ContractViolationError(
       `Path ${candidate} is outside WORKLOAD_WORK_DIR (${workDir})`,
     );

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-openai/tsconfig.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-openai/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
> **Stacked on PR #1344.** GitHub will retarget this PR to \`main\` automatically once #1344 merges.

## Summary
Slice 1 of the [cross-runtime drift experiment](../tree/codex/cross-runtime-drift-slice-1/docs/experiments/cross-runtime-drift-2026-05). Resolves Open Questions #1 and #3 from the plan-doc by writing the deliverables on disk:

- **\`WORKLOAD_CONTRACT.md\`** — six auto-checked rules (input fixture, output file, tool-call NDJSON shape, run-meta.json, runtime/exit_code) + two design rules (manual function-calling on Gemini side, no extra tools/MCP servers).
- **\`workload-openai/\`** — \`@openai/agents\` v0.11.4 implementation, standard agent loop.
- **\`workload-gemini/\`** — \`@google/genai\` v2.6.0 implementation with \`automaticFunctionCalling.disable = true\` and our own loop.
- **\`contract-checker/check.py\`** + 10 stdlib unit tests covering both runtimes' happy path plus each individual failure mode.

Both TS workloads compile clean with \`npx tsc -p tsconfig.json\`. The contract-checker passes 10/10 unit tests with no API keys required.

The plan-doc Status block, Open Questions section, and Sequencing table are updated to mark Slice 0 + Slice 1 done. Slices 2–5 stay TODO.

## What's intentionally NOT here
- No Runner capture wiring (arrives in Slice 3 with the \`assay-bpf-runner\` workflow extension).
- No \`compare/drift.py\` (Slice 2 — locks the output schema against synthetic archives first).
- No \`GOOGLE_API_KEY\` workflow secret (local-only until the workload contract is reviewed).
- No OTel trace emission (cross-runtime comparison is between two Runner archives, not traces).

## Test plan
- [x] Pre-commit + pre-push gates green (typos, fmt, clippy, linux compile)
- [x] \`npx tsc -p tsconfig.json\` clean for workload-openai
- [x] \`npx tsc -p tsconfig.json\` clean for workload-gemini
- [x] \`python3 -m unittest discover -s contract-checker -p 'test_*.py'\` → 10/10 OK
- [ ] User: run workload-openai locally with \`OPENAI_API_KEY\`, confirm contract-checker exit 0
- [ ] User: run workload-gemini locally with \`GOOGLE_API_KEY\`, confirm contract-checker exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)