### PR TITLE
feat(experiments): guard overhead span-event limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,11 @@ All notable changes to this project will be documented in this file.
   OpenTelemetry Span Limits default, retained event-index ranges, and a
   local `OTEL_SPAN_EVENT_COUNT_LIMIT=1000` repro before treating the
   128-event cap as an OTel SDK configuration boundary.
+- Added a span-event limit guardrail to the overhead harness. Non-baseline
+  sweep samples and summaries now record the effective OTel span-event
+  limit and warn when `target_span_events` exceeds that limit, so future
+  dispatches cannot silently treat clipped span-event counts as throughput
+  evidence.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05.md
@@ -762,6 +762,10 @@ Slice 12 acceptance rules:
   `kernel_layer != complete`, `cgroup_correlation != clean`, trace event
   counts are lower than target, archive/trace extraction fails, or
   p99/median enters the fail band.
+- Any sample with `span_event_limit_warning` set may not be cited as
+  evidence of OTel span-event throughput above the effective limit.
+  Raise `OTEL_SPAN_EVENT_COUNT_LIMIT` and verify retained event counts
+  before interpreting timing above 128 span events.
 - If `corner-lite` fails but single-axis cells pass, report interaction
   pressure rather than dropping the corner.
 - If `kc1000` fails, do not claim whether the boundary is kernel-event

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -274,6 +274,13 @@ Warm-up failures do not abort the harness; inspect
 a dispatch failed, treat that dispatch as inconclusive even when the
 measured samples pass.
 
+Samples and summaries now also record the effective OTel span-event
+limit for non-baseline sweep cells. If `target_span_events` exceeds that
+effective limit, the harness sets `span_event_limit_warning`; do not
+interpret span-event timing above the limit unless
+`OTEL_SPAN_EVENT_COUNT_LIMIT` was raised and retained event counts were
+verified first.
+
 That boundary-finding sweep has now been dispatched and summarized in
 [`findings.md`](findings.md):
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -30,6 +30,8 @@ SUMMARY_SCHEMA = "assay.experiment.overhead_summary.v0"
 PAIRED_SEQUENCE_SCHEMA = "assay.experiment.paired_sequence.v0"
 EVENT_RATE_SWEEP_SCHEMA = "assay.experiment.event_rate_sweep.v0"
 EVENT_RATE_SWEEP_SCHEMA_V0_1 = "assay.experiment.event_rate_sweep.v0.1"
+OTEL_SPAN_EVENT_COUNT_LIMIT_ENV = "OTEL_SPAN_EVENT_COUNT_LIMIT"
+DEFAULT_OTEL_SPAN_EVENT_COUNT_LIMIT = 128
 DEFAULT_ARM = "arm-b-otel"
 ARM_A = "arm-a-runner-only"
 ARM_B = "arm-b-otel"
@@ -218,16 +220,59 @@ def event_rate_sweep_config(args: argparse.Namespace) -> dict[str, Any] | None:
         if kernel_level in {"x500", "x1000"} or span_level in {"x500", "x1000"}
         else EVENT_RATE_SWEEP_SCHEMA
     )
-    return {
+    target_span_events = SWEEP_SPAN_EVENT_TARGETS[span_level]
+    config = {
         "schema": schema,
         "kernel_event_rate": kernel_level,
         "span_event_rate": span_level,
         "concurrency": concurrency,
         "payload_size": payload_size,
         "target_kernel_events": SWEEP_KERNEL_EVENT_TARGETS[kernel_level],
-        "target_span_events": SWEEP_SPAN_EVENT_TARGETS[span_level],
+        "target_span_events": target_span_events,
         "payload_bytes": SWEEP_PAYLOAD_BYTES[payload_size],
     }
+    config.update(span_event_limit_metadata(target_span_events))
+    return config
+
+
+def span_event_limit_metadata(target_span_events: int) -> dict[str, Any]:
+    raw_limit = os.environ.get(OTEL_SPAN_EVENT_COUNT_LIMIT_ENV)
+    source = "default"
+    limit = DEFAULT_OTEL_SPAN_EVENT_COUNT_LIMIT
+    if raw_limit is not None:
+        try:
+            parsed = int(raw_limit)
+        except ValueError:
+            parsed = DEFAULT_OTEL_SPAN_EVENT_COUNT_LIMIT
+            source = "invalid-env"
+        else:
+            if parsed >= 0:
+                limit = parsed
+                source = "env"
+            else:
+                source = "invalid-env"
+    metadata: dict[str, Any] = {
+        "span_event_limit_effective": limit,
+        "span_event_limit_source": source,
+    }
+    if target_span_events > limit:
+        metadata["span_event_limit_warning"] = span_event_limit_warning(
+            target_span_events=target_span_events,
+            limit=limit,
+            source=source,
+        )
+    return metadata
+
+
+def span_event_limit_warning(
+    *, target_span_events: int, limit: int, source: str
+) -> str:
+    return (
+        f"target_span_events={target_span_events} exceeds effective OTel "
+        f"SpanLimits.EventCountLimit={limit} (source={source}); set "
+        f"{OTEL_SPAN_EVENT_COUNT_LIMIT_ENV} above the target to measure all "
+        "requested span events"
+    )
 
 
 def sweep_workload_args(event_rate_sweep: dict[str, Any] | None) -> list[str]:
@@ -256,6 +301,7 @@ def event_rate_sweep_for_arm(
     arm_sweep = dict(event_rate_sweep)
     arm_sweep["span_event_rate"] = "baseline"
     arm_sweep["target_span_events"] = 0
+    arm_sweep.pop("span_event_limit_warning", None)
     return arm_sweep
 
 
@@ -904,6 +950,16 @@ def summary_markdown(summary: dict[str, Any], *, artifact_name: str | None = Non
             f"concurrency={event_rate_sweep['concurrency']}; "
             f"payload={event_rate_sweep['payload_size']}` |"
         )
+        lines.append(
+            "| OTel span event limit | "
+            f"`{event_rate_sweep.get('span_event_limit_effective')}` "
+            f"({event_rate_sweep.get('span_event_limit_source', 'unknown')}) |"
+        )
+        if event_rate_sweep.get("span_event_limit_warning"):
+            lines.append(
+                "| OTel span event warning | "
+                f"`{event_rate_sweep['span_event_limit_warning']}` |"
+            )
     if isinstance(phase_timings, dict) and phase_timings:
         lines.extend(
             [

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json
@@ -61,6 +61,21 @@
     "payload_bytes": {
       "type": "integer",
       "minimum": 1
+    },
+    "span_event_limit_effective": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "span_event_limit_source": {
+      "enum": [
+        "default",
+        "env",
+        "invalid-env"
+      ]
+    },
+    "span_event_limit_warning": {
+      "type": "string",
+      "minLength": 1
     }
   }
 }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json
@@ -57,6 +57,21 @@
     "payload_bytes": {
       "type": "integer",
       "minimum": 1
+    },
+    "span_event_limit_effective": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "span_event_limit_source": {
+      "enum": [
+        "default",
+        "env",
+        "invalid-env"
+      ]
+    },
+    "span_event_limit_warning": {
+      "type": "string",
+      "minLength": 1
     }
   }
 }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
@@ -297,6 +297,21 @@
         "payload_bytes": {
           "type": "integer",
           "minimum": 1
+        },
+        "span_event_limit_effective": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "span_event_limit_source": {
+          "enum": [
+            "default",
+            "env",
+            "invalid-env"
+          ]
+        },
+        "span_event_limit_warning": {
+          "type": "string",
+          "minLength": 1
         }
       }
     }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
@@ -281,6 +281,21 @@
         "payload_bytes": {
           "type": "integer",
           "minimum": 1
+        },
+        "span_event_limit_effective": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "span_event_limit_source": {
+          "enum": [
+            "default",
+            "env",
+            "invalid-env"
+          ]
+        },
+        "span_event_limit_warning": {
+          "type": "string",
+          "minLength": 1
         }
       }
     }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import platform
 import subprocess
 import tempfile
 import tarfile
 import unittest
+from unittest import mock
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -305,6 +307,27 @@ class OverheadHarnessTests(unittest.TestCase):
         }
         assert_matches_schema(self, payload, schema, root=schema)
 
+    def test_event_rate_sweep_v01_schema_accepts_span_limit_warning(self) -> None:
+        schema = load_schema("event-rate-sweep-v0.1.schema.json")
+        payload = {
+            "schema": "assay.experiment.event_rate_sweep.v0.1",
+            "kernel_event_rate": "baseline",
+            "span_event_rate": "x500",
+            "concurrency": 1,
+            "payload_size": "small",
+            "target_kernel_events": 0,
+            "target_span_events": 500,
+            "payload_bytes": 128,
+            "span_event_limit_effective": 128,
+            "span_event_limit_source": "default",
+            "span_event_limit_warning": overhead_harness.span_event_limit_warning(
+                target_span_events=500,
+                limit=128,
+                source="default",
+            ),
+        }
+        assert_matches_schema(self, payload, schema, root=schema)
+
     def test_event_rate_sweep_config_maps_levels_to_targets(self) -> None:
         args = type(
             "Args",
@@ -342,6 +365,66 @@ class OverheadHarnessTests(unittest.TestCase):
         self.assertEqual(config["target_span_events"], 500)
         self.assertEqual(config["payload_bytes"], 65536)
         self.assertEqual(config["concurrency"], 8)
+        self.assertEqual(config["span_event_limit_effective"], 128)
+        self.assertEqual(config["span_event_limit_source"], "default")
+        self.assertEqual(
+            config["span_event_limit_warning"],
+            overhead_harness.span_event_limit_warning(
+                target_span_events=500,
+                limit=128,
+                source="default",
+            ),
+        )
+
+    def test_event_rate_sweep_config_uses_span_limit_env_override(self) -> None:
+        args = type(
+            "Args",
+            (),
+            {
+                "sweep_kernel_event_rate": "baseline",
+                "sweep_span_event_rate": "x1000",
+                "sweep_concurrency": 1,
+                "sweep_payload_size": "small",
+            },
+        )()
+        with mock.patch.dict(
+            os.environ,
+            {"OTEL_SPAN_EVENT_COUNT_LIMIT": "1000"},
+        ):
+            config = overhead_harness.event_rate_sweep_config(args)
+
+        self.assertEqual(config["span_event_limit_effective"], 1000)
+        self.assertEqual(config["span_event_limit_source"], "env")
+        self.assertNotIn("span_event_limit_warning", config)
+
+    def test_event_rate_sweep_config_warns_against_lower_env_override(self) -> None:
+        args = type(
+            "Args",
+            (),
+            {
+                "sweep_kernel_event_rate": "baseline",
+                "sweep_span_event_rate": "high",
+                "sweep_concurrency": 1,
+                "sweep_payload_size": "small",
+            },
+        )()
+        with mock.patch.dict(
+            os.environ,
+            {"OTEL_SPAN_EVENT_COUNT_LIMIT": "64"},
+        ):
+            config = overhead_harness.event_rate_sweep_config(args)
+
+        self.assertEqual(config["target_span_events"], 100)
+        self.assertEqual(config["span_event_limit_effective"], 64)
+        self.assertEqual(config["span_event_limit_source"], "env")
+        self.assertEqual(
+            config["span_event_limit_warning"],
+            overhead_harness.span_event_limit_warning(
+                target_span_events=100,
+                limit=64,
+                source="env",
+            ),
+        )
 
     def test_baseline_event_rate_sweep_config_is_null(self) -> None:
         args = type(
@@ -366,6 +449,8 @@ class OverheadHarnessTests(unittest.TestCase):
             "target_kernel_events": 25,
             "target_span_events": 100,
             "payload_bytes": 128,
+            "span_event_limit_effective": 128,
+            "span_event_limit_source": "default",
         }
         arm_a = overhead_harness.event_rate_sweep_for_arm(
             overhead_harness.ARM_A,
@@ -375,6 +460,8 @@ class OverheadHarnessTests(unittest.TestCase):
         self.assertEqual(arm_a["span_event_rate"], "baseline")
         self.assertEqual(arm_a["target_span_events"], 0)
         self.assertEqual(arm_a["target_kernel_events"], 25)
+        self.assertEqual(arm_a["span_event_limit_effective"], 128)
+        self.assertNotIn("span_event_limit_warning", arm_a)
         self.assertEqual(
             overhead_harness.event_rate_sweep_for_arm(overhead_harness.ARM_C, config),
             config,
@@ -721,6 +808,18 @@ class OverheadHarnessTests(unittest.TestCase):
 
             self.assertEqual(sample["event_rate_sweep"]["target_kernel_events"], 25)
             self.assertEqual(sample["event_rate_sweep"]["target_span_events"], 1)
+            self.assertEqual(
+                sample["event_rate_sweep"]["span_event_limit_effective"],
+                128,
+            )
+            self.assertEqual(
+                sample["event_rate_sweep"]["span_event_limit_source"],
+                "default",
+            )
+            self.assertNotIn(
+                "span_event_limit_warning",
+                sample["event_rate_sweep"],
+            )
             self.assertEqual(summary["event_rate_sweep"], sample["event_rate_sweep"])
 
     def test_harness_records_warmup_samples_outside_summary(self) -> None:


### PR DESCRIPTION
Summary

Adds the post-Slice-12 guardrail before any future span-limit characterization work: overhead sweep samples and summaries now record the effective OTel span-event limit and warn when the requested target exceeds it.

What changed

- Adds effective span-event limit metadata to non-baseline event-rate sweep config:
  - `span_event_limit_effective`
  - `span_event_limit_source` (`default`, `env`, `invalid-env`)
  - `span_event_limit_warning` when `target_span_events` exceeds the effective limit
- Uses the OTel default `OTEL_SPAN_EVENT_COUNT_LIMIT=128` unless an env override is present.
- Removes the warning for Arm A after it drops span pressure to `baseline` / `0`.
- Surfaces the effective limit and warning in `summary.md` / GitHub step summary.
- Extends experiment-scoped event-rate sweep schemas and embedded sample/summary schema defs with optional guardrail fields.
- Updates the plan/README acceptance language: samples with `span_event_limit_warning` must not be cited as throughput evidence above the effective limit.

Validation

- python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py' -> 37 OK
- python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py' -> 92 OK
- schema JSON parse checks -> OK
- git diff --check
- changed-docs local-link sanity -> OK
- pre-commit + pre-push hooks green

Non-claims

- Does not run the OTel span-limit characterization from #1408.
- Does not change the default OTel workload limit.
- Does not publish new measurement artifacts or timing slopes.
- Does not reopen the closed default-config overhead arc.
