### PR TITLE
docs(experiments): record overhead Slice 10 smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ All notable changes to this project will be documented in this file.
   controlled kernel-event and OTel event pressure, and samples/summaries
   embed `assay.experiment.event_rate_sweep.v0` metadata without
   publishing new measurements.
+- Recorded the post-merge Slice 10 smoke dispatches for the event-rate
+  sweep. Runs 26508127380 and 26508355816 verified paired Arm A/C sweep
+  metadata, kernel-event pressure, Arm C span-event metadata, and clean
+  health gates without promoting n=2 smoke runs into benchmark findings.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -1,7 +1,7 @@
 # Runner vs OTel Overhead Measurement Plan (2026-05)
 
 > **Status:** measurement follow-up with Slices 1-9 complete and Slice 10
-> planned. This
+> smoke-verified. This
 > document turns the explicit overhead non-claim from
 > [`runner-vs-otel-2026-05`](runner-vs-otel-2026-05/) into a reproducible
 > measurement plan and findings trail. It does not commit generated
@@ -76,11 +76,16 @@
 > decomposition remains unpublished and should stop at this measurement
 > budget.
 >
-> **Slice 10 status:** harness-ready. The overhead workflow now accepts
+> **Slice 10 status:** smoke-verified. The overhead workflow accepts
 > controlled kernel-event rate, span/event rate, concurrency, and payload
-> size inputs. The next question is "when does overhead become visible,
-> and which component scales with event pressure?" No sweep measurements
-> have been dispatched or published yet.
+> size inputs. Two small paired A/C smoke dispatches passed on main:
+> [26508127380](https://github.com/Rul1an/assay/actions/runs/26508127380)
+> (`kernel=low`, `span=baseline`, `concurrency=1`) and
+> [26508355816](https://github.com/Rul1an/assay/actions/runs/26508355816)
+> (`kernel=medium`, `span=low`, `concurrency=2`). Both had 2/2 valid
+> samples per arm, 0 discarded samples, clean Runner health gates, and
+> matching host class. These are workflow and metadata smoke checks, not
+> published sweep measurements.
 
 ## Research Question
 
@@ -569,6 +574,24 @@ Acceptance rules for Slice 10:
 - Stop if tails fail the existing p99/median health band; do not rescue
   the result by picking only favorable levels.
 
+Smoke status:
+
+- Run
+  [26508127380](https://github.com/Rul1an/assay/actions/runs/26508127380)
+  verified the post-merge paired A/C path with `kernel=low`,
+  `span=baseline`, `concurrency=1`, and `payload=small`.
+- Run
+  [26508355816](https://github.com/Rul1an/assay/actions/runs/26508355816)
+  verified the non-baseline span/event metadata and `concurrency=2`
+  kernel-pressure path with `kernel=medium`, `span=low`,
+  `concurrency=2`, and `payload=small`.
+- The second smoke produced `assay.sweep.*` trace attributes and
+  `assay.sweep.span_event` events in Arm C, while Arm A correctly
+  recorded `span_event_rate=baseline` and `target_span_events=0`.
+- Both smoke runs remain review artifacts only. The first real findings
+  slice should still use a predeclared small matrix and report slopes or
+  thresholds, not these n=2 smoke medians.
+
 ## Non-Claims
 
 - Does not rank OpenTelemetry, OpenInference, or Runner as products.
@@ -592,7 +615,7 @@ Acceptance rules for Slice 10:
 | 7 | **Done**: Arm A pure-L2 decomposition via `arm=arm-a-runner-only`, dispatched in runs [26463798358](https://github.com/Rul1an/assay/actions/runs/26463798358), [26464003194](https://github.com/Rul1an/assay/actions/runs/26464003194), and healthy repeat [26473448298](https://github.com/Rul1an/assay/actions/runs/26473448298) | RSS decomposition landed; wall-clock decomposition remains inconclusive because Arm A is still slower than Arm C at the median |
 | 8 | **Done**: Runner phase timing via hidden `--phase-timing-log` and harness `phase_timings_ms` aggregation, dispatched in runs [26476490968](https://github.com/Rul1an/assay/actions/runs/26476490968) and [26476824593](https://github.com/Rul1an/assay/actions/runs/26476824593) | phase data explains part, not all, of the Arm A / Arm C median gap; no additive wall-clock decomposition claim |
 | 9 | **Done**: paired Arm A/C residual diagnostics via workflow `arm=paired-a-c`, dispatched in run [26479319306](https://github.com/Rul1an/assay/actions/runs/26479319306) | residuals shrink/change sign under pairing; wall-clock decomposition remains unpublished and should stop at this measurement budget |
-| 10 | **Harness-ready**: controlled event-rate / workload-intensity sweep via workflow inputs and sample/summary metadata | no broad rerun; dispatch only a small matrix first, with kernel-event count, span/event count, concurrency, phase timing, residual, RSS, and health gates reported by level |
+| 10 | **Smoke-verified**: controlled event-rate / workload-intensity sweep via workflow inputs and sample/summary metadata, with paired smoke runs [26508127380](https://github.com/Rul1an/assay/actions/runs/26508127380) and [26508355816](https://github.com/Rul1an/assay/actions/runs/26508355816) | no broad rerun; dispatch only a small matrix first, with kernel-event count, span/event count, concurrency, phase timing, residual, RSS, and health gates reported by level |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -5,7 +5,7 @@
 > rendering, Slice 5 findings, Slice 6 same-host Arm B dispatches, and
 > Slice 7 Arm A runner-only dispatches, Slice 8 phase timing diagnostics,
 > and Slice 9 paired A/C residual diagnostics have landed. Slice 10 is
-> harness-ready as a controlled event-rate / workload-intensity sweep. This
+> smoke-verified as a controlled event-rate / workload-intensity sweep. This
 > directory contains the
 > experiment-scoped measurement
 > harness and schema sidecars for the plan in
@@ -186,6 +186,23 @@ The local unit tests exercise the Arm A / Arm C paths with a fake
 `assay` binary that emits the expected archive shape. Real
 `assay runner-spike` validation is provided by the delegated workflow
 dispatches listed above.
+
+Two post-merge Slice 10 smoke dispatches validated the real workflow
+path on main:
+
+- [Run 26508127380](https://github.com/Rul1an/assay/actions/runs/26508127380)
+  ran paired A/C with `kernel=low`, `span=baseline`, `concurrency=1`,
+  and `payload=small`: 2/2 valid samples per arm, 0 discarded, clean
+  health gates.
+- [Run 26508355816](https://github.com/Rul1an/assay/actions/runs/26508355816)
+  ran paired A/C with `kernel=medium`, `span=low`, `concurrency=2`,
+  and `payload=small`: 2/2 valid samples per arm, 0 discarded, clean
+  health gates. The artifacts showed `event-rate-sweep/worker-*`
+  kernel events for both arms and `assay.sweep.*` trace metadata for
+  Arm C.
+
+Those runs are smoke evidence only. They prove the knobs reach the real
+workload and fixture paths; they are not sweep findings.
 
 Do not commit the uploaded artifacts until the findings slice decides
 which measurements should become evidence.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -21,6 +21,8 @@
 | 8 phase A | [26476490968](https://github.com/Rul1an/assay/actions/runs/26476490968) | Arm A runner-only | 20 wall-clock + phase timing | 20 valid, 0 discarded, same host class |
 | 8 phase C | [26476824593](https://github.com/Rul1an/assay/actions/runs/26476824593) | Arm C dual capture | 20 wall-clock + phase timing | 20 valid, 0 discarded, same host class |
 | 9 paired A/C | [26479319306](https://github.com/Rul1an/assay/actions/runs/26479319306) | Arm A + Arm C paired | 20 adjacent pairs | 20 valid per arm, 0 discarded, same job and host class |
+| 10 smoke kernel | [26508127380](https://github.com/Rul1an/assay/actions/runs/26508127380) | Arm A + Arm C paired | 2 adjacent pairs, `kernel=low`, `span=baseline`, `concurrency=1` | 2 valid per arm, 0 discarded, clean health gates |
+| 10 smoke span/concurrency | [26508355816](https://github.com/Rul1an/assay/actions/runs/26508355816) | Arm A + Arm C paired | 2 adjacent pairs, `kernel=medium`, `span=low`, `concurrency=2` | 2 valid per arm, 0 discarded, clean health gates |
 
 Generated artifacts from those runs were inspected as review artifacts
 only. They are intentionally not committed as benchmark evidence in this
@@ -42,6 +44,14 @@ The paired Slice 9 run is also diagnostic. It keeps Arm A and Arm C
 adjacent in one delegated job to reduce inter-dispatch drift. It does
 not replace the same-host baselines below, and its unhealthy tails keep
 wall-clock publication caveats in force.
+
+The Slice 10 smoke runs are workflow and metadata validation only. They
+show that the event-rate sweep knobs reach the real delegated workload:
+both arms captured `event-rate-sweep/worker-*` kernel events, Arm C
+emitted `assay.sweep.*` trace metadata when span/event pressure was
+requested, and Arm A correctly recorded `span_event_rate=baseline` with
+`target_span_events=0`. They are too small to support slope, threshold,
+or benchmark findings.
 
 ## Same-Host Baselines
 
@@ -307,8 +317,9 @@ Next engineering slice:
 > Do not add another broad Arm A/C wall-clock rerun for this arc. The
 > paired residual diagnostic has landed and shows that the median gap is
 > not stable enough for an additive wall-clock decomposition at the
-> current measurement budget. If the overhead arc continues, the next
-> slice is the controlled event-rate / workload-intensity sweep now wired
-> into the overhead harness: vary kernel-event rate, span/event rate,
-> concurrency, and payload size, then report slopes and thresholds rather
-> than another single wall-clock delta.
+> current measurement budget. Slice 10 smoke runs have now validated the
+> event-rate / workload-intensity knobs on main. If the overhead arc
+> continues, the next slice should be a predeclared small matrix that
+> varies kernel-event rate, span/event rate, concurrency, and payload
+> size, then reports slopes and thresholds rather than another single
+> wall-clock delta.

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -43,7 +43,7 @@
 | `assay.experiment.overhead_sample.v0` | One overhead measurement sample for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-sample-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json) |
 | `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-summary-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json) |
 | `assay.experiment.runner_phase_timing.v0` | Phase-timing side-log emitted by `assay runner-spike run --phase-timing-log` | experiment-scoped; sidecar active | [`runner-phase-timing-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json) |
-| `assay.experiment.event_rate_sweep.v0` | Event-rate/workload-intensity cell metadata embedded in overhead samples and summaries | experiment-scoped; sidecar active; Slice 10 harness-ready | [`event-rate-sweep-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json) |
+| `assay.experiment.event_rate_sweep.v0` | Event-rate/workload-intensity cell metadata embedded in overhead samples and summaries | experiment-scoped; sidecar active; Slice 10 smoke-verified | [`event-rate-sweep-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json) |
 
 The overhead schemas remain experiment-scoped. They are validated by the
 local harness tests against synthetic samples, summaries, phase


### PR DESCRIPTION
Summary

Records the post-merge Slice 10 smoke validation for the Runner-vs-OTel overhead event-rate sweep.

What changed

- Marks Slice 10 as smoke-verified rather than merely harness-ready.
- Adds the two main-branch paired A/C smoke runs:
  - 26508127380: kernel=low, span=baseline, concurrency=1, payload=small.
  - 26508355816: kernel=medium, span=low, concurrency=2, payload=small.
- Documents that both runs were 2/2 valid per arm, 0 discarded, clean health gates, matching host class.
- Notes the metadata checks: event-rate-sweep worker kernel events for both arms, Arm C assay.sweep.* trace metadata, and Arm A span pressure correctly recorded as baseline/0.
- Keeps the runs as smoke evidence only, not benchmark findings.

Validation

- python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py' -> 31 OK
- python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py' -> 92 OK
- git diff --check
- pre-commit + pre-push hooks green

Non-claims

- Does not commit generated measurement artifacts.
- Does not publish event-rate sweep slopes or thresholds.
- Does not promote n=2 smoke medians into benchmark findings.
- Does not reopen the broad Arm A/C wall-clock decomposition loop.
