### PR TITLE
docs(experiments): plan overhead phase timing diagnostics

### DIFF
--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -145,6 +145,7 @@ jobs:
           test -f dist/workload.js
 
       - name: Run Arm C overhead harness
+        id: arm-c-harness
         shell: bash
         env:
           REPETITIONS: ${{ inputs.repetitions }}
@@ -158,6 +159,7 @@ jobs:
           if [ "$MEASURE_RSS" = "true" ]; then
             RSS_FLAG=(--measure-rss)
           fi
+          set +e
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-c-dual-capture \
             --iterations "$REPETITIONS" \
@@ -171,19 +173,41 @@ jobs:
             --ebpf-obj "$PWD/target/assay-ebpf.o" \
             --delegated-workflow-url "$WORKFLOW_URL" \
             "${RSS_FLAG[@]}"
+          status=$?
+          set -e
+          echo "harness_status=$status" >> "$GITHUB_OUTPUT"
 
-          cat "$OUT_DIR/arm-c-dual-capture/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$OUT_DIR/arm-c-dual-capture/summary.md" ]; then
+            cat "$OUT_DIR/arm-c-dual-capture/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Runner-vs-OTel Overhead Summary"
+              echo
+              echo "No Arm C summary was produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           {
             echo
             echo "- artifact: \`runner-otel-overhead-arm-c-${GITHUB_RUN_ID}\`"
+            echo "- harness exit: \`$status\`"
           } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Require Arm C artifacts on harness success
+        if: ${{ always() && steps.arm-c-harness.outputs.harness_status == '0' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d overhead-runs
+          find overhead-runs -type f -print -quit | grep -q .
 
       - name: Upload Arm C overhead artifacts
+        if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: runner-otel-overhead-arm-c-${{ github.run_id }}
           path: overhead-runs/
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 30
 
   arm-a-overhead:
@@ -271,6 +295,7 @@ jobs:
           node --check fixture-agent.js
 
       - name: Run Arm A overhead harness
+        id: arm-a-harness
         shell: bash
         env:
           REPETITIONS: ${{ inputs.repetitions }}
@@ -284,6 +309,7 @@ jobs:
           if [ "$MEASURE_RSS" = "true" ]; then
             RSS_FLAG=(--measure-rss)
           fi
+          set +e
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-a-runner-only \
             --iterations "$REPETITIONS" \
@@ -298,19 +324,41 @@ jobs:
             --runner-fixture-agent "$PWD/runner-fixtures/openai-agents/fixture-agent.js" \
             --delegated-workflow-url "$WORKFLOW_URL" \
             "${RSS_FLAG[@]}"
+          status=$?
+          set -e
+          echo "harness_status=$status" >> "$GITHUB_OUTPUT"
 
-          cat "$OUT_DIR/arm-a-runner-only/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$OUT_DIR/arm-a-runner-only/summary.md" ]; then
+            cat "$OUT_DIR/arm-a-runner-only/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Runner-vs-OTel Overhead Summary"
+              echo
+              echo "No Arm A summary was produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           {
             echo
             echo "- artifact: \`runner-otel-overhead-arm-a-${GITHUB_RUN_ID}\`"
+            echo "- harness exit: \`$status\`"
           } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Require Arm A artifacts on harness success
+        if: ${{ always() && steps.arm-a-harness.outputs.harness_status == '0' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d overhead-runs
+          find overhead-runs -type f -print -quit | grep -q .
 
       - name: Upload Arm A overhead artifacts
+        if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: runner-otel-overhead-arm-a-${{ github.run_id }}
           path: overhead-runs/
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 30
 
   arm-b-overhead:
@@ -366,6 +414,7 @@ jobs:
           test -f dist/workload.js
 
       - name: Run Arm B overhead harness
+        id: arm-b-harness
         shell: bash
         env:
           REPETITIONS: ${{ inputs.repetitions }}
@@ -379,6 +428,7 @@ jobs:
           if [ "$MEASURE_RSS" = "true" ]; then
             RSS_FLAG=(--measure-rss)
           fi
+          set +e
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-b-otel \
             --iterations "$REPETITIONS" \
@@ -389,17 +439,39 @@ jobs:
             --workload-dir "$PWD/docs/experiments/runner-vs-otel-2026-05/workload" \
             --delegated-workflow-url "$WORKFLOW_URL" \
             "${RSS_FLAG[@]}"
+          status=$?
+          set -e
+          echo "harness_status=$status" >> "$GITHUB_OUTPUT"
 
-          cat "$OUT_DIR/arm-b-otel/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$OUT_DIR/arm-b-otel/summary.md" ]; then
+            cat "$OUT_DIR/arm-b-otel/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Runner-vs-OTel Overhead Summary"
+              echo
+              echo "No Arm B summary was produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           {
             echo
             echo "- artifact: \`runner-otel-overhead-arm-b-${GITHUB_RUN_ID}\`"
+            echo "- harness exit: \`$status\`"
           } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Require Arm B artifacts on harness success
+        if: ${{ always() && steps.arm-b-harness.outputs.harness_status == '0' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d overhead-runs
+          find overhead-runs -type f -print -quit | grep -q .
 
       - name: Upload Arm B overhead artifacts
+        if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: runner-otel-overhead-arm-b-${{ github.run_id }}
           path: overhead-runs/
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ All notable changes to this project will be documented in this file.
   The findings now record the same-host three-arm measurement set and
   classify wall-clock decomposition as inconclusive while showing that
   the observed RSS delta is dominated by Runner capture.
+- Tightened the Runner-vs-OTel overhead workflow diagnostics so failed
+  harness runs still upload partial measurement artifacts and planned
+  the next phase-timing slice for localizing Runner wall-clock overhead.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -50,6 +50,14 @@
 > is only for decomposing the current Arm C delta into "Runner archive
 > only" versus "Runner archive plus OTel trace"; it is not a new product
 > benchmark.
+>
+> **Slice 8 status:** planned. A diagnostic repeat of Arm A wall-clock
+> ([GitHub Actions run 26472122983](https://github.com/Rul1an/assay/actions/runs/26472122983))
+> failed because one sample was discarded. The temporary runner workspace
+> showed the same first-sample cgroup spawn failure pattern seen during
+> the original sanity attempt. The workflow now uploads partial artifacts
+> even when the harness exits non-zero, and the next measurement slice
+> should instrument Runner phase timing before another broad comparison.
 
 ## Research Question
 
@@ -297,6 +305,40 @@ different threshold model. For v0, `p99/median < 1.5` is healthy,
 `1.5-2.0` is warning territory, and `> 2.0` is a fail signal requiring
 investigation before publication.
 
+## Phase-Timing Follow-up
+
+The same-host results make RSS attribution clear enough, but wall-clock
+remains too coarse. The next slice should localize Runner overhead before
+claiming a wall-clock decomposition.
+
+Required phase buckets:
+
+| Phase | Question | Expected source |
+|---|---|---|
+| `preflight_ms` | Is host/tooling preflight or per-run directory setup visible in the sample? | overhead harness |
+| `cgroup_prepare_ms` | Does cgroup domain-root resolution or session setup dominate? | runner-spike / `assay-runner-linux` |
+| `monitor_attach_ms` | Does eBPF/LSM/tracepoint attach dominate? | runner-spike + monitor adapter |
+| `child_spawn_ms` | Is process placement/spawn the failure or tail source? | runner-spike / cgroup placement |
+| `child_runtime_ms` | How long does the deterministic fixture itself run? | runner-spike child wait |
+| `event_flush_ms` | Does SDK/kernel event flush add tail latency? | runner-spike archive assembly |
+| `archive_write_ms` | Does tar/gzip or layer materialization dominate? | runner-spike archive assembly |
+| `health_parse_ms` | Does post-run health/correlation parsing add measurable cost? | overhead harness |
+
+Acceptance rules for this slice:
+
+- Emit phase timings as experiment-scoped diagnostics, not Runner archive
+  evidence, unless a later contract explicitly promotes them.
+- Keep raw end-to-end `wall_clock_ms`; phase timings are explanatory
+  projections and must not replace the sample timing.
+- Upload partial artifacts when the harness fails, because discarded
+  samples and cgroup errors are the evidence needed for diagnosis.
+- Add a one-sample warmup option only after phase data confirms the
+  first-sample cgroup spawn failure is a warmup artifact rather than a
+  correctness bug.
+- Do not publish a wall-clock additive split until Arm A produces a
+  complete n >= 20 run with healthy p99/median, or the phase data
+  explains the tail and failure mode well enough to scope the claim.
+
 ## Non-Claims
 
 - Does not rank OpenTelemetry, OpenInference, or Runner as products.
@@ -317,7 +359,8 @@ investigation before publication.
 | 4 | **Done**: summary renderer + BMF-compatible export | JSON schema-like tests over synthetic samples |
 | 5 | **Done**: initial findings update in [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md) | No deltas unless same-host arms exist |
 | 6 | **Done**: same-host Arm B delegated workflow path via `arm=arm-b-otel`, dispatched in runs [26459699303](https://github.com/Rul1an/assay/actions/runs/26459699303) and [26461726436](https://github.com/Rul1an/assay/actions/runs/26461726436) | n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; `host_class` matches Arm C |
-| 7 | **Ready to dispatch**: Arm A pure-L2 decomposition via `arm=arm-a-runner-only` | separately dispatch n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; compare only if `host_class` matches Arms B/C |
+| 7 | **Done**: Arm A pure-L2 decomposition via `arm=arm-a-runner-only`, dispatched in runs [26463798358](https://github.com/Rul1an/assay/actions/runs/26463798358) and [26464003194](https://github.com/Rul1an/assay/actions/runs/26464003194) | RSS decomposition landed; wall-clock decomposition remains inconclusive because Arm A tail was unhealthy |
+| 8 | **Planned**: Runner phase timing + partial-failure artifact capture | localize cgroup setup, monitor attach, child spawn/runtime, event flush, archive write, and health parsing before another wall-clock claim |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -109,6 +109,19 @@ passed as
 5/5 valid samples and 0 discarded samples. Both emitted the same
 `linux-aarch64-6.8.0-117-generic` host class as Arm B and Arm C.
 
+Diagnostic repeat run
+[26472122983](https://github.com/Rul1an/assay/actions/runs/26472122983)
+failed because the harness discarded one Arm A sample. Failed harness
+runs now still upload partial `overhead-runs/` artifacts when available;
+those artifacts are diagnostic evidence and should not be promoted to
+findings unless the findings text explicitly explains why the sample was
+discarded.
+
+The next overhead slice is phase timing rather than another broad
+comparison. It should identify whether Runner wall-clock overhead is
+coming from cgroup setup, monitor attach, child spawn/runtime, event
+flush, archive writing, or health parsing.
+
 The local unit tests exercise the Arm A / Arm C paths with a fake `assay` binary
 that emits the expected archive shape. The first validation against real
 `assay runner-spike` output happens on the first delegated workflow

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -16,10 +16,17 @@
 | 7 sanity | [26463582658](https://github.com/Rul1an/assay/actions/runs/26463582658) | Arm A runner-only | 2 wall-clock | 2 valid, 0 discarded, kernel layer complete |
 | 7 wall | [26463798358](https://github.com/Rul1an/assay/actions/runs/26463798358) | Arm A runner-only | 20 wall-clock | 20 valid, 0 discarded, same host class |
 | 7 RSS | [26464003194](https://github.com/Rul1an/assay/actions/runs/26464003194) | Arm A runner-only | 5 RSS | 5 valid, 0 discarded, same host class |
+| 8 diagnostic | [26472122983](https://github.com/Rul1an/assay/actions/runs/26472122983) | Arm A runner-only | 20 wall-clock repeat | failed; one sample discarded, partial artifacts not uploaded by the old workflow |
 
 Generated artifacts from those runs were inspected as review artifacts
 only. They are intentionally not committed as benchmark evidence in this
 slice.
+
+The failed diagnostic repeat is listed to explain the next work, not to
+replace the successful Slice 7 findings. It showed that repeating Arm A
+wall-clock without deeper instrumentation can still hit a discarded
+sample, so the correct next step is phase timing and failure-artifact
+capture rather than another broad n=20 rerun.
 
 ## Same-Host Baselines
 
@@ -181,3 +188,10 @@ Arm A measurements have landed. The safe publication language is now:
 > points to Runner capture as the memory-cost source; wall-clock
 > decomposition remains inconclusive and should not be reported as an
 > additive split.
+
+Next engineering slice:
+
+> Instrument Runner phase timing for cgroup setup, monitor attach, child
+> spawn/runtime, event flush, archive write, and health parsing. Failed
+> harness runs should upload partial artifacts so discarded samples can
+> be inspected from GitHub rather than from a temporary runner workspace.


### PR DESCRIPTION
## Summary

Plans the next Runner-vs-OTel overhead slice after the same-host Arm A decomposition runs: phase timing diagnostics before another broad wall-clock claim.

What changed:

- The overhead workflow now uploads `overhead-runs/` artifacts with `if: always()` when a harness step fails, and records the harness exit code in the step summary.
- Arm A/B/C summary appends now tolerate missing `summary.md` and still leave a useful GitHub step summary.
- The overhead plan, README, findings, and changelog now record the Arm A diagnostic repeat run `26472122983` and explain why phase timing is the right next step.
- The planned phase buckets cover preflight, cgroup setup, monitor attach, child spawn/runtime, event flush, archive write, and health parsing.

## Why

The successful same-host Arm A runs made RSS attribution clear, but wall-clock remains noisy. A diagnostic repeat hit a discarded first sample with the same cgroup-spawn failure pattern seen in the original sanity attempt. The old workflow did not upload partial artifacts after the harness exited non-zero, which made diagnosis depend on inspecting the temporary runner workspace.

This PR fixes that workflow-DX gap and scopes the next measurement slice without adding a new benchmark claim.

## Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 21 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 92 OK
- `actionlint .github/workflows/runner-otel-overhead-experiment.yml`
- `zizmor .github/workflows/runner-otel-overhead-experiment.yml` -> no findings
- local changed-docs link check -> OK
- `git diff --check`
- pre-commit + pre-push hooks green

## Non-claims

- Does not add phase timing instrumentation yet.
- Does not rerun Arm A measurements in this PR.
- Does not commit benchmark artifacts.
- Does not publish a wall-clock additive decomposition claim.
