### PR TITLE
feat(experiments): runner-vs-otel overhead Slice 2 Arm C workflow

### DIFF
--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -1,0 +1,162 @@
+name: Runner OTel Overhead Experiment
+
+# Manually-dispatched overhead measurement workflow for the
+# runner-vs-otel overhead follow-up. This is intentionally not a PR gate
+# and does not commit benchmark results. Artifacts are uploaded for
+# maintainer review and later findings slices.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repetitions:
+        description: "Number of Arm C overhead samples to collect"
+        required: true
+        default: "20"
+        type: string
+      build_ebpf:
+        description: "Rebuild eBPF artifact before running Arm C"
+        required: true
+        default: true
+        type: boolean
+      timeout_seconds:
+        description: "Per-sample timeout passed to the overhead harness"
+        required: true
+        default: "300"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-otel-overhead-experiment-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-delegated-runner:
+    name: Prepare delegated runner
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    timeout-minutes: 5
+    steps:
+      - name: Reset workspace ownership
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo find "$GITHUB_WORKSPACE/.." -maxdepth 2 -type d -name "_actions" -exec rm -rf {} + 2>/dev/null || true
+          if [ -d "$GITHUB_WORKSPACE" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true
+          fi
+
+  arm-c-overhead:
+    name: Arm C overhead capture
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    needs: prepare-delegated-runner
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Preflight delegated host
+        shell: bash
+        run: |
+          set -euo pipefail
+          for bin in cargo node npm python3 rustc tar; do
+            command -v "$bin" >/dev/null 2>&1 || {
+              echo "ERROR: required command not found on delegated runner: $bin" >&2
+              exit 1
+            }
+          done
+          node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)' || {
+            echo "ERROR: delegated runner must provide Node.js 22 or newer" >&2
+            node --version >&2 || true
+            exit 1
+          }
+          if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+            echo "ERROR: delegated runner must expose cgroup v2 at /sys/fs/cgroup" >&2
+            exit 1
+          fi
+          {
+            echo "## Delegated runner preflight"
+            echo "- kernel: $(uname -r)"
+            echo "- node: $(node --version)"
+            echo "- rustc: $(rustc --version)"
+            echo "- python3: $(python3 --version)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build assay CLI (runner feature)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p assay-cli --no-default-features --features runner
+
+      - name: Build eBPF artifact
+        if: ${{ inputs.build_ebpf }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v docker >/dev/null 2>&1; then
+            cargo xtask build-image
+            cargo xtask build-ebpf --docker
+          else
+            cargo xtask build-ebpf
+          fi
+          test -f target/assay-ebpf.o
+
+      - name: Verify eBPF artifact present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f target/assay-ebpf.o ]; then
+            echo "ERROR: target/assay-ebpf.o is required. Run with build_ebpf=true." >&2
+            exit 1
+          fi
+
+      - name: Build experiment workload
+        working-directory: docs/experiments/runner-vs-otel-2026-05/workload
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund --ignore-scripts
+          npx tsc -p tsconfig.json
+          test -f dist/workload.js
+
+      - name: Run Arm C overhead harness
+        shell: bash
+        env:
+          REPETITIONS: ${{ inputs.repetitions }}
+          TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+        run: |
+          set -euo pipefail
+          OUT_DIR="$PWD/overhead-runs"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
+            --arm arm-c-dual-capture \
+            --iterations "$REPETITIONS" \
+            --skip-build \
+            --clean \
+            --sudo \
+            --timeout-seconds "$TIMEOUT_SECONDS" \
+            --out-dir "$OUT_DIR" \
+            --workload-dir "$PWD/docs/experiments/runner-vs-otel-2026-05/workload" \
+            --assay-bin "$PWD/target/debug/assay" \
+            --ebpf-obj "$PWD/target/assay-ebpf.o" \
+            --delegated-workflow-url "$WORKFLOW_URL"
+
+          SUMMARY="$OUT_DIR/arm-c-dual-capture/summary.json"
+          VALID="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["valid_samples"])' "$SUMMARY")"
+          DISCARDED="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["discarded_samples"])' "$SUMMARY")"
+          {
+            echo "## Arm C overhead summary"
+            echo "- valid samples: $VALID"
+            echo "- discarded samples: $DISCARDED"
+            echo "- artifact: runner-otel-overhead-arm-c-${GITHUB_RUN_ID}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Arm C overhead artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: runner-otel-overhead-arm-c-${{ github.run_id }}
+          path: overhead-runs/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -90,6 +90,14 @@ jobs:
           set -euo pipefail
           cargo build -p assay-cli --no-default-features --features runner
 
+      - name: Run overhead harness unit tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover \
+            -s docs/experiments/runner-vs-otel-overhead-2026-05 \
+            -p 'test_*.py'
+
       - name: Build eBPF artifact
         if: ${{ inputs.build_ebpf }}
         shell: bash
@@ -144,14 +152,23 @@ jobs:
             --delegated-workflow-url "$WORKFLOW_URL"
 
           SUMMARY="$OUT_DIR/arm-c-dual-capture/summary.json"
-          VALID="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["valid_samples"])' "$SUMMARY")"
-          DISCARDED="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["discarded_samples"])' "$SUMMARY")"
-          {
-            echo "## Arm C overhead summary"
-            echo "- valid samples: $VALID"
-            echo "- discarded samples: $DISCARDED"
-            echo "- artifact: runner-otel-overhead-arm-c-${GITHUB_RUN_ID}"
-          } >> "$GITHUB_STEP_SUMMARY"
+          python3 - "$SUMMARY" "runner-otel-overhead-arm-c-${GITHUB_RUN_ID}" <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          import sys
+
+          summary_path, artifact_name = sys.argv[1], sys.argv[2]
+          with open(summary_path, encoding="utf-8") as fh:
+              summary = json.load(fh)
+          wall = summary["wall_clock_ms"]
+          print("## Arm C overhead summary")
+          print(f"- valid samples: {summary['valid_samples']}")
+          print(f"- discarded samples: {summary['discarded_samples']}")
+          print(f"- wall median ms: {wall['median']}")
+          print(f"- wall p95 ms: {wall['p95']}")
+          print(f"- wall p99 ms: {wall['p99']}")
+          print(f"- wall p99/median: {wall['p99_over_median']}")
+          print(f"- artifact: {artifact_name}")
+          PY
 
       - name: Upload Arm C overhead artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ All notable changes to this project will be documented in this file.
   publish benchmark numbers.
 - Added the Slice 2 delegated Arm C overhead workflow for
   `assay-bpf-runner`. The workflow uploads health-gated overhead
-  artifacts for review but still does not commit benchmark numbers.
+  artifacts for review but still does not commit benchmark numbers. BMF
+  metric keys now use full arm slugs such as `arm_b_otel` and
+  `arm_c_dual_capture` to keep future arms unambiguous.
 
 ## [3.12.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
   `assay.experiment.overhead_summary.v0` schema sidecars and tests. The
   harness emits local measurement artifacts but does not commit or
   publish benchmark numbers.
+- Added the Slice 2 delegated Arm C overhead workflow for
+  `assay-bpf-runner`. The workflow uploads health-gated overhead
+  artifacts for review but still does not commit benchmark numbers.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -9,6 +9,11 @@
 > **Slice 1 status:** local Arm B harness and schema sidecars live under
 > [`runner-vs-otel-overhead-2026-05/`](runner-vs-otel-overhead-2026-05/).
 > Generated measurements are still not committed evidence.
+>
+> **Slice 2 status:** delegated Arm C workflow is available as
+> [`.github/workflows/runner-otel-overhead-experiment.yml`](../../.github/workflows/runner-otel-overhead-experiment.yml).
+> It uploads review artifacts and still does not commit benchmark
+> numbers.
 
 ## Research Question
 
@@ -264,7 +269,7 @@ investigation before publication.
 |---|---|---|
 | 0 | This plan doc | Links from runner-vs-otel plan and README |
 | 1 | **Done**: local harness for Arm B wall-clock + size output, plus `overhead-sample-v0` and `overhead-summary-v0` schema sidecars | n=20 local dry run, no live API dependency, sidecar tests pass |
-| 2 | Delegated Arm C harness with health-gated samples | n=20 on `assay-bpf-runner`, all health gates clean |
+| 2 | **Ready to dispatch**: delegated Arm C harness with health-gated samples via [`.github/workflows/runner-otel-overhead-experiment.yml`](../../.github/workflows/runner-otel-overhead-experiment.yml) | n=20 on `assay-bpf-runner`, all health gates clean |
 | 3 | RSS collection per arm | n=5 per arm, platform-specific parser tests, tool versions recorded per sample |
 | 4 | Summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
 | 5 | Findings update | No deltas unless same-host arms exist |

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -24,6 +24,10 @@ The harness writes:
 The experiment schemas are intentionally not Runner archive contracts.
 They are local measurement evidence for the overhead follow-up only.
 
+BMF metric keys use the full arm slug so future arms stay
+unambiguous: `runner_vs_otel.arm_b_otel.*` for local Arm B and
+`runner_vs_otel.arm_c_dual_capture.*` for delegated Arm C.
+
 ## Local Smoke
 
 From the repository root:
@@ -48,6 +52,11 @@ Arm C is dispatched manually through
 The workflow runs on `assay-bpf-runner`, invokes the same harness with
 `--arm arm-c-dual-capture`, uploads `overhead-runs/`, and fails if any
 sample is either non-zero exit or capture-unclean.
+
+The local unit tests exercise the Arm C path with a fake `assay` binary
+that emits the expected archive shape. The first validation against real
+`assay runner-spike` output happens on the first delegated workflow
+dispatch.
 
 Do not commit the uploaded artifacts until the findings slice decides
 which measurements should become evidence.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -1,13 +1,14 @@
 # Runner vs OTel Overhead Harness
 
-> **Status:** Slice 1 local Arm B harness. This directory contains the
-> experiment-scoped measurement harness and schema sidecars for the
-> plan in [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
+> **Status:** Slice 1 local Arm B harness plus Slice 2 delegated Arm C
+> dispatch pipeline. This directory contains the experiment-scoped
+> measurement harness and schema sidecars for the plan in
+> [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
 > It does not contain committed benchmark results.
 
 ## What This Emits
 
-The local harness writes:
+The harness writes:
 
 - `arm-b-otel/samples.jsonl` using
   `assay.experiment.overhead_sample.v0`;
@@ -18,7 +19,7 @@ The local harness writes:
 - `artifacts/trace-sizes.json`, a trace-size side artifact for overhead
   bookkeeping; and
 - `artifacts/archive-sizes.json`, an archive-size side artifact that is
-  present but empty for Slice 1.
+  empty for Arm B and populated for Arm C.
 
 The experiment schemas are intentionally not Runner archive contracts.
 They are local measurement evidence for the overhead follow-up only.
@@ -39,6 +40,17 @@ For the Slice 1 acceptance dry run, use `--iterations 20` and a
 temporary output directory. Do not commit generated measurements until
 the findings slice decides what should become evidence. The default
 `runs/overhead-2026-05/` output path is ignored for this reason.
+
+## Delegated Arm C
+
+Arm C is dispatched manually through
+[`runner-otel-overhead-experiment.yml`](../../../.github/workflows/runner-otel-overhead-experiment.yml).
+The workflow runs on `assay-bpf-runner`, invokes the same harness with
+`--arm arm-c-dual-capture`, uploads `overhead-runs/`, and fails if any
+sample is either non-zero exit or capture-unclean.
+
+Do not commit the uploaded artifacts until the findings slice decides
+which measurements should become evidence.
 
 ## Tests
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Local Arm B overhead harness for runner-vs-OTel.
+"""Overhead harness for runner-vs-OTel.
 
-Slice 1 intentionally measures only the local OTel-only workload path.
-It emits experiment-scoped samples and summaries; the optional BMF file
-is derived from the summary and is the only Bencher-shaped artifact.
+Slice 1 measures the local OTel-only workload path. Slice 2 adds the
+delegated Arm C Runner capture path. The harness emits
+experiment-scoped samples and summaries; the optional BMF file is
+derived from the summary and is the only Bencher-shaped artifact.
 """
 
 from __future__ import annotations
@@ -11,10 +12,12 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import platform
 import shutil
 import socket
 import subprocess
+import tarfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +27,8 @@ EXPERIMENT = "runner-vs-otel-overhead-2026-05"
 SAMPLE_SCHEMA = "assay.experiment.overhead_sample.v0"
 SUMMARY_SCHEMA = "assay.experiment.overhead_summary.v0"
 DEFAULT_ARM = "arm-b-otel"
+ARM_B = "arm-b-otel"
+ARM_C = "arm-c-dual-capture"
 
 
 def repo_root() -> Path:
@@ -112,6 +117,40 @@ def file_size(path: Path) -> int | None:
     return path.stat().st_size if path.exists() else None
 
 
+def directory_size(path: Path) -> int | None:
+    if not path.exists():
+        return None
+    total = 0
+    for child in path.rglob("*"):
+        if child.is_file():
+            total += child.stat().st_size
+    return total
+
+
+def load_archive_health(archive_contents: Path) -> dict[str, Any]:
+    health_path = archive_contents / "observation-health.json"
+    if not health_path.exists():
+        return {
+            "kernel_layer": "absent",
+            "ringbuf_drops": 0,
+            "cgroup_correlation": "unknown",
+        }
+    payload = json.loads(health_path.read_text(encoding="utf-8"))
+    return {
+        "kernel_layer": payload.get("kernel_layer", "unknown"),
+        "ringbuf_drops": int(payload.get("ringbuf_drops", -1)),
+        "cgroup_correlation": payload.get("cgroup_correlation", "unknown"),
+    }
+
+
+def extract_archive(archive: Path, destination: Path) -> None:
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+    with tarfile.open(archive, "r:gz") as tar:
+        tar.extractall(destination)
+
+
 def percentile(values: list[float], pct: float) -> float | None:
     if not values:
         return None
@@ -139,28 +178,68 @@ def normalized_exit_code(returncode: int) -> int:
 def one_sample(
     *,
     arm_dir: Path,
+    arm: str,
     workload_dir: Path,
     iteration: int,
     commit: str,
     versions: dict[str, str | None],
     timeout_seconds: float,
+    assay_bin: Path | None = None,
+    ebpf_obj: Path | None = None,
+    use_sudo: bool = False,
 ) -> dict[str, Any]:
-    run_id = f"overhead_arm_b_{iteration:03d}"
+    run_id = f"overhead_{arm.replace('-', '_')}_{iteration:03d}"
     run_dir = arm_dir / f"run_{iteration:03d}"
     work_dir = run_dir / "work"
     trace_path = run_dir / "trace.json"
+    archive_path = run_dir / "archive.tar.gz"
+    archive_contents = run_dir / "archive-contents"
+    sdk_log = run_dir / "sdk-events.ndjson"
     run_dir.mkdir(parents=True, exist_ok=True)
     started_at = utc_now()
-    command = [
-        "node",
-        "dist/workload.js",
-        "--run-id",
-        run_id,
-        "--work-dir",
-        str(work_dir),
-        "--trace-out",
-        str(trace_path),
-    ]
+    if arm == ARM_B:
+        command = [
+            "node",
+            "dist/workload.js",
+            "--run-id",
+            run_id,
+            "--work-dir",
+            str(work_dir),
+            "--trace-out",
+            str(trace_path),
+        ]
+    elif arm == ARM_C:
+        if assay_bin is None or ebpf_obj is None:
+            raise ValueError("Arm C requires --assay-bin and --ebpf-obj")
+        command = [
+            str(assay_bin),
+            "runner-spike",
+            "run",
+            "--agent-shim",
+            "openai-agents",
+            "--kernel-capture",
+            "--ebpf",
+            str(ebpf_obj),
+            "--run-id",
+            run_id,
+            "--output",
+            str(archive_path),
+            "--sdk-event-log",
+            str(sdk_log),
+            "--",
+            "node",
+            str(workload_dir / "dist/workload.js"),
+            "--run-id",
+            run_id,
+            "--work-dir",
+            str(work_dir),
+            "--trace-out",
+            str(trace_path),
+        ]
+        if use_sudo:
+            command = ["sudo", "-E", "env", f"PATH={os_environ_path()}"] + command
+    else:
+        raise ValueError(f"unsupported arm: {arm}")
 
     start = time.perf_counter()
     try:
@@ -183,11 +262,25 @@ def one_sample(
     elapsed_ms = (time.perf_counter() - start) * 1000.0
     (run_dir / "stdout.log").write_text(stdout, encoding="utf-8")
     (run_dir / "stderr.log").write_text(stderr, encoding="utf-8")
+    if use_sudo and run_dir.exists():
+        subprocess.run(
+            ["sudo", "chown", "-R", f"{os_getuid()}:{os_getgid()}", str(run_dir)],
+            check=False,
+        )
+
+    health = None
+    archive_targz = None
+    archive_extracted = None
+    if archive_path.exists():
+        archive_targz = file_size(archive_path)
+        extract_archive(archive_path, archive_contents)
+        health = load_archive_health(archive_contents)
+        archive_extracted = directory_size(archive_contents)
 
     return {
         "schema": SAMPLE_SCHEMA,
         "experiment": EXPERIMENT,
-        "arm": DEFAULT_ARM,
+        "arm": arm,
         "iteration": iteration,
         "host": socket.gethostname(),
         "host_class": host_class(),
@@ -197,13 +290,36 @@ def one_sample(
         "wall_clock_ms": elapsed_ms,
         "peak_rss_bytes": None,
         "exit_code": exit_code,
-        "health": None,
+        "health": health,
         "artifact_bytes": {
             "trace_json": file_size(trace_path),
-            "archive_targz": None,
-            "archive_extracted": None,
+            "archive_targz": archive_targz,
+            "archive_extracted": archive_extracted,
         },
     }
+
+
+def os_environ_path() -> str:
+    return os.environ.get("PATH", "")
+
+
+def os_getuid() -> int:
+    return os.getuid()
+
+
+def os_getgid() -> int:
+    return os.getgid()
+
+
+def is_capture_clean(sample: dict[str, Any]) -> bool:
+    health = sample.get("health")
+    if health is None:
+        return True
+    return (
+        health.get("kernel_layer") == "complete"
+        and health.get("ringbuf_drops") == 0
+        and health.get("cgroup_correlation") == "clean"
+    )
 
 
 def summarize(
@@ -211,7 +327,11 @@ def summarize(
     *,
     delegated_workflow_url: str | None,
 ) -> dict[str, Any]:
-    valid = [sample for sample in samples if sample["exit_code"] == 0]
+    valid = [
+        sample
+        for sample in samples
+        if sample["exit_code"] == 0 and is_capture_clean(sample)
+    ]
     wall = [float(sample["wall_clock_ms"]) for sample in valid]
     rss = [
         int(sample["peak_rss_bytes"])
@@ -239,7 +359,7 @@ def summarize(
     return {
         "schema": SUMMARY_SCHEMA,
         "experiment": EXPERIMENT,
-        "arm": DEFAULT_ARM,
+        "arm": first.get("arm", ARM_B),
         "host": first.get("host", socket.gethostname()),
         "host_class": first.get("host_class", host_class()),
         "kernel": platform.release(),
@@ -270,7 +390,8 @@ def summarize(
 
 
 def bmf_export(summary: dict[str, Any]) -> dict[str, dict[str, float | int]]:
-    prefix = "runner_vs_otel.arm_b"
+    arm_key = str(summary["arm"]).replace("arm-", "arm_").replace("-", "_")
+    prefix = f"runner_vs_otel.{arm_key}"
     values: dict[str, float | int | None] = {
         f"{prefix}.wall_clock_ms.median": summary["wall_clock_ms"]["median"],
         f"{prefix}.wall_clock_ms.p95": summary["wall_clock_ms"]["p95"],
@@ -295,6 +416,7 @@ def write_json(path: Path, payload: Any) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arm", choices=[ARM_B, ARM_C], default=ARM_B)
     parser.add_argument("--iterations", type=int, default=20)
     parser.add_argument("--out-dir", type=Path, default=default_out_dir())
     parser.add_argument("--workload-dir", type=Path, default=default_workload_dir())
@@ -302,6 +424,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--clean", action="store_true")
     parser.add_argument("--delegated-workflow-url")
     parser.add_argument("--timeout-seconds", type=float, default=300.0)
+    parser.add_argument("--assay-bin", type=Path)
+    parser.add_argument("--ebpf-obj", type=Path)
+    parser.add_argument("--sudo", action="store_true")
     args = parser.parse_args(argv)
 
     if args.iterations < 1:
@@ -310,7 +435,7 @@ def main(argv: list[str] | None = None) -> int:
         shutil.rmtree(args.out_dir)
 
     ensure_workload_built(args.workload_dir, skip_build=args.skip_build)
-    arm_dir = args.out_dir / DEFAULT_ARM
+    arm_dir = args.out_dir / args.arm
     artifacts_dir = args.out_dir / "artifacts"
     arm_dir.mkdir(parents=True, exist_ok=True)
     artifacts_dir.mkdir(parents=True, exist_ok=True)
@@ -320,11 +445,15 @@ def main(argv: list[str] | None = None) -> int:
     samples = [
         one_sample(
             arm_dir=arm_dir,
+            arm=args.arm,
             workload_dir=args.workload_dir,
             iteration=iteration,
             commit=commit,
             versions=versions,
             timeout_seconds=args.timeout_seconds,
+            assay_bin=args.assay_bin,
+            ebpf_obj=args.ebpf_obj,
+            use_sudo=args.sudo,
         )
         for iteration in range(1, args.iterations + 1)
     ]
@@ -339,7 +468,7 @@ def main(argv: list[str] | None = None) -> int:
     write_json(
         artifacts_dir / "trace-sizes.json",
         {
-            "arm": DEFAULT_ARM,
+            "arm": args.arm,
             "trace_json_bytes": [
                 sample["artifact_bytes"]["trace_json"] for sample in samples
             ],
@@ -348,9 +477,17 @@ def main(argv: list[str] | None = None) -> int:
     write_json(
         artifacts_dir / "archive-sizes.json",
         {
-            "arm": DEFAULT_ARM,
-            "archive_targz_bytes": [],
-            "archive_extracted_bytes": [],
+            "arm": args.arm,
+            "archive_targz_bytes": [
+                sample["artifact_bytes"]["archive_targz"]
+                for sample in samples
+                if sample["artifact_bytes"]["archive_targz"] is not None
+            ],
+            "archive_extracted_bytes": [
+                sample["artifact_bytes"]["archive_extracted"]
+                for sample in samples
+                if sample["artifact_bytes"]["archive_extracted"] is not None
+            ],
         },
     )
     write_json(artifacts_dir / "bmf.json", bmf_export(summary))

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -148,7 +148,7 @@ def extract_archive(archive: Path, destination: Path) -> None:
         shutil.rmtree(destination)
     destination.mkdir(parents=True)
     with tarfile.open(archive, "r:gz") as tar:
-        tar.extractall(destination)
+        tar.extractall(destination, filter="data")
 
 
 def percentile(values: list[float], pct: float) -> float | None:

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import tempfile
+import tarfile
 import unittest
 from datetime import datetime
 from pathlib import Path
@@ -143,6 +144,48 @@ fs.writeFileSync(traceOut, JSON.stringify({ resourceSpans: [] }) + "\\n");
     )
 
 
+def write_fake_assay(root: Path) -> Path:
+    fake = root / "fake-assay.py"
+    fake.write_text(
+        """
+#!/usr/bin/env python3
+import json
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+args = sys.argv[1:]
+output = Path(args[args.index("--output") + 1])
+trace = None
+if "--" in args:
+    child = args[args.index("--") + 1:]
+    if "--trace-out" in child:
+        trace = Path(child[child.index("--trace-out") + 1])
+if trace is not None:
+    trace.parent.mkdir(parents=True, exist_ok=True)
+    trace.write_text(json.dumps({"resourceSpans": []}) + "\\n", encoding="utf-8")
+
+output.parent.mkdir(parents=True, exist_ok=True)
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
+    (root / "observation-health.json").write_text(
+        json.dumps({
+            "kernel_layer": "complete",
+            "ringbuf_drops": 0,
+            "cgroup_correlation": "clean"
+        }) + "\\n",
+        encoding="utf-8",
+    )
+    with tarfile.open(output, "w:gz") as tar:
+        tar.add(root / "observation-health.json", arcname="observation-health.json")
+""".lstrip(),
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+    return fake
+
+
 class OverheadHarnessTests(unittest.TestCase):
     def sample(self, **overrides: Any) -> dict[str, Any]:
         payload = {
@@ -222,7 +265,7 @@ class OverheadHarnessTests(unittest.TestCase):
             delegated_workflow_url=None,
         )
         bmf = overhead_harness.bmf_export(summary)
-        self.assertIn("runner_vs_otel.arm_b.wall_clock_ms.median", bmf)
+        self.assertIn("runner_vs_otel.arm_b_otel.wall_clock_ms.median", bmf)
         self.assertTrue(all(set(value) == {"value"} for value in bmf.values()))
 
     def test_host_class_is_schema_safe(self) -> None:
@@ -290,6 +333,63 @@ class OverheadHarnessTests(unittest.TestCase):
             self.assertEqual(summary["valid_samples"], 20)
             self.assertEqual(summary["discarded_samples"], 0)
             self.assertTrue(bmf)
+
+    def test_arm_c_sample_extracts_archive_health_and_sizes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workload = root / "workload"
+            out_dir = root / "overhead"
+            write_stub_workload(workload)
+            fake_assay = write_fake_assay(root)
+            fake_ebpf = root / "assay-ebpf.o"
+            fake_ebpf.write_bytes(b"fake ebpf")
+
+            status = overhead_harness.main(
+                [
+                    "--arm",
+                    "arm-c-dual-capture",
+                    "--iterations",
+                    "1",
+                    "--skip-build",
+                    "--clean",
+                    "--timeout-seconds",
+                    "10",
+                    "--workload-dir",
+                    str(workload),
+                    "--out-dir",
+                    str(out_dir),
+                    "--assay-bin",
+                    str(fake_assay),
+                    "--ebpf-obj",
+                    str(fake_ebpf),
+                ]
+            )
+            self.assertEqual(status, 0)
+
+            sample = json.loads(
+                (out_dir / "arm-c-dual-capture" / "samples.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()[0]
+            )
+            summary = json.loads(
+                (out_dir / "arm-c-dual-capture" / "summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            archive_sizes = json.loads(
+                (out_dir / "artifacts" / "archive-sizes.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+            self.assertEqual(sample["health"]["kernel_layer"], "complete")
+            self.assertEqual(sample["health"]["ringbuf_drops"], 0)
+            self.assertEqual(sample["health"]["cgroup_correlation"], "clean")
+            self.assertGreater(sample["artifact_bytes"]["archive_targz"], 0)
+            self.assertGreater(sample["artifact_bytes"]["archive_extracted"], 0)
+            self.assertEqual(summary["valid_samples"], 1)
+            self.assertEqual(archive_sizes["arm"], "arm-c-dual-capture")
+            self.assertEqual(len(archive_sizes["archive_targz_bytes"]), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary

Implements Slice 2 of the runner-vs-otel overhead follow-up: delegated Arm C overhead capture wiring on assay-bpf-runner. This adds the workflow and harness support needed to collect health-gated Runner capture samples, but does not commit benchmark outputs or publish overhead claims.

What changed

- Added .github/workflows/runner-otel-overhead-experiment.yml (workflow_dispatch only) for Arm C overhead captures on assay-bpf-runner.
- Extended overhead_harness.py with --arm arm-c-dual-capture, --assay-bin, --ebpf-obj, --sudo, archive extraction, observation-health parsing, archive compressed/extracted size tracking, and health-gated summaries.
- Parameterized BMF metric prefixes by arm.
- Added fake Arm C unit coverage that writes a synthetic Runner archive and validates health + archive-size extraction without requiring eBPF.
- Updated README, plan-doc status, and changelog.

Validation

- python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p "test_*.py" -> 11 OK
- python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p "test_*.py" -> 92 OK
- python3 -m py_compile overhead_harness.py test_overhead_harness.py
- local markdown link check over changed docs -> OK
- actionlint .github/workflows/runner-otel-overhead-experiment.yml
- zizmor .github/workflows/runner-otel-overhead-experiment.yml -> no findings
- git diff --check
- pre-commit + pre-push hooks green

Non-claims

- Does not dispatch the live workflow yet.
- Does not commit overhead measurements.
- Does not add RSS collection yet.
- Does not publish benchmark claims or same-host deltas.
