### PR TITLE
feat(experiments): add network projection v0

### DIFF
--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -449,6 +449,7 @@ jobs:
               --path-alias "${A_PATHS[1]}=workdir/output" \
               --path-alias "${B_PATHS[0]}=workdir/input" \
               --path-alias "${B_PATHS[1]}=workdir/output" \
+              --network-alias "127.0.0.53:53=dns" \
               --out-json "${REPORT_BASE}.json" \
               --out-md "${REPORT_BASE}.md"
             {

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -120,6 +120,11 @@ Runtime/Noise Taxonomy v0 is also emitted in JSON reports, but it is
 vocabulary-only in this slice: it validates declared projection classes
 and preserves `unknown`; it does not infer loader, package, SDK, or cache
 classes heuristically.
+Network projection v0 follows the same additive discipline for
+`network_endpoints`: `--network-alias RAW_ENDPOINT=CLASS` and
+`--network-cidr CIDR=CLASS` can project declared endpoints or IP ranges
+to taxonomy classes such as `provider_api` or `dns`, while unmatched
+endpoints remain raw/unknown.
 
 ## What's done in Slice 1
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -53,6 +53,8 @@ import tarfile
 from pathlib import Path
 from typing import Any, Iterable
 
+ParsedNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
 # ---------------------------------------------------------------------------
 # Schema strings (also used to identify fixture archives in tests)
 # ---------------------------------------------------------------------------
@@ -698,8 +700,8 @@ def _network_alias_dict(
 
 def _network_cidr_tuple(
     network_cidrs: tuple[NetworkCidrAlias, ...]
-) -> tuple[tuple[Any, NetworkCidrAlias], ...]:
-    out: list[tuple[Any, NetworkCidrAlias]] = []
+) -> tuple[tuple[ParsedNetwork, NetworkCidrAlias], ...]:
+    out: list[tuple[ParsedNetwork, NetworkCidrAlias]] = []
     seen: set[str] = set()
     for alias in network_cidrs:
         network = ipaddress.ip_network(alias.cidr, strict=False)
@@ -722,7 +724,7 @@ def _endpoint_host(endpoint: str) -> str:
 def _project_network_endpoint(
     endpoint: str,
     exact_aliases: dict[str, NetworkAlias],
-    cidr_aliases: tuple[tuple[Any, NetworkCidrAlias], ...],
+    cidr_aliases: tuple[tuple[ParsedNetwork, NetworkCidrAlias], ...],
 ) -> NetworkProjectedValue:
     exact = exact_aliases.get(endpoint)
     if exact is not None:
@@ -770,7 +772,7 @@ def _network_projection_payload(
     a_values: list[str],
     b_values: list[str],
     exact_aliases: dict[str, NetworkAlias],
-    cidr_aliases: tuple[tuple[Any, NetworkCidrAlias], ...],
+    cidr_aliases: tuple[tuple[ParsedNetwork, NetworkCidrAlias], ...],
 ) -> dict[str, Any]:
     if not exact_aliases and not cidr_aliases:
         return {

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -13,6 +13,7 @@ Scope (v0, Slice 2):
   - tool invocation order (SDK events' seq per tool_call_id)
   - kernel file operations (layers/kernel.ndjson open metadata)
   - path projection v0 over explicitly declared raw=logical aliases
+  - network projection v0 over explicitly declared endpoint/CIDR aliases
   - runtime/noise taxonomy v0 metadata for projection classes
 
 Out of scope (explicit follow-ups, NOT silent gaps):
@@ -45,6 +46,7 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import hashlib
+import ipaddress
 import json
 import sys
 import tarfile
@@ -85,6 +87,7 @@ CLASSIFICATION_RUNTIME = "runtime-induced"
 CLASSIFICATION_INCONCLUSIVE = "inconclusive"
 
 PATH_PROJECTION_SCHEMA = "assay.runner.path_projection.v0"
+NETWORK_PROJECTION_SCHEMA = "assay.runner.network_projection.v0"
 RUNTIME_NOISE_TAXONOMY_SCHEMA = "assay.runner.runtime_noise_taxonomy.v0"
 
 CLAIM_RAW_OBSERVED = "raw_observed"
@@ -452,6 +455,38 @@ class PathAlias:
         _validate_taxonomy_class(self.path_class, domain="path")
 
 
+@dataclasses.dataclass(frozen=True)
+class NetworkAlias:
+    """A declared raw endpoint -> network role projection rule."""
+
+    raw_endpoint: str
+    network_class: str
+    relation: str = "declared_endpoint"
+    rule: str = "declared_network_alias"
+    confidence: str = "declared"
+
+    def __post_init__(self) -> None:
+        _validate_taxonomy_class(self.network_class, domain="network")
+
+
+@dataclasses.dataclass(frozen=True)
+class NetworkCidrAlias:
+    """A declared CIDR -> network role projection rule."""
+
+    cidr: str
+    network_class: str
+    relation: str = "declared_cidr"
+    rule: str = "declared_network_cidr_alias"
+    confidence: str = "declared"
+
+    def __post_init__(self) -> None:
+        _validate_taxonomy_class(self.network_class, domain="network")
+        try:
+            ipaddress.ip_network(self.cidr, strict=False)
+        except ValueError as exc:
+            raise ValueError(f"invalid network CIDR {self.cidr!r}: {exc}") from exc
+
+
 def _taxonomy_payload() -> dict[str, Any]:
     return {
         "schema": RUNTIME_NOISE_TAXONOMY_SCHEMA,
@@ -499,6 +534,28 @@ def _parse_path_alias(raw: str) -> PathAlias:
     if not raw_path or not projected_path:
         raise ValueError("expected non-empty RAW and PROJECTED")
     return PathAlias(raw_path=raw_path, projected_path=projected_path)
+
+
+def _parse_network_alias(raw: str) -> NetworkAlias:
+    if "=" not in raw:
+        raise ValueError("expected RAW_ENDPOINT=CLASS")
+    raw_endpoint, network_class = raw.split("=", 1)
+    raw_endpoint = raw_endpoint.strip()
+    network_class = network_class.strip()
+    if not raw_endpoint or not network_class:
+        raise ValueError("expected non-empty RAW_ENDPOINT and CLASS")
+    return NetworkAlias(raw_endpoint=raw_endpoint, network_class=network_class)
+
+
+def _parse_network_cidr(raw: str) -> NetworkCidrAlias:
+    if "=" not in raw:
+        raise ValueError("expected CIDR=CLASS")
+    cidr, network_class = raw.split("=", 1)
+    cidr = cidr.strip()
+    network_class = network_class.strip()
+    if not cidr or not network_class:
+        raise ValueError("expected non-empty CIDR and CLASS")
+    return NetworkCidrAlias(cidr=cidr, network_class=network_class)
 
 
 def _project_single_path(path: str, aliases: dict[str, PathAlias]) -> ProjectedValue:
@@ -615,6 +672,159 @@ def _path_alias_dict(path_aliases: tuple[PathAlias, ...]) -> dict[str, PathAlias
     return out
 
 
+@dataclasses.dataclass(frozen=True)
+class NetworkProjectedValue:
+    raw_value: str
+    projected_value: str
+    network_class: str
+    relation: str
+    rule: str
+    confidence: str
+    claim_level: str
+
+
+def _network_alias_dict(
+    network_aliases: tuple[NetworkAlias, ...]
+) -> dict[str, NetworkAlias]:
+    out: dict[str, NetworkAlias] = {}
+    for alias in network_aliases:
+        if alias.raw_endpoint in out:
+            raise ValueError(
+                f"duplicate network alias for {alias.raw_endpoint!r}"
+            )
+        out[alias.raw_endpoint] = alias
+    return out
+
+
+def _network_cidr_tuple(
+    network_cidrs: tuple[NetworkCidrAlias, ...]
+) -> tuple[tuple[Any, NetworkCidrAlias], ...]:
+    out: list[tuple[Any, NetworkCidrAlias]] = []
+    seen: set[str] = set()
+    for alias in network_cidrs:
+        network = ipaddress.ip_network(alias.cidr, strict=False)
+        key = str(network)
+        if key in seen:
+            raise ValueError(f"duplicate network CIDR alias for {key!r}")
+        seen.add(key)
+        out.append((network, alias))
+    return tuple(out)
+
+
+def _endpoint_host(endpoint: str) -> str:
+    if endpoint.startswith("["):
+        end = endpoint.find("]")
+        if end > 1:
+            return endpoint[1:end]
+    return endpoint.rsplit(":", 1)[0] if ":" in endpoint else endpoint
+
+
+def _project_network_endpoint(
+    endpoint: str,
+    exact_aliases: dict[str, NetworkAlias],
+    cidr_aliases: tuple[tuple[Any, NetworkCidrAlias], ...],
+) -> NetworkProjectedValue:
+    exact = exact_aliases.get(endpoint)
+    if exact is not None:
+        return NetworkProjectedValue(
+            raw_value=endpoint,
+            projected_value=exact.network_class,
+            network_class=exact.network_class,
+            relation=exact.relation,
+            rule=exact.rule,
+            confidence=exact.confidence,
+            claim_level=CLAIM_PROJECTED_EQUIVALENT,
+        )
+
+    host = _endpoint_host(endpoint)
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        address = None
+    if address is not None:
+        for network, alias in cidr_aliases:
+            if address in network:
+                return NetworkProjectedValue(
+                    raw_value=endpoint,
+                    projected_value=alias.network_class,
+                    network_class=alias.network_class,
+                    relation=alias.relation,
+                    rule=alias.rule,
+                    confidence=alias.confidence,
+                    claim_level=CLAIM_PROJECTED_EQUIVALENT,
+                )
+
+    return NetworkProjectedValue(
+        raw_value=endpoint,
+        projected_value=endpoint,
+        network_class=PATH_CLASS_UNKNOWN,
+        relation="unmatched",
+        rule="no_declared_network_alias",
+        confidence="unknown",
+        claim_level=CLAIM_RAW_OBSERVED,
+    )
+
+
+def _network_projection_payload(
+    dimension: str,
+    a_values: list[str],
+    b_values: list[str],
+    exact_aliases: dict[str, NetworkAlias],
+    cidr_aliases: tuple[tuple[Any, NetworkCidrAlias], ...],
+) -> dict[str, Any]:
+    if not exact_aliases and not cidr_aliases:
+        return {
+            "schema": NETWORK_PROJECTION_SCHEMA,
+            "status": "not_applied",
+            "reason": "no network aliases declared",
+            "taxonomy_schema": RUNTIME_NOISE_TAXONOMY_SCHEMA,
+            "non_claims": list(PROJECTION_NON_CLAIMS),
+        }
+
+    projected_a = [
+        _project_network_endpoint(value, exact_aliases, cidr_aliases)
+        for value in a_values
+    ]
+    projected_b = [
+        _project_network_endpoint(value, exact_aliases, cidr_aliases)
+        for value in b_values
+    ]
+    a_projected_values = [item.projected_value for item in projected_a]
+    b_projected_values = [item.projected_value for item in projected_b]
+    only_a, only_b, both = _diff_lists(a_projected_values, b_projected_values)
+    mappings = [
+        {"side": "a", **dataclasses.asdict(item)} for item in projected_a
+    ] + [{"side": "b", **dataclasses.asdict(item)} for item in projected_b]
+    rules = sorted(
+        {
+            item.rule
+            for item in [*projected_a, *projected_b]
+            if item.rule != "no_declared_network_alias"
+        }
+    )
+    has_projected_match = any(
+        item.claim_level == CLAIM_PROJECTED_EQUIVALENT
+        and item.projected_value in both
+        for item in [*projected_a, *projected_b]
+    )
+    claim_level = (
+        CLAIM_PROJECTED_EQUIVALENT if has_projected_match else CLAIM_INCONCLUSIVE
+    )
+    return {
+        "schema": NETWORK_PROJECTION_SCHEMA,
+        "status": "applied",
+        "dimension": dimension,
+        "claim_level": claim_level,
+        "taxonomy_schema": RUNTIME_NOISE_TAXONOMY_SCHEMA,
+        "only_in_a": only_a,
+        "only_in_b": only_b,
+        "in_both": both,
+        "rules": rules,
+        "mappings": mappings,
+        "non_claims": list(PROJECTION_NON_CLAIMS),
+    }
+
+
 def _network_endpoint_matches_provider(
     item: str, provider_hosts: tuple[str, ...]
 ) -> bool:
@@ -725,6 +935,8 @@ def build_drift_report(
     provider_hosts: tuple[str, ...] = DEFAULT_PROVIDER_HOSTS,
     fixture_paths: frozenset[str] = frozenset(),
     path_aliases: tuple[PathAlias, ...] = (),
+    network_aliases: tuple[NetworkAlias, ...] = (),
+    network_cidrs: tuple[NetworkCidrAlias, ...] = (),
 ) -> list[DriftRow]:
     """Compute per-dimension drift rows between two archives.
 
@@ -736,6 +948,8 @@ def build_drift_report(
 
     rows: list[DriftRow] = []
     aliases = _path_alias_dict(path_aliases)
+    exact_network_aliases = _network_alias_dict(network_aliases)
+    cidr_network_aliases = _network_cidr_tuple(network_cidrs)
 
     # --- filesystem paths touched ---
     a_paths = a.capability_surface.get("filesystem_paths", [])
@@ -817,6 +1031,13 @@ def build_drift_report(
             in_both=both,
             classification=cls,
             detail=detail,
+            projection=_network_projection_payload(
+                "network_endpoints",
+                a_net,
+                b_net,
+                exact_network_aliases,
+                cidr_network_aliases,
+            ),
         )
     )
 
@@ -1126,6 +1347,28 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--network-alias",
+        action="append",
+        default=[],
+        help=(
+            "Declare an exact raw network endpoint to taxonomy class "
+            "projection as RAW_ENDPOINT=CLASS. The raw endpoint remains "
+            "in only_in_a/only_in_b/in_both; the projection is emitted "
+            "under row.projection. Example: "
+            "--network-alias 127.0.0.53:53=dns."
+        ),
+    )
+    parser.add_argument(
+        "--network-cidr",
+        action="append",
+        default=[],
+        help=(
+            "Declare a CIDR to taxonomy class projection as CIDR=CLASS. "
+            "The endpoint host must be an IP address and fall inside the "
+            "CIDR. Example: --network-cidr 34.120.0.0/14=provider_api."
+        ),
+    )
+    parser.add_argument(
         "--provider-host",
         action="append",
         default=[],
@@ -1152,9 +1395,25 @@ def main(argv: list[str] | None = None) -> int:
         print(f"bad --path-alias: {exc}", file=sys.stderr)
         return 2
     try:
-        _path_alias_dict(path_aliases)
+        network_aliases = tuple(
+            _parse_network_alias(item) for item in args.network_alias
+        )
     except ValueError as exc:
-        print(f"bad --path-alias: {exc}", file=sys.stderr)
+        print(f"bad --network-alias: {exc}", file=sys.stderr)
+        return 2
+    try:
+        network_cidrs = tuple(
+            _parse_network_cidr(item) for item in args.network_cidr
+        )
+    except ValueError as exc:
+        print(f"bad --network-cidr: {exc}", file=sys.stderr)
+        return 2
+    try:
+        _path_alias_dict(path_aliases)
+        _network_alias_dict(network_aliases)
+        _network_cidr_tuple(network_cidrs)
+    except ValueError as exc:
+        print(f"bad projection config: {exc}", file=sys.stderr)
         return 2
 
     try:
@@ -1164,6 +1423,8 @@ def main(argv: list[str] | None = None) -> int:
             provider_hosts=provider_hosts,
             fixture_paths=fixture_paths,
             path_aliases=path_aliases,
+            network_aliases=network_aliases,
+            network_cidrs=network_cidrs,
         )
     except ValueError as exc:
         print(f"bad projection config: {exc}", file=sys.stderr)

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -292,6 +292,147 @@ class DriftReportClassificationTests(unittest.TestCase):
                 path_class=drift.NETWORK_CLASS_PROVIDER_API,
             )
 
+    def test_network_projection_exact_alias_maps_provider_role(self) -> None:
+        rows = drift.build_drift_report(
+            self.a,
+            self.b,
+            network_aliases=(
+                drift.NetworkAlias(
+                    "api.openai.com:443", drift.NETWORK_CLASS_PROVIDER_API
+                ),
+                drift.NetworkAlias(
+                    "generativelanguage.googleapis.com:443",
+                    drift.NETWORK_CLASS_PROVIDER_API,
+                ),
+                drift.NetworkAlias(
+                    "oauth2.googleapis.com:443",
+                    drift.NETWORK_CLASS_PROVIDER_API,
+                ),
+            ),
+        )
+        row = self._by_dim(rows)["network_endpoints"]
+        # Raw values stay exactly as observed.
+        self.assertIn("api.openai.com:443", row.only_in_a)
+        projection = row.projection
+        self.assertEqual(
+            projection["schema"], drift.NETWORK_PROJECTION_SCHEMA
+        )
+        self.assertEqual(projection["status"], "applied")
+        self.assertIn(drift.NETWORK_CLASS_PROVIDER_API, projection["in_both"])
+        self.assertIn(
+            "declared_network_alias", projection["rules"]
+        )
+
+    def test_network_projection_cidr_alias_maps_ip_endpoints(self) -> None:
+        a = drift.ArchiveObservation(
+            path="a",
+            run_id="a",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:aa",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["162.159.140.245:443"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+        )
+        b = drift.ArchiveObservation(
+            path="b",
+            run_id="b",
+            runtime_label="gemini-genai",
+            manifest_digest="sha256:bb",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["172.66.0.243:443"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+        )
+        rows = drift.build_drift_report(
+            a,
+            b,
+            network_cidrs=(
+                drift.NetworkCidrAlias(
+                    "162.159.0.0/16", drift.NETWORK_CLASS_PROVIDER_API
+                ),
+                drift.NetworkCidrAlias(
+                    "172.66.0.0/16", drift.NETWORK_CLASS_PROVIDER_API
+                ),
+            ),
+        )
+        row = self._by_dim(rows)["network_endpoints"]
+        self.assertIn(drift.NETWORK_CLASS_PROVIDER_API, row.projection["in_both"])
+        self.assertIn(
+            "declared_network_cidr_alias", row.projection["rules"]
+        )
+
+    def test_network_projection_cidr_alias_handles_bracketed_ipv6(self) -> None:
+        a = drift.ArchiveObservation(
+            path="a",
+            run_id="a",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:aa",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["[2a00:1450:400e:806::200a]:443"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+        )
+        rows = drift.build_drift_report(
+            a,
+            a,
+            network_cidrs=(
+                drift.NetworkCidrAlias(
+                    "2a00:1450:400e::/48", drift.NETWORK_CLASS_PROVIDER_API
+                ),
+            ),
+        )
+        row = self._by_dim(rows)["network_endpoints"]
+        self.assertIn(drift.NETWORK_CLASS_PROVIDER_API, row.projection["in_both"])
+
+    def test_duplicate_network_alias_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            drift.build_drift_report(
+                self.a,
+                self.b,
+                network_aliases=(
+                    drift.NetworkAlias(
+                        "api.openai.com:443",
+                        drift.NETWORK_CLASS_PROVIDER_API,
+                    ),
+                    drift.NetworkAlias(
+                        "api.openai.com:443",
+                        drift.NETWORK_CLASS_TELEMETRY,
+                    ),
+                ),
+            )
+
+    def test_network_alias_rejects_path_only_taxonomy_class(self) -> None:
+        with self.assertRaises(ValueError):
+            drift.NetworkAlias(
+                "api.openai.com:443",
+                drift.PATH_CLASS_WORKLOAD_FIXTURE,
+            )
+
     def test_taxonomy_payload_preserves_unknowns_and_non_claims(self) -> None:
         payload = drift._taxonomy_payload()
         self.assertEqual(
@@ -544,6 +685,21 @@ class MainCliTests(unittest.TestCase):
                 ]
             )
             self.assertEqual(rc, 2)
+
+    def test_main_returns_2_on_duplicate_network_alias(self) -> None:
+        rc = drift.main(
+            [
+                "--archive-a",
+                str(ARM_A),
+                "--archive-b",
+                str(ARM_B),
+                "--network-alias",
+                "api.openai.com:443=provider_api",
+                "--network-alias",
+                "api.openai.com:443=telemetry",
+            ]
+        )
+        self.assertEqual(rc, 2)
 
 
 class RuntimeLabelDerivationTests(unittest.TestCase):

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -426,6 +426,23 @@ class DriftReportClassificationTests(unittest.TestCase):
                 ),
             )
 
+    def test_duplicate_network_cidr_alias_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            drift.build_drift_report(
+                self.a,
+                self.b,
+                network_cidrs=(
+                    drift.NetworkCidrAlias(
+                        "162.159.0.0/16",
+                        drift.NETWORK_CLASS_PROVIDER_API,
+                    ),
+                    drift.NetworkCidrAlias(
+                        "162.159.140.245/16",
+                        drift.NETWORK_CLASS_TELEMETRY,
+                    ),
+                ),
+            )
+
     def test_network_alias_rejects_path_only_taxonomy_class(self) -> None:
         with self.assertRaises(ValueError):
             drift.NetworkAlias(
@@ -697,6 +714,21 @@ class MainCliTests(unittest.TestCase):
                 "api.openai.com:443=provider_api",
                 "--network-alias",
                 "api.openai.com:443=telemetry",
+            ]
+        )
+        self.assertEqual(rc, 2)
+
+    def test_main_returns_2_on_duplicate_network_cidr(self) -> None:
+        rc = drift.main(
+            [
+                "--archive-a",
+                str(ARM_A),
+                "--archive-b",
+                str(ARM_B),
+                "--network-cidr",
+                "162.159.0.0/16=provider_api",
+                "--network-cidr",
+                "162.159.140.245/16=telemetry",
             ]
         )
         self.assertEqual(rc, 2)

--- a/docs/reference/runner/projection-roadmap.md
+++ b/docs/reference/runner/projection-roadmap.md
@@ -192,16 +192,21 @@ upgrade a projection into primary evidence.
 Network projection should follow path projection. Keep the taxonomy
 small and allow `unknown`.
 
+Implementation note: the cross-runtime drift comparator now supports
+declared exact endpoint aliases and CIDR aliases. Raw endpoints remain
+unchanged in the report; projection is additive and unmatched endpoints
+stay `unknown`.
+
 ### Shape
 
 ```json
 {
   "raw_endpoint": "34.120.x.x:443",
   "projected_endpoint": "provider_api",
-  "provider": "google",
-  "rule": "provider_allowlist",
-  "confidence": "allowlist",
-  "claim_level": "classified_drift"
+  "network_class": "provider_api",
+  "rule": "declared_network_cidr_alias",
+  "confidence": "declared",
+  "claim_level": "projected_equivalent"
 }
 ```
 
@@ -315,7 +320,7 @@ Projection reports MUST carry explicit non-claims. Initial codes:
 | 1 | Path projection helper over existing cross-runtime drift fixtures | Unit tests with raw/projected dual view |
 | 2 | Runtime/noise taxonomy constants and docs | Unknown-preserving tests |
 | 3 | Report provenance metadata block | Existing live run can be re-rendered with metadata |
-| 4 | Network projection helper | Provider allowlist and unknown fallback tests |
+| 4 | Network projection helper | Exact endpoint, CIDR, and unknown fallback tests |
 | 5 | Draft `assay.runner.runtime_drift.v0` projection schema | Synthetic fixture covers all claim levels |
 | 6 | Kernel event v0.2 feasibility note | No code until projection reports prove value |
 

--- a/docs/reference/runner/projection-roadmap.md
+++ b/docs/reference/runner/projection-roadmap.md
@@ -201,12 +201,26 @@ stay `unknown`.
 
 ```json
 {
-  "raw_endpoint": "34.120.x.x:443",
-  "projected_endpoint": "provider_api",
-  "network_class": "provider_api",
-  "rule": "declared_network_cidr_alias",
-  "confidence": "declared",
-  "claim_level": "projected_equivalent"
+  "projection": {
+    "schema": "assay.runner.network_projection.v0",
+    "status": "applied",
+    "dimension": "network_endpoints",
+    "claim_level": "projected_equivalent",
+    "in_both": ["provider_api"],
+    "rules": ["declared_network_cidr_alias"],
+    "mappings": [
+      {
+        "side": "a",
+        "raw_value": "34.120.10.20:443",
+        "projected_value": "provider_api",
+        "network_class": "provider_api",
+        "relation": "declared_cidr",
+        "rule": "declared_network_cidr_alias",
+        "confidence": "declared",
+        "claim_level": "projected_equivalent"
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
Summary

Adds Network Projection v0 to the cross-runtime drift comparator. This mirrors Path Projection v0's discipline for `network_endpoints`: raw evidence stays in `only_in_a` / `only_in_b` / `in_both`, while declared network rules emit an additive `row.projection` block.

What changed

- `compare/drift.py`
  - New schema string: `assay.runner.network_projection.v0`
  - New `NetworkAlias` for exact `RAW_ENDPOINT=CLASS` projection
  - New `NetworkCidrAlias` for `CIDR=CLASS` projection
  - New CLI flags:
    - `--network-alias 127.0.0.53:53=dns`
    - `--network-cidr 34.120.0.0/14=provider_api`
  - CIDR projection handles IPv4 and bracketed IPv6 endpoints.
  - Duplicate exact endpoints / normalized CIDRs fail fast with exit code 2.
  - Taxonomy validation uses `domain="network"`, so path-only classes cannot be used for endpoints.
- Workflow
  - Drift reports now pass the declared local resolver endpoint as `dns` when present: `127.0.0.53:53=dns`.
- Docs
  - README documents additive network projection.
  - Projection roadmap marks Network Projection v0 as implemented and updates the JSON shape.

Claim discipline

- No heuristic provider-IP attribution.
- No reverse DNS / SNI inference.
- No rewrite of raw `capability_surface.network_endpoints`.
- Unmatched endpoints remain raw/unknown.
- A projected match means only: declared rules mapped both raw endpoints to the same role.

Validation

- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 64 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/contract-checker -p 'test_*.py'` -> 14 OK
- Synthetic smoke: OpenAI + Gemini provider hostnames project to `provider_api` while raw endpoints remain visible
- `actionlint .github/workflows/cross-runtime-drift-experiment.yml`
- `zizmor .github/workflows/cross-runtime-drift-experiment.yml`
- `git diff --check`
- local markdown link sanity
- commit hooks + push hooks passed