### PR TITLE
fix(experiments): require both eBPF digest files

### DIFF
--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -412,18 +412,19 @@ jobs:
           KERNEL_ARCH="$(uname -m)"
           WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           RUNNER_LABEL="${RUNNER_NAME:-assay-bpf-runner}"
-          EBPF_OBJECT_DIGEST=""
-          if [ -f arm-a-openai-runs/ebpf-object.sha256 ] && [ -f arm-b-gemini-runs/ebpf-object.sha256 ]; then
-            A_EBPF_DIGEST="$(cat arm-a-openai-runs/ebpf-object.sha256)"
-            B_EBPF_DIGEST="$(cat arm-b-gemini-runs/ebpf-object.sha256)"
-            if [ "$A_EBPF_DIGEST" != "$B_EBPF_DIGEST" ]; then
-              echo "ERROR: arm A and arm B used different eBPF object digests" >&2
-              echo "arm A: $A_EBPF_DIGEST" >&2
-              echo "arm B: $B_EBPF_DIGEST" >&2
-              exit 1
-            fi
-            EBPF_OBJECT_DIGEST="$A_EBPF_DIGEST"
+          if [ ! -f arm-a-openai-runs/ebpf-object.sha256 ] || [ ! -f arm-b-gemini-runs/ebpf-object.sha256 ]; then
+            echo "ERROR: missing eBPF object digest file from one or both arms" >&2
+            exit 1
           fi
+          A_EBPF_DIGEST="$(cat arm-a-openai-runs/ebpf-object.sha256)"
+          B_EBPF_DIGEST="$(cat arm-b-gemini-runs/ebpf-object.sha256)"
+          if [ "$A_EBPF_DIGEST" != "$B_EBPF_DIGEST" ]; then
+            echo "ERROR: arm A and arm B used different eBPF object digests" >&2
+            echo "arm A: $A_EBPF_DIGEST" >&2
+            echo "arm B: $B_EBPF_DIGEST" >&2
+            exit 1
+          fi
+          EBPF_OBJECT_DIGEST="$A_EBPF_DIGEST"
           mkdir -p "$DRIFT_OUT"
 
           # Stable sort to align iterations: i-th OpenAI run vs i-th


### PR DESCRIPTION
Summary

Small follow-up to #1359's drift report provenance metadata. The compare job already failed when Arm A and Arm B reported different eBPF object digests, but it silently continued if one digest file was missing and the other existed.

This PR makes digest-file presence part of the invariant:

- both `arm-a-openai-runs/ebpf-object.sha256` and `arm-b-gemini-runs/ebpf-object.sha256` must exist
- if either is missing, `drift-compare` exits before running the comparator
- if both exist but differ, the existing mismatch error remains
- if both exist and match, the digest is passed to `--ebpf-object-digest`

Validation

- `actionlint .github/workflows/cross-runtime-drift-experiment.yml`
- `zizmor .github/workflows/cross-runtime-drift-experiment.yml`
- `git diff --check`
- commit + push hooks passed