### PR TITLE
feat(experiments): polish runtime drift provenance UX

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1504,20 +1504,38 @@ def _fmt_optional(value: str | None) -> str:
     return value if value else "<unknown>"
 
 
+def _single_line(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _md_inline_code(value: str) -> str:
+    value = _single_line(value)
+    max_run = 0
+    current_run = 0
+    for char in value:
+        if char == "`":
+            current_run += 1
+            max_run = max(max_run, current_run)
+        else:
+            current_run = 0
+    fence = "`" * (max_run + 1)
+    return f"{fence}{value}{fence}"
+
+
 def _fmt_render_metadata(provenance: ReportProvenance) -> str:
     parts = [
-        f"`{_md_escape_cell(provenance.render_kind)}`",
-        f"at `{_md_escape_cell(_fmt_optional(provenance.rendered_at))}`",
+        _md_inline_code(provenance.render_kind),
+        f"at {_md_inline_code(_fmt_optional(provenance.rendered_at))}",
         (
             "using comparator "
-            f"`{_md_escape_cell(_fmt_optional(provenance.comparator_commit))}`"
+            f"{_md_inline_code(_fmt_optional(provenance.comparator_commit))}"
         ),
     ]
     if provenance.source_run_url:
-        parts.append(f"from {provenance.source_run_url}")
+        parts.append(f"from {_md_inline_code(provenance.source_run_url)}")
     if provenance.raw_captures_unchanged is not None:
         raw_state = str(provenance.raw_captures_unchanged).lower()
-        parts.append(f"raw captures unchanged `{raw_state}`")
+        parts.append(f"raw captures unchanged {_md_inline_code(raw_state)}")
     return "; ".join(parts)
 
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1500,10 +1500,32 @@ def _fmt_projection(projection: dict[str, Any]) -> str:
     return _md_escape_cell(claim)
 
 
+def _fmt_optional(value: str | None) -> str:
+    return value if value else "<unknown>"
+
+
+def _fmt_render_metadata(provenance: ReportProvenance) -> str:
+    parts = [
+        f"`{_md_escape_cell(provenance.render_kind)}`",
+        f"at `{_md_escape_cell(_fmt_optional(provenance.rendered_at))}`",
+        (
+            "using comparator "
+            f"`{_md_escape_cell(_fmt_optional(provenance.comparator_commit))}`"
+        ),
+    ]
+    if provenance.source_run_url:
+        parts.append(f"from {provenance.source_run_url}")
+    if provenance.raw_captures_unchanged is not None:
+        raw_state = str(provenance.raw_captures_unchanged).lower()
+        parts.append(f"raw captures unchanged `{raw_state}`")
+    return "; ".join(parts)
+
+
 def report_to_md(
     a: ArchiveObservation,
     b: ArchiveObservation,
     rows: list[DriftRow],
+    provenance: ReportProvenance | None = None,
 ) -> str:
     lines: list[str] = []
     lines.append("# Cross-Runtime Drift Report")
@@ -1518,6 +1540,8 @@ def report_to_md(
         f"(`{_md_escape_cell(b.path)}`, "
         f"manifest `{b.manifest_digest}`)"
     )
+    if provenance is not None:
+        lines.append(f"- **Render:** {_fmt_render_metadata(provenance)}")
     lines.append("")
     lines.append(
         "| Dimension | Source | Classification | Only in A | Only in B | "
@@ -1743,7 +1767,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             args.out_md.parent.mkdir(parents=True, exist_ok=True)
             args.out_md.write_text(
-                report_to_md(a, b, rows), encoding="utf-8"
+                report_to_md(a, b, rows, provenance), encoding="utf-8"
             )
         except OSError as exc:
             print(f"failed to write --out-md: {exc}", file=sys.stderr)

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -1209,6 +1209,23 @@ class MainCliTests(unittest.TestCase):
         self.assertIn("`def4567`", md)
         self.assertIn("raw captures unchanged `true`", md)
 
+    def test_report_markdown_normalizes_source_run_url(self) -> None:
+        a = drift.parse_archive(ARM_A)
+        b = drift.parse_archive(ARM_B)
+        rows = drift.build_drift_report(a, b)
+        md = drift.report_to_md(
+            a,
+            b,
+            rows,
+            drift.ReportProvenance(
+                comparator_commit="def4567",
+                render_kind="re_render",
+                source_run_url="https://example.test/run\n- injected",
+            ),
+        )
+        self.assertIn("from `https://example.test/run - injected`", md)
+        self.assertNotIn("\n- injected", md)
+
     def test_main_can_declare_raw_captures_changed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out_json = Path(tmp) / "drift.json"
@@ -1508,6 +1525,10 @@ class RuntimeDriftSchemaSidecarTests(unittest.TestCase):
         self.assertEqual(
             schema["$defs"]["provenance"]["properties"]["schema"]["const"],
             drift.DRIFT_REPORT_PROVENANCE_SCHEMA,
+        )
+        self.assertIn(
+            "assay_commit",
+            schema["$defs"]["provenance"]["required"],
         )
         self.assertEqual(
             schema["$defs"]["render_metadata"]["properties"]["kind"]["enum"],

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -53,6 +53,7 @@ SUPPORTED_SCHEMA_KEYWORDS = frozenset(
         "else",
         "enum",
         "examples",
+        "format",
         "if",
         "items",
         "maxItems",
@@ -95,6 +96,18 @@ def _json_type_matches(value: Any, expected: str) -> bool:
     if expected == "boolean":
         return isinstance(value, bool)
     raise AssertionError(f"unsupported JSON Schema type in test helper: {expected}")
+
+
+def _is_rfc3339_date_time(value: str) -> bool:
+    return bool(
+        re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T"
+            r"\d{2}:\d{2}:\d{2}"
+            r"(?:\.\d+)?"
+            r"(?:Z|[+-]\d{2}:\d{2})",
+            value,
+        )
+    )
 
 
 def assert_schema_uses_only_supported_keywords(
@@ -219,6 +232,11 @@ def assert_matches_supported_schema_keywords(
             testcase.assertGreaterEqual(len(value), schema["minLength"], path)
         if "pattern" in schema:
             testcase.assertRegex(value, re.compile(schema["pattern"]), path)
+        if schema.get("format") == "date-time":
+            testcase.assertTrue(
+                _is_rfc3339_date_time(value),
+                f"{path}: expected RFC3339 date-time, got {value!r}",
+            )
 
     if isinstance(value, int) and not isinstance(value, bool):
         if "minimum" in schema:
@@ -1075,6 +1093,33 @@ class MainCliTests(unittest.TestCase):
             self.assertIn("filesystem_paths_touched", md)
             self.assertIn("read:workdir/input", md)
 
+    def test_main_can_emit_synthetic_fixture_render_kind(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_json = Path(tmp) / "drift.json"
+            rc = drift.main(
+                [
+                    "--archive-a",
+                    str(ARM_A),
+                    "--archive-b",
+                    str(ARM_B),
+                    "--out-json",
+                    str(out_json),
+                    "--render-kind",
+                    "synthetic_fixture",
+                    "--rendered-at",
+                    "2026-05-25T19:20:00Z",
+                    "--comparator-commit",
+                    "abcdef1",
+                    "--raw-captures-unchanged",
+                ]
+            )
+            self.assertEqual(rc, 0)
+            payload = json.loads(out_json.read_text(encoding="utf-8"))
+            self.assertEqual(
+                payload["provenance"]["render_metadata"]["kind"],
+                "synthetic_fixture",
+            )
+
     def test_main_writes_explicit_report_provenance(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             out_json = Path(tmp) / "drift.json"
@@ -1089,9 +1134,9 @@ class MainCliTests(unittest.TestCase):
                     "--assay-version",
                     "3.11.3",
                     "--assay-commit",
-                    "abc123",
+                    "abc1234",
                     "--comparator-commit",
-                    "def456",
+                    "def4567",
                     "--rendered-at",
                     "2026-05-25T18:55:39Z",
                     "--render-kind",
@@ -1117,13 +1162,13 @@ class MainCliTests(unittest.TestCase):
             payload = json.loads(out_json.read_text(encoding="utf-8"))
             provenance = payload["provenance"]
             self.assertEqual(provenance["assay_version"], "3.11.3")
-            self.assertEqual(provenance["assay_commit"], "abc123")
+            self.assertEqual(provenance["assay_commit"], "abc1234")
             self.assertEqual(
                 provenance["render_metadata"],
                 {
                     "kind": "re_render",
                     "rendered_at": "2026-05-25T18:55:39Z",
-                    "comparator_commit": "def456",
+                    "comparator_commit": "def4567",
                     "source_run_url": (
                         "https://github.com/Rul1an/assay/actions/runs/source"
                     ),
@@ -1141,6 +1186,28 @@ class MainCliTests(unittest.TestCase):
             self.assertEqual(
                 provenance["ebpf_object_digest"], "sha256:" + "1" * 64
             )
+
+    def test_report_markdown_surfaces_render_metadata(self) -> None:
+        a = drift.parse_archive(ARM_A)
+        b = drift.parse_archive(ARM_B)
+        rows = drift.build_drift_report(a, b)
+        md = drift.report_to_md(
+            a,
+            b,
+            rows,
+            drift.ReportProvenance(
+                assay_commit="abc1234",
+                comparator_commit="def4567",
+                rendered_at="2026-05-25T18:55:39Z",
+                render_kind="re_render",
+                source_run_url="https://github.com/Rul1an/assay/actions/runs/1",
+                raw_captures_unchanged=True,
+            ),
+        )
+        self.assertIn("**Render:** `re_render`", md)
+        self.assertIn("`2026-05-25T18:55:39Z`", md)
+        self.assertIn("`def4567`", md)
+        self.assertIn("raw captures unchanged `true`", md)
 
     def test_main_can_declare_raw_captures_changed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -1445,6 +1512,16 @@ class RuntimeDriftSchemaSidecarTests(unittest.TestCase):
         self.assertEqual(
             schema["$defs"]["render_metadata"]["properties"]["kind"]["enum"],
             ["live_capture", "re_render", "synthetic_fixture", "unspecified"],
+        )
+        self.assertEqual(
+            schema["$defs"]["render_metadata"]["properties"]["rendered_at"][
+                "format"
+            ],
+            "date-time",
+        )
+        self.assertEqual(
+            schema["$defs"]["git_sha_or_null"]["pattern"],
+            "^[0-9a-f]{7,40}$",
         )
         self.assertIn(
             drift.PATH_PROJECTION_SCHEMA,

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
@@ -59,7 +59,7 @@ projection/report layer is newer and records its own render metadata.
 For these committed reports, `provenance.assay_commit` is the original
 capture commit (`e3f6ef9d`) and
 `provenance.render_metadata.comparator_commit` is the comparator support
-commit used for the re-render (`c5495af5`).
+commit used for the re-render (`02d31f40`).
 
 All six archives passed the workflow health gate before artifact upload:
 `ringbuf_drops == 0`, `kernel_layer == "complete"`, and

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/README.md
@@ -59,7 +59,7 @@ projection/report layer is newer and records its own render metadata.
 For these committed reports, `provenance.assay_commit` is the original
 capture commit (`e3f6ef9d`) and
 `provenance.render_metadata.comparator_commit` is the comparator support
-commit used for the re-render (`d1277d82`).
+commit used for the re-render (`c5495af5`).
 
 All six archives passed the workflow health gate before artifact upload:
 `ringbuf_drops == 0`, `kernel_layer == "complete"`, and

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.json
@@ -103,8 +103,8 @@
     "assay_commit": "e3f6ef9d",
     "render_metadata": {
       "kind": "re_render",
-      "rendered_at": "2026-05-25T19:20:03Z",
-      "comparator_commit": "c5495af5",
+      "rendered_at": "2026-05-25T19:25:22Z",
+      "comparator_commit": "02d31f40",
       "source_run_url": "https://github.com/Rul1an/assay/actions/runs/26398427430",
       "raw_captures_unchanged": true
     },

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.json
@@ -103,8 +103,8 @@
     "assay_commit": "e3f6ef9d",
     "render_metadata": {
       "kind": "re_render",
-      "rendered_at": "2026-05-25T19:00:35Z",
-      "comparator_commit": "d1277d82",
+      "rendered_at": "2026-05-25T19:20:03Z",
+      "comparator_commit": "c5495af5",
       "source_run_url": "https://github.com/Rul1an/assay/actions/runs/26398427430",
       "raw_captures_unchanged": true
     },

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.md
@@ -2,6 +2,7 @@
 
 - **Arm A:** `openai-agents` (`docs/experiments/cross-runtime-drift-2026-05/runs/a0/run_arm_a-openai_20260525T113813Z_1/archive.tar.gz`, manifest `sha256:686b57e6bc0cd4f1d99e354ed6c35846c8d64cfc90b6fc9e75e9c75c05c8d800`)
 - **Arm B:** `gemini-genai` (`docs/experiments/cross-runtime-drift-2026-05/runs/b0/run_arm_b-gemini_20260525T114112Z_1/archive.tar.gz`, manifest `sha256:f392cea861f0d671d66756c608960ed5e58154e4f1cc24be6e1b53748bea94d0`)
+- **Render:** `re_render`; at `2026-05-25T19:20:03Z`; using comparator `c5495af5`; from https://github.com/Rul1an/assay/actions/runs/26398427430; raw captures unchanged `true`
 
 | Dimension | Source | Classification | Only in A | Only in B | In both | Projection | Detail |
 |---|---|---|---|---|---|---|---|

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_1.md
@@ -2,7 +2,7 @@
 
 - **Arm A:** `openai-agents` (`docs/experiments/cross-runtime-drift-2026-05/runs/a0/run_arm_a-openai_20260525T113813Z_1/archive.tar.gz`, manifest `sha256:686b57e6bc0cd4f1d99e354ed6c35846c8d64cfc90b6fc9e75e9c75c05c8d800`)
 - **Arm B:** `gemini-genai` (`docs/experiments/cross-runtime-drift-2026-05/runs/b0/run_arm_b-gemini_20260525T114112Z_1/archive.tar.gz`, manifest `sha256:f392cea861f0d671d66756c608960ed5e58154e4f1cc24be6e1b53748bea94d0`)
-- **Render:** `re_render`; at `2026-05-25T19:20:03Z`; using comparator `c5495af5`; from https://github.com/Rul1an/assay/actions/runs/26398427430; raw captures unchanged `true`
+- **Render:** `re_render`; at `2026-05-25T19:25:22Z`; using comparator `02d31f40`; from `https://github.com/Rul1an/assay/actions/runs/26398427430`; raw captures unchanged `true`
 
 | Dimension | Source | Classification | Only in A | Only in B | In both | Projection | Detail |
 |---|---|---|---|---|---|---|---|

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.json
@@ -103,8 +103,8 @@
     "assay_commit": "e3f6ef9d",
     "render_metadata": {
       "kind": "re_render",
-      "rendered_at": "2026-05-25T19:20:03Z",
-      "comparator_commit": "c5495af5",
+      "rendered_at": "2026-05-25T19:25:22Z",
+      "comparator_commit": "02d31f40",
       "source_run_url": "https://github.com/Rul1an/assay/actions/runs/26398427430",
       "raw_captures_unchanged": true
     },

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.json
@@ -103,8 +103,8 @@
     "assay_commit": "e3f6ef9d",
     "render_metadata": {
       "kind": "re_render",
-      "rendered_at": "2026-05-25T19:00:35Z",
-      "comparator_commit": "d1277d82",
+      "rendered_at": "2026-05-25T19:20:03Z",
+      "comparator_commit": "c5495af5",
       "source_run_url": "https://github.com/Rul1an/assay/actions/runs/26398427430",
       "raw_captures_unchanged": true
     },

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.md
@@ -2,6 +2,7 @@
 
 - **Arm A:** `openai-agents` (`docs/experiments/cross-runtime-drift-2026-05/runs/a0/run_arm_a-openai_20260525T113821Z_2/archive.tar.gz`, manifest `sha256:cf7b63c6adfb8903a9b339b3a0e9e87d962cc3edaf4e3ed2d69b83ff6c3ac1e7`)
 - **Arm B:** `gemini-genai` (`docs/experiments/cross-runtime-drift-2026-05/runs/b0/run_arm_b-gemini_20260525T114117Z_2/archive.tar.gz`, manifest `sha256:d00cbb92bdb3f967fc0d2c735964594e2474d4dda027f2e477bf46f433f29c2d`)
+- **Render:** `re_render`; at `2026-05-25T19:20:03Z`; using comparator `c5495af5`; from https://github.com/Rul1an/assay/actions/runs/26398427430; raw captures unchanged `true`
 
 | Dimension | Source | Classification | Only in A | Only in B | In both | Projection | Detail |
 |---|---|---|---|---|---|---|---|

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_2.md
@@ -2,7 +2,7 @@
 
 - **Arm A:** `openai-agents` (`docs/experiments/cross-runtime-drift-2026-05/runs/a0/run_arm_a-openai_20260525T113821Z_2/archive.tar.gz`, manifest `sha256:cf7b63c6adfb8903a9b339b3a0e9e87d962cc3edaf4e3ed2d69b83ff6c3ac1e7`)
 - **Arm B:** `gemini-genai` (`docs/experiments/cross-runtime-drift-2026-05/runs/b0/run_arm_b-gemini_20260525T114117Z_2/archive.tar.gz`, manifest `sha256:d00cbb92bdb3f967fc0d2c735964594e2474d4dda027f2e477bf46f433f29c2d`)
-- **Render:** `re_render`; at `2026-05-25T19:20:03Z`; using comparator `c5495af5`; from https://github.com/Rul1an/assay/actions/runs/26398427430; raw captures unchanged `true`
+- **Render:** `re_render`; at `2026-05-25T19:25:22Z`; using comparator `02d31f40`; from `https://github.com/Rul1an/assay/actions/runs/26398427430`; raw captures unchanged `true`
 
 | Dimension | Source | Classification | Only in A | Only in B | In both | Projection | Detail |
 |---|---|---|---|---|---|---|---|

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.json
@@ -103,8 +103,8 @@
     "assay_commit": "e3f6ef9d",
     "render_metadata": {
       "kind": "re_render",
-      "rendered_at": "2026-05-25T19:20:03Z",
-      "comparator_commit": "c5495af5",
+      "rendered_at": "2026-05-25T19:25:22Z",
+      "comparator_commit": "02d31f40",
       "source_run_url": "https://github.com/Rul1an/assay/actions/runs/26398427430",
       "raw_captures_unchanged": true
     },

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.json
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.json
@@ -103,8 +103,8 @@
     "assay_commit": "e3f6ef9d",
     "render_metadata": {
       "kind": "re_render",
-      "rendered_at": "2026-05-25T19:00:35Z",
-      "comparator_commit": "d1277d82",
+      "rendered_at": "2026-05-25T19:20:03Z",
+      "comparator_commit": "c5495af5",
       "source_run_url": "https://github.com/Rul1an/assay/actions/runs/26398427430",
       "raw_captures_unchanged": true
     },

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.md
@@ -2,7 +2,7 @@
 
 - **Arm A:** `openai-agents` (`docs/experiments/cross-runtime-drift-2026-05/runs/a0/run_arm_a-openai_20260525T113828Z_3/archive.tar.gz`, manifest `sha256:8e579ce4487d1ed44d365e4e8f50b3138e384cb91a690a61fc6b973172abf273`)
 - **Arm B:** `gemini-genai` (`docs/experiments/cross-runtime-drift-2026-05/runs/b0/run_arm_b-gemini_20260525T114122Z_3/archive.tar.gz`, manifest `sha256:c83f4f6b7b5425bbe95f3fe2f94adb30f0728b129aa9715b60d099cf63ebe932`)
-- **Render:** `re_render`; at `2026-05-25T19:20:03Z`; using comparator `c5495af5`; from https://github.com/Rul1an/assay/actions/runs/26398427430; raw captures unchanged `true`
+- **Render:** `re_render`; at `2026-05-25T19:25:22Z`; using comparator `02d31f40`; from `https://github.com/Rul1an/assay/actions/runs/26398427430`; raw captures unchanged `true`
 
 | Dimension | Source | Classification | Only in A | Only in B | In both | Projection | Detail |
 |---|---|---|---|---|---|---|---|

--- a/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/runs/drift/drift_pair_3.md
@@ -2,6 +2,7 @@
 
 - **Arm A:** `openai-agents` (`docs/experiments/cross-runtime-drift-2026-05/runs/a0/run_arm_a-openai_20260525T113828Z_3/archive.tar.gz`, manifest `sha256:8e579ce4487d1ed44d365e4e8f50b3138e384cb91a690a61fc6b973172abf273`)
 - **Arm B:** `gemini-genai` (`docs/experiments/cross-runtime-drift-2026-05/runs/b0/run_arm_b-gemini_20260525T114122Z_3/archive.tar.gz`, manifest `sha256:c83f4f6b7b5425bbe95f3fe2f94adb30f0728b129aa9715b60d099cf63ebe932`)
+- **Render:** `re_render`; at `2026-05-25T19:20:03Z`; using comparator `c5495af5`; from https://github.com/Rul1an/assay/actions/runs/26398427430; raw captures unchanged `true`
 
 | Dimension | Source | Classification | Only in A | Only in B | In both | Projection | Detail |
 |---|---|---|---|---|---|---|---|

--- a/docs/reference/runner/runtime-drift-v0.md
+++ b/docs/reference/runner/runtime-drift-v0.md
@@ -85,6 +85,16 @@ produced the drift report from those archives. These can intentionally
 differ when old archives are re-rendered after a projection or schema
 change.
 
+Commit anchors are Git SHA identifiers: either full 40-character SHAs
+or unambiguous 7-40 character lowercase hexadecimal abbreviations.
+`render_metadata.rendered_at` uses RFC3339 date-time syntax such as
+`2026-05-25T19:00:35Z`.
+
+Runtime drift v0 uses a required-but-nullable convention for provenance:
+schema-critical keys are present even when the caller does not know the
+value yet. A present `null` means "unknown/not supplied"; absence means
+the report does not satisfy the v0 shape.
+
 ## Contract Principles
 
 1. **Raw evidence is preserved.** `only_in_a`, `only_in_b`, and

--- a/docs/reference/runner/schema/runtime-drift-v0.schema.json
+++ b/docs/reference/runner/schema/runtime-drift-v0.schema.json
@@ -51,6 +51,14 @@
         "null"
       ]
     },
+    "git_sha_or_null": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{7,40}$",
+      "description": "Full Git SHA or unambiguous abbreviation."
+    },
     "string_array": {
       "type": "array",
       "items": {
@@ -133,6 +141,9 @@
         "schema": {
           "const": "assay.runner.drift_report_provenance.v0"
         },
+        "assay_commit": {
+          "$ref": "#/$defs/git_sha_or_null"
+        },
         "render_metadata": {
           "$ref": "#/$defs/render_metadata"
         },
@@ -178,10 +189,14 @@
           ]
         },
         "rendered_at": {
-          "$ref": "#/$defs/nullable_string"
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
         },
         "comparator_commit": {
-          "$ref": "#/$defs/nullable_string"
+          "$ref": "#/$defs/git_sha_or_null"
         },
         "source_run_url": {
           "$ref": "#/$defs/nullable_string"

--- a/docs/reference/runner/schema/runtime-drift-v0.schema.json
+++ b/docs/reference/runner/schema/runtime-drift-v0.schema.json
@@ -130,6 +130,7 @@
       "additionalProperties": true,
       "required": [
         "schema",
+        "assay_commit",
         "render_metadata",
         "input_archives",
         "runner_schema_versions",


### PR DESCRIPTION
Summary
- Polishes the runtime drift provenance contract for machine validation and human review.
- Adds JSON Schema constraints for render timestamps (`format: date-time`) and Git commit anchors (`^[0-9a-f]{7,40}$`).
- Documents the required-but-nullable provenance convention and commit-anchor format.
- Mirrors render metadata into Markdown reports so a reviewer reading only `drift_pair_*.md` can see `kind`, timestamp, comparator commit, source run, and raw-capture status.
- Adds a synthetic-fixture CLI smoke test for `--render-kind synthetic_fixture`, so that enum value is exercised rather than dead vocabulary.
- Re-renders the committed drift reports with comparator anchor `c5495af5` and Markdown render headers.

Why two commits
- `c5495af5` adds comparator/schema/docs/tests support.
- `48de957d` re-renders committed reports and points `render_metadata.comparator_commit` at `c5495af5`.
- Please merge with a merge commit, not squash, so the comparator anchor remains reachable.

Validation
- `python3 -m json.tool docs/reference/runner/schema/runtime-drift-v0.schema.json >/dev/null`
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 83/83 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/contract-checker -p 'test_*.py'` -> 14/14 OK
- Local markdown link check
- `git diff --check`
- Sanity: all three drift JSONs are `re_render`, `comparator_commit=c5495af5`, `raw_captures_unchanged=true`, `assay_commit=e3f6ef9d`

Non-claims
- No new live captures.
- No drift classification logic changes.
- No raw A0/B0 archive changes.