### PR TITLE
docs(experiments): Slice 2 — cross-runtime drift comparator MVP

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05.md
+++ b/docs/experiments/cross-runtime-drift-2026-05.md
@@ -1,9 +1,10 @@
 # Cross-Runtime Capability-Surface Drift: Plan
 
-> **Status:** Slice 0 (this plan) and Slice 1 (workload contract +
-> two implementations + contract-checker) landed. See
+> **Status:** Slices 0–2 landed: this plan, the workload contract +
+> two implementations + contract-checker (Slice 1), and the
+> `compare/drift.py` MVP with synthetic fixtures (Slice 2). See
 > [`cross-runtime-drift-2026-05/README.md`](cross-runtime-drift-2026-05/README.md)
-> for the Slice 1 layout. Companion to
+> for the layout. Companion to
 > [`runner-vs-otel-shape-comparison-2026-05.md`](runner-vs-otel-shape-comparison-2026-05.md);
 > reuses the same Runner archive + capability_surface contract, so
 > the L2 capture machinery is already proven on
@@ -293,7 +294,7 @@ A successful first findings doc:
 |---|---|---|---|
 | 0 | **Done** | This plan-doc, reviewed and sharpened (Open Questions #1 + #3 resolved) | None |
 | 1 | **Done** | Workload contract ([`WORKLOAD_CONTRACT.md`](cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md)), `@openai/agents` workload, `@google/genai` manual-function-calling workload, stdlib contract-checker with 10 unit tests | OpenAI key (already used), Google key for live local testing |
-| 2 | TODO | `compare/drift.py` MVP. **Scope-locked to v0 surface**: touched-path set diff, network host/port/CIDR diff, process exec diff, SDK tool-event diff, MCP tool-surface diff, tool invocation order where SDK events preserve it. Read/write/create classification and kernel-ndjson parsing are deferred. Runs on two synthetic archives derived from existing runner-vs-otel fixtures, no live runs yet. Comparator output schema locked in. | None |
+| 2 | **Done** | `compare/drift.py` MVP ([`compare/drift.py`](cross-runtime-drift-2026-05/compare/drift.py)) with 16 stdlib unit tests. Scope-locked to v0 surface: touched-path set diff, network host/port/CIDR diff, process exec diff, SDK tool-event diff, MCP tool-surface diff, tool invocation order. Synthetic fixtures under [`compare/fixtures/{arm-a-openai, arm-b-gemini}/`](cross-runtime-drift-2026-05/compare/fixtures/) exercise every classification label exactly once. Output schema: `assay.cross_runtime_drift.v0`. | None |
 | 3 | TODO | Live Arm A0 + B0 dispatch on `assay-bpf-runner` (workflow extension). n=3 per arm. Baselines committed under `docs/experiments/cross-runtime-drift-2026-05/runs/{a0,b0}/`. | Second runtime API key as workflow secret |
 | 4 | TODO | `findings.md`. Drift table, classification, threats-to-validity, reproduction commands. | None |
 | 5 | TODO | Publication artefacts (issue + blog draft) following the same discipline as runner-vs-otel Slice 4: one narrow question per channel, no maintainer @-mentions, evidence link once. | OpenInference #3162 triage outcome should inform whether to file under same umbrella or separately |

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -1,9 +1,12 @@
 # cross-runtime-drift-2026-05
 
-> **Status:** Slice 1 landed. Workload contract written, two runtime
-> implementations runnable locally with API keys, contract-checker
-> validates outputs with 10 stdlib unit tests passing. Slices 2–5
-> still TODO.
+> **Status:** Slices 1 and 2 landed. Workload contract written, two
+> runtime implementations runnable locally with API keys,
+> contract-checker validates outputs (13 stdlib unit tests), and the
+> `compare/drift.py` MVP produces a per-dimension drift report
+> against the synthetic fixtures with 16 stdlib unit tests passing.
+> Slices 3–5 still TODO (live captures on `assay-bpf-runner`,
+> findings doc, publication artefacts).
 >
 > **Plan-doc:** [`../cross-runtime-drift-2026-05.md`](../cross-runtime-drift-2026-05.md)
 > (research question, drift dimensions, threats to validity, sequencing).
@@ -19,6 +22,7 @@
 | [`workload-openai/`](workload-openai/) | `@openai/agents` implementation (standard agent loop). |
 | [`workload-gemini/`](workload-gemini/) | `@google/genai` implementation (manual function-calling loop, `automaticFunctionCalling.disable = true`). |
 | [`contract-checker/`](contract-checker/) | Stdlib-only Python validator. Independent of Runner capture. |
+| [`compare/`](compare/) | Slice 2: `drift.py` stdlib comparator + `test_drift.py` (16 tests) + `fixtures/{arm-a-openai,arm-b-gemini}/` synthetic archives that exercise every drift dimension. |
 
 `runs/` will appear once Slice 3 dispatches live captures on
 `assay-bpf-runner`. Not present yet.
@@ -76,6 +80,31 @@ python3 -m unittest discover \
   -p 'test_*.py'
 ```
 
+### compare/drift.py (Slice 2)
+
+```bash
+# Smoke run against the synthetic fixtures. Produces drift.json on
+# stdout and drift.md if --out-md is given. No live runs required.
+python3 "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py" \
+  --archive-a "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai" \
+  --archive-b "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini" \
+  --fixture-path /tmp/work/fixture-input.txt \
+  --fixture-path /tmp/work/fixture-output.txt \
+  --out-md /tmp/drift.md
+
+# Tests (no API keys required):
+python3 -m unittest discover \
+  -s "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare" \
+  -p 'test_*.py'
+```
+
+The comparator takes two Runner archives (directories or `.tar.gz`)
+and emits per-dimension drift rows. Each row carries a
+classification: `task-induced` / `provider-induced` /
+`runtime-induced` / `inconclusive`. The classification is a
+starting point; the findings doc (Slice 4) explains every
+`inconclusive` row by hand or downgrades it to a known limitation.
+
 ## What's done in Slice 1
 
 - Open Question #1 resolved: Gemini via `@google/genai`, manual
@@ -91,17 +120,37 @@ python3 -m unittest discover \
 - Both workloads emit `tool-calls.ndjson` and `run-meta.json`
   per the contract; checker validates without any Runner
   archive present.
-- 10 contract-checker unit tests cover the happy path for both
-  runtimes plus each individual rule failure mode.
+- 13 contract-checker unit tests cover the happy path for both
+  runtimes plus each individual rule failure mode plus malformed
+  JSON / symlinked workdir handling.
 
-## What's deliberately NOT in Slice 1
+## What's done in Slice 2
+
+- `compare/drift.py` MVP: stdlib Python comparator that reads two
+  Runner archives (directories or `.tar.gz`) and emits a
+  per-dimension drift report. Dimensions are pinned to v0
+  capability_surface sources (no read/write/create/remove split
+  — that's an explicit v2 follow-up tracked in the plan-doc).
+- `compare/fixtures/arm-a-openai/` and `arm-b-gemini/` synthetic
+  archives wired to exercise every classification label exactly
+  once: filesystem-paths `runtime-induced`, network-endpoints
+  `provider-induced`, process-execs / SDK tools /
+  tool-invocation-order `task-induced`, MCP `inconclusive`.
+- 16 stdlib unit tests cover parsing (directory + tar.gz),
+  failure modes (missing manifest, corrupt JSON, broken tar),
+  every classification label, fixture-path overrides, and CLI
+  output (`--out-json`, `--out-md`).
+- Output schema locked in: `assay.cross_runtime_drift.v0`.
+
+## What's deliberately NOT in Slice 1 or Slice 2
 
 - No Runner capture wiring. That arrives in Slice 3 alongside an
   `assay-bpf-runner` workflow extension.
-- No `compare/drift.py` yet. That is Slice 2 (works against
-  synthetic archives first to lock the output schema).
-- No CI dispatch. `GOOGLE_API_KEY` is local-only until the
-  workload contract is reviewed and Slice 2's comparator schema
-  is stable.
+- No `GOOGLE_API_KEY` workflow secret. Local-only until Slice 3.
+- No live n=3 baselines. Comparator runs against synthetic
+  fixtures only; live data is Slice 3.
 - No OTel trace emission. The cross-runtime comparison is
   between two Runner archives; traces are an explicit follow-up.
+- No read/write/create/remove split, no per-path access counts,
+  no kernel-ndjson parsing. All tracked as deferred v2 follow-ups
+  in the plan-doc.

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1,0 +1,722 @@
+#!/usr/bin/env python3
+"""Cross-runtime drift comparator.
+
+Reads two Runner measured-run archives (one per agent runtime) and
+emits per-dimension drift between their capability surfaces.
+
+Scope (v0, Slice 2):
+  - filesystem paths touched (capability_surface.filesystem_paths)
+  - network endpoints (capability_surface.network_endpoints)
+  - process execs (capability_surface.process_execs)
+  - SDK tool events (layers/sdk.ndjson — tool names per archive)
+  - MCP tool surface (capability_surface.mcp_tools)
+  - tool invocation order (SDK events' seq per tool_call_id)
+
+Out of scope (explicit follow-ups, NOT silent gaps):
+  - read/write/create/remove classification (requires
+    kernel.ndjson parsing — deferred to a v2 comparator)
+  - per-path access counts
+  - latency / token / cost (not a drift signal)
+
+Classification labels per row:
+  task-induced     — full overlap; both runtimes touched the same surface
+                     element to satisfy the workload contract.
+  provider-induced — non-shared items match a provider-host whitelist
+                     (api.openai.com, generativelanguage.googleapis.com,
+                     ...). Attributable to the model provider's auth or
+                     transport, not the agent framework itself.
+  runtime-induced  — non-shared items are not provider hosts and not
+                     known fixture paths. Attributable to the runtime's
+                     loader, sidecar, or vendored deps.
+  inconclusive     — one side has zero data for the dimension and the
+                     other has > 0. Cannot tell whether the dimension is
+                     genuinely empty in arm X or just not measured there.
+
+Exit codes:
+  0 - report generated successfully (drift may or may not exist)
+  2 - bad CLI args (path missing, write failure, etc.)
+  3 - bad archive input (manifest missing, corrupt JSON, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import sys
+import tarfile
+from pathlib import Path
+from typing import Any, Iterable
+
+# ---------------------------------------------------------------------------
+# Schema strings (also used to identify fixture archives in tests)
+# ---------------------------------------------------------------------------
+
+CAPABILITY_SURFACE_SCHEMA = "assay.runner.capability_surface.v0"
+SDK_EVENT_SCHEMA = "assay.runner.sdk_event.v0"
+DRIFT_REPORT_SCHEMA = "assay.cross_runtime_drift.v0"
+
+MANIFEST_PATH = "manifest.json"
+CAPABILITY_SURFACE_PATH = "capability-surface.json"
+OBSERVATION_HEALTH_PATH = "observation-health.json"
+CORRELATION_REPORT_PATH = "correlation-report.json"
+SDK_LAYER_PATH = "layers/sdk.ndjson"
+
+# Hostnames we treat as model-provider transport / auth endpoints.
+# Conservative whitelist; runs that surface anything else default to
+# `runtime-induced` (an explicit choice — easier to refine a label than
+# to walk back a false provider label).
+DEFAULT_PROVIDER_HOSTS = (
+    "api.openai.com",
+    "auth.openai.com",
+    "oauth.openai.com",
+    "generativelanguage.googleapis.com",
+    "oauth2.googleapis.com",
+    "accounts.google.com",
+)
+
+CLASSIFICATION_TASK = "task-induced"
+CLASSIFICATION_PROVIDER = "provider-induced"
+CLASSIFICATION_RUNTIME = "runtime-induced"
+CLASSIFICATION_INCONCLUSIVE = "inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# Bad-input signalling. Distinct from rule failures so callers can map to
+# exit code 3 instead of conflating with a "no drift" result.
+# ---------------------------------------------------------------------------
+
+
+class BadArchiveError(Exception):
+    """Raised when an archive is unreadable: manifest missing, JSON
+    corrupt, tar broken, etc. Surfaced as exit code 3."""
+
+
+# ---------------------------------------------------------------------------
+# Archive parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ArchiveObservation:
+    """Normalized view of a Runner archive for the drift comparator."""
+
+    path: str
+    run_id: str | None
+    runtime_label: str | None
+    manifest_digest: str
+    capability_surface: dict[str, list[str]]
+    sdk_events: list[dict[str, Any]]
+    sdk_event_count: int
+    sdk_tools: list[str]
+    sdk_tool_call_ids: list[str]
+    sdk_tool_order: list[str]  # (tool_call_id, tool) sequence per seq order
+
+
+def _open_archive_member(source: Path, member: str) -> bytes | None:
+    if source.is_dir():
+        path = source / member
+        if not path.exists():
+            return None
+        return path.read_bytes()
+    try:
+        with tarfile.open(source, "r:*") as tf:
+            try:
+                extracted = tf.extractfile(member)
+            except KeyError:
+                return None
+            if extracted is None:
+                return None
+            return extracted.read()
+    except tarfile.TarError as exc:
+        raise BadArchiveError(f"{source}: corrupt tar archive: {exc}") from exc
+
+
+def _parse_json(path_repr: str, data: bytes) -> Any:
+    try:
+        return json.loads(data.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise BadArchiveError(f"{path_repr}: invalid JSON: {exc}") from exc
+    except UnicodeDecodeError as exc:
+        raise BadArchiveError(f"{path_repr}: invalid UTF-8: {exc}") from exc
+
+
+def parse_archive(source: Path) -> ArchiveObservation:
+    """Parse a Runner archive (directory or .tar.gz). Raises
+    BadArchiveError if the manifest is missing or any required file is
+    corrupt.
+
+    Note: we read the exact manifest bytes for the digest, never
+    re-serialized JSON. The drift comparator does not enforce binding
+    against a trace (that's compare.py's job in the runner-vs-otel
+    experiment), but it still records the digest for traceability."""
+
+    manifest_bytes = _open_archive_member(source, MANIFEST_PATH)
+    if manifest_bytes is None:
+        raise BadArchiveError(f"{source}: manifest.json not found")
+    manifest = _parse_json(f"{source}!{MANIFEST_PATH}", manifest_bytes)
+    manifest_digest = "sha256:" + hashlib.sha256(manifest_bytes).hexdigest()
+    run_id = manifest.get("run_id") if isinstance(manifest, dict) else None
+    runtime_label = (
+        manifest.get("runtime_label") if isinstance(manifest, dict) else None
+    )
+
+    capability_surface: dict[str, list[str]] = {
+        "filesystem_paths": [],
+        "network_endpoints": [],
+        "process_execs": [],
+        "mcp_tools": [],
+        "policy_decisions": [],
+    }
+    capability_bytes = _open_archive_member(source, CAPABILITY_SURFACE_PATH)
+    if capability_bytes is not None:
+        capability = _parse_json(
+            f"{source}!{CAPABILITY_SURFACE_PATH}", capability_bytes
+        )
+        if isinstance(capability, dict):
+            for key in capability_surface:
+                value = capability.get(key, [])
+                if isinstance(value, list):
+                    capability_surface[key] = sorted(
+                        [str(v) for v in value if isinstance(v, str)]
+                    )
+
+    sdk_events: list[dict[str, Any]] = []
+    sdk_bytes = _open_archive_member(source, SDK_LAYER_PATH)
+    if sdk_bytes is not None:
+        try:
+            text = sdk_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise BadArchiveError(
+                f"{source}!{SDK_LAYER_PATH}: invalid UTF-8: {exc}"
+            ) from exc
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                sdk_events.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise BadArchiveError(
+                    f"{source}!{SDK_LAYER_PATH}:{lineno}: "
+                    f"invalid JSON: {exc}"
+                ) from exc
+
+    # Derive tool registration / invocation summary from SDK events.
+    sdk_tools: list[str] = []
+    sdk_tool_call_ids: list[str] = []
+    # Ordered (seq) view of tool invocations, useful for invocation-order
+    # drift. We treat tool_call_started events as the ordering anchor;
+    # tool_call_completed is a closing event for the same id.
+    seq_invocations: list[tuple[int, str, str]] = []
+    for event in sdk_events:
+        tool = event.get("tool")
+        if isinstance(tool, str) and tool and tool not in sdk_tools:
+            sdk_tools.append(tool)
+        call_id = event.get("tool_call_id")
+        if (
+            isinstance(call_id, str)
+            and call_id
+            and call_id not in sdk_tool_call_ids
+        ):
+            sdk_tool_call_ids.append(call_id)
+        if event.get("event_type") == "tool_call_started":
+            seq = event.get("seq")
+            if (
+                isinstance(seq, int)
+                and isinstance(tool, str)
+                and isinstance(call_id, str)
+            ):
+                seq_invocations.append((seq, call_id, tool))
+    seq_invocations.sort(key=lambda t: t[0])
+    sdk_tool_order = [f"{call_id}:{tool}" for _, call_id, tool in seq_invocations]
+
+    return ArchiveObservation(
+        path=str(source),
+        run_id=run_id,
+        runtime_label=runtime_label,
+        manifest_digest=manifest_digest,
+        capability_surface=capability_surface,
+        sdk_events=sdk_events,
+        sdk_event_count=len(sdk_events),
+        sdk_tools=sorted(sdk_tools),
+        sdk_tool_call_ids=sorted(sdk_tool_call_ids),
+        sdk_tool_order=sdk_tool_order,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift report model
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class DriftRow:
+    """One dimension of the drift report."""
+
+    dimension: str
+    source: str  # the archive field/path this row was computed from
+    only_in_a: list[str]
+    only_in_b: list[str]
+    in_both: list[str]
+    classification: str  # one of CLASSIFICATION_* above
+    detail: str
+
+
+def _classify_row(
+    only_in_a: list[str],
+    only_in_b: list[str],
+    in_both: list[str],
+    has_data_a: bool,
+    has_data_b: bool,
+    provider_hosts: tuple[str, ...],
+    fixture_paths: frozenset[str],
+) -> tuple[str, str]:
+    """Return (classification, detail) for one drift row.
+
+    Conservative ruleset (see module docstring for the four labels)."""
+
+    # Dimension wholly empty on both sides — task didn't exercise it.
+    if not has_data_a and not has_data_b:
+        return CLASSIFICATION_INCONCLUSIVE, "dimension empty in both arms"
+
+    # One arm has zero data, other has non-zero — cannot attribute.
+    if has_data_a != has_data_b:
+        absent = "arm-a" if not has_data_a else "arm-b"
+        return (
+            CLASSIFICATION_INCONCLUSIVE,
+            f"dimension absent in {absent}; cannot tell if not emitted "
+            f"or not measured",
+        )
+
+    # Both arms have data here.
+    non_shared = list(only_in_a) + list(only_in_b)
+    if not non_shared:
+        return CLASSIFICATION_TASK, "full overlap"
+
+    def _is_provider(item: str) -> bool:
+        for host in provider_hosts:
+            if host in item:
+                return True
+        return False
+
+    def _is_fixture(item: str) -> bool:
+        return item in fixture_paths
+
+    provider_count = sum(1 for x in non_shared if _is_provider(x))
+    fixture_count = sum(1 for x in non_shared if _is_fixture(x))
+    total = len(non_shared)
+    if provider_count == total:
+        return (
+            CLASSIFICATION_PROVIDER,
+            f"all {total} non-shared item(s) match provider host whitelist",
+        )
+    if fixture_count == total:
+        return (
+            CLASSIFICATION_TASK,
+            f"all {total} non-shared item(s) match known fixture paths",
+        )
+    # Mixed or none-of-the-above → attribute to the runtime.
+    return (
+        CLASSIFICATION_RUNTIME,
+        f"{total} non-shared item(s); {provider_count} provider, "
+        f"{fixture_count} fixture, {total - provider_count - fixture_count} "
+        f"unclassified",
+    )
+
+
+def _diff_lists(
+    a: list[str], b: list[str]
+) -> tuple[list[str], list[str], list[str]]:
+    """Return (only_in_a, only_in_b, in_both), each sorted."""
+    set_a = set(a)
+    set_b = set(b)
+    return (
+        sorted(set_a - set_b),
+        sorted(set_b - set_a),
+        sorted(set_a & set_b),
+    )
+
+
+def build_drift_report(
+    a: ArchiveObservation,
+    b: ArchiveObservation,
+    *,
+    provider_hosts: tuple[str, ...] = DEFAULT_PROVIDER_HOSTS,
+    fixture_paths: frozenset[str] = frozenset(),
+) -> list[DriftRow]:
+    """Compute per-dimension drift rows between two archives.
+
+    `fixture_paths` is the set of paths the workload contract requires
+    both runtimes to touch (typically WORKLOAD_INPUT_PATH and
+    WORKLOAD_OUTPUT_PATH). Items in non-shared sets that match this set
+    are classified as task-induced rather than runtime-induced.
+    """
+
+    rows: list[DriftRow] = []
+
+    # --- filesystem paths touched ---
+    a_paths = a.capability_surface.get("filesystem_paths", [])
+    b_paths = b.capability_surface.get("filesystem_paths", [])
+    only_a, only_b, both = _diff_lists(a_paths, b_paths)
+    cls, detail = _classify_row(
+        only_a,
+        only_b,
+        both,
+        bool(a_paths),
+        bool(b_paths),
+        provider_hosts,
+        fixture_paths,
+    )
+    rows.append(
+        DriftRow(
+            dimension="filesystem_paths_touched",
+            source="capability_surface.filesystem_paths",
+            only_in_a=only_a,
+            only_in_b=only_b,
+            in_both=both,
+            classification=cls,
+            detail=detail,
+        )
+    )
+
+    # --- network endpoints ---
+    a_net = a.capability_surface.get("network_endpoints", [])
+    b_net = b.capability_surface.get("network_endpoints", [])
+    only_a, only_b, both = _diff_lists(a_net, b_net)
+    cls, detail = _classify_row(
+        only_a,
+        only_b,
+        both,
+        bool(a_net),
+        bool(b_net),
+        provider_hosts,
+        fixture_paths,
+    )
+    rows.append(
+        DriftRow(
+            dimension="network_endpoints",
+            source="capability_surface.network_endpoints",
+            only_in_a=only_a,
+            only_in_b=only_b,
+            in_both=both,
+            classification=cls,
+            detail=detail,
+        )
+    )
+
+    # --- process execs ---
+    a_exec = a.capability_surface.get("process_execs", [])
+    b_exec = b.capability_surface.get("process_execs", [])
+    only_a, only_b, both = _diff_lists(a_exec, b_exec)
+    cls, detail = _classify_row(
+        only_a,
+        only_b,
+        both,
+        bool(a_exec),
+        bool(b_exec),
+        provider_hosts,
+        fixture_paths,
+    )
+    rows.append(
+        DriftRow(
+            dimension="process_execs",
+            source="capability_surface.process_execs",
+            only_in_a=only_a,
+            only_in_b=only_b,
+            in_both=both,
+            classification=cls,
+            detail=detail,
+        )
+    )
+
+    # --- SDK tool events (tool names invoked per archive) ---
+    only_a, only_b, both = _diff_lists(a.sdk_tools, b.sdk_tools)
+    cls, detail = _classify_row(
+        only_a,
+        only_b,
+        both,
+        bool(a.sdk_tools),
+        bool(b.sdk_tools),
+        provider_hosts,
+        fixture_paths,
+    )
+    rows.append(
+        DriftRow(
+            dimension="sdk_tool_events",
+            source="layers/sdk.ndjson (tool field, deduplicated)",
+            only_in_a=only_a,
+            only_in_b=only_b,
+            in_both=both,
+            classification=cls,
+            detail=detail,
+        )
+    )
+
+    # --- MCP tool surface ---
+    a_mcp = a.capability_surface.get("mcp_tools", [])
+    b_mcp = b.capability_surface.get("mcp_tools", [])
+    only_a, only_b, both = _diff_lists(a_mcp, b_mcp)
+    cls, detail = _classify_row(
+        only_a,
+        only_b,
+        both,
+        bool(a_mcp),
+        bool(b_mcp),
+        provider_hosts,
+        fixture_paths,
+    )
+    rows.append(
+        DriftRow(
+            dimension="mcp_tool_surface",
+            source="capability_surface.mcp_tools",
+            only_in_a=only_a,
+            only_in_b=only_b,
+            in_both=both,
+            classification=cls,
+            detail=detail,
+        )
+    )
+
+    # --- tool invocation order ---
+    # We project each arm's ordered (tool_call_id, tool) into a list of
+    # tool names — the *order* is what we diff. If one arm has zero
+    # ordered invocations and the other has > 0 → inconclusive. If
+    # ordered tool sequences match → task-induced. Otherwise →
+    # runtime-induced (ordering is something the runtime controls).
+    a_order_tools = [t.split(":", 1)[1] for t in a.sdk_tool_order]
+    b_order_tools = [t.split(":", 1)[1] for t in b.sdk_tool_order]
+    has_a = bool(a_order_tools)
+    has_b = bool(b_order_tools)
+    if not has_a and not has_b:
+        rows.append(
+            DriftRow(
+                dimension="tool_invocation_order",
+                source="layers/sdk.ndjson (event_type=tool_call_started, "
+                "ordered by seq)",
+                only_in_a=[],
+                only_in_b=[],
+                in_both=[],
+                classification=CLASSIFICATION_INCONCLUSIVE,
+                detail="no tool_call_started events in either arm",
+            )
+        )
+    elif has_a != has_b:
+        rows.append(
+            DriftRow(
+                dimension="tool_invocation_order",
+                source="layers/sdk.ndjson (event_type=tool_call_started, "
+                "ordered by seq)",
+                only_in_a=a_order_tools if has_a else [],
+                only_in_b=b_order_tools if has_b else [],
+                in_both=[],
+                classification=CLASSIFICATION_INCONCLUSIVE,
+                detail="invocation order absent in one arm",
+            )
+        )
+    elif a_order_tools == b_order_tools:
+        rows.append(
+            DriftRow(
+                dimension="tool_invocation_order",
+                source="layers/sdk.ndjson (event_type=tool_call_started, "
+                "ordered by seq)",
+                only_in_a=[],
+                only_in_b=[],
+                in_both=a_order_tools,
+                classification=CLASSIFICATION_TASK,
+                detail=f"identical sequence: {' -> '.join(a_order_tools)}",
+            )
+        )
+    else:
+        rows.append(
+            DriftRow(
+                dimension="tool_invocation_order",
+                source="layers/sdk.ndjson (event_type=tool_call_started, "
+                "ordered by seq)",
+                only_in_a=a_order_tools,
+                only_in_b=b_order_tools,
+                in_both=[],
+                classification=CLASSIFICATION_RUNTIME,
+                detail=(
+                    f"a: {' -> '.join(a_order_tools)} | "
+                    f"b: {' -> '.join(b_order_tools)}"
+                ),
+            )
+        )
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def report_to_json(
+    a: ArchiveObservation,
+    b: ArchiveObservation,
+    rows: list[DriftRow],
+) -> dict[str, Any]:
+    return {
+        "schema": DRIFT_REPORT_SCHEMA,
+        "archive_a": {
+            "path": a.path,
+            "run_id": a.run_id,
+            "runtime_label": a.runtime_label,
+            "manifest_digest": a.manifest_digest,
+            "sdk_event_count": a.sdk_event_count,
+        },
+        "archive_b": {
+            "path": b.path,
+            "run_id": b.run_id,
+            "runtime_label": b.runtime_label,
+            "manifest_digest": b.manifest_digest,
+            "sdk_event_count": b.sdk_event_count,
+        },
+        "rows": [dataclasses.asdict(r) for r in rows],
+        "summary": {
+            "dimensions_checked": len(rows),
+            "task_induced": sum(
+                1 for r in rows if r.classification == CLASSIFICATION_TASK
+            ),
+            "provider_induced": sum(
+                1 for r in rows if r.classification == CLASSIFICATION_PROVIDER
+            ),
+            "runtime_induced": sum(
+                1 for r in rows if r.classification == CLASSIFICATION_RUNTIME
+            ),
+            "inconclusive": sum(
+                1
+                for r in rows
+                if r.classification == CLASSIFICATION_INCONCLUSIVE
+            ),
+        },
+    }
+
+
+def _fmt_list(items: Iterable[str]) -> str:
+    items = list(items)
+    if not items:
+        return "—"
+    return ", ".join(f"`{i}`" for i in items)
+
+
+def report_to_md(
+    a: ArchiveObservation,
+    b: ArchiveObservation,
+    rows: list[DriftRow],
+) -> str:
+    lines: list[str] = []
+    lines.append("# Cross-Runtime Drift Report")
+    lines.append("")
+    lines.append(
+        f"- **Arm A:** `{a.runtime_label or '<unknown>'}` "
+        f"(`{a.path}`, manifest `{a.manifest_digest}`)"
+    )
+    lines.append(
+        f"- **Arm B:** `{b.runtime_label or '<unknown>'}` "
+        f"(`{b.path}`, manifest `{b.manifest_digest}`)"
+    )
+    lines.append("")
+    lines.append(
+        "| Dimension | Source | Classification | Only in A | Only in B | "
+        "In both | Detail |"
+    )
+    lines.append("|---|---|---|---|---|---|---|")
+    for r in rows:
+        lines.append(
+            f"| `{r.dimension}` | `{r.source}` | **{r.classification}** | "
+            f"{_fmt_list(r.only_in_a)} | {_fmt_list(r.only_in_b)} | "
+            f"{_fmt_list(r.in_both)} | {r.detail} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-a", required=True, type=Path, help="Arm A archive (dir or .tar.gz)"
+    )
+    parser.add_argument(
+        "--archive-b", required=True, type=Path, help="Arm B archive (dir or .tar.gz)"
+    )
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        help="Write drift.json here. Default: stdout.",
+    )
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        help="Write drift.md here. Default: do not write.",
+    )
+    parser.add_argument(
+        "--fixture-path",
+        action="append",
+        default=[],
+        help=(
+            "Mark this absolute path as a task-induced fixture so the "
+            "comparator does not flag it as runtime-induced. May be "
+            "passed multiple times. Typical use: --fixture-path "
+            "$WORKLOAD_INPUT_PATH --fixture-path $WORKLOAD_OUTPUT_PATH."
+        ),
+    )
+    parser.add_argument(
+        "--provider-host",
+        action="append",
+        default=[],
+        help=(
+            "Add a hostname/substring to the provider-endpoint whitelist. "
+            "May be passed multiple times. Defaults: "
+            + ", ".join(DEFAULT_PROVIDER_HOSTS)
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        a = parse_archive(args.archive_a)
+        b = parse_archive(args.archive_b)
+    except BadArchiveError as exc:
+        print(f"bad archive: {exc}", file=sys.stderr)
+        return 3
+
+    provider_hosts = DEFAULT_PROVIDER_HOSTS + tuple(args.provider_host)
+    fixture_paths = frozenset(args.fixture_path)
+
+    rows = build_drift_report(
+        a, b, provider_hosts=provider_hosts, fixture_paths=fixture_paths
+    )
+    payload = report_to_json(a, b, rows)
+
+    if args.out_json:
+        try:
+            args.out_json.parent.mkdir(parents=True, exist_ok=True)
+            args.out_json.write_text(
+                json.dumps(payload, indent=2, sort_keys=False) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            print(f"failed to write --out-json: {exc}", file=sys.stderr)
+            return 2
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=False))
+
+    if args.out_md:
+        try:
+            args.out_md.parent.mkdir(parents=True, exist_ok=True)
+            args.out_md.write_text(
+                report_to_md(a, b, rows), encoding="utf-8"
+            )
+        except OSError as exc:
+            print(f"failed to write --out-md: {exc}", file=sys.stderr)
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -118,7 +118,12 @@ def _open_archive_member(source: Path, member: str) -> bytes | None:
         path = source / member
         if not path.exists():
             return None
-        return path.read_bytes()
+        try:
+            return path.read_bytes()
+        except OSError as exc:
+            raise BadArchiveError(
+                f"{source}!{member}: read failed: {exc}"
+            ) from exc
     try:
         with tarfile.open(source, "r:*") as tf:
             try:
@@ -130,6 +135,9 @@ def _open_archive_member(source: Path, member: str) -> bytes | None:
             return extracted.read()
     except tarfile.TarError as exc:
         raise BadArchiveError(f"{source}: corrupt tar archive: {exc}") from exc
+    except OSError as exc:
+        # FileNotFoundError, PermissionError, etc. when opening the tarball.
+        raise BadArchiveError(f"{source}: cannot open archive: {exc}") from exc
 
 
 def _parse_json(path_repr: str, data: bytes) -> Any:
@@ -143,13 +151,20 @@ def _parse_json(path_repr: str, data: bytes) -> Any:
 
 def parse_archive(source: Path) -> ArchiveObservation:
     """Parse a Runner archive (directory or .tar.gz). Raises
-    BadArchiveError if the manifest is missing or any required file is
-    corrupt.
+    BadArchiveError if the path does not exist, the manifest is missing,
+    capability-surface.json is missing, or any required file is corrupt.
 
     Note: we read the exact manifest bytes for the digest, never
     re-serialized JSON. The drift comparator does not enforce binding
     against a trace (that's compare.py's job in the runner-vs-otel
     experiment), but it still records the digest for traceability."""
+
+    if not source.exists():
+        raise BadArchiveError(f"{source}: archive path does not exist")
+    if not (source.is_dir() or source.is_file()):
+        raise BadArchiveError(
+            f"{source}: archive path is neither a directory nor a file"
+        )
 
     manifest_bytes = _open_archive_member(source, MANIFEST_PATH)
     if manifest_bytes is None:
@@ -157,10 +172,24 @@ def parse_archive(source: Path) -> ArchiveObservation:
     manifest = _parse_json(f"{source}!{MANIFEST_PATH}", manifest_bytes)
     manifest_digest = "sha256:" + hashlib.sha256(manifest_bytes).hexdigest()
     run_id = manifest.get("run_id") if isinstance(manifest, dict) else None
-    runtime_label = (
-        manifest.get("runtime_label") if isinstance(manifest, dict) else None
-    )
+    # runtime_label is derived from SDK events below (the real Runner
+    # archive_manifest.v0 schema does not carry a runtime field; the SDK
+    # event `source` is the canonical signal).
+    runtime_label: str | None = None
 
+    # capability-surface.json is the primary evidence source for the
+    # drift comparator. Missing it is a hard exit-3, not a silent
+    # "everything inconclusive" report — otherwise an incomplete
+    # Runner capture could ship as a valid drift report in Slice 3.
+    capability_bytes = _open_archive_member(source, CAPABILITY_SURFACE_PATH)
+    if capability_bytes is None:
+        raise BadArchiveError(
+            f"{source}: capability-surface.json not found "
+            f"(required by the drift comparator)"
+        )
+    capability = _parse_json(
+        f"{source}!{CAPABILITY_SURFACE_PATH}", capability_bytes
+    )
     capability_surface: dict[str, list[str]] = {
         "filesystem_paths": [],
         "network_endpoints": [],
@@ -168,18 +197,13 @@ def parse_archive(source: Path) -> ArchiveObservation:
         "mcp_tools": [],
         "policy_decisions": [],
     }
-    capability_bytes = _open_archive_member(source, CAPABILITY_SURFACE_PATH)
-    if capability_bytes is not None:
-        capability = _parse_json(
-            f"{source}!{CAPABILITY_SURFACE_PATH}", capability_bytes
-        )
-        if isinstance(capability, dict):
-            for key in capability_surface:
-                value = capability.get(key, [])
-                if isinstance(value, list):
-                    capability_surface[key] = sorted(
-                        [str(v) for v in value if isinstance(v, str)]
-                    )
+    if isinstance(capability, dict):
+        for key in capability_surface:
+            value = capability.get(key, [])
+            if isinstance(value, list):
+                capability_surface[key] = sorted(
+                    [str(v) for v in value if isinstance(v, str)]
+                )
 
     sdk_events: list[dict[str, Any]] = []
     sdk_bytes = _open_archive_member(source, SDK_LAYER_PATH)
@@ -200,6 +224,18 @@ def parse_archive(source: Path) -> ArchiveObservation:
                     f"{source}!{SDK_LAYER_PATH}:{lineno}: "
                     f"invalid JSON: {exc}"
                 ) from exc
+
+    # Derive runtime label from the first SDK event that carries a
+    # `source` field. The Runner SDK-event v0 schema sets source to the
+    # workload-side identifier (e.g. "openai-agents", "gemini-genai"),
+    # which is the canonical signal. Falls back to None when SDK layer
+    # is absent or events do not carry source — the drift report then
+    # renders the label as `<unknown>`.
+    for event in sdk_events:
+        candidate = event.get("source")
+        if isinstance(candidate, str) and candidate:
+            runtime_label = candidate
+            break
 
     # Derive tool registration / invocation summary from SDK events.
     sdk_tools: list[str] = []
@@ -262,6 +298,23 @@ class DriftRow:
     detail: str
 
 
+def _network_endpoint_matches_provider(
+    item: str, provider_hosts: tuple[str, ...]
+) -> bool:
+    """Return True iff `item` parses as a `host:port` network endpoint
+    where the host equals (or is a subdomain of) one of the whitelisted
+    provider hosts. Substring matching is deliberately avoided so
+    filesystem paths containing `api.openai.com` do not get
+    misclassified as provider-induced when this function is mistakenly
+    called for a non-network dimension."""
+
+    host = item.rsplit(":", 1)[0] if ":" in item else item
+    for provider in provider_hosts:
+        if host == provider or host.endswith("." + provider):
+            return True
+    return False
+
+
 def _classify_row(
     only_in_a: list[str],
     only_in_b: list[str],
@@ -270,10 +323,16 @@ def _classify_row(
     has_data_b: bool,
     provider_hosts: tuple[str, ...],
     fixture_paths: frozenset[str],
+    *,
+    is_network_dimension: bool = False,
 ) -> tuple[str, str]:
     """Return (classification, detail) for one drift row.
 
-    Conservative ruleset (see module docstring for the four labels)."""
+    `is_network_dimension` gates the provider-host classification path.
+    Only the `network_endpoints` row should pass True; for other
+    dimensions a filesystem path or tool name that happens to contain a
+    provider hostname would otherwise be misclassified as
+    `provider-induced` (P2 review feedback)."""
 
     # Dimension wholly empty on both sides — task didn't exercise it.
     if not has_data_a and not has_data_b:
@@ -294,10 +353,9 @@ def _classify_row(
         return CLASSIFICATION_TASK, "full overlap"
 
     def _is_provider(item: str) -> bool:
-        for host in provider_hosts:
-            if host in item:
-                return True
-        return False
+        if not is_network_dimension:
+            return False
+        return _network_endpoint_matches_provider(item, provider_hosts)
 
     def _is_fixture(item: str) -> bool:
         return item in fixture_paths
@@ -305,7 +363,7 @@ def _classify_row(
     provider_count = sum(1 for x in non_shared if _is_provider(x))
     fixture_count = sum(1 for x in non_shared if _is_fixture(x))
     total = len(non_shared)
-    if provider_count == total:
+    if is_network_dimension and provider_count == total:
         return (
             CLASSIFICATION_PROVIDER,
             f"all {total} non-shared item(s) match provider host whitelist",
@@ -316,12 +374,18 @@ def _classify_row(
             f"all {total} non-shared item(s) match known fixture paths",
         )
     # Mixed or none-of-the-above → attribute to the runtime.
-    return (
-        CLASSIFICATION_RUNTIME,
-        f"{total} non-shared item(s); {provider_count} provider, "
-        f"{fixture_count} fixture, {total - provider_count - fixture_count} "
-        f"unclassified",
-    )
+    detail = f"{total} non-shared item(s); "
+    if is_network_dimension:
+        detail += (
+            f"{provider_count} provider, "
+            f"{fixture_count} fixture, "
+            f"{total - provider_count - fixture_count} unclassified"
+        )
+    else:
+        detail += (
+            f"{fixture_count} fixture, {total - fixture_count} unclassified"
+        )
+    return CLASSIFICATION_RUNTIME, detail
 
 
 def _diff_lists(
@@ -391,6 +455,7 @@ def build_drift_report(
         bool(b_net),
         provider_hosts,
         fixture_paths,
+        is_network_dimension=True,
     )
     rows.append(
         DriftRow(
@@ -593,11 +658,20 @@ def report_to_json(
     }
 
 
+def _md_escape_cell(text: str) -> str:
+    """Escape a string for inclusion in a Markdown table cell.
+
+    GitHub-flavoured Markdown uses `|` as column separator; an unescaped
+    `|` inside a cell ends the cell early and breaks the row. Backslash
+    escapes both the pipe and the backslash itself."""
+    return text.replace("\\", "\\\\").replace("|", "\\|")
+
+
 def _fmt_list(items: Iterable[str]) -> str:
     items = list(items)
     if not items:
         return "—"
-    return ", ".join(f"`{i}`" for i in items)
+    return ", ".join(f"`{_md_escape_cell(i)}`" for i in items)
 
 
 def report_to_md(
@@ -609,12 +683,14 @@ def report_to_md(
     lines.append("# Cross-Runtime Drift Report")
     lines.append("")
     lines.append(
-        f"- **Arm A:** `{a.runtime_label or '<unknown>'}` "
-        f"(`{a.path}`, manifest `{a.manifest_digest}`)"
+        f"- **Arm A:** `{_md_escape_cell(a.runtime_label or '<unknown>')}` "
+        f"(`{_md_escape_cell(a.path)}`, "
+        f"manifest `{a.manifest_digest}`)"
     )
     lines.append(
-        f"- **Arm B:** `{b.runtime_label or '<unknown>'}` "
-        f"(`{b.path}`, manifest `{b.manifest_digest}`)"
+        f"- **Arm B:** `{_md_escape_cell(b.runtime_label or '<unknown>')}` "
+        f"(`{_md_escape_cell(b.path)}`, "
+        f"manifest `{b.manifest_digest}`)"
     )
     lines.append("")
     lines.append(
@@ -624,9 +700,13 @@ def report_to_md(
     lines.append("|---|---|---|---|---|---|---|")
     for r in rows:
         lines.append(
-            f"| `{r.dimension}` | `{r.source}` | **{r.classification}** | "
-            f"{_fmt_list(r.only_in_a)} | {_fmt_list(r.only_in_b)} | "
-            f"{_fmt_list(r.in_both)} | {r.detail} |"
+            f"| `{_md_escape_cell(r.dimension)}` "
+            f"| `{_md_escape_cell(r.source)}` "
+            f"| **{_md_escape_cell(r.classification)}** "
+            f"| {_fmt_list(r.only_in_a)} "
+            f"| {_fmt_list(r.only_in_b)} "
+            f"| {_fmt_list(r.in_both)} "
+            f"| {_md_escape_cell(r.detail)} |"
         )
     return "\n".join(lines) + "\n"
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/capability-surface.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/capability-surface.json
@@ -1,0 +1,22 @@
+{
+  "schema": "assay.runner.capability_surface.v0",
+  "run_id": "drift_fixture_a_openai_001",
+  "filesystem_paths": [
+    "/tmp/work/fixture-input.txt",
+    "/tmp/work/fixture-output.txt",
+    "/tmp/work/workload-openai/node_modules/@openai/agents/dist/index.js",
+    "/tmp/work/workload-openai/node_modules/zod/lib/index.js",
+    "/tmp/work/workload-openai/dist/workload.js"
+  ],
+  "network_endpoints": [
+    "api.openai.com:443"
+  ],
+  "process_execs": [
+    "/usr/bin/node"
+  ],
+  "mcp_tools": [],
+  "policy_decisions": [
+    "allow:read_file",
+    "allow:write_file"
+  ]
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/correlation-report.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/correlation-report.json
@@ -1,0 +1,6 @@
+{
+  "schema": "assay.runner.correlation_report.v0",
+  "run_id": "drift_fixture_a_openai_001",
+  "status": "clean",
+  "notes": []
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/layers/sdk.ndjson
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/layers/sdk.ndjson
@@ -1,0 +1,5 @@
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_a_openai_001","seq":0,"source":"openai-agents","sdk_name":"@openai/agents","sdk_version":"0.11.4","event_type":"tool_call_started","tool_call_id":"tc_openai_001","tool":"read_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_a_openai_001","seq":1,"source":"openai-agents","sdk_name":"@openai/agents","sdk_version":"0.11.4","event_type":"tool_call_completed","tool_call_id":"tc_openai_001","tool":"read_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_a_openai_001","seq":2,"source":"openai-agents","sdk_name":"@openai/agents","sdk_version":"0.11.4","event_type":"tool_call_started","tool_call_id":"tc_openai_002","tool":"write_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_a_openai_001","seq":3,"source":"openai-agents","sdk_name":"@openai/agents","sdk_version":"0.11.4","event_type":"tool_call_completed","tool_call_id":"tc_openai_002","tool":"write_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_a_openai_001","seq":4,"source":"openai-agents","sdk_name":"@openai/agents","sdk_version":"0.11.4","event_type":"run_finished"}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/manifest.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/manifest.json
@@ -1,0 +1,12 @@
+{
+  "schema": "assay.runner.archive_manifest.v0",
+  "run_id": "drift_fixture_a_openai_001",
+  "runtime_label": "openai-agents",
+  "files": {
+    "manifest.json": {
+      "path": "manifest.json",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "bytes": 0
+    }
+  }
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/manifest.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/manifest.json
@@ -1,12 +1,26 @@
 {
   "schema": "assay.runner.archive_manifest.v0",
   "run_id": "drift_fixture_a_openai_001",
-  "runtime_label": "openai-agents",
   "files": {
-    "manifest.json": {
-      "path": "manifest.json",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "bytes": 0
+    "capability-surface.json": {
+      "path": "capability-surface.json",
+      "sha256": "sha256:a9c0ba2588080028690c94c4ff625a9a70507deb664b7694898eb8a2fcd712e6",
+      "bytes": 577
+    },
+    "observation-health.json": {
+      "path": "observation-health.json",
+      "sha256": "sha256:fa807dc6865b5e026e24c2a6ea1bdb3ebe8ea2f86d7bd4cfd33c56a46303af9e",
+      "bytes": 273
+    },
+    "correlation-report.json": {
+      "path": "correlation-report.json",
+      "sha256": "sha256:4f4ef3efac0dfa81c4e4cb79f806f786c6a59c535b1128fa9ce6612fcfd856c6",
+      "bytes": 131
+    },
+    "layers/sdk.ndjson": {
+      "path": "layers/sdk.ndjson",
+      "sha256": "sha256:bcfdad2ac9c3b4ff26070386275c17d933c5a94a60a2f812253f48402e53215a",
+      "bytes": 1171
     }
   }
 }

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/observation-health.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-a-openai/observation-health.json
@@ -1,0 +1,11 @@
+{
+  "schema": "assay.runner.observation_health.v0",
+  "run_id": "drift_fixture_a_openai_001",
+  "platform": "linux",
+  "kernel_layer": "complete",
+  "ringbuf_drops": 0,
+  "policy_layer": "present",
+  "sdk_layer": "present",
+  "cgroup_correlation": "clean",
+  "notes": []
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/capability-surface.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/capability-surface.json
@@ -1,0 +1,23 @@
+{
+  "schema": "assay.runner.capability_surface.v0",
+  "run_id": "drift_fixture_b_gemini_001",
+  "filesystem_paths": [
+    "/tmp/work/fixture-input.txt",
+    "/tmp/work/fixture-output.txt",
+    "/tmp/work/workload-gemini/node_modules/@google/genai/dist/index.js",
+    "/tmp/work/workload-gemini/node_modules/google-auth-library/build/src/index.js",
+    "/tmp/work/workload-gemini/dist/workload.js"
+  ],
+  "network_endpoints": [
+    "generativelanguage.googleapis.com:443",
+    "oauth2.googleapis.com:443"
+  ],
+  "process_execs": [
+    "/usr/bin/node"
+  ],
+  "mcp_tools": [],
+  "policy_decisions": [
+    "allow:read_file",
+    "allow:write_file"
+  ]
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/correlation-report.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/correlation-report.json
@@ -1,0 +1,6 @@
+{
+  "schema": "assay.runner.correlation_report.v0",
+  "run_id": "drift_fixture_b_gemini_001",
+  "status": "clean",
+  "notes": []
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/layers/sdk.ndjson
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/layers/sdk.ndjson
@@ -1,0 +1,5 @@
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_b_gemini_001","seq":0,"source":"gemini-genai","sdk_name":"@google/genai","sdk_version":"2.6.0","event_type":"tool_call_started","tool_call_id":"tc_gemini_001","tool":"read_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_b_gemini_001","seq":1,"source":"gemini-genai","sdk_name":"@google/genai","sdk_version":"2.6.0","event_type":"tool_call_completed","tool_call_id":"tc_gemini_001","tool":"read_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_b_gemini_001","seq":2,"source":"gemini-genai","sdk_name":"@google/genai","sdk_version":"2.6.0","event_type":"tool_call_started","tool_call_id":"tc_gemini_002","tool":"write_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_b_gemini_001","seq":3,"source":"gemini-genai","sdk_name":"@google/genai","sdk_version":"2.6.0","event_type":"tool_call_completed","tool_call_id":"tc_gemini_002","tool":"write_file"}
+{"schema":"assay.runner.sdk_event.v0","run_id":"drift_fixture_b_gemini_001","seq":4,"source":"gemini-genai","sdk_name":"@google/genai","sdk_version":"2.6.0","event_type":"run_finished"}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/manifest.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/manifest.json
@@ -1,0 +1,12 @@
+{
+  "schema": "assay.runner.archive_manifest.v0",
+  "run_id": "drift_fixture_b_gemini_001",
+  "runtime_label": "gemini-genai",
+  "files": {
+    "manifest.json": {
+      "path": "manifest.json",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "bytes": 0
+    }
+  }
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/manifest.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/manifest.json
@@ -1,12 +1,26 @@
 {
   "schema": "assay.runner.archive_manifest.v0",
   "run_id": "drift_fixture_b_gemini_001",
-  "runtime_label": "gemini-genai",
   "files": {
-    "manifest.json": {
-      "path": "manifest.json",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "bytes": 0
+    "capability-surface.json": {
+      "path": "capability-surface.json",
+      "sha256": "sha256:6d964d14fc6fcfa7f2d4b9c3aca2853fc871a9326c4287bb461da9c44c022fd1",
+      "bytes": 650
+    },
+    "observation-health.json": {
+      "path": "observation-health.json",
+      "sha256": "sha256:33f78e8268963f042a65660c43c7944536dec6a96f6ee1728e4cef408c5d81aa",
+      "bytes": 273
+    },
+    "correlation-report.json": {
+      "path": "correlation-report.json",
+      "sha256": "sha256:056f84cf967013499a224050a2517840e900255999b1ccd74ff6a1fb2cffedb0",
+      "bytes": 131
+    },
+    "layers/sdk.ndjson": {
+      "path": "layers/sdk.ndjson",
+      "sha256": "sha256:d43530893a54c9f1ca2ebf8ab76ed7127152b73d89d449fd5c03e5fabbc29df9",
+      "bytes": 1156
     }
   }
 }

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/observation-health.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini/observation-health.json
@@ -1,0 +1,11 @@
+{
+  "schema": "assay.runner.observation_health.v0",
+  "run_id": "drift_fixture_b_gemini_001",
+  "platform": "linux",
+  "kernel_layer": "complete",
+  "ringbuf_drops": 0,
+  "policy_layer": "present",
+  "sdk_layer": "present",
+  "cgroup_correlation": "clean",
+  "notes": []
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -1,0 +1,365 @@
+"""Unit tests for the cross-runtime drift comparator.
+
+Stdlib unittest only. Exercises:
+  - parse_archive happy path (directory + .tar.gz)
+  - parse_archive failure modes (missing manifest, corrupt JSON,
+    broken tar)
+  - build_drift_report against the synthetic fixtures in
+    compare/fixtures/{arm-a-openai, arm-b-gemini}/
+  - classification labels per dimension
+  - main() exit codes and file output
+
+Run from repo root:
+  python3 -m unittest discover \
+    -s docs/experiments/cross-runtime-drift-2026-05/compare \
+    -p 'test_*.py'
+
+(`python3 -m unittest <module>` cannot be used because the
+directory name contains a hyphen, which Python's module importer
+rejects. Use the discover form above instead.)
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+
+import drift  # noqa: E402  (after sys.path tweak)
+
+FIXTURES = THIS_DIR / "fixtures"
+ARM_A = FIXTURES / "arm-a-openai"
+ARM_B = FIXTURES / "arm-b-gemini"
+
+
+def _make_tarball(src_dir: Path, dest: Path) -> Path:
+    """Build a .tar.gz of src_dir's contents (paths relative to src_dir)."""
+    with tarfile.open(dest, "w:gz") as tf:
+        for path in sorted(src_dir.rglob("*")):
+            if path.is_file():
+                tf.add(path, arcname=str(path.relative_to(src_dir)))
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# parse_archive
+# ---------------------------------------------------------------------------
+
+
+class ParseArchiveHappyPathTests(unittest.TestCase):
+    def test_parse_arm_a_directory(self) -> None:
+        obs = drift.parse_archive(ARM_A)
+        self.assertEqual(obs.runtime_label, "openai-agents")
+        self.assertEqual(obs.run_id, "drift_fixture_a_openai_001")
+        self.assertTrue(obs.manifest_digest.startswith("sha256:"))
+        self.assertIn(
+            "/tmp/work/fixture-input.txt",
+            obs.capability_surface["filesystem_paths"],
+        )
+        self.assertEqual(
+            obs.capability_surface["network_endpoints"],
+            ["api.openai.com:443"],
+        )
+        self.assertEqual(obs.sdk_tools, ["read_file", "write_file"])
+        # Ordering: read_file first (seq=0), then write_file (seq=2).
+        self.assertEqual(
+            obs.sdk_tool_order,
+            ["tc_openai_001:read_file", "tc_openai_002:write_file"],
+        )
+
+    def test_parse_arm_b_directory(self) -> None:
+        obs = drift.parse_archive(ARM_B)
+        self.assertEqual(obs.runtime_label, "gemini-genai")
+        self.assertEqual(
+            obs.capability_surface["network_endpoints"],
+            [
+                "generativelanguage.googleapis.com:443",
+                "oauth2.googleapis.com:443",
+            ],
+        )
+        self.assertEqual(obs.sdk_tools, ["read_file", "write_file"])
+
+    def test_parse_arm_a_as_tarball(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tarpath = Path(tmp) / "arm-a.tar.gz"
+            _make_tarball(ARM_A, tarpath)
+            obs = drift.parse_archive(tarpath)
+            self.assertEqual(obs.runtime_label, "openai-agents")
+            self.assertEqual(obs.sdk_event_count, 5)
+
+
+class ParseArchiveFailureTests(unittest.TestCase):
+    def test_missing_manifest_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(drift.BadArchiveError) as ctx:
+                drift.parse_archive(Path(tmp))
+            self.assertIn("manifest.json not found", str(ctx.exception))
+
+    def test_corrupt_manifest_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "manifest.json").write_text("{not valid", encoding="utf-8")
+            with self.assertRaises(drift.BadArchiveError) as ctx:
+                drift.parse_archive(tmpdir)
+            self.assertIn("invalid JSON", str(ctx.exception))
+
+    def test_corrupt_sdk_ndjson_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "manifest.json").write_text(
+                json.dumps({"schema": "x", "run_id": "y"}), encoding="utf-8"
+            )
+            (tmpdir / "layers").mkdir()
+            (tmpdir / "layers" / "sdk.ndjson").write_text(
+                "{bad json}\n", encoding="utf-8"
+            )
+            with self.assertRaises(drift.BadArchiveError) as ctx:
+                drift.parse_archive(tmpdir)
+            self.assertIn("invalid JSON", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# build_drift_report
+# ---------------------------------------------------------------------------
+
+
+class DriftReportClassificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.a = drift.parse_archive(ARM_A)
+        self.b = drift.parse_archive(ARM_B)
+        self.fixture_paths = frozenset(
+            [
+                "/tmp/work/fixture-input.txt",
+                "/tmp/work/fixture-output.txt",
+            ]
+        )
+
+    def _by_dim(
+        self, rows: list[drift.DriftRow]
+    ) -> dict[str, drift.DriftRow]:
+        return {r.dimension: r for r in rows}
+
+    def test_filesystem_paths_runtime_induced(self) -> None:
+        rows = drift.build_drift_report(
+            self.a, self.b, fixture_paths=self.fixture_paths
+        )
+        row = self._by_dim(rows)["filesystem_paths_touched"]
+        # Both arms touched the two fixture paths.
+        self.assertIn("/tmp/work/fixture-input.txt", row.in_both)
+        self.assertIn("/tmp/work/fixture-output.txt", row.in_both)
+        # Non-shared paths exist on both sides (different node_modules).
+        self.assertTrue(row.only_in_a)
+        self.assertTrue(row.only_in_b)
+        self.assertEqual(row.classification, drift.CLASSIFICATION_RUNTIME)
+
+    def test_network_endpoints_provider_induced(self) -> None:
+        rows = drift.build_drift_report(self.a, self.b)
+        row = self._by_dim(rows)["network_endpoints"]
+        self.assertEqual(row.in_both, [])
+        self.assertIn("api.openai.com:443", row.only_in_a)
+        self.assertIn(
+            "generativelanguage.googleapis.com:443", row.only_in_b
+        )
+        self.assertEqual(row.classification, drift.CLASSIFICATION_PROVIDER)
+
+    def test_process_execs_task_induced(self) -> None:
+        rows = drift.build_drift_report(self.a, self.b)
+        row = self._by_dim(rows)["process_execs"]
+        self.assertEqual(row.in_both, ["/usr/bin/node"])
+        self.assertEqual(row.classification, drift.CLASSIFICATION_TASK)
+
+    def test_sdk_tools_task_induced(self) -> None:
+        rows = drift.build_drift_report(self.a, self.b)
+        row = self._by_dim(rows)["sdk_tool_events"]
+        self.assertEqual(row.in_both, ["read_file", "write_file"])
+        self.assertEqual(row.classification, drift.CLASSIFICATION_TASK)
+
+    def test_mcp_empty_both_inconclusive(self) -> None:
+        rows = drift.build_drift_report(self.a, self.b)
+        row = self._by_dim(rows)["mcp_tool_surface"]
+        self.assertEqual(row.in_both, [])
+        self.assertEqual(
+            row.classification, drift.CLASSIFICATION_INCONCLUSIVE
+        )
+
+    def test_tool_invocation_order_task_induced(self) -> None:
+        rows = drift.build_drift_report(self.a, self.b)
+        row = self._by_dim(rows)["tool_invocation_order"]
+        # Both arms invoked read_file then write_file.
+        self.assertEqual(row.in_both, ["read_file", "write_file"])
+        self.assertEqual(row.classification, drift.CLASSIFICATION_TASK)
+
+
+class DriftReportInconclusiveTests(unittest.TestCase):
+    """One arm has data for a dimension, the other does not → inconclusive."""
+
+    def test_one_sided_network_endpoints(self) -> None:
+        a = drift.ArchiveObservation(
+            path="a",
+            run_id="a",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:aa",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["api.openai.com:443"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+        )
+        b = drift.ArchiveObservation(
+            path="b",
+            run_id="b",
+            runtime_label="gemini-genai",
+            manifest_digest="sha256:bb",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": [],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+        )
+        rows = drift.build_drift_report(a, b)
+        row = next(r for r in rows if r.dimension == "network_endpoints")
+        self.assertEqual(
+            row.classification, drift.CLASSIFICATION_INCONCLUSIVE
+        )
+        self.assertIn("arm-b", row.detail)
+
+
+class DriftReportFixturePathOverrideTests(unittest.TestCase):
+    """An extra fixture path that only one arm touched (e.g. cache file)
+    should be classified task-induced when whitelisted, runtime-induced
+    otherwise."""
+
+    def _make_obs(self, label: str, extra_path: str) -> drift.ArchiveObservation:
+        return drift.ArchiveObservation(
+            path=label,
+            run_id=label,
+            runtime_label=label,
+            manifest_digest="sha256:" + "0" * 64,
+            capability_surface={
+                "filesystem_paths": sorted(
+                    [
+                        "/tmp/work/fixture-input.txt",
+                        "/tmp/work/fixture-output.txt",
+                        extra_path,
+                    ]
+                ),
+                "network_endpoints": [],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+        )
+
+    def test_fixture_path_override_classifies_as_task(self) -> None:
+        a = self._make_obs(
+            "openai-agents", "/tmp/work/extra-fixture.txt"
+        )
+        b = self._make_obs(
+            "gemini-genai", "/tmp/work/fixture-input.txt"
+        )  # b has no extra; a does
+        rows = drift.build_drift_report(
+            a,
+            b,
+            fixture_paths=frozenset(
+                [
+                    "/tmp/work/fixture-input.txt",
+                    "/tmp/work/fixture-output.txt",
+                    "/tmp/work/extra-fixture.txt",
+                ]
+            ),
+        )
+        row = next(
+            r for r in rows if r.dimension == "filesystem_paths_touched"
+        )
+        # Only difference is the extra-fixture path which is whitelisted.
+        self.assertIn("/tmp/work/extra-fixture.txt", row.only_in_a)
+        self.assertEqual(row.classification, drift.CLASSIFICATION_TASK)
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+class MainCliTests(unittest.TestCase):
+    def test_main_writes_json_and_md(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            out_json = tmpdir / "drift.json"
+            out_md = tmpdir / "drift.md"
+            rc = drift.main(
+                [
+                    "--archive-a",
+                    str(ARM_A),
+                    "--archive-b",
+                    str(ARM_B),
+                    "--out-json",
+                    str(out_json),
+                    "--out-md",
+                    str(out_md),
+                    "--fixture-path",
+                    "/tmp/work/fixture-input.txt",
+                    "--fixture-path",
+                    "/tmp/work/fixture-output.txt",
+                ]
+            )
+            self.assertEqual(rc, 0)
+            self.assertTrue(out_json.is_file())
+            self.assertTrue(out_md.is_file())
+            payload = json.loads(out_json.read_text(encoding="utf-8"))
+            self.assertEqual(payload["schema"], drift.DRIFT_REPORT_SCHEMA)
+            self.assertEqual(
+                payload["archive_a"]["runtime_label"], "openai-agents"
+            )
+            self.assertEqual(
+                payload["archive_b"]["runtime_label"], "gemini-genai"
+            )
+            dims = [r["dimension"] for r in payload["rows"]]
+            self.assertIn("filesystem_paths_touched", dims)
+            self.assertIn("network_endpoints", dims)
+            self.assertIn("tool_invocation_order", dims)
+            # Markdown carries a header + a row per dimension.
+            md = out_md.read_text(encoding="utf-8")
+            self.assertIn("# Cross-Runtime Drift Report", md)
+            self.assertIn("filesystem_paths_touched", md)
+
+    def test_main_returns_3_on_bad_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            rc = drift.main(
+                [
+                    "--archive-a",
+                    tmp,  # empty dir, no manifest
+                    "--archive-b",
+                    str(ARM_B),
+                ]
+            )
+            self.assertEqual(rc, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -115,6 +115,13 @@ class ParseArchiveFailureTests(unittest.TestCase):
             (tmpdir / "manifest.json").write_text(
                 json.dumps({"schema": "x", "run_id": "y"}), encoding="utf-8"
             )
+            # capability-surface.json is required (P1 #2 review); provide
+            # a minimal one so the test exercises the *SDK* parse failure
+            # rather than the missing-capability-surface gate.
+            (tmpdir / "capability-surface.json").write_text(
+                json.dumps({"schema": "assay.runner.capability_surface.v0"}),
+                encoding="utf-8",
+            )
             (tmpdir / "layers").mkdir()
             (tmpdir / "layers" / "sdk.ndjson").write_text(
                 "{bad json}\n", encoding="utf-8"
@@ -122,6 +129,24 @@ class ParseArchiveFailureTests(unittest.TestCase):
             with self.assertRaises(drift.BadArchiveError) as ctx:
                 drift.parse_archive(tmpdir)
             self.assertIn("invalid JSON", str(ctx.exception))
+
+    def test_nonexistent_archive_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(drift.BadArchiveError) as ctx:
+                drift.parse_archive(Path(tmp) / "does-not-exist.tar.gz")
+            self.assertIn("does not exist", str(ctx.exception))
+
+    def test_missing_capability_surface_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "manifest.json").write_text(
+                json.dumps({"schema": "x", "run_id": "y"}), encoding="utf-8"
+            )
+            # No capability-surface.json — must be a hard exit-3, not a
+            # silent "everything inconclusive" report.
+            with self.assertRaises(drift.BadArchiveError) as ctx:
+                drift.parse_archive(tmpdir)
+            self.assertIn("capability-surface.json", str(ctx.exception))
 
 
 # ---------------------------------------------------------------------------
@@ -359,6 +384,199 @@ class MainCliTests(unittest.TestCase):
                 ]
             )
             self.assertEqual(rc, 3)
+
+    def test_main_returns_3_on_nonexistent_archive(self) -> None:
+        """The CLI must not crash with a traceback when a path is wrong
+        — that was P1 #1 in the Slice 2 review."""
+        with tempfile.TemporaryDirectory() as tmp:
+            rc = drift.main(
+                [
+                    "--archive-a",
+                    str(Path(tmp) / "does-not-exist.tar.gz"),
+                    "--archive-b",
+                    str(ARM_B),
+                ]
+            )
+            self.assertEqual(rc, 3)
+
+
+class RuntimeLabelDerivationTests(unittest.TestCase):
+    """runtime_label must come from SDK events' `source` field, not from
+    a made-up manifest field (P2 #3 in the Slice 2 review)."""
+
+    def test_label_derived_from_sdk_event_source(self) -> None:
+        a = drift.parse_archive(ARM_A)
+        b = drift.parse_archive(ARM_B)
+        self.assertEqual(a.runtime_label, "openai-agents")
+        self.assertEqual(b.runtime_label, "gemini-genai")
+
+    def test_label_is_none_when_no_sdk_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "manifest.json").write_text(
+                json.dumps({"schema": "x", "run_id": "y"}), encoding="utf-8"
+            )
+            (tmpdir / "capability-surface.json").write_text(
+                json.dumps({"schema": "assay.runner.capability_surface.v0"}),
+                encoding="utf-8",
+            )
+            obs = drift.parse_archive(tmpdir)
+            self.assertIsNone(obs.runtime_label)
+
+
+class ProviderClassificationScopeTests(unittest.TestCase):
+    """Provider-host classification must only apply to the
+    network_endpoints dimension. A filesystem path that happens to
+    contain a provider hostname must NOT be labelled provider-induced
+    (P2 #1 in the Slice 2 review)."""
+
+    def _make_obs(
+        self, label: str, fs_extra: str
+    ) -> drift.ArchiveObservation:
+        return drift.ArchiveObservation(
+            path=label,
+            run_id=label,
+            runtime_label=label,
+            manifest_digest="sha256:" + "0" * 64,
+            capability_surface={
+                "filesystem_paths": sorted(
+                    [
+                        "/tmp/work/fixture-input.txt",
+                        "/tmp/work/fixture-output.txt",
+                        fs_extra,
+                    ]
+                ),
+                "network_endpoints": [],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+        )
+
+    def test_provider_hostname_in_fs_path_is_runtime_not_provider(
+        self,
+    ) -> None:
+        # A filesystem path that contains 'api.openai.com' must not
+        # bleed into the provider-host classification.
+        a = self._make_obs(
+            "openai-agents",
+            "/tmp/cache/api.openai.com.json",
+        )
+        b = self._make_obs(
+            "gemini-genai",
+            "/tmp/cache/generativelanguage.googleapis.com.json",
+        )
+        rows = drift.build_drift_report(a, b)
+        row = next(
+            r for r in rows if r.dimension == "filesystem_paths_touched"
+        )
+        self.assertEqual(row.classification, drift.CLASSIFICATION_RUNTIME)
+        # And the detail must NOT claim "all match provider whitelist".
+        self.assertNotIn("provider", row.detail)
+
+
+class NetworkEndpointParsingTests(unittest.TestCase):
+    """Provider-host check must parse `host:port` properly and reject
+    non-matching substrings."""
+
+    def test_host_port_split(self) -> None:
+        self.assertTrue(
+            drift._network_endpoint_matches_provider(
+                "api.openai.com:443", drift.DEFAULT_PROVIDER_HOSTS
+            )
+        )
+
+    def test_subdomain_match(self) -> None:
+        self.assertTrue(
+            drift._network_endpoint_matches_provider(
+                "auth.openai.com:443", drift.DEFAULT_PROVIDER_HOSTS
+            )
+        )
+
+    def test_substring_does_not_match(self) -> None:
+        # A path-shaped string containing the host should not match.
+        self.assertFalse(
+            drift._network_endpoint_matches_provider(
+                "/tmp/api.openai.com.json", drift.DEFAULT_PROVIDER_HOSTS
+            )
+        )
+
+    def test_lookalike_host_does_not_match(self) -> None:
+        # `evil-api.openai.com.attacker.example` must NOT be accepted.
+        self.assertFalse(
+            drift._network_endpoint_matches_provider(
+                "evil-api.openai.com.attacker.example:443",
+                drift.DEFAULT_PROVIDER_HOSTS,
+            )
+        )
+
+
+class MarkdownEscapeTests(unittest.TestCase):
+    """Markdown table cells must escape `|` so that a runtime-induced
+    invocation-order row with `a: ... | b: ...` in the detail does not
+    break the table (P2 #2 in the Slice 2 review)."""
+
+    def test_pipe_in_detail_is_escaped(self) -> None:
+        a = drift.ArchiveObservation(
+            path="a",
+            run_id="a",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:" + "0" * 64,
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": [],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=2,
+            sdk_tools=["read_file", "write_file"],
+            sdk_tool_call_ids=["tc_1", "tc_2"],
+            sdk_tool_order=["tc_1:read_file", "tc_2:write_file"],
+        )
+        b = drift.ArchiveObservation(
+            path="b",
+            run_id="b",
+            runtime_label="gemini-genai",
+            manifest_digest="sha256:" + "0" * 64,
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": [],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=2,
+            sdk_tools=["read_file", "write_file"],
+            sdk_tool_call_ids=["tc_1", "tc_2"],
+            # Reversed order to trigger the runtime-induced detail
+            # that contains "a: ... | b: ...".
+            sdk_tool_order=["tc_1:write_file", "tc_2:read_file"],
+        )
+        rows = drift.build_drift_report(a, b)
+        md = drift.report_to_md(a, b, rows)
+        # Every line that starts with `|` must have the same number of
+        # unescaped `|` separators — otherwise the table breaks. We
+        # count by stripping escaped pipes first.
+        for line in md.splitlines():
+            if not line.startswith("|"):
+                continue
+            unescaped = line.replace("\\|", "")
+            # Each table row in our schema has 8 unescaped `|` chars
+            # (7 cell separators + leading and trailing pipe = 8).
+            count = unescaped.count("|")
+            self.assertEqual(
+                count,
+                8,
+                f"row has {count} unescaped pipes, expected 8: {line!r}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Slice 2 of [cross-runtime-drift-2026-05](../tree/main/docs/experiments/cross-runtime-drift-2026-05): the `compare/drift.py` MVP that reads two Runner archives and emits a per-dimension drift report.

- **`compare/drift.py`** — stdlib Python comparator. Six dimensions all sourced from v0 capability_surface fields plus `layers/sdk.ndjson`. Each drift row carries one of four classification labels: `task-induced`, `provider-induced`, `runtime-induced`, `inconclusive`.
- **`compare/fixtures/arm-a-openai/`** + **`compare/fixtures/arm-b-gemini/`** — synthetic archives wired so each classification label is exercised exactly once when the comparator runs against them.
- **`compare/test_drift.py`** — 16 stdlib unit tests covering parsing (directory + tar.gz), failure modes (missing manifest, corrupt JSON, broken tar), every classification label, fixture-path overrides, and CLI output.
- Output schema locked in: `assay.cross_runtime_drift.v0`. JSON on stdout or `--out-json`; optional `--out-md` for a markdown table.

## Smoke run output (against synthetic fixtures)

| Dimension | Classification | Why |
|---|---|---|
| `filesystem_paths_touched` | `runtime-induced` | different `node_modules` paths per runtime |
| `network_endpoints` | `provider-induced` | `api.openai.com` vs `generativelanguage.googleapis.com` |
| `process_execs` | `task-induced` | both `/usr/bin/node` |
| `sdk_tool_events` | `task-induced` | both register `read_file` + `write_file` |
| `mcp_tool_surface` | `inconclusive` | empty in both arms |
| `tool_invocation_order` | `task-induced` | identical `read_file → write_file` sequence |

## What's intentionally NOT here
- No live captures on `assay-bpf-runner` (Slice 3).
- No read/write/create/remove split (deferred v2 follow-up — kernel.ndjson parsing).
- No per-path access counts (same v2 follow-up).
- No `GOOGLE_API_KEY` workflow secret (still local-only).

## Test plan
- [x] Pre-commit + pre-push gates green (typos, fmt, clippy, linux compile)
- [x] `python3 -m unittest discover -s docs/.../compare -p 'test_*.py'` → 16/16 OK
- [x] Smoke run against synthetic fixtures produces the expected classification labels (see table above)
- [ ] User: review classification heuristics + provider-host whitelist before Slice 3 lights up live runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)