### PR TITLE
feat(experiments): runner-vs-otel overhead Slice 1 harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
   fixes the sample sizes, host-boundary rules, BMF-compatible output
   shape, and non-claims required before publishing wall-clock or RSS
   numbers.
+- Added the Slice 1 local Arm B overhead harness with
+  `assay.experiment.overhead_sample.v0` /
+  `assay.experiment.overhead_summary.v0` schema sidecars and tests. The
+  harness emits local measurement artifacts but does not commit or
+  publish benchmark numbers.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-2026-05/.gitignore
+++ b/docs/experiments/runner-vs-otel-2026-05/.gitignore
@@ -2,4 +2,5 @@ workload/node_modules/
 workload/dist/
 workload/package-lock.json
 runs/run_*/
+runs/overhead-2026-05/
 !runs/v1-baseline/

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -5,6 +5,10 @@
 > [`runner-vs-otel-2026-05`](runner-vs-otel-2026-05/) into a reproducible
 > measurement plan. It does not add live measurements, does not publish a
 > benchmark claim, and does not change Runner archive semantics.
+>
+> **Slice 1 status:** local Arm B harness and schema sidecars live under
+> [`runner-vs-otel-overhead-2026-05/`](runner-vs-otel-overhead-2026-05/).
+> Generated measurements are still not committed evidence.
 
 ## Research Question
 
@@ -259,7 +263,7 @@ investigation before publication.
 | Slice | Deliverable | Gate |
 |---|---|---|
 | 0 | This plan doc | Links from runner-vs-otel plan and README |
-| 1 | Local harness for Arm B wall-clock + size output, plus `overhead-sample-v0` and `overhead-summary-v0` schema sidecars | n=20 local dry run, no live API dependency, sidecar tests pass |
+| 1 | **Done**: local harness for Arm B wall-clock + size output, plus `overhead-sample-v0` and `overhead-summary-v0` schema sidecars | n=20 local dry run, no live API dependency, sidecar tests pass |
 | 2 | Delegated Arm C harness with health-gated samples | n=20 on `assay-bpf-runner`, all health gates clean |
 | 3 | RSS collection per arm | n=5 per arm, platform-specific parser tests, tool versions recorded per sample |
 | 4 | Summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -1,0 +1,45 @@
+# Runner vs OTel Overhead Harness
+
+> **Status:** Slice 1 local Arm B harness. This directory contains the
+> experiment-scoped measurement harness and schema sidecars for the
+> plan in [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
+> It does not contain committed benchmark results.
+
+## What This Emits
+
+The local harness writes:
+
+- `arm-b-otel/samples.jsonl` using
+  `assay.experiment.overhead_sample.v0`;
+- `arm-b-otel/summary.json` using
+  `assay.experiment.overhead_summary.v0`;
+- `artifacts/bmf.json`, a derived Bencher Metric Format export whose
+  metric keys map to `{ "value": ... }` objects.
+
+The experiment schemas are intentionally not Runner archive contracts.
+They are local measurement evidence for the overhead follow-up only.
+
+## Local Smoke
+
+From the repository root:
+
+```bash
+python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
+  --iterations 1 \
+  --skip-build \
+  --clean \
+  --out-dir "$(mktemp -d)/overhead"
+```
+
+For the Slice 1 acceptance dry run, use `--iterations 20` and a
+temporary output directory. Do not commit generated measurements until
+the findings slice decides what should become evidence. The default
+`runs/overhead-2026-05/` output path is ignored for this reason.
+
+## Tests
+
+```bash
+python3 -m unittest discover \
+  -s docs/experiments/runner-vs-otel-overhead-2026-05 \
+  -p 'test_*.py'
+```

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -14,7 +14,11 @@ The local harness writes:
 - `arm-b-otel/summary.json` using
   `assay.experiment.overhead_summary.v0`;
 - `artifacts/bmf.json`, a derived Bencher Metric Format export whose
-  metric keys map to `{ "value": ... }` objects.
+  metric keys map to `{ "value": ... }` objects;
+- `artifacts/trace-sizes.json`, a trace-size side artifact for overhead
+  bookkeeping; and
+- `artifacts/archive-sizes.json`, an archive-size side artifact that is
+  present but empty for Slice 1.
 
 The experiment schemas are intentionally not Runner archive contracts.
 They are local measurement evidence for the overhead follow-up only.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Local Arm B overhead harness for runner-vs-OTel.
+
+Slice 1 intentionally measures only the local OTel-only workload path.
+It emits experiment-scoped samples and summaries; the optional BMF file
+is derived from the summary and is the only Bencher-shaped artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import platform
+import shutil
+import socket
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+EXPERIMENT = "runner-vs-otel-overhead-2026-05"
+SAMPLE_SCHEMA = "assay.experiment.overhead_sample.v0"
+SUMMARY_SCHEMA = "assay.experiment.overhead_summary.v0"
+DEFAULT_ARM = "arm-b-otel"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def default_workload_dir() -> Path:
+    return repo_root() / "docs/experiments/runner-vs-otel-2026-05/workload"
+
+
+def default_out_dir() -> Path:
+    return (
+        repo_root()
+        / "docs/experiments/runner-vs-otel-2026-05/runs/overhead-2026-05"
+    )
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def run_text(command: list[str], cwd: Path | None = None) -> str | None:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip().splitlines()[0] if result.stdout.strip() else None
+
+
+def assay_commit() -> str:
+    return run_text(["git", "rev-parse", "--short=8", "HEAD"], repo_root()) or "unknown"
+
+
+def host_class() -> str:
+    parts = [
+        platform.system().lower() or "unknown",
+        platform.machine().lower() or "unknown",
+        (platform.release() or "unknown").replace(" ", "_"),
+    ]
+    return "-".join(part.replace("/", "_") for part in parts)
+
+
+def tool_versions(workload_dir: Path) -> dict[str, str | None]:
+    return {
+        "python": platform.python_version(),
+        "node": run_text(["node", "--version"]),
+        "npm": run_text(["npm", "--version"]),
+        "hyperfine": run_text(["hyperfine", "--version"]),
+        "time": "python-time.perf_counter",
+        "workload_package": run_text(
+            ["node", "-p", "require('./package.json').version"], workload_dir
+        ),
+    }
+
+
+def ensure_workload_built(workload_dir: Path, *, skip_build: bool) -> None:
+    if skip_build:
+        return
+    if not (workload_dir / "node_modules").exists():
+        subprocess.run(
+            ["npm", "install", "--no-audit", "--no-fund", "--ignore-scripts"],
+            cwd=workload_dir,
+            check=True,
+        )
+    subprocess.run(["npx", "tsc", "-p", "tsconfig.json"], cwd=workload_dir, check=True)
+
+
+def file_size(path: Path) -> int | None:
+    return path.stat().st_size if path.exists() else None
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, math.ceil((pct / 100.0) * len(ordered)) - 1))
+    return ordered[index]
+
+
+def median(values: list[float]) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+def one_sample(
+    *,
+    arm_dir: Path,
+    workload_dir: Path,
+    iteration: int,
+    commit: str,
+    versions: dict[str, str | None],
+) -> dict[str, Any]:
+    run_id = f"overhead_arm_b_{iteration:03d}"
+    run_dir = arm_dir / f"run_{iteration:03d}"
+    work_dir = run_dir / "work"
+    trace_path = run_dir / "trace.json"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    started_at = utc_now()
+    command = [
+        "node",
+        "dist/workload.js",
+        "--run-id",
+        run_id,
+        "--work-dir",
+        str(work_dir),
+        "--trace-out",
+        str(trace_path),
+    ]
+
+    start = time.perf_counter()
+    result = subprocess.run(
+        command,
+        cwd=workload_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    (run_dir / "stdout.log").write_text(result.stdout, encoding="utf-8")
+    (run_dir / "stderr.log").write_text(result.stderr, encoding="utf-8")
+
+    return {
+        "schema": SAMPLE_SCHEMA,
+        "experiment": EXPERIMENT,
+        "arm": DEFAULT_ARM,
+        "iteration": iteration,
+        "host": socket.gethostname(),
+        "host_class": host_class(),
+        "assay_commit": commit,
+        "started_at": started_at,
+        "tool_versions": versions,
+        "wall_clock_ms": elapsed_ms,
+        "peak_rss_bytes": None,
+        "exit_code": result.returncode,
+        "health": None,
+        "artifact_bytes": {
+            "trace_json": file_size(trace_path),
+            "archive_targz": None,
+            "archive_extracted": None,
+        },
+    }
+
+
+def summarize(
+    samples: list[dict[str, Any]],
+    *,
+    delegated_workflow_url: str | None,
+) -> dict[str, Any]:
+    valid = [sample for sample in samples if sample["exit_code"] == 0]
+    wall = [float(sample["wall_clock_ms"]) for sample in valid]
+    rss = [
+        int(sample["peak_rss_bytes"])
+        for sample in valid
+        if sample.get("peak_rss_bytes") is not None
+    ]
+    trace_sizes = [
+        int(sample["artifact_bytes"]["trace_json"])
+        for sample in valid
+        if sample["artifact_bytes"].get("trace_json") is not None
+    ]
+    archive_targz = [
+        int(sample["artifact_bytes"]["archive_targz"])
+        for sample in valid
+        if sample["artifact_bytes"].get("archive_targz") is not None
+    ]
+    archive_extracted = [
+        int(sample["artifact_bytes"]["archive_extracted"])
+        for sample in valid
+        if sample["artifact_bytes"].get("archive_extracted") is not None
+    ]
+    wall_median = median(wall)
+    wall_p99 = percentile(wall, 99)
+    first = samples[0] if samples else {}
+    return {
+        "schema": SUMMARY_SCHEMA,
+        "experiment": EXPERIMENT,
+        "arm": DEFAULT_ARM,
+        "host": first.get("host", socket.gethostname()),
+        "host_class": first.get("host_class", host_class()),
+        "kernel": platform.release(),
+        "assay_commit": first.get("assay_commit", assay_commit()),
+        "delegated_workflow_url": delegated_workflow_url,
+        "valid_samples": len(valid),
+        "discarded_samples": len(samples) - len(valid),
+        "wall_clock_ms": {
+            "median": wall_median,
+            "p95": percentile(wall, 95),
+            "p99": wall_p99,
+            "p99_over_median": (wall_p99 / wall_median)
+            if wall_p99 is not None and wall_median
+            else None,
+        },
+        "peak_rss_bytes": {
+            "median": median([float(value) for value in rss]),
+            "max": max(rss) if rss else None,
+        },
+        "artifact_bytes": {
+            "trace_json_median": median([float(value) for value in trace_sizes]),
+            "archive_targz_median": median([float(value) for value in archive_targz]),
+            "archive_extracted_median": median(
+                [float(value) for value in archive_extracted]
+            ),
+        },
+    }
+
+
+def bmf_export(summary: dict[str, Any]) -> dict[str, dict[str, float | int]]:
+    prefix = "runner_vs_otel.arm_b"
+    values: dict[str, float | int | None] = {
+        f"{prefix}.wall_clock_ms.median": summary["wall_clock_ms"]["median"],
+        f"{prefix}.wall_clock_ms.p95": summary["wall_clock_ms"]["p95"],
+        f"{prefix}.wall_clock_ms.p99": summary["wall_clock_ms"]["p99"],
+        f"{prefix}.wall_clock_ms.p99_over_median": summary["wall_clock_ms"][
+            "p99_over_median"
+        ],
+        f"{prefix}.artifact_bytes.trace_json_median": summary["artifact_bytes"][
+            "trace_json_median"
+        ],
+    }
+    return {key: {"value": value} for key, value in values.items() if value is not None}
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--out-dir", type=Path, default=default_out_dir())
+    parser.add_argument("--workload-dir", type=Path, default=default_workload_dir())
+    parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--clean", action="store_true")
+    parser.add_argument("--delegated-workflow-url")
+    args = parser.parse_args(argv)
+
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    if args.clean and args.out_dir.exists():
+        shutil.rmtree(args.out_dir)
+
+    ensure_workload_built(args.workload_dir, skip_build=args.skip_build)
+    arm_dir = args.out_dir / DEFAULT_ARM
+    artifacts_dir = args.out_dir / "artifacts"
+    arm_dir.mkdir(parents=True, exist_ok=True)
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    commit = assay_commit()
+    versions = tool_versions(args.workload_dir)
+    samples = [
+        one_sample(
+            arm_dir=arm_dir,
+            workload_dir=args.workload_dir,
+            iteration=iteration,
+            commit=commit,
+            versions=versions,
+        )
+        for iteration in range(1, args.iterations + 1)
+    ]
+    summary = summarize(samples, delegated_workflow_url=args.delegated_workflow_url)
+
+    samples_path = arm_dir / "samples.jsonl"
+    samples_path.write_text(
+        "".join(json.dumps(sample, sort_keys=True) + "\n" for sample in samples),
+        encoding="utf-8",
+    )
+    write_json(arm_dir / "summary.json", summary)
+    write_json(
+        artifacts_dir / "trace-sizes.json",
+        {
+            "arm": DEFAULT_ARM,
+            "trace_json_bytes": [
+                sample["artifact_bytes"]["trace_json"] for sample in samples
+            ],
+        },
+    )
+    write_json(
+        artifacts_dir / "archive-sizes.json",
+        {
+            "arm": DEFAULT_ARM,
+            "archive_targz_bytes": [],
+            "archive_extracted_bytes": [],
+        },
+    )
+    write_json(artifacts_dir / "bmf.json", bmf_export(summary))
+
+    print(f"wrote {samples_path}")
+    print(f"wrote {arm_dir / 'summary.json'}")
+    print(f"wrote {artifacts_dir / 'bmf.json'}")
+    if summary["valid_samples"] != args.iterations:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -63,7 +63,10 @@ def run_text(command: list[str], cwd: Path | None = None) -> str | None:
 
 
 def assay_commit() -> str:
-    return run_text(["git", "rev-parse", "--short=8", "HEAD"], repo_root()) or "unknown"
+    commit = run_text(["git", "rev-parse", "--short=8", "HEAD"], repo_root())
+    if not commit:
+        raise RuntimeError("could not resolve git commit for overhead sample provenance")
+    return commit
 
 
 def host_class() -> str:
@@ -76,14 +79,19 @@ def host_class() -> str:
 
 
 def tool_versions(workload_dir: Path) -> dict[str, str | None]:
+    def clean(value: str | None) -> str | None:
+        if value in (None, "", "undefined"):
+            return None
+        return value
+
     return {
         "python": platform.python_version(),
-        "node": run_text(["node", "--version"]),
-        "npm": run_text(["npm", "--version"]),
-        "hyperfine": run_text(["hyperfine", "--version"]),
+        "node": clean(run_text(["node", "--version"])),
+        "npm": clean(run_text(["npm", "--version"])),
+        "hyperfine": clean(run_text(["hyperfine", "--version"])),
         "time": "python-time.perf_counter",
-        "workload_package": run_text(
-            ["node", "-p", "require('./package.json').version"], workload_dir
+        "workload_package": clean(
+            run_text(["node", "-p", "require('./package.json').version"], workload_dir)
         ),
     }
 
@@ -122,6 +130,12 @@ def median(values: list[float]) -> float | None:
     return (ordered[mid - 1] + ordered[mid]) / 2
 
 
+def normalized_exit_code(returncode: int) -> int:
+    if returncode < 0:
+        return 128 + abs(returncode)
+    return returncode
+
+
 def one_sample(
     *,
     arm_dir: Path,
@@ -129,6 +143,7 @@ def one_sample(
     iteration: int,
     commit: str,
     versions: dict[str, str | None],
+    timeout_seconds: float,
 ) -> dict[str, Any]:
     run_id = f"overhead_arm_b_{iteration:03d}"
     run_dir = arm_dir / f"run_{iteration:03d}"
@@ -148,16 +163,26 @@ def one_sample(
     ]
 
     start = time.perf_counter()
-    result = subprocess.run(
-        command,
-        cwd=workload_dir,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            command,
+            cwd=workload_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout_seconds,
+        )
+        stdout = result.stdout
+        stderr = result.stderr
+        exit_code = normalized_exit_code(result.returncode)
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        stderr += f"\noverhead harness timeout after {timeout_seconds} seconds\n"
+        exit_code = 124
     elapsed_ms = (time.perf_counter() - start) * 1000.0
-    (run_dir / "stdout.log").write_text(result.stdout, encoding="utf-8")
-    (run_dir / "stderr.log").write_text(result.stderr, encoding="utf-8")
+    (run_dir / "stdout.log").write_text(stdout, encoding="utf-8")
+    (run_dir / "stderr.log").write_text(stderr, encoding="utf-8")
 
     return {
         "schema": SAMPLE_SCHEMA,
@@ -171,7 +196,7 @@ def one_sample(
         "tool_versions": versions,
         "wall_clock_ms": elapsed_ms,
         "peak_rss_bytes": None,
-        "exit_code": result.returncode,
+        "exit_code": exit_code,
         "health": None,
         "artifact_bytes": {
             "trace_json": file_size(trace_path),
@@ -276,6 +301,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--skip-build", action="store_true")
     parser.add_argument("--clean", action="store_true")
     parser.add_argument("--delegated-workflow-url")
+    parser.add_argument("--timeout-seconds", type=float, default=300.0)
     args = parser.parse_args(argv)
 
     if args.iterations < 1:
@@ -298,6 +324,7 @@ def main(argv: list[str] | None = None) -> int:
             iteration=iteration,
             commit=commit,
             versions=versions,
+            timeout_seconds=args.timeout_seconds,
         )
         for iteration in range(1, args.iterations + 1)
     ]

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
@@ -57,11 +57,46 @@
     },
     "tool_versions": {
       "type": "object",
-      "additionalProperties": {
-        "type": [
-          "string",
-          "null"
-        ]
+      "additionalProperties": false,
+      "required": [
+        "python",
+        "node",
+        "npm",
+        "hyperfine",
+        "time",
+        "workload_package"
+      ],
+      "properties": {
+        "python": {
+          "type": "string"
+        },
+        "node": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "npm": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hyperfine": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "time": {
+          "const": "python-time.perf_counter"
+        },
+        "workload_package": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       }
     },
     "wall_clock_ms": {

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json",
+  "title": "Runner vs OTel overhead sample v0",
+  "description": "One experiment-scoped overhead measurement sample. This is not a Runner archive contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "experiment",
+    "arm",
+    "iteration",
+    "host",
+    "host_class",
+    "assay_commit",
+    "started_at",
+    "tool_versions",
+    "wall_clock_ms",
+    "peak_rss_bytes",
+    "exit_code",
+    "health",
+    "artifact_bytes"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.experiment.overhead_sample.v0"
+    },
+    "experiment": {
+      "const": "runner-vs-otel-overhead-2026-05"
+    },
+    "arm": {
+      "enum": [
+        "arm-b-otel",
+        "arm-c-dual-capture",
+        "arm-a-runner-only"
+      ]
+    },
+    "iteration": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "host": {
+      "type": "string",
+      "minLength": 1
+    },
+    "host_class": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+$"
+    },
+    "assay_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,64}$"
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "tool_versions": {
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "wall_clock_ms": {
+      "type": "number",
+      "minimum": 0
+    },
+    "peak_rss_bytes": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "exit_code": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "health": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kernel_layer",
+            "ringbuf_drops",
+            "cgroup_correlation"
+          ],
+          "properties": {
+            "kernel_layer": {
+              "type": "string"
+            },
+            "ringbuf_drops": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "cgroup_correlation": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "artifact_bytes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trace_json",
+        "archive_targz",
+        "archive_extracted"
+      ],
+      "properties": {
+        "trace_json": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "archive_targz": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "archive_extracted": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json",
+  "title": "Runner vs OTel overhead summary v0",
+  "description": "Aggregated experiment-scoped overhead measurements. This is not a Runner archive contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "experiment",
+    "arm",
+    "host",
+    "host_class",
+    "kernel",
+    "assay_commit",
+    "delegated_workflow_url",
+    "valid_samples",
+    "discarded_samples",
+    "wall_clock_ms",
+    "peak_rss_bytes",
+    "artifact_bytes"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.experiment.overhead_summary.v0"
+    },
+    "experiment": {
+      "const": "runner-vs-otel-overhead-2026-05"
+    },
+    "arm": {
+      "enum": [
+        "arm-b-otel",
+        "arm-c-dual-capture",
+        "arm-a-runner-only"
+      ]
+    },
+    "host": {
+      "type": "string",
+      "minLength": 1
+    },
+    "host_class": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+$"
+    },
+    "kernel": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "assay_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,64}$"
+    },
+    "delegated_workflow_url": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "valid_samples": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "discarded_samples": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "wall_clock_ms": {
+      "$ref": "#/$defs/wall_clock_stats"
+    },
+    "peak_rss_bytes": {
+      "$ref": "#/$defs/rss_stats"
+    },
+    "artifact_bytes": {
+      "$ref": "#/$defs/artifact_stats"
+    }
+  },
+  "$defs": {
+    "number_or_null": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "integer_or_null": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "wall_clock_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "median",
+        "p95",
+        "p99",
+        "p99_over_median"
+      ],
+      "properties": {
+        "median": {
+          "$ref": "#/$defs/number_or_null"
+        },
+        "p95": {
+          "$ref": "#/$defs/number_or_null"
+        },
+        "p99": {
+          "$ref": "#/$defs/number_or_null"
+        },
+        "p99_over_median": {
+          "$ref": "#/$defs/number_or_null"
+        }
+      }
+    },
+    "rss_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "median",
+        "max"
+      ],
+      "properties": {
+        "median": {
+          "$ref": "#/$defs/number_or_null"
+        },
+        "max": {
+          "$ref": "#/$defs/integer_or_null"
+        }
+      }
+    },
+    "artifact_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trace_json_median",
+        "archive_targz_median",
+        "archive_extracted_median"
+      ],
+      "properties": {
+        "trace_json_median": {
+          "$ref": "#/$defs/number_or_null"
+        },
+        "archive_targz_median": {
+          "$ref": "#/$defs/number_or_null"
+        },
+        "archive_extracted_median": {
+          "$ref": "#/$defs/number_or_null"
+        }
+      }
+    }
+  }
+}

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import re
+import tempfile
 import unittest
 from datetime import datetime
 from pathlib import Path
@@ -90,6 +90,8 @@ def assert_matches_schema(
         test.assertIn(payload, node["enum"], path)
     if "pattern" in node and isinstance(payload, str):
         test.assertRegex(payload, node["pattern"], path)
+    if "minLength" in node and isinstance(payload, str):
+        test.assertGreaterEqual(len(payload), node["minLength"], path)
     if node.get("format") == "date-time":
         value = payload.replace("Z", "+00:00")
         datetime.fromisoformat(value)
@@ -115,6 +117,32 @@ def assert_matches_schema(
                 )
 
 
+def write_stub_workload(root: Path) -> None:
+    (root / "dist").mkdir(parents=True)
+    (root / "package.json").write_text(
+        json.dumps({"name": "overhead-stub-workload", "version": "0.0.0"}),
+        encoding="utf-8",
+    )
+    (root / "dist" / "workload.js").write_text(
+        """
+const fs = require("fs");
+const path = require("path");
+const args = process.argv.slice(2);
+const get = (name) => {
+  const idx = args.indexOf(`--${name}`);
+  return idx >= 0 ? args[idx + 1] : undefined;
+};
+const traceOut = get("trace-out");
+const workDir = get("work-dir");
+fs.mkdirSync(path.dirname(traceOut), { recursive: true });
+fs.mkdirSync(workDir, { recursive: true });
+fs.writeFileSync(traceOut, JSON.stringify({ resourceSpans: [] }) + "\\n");
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 class OverheadHarnessTests(unittest.TestCase):
     def sample(self, **overrides: Any) -> dict[str, Any]:
         payload = {
@@ -129,8 +157,10 @@ class OverheadHarnessTests(unittest.TestCase):
             "tool_versions": {
                 "python": "3.12.0",
                 "node": "v22.16.0",
+                "npm": "10.0.0",
                 "hyperfine": None,
                 "time": "python-time.perf_counter",
+                "workload_package": "0.0.0",
             },
             "wall_clock_ms": 12.5,
             "peak_rss_bytes": None,
@@ -201,6 +231,65 @@ class OverheadHarnessTests(unittest.TestCase):
     def test_percentile_uses_nearest_rank(self) -> None:
         self.assertEqual(overhead_harness.percentile([1, 2, 3, 4, 5], 95), 5)
         self.assertEqual(overhead_harness.percentile([1, 2, 3, 4, 5], 50), 3)
+
+    def test_negative_returncode_is_schema_safe(self) -> None:
+        self.assertEqual(overhead_harness.normalized_exit_code(-15), 143)
+        self.assertEqual(overhead_harness.normalized_exit_code(2), 2)
+
+    def test_tool_versions_schema_rejects_typo_keys(self) -> None:
+        schema = load_schema("overhead-sample-v0.schema.json")
+        sample = self.sample()
+        sample["tool_versions"]["hyprfine"] = None
+        with self.assertRaises(AssertionError):
+            assert_matches_schema(self, sample, schema, root=schema)
+
+    def test_harness_emits_twenty_valid_stub_samples(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workload = root / "workload"
+            out_dir = root / "overhead"
+            write_stub_workload(workload)
+
+            status = overhead_harness.main(
+                [
+                    "--iterations",
+                    "20",
+                    "--skip-build",
+                    "--clean",
+                    "--timeout-seconds",
+                    "10",
+                    "--workload-dir",
+                    str(workload),
+                    "--out-dir",
+                    str(out_dir),
+                ]
+            )
+            self.assertEqual(status, 0)
+
+            samples = [
+                json.loads(line)
+                for line in (out_dir / "arm-b-otel" / "samples.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            summary = json.loads(
+                (out_dir / "arm-b-otel" / "summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            bmf = json.loads(
+                (out_dir / "artifacts" / "bmf.json").read_text(encoding="utf-8")
+            )
+
+            sample_schema = load_schema("overhead-sample-v0.schema.json")
+            summary_schema = load_schema("overhead-summary-v0.schema.json")
+            self.assertEqual(len(samples), 20)
+            for sample in samples:
+                assert_matches_schema(self, sample, sample_schema, root=sample_schema)
+            assert_matches_schema(self, summary, summary_schema, root=summary_schema)
+            self.assertEqual(summary["valid_samples"], 20)
+            self.assertEqual(summary["discarded_samples"], 0)
+            self.assertTrue(bmf)
 
 
 if __name__ == "__main__":

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -1,0 +1,207 @@
+"""Tests for the runner-vs-OTel overhead Slice 1 harness."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import unittest
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+HARNESS_PATH = ROOT / "overhead_harness.py"
+
+spec = importlib.util.spec_from_file_location("overhead_harness", HARNESS_PATH)
+assert spec is not None and spec.loader is not None
+overhead_harness = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(overhead_harness)
+
+
+def load_schema(name: str) -> dict[str, Any]:
+    return json.loads((ROOT / "schema" / name).read_text(encoding="utf-8"))
+
+
+def resolve_ref(schema: dict[str, Any], ref: str) -> dict[str, Any]:
+    if not ref.startswith("#/$defs/"):
+        raise AssertionError(f"unsupported $ref: {ref}")
+    target: Any = schema
+    for part in ref.removeprefix("#/").split("/"):
+        target = target[part]
+    if not isinstance(target, dict):
+        raise AssertionError(f"$ref did not resolve to object: {ref}")
+    return target
+
+
+def assert_matches_schema(
+    test: unittest.TestCase,
+    payload: Any,
+    node: dict[str, Any],
+    *,
+    root: dict[str, Any],
+    path: str = "$",
+) -> None:
+    if "$ref" in node:
+        return assert_matches_schema(
+            test, payload, resolve_ref(root, node["$ref"]), root=root, path=path
+        )
+
+    if "oneOf" in node:
+        errors = []
+        for option in node["oneOf"]:
+            try:
+                assert_matches_schema(test, payload, option, root=root, path=path)
+                return
+            except AssertionError as exc:
+                errors.append(str(exc))
+        raise AssertionError(f"{path}: no oneOf option matched: {errors}")
+
+    expected_type = node.get("type")
+    if expected_type is not None:
+        types = expected_type if isinstance(expected_type, list) else [expected_type]
+        if "null" in types and payload is None:
+            return
+        type_ok = False
+        for typ in types:
+            if typ == "object":
+                type_ok = isinstance(payload, dict)
+            elif typ == "array":
+                type_ok = isinstance(payload, list)
+            elif typ == "string":
+                type_ok = isinstance(payload, str)
+            elif typ == "integer":
+                type_ok = isinstance(payload, int) and not isinstance(payload, bool)
+            elif typ == "number":
+                type_ok = (
+                    isinstance(payload, (int, float)) and not isinstance(payload, bool)
+                )
+            elif typ == "null":
+                type_ok = payload is None
+            else:
+                raise AssertionError(f"{path}: unsupported type {typ!r}")
+            if type_ok:
+                break
+        test.assertTrue(type_ok, f"{path}: expected {types}, got {type(payload)}")
+
+    if "const" in node:
+        test.assertEqual(payload, node["const"], path)
+    if "enum" in node:
+        test.assertIn(payload, node["enum"], path)
+    if "pattern" in node and isinstance(payload, str):
+        test.assertRegex(payload, node["pattern"], path)
+    if node.get("format") == "date-time":
+        value = payload.replace("Z", "+00:00")
+        datetime.fromisoformat(value)
+    if "minimum" in node and payload is not None:
+        test.assertGreaterEqual(payload, node["minimum"], path)
+
+    if isinstance(payload, dict):
+        required = node.get("required", [])
+        for key in required:
+            test.assertIn(key, payload, f"{path}: missing {key}")
+        properties = node.get("properties", {})
+        if node.get("additionalProperties") is False:
+            test.assertLessEqual(set(payload), set(properties), path)
+        additional = node.get("additionalProperties")
+        for key, value in payload.items():
+            if key in properties:
+                assert_matches_schema(
+                    test, value, properties[key], root=root, path=f"{path}.{key}"
+                )
+            elif isinstance(additional, dict):
+                assert_matches_schema(
+                    test, value, additional, root=root, path=f"{path}.{key}"
+                )
+
+
+class OverheadHarnessTests(unittest.TestCase):
+    def sample(self, **overrides: Any) -> dict[str, Any]:
+        payload = {
+            "schema": overhead_harness.SAMPLE_SCHEMA,
+            "experiment": overhead_harness.EXPERIMENT,
+            "arm": "arm-b-otel",
+            "iteration": 1,
+            "host": "devhost",
+            "host_class": "darwin-arm64-23.0.0",
+            "assay_commit": "abcdef1",
+            "started_at": "2026-05-26T00:00:00Z",
+            "tool_versions": {
+                "python": "3.12.0",
+                "node": "v22.16.0",
+                "hyperfine": None,
+                "time": "python-time.perf_counter",
+            },
+            "wall_clock_ms": 12.5,
+            "peak_rss_bytes": None,
+            "exit_code": 0,
+            "health": None,
+            "artifact_bytes": {
+                "trace_json": 123,
+                "archive_targz": None,
+                "archive_extracted": None,
+            },
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_sample_schema_accepts_arm_b_sample(self) -> None:
+        schema = load_schema("overhead-sample-v0.schema.json")
+        assert_matches_schema(self, self.sample(), schema, root=schema)
+
+    def test_sample_schema_requires_extracted_size_key(self) -> None:
+        schema = load_schema("overhead-sample-v0.schema.json")
+        sample = self.sample()
+        del sample["artifact_bytes"]["archive_extracted"]
+        with self.assertRaises(AssertionError):
+            assert_matches_schema(self, sample, schema, root=schema)
+
+    def test_summary_schema_accepts_summary(self) -> None:
+        samples = [
+            self.sample(iteration=1, wall_clock_ms=10.0),
+            self.sample(
+                iteration=2,
+                wall_clock_ms=20.0,
+                artifact_bytes={
+                    "trace_json": 200,
+                    "archive_targz": None,
+                    "archive_extracted": None,
+                },
+            ),
+        ]
+        summary = overhead_harness.summarize(samples, delegated_workflow_url=None)
+        schema = load_schema("overhead-summary-v0.schema.json")
+        assert_matches_schema(self, summary, schema, root=schema)
+        self.assertEqual(summary["valid_samples"], 2)
+        self.assertEqual(summary["wall_clock_ms"]["median"], 15.0)
+        self.assertEqual(summary["artifact_bytes"]["trace_json_median"], 161.5)
+
+    def test_summary_schema_requires_provenance(self) -> None:
+        summary = overhead_harness.summarize(
+            [self.sample()],
+            delegated_workflow_url=None,
+        )
+        del summary["host_class"]
+        schema = load_schema("overhead-summary-v0.schema.json")
+        with self.assertRaises(AssertionError):
+            assert_matches_schema(self, summary, schema, root=schema)
+
+    def test_bmf_export_is_metric_keyed_value_objects(self) -> None:
+        summary = overhead_harness.summarize(
+            [self.sample()],
+            delegated_workflow_url=None,
+        )
+        bmf = overhead_harness.bmf_export(summary)
+        self.assertIn("runner_vs_otel.arm_b.wall_clock_ms.median", bmf)
+        self.assertTrue(all(set(value) == {"value"} for value in bmf.values()))
+
+    def test_host_class_is_schema_safe(self) -> None:
+        self.assertRegex(overhead_harness.host_class(), r"^[A-Za-z0-9_.-]+$")
+
+    def test_percentile_uses_nearest_rank(self) -> None:
+        self.assertEqual(overhead_harness.percentile([1, 2, 3, 4, 5], 95), 5)
+        self.assertEqual(overhead_harness.percentile([1, 2, 3, 4, 5], 50), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -32,16 +32,17 @@
 | `assay.runner.drift_report_provenance.v0` | Render and capture provenance embedded in runtime-drift reports | embedded report metadata | described in [`runtime-drift-v0.md`](runtime-drift-v0.md) |
 | `assay.runner.cross_runtime_diff.v0.clean` | Earlier clean-output cross-runtime diff shape | reference schema | [`cross-runtime-diff-v0-clean.schema.json`](schema/cross-runtime-diff-v0-clean.schema.json) |
 
-## Planned Experiment Schemas
+## Experiment Schemas
 
-| Schema | Scope | Status | Planned Sidecar |
+| Schema | Scope | Status | Sidecar |
 |---|---|---|---|
-| `assay.experiment.overhead_sample.v0` | One overhead measurement sample for runner-vs-OTel | plan-only | `docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json` |
-| `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | plan-only | `docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json` |
+| `assay.experiment.overhead_sample.v0` | One overhead measurement sample for runner-vs-OTel | experiment-scoped; Slice 1 sidecar active | [`overhead-sample-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json) |
+| `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | experiment-scoped; Slice 1 sidecar active | [`overhead-summary-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json) |
 
-The planned overhead schemas remain experiment-scoped until the harness
-exists, emits them, and sidecar tests validate them against synthetic
-and live samples.
+The overhead schemas remain experiment-scoped. They are validated by the
+local harness tests against synthetic samples and summaries, but they are
+not Runner archive contracts and are not promoted to stable product
+surface.
 
 ## Version Notes
 


### PR DESCRIPTION
Summary

Implements Slice 1 of the runner-vs-otel overhead follow-up: a local Arm B harness plus experiment-scoped schema sidecars and tests. This keeps the work in measurement-contract space; it does not commit benchmark outputs or publish overhead claims.

What changed

- Added docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py for local Arm B OTel-only wall-clock and trace-size samples.
- Added overhead-sample-v0 and overhead-summary-v0 JSON Schema sidecars.
- Added stdlib unit tests that validate synthetic samples/summaries against the sidecars and assert the BMF export shape.
- Added a README with local smoke instructions and clarified generated outputs should not be committed yet.
- Updated the overhead plan, schema overview, changelog, and runner-vs-otel .gitignore.

Validation

- python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p "test_*.py" -> 7 OK
- python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p "test_*.py" -> 92 OK
- n=20 local Arm B dry run to a temp directory -> valid_samples=20, discarded_samples=0, bmf_metrics=5
- local markdown link check over changed docs -> OK
- git diff --check
- pre-commit + pre-push hooks green

Non-claims

- Does not add live overhead numbers to committed evidence.
- Does not implement delegated Arm C overhead capture yet.
- Does not add RSS collection yet.
- Does not publish benchmark claims or same-host deltas.
