### PR TITLE
feat(experiments): add drift report provenance metadata

### DIFF
--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -163,6 +163,7 @@ jobs:
           HEALTH_GATE="$PWD/docs/experiments/cross-runtime-drift-2026-05/compare/health_gate.py"
           OUT_ROOT="$PWD/arm-${ARM}-runs"
           mkdir -p "$OUT_ROOT"
+          sha256sum "$EBPF_OBJ" | awk '{ print "sha256:" $1 }' > "$OUT_ROOT/ebpf-object.sha256"
 
           for i in $(seq 1 "$REPETITIONS"); do
             RUN_ID="run_arm_${ARM}_$(date -u +%Y%m%dT%H%M%SZ)_$i"
@@ -323,6 +324,7 @@ jobs:
           HEALTH_GATE="$PWD/docs/experiments/cross-runtime-drift-2026-05/compare/health_gate.py"
           OUT_ROOT="$PWD/arm-${ARM}-runs"
           mkdir -p "$OUT_ROOT"
+          sha256sum "$EBPF_OBJ" | awk '{ print "sha256:" $1 }' > "$OUT_ROOT/ebpf-object.sha256"
 
           for i in $(seq 1 "$REPETITIONS"); do
             RUN_ID="run_arm_${ARM}_$(date -u +%Y%m%dT%H%M%SZ)_$i"
@@ -404,6 +406,24 @@ jobs:
           set -euo pipefail
           DRIFT_PY="$PWD/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py"
           DRIFT_OUT="$PWD/drift-reports"
+          ASSAY_VERSION="$(awk -F'"' '/^version =/ { print $2; exit }' Cargo.toml)"
+          KERNEL_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          KERNEL_RELEASE="$(uname -r)"
+          KERNEL_ARCH="$(uname -m)"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          RUNNER_LABEL="${RUNNER_NAME:-assay-bpf-runner}"
+          EBPF_OBJECT_DIGEST=""
+          if [ -f arm-a-openai-runs/ebpf-object.sha256 ] && [ -f arm-b-gemini-runs/ebpf-object.sha256 ]; then
+            A_EBPF_DIGEST="$(cat arm-a-openai-runs/ebpf-object.sha256)"
+            B_EBPF_DIGEST="$(cat arm-b-gemini-runs/ebpf-object.sha256)"
+            if [ "$A_EBPF_DIGEST" != "$B_EBPF_DIGEST" ]; then
+              echo "ERROR: arm A and arm B used different eBPF object digests" >&2
+              echo "arm A: $A_EBPF_DIGEST" >&2
+              echo "arm B: $B_EBPF_DIGEST" >&2
+              exit 1
+            fi
+            EBPF_OBJECT_DIGEST="$A_EBPF_DIGEST"
+          fi
           mkdir -p "$DRIFT_OUT"
 
           # Stable sort to align iterations: i-th OpenAI run vs i-th
@@ -450,6 +470,14 @@ jobs:
               --path-alias "${B_PATHS[0]}=workdir/input" \
               --path-alias "${B_PATHS[1]}=workdir/output" \
               --network-alias "127.0.0.53:53=dns" \
+              --assay-version "$ASSAY_VERSION" \
+              --assay-commit "$GITHUB_SHA" \
+              --workflow-url "$WORKFLOW_URL" \
+              --runner-label "$RUNNER_LABEL" \
+              --kernel-os "$KERNEL_OS" \
+              --kernel-release "$KERNEL_RELEASE" \
+              --kernel-arch "$KERNEL_ARCH" \
+              --ebpf-object-digest "$EBPF_OBJECT_DIGEST" \
               --out-json "${REPORT_BASE}.json" \
               --out-md "${REPORT_BASE}.md"
             {

--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for bin in cargo node npm python3 rustc tar; do
+          for bin in awk cargo node npm python3 rustc sha256sum tar; do
             command -v "$bin" >/dev/null 2>&1 || {
               echo "ERROR: required command not found on delegated runner: $bin" >&2
               exit 1
@@ -257,7 +257,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for bin in cargo node npm python3 rustc tar; do
+          for bin in awk cargo node npm python3 rustc sha256sum tar; do
             command -v "$bin" >/dev/null 2>&1 || {
               echo "ERROR: required command not found on delegated runner: $bin" >&2
               exit 1

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -125,6 +125,11 @@ Network projection v0 follows the same additive discipline for
 `--network-cidr CIDR=CLASS` can project declared endpoints or IP ranges
 to taxonomy classes such as `provider_api` or `dns`, while unmatched
 endpoints remain raw/unknown.
+Report provenance metadata is emitted under `provenance` in every JSON
+report. The comparator derives input archive manifest digests, schema
+versions, observation-health gates, and correlation status from the
+archives; workflow/commit/kernel/eBPF anchors are optional CLI inputs and
+remain `null` when the caller does not provide them.
 
 ## What's done in Slice 1
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -62,6 +62,7 @@ ParsedNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
 CAPABILITY_SURFACE_SCHEMA = "assay.runner.capability_surface.v0"
 SDK_EVENT_SCHEMA = "assay.runner.sdk_event.v0"
 DRIFT_REPORT_SCHEMA = "assay.cross_runtime_drift.v0"
+DRIFT_REPORT_PROVENANCE_SCHEMA = "assay.runner.drift_report_provenance.v0"
 
 MANIFEST_PATH = "manifest.json"
 CAPABILITY_SURFACE_PATH = "capability-surface.json"
@@ -195,6 +196,14 @@ class ArchiveObservation:
     sdk_tool_call_ids: list[str]
     sdk_tool_order: list[str]  # (tool_call_id, tool) sequence per seq order
     kernel_file_operations: list[str] = dataclasses.field(default_factory=list)
+    manifest_schema: str | None = None
+    capability_surface_schema: str | None = None
+    observation_health_schema: str | None = None
+    correlation_report_schema: str | None = None
+    sdk_event_schema: str | None = None
+    kernel_event_schema: str | None = None
+    observation_health: dict[str, Any] = dataclasses.field(default_factory=dict)
+    correlation_report: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
 def _open_archive_member(source: Path, member: str) -> bytes | None:
@@ -233,6 +242,14 @@ def _parse_json(path_repr: str, data: bytes) -> Any:
         raise BadArchiveError(f"{path_repr}: invalid UTF-8: {exc}") from exc
 
 
+def _schema_from(value: Any) -> str | None:
+    if isinstance(value, dict):
+        schema = value.get("schema")
+        if isinstance(schema, str) and schema:
+            return schema
+    return None
+
+
 def parse_archive(source: Path) -> ArchiveObservation:
     """Parse a Runner archive (directory or .tar.gz). Raises
     BadArchiveError if the path does not exist, the manifest is missing,
@@ -256,6 +273,7 @@ def parse_archive(source: Path) -> ArchiveObservation:
     manifest = _parse_json(f"{source}!{MANIFEST_PATH}", manifest_bytes)
     manifest_digest = "sha256:" + hashlib.sha256(manifest_bytes).hexdigest()
     run_id = manifest.get("run_id") if isinstance(manifest, dict) else None
+    manifest_schema = _schema_from(manifest)
     # runtime_label is derived from SDK events below (the real Runner
     # archive_manifest.v0 schema does not carry a runtime field; the SDK
     # event `source` is the canonical signal).
@@ -274,6 +292,7 @@ def parse_archive(source: Path) -> ArchiveObservation:
     capability = _parse_json(
         f"{source}!{CAPABILITY_SURFACE_PATH}", capability_bytes
     )
+    capability_surface_schema = _schema_from(capability)
     capability_surface: dict[str, list[str]] = {
         "filesystem_paths": [],
         "network_endpoints": [],
@@ -289,7 +308,30 @@ def parse_archive(source: Path) -> ArchiveObservation:
                     [str(v) for v in value if isinstance(v, str)]
                 )
 
+    observation_health: dict[str, Any] = {}
+    observation_health_schema: str | None = None
+    observation_bytes = _open_archive_member(source, OBSERVATION_HEALTH_PATH)
+    if observation_bytes is not None:
+        health = _parse_json(
+            f"{source}!{OBSERVATION_HEALTH_PATH}", observation_bytes
+        )
+        if isinstance(health, dict):
+            observation_health = health
+            observation_health_schema = _schema_from(health)
+
+    correlation_report: dict[str, Any] = {}
+    correlation_report_schema: str | None = None
+    correlation_bytes = _open_archive_member(source, CORRELATION_REPORT_PATH)
+    if correlation_bytes is not None:
+        correlation = _parse_json(
+            f"{source}!{CORRELATION_REPORT_PATH}", correlation_bytes
+        )
+        if isinstance(correlation, dict):
+            correlation_report = correlation
+            correlation_report_schema = _schema_from(correlation)
+
     sdk_events: list[dict[str, Any]] = []
+    sdk_event_schema: str | None = None
     sdk_bytes = _open_archive_member(source, SDK_LAYER_PATH)
     if sdk_bytes is not None:
         try:
@@ -308,8 +350,11 @@ def parse_archive(source: Path) -> ArchiveObservation:
                     f"{source}!{SDK_LAYER_PATH}:{lineno}: "
                     f"invalid JSON: {exc}"
                 ) from exc
+            if sdk_event_schema is None:
+                sdk_event_schema = _schema_from(sdk_events[-1])
 
     kernel_events: list[dict[str, Any]] = []
+    kernel_event_schema: str | None = None
     kernel_bytes = _open_archive_member(source, KERNEL_LAYER_PATH)
     if kernel_bytes is not None:
         try:
@@ -330,6 +375,8 @@ def parse_archive(source: Path) -> ArchiveObservation:
                 ) from exc
             if isinstance(event, dict):
                 kernel_events.append(event)
+                if kernel_event_schema is None:
+                    kernel_event_schema = _schema_from(event)
 
     # Derive runtime label from the first SDK event that carries a
     # `source` field. The Runner SDK-event v0 schema sets source to the
@@ -385,6 +432,14 @@ def parse_archive(source: Path) -> ArchiveObservation:
         sdk_tool_call_ids=sorted(sdk_tool_call_ids),
         sdk_tool_order=sdk_tool_order,
         kernel_file_operations=kernel_file_operations,
+        manifest_schema=manifest_schema,
+        capability_surface_schema=capability_surface_schema,
+        observation_health_schema=observation_health_schema,
+        correlation_report_schema=correlation_report_schema,
+        sdk_event_schema=sdk_event_schema,
+        kernel_event_schema=kernel_event_schema,
+        observation_health=observation_health,
+        correlation_report=correlation_report,
     )
 
 
@@ -435,6 +490,20 @@ class DriftRow:
     classification: str  # one of CLASSIFICATION_* above
     detail: str
     projection: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass(frozen=True)
+class ReportProvenance:
+    """Optional report-level anchors supplied by the caller/workflow."""
+
+    assay_version: str | None = None
+    assay_commit: str | None = None
+    workflow_url: str | None = None
+    runner_label: str | None = None
+    kernel_os: str | None = None
+    kernel_release: str | None = None
+    kernel_arch: str | None = None
+    ebpf_object_digest: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1186,8 +1255,18 @@ def build_drift_report(
 
 
 def _operation_fixture_paths(fixture_paths: frozenset[str]) -> frozenset[str]:
-    prefixes = ("read", "write", "read_write", "create", "truncate", "append", "exclusive")
-    return frozenset(f"{prefix}:{path}" for path in fixture_paths for prefix in prefixes)
+    prefixes = (
+        "read",
+        "write",
+        "read_write",
+        "create",
+        "truncate",
+        "append",
+        "exclusive",
+    )
+    return frozenset(
+        f"{prefix}:{path}" for path in fixture_paths for prefix in prefixes
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1195,10 +1274,120 @@ def _operation_fixture_paths(fixture_paths: frozenset[str]) -> frozenset[str]:
 # ---------------------------------------------------------------------------
 
 
+def _compact_health(archive: ArchiveObservation) -> dict[str, Any]:
+    return {
+        "schema": archive.observation_health_schema,
+        "kernel_layer": archive.observation_health.get("kernel_layer"),
+        "ringbuf_drops": archive.observation_health.get("ringbuf_drops"),
+        "cgroup_correlation": archive.observation_health.get(
+            "cgroup_correlation"
+        ),
+        "policy_layer": archive.observation_health.get("policy_layer"),
+        "sdk_layer": archive.observation_health.get("sdk_layer"),
+    }
+
+
+def _compact_correlation(archive: ArchiveObservation) -> dict[str, Any]:
+    return {
+        "schema": archive.correlation_report_schema,
+        "status": archive.correlation_report.get("status"),
+    }
+
+
+def _archive_provenance(role: str, archive: ArchiveObservation) -> dict[str, Any]:
+    return {
+        "role": role,
+        "path": archive.path,
+        "run_id": archive.run_id,
+        "runtime_label": archive.runtime_label,
+        "manifest_digest": archive.manifest_digest,
+        "schemas": {
+            "archive_manifest": archive.manifest_schema,
+            "capability_surface": archive.capability_surface_schema,
+            "observation_health": archive.observation_health_schema,
+            "correlation_report": archive.correlation_report_schema,
+            "sdk_event": archive.sdk_event_schema,
+            "kernel_event": archive.kernel_event_schema,
+        },
+        "observation_health": _compact_health(archive),
+        "correlation_report": _compact_correlation(archive),
+    }
+
+
+def _schema_versions(
+    a: ArchiveObservation, b: ArchiveObservation
+) -> dict[str, list[str]]:
+    return {
+        "archive_manifest": sorted(
+            {x for x in (a.manifest_schema, b.manifest_schema) if x}
+        ),
+        "capability_surface": sorted(
+            {
+                x
+                for x in (a.capability_surface_schema, b.capability_surface_schema)
+                if x
+            }
+        ),
+        "observation_health": sorted(
+            {
+                x
+                for x in (a.observation_health_schema, b.observation_health_schema)
+                if x
+            }
+        ),
+        "correlation_report": sorted(
+            {
+                x
+                for x in (a.correlation_report_schema, b.correlation_report_schema)
+                if x
+            }
+        ),
+        "sdk_event": sorted(
+            {x for x in (a.sdk_event_schema, b.sdk_event_schema) if x}
+        ),
+        "kernel_event": sorted(
+            {x for x in (a.kernel_event_schema, b.kernel_event_schema) if x}
+        ),
+    }
+
+
+def _provenance_payload(
+    a: ArchiveObservation,
+    b: ArchiveObservation,
+    provenance: ReportProvenance,
+) -> dict[str, Any]:
+    return {
+        "schema": DRIFT_REPORT_PROVENANCE_SCHEMA,
+        "assay_version": provenance.assay_version,
+        "assay_commit": provenance.assay_commit,
+        "runner_schema_versions": _schema_versions(a, b),
+        "kernel": {
+            "os": provenance.kernel_os,
+            "release": provenance.kernel_release,
+            "arch": provenance.kernel_arch,
+        },
+        "ebpf_object_digest": provenance.ebpf_object_digest,
+        "workflow": {
+            "url": provenance.workflow_url,
+            "runner_label": provenance.runner_label,
+        },
+        "input_archives": [
+            _archive_provenance("archive_a", a),
+            _archive_provenance("archive_b", b),
+        ],
+        "non_claims": [
+            "provenance_no_evidence_rewrite",
+            "provenance_unknowns_preserved",
+            "provenance_metadata_not_policy_verdict",
+        ],
+    }
+
+
 def report_to_json(
     a: ArchiveObservation,
     b: ArchiveObservation,
     rows: list[DriftRow],
+    provenance: ReportProvenance = ReportProvenance(),
 ) -> dict[str, Any]:
     return {
         "schema": DRIFT_REPORT_SCHEMA,
@@ -1217,6 +1406,7 @@ def report_to_json(
             "sdk_event_count": b.sdk_event_count,
         },
         "taxonomy": _taxonomy_payload(),
+        "provenance": _provenance_payload(a, b, provenance),
         "rows": [dataclasses.asdict(r) for r in rows],
         "summary": {
             "dimensions_checked": len(rows),
@@ -1380,6 +1570,17 @@ def main(argv: list[str] | None = None) -> int:
             + ", ".join(DEFAULT_PROVIDER_HOSTS)
         ),
     )
+    parser.add_argument("--assay-version", help="Assay version that produced the report.")
+    parser.add_argument("--assay-commit", help="Git commit associated with the report.")
+    parser.add_argument("--workflow-url", help="GitHub Actions run URL, if any.")
+    parser.add_argument("--runner-label", help="Runner label or host class.")
+    parser.add_argument("--kernel-os", help="Kernel OS for the capture host.")
+    parser.add_argument("--kernel-release", help="Kernel release for the capture host.")
+    parser.add_argument("--kernel-arch", help="Kernel architecture for the capture host.")
+    parser.add_argument(
+        "--ebpf-object-digest",
+        help="sha256 digest of the eBPF object used for capture, if known.",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -1431,7 +1632,17 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(f"bad projection config: {exc}", file=sys.stderr)
         return 2
-    payload = report_to_json(a, b, rows)
+    provenance = ReportProvenance(
+        assay_version=args.assay_version or None,
+        assay_commit=args.assay_commit or None,
+        workflow_url=args.workflow_url or None,
+        runner_label=args.runner_label or None,
+        kernel_os=args.kernel_os or None,
+        kernel_release=args.kernel_release or None,
+        kernel_arch=args.kernel_arch or None,
+        ebpf_object_digest=args.ebpf_object_digest or None,
+    )
+    payload = report_to_json(a, b, rows, provenance)
 
     if args.out_json:
         try:

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -292,6 +292,10 @@ def parse_archive(source: Path) -> ArchiveObservation:
     capability = _parse_json(
         f"{source}!{CAPABILITY_SURFACE_PATH}", capability_bytes
     )
+    if not isinstance(capability, dict):
+        raise BadArchiveError(
+            f"{source}!{CAPABILITY_SURFACE_PATH}: expected JSON object"
+        )
     capability_surface_schema = _schema_from(capability)
     capability_surface: dict[str, list[str]] = {
         "filesystem_paths": [],
@@ -300,13 +304,12 @@ def parse_archive(source: Path) -> ArchiveObservation:
         "mcp_tools": [],
         "policy_decisions": [],
     }
-    if isinstance(capability, dict):
-        for key in capability_surface:
-            value = capability.get(key, [])
-            if isinstance(value, list):
-                capability_surface[key] = sorted(
-                    [str(v) for v in value if isinstance(v, str)]
-                )
+    for key in capability_surface:
+        value = capability.get(key, [])
+        if isinstance(value, list):
+            capability_surface[key] = sorted(
+                [str(v) for v in value if isinstance(v, str)]
+            )
 
     observation_health: dict[str, Any] = {}
     observation_health_schema: str | None = None
@@ -315,9 +318,12 @@ def parse_archive(source: Path) -> ArchiveObservation:
         health = _parse_json(
             f"{source}!{OBSERVATION_HEALTH_PATH}", observation_bytes
         )
-        if isinstance(health, dict):
-            observation_health = health
-            observation_health_schema = _schema_from(health)
+        if not isinstance(health, dict):
+            raise BadArchiveError(
+                f"{source}!{OBSERVATION_HEALTH_PATH}: expected JSON object"
+            )
+        observation_health = health
+        observation_health_schema = _schema_from(health)
 
     correlation_report: dict[str, Any] = {}
     correlation_report_schema: str | None = None
@@ -326,9 +332,12 @@ def parse_archive(source: Path) -> ArchiveObservation:
         correlation = _parse_json(
             f"{source}!{CORRELATION_REPORT_PATH}", correlation_bytes
         )
-        if isinstance(correlation, dict):
-            correlation_report = correlation
-            correlation_report_schema = _schema_from(correlation)
+        if not isinstance(correlation, dict):
+            raise BadArchiveError(
+                f"{source}!{CORRELATION_REPORT_PATH}: expected JSON object"
+            )
+        correlation_report = correlation
+        correlation_report_schema = _schema_from(correlation)
 
     sdk_events: list[dict[str, Any]] = []
     sdk_event_schema: str | None = None
@@ -344,14 +353,19 @@ def parse_archive(source: Path) -> ArchiveObservation:
             if not line.strip():
                 continue
             try:
-                sdk_events.append(json.loads(line))
+                event = json.loads(line)
             except json.JSONDecodeError as exc:
                 raise BadArchiveError(
                     f"{source}!{SDK_LAYER_PATH}:{lineno}: "
                     f"invalid JSON: {exc}"
                 ) from exc
+            if not isinstance(event, dict):
+                raise BadArchiveError(
+                    f"{source}!{SDK_LAYER_PATH}:{lineno}: expected JSON object"
+                )
+            sdk_events.append(event)
             if sdk_event_schema is None:
-                sdk_event_schema = _schema_from(sdk_events[-1])
+                sdk_event_schema = _schema_from(event)
 
     kernel_events: list[dict[str, Any]] = []
     kernel_event_schema: str | None = None

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -58,6 +58,27 @@ class ParseArchiveHappyPathTests(unittest.TestCase):
         self.assertEqual(obs.runtime_label, "openai-agents")
         self.assertEqual(obs.run_id, "drift_fixture_a_openai_001")
         self.assertTrue(obs.manifest_digest.startswith("sha256:"))
+        self.assertEqual(
+            obs.manifest_schema, "assay.runner.archive_manifest.v0"
+        )
+        self.assertEqual(
+            obs.capability_surface_schema,
+            "assay.runner.capability_surface.v0",
+        )
+        self.assertEqual(
+            obs.observation_health_schema,
+            "assay.runner.observation_health.v0",
+        )
+        self.assertEqual(
+            obs.correlation_report_schema,
+            "assay.runner.correlation_report.v0",
+        )
+        self.assertEqual(obs.sdk_event_schema, drift.SDK_EVENT_SCHEMA)
+        self.assertEqual(
+            obs.kernel_event_schema, "assay.runner.kernel_event.v0"
+        )
+        self.assertEqual(obs.observation_health["ringbuf_drops"], 0)
+        self.assertEqual(obs.correlation_report["status"], "clean")
         self.assertIn(
             "/tmp/work/fixture-input.txt",
             obs.capability_surface["filesystem_paths"],
@@ -635,6 +656,22 @@ class MainCliTests(unittest.TestCase):
                 drift.RUNTIME_NOISE_TAXONOMY_SCHEMA,
             )
             self.assertEqual(
+                payload["provenance"]["schema"],
+                drift.DRIFT_REPORT_PROVENANCE_SCHEMA,
+            )
+            self.assertEqual(
+                payload["provenance"]["input_archives"][0]["schemas"][
+                    "archive_manifest"
+                ],
+                "assay.runner.archive_manifest.v0",
+            )
+            self.assertEqual(
+                payload["provenance"]["input_archives"][0][
+                    "observation_health"
+                ]["ringbuf_drops"],
+                0,
+            )
+            self.assertEqual(
                 payload["archive_a"]["runtime_label"], "openai-agents"
             )
             self.assertEqual(
@@ -657,6 +694,52 @@ class MainCliTests(unittest.TestCase):
             self.assertIn("# Cross-Runtime Drift Report", md)
             self.assertIn("filesystem_paths_touched", md)
             self.assertIn("read:workdir/input", md)
+
+    def test_main_writes_explicit_report_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_json = Path(tmp) / "drift.json"
+            rc = drift.main(
+                [
+                    "--archive-a",
+                    str(ARM_A),
+                    "--archive-b",
+                    str(ARM_B),
+                    "--out-json",
+                    str(out_json),
+                    "--assay-version",
+                    "3.11.3",
+                    "--assay-commit",
+                    "abc123",
+                    "--workflow-url",
+                    "https://github.com/Rul1an/assay/actions/runs/1",
+                    "--runner-label",
+                    "assay-bpf-runner",
+                    "--kernel-os",
+                    "linux",
+                    "--kernel-release",
+                    "6.8.0-117-generic",
+                    "--kernel-arch",
+                    "aarch64",
+                    "--ebpf-object-digest",
+                    "sha256:" + "1" * 64,
+                ]
+            )
+            self.assertEqual(rc, 0)
+            payload = json.loads(out_json.read_text(encoding="utf-8"))
+            provenance = payload["provenance"]
+            self.assertEqual(provenance["assay_version"], "3.11.3")
+            self.assertEqual(provenance["assay_commit"], "abc123")
+            self.assertEqual(
+                provenance["workflow"]["url"],
+                "https://github.com/Rul1an/assay/actions/runs/1",
+            )
+            self.assertEqual(
+                provenance["workflow"]["runner_label"], "assay-bpf-runner"
+            )
+            self.assertEqual(provenance["kernel"]["os"], "linux")
+            self.assertEqual(
+                provenance["ebpf_object_digest"], "sha256:" + "1" * 64
+            )
 
     def test_main_returns_3_on_bad_archive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -178,6 +178,71 @@ class ParseArchiveFailureTests(unittest.TestCase):
                 drift.parse_archive(tmpdir)
             self.assertIn("capability-surface.json", str(ctx.exception))
 
+    def test_non_object_capability_surface_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "manifest.json").write_text(
+                json.dumps({"schema": "x", "run_id": "y"}), encoding="utf-8"
+            )
+            (tmpdir / "capability-surface.json").write_text(
+                json.dumps(["not", "an", "object"]), encoding="utf-8"
+            )
+            with self.assertRaises(drift.BadArchiveError) as ctx:
+                drift.parse_archive(tmpdir)
+            self.assertIn("expected JSON object", str(ctx.exception))
+
+    def test_non_object_observation_health_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "manifest.json").write_text(
+                json.dumps({"schema": "x", "run_id": "y"}), encoding="utf-8"
+            )
+            (tmpdir / "capability-surface.json").write_text(
+                json.dumps({"schema": "assay.runner.capability_surface.v0"}),
+                encoding="utf-8",
+            )
+            (tmpdir / "observation-health.json").write_text(
+                json.dumps(["not", "an", "object"]), encoding="utf-8"
+            )
+            with self.assertRaises(drift.BadArchiveError) as ctx:
+                drift.parse_archive(tmpdir)
+            self.assertIn("expected JSON object", str(ctx.exception))
+
+    def test_non_object_correlation_report_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "manifest.json").write_text(
+                json.dumps({"schema": "x", "run_id": "y"}), encoding="utf-8"
+            )
+            (tmpdir / "capability-surface.json").write_text(
+                json.dumps({"schema": "assay.runner.capability_surface.v0"}),
+                encoding="utf-8",
+            )
+            (tmpdir / "correlation-report.json").write_text(
+                json.dumps(["not", "an", "object"]), encoding="utf-8"
+            )
+            with self.assertRaises(drift.BadArchiveError) as ctx:
+                drift.parse_archive(tmpdir)
+            self.assertIn("expected JSON object", str(ctx.exception))
+
+    def test_non_object_sdk_event_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            (tmpdir / "manifest.json").write_text(
+                json.dumps({"schema": "x", "run_id": "y"}), encoding="utf-8"
+            )
+            (tmpdir / "capability-surface.json").write_text(
+                json.dumps({"schema": "assay.runner.capability_surface.v0"}),
+                encoding="utf-8",
+            )
+            (tmpdir / "layers").mkdir()
+            (tmpdir / "layers" / "sdk.ndjson").write_text(
+                json.dumps(["not", "an", "object"]) + "\n", encoding="utf-8"
+            )
+            with self.assertRaises(drift.BadArchiveError) as ctx:
+                drift.parse_archive(tmpdir)
+            self.assertIn("expected JSON object", str(ctx.exception))
+
 
 # ---------------------------------------------------------------------------
 # build_drift_report

--- a/docs/reference/runner/projection-roadmap.md
+++ b/docs/reference/runner/projection-roadmap.md
@@ -155,6 +155,13 @@ depending on the policy layer that consumes the report.
 Report-level provenance should land early because it improves every
 later experiment at low implementation cost.
 
+Implementation note: the cross-runtime drift comparator now emits a
+`provenance` block in JSON reports. Archive manifest digests, schema
+versions, observation-health gates, and correlation status are derived
+from the two input archives. Workflow URL, runner label, kernel tuple,
+Assay version/commit, and eBPF object digest are caller-supplied anchors
+and stay `null` when not provided.
+
 Minimum metadata block:
 
 ```json


### PR DESCRIPTION
Summary

Adds Report Provenance Metadata to cross-runtime drift reports, following Phase 3 of the Runner projection roadmap. The new `provenance` block anchors each report to its input archive digests/schema versions, observation-health/correlation status, and optional workflow/runtime metadata.

What changed

- `compare/drift.py`
  - New schema string: `assay.runner.drift_report_provenance.v0`
  - `ArchiveObservation` now records archive/capability/health/correlation/SDK/kernel schema strings.
  - Optional `observation-health.json` + `correlation-report.json` are parsed into compact provenance fields.
  - `report_to_json()` now emits `provenance` with:
    - Assay version / commit when supplied
    - runner schema versions derived from both input archives
    - kernel tuple when supplied
    - eBPF object digest when supplied
    - workflow URL + runner label when supplied
    - per-input archive manifest digest + health/correlation summary
  - New CLI flags: `--assay-version`, `--assay-commit`, `--workflow-url`, `--runner-label`, `--kernel-os`, `--kernel-release`, `--kernel-arch`, `--ebpf-object-digest`.
- Workflow
  - Captures `assay-ebpf.o` SHA-256 in each arm artifact.
  - Drift compare job verifies both arms used the same eBPF object digest before writing it into report provenance.
  - Drift reports now include workflow URL, commit SHA, runner label, kernel tuple, Assay version, and eBPF digest.
- Docs
  - Experiment README and projection roadmap updated with the implemented provenance behavior.

Claim discipline

- Provenance does not rewrite evidence.
- Missing caller-supplied anchors remain `null`.
- eBPF digest is written only if both capture arms report the same digest; mismatch fails the workflow.
- Metadata is reproducibility context, not a policy verdict and not a promotion of projection output to primary evidence.

Validation

- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 67 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/contract-checker -p 'test_*.py'` -> 14 OK
- Synthetic smoke confirms `provenance` JSON with schema versions, health/correlation, workflow/kernel anchors
- `actionlint .github/workflows/cross-runtime-drift-experiment.yml`
- `zizmor .github/workflows/cross-runtime-drift-experiment.yml`
- `git diff --check`
- local markdown link sanity
- commit hooks + push hooks passed