### PR TITLE
docs(experiments): document kernel v0 drift granularity boundary

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -29,6 +29,7 @@
 | [`compare/`](compare/) | Slice 2 + Slice 3 helpers: `drift.py` stdlib comparator, `health_gate.py`, `extract_fixture_paths.py`, 50 stdlib unit tests, and `fixtures/{arm-a-openai,arm-b-gemini}/` synthetic archives that exercise every drift classification label. |
 | [`runs/`](runs/) | Slice 3 live Arm A0 + B0 baselines + per-pair drift reports from workflow run 26394765509. See [`runs/README.md`](runs/README.md). |
 | [`findings.md`](findings.md) | Slice 4: live n=3 findings write-up plus threats to validity and reproduction commands. |
+| [`kernel-v0-feasibility.md`](kernel-v0-feasibility.md) | Follow-up diagnostic: what `layers/kernel.ndjson` v0 can support today, and why read/write/create/remove classification still needs a Runner schema extension. |
 | [`publication/`](publication/) | Slice 5: blog draft + discussion-comment draft, both gated on the OpenInference #3162 triage signal. Not filed, not published. |
 
 ## Running locally
@@ -167,5 +168,8 @@ starting point; the findings doc (Slice 4) explains every
 - No OTel trace emission. The cross-runtime comparison is
   between two Runner archives; traces are an explicit follow-up.
 - No read/write/create/remove split, no per-path access counts,
-  no kernel-ndjson parsing. All tracked as deferred v2 follow-ups
-  in the plan-doc.
+  no operation-aware kernel parsing. The follow-up note
+  [`kernel-v0-feasibility.md`](kernel-v0-feasibility.md) records what
+  the current kernel-event v0 shape can support and why read/write
+  classification remains a schema-level follow-up rather than a
+  comparator-only patch.

--- a/docs/experiments/cross-runtime-drift-2026-05/findings.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/findings.md
@@ -180,7 +180,11 @@ adds four things the synthetic fixture could not:
 - **Provider-level network attribution.** Live network rows are IP-based.
   They do not prove provider-induced drift without a hostname/DNS layer.
 - **Read/write/create/remove classification.** Capability_surface v0
-  records touched paths undifferentiated.
+  records touched paths undifferentiated. The follow-up diagnostic
+  [`kernel-v0-feasibility.md`](kernel-v0-feasibility.md) confirms that
+  the current `layers/kernel.ndjson` v0 shape also lacks open flags or
+  operation categories, so read/write classification needs a Runner
+  schema extension rather than only a comparator change.
 - **Per-path access counts and ordering.** Same v2-comparator follow-up.
 - **Cross-distro portability.** All captures are Linux/kernel-specific.
 - **N > 3 stability.** n=3 is enough for this shape claim; if future runs

--- a/docs/experiments/cross-runtime-drift-2026-05/kernel-v0-feasibility.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/kernel-v0-feasibility.md
@@ -1,0 +1,132 @@
+# Kernel v0 feasibility note
+
+> **Status:** follow-up diagnostic after the live n=3 baseline. This
+> note inspects the committed `layers/kernel.ndjson` files and decides
+> what the current Runner kernel-event v0 shape can and cannot support
+> for the cross-runtime drift experiment.
+>
+> **Conclusion:** kernel v0 can support event-kind counts and touched
+> path / endpoint summaries. It cannot support honest read/write/create
+> / remove classification yet, because each event carries only `kind`,
+> `value`, `seq`, `pid`, `run_id`, `schema`, and numeric `event_type`.
+
+## Why this note exists
+
+The Slice 4 findings mark read/write/create/remove path drift as a v2
+follow-up. Before building a larger comparator, we need to know whether
+the committed kernel layer already carries enough evidence.
+
+It does not. The relevant records currently look like:
+
+```json
+{
+  "schema": "assay.runner.kernel_event.v0",
+  "run_id": "run_arm_a-openai_20260525T100626Z_1",
+  "seq": 0,
+  "pid": 146927,
+  "event_type": 1,
+  "kind": "openat",
+  "value": "/path/to/package.json"
+}
+```
+
+There is no open flag, syscall return value, access mode, file
+descriptor correlation, or close/write/read pairing. A v2 comparator
+that labels a path as "read" or "write" from this shape would be
+guessing.
+
+## Live kernel-event counts
+
+The committed live archives under [`runs/a0/`](runs/a0/) and
+[`runs/b0/`](runs/b0/) are still useful. They show stable kernel-event
+shape across all three pairs:
+
+| Arm | Run | Total kernel events | `openat` events | `connect` events | Unique open paths | Unique connect endpoints |
+|---|---|---:|---:|---:|---:|---:|
+| OpenAI Agents | `run_arm_a-openai_20260525T100626Z_1` | 18 | 10 | 8 | 10 | 5 |
+| OpenAI Agents | `run_arm_a-openai_20260525T100636Z_2` | 18 | 10 | 8 | 10 | 4 |
+| OpenAI Agents | `run_arm_a-openai_20260525T100645Z_3` | 18 | 10 | 8 | 10 | 5 |
+| Gemini GenAI | `run_arm_b-gemini_20260525T100327Z_1` | 27 | 10 | 17 | 10 | 17 |
+| Gemini GenAI | `run_arm_b-gemini_20260525T100331Z_2` | 27 | 10 | 17 | 10 | 17 |
+| Gemini GenAI | `run_arm_b-gemini_20260525T100334Z_3` | 27 | 10 | 17 | 10 | 17 |
+
+The main findings doc already reflects the high-level result:
+
+- filesystem drift is narrow and stable;
+- SDK tool surface and invocation order are task-induced;
+- live network rows are IP-based and therefore not provider-attributed
+  under v0;
+- Gemini has a larger observed connect surface in this particular run,
+  but v0 cannot convert that into a provider-host claim.
+
+## What v0 can support next
+
+A small comparator extension could add these non-ambiguous rows:
+
+| Candidate row | Evidence source | Safe interpretation |
+|---|---|---|
+| `kernel_event_kinds` | `layers/kernel.ndjson.kind` | Which kernel event types appeared in each archive. |
+| `kernel_event_kind_counts` | `layers/kernel.ndjson.kind` counts | Event-count drift by kind, with no security verdict. |
+| `kernel_open_paths_sequence` | ordered `openat.value` | Ordered touched-path shape, not read/write semantics. |
+| `kernel_connect_sequence` | ordered `connect.value` | Ordered endpoint shape, still IP-based. |
+
+Those rows would make the live drift report more transparent without
+pretending v0 knows more than it does.
+
+## What requires a Runner schema change
+
+Read/write/create/remove path classification needs more evidence in the
+kernel layer, for example:
+
+- syscall-specific open flags for `openat` / `openat2`;
+- return-value success/failure;
+- file descriptor correlation if later `read`, `write`, or `close`
+  events are used;
+- normalized operation category emitted by Runner after parsing the raw
+  syscall fields.
+
+Until then, the correct publication language is "filesystem paths
+touched", not "files read" or "files written".
+
+## Reproduction
+
+```bash
+python3 - <<'PY'
+import json
+import tarfile
+from pathlib import Path
+
+root = Path("docs/experiments/cross-runtime-drift-2026-05/runs")
+for arm in ["a0", "b0"]:
+    print("ARM", arm)
+    for archive in sorted((root / arm).glob("*/archive.tar.gz")):
+        with tarfile.open(archive, "r:gz") as tf:
+            member = tf.extractfile("layers/kernel.ndjson")
+            assert member is not None
+            events = [
+                json.loads(line)
+                for line in member.read().decode("utf-8").splitlines()
+                if line.strip()
+            ]
+        kinds = {}
+        for event in events:
+            kinds[event["kind"]] = kinds.get(event["kind"], 0) + 1
+        opens = sorted(
+            {event["value"] for event in events if event.get("kind") == "openat"}
+        )
+        connects = sorted(
+            {event["value"] for event in events if event.get("kind") == "connect"}
+        )
+        print(
+            archive.parent.name,
+            "events",
+            len(events),
+            "kinds",
+            kinds,
+            "open_paths",
+            len(opens),
+            "connects",
+            len(connects),
+        )
+PY
+```


### PR DESCRIPTION
Summary
Adds a small follow-up diagnostic for the cross-runtime-drift-2026-05 experiment after the live n=3 baseline landed.

What it records
- `layers/kernel.ndjson` v0 currently carries `kind`, `value`, `seq`, `pid`, `run_id`, `schema`, and numeric `event_type`.
- That is enough for event-kind counts and ordered touched-path / endpoint summaries.
- It is not enough for honest read/write/create/remove path classification because open flags, return values, fd correlation, and normalized operation categories are absent.

Live counts from the committed baseline
- OpenAI Agents: 18 kernel events per run, 10 `openat`, 8 `connect`.
- Gemini GenAI: 27 kernel events per run, 10 `openat`, 17 `connect`.
- Unique open paths are stable at 10 per run across both arms.

Files
- `kernel-v0-feasibility.md` — diagnostic note + reproduction snippet.
- `README.md` and `findings.md` — link the note and tighten the v2 follow-up language.

Test plan
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 50/50 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/contract-checker -p 'test_*.py'` -> 14/14 OK
- `git diff --check` OK
- local markdown-link sanity check OK
- live kernel-count reproduction snippet verified against committed archives