### PR TITLE
docs(experiments): add Arm A overhead decomposition findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ All notable changes to this project will be documented in this file.
 - Added optional Arm A runner-only overhead dispatch wiring so the
   current Arm C delta can be decomposed into Runner archive-only cost
   versus Runner archive plus OTel trace cost.
+- Updated the overhead findings after the Arm A runner-only dispatches.
+  The findings now record the same-host three-arm measurement set and
+  classify wall-clock decomposition as inconclusive while showing that
+  the observed RSS delta is dominated by Runner capture.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -1,6 +1,6 @@
 # Runner vs OTel Overhead Measurement Plan (2026-05)
 
-> **Status:** measurement follow-up with Slices 1-6 complete. This
+> **Status:** measurement follow-up with Slices 1-7 complete. This
 > document turns the explicit overhead non-claim from
 > [`runner-vs-otel-2026-05`](runner-vs-otel-2026-05/) into a reproducible
 > measurement plan and findings trail. It does not commit generated
@@ -41,10 +41,15 @@
 > document now reports a narrow same-host delta for this deterministic
 > workload.
 >
-> **Slice 7 status:** the delegated workflow can now dispatch optional
-> Arm A (`arm-a-runner-only`) on `assay-bpf-runner`. Arm A is only for
-> decomposing the current Arm C delta into "Runner archive only" versus
-> "Runner archive plus OTel trace"; it is not a new product benchmark.
+> **Slice 7 status:** optional Arm A (`arm-a-runner-only`) passed on
+> [GitHub Actions run 26463798358](https://github.com/Rul1an/assay/actions/runs/26463798358)
+> for wall-clock (20/20 valid, 0 discarded) and
+> [GitHub Actions run 26464003194](https://github.com/Rul1an/assay/actions/runs/26464003194)
+> for RSS (5/5 valid, 0 discarded). Both emitted the same
+> `linux-aarch64-6.8.0-117-generic` host class as Arm B and Arm C. Arm A
+> is only for decomposing the current Arm C delta into "Runner archive
+> only" versus "Runner archive plus OTel trace"; it is not a new product
+> benchmark.
 
 ## Research Question
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -3,15 +3,15 @@
 > **Status:** Slice 1 local Arm B harness, Slice 2 delegated Arm C
 > dispatch pipeline, Slice 3 RSS collection, Slice 4 summary/BMF
 > rendering, Slice 5 findings, Slice 6 same-host Arm B dispatches, and
-> Slice 7 Arm A runner-only dispatch wiring. This directory contains the
+> Slice 7 Arm A runner-only dispatches. This directory contains the
 > experiment-scoped measurement
 > harness and schema sidecars for the plan in
 > [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
 > It does not contain committed benchmark results.
 >
 > Current findings are in [`findings.md`](findings.md). They summarize
-> the delegated same-host Arm B-vs-Arm C delta and keep the caveats
-> attached.
+> the delegated same-host Arm A / Arm B / Arm C measurement set and keep
+> the caveats attached.
 
 ## What This Emits
 
@@ -100,6 +100,14 @@ to split the current Arm C delta into "Runner archive only" versus
 "Runner archive plus OTel trace": first `arm=arm-a-runner-only`,
 `repetitions=20`, `measure_rss=false`, then `repetitions=5`,
 `measure_rss=true`.
+
+The first Arm A wall-clock run passed as
+[GitHub Actions run 26463798358](https://github.com/Rul1an/assay/actions/runs/26463798358):
+20/20 valid samples and 0 discarded samples. The matching Arm A RSS run
+passed as
+[GitHub Actions run 26464003194](https://github.com/Rul1an/assay/actions/runs/26464003194):
+5/5 valid samples and 0 discarded samples. Both emitted the same
+`linux-aarch64-6.8.0-117-generic` host class as Arm B and Arm C.
 
 The local unit tests exercise the Arm A / Arm C paths with a fake `assay` binary
 that emits the expected archive shape. The first validation against real

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -2,9 +2,8 @@
 
 > **Status:** same-host findings update. This document summarizes the
 > overhead follow-up evidence collected so far. It does not commit the
-> generated measurement artifacts. Direct Arm B-vs-Arm C deltas are
-> reported only for the matching `linux-aarch64-6.8.0-117-generic` host
-> class.
+> generated measurement artifacts. Direct arm deltas are reported only
+> for the matching `linux-aarch64-6.8.0-117-generic` host class.
 
 ## Evidence Anchors
 
@@ -14,6 +13,9 @@
 | 3 | [26454010701](https://github.com/Rul1an/assay/actions/runs/26454010701) | Arm C dual capture | 5 RSS | 5 valid, 0 discarded, all health gates clean |
 | 6 wall | [26459699303](https://github.com/Rul1an/assay/actions/runs/26459699303) | Arm B OTel-only | 20 wall-clock | 20 valid, 0 discarded, same host class |
 | 6 RSS | [26461726436](https://github.com/Rul1an/assay/actions/runs/26461726436) | Arm B OTel-only | 5 RSS | 5 valid, 0 discarded, same host class |
+| 7 sanity | [26463582658](https://github.com/Rul1an/assay/actions/runs/26463582658) | Arm A runner-only | 2 wall-clock | 2 valid, 0 discarded, kernel layer complete |
+| 7 wall | [26463798358](https://github.com/Rul1an/assay/actions/runs/26463798358) | Arm A runner-only | 20 wall-clock | 20 valid, 0 discarded, same host class |
+| 7 RSS | [26464003194](https://github.com/Rul1an/assay/actions/runs/26464003194) | Arm A runner-only | 5 RSS | 5 valid, 0 discarded, same host class |
 
 Generated artifacts from those runs were inspected as review artifacts
 only. They are intentionally not committed as benchmark evidence in this
@@ -21,12 +23,21 @@ slice.
 
 ## Same-Host Baselines
 
-Both arms now have clean measurements on the same delegated
-`assay-bpf-runner` host class:
+All three arms now have clean measurements on the same delegated
+`assay-bpf-runner` host class. The runs were dispatched separately, so
+they characterize a shared host class, not co-temporal variance.
 
 | Metric | Value | Interpretation |
 |---|---:|---|
 | Host class | `linux-aarch64-6.8.0-117-generic` | Delegated Linux runner machine/OS/kernel boundary |
+| Arm A wall-clock valid samples | `20/20` | Meets the n >= 20 gate |
+| Arm A wall median | `1,816.127 ms` | Runner archive-only baseline on this host class |
+| Arm A wall p95 | `2,220.031 ms` | One tail sample exceeded the healthy band |
+| Arm A wall p99 | `3,929.928 ms` | Nearest-rank p99 for n=20; first sample was the outlier |
+| Arm A wall p99/median | `2.164` | Above the v0 `> 2.0` fail band; wall-clock decomposition is inconclusive |
+| Arm A RSS valid samples | `5/5` | Meets the n >= 5 gate |
+| Arm A peak RSS median | `116,641,792 bytes` | Runner archive-only memory baseline |
+| Arm A peak RSS max | `116,645,888 bytes` | No large RSS outlier in the n=5 sample |
 | Arm B wall-clock valid samples | `20/20` | Meets the n >= 20 gate |
 | Arm B wall median | `879.961 ms` | OTel-only baseline on this host class |
 | Arm B wall p95 | `924.845 ms` | Tail sample remained close to median |
@@ -44,9 +55,12 @@ Both arms now have clean measurements on the same delegated
 | Arm C peak RSS median | `116,649,984 bytes` | Dual-capture memory baseline |
 | Arm C peak RSS max | `116,781,056 bytes` | No large RSS outlier in the n=5 sample |
 | Arm B trace JSON median | `3,204 bytes` | L1 trace footprint baseline |
+| Arm A trace JSON median | `null` | Expected: runner-only arm emits no OTel trace JSON |
+| Arm A archive `.tar.gz` median | `1,626 bytes` | L2 compressed archive footprint baseline without trace export |
+| Arm A archive extracted median | `5,638 bytes` | Review/storage footprint baseline without trace export |
 | Arm C trace JSON median | `3,220 bytes` | L1 trace plus Runner wrapper footprint |
-| Arm C archive `.tar.gz` median | `1,776-1,777 bytes` | L2 compressed archive footprint baseline |
-| Arm C archive extracted median | `8,186-8,187 bytes` | Review/storage footprint baseline |
+| Arm C archive `.tar.gz` median | `1,776 bytes` | L2 compressed archive footprint baseline |
+| Arm C archive extracted median | `8,186 bytes` | Review/storage footprint baseline |
 
 The one-byte artifact-size spread between Slice 2 and Slice 3 is
 expected for freshly generated archives and traces. The useful claim is
@@ -72,18 +86,59 @@ not a product benchmark.
 
 The wall-clock delta is the cost of the current dual-capture path on
 this host class: Runner archive capture plus the existing OTel trace
-around the deterministic workload. It does not decompose how much of
-that cost is pure Runner archive capture versus coordination around the
-OTel trace; optional Arm A remains the path for that question.
+around the deterministic workload. The Arm A section below records the
+runner-only decomposition attempt, but that decomposition is not stable
+enough to turn this delta into an additive wall-clock cost model.
+
+## Runner-Only Decomposition
+
+Arm A adds the runner-only comparison point: `assay runner-spike` with
+Linux/eBPF archive capture and the deterministic OpenAI Agents fixture,
+but without OTel trace export. All three arms emitted the same
+`host_class`, but the runs were separate dispatches and Arm A uses the
+fixture-agent path rather than the OTel workload wrapper. Treat this as
+an experiment-scoped decomposition aid, not as a general additive cost
+model.
+
+| Metric | Arm B OTel-only | Arm A runner-only | Arm C dual capture |
+|---|---:|---:|---:|
+| Wall median | `879.961 ms` | `1,816.127 ms` | `1,737.838 ms` |
+| Wall p95 | `924.845 ms` | `2,220.031 ms` | `2,051.039 ms` |
+| Wall p99 | `964.023 ms` | `3,929.928 ms` | `2,070.354 ms` |
+| Wall p99/median | `1.096` | `2.164` | `1.191` |
+| Peak RSS median | `108,953,600 bytes` | `116,641,792 bytes` | `116,649,984 bytes` |
+| Peak RSS max | `110,493,696 bytes` | `116,645,888 bytes` | `116,781,056 bytes` |
+| Trace JSON median | `3,204 bytes` | `null` | `3,220 bytes` |
+| Archive `.tar.gz` median | `null` | `1,626 bytes` | `1,776 bytes` |
+| Archive extracted median | `null` | `5,638 bytes` | `8,186 bytes` |
+
+The decomposition read is:
+
+- **RSS:** useful and stable. Arm A and Arm C differ by only `8,192`
+  bytes at the median RSS level (`0.007%`). The observed same-host RSS
+  increase over Arm B is therefore dominated by Runner capture rather
+  than by adding the OTel trace wrapper around Runner capture.
+- **Wall-clock:** inconclusive as an additive decomposition. Arm A's
+  median is `78.289 ms` higher than Arm C, and Arm A's p99/median ratio
+  is `2.164` because the first wall-clock sample was a tail outlier.
+  This means the current wall-clock data should be read as "Runner
+  capture is the dominant overhead class, but the split between
+  runner-only and runner-plus-OTel is not stable enough to publish as an
+  additive cost."
 
 ## What This Means
 
-- The delegated measurement harness is usable for both arms: wall-clock
+- The delegated measurement harness is usable for all three arms: wall-clock
   and RSS runs produced all-valid samples on the same host class.
 - The observed Arm C tail ratio is healthy for this deterministic
   workload on `assay-bpf-runner`.
 - The observed Arm C median wall-clock is about 2x Arm B on the same
   host class for this workload, while RSS increases by about 7%.
+- The observed Arm A and Arm C RSS medians are effectively identical at
+  this scale, so the RSS delta versus Arm B is attributable to Runner
+  capture rather than trace JSON export.
+- Arm A's wall-clock tail was not healthy, so the wall-clock
+  decomposition remains a caution, not a benchmark claim.
 - The RSS path works on the delegated Linux runner with GNU
   `/usr/bin/time -v`; samples record the RSS tool version and emit
   `peak_rss_bytes` into both `summary.json` and the BMF export.
@@ -98,9 +153,11 @@ OTel trace; optional Arm A remains the path for that question.
 - No model/provider latency claim is made. The workload is deterministic
   and measurement-scoped.
 - No co-temporal variance claim is made. Arm B and Arm C ran on the same
-  host class at different times.
-- No decomposition claim is made between "Runner archive only" and
-  "Runner archive plus OTel trace".
+  host class at different times, and Arm A was dispatched separately as
+  well.
+- No additive wall-clock decomposition claim is made between "Runner
+  archive only" and "Runner archive plus OTel trace". The Arm A
+  wall-clock tail was not healthy enough for that claim.
 - No Trust Card or Trust Basis claim is added. This remains an
   experiment-scoped measurement follow-up.
 - The generated artifacts remain review artifacts until a later decision
@@ -116,6 +173,11 @@ The correct publication language is now:
 > workload. The result is not co-temporal and does not decompose Runner
 > archive-only cost.
 
-Optional Arm A now has dispatch wiring, but measurements have not landed
-yet. Use it only if the current Arm C delta needs decomposition into
-"Runner archive only" versus "Runner archive plus OTel trace".
+Arm A measurements have landed. The safe publication language is now:
+
+> On the same delegated host class, Arm A runner-only and Arm C
+> dual-capture had effectively identical median RSS, while Arm A
+> wall-clock showed an unhealthy tail outlier. The RSS decomposition
+> points to Runner capture as the memory-cost source; wall-clock
+> decomposition remains inconclusive and should not be reported as an
+> additive split.


### PR DESCRIPTION
Summary

Updates the Runner-vs-OTel overhead findings after the optional Arm A runner-only decomposition dispatches landed.

What changed

- Adds Arm A evidence anchors:
  - sanity run 26463582658: 2/2 valid, 0 discarded, kernel layer complete
  - wall-clock run 26463798358: 20/20 valid, 0 discarded
  - RSS run 26464003194: 5/5 valid, 0 discarded
- Updates the plan and harness README from Arm A wiring to Arm A dispatches.
- Adds the three-arm same-host table for Arm B OTel-only, Arm A runner-only, and Arm C dual-capture.
- Records the decomposition result carefully:
  - RSS decomposition is useful: Arm A and Arm C median RSS differ by only 8,192 bytes (0.007%), so the observed same-host RSS delta over Arm B is dominated by Runner capture.
  - Wall-clock decomposition is inconclusive: Arm A median was 78.289 ms higher than Arm C and Arm A p99/median was 2.164 due to a first-sample outlier.
- Keeps generated measurement artifacts out of git.

Validation

- python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py' -> 21 OK
- python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py' -> 92 OK
- local markdown link check over changed docs -> OK
- git diff --check
- pre-commit + pre-push hooks green

Non-claims

- Does not commit generated overhead artifacts.
- Does not publish a product benchmark.
- Does not claim co-temporal variance characterization.
- Does not claim an additive wall-clock split between Runner archive-only and Runner-plus-OTel.
