### PR TITLE
docs(experiments): Slice 3 — cross-runtime drift workflow + dispatch docs

### DIFF
--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -148,6 +148,8 @@ jobs:
           ASSAY_BIN="$PWD/target/debug/assay"
           EBPF_OBJ="$PWD/target/assay-ebpf.o"
           WORKLOAD_JS="$PWD/${{ env.WORKLOAD_DIR }}/dist/workload.js"
+          CONTRACT_CHECK="$PWD/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py"
+          HEALTH_GATE="$PWD/docs/experiments/cross-runtime-drift-2026-05/compare/health_gate.py"
           OUT_ROOT="$PWD/arm-${ARM}-runs"
           mkdir -p "$OUT_ROOT"
 
@@ -177,6 +179,19 @@ jobs:
             # Child ran under sudo; chown so subsequent steps + the
             # artifact upload action can read.
             sudo chown -R "$(id -u):$(id -g)" "$RUN_DIR"
+
+            # Health gate. Fail the iteration if eBPF dropped events,
+            # the kernel layer is degraded, or cgroup correlation broke.
+            # The docs document discarding such runs; the workflow
+            # enforces it before any artifact upload (P2 review).
+            python3 "$HEALTH_GATE" --archive "$ARCHIVE_OUT"
+
+            # Workload contract check. A run where the workload exited
+            # 0 but produced wrong tool order, missing output, or
+            # non-uppercase contents is a Slice 1 contract violation and
+            # must not be shipped as a valid Slice 3 baseline (P1
+            # review).
+            python3 "$CONTRACT_CHECK" --work-dir "$WORK_DIR"
 
             echo "::endgroup::"
           done
@@ -282,6 +297,8 @@ jobs:
           ASSAY_BIN="$PWD/target/debug/assay"
           EBPF_OBJ="$PWD/target/assay-ebpf.o"
           WORKLOAD_JS="$PWD/${{ env.WORKLOAD_DIR }}/dist/workload.js"
+          CONTRACT_CHECK="$PWD/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py"
+          HEALTH_GATE="$PWD/docs/experiments/cross-runtime-drift-2026-05/compare/health_gate.py"
           OUT_ROOT="$PWD/arm-${ARM}-runs"
           mkdir -p "$OUT_ROOT"
 
@@ -309,6 +326,11 @@ jobs:
                 -- node "$WORKLOAD_JS"
 
             sudo chown -R "$(id -u):$(id -g)" "$RUN_DIR"
+
+            # Health gate + workload contract check. Same gates as
+            # Arm A — P1 + P2 review feedback on PR #1347.
+            python3 "$HEALTH_GATE" --archive "$ARCHIVE_OUT"
+            python3 "$CONTRACT_CHECK" --work-dir "$WORK_DIR"
 
             echo "::endgroup::"
           done
@@ -364,6 +386,13 @@ jobs:
             exit 1
           fi
 
+          # Per pair we extract the four real fixture paths from each
+          # run's tool-calls.ndjson — that is the absolute path the
+          # workload actually called (and the kernel observed). The
+          # contract-checker has already verified these line-by-line in
+          # the per-iteration step, so reading them here is safe.
+          EXTRACT_PATHS="$PWD/docs/experiments/cross-runtime-drift-2026-05/compare/extract_fixture_paths.py"
+
           for i in "${!A_RUNS[@]}"; do
             A_DIR="${A_RUNS[$i]}"
             B_DIR="${B_RUNS[$i]}"
@@ -371,12 +400,21 @@ jobs:
             B_ARCHIVE="$B_DIR/archive.tar.gz"
             REPORT_BASE="$DRIFT_OUT/drift_pair_$((i + 1))"
 
+            # Four fixture paths: input + output for each arm. Without
+            # these, the absolute /workdir paths the workload actually
+            # touched would be misclassified as runtime-induced
+            # filesystem drift (P1 review on PR #1347).
+            mapfile -t A_PATHS < <(python3 "$EXTRACT_PATHS" --tool-calls "$A_DIR/workdir/tool-calls.ndjson")
+            mapfile -t B_PATHS < <(python3 "$EXTRACT_PATHS" --tool-calls "$B_DIR/workdir/tool-calls.ndjson")
+
             echo "::group::Drift pair $((i + 1)): $A_DIR vs $B_DIR"
             python3 "$DRIFT_PY" \
               --archive-a "$A_ARCHIVE" \
               --archive-b "$B_ARCHIVE" \
-              --fixture-path "/tmp/work/fixture-input.txt" \
-              --fixture-path "/tmp/work/fixture-output.txt" \
+              --fixture-path "${A_PATHS[0]}" \
+              --fixture-path "${A_PATHS[1]}" \
+              --fixture-path "${B_PATHS[0]}" \
+              --fixture-path "${B_PATHS[1]}" \
               --out-json "${REPORT_BASE}.json" \
               --out-md "${REPORT_BASE}.md"
             {

--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -1,0 +1,397 @@
+name: Cross-Runtime Drift Experiment
+
+# Manually-dispatched workflow that runs the
+# cross-runtime-drift-2026-05 experiment's Arm A (OpenAI Agents) and
+# Arm B (Gemini GenAI) on the delegated `assay-bpf-runner` host, then
+# runs `compare/drift.py` over each (A_i, B_i) pair. Produces real
+# Runner archives + drift reports as workflow artifacts; baselines
+# under `runs/{a0,b0}/` are committed separately by the maintainer
+# after reviewing the artifacts.
+#
+# Discipline:
+#  - workflow_dispatch only; no pull_request trigger (matches
+#    runner-otel-experiment.yml).
+#  - Uses the same self-hosted runner as the Phase 1 delegated gates.
+#  - Requires repo secrets OPENAI_API_KEY and GOOGLE_API_KEY. The job
+#    fails fast with a clear message if either is missing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repetitions:
+        description: "Number of dual-capture iterations per arm (n)"
+        required: true
+        default: "3"
+        type: string
+      build_ebpf:
+        description: "Rebuild eBPF artifact (target/assay-ebpf.o) before the run"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-runtime-drift-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-delegated-runner:
+    name: Prepare delegated runner
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    timeout-minutes: 5
+    steps:
+      - name: Reset workspace ownership
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Mirror the prepare-delegated-runner pattern from
+          # runner-otel-experiment.yml / runner-spike-delegated.yml so
+          # action and cargo cache state from a previous run does not
+          # block this job.
+          sudo find "$GITHUB_WORKSPACE/.." -maxdepth 2 -type d -name "_actions" -exec rm -rf {} + 2>/dev/null || true
+          if [ -d "$GITHUB_WORKSPACE" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true
+          fi
+
+  arm-a-openai:
+    name: Arm A — OpenAI Agents (capture)
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    needs: prepare-delegated-runner
+    timeout-minutes: 30
+    env:
+      ARM: a-openai
+      AGENT_SHIM: openai-agents
+      WORKLOAD_DIR: docs/experiments/cross-runtime-drift-2026-05/workload-openai
+    steps:
+      - name: Fail fast if OPENAI_API_KEY is missing
+        shell: bash
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "ERROR: OPENAI_API_KEY repo secret is not set" >&2
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Preflight delegated host
+        shell: bash
+        run: |
+          set -euo pipefail
+          for bin in cargo node npm python3 rustc tar; do
+            command -v "$bin" >/dev/null 2>&1 || {
+              echo "ERROR: required command not found on delegated runner: $bin" >&2
+              exit 1
+            }
+          done
+          node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)' || {
+            echo "ERROR: delegated runner must provide Node.js 22 or newer" >&2
+            node --version >&2 || true
+            exit 1
+          }
+          if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+            echo "ERROR: delegated runner must expose cgroup v2 at /sys/fs/cgroup" >&2
+            exit 1
+          fi
+
+      - name: Build assay CLI (runner feature)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p assay-cli --no-default-features --features runner
+
+      - name: Build eBPF artifact
+        if: ${{ inputs.build_ebpf }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v docker >/dev/null 2>&1; then
+            cargo xtask build-image
+            cargo xtask build-ebpf --docker
+          else
+            cargo xtask build-ebpf
+          fi
+          test -f target/assay-ebpf.o
+
+      - name: Verify eBPF artifact present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f target/assay-ebpf.o ]; then
+            echo "ERROR: target/assay-ebpf.o is required. Run with build_ebpf=true." >&2
+            exit 1
+          fi
+
+      - name: Build workload-openai
+        working-directory: ${{ env.WORKLOAD_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund --ignore-scripts
+          npx tsc -p tsconfig.json
+          test -f dist/workload.js
+
+      - name: Run Arm A captures (N times)
+        shell: bash
+        env:
+          REPETITIONS: ${{ inputs.repetitions }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          ASSAY_BIN="$PWD/target/debug/assay"
+          EBPF_OBJ="$PWD/target/assay-ebpf.o"
+          WORKLOAD_JS="$PWD/${{ env.WORKLOAD_DIR }}/dist/workload.js"
+          OUT_ROOT="$PWD/arm-${ARM}-runs"
+          mkdir -p "$OUT_ROOT"
+
+          for i in $(seq 1 "$REPETITIONS"); do
+            RUN_ID="run_arm_${ARM}_$(date -u +%Y%m%dT%H%M%SZ)_$i"
+            RUN_DIR="$OUT_ROOT/$RUN_ID"
+            mkdir -p "$RUN_DIR/workdir"
+            ARCHIVE_OUT="$RUN_DIR/archive.tar.gz"
+            SDK_LOG="$RUN_DIR/sdk-events.ndjson"
+            WORK_DIR="$RUN_DIR/workdir"
+
+            echo "::group::Arm A iteration $i/$REPETITIONS ($RUN_ID)"
+
+            sudo -E env \
+              "PATH=$PATH" \
+              "OPENAI_API_KEY=$OPENAI_API_KEY" \
+              "WORKLOAD_WORK_DIR=$WORK_DIR" \
+              "$ASSAY_BIN" runner-spike run \
+                --agent-shim "$AGENT_SHIM" \
+                --kernel-capture \
+                --ebpf "$EBPF_OBJ" \
+                --run-id "$RUN_ID" \
+                --output "$ARCHIVE_OUT" \
+                --sdk-event-log "$SDK_LOG" \
+                -- node "$WORKLOAD_JS"
+
+            # Child ran under sudo; chown so subsequent steps + the
+            # artifact upload action can read.
+            sudo chown -R "$(id -u):$(id -g)" "$RUN_DIR"
+
+            echo "::endgroup::"
+          done
+
+      - name: Upload Arm A run artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cross-runtime-drift-arm-a-openai-${{ github.run_id }}
+          path: arm-a-openai-runs/
+          if-no-files-found: error
+          retention-days: 30
+
+  arm-b-gemini:
+    name: Arm B — Gemini GenAI (capture)
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    needs: prepare-delegated-runner
+    timeout-minutes: 30
+    env:
+      ARM: b-gemini
+      AGENT_SHIM: gemini-google-genai
+      WORKLOAD_DIR: docs/experiments/cross-runtime-drift-2026-05/workload-gemini
+    steps:
+      - name: Fail fast if GOOGLE_API_KEY is missing
+        shell: bash
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GOOGLE_API_KEY:-}" ]; then
+            echo "ERROR: GOOGLE_API_KEY repo secret is not set" >&2
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Preflight delegated host
+        shell: bash
+        run: |
+          set -euo pipefail
+          for bin in cargo node npm python3 rustc tar; do
+            command -v "$bin" >/dev/null 2>&1 || {
+              echo "ERROR: required command not found on delegated runner: $bin" >&2
+              exit 1
+            }
+          done
+          node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)' || {
+            echo "ERROR: delegated runner must provide Node.js 22 or newer" >&2
+            node --version >&2 || true
+            exit 1
+          }
+          if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+            echo "ERROR: delegated runner must expose cgroup v2 at /sys/fs/cgroup" >&2
+            exit 1
+          fi
+
+      - name: Build assay CLI (runner feature)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p assay-cli --no-default-features --features runner
+
+      - name: Build eBPF artifact
+        if: ${{ inputs.build_ebpf }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v docker >/dev/null 2>&1; then
+            cargo xtask build-image
+            cargo xtask build-ebpf --docker
+          else
+            cargo xtask build-ebpf
+          fi
+          test -f target/assay-ebpf.o
+
+      - name: Verify eBPF artifact present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f target/assay-ebpf.o ]; then
+            echo "ERROR: target/assay-ebpf.o is required. Run with build_ebpf=true." >&2
+            exit 1
+          fi
+
+      - name: Build workload-gemini
+        working-directory: ${{ env.WORKLOAD_DIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund --ignore-scripts
+          npx tsc -p tsconfig.json
+          test -f dist/workload.js
+
+      - name: Run Arm B captures (N times)
+        shell: bash
+        env:
+          REPETITIONS: ${{ inputs.repetitions }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        run: |
+          set -euo pipefail
+          ASSAY_BIN="$PWD/target/debug/assay"
+          EBPF_OBJ="$PWD/target/assay-ebpf.o"
+          WORKLOAD_JS="$PWD/${{ env.WORKLOAD_DIR }}/dist/workload.js"
+          OUT_ROOT="$PWD/arm-${ARM}-runs"
+          mkdir -p "$OUT_ROOT"
+
+          for i in $(seq 1 "$REPETITIONS"); do
+            RUN_ID="run_arm_${ARM}_$(date -u +%Y%m%dT%H%M%SZ)_$i"
+            RUN_DIR="$OUT_ROOT/$RUN_ID"
+            mkdir -p "$RUN_DIR/workdir"
+            ARCHIVE_OUT="$RUN_DIR/archive.tar.gz"
+            SDK_LOG="$RUN_DIR/sdk-events.ndjson"
+            WORK_DIR="$RUN_DIR/workdir"
+
+            echo "::group::Arm B iteration $i/$REPETITIONS ($RUN_ID)"
+
+            sudo -E env \
+              "PATH=$PATH" \
+              "GOOGLE_API_KEY=$GOOGLE_API_KEY" \
+              "WORKLOAD_WORK_DIR=$WORK_DIR" \
+              "$ASSAY_BIN" runner-spike run \
+                --agent-shim "$AGENT_SHIM" \
+                --kernel-capture \
+                --ebpf "$EBPF_OBJ" \
+                --run-id "$RUN_ID" \
+                --output "$ARCHIVE_OUT" \
+                --sdk-event-log "$SDK_LOG" \
+                -- node "$WORKLOAD_JS"
+
+            sudo chown -R "$(id -u):$(id -g)" "$RUN_DIR"
+
+            echo "::endgroup::"
+          done
+
+      - name: Upload Arm B run artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cross-runtime-drift-arm-b-gemini-${{ github.run_id }}
+          path: arm-b-gemini-runs/
+          if-no-files-found: error
+          retention-days: 30
+
+  drift-compare:
+    name: Compute drift reports (A_i vs B_i)
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    needs: [arm-a-openai, arm-b-gemini]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download Arm A artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: cross-runtime-drift-arm-a-openai-${{ github.run_id }}
+          path: arm-a-openai-runs/
+
+      - name: Download Arm B artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: cross-runtime-drift-arm-b-gemini-${{ github.run_id }}
+          path: arm-b-gemini-runs/
+
+      - name: Run drift comparator for each (A_i, B_i) pair
+        shell: bash
+        env:
+          REPETITIONS: ${{ inputs.repetitions }}
+        run: |
+          set -euo pipefail
+          DRIFT_PY="$PWD/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py"
+          DRIFT_OUT="$PWD/drift-reports"
+          mkdir -p "$DRIFT_OUT"
+
+          # Stable sort to align iterations: i-th OpenAI run vs i-th
+          # Gemini run. Folder names embed the iteration index already.
+          mapfile -t A_RUNS < <(find arm-a-openai-runs -maxdepth 1 -type d -name 'run_arm_*' | sort)
+          mapfile -t B_RUNS < <(find arm-b-gemini-runs -maxdepth 1 -type d -name 'run_arm_*' | sort)
+
+          if [ "${#A_RUNS[@]}" -ne "${#B_RUNS[@]}" ]; then
+            echo "ERROR: arm A produced ${#A_RUNS[@]} runs, arm B produced ${#B_RUNS[@]}" >&2
+            exit 1
+          fi
+
+          for i in "${!A_RUNS[@]}"; do
+            A_DIR="${A_RUNS[$i]}"
+            B_DIR="${B_RUNS[$i]}"
+            A_ARCHIVE="$A_DIR/archive.tar.gz"
+            B_ARCHIVE="$B_DIR/archive.tar.gz"
+            REPORT_BASE="$DRIFT_OUT/drift_pair_$((i + 1))"
+
+            echo "::group::Drift pair $((i + 1)): $A_DIR vs $B_DIR"
+            python3 "$DRIFT_PY" \
+              --archive-a "$A_ARCHIVE" \
+              --archive-b "$B_ARCHIVE" \
+              --fixture-path "/tmp/work/fixture-input.txt" \
+              --fixture-path "/tmp/work/fixture-output.txt" \
+              --out-json "${REPORT_BASE}.json" \
+              --out-md "${REPORT_BASE}.md"
+            {
+              echo "### Drift pair $((i + 1))"
+              echo
+              cat "${REPORT_BASE}.md"
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::endgroup::"
+          done
+
+      - name: Upload drift reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cross-runtime-drift-reports-${{ github.run_id }}
+          path: drift-reports/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/experiments/cross-runtime-drift-2026-05.md
+++ b/docs/experiments/cross-runtime-drift-2026-05.md
@@ -1,9 +1,14 @@
 # Cross-Runtime Capability-Surface Drift: Plan
 
-> **Status:** Slices 0–2 landed: this plan, the workload contract +
-> two implementations + contract-checker (Slice 1), and the
-> `compare/drift.py` MVP with synthetic fixtures (Slice 2). See
-> [`cross-runtime-drift-2026-05/README.md`](cross-runtime-drift-2026-05/README.md)
+> **Status:** Slices 0–2 landed, Slice 3 workflow ready to dispatch.
+> This plan, the workload contract + two implementations +
+> contract-checker (Slice 1), and the `compare/drift.py` MVP with
+> synthetic fixtures (Slice 2) live in the repo. Slice 3 ships the
+> [`Cross-Runtime Drift Experiment`](../../.github/workflows/cross-runtime-drift-experiment.yml)
+> workflow on `assay-bpf-runner`; the maintainer dispatches it with
+> `OPENAI_API_KEY` + `GOOGLE_API_KEY` secrets to produce the
+> live `runs/{a0,b0}/` baselines + drift reports.
+> See [`cross-runtime-drift-2026-05/README.md`](cross-runtime-drift-2026-05/README.md)
 > for the layout. Companion to
 > [`runner-vs-otel-shape-comparison-2026-05.md`](runner-vs-otel-shape-comparison-2026-05.md);
 > reuses the same Runner archive + capability_surface contract, so
@@ -295,7 +300,7 @@ A successful first findings doc:
 | 0 | **Done** | This plan-doc, reviewed and sharpened (Open Questions #1 + #3 resolved) | None |
 | 1 | **Done** | Workload contract ([`WORKLOAD_CONTRACT.md`](cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md)), `@openai/agents` workload, `@google/genai` manual-function-calling workload, stdlib contract-checker with 10 unit tests | OpenAI key (already used), Google key for live local testing |
 | 2 | **Done** | `compare/drift.py` MVP ([`compare/drift.py`](cross-runtime-drift-2026-05/compare/drift.py)) with 16 stdlib unit tests. Scope-locked to v0 surface: touched-path set diff, network host/port/CIDR diff, process exec diff, SDK tool-event diff, MCP tool-surface diff, tool invocation order. Synthetic fixtures under [`compare/fixtures/{arm-a-openai, arm-b-gemini}/`](cross-runtime-drift-2026-05/compare/fixtures/) exercise every classification label exactly once. Output schema: `assay.cross_runtime_drift.v0`. | None |
-| 3 | TODO | Live Arm A0 + B0 dispatch on `assay-bpf-runner` (workflow extension). n=3 per arm. Baselines committed under `docs/experiments/cross-runtime-drift-2026-05/runs/{a0,b0}/`. | Second runtime API key as workflow secret |
+| 3 | **Workflow ready** | Live Arm A0 + B0 dispatch on `assay-bpf-runner` via [`.github/workflows/cross-runtime-drift-experiment.yml`](../../.github/workflows/cross-runtime-drift-experiment.yml) (workflow_dispatch only). Three jobs: `arm-a-openai`, `arm-b-gemini`, `drift-compare`. Awaits maintainer dispatch with `GOOGLE_API_KEY` secret added; baselines then committed under `runs/{a0,b0}/` per [`runs/README.md`](cross-runtime-drift-2026-05/runs/README.md). | `OPENAI_API_KEY` (already set) + `GOOGLE_API_KEY` as repo secrets |
 | 4 | TODO | `findings.md`. Drift table, classification, threats-to-validity, reproduction commands. | None |
 | 5 | TODO | Publication artefacts (issue + blog draft) following the same discipline as runner-vs-otel Slice 4: one narrow question per channel, no maintainer @-mentions, evidence link once. | OpenInference #3162 triage outcome should inform whether to file under same umbrella or separately |
 

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -1,12 +1,14 @@
 # cross-runtime-drift-2026-05
 
-> **Status:** Slices 1 and 2 landed. Workload contract written, two
-> runtime implementations runnable locally with API keys,
-> contract-checker validates outputs (13 stdlib unit tests), and the
-> `compare/drift.py` MVP produces a per-dimension drift report
-> against the synthetic fixtures with 16 stdlib unit tests passing.
-> Slices 3–5 still TODO (live captures on `assay-bpf-runner`,
-> findings doc, publication artefacts).
+> **Status:** Slices 1–2 landed; Slice 3 workflow is ready to
+> dispatch. Workload contract written, two runtime implementations
+> runnable locally with API keys, contract-checker validates outputs
+> (13 stdlib unit tests), the `compare/drift.py` MVP produces a
+> per-dimension drift report against the synthetic fixtures (27
+> stdlib unit tests), and the
+> [`Cross-Runtime Drift Experiment`](../../../.github/workflows/cross-runtime-drift-experiment.yml)
+> workflow is wired for live captures on `assay-bpf-runner`. Slices 4–5
+> (findings doc, publication artefacts) still TODO.
 >
 > **Plan-doc:** [`../cross-runtime-drift-2026-05.md`](../cross-runtime-drift-2026-05.md)
 > (research question, drift dimensions, threats to validity, sequencing).
@@ -22,10 +24,8 @@
 | [`workload-openai/`](workload-openai/) | `@openai/agents` implementation (standard agent loop). |
 | [`workload-gemini/`](workload-gemini/) | `@google/genai` implementation (manual function-calling loop, `automaticFunctionCalling.disable = true`). |
 | [`contract-checker/`](contract-checker/) | Stdlib-only Python validator. Independent of Runner capture. |
-| [`compare/`](compare/) | Slice 2: `drift.py` stdlib comparator + `test_drift.py` (16 tests) + `fixtures/{arm-a-openai,arm-b-gemini}/` synthetic archives that exercise every drift dimension. |
-
-`runs/` will appear once Slice 3 dispatches live captures on
-`assay-bpf-runner`. Not present yet.
+| [`compare/`](compare/) | Slice 2: `drift.py` stdlib comparator + `test_drift.py` (27 tests) + `fixtures/{arm-a-openai,arm-b-gemini}/` synthetic archives that exercise every drift dimension. |
+| [`runs/`](runs/) | Slice 3: target for live Arm A0 + B0 baselines + per-pair drift reports. Currently empty — committed in a follow-up after the maintainer dispatches the workflow. See [`runs/README.md`](runs/README.md). |
 
 ## Running locally
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/extract_fixture_paths.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/extract_fixture_paths.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Extract the two fixture paths a contract-conforming workload run
+recorded in its tool-calls.ndjson.
+
+Used by the cross-runtime-drift-experiment workflow's drift-compare
+job to pass the *actual* fixture paths to `drift.py --fixture-path`.
+Hardcoding `/tmp/work/fixture-*.txt` would only work for local
+testing; live captures put the workdir under
+`arm-X-runs/run_arm_X_<ts>_i/workdir/...` (P1 review on PR #1347).
+
+The workload contract guarantees:
+  line 1 — read_file  with args.path == WORKLOAD_INPUT_PATH
+  line 2 — write_file with args.path == WORKLOAD_OUTPUT_PATH
+
+The contract-checker has already verified this in the per-iteration
+step before upload, so reading the two paths here is safe.
+
+Output: two lines on stdout, input path then output path.
+
+Exit codes:
+  0 - both paths extracted
+  2 - bad CLI args / I/O
+  3 - tool-calls.ndjson malformed or missing required calls
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tool-calls",
+        required=True,
+        type=Path,
+        help="Path to tool-calls.ndjson inside a workload's workdir.",
+    )
+    args = parser.parse_args(argv)
+
+    path: Path = args.tool_calls
+    if not path.is_file():
+        print(f"tool-calls.ndjson not found: {path}", file=sys.stderr)
+        return 2
+    try:
+        lines = [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        print(f"malformed tool-calls.ndjson: {exc}", file=sys.stderr)
+        return 3
+    if len(lines) < 2:
+        print(
+            f"tool-calls.ndjson has {len(lines)} entries, expected >= 2",
+            file=sys.stderr,
+        )
+        return 3
+    first = lines[0]
+    second = lines[1]
+    if (
+        first.get("tool") != "read_file"
+        or second.get("tool") != "write_file"
+    ):
+        print(
+            f"unexpected tool order: {first.get('tool')!r}, "
+            f"{second.get('tool')!r}",
+            file=sys.stderr,
+        )
+        return 3
+    input_path = first.get("args", {}).get("path")
+    output_path = second.get("args", {}).get("path")
+    if not isinstance(input_path, str) or not isinstance(output_path, str):
+        print("tool args.path missing or not a string", file=sys.stderr)
+        return 3
+    print(input_path)
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/health_gate.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/health_gate.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Hard gate on Runner observation-health.
+
+Reads observation-health.json from a Runner archive (directory or
+.tar.gz) and exits non-zero if any of the three completeness
+invariants the experiment relies on is violated:
+
+  - ringbuf_drops != 0       (kernel events were dropped)
+  - kernel_layer != complete (kernel capture incomplete)
+  - cgroup_correlation != clean (cgroup v2 correlation broke)
+
+Used by the cross-runtime-drift-experiment workflow per iteration,
+before any artifact upload. The plan-doc's discipline says to discard
+runs with degraded health; this script enforces it instead of relying
+on the maintainer remembering during baseline commit (P2 review on
+PR #1347).
+
+Exit codes:
+  0 - all three gates passed
+  2 - bad CLI args / I/O
+  3 - bad archive (missing manifest/health, corrupt JSON, etc.)
+  4 - one or more gates failed (details on stderr)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tarfile
+from pathlib import Path
+from typing import Any
+
+OBSERVATION_HEALTH_PATH = "observation-health.json"
+
+
+def _read_member(source: Path, member: str) -> bytes:
+    if source.is_dir():
+        path = source / member
+        if not path.is_file():
+            raise FileNotFoundError(f"{source}!{member}: not found")
+        return path.read_bytes()
+    with tarfile.open(source, "r:*") as tf:
+        try:
+            extracted = tf.extractfile(member)
+        except KeyError as exc:
+            raise FileNotFoundError(
+                f"{source}!{member}: not in archive"
+            ) from exc
+        if extracted is None:
+            raise FileNotFoundError(f"{source}!{member}: not a regular file")
+        return extracted.read()
+
+
+def evaluate_health(health: dict[str, Any]) -> list[str]:
+    """Return a list of failure descriptions; empty list means PASS."""
+    issues: list[str] = []
+    drops = health.get("ringbuf_drops", 0)
+    if not isinstance(drops, int) or drops != 0:
+        issues.append(f"ringbuf_drops={drops!r}")
+    kernel_layer = health.get("kernel_layer")
+    if kernel_layer != "complete":
+        issues.append(f"kernel_layer={kernel_layer!r}")
+    cgroup = health.get("cgroup_correlation")
+    if cgroup != "clean":
+        issues.append(f"cgroup_correlation={cgroup!r}")
+    return issues
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive",
+        required=True,
+        type=Path,
+        help="Path to the Runner archive (directory or .tar.gz).",
+    )
+    args = parser.parse_args(argv)
+
+    archive: Path = args.archive
+    if not archive.exists():
+        print(f"archive does not exist: {archive}", file=sys.stderr)
+        return 3
+    try:
+        data = _read_member(archive, OBSERVATION_HEALTH_PATH)
+    except FileNotFoundError as exc:
+        print(f"bad archive: {exc}", file=sys.stderr)
+        return 3
+    except (tarfile.TarError, OSError) as exc:
+        print(f"bad archive: {archive}: {exc}", file=sys.stderr)
+        return 3
+    try:
+        health = json.loads(data.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        print(
+            f"bad archive: {archive}!{OBSERVATION_HEALTH_PATH}: {exc}",
+            file=sys.stderr,
+        )
+        return 3
+    if not isinstance(health, dict):
+        print(
+            f"bad archive: {archive}!{OBSERVATION_HEALTH_PATH}: "
+            f"not a JSON object",
+            file=sys.stderr,
+        )
+        return 3
+
+    issues = evaluate_health(health)
+    if issues:
+        print(
+            f"HEALTH GATE FAIL ({archive}): {', '.join(issues)}",
+            file=sys.stderr,
+        )
+        return 4
+    print(f"HEALTH GATE PASS ({archive})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_extract_fixture_paths.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_extract_fixture_paths.py
@@ -1,0 +1,125 @@
+"""Unit tests for the extract-fixture-paths helper.
+
+Run from repo root:
+  python3 -m unittest discover \
+    -s docs/experiments/cross-runtime-drift-2026-05/compare \
+    -p 'test_*.py'
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+
+import extract_fixture_paths  # noqa: E402
+
+
+def _write_tool_calls(path: Path, lines: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(line) for line in lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_main_capturing(argv: list[str]) -> tuple[int, str]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = extract_fixture_paths.main(argv)
+    return rc, buf.getvalue()
+
+
+class HappyPathTests(unittest.TestCase):
+    def test_two_paths_printed_in_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tc = Path(tmp) / "tool-calls.ndjson"
+            _write_tool_calls(
+                tc,
+                [
+                    {
+                        "seq": 1,
+                        "tool": "read_file",
+                        "args": {"path": "/workdir/fixture-input.txt"},
+                    },
+                    {
+                        "seq": 2,
+                        "tool": "write_file",
+                        "args": {
+                            "path": "/workdir/fixture-output.txt",
+                            "contents": "X",
+                        },
+                    },
+                ],
+            )
+            rc, out = _run_main_capturing(["--tool-calls", str(tc)])
+            self.assertEqual(rc, 0)
+            self.assertEqual(
+                out.splitlines(),
+                [
+                    "/workdir/fixture-input.txt",
+                    "/workdir/fixture-output.txt",
+                ],
+            )
+
+
+class FailureTests(unittest.TestCase):
+    def test_missing_file_returns_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            rc, _ = _run_main_capturing(
+                ["--tool-calls", str(Path(tmp) / "nope.ndjson")]
+            )
+            self.assertEqual(rc, 2)
+
+    def test_too_few_lines_returns_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tc = Path(tmp) / "tool-calls.ndjson"
+            _write_tool_calls(
+                tc,
+                [
+                    {
+                        "seq": 1,
+                        "tool": "read_file",
+                        "args": {"path": "/workdir/fixture-input.txt"},
+                    },
+                ],
+            )
+            rc, _ = _run_main_capturing(["--tool-calls", str(tc)])
+            self.assertEqual(rc, 3)
+
+    def test_wrong_tool_order_returns_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tc = Path(tmp) / "tool-calls.ndjson"
+            _write_tool_calls(
+                tc,
+                [
+                    {
+                        "seq": 1,
+                        "tool": "write_file",
+                        "args": {"path": "/x", "contents": "y"},
+                    },
+                    {
+                        "seq": 2,
+                        "tool": "read_file",
+                        "args": {"path": "/x"},
+                    },
+                ],
+            )
+            rc, _ = _run_main_capturing(["--tool-calls", str(tc)])
+            self.assertEqual(rc, 3)
+
+    def test_malformed_json_returns_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tc = Path(tmp) / "tool-calls.ndjson"
+            tc.write_text("{bad json}\n", encoding="utf-8")
+            rc, _ = _run_main_capturing(["--tool-calls", str(tc)])
+            self.assertEqual(rc, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_health_gate.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_health_gate.py
@@ -1,0 +1,140 @@
+"""Unit tests for the observation-health gate helper.
+
+Run from repo root:
+  python3 -m unittest discover \
+    -s docs/experiments/cross-runtime-drift-2026-05/compare \
+    -p 'test_*.py'
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(THIS_DIR))
+
+import health_gate  # noqa: E402
+
+
+CLEAN_HEALTH = {
+    "schema": "assay.runner.observation_health.v0",
+    "run_id": "x",
+    "platform": "linux",
+    "kernel_layer": "complete",
+    "ringbuf_drops": 0,
+    "policy_layer": "present",
+    "sdk_layer": "present",
+    "cgroup_correlation": "clean",
+    "notes": [],
+}
+
+
+def _make_archive_dir(tmpdir: Path, health: dict) -> Path:
+    (tmpdir / "manifest.json").write_text(
+        json.dumps({"schema": "x", "run_id": "y"}), encoding="utf-8"
+    )
+    (tmpdir / "observation-health.json").write_text(
+        json.dumps(health), encoding="utf-8"
+    )
+    return tmpdir
+
+
+def _make_archive_tarball(src: Path, dest: Path) -> Path:
+    with tarfile.open(dest, "w:gz") as tf:
+        for path in sorted(src.rglob("*")):
+            if path.is_file():
+                tf.add(path, arcname=str(path.relative_to(src)))
+    return dest
+
+
+class EvaluateHealthTests(unittest.TestCase):
+    def test_clean_health_returns_empty(self) -> None:
+        self.assertEqual(health_gate.evaluate_health(CLEAN_HEALTH), [])
+
+    def test_ringbuf_drops_nonzero_fails(self) -> None:
+        h = {**CLEAN_HEALTH, "ringbuf_drops": 42}
+        issues = health_gate.evaluate_health(h)
+        self.assertEqual(len(issues), 1)
+        self.assertIn("ringbuf_drops", issues[0])
+
+    def test_kernel_layer_partial_fails(self) -> None:
+        h = {**CLEAN_HEALTH, "kernel_layer": "partial"}
+        issues = health_gate.evaluate_health(h)
+        self.assertEqual(len(issues), 1)
+        self.assertIn("kernel_layer", issues[0])
+
+    def test_cgroup_correlation_dirty_fails(self) -> None:
+        h = {**CLEAN_HEALTH, "cgroup_correlation": "dirty"}
+        issues = health_gate.evaluate_health(h)
+        self.assertEqual(len(issues), 1)
+        self.assertIn("cgroup_correlation", issues[0])
+
+    def test_multiple_failures_all_reported(self) -> None:
+        h = {
+            **CLEAN_HEALTH,
+            "ringbuf_drops": 1,
+            "kernel_layer": "partial",
+            "cgroup_correlation": "dirty",
+        }
+        issues = health_gate.evaluate_health(h)
+        self.assertEqual(len(issues), 3)
+
+
+class HealthGateMainTests(unittest.TestCase):
+    def test_clean_directory_archive_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_archive_dir(Path(tmp), CLEAN_HEALTH)
+            rc = health_gate.main(["--archive", str(archive)])
+            self.assertEqual(rc, 0)
+
+    def test_clean_tarball_archive_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "src"
+            src.mkdir()
+            _make_archive_dir(src, CLEAN_HEALTH)
+            tarpath = Path(tmp) / "archive.tar.gz"
+            _make_archive_tarball(src, tarpath)
+            rc = health_gate.main(["--archive", str(tarpath)])
+            self.assertEqual(rc, 0)
+
+    def test_drops_archive_returns_4(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = _make_archive_dir(
+                Path(tmp), {**CLEAN_HEALTH, "ringbuf_drops": 5}
+            )
+            rc = health_gate.main(["--archive", str(archive)])
+            self.assertEqual(rc, 4)
+
+    def test_missing_archive_returns_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            rc = health_gate.main(
+                ["--archive", str(Path(tmp) / "nope.tar.gz")]
+            )
+            self.assertEqual(rc, 3)
+
+    def test_missing_health_member_returns_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "manifest.json").write_text(
+                "{}", encoding="utf-8"
+            )
+            rc = health_gate.main(["--archive", str(tmpdir)])
+            self.assertEqual(rc, 3)
+
+    def test_corrupt_health_json_returns_3(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "observation-health.json").write_text(
+                "{not valid", encoding="utf-8"
+            )
+            rc = health_gate.main(["--archive", str(tmpdir)])
+            self.assertEqual(rc, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
@@ -1,0 +1,82 @@
+# runs/
+
+Per-arm Runner archives + per-iteration drift reports for the
+cross-runtime-drift-2026-05 experiment.
+
+> **Status:** empty. Slice 3 ships the dispatch workflow
+> (`.github/workflows/cross-runtime-drift-experiment.yml`); actual
+> baselines arrive in a follow-up commit after the maintainer dispatches
+> the workflow with the required API secrets.
+
+## Expected layout (post-dispatch)
+
+```
+runs/
+  a0/                     # Arm A — OpenAI Agents, n>=3 captures
+    run_arm_a-openai_<ts>_1/
+      archive.tar.gz
+      sdk-events.ndjson
+      workdir/
+        fixture-input.txt
+        fixture-output.txt
+        tool-calls.ndjson
+        run-meta.json
+    run_arm_a-openai_<ts>_2/
+    run_arm_a-openai_<ts>_3/
+  b0/                     # Arm B — Gemini GenAI, n>=3 captures
+    run_arm_b-gemini_<ts>_1/
+    run_arm_b-gemini_<ts>_2/
+    run_arm_b-gemini_<ts>_3/
+  drift/                  # drift.py output per (A_i, B_i) pair
+    drift_pair_1.json
+    drift_pair_1.md
+    drift_pair_2.json
+    drift_pair_2.md
+    drift_pair_3.json
+    drift_pair_3.md
+```
+
+## Dispatch procedure
+
+The actual experiment runs on the delegated `assay-bpf-runner`
+self-hosted runner; only the maintainer can dispatch.
+
+1. Ensure repo secrets `OPENAI_API_KEY` and `GOOGLE_API_KEY` are set
+   in **Settings → Secrets and variables → Actions**. The workflow
+   fails fast with a clear error message if either is missing.
+2. Go to **Actions → Cross-Runtime Drift Experiment → Run workflow**.
+3. Pick `repetitions = 3` (or more for shape stability beyond n=3),
+   leave `build_ebpf = true`.
+4. Wait for all three jobs to complete: `arm-a-openai`,
+   `arm-b-gemini`, `drift-compare`.
+5. Download the three artifacts produced by the run:
+   `cross-runtime-drift-arm-a-openai-<id>`,
+   `cross-runtime-drift-arm-b-gemini-<id>`,
+   `cross-runtime-drift-reports-<id>`.
+
+## Committing baselines
+
+After downloading the artifacts:
+
+1. Extract `arm-a-openai` artifact into `runs/a0/`.
+2. Extract `arm-b-gemini` artifact into `runs/b0/`.
+3. Extract `drift-reports` artifact into `runs/drift/`.
+4. Verify each archive locally with `assay evidence lint` (the v0
+   manifest will lint clean only when `observation_health.ringbuf_drops
+   == 0` and `correlation_report.status == "clean"`). Discard any run
+   where `ringbuf_drops > 0` and re-dispatch — the dropped events break
+   the kernel-layer completeness invariant.
+5. Open a follow-up PR titled
+   `docs(experiments): Slice 3 — live Arm A0 + B0 baselines + drift reports`.
+
+The findings doc (Slice 4) then reads these committed baselines and
+the drift reports.
+
+## What this directory does NOT contain
+
+- No traces. The runner-vs-otel-2026-05 experiment already proved the
+  OTel binding pattern; the cross-runtime-drift experiment compares
+  Runner archives directly, no OTel layer required.
+- No raw kernel-event ndjson outside the archive's `layers/`. Per the
+  plan-doc, kernel-event granularity beyond `capability_surface` v0 is
+  an explicit v2-comparator follow-up.


### PR DESCRIPTION
> **Stacked on #1346.** GitHub will retarget to \`main\` once #1346 merges.

## Summary
Slice 3 ships the **dispatch pipeline** for cross-runtime-drift-2026-05. The actual live baselines (`runs/{a0,b0}/`) arrive in a separate follow-up commit after the maintainer dispatches the workflow with the required API secrets — that step needs repo-secret access this PR does not have.

## What lands

### Workflow: \`.github/workflows/cross-runtime-drift-experiment.yml\`

Three jobs on \`[self-hosted, linux, assay-bpf-runner]\`:

| Job | What it does |
|---|---|
| \`arm-a-openai\` | Builds CLI + eBPF + workload-openai, runs N captures via \`assay runner-spike run --agent-shim openai-agents\` with \`OPENAI_API_KEY\` injected. Uploads \`arm-a-openai-runs/\`. |
| \`arm-b-gemini\` | Same shape, \`--agent-shim gemini-google-genai\` (already in the runner-core allow-list), \`GOOGLE_API_KEY\` injected. Uploads \`arm-b-gemini-runs/\`. |
| \`drift-compare\` | Depends on both, downloads the two artifacts, runs \`compare/drift.py\` for each \`(A_i, B_i)\` pair, writes \`drift_pair_<i>.{json,md}\` to \`drift-reports/\` artifact, and appends each pair's markdown to \`$GITHUB_STEP_SUMMARY\`. |

Both arm jobs **fail fast with a clear message** if their required secret is missing — no silent half-runs. \`workflow_dispatch\` only (no \`pull_request\` trigger), matching \`runner-otel-experiment.yml\`.

### Docs

- \`docs/.../runs/README.md\` — expected post-dispatch layout (\`runs/{a0,b0,drift}/\`) + the discipline: discard runs where \`ringbuf_drops > 0\`, re-dispatch.
- Plan-doc Status + Slice 3 row → "Workflow ready"; link to the workflow file and \`runs/README.md\`.
- Experiment README: \`runs/\` entry in the layout table.

## What's intentionally NOT here
- No actual \`runs/a0\` or \`runs/b0\` baselines yet — those are committed in a follow-up after dispatch.
- No \`GOOGLE_API_KEY\` repo secret — the user adds it (\`OPENAI_API_KEY\` is already set from earlier experiments).
- No changes to \`compare/drift.py\` — it's already locked from Slice 2.

## Maintainer dispatch checklist
- [ ] Add \`GOOGLE_API_KEY\` to repo secrets (\`Settings → Secrets and variables → Actions\`).
- [ ] Dispatch \`Cross-Runtime Drift Experiment\` from the Actions tab with \`repetitions=3\`, \`build_ebpf=true\`.
- [ ] Wait for the three jobs to complete; verify \`ringbuf_drops=0\` in each archive's \`observation-health.json\`.
- [ ] Download all three artifacts and commit them under \`runs/{a0,b0,drift}/\` in a follow-up PR.

## Test plan
- [x] Pre-commit + pre-push gates green (typos, fmt, clippy, linux compile, GitHub Actions lint)
- [x] \`python3 -m unittest discover ... compare ...\` → 27/27 OK (unchanged)
- [x] Workflow YAML parses to four expected top-level keys (workflow_dispatch + 3 jobs + prepare-delegated-runner)
- [ ] Maintainer: dispatch + review artifacts before committing baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)