### PR TITLE
docs(experiments): sync runner-vs-otel roadmap status

### DIFF
--- a/docs/experiments/runner-vs-otel-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-2026-05/README.md
@@ -1,7 +1,13 @@
 # Runner vs OTel: Shape Comparison Experiment Package
 
-> **Status:** v1 infrastructure landed; v1 data collection requires the
-> delegated `assay-bpf-runner` host (Arms A and C).
+> **Status:** v1 evidence and Slice 2-4 follow-ups landed on `main`.
+> Arm B trace-only runs, Arm C delegated Linux/eBPF dual-capture runs,
+> SDK-layer ingestion, tool-level L1/L2 join, and the controlled
+> tool-call argument tampering scenario all have committed evidence
+> under [`runs/`](runs/). Publication drafts live under
+> [`publication/`](publication/) and remain gated on OpenInference
+> [#3162](https://github.com/Arize-ai/openinference/issues/3162)
+> triage.
 >
 > **Plan doc:** [../runner-vs-otel-shape-comparison-2026-05.md](../runner-vs-otel-shape-comparison-2026-05.md)
 > — read this first for the framing, hypotheses, claim-class taxonomy, and
@@ -12,11 +18,11 @@
 | Path | Purpose |
 |---|---|
 | `compare/compare.py` | Stdlib-only Python comparator. Reads a Runner archive (`.tar.gz` or extracted dir) plus an OTLP/JSON trace and emits the field matrix as JSON and Markdown. |
-| `compare/tests/test_compare.py` | Six unit tests over synthetic fixtures. Includes the explicit-mismatch guard for the manifest-digest binding. |
+| `compare/tests/test_compare.py` | Stdlib unit tests over synthetic fixtures. Includes the explicit-mismatch guard for the manifest-digest binding and the Slice 2/3 join + intent/effect cases. |
 | `compare/tests/fixtures/` | Synthetic Runner archive directory tree and a matching OTLP trace JSON, used by the unit tests and by Arm B as a placeholder archive side. |
 | `workload/` | Node.js + TypeScript workload that wraps the existing deterministic OpenAI Agents fixture (`runner-fixtures/openai-agents/fixture-agent.js`) with OpenTelemetry tracing. Produces one OTLP/JSON trace per run and, in dual-capture mode, attaches the `assay.archive.manifest_digest` event. |
 | `run-arm-b.sh` | Local trace-only orchestrator (no eBPF required). |
-| `runs/` | Per-run artifact directory. Each run lands under `runs/<run-id>/`. Git-ignored content but the directory itself is tracked via `.gitkeep`. |
+| `runs/` | Committed per-run evidence for Arm B, Arm C, Slice 2, and Slice 3. |
 
 ## How to run each arm
 
@@ -88,9 +94,10 @@ python3 docs/experiments/runner-vs-otel-2026-05/compare/compare.py \
   --out-md "/tmp/assay-runner-otel-experiment/$RUN_ID/matrix.md"
 ```
 
-Repeat Arm C at least three times to fill the determinism rows of the
-measurement plan. Use the same `--run-id` per repetition only if you want to
-exercise idempotency; otherwise generate fresh IDs.
+The committed Arm C baselines were produced through the workflow form of
+this invocation and repeated three times. The shell outline above is kept
+as a developer reference; [`v1-findings.md`](v1-findings.md) is the source
+of truth for the actual run IDs, workflow runs, and evidence directories.
 
 ## Measurement plan execution checklist
 
@@ -98,9 +105,9 @@ Lifted from the plan doc, mapped to concrete commands:
 
 | Metric | Sample size | Command |
 |---|---:|---|
-| Archive determinism | n=3 | Arm C x 3; compare `manifest_digest` across runs |
-| Trace shape stability | n=3 | Arm C x 3; diff span tree + attribute keys |
-| `gen_ai.tool.call.id` presence | n=3 per path | Arm B run with each instrumentation under test |
+| Per-run manifest binding | n=3 | Done in Arm C + Slice 2/3; each trace binds to its own archive digest |
+| Trace shape stability | n=3 | Done in Arm B and Arm C; see committed `trace.json` + `matrix.json` |
+| `gen_ai.tool.call.id` presence | n=3 per path | Done for direct manual OTel SDK and Runner SDK event ingestion; other instrumentation paths remain optional follow-ups |
 | End-to-end wall clock | n>=20 per arm | `hyperfine` over each arm (see `scripts/perf_e2e.sh`) |
 | Peak RSS | n>=5 per arm | `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux) |
 | Archive size | n=3 | `stat` on `<archive>.tar.gz` |
@@ -113,36 +120,32 @@ existing Criterion / Bencher baseline.
 ## Comparator tests
 
 ```bash
-python3 docs/experiments/runner-vs-otel-2026-05/compare/tests/test_compare.py
+python3 -m unittest discover \
+  -s docs/experiments/runner-vs-otel-2026-05/compare/tests \
+  -p 'test_*.py'
 ```
 
 Expected output:
 
 ```
-test_archive_parsing ... ok
-test_field_matrix_row_count ... ok
-test_manifest_digest_binding_mismatch_is_explicit ... ok
-test_markdown_renders ... ok
-test_tool_call_id_join ... ok
-test_trace_parsing ... ok
 ----------------------------------------------------------------------
-Ran 6 tests in 0.0xxs
+Ran 17 tests in 0.0xxs
 OK
 ```
 
 The unit tests run in stdlib Python; no virtualenv or extra packages needed.
 
-## Reproducibility pins (fill before publication)
+## Reproducibility pins
 
 | Source | Pin |
 |---|---|
-| OpenTelemetry GenAI semconv | `<commit SHA of open-telemetry/semantic-conventions when run>` |
-| `@opentelemetry/api`, `sdk-trace-base`, `sdk-trace-node`, `resources`, `semantic-conventions` | versions from `workload/package-lock.json` after first run |
+| OpenTelemetry GenAI semconv | Attribute names used by the workload: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.tool.name`, `gen_ai.tool.call.id`, and opt-in `gen_ai.tool.call.arguments` |
+| `@opentelemetry/api`, `sdk-trace-base`, `sdk-trace-node`, `resources`, `semantic-conventions` | See `workload/package-lock.json` |
 | `@openai/agents` | `0.11.4` (pinned) |
-| `assay` workspace | git commit + tag |
-| `assay-runner-spike` | git commit |
-| Kernel version | `uname -r` output on the delegated host |
-| Python | `3.11+` for the comparator |
+| `assay` workspace | See per-slice workflow run links in `v1-findings.md` |
+| `assay runner-spike` | Built from the workflow head commit recorded per slice |
+| Kernel version | Delegated Arm C runs used `6.8.0-117-generic` on `assay-bpf-runner` |
+| Python | Stdlib comparator; tests pass on local Python and workflow Python |
 
 ## What this experiment package does and does not do
 

--- a/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
+++ b/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
@@ -8,11 +8,13 @@
 > intent-effect-mismatch` on the agent's reported fictional path) all
 > have committed per-run evidence. Arm A (Runner-only) is implicitly
 > covered by the archive half of Arm C. **Slice 4 publication drafts**
-> (OpenInference discussion + blog) are prepared under
-> [`publication/`](publication/) but not yet filed and not yet on
-> `main` either; the discipline is to revise both pieces in repo
-> before either goes outward. Overhead measurement at n≥20 and the L3
-> (Tetragon/Falco/Tracee) comparison remain open follow-ups.
+> (OpenInference discussion + blog) are committed under
+> [`publication/`](publication/). The narrow OpenInference vocabulary
+> question is filed as
+> [Arize-ai/openinference#3162](https://github.com/Arize-ai/openinference/issues/3162);
+> the blog remains unpublished pending maintainer triage. Overhead
+> measurement at n≥20 and the L3 (Tetragon/Falco/Tracee) comparison
+> remain open follow-ups.
 >
 > **Plan:** [../runner-vs-otel-shape-comparison-2026-05.md](../runner-vs-otel-shape-comparison-2026-05.md)
 >

--- a/docs/experiments/runner-vs-otel-shape-comparison-2026-05.md
+++ b/docs/experiments/runner-vs-otel-shape-comparison-2026-05.md
@@ -1,18 +1,20 @@
 # Runner Archives Next to OTel Traces: Shape Comparison Plan
 
-> **Status:** v1 baselines landed. Arm B (trace-only, macOS local, n=3 +
-> dual-simulation) and Arm C (delegated `assay-bpf-runner`, n=3 with real
-> Linux/eBPF capture) both have committed evidence. Run-level
-> `assay.run.id` + `assay.archive.manifest_digest` binding is verifiable
-> from the committed artefacts. Tool-level `gen_ai.tool.call.id` join is
-> **not yet demonstrated** because the Arm C archive's `sdk_layer` was
-> `absent` (the workload writes OTel spans but does not yet emit into
-> `$ASSAY_RUNNER_SDK_EVENT_LOG`). Live-eBPF byte-identical archive
-> determinism is an explicit non-goal. See
+> **Status:** v1 baselines and Slice 2-4 follow-ups landed. Arm B
+> (trace-only, macOS local, n=3 + dual-simulation), Arm C (delegated
+> `assay-bpf-runner`, n=3 with real Linux/eBPF capture), SDK-layer
+> ingestion, tool-level `gen_ai.tool.call.id` join, and the controlled
+> tool-call argument tampering scenario all have committed evidence.
+> Run-level `assay.run.id` + `assay.archive.manifest_digest` binding
+> and tool-level L1/L2 join are verifiable from the committed
+> artefacts. Live-eBPF byte-identical archive determinism is an
+> explicit non-goal. OpenInference vocabulary outreach is filed as
+> [Arize-ai/openinference#3162](https://github.com/Arize-ai/openinference/issues/3162);
+> blog/publication drafts remain gated on maintainer triage. See
 > [`runner-vs-otel-2026-05/v1-findings.md`](runner-vs-otel-2026-05/v1-findings.md)
 > for the per-run evidence and refined claims.
 >
-> **Last updated:** 2026-05-24
+> **Last updated:** 2026-05-25
 >
 > **Scope:** compare an Assay-Runner measured-run archive with an
 > OpenTelemetry-family trace for the same deterministic agent workload. This is
@@ -93,7 +95,7 @@ Use the same deterministic agent workload in all arms.
 |---|---:|---:|---|
 | A - Runner only | Yes | No | Establish measured-run baseline (capability surface + health gates) on a known-good archive. Archive shape stability across n=3 is the target; cross-run byte identity is a non-goal under live eBPF capture (run id, timestamps, PIDs, inodes vary). |
 | B - Trace only | No | Yes | Establish trace shape without eBPF/cgroup capture. |
-| C - Dual capture | Yes | Yes | Main comparison arm. v1 demonstrates run-level binding via `assay.run.id` + `assay.archive.manifest_digest`. Tool-level `gen_ai.tool.call.id` join across L1 and L2 is gated on the SDK-layer ingestion fix (Slice 2) — see v1-findings.md. |
+| C - Dual capture | Yes | Yes | Main comparison arm. v1 demonstrates run-level binding via `assay.run.id` + `assay.archive.manifest_digest`; Slice 2 demonstrates tool-level `gen_ai.tool.call.id` join across L1 and L2; Slice 3 demonstrates reported intent vs measured effect divergence at the same tool call. |
 
 v1 should run arm C at least three times for shape stability and archive
 determinism. Overhead measurements need a larger sample; see
@@ -118,15 +120,17 @@ single-runtime shape comparison is stable.
 
 ## v1.5 Adversarial Scenario
 
-Do not let this disappear into a vague follow-up. Plan it as v1.5:
+This scenario is now demonstrated by Slice 3 evidence under
+[`runner-vs-otel-2026-05/runs/slice3-arm-c/`](runner-vs-otel-2026-05/runs/slice3-arm-c/).
+The original planned shape was:
 
 | Scenario | Reported L1 behavior | Measured L2 behavior | Why it matters |
 |---|---|---|---|
 | Tool-call argument tampering | `gen_ai.tool.name = fs.read`, `gen_ai.tool.call.arguments.path = /workdir/safe.txt` | kernel layer observes open/read outside the reported path, such as a normalized traversal to `/etc/passwd` or a controlled test file outside workdir | Demonstrates L1 intent/reporting can diverge from L2 effects. |
 
-Use a safe fixture path rather than a real sensitive file if possible. The
-claim is not "the agent stole secrets"; the claim is "reported tool arguments
-and measured filesystem effects can diverge."
+The implemented scenario uses a safe fixture path rather than a real
+sensitive file. The claim is not "the agent stole secrets"; the claim is
+"reported tool arguments and measured filesystem effects can diverge."
 
 ## Trace Attribute Plan
 
@@ -357,12 +361,12 @@ Markdown table.
 
 | Field | L1 Trace | L2 Archive | Join Key | Claim Strength | Notes |
 |---|---|---|---|---|---|
-| `gen_ai.provider.name` | TODO | TODO | run | Positive observation | |
-| `gen_ai.tool.call.id` | TODO | TODO | tool | Joinability | |
-| `assay.archive.manifest_digest` | TODO | TODO | digest | Tamper-evident binding | |
-| `capability_surface.filesystem_paths` | TODO | TODO | none | Bounded negative if healthy | |
-| `observation_health.ringbuf_drops` | no | TODO | archive | Measurement integrity | |
-| `gen_ai.usage.input_tokens` | TODO | no | span | Cost/context | |
+| `gen_ai.provider.name` | yes (`openai`) | no | run | Positive observation | Present in the OTel trace; not a Runner archive field. |
+| `gen_ai.tool.call.id` | yes (`tc_runner_policy_001`) | yes after Slice 2 SDK ingestion | tool | Joinability | Primary tool-level join works in `runs/slice2-arm-c/` and `runs/slice3-arm-c/`. |
+| `assay.archive.manifest_digest` | yes | yes (`manifest.json` digest) | digest | Tamper-evident binding | All committed Arm C runs pass `--require-binding-match`. |
+| `capability_surface.filesystem_paths` | no | yes | none | Bounded negative if healthy | L2-only measured effect surface. |
+| `observation_health.ringbuf_drops` | no | yes (`0`) | archive | Measurement integrity | Hard gate is clean across committed delegated runs. |
+| `gen_ai.usage.input_tokens` | absent in deterministic fixture trace | no | span | Cost/context | Requires provider/runtime usage reporting; not demonstrated by this fixture. |
 
 ## Claim Classes
 
@@ -444,17 +448,24 @@ Keep the discussion narrow. Ask for naming and domain placement, not adoption.
 
 ## Reproduction Checklist
 
-Fill this section after implementation.
+The implementation package now carries concrete commands and committed
+evidence:
 
-```bash
-# TODO: build assay with runner feature
-# TODO: run deterministic workload under Runner only
-# TODO: run deterministic workload under OTel/OpenInference only
-# TODO: run dual-capture workload
-# TODO: extract manifest.json and compute digest
-# TODO: generate normalized comparison JSON
-# TODO: generate Markdown field matrix
-```
+- local trace-only Arm B: [`runner-vs-otel-2026-05/run-arm-b.sh`](runner-vs-otel-2026-05/run-arm-b.sh);
+- delegated Arm C workflow:
+  [`.github/workflows/runner-otel-experiment.yml`](../../.github/workflows/runner-otel-experiment.yml);
+- comparator:
+  [`runner-vs-otel-2026-05/compare/compare.py`](runner-vs-otel-2026-05/compare/compare.py);
+- baseline evidence:
+  [`runner-vs-otel-2026-05/runs/`](runner-vs-otel-2026-05/runs/);
+- findings and exact run links:
+  [`runner-vs-otel-2026-05/v1-findings.md`](runner-vs-otel-2026-05/v1-findings.md).
+
+Use the `v1-findings.md` reproduction details as the source of truth for
+the commands that produced the committed evidence. Overhead
+measurements (`n>=20` wall clock, `n>=5` RSS) and the L3
+Tetragon/Falco/Tracee comparison remain explicit follow-ups rather than
+missing v1 checklist items.
 
 ## References to Verify Before Publication
 


### PR DESCRIPTION
Summary

Syncs the runner-vs-OTel experiment roadmap/docs with the evidence that has already landed on main.

What changed

- Updates the plan-doc status from "tool-level join not yet demonstrated" to the current truth: SDK-layer ingestion, tool-level L1/L2 join, and the controlled tool-call argument tampering scenario all have committed evidence.
- Replaces stale TODO field-matrix/reproduction checklist rows with observed values and links to the implementation package, runs, comparator, workflow, and findings doc.
- Updates the experiment package README from "data collection requires delegated host" to "evidence landed" and fixes the comparator test command/count (17 tests).
- Updates v1-findings.md to say publication drafts are committed and the OpenInference vocabulary question is filed as Arize-ai/openinference#3162.

What this does not do

- No new experiment evidence.
- No artifact re-render.
- No publication/blog posting.
- No new product claim beyond the already committed Slice 2/3/4 evidence.

Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-2026-05/compare/tests -p 'test_*.py'` -> 17 OK
- `git diff --check`
- Local changed-doc markdown link check
