### PR TITLE
docs(runner): tighten kernel event schema validation

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -22,11 +22,13 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import sys
 import tarfile
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 THIS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(THIS_DIR))
@@ -36,6 +38,139 @@ import drift  # noqa: E402  (after sys.path tweak)
 FIXTURES = THIS_DIR / "fixtures"
 ARM_A = FIXTURES / "arm-a-openai"
 ARM_B = FIXTURES / "arm-b-gemini"
+
+
+def _schema_ref(root: dict[str, Any], ref: str) -> dict[str, Any]:
+    if not ref.startswith("#/$defs/"):
+        raise AssertionError(f"unsupported schema ref: {ref}")
+    node: Any = root
+    for part in ref.lstrip("#/").split("/"):
+        node = node[part]
+    if not isinstance(node, dict):
+        raise AssertionError(f"schema ref did not resolve to object: {ref}")
+    return node
+
+
+def _json_type_matches(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    if expected == "boolean":
+        return isinstance(value, bool)
+    raise AssertionError(f"unsupported JSON Schema type in test helper: {expected}")
+
+
+def assert_json_schema_subset(
+    testcase: unittest.TestCase,
+    value: Any,
+    schema: dict[str, Any],
+    root: dict[str, Any] | None = None,
+    path: str = "$",
+) -> None:
+    """Validate the JSON Schema subset used by Runner sidecar tests.
+
+    This is intentionally small and stdlib-only. It covers the keywords
+    present in the Runner schema sidecars so tests catch type/enum drift
+    without pulling in a runtime dependency on `jsonschema`.
+    """
+
+    root = schema if root is None else root
+
+    if "$ref" in schema:
+        assert_json_schema_subset(
+            testcase, value, _schema_ref(root, schema["$ref"]), root, path
+        )
+        return
+
+    if "allOf" in schema:
+        for index, subschema in enumerate(schema["allOf"]):
+            assert_json_schema_subset(
+                testcase, value, subschema, root, f"{path}.allOf[{index}]"
+            )
+
+    if "anyOf" in schema:
+        failures = []
+        for index, subschema in enumerate(schema["anyOf"]):
+            try:
+                assert_json_schema_subset(
+                    testcase, value, subschema, root, f"{path}.anyOf[{index}]"
+                )
+                break
+            except AssertionError as exc:
+                failures.append(str(exc))
+        else:
+            raise AssertionError(f"{path}: no anyOf branch matched: {failures}")
+
+    if "if" in schema:
+        try:
+            assert_json_schema_subset(testcase, value, schema["if"], root, path)
+        except AssertionError:
+            pass
+        else:
+            if "then" in schema:
+                assert_json_schema_subset(
+                    testcase, value, schema["then"], root, f"{path}.then"
+                )
+
+    if "const" in schema:
+        testcase.assertEqual(value, schema["const"], f"{path}: const mismatch")
+
+    if "enum" in schema:
+        testcase.assertIn(value, schema["enum"], f"{path}: enum mismatch")
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        types = expected_type if isinstance(expected_type, list) else [expected_type]
+        testcase.assertTrue(
+            any(_json_type_matches(value, item) for item in types),
+            f"{path}: expected type {types}, got {type(value).__name__}",
+        )
+
+    if isinstance(value, str):
+        if "minLength" in schema:
+            testcase.assertGreaterEqual(len(value), schema["minLength"], path)
+        if "pattern" in schema:
+            testcase.assertRegex(value, re.compile(schema["pattern"]), path)
+
+    if isinstance(value, int) and not isinstance(value, bool):
+        if "minimum" in schema:
+            testcase.assertGreaterEqual(value, schema["minimum"], path)
+
+    if isinstance(value, list):
+        if "minItems" in schema:
+            testcase.assertGreaterEqual(len(value), schema["minItems"], path)
+        if "maxItems" in schema:
+            testcase.assertLessEqual(len(value), schema["maxItems"], path)
+        if schema.get("uniqueItems"):
+            testcase.assertEqual(len(value), len(set(map(json.dumps, value))), path)
+        if "items" in schema:
+            for index, item in enumerate(value):
+                assert_json_schema_subset(
+                    testcase, item, schema["items"], root, f"{path}[{index}]"
+                )
+
+    if isinstance(value, dict):
+        for key in schema.get("required", []):
+            testcase.assertIn(key, value, f"{path}: missing required key {key}")
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            testcase.assertLessEqual(
+                set(value),
+                set(properties),
+                f"{path}: unexpected keys {set(value) - set(properties)}",
+            )
+        for key, prop_schema in properties.items():
+            if key in value:
+                assert_json_schema_subset(
+                    testcase, value[key], prop_schema, root, f"{path}.{key}"
+                )
 
 
 def _make_tarball(src_dir: Path, dest: Path) -> Path:
@@ -1067,7 +1202,7 @@ class MarkdownEscapeTests(unittest.TestCase):
 
 
 class RuntimeDriftSchemaSidecarTests(unittest.TestCase):
-    def test_schema_sidecar_matches_comparator_contract(self) -> None:
+    def test_schema_sidecar_validates_comparator_output(self) -> None:
         schema_path = (
             THIS_DIR.parents[2]
             / "reference"
@@ -1112,10 +1247,40 @@ class RuntimeDriftSchemaSidecarTests(unittest.TestCase):
                 "summary",
             ],
         )
+        a = drift.parse_archive(ARM_A)
+        b = drift.parse_archive(ARM_B)
+        rows = drift.build_drift_report(
+            a,
+            b,
+            fixture_paths=frozenset(
+                [
+                    "/tmp/work/fixture-input.txt",
+                    "/tmp/work/fixture-output.txt",
+                ]
+            ),
+            path_aliases=(
+                drift.PathAlias(
+                    "/tmp/work/fixture-input.txt",
+                    "workdir/input",
+                ),
+                drift.PathAlias(
+                    "/tmp/work/fixture-output.txt",
+                    "workdir/output",
+                ),
+            ),
+            network_aliases=(
+                drift.NetworkAlias(
+                    "api.openai.com:443",
+                    drift.NETWORK_CLASS_PROVIDER_API,
+                ),
+            ),
+        )
+        payload = drift.report_to_json(a, b, rows)
+        assert_json_schema_subset(self, payload, schema)
 
 
 class KernelEventSchemaSidecarTests(unittest.TestCase):
-    def test_kernel_event_schema_sidecar_matches_fixture_shape(self) -> None:
+    def test_kernel_event_schema_sidecar_validates_fixture_lines(self) -> None:
         schema_path = (
             THIS_DIR.parents[2]
             / "reference"
@@ -1140,19 +1305,22 @@ class KernelEventSchemaSidecarTests(unittest.TestCase):
             schema["properties"]["operation_flags"]["items"]["enum"],
             ["create", "truncate", "append", "exclusive"],
         )
+        known_kinds = schema["properties"]["kind"]["anyOf"][0]["enum"]
+        self.assertEqual(
+            known_kinds,
+            ["openat", "connect", "exec", "file_blocked", "connect_blocked"],
+        )
 
-        allowed_keys = set(schema["properties"])
-        required_keys = set(schema["required"])
         for fixture in (ARM_A, ARM_B):
             kernel_path = fixture / "layers" / "kernel.ndjson"
             for line in kernel_path.read_text(encoding="utf-8").splitlines():
                 if not line.strip():
                     continue
                 event = json.loads(line)
-                self.assertTrue(required_keys.issubset(event))
-                self.assertLessEqual(set(event), allowed_keys)
-                if "status" in event:
-                    self.assertIn("return_value", event)
+                assert_json_schema_subset(self, event, schema)
+
+        for index, example in enumerate(schema["examples"]):
+            assert_json_schema_subset(self, example, schema, path=f"examples[{index}]")
 
 
 if __name__ == "__main__":

--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -91,9 +91,23 @@ Each line is one normalized kernel event. Common fields:
 | `run_id` | string | yes | Run identifier shared by all archive artifacts |
 | `seq` | integer | yes | Runner-assigned sequence in normalized kernel layer order |
 | `pid` | integer | yes | Kernel-observed thread-group id for the event |
-| `event_type` | integer | yes | Internal monitor event id (`1` for open, `2` for connect, etc.) |
-| `kind` | string | yes | Normalized event kind such as `openat`, `connect`, `exec`, `file_blocked` |
+| `event_type` | integer | yes | Internal monitor event id (`1` for `openat`, `2` for `connect`, etc.) |
+| `kind` | string | yes | Normalized event kind: `openat`, `connect`, `exec`, `file_blocked`, `connect_blocked`, or reserved `event_<id>` for unrecognized monitor ids |
 | `value` | string or null | yes | Normalized path or endpoint when available |
+
+Known v0 `event_type` / `kind` pairs:
+
+| `event_type` | `kind` |
+|---:|---|
+| `1` | `openat` |
+| `2` | `connect` |
+| `4` | `exec` |
+| `10` | `file_blocked` |
+| `20` | `connect_blocked` |
+
+Other internal monitor ids remain valid only as `kind=event_<id>`.
+`value=null` means the monitor event was preserved but the normalizer
+could not decode a path or endpoint from it.
 
 Open events may additionally carry syscall metadata:
 
@@ -110,6 +124,40 @@ Open events may additionally carry syscall metadata:
 These fields are optional so older v0 archives remain readable. Consumers that
 need read/write/create/remove distinctions must require the optional open
 metadata and treat older archives as inconclusive for that dimension.
+
+Open metadata example:
+
+```json
+{
+  "schema": "assay.runner.kernel_event.v0",
+  "run_id": "run_001",
+  "seq": 0,
+  "pid": 1234,
+  "event_type": 1,
+  "kind": "openat",
+  "value": "/tmp/work/fixture-output.txt",
+  "flags": 577,
+  "mode": 420,
+  "return_value": 4,
+  "access_mode": "write",
+  "operation_flags": ["create", "truncate"],
+  "status": "success"
+}
+```
+
+Undecoded event example:
+
+```json
+{
+  "schema": "assay.runner.kernel_event.v0",
+  "run_id": "run_001",
+  "seq": 1,
+  "pid": 1234,
+  "event_type": 999,
+  "kind": "event_999",
+  "value": null
+}
+```
 
 ## `observation-health.json`
 

--- a/docs/reference/runner/schema/kernel-event-v0.schema.json
+++ b/docs/reference/runner/schema/kernel-event-v0.schema.json
@@ -32,12 +32,26 @@
     },
     "event_type": {
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "description": "Internal monitor event id. Known v0 ids are 1=openat, 2=connect, 4=exec, 10=file_blocked, 20=connect_blocked; unknown ids are represented by kind=event_<id>."
     },
     "kind": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Normalized kernel event kind such as openat, connect, exec, file_blocked, connect_blocked, or event_<id>."
+      "anyOf": [
+        {
+          "enum": [
+            "openat",
+            "connect",
+            "exec",
+            "file_blocked",
+            "connect_blocked"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^event_[0-9]+$"
+        }
+      ],
+      "description": "Normalized kernel event kind. Known v0 kinds are enumerated; unrecognized monitor ids use event_<id>."
     },
     "value": {
       "type": [
@@ -98,6 +112,101 @@
   "allOf": [
     {
       "if": {
+        "properties": {
+          "kind": {
+            "const": "openat"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "event_type": {
+            "const": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "connect"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "event_type": {
+            "const": 2
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "exec"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "event_type": {
+            "const": 4
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "file_blocked"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "event_type": {
+            "const": 10
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "connect_blocked"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "event_type": {
+            "const": 20
+          }
+        }
+      }
+    },
+    {
+      "if": {
         "required": [
           "status"
         ]
@@ -107,6 +216,71 @@
           "return_value"
         ]
       }
+    }
+  ],
+  "examples": [
+    {
+      "schema": "assay.runner.kernel_event.v0",
+      "run_id": "run_001",
+      "seq": 0,
+      "pid": 1234,
+      "event_type": 1,
+      "kind": "openat",
+      "value": "/tmp/work/fixture-output.txt",
+      "flags": 577,
+      "mode": 420,
+      "return_value": 4,
+      "access_mode": "write",
+      "operation_flags": [
+        "create",
+        "truncate"
+      ],
+      "status": "success"
+    },
+    {
+      "schema": "assay.runner.kernel_event.v0",
+      "run_id": "run_001",
+      "seq": 1,
+      "pid": 1234,
+      "event_type": 2,
+      "kind": "connect",
+      "value": "203.0.113.10:443"
+    },
+    {
+      "schema": "assay.runner.kernel_event.v0",
+      "run_id": "run_001",
+      "seq": 2,
+      "pid": 1234,
+      "event_type": 4,
+      "kind": "exec",
+      "value": "/usr/bin/node"
+    },
+    {
+      "schema": "assay.runner.kernel_event.v0",
+      "run_id": "run_001",
+      "seq": 3,
+      "pid": 1234,
+      "event_type": 10,
+      "kind": "file_blocked",
+      "value": "/etc/shadow"
+    },
+    {
+      "schema": "assay.runner.kernel_event.v0",
+      "run_id": "run_001",
+      "seq": 4,
+      "pid": 1234,
+      "event_type": 20,
+      "kind": "connect_blocked",
+      "value": "198.51.100.7:25"
+    },
+    {
+      "schema": "assay.runner.kernel_event.v0",
+      "run_id": "run_001",
+      "seq": 5,
+      "pid": 1234,
+      "event_type": 999,
+      "kind": "event_999",
+      "value": null
     }
   ]
 }


### PR DESCRIPTION
Summary
- Tightens `kernel-event-v0.schema.json` around `kind` and `event_type` without closing the unknown-event escape hatch.
- Adds known v0 `event_type` / `kind` conditionals: `1=openat`, `2=connect`, `4=exec`, `10=file_blocked`, `20=connect_blocked`; unknown monitor ids remain valid as `kind=event_<id>`.
- Adds schema examples for enriched open metadata and a preserved undecoded event with `value=null`.
- Expands `artifacts-v0.md` with the event-type mapping and examples.
- Replaces ad hoc sidecar checks with a small stdlib-only JSON Schema subset validator shared by runtime-drift and kernel-event sidecar tests.

Claim discipline
- Still no unlink/remove, rename, mkdir/rmdir, fd-level byte counts, or close-pairing claims.
- `value=null` remains valid for preserved but undecoded monitor events.
- No new runtime dependency on `jsonschema`; tests validate the subset our sidecars use.

Validation
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 73 OK
- `git diff --check`
- Local markdown link check over changed docs