### PR TITLE
feat(experiments): runner-vs-otel overhead Slice 3 RSS collection

### DIFF
--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -23,6 +23,11 @@ on:
         required: true
         default: "300"
         type: string
+      measure_rss:
+        description: "Wrap each sample in /usr/bin/time to collect peak RSS"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -134,10 +139,15 @@ jobs:
         env:
           REPETITIONS: ${{ inputs.repetitions }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+          MEASURE_RSS: ${{ inputs.measure_rss }}
         run: |
           set -euo pipefail
           OUT_DIR="$PWD/overhead-runs"
           WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          RSS_FLAG=()
+          if [ "$MEASURE_RSS" = "true" ]; then
+            RSS_FLAG=(--measure-rss)
+          fi
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-c-dual-capture \
             --iterations "$REPETITIONS" \
@@ -149,7 +159,8 @@ jobs:
             --workload-dir "$PWD/docs/experiments/runner-vs-otel-2026-05/workload" \
             --assay-bin "$PWD/target/debug/assay" \
             --ebpf-obj "$PWD/target/assay-ebpf.o" \
-            --delegated-workflow-url "$WORKFLOW_URL"
+            --delegated-workflow-url "$WORKFLOW_URL" \
+            "${RSS_FLAG[@]}"
 
           SUMMARY="$OUT_DIR/arm-c-dual-capture/summary.json"
           python3 - "$SUMMARY" "runner-otel-overhead-arm-c-${GITHUB_RUN_ID}" <<'PY' >> "$GITHUB_STEP_SUMMARY"
@@ -167,6 +178,8 @@ jobs:
           print(f"- wall p95 ms: {wall['p95']}")
           print(f"- wall p99 ms: {wall['p99']}")
           print(f"- wall p99/median: {wall['p99_over_median']}")
+          print(f"- peak RSS median bytes: {summary['peak_rss_bytes']['median']}")
+          print(f"- peak RSS max bytes: {summary['peak_rss_bytes']['max']}")
           print(f"- artifact: {artifact_name}")
           PY
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
   artifacts for review but still does not commit benchmark numbers. BMF
   metric keys now use full arm slugs such as `arm_b_otel` and
   `arm_c_dual_capture` to keep future arms unambiguous.
+- Added Slice 3 RSS collection support to the overhead harness. The
+  harness can now wrap samples in `/usr/bin/time`, parse GNU time and
+  macOS time peak-RSS output, emit `rss-sizes.json`, and include RSS
+  metrics in the derived BMF export when present.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -10,10 +10,15 @@
 > [`runner-vs-otel-overhead-2026-05/`](runner-vs-otel-overhead-2026-05/).
 > Generated measurements are still not committed evidence.
 >
-> **Slice 2 status:** delegated Arm C workflow is available as
-> [`.github/workflows/runner-otel-overhead-experiment.yml`](../../.github/workflows/runner-otel-overhead-experiment.yml).
-> It uploads review artifacts and still does not commit benchmark
-> numbers.
+> **Slice 2 status:** delegated Arm C workflow passed on
+> [GitHub Actions run 26449999294](https://github.com/Rul1an/assay/actions/runs/26449999294):
+> 20/20 valid samples, 0 discarded samples, all Runner health gates
+> clean. The uploaded artifacts remain review artifacts and are not
+> committed benchmark numbers.
+>
+> **Slice 3 status:** RSS collection is wired through `--measure-rss`
+> and the `measure_rss` workflow input. The first delegated RSS dispatch
+> is still pending.
 
 ## Research Question
 
@@ -172,9 +177,9 @@ The BMF export is a derived artifact, for example:
 
 ```json
 {
-  "runner_vs_otel.arm_c.wall_clock_ms.median": { "value": 0 },
-  "runner_vs_otel.arm_c.wall_clock_ms.p99": { "value": 0 },
-  "runner_vs_otel.arm_c.peak_rss_bytes.max": { "value": 0 }
+  "runner_vs_otel.arm_c_dual_capture.wall_clock_ms.median": { "value": 0 },
+  "runner_vs_otel.arm_c_dual_capture.wall_clock_ms.p99": { "value": 0 },
+  "runner_vs_otel.arm_c_dual_capture.peak_rss_bytes.max": { "value": 0 }
 }
 ```
 
@@ -269,8 +274,8 @@ investigation before publication.
 |---|---|---|
 | 0 | This plan doc | Links from runner-vs-otel plan and README |
 | 1 | **Done**: local harness for Arm B wall-clock + size output, plus `overhead-sample-v0` and `overhead-summary-v0` schema sidecars | n=20 local dry run, no live API dependency, sidecar tests pass |
-| 2 | **Ready to dispatch**: delegated Arm C harness with health-gated samples via [`.github/workflows/runner-otel-overhead-experiment.yml`](../../.github/workflows/runner-otel-overhead-experiment.yml) | n=20 on `assay-bpf-runner`, all health gates clean |
-| 3 | RSS collection per arm | n=5 per arm, platform-specific parser tests, tool versions recorded per sample |
+| 2 | **Done**: delegated Arm C harness with health-gated samples via [`.github/workflows/runner-otel-overhead-experiment.yml`](../../.github/workflows/runner-otel-overhead-experiment.yml) | n=20 on `assay-bpf-runner`, all health gates clean |
+| 3 | **Ready to dispatch**: RSS collection per arm via `--measure-rss` / workflow `measure_rss=true` | n=5 per arm, platform-specific parser tests, tool versions recorded per sample |
 | 4 | Summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
 | 5 | Findings update | No deltas unless same-host arms exist |
 | 6 optional | Arm A pure-L2 decomposition | Only if Arm C overhead needs archive-only vs dual-capture separation |

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -233,6 +233,10 @@ macOS time expose different output shapes. Parser tests should assert
 the exact formats accepted by the harness rather than assuming the host
 tooling is interchangeable.
 
+Linux RSS collection requires GNU `/usr/bin/time -v` (time 1.7 or
+newer). BusyBox or Alpine-style `time` output is not accepted by the v0
+parser and should fail the sample rather than produce a silent null.
+
 Preferred tools:
 
 | Need | Linux | macOS |

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -19,7 +19,9 @@ The harness writes:
 - `artifacts/trace-sizes.json`, a trace-size side artifact for overhead
   bookkeeping; and
 - `artifacts/archive-sizes.json`, an archive-size side artifact that is
-  empty for Arm B and populated for Arm C.
+  empty for Arm B and populated for Arm C; and
+- `artifacts/rss-sizes.json`, a peak-RSS side artifact populated when
+  the harness runs with `--measure-rss`.
 
 The experiment schemas are intentionally not Runner archive contracts.
 They are local measurement evidence for the overhead follow-up only.
@@ -40,6 +42,10 @@ python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
   --out-dir "$(mktemp -d)/overhead"
 ```
 
+Add `--measure-rss` to collect peak RSS with `/usr/bin/time`. The
+harness currently parses GNU time (`-v`) on Linux and `/usr/bin/time -l`
+on macOS.
+
 For the Slice 1 acceptance dry run, use `--iterations 20` and a
 temporary output directory. Do not commit generated measurements until
 the findings slice decides what should become evidence. The default
@@ -52,6 +58,11 @@ Arm C is dispatched manually through
 The workflow runs on `assay-bpf-runner`, invokes the same harness with
 `--arm arm-c-dual-capture`, uploads `overhead-runs/`, and fails if any
 sample is either non-zero exit or capture-unclean.
+
+For the Slice 3 RSS run, dispatch the same workflow with
+`repetitions=5` and `measure_rss=true`. Keep `build_ebpf=true` unless a
+known-good `target/assay-ebpf.o` is already present on the delegated
+runner.
 
 The local unit tests exercise the Arm C path with a fake `assay` binary
 that emits the expected archive shape. The first validation against real

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -30,6 +30,8 @@ SUMMARY_SCHEMA = "assay.experiment.overhead_summary.v0"
 DEFAULT_ARM = "arm-b-otel"
 ARM_B = "arm-b-otel"
 ARM_C = "arm-c-dual-capture"
+RSS_TIME_PATH = Path("/usr/bin/time")
+RSS_SYSTEMS = {"darwin", "linux"}
 
 
 def repo_root() -> Path:
@@ -154,7 +156,7 @@ def extract_archive(archive: Path, destination: Path) -> None:
 
 
 def rss_time_tool_version() -> str | None:
-    time_path = Path("/usr/bin/time")
+    time_path = RSS_TIME_PATH
     if not time_path.exists():
         return None
     system = platform.system().lower()
@@ -166,12 +168,28 @@ def rss_time_tool_version() -> str | None:
 
 
 def rss_time_prefix() -> list[str]:
+    time_path = RSS_TIME_PATH
+    if not time_path.exists():
+        raise RuntimeError(f"{time_path} is required for --measure-rss")
     system = platform.system().lower()
     if system == "linux":
-        return ["/usr/bin/time", "-v"]
+        return [str(time_path), "-v"]
     if system == "darwin":
-        return ["/usr/bin/time", "-l"]
+        return [str(time_path), "-l"]
     raise RuntimeError(f"unsupported RSS measurement platform: {system}")
+
+
+def rss_time_preflight_error(
+    *,
+    system: str | None = None,
+    time_path: Path = RSS_TIME_PATH,
+) -> str | None:
+    host = (system or platform.system()).lower()
+    if host not in RSS_SYSTEMS:
+        return f"--measure-rss supports Linux and macOS only, got {host!r}"
+    if not time_path.exists():
+        return f"--measure-rss requires {time_path}"
+    return None
 
 
 def parse_peak_rss_bytes(stderr: str, *, system: str | None = None) -> int | None:
@@ -277,11 +295,17 @@ def one_sample(
         raise ValueError(f"unsupported arm: {arm}")
 
     run_command = rss_time_prefix() + command if measure_rss else command
+    env = None
+    if measure_rss:
+        env = os.environ.copy()
+        env["LC_ALL"] = "C"
+        env["LANG"] = "C"
     start = time.perf_counter()
     try:
         result = subprocess.run(
             run_command,
             cwd=workload_dir,
+            env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
@@ -474,6 +498,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.iterations < 1:
         parser.error("--iterations must be >= 1")
+    if args.measure_rss:
+        rss_error = rss_time_preflight_error()
+        if rss_error is not None:
+            parser.error(rss_error)
     if args.clean and args.out_dir.exists():
         shutil.rmtree(args.out_dir)
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -14,6 +14,7 @@ import json
 import math
 import os
 import platform
+import re
 import shutil
 import socket
 import subprocess
@@ -95,6 +96,7 @@ def tool_versions(workload_dir: Path) -> dict[str, str | None]:
         "npm": clean(run_text(["npm", "--version"])),
         "hyperfine": clean(run_text(["hyperfine", "--version"])),
         "time": "python-time.perf_counter",
+        "rss_time": clean(rss_time_tool_version()),
         "workload_package": clean(
             run_text(["node", "-p", "require('./package.json').version"], workload_dir)
         ),
@@ -151,6 +153,38 @@ def extract_archive(archive: Path, destination: Path) -> None:
         tar.extractall(destination, filter="data")
 
 
+def rss_time_tool_version() -> str | None:
+    time_path = Path("/usr/bin/time")
+    if not time_path.exists():
+        return None
+    system = platform.system().lower()
+    if system == "linux":
+        return run_text([str(time_path), "--version"]) or "GNU time"
+    if system == "darwin":
+        return "/usr/bin/time -l"
+    return str(time_path)
+
+
+def rss_time_prefix() -> list[str]:
+    system = platform.system().lower()
+    if system == "linux":
+        return ["/usr/bin/time", "-v"]
+    if system == "darwin":
+        return ["/usr/bin/time", "-l"]
+    raise RuntimeError(f"unsupported RSS measurement platform: {system}")
+
+
+def parse_peak_rss_bytes(stderr: str, *, system: str | None = None) -> int | None:
+    host = (system or platform.system()).lower()
+    if host == "linux":
+        match = re.search(r"Maximum resident set size \(kbytes\):\s*(\d+)", stderr)
+        return int(match.group(1)) * 1024 if match else None
+    if host == "darwin":
+        match = re.search(r"^\s*(\d+)\s+maximum resident set size\s*$", stderr, re.M)
+        return int(match.group(1)) if match else None
+    return None
+
+
 def percentile(values: list[float], pct: float) -> float | None:
     if not values:
         return None
@@ -187,6 +221,7 @@ def one_sample(
     assay_bin: Path | None = None,
     ebpf_obj: Path | None = None,
     use_sudo: bool = False,
+    measure_rss: bool = False,
 ) -> dict[str, Any]:
     run_id = f"overhead_{arm.replace('-', '_')}_{iteration:03d}"
     run_dir = arm_dir / f"run_{iteration:03d}"
@@ -241,10 +276,11 @@ def one_sample(
     else:
         raise ValueError(f"unsupported arm: {arm}")
 
+    run_command = rss_time_prefix() + command if measure_rss else command
     start = time.perf_counter()
     try:
         result = subprocess.run(
-            command,
+            run_command,
             cwd=workload_dir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -260,6 +296,10 @@ def one_sample(
         stderr += f"\noverhead harness timeout after {timeout_seconds} seconds\n"
         exit_code = 124
     elapsed_ms = (time.perf_counter() - start) * 1000.0
+    peak_rss_bytes = parse_peak_rss_bytes(stderr) if measure_rss else None
+    if measure_rss and peak_rss_bytes is None and exit_code == 0:
+        stderr += "\noverhead harness failed to parse peak RSS from /usr/bin/time output\n"
+        exit_code = 125
     (run_dir / "stdout.log").write_text(stdout, encoding="utf-8")
     (run_dir / "stderr.log").write_text(stderr, encoding="utf-8")
     if use_sudo and run_dir.exists():
@@ -288,7 +328,7 @@ def one_sample(
         "started_at": started_at,
         "tool_versions": versions,
         "wall_clock_ms": elapsed_ms,
-        "peak_rss_bytes": None,
+        "peak_rss_bytes": peak_rss_bytes,
         "exit_code": exit_code,
         "health": health,
         "artifact_bytes": {
@@ -402,6 +442,8 @@ def bmf_export(summary: dict[str, Any]) -> dict[str, dict[str, float | int]]:
         f"{prefix}.artifact_bytes.trace_json_median": summary["artifact_bytes"][
             "trace_json_median"
         ],
+        f"{prefix}.peak_rss_bytes.median": summary["peak_rss_bytes"]["median"],
+        f"{prefix}.peak_rss_bytes.max": summary["peak_rss_bytes"]["max"],
     }
     return {key: {"value": value} for key, value in values.items() if value is not None}
 
@@ -427,6 +469,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--assay-bin", type=Path)
     parser.add_argument("--ebpf-obj", type=Path)
     parser.add_argument("--sudo", action="store_true")
+    parser.add_argument("--measure-rss", action="store_true")
     args = parser.parse_args(argv)
 
     if args.iterations < 1:
@@ -454,6 +497,7 @@ def main(argv: list[str] | None = None) -> int:
             assay_bin=args.assay_bin,
             ebpf_obj=args.ebpf_obj,
             use_sudo=args.sudo,
+            measure_rss=args.measure_rss,
         )
         for iteration in range(1, args.iterations + 1)
     ]
@@ -487,6 +531,17 @@ def main(argv: list[str] | None = None) -> int:
                 sample["artifact_bytes"]["archive_extracted"]
                 for sample in samples
                 if sample["artifact_bytes"]["archive_extracted"] is not None
+            ],
+        },
+    )
+    write_json(
+        artifacts_dir / "rss-sizes.json",
+        {
+            "arm": args.arm,
+            "peak_rss_bytes": [
+                sample["peak_rss_bytes"]
+                for sample in samples
+                if sample["peak_rss_bytes"] is not None
             ],
         },
     )

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
@@ -64,6 +64,7 @@
         "npm",
         "hyperfine",
         "time",
+        "rss_time",
         "workload_package"
       ],
       "properties": {
@@ -90,6 +91,12 @@
         },
         "time": {
           "const": "python-time.perf_counter"
+        },
+        "rss_time": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "workload_package": {
           "type": [

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import platform
 import tempfile
 import tarfile
 import unittest
@@ -203,6 +204,7 @@ class OverheadHarnessTests(unittest.TestCase):
                 "npm": "10.0.0",
                 "hyperfine": None,
                 "time": "python-time.perf_counter",
+                "rss_time": "/usr/bin/time -l",
                 "workload_package": "0.0.0",
             },
             "wall_clock_ms": 12.5,
@@ -261,11 +263,12 @@ class OverheadHarnessTests(unittest.TestCase):
 
     def test_bmf_export_is_metric_keyed_value_objects(self) -> None:
         summary = overhead_harness.summarize(
-            [self.sample()],
+            [self.sample(peak_rss_bytes=1234)],
             delegated_workflow_url=None,
         )
         bmf = overhead_harness.bmf_export(summary)
         self.assertIn("runner_vs_otel.arm_b_otel.wall_clock_ms.median", bmf)
+        self.assertIn("runner_vs_otel.arm_b_otel.peak_rss_bytes.max", bmf)
         self.assertTrue(all(set(value) == {"value"} for value in bmf.values()))
 
     def test_host_class_is_schema_safe(self) -> None:
@@ -285,6 +288,23 @@ class OverheadHarnessTests(unittest.TestCase):
         sample["tool_versions"]["hyprfine"] = None
         with self.assertRaises(AssertionError):
             assert_matches_schema(self, sample, schema, root=schema)
+
+    def test_parse_gnu_time_peak_rss(self) -> None:
+        stderr = "Maximum resident set size (kbytes): 42\n"
+        self.assertEqual(
+            overhead_harness.parse_peak_rss_bytes(stderr, system="linux"),
+            42 * 1024,
+        )
+
+    def test_parse_darwin_time_peak_rss(self) -> None:
+        stderr = "123456 maximum resident set size\n"
+        self.assertEqual(
+            overhead_harness.parse_peak_rss_bytes(stderr, system="darwin"),
+            123456,
+        )
+
+    def test_parse_peak_rss_returns_none_for_missing_tool_output(self) -> None:
+        self.assertIsNone(overhead_harness.parse_peak_rss_bytes("", system="linux"))
 
     def test_harness_emits_twenty_valid_stub_samples(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -333,6 +353,53 @@ class OverheadHarnessTests(unittest.TestCase):
             self.assertEqual(summary["valid_samples"], 20)
             self.assertEqual(summary["discarded_samples"], 0)
             self.assertTrue(bmf)
+
+    @unittest.skipUnless(Path("/usr/bin/time").exists(), "/usr/bin/time not available")
+    def test_harness_can_emit_rss_sample(self) -> None:
+        if platform.system().lower() not in {"darwin", "linux"}:
+            self.skipTest("RSS parser only supports Darwin and Linux")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workload = root / "workload"
+            out_dir = root / "overhead"
+            write_stub_workload(workload)
+
+            status = overhead_harness.main(
+                [
+                    "--iterations",
+                    "1",
+                    "--skip-build",
+                    "--clean",
+                    "--measure-rss",
+                    "--timeout-seconds",
+                    "10",
+                    "--workload-dir",
+                    str(workload),
+                    "--out-dir",
+                    str(out_dir),
+                ]
+            )
+            self.assertEqual(status, 0)
+
+            sample = json.loads(
+                (out_dir / "arm-b-otel" / "samples.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()[0]
+            )
+            summary = json.loads(
+                (out_dir / "arm-b-otel" / "summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            rss_sizes = json.loads(
+                (out_dir / "artifacts" / "rss-sizes.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertIsInstance(sample["peak_rss_bytes"], int)
+            self.assertGreater(sample["peak_rss_bytes"], 0)
+            self.assertEqual(summary["peak_rss_bytes"]["max"], sample["peak_rss_bytes"])
+            self.assertEqual(rss_sizes["peak_rss_bytes"], [sample["peak_rss_bytes"]])
 
     def test_arm_c_sample_extracts_archive_health_and_sizes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import platform
+import subprocess
 import tempfile
 import tarfile
 import unittest
@@ -305,6 +306,71 @@ class OverheadHarnessTests(unittest.TestCase):
 
     def test_parse_peak_rss_returns_none_for_missing_tool_output(self) -> None:
         self.assertIsNone(overhead_harness.parse_peak_rss_bytes("", system="linux"))
+
+    def test_rss_preflight_rejects_missing_time_binary(self) -> None:
+        error = overhead_harness.rss_time_preflight_error(
+            system="linux",
+            time_path=Path("/definitely-not-installed/time"),
+        )
+        self.assertIn("--measure-rss requires", error or "")
+
+    def test_rss_preflight_rejects_unsupported_platform(self) -> None:
+        error = overhead_harness.rss_time_preflight_error(
+            system="plan9",
+            time_path=Path("/usr/bin/time"),
+        )
+        self.assertIn("supports Linux and macOS only", error or "")
+
+    def test_measure_rss_forces_stable_locale(self) -> None:
+        seen: dict[str, Any] = {}
+
+        def fake_run(
+            command: list[str],
+            **kwargs: Any,
+        ) -> subprocess.CompletedProcess[str]:
+            seen["command"] = command
+            seen["env"] = kwargs.get("env")
+            trace = command[command.index("--trace-out") + 1]
+            Path(trace).parent.mkdir(parents=True, exist_ok=True)
+            Path(trace).write_text('{"resourceSpans":[]}\n', encoding="utf-8")
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="",
+                stderr="123 maximum resident set size\n",
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workload = root / "workload"
+            write_stub_workload(workload)
+            original_run = overhead_harness.subprocess.run
+            original_prefix = overhead_harness.rss_time_prefix
+            original_parse = overhead_harness.parse_peak_rss_bytes
+            try:
+                overhead_harness.subprocess.run = fake_run  # type: ignore[assignment]
+                overhead_harness.rss_time_prefix = lambda: ["/usr/bin/time", "-l"]  # type: ignore[assignment]
+                overhead_harness.parse_peak_rss_bytes = (  # type: ignore[assignment]
+                    lambda stderr, system=None: 123
+                )
+                sample = overhead_harness.one_sample(
+                    arm_dir=root / "out",
+                    arm=overhead_harness.ARM_B,
+                    workload_dir=workload,
+                    iteration=1,
+                    commit="abcdef1",
+                    versions=self.sample()["tool_versions"],
+                    timeout_seconds=10,
+                    measure_rss=True,
+                )
+            finally:
+                overhead_harness.subprocess.run = original_run
+                overhead_harness.rss_time_prefix = original_prefix
+                overhead_harness.parse_peak_rss_bytes = original_parse
+
+        self.assertEqual(sample["peak_rss_bytes"], 123)
+        self.assertEqual(seen["env"]["LC_ALL"], "C")
+        self.assertEqual(seen["env"]["LANG"], "C")
 
     def test_harness_emits_twenty_valid_stub_samples(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Summary

Implements Slice 3 of the runner-vs-otel overhead follow-up: optional peak-RSS collection for both local Arm B and delegated Arm C samples. This keeps outputs experiment-scoped and does not commit benchmark artifacts.

What changed

- Adds `--measure-rss` to `overhead_harness.py`.
- Wraps samples with `/usr/bin/time` when RSS is requested:
  - Linux: GNU time `-v`, parses `Maximum resident set size (kbytes)` and converts to bytes.
  - macOS: `/usr/bin/time -l`, parses `maximum resident set size` bytes.
- Records the RSS timing tool in `tool_versions.rss_time`.
- Emits `peak_rss_bytes` per sample, summary median/max, `artifacts/rss-sizes.json`, and RSS BMF metrics when present.
- Adds workflow input `measure_rss` so the delegated Arm C workflow can run Slice 3 with `repetitions=5`.
- Updates the overhead plan with the successful Slice 2 dispatch result: run 26449999294, 20/20 valid samples, 0 discarded, health gates clean.

Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p "test_*.py"` -> 15 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p "test_*.py"` -> 92 OK
- `python3 -m py_compile docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py`
- `actionlint .github/workflows/runner-otel-overhead-experiment.yml`
- `zizmor .github/workflows/runner-otel-overhead-experiment.yml` -> no findings
- local markdown link check over changed docs -> OK
- `git diff --check`
- pre-commit + pre-push hooks green

Non-claims

- Does not dispatch the Slice 3 RSS workflow yet.
- Does not commit overhead measurement artifacts.
- Does not publish overhead claims or same-host deltas.
- Does not add Arm A decomposition.
