### PR TITLE
docs(experiments): polish runtime drift provenance v0.1

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -27,6 +27,7 @@ import sys
 import tarfile
 import tempfile
 import unittest
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -99,15 +100,19 @@ def _json_type_matches(value: Any, expected: str) -> bool:
 
 
 def _is_rfc3339_date_time(value: str) -> bool:
-    return bool(
-        re.fullmatch(
-            r"\d{4}-\d{2}-\d{2}T"
-            r"\d{2}:\d{2}:\d{2}"
-            r"(?:\.\d+)?"
-            r"(?:Z|[+-]\d{2}:\d{2})",
-            value,
-        )
-    )
+    if not re.fullmatch(
+        r"\d{4}-\d{2}-\d{2}T"
+        r"\d{2}:\d{2}:\d{2}"
+        r"(?:\.\d+)?"
+        r"(?:Z|[+-]\d{2}:\d{2})",
+        value,
+    ):
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
 
 
 def assert_schema_uses_only_supported_keywords(
@@ -1542,7 +1547,7 @@ class RuntimeDriftSchemaSidecarTests(unittest.TestCase):
         )
         self.assertEqual(
             schema["$defs"]["git_sha_or_null"]["pattern"],
-            "^[0-9a-f]{7,40}$",
+            "^[0-9a-f]{7,64}$",
         )
         self.assertIn(
             drift.PATH_PROJECTION_SCHEMA,
@@ -1598,6 +1603,24 @@ class RuntimeDriftSchemaSidecarTests(unittest.TestCase):
         )
         payload = drift.report_to_json(a, b, rows)
         assert_matches_supported_schema_keywords(self, payload, schema)
+
+    def test_schema_helper_rejects_semantically_invalid_date_time(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_matches_supported_schema_keywords(
+                self,
+                "2026-13-99T25:99:99Z",
+                {"type": "string", "format": "date-time"},
+            )
+
+    def test_schema_helper_accepts_sha256_length_git_object_id(self) -> None:
+        assert_matches_supported_schema_keywords(
+            self,
+            "a" * 64,
+            {
+                "type": ["string", "null"],
+                "pattern": "^[0-9a-f]{7,64}$",
+            },
+        )
 
 
 class KernelEventSchemaSidecarTests(unittest.TestCase):

--- a/docs/reference/runner/runtime-drift-v0.md
+++ b/docs/reference/runner/runtime-drift-v0.md
@@ -85,10 +85,20 @@ produced the drift report from those archives. These can intentionally
 differ when old archives are re-rendered after a projection or schema
 change.
 
-Commit anchors are Git SHA identifiers: either full 40-character SHAs
-or unambiguous 7-40 character lowercase hexadecimal abbreviations.
+Commit anchors are bare Git object identifiers: either full SHAs or
+unambiguous 7-64 character lowercase hexadecimal abbreviations. The
+upper bound deliberately allows both SHA-1-era 40-character object IDs
+and SHA-256-era 64-character object IDs.
 `render_metadata.rendered_at` uses RFC3339 date-time syntax such as
 `2026-05-25T19:00:35Z`.
+
+This schema uses two SHA conventions:
+
+- Git commit anchors use bare lowercase hex because Git itself resolves
+  full or abbreviated object IDs.
+- Content-addressed evidence digests use an algorithm prefix such as
+  `sha256:<hex>` so future multi-algorithm digest handling stays
+  explicit.
 
 Runtime drift v0 uses a required-but-nullable convention for provenance:
 schema-critical keys are present even when the caller does not know the

--- a/docs/reference/runner/schema/runtime-drift-v0.schema.json
+++ b/docs/reference/runner/schema/runtime-drift-v0.schema.json
@@ -56,8 +56,8 @@
         "string",
         "null"
       ],
-      "pattern": "^[0-9a-f]{7,40}$",
-      "description": "Full Git SHA or unambiguous abbreviation."
+      "pattern": "^[0-9a-f]{7,64}$",
+      "description": "Full Git object id or unambiguous abbreviation. Allows SHA-1 and SHA-256 era Git object ids."
     },
     "string_array": {
       "type": "array",


### PR DESCRIPTION
Summary

Polishes the runtime drift provenance v0.1 surface after the #1367 post-merge review, without re-rendering any committed drift reports.

What changed

- Extends `git_sha_or_null` from 7-40 hex to 7-64 hex so Git SHA-256 object IDs are valid alongside SHA-1-era IDs.
- Tightens the stdlib schema sidecar's `format: date-time` support from shape-only regex to semantic `datetime.fromisoformat(...)` validation after RFC3339 shape screening.
- Documents the two SHA conventions in `runtime-drift-v0.md`: bare Git object IDs for commit anchors, `sha256:<hex>` for content-addressed evidence digests.
- Adds regression tests for semantically invalid date-times and 64-character Git object IDs.

Scope notes

- No live evidence files are re-rendered in this PR.
- No workflow changes.
- The earlier `--raw-captures-unchanged` review item is already closed on main: `drift.py` uses `argparse.BooleanOptionalAction` and supports `--no-raw-captures-unchanged`.

Validation

- `python3 -m json.tool docs/reference/runner/schema/runtime-drift-v0.schema.json >/dev/null`
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 86 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/contract-checker -p 'test_*.py'` -> 14 OK
- `git diff --check`
- Local changed-doc markdown link check
