### PR TITLE
feat(experiments): add overhead event-rate sweep harness

### DIFF
--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -38,6 +38,40 @@ on:
         required: true
         default: false
         type: boolean
+      sweep_kernel_event_rate:
+        description: "Slice 10 kernel-event pressure target"
+        required: true
+        default: "baseline"
+        type: choice
+        options:
+          - baseline
+          - low
+          - medium
+          - high
+      sweep_span_event_rate:
+        description: "Slice 10 OTel span/event pressure target"
+        required: true
+        default: "baseline"
+        type: choice
+        options:
+          - baseline
+          - low
+          - medium
+          - high
+      sweep_concurrency:
+        description: "Slice 10 concurrent sweep workers"
+        required: true
+        default: "1"
+        type: string
+      sweep_payload_size:
+        description: "Slice 10 per-event payload size"
+        required: true
+        default: "small"
+        type: choice
+        options:
+          - small
+          - medium
+          - large
 
 permissions:
   contents: read
@@ -161,6 +195,10 @@ jobs:
           REPETITIONS: ${{ inputs.repetitions }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
           MEASURE_RSS: ${{ inputs.measure_rss }}
+          SWEEP_KERNEL_EVENT_RATE: ${{ inputs.sweep_kernel_event_rate }}
+          SWEEP_SPAN_EVENT_RATE: ${{ inputs.sweep_span_event_rate }}
+          SWEEP_CONCURRENCY: ${{ inputs.sweep_concurrency }}
+          SWEEP_PAYLOAD_SIZE: ${{ inputs.sweep_payload_size }}
         run: |
           set -euo pipefail
           OUT_DIR="$PWD/overhead-runs"
@@ -169,6 +207,12 @@ jobs:
           if [ "$MEASURE_RSS" = "true" ]; then
             RSS_FLAG=(--measure-rss)
           fi
+          SWEEP_ARGS=(
+            --sweep-kernel-event-rate "$SWEEP_KERNEL_EVENT_RATE"
+            --sweep-span-event-rate "$SWEEP_SPAN_EVENT_RATE"
+            --sweep-concurrency "$SWEEP_CONCURRENCY"
+            --sweep-payload-size "$SWEEP_PAYLOAD_SIZE"
+          )
           set +e
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm paired-a-c \
@@ -183,6 +227,7 @@ jobs:
             --ebpf-obj "$PWD/target/assay-ebpf.o" \
             --runner-fixture-agent "$PWD/runner-fixtures/openai-agents/fixture-agent.js" \
             --delegated-workflow-url "$WORKFLOW_URL" \
+            "${SWEEP_ARGS[@]}" \
             "${RSS_FLAG[@]}"
           status=$?
           set -e
@@ -317,6 +362,10 @@ jobs:
           REPETITIONS: ${{ inputs.repetitions }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
           MEASURE_RSS: ${{ inputs.measure_rss }}
+          SWEEP_KERNEL_EVENT_RATE: ${{ inputs.sweep_kernel_event_rate }}
+          SWEEP_SPAN_EVENT_RATE: ${{ inputs.sweep_span_event_rate }}
+          SWEEP_CONCURRENCY: ${{ inputs.sweep_concurrency }}
+          SWEEP_PAYLOAD_SIZE: ${{ inputs.sweep_payload_size }}
         run: |
           set -euo pipefail
           OUT_DIR="$PWD/overhead-runs"
@@ -325,6 +374,12 @@ jobs:
           if [ "$MEASURE_RSS" = "true" ]; then
             RSS_FLAG=(--measure-rss)
           fi
+          SWEEP_ARGS=(
+            --sweep-kernel-event-rate "$SWEEP_KERNEL_EVENT_RATE"
+            --sweep-span-event-rate "$SWEEP_SPAN_EVENT_RATE"
+            --sweep-concurrency "$SWEEP_CONCURRENCY"
+            --sweep-payload-size "$SWEEP_PAYLOAD_SIZE"
+          )
           set +e
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-c-dual-capture \
@@ -338,6 +393,7 @@ jobs:
             --assay-bin "$PWD/target/debug/assay" \
             --ebpf-obj "$PWD/target/assay-ebpf.o" \
             --delegated-workflow-url "$WORKFLOW_URL" \
+            "${SWEEP_ARGS[@]}" \
             "${RSS_FLAG[@]}"
           status=$?
           set -e
@@ -467,6 +523,10 @@ jobs:
           REPETITIONS: ${{ inputs.repetitions }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
           MEASURE_RSS: ${{ inputs.measure_rss }}
+          SWEEP_KERNEL_EVENT_RATE: ${{ inputs.sweep_kernel_event_rate }}
+          SWEEP_SPAN_EVENT_RATE: ${{ inputs.sweep_span_event_rate }}
+          SWEEP_CONCURRENCY: ${{ inputs.sweep_concurrency }}
+          SWEEP_PAYLOAD_SIZE: ${{ inputs.sweep_payload_size }}
         run: |
           set -euo pipefail
           OUT_DIR="$PWD/overhead-runs"
@@ -475,6 +535,12 @@ jobs:
           if [ "$MEASURE_RSS" = "true" ]; then
             RSS_FLAG=(--measure-rss)
           fi
+          SWEEP_ARGS=(
+            --sweep-kernel-event-rate "$SWEEP_KERNEL_EVENT_RATE"
+            --sweep-span-event-rate "$SWEEP_SPAN_EVENT_RATE"
+            --sweep-concurrency "$SWEEP_CONCURRENCY"
+            --sweep-payload-size "$SWEEP_PAYLOAD_SIZE"
+          )
           set +e
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-a-runner-only \
@@ -489,6 +555,7 @@ jobs:
             --ebpf-obj "$PWD/target/assay-ebpf.o" \
             --runner-fixture-agent "$PWD/runner-fixtures/openai-agents/fixture-agent.js" \
             --delegated-workflow-url "$WORKFLOW_URL" \
+            "${SWEEP_ARGS[@]}" \
             "${RSS_FLAG[@]}"
           status=$?
           set -e
@@ -586,6 +653,10 @@ jobs:
           REPETITIONS: ${{ inputs.repetitions }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
           MEASURE_RSS: ${{ inputs.measure_rss }}
+          SWEEP_KERNEL_EVENT_RATE: ${{ inputs.sweep_kernel_event_rate }}
+          SWEEP_SPAN_EVENT_RATE: ${{ inputs.sweep_span_event_rate }}
+          SWEEP_CONCURRENCY: ${{ inputs.sweep_concurrency }}
+          SWEEP_PAYLOAD_SIZE: ${{ inputs.sweep_payload_size }}
         run: |
           set -euo pipefail
           OUT_DIR="$PWD/overhead-runs"
@@ -594,6 +665,12 @@ jobs:
           if [ "$MEASURE_RSS" = "true" ]; then
             RSS_FLAG=(--measure-rss)
           fi
+          SWEEP_ARGS=(
+            --sweep-kernel-event-rate "$SWEEP_KERNEL_EVENT_RATE"
+            --sweep-span-event-rate "$SWEEP_SPAN_EVENT_RATE"
+            --sweep-concurrency "$SWEEP_CONCURRENCY"
+            --sweep-payload-size "$SWEEP_PAYLOAD_SIZE"
+          )
           set +e
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-b-otel \
@@ -604,6 +681,7 @@ jobs:
             --out-dir "$OUT_DIR" \
             --workload-dir "$PWD/docs/experiments/runner-vs-otel-2026-05/workload" \
             --delegated-workflow-url "$WORKFLOW_URL" \
+            "${SWEEP_ARGS[@]}" \
             "${RSS_FLAG[@]}"
           status=$?
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ All notable changes to this project will be documented in this file.
   question is how overhead scales with kernel-event rate, span/event
   rate, concurrency, and payload size, not another broad Arm A/C
   wall-clock rerun.
+- Added Slice 10 harness/workflow support for that event-rate sweep. The
+  overhead workflow now accepts sweep inputs, the workload can generate
+  controlled kernel-event and OTel event pressure, and samples/summaries
+  embed `assay.experiment.event_rate_sweep.v0` metadata without
+  publishing new measurements.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
@@ -21,6 +21,7 @@
  */
 
 import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { mkdir as mkdirAsync, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { Span, SpanStatusCode } from "@opentelemetry/api";
@@ -326,13 +327,13 @@ async function applySweepPressure(
 
   const workers = Math.min(config.sweepConcurrency, config.sweepKernelEvents);
   const sweepDir = join(config.workDir, "event-rate-sweep");
-  mkdirSync(sweepDir, { recursive: true });
+  await mkdirAsync(sweepDir, { recursive: true });
   await Promise.all(
     Array.from({ length: workers }, async (_, worker) => {
       for (let index = worker; index < config.sweepKernelEvents; index += workers) {
         const target = join(sweepDir, `worker-${worker}-${index}.txt`);
-        writeFileSync(target, payload, "utf8");
-        readFileSync(target, "utf8");
+        await writeFile(target, payload, "utf8");
+        await readFile(target, "utf8");
       }
     }),
   );

--- a/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
+++ b/docs/experiments/runner-vs-otel-2026-05/workload/src/workload.ts
@@ -23,7 +23,7 @@
 import { writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
-import { SpanStatusCode } from "@opentelemetry/api";
+import { Span, SpanStatusCode } from "@opentelemetry/api";
 import { Agent, Runner, Usage, tool } from "@openai/agents";
 import { z } from "zod";
 import { getTracer, flushTraceToFile } from "./otel-setup";
@@ -59,6 +59,14 @@ interface WorkloadConfig {
   captureSensitiveOtelContent: boolean;
   /** Absolute path the tool's tampered read targets (Slice 3 only). */
   tamperingTargetPath: string;
+  /** Slice 10: target file I/O pressure level for kernel-event sweeps. */
+  sweepKernelEvents: number;
+  /** Slice 10: target OTel span-event pressure level. */
+  sweepSpanEvents: number;
+  /** Slice 10: number of concurrent sweep workers. */
+  sweepConcurrency: number;
+  /** Slice 10: payload bytes written/read and attached to sweep events. */
+  sweepPayloadBytes: number;
 }
 
 class DeterministicToolCallModel {
@@ -142,6 +150,10 @@ export async function runWorkload(config: WorkloadConfig): Promise<void> {
       "assay.measurement.boundary": "linux_ebpf_cgroup_v2",
       "gen_ai.provider.name": "openai",
       "gen_ai.operation.name": "create_agent",
+      "assay.sweep.kernel_events.target": config.sweepKernelEvents,
+      "assay.sweep.span_events.target": config.sweepSpanEvents,
+      "assay.sweep.concurrency": config.sweepConcurrency,
+      "assay.sweep.payload_bytes": config.sweepPayloadBytes,
     });
 
     try {
@@ -249,6 +261,7 @@ export async function runWorkload(config: WorkloadConfig): Promise<void> {
       await runner.run(agent, "Read the deterministic fixture file.", {
         maxTurns: 2,
       });
+      await applySweepPressure(config, rootSpan);
       sdkEmitter.emit({ event_type: "run_finished" });
 
       if (config.archivePath) {
@@ -294,6 +307,37 @@ export async function runWorkload(config: WorkloadConfig): Promise<void> {
   await flushTraceToFile(config.tracePath);
 }
 
+async function applySweepPressure(
+  config: WorkloadConfig,
+  rootSpan: Span,
+): Promise<void> {
+  const payload = "x".repeat(config.sweepPayloadBytes);
+  for (let index = 0; index < config.sweepSpanEvents; index += 1) {
+    rootSpan.addEvent("assay.sweep.span_event", {
+      "assay.sweep.index": index,
+      "assay.sweep.payload_bytes": config.sweepPayloadBytes,
+      "assay.sweep.payload": payload,
+    });
+  }
+
+  if (config.sweepKernelEvents <= 0) {
+    return;
+  }
+
+  const workers = Math.min(config.sweepConcurrency, config.sweepKernelEvents);
+  const sweepDir = join(config.workDir, "event-rate-sweep");
+  mkdirSync(sweepDir, { recursive: true });
+  await Promise.all(
+    Array.from({ length: workers }, async (_, worker) => {
+      for (let index = worker; index < config.sweepKernelEvents; index += workers) {
+        const target = join(sweepDir, `worker-${worker}-${index}.txt`);
+        writeFileSync(target, payload, "utf8");
+        readFileSync(target, "utf8");
+      }
+    }),
+  );
+}
+
 function parseArgs(): WorkloadConfig {
   const args = process.argv.slice(2);
   const get = (name: string, required = false): string | undefined => {
@@ -303,6 +347,15 @@ function parseArgs(): WorkloadConfig {
     return undefined;
   };
   const has = (name: string): boolean => args.includes(`--${name}`);
+  const getInt = (name: string, fallback: number): number => {
+    const raw = get(name);
+    if (raw === undefined) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      throw new Error(`--${name} must be a non-negative integer`);
+    }
+    return parsed;
+  };
 
   const runId = get("run-id") ?? `run_experiment_${Date.now()}`;
   const workDir = get("work-dir") ?? join(tmpdir(), `assay-otel-${runId}`);
@@ -314,6 +367,7 @@ function parseArgs(): WorkloadConfig {
   const captureSensitiveOtelContent =
     has("capture-sensitive-otel-content") || tamperingMode;
   const tamperingTargetPath = join(workDir, "tampering-target.txt");
+  const sweepConcurrency = Math.max(1, getInt("sweep-concurrency", 1));
 
   return {
     runId,
@@ -325,6 +379,10 @@ function parseArgs(): WorkloadConfig {
     tamperingMode,
     captureSensitiveOtelContent,
     tamperingTargetPath,
+    sweepKernelEvents: getInt("sweep-kernel-events", 0),
+    sweepSpanEvents: getInt("sweep-span-events", 0),
+    sweepConcurrency,
+    sweepPayloadBytes: Math.max(1, getInt("sweep-payload-bytes", 128)),
   };
 }
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -76,11 +76,11 @@
 > decomposition remains unpublished and should stop at this measurement
 > budget.
 >
-> **Slice 10 status:** planned. The next experiment should not be another
-> broad Arm A/C wall-clock rerun. It should sweep controlled kernel-event
-> rate, span/event rate, and concurrency so the next question is "when
-> does overhead become visible, and which component scales with event
-> pressure?"
+> **Slice 10 status:** harness-ready. The overhead workflow now accepts
+> controlled kernel-event rate, span/event rate, concurrency, and payload
+> size inputs. The next question is "when does overhead become visible,
+> and which component scales with event pressure?" No sweep measurements
+> have been dispatched or published yet.
 
 ## Research Question
 
@@ -487,8 +487,8 @@ Slice 9 result:
 ## Event-Rate Sweep Follow-up
 
 Slice 10 is the next useful experiment if we want one more overhead
-slice. It should be a controlled event-rate and workload-intensity sweep,
-not another broad Arm A/C wall-clock repeat.
+slice. It is a controlled event-rate and workload-intensity sweep, not
+another broad Arm A/C wall-clock repeat.
 
 The question changes from:
 
@@ -537,6 +537,11 @@ Proposed arms:
 - **Arm B:** OTel/OpenInference-style tracing only.
 - **Arm C:** Runner archive capture plus OTel trace export.
 
+Arm A cannot apply OTel span/event pressure because it deliberately has
+no trace export. If a paired dispatch requests non-baseline span/event
+pressure, Arm A samples record `span_event_rate=baseline` and
+`target_span_events=0`; Arm C records and applies the requested target.
+
 Metrics:
 
 - `wall_clock_ms` as a secondary metric only;
@@ -551,8 +556,8 @@ Metrics:
 
 Acceptance rules for Slice 10:
 
-- Start with a plan-only PR or a harness-only PR. Do not commit sweep
-  measurements in the first slice.
+- Start with a harness-only PR. Do not commit sweep measurements in the
+  first slice.
 - Keep output experiment-scoped. If a new artifact is introduced, use an
   `assay.experiment.event_rate_sweep.v0` schema string and sidecar tests.
 - Use paired/counterbalanced order inside one delegated job whenever two
@@ -587,7 +592,7 @@ Acceptance rules for Slice 10:
 | 7 | **Done**: Arm A pure-L2 decomposition via `arm=arm-a-runner-only`, dispatched in runs [26463798358](https://github.com/Rul1an/assay/actions/runs/26463798358), [26464003194](https://github.com/Rul1an/assay/actions/runs/26464003194), and healthy repeat [26473448298](https://github.com/Rul1an/assay/actions/runs/26473448298) | RSS decomposition landed; wall-clock decomposition remains inconclusive because Arm A is still slower than Arm C at the median |
 | 8 | **Done**: Runner phase timing via hidden `--phase-timing-log` and harness `phase_timings_ms` aggregation, dispatched in runs [26476490968](https://github.com/Rul1an/assay/actions/runs/26476490968) and [26476824593](https://github.com/Rul1an/assay/actions/runs/26476824593) | phase data explains part, not all, of the Arm A / Arm C median gap; no additive wall-clock decomposition claim |
 | 9 | **Done**: paired Arm A/C residual diagnostics via workflow `arm=paired-a-c`, dispatched in run [26479319306](https://github.com/Rul1an/assay/actions/runs/26479319306) | residuals shrink/change sign under pairing; wall-clock decomposition remains unpublished and should stop at this measurement budget |
-| 10 | **Planned**: controlled event-rate / workload-intensity sweep | no broad rerun; plan or harness first, with kernel-event count, span/event count, concurrency, phase timing, residual, RSS, and health gates reported by level |
+| 10 | **Harness-ready**: controlled event-rate / workload-intensity sweep via workflow inputs and sample/summary metadata | no broad rerun; dispatch only a small matrix first, with kernel-event count, span/event count, concurrency, phase timing, residual, RSS, and health gates reported by level |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -5,7 +5,7 @@
 > rendering, Slice 5 findings, Slice 6 same-host Arm B dispatches, and
 > Slice 7 Arm A runner-only dispatches, Slice 8 phase timing diagnostics,
 > and Slice 9 paired A/C residual diagnostics have landed. Slice 10 is
-> planned as a controlled event-rate / workload-intensity sweep. This
+> harness-ready as a controlled event-rate / workload-intensity sweep. This
 > directory contains the
 > experiment-scoped measurement
 > harness and schema sidecars for the plan in
@@ -172,6 +172,15 @@ event count, span/event count, concurrency, and payload size. Its useful
 output is a set of slopes and thresholds, such as overhead per 1k kernel
 events or the event rate where ring-buffer retrieval becomes visible,
 not a product benchmark number.
+
+The delegated workflow exposes the Slice 10 knobs as
+`sweep_kernel_event_rate`, `sweep_span_event_rate`, `sweep_concurrency`,
+and `sweep_payload_size`. Baseline defaults preserve the pre-Slice-10
+behavior. Non-baseline runs embed `assay.experiment.event_rate_sweep.v0`
+metadata in each sample and summary so review artifacts remain
+self-describing. Arm A has no OTel trace export, so its sample metadata
+records any requested span/event pressure as `baseline` / `0` even when
+the paired Arm C sample applies the requested span/event target.
 
 The local unit tests exercise the Arm A / Arm C paths with a fake
 `assay` binary that emits the expected archive shape. Real

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -308,7 +308,7 @@ Next engineering slice:
 > paired residual diagnostic has landed and shows that the median gap is
 > not stable enough for an additive wall-clock decomposition at the
 > current measurement budget. If the overhead arc continues, the next
-> slice should be a controlled event-rate / workload-intensity sweep:
-> vary kernel-event rate, span/event rate, concurrency, and payload size,
-> then report slopes and thresholds rather than another single wall-clock
-> delta.
+> slice is the controlled event-rate / workload-intensity sweep now wired
+> into the overhead harness: vary kernel-event rate, span/event rate,
+> concurrency, and payload size, then report slopes and thresholds rather
+> than another single wall-clock delta.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -28,6 +28,7 @@ EXPERIMENT = "runner-vs-otel-overhead-2026-05"
 SAMPLE_SCHEMA = "assay.experiment.overhead_sample.v0"
 SUMMARY_SCHEMA = "assay.experiment.overhead_summary.v0"
 PAIRED_SEQUENCE_SCHEMA = "assay.experiment.paired_sequence.v0"
+EVENT_RATE_SWEEP_SCHEMA = "assay.experiment.event_rate_sweep.v0"
 DEFAULT_ARM = "arm-b-otel"
 ARM_A = "arm-a-runner-only"
 ARM_B = "arm-b-otel"
@@ -44,6 +45,24 @@ PHASE_TIMING_KEYS = [
     "event_flush_ms",
     "archive_write_ms",
 ]
+SWEEP_RATE_LEVELS = ("baseline", "low", "medium", "high")
+SWEEP_KERNEL_EVENT_TARGETS = {
+    "baseline": 0,
+    "low": 1,
+    "medium": 25,
+    "high": 100,
+}
+SWEEP_SPAN_EVENT_TARGETS = {
+    "baseline": 0,
+    "low": 1,
+    "medium": 25,
+    "high": 100,
+}
+SWEEP_PAYLOAD_BYTES = {
+    "small": 128,
+    "medium": 4096,
+    "large": 65536,
+}
 
 
 def repo_root() -> Path:
@@ -177,6 +196,69 @@ def load_phase_timings(path: Path) -> dict[str, float] | None:
     return parsed or None
 
 
+def event_rate_sweep_config(args: argparse.Namespace) -> dict[str, Any] | None:
+    kernel_level = args.sweep_kernel_event_rate
+    span_level = args.sweep_span_event_rate
+    concurrency = args.sweep_concurrency
+    payload_size = args.sweep_payload_size
+    if (
+        kernel_level == "baseline"
+        and span_level == "baseline"
+        and concurrency == 1
+        and payload_size == "small"
+    ):
+        return None
+    return {
+        "schema": EVENT_RATE_SWEEP_SCHEMA,
+        "kernel_event_rate": kernel_level,
+        "span_event_rate": span_level,
+        "concurrency": concurrency,
+        "payload_size": payload_size,
+        "target_kernel_events": SWEEP_KERNEL_EVENT_TARGETS[kernel_level],
+        "target_span_events": SWEEP_SPAN_EVENT_TARGETS[span_level],
+        "payload_bytes": SWEEP_PAYLOAD_BYTES[payload_size],
+    }
+
+
+def sweep_workload_args(event_rate_sweep: dict[str, Any] | None) -> list[str]:
+    if event_rate_sweep is None:
+        return []
+    return [
+        "--sweep-kernel-events",
+        str(event_rate_sweep["target_kernel_events"]),
+        "--sweep-span-events",
+        str(event_rate_sweep["target_span_events"]),
+        "--sweep-concurrency",
+        str(event_rate_sweep["concurrency"]),
+        "--sweep-payload-bytes",
+        str(event_rate_sweep["payload_bytes"]),
+    ]
+
+
+def event_rate_sweep_for_arm(
+    arm: str,
+    event_rate_sweep: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if event_rate_sweep is None:
+        return None
+    if arm != ARM_A:
+        return event_rate_sweep
+    arm_sweep = dict(event_rate_sweep)
+    arm_sweep["span_event_rate"] = "baseline"
+    arm_sweep["target_span_events"] = 0
+    return arm_sweep
+
+
+def sweep_env(event_rate_sweep: dict[str, Any] | None) -> dict[str, str]:
+    if event_rate_sweep is None:
+        return {}
+    return {
+        "ASSAY_SWEEP_KERNEL_EVENTS": str(event_rate_sweep["target_kernel_events"]),
+        "ASSAY_SWEEP_CONCURRENCY": str(event_rate_sweep["concurrency"]),
+        "ASSAY_SWEEP_PAYLOAD_BYTES": str(event_rate_sweep["payload_bytes"]),
+    }
+
+
 def phase_residual_ms(sample: dict[str, Any]) -> float | None:
     phases = sample.get("phase_timings_ms")
     if not isinstance(phases, dict):
@@ -285,7 +367,9 @@ def one_sample(
     use_sudo: bool = False,
     measure_rss: bool = False,
     runner_fixture_agent: Path | None = None,
+    event_rate_sweep: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    sample_event_rate_sweep = event_rate_sweep_for_arm(arm, event_rate_sweep)
     run_id = f"overhead_{arm.replace('-', '_')}_{iteration:03d}"
     run_dir = arm_dir / f"run_{iteration:03d}"
     work_dir = run_dir / "work"
@@ -306,7 +390,7 @@ def one_sample(
             str(work_dir),
             "--trace-out",
             str(trace_path),
-        ]
+        ] + sweep_workload_args(sample_event_rate_sweep)
     elif arm in {ARM_A, ARM_C}:
         if assay_bin is None or ebpf_obj is None:
             raise ValueError(f"{arm} requires --assay-bin and --ebpf-obj")
@@ -326,7 +410,7 @@ def one_sample(
                 str(work_dir),
                 "--trace-out",
                 str(trace_path),
-            ]
+            ] + sweep_workload_args(sample_event_rate_sweep)
         command = [
             str(assay_bin),
             "runner-spike",
@@ -357,6 +441,10 @@ def one_sample(
         env = os.environ.copy()
         env["LC_ALL"] = "C"
         env["LANG"] = "C"
+    sweep_environment = sweep_env(sample_event_rate_sweep)
+    if sweep_environment:
+        env = os.environ.copy() if env is None else env
+        env.update(sweep_environment)
     start = time.perf_counter()
     try:
         result = subprocess.run(
@@ -413,6 +501,7 @@ def one_sample(
         "exit_code": exit_code,
         "health": health,
         "phase_timings_ms": load_phase_timings(phase_timing_path),
+        "event_rate_sweep": sample_event_rate_sweep,
         "artifact_bytes": {
             "trace_json": file_size(trace_path),
             "archive_targz": archive_targz,
@@ -510,6 +599,7 @@ def summarize(
             ),
         },
         "phase_timings_ms": phase_timings,
+        "event_rate_sweep": first.get("event_rate_sweep"),
     }
 
 
@@ -638,6 +728,7 @@ def run_paired_ac(args: argparse.Namespace) -> int:
 
     commit = assay_commit()
     versions = tool_versions(args.workload_dir)
+    event_rate_sweep = event_rate_sweep_config(args)
     samples_by_arm: dict[str, list[dict[str, Any]]] = {ARM_A: [], ARM_C: []}
     order: list[dict[str, Any]] = []
     for pair in range(1, args.iterations + 1):
@@ -655,6 +746,7 @@ def run_paired_ac(args: argparse.Namespace) -> int:
                 use_sudo=args.sudo,
                 measure_rss=args.measure_rss,
                 runner_fixture_agent=args.runner_fixture_agent,
+                event_rate_sweep=event_rate_sweep,
             )
             samples_by_arm[arm].append(sample)
             order.append(
@@ -735,6 +827,7 @@ def summary_markdown(summary: dict[str, Any], *, artifact_name: str | None = Non
     rss = summary["peak_rss_bytes"]
     artifacts = summary["artifact_bytes"]
     phase_timings = summary.get("phase_timings_ms")
+    event_rate_sweep = summary.get("event_rate_sweep")
     tail_ratio = wall["p99_over_median"]
     lines = [
         "## Runner-vs-OTel Overhead Summary",
@@ -760,6 +853,14 @@ def summary_markdown(summary: dict[str, Any], *, artifact_name: str | None = Non
         lines.append(f"| Workflow | {summary['delegated_workflow_url']} |")
     if artifact_name:
         lines.append(f"| Artifact | `{artifact_name}` |")
+    if isinstance(event_rate_sweep, dict):
+        lines.append(
+            "| Event-rate sweep | "
+            f"`kernel={event_rate_sweep['kernel_event_rate']}; "
+            f"span={event_rate_sweep['span_event_rate']}; "
+            f"concurrency={event_rate_sweep['concurrency']}; "
+            f"payload={event_rate_sweep['payload_size']}` |"
+        )
     if isinstance(phase_timings, dict) and phase_timings:
         lines.extend(
             [
@@ -821,10 +922,28 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--sudo", action="store_true")
     parser.add_argument("--measure-rss", action="store_true")
+    parser.add_argument(
+        "--sweep-kernel-event-rate",
+        choices=SWEEP_RATE_LEVELS,
+        default="baseline",
+    )
+    parser.add_argument(
+        "--sweep-span-event-rate",
+        choices=SWEEP_RATE_LEVELS,
+        default="baseline",
+    )
+    parser.add_argument("--sweep-concurrency", type=int, default=1)
+    parser.add_argument(
+        "--sweep-payload-size",
+        choices=tuple(SWEEP_PAYLOAD_BYTES),
+        default="small",
+    )
     args = parser.parse_args(argv)
 
     if args.iterations < 1:
         parser.error("--iterations must be >= 1")
+    if args.sweep_concurrency < 1:
+        parser.error("--sweep-concurrency must be >= 1")
     if args.measure_rss:
         rss_error = rss_time_preflight_error()
         if rss_error is not None:
@@ -844,6 +963,7 @@ def main(argv: list[str] | None = None) -> int:
 
     commit = assay_commit()
     versions = tool_versions(args.workload_dir)
+    event_rate_sweep = event_rate_sweep_config(args)
     samples = [
         one_sample(
             arm_dir=arm_dir,
@@ -858,6 +978,7 @@ def main(argv: list[str] | None = None) -> int:
             use_sudo=args.sudo,
             measure_rss=args.measure_rss,
             runner_fixture_agent=args.runner_fixture_agent,
+            event_rate_sweep=event_rate_sweep,
         )
         for iteration in range(1, args.iterations + 1)
     ]

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json",
+  "title": "Runner vs OTel event-rate sweep cell v0",
+  "description": "Experiment-scoped event-rate/workload-intensity cell metadata embedded in overhead samples and summaries. This is not a Runner archive contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "kernel_event_rate",
+    "span_event_rate",
+    "concurrency",
+    "payload_size",
+    "target_kernel_events",
+    "target_span_events",
+    "payload_bytes"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.experiment.event_rate_sweep.v0"
+    },
+    "kernel_event_rate": {
+      "enum": [
+        "baseline",
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "span_event_rate": {
+      "enum": [
+        "baseline",
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "concurrency": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "payload_size": {
+      "enum": [
+        "small",
+        "medium",
+        "large"
+      ]
+    },
+    "target_kernel_events": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "target_span_events": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "payload_bytes": {
+      "type": "integer",
+      "minimum": 1
+    }
+  }
+}

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
@@ -160,6 +160,16 @@
         }
       ]
     },
+    "event_rate_sweep": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/event_rate_sweep"
+        }
+      ]
+    },
     "artifact_bytes": {
       "type": "object",
       "additionalProperties": false,
@@ -222,6 +232,64 @@
         },
         "archive_write_ms": {
           "$ref": "#/$defs/phase_ms"
+        }
+      }
+    },
+    "event_rate_sweep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "kernel_event_rate",
+        "span_event_rate",
+        "concurrency",
+        "payload_size",
+        "target_kernel_events",
+        "target_span_events",
+        "payload_bytes"
+      ],
+      "properties": {
+        "schema": {
+          "const": "assay.experiment.event_rate_sweep.v0"
+        },
+        "kernel_event_rate": {
+          "enum": [
+            "baseline",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "span_event_rate": {
+          "enum": [
+            "baseline",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "concurrency": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload_size": {
+          "enum": [
+            "small",
+            "medium",
+            "large"
+          ]
+        },
+        "target_kernel_events": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "target_span_events": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "payload_bytes": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
@@ -85,6 +85,16 @@
           "$ref": "#/$defs/phase_timing_summary"
         }
       ]
+    },
+    "event_rate_sweep": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/event_rate_sweep"
+        }
+      ]
     }
   },
   "$defs": {
@@ -206,6 +216,64 @@
         },
         "archive_write_ms": {
           "$ref": "#/$defs/phase_timing_stats"
+        }
+      }
+    },
+    "event_rate_sweep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "kernel_event_rate",
+        "span_event_rate",
+        "concurrency",
+        "payload_size",
+        "target_kernel_events",
+        "target_span_events",
+        "payload_bytes"
+      ],
+      "properties": {
+        "schema": {
+          "const": "assay.experiment.event_rate_sweep.v0"
+        },
+        "kernel_event_rate": {
+          "enum": [
+            "baseline",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "span_event_rate": {
+          "enum": [
+            "baseline",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "concurrency": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload_size": {
+          "enum": [
+            "small",
+            "medium",
+            "large"
+          ]
+        },
+        "target_kernel_events": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "target_span_events": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "payload_bytes": {
+          "type": "integer",
+          "minimum": 1
         }
       }
     }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -235,6 +235,7 @@ class OverheadHarnessTests(unittest.TestCase):
             "exit_code": 0,
             "health": None,
             "phase_timings_ms": None,
+            "event_rate_sweep": None,
             "artifact_bytes": {
                 "trace_json": 123,
                 "archive_targz": None,
@@ -276,6 +277,76 @@ class OverheadHarnessTests(unittest.TestCase):
         }
         assert_matches_schema(self, payload, schema, root=schema)
 
+    def test_event_rate_sweep_schema_accepts_cell(self) -> None:
+        schema = load_schema("event-rate-sweep-v0.schema.json")
+        payload = {
+            "schema": "assay.experiment.event_rate_sweep.v0",
+            "kernel_event_rate": "medium",
+            "span_event_rate": "low",
+            "concurrency": 4,
+            "payload_size": "medium",
+            "target_kernel_events": 25,
+            "target_span_events": 1,
+            "payload_bytes": 4096,
+        }
+        assert_matches_schema(self, payload, schema, root=schema)
+
+    def test_event_rate_sweep_config_maps_levels_to_targets(self) -> None:
+        args = type(
+            "Args",
+            (),
+            {
+                "sweep_kernel_event_rate": "high",
+                "sweep_span_event_rate": "medium",
+                "sweep_concurrency": 4,
+                "sweep_payload_size": "large",
+            },
+        )()
+        config = overhead_harness.event_rate_sweep_config(args)
+
+        self.assertEqual(config["schema"], "assay.experiment.event_rate_sweep.v0")
+        self.assertEqual(config["target_kernel_events"], 100)
+        self.assertEqual(config["target_span_events"], 25)
+        self.assertEqual(config["payload_bytes"], 65536)
+        self.assertEqual(config["concurrency"], 4)
+
+    def test_baseline_event_rate_sweep_config_is_null(self) -> None:
+        args = type(
+            "Args",
+            (),
+            {
+                "sweep_kernel_event_rate": "baseline",
+                "sweep_span_event_rate": "baseline",
+                "sweep_concurrency": 1,
+                "sweep_payload_size": "small",
+            },
+        )()
+        self.assertIsNone(overhead_harness.event_rate_sweep_config(args))
+
+    def test_event_rate_sweep_for_arm_a_drops_span_target(self) -> None:
+        config = {
+            "schema": "assay.experiment.event_rate_sweep.v0",
+            "kernel_event_rate": "medium",
+            "span_event_rate": "high",
+            "concurrency": 2,
+            "payload_size": "small",
+            "target_kernel_events": 25,
+            "target_span_events": 100,
+            "payload_bytes": 128,
+        }
+        arm_a = overhead_harness.event_rate_sweep_for_arm(
+            overhead_harness.ARM_A,
+            config,
+        )
+
+        self.assertEqual(arm_a["span_event_rate"], "baseline")
+        self.assertEqual(arm_a["target_span_events"], 0)
+        self.assertEqual(arm_a["target_kernel_events"], 25)
+        self.assertEqual(
+            overhead_harness.event_rate_sweep_for_arm(overhead_harness.ARM_C, config),
+            config,
+        )
+
     def test_phase_residual_subtracts_recorded_phases(self) -> None:
         sample = self.sample(
             wall_clock_ms=20.0,
@@ -293,6 +364,22 @@ class OverheadHarnessTests(unittest.TestCase):
         del sample["artifact_bytes"]["archive_extracted"]
         with self.assertRaises(AssertionError):
             assert_matches_schema(self, sample, schema, root=schema)
+
+    def test_sample_schema_accepts_event_rate_sweep_metadata(self) -> None:
+        schema = load_schema("overhead-sample-v0.schema.json")
+        sample = self.sample(
+            event_rate_sweep={
+                "schema": "assay.experiment.event_rate_sweep.v0",
+                "kernel_event_rate": "low",
+                "span_event_rate": "high",
+                "concurrency": 2,
+                "payload_size": "small",
+                "target_kernel_events": 1,
+                "target_span_events": 100,
+                "payload_bytes": 128,
+            }
+        )
+        assert_matches_schema(self, sample, schema, root=schema)
 
     def test_summary_schema_accepts_summary(self) -> None:
         samples = [
@@ -540,6 +627,52 @@ class OverheadHarnessTests(unittest.TestCase):
             self.assertTrue(bmf)
             self.assertIn("Runner-vs-OTel Overhead Summary", summary_md)
             self.assertIn("| Valid samples | `20` |", summary_md)
+
+    def test_harness_emits_event_rate_sweep_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workload = root / "workload"
+            out_dir = root / "overhead"
+            write_stub_workload(workload)
+
+            status = overhead_harness.main(
+                [
+                    "--iterations",
+                    "1",
+                    "--skip-build",
+                    "--clean",
+                    "--timeout-seconds",
+                    "10",
+                    "--workload-dir",
+                    str(workload),
+                    "--out-dir",
+                    str(out_dir),
+                    "--sweep-kernel-event-rate",
+                    "medium",
+                    "--sweep-span-event-rate",
+                    "low",
+                    "--sweep-concurrency",
+                    "4",
+                    "--sweep-payload-size",
+                    "medium",
+                ]
+            )
+            self.assertEqual(status, 0)
+
+            sample = json.loads(
+                (out_dir / "arm-b-otel" / "samples.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()[0]
+            )
+            summary = json.loads(
+                (out_dir / "arm-b-otel" / "summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+            self.assertEqual(sample["event_rate_sweep"]["target_kernel_events"], 25)
+            self.assertEqual(sample["event_rate_sweep"]["target_span_events"], 1)
+            self.assertEqual(summary["event_rate_sweep"], sample["event_rate_sweep"])
 
     @unittest.skipUnless(Path("/usr/bin/time").exists(), "/usr/bin/time not available")
     def test_harness_can_emit_rss_sample(self) -> None:

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -43,10 +43,11 @@
 | `assay.experiment.overhead_sample.v0` | One overhead measurement sample for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-sample-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json) |
 | `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-summary-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json) |
 | `assay.experiment.runner_phase_timing.v0` | Phase-timing side-log emitted by `assay runner-spike run --phase-timing-log` | experiment-scoped; sidecar active | [`runner-phase-timing-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json) |
+| `assay.experiment.event_rate_sweep.v0` | Event-rate/workload-intensity cell metadata embedded in overhead samples and summaries | experiment-scoped; sidecar active; Slice 10 planned | [`event-rate-sweep-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json) |
 
 The overhead schemas remain experiment-scoped. They are validated by the
-local harness tests against synthetic samples, summaries, and phase
-side-logs, but they are not Runner archive contracts and are not
+local harness tests against synthetic samples, summaries, phase
+side-logs, and event-rate sweep cells, but they are not Runner archive contracts and are not
 promoted to stable product surface.
 
 ## Version Notes

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -43,7 +43,7 @@
 | `assay.experiment.overhead_sample.v0` | One overhead measurement sample for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-sample-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json) |
 | `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-summary-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json) |
 | `assay.experiment.runner_phase_timing.v0` | Phase-timing side-log emitted by `assay runner-spike run --phase-timing-log` | experiment-scoped; sidecar active | [`runner-phase-timing-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json) |
-| `assay.experiment.event_rate_sweep.v0` | Event-rate/workload-intensity cell metadata embedded in overhead samples and summaries | experiment-scoped; sidecar active; Slice 10 planned | [`event-rate-sweep-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json) |
+| `assay.experiment.event_rate_sweep.v0` | Event-rate/workload-intensity cell metadata embedded in overhead samples and summaries | experiment-scoped; sidecar active; Slice 10 harness-ready | [`event-rate-sweep-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json) |
 
 The overhead schemas remain experiment-scoped. They are validated by the
 local harness tests against synthetic samples, summaries, phase

--- a/runner-fixtures/openai-agents/fixture-agent.js
+++ b/runner-fixtures/openai-agents/fixture-agent.js
@@ -34,6 +34,16 @@ function requiredEnv(name) {
   return value;
 }
 
+function optionalIntEnv(name, fallback) {
+  const value = process.env[name];
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
 function appendEvent(logPath, event) {
   fs.appendFileSync(logPath, `${JSON.stringify(event)}\n`, 'utf8');
 }
@@ -52,6 +62,26 @@ function makeEmitter({ logPath, runId, schema }) {
     });
     seq += 1;
   };
+}
+
+async function applySweepPressure(workDir) {
+  const kernelEvents = optionalIntEnv('ASSAY_SWEEP_KERNEL_EVENTS', 0);
+  if (kernelEvents <= 0) return;
+  const concurrency = Math.max(1, optionalIntEnv('ASSAY_SWEEP_CONCURRENCY', 1));
+  const payloadBytes = Math.max(1, optionalIntEnv('ASSAY_SWEEP_PAYLOAD_BYTES', 128));
+  const payload = 'x'.repeat(payloadBytes);
+  const workers = Math.min(concurrency, kernelEvents);
+  const sweepDir = path.join(workDir, 'event-rate-sweep');
+  fs.mkdirSync(sweepDir, { recursive: true });
+  await Promise.all(
+    Array.from({ length: workers }, async (_, worker) => {
+      for (let index = worker; index < kernelEvents; index += workers) {
+        const target = path.join(sweepDir, `worker-${worker}-${index}.txt`);
+        fs.writeFileSync(target, payload, 'utf8');
+        fs.readFileSync(target, 'utf8');
+      }
+    }),
+  );
 }
 
 class DeterministicToolCallModel {
@@ -148,6 +178,7 @@ async function main() {
 
   try {
     await runner.run(agent, 'Read the deterministic fixture file.', { maxTurns: 2 });
+    await applySweepPressure(workDir);
     emit({ event_type: 'run_finished' });
   } catch (error) {
     emit({ event_type: 'run_failed' });

--- a/runner-fixtures/openai-agents/fixture-agent.js
+++ b/runner-fixtures/openai-agents/fixture-agent.js
@@ -72,13 +72,13 @@ async function applySweepPressure(workDir) {
   const payload = 'x'.repeat(payloadBytes);
   const workers = Math.min(concurrency, kernelEvents);
   const sweepDir = path.join(workDir, 'event-rate-sweep');
-  fs.mkdirSync(sweepDir, { recursive: true });
+  await fs.promises.mkdir(sweepDir, { recursive: true });
   await Promise.all(
     Array.from({ length: workers }, async (_, worker) => {
       for (let index = worker; index < kernelEvents; index += workers) {
         const target = path.join(sweepDir, `worker-${worker}-${index}.txt`);
-        fs.writeFileSync(target, payload, 'utf8');
-        fs.readFileSync(target, 'utf8');
+        await fs.promises.writeFile(target, payload, 'utf8');
+        await fs.promises.readFile(target, 'utf8');
       }
     }),
   );


### PR DESCRIPTION
Summary

Implements the Slice 10 harness/workflow support for the Runner-vs-OTel event-rate / workload-intensity sweep. This does not dispatch or publish sweep measurements; it makes the next small matrix run self-describing and reproducible.

What changed

- Adds workflow_dispatch inputs for sweep_kernel_event_rate, sweep_span_event_rate, sweep_concurrency, and sweep_payload_size.
- Extends the overhead harness with event-rate sweep metadata and baseline-preserving defaults.
- Adds assay.experiment.event_rate_sweep.v0 sidecar schema and embeds that metadata in overhead samples/summaries when non-baseline knobs are used.
- Extends the OTel workload with controlled OTel span-event pressure and file I/O pressure.
- Extends the Arm A fixture with controlled file I/O pressure while explicitly dropping span-event pressure because Arm A has no OTel trace export.
- Updates docs, findings, schema overview, and changelog to mark Slice 10 as harness-ready, not measured.

Validation

- python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py' -> 31 OK
- npx tsc -p docs/experiments/runner-vs-otel-2026-05/workload/tsconfig.json
- node --check runner-fixtures/openai-agents/fixture-agent.js
- actionlint .github/workflows/runner-otel-overhead-experiment.yml
- zizmor .github/workflows/runner-otel-overhead-experiment.yml -> no findings
- local changed-docs link check -> OK
- schema JSON parse checks -> OK
- git diff --check
- pre-commit + pre-push hooks green

Non-claims

- Does not dispatch the Slice 10 sweep.
- Does not commit measurement artifacts.
- Does not publish product benchmark numbers.
- Does not reopen the broad Arm A/C wall-clock decomposition loop.
