### PR TITLE
feat(experiments): add paired overhead residual diagnostics

### DIFF
--- a/.github/workflows/pr-content-labeler.yml
+++ b/.github/workflows/pr-content-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Content Labels
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply content labels
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -22,6 +22,7 @@ on:
           - arm-a-runner-only
           - arm-c-dual-capture
           - arm-b-otel
+          - paired-a-c
       build_ebpf:
         description: "Rebuild eBPF artifact before running Arm C"
         required: true
@@ -59,6 +60,171 @@ jobs:
           if [ -d "$GITHUB_WORKSPACE" ]; then
             sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" || true
           fi
+
+  paired-ac-overhead:
+    name: Paired Arm A/C overhead capture
+    if: ${{ inputs.arm == 'paired-a-c' }}
+    runs-on: [self-hosted, linux, assay-bpf-runner]
+    needs: prepare-delegated-runner
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Preflight delegated host
+        shell: bash
+        run: |
+          set -euo pipefail
+          for bin in cargo node npm python3 rustc tar; do
+            command -v "$bin" >/dev/null 2>&1 || {
+              echo "ERROR: required command not found on delegated runner: $bin" >&2
+              exit 1
+            }
+          done
+          node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 22) process.exit(1)' || {
+            echo "ERROR: delegated runner must provide Node.js 22 or newer" >&2
+            node --version >&2 || true
+            exit 1
+          }
+          if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+            echo "ERROR: delegated runner must expose cgroup v2 at /sys/fs/cgroup" >&2
+            exit 1
+          fi
+          {
+            echo "## Delegated runner preflight"
+            echo "- arm: paired-a-c"
+            echo "- kernel: $(uname -r)"
+            echo "- node: $(node --version)"
+            echo "- rustc: $(rustc --version)"
+            echo "- python3: $(python3 --version)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build assay CLI (runner feature)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p assay-cli --no-default-features --features runner
+
+      - name: Run overhead harness unit tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover \
+            -s docs/experiments/runner-vs-otel-overhead-2026-05 \
+            -p 'test_*.py'
+
+      - name: Build eBPF artifact
+        if: ${{ inputs.build_ebpf }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v docker >/dev/null 2>&1; then
+            cargo xtask build-image
+            cargo xtask build-ebpf --docker
+          else
+            cargo xtask build-ebpf
+          fi
+          test -f target/assay-ebpf.o
+
+      - name: Verify eBPF artifact present
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f target/assay-ebpf.o ]; then
+            echo "ERROR: target/assay-ebpf.o is required. Run with build_ebpf=true." >&2
+            exit 1
+          fi
+
+      - name: Install Runner fixture dependencies
+        working-directory: runner-fixtures/openai-agents
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund --ignore-scripts
+          node --check fixture-agent.js
+
+      - name: Build experiment workload
+        working-directory: docs/experiments/runner-vs-otel-2026-05/workload
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --no-audit --no-fund --ignore-scripts
+          npx tsc -p tsconfig.json
+          test -f dist/workload.js
+
+      - name: Run paired Arm A/C overhead harness
+        id: paired-ac-harness
+        shell: bash
+        env:
+          REPETITIONS: ${{ inputs.repetitions }}
+          TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+          MEASURE_RSS: ${{ inputs.measure_rss }}
+        run: |
+          set -euo pipefail
+          OUT_DIR="$PWD/overhead-runs"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          RSS_FLAG=()
+          if [ "$MEASURE_RSS" = "true" ]; then
+            RSS_FLAG=(--measure-rss)
+          fi
+          set +e
+          python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
+            --arm paired-a-c \
+            --iterations "$REPETITIONS" \
+            --skip-build \
+            --clean \
+            --sudo \
+            --timeout-seconds "$TIMEOUT_SECONDS" \
+            --out-dir "$OUT_DIR" \
+            --workload-dir "$PWD/docs/experiments/runner-vs-otel-2026-05/workload" \
+            --assay-bin "$PWD/target/debug/assay" \
+            --ebpf-obj "$PWD/target/assay-ebpf.o" \
+            --runner-fixture-agent "$PWD/runner-fixtures/openai-agents/fixture-agent.js" \
+            --delegated-workflow-url "$WORKFLOW_URL" \
+            "${RSS_FLAG[@]}"
+          status=$?
+          set -e
+          echo "harness_status=$status" >> "$GITHUB_OUTPUT"
+
+          for arm in arm-a-runner-only arm-c-dual-capture; do
+            if [ -f "$OUT_DIR/$arm/summary.md" ]; then
+              cat "$OUT_DIR/$arm/summary.md" >> "$GITHUB_STEP_SUMMARY"
+              echo >> "$GITHUB_STEP_SUMMARY"
+            else
+              {
+                echo "## Runner-vs-OTel Overhead Summary"
+                echo
+                echo "No $arm summary was produced."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          {
+            echo
+            echo "- artifact: \`runner-otel-overhead-paired-ac-${GITHUB_RUN_ID}\`"
+            echo "- paired sequence: \`artifacts/paired-sequence.json\`"
+            echo "- harness exit: \`$status\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Require paired Arm A/C artifacts on harness success
+        if: ${{ always() && steps.paired-ac-harness.outputs.harness_status == '0' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f overhead-runs/arm-a-runner-only/summary.json
+          test -f overhead-runs/arm-c-dual-capture/summary.json
+          test -f overhead-runs/artifacts/paired-sequence.json
+
+      - name: Upload paired Arm A/C overhead artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: runner-otel-overhead-paired-ac-${{ github.run_id }}
+          path: overhead-runs/
+          if-no-files-found: warn
+          retention-days: 30
 
   arm-c-overhead:
     name: Arm C overhead capture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ All notable changes to this project will be documented in this file.
   dispatches. The phase data explains part of the Arm A / Arm C median
   wall-clock gap, mostly around monitor attach, but still withholds an
   additive wall-clock decomposition claim.
+- Added Slice 9 paired Arm A/C residual diagnostics planning and
+  workflow support. The overhead workflow can now run `arm=paired-a-c`
+  as adjacent counterbalanced pairs and emit `paired-sequence.json` with
+  per-sample phase residuals for review.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -386,6 +386,73 @@ Slice 8 result:
   minus summed phase medians leaves `72.711 ms` outside the timed phase
   buckets.
 
+## Residual Diagnostics Follow-up
+
+Slice 9 is the next useful experiment if the wall-clock question still
+matters. It should measure Arm A and Arm C in one delegated workflow job
+with adjacent, counterbalanced pairs (`A/C`, then `C/A`) and keep a
+derived residual record for each sample:
+
+```text
+phase_residual_ms = wall_clock_ms - sum(recorded phase_timings_ms)
+```
+
+This is deliberately not a new benchmark claim. It asks whether the
+unexplained `72.711 ms` median residual from Slice 8 is stable when arm
+order and runner load drift are reduced, and whether the unexplained
+time is tied to a specific pair/order position. Negative residuals are
+allowed as diagnostics; they mean the timed phase sum exceeded the outer
+wall-clock sample, usually because of clock asymmetry, overlapping phase
+boundaries, or measurement noise. They are not publishable overhead
+quantities by themselves.
+
+Pre-read and rationale:
+
+- Distributed tracing overhead is known to vary by workload,
+  configuration, and deployment environment. Nõu et al. report
+  throughput and latency impacts for OpenTelemetry/Elastic APM across
+  microservice and serverless workloads, and identify trace
+  serialization/export as a major source of overhead:
+  <https://doi.org/10.1145/3680256.3721316>.
+- The OpenTelemetry benchmark guidance frames overhead as
+  target-platform specific and separates span/instrumentation cost,
+  throughput, CPU, memory, and report shape:
+  <https://opentelemetry.io/docs/specs/otel/performance-benchmark/>.
+- BPF/eBPF overhead measurement is itself hard to isolate. Red Hat's BPF
+  performance guide calls out "who traces the tracer?" as the core
+  problem and emphasizes measuring the right hook/attach path:
+  <https://developers.redhat.com/articles/2022/06/22/measuring-bpf-performance-tips-tricks-and-best-practices>.
+- Observability-overhead noise is a known phenomenon. Reichelt, Jung,
+  and van Hoorn compare MooBench across GitHub Actions and bare-metal
+  environments and show that shared/cloud execution noise affects what
+  changes are detectable:
+  <https://arxiv.org/abs/2411.05491>.
+
+Acceptance rules for Slice 9:
+
+- Dispatch `arm=paired-a-c` only on `assay-bpf-runner`, with
+  `repetitions=20`, `measure_rss=false`, and phase timing enabled by the
+  Runner harness path.
+- Treat each repetition as a pair, not as independent arm samples. The
+  harness order is counterbalanced adjacent pairs: odd pairs run Arm A
+  then Arm C; even pairs run Arm C then Arm A.
+- Publish no additive wall-clock decomposition unless the paired
+  residuals either shrink below the existing unexplained gap or point to
+  a repeatable order/phase source.
+- If the residual remains material and order-independent, close the
+  wall-clock decomposition as "not additively decomposable at this
+  measurement budget" rather than adding another broad rerun.
+
+Decision tree after dispatch:
+
+- **Residual shrinks materially under pairing:** treat Slice 8 as
+  inflated by inter-dispatch drift and update findings with the paired
+  caveat.
+- **Residual is order-dependent:** file a narrow warmup/cache/order slice
+  instead of attributing the gap to capture mode.
+- **Residual remains material and order-independent:** stop the
+  wall-clock decomposition arc at the current measurement budget.
+
 ## Non-Claims
 
 - Does not rank OpenTelemetry, OpenInference, or Runner as products.
@@ -408,6 +475,7 @@ Slice 8 result:
 | 6 | **Done**: same-host Arm B delegated workflow path via `arm=arm-b-otel`, dispatched in runs [26459699303](https://github.com/Rul1an/assay/actions/runs/26459699303) and [26461726436](https://github.com/Rul1an/assay/actions/runs/26461726436) | n=20 wall-clock and n=5 RSS on `assay-bpf-runner`; `host_class` matches Arm C |
 | 7 | **Done**: Arm A pure-L2 decomposition via `arm=arm-a-runner-only`, dispatched in runs [26463798358](https://github.com/Rul1an/assay/actions/runs/26463798358), [26464003194](https://github.com/Rul1an/assay/actions/runs/26464003194), and healthy repeat [26473448298](https://github.com/Rul1an/assay/actions/runs/26473448298) | RSS decomposition landed; wall-clock decomposition remains inconclusive because Arm A is still slower than Arm C at the median |
 | 8 | **Done**: Runner phase timing via hidden `--phase-timing-log` and harness `phase_timings_ms` aggregation, dispatched in runs [26476490968](https://github.com/Rul1an/assay/actions/runs/26476490968) and [26476824593](https://github.com/Rul1an/assay/actions/runs/26476824593) | phase data explains part, not all, of the Arm A / Arm C median gap; no additive wall-clock decomposition claim |
+| 9 | **Ready to dispatch**: paired Arm A/C residual diagnostics via workflow `arm=paired-a-c` | n=20 adjacent counterbalanced pairs on one delegated runner job; inspect `artifacts/paired-sequence.json` before changing findings |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -4,7 +4,8 @@
 > dispatch pipeline, Slice 3 RSS collection, Slice 4 summary/BMF
 > rendering, Slice 5 findings, Slice 6 same-host Arm B dispatches, and
 > Slice 7 Arm A runner-only dispatches. Slice 8 phase timing diagnostics
-> have landed for Arm A/C. This directory contains the
+> have landed for Arm A/C, and Slice 9 paired A/C residual diagnostics
+> are ready to dispatch. This directory contains the
 > experiment-scoped measurement
 > harness and schema sidecars for the plan in
 > [`../runner-vs-otel-overhead-2026-05.md`](../runner-vs-otel-overhead-2026-05.md).
@@ -34,7 +35,10 @@ The harness writes:
   the harness runs with `--measure-rss`; and
 - `artifacts/phase-timings.json`, an experiment-scoped side artifact
   populated for Arm A / Arm C when `assay runner-spike` emits phase
-  timing diagnostics.
+  timing diagnostics; and
+- `artifacts/paired-sequence.json`, emitted only by `arm=paired-a-c`,
+  which carries `assay.experiment.paired_sequence.v0` and records
+  adjacent pair order and per-sample phase residuals.
 
 The experiment schemas are intentionally not Runner archive contracts.
 They are local measurement evidence for the overhead follow-up only.
@@ -78,6 +82,9 @@ The workflow runs on `assay-bpf-runner` and exposes an `arm` input:
   `assay runner-spike`, eBPF, and Runner health gates.
 - `arm-b-otel` runs `--arm arm-b-otel` on the same delegated host class
   without Runner capture.
+- `paired-a-c` runs Arm A and Arm C in one delegated job as adjacent,
+  counterbalanced pairs. Use this only for residual diagnostics after
+  broad Arm A/C phase timing has already landed.
 
 Arm A and Arm C fail if any sample is either non-zero exit or
 capture-unclean. Arm B fails if any sample exits non-zero. A direct arm
@@ -142,6 +149,14 @@ Phase timing is emitted as experiment-scoped diagnostics in
 `phase_timings_ms` on each sample and aggregated into `summary.json`.
 It is not a Runner archive contract and must not replace raw
 `wall_clock_ms`.
+
+For Slice 9, dispatch the same workflow with `arm=paired-a-c`,
+`repetitions=20`, `measure_rss=false`, and `build_ebpf=true`. The
+paired mode writes both Arm A and Arm C summaries plus
+`artifacts/paired-sequence.json`. That manifest records the actual
+`A/C`, then `C/A`, adjacent-pair order and the derived
+`phase_residual_ms` value for each sample. Negative residuals are
+diagnostic noise signals, not overhead claims.
 
 The local unit tests exercise the Arm A / Arm C paths with a fake `assay` binary
 that emits the expected archive shape. The first validation against real

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -247,7 +247,9 @@ publication language is now:
 
 Next engineering slice:
 
-> If this arc needs a sharper wall-clock explanation, either repeat the
-> phase-timing runs to characterize Arm A tail variance or decompose the
-> residual/outside-harness time. Do not publish an additive wall-clock
-> split from the current phase evidence.
+> If this arc needs a sharper wall-clock explanation, run the paired
+> Slice 9 residual diagnostic (`arm=paired-a-c`) before another broad
+> Arm A or Arm C rerun. It keeps Arm A and Arm C adjacent in one
+> delegated job, counterbalances order, and records per-sample
+> `phase_residual_ms`. Do not publish an additive wall-clock split from
+> the current phase evidence.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -27,10 +27,12 @@ from typing import Any
 EXPERIMENT = "runner-vs-otel-overhead-2026-05"
 SAMPLE_SCHEMA = "assay.experiment.overhead_sample.v0"
 SUMMARY_SCHEMA = "assay.experiment.overhead_summary.v0"
+PAIRED_SEQUENCE_SCHEMA = "assay.experiment.paired_sequence.v0"
 DEFAULT_ARM = "arm-b-otel"
 ARM_A = "arm-a-runner-only"
 ARM_B = "arm-b-otel"
 ARM_C = "arm-c-dual-capture"
+PAIRED_AC = "paired-a-c"
 RSS_TIME_PATH = Path("/usr/bin/time")
 RSS_SYSTEMS = {"darwin", "linux"}
 PHASE_TIMING_KEYS = [
@@ -173,6 +175,20 @@ def load_phase_timings(path: Path) -> dict[str, float] | None:
         if key in PHASE_TIMING_KEYS and isinstance(value, (int, float)):
             parsed[key] = float(value)
     return parsed or None
+
+
+def phase_residual_ms(sample: dict[str, Any]) -> float | None:
+    phases = sample.get("phase_timings_ms")
+    if not isinstance(phases, dict):
+        return None
+    values = [
+        float(phases[key])
+        for key in PHASE_TIMING_KEYS
+        if isinstance(phases.get(key), (int, float))
+    ]
+    if not values:
+        return None
+    return float(sample["wall_clock_ms"]) - sum(values)
 
 
 def extract_archive(archive: Path, destination: Path) -> None:
@@ -543,6 +559,153 @@ def bmf_export(summary: dict[str, Any]) -> dict[str, dict[str, float | int]]:
     return {key: {"value": value} for key, value in values.items() if value is not None}
 
 
+def write_run_outputs(
+    *,
+    out_dir: Path,
+    arm: str,
+    samples: list[dict[str, Any]],
+    summary: dict[str, Any],
+    artifact_suffix: str = "",
+) -> None:
+    arm_dir = out_dir / arm
+    artifacts_dir = out_dir / "artifacts"
+    samples_path = arm_dir / "samples.jsonl"
+    samples_path.write_text(
+        "".join(json.dumps(sample, sort_keys=True) + "\n" for sample in samples),
+        encoding="utf-8",
+    )
+    write_json(arm_dir / "summary.json", summary)
+    (arm_dir / "summary.md").write_text(summary_markdown(summary), encoding="utf-8")
+    write_json(
+        artifacts_dir / f"trace-sizes{artifact_suffix}.json",
+        {
+            "arm": arm,
+            "trace_json_bytes": [
+                sample["artifact_bytes"]["trace_json"] for sample in samples
+            ],
+        },
+    )
+    write_json(
+        artifacts_dir / f"archive-sizes{artifact_suffix}.json",
+        {
+            "arm": arm,
+            "archive_targz_bytes": [
+                sample["artifact_bytes"]["archive_targz"]
+                for sample in samples
+                if sample["artifact_bytes"]["archive_targz"] is not None
+            ],
+            "archive_extracted_bytes": [
+                sample["artifact_bytes"]["archive_extracted"]
+                for sample in samples
+                if sample["artifact_bytes"]["archive_extracted"] is not None
+            ],
+        },
+    )
+    write_json(
+        artifacts_dir / f"rss-sizes{artifact_suffix}.json",
+        {
+            "arm": arm,
+            "peak_rss_bytes": [
+                sample["peak_rss_bytes"]
+                for sample in samples
+                if sample["peak_rss_bytes"] is not None
+            ],
+        },
+    )
+    write_json(
+        artifacts_dir / f"phase-timings{artifact_suffix}.json",
+        {
+            "arm": arm,
+            "phase_timings_ms": [
+                sample["phase_timings_ms"]
+                for sample in samples
+                if sample.get("phase_timings_ms") is not None
+            ],
+        },
+    )
+
+
+def paired_ac_order(pair_index: int) -> list[str]:
+    return [ARM_A, ARM_C] if pair_index % 2 else [ARM_C, ARM_A]
+
+
+def run_paired_ac(args: argparse.Namespace) -> int:
+    ensure_workload_built(args.workload_dir, skip_build=args.skip_build)
+    artifacts_dir = args.out_dir / "artifacts"
+    for arm in (ARM_A, ARM_C):
+        (args.out_dir / arm).mkdir(parents=True, exist_ok=True)
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    commit = assay_commit()
+    versions = tool_versions(args.workload_dir)
+    samples_by_arm: dict[str, list[dict[str, Any]]] = {ARM_A: [], ARM_C: []}
+    order: list[dict[str, Any]] = []
+    for pair in range(1, args.iterations + 1):
+        for arm in paired_ac_order(pair):
+            sample = one_sample(
+                arm_dir=args.out_dir / arm,
+                arm=arm,
+                workload_dir=args.workload_dir,
+                iteration=pair,
+                commit=commit,
+                versions=versions,
+                timeout_seconds=args.timeout_seconds,
+                assay_bin=args.assay_bin,
+                ebpf_obj=args.ebpf_obj,
+                use_sudo=args.sudo,
+                measure_rss=args.measure_rss,
+                runner_fixture_agent=args.runner_fixture_agent,
+            )
+            samples_by_arm[arm].append(sample)
+            order.append(
+                {
+                    "pair": pair,
+                    "arm": arm,
+                    "iteration": pair,
+                    "started_at": sample["started_at"],
+                    "wall_clock_ms": sample["wall_clock_ms"],
+                    "phase_residual_ms": phase_residual_ms(sample),
+                    "exit_code": sample["exit_code"],
+                }
+            )
+
+    summaries = {
+        arm: summarize(samples, delegated_workflow_url=args.delegated_workflow_url)
+        for arm, samples in samples_by_arm.items()
+    }
+    bmf: dict[str, dict[str, float | int]] = {}
+    for arm, samples in samples_by_arm.items():
+        write_run_outputs(
+            out_dir=args.out_dir,
+            arm=arm,
+            samples=samples,
+            summary=summaries[arm],
+            artifact_suffix=f"-{arm}",
+        )
+        bmf.update(bmf_export(summaries[arm]))
+    write_json(artifacts_dir / "bmf.json", bmf)
+    write_json(
+        artifacts_dir / "paired-sequence.json",
+        {
+            "schema": PAIRED_SEQUENCE_SCHEMA,
+            "kind": PAIRED_AC,
+            "pairing": "counterbalanced-adjacent-pairs",
+            "arms": [ARM_A, ARM_C],
+            "pairs_per_arm": args.iterations,
+            "order": order,
+        },
+    )
+
+    print(f"wrote {args.out_dir / ARM_A / 'samples.jsonl'}")
+    print(f"wrote {args.out_dir / ARM_C / 'samples.jsonl'}")
+    print(f"wrote {artifacts_dir / 'paired-sequence.json'}")
+    print(f"wrote {artifacts_dir / 'bmf.json'}")
+    all_valid = all(
+        summary["valid_samples"] == args.iterations for summary in summaries.values()
+    )
+    return 0 if all_valid else 2
+
+
 def _md_value(value: Any, *, unit: str = "") -> str:
     if value is None:
         return "`null`"
@@ -637,7 +800,11 @@ def write_json(path: Path, payload: Any) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--arm", choices=[ARM_A, ARM_B, ARM_C], default=ARM_B)
+    parser.add_argument(
+        "--arm",
+        choices=[ARM_A, ARM_B, ARM_C, PAIRED_AC],
+        default=ARM_B,
+    )
     parser.add_argument("--iterations", type=int, default=20)
     parser.add_argument("--out-dir", type=Path, default=default_out_dir())
     parser.add_argument("--workload-dir", type=Path, default=default_workload_dir())
@@ -664,6 +831,10 @@ def main(argv: list[str] | None = None) -> int:
             parser.error(rss_error)
     if args.clean and args.out_dir.exists():
         shutil.rmtree(args.out_dir)
+    if args.arm == PAIRED_AC:
+        if args.assay_bin is None or args.ebpf_obj is None:
+            parser.error(f"--arm {PAIRED_AC} requires --assay-bin and --ebpf-obj")
+        return run_paired_ac(args)
 
     ensure_workload_built(args.workload_dir, skip_build=args.skip_build)
     arm_dir = args.out_dir / args.arm
@@ -693,59 +864,7 @@ def main(argv: list[str] | None = None) -> int:
     summary = summarize(samples, delegated_workflow_url=args.delegated_workflow_url)
 
     samples_path = arm_dir / "samples.jsonl"
-    samples_path.write_text(
-        "".join(json.dumps(sample, sort_keys=True) + "\n" for sample in samples),
-        encoding="utf-8",
-    )
-    write_json(arm_dir / "summary.json", summary)
-    (arm_dir / "summary.md").write_text(summary_markdown(summary), encoding="utf-8")
-    write_json(
-        artifacts_dir / "trace-sizes.json",
-        {
-            "arm": args.arm,
-            "trace_json_bytes": [
-                sample["artifact_bytes"]["trace_json"] for sample in samples
-            ],
-        },
-    )
-    write_json(
-        artifacts_dir / "archive-sizes.json",
-        {
-            "arm": args.arm,
-            "archive_targz_bytes": [
-                sample["artifact_bytes"]["archive_targz"]
-                for sample in samples
-                if sample["artifact_bytes"]["archive_targz"] is not None
-            ],
-            "archive_extracted_bytes": [
-                sample["artifact_bytes"]["archive_extracted"]
-                for sample in samples
-                if sample["artifact_bytes"]["archive_extracted"] is not None
-            ],
-        },
-    )
-    write_json(
-        artifacts_dir / "rss-sizes.json",
-        {
-            "arm": args.arm,
-            "peak_rss_bytes": [
-                sample["peak_rss_bytes"]
-                for sample in samples
-                if sample["peak_rss_bytes"] is not None
-            ],
-        },
-    )
-    write_json(
-        artifacts_dir / "phase-timings.json",
-        {
-            "arm": args.arm,
-            "phase_timings_ms": [
-                sample["phase_timings_ms"]
-                for sample in samples
-                if sample.get("phase_timings_ms") is not None
-            ],
-        },
-    )
+    write_run_outputs(out_dir=args.out_dir, arm=args.arm, samples=samples, summary=summary)
     write_json(artifacts_dir / "bmf.json", bmf_export(summary))
 
     print(f"wrote {samples_path}")

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -276,6 +276,17 @@ class OverheadHarnessTests(unittest.TestCase):
         }
         assert_matches_schema(self, payload, schema, root=schema)
 
+    def test_phase_residual_subtracts_recorded_phases(self) -> None:
+        sample = self.sample(
+            wall_clock_ms=20.0,
+            phase_timings_ms={
+                "preflight_ms": 1.0,
+                "child_runtime_ms": 4.0,
+                "archive_write_ms": 2.5,
+            },
+        )
+        self.assertEqual(overhead_harness.phase_residual_ms(sample), 12.5)
+
     def test_sample_schema_requires_extracted_size_key(self) -> None:
         schema = load_schema("overhead-sample-v0.schema.json")
         sample = self.sample()
@@ -705,6 +716,86 @@ class OverheadHarnessTests(unittest.TestCase):
             )
             self.assertIn(
                 "runner_vs_otel.arm_a_runner_only.phase_timings_ms.archive_write_ms.median",
+                bmf,
+            )
+
+    def test_paired_ac_runs_counterbalanced_adjacent_pairs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workload = root / "workload"
+            out_dir = root / "overhead"
+            fixture_agent = root / "fixture-agent.js"
+            write_stub_workload(workload)
+            fixture_agent.write_text("console.log('fake fixture')\n", encoding="utf-8")
+            fake_assay = write_fake_assay(root)
+            fake_ebpf = root / "assay-ebpf.o"
+            fake_ebpf.write_bytes(b"fake ebpf")
+
+            status = overhead_harness.main(
+                [
+                    "--arm",
+                    "paired-a-c",
+                    "--iterations",
+                    "2",
+                    "--skip-build",
+                    "--clean",
+                    "--timeout-seconds",
+                    "10",
+                    "--workload-dir",
+                    str(workload),
+                    "--out-dir",
+                    str(out_dir),
+                    "--assay-bin",
+                    str(fake_assay),
+                    "--ebpf-obj",
+                    str(fake_ebpf),
+                    "--runner-fixture-agent",
+                    str(fixture_agent),
+                ]
+            )
+            self.assertEqual(status, 0)
+
+            arm_a_summary = json.loads(
+                (out_dir / "arm-a-runner-only" / "summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            arm_c_summary = json.loads(
+                (out_dir / "arm-c-dual-capture" / "summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            sequence = json.loads(
+                (out_dir / "artifacts" / "paired-sequence.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            bmf = json.loads(
+                (out_dir / "artifacts" / "bmf.json").read_text(encoding="utf-8")
+            )
+
+            self.assertEqual(arm_a_summary["valid_samples"], 2)
+            self.assertEqual(arm_c_summary["valid_samples"], 2)
+            self.assertEqual(
+                sequence["schema"],
+                "assay.experiment.paired_sequence.v0",
+            )
+            self.assertEqual(
+                [entry["arm"] for entry in sequence["order"]],
+                [
+                    "arm-a-runner-only",
+                    "arm-c-dual-capture",
+                    "arm-c-dual-capture",
+                    "arm-a-runner-only",
+                ],
+            )
+            self.assertIsInstance(sequence["order"][0]["phase_residual_ms"], float)
+            self.assertIn(
+                "runner_vs_otel.arm_a_runner_only.wall_clock_ms.median",
+                bmf,
+            )
+            self.assertIn(
+                "runner_vs_otel.arm_c_dual_capture.wall_clock_ms.median",
                 bmf,
             )
 


### PR DESCRIPTION
Summary

Adds Slice 9 for the Runner-vs-OTel overhead arc: paired Arm A/C residual diagnostics plus a short research-informed rationale for why this is the next experiment instead of another broad rerun.

What changed

- Adds workflow option `arm=paired-a-c` to run Arm A and Arm C in one delegated `assay-bpf-runner` job.
- Runs adjacent counterbalanced pairs: odd pairs A/C, even pairs C/A.
- Extends `overhead_harness.py` with paired mode and a derived `phase_residual_ms = wall_clock_ms - sum(phase_timings_ms)` per sample in `artifacts/paired-sequence.json`.
- Adds `schema=assay.experiment.paired_sequence.v0`, documents negative residual semantics, and records the three-outcome Slice 9 decision tree.
- Keeps per-arm `samples.jsonl`, `summary.json`, `summary.md`, and combined BMF output for paired runs.
- Documents Slice 9 acceptance rules and the research pre-read: OpenTelemetry overhead is target/workload dependent, BPF overhead is hard to isolate, and observability overhead measurements are sensitive to execution-environment noise.
- Pins the PR content labeler action to a full commit SHA and moves it from `pull_request_target` to `pull_request` so the newly enforced workflow policy stays green.

Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 25 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 92 OK
- `python3 -m py_compile docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py`
- `actionlint .github/workflows/runner-otel-overhead-experiment.yml`
- `zizmor .github/workflows/runner-otel-overhead-experiment.yml` -> no findings
- local changed-docs link check -> OK
- `git diff --check`
- `actionlint .github/workflows/pr-content-labeler.yml .github/workflows/runner-otel-overhead-experiment.yml`
- `zizmor .github/workflows/pr-content-labeler.yml .github/workflows/runner-otel-overhead-experiment.yml` -> no findings
- Verified `actions/labeler` SHA `8558fd74291d67161a8a78ce36a881fa63b766a9` matches `refs/tags/v5`
- pre-commit + pre-push hooks green, including clippy and linux compile gate

Non-claims

- Does not dispatch the paired run yet.
- Does not commit benchmark artifacts.
- Does not publish an additive wall-clock decomposition claim.
- Does not promote `paired-sequence.json` to a Runner archive contract.
