### PR TITLE
feat(experiments): add overhead Slice 12 sweep harness

### DIFF
--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -13,6 +13,11 @@ on:
         required: true
         default: "20"
         type: string
+      warmup_iterations:
+        description: "Warm-up samples to run before measured samples"
+        required: true
+        default: "0"
+        type: string
       arm:
         description: "Measurement arm to run (dispatch once per arm)"
         required: true
@@ -39,7 +44,7 @@ on:
         default: false
         type: boolean
       sweep_kernel_event_rate:
-        description: "Slice 10 kernel-event pressure target"
+        description: "Slice 10/12 kernel-event pressure target"
         required: true
         default: "baseline"
         type: choice
@@ -48,8 +53,10 @@ on:
           - low
           - medium
           - high
+          - x500
+          - x1000
       sweep_span_event_rate:
-        description: "Slice 10 OTel span/event pressure target"
+        description: "Slice 10/12 OTel span/event pressure target"
         required: true
         default: "baseline"
         type: choice
@@ -58,13 +65,15 @@ on:
           - low
           - medium
           - high
+          - x500
+          - x1000
       sweep_concurrency:
-        description: "Slice 10 concurrent sweep workers"
+        description: "Slice 10/12 concurrent sweep workers"
         required: true
         default: "1"
         type: string
       sweep_payload_size:
-        description: "Slice 10 per-event payload size"
+        description: "Slice 10/12 per-event payload size"
         required: true
         default: "small"
         type: choice
@@ -100,7 +109,7 @@ jobs:
     if: ${{ inputs.arm == 'paired-a-c' }}
     runs-on: [self-hosted, linux, assay-bpf-runner]
     needs: prepare-delegated-runner
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -193,6 +202,7 @@ jobs:
         shell: bash
         env:
           REPETITIONS: ${{ inputs.repetitions }}
+          WARMUP_ITERATIONS: ${{ inputs.warmup_iterations }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
           MEASURE_RSS: ${{ inputs.measure_rss }}
           SWEEP_KERNEL_EVENT_RATE: ${{ inputs.sweep_kernel_event_rate }}
@@ -217,6 +227,7 @@ jobs:
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm paired-a-c \
             --iterations "$REPETITIONS" \
+            --warmup-iterations "$WARMUP_ITERATIONS" \
             --skip-build \
             --clean \
             --sudo \
@@ -276,7 +287,7 @@ jobs:
     if: ${{ inputs.arm == 'arm-c-dual-capture' }}
     runs-on: [self-hosted, linux, assay-bpf-runner]
     needs: prepare-delegated-runner
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -360,6 +371,7 @@ jobs:
         shell: bash
         env:
           REPETITIONS: ${{ inputs.repetitions }}
+          WARMUP_ITERATIONS: ${{ inputs.warmup_iterations }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
           MEASURE_RSS: ${{ inputs.measure_rss }}
           SWEEP_KERNEL_EVENT_RATE: ${{ inputs.sweep_kernel_event_rate }}
@@ -384,6 +396,7 @@ jobs:
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-c-dual-capture \
             --iterations "$REPETITIONS" \
+            --warmup-iterations "$WARMUP_ITERATIONS" \
             --skip-build \
             --clean \
             --sudo \
@@ -437,7 +450,7 @@ jobs:
     if: ${{ inputs.arm == 'arm-a-runner-only' }}
     runs-on: [self-hosted, linux, assay-bpf-runner]
     needs: prepare-delegated-runner
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -521,6 +534,7 @@ jobs:
         shell: bash
         env:
           REPETITIONS: ${{ inputs.repetitions }}
+          WARMUP_ITERATIONS: ${{ inputs.warmup_iterations }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
           MEASURE_RSS: ${{ inputs.measure_rss }}
           SWEEP_KERNEL_EVENT_RATE: ${{ inputs.sweep_kernel_event_rate }}
@@ -545,6 +559,7 @@ jobs:
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-a-runner-only \
             --iterations "$REPETITIONS" \
+            --warmup-iterations "$WARMUP_ITERATIONS" \
             --skip-build \
             --clean \
             --sudo \
@@ -599,7 +614,7 @@ jobs:
     if: ${{ inputs.arm == 'arm-b-otel' }}
     runs-on: [self-hosted, linux, assay-bpf-runner]
     needs: prepare-delegated-runner
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -651,6 +666,7 @@ jobs:
         shell: bash
         env:
           REPETITIONS: ${{ inputs.repetitions }}
+          WARMUP_ITERATIONS: ${{ inputs.warmup_iterations }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
           MEASURE_RSS: ${{ inputs.measure_rss }}
           SWEEP_KERNEL_EVENT_RATE: ${{ inputs.sweep_kernel_event_rate }}
@@ -675,6 +691,7 @@ jobs:
           python3 docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py \
             --arm arm-b-otel \
             --iterations "$REPETITIONS" \
+            --warmup-iterations "$WARMUP_ITERATIONS" \
             --skip-build \
             --clean \
             --timeout-seconds "$TIMEOUT_SECONDS" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,11 @@ All notable changes to this project will be documented in this file.
   overhead step is to extend event-rate targets beyond `high=100`, then
   run a small paired A/C widening matrix that reports health/fidelity
   boundaries rather than another broad wall-clock decomposition.
+- Added Slice 12 harness support for the boundary-finding sweep:
+  `assay.experiment.event_rate_sweep.v0.1` extended `x500` / `x1000`
+  targets, optional warm-up samples, and longer delegated workflow
+  timeouts. This does not dispatch the widening matrix or publish new
+  measurement claims.
 
 ## [3.12.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,9 @@ All notable changes to this project will be documented in this file.
 - Added Slice 12 harness support for the boundary-finding sweep:
   `assay.experiment.event_rate_sweep.v0.1` extended `x500` / `x1000`
   targets, optional warm-up samples, and longer delegated workflow
-  timeouts. This does not dispatch the widening matrix or publish new
+  timeouts. The docs pin warm-up failures as review-artifact diagnostics
+  that do not abort the harness but make an all-warm-up-failed dispatch
+  inconclusive. This does not dispatch the widening matrix or publish new
   measurement claims.
 
 ## [3.12.0] - 2026-05-25

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -716,6 +716,10 @@ Slice 12 harness/schema gate:
   Warm-up samples are written to review artifacts but excluded from
   `samples.jsonl`, `summary.json`, BMF metrics, and valid/discarded
   counts.
+- **Done:** Pin warm-up failure policy. Warm-up samples do not abort the
+  harness when they fail; failures remain visible in the warm-up artifact
+  with their `exit_code`. Treat a dispatch where all warm-up samples fail
+  as inconclusive even if measured samples later pass.
 
 Predeclared widening cells:
 
@@ -739,6 +743,10 @@ Slice 12 acceptance rules:
 - Every reported cell must state observed kernel worker files and Arm C
   span-event count against the declared numeric targets before timing is
   interpreted.
+- Warm-up failures do not abort the harness. They are recorded in
+  `warmup-samples*.jsonl` with the failing `exit_code` for review. If all
+  warm-up samples in a dispatch fail, treat the dispatch as inconclusive
+  regardless of measured-sample outcomes.
 - The n=5 widening pass is intentionally below OpenTelemetry's
   repetitions guidance for published benchmark numbers. It may identify
   candidate boundaries only; stable threshold claims require the n=20

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -99,11 +99,12 @@
 > no health boundary at 100 kernel events, 100 span events, concurrency
 > 4, and 64 KiB span payloads.
 >
-> **Slice 12 status:** planned as a boundary-finding follow-up. It should
-> extend the sweep targets beyond the Slice 11 starter matrix before
-> dispatching any wider cells. The goal is to find the first health,
-> fidelity, trace-size, or phase-timing boundary; it is not another broad
-> Arm A/C wall-clock rerun.
+> **Slice 12 status:** harness-ready, not dispatched. The workflow and
+> harness now support extended `x500` / `x1000` sweep targets via
+> `assay.experiment.event_rate_sweep.v0.1`, optional warm-up samples, and
+> longer delegated job timeouts. The goal remains to find the first
+> health, fidelity, trace-size, or phase-timing boundary; it is not
+> another broad Arm A/C wall-clock rerun.
 
 ## Research Question
 
@@ -683,7 +684,7 @@ SOTA / best-practice rationale as of May 2026:
 
 Design implications:
 
-- Prefer a geometric stress ladder over many nearby levels. The first
+- Prefer a stepped widening ladder over many nearby levels. The first
   boundary is more useful than a dense table of healthy medians.
 - Keep paired/counterbalanced Arm A/C order. It reduces dispatch-window
   drift and preserves the Slice 9 lesson.
@@ -699,43 +700,59 @@ Design implications:
 
 Slice 12 harness/schema gate:
 
-- Add extended targets without changing the baseline behavior. Existing
+- **Done:** Add extended targets without changing the baseline behavior. Existing
   `baseline` / `low` / `medium` / `high` samples must remain readable.
-- If new named levels are added, introduce
+- **Done:** If new named levels are added, introduce
   `assay.experiment.event_rate_sweep.v0.1` rather than silently changing
   the meaning of `event_rate_sweep.v0`.
-- Record the numeric target values in every sample and summary, as Slice
+- **Done:** Record the numeric target values in every sample and summary, as Slice
   10 already does. Readers should not need to know what a label meant in
   a particular code revision.
-- Keep Arm A's span/event target at `baseline` / `0` even when Arm C is
+- **Done:** Keep Arm A's span/event target at `baseline` / `0` even when Arm C is
   stressing span events.
+- **Done:** Extend delegated workflow timeouts to 240 minutes for Slice
+  12-sized paired dispatches.
+- **Done:** Add `--warmup-iterations` / workflow `warmup_iterations`.
+  Warm-up samples are written to review artifacts but excluded from
+  `samples.jsonl`, `summary.json`, BMF metrics, and valid/discarded
+  counts.
 
 Predeclared widening cells:
 
 Use paired A/C dispatches, `measure_rss=false`, `build_ebpf=true`,
-`timeout_seconds=300`, and `repetitions=5`. Do not add Arm B, RSS, or
-provider/model work to this slice.
+`timeout_seconds=300`, `repetitions=5`, and `warmup_iterations=1`. Do
+not add Arm B, RSS, or provider/model work to this slice. RSS is not a
+Slice 12 finding; the Slice 7 RSS conclusion remains the current memory
+result.
 
 | Cell | Kernel target | Span target | Concurrency | Payload | Purpose |
 |---|---:|---:|---:|---|---|
-| k500 | 500 | 0 | 4 | small | First 5x kernel-event step above Slice 11 |
-| k1000 | 1000 | 0 | 4 | small | Kernel-event boundary probe |
-| s500 | 0 | 500 | 1 | small | First 5x span-event step above Slice 11 |
-| s1000 | 0 | 1000 | 1 | small | Trace-export boundary probe |
-| kc1000 | 1000 | 0 | 16 | small | Kernel pressure plus scheduling pressure |
-| corner-lite | 1000 | 1000 | 8 | large | Combined stress corner for health, trace size, and tail behavior |
+| k500 | `x500` / 500 | `baseline` / 0 | 4 | small | First 5x kernel-event step above Slice 11 |
+| k1000 | `x1000` / 1000 | `baseline` / 0 | 4 | small | Kernel-event boundary probe |
+| s500 | `baseline` / 0 | `x500` / 500 | 1 | small | First 5x span-event step above Slice 11 |
+| s1000 | `baseline` / 0 | `x1000` / 1000 | 1 | small | Trace-export boundary probe |
+| kc1000 | `x1000` / 1000 | `baseline` / 0 | 16 | small | Kernel pressure plus scheduling pressure |
+| corner-lite | `x1000` / 1000 | `x1000` / 1000 | 8 | large | Combined stress corner for health, trace size, and tail behavior |
 
 Slice 12 acceptance rules:
 
 - Every reported cell must state observed kernel worker files and Arm C
   span-event count against the declared numeric targets before timing is
   interpreted.
+- The n=5 widening pass is intentionally below OpenTelemetry's
+  repetitions guidance for published benchmark numbers. It may identify
+  candidate boundaries only; stable threshold claims require the n=20
+  follow-up described below.
 - A cell is a boundary if any of these happens: `ringbuf_drops > 0`,
   `kernel_layer != complete`, `cgroup_correlation != clean`, trace event
   counts are lower than target, archive/trace extraction fails, or
   p99/median enters the fail band.
 - If `corner-lite` fails but single-axis cells pass, report interaction
   pressure rather than dropping the corner.
+- If `kc1000` fails, do not claim whether the boundary is kernel-event
+  rate or concurrency without a follow-up single-axis cell.
+- If `corner-lite` passes at n=5, treat it as preliminary. Publish
+  "healthy through corner-lite" only after an n=20 confirmation.
 - If all widening cells stay healthy, stop the slice with a threshold
   statement: "no health boundary through 1000 kernel events, 1000 span
   events, concurrency 16 on this host class." Do not keep widening in the
@@ -743,6 +760,10 @@ Slice 12 acceptance rules:
 - If exactly one boundary appears, repeat the first failing cell and the
   nearest healthy predecessor at n=20 in a separate findings slice before
   making a stable threshold claim.
+- Close the overhead arc after Slice 12 if it either publishes a stable
+  boundary/healthy-through threshold, or shows the current capture stack
+  cannot characterize the boundary at this measurement budget. Do not
+  open Slice 13 merely to widen the same ladder again.
 
 ## Non-Claims
 
@@ -769,7 +790,7 @@ Slice 12 acceptance rules:
 | 9 | **Done**: paired Arm A/C residual diagnostics via workflow `arm=paired-a-c`, dispatched in run [26479319306](https://github.com/Rul1an/assay/actions/runs/26479319306) | residuals shrink/change sign under pairing; wall-clock decomposition remains unpublished and should stop at this measurement budget |
 | 10 | **Smoke-verified**: controlled event-rate / workload-intensity sweep via workflow inputs and sample/summary metadata, with paired smoke runs [26508127380](https://github.com/Rul1an/assay/actions/runs/26508127380) and [26508355816](https://github.com/Rul1an/assay/actions/runs/26508355816) | no broad rerun; dispatch only a small matrix first, with kernel-event count, span/event count, concurrency, phase timing, residual, RSS, and health gates reported by level |
 | 11 | **Done**: predeclared Slice 11 starter matrix with five paired A/C cells: control, kernel-high, span-high, kernel-concurrent, and corner, dispatched in runs [26511405031](https://github.com/Rul1an/assay/actions/runs/26511405031), [26511787316](https://github.com/Rul1an/assay/actions/runs/26511787316), [26512146963](https://github.com/Rul1an/assay/actions/runs/26512146963), [26512515478](https://github.com/Rul1an/assay/actions/runs/26512515478), and [26512909068](https://github.com/Rul1an/assay/actions/runs/26512909068) | all cells 5/5 valid per arm with clean health gates; event counts matched targets; no health boundary reached at the starter matrix budget |
-| 12 | **Planned**: boundary-finding sweep with extended numeric targets above `high=100` | harness/schema gate first, then n=5 paired A/C cells; publish only boundary classes or repeat first boundary/predecessor at n=20 |
+| 12 | **Harness-ready**: boundary-finding sweep with extended `x500` / `x1000` targets, `event_rate_sweep.v0.1`, warm-up support, and 240-minute delegated timeouts | dispatch n=5 paired A/C cells with one warm-up pair; publish only boundary classes or repeat first boundary/predecessor at n=20 |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -178,7 +178,9 @@ The delegated workflow exposes the Slice 10 knobs as
 and `sweep_payload_size`. Baseline defaults preserve the pre-Slice-10
 behavior. Non-baseline runs embed `assay.experiment.event_rate_sweep.v0`
 metadata in each sample and summary so review artifacts remain
-self-describing. Arm A has no OTel trace export, so its sample metadata
+self-describing. Slice 12 extended `x500` / `x1000` targets use
+`assay.experiment.event_rate_sweep.v0.1` instead of changing the meaning
+of v0 labels. Arm A has no OTel trace export, so its sample metadata
 records any requested span/event pressure as `baseline` / `0` even when
 the paired Arm C sample applies the requested span/event target.
 
@@ -255,13 +257,18 @@ finding is a threshold statement: no health boundary was reached at the
 starter matrix budget.
 
 The next useful experiment is Slice 12 boundary-finding, not another
-single broad A/C wall-clock rerun. It should first extend the sweep
-schema/harness beyond the current `high=100` labels, then run a small
-paired A/C widening matrix over 500 and 1000 kernel/span-event targets,
-with concurrency and payload stress isolated. The output should be a
-boundary statement, such as "healthy through X" or "first unhealthy cell
-at Y", with event-count calibration and Runner health gates reported
-before timing is interpreted.
+single broad A/C wall-clock rerun. The harness is now ready for that
+slice: `x500` and `x1000` rate labels emit
+`assay.experiment.event_rate_sweep.v0.1`, workflow dispatches can add
+warm-up samples with `warmup_iterations`, and delegated jobs have enough
+timeout budget for paired widening cells.
+
+The Slice 12 dispatch should use paired A/C, `repetitions=5`,
+`warmup_iterations=1`, `measure_rss=false`, `build_ebpf=true`, and
+`timeout_seconds=300`. The output should be a boundary statement, such
+as "healthy through X" or "first unhealthy cell at Y", with event-count
+calibration and Runner health gates reported before timing is
+interpreted. RSS is intentionally not re-measured in this slice.
 
 Do not commit the uploaded artifacts until the findings slice decides
 which measurements should become evidence.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -269,6 +269,10 @@ The Slice 12 dispatch should use paired A/C, `repetitions=5`,
 as "healthy through X" or "first unhealthy cell at Y", with event-count
 calibration and Runner health gates reported before timing is
 interpreted. RSS is intentionally not re-measured in this slice.
+Warm-up failures do not abort the harness; inspect
+`warmup-samples*.jsonl` for their `exit_code`. If every warm-up sample in
+a dispatch failed, treat that dispatch as inconclusive even when the
+measured samples pass.
 
 Do not commit the uploaded artifacts until the findings slice decides
 which measurements should become evidence.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -373,9 +373,11 @@ Next engineering slice:
 > not stable enough for an additive wall-clock decomposition at the
 > current measurement budget. Slice 11 has now shown that the starter
 > event-rate matrix stays healthy and calibrates correctly. Slice 12 is
-> therefore predeclared as a boundary-finding sweep: extend the
-> sweep-target schema/harness beyond `high=100`, then run a small paired
-> A/C widening matrix. The intended finding is a health/fidelity boundary
+> therefore predeclared as a boundary-finding sweep. The harness now
+> supports extended `x500` / `x1000` targets through
+> `assay.experiment.event_rate_sweep.v0.1`, optional warm-up samples, and
+> longer delegated timeouts. The next step is to run the paired A/C
+> widening matrix. The intended finding is a health/fidelity boundary
 > statement, not another median wall-clock comparison.
 
 Slice 12 should only publish one of these outcomes:

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -29,6 +29,7 @@ SAMPLE_SCHEMA = "assay.experiment.overhead_sample.v0"
 SUMMARY_SCHEMA = "assay.experiment.overhead_summary.v0"
 PAIRED_SEQUENCE_SCHEMA = "assay.experiment.paired_sequence.v0"
 EVENT_RATE_SWEEP_SCHEMA = "assay.experiment.event_rate_sweep.v0"
+EVENT_RATE_SWEEP_SCHEMA_V0_1 = "assay.experiment.event_rate_sweep.v0.1"
 DEFAULT_ARM = "arm-b-otel"
 ARM_A = "arm-a-runner-only"
 ARM_B = "arm-b-otel"
@@ -45,18 +46,22 @@ PHASE_TIMING_KEYS = [
     "event_flush_ms",
     "archive_write_ms",
 ]
-SWEEP_RATE_LEVELS = ("baseline", "low", "medium", "high")
+SWEEP_RATE_LEVELS = ("baseline", "low", "medium", "high", "x500", "x1000")
 SWEEP_KERNEL_EVENT_TARGETS = {
     "baseline": 0,
     "low": 1,
     "medium": 25,
     "high": 100,
+    "x500": 500,
+    "x1000": 1000,
 }
 SWEEP_SPAN_EVENT_TARGETS = {
     "baseline": 0,
     "low": 1,
     "medium": 25,
     "high": 100,
+    "x500": 500,
+    "x1000": 1000,
 }
 SWEEP_PAYLOAD_BYTES = {
     "small": 128,
@@ -208,8 +213,13 @@ def event_rate_sweep_config(args: argparse.Namespace) -> dict[str, Any] | None:
         and payload_size == "small"
     ):
         return None
+    schema = (
+        EVENT_RATE_SWEEP_SCHEMA_V0_1
+        if kernel_level in {"x500", "x1000"} or span_level in {"x500", "x1000"}
+        else EVENT_RATE_SWEEP_SCHEMA
+    )
     return {
-        "schema": EVENT_RATE_SWEEP_SCHEMA,
+        "schema": schema,
         "kernel_event_rate": kernel_level,
         "span_event_rate": span_level,
         "concurrency": concurrency,
@@ -368,10 +378,16 @@ def one_sample(
     measure_rss: bool = False,
     runner_fixture_agent: Path | None = None,
     event_rate_sweep: dict[str, Any] | None = None,
+    run_prefix: str = "run",
 ) -> dict[str, Any]:
     sample_event_rate_sweep = event_rate_sweep_for_arm(arm, event_rate_sweep)
-    run_id = f"overhead_{arm.replace('-', '_')}_{iteration:03d}"
-    run_dir = arm_dir / f"run_{iteration:03d}"
+    run_id_suffix = (
+        f"{iteration:03d}"
+        if run_prefix == "run"
+        else f"{run_prefix}_{iteration:03d}"
+    )
+    run_id = f"overhead_{arm.replace('-', '_')}_{run_id_suffix}"
+    run_dir = arm_dir / f"{run_prefix}_{iteration:03d}"
     work_dir = run_dir / "work"
     trace_path = run_dir / "trace.json"
     archive_path = run_dir / "archive.tar.gz"
@@ -656,14 +672,17 @@ def write_run_outputs(
     samples: list[dict[str, Any]],
     summary: dict[str, Any],
     artifact_suffix: str = "",
+    warmup_samples: list[dict[str, Any]] | None = None,
 ) -> None:
     arm_dir = out_dir / arm
     artifacts_dir = out_dir / "artifacts"
     samples_path = arm_dir / "samples.jsonl"
-    samples_path.write_text(
-        "".join(json.dumps(sample, sort_keys=True) + "\n" for sample in samples),
-        encoding="utf-8",
-    )
+    write_jsonl(samples_path, samples)
+    if warmup_samples:
+        write_jsonl(
+            artifacts_dir / f"warmup-samples{artifact_suffix}.jsonl",
+            warmup_samples,
+        )
     write_json(arm_dir / "summary.json", summary)
     (arm_dir / "summary.md").write_text(summary_markdown(summary), encoding="utf-8")
     write_json(
@@ -730,7 +749,27 @@ def run_paired_ac(args: argparse.Namespace) -> int:
     versions = tool_versions(args.workload_dir)
     event_rate_sweep = event_rate_sweep_config(args)
     samples_by_arm: dict[str, list[dict[str, Any]]] = {ARM_A: [], ARM_C: []}
+    warmups_by_arm: dict[str, list[dict[str, Any]]] = {ARM_A: [], ARM_C: []}
     order: list[dict[str, Any]] = []
+    for warmup in range(1, args.warmup_iterations + 1):
+        for arm in paired_ac_order(warmup):
+            sample = one_sample(
+                arm_dir=args.out_dir / arm,
+                arm=arm,
+                workload_dir=args.workload_dir,
+                iteration=warmup,
+                commit=commit,
+                versions=versions,
+                timeout_seconds=args.timeout_seconds,
+                assay_bin=args.assay_bin,
+                ebpf_obj=args.ebpf_obj,
+                use_sudo=args.sudo,
+                measure_rss=args.measure_rss,
+                runner_fixture_agent=args.runner_fixture_agent,
+                event_rate_sweep=event_rate_sweep,
+                run_prefix="warmup",
+            )
+            warmups_by_arm[arm].append(sample)
     for pair in range(1, args.iterations + 1):
         for arm in paired_ac_order(pair):
             sample = one_sample(
@@ -773,6 +812,7 @@ def run_paired_ac(args: argparse.Namespace) -> int:
             samples=samples,
             summary=summaries[arm],
             artifact_suffix=f"-{arm}",
+            warmup_samples=warmups_by_arm[arm],
         )
         bmf.update(bmf_export(summaries[arm]))
     write_json(artifacts_dir / "bmf.json", bmf)
@@ -783,6 +823,7 @@ def run_paired_ac(args: argparse.Namespace) -> int:
             "kind": PAIRED_AC,
             "pairing": "counterbalanced-adjacent-pairs",
             "arms": [ARM_A, ARM_C],
+            "warmup_pairs_per_arm": args.warmup_iterations,
             "pairs_per_arm": args.iterations,
             "order": order,
         },
@@ -790,6 +831,8 @@ def run_paired_ac(args: argparse.Namespace) -> int:
 
     print(f"wrote {args.out_dir / ARM_A / 'samples.jsonl'}")
     print(f"wrote {args.out_dir / ARM_C / 'samples.jsonl'}")
+    if args.warmup_iterations:
+        print(f"wrote warm-up samples for {args.warmup_iterations} pair(s)")
     print(f"wrote {artifacts_dir / 'paired-sequence.json'}")
     print(f"wrote {artifacts_dir / 'bmf.json'}")
     all_valid = all(
@@ -899,6 +942,14 @@ def write_json(path: Path, payload: Any) -> None:
     )
 
 
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -907,6 +958,12 @@ def main(argv: list[str] | None = None) -> int:
         default=ARM_B,
     )
     parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument(
+        "--warmup-iterations",
+        type=int,
+        default=0,
+        help="Run extra warm-up samples before measured samples; excluded from summaries",
+    )
     parser.add_argument("--out-dir", type=Path, default=default_out_dir())
     parser.add_argument("--workload-dir", type=Path, default=default_workload_dir())
     parser.add_argument("--skip-build", action="store_true")
@@ -942,6 +999,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.iterations < 1:
         parser.error("--iterations must be >= 1")
+    if args.warmup_iterations < 0:
+        parser.error("--warmup-iterations must be >= 0")
     if args.sweep_concurrency < 1:
         parser.error("--sweep-concurrency must be >= 1")
     if args.measure_rss:
@@ -964,6 +1023,25 @@ def main(argv: list[str] | None = None) -> int:
     commit = assay_commit()
     versions = tool_versions(args.workload_dir)
     event_rate_sweep = event_rate_sweep_config(args)
+    warmup_samples = [
+        one_sample(
+            arm_dir=arm_dir,
+            arm=args.arm,
+            workload_dir=args.workload_dir,
+            iteration=iteration,
+            commit=commit,
+            versions=versions,
+            timeout_seconds=args.timeout_seconds,
+            assay_bin=args.assay_bin,
+            ebpf_obj=args.ebpf_obj,
+            use_sudo=args.sudo,
+            measure_rss=args.measure_rss,
+            runner_fixture_agent=args.runner_fixture_agent,
+            event_rate_sweep=event_rate_sweep,
+            run_prefix="warmup",
+        )
+        for iteration in range(1, args.warmup_iterations + 1)
+    ]
     samples = [
         one_sample(
             arm_dir=arm_dir,
@@ -985,12 +1063,20 @@ def main(argv: list[str] | None = None) -> int:
     summary = summarize(samples, delegated_workflow_url=args.delegated_workflow_url)
 
     samples_path = arm_dir / "samples.jsonl"
-    write_run_outputs(out_dir=args.out_dir, arm=args.arm, samples=samples, summary=summary)
+    write_run_outputs(
+        out_dir=args.out_dir,
+        arm=args.arm,
+        samples=samples,
+        summary=summary,
+        warmup_samples=warmup_samples,
+    )
     write_json(artifacts_dir / "bmf.json", bmf_export(summary))
 
     print(f"wrote {samples_path}")
     print(f"wrote {arm_dir / 'summary.json'}")
     print(f"wrote {arm_dir / 'summary.md'}")
+    if args.warmup_iterations:
+        print(f"wrote warm-up samples for {args.warmup_iterations} run(s)")
     print(f"wrote {artifacts_dir / 'bmf.json'}")
     if summary["valid_samples"] != args.iterations:
         return 2

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json",
-  "title": "Runner vs OTel event-rate sweep cell v0",
-  "description": "Experiment-scoped event-rate/workload-intensity cell metadata embedded in overhead samples and summaries. This is not a Runner archive contract. Slice 12 extended targets use assay.experiment.event_rate_sweep.v0.1.",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json",
+  "title": "Runner vs OTel event-rate sweep cell v0.1",
+  "description": "Experiment-scoped event-rate/workload-intensity cell metadata with Slice 12 extended targets. This is not a Runner archive contract.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -17,14 +17,16 @@
   ],
   "properties": {
     "schema": {
-      "const": "assay.experiment.event_rate_sweep.v0"
+      "const": "assay.experiment.event_rate_sweep.v0.1"
     },
     "kernel_event_rate": {
       "enum": [
         "baseline",
         "low",
         "medium",
-        "high"
+        "high",
+        "x500",
+        "x1000"
       ]
     },
     "span_event_rate": {
@@ -32,7 +34,9 @@
         "baseline",
         "low",
         "medium",
-        "high"
+        "high",
+        "x500",
+        "x1000"
       ]
     },
     "concurrency": {

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
@@ -250,14 +250,19 @@
       ],
       "properties": {
         "schema": {
-          "const": "assay.experiment.event_rate_sweep.v0"
+          "enum": [
+            "assay.experiment.event_rate_sweep.v0",
+            "assay.experiment.event_rate_sweep.v0.1"
+          ]
         },
         "kernel_event_rate": {
           "enum": [
             "baseline",
             "low",
             "medium",
-            "high"
+            "high",
+            "x500",
+            "x1000"
           ]
         },
         "span_event_rate": {
@@ -265,7 +270,9 @@
             "baseline",
             "low",
             "medium",
-            "high"
+            "high",
+            "x500",
+            "x1000"
           ]
         },
         "concurrency": {

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
@@ -234,14 +234,19 @@
       ],
       "properties": {
         "schema": {
-          "const": "assay.experiment.event_rate_sweep.v0"
+          "enum": [
+            "assay.experiment.event_rate_sweep.v0",
+            "assay.experiment.event_rate_sweep.v0.1"
+          ]
         },
         "kernel_event_rate": {
           "enum": [
             "baseline",
             "low",
             "medium",
-            "high"
+            "high",
+            "x500",
+            "x1000"
           ]
         },
         "span_event_rate": {
@@ -249,7 +254,9 @@
             "baseline",
             "low",
             "medium",
-            "high"
+            "high",
+            "x500",
+            "x1000"
           ]
         },
         "concurrency": {

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -291,6 +291,20 @@ class OverheadHarnessTests(unittest.TestCase):
         }
         assert_matches_schema(self, payload, schema, root=schema)
 
+    def test_event_rate_sweep_v01_schema_accepts_extended_targets(self) -> None:
+        schema = load_schema("event-rate-sweep-v0.1.schema.json")
+        payload = {
+            "schema": "assay.experiment.event_rate_sweep.v0.1",
+            "kernel_event_rate": "x1000",
+            "span_event_rate": "x500",
+            "concurrency": 8,
+            "payload_size": "large",
+            "target_kernel_events": 1000,
+            "target_span_events": 500,
+            "payload_bytes": 65536,
+        }
+        assert_matches_schema(self, payload, schema, root=schema)
+
     def test_event_rate_sweep_config_maps_levels_to_targets(self) -> None:
         args = type(
             "Args",
@@ -309,6 +323,25 @@ class OverheadHarnessTests(unittest.TestCase):
         self.assertEqual(config["target_span_events"], 25)
         self.assertEqual(config["payload_bytes"], 65536)
         self.assertEqual(config["concurrency"], 4)
+
+    def test_event_rate_sweep_config_maps_extended_targets_to_v01(self) -> None:
+        args = type(
+            "Args",
+            (),
+            {
+                "sweep_kernel_event_rate": "x1000",
+                "sweep_span_event_rate": "x500",
+                "sweep_concurrency": 8,
+                "sweep_payload_size": "large",
+            },
+        )()
+        config = overhead_harness.event_rate_sweep_config(args)
+
+        self.assertEqual(config["schema"], "assay.experiment.event_rate_sweep.v0.1")
+        self.assertEqual(config["target_kernel_events"], 1000)
+        self.assertEqual(config["target_span_events"], 500)
+        self.assertEqual(config["payload_bytes"], 65536)
+        self.assertEqual(config["concurrency"], 8)
 
     def test_baseline_event_rate_sweep_config_is_null(self) -> None:
         args = type(
@@ -377,6 +410,22 @@ class OverheadHarnessTests(unittest.TestCase):
                 "target_kernel_events": 1,
                 "target_span_events": 100,
                 "payload_bytes": 128,
+            }
+        )
+        assert_matches_schema(self, sample, schema, root=schema)
+
+    def test_sample_schema_accepts_event_rate_sweep_v01_metadata(self) -> None:
+        schema = load_schema("overhead-sample-v0.schema.json")
+        sample = self.sample(
+            event_rate_sweep={
+                "schema": "assay.experiment.event_rate_sweep.v0.1",
+                "kernel_event_rate": "x1000",
+                "span_event_rate": "x500",
+                "concurrency": 8,
+                "payload_size": "large",
+                "target_kernel_events": 1000,
+                "target_span_events": 500,
+                "payload_bytes": 65536,
             }
         )
         assert_matches_schema(self, sample, schema, root=schema)
@@ -674,6 +723,52 @@ class OverheadHarnessTests(unittest.TestCase):
             self.assertEqual(sample["event_rate_sweep"]["target_span_events"], 1)
             self.assertEqual(summary["event_rate_sweep"], sample["event_rate_sweep"])
 
+    def test_harness_records_warmup_samples_outside_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workload = root / "workload"
+            out_dir = root / "overhead"
+            write_stub_workload(workload)
+
+            status = overhead_harness.main(
+                [
+                    "--iterations",
+                    "1",
+                    "--warmup-iterations",
+                    "1",
+                    "--skip-build",
+                    "--clean",
+                    "--timeout-seconds",
+                    "10",
+                    "--workload-dir",
+                    str(workload),
+                    "--out-dir",
+                    str(out_dir),
+                ]
+            )
+            self.assertEqual(status, 0)
+
+            samples = (
+                (out_dir / "arm-b-otel" / "samples.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            )
+            warmups = (
+                (out_dir / "artifacts" / "warmup-samples.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            )
+            summary = json.loads(
+                (out_dir / "arm-b-otel" / "summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+            self.assertEqual(len(samples), 1)
+            self.assertEqual(len(warmups), 1)
+            self.assertEqual(summary["valid_samples"], 1)
+            self.assertEqual(summary["discarded_samples"], 0)
+
     @unittest.skipUnless(Path("/usr/bin/time").exists(), "/usr/bin/time not available")
     def test_harness_can_emit_rss_sample(self) -> None:
         if platform.system().lower() not in {"darwin", "linux"}:
@@ -870,6 +965,8 @@ class OverheadHarnessTests(unittest.TestCase):
                     "paired-a-c",
                     "--iterations",
                     "2",
+                    "--warmup-iterations",
+                    "1",
                     "--skip-build",
                     "--clean",
                     "--timeout-seconds",
@@ -906,9 +1003,22 @@ class OverheadHarnessTests(unittest.TestCase):
             bmf = json.loads(
                 (out_dir / "artifacts" / "bmf.json").read_text(encoding="utf-8")
             )
+            arm_a_warmups = (
+                (out_dir / "artifacts" / "warmup-samples-arm-a-runner-only.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            )
+            arm_c_warmups = (
+                (out_dir / "artifacts" / "warmup-samples-arm-c-dual-capture.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            )
 
             self.assertEqual(arm_a_summary["valid_samples"], 2)
             self.assertEqual(arm_c_summary["valid_samples"], 2)
+            self.assertEqual(sequence["warmup_pairs_per_arm"], 1)
+            self.assertEqual(len(arm_a_warmups), 1)
+            self.assertEqual(len(arm_c_warmups), 1)
             self.assertEqual(
                 sequence["schema"],
                 "assay.experiment.paired_sequence.v0",

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -44,6 +44,7 @@
 | `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-summary-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json) |
 | `assay.experiment.runner_phase_timing.v0` | Phase-timing side-log emitted by `assay runner-spike run --phase-timing-log` | experiment-scoped; sidecar active | [`runner-phase-timing-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json) |
 | `assay.experiment.event_rate_sweep.v0` | Event-rate/workload-intensity cell metadata embedded in overhead samples and summaries | experiment-scoped; sidecar active; Slice 10 smoke-verified | [`event-rate-sweep-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json) |
+| `assay.experiment.event_rate_sweep.v0.1` | Event-rate/workload-intensity cell metadata with Slice 12 extended targets | experiment-scoped; sidecar active; Slice 12 harness-ready | [`event-rate-sweep-v0.1.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json) |
 
 The overhead schemas remain experiment-scoped. They are validated by the
 local harness tests against synthetic samples, summaries, phase


### PR DESCRIPTION
Summary

Implements the Slice 12 harness/schema preparation for the Runner-vs-OTel overhead boundary-finding sweep. This makes the widened matrix dispatchable, but does not run the matrix or publish threshold claims.

What changed

- Adds extended sweep labels `x500` and `x1000`, mapping to 500 and 1000 kernel/span events.
- Introduces `assay.experiment.event_rate_sweep.v0.1` for extended targets while preserving v0 semantics for `baseline` / `low` / `medium` / `high`.
- Updates overhead sample/summary schemas to accept the v0.1 embedded event-rate metadata.
- Adds `--warmup-iterations` to the harness and `warmup_iterations` to the delegated workflow; warm-up samples are written as review artifacts and excluded from summaries/BMF/valid counts.
- Extends delegated overhead workflow job timeouts to 240 minutes for Slice 12 paired cells.
- Updates the plan, README, findings, schema overview, and changelog to mark Slice 12 as harness-ready, not dispatched.

Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 35 OK
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 92 OK
- `python3 -m py_compile docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py`
- schema JSON parse checks -> OK
- `actionlint .github/workflows/runner-otel-overhead-experiment.yml`
- `zizmor .github/workflows/runner-otel-overhead-experiment.yml` -> no findings
- local changed-docs link check -> OK
- `git diff --check`
- pre-commit + pre-push hooks green

Non-claims

- Does not dispatch the Slice 12 widening matrix.
- Does not commit measurement artifacts.
- Does not publish sweep thresholds, product benchmark numbers, or a renewed Arm A/C wall-clock decomposition.
- Does not re-measure RSS; Slice 12 remains health/fidelity boundary-finding only.
