### PR TITLE
feat(experiments): runner-vs-otel overhead Slice 4 summary renderer

### DIFF
--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -162,26 +162,11 @@ jobs:
             --delegated-workflow-url "$WORKFLOW_URL" \
             "${RSS_FLAG[@]}"
 
-          SUMMARY="$OUT_DIR/arm-c-dual-capture/summary.json"
-          python3 - "$SUMMARY" "runner-otel-overhead-arm-c-${GITHUB_RUN_ID}" <<'PY' >> "$GITHUB_STEP_SUMMARY"
-          import json
-          import sys
-
-          summary_path, artifact_name = sys.argv[1], sys.argv[2]
-          with open(summary_path, encoding="utf-8") as fh:
-              summary = json.load(fh)
-          wall = summary["wall_clock_ms"]
-          print("## Arm C overhead summary")
-          print(f"- valid samples: {summary['valid_samples']}")
-          print(f"- discarded samples: {summary['discarded_samples']}")
-          print(f"- wall median ms: {wall['median']}")
-          print(f"- wall p95 ms: {wall['p95']}")
-          print(f"- wall p99 ms: {wall['p99']}")
-          print(f"- wall p99/median: {wall['p99_over_median']}")
-          print(f"- peak RSS median bytes: {summary['peak_rss_bytes']['median']}")
-          print(f"- peak RSS max bytes: {summary['peak_rss_bytes']['max']}")
-          print(f"- artifact: {artifact_name}")
-          PY
+          cat "$OUT_DIR/arm-c-dual-capture/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo
+            echo "- artifact: \`runner-otel-overhead-arm-c-${GITHUB_RUN_ID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Arm C overhead artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable changes to this project will be documented in this file.
   harness can now wrap samples in `/usr/bin/time`, parse GNU time and
   macOS time peak-RSS output, emit `rss-sizes.json`, and include RSS
   metrics in the derived BMF export when present.
+- Added the Slice 4 overhead summary renderer. The harness now writes a
+  reviewer-friendly `summary.md` beside `summary.json`, and the
+  delegated workflow appends that Markdown to the GitHub step summary.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -16,9 +16,16 @@
 > clean. The uploaded artifacts remain review artifacts and are not
 > committed benchmark numbers.
 >
-> **Slice 3 status:** RSS collection is wired through `--measure-rss`
-> and the `measure_rss` workflow input. The first delegated RSS dispatch
-> is still pending.
+> **Slice 3 status:** delegated Arm C RSS workflow passed on
+> [GitHub Actions run 26454010701](https://github.com/Rul1an/assay/actions/runs/26454010701):
+> 5/5 valid samples, 0 discarded samples, all Runner health gates clean,
+> peak RSS median 116,649,984 bytes, max 116,781,056 bytes. The uploaded
+> artifacts remain review artifacts and are not committed benchmark
+> numbers.
+>
+> **Slice 4 status:** the harness emits schema-validated `summary.json`,
+> reviewer-friendly `summary.md`, and derived BMF metrics. This is still
+> per-arm baseline reporting; findings must not present cross-host deltas.
 
 ## Research Question
 
@@ -279,8 +286,8 @@ investigation before publication.
 | 0 | This plan doc | Links from runner-vs-otel plan and README |
 | 1 | **Done**: local harness for Arm B wall-clock + size output, plus `overhead-sample-v0` and `overhead-summary-v0` schema sidecars | n=20 local dry run, no live API dependency, sidecar tests pass |
 | 2 | **Done**: delegated Arm C harness with health-gated samples via [`.github/workflows/runner-otel-overhead-experiment.yml`](../../.github/workflows/runner-otel-overhead-experiment.yml) | n=20 on `assay-bpf-runner`, all health gates clean |
-| 3 | **Ready to dispatch**: RSS collection per arm via `--measure-rss` / workflow `measure_rss=true` | n=5 per arm, platform-specific parser tests, tool versions recorded per sample |
-| 4 | Summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
+| 3 | **Done**: RSS collection per arm via `--measure-rss` / workflow `measure_rss=true` | n=5 on `assay-bpf-runner`, platform-specific parser tests, tool versions recorded per sample |
+| 4 | **Done**: summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
 | 5 | Findings update | No deltas unless same-host arms exist |
 | 6 optional | Arm A pure-L2 decomposition | Only if Arm C overhead needs archive-only vs dual-capture separation |
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -1,8 +1,9 @@
 # Runner vs OTel Overhead Harness
 
-> **Status:** Slice 1 local Arm B harness plus Slice 2 delegated Arm C
-> dispatch pipeline. This directory contains the experiment-scoped
-> measurement harness and schema sidecars for the plan in
+> **Status:** Slice 1 local Arm B harness, Slice 2 delegated Arm C
+> dispatch pipeline, Slice 3 RSS collection, and Slice 4 summary/BMF
+> rendering. This directory contains the experiment-scoped measurement
+> harness and schema sidecars for the plan in
 > [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
 > It does not contain committed benchmark results.
 
@@ -14,6 +15,8 @@ The harness writes:
   `assay.experiment.overhead_sample.v0`;
 - `arm-b-otel/summary.json` using
   `assay.experiment.overhead_summary.v0`;
+- `arm-b-otel/summary.md`, a reviewer-friendly rendering of the same
+  summary;
 - `artifacts/bmf.json`, a derived Bencher Metric Format export whose
   metric keys map to `{ "value": ... }` objects;
 - `artifacts/trace-sizes.json`, a trace-size side artifact for overhead
@@ -62,7 +65,9 @@ sample is either non-zero exit or capture-unclean.
 For the Slice 3 RSS run, dispatch the same workflow with
 `repetitions=5` and `measure_rss=true`. Keep `build_ebpf=true` unless a
 known-good `target/assay-ebpf.o` is already present on the delegated
-runner.
+runner. The first delegated RSS run passed as
+[GitHub Actions run 26454010701](https://github.com/Rul1an/assay/actions/runs/26454010701):
+5/5 valid samples, 0 discarded samples, all health gates clean.
 
 The local unit tests exercise the Arm C path with a fake `assay` binary
 that emits the expected archive shape. The first validation against real

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -475,8 +475,11 @@ def bmf_export(summary: dict[str, Any]) -> dict[str, dict[str, float | int]]:
 def _md_value(value: Any, *, unit: str = "") -> str:
     if value is None:
         return "`null`"
-    if isinstance(value, float):
-        rendered = f"{value:.3f}".rstrip("0").rstrip(".")
+    if isinstance(value, (float, int)):
+        if unit == "bytes" and float(value).is_integer():
+            rendered = f"{int(value):,}"
+        else:
+            rendered = f"{float(value):,.3f}".rstrip("0").rstrip(".")
     else:
         rendered = str(value)
     suffix = f" {unit}" if unit else ""

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -472,6 +472,67 @@ def bmf_export(summary: dict[str, Any]) -> dict[str, dict[str, float | int]]:
     return {key: {"value": value} for key, value in values.items() if value is not None}
 
 
+def _md_value(value: Any, *, unit: str = "") -> str:
+    if value is None:
+        return "`null`"
+    if isinstance(value, float):
+        rendered = f"{value:.3f}".rstrip("0").rstrip(".")
+    else:
+        rendered = str(value)
+    suffix = f" {unit}" if unit else ""
+    return f"`{rendered}{suffix}`"
+
+
+def tail_ratio_status(value: float | int | None) -> str:
+    if value is None:
+        return "unknown"
+    if value < 1.5:
+        return "healthy"
+    if value <= 2.0:
+        return "warning"
+    return "fail"
+
+
+def summary_markdown(summary: dict[str, Any], *, artifact_name: str | None = None) -> str:
+    wall = summary["wall_clock_ms"]
+    rss = summary["peak_rss_bytes"]
+    artifacts = summary["artifact_bytes"]
+    tail_ratio = wall["p99_over_median"]
+    lines = [
+        "## Runner-vs-OTel Overhead Summary",
+        "",
+        "| Field | Value |",
+        "|---|---:|",
+        f"| Arm | `{summary['arm']}` |",
+        f"| Host class | `{summary['host_class']}` |",
+        f"| Kernel | `{summary['kernel']}` |",
+        f"| Valid samples | `{summary['valid_samples']}` |",
+        f"| Discarded samples | `{summary['discarded_samples']}` |",
+        f"| Wall median | {_md_value(wall['median'], unit='ms')} |",
+        f"| Wall p95 | {_md_value(wall['p95'], unit='ms')} |",
+        f"| Wall p99 | {_md_value(wall['p99'], unit='ms')} |",
+        f"| Wall p99/median | {_md_value(tail_ratio)} ({tail_ratio_status(tail_ratio)}) |",
+        f"| Peak RSS median | {_md_value(rss['median'], unit='bytes')} |",
+        f"| Peak RSS max | {_md_value(rss['max'], unit='bytes')} |",
+        f"| Trace JSON median | {_md_value(artifacts['trace_json_median'], unit='bytes')} |",
+        f"| Archive .tar.gz median | {_md_value(artifacts['archive_targz_median'], unit='bytes')} |",
+        f"| Archive extracted median | {_md_value(artifacts['archive_extracted_median'], unit='bytes')} |",
+    ]
+    if summary.get("delegated_workflow_url"):
+        lines.append(f"| Workflow | {summary['delegated_workflow_url']} |")
+    if artifact_name:
+        lines.append(f"| Artifact | `{artifact_name}` |")
+    lines.extend(
+        [
+            "",
+            "> Non-claim: this is a host-class baseline. Do not publish cross-host",
+            "> overhead deltas unless compared arms were measured on the same host class.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def write_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -537,6 +598,7 @@ def main(argv: list[str] | None = None) -> int:
         encoding="utf-8",
     )
     write_json(arm_dir / "summary.json", summary)
+    (arm_dir / "summary.md").write_text(summary_markdown(summary), encoding="utf-8")
     write_json(
         artifacts_dir / "trace-sizes.json",
         {
@@ -577,6 +639,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"wrote {samples_path}")
     print(f"wrote {arm_dir / 'summary.json'}")
+    print(f"wrote {arm_dir / 'summary.md'}")
     print(f"wrote {artifacts_dir / 'bmf.json'}")
     if summary["valid_samples"] != args.iterations:
         return 2

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -272,6 +272,27 @@ class OverheadHarnessTests(unittest.TestCase):
         self.assertIn("runner_vs_otel.arm_b_otel.peak_rss_bytes.max", bmf)
         self.assertTrue(all(set(value) == {"value"} for value in bmf.values()))
 
+    def test_summary_markdown_surfaces_core_review_fields(self) -> None:
+        summary = overhead_harness.summarize(
+            [
+                self.sample(iteration=1, wall_clock_ms=10.0, peak_rss_bytes=1000),
+                self.sample(iteration=2, wall_clock_ms=20.0, peak_rss_bytes=2000),
+            ],
+            delegated_workflow_url="https://github.com/Rul1an/assay/actions/runs/1",
+        )
+        markdown = overhead_harness.summary_markdown(
+            summary,
+            artifact_name="runner-otel-overhead-arm-c-1",
+        )
+
+        self.assertIn("## Runner-vs-OTel Overhead Summary", markdown)
+        self.assertIn("| Valid samples | `2` |", markdown)
+        self.assertIn("| Wall p99/median |", markdown)
+        self.assertIn("(healthy)", markdown)
+        self.assertIn("| Peak RSS max | `2000 bytes` |", markdown)
+        self.assertIn("runner-otel-overhead-arm-c-1", markdown)
+        self.assertIn("Non-claim", markdown)
+
     def test_host_class_is_schema_safe(self) -> None:
         self.assertRegex(overhead_harness.host_class(), r"^[A-Za-z0-9_.-]+$")
 
@@ -409,6 +430,9 @@ class OverheadHarnessTests(unittest.TestCase):
             bmf = json.loads(
                 (out_dir / "artifacts" / "bmf.json").read_text(encoding="utf-8")
             )
+            summary_md = (out_dir / "arm-b-otel" / "summary.md").read_text(
+                encoding="utf-8"
+            )
 
             sample_schema = load_schema("overhead-sample-v0.schema.json")
             summary_schema = load_schema("overhead-summary-v0.schema.json")
@@ -419,6 +443,8 @@ class OverheadHarnessTests(unittest.TestCase):
             self.assertEqual(summary["valid_samples"], 20)
             self.assertEqual(summary["discarded_samples"], 0)
             self.assertTrue(bmf)
+            self.assertIn("Runner-vs-OTel Overhead Summary", summary_md)
+            self.assertIn("| Valid samples | `20` |", summary_md)
 
     @unittest.skipUnless(Path("/usr/bin/time").exists(), "/usr/bin/time not available")
     def test_harness_can_emit_rss_sample(self) -> None:

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -289,9 +289,21 @@ class OverheadHarnessTests(unittest.TestCase):
         self.assertIn("| Valid samples | `2` |", markdown)
         self.assertIn("| Wall p99/median |", markdown)
         self.assertIn("(healthy)", markdown)
-        self.assertIn("| Peak RSS max | `2000 bytes` |", markdown)
+        self.assertIn("| Peak RSS max | `2,000 bytes` |", markdown)
         self.assertIn("runner-otel-overhead-arm-c-1", markdown)
         self.assertIn("Non-claim", markdown)
+
+    def test_summary_markdown_handles_zero_valid_samples(self) -> None:
+        summary = overhead_harness.summarize(
+            [self.sample(exit_code=1)],
+            delegated_workflow_url=None,
+        )
+        markdown = overhead_harness.summary_markdown(summary)
+
+        self.assertIn("| Valid samples | `0` |", markdown)
+        self.assertIn("| Wall median | `null` |", markdown)
+        self.assertIn("| Wall p99/median | `null` (unknown) |", markdown)
+        self.assertIn("| Peak RSS max | `null` |", markdown)
 
     def test_host_class_is_schema_safe(self) -> None:
         self.assertRegex(overhead_harness.host_class(), r"^[A-Za-z0-9_.-]+$")


### PR DESCRIPTION
Summary

Implements Slice 4 of the runner-vs-otel overhead follow-up: a reviewer-friendly summary renderer layered on top of the existing experiment-scoped JSON/BMF artifacts. This keeps JSON canonical, but makes delegated workflow runs readable from the GitHub step summary without downloading artifacts.

What changed

- Adds `summary_markdown(summary)` to `overhead_harness.py` and writes `arm-*/summary.md` beside `summary.json`.
- Replaces the workflow's ad-hoc summary Python snippet with `cat summary.md` into `$GITHUB_STEP_SUMMARY`.
- Includes tail-ratio interpretation using the existing overhead plan thresholds: healthy `<1.5`, warning `1.5-2.0`, fail `>2.0`.
- Records the successful Slice 3 RSS dispatch: run 26454010701, 5/5 valid, 0 discarded, all health gates clean, peak RSS median 116,649,984 bytes, max 116,781,056 bytes.
- Marks Slice 3 and Slice 4 done in the overhead plan while preserving the no-committed-benchmark-artifacts rule.

Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 19 OK
- `python3 -m py_compile docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py`
- `actionlint .github/workflows/runner-otel-overhead-experiment.yml`
- `zizmor .github/workflows/runner-otel-overhead-experiment.yml` -> no findings
- `git diff --check`
- pre-commit and pre-push hooks green during commit/push

Non-claims

- Does not commit overhead measurement artifacts.
- Does not publish benchmark claims or cross-host deltas.
- Does not add Arm A decomposition.
- Does not add the Slice 5 findings document yet.
