### PR TITLE
feat(experiments): runner-vs-otel same-host Arm B overhead workflow

### DIFF
--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -9,10 +9,19 @@ on:
   workflow_dispatch:
     inputs:
       repetitions:
-        description: "Number of Arm C overhead samples to collect"
+        description: "Number of overhead samples to collect"
         required: true
         default: "20"
         type: string
+      arm:
+        description: "Measurement arm to run"
+        required: true
+        default: "arm-c-dual-capture"
+        type: choice
+        options:
+          - arm-c-dual-capture
+          - arm-b-otel
+          - both
       build_ebpf:
         description: "Rebuild eBPF artifact before running Arm C"
         required: true
@@ -53,6 +62,7 @@ jobs:
 
   arm-c-overhead:
     name: Arm C overhead capture
+    if: ${{ inputs.arm == 'arm-c-dual-capture' || inputs.arm == 'both' }}
     runs-on: [self-hosted, linux, assay-bpf-runner]
     needs: prepare-delegated-runner
     timeout-minutes: 60
@@ -172,6 +182,97 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: runner-otel-overhead-arm-c-${{ github.run_id }}
+          path: overhead-runs/
+          if-no-files-found: error
+          retention-days: 30
+
+  arm-b-overhead:
+    name: Arm B overhead capture
+    if: ${{ inputs.arm == 'arm-b-otel' || inputs.arm == 'both' }}
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    needs: prepare-delegated-runner
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Preflight delegated host
+        shell: bash
+        run: |
+          set -euo pipefail
+          for bin in node npm python3 tar; do
+            command -v "$bin" >/dev/null 2>&1 || {
+              echo "ERROR: required command not found on delegated runner: $bin" >&2
+              exit 1
+            }
+          done
+          node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)' || {
+            echo "ERROR: delegated runner must provide Node.js 22 or newer" >&2
+            node --version >&2 || true
+            exit 1
+          }
+          {
+            echo "## Delegated runner preflight"
+            echo "- arm: arm-b-otel"
+            echo "- kernel: $(uname -r)"
+            echo "- node: $(node --version)"
+            echo "- python3: $(python3 --version)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run overhead harness unit tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover \
+            -s docs/experiments/runner-vs-otel-overhead-2026-05 \
+            -p 'test_*.py'
+
+      - name: Build experiment workload
+        working-directory: docs/experiments/runner-vs-otel-2026-05/workload
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund --ignore-scripts
+          npx tsc -p tsconfig.json
+          test -f dist/workload.js
+
+      - name: Run Arm B overhead harness
+        shell: bash
+        env:
+          REPETITIONS: ${{ inputs.repetitions }}
+          TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+          MEASURE_RSS: ${{ inputs.measure_rss }}
+        run: |
+          set -euo pipefail
+          OUT_DIR="$PWD/overhead-runs"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          RSS_FLAG=()
+          if [ "$MEASURE_RSS" = "true" ]; then
+            RSS_FLAG=(--measure-rss)
+          fi
+          python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
+            --arm arm-b-otel \
+            --iterations "$REPETITIONS" \
+            --skip-build \
+            --clean \
+            --timeout-seconds "$TIMEOUT_SECONDS" \
+            --out-dir "$OUT_DIR" \
+            --workload-dir "$PWD/docs/experiments/runner-vs-otel-2026-05/workload" \
+            --delegated-workflow-url "$WORKFLOW_URL" \
+            "${RSS_FLAG[@]}"
+
+          cat "$OUT_DIR/arm-b-otel/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo
+            echo "- artifact: \`runner-otel-overhead-arm-b-${GITHUB_RUN_ID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Arm B overhead artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: runner-otel-overhead-arm-b-${{ github.run_id }}
           path: overhead-runs/
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -14,14 +14,13 @@ on:
         default: "20"
         type: string
       arm:
-        description: "Measurement arm to run"
+        description: "Measurement arm to run (dispatch once per arm)"
         required: true
         default: "arm-c-dual-capture"
         type: choice
         options:
           - arm-c-dual-capture
           - arm-b-otel
-          - both
       build_ebpf:
         description: "Rebuild eBPF artifact before running Arm C"
         required: true
@@ -62,10 +61,10 @@ jobs:
 
   arm-c-overhead:
     name: Arm C overhead capture
-    if: ${{ inputs.arm == 'arm-c-dual-capture' || inputs.arm == 'both' }}
+    if: ${{ inputs.arm == 'arm-c-dual-capture' }}
     runs-on: [self-hosted, linux, assay-bpf-runner]
     needs: prepare-delegated-runner
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -188,10 +187,10 @@ jobs:
 
   arm-b-overhead:
     name: Arm B overhead capture
-    if: ${{ inputs.arm == 'arm-b-otel' || inputs.arm == 'both' }}
+    if: ${{ inputs.arm == 'arm-b-otel' }}
     runs-on: [self-hosted, linux, assay-bpf-runner]
     needs: prepare-delegated-runner
-    timeout-minutes: 30
+    timeout-minutes: 120
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this project will be documented in this file.
 - Added the Slice 5 overhead findings document. The findings summarize
   the clean delegated Arm C host-class baseline and explicitly withhold
   Arm B-vs-Arm C deltas until same-host Arm B measurements land.
+- Added a delegated same-host Arm B path to the Runner-vs-OTel overhead
+  workflow so `arm-b-otel` can be measured on `assay-bpf-runner` before
+  any Arm B-vs-Arm C delta is published.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -32,6 +32,10 @@
 > [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md).
 > The result is an Arm C host-class baseline, not a same-host overhead
 > delta.
+>
+> **Slice 6 status:** the delegated workflow can now dispatch same-host
+> Arm B (`arm-b-otel`) on `assay-bpf-runner`. The first same-host Arm B
+> measurement is still pending, so Arm B-vs-Arm C deltas remain withheld.
 
 ## Research Question
 
@@ -295,7 +299,8 @@ investigation before publication.
 | 3 | **Done**: RSS collection per arm via `--measure-rss` / workflow `measure_rss=true` | n=5 on `assay-bpf-runner`, platform-specific parser tests, tool versions recorded per sample |
 | 4 | **Done**: summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
 | 5 | **Done**: findings update in [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md) | No deltas unless same-host arms exist |
-| 6 optional | Arm A pure-L2 decomposition | Only if Arm C overhead needs archive-only vs dual-capture separation |
+| 6 | **Ready to dispatch**: same-host Arm B delegated workflow path via `arm=arm-b-otel` | n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; compare only if `host_class` matches Arm C |
+| 7 optional | Arm A pure-L2 decomposition | Only if Arm C overhead needs archive-only vs dual-capture separation |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -299,7 +299,7 @@ investigation before publication.
 | 3 | **Done**: RSS collection per arm via `--measure-rss` / workflow `measure_rss=true` | n=5 on `assay-bpf-runner`, platform-specific parser tests, tool versions recorded per sample |
 | 4 | **Done**: summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
 | 5 | **Done**: findings update in [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md) | No deltas unless same-host arms exist |
-| 6 | **Ready to dispatch**: same-host Arm B delegated workflow path via `arm=arm-b-otel` | n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; compare only if `host_class` matches Arm C |
+| 6 | **Ready to dispatch**: same-host Arm B delegated workflow path via `arm=arm-b-otel` | separately dispatch n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; compare only if `host_class` matches Arm C |
 | 7 optional | Arm A pure-L2 decomposition | Only if Arm C overhead needs archive-only vs dual-capture separation |
 
 ## Publication Rule

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -68,11 +68,11 @@ The workflow runs on `assay-bpf-runner` and exposes an `arm` input:
   `assay runner-spike`, eBPF, and Runner health gates.
 - `arm-b-otel` runs `--arm arm-b-otel` on the same delegated host class
   without Runner capture.
-- `both` runs both delegated arms and uploads separate artifacts.
 
 Arm C fails if any sample is either non-zero exit or capture-unclean.
 Arm B fails if any sample exits non-zero. A direct Arm B-vs-Arm C delta
-is only valid when the emitted `host_class` values match.
+is only valid when separately dispatched summaries emit matching
+`host_class` values.
 
 For the Slice 3 RSS run, dispatch the same workflow with
 `arm=arm-c-dual-capture`, `repetitions=5`, and `measure_rss=true`. Keep
@@ -81,7 +81,7 @@ present on the delegated runner. The first delegated RSS run passed as
 [GitHub Actions run 26454010701](https://github.com/Rul1an/assay/actions/runs/26454010701):
 5/5 valid samples, 0 discarded samples, all health gates clean.
 
-For the first same-host Arm B run, dispatch with `arm=arm-b-otel`,
+For the first same-host Arm B run, dispatch separately with `arm=arm-b-otel`,
 `repetitions=20`, and `measure_rss=false`, then dispatch a second Arm B
 RSS run with `repetitions=5` and `measure_rss=true`.
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -58,20 +58,32 @@ temporary output directory. Do not commit generated measurements until
 the findings slice decides what should become evidence. The default
 `runs/overhead-2026-05/` output path is ignored for this reason.
 
-## Delegated Arm C
+## Delegated Arm B / Arm C
 
-Arm C is dispatched manually through
+Arm B and Arm C are dispatched manually through
 [`runner-otel-overhead-experiment.yml`](../../../.github/workflows/runner-otel-overhead-experiment.yml).
-The workflow runs on `assay-bpf-runner`, invokes the same harness with
-`--arm arm-c-dual-capture`, uploads `overhead-runs/`, and fails if any
-sample is either non-zero exit or capture-unclean.
+The workflow runs on `assay-bpf-runner` and exposes an `arm` input:
+
+- `arm-c-dual-capture` runs `--arm arm-c-dual-capture` with
+  `assay runner-spike`, eBPF, and Runner health gates.
+- `arm-b-otel` runs `--arm arm-b-otel` on the same delegated host class
+  without Runner capture.
+- `both` runs both delegated arms and uploads separate artifacts.
+
+Arm C fails if any sample is either non-zero exit or capture-unclean.
+Arm B fails if any sample exits non-zero. A direct Arm B-vs-Arm C delta
+is only valid when the emitted `host_class` values match.
 
 For the Slice 3 RSS run, dispatch the same workflow with
-`repetitions=5` and `measure_rss=true`. Keep `build_ebpf=true` unless a
-known-good `target/assay-ebpf.o` is already present on the delegated
-runner. The first delegated RSS run passed as
+`arm=arm-c-dual-capture`, `repetitions=5`, and `measure_rss=true`. Keep
+`build_ebpf=true` unless a known-good `target/assay-ebpf.o` is already
+present on the delegated runner. The first delegated RSS run passed as
 [GitHub Actions run 26454010701](https://github.com/Rul1an/assay/actions/runs/26454010701):
 5/5 valid samples, 0 discarded samples, all health gates clean.
+
+For the first same-host Arm B run, dispatch with `arm=arm-b-otel`,
+`repetitions=20`, and `measure_rss=false`, then dispatch a second Arm B
+RSS run with `repetitions=5` and `measure_rss=true`.
 
 The local unit tests exercise the Arm C path with a fake `assay` binary
 that emits the expected archive shape. The first validation against real

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -70,8 +70,14 @@ archive bytes are deterministic across runs.
 ## Next Work
 
 The next useful measurement step is a same-host Arm B run on
-`assay-bpf-runner`. That would allow a narrow Arm B-vs-Arm C delta on the
-same host class. Until then, the correct publication language is:
+`assay-bpf-runner`. The delegated workflow now has an `arm=arm-b-otel`
+path for that purpose. To unblock a narrow Arm B-vs-Arm C delta, collect:
+
+- Arm B wall-clock: `repetitions=20`, `measure_rss=false`;
+- Arm B RSS: `repetitions=5`, `measure_rss=true`;
+- matching `host_class` values between the Arm B and Arm C summaries.
+
+Until then, the correct publication language is:
 
 > Arm C dual capture has a clean delegated host-class baseline. Direct
 > overhead deltas are still withheld because same-host Arm B data has not


### PR DESCRIPTION
Summary

Adds the next overhead follow-up step after Slice 5: a delegated Arm B path on `assay-bpf-runner`, so we can collect same-host OTel-only measurements before publishing any Arm B-vs-Arm C delta.

What changed

- Adds workflow_dispatch input `arm` with `arm-c-dual-capture` (default), `arm-b-otel`, and `both`.
- Keeps the existing Arm C job behind `arm=arm-c-dual-capture|both`.
- Adds a delegated Arm B job that:
  - runs on `[self-hosted, linux, assay-bpf-runner]`
  - builds the same workload
  - runs `overhead_harness.py --arm arm-b-otel`
  - supports `measure_rss=true`
  - uploads `runner-otel-overhead-arm-b-<run_id>` artifacts
  - appends generated `summary.md` to the step summary.
- Updates the overhead plan, README, findings, and changelog to mark the same-host Arm B path as ready to dispatch.

Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 20 OK
- `python3 -m py_compile docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py`
- `actionlint .github/workflows/runner-otel-overhead-experiment.yml`
- `zizmor .github/workflows/runner-otel-overhead-experiment.yml` -> no findings
- local markdown link check over changed docs -> OK
- `git diff --check`
- pre-commit + pre-push hooks green

Non-claims

- Does not dispatch the same-host Arm B run yet.
- Does not commit generated measurement artifacts.
- Does not publish Arm B-vs-Arm C deltas yet.
- Does not add optional Arm A decomposition.

Post-merge dispatch plan

1. Wall-clock: `arm=arm-b-otel`, `repetitions=20`, `measure_rss=false`.
2. RSS: `arm=arm-b-otel`, `repetitions=5`, `measure_rss=true`.
3. Compare only if Arm B and Arm C summaries emit the same `host_class`.
