### PR TITLE
feat(experiments): add runtime noise taxonomy v0

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -7,8 +7,8 @@
 > implementations runnable locally with API keys, contract-checker
 > validates outputs (14 stdlib unit tests), `compare/drift.py`
 > produces per-dimension drift reports (stdlib unit tests cover
-> `drift.py` + `health_gate.py` + `extract_fixture_paths.py`), emits
-> Runtime/Noise Taxonomy v0 metadata as vocabulary-only context, live
+> `drift.py` + `health_gate.py` + `extract_fixture_paths.py`), and emits
+> Runtime/Noise Taxonomy v0 metadata as vocabulary-only context. Live
 > Arm A0/B0 archives are under [`runs/`](runs/), [`findings.md`](findings.md)
 > reflects the live data, and [`publication/`](publication/) holds
 > blog + discussion-comment drafts gated on OpenInference #3162 triage.

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -7,7 +7,8 @@
 > implementations runnable locally with API keys, contract-checker
 > validates outputs (14 stdlib unit tests), `compare/drift.py`
 > produces per-dimension drift reports (stdlib unit tests cover
-> `drift.py` + `health_gate.py` + `extract_fixture_paths.py`), live
+> `drift.py` + `health_gate.py` + `extract_fixture_paths.py`), emits
+> Runtime/Noise Taxonomy v0 metadata as vocabulary-only context, live
 > Arm A0/B0 archives are under [`runs/`](runs/), [`findings.md`](findings.md)
 > reflects the live data, and [`publication/`](publication/) holds
 > blog + discussion-comment drafts gated on OpenInference #3162 triage.
@@ -115,6 +116,10 @@ Path projection v0 is additive: raw `only_in_*` and `in_both`
 values stay unchanged, while `--path-alias RAW=PROJECTED` emits an
 auditable `row.projection` block with mapping rule, confidence,
 claim level, and non-claims.
+Runtime/Noise Taxonomy v0 is also emitted in JSON reports, but it is
+vocabulary-only in this slice: it validates declared projection classes
+and preserves `unknown`; it does not infer loader, package, SDK, or cache
+classes heuristically.
 
 ## What's done in Slice 1
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -13,6 +13,7 @@ Scope (v0, Slice 2):
   - tool invocation order (SDK events' seq per tool_call_id)
   - kernel file operations (layers/kernel.ndjson open metadata)
   - path projection v0 over explicitly declared raw=logical aliases
+  - runtime/noise taxonomy v0 metadata for projection classes
 
 Out of scope (explicit follow-ups, NOT silent gaps):
   - unlink/remove classification
@@ -84,19 +85,77 @@ CLASSIFICATION_RUNTIME = "runtime-induced"
 CLASSIFICATION_INCONCLUSIVE = "inconclusive"
 
 PATH_PROJECTION_SCHEMA = "assay.runner.path_projection.v0"
+RUNTIME_NOISE_TAXONOMY_SCHEMA = "assay.runner.runtime_noise_taxonomy.v0"
 
 CLAIM_RAW_OBSERVED = "raw_observed"
 CLAIM_PROJECTED_EQUIVALENT = "projected_equivalent"
 CLAIM_INCONCLUSIVE = "inconclusive"
 
 PATH_CLASS_WORKLOAD_FIXTURE = "workload_fixture"
+PATH_CLASS_RUNTIME_PACKAGE = "runtime_package"
+PATH_CLASS_PROVIDER_SDK = "provider_sdk"
+PATH_CLASS_LOADER = "loader"
+PATH_CLASS_EXPERIMENT_HARNESS = "experiment_harness"
+PATH_CLASS_CACHE = "cache"
+NETWORK_CLASS_PROVIDER_API = "provider_api"
+NETWORK_CLASS_DNS = "dns"
+NETWORK_CLASS_TELEMETRY = "telemetry"
+NETWORK_CLASS_PACKAGE_FETCH = "package_fetch"
 PATH_CLASS_UNKNOWN = "unknown"
+
+TAXONOMY_CATEGORIES: dict[str, dict[str, Any]] = {
+    PATH_CLASS_WORKLOAD_FIXTURE: {
+        "applies_to": ["path", "operation"],
+        "meaning": "declared workload input, output, or scratch value",
+    },
+    PATH_CLASS_RUNTIME_PACKAGE: {
+        "applies_to": ["path"],
+        "meaning": "language runtime or package tree behavior",
+    },
+    PATH_CLASS_PROVIDER_SDK: {
+        "applies_to": ["path", "network", "sdk_event"],
+        "meaning": "provider client implementation behavior",
+    },
+    PATH_CLASS_LOADER: {
+        "applies_to": ["path", "process"],
+        "meaning": "dynamic loader, interpreter, locale, or bootstrap behavior",
+    },
+    PATH_CLASS_EXPERIMENT_HARNESS: {
+        "applies_to": ["path", "process", "metadata"],
+        "meaning": "runner, workflow, comparator, or test harness plumbing",
+    },
+    PATH_CLASS_CACHE: {
+        "applies_to": ["path"],
+        "meaning": "package manager, runtime, or tool cache path",
+    },
+    NETWORK_CLASS_PROVIDER_API: {
+        "applies_to": ["network"],
+        "meaning": "model/provider API endpoint",
+    },
+    NETWORK_CLASS_DNS: {
+        "applies_to": ["network"],
+        "meaning": "DNS lookup endpoint when visible",
+    },
+    NETWORK_CLASS_TELEMETRY: {
+        "applies_to": ["network"],
+        "meaning": "observability or SDK telemetry endpoint",
+    },
+    NETWORK_CLASS_PACKAGE_FETCH: {
+        "applies_to": ["network"],
+        "meaning": "dependency or package retrieval endpoint",
+    },
+    PATH_CLASS_UNKNOWN: {
+        "applies_to": ["all"],
+        "meaning": "observed value did not match a declared taxonomy rule",
+    },
+}
 
 PROJECTION_NON_CLAIMS = (
     "projection_no_raw_evidence_rewrite",
     "projection_no_semantic_workload_equivalence",
     "projection_no_policy_acceptability_verdict",
     "projection_unknowns_preserved",
+    "projection_no_heuristic_noise_taxonomy",
 )
 
 
@@ -389,6 +448,36 @@ class PathAlias:
     rule: str = "declared_path_alias"
     confidence: str = "declared"
 
+    def __post_init__(self) -> None:
+        _validate_taxonomy_class(self.path_class, domain="path")
+
+
+def _taxonomy_payload() -> dict[str, Any]:
+    return {
+        "schema": RUNTIME_NOISE_TAXONOMY_SCHEMA,
+        "status": "vocabulary_only",
+        "categories": TAXONOMY_CATEGORIES,
+        "non_claims": [
+            "taxonomy_no_heuristic_classification",
+            "taxonomy_unknowns_preserved",
+            "taxonomy_no_policy_verdict",
+        ],
+    }
+
+
+def _validate_taxonomy_class(category: str, *, domain: str) -> None:
+    spec = TAXONOMY_CATEGORIES.get(category)
+    if spec is None:
+        allowed = ", ".join(sorted(TAXONOMY_CATEGORIES))
+        raise ValueError(
+            f"unknown taxonomy class {category!r}; expected one of: {allowed}"
+        )
+    applies_to = spec.get("applies_to", [])
+    if "all" not in applies_to and domain not in applies_to:
+        raise ValueError(
+            f"taxonomy class {category!r} does not apply to {domain!r}"
+        )
+
 
 @dataclasses.dataclass(frozen=True)
 class ProjectedValue:
@@ -474,6 +563,7 @@ def _projection_payload(
             "schema": PATH_PROJECTION_SCHEMA,
             "status": "not_applied",
             "reason": "no path aliases declared",
+            "taxonomy_schema": RUNTIME_NOISE_TAXONOMY_SCHEMA,
             "non_claims": list(PROJECTION_NON_CLAIMS),
         }
 
@@ -506,6 +596,7 @@ def _projection_payload(
         "status": "applied",
         "dimension": dimension,
         "claim_level": claim_level,
+        "taxonomy_schema": RUNTIME_NOISE_TAXONOMY_SCHEMA,
         "only_in_a": only_a,
         "only_in_b": only_b,
         "in_both": both,
@@ -902,6 +993,7 @@ def report_to_json(
             "manifest_digest": b.manifest_digest,
             "sdk_event_count": b.sdk_event_count,
         },
+        "taxonomy": _taxonomy_payload(),
         "rows": [dataclasses.asdict(r) for r in rows],
         "summary": {
             "dimensions_checked": len(rows),

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -276,6 +276,33 @@ class DriftReportClassificationTests(unittest.TestCase):
                 ),
             )
 
+    def test_path_alias_rejects_unknown_taxonomy_class(self) -> None:
+        with self.assertRaises(ValueError):
+            drift.PathAlias(
+                "/tmp/work/fixture-input.txt",
+                "workdir/input",
+                path_class="not-a-real-class",
+            )
+
+    def test_path_alias_rejects_network_only_taxonomy_class(self) -> None:
+        with self.assertRaises(ValueError):
+            drift.PathAlias(
+                "/tmp/work/fixture-input.txt",
+                "workdir/input",
+                path_class=drift.NETWORK_CLASS_PROVIDER_API,
+            )
+
+    def test_taxonomy_payload_preserves_unknowns_and_non_claims(self) -> None:
+        payload = drift._taxonomy_payload()
+        self.assertEqual(
+            payload["schema"], drift.RUNTIME_NOISE_TAXONOMY_SCHEMA
+        )
+        self.assertEqual(payload["status"], "vocabulary_only")
+        self.assertIn(drift.PATH_CLASS_UNKNOWN, payload["categories"])
+        self.assertIn(
+            "taxonomy_unknowns_preserved", payload["non_claims"]
+        )
+
     def test_process_execs_task_induced(self) -> None:
         rows = drift.build_drift_report(self.a, self.b)
         row = self._by_dim(rows)["process_execs"]
@@ -445,6 +472,10 @@ class MainCliTests(unittest.TestCase):
             self.assertTrue(out_md.is_file())
             payload = json.loads(out_json.read_text(encoding="utf-8"))
             self.assertEqual(payload["schema"], drift.DRIFT_REPORT_SCHEMA)
+            self.assertEqual(
+                payload["taxonomy"]["schema"],
+                drift.RUNTIME_NOISE_TAXONOMY_SCHEMA,
+            )
             self.assertEqual(
                 payload["archive_a"]["runtime_label"], "openai-agents"
             )

--- a/docs/reference/runner/projection-roadmap.md
+++ b/docs/reference/runner/projection-roadmap.md
@@ -126,6 +126,11 @@ paths; it is to add a logical path layer above them.
 The taxonomy should be designed in parallel with path projection because
 path and network projection both need the same classification language.
 
+Implementation note: the cross-runtime drift comparator now emits this
+taxonomy as vocabulary-only metadata. It validates declared projection
+classes and preserves `unknown`, but it does not yet infer taxonomy
+classes from paths or endpoints.
+
 Initial taxonomy:
 
 | Category | Applies to | Notes |


### PR DESCRIPTION
Summary
- Implements Runtime/Noise Taxonomy v0 as the next slice after Path Projection v0.
- Adds `assay.runner.runtime_noise_taxonomy.v0` metadata to drift report JSON.
- Defines the initial vocabulary: `workload_fixture`, `runtime_package`, `provider_sdk`, `loader`, `experiment_harness`, `cache`, `provider_api`, `dns`, `telemetry`, `package_fetch`, `unknown`.
- Validates declared `PathAlias.path_class` values and rejects unknown or wrong-domain classes.
- Keeps the slice vocabulary-only: no heuristic path or endpoint classification yet; unknowns remain preserved.

Claim discipline
- Raw evidence is unchanged.
- Projection classes are validated, not inferred.
- The taxonomy is reviewer vocabulary, not a policy verdict.
- Unknown/unclassified values remain explicit.

Validation
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 58 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/contract-checker -p 'test_*.py'` -> 14 OK
- Synthetic smoke run confirms taxonomy metadata + projection rows carry taxonomy schema
- `actionlint .github/workflows/cross-runtime-drift-experiment.yml`
- `zizmor .github/workflows/cross-runtime-drift-experiment.yml`
- local markdown link check
- pre-commit + pre-push hooks