### PR TITLE
feat(experiments): add overhead phase timing diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ All notable changes to this project will be documented in this file.
 - Refreshed the Runner-vs-OTel overhead findings with a healthy Arm A
   wall-clock repeat, preserving the conclusion that RSS decomposes
   cleanly while wall-clock does not yet support an additive split.
+- Added Runner-vs-OTel overhead phase-timing diagnostics for Arm A/C:
+  `assay runner-spike` can now emit an experiment-scoped
+  `assay.experiment.runner_phase_timing.v0` side log, and the overhead
+  harness aggregates those phases into samples, summaries, Markdown, and
+  BMF output without changing Runner archive contracts.
 
 ## [3.12.0] - 2026-05-25
 

--- a/crates/assay-cli/src/cli/commands/runner_spike.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike.rs
@@ -50,6 +50,10 @@ pub struct RunnerSpikeRunArgs {
     #[arg(long, hide = true)]
     pub sdk_event_log: Option<PathBuf>,
 
+    /// Hidden overhead experiment path: write runner phase timing diagnostics.
+    #[arg(long, hide = true)]
+    pub phase_timing_log: Option<PathBuf>,
+
     /// Command to run.
     #[arg(allow_hyphen_values = true, required = true, trailing_var_arg = true)]
     pub command: Vec<String>,
@@ -130,9 +134,13 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
     use assay_runner_core::KernelLayerBuilder;
     use assay_runner_linux::CgroupManager;
     use assay_runner_schema::CgroupCorrelationStatus;
+    use std::collections::BTreeMap;
     use std::time::{Duration, Instant};
     use tokio_stream::StreamExt;
 
+    let total_start = Instant::now();
+    let mut phases = BTreeMap::new();
+    let phase_log = args.phase_timing_log.clone();
     let spec = build_spec(&args);
     spec.validate()?;
     let output = bundle_output_path(&args, &spec.run_id);
@@ -146,37 +154,105 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
             "Error: eBPF object not found at {}. Build it with 'cargo xtask build-ebpf' or provide --ebpf <path>.",
             ebpf_path.display()
         );
+        record_phase(&mut phases, "preflight_ms", total_start);
+        write_phase_timing_log(
+            phase_log.as_ref(),
+            &spec,
+            &phases,
+            Some(40),
+            None,
+            Some("ebpf_object_missing"),
+        )?;
         return Ok(40);
     }
 
+    record_phase(&mut phases, "preflight_ms", total_start);
+
+    let monitor_start = Instant::now();
     let mut monitor = match Monitor::load_file(&ebpf_path) {
         Ok(monitor) => monitor,
         Err(error) => {
             eprintln!("Failed to load eBPF: {error}");
+            record_phase(&mut phases, "monitor_attach_ms", monitor_start);
+            write_phase_timing_log(
+                phase_log.as_ref(),
+                &spec,
+                &phases,
+                Some(40),
+                None,
+                Some("ebpf_load_failed"),
+            )?;
             return Ok(40);
         }
     };
     if let Err(error) = monitor.configure_defaults() {
         eprintln!("Failed to configure eBPF defaults: {error}");
+        record_phase(&mut phases, "monitor_attach_ms", monitor_start);
+        write_phase_timing_log(
+            phase_log.as_ref(),
+            &spec,
+            &phases,
+            Some(40),
+            None,
+            Some("ebpf_configure_failed"),
+        )?;
         return Ok(40);
     }
     if let Err(error) = monitor.set_emit_inode_resolved(false) {
         eprintln!("Failed to disable runner-spike inode telemetry: {error}");
+        record_phase(&mut phases, "monitor_attach_ms", monitor_start);
+        write_phase_timing_log(
+            phase_log.as_ref(),
+            &spec,
+            &phases,
+            Some(40),
+            None,
+            Some("ebpf_inode_telemetry_config_failed"),
+        )?;
         return Ok(40);
     }
     if let Err(error) = monitor.set_dedup_open_paths(true) {
         eprintln!("Failed to enable runner-spike open path dedupe: {error}");
+        record_phase(&mut phases, "monitor_attach_ms", monitor_start);
+        write_phase_timing_log(
+            phase_log.as_ref(),
+            &spec,
+            &phases,
+            Some(40),
+            None,
+            Some("ebpf_open_path_dedupe_config_failed"),
+        )?;
         return Ok(40);
     }
     if let Err(error) = monitor.attach() {
         eprintln!("Failed to attach eBPF probes: {error}");
+        record_phase(&mut phases, "monitor_attach_ms", monitor_start);
+        write_phase_timing_log(
+            phase_log.as_ref(),
+            &spec,
+            &phases,
+            Some(40),
+            None,
+            Some("ebpf_attach_failed"),
+        )?;
         return Ok(40);
     }
+    record_phase(&mut phases, "monitor_attach_ms", monitor_start);
 
+    let cgroup_start = Instant::now();
     let cgroup_manager = match CgroupManager::new() {
         Ok(manager) => manager,
         Err(error) => {
             eprintln!("Failed to initialize runner cgroup manager: {error}");
+            record_phase(&mut phases, "cgroup_prepare_ms", cgroup_start);
+            write_phase_timing_log(
+                phase_log.as_ref(),
+                &spec,
+                &phases,
+                Some(40),
+                None,
+                Some("cgroup_manager_init_failed"),
+            )?;
             return Ok(40);
         }
     };
@@ -184,13 +260,32 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
         Ok(cgroup) => cgroup,
         Err(error) => {
             eprintln!("Failed to create runner cgroup session: {error}");
+            record_phase(&mut phases, "cgroup_prepare_ms", cgroup_start);
+            write_phase_timing_log(
+                phase_log.as_ref(),
+                &spec,
+                &phases,
+                Some(40),
+                None,
+                Some("cgroup_session_create_failed"),
+            )?;
             return Ok(40);
         }
     };
     if let Err(error) = monitor.set_monitored_cgroups(&[session_cgroup.id()]) {
         eprintln!("Failed to populate runner cgroup map: {error}");
+        record_phase(&mut phases, "cgroup_prepare_ms", cgroup_start);
+        write_phase_timing_log(
+            phase_log.as_ref(),
+            &spec,
+            &phases,
+            Some(40),
+            None,
+            Some("cgroup_monitor_map_failed"),
+        )?;
         return Ok(40);
     }
+    record_phase(&mut phases, "cgroup_prepare_ms", cgroup_start);
 
     let before_stats = monitor.snapshot_stats()?;
     // Stream is armed against the empty session cgroup. No events flow until
@@ -202,9 +297,28 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
     let clock = Instant::now();
     spec.append_run_started(&mut archive, 0, Duration::ZERO)?;
 
-    let mut child = spawn_child_in_cgroup(&spec, &session_cgroup)?;
+    let child_spawn_start = Instant::now();
+    let mut child = match spawn_child_in_cgroup(&spec, &session_cgroup) {
+        Ok(child) => {
+            record_phase(&mut phases, "child_spawn_ms", child_spawn_start);
+            child
+        }
+        Err(error) => {
+            record_phase(&mut phases, "child_spawn_ms", child_spawn_start);
+            write_phase_timing_log(
+                phase_log.as_ref(),
+                &spec,
+                &phases,
+                None,
+                None,
+                Some("child_spawn_failed"),
+            )?;
+            return Err(error);
+        }
+    };
     let mut cgroup_correlation = CgroupCorrelationStatus::Clean;
 
+    let child_runtime_start = Instant::now();
     let status = loop {
         tokio::select! {
             status = child.wait() => break status?,
@@ -224,7 +338,9 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
             }
         }
     };
+    record_phase(&mut phases, "child_runtime_ms", child_runtime_start);
 
+    let event_flush_start = Instant::now();
     let drain_complete = drain_kernel_events(
         &mut stream,
         &mut builder,
@@ -242,12 +358,16 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
     capture.apply_to_archive(&mut archive, cgroup_correlation)?;
     apply_policy_then_sdk_logs_if_requested(&spec, &args, &mut archive)?;
     spec.append_run_finished(&mut archive, 1, &status, clock.elapsed())?;
+    record_phase(&mut phases, "event_flush_ms", event_flush_start);
 
+    let archive_write_start = Instant::now();
     let mut file = File::create(&output)?;
     archive.write(&mut file)?;
+    record_phase(&mut phases, "archive_write_ms", archive_write_start);
     let exit_code = status.code();
     let signal = exit_signal(&status);
     let exit_status = exit_status_label(exit_code, signal);
+    write_phase_timing_log(phase_log.as_ref(), &spec, &phases, exit_code, signal, None)?;
 
     println!(
         "wrote runner-spike bundle: {} (run_id={}, status={}, kernel_capture={})",
@@ -258,6 +378,43 @@ async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> anyhow::Result
     );
 
     Ok(exit_status_code(exit_code, signal))
+}
+
+#[cfg(target_os = "linux")]
+fn record_phase(
+    phases: &mut std::collections::BTreeMap<&'static str, f64>,
+    name: &'static str,
+    start: std::time::Instant,
+) {
+    phases.insert(name, start.elapsed().as_secs_f64() * 1000.0);
+}
+
+#[cfg(target_os = "linux")]
+fn write_phase_timing_log(
+    path: Option<&PathBuf>,
+    spec: &RunSpec,
+    phases: &std::collections::BTreeMap<&'static str, f64>,
+    exit_code: Option<i32>,
+    signal: Option<i32>,
+    error: Option<&str>,
+) -> anyhow::Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let payload = serde_json::json!({
+        "schema": "assay.experiment.runner_phase_timing.v0",
+        "run_id": &spec.run_id,
+        "agent_shim": &spec.agent_shim,
+        "phases_ms": phases,
+        "exit_code": exit_code,
+        "signal": signal,
+        "error": error,
+    });
+    std::fs::write(path, serde_json::to_vec_pretty(&payload)?)?;
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
@@ -504,5 +661,26 @@ mod tests {
         let len = write_u32_decimal(12345, &mut buf);
 
         assert_eq!(&buf[..len], b"12345");
+    }
+
+    #[test]
+    fn phase_timing_log_is_experiment_scoped_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("phase-timing.json");
+        let spec = RunSpec::new(vec!["true".to_string()])
+            .with_run_id("run_001")
+            .with_agent_shim("openai-agents");
+        let mut phases = std::collections::BTreeMap::new();
+        phases.insert("child_runtime_ms", 12.5);
+
+        write_phase_timing_log(Some(&path), &spec, &phases, Some(0), None, None).unwrap();
+
+        let payload: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        assert_eq!(payload["schema"], "assay.experiment.runner_phase_timing.v0");
+        assert_eq!(payload["run_id"], "run_001");
+        assert_eq!(payload["phases_ms"]["child_runtime_ms"], 12.5);
+        assert_eq!(payload["exit_code"], 0);
+        assert!(payload["error"].is_null());
     }
 }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -60,8 +60,8 @@
 > ([GitHub Actions run 26473448298](https://github.com/Rul1an/assay/actions/runs/26473448298))
 > passed with 20/20 valid samples and a healthy p99/median ratio, but
 > Arm A remained slower than Arm C at the median. The next measurement
-> slice should instrument Runner phase timing before another wall-clock
-> decomposition claim.
+> slice instruments Runner phase timing and should be dispatched before
+> another wall-clock decomposition claim.
 
 ## Research Question
 
@@ -146,6 +146,7 @@ runs/overhead-2026-05/
   artifacts/
     trace-sizes.json
     archive-sizes.json
+    phase-timings.json
     bmf.json
 ```
 
@@ -173,6 +174,15 @@ Each line in `samples.jsonl` should be a self-contained measurement:
     "kernel_layer": "complete",
     "ringbuf_drops": 0,
     "cgroup_correlation": "clean"
+  },
+  "phase_timings_ms": {
+    "preflight_ms": 0.1,
+    "cgroup_prepare_ms": 1.2,
+    "monitor_attach_ms": 3.4,
+    "child_spawn_ms": 5.6,
+    "child_runtime_ms": 789.0,
+    "event_flush_ms": 100.0,
+    "archive_write_ms": 12.3
   },
   "artifact_bytes": {
     "trace_json": 12345,
@@ -210,6 +220,13 @@ Each line in `samples.jsonl` should be a self-contained measurement:
     "trace_json_median": 0,
     "archive_targz_median": 0,
     "archive_extracted_median": 0
+  },
+  "phase_timings_ms": {
+    "child_runtime_ms": {
+      "median": 0,
+      "p95": 0,
+      "p99": 0
+    }
   }
 }
 ```
@@ -228,6 +245,12 @@ The BMF export is a derived artifact, for example:
   "runner_vs_otel.arm_c_dual_capture.peak_rss_bytes.max": { "value": 0 }
 }
 ```
+
+Phase timing metrics, when present, use the same derived BMF convention,
+for example
+`runner_vs_otel.arm_c_dual_capture.phase_timings_ms.child_runtime_ms.median`.
+They are diagnostics for this experiment and do not replace
+`wall_clock_ms`.
 
 The JSON shape is intentionally experiment-scoped. It is not a Runner
 archive contract. The `assay.experiment.*` namespace is reserved for
@@ -326,7 +349,7 @@ Required phase buckets:
 | `child_runtime_ms` | How long does the deterministic fixture itself run? | runner-spike child wait |
 | `event_flush_ms` | Does SDK/kernel event flush add tail latency? | runner-spike archive assembly |
 | `archive_write_ms` | Does tar/gzip or layer materialization dominate? | runner-spike archive assembly |
-| `health_parse_ms` | Does post-run health/correlation parsing add measurable cost? | overhead harness |
+| `health_parse_ms` | Does post-run health/correlation parsing add measurable cost? | overhead harness follow-up if extraction proves material |
 
 Acceptance rules for this slice:
 
@@ -340,7 +363,8 @@ Acceptance rules for this slice:
   the first-sample cgroup spawn failure is a warmup artifact rather than
   a correctness bug.
 - Do not publish a wall-clock additive split until phase data explains
-  why the healthy Arm A repeat remains slower than Arm C at the median.
+  why the healthy Arm A repeat remains slower than Arm C at the median,
+  or shows that the gap lives outside the instrumented Runner phases.
 
 ## Non-Claims
 
@@ -363,7 +387,7 @@ Acceptance rules for this slice:
 | 5 | **Done**: initial findings update in [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md) | No deltas unless same-host arms exist |
 | 6 | **Done**: same-host Arm B delegated workflow path via `arm=arm-b-otel`, dispatched in runs [26459699303](https://github.com/Rul1an/assay/actions/runs/26459699303) and [26461726436](https://github.com/Rul1an/assay/actions/runs/26461726436) | n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; `host_class` matches Arm C |
 | 7 | **Done**: Arm A pure-L2 decomposition via `arm=arm-a-runner-only`, dispatched in runs [26463798358](https://github.com/Rul1an/assay/actions/runs/26463798358), [26464003194](https://github.com/Rul1an/assay/actions/runs/26464003194), and healthy repeat [26473448298](https://github.com/Rul1an/assay/actions/runs/26473448298) | RSS decomposition landed; wall-clock decomposition remains inconclusive because Arm A is still slower than Arm C at the median |
-| 8 | **Planned**: Runner phase timing | localize cgroup setup, monitor attach, child spawn/runtime, event flush, archive write, and health parsing before another wall-clock claim |
+| 8 | **Ready to dispatch**: Runner phase timing via hidden `--phase-timing-log` and harness `phase_timings_ms` aggregation | dispatch Arm A and Arm C wall-clock runs; localize cgroup setup, monitor attach, child spawn/runtime, event flush, and archive write before another wall-clock claim |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -3,7 +3,8 @@
 > **Status:** Slice 1 local Arm B harness, Slice 2 delegated Arm C
 > dispatch pipeline, Slice 3 RSS collection, Slice 4 summary/BMF
 > rendering, Slice 5 findings, Slice 6 same-host Arm B dispatches, and
-> Slice 7 Arm A runner-only dispatches. This directory contains the
+> Slice 7 Arm A runner-only dispatches. Slice 8 phase timing diagnostics
+> are wired for Arm A/C and ready to dispatch. This directory contains the
 > experiment-scoped measurement
 > harness and schema sidecars for the plan in
 > [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
@@ -30,7 +31,10 @@ The harness writes:
 - `artifacts/archive-sizes.json`, an archive-size side artifact that is
   empty for Arm B and populated for Arm A / Arm C; and
 - `artifacts/rss-sizes.json`, a peak-RSS side artifact populated when
-  the harness runs with `--measure-rss`.
+  the harness runs with `--measure-rss`; and
+- `artifacts/phase-timings.json`, an experiment-scoped side artifact
+  populated for Arm A / Arm C when `assay runner-spike` emits phase
+  timing diagnostics.
 
 The experiment schemas are intentionally not Runner archive contracts.
 They are local measurement evidence for the overhead follow-up only.
@@ -129,6 +133,11 @@ The next overhead slice is phase timing rather than another broad
 comparison. It should identify whether Runner wall-clock overhead is
 coming from cgroup setup, monitor attach, child spawn/runtime, event
 flush, archive writing, or health parsing.
+
+Phase timing is emitted as experiment-scoped diagnostics in
+`phase_timings_ms` on each sample and aggregated into `summary.json`.
+It is not a Runner archive contract and must not replace raw
+`wall_clock_ms`.
 
 The local unit tests exercise the Arm A / Arm C paths with a fake `assay` binary
 that emits the expected archive shape. The first validation against real

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -33,6 +33,15 @@ ARM_B = "arm-b-otel"
 ARM_C = "arm-c-dual-capture"
 RSS_TIME_PATH = Path("/usr/bin/time")
 RSS_SYSTEMS = {"darwin", "linux"}
+PHASE_TIMING_KEYS = [
+    "preflight_ms",
+    "cgroup_prepare_ms",
+    "monitor_attach_ms",
+    "child_spawn_ms",
+    "child_runtime_ms",
+    "event_flush_ms",
+    "archive_write_ms",
+]
 
 
 def repo_root() -> Path:
@@ -152,6 +161,20 @@ def load_archive_health(archive_contents: Path) -> dict[str, Any]:
     }
 
 
+def load_phase_timings(path: Path) -> dict[str, float] | None:
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    phases = payload.get("phases_ms")
+    if not isinstance(phases, dict):
+        return None
+    parsed: dict[str, float] = {}
+    for key, value in phases.items():
+        if key in PHASE_TIMING_KEYS and isinstance(value, (int, float)):
+            parsed[key] = float(value)
+    return parsed or None
+
+
 def extract_archive(archive: Path, destination: Path) -> None:
     if destination.exists():
         shutil.rmtree(destination)
@@ -254,6 +277,7 @@ def one_sample(
     archive_path = run_dir / "archive.tar.gz"
     archive_contents = run_dir / "archive-contents"
     sdk_log = run_dir / "sdk-events.ndjson"
+    phase_timing_path = run_dir / "phase-timing.json"
     run_dir.mkdir(parents=True, exist_ok=True)
     started_at = utc_now()
     if arm == ARM_B:
@@ -302,6 +326,8 @@ def one_sample(
             str(archive_path),
             "--sdk-event-log",
             str(sdk_log),
+            "--phase-timing-log",
+            str(phase_timing_path),
             "--",
         ] + agent_command
         if use_sudo:
@@ -370,6 +396,7 @@ def one_sample(
         "peak_rss_bytes": peak_rss_bytes,
         "exit_code": exit_code,
         "health": health,
+        "phase_timings_ms": load_phase_timings(phase_timing_path),
         "artifact_bytes": {
             "trace_json": file_size(trace_path),
             "archive_targz": archive_targz,
@@ -434,6 +461,7 @@ def summarize(
     ]
     wall_median = median(wall)
     wall_p99 = percentile(wall, 99)
+    phase_timings = summarize_phase_timings(valid)
     first = samples[0] if samples else {}
     return {
         "schema": SUMMARY_SCHEMA,
@@ -465,7 +493,28 @@ def summarize(
                 [float(value) for value in archive_extracted]
             ),
         },
+        "phase_timings_ms": phase_timings,
     }
+
+
+def summarize_phase_timings(
+    samples: list[dict[str, Any]],
+) -> dict[str, dict[str, float | None]] | None:
+    summary: dict[str, dict[str, float | None]] = {}
+    for key in PHASE_TIMING_KEYS:
+        values = [
+            float(sample["phase_timings_ms"][key])
+            for sample in samples
+            if isinstance(sample.get("phase_timings_ms"), dict)
+            and sample["phase_timings_ms"].get(key) is not None
+        ]
+        if values:
+            summary[key] = {
+                "median": median(values),
+                "p95": percentile(values, 95),
+                "p99": percentile(values, 99),
+            }
+    return summary or None
 
 
 def bmf_export(summary: dict[str, Any]) -> dict[str, dict[str, float | int]]:
@@ -484,6 +533,13 @@ def bmf_export(summary: dict[str, Any]) -> dict[str, dict[str, float | int]]:
         f"{prefix}.peak_rss_bytes.median": summary["peak_rss_bytes"]["median"],
         f"{prefix}.peak_rss_bytes.max": summary["peak_rss_bytes"]["max"],
     }
+    phase_timings = summary.get("phase_timings_ms")
+    if isinstance(phase_timings, dict):
+        for phase, stats in phase_timings.items():
+            if not isinstance(stats, dict):
+                continue
+            for stat in ("median", "p95", "p99"):
+                values[f"{prefix}.phase_timings_ms.{phase}.{stat}"] = stats.get(stat)
     return {key: {"value": value} for key, value in values.items() if value is not None}
 
 
@@ -515,6 +571,7 @@ def summary_markdown(summary: dict[str, Any], *, artifact_name: str | None = Non
     wall = summary["wall_clock_ms"]
     rss = summary["peak_rss_bytes"]
     artifacts = summary["artifact_bytes"]
+    phase_timings = summary.get("phase_timings_ms")
     tail_ratio = wall["p99_over_median"]
     lines = [
         "## Runner-vs-OTel Overhead Summary",
@@ -540,6 +597,25 @@ def summary_markdown(summary: dict[str, Any], *, artifact_name: str | None = Non
         lines.append(f"| Workflow | {summary['delegated_workflow_url']} |")
     if artifact_name:
         lines.append(f"| Artifact | `{artifact_name}` |")
+    if isinstance(phase_timings, dict) and phase_timings:
+        lines.extend(
+            [
+                "",
+                "### Phase Timings",
+                "",
+                "| Phase | Median | p95 | p99 |",
+                "|---|---:|---:|---:|",
+            ]
+        )
+        for phase in PHASE_TIMING_KEYS:
+            stats = phase_timings.get(phase)
+            if not isinstance(stats, dict):
+                continue
+            lines.append(
+                f"| `{phase}` | {_md_value(stats.get('median'), unit='ms')} | "
+                f"{_md_value(stats.get('p95'), unit='ms')} | "
+                f"{_md_value(stats.get('p99'), unit='ms')} |"
+            )
     lines.extend(
         [
             "",
@@ -656,6 +732,17 @@ def main(argv: list[str] | None = None) -> int:
                 sample["peak_rss_bytes"]
                 for sample in samples
                 if sample["peak_rss_bytes"] is not None
+            ],
+        },
+    )
+    write_json(
+        artifacts_dir / "phase-timings.json",
+        {
+            "arm": args.arm,
+            "phase_timings_ms": [
+                sample["phase_timings_ms"]
+                for sample in samples
+                if sample.get("phase_timings_ms") is not None
             ],
         },
     )

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
@@ -19,6 +19,7 @@
     "peak_rss_bytes",
     "exit_code",
     "health",
+    "phase_timings_ms",
     "artifact_bytes"
   ],
   "properties": {
@@ -149,6 +150,16 @@
         }
       ]
     },
+    "phase_timings_ms": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/phase_timings"
+        }
+      ]
+    },
     "artifact_bytes": {
       "type": "object",
       "additionalProperties": false,
@@ -178,6 +189,39 @@
             "null"
           ],
           "minimum": 0
+        }
+      }
+    }
+  },
+  "$defs": {
+    "phase_ms": {
+      "type": "number",
+      "minimum": 0
+    },
+    "phase_timings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "preflight_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "cgroup_prepare_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "monitor_attach_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "child_spawn_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "child_runtime_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "event_flush_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "archive_write_ms": {
+          "$ref": "#/$defs/phase_ms"
         }
       }
     }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
@@ -18,7 +18,8 @@
     "discarded_samples",
     "wall_clock_ms",
     "peak_rss_bytes",
-    "artifact_bytes"
+    "artifact_bytes",
+    "phase_timings_ms"
   ],
   "properties": {
     "schema": {
@@ -74,6 +75,16 @@
     },
     "artifact_bytes": {
       "$ref": "#/$defs/artifact_stats"
+    },
+    "phase_timings_ms": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/phase_timing_summary"
+        }
+      ]
     }
   },
   "$defs": {
@@ -148,6 +159,53 @@
         },
         "archive_extracted_median": {
           "$ref": "#/$defs/number_or_null"
+        }
+      }
+    },
+    "phase_timing_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "median",
+        "p95",
+        "p99"
+      ],
+      "properties": {
+        "median": {
+          "$ref": "#/$defs/number_or_null"
+        },
+        "p95": {
+          "$ref": "#/$defs/number_or_null"
+        },
+        "p99": {
+          "$ref": "#/$defs/number_or_null"
+        }
+      }
+    },
+    "phase_timing_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "preflight_ms": {
+          "$ref": "#/$defs/phase_timing_stats"
+        },
+        "cgroup_prepare_ms": {
+          "$ref": "#/$defs/phase_timing_stats"
+        },
+        "monitor_attach_ms": {
+          "$ref": "#/$defs/phase_timing_stats"
+        },
+        "child_spawn_ms": {
+          "$ref": "#/$defs/phase_timing_stats"
+        },
+        "child_runtime_ms": {
+          "$ref": "#/$defs/phase_timing_stats"
+        },
+        "event_flush_ms": {
+          "$ref": "#/$defs/phase_timing_stats"
+        },
+        "archive_write_ms": {
+          "$ref": "#/$defs/phase_timing_stats"
         }
       }
     }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json",
+  "title": "Runner phase timing diagnostics v0",
+  "description": "Experiment-scoped phase timing side-log emitted by assay runner-spike run --phase-timing-log. This is not a Runner archive contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "run_id",
+    "agent_shim",
+    "phases_ms",
+    "exit_code",
+    "signal",
+    "error"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.experiment.runner_phase_timing.v0"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "agent_shim": {
+      "type": "string",
+      "minLength": 1
+    },
+    "phases_ms": {
+      "$ref": "#/$defs/phase_timings"
+    },
+    "exit_code": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "signal": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "error": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "$defs": {
+    "phase_ms": {
+      "type": "number",
+      "minimum": 0
+    },
+    "phase_timings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "preflight_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "cgroup_prepare_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "monitor_attach_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "child_spawn_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "child_runtime_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "event_flush_ms": {
+          "$ref": "#/$defs/phase_ms"
+        },
+        "archive_write_ms": {
+          "$ref": "#/$defs/phase_ms"
+        }
+      }
+    }
+  }
+}

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -159,6 +159,9 @@ from pathlib import Path
 
 args = sys.argv[1:]
 output = Path(args[args.index("--output") + 1])
+phase_timing = None
+if "--phase-timing-log" in args:
+    phase_timing = Path(args[args.index("--phase-timing-log") + 1])
 trace = None
 if "--" in args:
     child = args[args.index("--") + 1:]
@@ -167,6 +170,24 @@ if "--" in args:
 if trace is not None:
     trace.parent.mkdir(parents=True, exist_ok=True)
     trace.write_text(json.dumps({"resourceSpans": []}) + "\\n", encoding="utf-8")
+if phase_timing is not None:
+    phase_timing.parent.mkdir(parents=True, exist_ok=True)
+    phase_timing.write_text(json.dumps({
+        "schema": "assay.experiment.runner_phase_timing.v0",
+        "run_id": "fake_run",
+        "phases_ms": {
+            "preflight_ms": 1.0,
+            "cgroup_prepare_ms": 2.0,
+            "monitor_attach_ms": 3.0,
+            "child_spawn_ms": 4.0,
+            "child_runtime_ms": 5.0,
+            "event_flush_ms": 6.0,
+            "archive_write_ms": 7.0
+        },
+        "exit_code": 0,
+        "signal": None,
+        "error": None
+    }) + "\\n", encoding="utf-8")
 
 output.parent.mkdir(parents=True, exist_ok=True)
 with tempfile.TemporaryDirectory() as tmp:
@@ -212,6 +233,7 @@ class OverheadHarnessTests(unittest.TestCase):
             "peak_rss_bytes": None,
             "exit_code": 0,
             "health": None,
+            "phase_timings_ms": None,
             "artifact_bytes": {
                 "trace_json": 123,
                 "archive_targz": None,
@@ -224,6 +246,17 @@ class OverheadHarnessTests(unittest.TestCase):
     def test_sample_schema_accepts_arm_b_sample(self) -> None:
         schema = load_schema("overhead-sample-v0.schema.json")
         assert_matches_schema(self, self.sample(), schema, root=schema)
+
+    def test_sample_schema_accepts_phase_timings(self) -> None:
+        schema = load_schema("overhead-sample-v0.schema.json")
+        sample = self.sample(
+            phase_timings_ms={
+                "preflight_ms": 1.0,
+                "child_runtime_ms": 42.0,
+                "archive_write_ms": 7.0,
+            }
+        )
+        assert_matches_schema(self, sample, schema, root=schema)
 
     def test_sample_schema_requires_extracted_size_key(self) -> None:
         schema = load_schema("overhead-sample-v0.schema.json")
@@ -264,19 +297,38 @@ class OverheadHarnessTests(unittest.TestCase):
 
     def test_bmf_export_is_metric_keyed_value_objects(self) -> None:
         summary = overhead_harness.summarize(
-            [self.sample(peak_rss_bytes=1234)],
+            [
+                self.sample(
+                    peak_rss_bytes=1234,
+                    phase_timings_ms={"child_runtime_ms": 42.0},
+                )
+            ],
             delegated_workflow_url=None,
         )
         bmf = overhead_harness.bmf_export(summary)
         self.assertIn("runner_vs_otel.arm_b_otel.wall_clock_ms.median", bmf)
         self.assertIn("runner_vs_otel.arm_b_otel.peak_rss_bytes.max", bmf)
+        self.assertIn(
+            "runner_vs_otel.arm_b_otel.phase_timings_ms.child_runtime_ms.median",
+            bmf,
+        )
         self.assertTrue(all(set(value) == {"value"} for value in bmf.values()))
 
     def test_summary_markdown_surfaces_core_review_fields(self) -> None:
         summary = overhead_harness.summarize(
             [
-                self.sample(iteration=1, wall_clock_ms=10.0, peak_rss_bytes=1000),
-                self.sample(iteration=2, wall_clock_ms=20.0, peak_rss_bytes=2000),
+                self.sample(
+                    iteration=1,
+                    wall_clock_ms=10.0,
+                    peak_rss_bytes=1000,
+                    phase_timings_ms={"child_runtime_ms": 10.0},
+                ),
+                self.sample(
+                    iteration=2,
+                    wall_clock_ms=20.0,
+                    peak_rss_bytes=2000,
+                    phase_timings_ms={"child_runtime_ms": 20.0},
+                ),
             ],
             delegated_workflow_url="https://github.com/Rul1an/assay/actions/runs/1",
         )
@@ -290,6 +342,8 @@ class OverheadHarnessTests(unittest.TestCase):
         self.assertIn("| Wall p99/median |", markdown)
         self.assertIn("(healthy)", markdown)
         self.assertIn("| Peak RSS max | `2,000 bytes` |", markdown)
+        self.assertIn("### Phase Timings", markdown)
+        self.assertIn("| `child_runtime_ms` | `15 ms` |", markdown)
         self.assertIn("runner-otel-overhead-arm-c-1", markdown)
         self.assertIn("Non-claim", markdown)
 
@@ -556,9 +610,14 @@ class OverheadHarnessTests(unittest.TestCase):
             self.assertEqual(sample["health"]["kernel_layer"], "complete")
             self.assertEqual(sample["health"]["ringbuf_drops"], 0)
             self.assertEqual(sample["health"]["cgroup_correlation"], "clean")
+            self.assertEqual(sample["phase_timings_ms"]["child_runtime_ms"], 5.0)
             self.assertGreater(sample["artifact_bytes"]["archive_targz"], 0)
             self.assertGreater(sample["artifact_bytes"]["archive_extracted"], 0)
             self.assertEqual(summary["valid_samples"], 1)
+            self.assertEqual(
+                summary["phase_timings_ms"]["child_runtime_ms"]["median"],
+                5.0,
+            )
             self.assertEqual(archive_sizes["arm"], "arm-c-dual-capture")
             self.assertEqual(len(archive_sizes["archive_targz_bytes"]), 1)
 
@@ -614,11 +673,20 @@ class OverheadHarnessTests(unittest.TestCase):
 
             self.assertEqual(sample["arm"], "arm-a-runner-only")
             self.assertEqual(sample["artifact_bytes"]["trace_json"], None)
+            self.assertEqual(sample["phase_timings_ms"]["archive_write_ms"], 7.0)
             self.assertGreater(sample["artifact_bytes"]["archive_targz"], 0)
             self.assertGreater(sample["artifact_bytes"]["archive_extracted"], 0)
             self.assertEqual(summary["valid_samples"], 1)
+            self.assertEqual(
+                summary["phase_timings_ms"]["archive_write_ms"]["median"],
+                7.0,
+            )
             self.assertIn(
                 "runner_vs_otel.arm_a_runner_only.wall_clock_ms.median",
+                bmf,
+            )
+            self.assertIn(
+                "runner_vs_otel.arm_a_runner_only.phase_timings_ms.archive_write_ms.median",
                 bmf,
             )
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -175,6 +175,7 @@ if phase_timing is not None:
     phase_timing.write_text(json.dumps({
         "schema": "assay.experiment.runner_phase_timing.v0",
         "run_id": "fake_run",
+        "agent_shim": "openai-agents",
         "phases_ms": {
             "preflight_ms": 1.0,
             "cgroup_prepare_ms": 2.0,
@@ -257,6 +258,23 @@ class OverheadHarnessTests(unittest.TestCase):
             }
         )
         assert_matches_schema(self, sample, schema, root=schema)
+
+    def test_phase_timing_schema_accepts_side_log(self) -> None:
+        schema = load_schema("runner-phase-timing-v0.schema.json")
+        payload = {
+            "schema": "assay.experiment.runner_phase_timing.v0",
+            "run_id": "run_001",
+            "agent_shim": "openai-agents",
+            "phases_ms": {
+                "preflight_ms": 1.0,
+                "child_runtime_ms": 42.0,
+                "archive_write_ms": 7.0,
+            },
+            "exit_code": 0,
+            "signal": None,
+            "error": None,
+        }
+        assert_matches_schema(self, payload, schema, root=schema)
 
     def test_sample_schema_requires_extracted_size_key(self) -> None:
         schema = load_schema("overhead-sample-v0.schema.json")

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -42,11 +42,12 @@
 |---|---|---|---|
 | `assay.experiment.overhead_sample.v0` | One overhead measurement sample for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-sample-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json) |
 | `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-summary-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json) |
+| `assay.experiment.runner_phase_timing.v0` | Phase-timing side-log emitted by `assay runner-spike run --phase-timing-log` | experiment-scoped; sidecar active | [`runner-phase-timing-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json) |
 
 The overhead schemas remain experiment-scoped. They are validated by the
-local harness tests against synthetic samples and summaries, but they are
-not Runner archive contracts and are not promoted to stable product
-surface.
+local harness tests against synthetic samples, summaries, and phase
+side-logs, but they are not Runner archive contracts and are not
+promoted to stable product surface.
 
 ## Version Notes
 

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -40,8 +40,8 @@
 
 | Schema | Scope | Status | Sidecar |
 |---|---|---|---|
-| `assay.experiment.overhead_sample.v0` | One overhead measurement sample for runner-vs-OTel | experiment-scoped; Slice 1 sidecar active | [`overhead-sample-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json) |
-| `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | experiment-scoped; Slice 1 sidecar active | [`overhead-summary-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json) |
+| `assay.experiment.overhead_sample.v0` | One overhead measurement sample for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-sample-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json) |
+| `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-summary-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json) |
 
 The overhead schemas remain experiment-scoped. They are validated by the
 local harness tests against synthetic samples and summaries, but they are


### PR DESCRIPTION
## Summary

Adds Slice 8 phase timing diagnostics for the runner-vs-OTel overhead experiment. This instruments the Runner capture path enough to explain the current wall-clock anomaly before publishing any additive decomposition claim.

## What changed

- Adds hidden `assay runner-spike run --phase-timing-log <path>` output with experiment-scoped `assay.experiment.runner_phase_timing.v0` JSON.
- Records phase buckets for preflight, cgroup prepare, monitor attach, child spawn, child runtime, event flush, and archive write.
- Updates the overhead harness to pass the phase log for Arm A/C, ingest per-sample `phase_timings_ms`, aggregate median/p95/p99 in `summary.json`, render Markdown phase tables, export BMF phase metrics, and write `artifacts/phase-timings.json`.
- Tightens overhead sample/summary sidecars and tests for the new phase timing fields.
- Updates the overhead plan, README, schema overview, and changelog to mark Slice 8 as ready to dispatch.

## Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 22 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 92 OK
- `cargo check -p assay-cli`
- `cargo test -p assay-cli runner_spike`
- `cargo fmt --check`
- `git diff --check`
- local changed-docs link check -> OK
- pre-commit + pre-push hooks green, including linux compile gate

## Non-claims

- Does not dispatch live phase timing runs yet.
- Does not commit benchmark artifacts.
- Does not promote phase timing to a Runner archive contract.
- Does not publish an additive wall-clock decomposition claim.


## Delegated lane gate

- Head SHA: `a6d028b163f04c98c9076833e946e8f49ca7856a`
- Head SHA prefix: `a6d028b163f0`
- gate: all
- Runner Spike Delegated: https://github.com/Rul1an/assay/actions/runs/26475715882
