### PR TITLE
docs(experiments): add same-host overhead findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ All notable changes to this project will be documented in this file.
 - Added a delegated same-host Arm B path to the Runner-vs-OTel overhead
   workflow so `arm-b-otel` can be measured on `assay-bpf-runner` before
   any Arm B-vs-Arm C delta is published.
+- Updated the overhead findings after the same-host Arm B dispatches.
+  The findings now report the narrow `linux-aarch64-6.8.0-117-generic`
+  Arm B-vs-Arm C delta while preserving the non-co-temporal and
+  non-decomposition caveats.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-2026-05/README.md
@@ -124,7 +124,8 @@ The follow-up measurement contract is tracked in
 Current overhead findings are tracked in
 [`../runner-vs-otel-overhead-2026-05/findings.md`](../runner-vs-otel-overhead-2026-05/findings.md).
 Do not publish overhead claims from the `n=3` evidence slices, and do
-not publish Arm B-vs-Arm C deltas until same-host Arm B data exists.
+not publish Arm B-vs-Arm C deltas without the same-host, non-co-temporal,
+and non-decomposition caveats from that findings document.
 
 ## Comparator tests
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -1,6 +1,6 @@
 # Runner vs OTel Overhead Measurement Plan (2026-05)
 
-> **Status:** measurement follow-up with Slices 1-5 complete. This
+> **Status:** measurement follow-up with Slices 1-6 complete. This
 > document turns the explicit overhead non-claim from
 > [`runner-vs-otel-2026-05`](runner-vs-otel-2026-05/) into a reproducible
 > measurement plan and findings trail. It does not commit generated
@@ -28,14 +28,18 @@
 > reviewer-friendly `summary.md`, and derived BMF metrics. This is still
 > per-arm baseline reporting; findings must not present cross-host deltas.
 >
-> **Slice 5 status:** findings are summarized in
+> **Slice 5 status:** initial findings are summarized in
 > [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md).
-> The result is an Arm C host-class baseline, not a same-host overhead
-> delta.
+> The initial result was an Arm C host-class baseline.
 >
-> **Slice 6 status:** the delegated workflow can now dispatch same-host
-> Arm B (`arm-b-otel`) on `assay-bpf-runner`. The first same-host Arm B
-> measurement is still pending, so Arm B-vs-Arm C deltas remain withheld.
+> **Slice 6 status:** same-host Arm B passed on
+> [GitHub Actions run 26459699303](https://github.com/Rul1an/assay/actions/runs/26459699303)
+> for wall-clock (20/20 valid, 0 discarded) and
+> [GitHub Actions run 26461726436](https://github.com/Rul1an/assay/actions/runs/26461726436)
+> for RSS (5/5 valid, 0 discarded). Both emitted the same
+> `linux-aarch64-6.8.0-117-generic` host class as Arm C, so the findings
+> document now reports a narrow same-host delta for this deterministic
+> workload.
 
 ## Research Question
 
@@ -298,13 +302,15 @@ investigation before publication.
 | 2 | **Done**: delegated Arm C harness with health-gated samples via [`.github/workflows/runner-otel-overhead-experiment.yml`](../../.github/workflows/runner-otel-overhead-experiment.yml) | n=20 on `assay-bpf-runner`, all health gates clean |
 | 3 | **Done**: RSS collection per arm via `--measure-rss` / workflow `measure_rss=true` | n=5 on `assay-bpf-runner`, platform-specific parser tests, tool versions recorded per sample |
 | 4 | **Done**: summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
-| 5 | **Done**: findings update in [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md) | No deltas unless same-host arms exist |
-| 6 | **Ready to dispatch**: same-host Arm B delegated workflow path via `arm=arm-b-otel` | separately dispatch n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; compare only if `host_class` matches Arm C |
+| 5 | **Done**: initial findings update in [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md) | No deltas unless same-host arms exist |
+| 6 | **Done**: same-host Arm B delegated workflow path via `arm=arm-b-otel`, dispatched in runs [26459699303](https://github.com/Rul1an/assay/actions/runs/26459699303) and [26461726436](https://github.com/Rul1an/assay/actions/runs/26461726436) | n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; `host_class` matches Arm C |
 | 7 optional | Arm A pure-L2 decomposition | Only if Arm C overhead needs archive-only vs dual-capture separation |
 
 ## Publication Rule
 
-Publication may mention that a clean Arm C host-class baseline exists,
-but must not present Arm B-vs-Arm C overhead deltas until same-host Arm B
-measurements land. Do not add overhead numbers to the OpenInference
-discussion unless that distinction is explicit in the wording.
+Publication may mention the same-host Arm B-vs-Arm C delta only with the
+host-class and non-decomposition caveats from the findings document. Do
+not present it as a product benchmark, model/provider latency claim, or
+co-temporal variance result. Do not add overhead numbers to the
+OpenInference discussion unless that distinction is explicit in the
+wording.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -1,15 +1,16 @@
 # Runner vs OTel Overhead Harness
 
 > **Status:** Slice 1 local Arm B harness, Slice 2 delegated Arm C
-> dispatch pipeline, Slice 3 RSS collection, and Slice 4 summary/BMF
-> rendering. This directory contains the experiment-scoped measurement
+> dispatch pipeline, Slice 3 RSS collection, Slice 4 summary/BMF
+> rendering, Slice 5 findings, and Slice 6 same-host Arm B dispatches.
+> This directory contains the experiment-scoped measurement
 > harness and schema sidecars for the plan in
 > [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
 > It does not contain committed benchmark results.
 >
 > Current findings are in [`findings.md`](findings.md). They summarize
-> the delegated Arm C host-class baseline and intentionally withhold
-> cross-host deltas.
+> the delegated same-host Arm B-vs-Arm C delta and keep the caveats
+> attached.
 
 ## What This Emits
 
@@ -81,9 +82,13 @@ present on the delegated runner. The first delegated RSS run passed as
 [GitHub Actions run 26454010701](https://github.com/Rul1an/assay/actions/runs/26454010701):
 5/5 valid samples, 0 discarded samples, all health gates clean.
 
-For the first same-host Arm B run, dispatch separately with `arm=arm-b-otel`,
-`repetitions=20`, and `measure_rss=false`, then dispatch a second Arm B
-RSS run with `repetitions=5` and `measure_rss=true`.
+The first same-host Arm B wall-clock run passed as
+[GitHub Actions run 26459699303](https://github.com/Rul1an/assay/actions/runs/26459699303):
+20/20 valid samples and 0 discarded samples. The matching Arm B RSS run
+passed as
+[GitHub Actions run 26461726436](https://github.com/Rul1an/assay/actions/runs/26461726436):
+5/5 valid samples and 0 discarded samples. Both emitted the same
+`linux-aarch64-6.8.0-117-generic` host class as Arm C.
 
 The local unit tests exercise the Arm C path with a fake `assay` binary
 that emits the expected archive shape. The first validation against real

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -1,9 +1,10 @@
 # Runner vs OTel Overhead Findings (2026-05)
 
-> **Status:** Slice 5 findings update. This document summarizes the
+> **Status:** same-host findings update. This document summarizes the
 > overhead follow-up evidence collected so far. It does not commit the
-> generated measurement artifacts and does not publish cross-host
-> overhead deltas.
+> generated measurement artifacts. Direct Arm B-vs-Arm C deltas are
+> reported only for the matching `linux-aarch64-6.8.0-117-generic` host
+> class.
 
 ## Evidence Anchors
 
@@ -11,42 +12,78 @@
 |---|---|---|---:|---|
 | 2 | [26449999294](https://github.com/Rul1an/assay/actions/runs/26449999294) | Arm C dual capture | 20 wall-clock | 20 valid, 0 discarded, all health gates clean |
 | 3 | [26454010701](https://github.com/Rul1an/assay/actions/runs/26454010701) | Arm C dual capture | 5 RSS | 5 valid, 0 discarded, all health gates clean |
+| 6 wall | [26459699303](https://github.com/Rul1an/assay/actions/runs/26459699303) | Arm B OTel-only | 20 wall-clock | 20 valid, 0 discarded, same host class |
+| 6 RSS | [26461726436](https://github.com/Rul1an/assay/actions/runs/26461726436) | Arm B OTel-only | 5 RSS | 5 valid, 0 discarded, same host class |
 
 Generated artifacts from those runs were inspected as review artifacts
 only. They are intentionally not committed as benchmark evidence in this
 slice.
 
-## Arm C Host-Class Baseline
+## Same-Host Baselines
 
-The delegated Runner capture path is now measured on the
+Both arms now have clean measurements on the same delegated
 `assay-bpf-runner` host class:
 
 | Metric | Value | Interpretation |
 |---|---:|---|
-| Host class | `linux-aarch64-6.8.0-117-generic` | Delegated Linux/eBPF runner baseline |
-| Wall-clock valid samples | `20/20` | Meets the n >= 20 gate |
-| Wall median | `1,737.838 ms` | Baseline for Arm C on this host class |
-| Wall p95 | `2,051.039 ms` | Tail sample remained close to median |
-| Wall p99 | `2,070.354 ms` | Nearest-rank p99 for n=20 |
-| Wall p99/median | `1.191` | Healthy per the v0 `< 1.5` tail-ratio band |
-| RSS valid samples | `5/5` | Meets the n >= 5 gate |
-| Peak RSS median | `116,649,984 bytes` | Memory baseline for Arm C on this host class |
-| Peak RSS max | `116,781,056 bytes` | No large RSS outlier in the n=5 sample |
-| Trace JSON median | `3,220 bytes` | L1 trace footprint baseline |
-| Archive `.tar.gz` median | `1,776-1,777 bytes` | L2 compressed archive footprint baseline |
-| Archive extracted median | `8,186-8,187 bytes` | Review/storage footprint baseline |
+| Host class | `linux-aarch64-6.8.0-117-generic` | Delegated Linux runner machine/OS/kernel boundary |
+| Arm B wall-clock valid samples | `20/20` | Meets the n >= 20 gate |
+| Arm B wall median | `879.961 ms` | OTel-only baseline on this host class |
+| Arm B wall p95 | `924.845 ms` | Tail sample remained close to median |
+| Arm B wall p99 | `964.023 ms` | Nearest-rank p99 for n=20 |
+| Arm B wall p99/median | `1.096` | Healthy per the v0 `< 1.5` tail-ratio band |
+| Arm B RSS valid samples | `5/5` | Meets the n >= 5 gate |
+| Arm B peak RSS median | `108,953,600 bytes` | OTel-only memory baseline |
+| Arm B peak RSS max | `110,493,696 bytes` | No large RSS outlier in the n=5 sample |
+| Arm C wall-clock valid samples | `20/20` | Meets the n >= 20 gate |
+| Arm C wall median | `1,737.838 ms` | Dual-capture baseline on this host class |
+| Arm C wall p95 | `2,051.039 ms` | Tail sample remained close to median |
+| Arm C wall p99 | `2,070.354 ms` | Nearest-rank p99 for n=20 |
+| Arm C wall p99/median | `1.191` | Healthy per the v0 `< 1.5` tail-ratio band |
+| Arm C RSS valid samples | `5/5` | Meets the n >= 5 gate |
+| Arm C peak RSS median | `116,649,984 bytes` | Dual-capture memory baseline |
+| Arm C peak RSS max | `116,781,056 bytes` | No large RSS outlier in the n=5 sample |
+| Arm B trace JSON median | `3,204 bytes` | L1 trace footprint baseline |
+| Arm C trace JSON median | `3,220 bytes` | L1 trace plus Runner wrapper footprint |
+| Arm C archive `.tar.gz` median | `1,776-1,777 bytes` | L2 compressed archive footprint baseline |
+| Arm C archive extracted median | `8,186-8,187 bytes` | Review/storage footprint baseline |
 
 The one-byte artifact-size spread between Slice 2 and Slice 3 is
 expected for freshly generated archives and traces. The useful claim is
 that the footprint is tiny and stable at this workload scale, not that
 archive bytes are deterministic across runs.
 
+## Same-Host Delta
+
+Because Arm B and Arm C emitted the same `host_class`, a narrow
+same-host delta is now valid for this deterministic workload. The runs
+were not co-temporal, so this is still a host-class baseline comparison,
+not a product benchmark.
+
+| Metric | Arm B OTel-only | Arm C dual capture | Delta |
+|---|---:|---:|---:|
+| Wall median | `879.961 ms` | `1,737.838 ms` | `+857.878 ms` (`+97.5%`) |
+| Wall p95 | `924.845 ms` | `2,051.039 ms` | `+1,126.195 ms` (`+121.8%`) |
+| Wall p99 | `964.023 ms` | `2,070.354 ms` | `+1,106.331 ms` (`+114.8%`) |
+| Wall p99/median | `1.096` | `1.191` | `+0.096` |
+| Peak RSS median | `108,953,600 bytes` | `116,649,984 bytes` | `+7,696,384 bytes` (`+7.1%`) |
+| Peak RSS max | `110,493,696 bytes` | `116,781,056 bytes` | `+6,287,360 bytes` (`+5.7%`) |
+| Trace JSON median | `3,204 bytes` | `3,220 bytes` | `+16 bytes` |
+
+The wall-clock delta is the cost of the current dual-capture path on
+this host class: Runner archive capture plus the existing OTel trace
+around the deterministic workload. It does not decompose how much of
+that cost is pure Runner archive capture versus coordination around the
+OTel trace; optional Arm A remains the path for that question.
+
 ## What This Means
 
-- The delegated Arm C measurement harness is usable: both wall-clock and
-  RSS runs produced all-valid samples with clean Runner health gates.
+- The delegated measurement harness is usable for both arms: wall-clock
+  and RSS runs produced all-valid samples on the same host class.
 - The observed Arm C tail ratio is healthy for this deterministic
   workload on `assay-bpf-runner`.
+- The observed Arm C median wall-clock is about 2x Arm B on the same
+  host class for this workload, while RSS increases by about 7%.
 - The RSS path works on the delegated Linux runner with GNU
   `/usr/bin/time -v`; samples record the RSS tool version and emit
   `peak_rss_bytes` into both `summary.json` and the BMF export.
@@ -56,12 +93,14 @@ archive bytes are deterministic across runs.
 
 ## What This Does Not Mean
 
-- No direct Arm B-vs-Arm C overhead delta is reported here. Arm B was
-  not measured on the same `linux-aarch64-6.8.0-117-generic` host class.
 - No product ranking is implied between OpenTelemetry, OpenInference, or
   Assay-Runner.
 - No model/provider latency claim is made. The workload is deterministic
   and measurement-scoped.
+- No co-temporal variance claim is made. Arm B and Arm C ran on the same
+  host class at different times.
+- No decomposition claim is made between "Runner archive only" and
+  "Runner archive plus OTel trace".
 - No Trust Card or Trust Basis claim is added. This remains an
   experiment-scoped measurement follow-up.
 - The generated artifacts remain review artifacts until a later decision
@@ -69,19 +108,13 @@ archive bytes are deterministic across runs.
 
 ## Next Work
 
-The next useful measurement step is a same-host Arm B run on
-`assay-bpf-runner`. The delegated workflow now has an `arm=arm-b-otel`
-path for that purpose. To unblock a narrow Arm B-vs-Arm C delta, collect:
+The correct publication language is now:
 
-- Arm B wall-clock: `repetitions=20`, `measure_rss=false`;
-- Arm B RSS: `repetitions=5`, `measure_rss=true`;
-- matching `host_class` values between the Arm B and Arm C summaries.
-
-Until then, the correct publication language is:
-
-> Arm C dual capture has a clean delegated host-class baseline. Direct
-> overhead deltas are still withheld because same-host Arm B data has not
-> landed.
+> On the `linux-aarch64-6.8.0-117-generic` delegated runner host class,
+> the current dual-capture path measured roughly +858 ms median
+> wall-clock and +7.7 MB median RSS over OTel-only for this deterministic
+> workload. The result is not co-temporal and does not decompose Runner
+> archive-only cost.
 
 Optional Arm A remains deferred unless Arm C needs decomposition into
 "Runner archive only" versus "Runner archive plus OTel trace".


### PR DESCRIPTION
Summary

Updates the Runner-vs-OTel overhead findings after the same-host Arm B dispatches landed on `assay-bpf-runner`.

What changed

- Adds Arm B same-host evidence anchors:
  - wall-clock run 26459699303: 20/20 valid, 0 discarded
  - RSS run 26461726436: 5/5 valid, 0 discarded
- Confirms both Arm B summaries emitted the same `linux-aarch64-6.8.0-117-generic` host class as the earlier Arm C runs.
- Reports the narrow same-host delta for this deterministic workload:
  - wall median: Arm B 879.961 ms vs Arm C 1,737.838 ms => +857.878 ms (+97.5%)
  - peak RSS median: Arm B 108,953,600 bytes vs Arm C 116,649,984 bytes => +7,696,384 bytes (+7.1%)
- Updates the overhead plan, experiment READMEs, and changelog so they no longer describe same-host Arm B as pending.

Non-claims

- Does not commit generated measurement artifacts.
- Does not claim co-temporal variance; Arm B and Arm C ran on the same host class at different times.
- Does not decompose Runner archive-only cost from dual-capture cost; optional Arm A remains the path for that question.
- Does not make a product benchmark or model/provider latency claim.

Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 20 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 92 OK
- local markdown link check over changed docs -> OK
- `git diff --check`
- pre-commit + pre-push hooks green
