### PR TITLE
fix(experiments): cross-runtime drift workloads — SDK events + Gemini model bump

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/sdk-events.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/sdk-events.ts
@@ -1,0 +1,120 @@
+/**
+ * Parallel SDK event emitter for the runner-vs-otel-2026-05 experiment.
+ *
+ * Under Arm C (`assay runner-spike --agent-shim openai-agents -- node
+ * workload.js`), the parent `assay` process exposes three env vars that
+ * the agent shim is expected to honour:
+ *
+ *   ASSAY_RUNNER_SDK_EVENT_LOG   path to an NDJSON log file the runner
+ *                                folds into the archive's
+ *                                layers/sdk.ndjson (and through that
+ *                                into observation_health.sdk_layer)
+ *   ASSAY_RUNNER_RUN_ID          the run id the parent uses for archive
+ *                                identity; the SDK events must carry the
+ *                                same id
+ *   ASSAY_RUNNER_SDK_EVENT_SCHEMA the schema string events must declare;
+ *                                normally `assay.runner.sdk_event.v0`
+ *
+ * The pre-existing `runner-fixtures/openai-agents/fixture-agent.js`
+ * fixture writes into this log; our experiment workload was missing
+ * this path, which left the archive's SDK layer empty and made the
+ * comparator's `gen_ai.tool.call.id` join report `archive-side-absent`
+ * for Arm C. Slice 2 of the runner-vs-otel experiment closes that gap
+ * without removing the OTel tracing path (the two streams now run in
+ * parallel and share the same `tool_call_id`).
+ *
+ * Event shape mirrors what assay-runner-schema's `SdkLayerEvent`
+ * accepts (see crates/assay-runner-schema/src/sdk_event.rs): schema,
+ * run_id, seq, event_type, source, sdk_name?, sdk_version?,
+ * tool_call_id?, tool?
+ */
+
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface SdkEventCore {
+  event_type: string;
+  tool_call_id?: string;
+  tool?: string;
+}
+
+export interface SdkEmitterConfig {
+  logPath: string;
+  runId: string;
+  schema: string;
+  source: string;
+  sdkName?: string;
+  sdkVersion?: string;
+}
+
+export interface SdkEmitter {
+  emit(event: SdkEventCore): void;
+  /** True iff a usable log path was discovered in the environment. */
+  readonly active: boolean;
+}
+
+/**
+ * Construct an emitter from environment variables. If
+ * `ASSAY_RUNNER_SDK_EVENT_LOG` is not set (Arm B, local dev), the
+ * emitter is a no-op and `active` is false — the workload can call
+ * `emit()` unconditionally and Arm B behaviour is preserved.
+ */
+export function sdkEmitterFromEnv(opts: {
+  fallbackRunId: string;
+  source: string;
+  sdkName?: string;
+  sdkVersion?: string;
+}): SdkEmitter {
+  const logPath = process.env.ASSAY_RUNNER_SDK_EVENT_LOG;
+  if (!logPath) {
+    return new NoOpSdkEmitter();
+  }
+  const runId = process.env.ASSAY_RUNNER_RUN_ID || opts.fallbackRunId;
+  const schema =
+    process.env.ASSAY_RUNNER_SDK_EVENT_SCHEMA || "assay.runner.sdk_event.v0";
+  return new FileSdkEmitter({
+    logPath,
+    runId,
+    schema,
+    source: opts.source,
+    sdkName: opts.sdkName,
+    sdkVersion: opts.sdkVersion,
+  });
+}
+
+class NoOpSdkEmitter implements SdkEmitter {
+  public readonly active = false;
+  emit(_event: SdkEventCore): void {
+    // intentional no-op; Arm B and local dev have no SDK log to write to
+  }
+}
+
+class FileSdkEmitter implements SdkEmitter {
+  public readonly active = true;
+  private seq = 0;
+
+  constructor(private readonly cfg: SdkEmitterConfig) {
+    // Ensure the parent directory exists; truncate (overwrite) the log
+    // on construction so a re-run of the same workload doesn't leave
+    // stale events from a previous run.
+    const dir = dirname(cfg.logPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(cfg.logPath, "", "utf8");
+  }
+
+  emit(event: SdkEventCore): void {
+    const record = {
+      schema: this.cfg.schema,
+      run_id: this.cfg.runId,
+      seq: this.seq,
+      source: this.cfg.source,
+      sdk_name: this.cfg.sdkName ?? null,
+      sdk_version: this.cfg.sdkVersion ?? null,
+      ...event,
+    };
+    appendFileSync(this.cfg.logPath, JSON.stringify(record) + "\n", "utf8");
+    this.seq += 1;
+  }
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
@@ -18,6 +18,7 @@ import {
   statSync,
 } from "node:fs";
 import { resolve, dirname, relative, isAbsolute } from "node:path";
+import { sdkEmitterFromEnv, type SdkEmitter } from "./sdk-events";
 import {
   GoogleGenAI,
   type Content,
@@ -55,7 +56,14 @@ function loadEnv(): WorkloadEnv {
   );
   const inputContents =
     process.env.WORKLOAD_INPUT_CONTENTS ?? "cross-runtime drift fixture\n";
-  const model = process.env.WORKLOAD_MODEL ?? "gemini-2.0-flash";
+  // gemini-2.0-flash is no longer available to new users as of 2026-05;
+  // the API returns 404 with "Please update your code to use a newer
+  // model for the latest features and improvements." Default bumped to
+  // gemini-2.5-flash, which is the current generally-available stable
+  // model. Override via WORKLOAD_MODEL if you need to pin a specific
+  // version (the run-meta.json captures whatever was used so the
+  // baseline carries the pin).
+  const model = process.env.WORKLOAD_MODEL ?? "gemini-2.5-flash";
 
   return {
     workDir: absWorkDir,
@@ -173,6 +181,7 @@ async function runManualLoop(
   env: WorkloadEnv,
   toolCallsPath: string,
   seq: { value: number },
+  sdk: SdkEmitter,
 ): Promise<DispatchOutcome> {
   const prompt =
     `Read the file at \`${env.inputPath}\`, uppercase its contents, then ` +
@@ -203,6 +212,7 @@ async function runManualLoop(
     if (!calls || calls.length === 0) {
       const text = String(response.text ?? "").trim();
       if (/^DONE[.!]?$/i.test(text)) {
+        sdk.emit({ event_type: "run_finished" });
         return { exitCode: 0, modelReply: text };
       }
       return { exitCode: 3, modelReply: text };
@@ -220,14 +230,31 @@ async function runManualLoop(
       const name = call.name ?? "";
       const args = (call.args ?? {}) as Record<string, unknown>;
 
+      // Synthesize a tool_call_id from the call's own .id when the SDK
+      // provides it, otherwise from seq — both work for the drift
+      // comparator's tool_invocation_order dimension.
+      const callId =
+        (typeof call.id === "string" && call.id) ||
+        `tc_gemini_${seq.value + 1}`;
+
       if (name === "read_file") {
         const path = ensureInsideWorkDir(
           env.workDir,
           String(args.path ?? ""),
         );
         assertPathEquals("read_file", env.inputPath, path);
+        sdk.emit({
+          event_type: "tool_call_started",
+          tool_call_id: callId,
+          tool: "read_file",
+        });
         appendToolCall(toolCallsPath, seq, "read_file", { path });
         const data = readFileSync(path, "utf-8");
+        sdk.emit({
+          event_type: "tool_call_completed",
+          tool_call_id: callId,
+          tool: "read_file",
+        });
         responseParts.push({
           functionResponse: {
             name,
@@ -241,12 +268,22 @@ async function runManualLoop(
         );
         assertPathEquals("write_file", env.outputPath, path);
         const fileContents = String(args.contents ?? "");
+        sdk.emit({
+          event_type: "tool_call_started",
+          tool_call_id: callId,
+          tool: "write_file",
+        });
         appendToolCall(toolCallsPath, seq, "write_file", {
           path,
           contents: fileContents,
         });
         mkdirSync(dirname(path), { recursive: true });
         writeFileSync(path, fileContents, { encoding: "utf-8" });
+        sdk.emit({
+          event_type: "tool_call_completed",
+          tool_call_id: callId,
+          tool: "write_file",
+        });
         responseParts.push({
           functionResponse: {
             name,
@@ -284,10 +321,32 @@ async function main(): Promise<number> {
   const seq = { value: 0 };
   const ai = new GoogleGenAI({ apiKey: env.apiKey });
 
+  // SDK-event emitter. Active when assay runner-spike has set
+  // ASSAY_RUNNER_SDK_EVENT_LOG; no-op for local dev. The emitter's
+  // constructor truncates the log path, which is what runner-spike
+  // requires in order to ingest layers/sdk.ndjson — without this the
+  // runner exits with "failed to read runner-spike SDK event log ...
+  // No such file or directory" even when the workload itself ran fine.
+  let geminiSdkVersion = "unknown";
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    geminiSdkVersion = (require("@google/genai/package.json") as {
+      version: string;
+    }).version;
+  } catch {
+    // best-effort
+  }
+  const sdk = sdkEmitterFromEnv({
+    fallbackRunId: process.env.ASSAY_RUNNER_RUN_ID ?? `local_${Date.now()}`,
+    source: "gemini-genai",
+    sdkName: "@google/genai",
+    sdkVersion: geminiSdkVersion,
+  });
+
   const startedAt = new Date().toISOString();
   let outcome: DispatchOutcome = { exitCode: 1, modelReply: "" };
   try {
-    outcome = await runManualLoop(ai, env, toolCallsPath, seq);
+    outcome = await runManualLoop(ai, env, toolCallsPath, seq, sdk);
   } catch (err) {
     process.stderr.write(`workload-gemini error: ${(err as Error).message}\n`);
     if (err instanceof ContractViolationError) {

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/sdk-events.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/sdk-events.ts
@@ -1,0 +1,120 @@
+/**
+ * Parallel SDK event emitter for the runner-vs-otel-2026-05 experiment.
+ *
+ * Under Arm C (`assay runner-spike --agent-shim openai-agents -- node
+ * workload.js`), the parent `assay` process exposes three env vars that
+ * the agent shim is expected to honour:
+ *
+ *   ASSAY_RUNNER_SDK_EVENT_LOG   path to an NDJSON log file the runner
+ *                                folds into the archive's
+ *                                layers/sdk.ndjson (and through that
+ *                                into observation_health.sdk_layer)
+ *   ASSAY_RUNNER_RUN_ID          the run id the parent uses for archive
+ *                                identity; the SDK events must carry the
+ *                                same id
+ *   ASSAY_RUNNER_SDK_EVENT_SCHEMA the schema string events must declare;
+ *                                normally `assay.runner.sdk_event.v0`
+ *
+ * The pre-existing `runner-fixtures/openai-agents/fixture-agent.js`
+ * fixture writes into this log; our experiment workload was missing
+ * this path, which left the archive's SDK layer empty and made the
+ * comparator's `gen_ai.tool.call.id` join report `archive-side-absent`
+ * for Arm C. Slice 2 of the runner-vs-otel experiment closes that gap
+ * without removing the OTel tracing path (the two streams now run in
+ * parallel and share the same `tool_call_id`).
+ *
+ * Event shape mirrors what assay-runner-schema's `SdkLayerEvent`
+ * accepts (see crates/assay-runner-schema/src/sdk_event.rs): schema,
+ * run_id, seq, event_type, source, sdk_name?, sdk_version?,
+ * tool_call_id?, tool?
+ */
+
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface SdkEventCore {
+  event_type: string;
+  tool_call_id?: string;
+  tool?: string;
+}
+
+export interface SdkEmitterConfig {
+  logPath: string;
+  runId: string;
+  schema: string;
+  source: string;
+  sdkName?: string;
+  sdkVersion?: string;
+}
+
+export interface SdkEmitter {
+  emit(event: SdkEventCore): void;
+  /** True iff a usable log path was discovered in the environment. */
+  readonly active: boolean;
+}
+
+/**
+ * Construct an emitter from environment variables. If
+ * `ASSAY_RUNNER_SDK_EVENT_LOG` is not set (Arm B, local dev), the
+ * emitter is a no-op and `active` is false — the workload can call
+ * `emit()` unconditionally and Arm B behaviour is preserved.
+ */
+export function sdkEmitterFromEnv(opts: {
+  fallbackRunId: string;
+  source: string;
+  sdkName?: string;
+  sdkVersion?: string;
+}): SdkEmitter {
+  const logPath = process.env.ASSAY_RUNNER_SDK_EVENT_LOG;
+  if (!logPath) {
+    return new NoOpSdkEmitter();
+  }
+  const runId = process.env.ASSAY_RUNNER_RUN_ID || opts.fallbackRunId;
+  const schema =
+    process.env.ASSAY_RUNNER_SDK_EVENT_SCHEMA || "assay.runner.sdk_event.v0";
+  return new FileSdkEmitter({
+    logPath,
+    runId,
+    schema,
+    source: opts.source,
+    sdkName: opts.sdkName,
+    sdkVersion: opts.sdkVersion,
+  });
+}
+
+class NoOpSdkEmitter implements SdkEmitter {
+  public readonly active = false;
+  emit(_event: SdkEventCore): void {
+    // intentional no-op; Arm B and local dev have no SDK log to write to
+  }
+}
+
+class FileSdkEmitter implements SdkEmitter {
+  public readonly active = true;
+  private seq = 0;
+
+  constructor(private readonly cfg: SdkEmitterConfig) {
+    // Ensure the parent directory exists; truncate (overwrite) the log
+    // on construction so a re-run of the same workload doesn't leave
+    // stale events from a previous run.
+    const dir = dirname(cfg.logPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(cfg.logPath, "", "utf8");
+  }
+
+  emit(event: SdkEventCore): void {
+    const record = {
+      schema: this.cfg.schema,
+      run_id: this.cfg.runId,
+      seq: this.seq,
+      source: this.cfg.source,
+      sdk_name: this.cfg.sdkName ?? null,
+      sdk_version: this.cfg.sdkVersion ?? null,
+      ...event,
+    };
+    appendFileSync(this.cfg.logPath, JSON.stringify(record) + "\n", "utf8");
+    this.seq += 1;
+  }
+}

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
@@ -13,6 +13,7 @@ import { mkdirSync, readFileSync, writeFileSync, appendFileSync, statSync } from
 import { resolve, dirname, relative, isAbsolute } from "node:path";
 import { Agent, Runner, tool } from "@openai/agents";
 import { z } from "zod";
+import { sdkEmitterFromEnv } from "./sdk-events";
 
 interface WorkloadEnv {
   workDir: string;
@@ -113,6 +114,29 @@ async function main(): Promise<number> {
 
   const seq = { value: 0 };
 
+  // SDK-event emitter. Active when assay runner-spike has set
+  // ASSAY_RUNNER_SDK_EVENT_LOG; no-op for local dev runs. The
+  // emitter's constructor truncates the log file, which is what
+  // runner-spike requires in order to ingest layers/sdk.ndjson.
+  // Without this the runner exits with
+  // "failed to read runner-spike SDK event log ... No such file or
+  // directory" even when the workload itself ran fine.
+  let openaiSdkVersion = "unknown";
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    openaiSdkVersion = (require("@openai/agents/package.json") as {
+      version: string;
+    }).version;
+  } catch {
+    // best-effort; emitter accepts unknown
+  }
+  const sdk = sdkEmitterFromEnv({
+    fallbackRunId: process.env.ASSAY_RUNNER_RUN_ID ?? `local_${Date.now()}`,
+    source: "openai-agents",
+    sdkName: "@openai/agents",
+    sdkVersion: openaiSdkVersion,
+  });
+
   const readFileTool = tool({
     name: "read_file",
     description: "Read a UTF-8 file from the workload work directory.",
@@ -122,8 +146,20 @@ async function main(): Promise<number> {
     execute: async ({ path }) => {
       const abs = ensureInsideWorkDir(env.workDir, path);
       assertPathEquals("read_file", env.inputPath, abs);
+      const callId = `tc_openai_${seq.value + 1}`;
+      sdk.emit({
+        event_type: "tool_call_started",
+        tool_call_id: callId,
+        tool: "read_file",
+      });
       appendToolCall(toolCallsPath, seq, "read_file", { path: abs });
-      return readFileSync(abs, "utf-8");
+      const data = readFileSync(abs, "utf-8");
+      sdk.emit({
+        event_type: "tool_call_completed",
+        tool_call_id: callId,
+        tool: "read_file",
+      });
+      return data;
     },
   });
 
@@ -137,12 +173,23 @@ async function main(): Promise<number> {
     execute: async ({ path, contents }) => {
       const abs = ensureInsideWorkDir(env.workDir, path);
       assertPathEquals("write_file", env.outputPath, abs);
+      const callId = `tc_openai_${seq.value + 1}`;
+      sdk.emit({
+        event_type: "tool_call_started",
+        tool_call_id: callId,
+        tool: "write_file",
+      });
       appendToolCall(toolCallsPath, seq, "write_file", {
         path: abs,
         contents,
       });
       mkdirSync(dirname(abs), { recursive: true });
       writeFileSync(abs, contents, { encoding: "utf-8" });
+      sdk.emit({
+        event_type: "tool_call_completed",
+        tool_call_id: callId,
+        tool: "write_file",
+      });
       return "ok";
     },
   });
@@ -177,6 +224,7 @@ async function main(): Promise<number> {
     if (!/^DONE[.!]?$/i.test(modelReply)) {
       exitCode = 3;
     }
+    sdk.emit({ event_type: "run_finished" });
   } catch (err) {
     process.stderr.write(`workload-openai error: ${(err as Error).message}\n`);
     if (err instanceof ContractViolationError) {


### PR DESCRIPTION
> **Live-dispatch unblocker.** Run [#26391656444](https://github.com/Rul1an/assay/actions/runs/26391656444) failed on Arm B; this PR fixes the two underlying issues so the next dispatch produces real baselines.

## Summary

### Issue 1 — Gemini model deprecated
Arm B exited 2 with:
> \`This model models/gemini-2.0-flash is no longer available to new users. Please update your code to use a newer model for the latest features and improvements.\` (HTTP 404)

Workload defaulted to \`gemini-2.0-flash\`, which Google retired for new traffic in 2026-05. Default bumped to **\`gemini-2.5-flash\`** (current GA stable). \`WORKLOAD_MODEL\` override still works; \`run-meta.json\` captures whichever model was used so the baseline carries the pin.

### Issue 2 — Missing SDK event emission
After Gemini's failure, \`assay runner-spike\` itself errored:
> \`fatal: failed to read runner-spike SDK event log .../sdk-events.ndjson: No such file or directory\`

Arm A would have hit the same issue. Both cross-runtime-drift workloads were missing the \`ASSAY_RUNNER_SDK_EVENT_LOG\` writer — they only emitted \`tool-calls.ndjson\` + \`run-meta.json\`.

**Fix:** copied [\`runner-vs-otel-2026-05/workload/src/sdk-events.ts\`](https://github.com/Rul1an/assay/blob/main/docs/experiments/runner-vs-otel-2026-05/workload/src/sdk-events.ts) into both workloads and hooked it into the tool handlers + run-finished site. The emitter is a no-op when the env is unset (local-dev path unchanged) and on construction it truncates the log file so runner-spike always finds a readable empty file even if the run produces zero events.

Per-tool emission: each \`read_file\` / \`write_file\` call emits \`{event_type: tool_call_started, tool_call_id, tool}\` before the side-effect and \`{event_type: tool_call_completed, ...}\` after. A \`run_finished\` event closes the layer. Tool-call-IDs: \`tc_openai_<seq>\` / \`tc_gemini_<seq>\` synthesized; Gemini prefers \`call.id\` from \`FunctionCall\` when present.

## What's intentionally NOT in this PR
- No changes to \`compare/drift.py\` or its helpers (Slice 2 is locked).
- No changes to the workflow YAML (Slice 3 wiring is correct; the bug was workload-side only).
- No new tests for the SDK emitter — runner-vs-otel already exercises this code path end-to-end on assay-bpf-runner, and unit-testing the emitter without a runner-spike host would duplicate that coverage.

## Test plan
- [x] \`npx tsc -p tsconfig.json\` clean for workload-openai
- [x] \`npx tsc -p tsconfig.json\` clean for workload-gemini
- [x] \`python3 -m unittest discover ... compare ...\` → 50/50 OK (unchanged)
- [ ] Re-dispatch \`Cross-Runtime Drift Experiment\` after merge; expect all three jobs (arm-a-openai, arm-b-gemini, drift-compare) to succeed and produce non-empty \`layers/sdk.ndjson\` in each archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)