### PR TITLE
chore(deps): roll up cargo patch bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,9 +2652,9 @@ checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "landlock"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
 dependencies = [
  "enumflags2",
  "libc",
@@ -4508,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4663,9 +4663,9 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
 dependencies = [
  "bstr",
 ]

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -82,7 +82,7 @@ ratatui = { workspace = true, optional = true }
 crossterm = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-landlock = "=0.4.4"
+landlock = "=0.4.5"
 
 
 


### PR DESCRIPTION
Summary
Rolls up the three open Dependabot Cargo patch bumps into one maintainer PR so we only need one up-to-date CI/delegated proof on current main:

- landlock 0.4.4 -> 0.4.5
- similar 3.1.0 -> 3.1.1
- serde_json 1.0.149 -> 1.0.150

Why rollup
The individual Dependabot PRs were behind main and each Cargo.lock change trips the Assay-Runner lane policy (`gates=all`). Updating them separately would require three fresh delegated proofs. This PR carries the same dependency changes together and supersedes #1373, #1374, and #1375.

Local validation
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --workspace --locked`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets -- -D warnings`
- `bash scripts/ci/check-public-crate-policy.sh`
- `bash scripts/ci/check_assay_cli_publish_shape.sh`
- `git diff --check`
- pre-commit + pre-push hooks

Next
- Dispatch `Runner Spike Delegated` with `gates=all` for this PR head.
- Close the three Dependabot PRs as superseded after this PR is green/merged.