### PR TITLE
docs(experiments): runner-vs-otel overhead Slice 5 findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this project will be documented in this file.
 - Added the Slice 4 overhead summary renderer. The harness now writes a
   reviewer-friendly `summary.md` beside `summary.json`, and the
   delegated workflow appends that Markdown to the GitHub step summary.
+- Added the Slice 5 overhead findings document. The findings summarize
+  the clean delegated Arm C host-class baseline and explicitly withhold
+  Arm B-vs-Arm C deltas until same-host Arm B measurements land.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-2026-05/README.md
@@ -121,7 +121,10 @@ existing Criterion / Bencher baseline.
 
 The follow-up measurement contract is tracked in
 [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
-Do not publish overhead claims from the `n=3` evidence slices.
+Current overhead findings are tracked in
+[`../runner-vs-otel-overhead-2026-05/findings.md`](../runner-vs-otel-overhead-2026-05/findings.md).
+Do not publish overhead claims from the `n=3` evidence slices, and do
+not publish Arm B-vs-Arm C deltas until same-host Arm B data exists.
 
 ## Comparator tests
 

--- a/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
+++ b/docs/experiments/runner-vs-otel-2026-05/v1-findings.md
@@ -406,10 +406,11 @@ Neither artifact is published yet.
 
 - **Overhead measurements at statistical power.** Wall-clock at
   `n >= 20`, RSS at `n >= 5`, archive/trace size at `n = 3`.
-  v1/Slice 2/Slice 3 each ran `n = 3` purely for shape stability;
-  latency claims at `n = 3` are not yet defensible. The measurement
-  follow-up is scoped in
-  [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
+  v1/Slice 2/Slice 3 each ran `n = 3` purely for shape stability.
+  The follow-up now has a clean delegated Arm C host-class baseline, but
+  direct Arm B-vs-Arm C deltas remain withheld until same-host Arm B data
+  lands. See
+  [`../runner-vs-otel-overhead-2026-05/findings.md`](../runner-vs-otel-overhead-2026-05/findings.md).
 - **L3 (Tetragon/Falco/Tracee) comparison.** Explicit follow-up in
   the plan doc.
 - **Kernel-event granularity beyond capability_surface.** The

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -1,10 +1,11 @@
 # Runner vs OTel Overhead Measurement Plan (2026-05)
 
-> **Status:** plan-only follow-up. This document turns the explicit
-> overhead non-claim from
+> **Status:** measurement follow-up with Slices 1-5 complete. This
+> document turns the explicit overhead non-claim from
 > [`runner-vs-otel-2026-05`](runner-vs-otel-2026-05/) into a reproducible
-> measurement plan. It does not add live measurements, does not publish a
-> benchmark claim, and does not change Runner archive semantics.
+> measurement plan and findings trail. It does not commit generated
+> benchmark artifacts, does not publish cross-host deltas, and does not
+> change Runner archive semantics.
 >
 > **Slice 1 status:** local Arm B harness and schema sidecars live under
 > [`runner-vs-otel-overhead-2026-05/`](runner-vs-otel-overhead-2026-05/).
@@ -26,6 +27,11 @@
 > **Slice 4 status:** the harness emits schema-validated `summary.json`,
 > reviewer-friendly `summary.md`, and derived BMF metrics. This is still
 > per-arm baseline reporting; findings must not present cross-host deltas.
+>
+> **Slice 5 status:** findings are summarized in
+> [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md).
+> The result is an Arm C host-class baseline, not a same-host overhead
+> delta.
 
 ## Research Question
 
@@ -288,11 +294,12 @@ investigation before publication.
 | 2 | **Done**: delegated Arm C harness with health-gated samples via [`.github/workflows/runner-otel-overhead-experiment.yml`](../../.github/workflows/runner-otel-overhead-experiment.yml) | n=20 on `assay-bpf-runner`, all health gates clean |
 | 3 | **Done**: RSS collection per arm via `--measure-rss` / workflow `measure_rss=true` | n=5 on `assay-bpf-runner`, platform-specific parser tests, tool versions recorded per sample |
 | 4 | **Done**: summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
-| 5 | Findings update | No deltas unless same-host arms exist |
+| 5 | **Done**: findings update in [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md) | No deltas unless same-host arms exist |
 | 6 optional | Arm A pure-L2 decomposition | Only if Arm C overhead needs archive-only vs dual-capture separation |
 
 ## Publication Rule
 
-Do not add overhead numbers to the OpenInference discussion or blog until
-Slices 1-5 have landed and the findings document can distinguish
-same-host deltas from host-class baselines.
+Publication may mention that a clean Arm C host-class baseline exists,
+but must not present Arm B-vs-Arm C overhead deltas until same-host Arm B
+measurements land. Do not add overhead numbers to the OpenInference
+discussion unless that distinction is explicit in the wording.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -6,6 +6,10 @@
 > harness and schema sidecars for the plan in
 > [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
 > It does not contain committed benchmark results.
+>
+> Current findings are in [`findings.md`](findings.md). They summarize
+> the delegated Arm C host-class baseline and intentionally withhold
+> cross-host deltas.
 
 ## What This Emits
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -1,0 +1,81 @@
+# Runner vs OTel Overhead Findings (2026-05)
+
+> **Status:** Slice 5 findings update. This document summarizes the
+> overhead follow-up evidence collected so far. It does not commit the
+> generated measurement artifacts and does not publish cross-host
+> overhead deltas.
+
+## Evidence Anchors
+
+| Slice | Workflow run | Arm | Samples | Result |
+|---|---|---|---:|---|
+| 2 | [26449999294](https://github.com/Rul1an/assay/actions/runs/26449999294) | Arm C dual capture | 20 wall-clock | 20 valid, 0 discarded, all health gates clean |
+| 3 | [26454010701](https://github.com/Rul1an/assay/actions/runs/26454010701) | Arm C dual capture | 5 RSS | 5 valid, 0 discarded, all health gates clean |
+
+Generated artifacts from those runs were inspected as review artifacts
+only. They are intentionally not committed as benchmark evidence in this
+slice.
+
+## Arm C Host-Class Baseline
+
+The delegated Runner capture path is now measured on the
+`assay-bpf-runner` host class:
+
+| Metric | Value | Interpretation |
+|---|---:|---|
+| Host class | `linux-aarch64-6.8.0-117-generic` | Delegated Linux/eBPF runner baseline |
+| Wall-clock valid samples | `20/20` | Meets the n >= 20 gate |
+| Wall median | `1,737.838 ms` | Baseline for Arm C on this host class |
+| Wall p95 | `2,051.039 ms` | Tail sample remained close to median |
+| Wall p99 | `2,070.354 ms` | Nearest-rank p99 for n=20 |
+| Wall p99/median | `1.191` | Healthy per the v0 `< 1.5` tail-ratio band |
+| RSS valid samples | `5/5` | Meets the n >= 5 gate |
+| Peak RSS median | `116,649,984 bytes` | Memory baseline for Arm C on this host class |
+| Peak RSS max | `116,781,056 bytes` | No large RSS outlier in the n=5 sample |
+| Trace JSON median | `3,220 bytes` | L1 trace footprint baseline |
+| Archive `.tar.gz` median | `1,776-1,777 bytes` | L2 compressed archive footprint baseline |
+| Archive extracted median | `8,186-8,187 bytes` | Review/storage footprint baseline |
+
+The one-byte artifact-size spread between Slice 2 and Slice 3 is
+expected for freshly generated archives and traces. The useful claim is
+that the footprint is tiny and stable at this workload scale, not that
+archive bytes are deterministic across runs.
+
+## What This Means
+
+- The delegated Arm C measurement harness is usable: both wall-clock and
+  RSS runs produced all-valid samples with clean Runner health gates.
+- The observed Arm C tail ratio is healthy for this deterministic
+  workload on `assay-bpf-runner`.
+- The RSS path works on the delegated Linux runner with GNU
+  `/usr/bin/time -v`; samples record the RSS tool version and emit
+  `peak_rss_bytes` into both `summary.json` and the BMF export.
+- The summary renderer now gives reviewers the same metrics in
+  `summary.md` and in the GitHub step summary, while `summary.json`
+  remains canonical.
+
+## What This Does Not Mean
+
+- No direct Arm B-vs-Arm C overhead delta is reported here. Arm B was
+  not measured on the same `linux-aarch64-6.8.0-117-generic` host class.
+- No product ranking is implied between OpenTelemetry, OpenInference, or
+  Assay-Runner.
+- No model/provider latency claim is made. The workload is deterministic
+  and measurement-scoped.
+- No Trust Card or Trust Basis claim is added. This remains an
+  experiment-scoped measurement follow-up.
+- The generated artifacts remain review artifacts until a later decision
+  explicitly promotes a measurement bundle into committed evidence.
+
+## Next Work
+
+The next useful measurement step is a same-host Arm B run on
+`assay-bpf-runner`. That would allow a narrow Arm B-vs-Arm C delta on the
+same host class. Until then, the correct publication language is:
+
+> Arm C dual capture has a clean delegated host-class baseline. Direct
+> overhead deltas are still withheld because same-host Arm B data has not
+> landed.
+
+Optional Arm A remains deferred unless Arm C needs decomposition into
+"Runner archive only" versus "Runner archive plus OTel trace".


### PR DESCRIPTION
Summary

Lands Slice 5 of the runner-vs-otel overhead follow-up as a findings-only update. This turns the Slice 2 + Slice 3 delegated workflow results into an explicit host-class baseline without committing generated benchmark artifacts or publishing cross-host deltas.

What changed

- Adds `docs/experiments/runner-vs-otel-overhead-2026-05/findings.md`.
- Anchors the two delegated runs:
  - Slice 2 wall-clock: run 26449999294, 20/20 valid, 0 discarded, all health gates clean.
  - Slice 3 RSS: run 26454010701, 5/5 valid, 0 discarded, all health gates clean.
- Records the Arm C delegated host-class baseline:
  - host class `linux-aarch64-6.8.0-117-generic`
  - wall median 1,737.838 ms, p95 2,051.039 ms, p99 2,070.354 ms, p99/median 1.191 healthy
  - peak RSS median 116,649,984 bytes, max 116,781,056 bytes
  - trace/archive size medians as review-artifact baselines
- Updates the overhead plan + README + main runner-vs-otel README/findings to point at the new findings doc.
- Keeps the publication rule honest: Arm C has a clean host-class baseline; Arm B-vs-Arm C deltas remain withheld until same-host Arm B data lands.

Validation

- local markdown link checker over changed docs -> OK
- `git diff --check`
- pre-commit + pre-push hooks green

Non-claims

- Does not commit generated measurement artifacts.
- Does not publish benchmark claims or cross-host deltas.
- Does not add same-host Arm B measurements.
- Does not add optional Arm A decomposition.
