### PR TITLE
docs(experiments): plan overhead Slice 11 starter matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ All notable changes to this project will be documented in this file.
   sweep. Runs 26508127380 and 26508355816 verified paired Arm A/C sweep
   metadata, kernel-event pressure, Arm C span-event metadata, and clean
   health gates without promoting n=2 smoke runs into benchmark findings.
+- Planned the Slice 11 starter matrix for the event-rate sweep:
+  predeclared paired A/C control, kernel-high, span-high,
+  kernel-concurrent, and corner cells with n=5 per cell and explicit
+  event-count, health-gate, and non-publication rules.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -592,6 +592,43 @@ Smoke status:
   slice should still use a predeclared small matrix and report slopes or
   thresholds, not these n=2 smoke medians.
 
+Slice 11 starter matrix:
+
+The first real sweep should stay small enough to inspect manually and
+large enough to separate "knob works" from "signal exists." Use paired
+A/C dispatches, `measure_rss=false`, `build_ebpf=true`,
+`timeout_seconds=300`, and `repetitions=5` for each cell. Do not add
+Arm B or RSS until these cells pass health gates.
+
+| Cell | Kernel-event rate | Span/event rate | Concurrency | Payload | Purpose |
+|---|---|---|---:|---|---|
+| control | `baseline` | `baseline` | `1` | `small` | Same workflow shape with no sweep pressure |
+| kernel-high | `high` | `baseline` | `1` | `small` | Is eBPF/kernel-event pressure visible by itself? |
+| span-high | `baseline` | `high` | `1` | `small` | Is OTel span-event pressure visible by itself? |
+| kernel-concurrent | `high` | `baseline` | `4` | `small` | Does kernel pressure change under modest concurrency? |
+| corner | `high` | `high` | `4` | `large` | First combined stress corner for drops, trace growth, and archive growth |
+
+The smoke dispatches verify environment and CLI propagation only. They
+do not verify rate calibration, payload-size behavior, or high
+concurrency. The Slice 11 analysis must therefore check observed kernel
+event paths and Arm C trace event counts against the declared targets in
+each cell before interpreting timing.
+
+Slice 11 acceptance rules:
+
+- Publish no slope or threshold unless every reported cell has 5/5 valid
+  samples per arm, 0 discarded samples, `ringbuf_drops=0`,
+  `kernel_layer=complete`, and `cgroup_correlation=clean`.
+- Treat the `corner` cell as a threshold probe. If it produces drops,
+  trace truncation, or unhealthy tails, report the failure boundary
+  instead of dropping the cell.
+- If all starter cells are healthy but show no measurable signal, do not
+  keep broad-rerunning. Either widen the event-rate levels in a new
+  predeclared slice or close the sweep as "no visible signal at the
+  starter matrix budget."
+- Keep artifacts review-only until a findings PR decides which summary
+  tables should become committed evidence.
+
 ## Non-Claims
 
 - Does not rank OpenTelemetry, OpenInference, or Runner as products.
@@ -616,6 +653,7 @@ Smoke status:
 | 8 | **Done**: Runner phase timing via hidden `--phase-timing-log` and harness `phase_timings_ms` aggregation, dispatched in runs [26476490968](https://github.com/Rul1an/assay/actions/runs/26476490968) and [26476824593](https://github.com/Rul1an/assay/actions/runs/26476824593) | phase data explains part, not all, of the Arm A / Arm C median gap; no additive wall-clock decomposition claim |
 | 9 | **Done**: paired Arm A/C residual diagnostics via workflow `arm=paired-a-c`, dispatched in run [26479319306](https://github.com/Rul1an/assay/actions/runs/26479319306) | residuals shrink/change sign under pairing; wall-clock decomposition remains unpublished and should stop at this measurement budget |
 | 10 | **Smoke-verified**: controlled event-rate / workload-intensity sweep via workflow inputs and sample/summary metadata, with paired smoke runs [26508127380](https://github.com/Rul1an/assay/actions/runs/26508127380) and [26508355816](https://github.com/Rul1an/assay/actions/runs/26508355816) | no broad rerun; dispatch only a small matrix first, with kernel-event count, span/event count, concurrency, phase timing, residual, RSS, and health gates reported by level |
+| 11 | **Planned**: predeclared Slice 10 starter matrix with five paired A/C cells: control, kernel-high, span-high, kernel-concurrent, and corner | n=5 paired samples per cell; observed event counts match targets; publish only slopes/thresholds with health gates, never n=2 smoke medians |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -204,6 +204,42 @@ path on main:
 Those runs are smoke evidence only. They prove the knobs reach the real
 workload and fixture paths; they are not sweep findings.
 
+To reproduce the smoke inspection, download the run artifact and inspect
+the sample metadata plus captured kernel and trace artifacts:
+
+```bash
+gh run download 26508355816 --dir /tmp/assay-slice10-smoke
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+root = Path('/tmp/assay-slice10-smoke/runner-otel-overhead-paired-ac-26508355816')
+for arm in ['arm-a-runner-only', 'arm-c-dual-capture']:
+    summary = json.loads((root / arm / 'summary.json').read_text())
+    print(arm, summary['valid_samples'], summary['discarded_samples'])
+    print(summary['event_rate_sweep'])
+    mentions = 0
+    for kernel in (root / arm).glob('run_*/archive-contents/layers/kernel.ndjson'):
+        mentions += kernel.read_text(errors='replace').count('event-rate-sweep/worker-')
+    print('kernel sweep mentions', mentions)
+
+trace = (root / 'arm-c-dual-capture' / 'run_001' / 'trace.json').read_text()
+print('Arm C sweep attrs', 'assay.sweep.span_events.target' in trace)
+print('Arm C span events', trace.count('assay.sweep.span_event'))
+PY
+```
+
+The smoke runs do not verify rate calibration, payload sizes other than
+`small`, concurrency above `2`, or `medium`/`high` span-event behavior.
+The first real matrix slice should check observed event counts against
+declared targets before interpreting timing.
+
+The predeclared Slice 11 starter matrix is five paired A/C cells with
+`repetitions=5`, `measure_rss=false`, and `build_ebpf=true`: control,
+kernel-high, span-high, kernel-concurrent, and corner. Its output should
+be slopes or thresholds with health gates, not another single broad
+wall-clock delta.
+
 Do not commit the uploaded artifacts until the findings slice decides
 which measurements should become evidence.
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -319,7 +319,9 @@ Next engineering slice:
 > not stable enough for an additive wall-clock decomposition at the
 > current measurement budget. Slice 10 smoke runs have now validated the
 > event-rate / workload-intensity knobs on main. If the overhead arc
-> continues, the next slice should be a predeclared small matrix that
-> varies kernel-event rate, span/event rate, concurrency, and payload
-> size, then reports slopes and thresholds rather than another single
+> continues, the next slice should run the predeclared Slice 11 starter
+> matrix: control, kernel-high, span-high, kernel-concurrent, and corner
+> cells with paired A/C order and `repetitions=5`. It should first
+> verify observed kernel and span/event counts against the declared
+> targets, then report slopes or thresholds rather than another single
 > wall-clock delta.


### PR DESCRIPTION
Summary

Plans the first real event-rate sweep matrix after Slice 10 smoke validation. This keeps the next dispatch predeclared before running any broader measurement cells.

What changed

- Adds a Slice 11 starter matrix to the Runner-vs-OTel overhead plan.
- Predeclares five paired Arm A/C cells: control, kernel-high, span-high, kernel-concurrent, and corner.
- Pins the dispatch shape: repetitions=5, paired A/C, measure_rss=false, build_ebpf=true, timeout_seconds=300.
- Adds acceptance rules for event-count verification, clean Runner health gates, tail-health handling, and corner-cell failure boundaries.
- Adds README reproduction commands for the Slice 10 smoke artifact inspection.
- Updates findings/CHANGELOG language so the next step is slopes/thresholds, not another single wall-clock delta.

Validation

- python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py' -> 31 OK
- python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py' -> 92 OK
- git diff --check
- pre-commit + pre-push hooks green

Non-claims

- Does not dispatch the Slice 11 matrix.
- Does not commit measurement artifacts.
- Does not publish sweep slopes, thresholds, or benchmark numbers.
- Does not reopen the broad Arm A/C wall-clock decomposition loop.
