### PR TITLE
feat(experiments): add overhead Arm A decomposition path

### DIFF
--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -19,6 +19,7 @@ on:
         default: "arm-c-dual-capture"
         type: choice
         options:
+          - arm-a-runner-only
           - arm-c-dual-capture
           - arm-b-otel
       build_ebpf:
@@ -181,6 +182,133 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: runner-otel-overhead-arm-c-${{ github.run_id }}
+          path: overhead-runs/
+          if-no-files-found: error
+          retention-days: 30
+
+  arm-a-overhead:
+    name: Arm A overhead capture
+    if: ${{ inputs.arm == 'arm-a-runner-only' }}
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    needs: prepare-delegated-runner
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Preflight delegated host
+        shell: bash
+        run: |
+          set -euo pipefail
+          for bin in cargo node npm python3 rustc tar; do
+            command -v "$bin" >/dev/null 2>&1 || {
+              echo "ERROR: required command not found on delegated runner: $bin" >&2
+              exit 1
+            }
+          done
+          node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)' || {
+            echo "ERROR: delegated runner must provide Node.js 22 or newer" >&2
+            node --version >&2 || true
+            exit 1
+          }
+          if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+            echo "ERROR: delegated runner must expose cgroup v2 at /sys/fs/cgroup" >&2
+            exit 1
+          fi
+          {
+            echo "## Delegated runner preflight"
+            echo "- arm: arm-a-runner-only"
+            echo "- kernel: $(uname -r)"
+            echo "- node: $(node --version)"
+            echo "- rustc: $(rustc --version)"
+            echo "- python3: $(python3 --version)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build assay CLI (runner feature)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p assay-cli --no-default-features --features runner
+
+      - name: Run overhead harness unit tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover \
+            -s docs/experiments/runner-vs-otel-overhead-2026-05 \
+            -p 'test_*.py'
+
+      - name: Build eBPF artifact
+        if: ${{ inputs.build_ebpf }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v docker >/dev/null 2>&1; then
+            cargo xtask build-image
+            cargo xtask build-ebpf --docker
+          else
+            cargo xtask build-ebpf
+          fi
+          test -f target/assay-ebpf.o
+
+      - name: Verify eBPF artifact present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f target/assay-ebpf.o ]; then
+            echo "ERROR: target/assay-ebpf.o is required. Run with build_ebpf=true." >&2
+            exit 1
+          fi
+
+      - name: Install Runner fixture dependencies
+        working-directory: runner-fixtures/openai-agents
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund --ignore-scripts
+          node --check fixture-agent.js
+
+      - name: Run Arm A overhead harness
+        shell: bash
+        env:
+          REPETITIONS: ${{ inputs.repetitions }}
+          TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+          MEASURE_RSS: ${{ inputs.measure_rss }}
+        run: |
+          set -euo pipefail
+          OUT_DIR="$PWD/overhead-runs"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          RSS_FLAG=()
+          if [ "$MEASURE_RSS" = "true" ]; then
+            RSS_FLAG=(--measure-rss)
+          fi
+          python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
+            --arm arm-a-runner-only \
+            --iterations "$REPETITIONS" \
+            --skip-build \
+            --clean \
+            --sudo \
+            --timeout-seconds "$TIMEOUT_SECONDS" \
+            --out-dir "$OUT_DIR" \
+            --workload-dir "$PWD/docs/experiments/runner-vs-otel-2026-05/workload" \
+            --assay-bin "$PWD/target/debug/assay" \
+            --ebpf-obj "$PWD/target/assay-ebpf.o" \
+            --runner-fixture-agent "$PWD/runner-fixtures/openai-agents/fixture-agent.js" \
+            --delegated-workflow-url "$WORKFLOW_URL" \
+            "${RSS_FLAG[@]}"
+
+          cat "$OUT_DIR/arm-a-runner-only/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo
+            echo "- artifact: \`runner-otel-overhead-arm-a-${GITHUB_RUN_ID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Arm A overhead artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: runner-otel-overhead-arm-a-${{ github.run_id }}
           path: overhead-runs/
           if-no-files-found: error
           retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ All notable changes to this project will be documented in this file.
   The findings now report the narrow `linux-aarch64-6.8.0-117-generic`
   Arm B-vs-Arm C delta while preserving the non-co-temporal and
   non-decomposition caveats.
+- Added optional Arm A runner-only overhead dispatch wiring so the
+  current Arm C delta can be decomposed into Runner archive-only cost
+  versus Runner archive plus OTel trace cost.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -40,6 +40,11 @@
 > `linux-aarch64-6.8.0-117-generic` host class as Arm C, so the findings
 > document now reports a narrow same-host delta for this deterministic
 > workload.
+>
+> **Slice 7 status:** the delegated workflow can now dispatch optional
+> Arm A (`arm-a-runner-only`) on `assay-bpf-runner`. Arm A is only for
+> decomposing the current Arm C delta into "Runner archive only" versus
+> "Runner archive plus OTel trace"; it is not a new product benchmark.
 
 ## Research Question
 
@@ -112,6 +117,9 @@ The harness should produce one directory per arm:
 
 ```text
 runs/overhead-2026-05/
+  arm-a-runner-only/
+    samples.jsonl
+    summary.json
   arm-b-otel/
     samples.jsonl
     summary.json
@@ -230,10 +238,10 @@ requires Arm B to run on the delegated runner too. `host_class` is the
 mechanical comparison key for this rule. It should be a stable label for
 the hardware/OS/kernel boundary, not a free-form display name.
 
-Arm A stays out of the v0 sequence unless Arm C overhead needs
+Arm A stays out of the headline delta unless Arm C overhead needs
 decomposition into "Runner archive only" versus "Runner archive plus
-OTel trace". If needed, add it as a follow-up Slice 6 with the same
-sample-count, health, and provenance gates.
+OTel trace". It uses the same sample-count, health, and provenance gates
+as Arm C.
 
 ## Tooling
 
@@ -304,7 +312,7 @@ investigation before publication.
 | 4 | **Done**: summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
 | 5 | **Done**: initial findings update in [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md) | No deltas unless same-host arms exist |
 | 6 | **Done**: same-host Arm B delegated workflow path via `arm=arm-b-otel`, dispatched in runs [26459699303](https://github.com/Rul1an/assay/actions/runs/26459699303) and [26461726436](https://github.com/Rul1an/assay/actions/runs/26461726436) | n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; `host_class` matches Arm C |
-| 7 optional | Arm A pure-L2 decomposition | Only if Arm C overhead needs archive-only vs dual-capture separation |
+| 7 | **Ready to dispatch**: Arm A pure-L2 decomposition via `arm=arm-a-runner-only` | separately dispatch n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; compare only if `host_class` matches Arms B/C |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -2,8 +2,9 @@
 
 > **Status:** Slice 1 local Arm B harness, Slice 2 delegated Arm C
 > dispatch pipeline, Slice 3 RSS collection, Slice 4 summary/BMF
-> rendering, Slice 5 findings, and Slice 6 same-host Arm B dispatches.
-> This directory contains the experiment-scoped measurement
+> rendering, Slice 5 findings, Slice 6 same-host Arm B dispatches, and
+> Slice 7 Arm A runner-only dispatch wiring. This directory contains the
+> experiment-scoped measurement
 > harness and schema sidecars for the plan in
 > [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
 > It does not contain committed benchmark results.
@@ -27,7 +28,7 @@ The harness writes:
 - `artifacts/trace-sizes.json`, a trace-size side artifact for overhead
   bookkeeping; and
 - `artifacts/archive-sizes.json`, an archive-size side artifact that is
-  empty for Arm B and populated for Arm C; and
+  empty for Arm B and populated for Arm A / Arm C; and
 - `artifacts/rss-sizes.json`, a peak-RSS side artifact populated when
   the harness runs with `--measure-rss`.
 
@@ -36,7 +37,8 @@ They are local measurement evidence for the overhead follow-up only.
 
 BMF metric keys use the full arm slug so future arms stay
 unambiguous: `runner_vs_otel.arm_b_otel.*` for local Arm B and
-`runner_vs_otel.arm_c_dual_capture.*` for delegated Arm C.
+`runner_vs_otel.arm_c_dual_capture.*` for delegated Arm C. Arm A uses
+`runner_vs_otel.arm_a_runner_only.*`.
 
 ## Local Smoke
 
@@ -59,20 +61,23 @@ temporary output directory. Do not commit generated measurements until
 the findings slice decides what should become evidence. The default
 `runs/overhead-2026-05/` output path is ignored for this reason.
 
-## Delegated Arm B / Arm C
+## Delegated Arm A / Arm B / Arm C
 
 Arm B and Arm C are dispatched manually through
 [`runner-otel-overhead-experiment.yml`](../../../.github/workflows/runner-otel-overhead-experiment.yml).
 The workflow runs on `assay-bpf-runner` and exposes an `arm` input:
 
+- `arm-a-runner-only` runs `--arm arm-a-runner-only` with
+  `assay runner-spike`, eBPF, and the deterministic OpenAI Agents
+  fixture, but without OTel trace export.
 - `arm-c-dual-capture` runs `--arm arm-c-dual-capture` with
   `assay runner-spike`, eBPF, and Runner health gates.
 - `arm-b-otel` runs `--arm arm-b-otel` on the same delegated host class
   without Runner capture.
 
-Arm C fails if any sample is either non-zero exit or capture-unclean.
-Arm B fails if any sample exits non-zero. A direct Arm B-vs-Arm C delta
-is only valid when separately dispatched summaries emit matching
+Arm A and Arm C fail if any sample is either non-zero exit or
+capture-unclean. Arm B fails if any sample exits non-zero. A direct arm
+delta is only valid when separately dispatched summaries emit matching
 `host_class` values.
 
 For the Slice 3 RSS run, dispatch the same workflow with
@@ -90,7 +95,13 @@ passed as
 5/5 valid samples and 0 discarded samples. Both emitted the same
 `linux-aarch64-6.8.0-117-generic` host class as Arm C.
 
-The local unit tests exercise the Arm C path with a fake `assay` binary
+Arm A is the optional decomposition arm. Dispatch it only when you need
+to split the current Arm C delta into "Runner archive only" versus
+"Runner archive plus OTel trace": first `arm=arm-a-runner-only`,
+`repetitions=20`, `measure_rss=false`, then `repetitions=5`,
+`measure_rss=true`.
+
+The local unit tests exercise the Arm A / Arm C paths with a fake `assay` binary
 that emits the expected archive shape. The first validation against real
 `assay runner-spike` output happens on the first delegated workflow
 dispatch.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -116,5 +116,6 @@ The correct publication language is now:
 > workload. The result is not co-temporal and does not decompose Runner
 > archive-only cost.
 
-Optional Arm A remains deferred unless Arm C needs decomposition into
+Optional Arm A now has dispatch wiring, but measurements have not landed
+yet. Use it only if the current Arm C delta needs decomposition into
 "Runner archive only" versus "Runner archive plus OTel trace".

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -28,6 +28,7 @@ EXPERIMENT = "runner-vs-otel-overhead-2026-05"
 SAMPLE_SCHEMA = "assay.experiment.overhead_sample.v0"
 SUMMARY_SCHEMA = "assay.experiment.overhead_summary.v0"
 DEFAULT_ARM = "arm-b-otel"
+ARM_A = "arm-a-runner-only"
 ARM_B = "arm-b-otel"
 ARM_C = "arm-c-dual-capture"
 RSS_TIME_PATH = Path("/usr/bin/time")
@@ -40,6 +41,10 @@ def repo_root() -> Path:
 
 def default_workload_dir() -> Path:
     return repo_root() / "docs/experiments/runner-vs-otel-2026-05/workload"
+
+
+def default_runner_fixture_agent() -> Path:
+    return repo_root() / "runner-fixtures/openai-agents/fixture-agent.js"
 
 
 def default_out_dir() -> Path:
@@ -240,6 +245,7 @@ def one_sample(
     ebpf_obj: Path | None = None,
     use_sudo: bool = False,
     measure_rss: bool = False,
+    runner_fixture_agent: Path | None = None,
 ) -> dict[str, Any]:
     run_id = f"overhead_{arm.replace('-', '_')}_{iteration:03d}"
     run_dir = arm_dir / f"run_{iteration:03d}"
@@ -261,9 +267,26 @@ def one_sample(
             "--trace-out",
             str(trace_path),
         ]
-    elif arm == ARM_C:
+    elif arm in {ARM_A, ARM_C}:
         if assay_bin is None or ebpf_obj is None:
-            raise ValueError("Arm C requires --assay-bin and --ebpf-obj")
+            raise ValueError(f"{arm} requires --assay-bin and --ebpf-obj")
+        if arm == ARM_A:
+            agent_command = [
+                "node",
+                str(runner_fixture_agent or default_runner_fixture_agent()),
+                str(work_dir),
+            ]
+        else:
+            agent_command = [
+                "node",
+                str(workload_dir / "dist/workload.js"),
+                "--run-id",
+                run_id,
+                "--work-dir",
+                str(work_dir),
+                "--trace-out",
+                str(trace_path),
+            ]
         command = [
             str(assay_bin),
             "runner-spike",
@@ -280,15 +303,7 @@ def one_sample(
             "--sdk-event-log",
             str(sdk_log),
             "--",
-            "node",
-            str(workload_dir / "dist/workload.js"),
-            "--run-id",
-            run_id,
-            "--work-dir",
-            str(work_dir),
-            "--trace-out",
-            str(trace_path),
-        ]
+        ] + agent_command
         if use_sudo:
             command = ["sudo", "-E", "env", f"PATH={os_environ_path()}"] + command
     else:
@@ -546,7 +561,7 @@ def write_json(path: Path, payload: Any) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--arm", choices=[ARM_B, ARM_C], default=ARM_B)
+    parser.add_argument("--arm", choices=[ARM_A, ARM_B, ARM_C], default=ARM_B)
     parser.add_argument("--iterations", type=int, default=20)
     parser.add_argument("--out-dir", type=Path, default=default_out_dir())
     parser.add_argument("--workload-dir", type=Path, default=default_workload_dir())
@@ -556,6 +571,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeout-seconds", type=float, default=300.0)
     parser.add_argument("--assay-bin", type=Path)
     parser.add_argument("--ebpf-obj", type=Path)
+    parser.add_argument(
+        "--runner-fixture-agent",
+        type=Path,
+        default=default_runner_fixture_agent(),
+    )
     parser.add_argument("--sudo", action="store_true")
     parser.add_argument("--measure-rss", action="store_true")
     args = parser.parse_args(argv)
@@ -590,6 +610,7 @@ def main(argv: list[str] | None = None) -> int:
             ebpf_obj=args.ebpf_obj,
             use_sudo=args.sudo,
             measure_rss=args.measure_rss,
+            runner_fixture_agent=args.runner_fixture_agent,
         )
         for iteration in range(1, args.iterations + 1)
     ]

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -562,6 +562,66 @@ class OverheadHarnessTests(unittest.TestCase):
             self.assertEqual(archive_sizes["arm"], "arm-c-dual-capture")
             self.assertEqual(len(archive_sizes["archive_targz_bytes"]), 1)
 
+    def test_arm_a_sample_extracts_archive_without_trace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workload = root / "workload"
+            out_dir = root / "overhead"
+            fixture_agent = root / "fixture-agent.js"
+            write_stub_workload(workload)
+            fixture_agent.write_text("console.log('fake fixture')\n", encoding="utf-8")
+            fake_assay = write_fake_assay(root)
+            fake_ebpf = root / "assay-ebpf.o"
+            fake_ebpf.write_bytes(b"fake ebpf")
+
+            status = overhead_harness.main(
+                [
+                    "--arm",
+                    "arm-a-runner-only",
+                    "--iterations",
+                    "1",
+                    "--skip-build",
+                    "--clean",
+                    "--timeout-seconds",
+                    "10",
+                    "--workload-dir",
+                    str(workload),
+                    "--out-dir",
+                    str(out_dir),
+                    "--assay-bin",
+                    str(fake_assay),
+                    "--ebpf-obj",
+                    str(fake_ebpf),
+                    "--runner-fixture-agent",
+                    str(fixture_agent),
+                ]
+            )
+            self.assertEqual(status, 0)
+
+            sample = json.loads(
+                (out_dir / "arm-a-runner-only" / "samples.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()[0]
+            )
+            summary = json.loads(
+                (out_dir / "arm-a-runner-only" / "summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            bmf = json.loads(
+                (out_dir / "artifacts" / "bmf.json").read_text(encoding="utf-8")
+            )
+
+            self.assertEqual(sample["arm"], "arm-a-runner-only")
+            self.assertEqual(sample["artifact_bytes"]["trace_json"], None)
+            self.assertGreater(sample["artifact_bytes"]["archive_targz"], 0)
+            self.assertGreater(sample["artifact_bytes"]["archive_extracted"], 0)
+            self.assertEqual(summary["valid_samples"], 1)
+            self.assertIn(
+                "runner_vs_otel.arm_a_runner_only.wall_clock_ms.median",
+                bmf,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary

Adds the optional Arm A runner-only decomposition path for the Runner-vs-OTel overhead experiment. This lets us split the current Arm C dual-capture delta into "Runner archive only" versus "Runner archive plus OTel trace" once dispatched on the same `assay-bpf-runner` host class.

What changed

- Adds `arm-a-runner-only` to `.github/workflows/runner-otel-overhead-experiment.yml`.
- Extends `overhead_harness.py` with `ARM_A`, using `assay runner-spike` + eBPF + the deterministic `runner-fixtures/openai-agents/fixture-agent.js` without OTel trace export.
- Keeps Arm A output in the existing experiment-scoped `overhead_sample.v0` / `overhead_summary.v0` schemas, which already allowed `arm-a-runner-only`.
- Adds unit coverage using the fake assay archive path and asserts Arm A emits archive sizes without a trace JSON.
- Updates README, plan-doc, findings, and changelog to describe Arm A as ready-to-dispatch decomposition only.

Non-claims

- Does not dispatch Arm A yet.
- Does not commit generated measurement artifacts.
- Does not replace the same-host Arm B-vs-Arm C findings.
- Does not publish an Arm A decomposition claim until n=20 wall-clock and n=5 RSS Arm A runs land with matching `host_class`.

Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 21 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 92 OK
- `python3 -m py_compile docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py`
- `actionlint .github/workflows/runner-otel-overhead-experiment.yml`
- `zizmor .github/workflows/runner-otel-overhead-experiment.yml` -> no findings
- local markdown link check over changed docs -> OK
- `git diff --check`
- pre-commit + pre-push hooks green
