### PR TITLE
Add CycloneDX ML-BOM formulation fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added a CycloneDX ML-BOM formulation fixture that keeps training,
+  evaluation, and handoff workflow context in the source BOM while proving the
+  importer still emits only the bounded inventory receipt claim.
 - Added a plan-only Runner-vs-OTel overhead measurement follow-up that
   fixes the sample sizes, host-boundary rules, BMF-compatible output
   shape, and non-claims required before publishing wall-clock or RSS

--- a/crates/assay-cli/tests/evidence_test/importer_receipts.rs
+++ b/crates/assay-cli/tests/evidence_test/importer_receipts.rs
@@ -317,3 +317,80 @@ fn test_cyclonedx_mlbom_model_receipts_verify_and_feed_trust_basis_generation() 
         "CycloneDX ML-BOM model receipts should surface the bounded inventory receipt boundary claim"
     );
 }
+
+#[test]
+fn test_cyclonedx_mlbom_formulation_fixture_stays_inventory_only() {
+    let dir = tempdir().unwrap();
+    let input = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(
+        "../../examples/cyclonedx-mlbom-model-component-evidence/fixtures/model-handoff-formulation.cdx.json",
+    );
+    let bundle = dir
+        .path()
+        .join("cyclonedx-model-formulation-receipts.tar.gz");
+
+    assert!(
+        input.exists(),
+        "fixture should exist at {}",
+        input.display()
+    );
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("import")
+        .arg("cyclonedx-mlbom-model")
+        .arg("--input")
+        .arg(&input)
+        .arg("--bundle-out")
+        .arg(&bundle)
+        .arg("--source-artifact-ref")
+        .arg("model-handoff-formulation.cdx.json")
+        .arg("--bom-ref")
+        .arg("pkg:huggingface/example/support-ticket-classifier@1.0.0")
+        .arg("--run-id")
+        .arg("cyclonedx_formulation_boundary")
+        .arg("--import-time")
+        .arg("2026-04-28T12:00:00Z")
+        .assert()
+        .success();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .arg("evidence")
+        .arg("verify")
+        .arg(&bundle)
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .arg("trust-basis")
+        .arg("generate")
+        .arg(&bundle)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claims = json["claims"].as_array().unwrap();
+    assert_eq!(claim(claims, "bundle_verified")["level"], "verified");
+    assert_eq!(
+        claim(claims, "external_eval_receipt_boundary_visible")["level"],
+        "absent",
+        "CycloneDX formulation metrics are source-BOM context, not eval receipts"
+    );
+    assert_eq!(
+        claim(claims, "external_decision_receipt_boundary_visible")["level"],
+        "absent",
+        "CycloneDX formulation handoff outputs are not decision receipts"
+    );
+    assert_eq!(
+        claim(claims, "external_inventory_receipt_boundary_visible")["level"],
+        "verified",
+        "CycloneDX ML-BOM formulation fixture should remain an inventory receipt"
+    );
+}

--- a/examples/cyclonedx-mlbom-model-component-evidence/README.md
+++ b/examples/cyclonedx-mlbom-model-component-evidence/README.md
@@ -68,6 +68,10 @@ considered later only for a separate formulation or evaluation receipt lane
 backed by a real downstream consumer request. Until then, formulation stays
 bound through the source BOM digest.
 
+The handoff task in this fixture uses an Assay command because this is the
+Assay-side consumer example. A generic CycloneDX example should keep the same
+structure but replace that command with a project-neutral evidence producer.
+
 ## Not Imported
 
 The v1 receipt excludes:

--- a/examples/cyclonedx-mlbom-model-component-evidence/README.md
+++ b/examples/cyclonedx-mlbom-model-component-evidence/README.md
@@ -50,6 +50,24 @@ The receipt may include compact model identity fields plus bounded refs:
 The importer does not dereference refs, resolve network URLs, expand dataset
 components, or import full `modelCard` bodies.
 
+## Formulation Fixture
+
+`fixtures/model-handoff-formulation.cdx.json` extends the small model example
+with CycloneDX `formulation[]` workflow data. The formulation shows an
+illustrative model training, evaluation, and evidence-handoff workflow using
+CycloneDX workflow, task, step, metric-output, and evidence-output structures.
+
+For this importer, formulation remains source-BOM context. Assay still reduces
+only the selected `machine-learning-model` component plus bounded refs, and the
+receipt binds back to the exact CycloneDX artifact through
+`source_artifact_digest`. Formulation, metrics, task outputs, and evidence
+external references are not promoted into evaluation or decision receipts.
+
+Formulation parsing is intentionally out of scope for this importer. It may be
+considered later only for a separate formulation or evaluation receipt lane
+backed by a real downstream consumer request. Until then, formulation stays
+bound through the source BOM digest.
+
 ## Not Imported
 
 The v1 receipt excludes:
@@ -62,6 +80,7 @@ The v1 receipt excludes:
 - dataset component bodies
 - model metrics
 - ethical, fairness, and limitation sections
+- formulation workflows, tasks, steps, metrics, and handoff outputs
 
 Those fields are important in CycloneDX ML-BOMs. P43 simply keeps the Assay
 receipt unit small enough to review and portable enough to bundle.

--- a/examples/cyclonedx-mlbom-model-component-evidence/fixtures/model-handoff-formulation.cdx.json
+++ b/examples/cyclonedx-mlbom-model-component-evidence/fixtures/model-handoff-formulation.cdx.json
@@ -303,7 +303,7 @@
                   "name": "write handoff evidence",
                   "commands": [
                     {
-                      "executed": "assay evidence import cyclonedx-mlbom-model --input model.cdx.json --bom-ref pkg:huggingface/example/support-ticket-classifier@1.0.0"
+                      "executed": "assay evidence import cyclonedx-mlbom-model --input model-handoff-formulation.cdx.json --bom-ref pkg:huggingface/example/support-ticket-classifier@1.0.0"
                     }
                   ]
                 }

--- a/examples/cyclonedx-mlbom-model-component-evidence/fixtures/model-handoff-formulation.cdx.json
+++ b/examples/cyclonedx-mlbom-model-component-evidence/fixtures/model-handoff-formulation.cdx.json
@@ -1,0 +1,346 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.7.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "serialNumber": "urn:uuid:77f95a25-8895-45e0-a25d-15e5aa772d7a",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-04-28T12:00:00Z",
+    "component": {
+      "type": "application",
+      "bom-ref": "component-support-triage-service",
+      "name": "support-triage-service",
+      "version": "1.0.0",
+      "description": "Fictional application that uses a text classification model to route support tickets."
+    }
+  },
+  "components": [
+    {
+      "type": "machine-learning-model",
+      "bom-ref": "pkg:huggingface/example/support-ticket-classifier@1.0.0",
+      "publisher": "Example ML Team",
+      "name": "support-ticket-classifier",
+      "version": "1.0.0",
+      "purl": "pkg:huggingface/example/support-ticket-classifier@1.0.0",
+      "description": "Fictional supervised text classification model for support ticket routing.",
+      "externalReferences": [
+        {
+          "type": "formulation",
+          "url": "urn:cdx:77f95a25-8895-45e0-a25d-15e5aa772d7a/1#formula-support-ticket-classifier-handoff"
+        },
+        {
+          "type": "evidence",
+          "url": "https://example.com/evidence/support-ticket-classifier/handoff.json"
+        }
+      ],
+      "modelCard": {
+        "bom-ref": "model-card-support-ticket-classifier",
+        "modelParameters": {
+          "approach": {
+            "type": "supervised"
+          },
+          "task": "text-classification",
+          "architectureFamily": "transformer",
+          "modelArchitecture": "encoder-only transformer",
+          "datasets": [
+            {
+              "ref": "component-support-ticket-training-data"
+            },
+            {
+              "ref": "component-support-ticket-evaluation-data"
+            }
+          ],
+          "inputs": [
+            {
+              "format": "text/plain"
+            }
+          ],
+          "outputs": [
+            {
+              "format": "application/json"
+            }
+          ]
+        },
+        "quantitativeAnalysis": {
+          "performanceMetrics": [
+            {
+              "type": "macro-f1",
+              "value": "0.91",
+              "slice": "held-out-evaluation"
+            }
+          ]
+        },
+        "considerations": {
+          "users": [
+            "Support operations staff reviewing suggested ticket queues."
+          ],
+          "useCases": [
+            "Suggest an initial support queue for a newly received support ticket."
+          ],
+          "technicalLimitations": [
+            "The model, metric, and dataset values in this example are illustrative."
+          ],
+          "performanceTradeoffs": [
+            "The illustrative metric demonstrates the CycloneDX modelCard structure only."
+          ],
+          "ethicalConsiderations": [
+            {
+              "name": "automation bias",
+              "mitigationStrategy": "Human review remains responsible for final ticket routing."
+            }
+          ],
+          "fairnessAssessments": [
+            {
+              "groupAtRisk": "Customers using underrepresented languages or dialects",
+              "benefits": "Faster initial triage when the model is reliable for the submitted language.",
+              "harms": "Misrouting can delay support if the model performs poorly for the submitted language.",
+              "mitigationStrategy": "Monitor routing quality across language slices and allow manual override."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "data",
+      "bom-ref": "component-support-ticket-training-data",
+      "name": "support-ticket-training-data",
+      "version": "2026.04",
+      "description": "Fictional dataset component used to train the support ticket classifier.",
+      "data": [
+        {
+          "bom-ref": "data-support-ticket-training-data",
+          "type": "dataset",
+          "name": "Support Ticket Training Data",
+          "contents": {
+            "url": "https://example.com/datasets/support-tickets/train.jsonl"
+          },
+          "classification": "internal",
+          "description": "Illustrative training split for the fictional support ticket classifier."
+        }
+      ]
+    },
+    {
+      "type": "data",
+      "bom-ref": "component-support-ticket-evaluation-data",
+      "name": "support-ticket-evaluation-data",
+      "version": "2026.04",
+      "description": "Fictional held-out dataset component used to evaluate the support ticket classifier.",
+      "data": [
+        {
+          "bom-ref": "data-support-ticket-evaluation-data",
+          "type": "dataset",
+          "name": "Support Ticket Evaluation Data",
+          "contents": {
+            "url": "https://example.com/datasets/support-tickets/eval.jsonl"
+          },
+          "classification": "internal",
+          "description": "Illustrative evaluation split for the fictional support ticket classifier."
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "component-support-triage-service",
+      "dependsOn": [
+        "pkg:huggingface/example/support-ticket-classifier@1.0.0"
+      ]
+    },
+    {
+      "ref": "pkg:huggingface/example/support-ticket-classifier@1.0.0",
+      "dependsOn": [
+        "component-support-ticket-training-data",
+        "component-support-ticket-evaluation-data"
+      ]
+    },
+    {
+      "ref": "component-support-ticket-training-data"
+    },
+    {
+      "ref": "component-support-ticket-evaluation-data"
+    }
+  ],
+  "formulation": [
+    {
+      "bom-ref": "formula-support-ticket-classifier-handoff",
+      "workflows": [
+        {
+          "bom-ref": "workflow-support-ticket-classifier-handoff",
+          "uid": "uuid:68b412bb-b470-4780-a38f-1a165661e78f",
+          "name": "support-ticket-classifier handoff workflow",
+          "description": "Illustrative workflow showing model training, evaluation, and evidence handoff.",
+          "taskTypes": [
+            "build",
+            "test",
+            "release"
+          ],
+          "tasks": [
+            {
+              "bom-ref": "task-collect-model-inputs",
+              "uid": "uuid:0c5a64cf-df78-4ac1-a186-6dc28ce90130",
+              "name": "collect model inputs",
+              "description": "Collect the training and evaluation datasets used by the workflow.",
+              "taskTypes": [
+                "copy"
+              ],
+              "inputs": [
+                {
+                  "resource": {
+                    "ref": "component-support-ticket-training-data"
+                  }
+                },
+                {
+                  "resource": {
+                    "ref": "component-support-ticket-evaluation-data"
+                  }
+                }
+              ]
+            },
+            {
+              "bom-ref": "task-train-model",
+              "uid": "uuid:b460d123-adad-42b9-94fd-d741be9e813b",
+              "name": "train model",
+              "description": "Train the model from the collected training dataset.",
+              "taskTypes": [
+                "build"
+              ],
+              "inputs": [
+                {
+                  "resource": {
+                    "ref": "component-support-ticket-training-data"
+                  }
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "artifact",
+                  "resource": {
+                    "ref": "pkg:huggingface/example/support-ticket-classifier@1.0.0"
+                  }
+                }
+              ],
+              "steps": [
+                {
+                  "name": "run training job",
+                  "commands": [
+                    {
+                      "executed": "python train.py --dataset support-ticket-training-data --out model/"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "bom-ref": "task-evaluate-model",
+              "uid": "uuid:cf06d47f-d414-4f25-bbfb-55e8b377fc90",
+              "name": "evaluate model",
+              "description": "Evaluate the trained model against the held-out dataset.",
+              "taskTypes": [
+                "test"
+              ],
+              "inputs": [
+                {
+                  "resource": {
+                    "ref": "pkg:huggingface/example/support-ticket-classifier@1.0.0"
+                  }
+                },
+                {
+                  "resource": {
+                    "ref": "component-support-ticket-evaluation-data"
+                  }
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "metrics",
+                  "resource": {
+                    "externalReference": {
+                      "type": "quality-metrics",
+                      "url": "https://example.com/evidence/support-ticket-classifier/metrics.json"
+                    }
+                  }
+                }
+              ],
+              "steps": [
+                {
+                  "name": "run evaluation job",
+                  "commands": [
+                    {
+                      "executed": "python evaluate.py --model model/ --dataset support-ticket-evaluation-data"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "bom-ref": "task-produce-handoff-evidence",
+              "uid": "uuid:ea9191a2-e94f-42b8-a950-4ba55a18b1eb",
+              "name": "produce handoff evidence",
+              "description": "Publish a bounded evidence artifact that links reviewers back to the model BOM.",
+              "taskTypes": [
+                "release"
+              ],
+              "inputs": [
+                {
+                  "resource": {
+                    "ref": "pkg:huggingface/example/support-ticket-classifier@1.0.0"
+                  }
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "evidence",
+                  "resource": {
+                    "externalReference": {
+                      "type": "evidence",
+                      "url": "https://example.com/evidence/support-ticket-classifier/handoff.json"
+                    }
+                  }
+                }
+              ],
+              "steps": [
+                {
+                  "name": "write handoff evidence",
+                  "commands": [
+                    {
+                      "executed": "assay evidence import cyclonedx-mlbom-model --input model.cdx.json --bom-ref pkg:huggingface/example/support-ticket-classifier@1.0.0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "taskDependencies": [
+            {
+              "ref": "task-train-model",
+              "dependsOn": [
+                "task-collect-model-inputs"
+              ]
+            },
+            {
+              "ref": "task-evaluate-model",
+              "dependsOn": [
+                "task-train-model"
+              ]
+            },
+            {
+              "ref": "task-produce-handoff-evidence",
+              "dependsOn": [
+                "task-evaluate-model"
+              ]
+            },
+            {
+              "ref": "task-collect-model-inputs"
+            }
+          ],
+          "trigger": {
+            "bom-ref": "trigger-support-ticket-classifier-handoff",
+            "uid": "uuid:e4b12e97-410a-4dd1-8b27-6757ad677b4e",
+            "type": "manual",
+            "name": "manual model handoff"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a CycloneDX ML-BOM fixture that includes `formulation[]` workflow data for a fictional ML model training, evaluation, and evidence handoff flow.

The fixture keeps Assay's importer boundary deliberately small: the CycloneDX BOM can carry model process context, metrics, and evidence references, but `assay evidence import cyclonedx-mlbom-model` still reduces only the selected `machine-learning-model` component plus bounded refs and the source BOM digest.

## Changes

- Add `model-handoff-formulation.cdx.json`, a schema-valid CycloneDX 1.7 ML-BOM fixture with model, datasets, dependencies, model card, and formulation workflow.
- Document that formulation is source-BOM context and is not promoted into eval or decision receipts by this importer.
- Document that the Assay command in the handoff task is local to this consumer fixture; any upstream CycloneDX example should keep the structure but use a project-neutral evidence producer command and its own serial number.
- Add a regression test proving the formulation fixture remains an inventory receipt boundary in Trust Basis output.
- Add a changelog note for the example fixture.

## Review notes

- Compared with CycloneDX `MBOM/helloworld-c/mbom.json`: this fixture follows the same formulation shape of one formula with one workflow, task-level `taskTypes`, command steps, and a manual trigger. It has multiple tasks because the ML handoff example needs training, evaluation, and evidence-handoff phases.
- This PR intentionally stays local to Assay. It is not the upstream CycloneDX example PR.
- Un-draft criterion: local validation remains green and PR CI clears. Upstream CycloneDX timing stays separate from this PR.

## Validation

- `npx --yes ajv-cli@5.0.0 validate -s bom-1.7.schema.json -r spdx.schema.json -r jsf-0.82.schema.json -r cryptography-defs.schema.json -d examples/cyclonedx-mlbom-model-component-evidence/fixtures/model-handoff-formulation.cdx.json --strict=false`
- `cargo fmt --package assay-cli`
- `git diff --check`
- `cargo test -p assay-cli --test evidence_test cyclonedx_mlbom -- --nocapture`
- pre-commit hooks during commit
- pre-push hooks during push, including workspace clippy and linux compile gate
