### PR TITLE
feat(experiments): add runtime drift render provenance

### DIFF
--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -473,6 +473,11 @@ jobs:
               --network-alias "127.0.0.53:53=dns" \
               --assay-version "$ASSAY_VERSION" \
               --assay-commit "$GITHUB_SHA" \
+              --comparator-commit "$GITHUB_SHA" \
+              --rendered-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              --render-kind "live_capture" \
+              --source-run-url "$WORKFLOW_URL" \
+              --raw-captures-unchanged \
               --workflow-url "$WORKFLOW_URL" \
               --runner-label "$RUNNER_LABEL" \
               --kernel-os "$KERNEL_OS" \

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -131,6 +131,10 @@ report. The comparator derives input archive manifest digests, schema
 versions, observation-health gates, and correlation status from the
 archives; workflow/commit/kernel/eBPF anchors are optional CLI inputs and
 remain `null` when the caller does not provide them.
+`provenance.assay_commit` is the capture anchor for the input archives.
+`provenance.render_metadata.comparator_commit` is the render anchor for
+the comparator that produced the report. They intentionally differ when
+committed archives are re-rendered after projection/schema changes.
 
 ## What's done in Slice 1
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1641,9 +1641,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--raw-captures-unchanged",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=None,
-        help="Declare that report rendering did not mutate the input archives.",
+        help=(
+            "Declare whether report rendering mutated the input archives. "
+            "Use --raw-captures-unchanged, --no-raw-captures-unchanged, "
+            "or omit for unknown/null."
+        ),
     )
     parser.add_argument("--workflow-url", help="GitHub Actions run URL, if any.")
     parser.add_argument("--runner-label", help="Runner label or host class.")

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -528,7 +528,14 @@ class ReportProvenance:
     """Optional report-level anchors supplied by the caller/workflow."""
 
     assay_version: str | None = None
+    # Capture anchor: the Assay revision that produced the input archives.
     assay_commit: str | None = None
+    # Render anchor: the comparator revision that produced this report.
+    comparator_commit: str | None = None
+    rendered_at: str | None = None
+    render_kind: str = "unspecified"
+    source_run_url: str | None = None
+    raw_captures_unchanged: bool | None = None
     workflow_url: str | None = None
     runner_label: str | None = None
     kernel_os: str | None = None
@@ -1391,6 +1398,13 @@ def _provenance_payload(
         "schema": DRIFT_REPORT_PROVENANCE_SCHEMA,
         "assay_version": provenance.assay_version,
         "assay_commit": provenance.assay_commit,
+        "render_metadata": {
+            "kind": provenance.render_kind,
+            "rendered_at": provenance.rendered_at,
+            "comparator_commit": provenance.comparator_commit,
+            "source_run_url": provenance.source_run_url,
+            "raw_captures_unchanged": provenance.raw_captures_unchanged,
+        },
         "runner_schema_versions": _schema_versions(a, b),
         "kernel": {
             "os": provenance.kernel_os,
@@ -1410,6 +1424,7 @@ def _provenance_payload(
             "provenance_no_evidence_rewrite",
             "provenance_unknowns_preserved",
             "provenance_metadata_not_policy_verdict",
+            "provenance_capture_commit_distinct_from_render_commit",
         ],
     }
 
@@ -1602,7 +1617,34 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument("--assay-version", help="Assay version that produced the report.")
-    parser.add_argument("--assay-commit", help="Git commit associated with the report.")
+    parser.add_argument(
+        "--assay-commit",
+        help="Capture commit: Git commit that produced the input archives.",
+    )
+    parser.add_argument(
+        "--comparator-commit",
+        help="Render commit: Git commit whose comparator produced this report.",
+    )
+    parser.add_argument(
+        "--rendered-at",
+        help="UTC timestamp for report rendering, usually RFC3339/Zulu.",
+    )
+    parser.add_argument(
+        "--render-kind",
+        choices=("live_capture", "re_render", "synthetic_fixture", "unspecified"),
+        default="unspecified",
+        help="Whether this report came from a fresh workflow capture or a re-render.",
+    )
+    parser.add_argument(
+        "--source-run-url",
+        help="Original workflow/run URL for the source captures, if different from this render.",
+    )
+    parser.add_argument(
+        "--raw-captures-unchanged",
+        action="store_true",
+        default=None,
+        help="Declare that report rendering did not mutate the input archives.",
+    )
     parser.add_argument("--workflow-url", help="GitHub Actions run URL, if any.")
     parser.add_argument("--runner-label", help="Runner label or host class.")
     parser.add_argument("--kernel-os", help="Kernel OS for the capture host.")
@@ -1666,6 +1708,11 @@ def main(argv: list[str] | None = None) -> int:
     provenance = ReportProvenance(
         assay_version=args.assay_version or None,
         assay_commit=args.assay_commit or None,
+        comparator_commit=args.comparator_commit or None,
+        rendered_at=args.rendered_at or None,
+        render_kind=args.render_kind,
+        source_run_url=args.source_run_url or None,
+        raw_captures_unchanged=args.raw_captures_unchanged,
         workflow_url=args.workflow_url or None,
         runner_label=args.runner_label or None,
         kernel_os=args.kernel_os or None,

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -1142,6 +1142,29 @@ class MainCliTests(unittest.TestCase):
                 provenance["ebpf_object_digest"], "sha256:" + "1" * 64
             )
 
+    def test_main_can_declare_raw_captures_changed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_json = Path(tmp) / "drift.json"
+            rc = drift.main(
+                [
+                    "--archive-a",
+                    str(ARM_A),
+                    "--archive-b",
+                    str(ARM_B),
+                    "--out-json",
+                    str(out_json),
+                    "--no-raw-captures-unchanged",
+                ]
+            )
+            self.assertEqual(rc, 0)
+            payload = json.loads(out_json.read_text(encoding="utf-8"))
+            self.assertIs(
+                payload["provenance"]["render_metadata"][
+                    "raw_captures_unchanged"
+                ],
+                False,
+            )
+
     def test_main_returns_3_on_bad_archive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             rc = drift.main(

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -1090,6 +1090,15 @@ class MainCliTests(unittest.TestCase):
                     "3.11.3",
                     "--assay-commit",
                     "abc123",
+                    "--comparator-commit",
+                    "def456",
+                    "--rendered-at",
+                    "2026-05-25T18:55:39Z",
+                    "--render-kind",
+                    "re_render",
+                    "--source-run-url",
+                    "https://github.com/Rul1an/assay/actions/runs/source",
+                    "--raw-captures-unchanged",
                     "--workflow-url",
                     "https://github.com/Rul1an/assay/actions/runs/1",
                     "--runner-label",
@@ -1109,6 +1118,18 @@ class MainCliTests(unittest.TestCase):
             provenance = payload["provenance"]
             self.assertEqual(provenance["assay_version"], "3.11.3")
             self.assertEqual(provenance["assay_commit"], "abc123")
+            self.assertEqual(
+                provenance["render_metadata"],
+                {
+                    "kind": "re_render",
+                    "rendered_at": "2026-05-25T18:55:39Z",
+                    "comparator_commit": "def456",
+                    "source_run_url": (
+                        "https://github.com/Rul1an/assay/actions/runs/source"
+                    ),
+                    "raw_captures_unchanged": True,
+                },
+            )
             self.assertEqual(
                 provenance["workflow"]["url"],
                 "https://github.com/Rul1an/assay/actions/runs/1",
@@ -1397,6 +1418,10 @@ class RuntimeDriftSchemaSidecarTests(unittest.TestCase):
         self.assertEqual(
             schema["$defs"]["provenance"]["properties"]["schema"]["const"],
             drift.DRIFT_REPORT_PROVENANCE_SCHEMA,
+        )
+        self.assertEqual(
+            schema["$defs"]["render_metadata"]["properties"]["kind"]["enum"],
+            ["live_capture", "re_render", "synthetic_fixture", "unspecified"],
         )
         self.assertIn(
             drift.PATH_PROJECTION_SCHEMA,

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
@@ -52,6 +52,10 @@ The A0/B0 archives are the original workflow artifacts. The
 `runs/drift/` reports were re-rendered from those committed archives
 after the runtime-drift projection schema was frozen as
 `assay.runner.runtime_drift.v0`; the raw captures were not regenerated.
+The comparator at re-render time uses projection, taxonomy, and
+provenance fields that did not exist at original capture time. This
+asymmetry is intentional: raw evidence is unchanged, while the
+projection/report layer is newer and records its own render metadata.
 
 All six archives passed the workflow health gate before artifact upload:
 `ringbuf_drops == 0`, `kernel_layer == "complete"`, and

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
@@ -56,6 +56,10 @@ The comparator at re-render time uses projection, taxonomy, and
 provenance fields that did not exist at original capture time. This
 asymmetry is intentional: raw evidence is unchanged, while the
 projection/report layer is newer and records its own render metadata.
+For these committed reports, `provenance.assay_commit` is the original
+capture commit (`e3f6ef9d`) and
+`provenance.render_metadata.comparator_commit` is the comparator support
+commit used for the re-render (`d1277d82`).
 
 All six archives passed the workflow health gate before artifact upload:
 `ringbuf_drops == 0`, `kernel_layer == "complete"`, and

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.json
@@ -101,6 +101,13 @@
     "schema": "assay.runner.drift_report_provenance.v0",
     "assay_version": null,
     "assay_commit": "e3f6ef9d",
+    "render_metadata": {
+      "kind": "re_render",
+      "rendered_at": "2026-05-25T19:00:35Z",
+      "comparator_commit": "d1277d82",
+      "source_run_url": "https://github.com/Rul1an/assay/actions/runs/26398427430",
+      "raw_captures_unchanged": true
+    },
     "runner_schema_versions": {
       "archive_manifest": [
         "assay.runner.archive_manifest.v0"
@@ -190,7 +197,8 @@
     "non_claims": [
       "provenance_no_evidence_rewrite",
       "provenance_unknowns_preserved",
-      "provenance_metadata_not_policy_verdict"
+      "provenance_metadata_not_policy_verdict",
+      "provenance_capture_commit_distinct_from_render_commit"
     ]
   },
   "rows": [

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.json
@@ -101,6 +101,13 @@
     "schema": "assay.runner.drift_report_provenance.v0",
     "assay_version": null,
     "assay_commit": "e3f6ef9d",
+    "render_metadata": {
+      "kind": "re_render",
+      "rendered_at": "2026-05-25T19:00:35Z",
+      "comparator_commit": "d1277d82",
+      "source_run_url": "https://github.com/Rul1an/assay/actions/runs/26398427430",
+      "raw_captures_unchanged": true
+    },
     "runner_schema_versions": {
       "archive_manifest": [
         "assay.runner.archive_manifest.v0"
@@ -190,7 +197,8 @@
     "non_claims": [
       "provenance_no_evidence_rewrite",
       "provenance_unknowns_preserved",
-      "provenance_metadata_not_policy_verdict"
+      "provenance_metadata_not_policy_verdict",
+      "provenance_capture_commit_distinct_from_render_commit"
     ]
   },
   "rows": [

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.json
@@ -101,6 +101,13 @@
     "schema": "assay.runner.drift_report_provenance.v0",
     "assay_version": null,
     "assay_commit": "e3f6ef9d",
+    "render_metadata": {
+      "kind": "re_render",
+      "rendered_at": "2026-05-25T19:00:35Z",
+      "comparator_commit": "d1277d82",
+      "source_run_url": "https://github.com/Rul1an/assay/actions/runs/26398427430",
+      "raw_captures_unchanged": true
+    },
     "runner_schema_versions": {
       "archive_manifest": [
         "assay.runner.archive_manifest.v0"
@@ -190,7 +197,8 @@
     "non_claims": [
       "provenance_no_evidence_rewrite",
       "provenance_unknowns_preserved",
-      "provenance_metadata_not_policy_verdict"
+      "provenance_metadata_not_policy_verdict",
+      "provenance_capture_commit_distinct_from_render_commit"
     ]
   },
   "rows": [

--- a/docs/reference/runner/projection-roadmap.md
+++ b/docs/reference/runner/projection-roadmap.md
@@ -159,8 +159,8 @@ Implementation note: the cross-runtime drift comparator now emits a
 `provenance` block in JSON reports. Archive manifest digests, schema
 versions, observation-health gates, and correlation status are derived
 from the two input archives. Workflow URL, runner label, kernel tuple,
-Assay version/commit, and eBPF object digest are caller-supplied anchors
-and stay `null` when not provided.
+Assay version/capture commit, render metadata, and eBPF object digest
+are caller-supplied anchors and stay `null` when not provided.
 
 Minimum metadata block:
 
@@ -168,6 +168,13 @@ Minimum metadata block:
 {
   "assay_version": "3.x.y",
   "assay_commit": "sha",
+  "render_metadata": {
+    "kind": "live_capture | re_render | synthetic_fixture | unspecified",
+    "rendered_at": "2026-05-25T18:55:39Z",
+    "comparator_commit": "sha",
+    "source_run_url": "https://github.com/Rul1an/assay/actions/runs/...",
+    "raw_captures_unchanged": true
+  },
   "runner_schema_versions": {
     "archive": "assay.runner.archive.v0",
     "kernel_event": "assay.runner.kernel_event.v0"

--- a/docs/reference/runner/projection-roadmap.md
+++ b/docs/reference/runner/projection-roadmap.md
@@ -160,7 +160,9 @@ Implementation note: the cross-runtime drift comparator now emits a
 versions, observation-health gates, and correlation status are derived
 from the two input archives. Workflow URL, runner label, kernel tuple,
 Assay version/capture commit, render metadata, and eBPF object digest
-are caller-supplied anchors and stay `null` when not provided.
+are caller-supplied anchors. `render_metadata.kind` is always present
+and defaults to `unspecified`; the other optional render metadata fields
+stay `null` when not provided.
 
 Minimum metadata block:
 

--- a/docs/reference/runner/runtime-drift-v0.md
+++ b/docs/reference/runner/runtime-drift-v0.md
@@ -68,6 +68,23 @@ Top-level fields:
 | `rows` | array | yes | Per-dimension drift rows |
 | `summary` | object | yes | Classification counts across rows |
 
+### Archive References
+
+`archive_a.path` and `archive_b.path` are informational location
+anchors, not identity fields. For committed re-renders they are normally
+repo-root-relative paths so a reviewer can follow them in the repository.
+For fresh workflow captures they may be absolute paths on the capture
+host. Archive identity comes from `manifest_digest`.
+
+### Provenance Anchors
+
+`provenance.assay_commit` is the **capture** anchor: the Assay revision
+that produced the input archives. `provenance.render_metadata` is the
+**render** anchor: the comparator revision and render context that
+produced the drift report from those archives. These can intentionally
+differ when old archives are re-rendered after a projection or schema
+change.
+
 ## Contract Principles
 
 1. **Raw evidence is preserved.** `only_in_a`, `only_in_b`, and
@@ -84,7 +101,7 @@ Top-level fields:
    recalculate capture health.
 6. **Provenance anchors the comparison.** Input manifest digests, Runner
    schema versions, kernel metadata, eBPF object digest, workflow URL,
-   and Assay commit are report metadata when available.
+   capture commit, and render metadata are report metadata when available.
 7. **Policy acceptability is out of scope.** A `runtime-induced` row is
    evidence shape, not a policy failure.
 

--- a/docs/reference/runner/schema/runtime-drift-v0.schema.json
+++ b/docs/reference/runner/schema/runtime-drift-v0.schema.json
@@ -57,6 +57,12 @@
         "type": "string"
       }
     },
+    "nullable_boolean": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "archive_ref": {
       "type": "object",
       "additionalProperties": false,
@@ -69,7 +75,8 @@
       ],
       "properties": {
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Archive path as emitted by the comparator. Committed re-renders normally use repo-root-relative paths; fresh workflow captures may use capture-host absolute paths."
         },
         "run_id": {
           "$ref": "#/$defs/nullable_string"
@@ -115,6 +122,7 @@
       "additionalProperties": true,
       "required": [
         "schema",
+        "render_metadata",
         "input_archives",
         "runner_schema_versions",
         "kernel",
@@ -124,6 +132,9 @@
       "properties": {
         "schema": {
           "const": "assay.runner.drift_report_provenance.v0"
+        },
+        "render_metadata": {
+          "$ref": "#/$defs/render_metadata"
         },
         "input_archives": {
           "type": "array",
@@ -144,6 +155,39 @@
         },
         "non_claims": {
           "$ref": "#/$defs/string_array"
+        }
+      }
+    },
+    "render_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "rendered_at",
+        "comparator_commit",
+        "source_run_url",
+        "raw_captures_unchanged"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "live_capture",
+            "re_render",
+            "synthetic_fixture",
+            "unspecified"
+          ]
+        },
+        "rendered_at": {
+          "$ref": "#/$defs/nullable_string"
+        },
+        "comparator_commit": {
+          "$ref": "#/$defs/nullable_string"
+        },
+        "source_run_url": {
+          "$ref": "#/$defs/nullable_string"
+        },
+        "raw_captures_unchanged": {
+          "$ref": "#/$defs/nullable_boolean"
         }
       }
     },


### PR DESCRIPTION
Summary
- Adds explicit render metadata to runtime drift provenance so a report distinguishes the archive capture anchor from the comparator render anchor.
- Keeps `provenance.assay_commit` as the capture commit for the input archives.
- Adds `provenance.render_metadata` with `kind`, `rendered_at`, `comparator_commit`, `source_run_url`, and `raw_captures_unchanged`.
- Updates the cross-runtime drift workflow to populate render metadata for fresh live captures.
- Re-renders the committed `runs/drift/drift_pair_{1,2,3}.json` payloads as `kind=re_render`, with source run 26398427430 and `comparator_commit=d1277d82`.

Why two commits
- Commit `d1277d82` adds the comparator/schema support.
- Commit `d50023c6` re-renders the committed reports and points their render metadata at `d1277d82`.
- Please merge this PR with a merge commit rather than squash so `d1277d82` remains reachable as the comparator render anchor.

Validation
- `python3 -m json.tool docs/reference/runner/schema/runtime-drift-v0.schema.json >/dev/null`
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 80/80 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/contract-checker -p 'test_*.py'` -> 14/14 OK
- `actionlint .github/workflows/cross-runtime-drift-experiment.yml`
- `git diff --check`
- Local markdown link check
- Sanity: all three committed drift reports have `render_metadata.kind=re_render`, `comparator_commit=d1277d82`, `raw_captures_unchanged=true`, and `assay_commit=e3f6ef9d`

Non-claims
- No new live captures.
- No comparator classification logic changes.
- No change to raw A0/B0 archive artifacts.