### PR TITLE
feat(experiments): add path projection v0 to drift comparator

### DIFF
--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -445,6 +445,10 @@ jobs:
               --fixture-path "${A_PATHS[1]}" \
               --fixture-path "${B_PATHS[0]}" \
               --fixture-path "${B_PATHS[1]}" \
+              --path-alias "${A_PATHS[0]}=workdir/input" \
+              --path-alias "${A_PATHS[1]}=workdir/output" \
+              --path-alias "${B_PATHS[0]}=workdir/input" \
+              --path-alias "${B_PATHS[1]}=workdir/output" \
               --out-json "${REPORT_BASE}.json" \
               --out-md "${REPORT_BASE}.md"
             {

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -6,7 +6,7 @@
 > on `assay-bpf-runner`. Workload contract written, two runtime
 > implementations runnable locally with API keys, contract-checker
 > validates outputs (14 stdlib unit tests), `compare/drift.py`
-> produces per-dimension drift reports (51 stdlib unit tests covering
+> produces per-dimension drift reports (53 stdlib unit tests covering
 > `drift.py` + `health_gate.py` + `extract_fixture_paths.py`), live
 > Arm A0/B0 archives are under [`runs/`](runs/), [`findings.md`](findings.md)
 > reflects the live data, and [`publication/`](publication/) holds
@@ -26,7 +26,7 @@
 | [`workload-openai/`](workload-openai/) | `@openai/agents` implementation (standard agent loop). |
 | [`workload-gemini/`](workload-gemini/) | `@google/genai` implementation (manual function-calling loop, `automaticFunctionCalling.disable = true`). |
 | [`contract-checker/`](contract-checker/) | Stdlib-only Python validator. Independent of Runner capture. |
-| [`compare/`](compare/) | Slice 2 + Slice 3 helpers: `drift.py` stdlib comparator, `health_gate.py`, `extract_fixture_paths.py`, 51 stdlib unit tests, and `fixtures/{arm-a-openai,arm-b-gemini}/` synthetic archives that exercise every drift classification label. |
+| [`compare/`](compare/) | Slice 2 + Slice 3 helpers: `drift.py` stdlib comparator, `health_gate.py`, `extract_fixture_paths.py`, 53 stdlib unit tests, and `fixtures/{arm-a-openai,arm-b-gemini}/` synthetic archives that exercise every drift classification label. |
 | [`runs/`](runs/) | Slice 3 live Arm A0 + B0 baselines + per-pair drift reports from workflow run 26398427430. See [`runs/README.md`](runs/README.md). |
 | [`findings.md`](findings.md) | Slice 4: live n=3 findings write-up plus threats to validity and reproduction commands. |
 | [`kernel-v0-feasibility.md`](kernel-v0-feasibility.md) | Follow-up diagnostic: what `layers/kernel.ndjson` can support now that open metadata is present, and what still remains out of scope. |
@@ -95,6 +95,8 @@ python3 "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/drift.p
   --archive-b "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini" \
   --fixture-path /tmp/work/fixture-input.txt \
   --fixture-path /tmp/work/fixture-output.txt \
+  --path-alias /tmp/work/fixture-input.txt=workdir/input \
+  --path-alias /tmp/work/fixture-output.txt=workdir/output \
   --out-md /tmp/drift.md
 
 # Tests (no API keys required):
@@ -109,6 +111,10 @@ classification: `task-induced` / `provider-induced` /
 `runtime-induced` / `inconclusive`. The classification is a
 starting point; the findings doc (Slice 4) explains every
 `inconclusive` row by hand or downgrades it to a known limitation.
+Path projection v0 is additive: raw `only_in_*` and `in_both`
+values stay unchanged, while `--path-alias RAW=PROJECTED` emits an
+auditable `row.projection` block with mapping rule, confidence,
+claim level, and non-claims.
 
 ## What's done in Slice 1
 

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -6,7 +6,7 @@
 > on `assay-bpf-runner`. Workload contract written, two runtime
 > implementations runnable locally with API keys, contract-checker
 > validates outputs (14 stdlib unit tests), `compare/drift.py`
-> produces per-dimension drift reports (53 stdlib unit tests covering
+> produces per-dimension drift reports (stdlib unit tests cover
 > `drift.py` + `health_gate.py` + `extract_fixture_paths.py`), live
 > Arm A0/B0 archives are under [`runs/`](runs/), [`findings.md`](findings.md)
 > reflects the live data, and [`publication/`](publication/) holds
@@ -26,7 +26,7 @@
 | [`workload-openai/`](workload-openai/) | `@openai/agents` implementation (standard agent loop). |
 | [`workload-gemini/`](workload-gemini/) | `@google/genai` implementation (manual function-calling loop, `automaticFunctionCalling.disable = true`). |
 | [`contract-checker/`](contract-checker/) | Stdlib-only Python validator. Independent of Runner capture. |
-| [`compare/`](compare/) | Slice 2 + Slice 3 helpers: `drift.py` stdlib comparator, `health_gate.py`, `extract_fixture_paths.py`, 53 stdlib unit tests, and `fixtures/{arm-a-openai,arm-b-gemini}/` synthetic archives that exercise every drift classification label. |
+| [`compare/`](compare/) | Slice 2 + Slice 3 helpers: `drift.py` stdlib comparator, `health_gate.py`, `extract_fixture_paths.py`, stdlib unit tests, and `fixtures/{arm-a-openai,arm-b-gemini}/` synthetic archives that exercise every drift classification label. |
 | [`runs/`](runs/) | Slice 3 live Arm A0 + B0 baselines + per-pair drift reports from workflow run 26398427430. See [`runs/README.md`](runs/README.md). |
 | [`findings.md`](findings.md) | Slice 4: live n=3 findings write-up plus threats to validity and reproduction commands. |
 | [`kernel-v0-feasibility.md`](kernel-v0-feasibility.md) | Follow-up diagnostic: what `layers/kernel.ndjson` can support now that open metadata is present, and what still remains out of scope. |

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -515,6 +515,15 @@ def _projection_payload(
     }
 
 
+def _path_alias_dict(path_aliases: tuple[PathAlias, ...]) -> dict[str, PathAlias]:
+    out: dict[str, PathAlias] = {}
+    for alias in path_aliases:
+        if alias.raw_path in out:
+            raise ValueError(f"duplicate path alias for {alias.raw_path!r}")
+        out[alias.raw_path] = alias
+    return out
+
+
 def _network_endpoint_matches_provider(
     item: str, provider_hosts: tuple[str, ...]
 ) -> bool:
@@ -635,7 +644,7 @@ def build_drift_report(
     """
 
     rows: list[DriftRow] = []
-    aliases = {alias.raw_path: alias for alias in path_aliases}
+    aliases = _path_alias_dict(path_aliases)
 
     # --- filesystem paths touched ---
     a_paths = a.capability_surface.get("filesystem_paths", [])
@@ -1050,14 +1059,23 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(f"bad --path-alias: {exc}", file=sys.stderr)
         return 2
+    try:
+        _path_alias_dict(path_aliases)
+    except ValueError as exc:
+        print(f"bad --path-alias: {exc}", file=sys.stderr)
+        return 2
 
-    rows = build_drift_report(
-        a,
-        b,
-        provider_hosts=provider_hosts,
-        fixture_paths=fixture_paths,
-        path_aliases=path_aliases,
-    )
+    try:
+        rows = build_drift_report(
+            a,
+            b,
+            provider_hosts=provider_hosts,
+            fixture_paths=fixture_paths,
+            path_aliases=path_aliases,
+        )
+    except ValueError as exc:
+        print(f"bad projection config: {exc}", file=sys.stderr)
+        return 2
     payload = report_to_json(a, b, rows)
 
     if args.out_json:

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -12,10 +12,12 @@ Scope (v0, Slice 2):
   - MCP tool surface (capability_surface.mcp_tools)
   - tool invocation order (SDK events' seq per tool_call_id)
   - kernel file operations (layers/kernel.ndjson open metadata)
+  - path projection v0 over explicitly declared raw=logical aliases
 
 Out of scope (explicit follow-ups, NOT silent gaps):
   - unlink/remove classification
   - per-path access counts
+  - heuristic path taxonomy (node_modules/cache/provider SDK/etc.)
   - latency / token / cost (not a drift signal)
 
 Classification labels per row:
@@ -80,6 +82,22 @@ CLASSIFICATION_TASK = "task-induced"
 CLASSIFICATION_PROVIDER = "provider-induced"
 CLASSIFICATION_RUNTIME = "runtime-induced"
 CLASSIFICATION_INCONCLUSIVE = "inconclusive"
+
+PATH_PROJECTION_SCHEMA = "assay.runner.path_projection.v0"
+
+CLAIM_RAW_OBSERVED = "raw_observed"
+CLAIM_PROJECTED_EQUIVALENT = "projected_equivalent"
+CLAIM_INCONCLUSIVE = "inconclusive"
+
+PATH_CLASS_WORKLOAD_FIXTURE = "workload_fixture"
+PATH_CLASS_UNKNOWN = "unknown"
+
+PROJECTION_NON_CLAIMS = (
+    "projection_no_raw_evidence_rewrite",
+    "projection_no_semantic_workload_equivalence",
+    "projection_no_policy_acceptability_verdict",
+    "projection_unknowns_preserved",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -352,6 +370,149 @@ class DriftRow:
     in_both: list[str]
     classification: str  # one of CLASSIFICATION_* above
     detail: str
+    projection: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass(frozen=True)
+class PathAlias:
+    """A declared raw path -> logical path projection rule.
+
+    The comparator deliberately starts with exact aliases only. This
+    keeps projection auditable and prevents path-normalization from
+    becoming a hidden rewrite layer.
+    """
+
+    raw_path: str
+    projected_path: str
+    path_class: str = PATH_CLASS_WORKLOAD_FIXTURE
+    relation: str = "declared_path"
+    rule: str = "declared_path_alias"
+    confidence: str = "declared"
+
+
+@dataclasses.dataclass(frozen=True)
+class ProjectedValue:
+    raw_value: str
+    projected_value: str
+    path_class: str
+    relation: str
+    rule: str
+    confidence: str
+    claim_level: str
+
+
+def _parse_path_alias(raw: str) -> PathAlias:
+    if "=" not in raw:
+        raise ValueError("expected RAW=PROJECTED")
+    raw_path, projected_path = raw.split("=", 1)
+    raw_path = raw_path.strip()
+    projected_path = projected_path.strip()
+    if not raw_path or not projected_path:
+        raise ValueError("expected non-empty RAW and PROJECTED")
+    return PathAlias(raw_path=raw_path, projected_path=projected_path)
+
+
+def _project_single_path(path: str, aliases: dict[str, PathAlias]) -> ProjectedValue:
+    alias = aliases.get(path)
+    if alias is None:
+        return ProjectedValue(
+            raw_value=path,
+            projected_value=path,
+            path_class=PATH_CLASS_UNKNOWN,
+            relation="unmatched",
+            rule="no_declared_alias",
+            confidence="unknown",
+            claim_level=CLAIM_RAW_OBSERVED,
+        )
+    return ProjectedValue(
+        raw_value=path,
+        projected_value=alias.projected_path,
+        path_class=alias.path_class,
+        relation=alias.relation,
+        rule=alias.rule,
+        confidence=alias.confidence,
+        claim_level=CLAIM_PROJECTED_EQUIVALENT,
+    )
+
+
+def _project_path_value(
+    value: str, aliases: dict[str, PathAlias]
+) -> ProjectedValue:
+    """Project either a plain path or an operation-aware `op:path`.
+
+    `kernel_file_operations` values use `read:/path`, `write:/path`,
+    etc. The operation prefix is raw evidence from kernel-event open
+    metadata, so projection only touches the path suffix.
+    """
+
+    if ":" not in value:
+        return _project_single_path(value, aliases)
+    op, path = value.split(":", 1)
+    # Avoid treating URI-ish or host:port values as path operations.
+    if "/" not in path:
+        return _project_single_path(value, aliases)
+    projected = _project_single_path(path, aliases)
+    return ProjectedValue(
+        raw_value=value,
+        projected_value=f"{op}:{projected.projected_value}",
+        path_class=projected.path_class,
+        relation=projected.relation,
+        rule=projected.rule,
+        confidence=projected.confidence,
+        claim_level=projected.claim_level,
+    )
+
+
+def _projection_payload(
+    dimension: str,
+    a_values: list[str],
+    b_values: list[str],
+    aliases: dict[str, PathAlias],
+) -> dict[str, Any]:
+    if not aliases:
+        return {
+            "schema": PATH_PROJECTION_SCHEMA,
+            "status": "not_applied",
+            "reason": "no path aliases declared",
+            "non_claims": list(PROJECTION_NON_CLAIMS),
+        }
+
+    projected_a = [_project_path_value(value, aliases) for value in a_values]
+    projected_b = [_project_path_value(value, aliases) for value in b_values]
+    a_projected_values = [item.projected_value for item in projected_a]
+    b_projected_values = [item.projected_value for item in projected_b]
+    only_a, only_b, both = _diff_lists(a_projected_values, b_projected_values)
+    mappings = [
+        {"side": "a", **dataclasses.asdict(item)} for item in projected_a
+    ] + [{"side": "b", **dataclasses.asdict(item)} for item in projected_b]
+    rules = sorted(
+        {
+            item.rule
+            for item in [*projected_a, *projected_b]
+            if item.rule != "no_declared_alias"
+        }
+    )
+    has_projected_match = any(
+        item.claim_level == CLAIM_PROJECTED_EQUIVALENT
+        and item.projected_value in both
+        for item in [*projected_a, *projected_b]
+    )
+    if has_projected_match:
+        claim_level = CLAIM_PROJECTED_EQUIVALENT
+    else:
+        claim_level = CLAIM_INCONCLUSIVE
+    return {
+        "schema": PATH_PROJECTION_SCHEMA,
+        "status": "applied",
+        "dimension": dimension,
+        "claim_level": claim_level,
+        "only_in_a": only_a,
+        "only_in_b": only_b,
+        "in_both": both,
+        "rules": rules,
+        "mappings": mappings,
+        "non_claims": list(PROJECTION_NON_CLAIMS),
+    }
 
 
 def _network_endpoint_matches_provider(
@@ -463,6 +624,7 @@ def build_drift_report(
     *,
     provider_hosts: tuple[str, ...] = DEFAULT_PROVIDER_HOSTS,
     fixture_paths: frozenset[str] = frozenset(),
+    path_aliases: tuple[PathAlias, ...] = (),
 ) -> list[DriftRow]:
     """Compute per-dimension drift rows between two archives.
 
@@ -473,6 +635,7 @@ def build_drift_report(
     """
 
     rows: list[DriftRow] = []
+    aliases = {alias.raw_path: alias for alias in path_aliases}
 
     # --- filesystem paths touched ---
     a_paths = a.capability_surface.get("filesystem_paths", [])
@@ -496,6 +659,9 @@ def build_drift_report(
             in_both=both,
             classification=cls,
             detail=detail,
+            projection=_projection_payload(
+                "filesystem_paths_touched", a_paths, b_paths, aliases
+            ),
         )
     )
 
@@ -519,6 +685,12 @@ def build_drift_report(
             in_both=both,
             classification=cls,
             detail=detail,
+            projection=_projection_payload(
+                "kernel_file_operations",
+                a.kernel_file_operations,
+                b.kernel_file_operations,
+                aliases,
+            ),
         )
     )
 
@@ -758,6 +930,16 @@ def _fmt_list(items: Iterable[str]) -> str:
     return ", ".join(f"`{_md_escape_cell(i)}`" for i in items)
 
 
+def _fmt_projection(projection: dict[str, Any]) -> str:
+    if projection.get("status") != "applied":
+        return "—"
+    claim = str(projection.get("claim_level", CLAIM_INCONCLUSIVE))
+    in_both = projection.get("in_both")
+    if isinstance(in_both, list) and in_both:
+        return f"{_md_escape_cell(claim)}: {_fmt_list(str(i) for i in in_both)}"
+    return _md_escape_cell(claim)
+
+
 def report_to_md(
     a: ArchiveObservation,
     b: ArchiveObservation,
@@ -779,9 +961,9 @@ def report_to_md(
     lines.append("")
     lines.append(
         "| Dimension | Source | Classification | Only in A | Only in B | "
-        "In both | Detail |"
+        "In both | Projection | Detail |"
     )
-    lines.append("|---|---|---|---|---|---|---|")
+    lines.append("|---|---|---|---|---|---|---|---|")
     for r in rows:
         lines.append(
             f"| `{_md_escape_cell(r.dimension)}` "
@@ -790,6 +972,7 @@ def report_to_md(
             f"| {_fmt_list(r.only_in_a)} "
             f"| {_fmt_list(r.only_in_b)} "
             f"| {_fmt_list(r.in_both)} "
+            f"| {_fmt_projection(r.projection)} "
             f"| {_md_escape_cell(r.detail)} |"
         )
     return "\n".join(lines) + "\n"
@@ -830,11 +1013,23 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--path-alias",
+        action="append",
+        default=[],
+        help=(
+            "Declare an exact raw-path to logical-path projection as "
+            "RAW=PROJECTED. The raw value remains in only_in_a/only_in_b/"
+            "in_both; the projection is emitted under row.projection. May "
+            "be passed multiple times, e.g. "
+            "--path-alias $A_INPUT=workdir/input."
+        ),
+    )
+    parser.add_argument(
         "--provider-host",
         action="append",
         default=[],
         help=(
-            "Add a hostname/substring to the provider-endpoint whitelist. "
+            "Add a hostname to the provider-endpoint whitelist. "
             "May be passed multiple times. Defaults: "
             + ", ".join(DEFAULT_PROVIDER_HOSTS)
         ),
@@ -850,9 +1045,18 @@ def main(argv: list[str] | None = None) -> int:
 
     provider_hosts = DEFAULT_PROVIDER_HOSTS + tuple(args.provider_host)
     fixture_paths = frozenset(args.fixture_path)
+    try:
+        path_aliases = tuple(_parse_path_alias(item) for item in args.path_alias)
+    except ValueError as exc:
+        print(f"bad --path-alias: {exc}", file=sys.stderr)
+        return 2
 
     rows = build_drift_report(
-        a, b, provider_hosts=provider_hosts, fixture_paths=fixture_paths
+        a,
+        b,
+        provider_hosts=provider_hosts,
+        fixture_paths=fixture_paths,
+        path_aliases=path_aliases,
     )
     payload = report_to_json(a, b, rows)
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/extract_fixture_paths.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/extract_fixture_paths.py
@@ -3,7 +3,8 @@
 recorded in its tool-calls.ndjson.
 
 Used by the cross-runtime-drift-experiment workflow's drift-compare
-job to pass the *actual* fixture paths to `drift.py --fixture-path`.
+job to pass the *actual* fixture paths to `drift.py --fixture-path`
+and `--path-alias`.
 Hardcoding `/tmp/work/fixture-*.txt` would only work for local
 testing; live captures put the workdir under
 `arm-X-runs/run_arm_X_<ts>_i/workdir/...` (P1 review on PR #1347).

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -218,6 +218,49 @@ class DriftReportClassificationTests(unittest.TestCase):
         )
         self.assertEqual(row.classification, drift.CLASSIFICATION_TASK)
 
+    def test_path_projection_preserves_raw_and_maps_logical_roles(self) -> None:
+        rows = drift.build_drift_report(
+            self.a,
+            self.b,
+            fixture_paths=self.fixture_paths,
+            path_aliases=(
+                drift.PathAlias(
+                    "/tmp/work/fixture-input.txt", "workdir/input"
+                ),
+                drift.PathAlias(
+                    "/tmp/work/fixture-output.txt", "workdir/output"
+                ),
+            ),
+        )
+        row = self._by_dim(rows)["kernel_file_operations"]
+        # Raw values stay exactly as observed.
+        self.assertIn("read:/tmp/work/fixture-input.txt", row.in_both)
+        projection = row.projection
+        self.assertEqual(
+            projection["schema"], drift.PATH_PROJECTION_SCHEMA
+        )
+        self.assertEqual(projection["status"], "applied")
+        self.assertIn("read:workdir/input", projection["in_both"])
+        self.assertIn("write:workdir/output", projection["in_both"])
+        self.assertIn(
+            "projection_no_raw_evidence_rewrite",
+            projection["non_claims"],
+        )
+
+    def test_path_projection_unknown_only_is_inconclusive(self) -> None:
+        rows = drift.build_drift_report(
+            self.a,
+            self.b,
+            path_aliases=(
+                drift.PathAlias("/does/not/exist.txt", "workdir/missing"),
+            ),
+        )
+        row = self._by_dim(rows)["filesystem_paths_touched"]
+        self.assertEqual(row.projection["status"], "applied")
+        self.assertEqual(
+            row.projection["claim_level"], drift.CLAIM_INCONCLUSIVE
+        )
+
     def test_process_execs_task_induced(self) -> None:
         rows = drift.build_drift_report(self.a, self.b)
         row = self._by_dim(rows)["process_execs"]
@@ -376,6 +419,10 @@ class MainCliTests(unittest.TestCase):
                     "/tmp/work/fixture-input.txt",
                     "--fixture-path",
                     "/tmp/work/fixture-output.txt",
+                    "--path-alias",
+                    "/tmp/work/fixture-input.txt=workdir/input",
+                    "--path-alias",
+                    "/tmp/work/fixture-output.txt=workdir/output",
                 ]
             )
             self.assertEqual(rc, 0)
@@ -394,10 +441,18 @@ class MainCliTests(unittest.TestCase):
             self.assertIn("kernel_file_operations", dims)
             self.assertIn("network_endpoints", dims)
             self.assertIn("tool_invocation_order", dims)
+            kernel_row = next(
+                r for r in payload["rows"]
+                if r["dimension"] == "kernel_file_operations"
+            )
+            self.assertIn(
+                "read:workdir/input", kernel_row["projection"]["in_both"]
+            )
             # Markdown carries a header + a row per dimension.
             md = out_md.read_text(encoding="utf-8")
             self.assertIn("# Cross-Runtime Drift Report", md)
             self.assertIn("filesystem_paths_touched", md)
+            self.assertIn("read:workdir/input", md)
 
     def test_main_returns_3_on_bad_archive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -595,13 +650,13 @@ class MarkdownEscapeTests(unittest.TestCase):
             if not line.startswith("|"):
                 continue
             unescaped = line.replace("\\|", "")
-            # Each table row in our schema has 8 unescaped `|` chars
-            # (7 cell separators + leading and trailing pipe = 8).
+            # Each table row in our schema has 9 unescaped `|` chars
+            # (8 cell separators + leading and trailing pipe = 9).
             count = unescaped.count("|")
             self.assertEqual(
                 count,
-                8,
-                f"row has {count} unescaped pipes, expected 8: {line!r}",
+                9,
+                f"row has {count} unescaped pipes, expected 9: {line!r}",
             )
 
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -261,6 +261,21 @@ class DriftReportClassificationTests(unittest.TestCase):
             row.projection["claim_level"], drift.CLAIM_INCONCLUSIVE
         )
 
+    def test_duplicate_path_alias_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            drift.build_drift_report(
+                self.a,
+                self.b,
+                path_aliases=(
+                    drift.PathAlias(
+                        "/tmp/work/fixture-input.txt", "workdir/input"
+                    ),
+                    drift.PathAlias(
+                        "/tmp/work/fixture-input.txt", "workdir/again"
+                    ),
+                ),
+            )
+
     def test_process_execs_task_induced(self) -> None:
         rows = drift.build_drift_report(self.a, self.b)
         row = self._by_dim(rows)["process_execs"]
@@ -479,6 +494,25 @@ class MainCliTests(unittest.TestCase):
                 ]
             )
             self.assertEqual(rc, 3)
+
+    def test_main_returns_2_on_duplicate_path_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_json = Path(tmp) / "drift.json"
+            rc = drift.main(
+                [
+                    "--archive-a",
+                    str(ARM_A),
+                    "--archive-b",
+                    str(ARM_B),
+                    "--path-alias",
+                    "/tmp/work/fixture-input.txt=workdir/input",
+                    "--path-alias",
+                    "/tmp/work/fixture-input.txt=workdir/again",
+                    "--out-json",
+                    str(out_json),
+                ]
+            )
+            self.assertEqual(rc, 2)
 
 
 class RuntimeLabelDerivationTests(unittest.TestCase):

--- a/docs/experiments/cross-runtime-drift-2026-05/findings.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/findings.md
@@ -239,6 +239,8 @@ python3 "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/drift.p
   --archive-b "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini" \
   --fixture-path /tmp/work/fixture-input.txt \
   --fixture-path /tmp/work/fixture-output.txt \
+  --path-alias /tmp/work/fixture-input.txt=workdir/input \
+  --path-alias /tmp/work/fixture-output.txt=workdir/output \
   --out-md /tmp/drift-smoke.md
 
 # 2. Unit tests.

--- a/docs/experiments/cross-runtime-drift-2026-05/publication/blog-draft.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/publication/blog-draft.md
@@ -31,7 +31,7 @@ experiment in [`Rul1an/assay`](https://github.com/Rul1an/assay)
 tries to answer. Everything in this post is verifiable from
 [`docs/experiments/cross-runtime-drift-2026-05/`](https://github.com/Rul1an/assay/tree/main/docs/experiments/cross-runtime-drift-2026-05)
 — including a stdlib-only Python comparator
-(`compare/drift.py`, 50 unit tests passing) that takes two
+(`compare/drift.py`, 53 unit tests passing) that takes two
 Runner archives and produces the table shown below.
 
 ## TL;DR for runtime-selection folks
@@ -234,7 +234,7 @@ git clone https://github.com/Rul1an/assay
 cd assay
 export REPO_ROOT="$PWD"
 
-# Comparator + helpers (50 unit tests, no API keys required).
+# Comparator + helpers (53 unit tests, no API keys required).
 python3 -m unittest discover \
   -s "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare" \
   -p 'test_*.py'
@@ -245,6 +245,8 @@ python3 "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/drift.p
   --archive-b "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/fixtures/arm-b-gemini" \
   --fixture-path /tmp/work/fixture-input.txt \
   --fixture-path /tmp/work/fixture-output.txt \
+  --path-alias /tmp/work/fixture-input.txt=workdir/input \
+  --path-alias /tmp/work/fixture-output.txt=workdir/output \
   --out-md /tmp/drift.md
 cat /tmp/drift.md
 

--- a/docs/experiments/cross-runtime-drift-2026-05/publication/blog-draft.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/publication/blog-draft.md
@@ -31,7 +31,7 @@ experiment in [`Rul1an/assay`](https://github.com/Rul1an/assay)
 tries to answer. Everything in this post is verifiable from
 [`docs/experiments/cross-runtime-drift-2026-05/`](https://github.com/Rul1an/assay/tree/main/docs/experiments/cross-runtime-drift-2026-05)
 — including a stdlib-only Python comparator
-(`compare/drift.py`, 53 unit tests passing) that takes two
+(`compare/drift.py`, covered by stdlib unit tests) that takes two
 Runner archives and produces the table shown below.
 
 ## TL;DR for runtime-selection folks
@@ -234,7 +234,7 @@ git clone https://github.com/Rul1an/assay
 cd assay
 export REPO_ROOT="$PWD"
 
-# Comparator + helpers (53 unit tests, no API keys required).
+# Comparator + helpers (no API keys required).
 python3 -m unittest discover \
   -s "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare" \
   -p 'test_*.py'


### PR DESCRIPTION
Summary
- Implements Path Projection v0 as the first slice from the Runner projection roadmap.
- Adds `drift.py --path-alias RAW=PROJECTED` for exact declared raw-path to logical-path projection.
- Preserves raw `only_in_a` / `only_in_b` / `in_both` values and emits additive `row.projection` blocks with schema, rules, mappings, confidence, claim level, and non-claims.
- Projects both plain filesystem paths and operation-aware `op:path` values such as `read:/...` -> `read:workdir/input`.
- Updates the cross-runtime drift workflow to pass live per-run input/output aliases as `workdir/input` and `workdir/output`.

Claim discipline
- No heuristic path taxonomy yet: no `node_modules`, cache, loader, or provider-SDK guessing.
- Unknown paths remain raw/unknown.
- Projection does not rewrite source evidence and does not claim semantic workload equivalence.

Validation
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 53 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/contract-checker -p 'test_*.py'` -> 14 OK
- Synthetic smoke run shows projected `workdir/input` + `workdir/output` rows
- `actionlint .github/workflows/cross-runtime-drift-experiment.yml`
- `zizmor .github/workflows/cross-runtime-drift-experiment.yml`
- local markdown link check
- pre-commit + pre-push hooks