### PR TITLE
chore(release): prepare v3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,106 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.12.0] - 2026-05-25
+
+> **Runner evidence and drift-reporting release.**
+>
+> `v3.12.0` turns the post-`v3.11.3` measured-run work into a release
+> line: real Linux/eBPF experiment packages, runtime-drift projection
+> reports, schema sidecars, and release-grade provenance around how drift
+> reports were rendered. The new surfaces remain low-level and
+> evidence-first. They do not introduce new Trust Card claims, policy
+> verdicts, or standalone guarantees for the `assay-runner-*` crates.
+
+### Runner-vs-OTel / OpenInference experiment package
+
+- Added the `runner-vs-otel-2026-05` experiment package with a controlled
+  three-arm comparison between in-process OTel/OpenInference-style traces
+  and out-of-band Runner archives captured with Linux/eBPF + cgroup-v2.
+- Recorded real delegated Arm C baselines (`n=3`) with per-run
+  tamper-evident manifest binding, clean measurement-health gates
+  (`ringbuf_drops=0`, `kernel_layer=complete`,
+  `cgroup_correlation=clean`), and explicit non-claims around archive byte
+  determinism.
+- Added SDK-layer ingestion for tool-level `gen_ai.tool.call.id` joins and
+  a controlled tool-call argument tampering scenario where reported intent
+  and measured filesystem effect diverge at the same tool call id.
+- Added publication drafts and the filed OpenInference vocabulary discussion
+  framing for runtime-evidence artifact links. The ask stays vocabulary-only:
+  no request for OpenInference or OTel to adopt Assay-Runner.
+
+### Cross-runtime drift experiment package
+
+- Added the `cross-runtime-drift-2026-05` experiment package: workload
+  contract, OpenAI Agents and Google GenAI implementations, stdlib contract
+  checker, delegated runner workflow, live Arm A0/B0 baselines, and a
+  stdlib drift comparator.
+- Added path projection v0 and network projection v0 as additive report
+  projections. Raw observed values remain the source of truth; declared
+  projection aliases add logical labels such as `workdir/input`,
+  `workdir/output`, and `dns` without claiming semantic equivalence.
+- Added runtime/noise taxonomy v0 as vocabulary-only metadata. The taxonomy
+  travels with drift reports but does not yet classify raw paths or endpoints
+  heuristically.
+- Added drift-report provenance v0 and render metadata so each report
+  records the capture anchor, comparator/render anchor, workflow URL, runner
+  schema versions, and whether committed reports are re-renders over
+  unchanged raw archives.
+- Polished drift-report UX: compact projection mappings, per-arm unmatched
+  summaries, deduplicated Markdown `raw -> projected` examples, and
+  regenerated committed drift reports with self-contained provenance.
+
+### Runner artifact contracts and schema validation
+
+- Hardened Linux cgroup root selection for delegated runner-spike runs under
+  `sudo`: systemd `*.scope` cgroups are now treated as leaf scopes and the
+  runner ascends to the surrounding slice before creating the Assay session
+  cgroup. This avoids `Operation not supported (os error 95)` failures on
+  revived self-hosted runner services.
+- Added kernel-event metadata support for `openat` / `openat2` observations:
+  decoded flags, access mode, operation flags, return value, and
+  success/error status where available. This improves file-operation
+  granularity without overclaiming read/write semantics outside the captured
+  metadata.
+- Added JSON Schema sidecars for the runtime drift report and kernel event
+  NDJSON line shape, plus stdlib schema-walker tests that validate committed
+  fixtures and examples without adding a test-time `jsonschema` dependency.
+- Tightened schema documentation around nullable-required fields, git commit
+  anchors versus content-addressed `sha256:` digests, `kind` /
+  `event_type` consistency, and committed re-render path conventions.
+
+### Release and CI hygiene
+
+- Synced the Runner-vs-OTel and cross-runtime drift roadmaps so completed
+  slices on `main` are clearly distinguished from future follow-ups.
+- Kept release-truth wording bounded: experiment artifacts and reports are
+  committed evidence packages, not product endorsements, Trust Card claims,
+  or policy verdicts.
+- Updated the release checklist to include the four `assay-runner-*` crates
+  in the Trusted Publishing review, matching the public-crate contract that
+  `v3.11.3` established.
+
+### Known follow-ups
+
+- Runtime drift `unmatched_summary` is emitted in a stable shape but the
+  current `runtime-drift-v0` schema only types it as an object. A future
+  v0.2 schema bump should lock the per-arm summary sub-shape.
+- Drift projections still avoid heuristic path/runtime noise classification.
+  Unknown raw values remain raw until a declared projection rule or a future
+  taxonomy rule classifies them.
+- The Runner-vs-OTel and cross-runtime experiments do not yet include
+  statistically powered overhead measurements or an L3 generic kernel
+  observability comparison.
+
+### Non-change
+
+- No new Trust Basis or Trust Card claim family ships in this release.
+- No new public guarantee is made for the `assay-runner-*` crates beyond the
+  `v3.11.3` framing: they remain internal/experimental substrate crates
+  published so `assay-cli` can resolve its default `runner` feature.
+- The cross-runtime drift reports are comparison/projection artifacts, not a
+  policy verdict about which runtime is "better" or "safer".
+
 ## [3.11.3] - 2026-05-23
 
 > **Public crate contract update for Assay-Runner substrate.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-spike"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "assay-runner-core",
  "assay-runner-schema",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.11.3"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.11.3"
+version = "3.12.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -74,19 +74,19 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.11.3" }
-assay-common = { path = "crates/assay-common", version = "3.11.3", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.11.3" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.11.3" }
-assay-policy = { path = "crates/assay-policy", version = "3.11.3" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.11.3" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.11.3" }
-assay-sim = { path = "crates/assay-sim", version = "3.11.3" }
-assay-registry = { path = "crates/assay-registry", version = "3.11.3" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.11.3" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.11.3" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.11.3" }
-assay-runner-spike = { path = "crates/assay-runner-spike", version = "3.11.3" }
+assay-core = { path = "crates/assay-core", version = "3.12.0" }
+assay-common = { path = "crates/assay-common", version = "3.12.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.12.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.12.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.12.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.12.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.12.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.12.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.12.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.12.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.12.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.12.0" }
+assay-runner-spike = { path = "crates/assay-runner-spike", version = "3.12.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/crates/assay-runner-linux/src/cgroup.rs
+++ b/crates/assay-runner-linux/src/cgroup.rs
@@ -68,7 +68,7 @@ impl CgroupManager {
         loop {
             let cgroup_type = fs::read_to_string(path.join("cgroup.type"))
                 .with_context(|| format!("Failed to read cgroup type for {}", path.display()))?;
-            if cgroup_type.trim() == "domain" {
+            if cgroup_type.trim() == "domain" && !Self::is_systemd_scope(&path) {
                 return Ok(path);
             }
 
@@ -84,6 +84,12 @@ impl CgroupManager {
                 .ok_or_else(|| anyhow!("Could not ascend from cgroup path {}", path.display()))?
                 .to_path_buf();
         }
+    }
+
+    fn is_systemd_scope(path: &Path) -> bool {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".scope"))
     }
 
     /// Creates a new ephemeral cgroup.
@@ -305,6 +311,28 @@ mod tests {
             CgroupManager::nearest_domain_root(&root, service).expect("resolve domain root");
 
         assert_eq!(resolved, system_slice);
+        fs::remove_dir_all(root).expect("remove temp cgroup tree");
+    }
+
+    #[test]
+    fn nearest_domain_root_ascends_from_systemd_session_scope() {
+        let root = temp_cgroup_tree("session-scope");
+        let user_slice = root.join("user.slice");
+        let user_id_slice = user_slice.join("user-1000.slice");
+        let session_scope = user_id_slice.join("session-263.scope");
+        fs::create_dir_all(&session_scope).expect("create fake session cgroup");
+        fs::write(root.join("cgroup.type"), "domain\n").expect("write root cgroup type");
+        fs::write(user_slice.join("cgroup.type"), "domain\n")
+            .expect("write user slice cgroup type");
+        fs::write(user_id_slice.join("cgroup.type"), "domain\n")
+            .expect("write user id slice cgroup type");
+        fs::write(session_scope.join("cgroup.type"), "domain\n")
+            .expect("write session scope cgroup type");
+
+        let resolved =
+            CgroupManager::nearest_domain_root(&root, session_scope).expect("resolve domain root");
+
+        assert_eq!(resolved, user_id_slice);
         fs::remove_dir_all(root).expect("remove temp cgroup tree");
     }
 }

--- a/docs/reference/release.md
+++ b/docs/reference/release.md
@@ -23,6 +23,10 @@ This document outlines the canonical checklist for releasing new versions of Ass
   - `assay-policy`
   - `assay-mcp-server`
   - `assay-monitor`
+  - `assay-runner-schema`
+  - `assay-runner-linux`
+  - `assay-runner-core`
+  - `assay-runner-spike`
   - `assay-sim`
   - `assay-cli`
 - [ ] **Non-crates.io workspace members**: Confirm these remain `publish = false` unless a dedicated distribution freeze changes the contract:


### PR DESCRIPTION
## Summary

Prepare the `v3.12.0` release line after the Runner evidence and runtime-drift reporting work that landed since `v3.11.3`.

This is a release-prep PR only: it updates repository release truth, but does not tag, publish crates, or create a GitHub Release by itself.

## What changed

- Bump the workspace package version and internal workspace dependency pins from `3.11.3` to `3.12.0`.
- Refresh `Cargo.lock` for the new workspace version.
- Add the `3.12.0` changelog entry covering:
  - Runner-vs-OTel / OpenInference experiment package
  - Cross-runtime drift experiment package
  - path/network projection, runtime/noise taxonomy, drift-report provenance, render metadata, compact projection UX
  - kernel-event metadata schema sidecar and validation
  - explicit non-claims around Trust Card/Trust Basis, policy verdicts, and standalone runner crate guarantees
- Update the release checklist so Trusted Publishing review includes the four `assay-runner-*` crates that became part of the public-crate contract in `v3.11.3`.

## Validation

- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --workspace`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --workspace --locked`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets -- -D warnings`
- `bash scripts/ci/check-public-crate-policy.sh`
- `bash scripts/ci/check_assay_cli_publish_shape.sh`
- `git diff --check`
- `cargo publish --package assay-common --dry-run --allow-dirty`
- `cargo publish --package assay-runner-schema --dry-run --allow-dirty`

Note: local Python is 3.14, while PyO3 0.24.2 supports up to Python 3.13 unless `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` is set. The release-prep checks were run with that env var for the workspace/PyO3 path.

## After merge

1. Tag `v3.12.0` from `main`.
2. Push the tag and monitor `.github/workflows/release.yml`.
3. Confirm crates.io publish, release assets, SBOM, MCPB, provenance, proof kit, and offline verification per `docs/reference/release.md`.
