### PR TITLE
docs(experiments): record overhead Slice 12 boundary findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,11 @@ All notable changes to this project will be documented in this file.
   that do not abort the harness but make an all-warm-up-failed dispatch
   inconclusive. This does not dispatch the widening matrix or publish new
   measurement claims.
+- Recorded Slice 12 boundary-finding results. The widened paired A/C
+  runs kept Runner health clean and kernel-event calibration exact
+  through `x1000` / concurrency 16, while widened OTel span-event cells
+  hit the default 128-event retention boundary at `s500`, so no timing
+  slope is published beyond that span-fidelity limit.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -1,7 +1,6 @@
 # Runner vs OTel Overhead Measurement Plan (2026-05)
 
-> **Status:** measurement follow-up with Slices 1-11 complete and Slice 12
-> planned. This
+> **Status:** measurement follow-up with Slices 1-12 complete. This
 > document turns the explicit overhead non-claim from
 > [`runner-vs-otel-2026-05`](runner-vs-otel-2026-05/) into a reproducible
 > measurement plan and findings trail. It does not commit generated
@@ -99,12 +98,20 @@
 > no health boundary at 100 kernel events, 100 span events, concurrency
 > 4, and 64 KiB span payloads.
 >
-> **Slice 12 status:** harness-ready, not dispatched. The workflow and
-> harness now support extended `x500` / `x1000` sweep targets via
-> `assay.experiment.event_rate_sweep.v0.1`, optional warm-up samples, and
-> longer delegated job timeouts. The goal remains to find the first
-> health, fidelity, trace-size, or phase-timing boundary; it is not
-> another broad Arm A/C wall-clock rerun.
+> **Slice 12 status:** boundary-finding sweep dispatched and summarized
+> in
+> [`runner-vs-otel-overhead-2026-05/findings.md`](runner-vs-otel-overhead-2026-05/findings.md).
+> Runs [26517696032](https://github.com/Rul1an/assay/actions/runs/26517696032),
+> [26518158603](https://github.com/Rul1an/assay/actions/runs/26518158603),
+> [26518522754](https://github.com/Rul1an/assay/actions/runs/26518522754),
+> [26518894002](https://github.com/Rul1an/assay/actions/runs/26518894002),
+> [26519398461](https://github.com/Rul1an/assay/actions/runs/26519398461), and
+> [26520226593](https://github.com/Rul1an/assay/actions/runs/26520226593)
+> passed with 5/5 measured samples per arm, 0 discarded samples, clean
+> Runner health gates, and successful warm-up samples. The kernel branch
+> stayed healthy through `x1000` and concurrency 16; the span branch hit
+> the default OTel event-retention fidelity boundary at `s500`
+> (128/500 retained events).
 
 ## Research Question
 
@@ -773,6 +780,32 @@ Slice 12 acceptance rules:
   cannot characterize the boundary at this measurement budget. Do not
   open Slice 13 merely to widen the same ladder again.
 
+Slice 12 result:
+
+- Runs
+  [26517696032](https://github.com/Rul1an/assay/actions/runs/26517696032),
+  [26518158603](https://github.com/Rul1an/assay/actions/runs/26518158603),
+  [26518522754](https://github.com/Rul1an/assay/actions/runs/26518522754),
+  [26518894002](https://github.com/Rul1an/assay/actions/runs/26518894002),
+  [26519398461](https://github.com/Rul1an/assay/actions/runs/26519398461), and
+  [26520226593](https://github.com/Rul1an/assay/actions/runs/26520226593)
+  completed the six predeclared cells.
+- Every cell had 5/5 measured samples per arm, 0 discarded samples,
+  successful warm-up samples, clean Runner health gates, and matching
+  host class.
+- Kernel-event calibration matched the declared targets exactly through
+  `x1000`: 500/500 or 1000/1000 unique `event-rate-sweep/worker-*`
+  files per measured sample in both arms.
+- Arm C span-event fidelity failed at the first widened span cell:
+  `s500` retained 128/500 `assay.sweep.span_event` entries per sample,
+  and `s1000` / `corner-lite` retained 128/1000. This matches the
+  default OpenTelemetry JS SDK span-event count limit for the workload
+  configuration.
+- Therefore the current arc closes with a split boundary statement:
+  Runner kernel capture is healthy through the widened kernel cells, but
+  default OTel span-event retention becomes the limiting fidelity
+  boundary before span timing can be interpreted above 100 events.
+
 ## Non-Claims
 
 - Does not rank OpenTelemetry, OpenInference, or Runner as products.
@@ -798,7 +831,7 @@ Slice 12 acceptance rules:
 | 9 | **Done**: paired Arm A/C residual diagnostics via workflow `arm=paired-a-c`, dispatched in run [26479319306](https://github.com/Rul1an/assay/actions/runs/26479319306) | residuals shrink/change sign under pairing; wall-clock decomposition remains unpublished and should stop at this measurement budget |
 | 10 | **Smoke-verified**: controlled event-rate / workload-intensity sweep via workflow inputs and sample/summary metadata, with paired smoke runs [26508127380](https://github.com/Rul1an/assay/actions/runs/26508127380) and [26508355816](https://github.com/Rul1an/assay/actions/runs/26508355816) | no broad rerun; dispatch only a small matrix first, with kernel-event count, span/event count, concurrency, phase timing, residual, RSS, and health gates reported by level |
 | 11 | **Done**: predeclared Slice 11 starter matrix with five paired A/C cells: control, kernel-high, span-high, kernel-concurrent, and corner, dispatched in runs [26511405031](https://github.com/Rul1an/assay/actions/runs/26511405031), [26511787316](https://github.com/Rul1an/assay/actions/runs/26511787316), [26512146963](https://github.com/Rul1an/assay/actions/runs/26512146963), [26512515478](https://github.com/Rul1an/assay/actions/runs/26512515478), and [26512909068](https://github.com/Rul1an/assay/actions/runs/26512909068) | all cells 5/5 valid per arm with clean health gates; event counts matched targets; no health boundary reached at the starter matrix budget |
-| 12 | **Harness-ready**: boundary-finding sweep with extended `x500` / `x1000` targets, `event_rate_sweep.v0.1`, warm-up support, and 240-minute delegated timeouts | dispatch n=5 paired A/C cells with one warm-up pair; publish only boundary classes or repeat first boundary/predecessor at n=20 |
+| 12 | **Done**: boundary-finding sweep with extended `x500` / `x1000` targets, dispatched in runs [26517696032](https://github.com/Rul1an/assay/actions/runs/26517696032), [26518158603](https://github.com/Rul1an/assay/actions/runs/26518158603), [26518522754](https://github.com/Rul1an/assay/actions/runs/26518522754), [26518894002](https://github.com/Rul1an/assay/actions/runs/26518894002), [26519398461](https://github.com/Rul1an/assay/actions/runs/26519398461), and [26520226593](https://github.com/Rul1an/assay/actions/runs/26520226593) | kernel branch healthy through `x1000` / concurrency 16; span branch hits default OTel 128-event fidelity boundary at `s500`; no timing slope above that span boundary |
 
 ## Publication Rule
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -2,10 +2,10 @@
 
 > **Status:** Slice 1 local Arm B harness, Slice 2 delegated Arm C
 > dispatch pipeline, Slice 3 RSS collection, Slice 4 summary/BMF
-> rendering, Slice 5 findings, Slice 6 same-host Arm B dispatches, and
+> rendering, Slice 5 findings, Slice 6 same-host Arm B dispatches,
 > Slice 7 Arm A runner-only dispatches, Slice 8 phase timing diagnostics,
-> and Slice 9 paired A/C residual diagnostics have landed. Slice 10 is
-> smoke-verified as a controlled event-rate / workload-intensity sweep. This
+> Slice 9 paired A/C residual diagnostics, Slice 10 smoke validation,
+> Slice 11 starter matrix, and Slice 12 boundary-finding have landed. This
 > directory contains the
 > experiment-scoped measurement
 > harness and schema sidecars for the plan in
@@ -256,14 +256,14 @@ samples, clean Runner health gates, and matching host class. The current
 finding is a threshold statement: no health boundary was reached at the
 starter matrix budget.
 
-The next useful experiment is Slice 12 boundary-finding, not another
-single broad A/C wall-clock rerun. The harness is now ready for that
-slice: `x500` and `x1000` rate labels emit
+The next useful experiment was Slice 12 boundary-finding, not another
+single broad A/C wall-clock rerun. The harness supports that slice:
+`x500` and `x1000` rate labels emit
 `assay.experiment.event_rate_sweep.v0.1`, workflow dispatches can add
 warm-up samples with `warmup_iterations`, and delegated jobs have enough
 timeout budget for paired widening cells.
 
-The Slice 12 dispatch should use paired A/C, `repetitions=5`,
+The completed Slice 12 dispatches used paired A/C, `repetitions=5`,
 `warmup_iterations=1`, `measure_rss=false`, `build_ebpf=true`, and
 `timeout_seconds=300`. The output should be a boundary statement, such
 as "healthy through X" or "first unhealthy cell at Y", with event-count
@@ -273,6 +273,24 @@ Warm-up failures do not abort the harness; inspect
 `warmup-samples*.jsonl` for their `exit_code`. If every warm-up sample in
 a dispatch failed, treat that dispatch as inconclusive even when the
 measured samples pass.
+
+That boundary-finding sweep has now been dispatched and summarized in
+[`findings.md`](findings.md):
+
+- k500: [run 26517696032](https://github.com/Rul1an/assay/actions/runs/26517696032)
+- k1000: [run 26518158603](https://github.com/Rul1an/assay/actions/runs/26518158603)
+- s500: [run 26518522754](https://github.com/Rul1an/assay/actions/runs/26518522754)
+- s1000: [run 26518894002](https://github.com/Rul1an/assay/actions/runs/26518894002)
+- kc1000: [run 26519398461](https://github.com/Rul1an/assay/actions/runs/26519398461)
+- corner-lite: [run 26520226593](https://github.com/Rul1an/assay/actions/runs/26520226593)
+
+All six cells passed with 5/5 measured samples per arm, 0 discarded
+samples, successful warm-up samples, clean Runner health gates, and
+matching host class. Kernel-event calibration matched targets through
+1000 worker files per measured sample. The first widened span cell
+(`s500`) retained only 128/500 Arm C span events, and later span cells
+retained 128/1000. The current default-config boundary is therefore OTel
+span-event fidelity, not Runner health.
 
 Do not commit the uploaded artifacts until the findings slice decides
 which measurements should become evidence.

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/findings.md
@@ -1,6 +1,6 @@
 # Runner vs OTel Overhead Findings (2026-05)
 
-> **Status:** event-rate starter-matrix findings update. This document summarizes the
+> **Status:** event-rate boundary-finding update. This document summarizes the
 > overhead follow-up evidence collected so far. It does not commit the
 > generated measurement artifacts. Direct arm deltas are reported only
 > for the matching `linux-aarch64-6.8.0-117-generic` host class.
@@ -28,6 +28,12 @@
 | 11 span-high | [26512146963](https://github.com/Rul1an/assay/actions/runs/26512146963) | Arm A + Arm C paired | 5 adjacent pairs, `kernel=baseline`, `span=high`, `concurrency=1` | 5 valid per arm, 0 discarded, 100 Arm C span events per sample |
 | 11 kernel-concurrent | [26512515478](https://github.com/Rul1an/assay/actions/runs/26512515478) | Arm A + Arm C paired | 5 adjacent pairs, `kernel=high`, `span=baseline`, `concurrency=4` | 5 valid per arm, 0 discarded, 100 kernel worker files per arm |
 | 11 corner | [26512909068](https://github.com/Rul1an/assay/actions/runs/26512909068) | Arm A + Arm C paired | 5 adjacent pairs, `kernel=high`, `span=high`, `concurrency=4`, `payload=large` | 5 valid per arm, 0 discarded, 100 kernel worker files and 100 Arm C span events per sample |
+| 12 k500 | [26517696032](https://github.com/Rul1an/assay/actions/runs/26517696032) | Arm A + Arm C paired | 5 adjacent pairs plus warm-up, `kernel=x500`, `span=baseline`, `concurrency=4` | 5 valid per arm, 0 discarded, 500 kernel worker files per arm |
+| 12 k1000 | [26518158603](https://github.com/Rul1an/assay/actions/runs/26518158603) | Arm A + Arm C paired | 5 adjacent pairs plus warm-up, `kernel=x1000`, `span=baseline`, `concurrency=4` | 5 valid per arm, 0 discarded, 1000 kernel worker files per arm |
+| 12 s500 | [26518522754](https://github.com/Rul1an/assay/actions/runs/26518522754) | Arm A + Arm C paired | 5 adjacent pairs plus warm-up, `kernel=baseline`, `span=x500`, `concurrency=1` | 5 valid per arm, 0 discarded, Arm C retained 128/500 span events |
+| 12 s1000 | [26518894002](https://github.com/Rul1an/assay/actions/runs/26518894002) | Arm A + Arm C paired | 5 adjacent pairs plus warm-up, `kernel=baseline`, `span=x1000`, `concurrency=1` | 5 valid per arm, 0 discarded, Arm C retained 128/1000 span events |
+| 12 kc1000 | [26519398461](https://github.com/Rul1an/assay/actions/runs/26519398461) | Arm A + Arm C paired | 5 adjacent pairs plus warm-up, `kernel=x1000`, `span=baseline`, `concurrency=16` | 5 valid per arm, 0 discarded, 1000 kernel worker files per arm |
+| 12 corner-lite | [26520226593](https://github.com/Rul1an/assay/actions/runs/26520226593) | Arm A + Arm C paired | 5 adjacent pairs plus warm-up, `kernel=x1000`, `span=x1000`, `concurrency=8`, `payload=large` | 5 valid per arm, 0 discarded, 1000 kernel worker files per arm; Arm C retained 128/1000 span events |
 
 Generated artifacts from those runs were inspected as review artifacts
 only. They are intentionally not committed as benchmark evidence in this
@@ -62,6 +68,13 @@ The Slice 11 starter matrix is the first event-rate sweep findings
 slice. It is still small (`n=5` adjacent pairs per cell), so it reports
 health, calibration, and threshold signals only. It does not publish a
 product benchmark or a new additive wall-clock decomposition.
+
+The Slice 12 boundary-finding sweep is the widened event-rate pass. It
+ran the predeclared cells sequentially because the workflow concurrency
+group keeps only one active delegated overhead run at a time. All six
+completed runs had 5/5 measured samples per arm, 0 discarded samples,
+clean Runner health gates, and successful warm-up samples. The finding
+is a fidelity/health boundary result, not a benchmark result.
 
 ## Same-Host Baselines
 
@@ -291,6 +304,60 @@ publishable Slice 11 result is narrower:
 - larger OTel span payloads scale trace size clearly, but did not
   destabilize Runner health at this matrix budget.
 
+## Event-Rate Boundary Sweep
+
+Slice 12 ran the predeclared widened A/C matrix with
+`repetitions=5`, `warmup_iterations=1`, `measure_rss=false`,
+`build_ebpf=true`, and `timeout_seconds=300`. Warm-up samples are
+review artifacts only; all measured cells below had 5 valid samples per
+arm and 0 discarded samples.
+
+| Cell | Run | Arm A wall median | Arm C wall median | Arm C - Arm A | Tail band | Fidelity read |
+|---|---|---:|---:|---:|---|---|
+| k500 | [26517696032](https://github.com/Rul1an/assay/actions/runs/26517696032) | `1,903.863 ms` | `2,177.001 ms` | `+273.138 ms` | Arm A warning (`1.724`), Arm C healthy (`1.098`) | 500/500 kernel worker files in both arms |
+| k1000 | [26518158603](https://github.com/Rul1an/assay/actions/runs/26518158603) | `2,407.982 ms` | `2,290.073 ms` | `-117.910 ms` | Arm A warning (`1.604`), Arm C healthy (`1.304`) | 1000/1000 kernel worker files in both arms |
+| s500 | [26518522754](https://github.com/Rul1an/assay/actions/runs/26518522754) | `1,761.804 ms` | `1,780.047 ms` | `+18.244 ms` | healthy (`1.157` / `1.192`) | Arm C retained 128/500 span events |
+| s1000 | [26518894002](https://github.com/Rul1an/assay/actions/runs/26518894002) | `1,777.862 ms` | `1,811.485 ms` | `+33.623 ms` | healthy (`1.040` / `1.026`) | Arm C retained 128/1000 span events |
+| kc1000 | [26519398461](https://github.com/Rul1an/assay/actions/runs/26519398461) | `2,101.253 ms` | `2,623.885 ms` | `+522.632 ms` | healthy (`1.314` / `1.057`) | 1000/1000 kernel worker files in both arms, concurrency 16 |
+| corner-lite | [26520226593](https://github.com/Rul1an/assay/actions/runs/26520226593) | `2,283.301 ms` | `2,787.537 ms` | `+504.236 ms` | healthy (`1.094` / `1.466`) | 1000/1000 kernel worker files; Arm C retained 128/1000 span events |
+
+The kernel-capture branch stayed healthy through the widened cells:
+`x1000` kernel worker files calibrated exactly for both arms, and the
+`kc1000` cell stayed clean even at concurrency 16. The two kernel-only
+cells put Arm A's tail ratio in the warning band, but no cell crossed
+the fail boundary (`p99/median > 2.0`), and no Runner health gate
+degraded.
+
+The span/event branch hit a fidelity boundary before timing can be
+interpreted. At both `x500` and `x1000`, the Arm C trace retained exactly
+128 `assay.sweep.span_event` entries per sample. That matches the
+OpenTelemetry JS SDK default span event count limit in this workload
+configuration, so the apparent wall-clock and trace-size behavior above
+100 span events is not evidence that the system handled 500 or 1000
+trace records. It is evidence that the default OTel span limit preserves
+only 128 events.
+
+The `corner-lite` cell is therefore a mixed result: Runner kernel
+capture stayed healthy at 1000 worker files with large payloads and
+concurrency 8, but the OTel span side was already lossy at 128/1000
+events. Its median Arm C trace grew to `8,494,070 bytes` because the
+retained events carried 64 KiB payloads, but the cell cannot support a
+"healthy through x1000 span events" claim.
+
+The Slice 12 boundary result is:
+
+- **Kernel side:** healthy through `x1000` kernel events and concurrency
+  16 on this host class, at `n=5` and without RSS collection.
+- **Span side:** first widened span cell (`s500`) is a trace-fidelity
+  boundary under the default OTel JS SDK limits: 128/500 events retained.
+- **Corner side:** combined kernel + span stress is bounded by the same
+  span-fidelity limit, not by Runner health.
+
+That closes the current event-rate arc for the default configuration.
+A future experiment can deliberately raise `OTEL_SPAN_EVENT_COUNT_LIMIT`
+and rerun the span cells, but that would be a new span-limit study, not
+a continuation of the default-config boundary sweep.
+
 ## What This Means
 
 - The delegated measurement harness is usable for all three arms: wall-clock
@@ -316,6 +383,10 @@ publishable Slice 11 result is narrower:
 - Slice 11 shifts the useful overhead question from "which arm is
   faster?" to "where do health gates or artifact sizes start to scale?"
   At the starter matrix levels, the health boundary was not reached.
+- Slice 12 extends that result: Runner kernel capture remained healthy
+  through 1000 worker files and concurrency 16, while widened OTel span
+  pressure hit the default SDK event-retention limit at the first
+  widened span cell.
 - The RSS path works on the delegated Linux runner with GNU
   `/usr/bin/time -v`; samples record the RSS tool version and emit
   `peak_rss_bytes` into both `summary.json` and the BMF export.
@@ -336,10 +407,10 @@ publishable Slice 11 result is narrower:
   archive only" and "Runner archive plus OTel trace". The phase-timing
   and paired residual runs show that the median gap is not stable under
   pairing, and the paired run has unhealthy tails.
-- Slice 11 does not prove that higher event rates are safe. It only says
-  that the starter matrix up to 100 kernel events, 100 span events,
-  concurrency 4, and 64 KiB span payloads stayed healthy on this host
-  class.
+- Slice 12 does not prove that 500 or 1000 OTel span events are safe or
+  cheap under the default workload configuration. The trace retained
+  only 128 span events at those targets, so timing above that point is
+  fidelity-limited.
 - No Trust Card or Trust Basis claim is added. This remains an
   experiment-scoped measurement follow-up.
 - The generated artifacts remain review artifacts until a later decision
@@ -371,18 +442,13 @@ Next engineering slice:
 > Do not add another broad Arm A/C wall-clock rerun for this arc. The
 > paired residual diagnostic has landed and shows that the median gap is
 > not stable enough for an additive wall-clock decomposition at the
-> current measurement budget. Slice 11 has now shown that the starter
-> event-rate matrix stays healthy and calibrates correctly. Slice 12 is
-> therefore predeclared as a boundary-finding sweep. The harness now
-> supports extended `x500` / `x1000` targets through
-> `assay.experiment.event_rate_sweep.v0.1`, optional warm-up samples, and
-> longer delegated timeouts. The next step is to run the paired A/C
-> widening matrix. The intended finding is a health/fidelity boundary
-> statement, not another median wall-clock comparison.
+> current measurement budget. Slice 12 has now produced the intended
+> boundary statement: kernel capture stayed healthy through the widened
+> kernel cells, and span widening hit the default OTel event-retention
+> boundary at the first widened span cell.
 
-Slice 12 should only publish one of these outcomes:
-
-- healthy through the widened numeric targets on this host class;
-- first unhealthy boundary found, with the nearest healthy predecessor;
-- inconclusive because event-count calibration, Runner health, or tail
-  health failed before timing could be interpreted.
+The only logical follow-up is a new, explicitly scoped span-limit study:
+configure the OTel SDK span-event limit above the requested target,
+verify retained event counts first, and then rerun only the span cells
+needed to answer whether trace export cost scales after the fidelity
+boundary is removed.

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -44,7 +44,7 @@
 | `assay.experiment.overhead_summary.v0` | Aggregated overhead summary for runner-vs-OTel | experiment-scoped; sidecar active; phase timing diagnostics included | [`overhead-summary-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json) |
 | `assay.experiment.runner_phase_timing.v0` | Phase-timing side-log emitted by `assay runner-spike run --phase-timing-log` | experiment-scoped; sidecar active | [`runner-phase-timing-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json) |
 | `assay.experiment.event_rate_sweep.v0` | Event-rate/workload-intensity cell metadata embedded in overhead samples and summaries | experiment-scoped; sidecar active; Slice 10 smoke-verified | [`event-rate-sweep-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json) |
-| `assay.experiment.event_rate_sweep.v0.1` | Event-rate/workload-intensity cell metadata with Slice 12 extended targets | experiment-scoped; sidecar active; Slice 12 harness-ready | [`event-rate-sweep-v0.1.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json) |
+| `assay.experiment.event_rate_sweep.v0.1` | Event-rate/workload-intensity cell metadata with Slice 12 extended targets | experiment-scoped; sidecar active; Slice 12 measured | [`event-rate-sweep-v0.1.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json) |
 
 The overhead schemas remain experiment-scoped. They are validated by the
 local harness tests against synthetic samples, summaries, phase


### PR DESCRIPTION
Summary

Records the post-#1406 Slice 12 boundary-finding sweep results for the runner-vs-OTel overhead experiment. This is a findings-only update: no generated measurement artifacts are committed and no product benchmark claim is published.

What changed

- Adds the six Slice 12 run anchors:
  - k500: 26517696032
  - k1000: 26518158603
  - s500: 26518522754
  - s1000: 26518894002
  - kc1000: 26519398461
  - corner-lite: 26520226593
- Records that all six paired A/C cells completed with 5/5 measured samples per arm, 0 discarded samples, successful warm-up samples, clean Runner health gates, and matching host class.
- Records the split boundary finding:
  - Kernel side: healthy through x1000 kernel worker files and concurrency 16.
  - Span side: first widened span cell hits the default OTel event-retention fidelity boundary: s500 retained 128/500 Arm C span events, and s1000/corner-lite retained 128/1000.
  - Corner side: bounded by the same span-fidelity limit, not by Runner health.
- Updates the plan, findings, README, schema overview status, and changelog to mark Slice 12 as measured/done.

Validation

- python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py' -> 35 OK
- python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py' -> 92 OK
- git diff --check
- local changed-docs link sanity -> OK
- pre-commit + pre-push hooks green

Non-claims

- Does not commit Slice 12 measurement artifacts.
- Does not publish product benchmark numbers.
- Does not publish timing slopes above the OTel span-fidelity boundary.
- Does not reopen the broad Arm A/C wall-clock decomposition loop.
