### PR TITLE
docs(runner): add kernel event v0 schema sidecar

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -1114,5 +1114,46 @@ class RuntimeDriftSchemaSidecarTests(unittest.TestCase):
         )
 
 
+class KernelEventSchemaSidecarTests(unittest.TestCase):
+    def test_kernel_event_schema_sidecar_matches_fixture_shape(self) -> None:
+        schema_path = (
+            THIS_DIR.parents[2]
+            / "reference"
+            / "runner"
+            / "schema"
+            / "kernel-event-v0.schema.json"
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            schema["properties"]["schema"]["const"],
+            "assay.runner.kernel_event.v0",
+        )
+        self.assertEqual(
+            schema["properties"]["access_mode"]["enum"],
+            ["read", "write", "read_write", "unknown"],
+        )
+        self.assertEqual(
+            schema["properties"]["status"]["enum"],
+            ["success", "error"],
+        )
+        self.assertEqual(
+            schema["properties"]["operation_flags"]["items"]["enum"],
+            ["create", "truncate", "append", "exclusive"],
+        )
+
+        allowed_keys = set(schema["properties"])
+        required_keys = set(schema["required"])
+        for fixture in (ARM_A, ARM_B):
+            kernel_path = fixture / "layers" / "kernel.ndjson"
+            for line in kernel_path.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                event = json.loads(line)
+                self.assertTrue(required_keys.issubset(event))
+                self.assertLessEqual(set(event), allowed_keys)
+                if "status" in event:
+                    self.assertIn("return_value", event)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/experiments/cross-runtime-drift-2026-05/kernel-v0-feasibility.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/kernel-v0-feasibility.md
@@ -9,7 +9,8 @@
 > **Conclusion:** old archives can only support event-kind counts and
 > touched path / endpoint summaries. New archives can support honest
 > read/write/create/truncate classification for successful `openat` /
-> `openat2` events.
+> `openat2` events. The enriched line shape is now frozen in
+> [`../../reference/runner/schema/kernel-event-v0.schema.json`](../../reference/runner/schema/kernel-event-v0.schema.json).
 
 ## Why this note exists
 

--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -74,6 +74,15 @@ Schema string:
 assay.runner.kernel_event.v0
 ```
 
+Machine-readable line schema:
+
+[`schema/kernel-event-v0.schema.json`](schema/kernel-event-v0.schema.json)
+
+`layers/kernel.ndjson` is an NDJSON stream: each non-empty line validates
+independently against the line schema. The schema covers the enriched
+open metadata shape now emitted by Runner while preserving compatibility
+with older v0 archives where those open metadata fields are absent.
+
 Each line is one normalized kernel event. Common fields:
 
 | Field | Type | Required | Semantics |

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -29,6 +29,7 @@ Phase 2B capability-diff planning slice.
 - [Runner projection roadmap](projection-roadmap.md)
 - [Runner runtime drift projection v0 contract](runtime-drift-v0.md)
 - [Runner cross-runtime diff v0 clean-output JSON Schema](schema/cross-runtime-diff-v0-clean.schema.json)
+- [Runner kernel event v0 JSON Schema](schema/kernel-event-v0.schema.json)
 - [Runner runtime drift projection v0 JSON Schema](schema/runtime-drift-v0.schema.json)
 - [Runner second runtime Phase 2B plan](second-runtime-plan.md)
 - [Runner second runtime candidate selection](second-runtime-candidate-selection.md)

--- a/docs/reference/runner/projection-roadmap.md
+++ b/docs/reference/runner/projection-roadmap.md
@@ -294,12 +294,20 @@ Example row:
 }
 ```
 
-## Phase 6: Kernel Event v0.2
+## Phase 6: Kernel Event Metadata Schema
 
 Kernel expansion is valuable, but it should come after the projection
-layer is readable. The open metadata added to kernel event v0 already
-supports operation-aware projections for `openat` and `openat2` calls.
-Successful calls can project access and operation hints:
+layer is readable. That condition is now met by
+[`runtime-drift-v0.md`](runtime-drift-v0.md). The first kernel follow-up
+is deliberately small: freeze the current enriched `kernel_event.v0`
+line shape in
+[`schema/kernel-event-v0.schema.json`](schema/kernel-event-v0.schema.json)
+so consumers can validate whether an archive supports operation-aware
+open projections.
+
+The open metadata added to kernel event v0 already supports
+operation-aware projections for `openat` and `openat2` calls. Successful
+calls can project access and operation hints:
 
 - `read`;
 - `write`;
@@ -312,7 +320,7 @@ Failed calls are represented separately by the kernel event `status`
 field (`status=error`) derived from the syscall return value. `error` is
 not an operation class alongside `read` or `write`.
 
-Kernel event v0.2 should consider:
+Future kernel-event expansion should consider:
 
 | Candidate | Why | Caution |
 |---|---|---|
@@ -346,7 +354,7 @@ Projection reports MUST carry explicit non-claims. Initial codes:
 | 3 | Report provenance metadata block | Existing live run can be re-rendered with metadata |
 | 4 | Network projection helper | Exact endpoint, CIDR, and unknown fallback tests |
 | 5 | Freeze `assay.runner.runtime_drift.v0` projection schema | Synthetic fixture covers all claim levels + schema sidecar matches comparator output |
-| 6 | Kernel event v0.2 feasibility note | No code until projection reports prove value |
+| 6 | Kernel event metadata schema sidecar | Enriched open metadata line shape is machine-readable; no new syscall claims |
 
 ## Relationship To Existing Contracts
 

--- a/docs/reference/runner/schema/kernel-event-v0.schema.json
+++ b/docs/reference/runner/schema/kernel-event-v0.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/reference/runner/schema/kernel-event-v0.schema.json",
+  "title": "Assay Runner Kernel Event v0",
+  "description": "Line schema for one layers/kernel.ndjson record. The stream is NDJSON: validate each non-empty line independently against this schema. Open-event metadata fields are optional so older v0 archives remain readable.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "run_id",
+    "seq",
+    "pid",
+    "event_type",
+    "kind",
+    "value"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.runner.kernel_event.v0"
+    },
+    "run_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]+$"
+    },
+    "seq": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "pid": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "event_type": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "kind": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Normalized kernel event kind such as openat, connect, exec, file_blocked, connect_blocked, or event_<id>."
+    },
+    "value": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Normalized path or endpoint when available."
+    },
+    "flags": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Linux open flags captured from an open-style syscall."
+    },
+    "mode": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Linux create mode argument when present."
+    },
+    "resolve": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "openat2 resolve flags when non-zero."
+    },
+    "return_value": {
+      "type": "integer",
+      "description": "Syscall return value; non-negative means success for open-style events."
+    },
+    "access_mode": {
+      "enum": [
+        "read",
+        "write",
+        "read_write",
+        "unknown"
+      ],
+      "description": "Derived from flags & O_ACCMODE for open-style events."
+    },
+    "operation_flags": {
+      "type": "array",
+      "items": {
+        "enum": [
+          "create",
+          "truncate",
+          "append",
+          "exclusive"
+        ]
+      },
+      "uniqueItems": true,
+      "description": "Derived operation hints from open flags. These are open-intent hints, not fd-level byte evidence."
+    },
+    "status": {
+      "enum": [
+        "success",
+        "error"
+      ],
+      "description": "Derived from return_value for open-style events."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "return_value"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Summary
- Adds a machine-readable JSON Schema sidecar for one `layers/kernel.ndjson` line: `docs/reference/runner/schema/kernel-event-v0.schema.json`.
- Documents the sidecar from the Runner artifact contract and reference index.
- Updates the projection roadmap Phase 6 from a vague v0.2 follow-up into the concrete kernel-event metadata schema sidecar step.
- Links the cross-runtime drift feasibility note to the schema.
- Adds a stdlib test that checks the schema sidecar against the fixture kernel-event shape.

Claim discipline
- Keeps the schema string as `assay.runner.kernel_event.v0`; open metadata fields remain optional so old v0 archives stay readable.
- Does not add unlink/remove, rename, mkdir/rmdir, fd-level byte counts, or close pairing claims.
- Treats `operation_flags` as open-intent hints, not proof that bytes were read/written.

Validation
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 73 OK
- `cargo test -p assay-runner-core kernel:: --lib` -> 17 OK
- `git diff --check`
- Local markdown link check over changed docs