### PR TITLE
Fix gate drift in split review scripts and Wave 0 gating

### DIFF
--- a/.github/workflows/split-wave0-gates.yml
+++ b/.github/workflows/split-wave0-gates.yml
@@ -35,6 +35,7 @@ jobs:
       assay_common_changed: ${{ steps.detect.outputs.assay_common_changed }}
       assay_policy_changed: ${{ steps.detect.outputs.assay_policy_changed }}
       assay_metrics_changed: ${{ steps.detect.outputs.assay_metrics_changed }}
+      unmatched_assay_crate_changed: ${{ steps.detect.outputs.unmatched_assay_crate_changed }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
@@ -91,6 +92,14 @@ jobs:
           assay_common_changed="$(flag_from_prefix 'crates/assay-common/')"
           assay_policy_changed="$(flag_from_prefix 'crates/assay-policy/')"
           assay_metrics_changed="$(flag_from_prefix 'crates/assay-metrics/')"
+          if [[ "${run_all}" == "true" || "${global_changed}" == "true" ]]; then
+            unmatched_assay_crate_changed=true
+          elif grep -Eq '^crates/assay-[^/]+/' "$changed_file" && \
+               ! grep -Eq '^crates/(assay-core|assay-cli|assay-registry|assay-evidence|assay-common|assay-policy|assay-metrics)/' "$changed_file"; then
+            unmatched_assay_crate_changed=true
+          else
+            unmatched_assay_crate_changed=false
+          fi
 
           if [[ "${assay_core_changed}" == "true" || "${assay_cli_changed}" == "true" || "${assay_registry_changed}" == "true" || "${assay_evidence_changed}" == "true" ]]; then
             hotspot_changed=true
@@ -98,7 +107,7 @@ jobs:
             hotspot_changed=false
           fi
 
-          if [[ "${global_changed}" == "true" || "${hotspot_changed}" == "true" || "${assay_common_changed}" == "true" || "${assay_policy_changed}" == "true" || "${assay_metrics_changed}" == "true" ]]; then
+          if [[ "${global_changed}" == "true" || "${hotspot_changed}" == "true" || "${assay_common_changed}" == "true" || "${assay_policy_changed}" == "true" || "${assay_metrics_changed}" == "true" || "${unmatched_assay_crate_changed}" == "true" ]]; then
             any_relevant=true
             semver_relevant=true
           else
@@ -120,6 +129,7 @@ jobs:
             echo "assay_common_changed=${assay_common_changed}"
             echo "assay_policy_changed=${assay_policy_changed}"
             echo "assay_metrics_changed=${assay_metrics_changed}"
+            echo "unmatched_assay_crate_changed=${unmatched_assay_crate_changed}"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -137,6 +147,7 @@ jobs:
             echo "- hotspot_changed: ${hotspot_changed}"
             echo "- any_relevant: ${any_relevant}"
             echo "- semver_relevant: ${semver_relevant}"
+            echo "- unmatched_assay_crate_changed: ${unmatched_assay_crate_changed}"
             if [[ "${run_all}" == "false" || -n "${simulated}" ]]; then
               echo ""
               echo "### Changed files"

--- a/docs/contributing/WAVE0-GATES.md
+++ b/docs/contributing/WAVE0-GATES.md
@@ -14,7 +14,7 @@ Wave 0 gates are the pre-refactor guardrails for:
 ## Baseline SHA policy (semver checks)
 
 - Source of truth: workflow env `WAVE0_SEMVER_BASELINE_SHA`.
-- Current pinned baseline: `b56610681f623394c14ec587cb7e3ed1921a2583`.
+- Current pinned baseline: `9cc23b4c684be7cfd81f170c4f66d59903dd76eb`.
 - Reset cadence: update once at the start of a refactor sprint, not during a sprint.
 - Update rule: change SHA + mention the reset in PR description with reason.
 

--- a/scripts/ci/review-adr025-i1-step4-b.sh
+++ b/scripts/ci/review-adr025-i1-step4-b.sh
@@ -65,7 +65,7 @@ rg -n "schemas/soak_readiness_policy_v1\.json" .github/workflows/release.yml >/d
 }
 
 echo "[review] ensure fail-closed only in release path"
-if rg -n "adr025-soak-enforce\.sh" .github/workflows/*.yml | rg -v "^\.github/workflows/release\.yml:" >/dev/null; then
+if rg -n "adr025-soak-enforce\.sh" .github/workflows/*.yml | cut -d: -f1 | rg -v "^\.github/workflows/release\.yml$" >/dev/null; then
   echo "FAIL: enforcement script must only be wired in release workflow for Step4B"
   exit 1
 fi

--- a/scripts/ci/review-adr025-i2-step2.sh
+++ b/scripts/ci/review-adr025-i2-step2.sh
@@ -9,12 +9,8 @@ git rev-parse --verify "$BASE_REF" >/dev/null
 
 ALLOW_PREFIXES=(
   "scripts/ci/adr025-closure-evaluate.sh"
-  "scripts/ci/adr025-i2-closure-evaluate.sh"
   "scripts/ci/test-adr025-closure-evaluate.sh"
-  "scripts/ci/test-adr025-i2-closure-evaluate.sh"
   "scripts/ci/fixtures/adr025-i2/"
-  "scripts/ci/fixtures/adr025-i2/manifest_full.json"
-  "scripts/ci/fixtures/adr025-i2/soak_report_minimal.json"
   "scripts/ci/review-adr025-i2-step2.sh"
   "schemas/closure_policy_v1.json"
 )

--- a/scripts/ci/review-wave28-approval-required-step2.sh
+++ b/scripts/ci/review-wave28-approval-required-step2.sh
@@ -49,10 +49,12 @@ ALLOWLIST=(
   "docs/architecture/ADR-032-MCP-Policy-Obligations-and-Evidence-v2.md"
   "docs/architecture/PLAN-ADR-032-MCP-POLICY-ENFORCEMENT-2026q2.md"
 
-  # step2 docs
-  "docs/contributing/SPLIT-CHECKLIST-wave28-approval-required-step2.md"
-  "docs/contributing/SPLIT-MOVE-MAP-wave28-approval-required-step2.md"
-  "docs/contributing/SPLIT-REVIEW-PACK-wave28-approval-required-step2.md"
+  # wave28 docs present on current branch
+  "docs/contributing/SPLIT-PLAN-wave28-approval-required.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave28-approval-required-step1.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave28-approval-required-step3.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave28-approval-required-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave28-approval-required-step3.md"
 
   # gate
   "scripts/ci/review-wave28-approval-required-step2.sh"


### PR DESCRIPTION
## Summary
This PR applies the gate-drift audit fixes for split/review scripts and Wave 0 gate docs/detection.

### Included fixes
- fix `review-adr025-i1-step4-b.sh` release-workflow exclusion match
- remove stale I2-specific file references from `review-adr025-i2-step2.sh`
- align `review-wave28-approval-required-step2.sh` allowlist with existing wave28 docs on branch
- sync `docs/contributing/WAVE0-GATES.md` baseline SHA with workflow
- harden Wave 0 change detection by flagging changes in untracked `crates/assay-*` crates as relevant

## Why
These changes close mismatches found in automation `gate-drift-audit` so reviewer gates and docs reflect current branch structure and CI behavior.

## Validation
- pre-commit hooks passed
- workflow lint passed
- shellcheck passed
- cargo fmt check passed
- cargo clippy workspace gate passed during push hooks
