### PR TITLE
fix(experiments): tighten cross-runtime SDK event contract

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/WORKLOAD_CONTRACT.md
@@ -27,7 +27,9 @@
   *not* use a cassette/fake model here — the whole point is to
   measure each runtime's actual transport, loader, and SDK
   machinery against the kernel. Variance in the model's
-  *exact* string output is tolerated; variance in the
+  *exact* string output is tolerated; specifically, one terminal
+  newline on the uppercased file contents is not a drift dimension.
+  Variance in the
   *tool-call sequence* is a contract violation.
 
 ## Inputs
@@ -91,6 +93,11 @@ The agent **must** invoke tools in this order:
 1. `read_file(path = WORKLOAD_INPUT_PATH)`
 2. `write_file(path = WORKLOAD_OUTPUT_PATH, contents = <uppercase of step-1 result>)`
 
+The checker treats one terminal newline as insignificant for the
+uppercased contents. This keeps model style variance ("same text,
+missing final line terminator") from blocking a runtime-drift
+capture; any other content difference remains a contract failure.
+
 Any other order, any other tool, any repeated invocation of
 either tool, or any extra invocations counts as a contract
 violation. The contract-checker enforces this by reading a
@@ -129,11 +136,13 @@ code is advisory, not authoritative.
 Given `$WORKLOAD_WORK_DIR`, the checker confirms:
 
 1. `fixture-output.txt` exists and is non-empty.
-2. `fixture-output.txt` equals `WORKLOAD_INPUT_CONTENTS` uppercased.
+2. `fixture-output.txt` equals `WORKLOAD_INPUT_CONTENTS` uppercased
+   modulo one terminal newline.
 3. `tool-calls.ndjson` exists, has exactly two lines.
 4. Line 1: `tool == "read_file"`, `args.path == WORKLOAD_INPUT_PATH`.
 5. Line 2: `tool == "write_file"`, `args.path == WORKLOAD_OUTPUT_PATH`,
-   `args.contents == WORKLOAD_INPUT_CONTENTS.upper()`.
+   `args.contents == WORKLOAD_INPUT_CONTENTS.upper()` modulo one terminal
+   newline.
 6. `run-meta.json` exists and parses; `exit_code == 0`; `runtime`
    matches one of the two allowed values.
 7. (Design rule, not auto-checked) Both implementations use the

--- a/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/contract-checker/check.py
@@ -71,6 +71,24 @@ def _result(rule: str, passed: bool, detail: str = "") -> CheckResult:
     return CheckResult(rule=rule, passed=passed, detail=detail)
 
 
+def _strip_single_final_newline(value: str) -> str:
+    """Ignore one terminal newline for model-style variance only.
+
+    The drift experiment cares that the model/tool path uppercased the fixture
+    content; it does not use a final line terminator as a drift dimension.
+    """
+
+    if value.endswith("\n"):
+        return value[:-1]
+    return value
+
+
+def _contents_match(actual: str, expected: str) -> bool:
+    return _strip_single_final_newline(actual) == _strip_single_final_newline(
+        expected
+    )
+
+
 def check_output_exists(output_path: Path) -> CheckResult:
     if not output_path.is_file():
         return _result(
@@ -92,13 +110,16 @@ def check_output_uppercased(
 ) -> CheckResult:
     actual = output_path.read_text(encoding="utf-8")
     expected = expected_contents.upper()
-    if actual != expected:
+    if not _contents_match(actual, expected):
         return _result(
-            "2. fixture-output.txt equals input uppercased",
+            "2. fixture-output.txt equals input uppercased (final newline-insensitive)",
             False,
             f"expected {expected!r}, got {actual!r}",
         )
-    return _result("2. fixture-output.txt equals input uppercased", True)
+    return _result(
+        "2. fixture-output.txt equals input uppercased (final newline-insensitive)",
+        True,
+    )
 
 
 def check_tool_calls_two_lines(
@@ -170,14 +191,15 @@ def check_second_call_write(
         )
     actual = str(args.get("contents", ""))
     expected = expected_contents.upper()
-    if actual != expected:
+    if not _contents_match(actual, expected):
         return _result(
-            "5. line 2: write_file with correct path + contents",
+            "5. line 2: write_file with correct path + contents (final newline-insensitive)",
             False,
             f"expected contents {expected!r}, got {actual!r}",
         )
     return _result(
-        "5. line 2: write_file with correct path + contents", True
+        "5. line 2: write_file with correct path + contents (final newline-insensitive)",
+        True,
     )
 
 

--- a/docs/experiments/cross-runtime-drift-2026-05/contract-checker/test_check.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/contract-checker/test_check.py
@@ -95,6 +95,36 @@ class HappyPathTests(unittest.TestCase):
             rc = check.main(["--work-dir", str(tmpdir)])
             self.assertEqual(rc, 0)
 
+    def test_missing_final_newline_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp).resolve()
+            input_contents = "cross-runtime drift fixture\n"
+            output_contents = "CROSS-RUNTIME DRIFT FIXTURE"
+            input_path = tmpdir / "fixture-input.txt"
+            output_path = tmpdir / "fixture-output.txt"
+            write_valid_workdir(
+                tmpdir,
+                input_contents=input_contents,
+                output_contents=output_contents,
+                tool_calls=[
+                    {
+                        "seq": 1,
+                        "tool": "read_file",
+                        "args": {"path": str(input_path)},
+                    },
+                    {
+                        "seq": 2,
+                        "tool": "write_file",
+                        "args": {
+                            "path": str(output_path),
+                            "contents": output_contents,
+                        },
+                    },
+                ],
+            )
+            rc = check.main(["--work-dir", str(tmpdir)])
+            self.assertEqual(rc, 0)
+
 
 class RuleFailureTests(unittest.TestCase):
     def test_missing_output_file_fails(self) -> None:

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/sdk-events.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/sdk-events.ts
@@ -1,9 +1,9 @@
 /**
- * Parallel SDK event emitter for the runner-vs-otel-2026-05 experiment.
+ * Parallel SDK event emitter for the cross-runtime-drift-2026-05 experiment.
  *
- * Under Arm C (`assay runner-spike --agent-shim openai-agents -- node
- * workload.js`), the parent `assay` process exposes three env vars that
- * the agent shim is expected to honour:
+ * In live Runner captures, the workflow invokes `assay runner-spike` with
+ * `--sdk-event-log <path>`. The parent `assay` process then exposes three
+ * env vars that each runtime workload is expected to honour:
  *
  *   ASSAY_RUNNER_SDK_EVENT_LOG   path to an NDJSON log file the runner
  *                                folds into the archive's
@@ -15,13 +15,10 @@
  *   ASSAY_RUNNER_SDK_EVENT_SCHEMA the schema string events must declare;
  *                                normally `assay.runner.sdk_event.v0`
  *
- * The pre-existing `runner-fixtures/openai-agents/fixture-agent.js`
- * fixture writes into this log; our experiment workload was missing
- * this path, which left the archive's SDK layer empty and made the
- * comparator's `gen_ai.tool.call.id` join report `archive-side-absent`
- * for Arm C. Slice 2 of the runner-vs-otel experiment closes that gap
- * without removing the OTel tracing path (the two streams now run in
- * parallel and share the same `tool_call_id`).
+ * These events give each runtime archive a non-empty SDK layer for the drift
+ * comparator's SDK-tool and invocation-order dimensions. The same helper is
+ * used by the OpenAI and Gemini workload implementations so both arms produce
+ * the same event shape.
  *
  * Event shape mirrors what assay-runner-schema's `SdkLayerEvent`
  * accepts (see crates/assay-runner-schema/src/sdk_event.rs): schema,
@@ -55,9 +52,9 @@ export interface SdkEmitter {
 
 /**
  * Construct an emitter from environment variables. If
- * `ASSAY_RUNNER_SDK_EVENT_LOG` is not set (Arm B, local dev), the
+ * `ASSAY_RUNNER_SDK_EVENT_LOG` is not set (local dev / no runner-spike), the
  * emitter is a no-op and `active` is false — the workload can call
- * `emit()` unconditionally and Arm B behaviour is preserved.
+ * `emit()` unconditionally and local behaviour is preserved.
  */
 export function sdkEmitterFromEnv(opts: {
   fallbackRunId: string;
@@ -85,7 +82,7 @@ export function sdkEmitterFromEnv(opts: {
 class NoOpSdkEmitter implements SdkEmitter {
   public readonly active = false;
   emit(_event: SdkEventCore): void {
-    // intentional no-op; Arm B and local dev have no SDK log to write to
+    // intentional no-op; local dev has no SDK log to write to
   }
 }
 

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-gemini/src/workload.ts
@@ -212,7 +212,6 @@ async function runManualLoop(
     if (!calls || calls.length === 0) {
       const text = String(response.text ?? "").trim();
       if (/^DONE[.!]?$/i.test(text)) {
-        sdk.emit({ event_type: "run_finished" });
         return { exitCode: 0, modelReply: text };
       }
       return { exitCode: 3, modelReply: text };
@@ -368,20 +367,14 @@ async function main(): Promise<number> {
     }
   }
 
-  const sdkVersion: string = (() => {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const pkg = require("@google/genai/package.json") as { version: string };
-      return pkg.version;
-    } catch {
-      return "unknown";
-    }
-  })();
+  sdk.emit({
+    event_type: outcome.exitCode === 0 ? "run_finished" : "run_failed",
+  });
 
   const meta = {
     runtime: "gemini-genai",
     model: env.model,
-    sdk_version: sdkVersion,
+    sdk_version: geminiSdkVersion,
     started_at: startedAt,
     ended_at: endedAt,
     exit_code: outcome.exitCode,

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/sdk-events.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/sdk-events.ts
@@ -1,9 +1,9 @@
 /**
- * Parallel SDK event emitter for the runner-vs-otel-2026-05 experiment.
+ * Parallel SDK event emitter for the cross-runtime-drift-2026-05 experiment.
  *
- * Under Arm C (`assay runner-spike --agent-shim openai-agents -- node
- * workload.js`), the parent `assay` process exposes three env vars that
- * the agent shim is expected to honour:
+ * In live Runner captures, the workflow invokes `assay runner-spike` with
+ * `--sdk-event-log <path>`. The parent `assay` process then exposes three
+ * env vars that each runtime workload is expected to honour:
  *
  *   ASSAY_RUNNER_SDK_EVENT_LOG   path to an NDJSON log file the runner
  *                                folds into the archive's
@@ -15,13 +15,10 @@
  *   ASSAY_RUNNER_SDK_EVENT_SCHEMA the schema string events must declare;
  *                                normally `assay.runner.sdk_event.v0`
  *
- * The pre-existing `runner-fixtures/openai-agents/fixture-agent.js`
- * fixture writes into this log; our experiment workload was missing
- * this path, which left the archive's SDK layer empty and made the
- * comparator's `gen_ai.tool.call.id` join report `archive-side-absent`
- * for Arm C. Slice 2 of the runner-vs-otel experiment closes that gap
- * without removing the OTel tracing path (the two streams now run in
- * parallel and share the same `tool_call_id`).
+ * These events give each runtime archive a non-empty SDK layer for the drift
+ * comparator's SDK-tool and invocation-order dimensions. The same helper is
+ * used by the OpenAI and Gemini workload implementations so both arms produce
+ * the same event shape.
  *
  * Event shape mirrors what assay-runner-schema's `SdkLayerEvent`
  * accepts (see crates/assay-runner-schema/src/sdk_event.rs): schema,
@@ -55,9 +52,9 @@ export interface SdkEmitter {
 
 /**
  * Construct an emitter from environment variables. If
- * `ASSAY_RUNNER_SDK_EVENT_LOG` is not set (Arm B, local dev), the
+ * `ASSAY_RUNNER_SDK_EVENT_LOG` is not set (local dev / no runner-spike), the
  * emitter is a no-op and `active` is false — the workload can call
- * `emit()` unconditionally and Arm B behaviour is preserved.
+ * `emit()` unconditionally and local behaviour is preserved.
  */
 export function sdkEmitterFromEnv(opts: {
   fallbackRunId: string;
@@ -85,7 +82,7 @@ export function sdkEmitterFromEnv(opts: {
 class NoOpSdkEmitter implements SdkEmitter {
   public readonly active = false;
   emit(_event: SdkEventCore): void {
-    // intentional no-op; Arm B and local dev have no SDK log to write to
+    // intentional no-op; local dev has no SDK log to write to
   }
 }
 

--- a/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
+++ b/docs/experiments/cross-runtime-drift-2026-05/workload-openai/src/workload.ts
@@ -224,7 +224,6 @@ async function main(): Promise<number> {
     if (!/^DONE[.!]?$/i.test(modelReply)) {
       exitCode = 3;
     }
-    sdk.emit({ event_type: "run_finished" });
   } catch (err) {
     process.stderr.write(`workload-openai error: ${(err as Error).message}\n`);
     if (err instanceof ContractViolationError) {
@@ -257,20 +256,12 @@ async function main(): Promise<number> {
     }
   }
 
-  const sdkVersion: string = (() => {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const pkg = require("@openai/agents/package.json") as { version: string };
-      return pkg.version;
-    } catch {
-      return "unknown";
-    }
-  })();
+  sdk.emit({ event_type: exitCode === 0 ? "run_finished" : "run_failed" });
 
   const meta = {
     runtime: "openai-agents",
     model: env.model,
-    sdk_version: sdkVersion,
+    sdk_version: openaiSdkVersion,
     started_at: startedAt,
     ended_at: endedAt,
     exit_code: exitCode,


### PR DESCRIPTION
## Summary

Follow-up to #1350 after the live dispatch exposed one more workload-contract issue and the review cleanup landed after #1350 had already merged.

Changes:
- Rewrite copied SDK-emitter comments so they describe `cross-runtime-drift-2026-05`, not `runner-vs-otel`.
- Emit a terminal SDK event on every workload outcome: `run_finished` for exit 0, `run_failed` otherwise.
- Reuse the already-read SDK version for `run-meta.json` so emitter provenance and metadata cannot drift within a run.
- Relax the workload contract/checker to be insensitive to exactly one terminal newline in the uppercased contents. The live OpenAI run produced `CROSS-RUNTIME DRIFT FIXTURE` while the fixture default is `cross-runtime drift fixture\n`; for this experiment the final newline is model-style variance, not a runtime-drift dimension.
- Add checker coverage for the missing-final-newline case.

## Test plan

- `npx tsc -p tsconfig.json` in `workload-openai`
- `npx tsc -p tsconfig.json` in `workload-gemini`
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/contract-checker -p 'test_*.py'` -> 14/14 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 50/50 OK
- pre-commit/pre-push hooks green

## Dispatch note

After merge, rerun Cross-Runtime Drift Experiment with `repetitions=3`, `build_ebpf=true`. The previous Arm A failure should now pass the contract checker modulo the final newline.
