### PR TITLE
docs(experiments): plan agent observability fidelity roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,13 @@ All notable changes to this project will be documented in this file.
   separates the three closed arc results: non-additive wall-clock behavior,
   stable RSS decomposition, and the Runner-kernel / OTel-span fidelity
   boundary.
+- Added a SOTA-informed agent-observability fidelity roadmap that turns
+  the completed overhead and trace/archive experiments into prioritized
+  follow-up slices for calibration guardrails, portable evidence packs,
+  semantic-gap scenarios, and OTel/OpenInference interoperability. The
+  roadmap now starts with experiment namespace-governance rules for
+  naming, promotion, artifact-family inventory, calibration verdicts and
+  methods, and evidence-pack minimums.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/agent-observability-fidelity-2026-05.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05.md
@@ -1,0 +1,372 @@
+# Agent Observability Fidelity Roadmap (2026-05)
+
+> **Status:** plan-only follow-up after the completed
+> Runner-vs-OTel overhead arc. This document ranks the next useful
+> experiments for improving Assay's agent-observability surface. It does
+> not dispatch new runs, does not commit measurement artifacts, and does
+> not open the optional OTel span-limit study tracked in
+> [issue #1408](https://github.com/Rul1an/assay/issues/1408).
+>
+> **Last updated:** 2026-05-27
+
+## Executive Decision
+
+The overhead arc is closed. The next valuable work is not another broad
+wall-clock rerun. The useful whitespace is **fidelity-aware agent
+observability**: making every trace/archive/receipt comparison say what
+was requested, what was actually retained or measured, which layer
+supports the claim, and where loss or semantic ambiguity begins.
+
+Priority order:
+
+0. **Experiment namespace governance** - pin naming, promotion, and
+   cross-arc field rules before adding more observability artifacts.
+1. **Fidelity calibration guardrails** - make requested-vs-observed
+   counts first-class across Runner, OTel, and joined artifacts.
+2. **Portable incident evidence packs** - turn one failing run into a
+   bounded, reviewable evidence bundle.
+3. **Semantic-gap experiments** - prove where reported trace intent and
+   measured system effect diverge at the same tool call.
+4. **Interop matrix** - compare OTel GenAI, OpenInference, and Runner
+   evidence boundaries without pretending they measure the same thing.
+5. **Optional OTel span-limit characterization** - only when an external
+   consumer needs behavior above the default 128 span-event limit.
+
+## Why This Direction
+
+The latest overhead results produced three stable facts:
+
+- Wall-clock decomposition between Runner capture and OTel trace export
+  did not remain stable under paired A/C diagnostics.
+- Peak RSS decomposed cleanly: Runner capture dominated the observed RSS
+  increase, while OTel trace export added no measurable RSS at that
+  scale.
+- Runner kernel capture stayed healthy through 1000 worker files and
+  concurrency 16, while default OpenTelemetry span retention clipped at
+  `SpanLimits.EventCountLimit=128`.
+
+The third result is the pivot. It shows that an observability system can
+look efficient because it stopped retaining the requested signal. Assay
+should therefore improve toward **calibrated fidelity** rather than raw
+latency claims.
+
+## SOTA Anchors
+
+| Anchor | Relevance |
+|---|---|
+| [OpenTelemetry GenAI agent spans](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) | The GenAI agent conventions are still marked Development and include an opt-in path for latest experimental conventions. Assay should treat semantic versions and emitted convention families as measured configuration, not background context. |
+| [OpenTelemetry Trace SDK Span Limits](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-limits) | `EventCountLimit` defaults to 128. This exactly matches the Slice 12 span-retention boundary and should be surfaced in samples before timing is interpreted. |
+| [AgentSight: System-Level Observability for AI Agents Using eBPF](https://arxiv.org/abs/2508.02736) | Confirms the research direction for framework-agnostic, system-boundary observation of agents. Assay's differentiator is joining that boundary evidence to trace/receipt semantics and health gates. |
+| [AgentTrace: A Structured Logging Framework for Agent System Observability](https://arxiv.org/abs/2602.10133) | Reinforces structured trace records as reliability and trust-calibration evidence, not just debugging logs. |
+| [AgentSim: A Platform for Verifiable Agent-Trace Simulation](https://arxiv.org/abs/2604.26653) | Points toward verifiable, replayable trace corpora. Assay should make failing/interesting runs portable and inspectable. |
+| [Beyond Black-Box Benchmarking](https://arxiv.org/abs/2503.06745) | Supports moving from pass/fail or product benchmarks to runtime-log and observability-driven analysis of agentic systems. |
+| [OpenInference semantic conventions](https://www.mintlify.com/Arize-ai/openinference/python/semantic-conventions) | Provides a richer OTel-compatible AI/ML semantic layer to compare against OTel GenAI and Runner measured effects. |
+
+## Step 0 - Experiment Namespace Governance
+
+**Goal:** keep the next artifacts from becoming another set of
+experiment-local one-offs.
+
+The governance decision lives in
+[`../reference/experiments/namespace-governance.md`](../reference/experiments/namespace-governance.md).
+The artifact-family inventory lives in
+[`../reference/artifact-families-inventory.md`](../reference/artifact-families-inventory.md).
+Together they pin four rules before the calibration/evidence-pack work
+begins:
+
+- new experiment schema strings should prefer
+  `assay.experiment.<arc_slug>.<artifact_slug>.v<N>`;
+- promotion from `assay.experiment.*` to `assay.runner.*`,
+  `assay.observability.*`, or a receipt family requires a real consumer
+  or repeated cross-arc use;
+- cross-arc fields such as `host_class`, `workflow_run_url`,
+  `tool_versions`, and `calibration_status` should be repeated locally
+  until multiple arcs prove the same nested shape.
+- proposed artifact families such as fidelity calibration, evidence
+  packs, binding evidence, semantic-gap findings, and interop mappings
+  must stay visibly proposed until a promotion PR names a consumer.
+
+This is intentionally a small docs step. It is not a schema promotion
+and does not rename historical overhead artifacts.
+
+## Experiment 1 - Fidelity Calibration Guardrails
+
+**Goal:** make every measurement artifact self-report whether the
+declared signal reached the observed layer.
+
+This is the immediate next code slice because it turns the Slice 12
+lesson into a general guardrail. The overhead harness already records
+`span_event_limit_effective`, `span_event_limit_source`, and
+`span_event_limit_warning`; the next slice should generalize this into
+observed-count fields and summary-level calibration gates.
+
+### Proposed fields
+
+| Field | Meaning | Layer |
+|---|---|---|
+| `target_kernel_events` | Requested kernel worker-file pressure | workload config |
+| `observed_kernel_worker_files` | Unique `event-rate-sweep/worker-*` files observed in extracted archive contents | Runner archive |
+| `target_span_events` | Requested OTel span events | workload config |
+| `retained_span_events` | Span events retained in trace JSON | OTel trace |
+| `dropped_span_events_estimate` | `target_span_events - retained_span_events` when both are known | derived diagnostic |
+| `span_event_limit_effective` | Effective OTel span event limit | OTel SDK config |
+| `trace_semconv_family` | OTel GenAI / OpenInference convention family emitted | trace config |
+| `calibration_status` | `clean`, `lossy`, `inconclusive`, or `not_applicable` | joined summary |
+| `fidelity_verdict` | Review-facing rollup across OTel and Runner capture | calibration summary |
+| `calibration_method` | How the observed count was produced | calibration metadata |
+| `calibration_agreement` | `match`, `clipped`, `drift`, `failed`, or `not_applicable` | calibration decision |
+
+### Acceptance rules
+
+- A cell may not support timing, throughput, or scaling claims until
+  calibration is `clean` or the finding is explicitly about loss.
+- Lossy cells are still useful evidence, but only for fidelity-boundary
+  statements.
+- `calibration_status=inconclusive` must be visible in `summary.md`,
+  not buried in artifacts.
+- Arm A remains asymmetric: OTel span fields are `not_applicable` rather
+  than zero-throughput evidence.
+- Every observed count must name its method. Example methods:
+  `archive_contents_worker_files_count`,
+  `kernel_ndjson_path_match_count`, `otel_trace_json_events_count`, and
+  `fixture_side_log_count`.
+- The first schema should expose per-layer agreement, not only one
+  summary boolean. A mixed cell can be `match` for kernel events and
+  `clipped` for span events.
+- `fidelity_verdict` should be a compact object for renderer/evidence
+  pack readers, backed by per-measurement `{target, observed, method,
+  agreement}` entries for auditability.
+
+### Output
+
+- New experiment-scoped calibration sidecar under the overhead package,
+  or promotion into `assay.observability.*` if it applies beyond the
+  overhead harness.
+- Unit tests covering default OTel limit, raised limit, Arm A
+  not-applicable behavior, and kernel worker-file counting.
+
+## Experiment 2 - Portable Incident Evidence Pack
+
+**Goal:** turn one interesting or failing agent run into a compact,
+portable, reviewable bundle.
+
+This is the first tool-facing slice after calibration because every
+later experiment should be able to hand reviewers a bounded evidence
+pack instead of a pile of raw artifacts. The first prototype should
+target one existing controlled scenario, not a broad production
+incident.
+
+### Minimum bundle
+
+| Required | Artifact |
+|---|---|
+| Yes | One-page Markdown summary |
+| Yes | Runner archive or verified archive reference |
+| Yes | Trace JSON or trace reference when a trace layer exists |
+| Yes | Observation health summary |
+| Yes | Redaction manifest, even if no redaction was applied |
+| Nice-to-have v1 | Expanded manifest/provenance table |
+| Nice-to-have v1 | Derived measured-effects summary |
+
+### Acceptance rules
+
+- The pack must never strengthen a claim beyond the underlying join and
+  calibration grades.
+- Redaction must be explicit: omitted content is named as omitted, not
+  silently removed.
+- The pack must be reproducible from input artifacts by a command, not
+  hand-curated.
+- The first pack should target one known scenario and produce stable
+  filenames, so later semantic-gap scenarios can reuse the same carrier.
+
+### Tool improvement
+
+This should become the bridge from research evidence to a practical
+Assay feature: "give me the portable evidence for this agent run."
+
+## Experiment 3 - Semantic Gap / Intent-vs-Effect Benchmark
+
+**Goal:** prove exactly where trace-reported intent, SDK events, policy
+events, and measured system effects diverge.
+
+This is the most strategically valuable new experiment. It extends the
+existing runner-vs-OTel shape comparison and cross-runtime drift work
+from "can we join layers?" to "what can the joined layers honestly
+claim when they disagree?"
+
+This experiment should come after the first evidence-pack prototype.
+The gap scenarios are the argument; the pack is how the argument becomes
+reviewable.
+
+### Baseline decision to make before dispatch
+
+Every semantic-gap scenario needs a non-gap baseline. The recommended
+baseline is one deterministic safe tool call that emits the same
+`tool_call_id` into trace/SDK/archive layers and whose measured effect
+matches the reported intent. Synthetic ground truth is acceptable for
+unit tests, but at least one delegated sanity run should prove the same
+join path under real Runner capture before gap findings are published.
+
+### Scenarios
+
+| Scenario | Reported trace intent | Measured effect | Expected claim |
+|---|---|---|---|
+| Matched safe read | tool call reports reading `safe.txt` | kernel observes read of `safe.txt` | strong positive join |
+| Argument/path rewrite | tool call reports `safe.txt` | kernel observes normalized alternate path | semantic mismatch at same tool call |
+| Hidden write | tool call reports read-only action | kernel observes create/write in workdir | L1 underreports side effect |
+| Retry/self-correction | trace records final successful action | kernel/archive records failed prior attempts | trace summary loses temporal evidence |
+| Runtime side effect | no tool-level trace event | archive records runtime loader/config/probe path | runtime-induced surface |
+| Weak join fallback | missing `tool_call_id`, only order/timestamp | effects are plausible but not strongly joinable | diagnostic-only claim |
+
+### Acceptance rules
+
+- Every row must emit an `assay.observability.join_result.v0` entry or a
+  newer successor.
+- Strong findings require unique `tool_call_id` or an explicitly
+  equivalent key.
+- Timestamp/order joins remain diagnostic and may not support semantic
+  equality claims.
+- The output must classify each scenario by claim class: reported
+  intent, measured effect, joined evidence, or inconclusive.
+- A measured effect mismatch is evidence of divergence. It is not by
+  itself evidence of malicious behavior, policy failure, or root-cause
+  attribution.
+
+### Tool improvement
+
+This experiment should drive product work on input-binding receipts and
+per-tool evidence rows. If the tool cannot clearly say "same tool call,
+different effect," the observability story is not strong enough yet.
+
+## Experiment 4 - OTel / OpenInference / Runner Interop Matrix
+
+**Goal:** compare semantic coverage across OTel GenAI, OpenInference,
+and Runner measured effects without treating them as interchangeable.
+
+### Matrix axes
+
+| Axis | Values |
+|---|---|
+| Trace vocabulary | OTel GenAI current default, OTel latest experimental opt-in, OpenInference |
+| OpenInference span kinds | `AGENT`, `LLM`, `TOOL`, `RETRIEVER`, `GUARDRAIL`, and related emitted kinds |
+| Agent shape | single tool call, retry, handoff, retrieval/tool mix |
+| Join key | `tool_call_id`, run id only, order/timestamp fallback |
+| Evidence layer | trace-only, archive-only, joined |
+
+### Acceptance rules
+
+- The matrix reports coverage and claim strength, not product ranking.
+- OTel GenAI convention version or opt-in value must be recorded.
+- OpenInference package/version must be recorded.
+- Missing fields are findings, not test failures, when the vocabulary
+  legitimately does not model the behavior.
+
+### Tool improvement
+
+This should produce a map from external semantic conventions to Assay's
+internal claim vocabulary. It informs importers, receipt families, and
+docs around what Assay can honestly consume.
+
+## Experiment 5 - Optional OTel Span-Limit Characterization
+
+**Goal:** characterize span-event throughput/fidelity only after raising
+the OTel SDK limit above the requested target.
+
+This remains optional. It should not be opened just because the default
+overhead arc found the 128-event boundary.
+
+### External triggers
+
+- A paper section needs a datapoint above the default cap.
+- A user asks how OTel behaves at high span-event rates.
+- An Assay feature becomes sensitive to traces with hundreds or
+  thousands of events per span.
+
+### Acceptance rules
+
+- Set `OTEL_SPAN_EVENT_COUNT_LIMIT` above the requested target before
+  dispatch.
+- Verify retained event counts before interpreting timing.
+- Any sample with `span_event_limit_warning` is non-citable for
+  throughput above the effective limit.
+- Keep this as a separate arc from the default-config overhead findings.
+
+## Required Product Development From The Latest Experiments
+
+These are not optional research niceties; they are engineering debt made
+visible by the overhead and shape-comparison arcs.
+
+1. **Observed-count metadata.** Samples and summaries need observed
+   counts for kernel files, retained span events, dropped span events,
+   and effective limits.
+2. **Calibration status.** Every summary should say whether the input
+   variable was actually observed before timing or scaling is discussed.
+3. **Join-result ergonomics.** `assay.observability.join_result.v0`
+   should become easier to emit from experiment comparators.
+4. **Binding evidence / join receipts.** Tool input, tool result, trace
+   id, archive digest, and measured effect need a bounded working shape,
+   but this must not be framed as a product line until a promotion PR
+   names the consumer.
+5. **Evidence-pack renderer.** The repo needs a reproducible way to turn
+   artifacts into a portable incident summary.
+6. **Semconv/version capture.** OTel GenAI and OpenInference convention
+   family/version must be recorded as effective config.
+7. **Runner-health operations.** Delegated experiments depend on
+   `assay-bpf-runner`; offline/backlog detection and recovery should
+   remain part of the runbook.
+
+## Recommended Slice Order
+
+| Slice | Status | Purpose | Exit gate |
+|---:|---|---|---|
+| 0 | Done in this plan | Namespace governance for experiment artifacts | Naming, promotion, cross-arc field, calibration-method, and evidence-pack minimum rules are documented. |
+| 1 | Planned | Fidelity calibration fields and summary rendering | One overhead-style fixture proves clean, lossy, and not-applicable calibration states. |
+| 2 | Planned | Portable evidence-pack prototype | One controlled scenario emits the minimum pack: summary, archive/ref, trace/ref, health, and redaction manifest. |
+| 3 | Planned | Semantic-gap scenario plan | Baseline plus six predeclared scenarios, claim classes, and join requirements documented before dispatch. |
+| 4 | Planned | Semantic-gap harness | Fake fixtures plus one delegated sanity run prove joined intent/effect rows and evidence-pack output. |
+| 5 | Planned | Interop matrix plan | OTel/OpenInference/Runner coverage axes and non-claims pinned. |
+| 6 | Optional | OTel span-limit study | Only after an external trigger; otherwise remains issue-only. |
+
+## Experiment vs Feature Boundary
+
+Not every follow-up needs full experiment-arc discipline:
+
+- **Experiment-like:** fidelity calibration, semantic-gap scenarios, and
+  interop matrix. These need predeclared inputs, acceptance criteria,
+  and closure rules.
+- **Feature-like:** evidence-pack rendering and join-result ergonomics.
+  These should iterate faster, but still preserve non-claims and
+  validation fixtures.
+
+Use the heavier slice discipline when the result will be interpreted as
+evidence. Use feature iteration when the task is improving how evidence
+is carried or rendered.
+
+## What Not To Do Yet
+
+- Do not start with the Interop Matrix. Without working calibration and
+  evidence-pack output, a matrix is mostly a promise rather than
+  inspectable evidence.
+- Do not turn the required product-development list into one epic. Each
+  item belongs to a different dependency chain.
+- Do not open a new paper arc yet. The argument is strong, but the
+  portable evidence format should exist before publication work starts.
+- Do not start #1408 unless an external trigger appears.
+
+## Closure Criterion
+
+This roadmap is successful when Assay can take one agent run and answer:
+
+```text
+What did the trace report?
+What did the system actually do?
+Which key joined those layers?
+Was the requested signal fully retained?
+What claim class is safe?
+What portable evidence can a reviewer inspect?
+```
+
+If the tool can answer those questions without hand-inspecting raw
+artifacts, the next frontier becomes policy/eval integration. Until
+then, more raw overhead runs are lower value than fidelity and
+joinability improvements.

--- a/docs/reference/artifact-families-inventory.md
+++ b/docs/reference/artifact-families-inventory.md
@@ -1,0 +1,66 @@
+# Assay Artifact Families Inventory
+
+> **Status:** orientation inventory. This page classifies current and
+> proposed artifact families as canonical, reference, experiment-scoped,
+> or proposed. It does not promote any artifact and does not define a new
+> schema.
+
+## Why This Exists
+
+Assay now has several evidence-bearing artifact families: Trust Card,
+Trust Basis, Runner archives, receipt families, observability join rows,
+experiment sidecars, and planned fidelity/evidence-pack outputs. This
+inventory keeps those families legible so new experiments do not
+accidentally present proposed artifacts as canonical product surfaces.
+
+## Status Classes
+
+| Status | Meaning |
+|---|---|
+| `canonical` | Product or release-line artifact family with existing user-facing meaning. |
+| `reference` | Stable research/reference vocabulary or schema family used to interpret evidence. |
+| `experiment-scoped` | Local measurement or comparison artifact for one experiment line. |
+| `proposed` | Planned or working-term artifact family; not yet a stable contract. |
+| `historical` | Kept for traceability, not a recommended new surface. |
+
+## Current Families
+
+| Family | Status | Namespace / docs | Role |
+|---|---|---|---|
+| Trust Card | `canonical` | CLI/reference docs | User-facing claim summary surface. |
+| Trust Basis | `canonical` | CLI/reference docs | Lower-level evidence basis for trust claims. |
+| Runner archive | `canonical` | `assay.runner.*` | Measured-run evidence captured by Runner. |
+| Runner projection/report schemas | `reference` | `docs/reference/runner/` | Runner-adjacent reports, diffs, and projections. |
+| Receipt families | `reference` | [`receipt-families.md`](receipt-families.md) | Bounded imported evidence receipts. |
+| Observability claim classes | `reference` | [`observability/claim-classes-v0.md`](observability/claim-classes-v0.md) | Vocabulary for what traces, archives, and joined artifacts can honestly claim. |
+| Observability join rows | `reference` | [`observability/join-contract-v0.md`](observability/join-contract-v0.md) | Join-grade rows for trace/archive/receipt comparisons. |
+| Overhead experiment sidecars | `experiment-scoped` | `assay.experiment.*` under `runner-vs-otel-overhead-2026-05/` | Samples, summaries, phase timings, paired sequences, and event-rate sweep cells. |
+| Cross-runtime drift outputs | `experiment-scoped` | `cross-runtime-drift-2026-05/` | Runtime capability-surface drift comparisons. |
+| Fidelity calibration | `proposed` | `assay.experiment.agent_observability_fidelity.calibration.v0` | Requested-vs-observed fidelity verdicts and per-layer count methods. |
+| Evidence pack | `proposed` | `assay.experiment.agent_observability_fidelity.evidence_pack.v0` | Portable bundle carrier for one run or scenario. |
+| Binding evidence / join receipts | `proposed` | undecided | Working term for tool-call input/output/effect binding evidence. Not a product line yet. |
+| Semantic-gap finding | `proposed` | undecided | Experiment result family for reported-intent vs measured-effect divergence. |
+| Interop mapping | `proposed` | undecided | Mapping rows between OTel GenAI, OpenInference, Runner, and Assay claim vocabulary. |
+
+## Promotion Rule
+
+Proposed or experiment-scoped artifacts should not be described as
+canonical until a promotion PR names:
+
+1. the consumer that needs the artifact;
+2. the namespace and stability promise;
+3. the validation fixtures or golden examples;
+4. the migration path from the experiment artifact, if any;
+5. the non-claims the promoted artifact still carries.
+
+See
+[`experiments/namespace-governance.md`](experiments/namespace-governance.md)
+for naming and promotion details.
+
+## Non-Claims
+
+- This inventory does not create new artifact families by itself.
+- This inventory does not require current experiment artifacts to be
+  renamed.
+- `proposed` means "useful working term," not "committed product
+  surface."

--- a/docs/reference/experiments/namespace-governance.md
+++ b/docs/reference/experiments/namespace-governance.md
@@ -1,0 +1,197 @@
+# Experiment Namespace Governance
+
+> **Status:** reference guidance for Assay experiment artifacts. This
+> document does not define a product API. It keeps experiment-scoped
+> schemas, cross-arc fields, and promotion decisions consistent before
+> the agent-observability fidelity roadmap adds more artifacts.
+
+## Problem
+
+Assay experiments now emit several useful but local artifact families:
+
+- overhead samples, summaries, paired sequences, phase timings, and
+  event-rate sweep cells;
+- cross-runtime drift reports and fixtures;
+- observability join and claim-class reference rows;
+- planned fidelity-calibration and evidence-pack artifacts.
+
+Without a naming and promotion rule, each new slice can create a locally
+reasonable schema that is hard to compare across arcs later. This doc
+sets the default rule before adding more fidelity and evidence-pack
+surfaces.
+
+## Naming Convention
+
+Use schema strings in this shape:
+
+```text
+assay.experiment.<arc_slug>.<artifact_slug>.v<N>
+```
+
+Examples:
+
+```text
+assay.experiment.agent_observability_fidelity.calibration.v0
+assay.experiment.agent_observability_fidelity.evidence_pack.v0
+assay.experiment.runner_vs_otel_overhead.event_rate_sweep.v0
+```
+
+Existing pre-governance schemas such as
+`assay.experiment.overhead_sample.v0` remain valid. Do not rename
+historical artifacts just to fit the new convention. New artifacts
+should use the arc/artifact split unless a narrower existing family
+already owns the shape.
+
+Rules:
+
+1. **Arc slug first.** The arc names the evidence boundary, not the
+   implementation module.
+2. **Artifact slug second.** The artifact names what the file contains:
+   `sample`, `summary`, `calibration`, `evidence_pack`,
+   `paired_sequence`, `phase_timing`, etc.
+3. **Version only on shape changes.** Additive optional fields may stay
+   within the same version when old artifacts still validate. Changed
+   meaning or required fields need a new version.
+4. **No product namespace by accident.** `assay.experiment.*` artifacts
+   remain local evidence until promoted explicitly.
+
+## Cross-Arc Fields
+
+Prefer repeating a small common field set in each experiment schema over
+creating a shared `assay.experiment.common.v0` too early. Duplication is
+acceptable while the fields are still proving themselves.
+
+Recommended common fields:
+
+| Field | Meaning |
+|---|---|
+| `schema` | Schema string for the artifact. |
+| `experiment` | Human-readable experiment slug. |
+| `assay_commit` | Source commit used to produce the artifact. |
+| `started_at` | ISO-8601 timestamp for the sample/run. |
+| `host_class` | Host/OS/kernel boundary for measurement claims. |
+| `workflow_run_url` | GitHub Actions run URL when produced by delegated workflow. |
+| `tool_versions` | Tool/runtime versions relevant to the artifact. |
+| `calibration_status` | `clean`, `lossy`, `inconclusive`, or `not_applicable` when the artifact interprets requested-vs-observed signals. |
+
+If three independent arcs need the same nested object with the same
+semantics, open a promotion PR to define a shared reference shape under
+`assay.observability.*` or another explicit namespace. Do not add a
+shared schema as a convenience before it has multiple consumers.
+
+## Promotion Criteria
+
+An experiment artifact may be promoted out of `assay.experiment.*` only
+when at least one of these triggers exists:
+
+- A production or CLI feature consumes it directly.
+- Two or more experiment arcs independently need the same shape.
+- A public reference doc or paper needs the shape as a stable citation
+  target.
+- External interoperability requires a stable contract.
+
+Promotion targets:
+
+| Target namespace | Use when |
+|---|---|
+| `assay.runner.*` | The shape is part of Runner archive, projection, or report contracts. |
+| `assay.observability.*` | The shape interprets or joins traces, archives, receipts, and external evidence. |
+| `assay.receipt.*` or receipt-family docs | The shape becomes a bounded imported evidence receipt. |
+
+Promotion requires:
+
+1. A reference page naming the new stability promise.
+2. A migration note for the experiment shape that motivated the
+   promotion.
+3. At least one validation fixture or golden file.
+4. A non-claims section stating what the promoted shape does not prove.
+
+## Fidelity Calibration Shapes
+
+Calibration artifacts should include method metadata. An observed count
+without its counting method is not reproducible.
+
+Recommended nested shape:
+
+```json
+{
+  "schema": "assay.experiment.agent_observability_fidelity.calibration.v0",
+  "fidelity_verdict": {
+    "runner_capture": "clean",
+    "otel_capture": "clipped",
+    "overall": "lossy"
+  },
+  "kernel_events": {
+    "target": 1000,
+    "observed": 1000,
+    "method": "archive_contents_worker_files_count",
+    "agreement": "match"
+  },
+  "span_events": {
+    "target": 500,
+    "observed": 128,
+    "method": "otel_trace_json_events_count",
+    "agreement": "clipped",
+    "effective_limit": 128,
+    "effective_limit_source": "otel_sdk_default"
+  }
+}
+```
+
+`fidelity_verdict` is the review-facing rollup. The per-measurement
+objects are the reproducibility layer. Keep both: a reviewer should see
+the verdict quickly, while an auditor can still see how every count was
+produced.
+
+Allowed `agreement` values:
+
+| Value | Meaning |
+|---|---|
+| `match` | Observed count matches the requested target. |
+| `clipped` | Observed count is lower because a known limit applied. |
+| `drift` | Observed count differs without a known clipping explanation. |
+| `failed` | Counting failed. |
+| `not_applicable` | The layer does not apply for this arm or artifact. |
+
+Allowed `method` values should be documented next to the schema that
+uses them. Initial methods:
+
+| Method | Meaning |
+|---|---|
+| `archive_contents_worker_files_count` | Count unique `event-rate-sweep/worker-*` files in extracted archive contents. |
+| `kernel_ndjson_path_match_count` | Count matching kernel events in `layers/kernel.ndjson`. |
+| `otel_trace_json_events_count` | Count retained OTel span events in trace JSON. |
+| `fixture_side_log_count` | Count fixture-emitted records from an explicit side log. |
+
+## Evidence Pack Minimum
+
+The first evidence-pack prototype should keep the mandatory set small:
+
+| Required | Artifact |
+|---|---|
+| Yes | One-page Markdown summary. |
+| Yes | Runner archive or verified archive reference. |
+| Yes | Trace JSON or trace reference when a trace layer exists. |
+| Yes | Observation health summary. |
+| Yes | Redaction manifest, even if it says no redaction was applied. |
+| Nice-to-have v1 | Expanded manifest/provenance table. |
+| Nice-to-have v1 | Derived measured-effects summary. |
+
+The pack must not strengthen a claim beyond the underlying calibration
+and join grades. It is a carrier for evidence, not a new source of
+truth.
+
+## Artifact Family Inventory
+
+Before adding a new artifact family, check
+[`../artifact-families-inventory.md`](../artifact-families-inventory.md).
+If the family is still `proposed`, describe it as a working term. Do not
+call it a product line, receipt family, or canonical artifact until a
+promotion PR says so.
+
+## Non-Claims
+
+- This document does not promote any existing experiment schema.
+- This document does not require historical schema renames.
+- This document does not define a universal Assay evidence-pack format.
+- This document does not make calibration or join rows product APIs.

--- a/docs/reference/observability/README.md
+++ b/docs/reference/observability/README.md
@@ -20,3 +20,17 @@ These contracts are intentionally separate from Runner archive schemas.
 Runner artifacts remain the primary measured-run evidence. The
 observability contracts describe comparison and interpretation output
 above those artifacts.
+
+The next planned experiment line for this layer is
+[`agent-observability-fidelity-2026-05`](../../experiments/agent-observability-fidelity-2026-05.md).
+It turns the completed overhead findings into a prioritized roadmap for
+calibration guardrails, semantic-gap scenarios, portable evidence packs,
+and OTel/OpenInference/Runner interoperability checks.
+
+Experiment-scoped schema naming and promotion rules for that roadmap are
+tracked in
+[`../experiments/namespace-governance.md`](../experiments/namespace-governance.md).
+Artifact-family status is tracked in
+[`../artifact-families-inventory.md`](../artifact-families-inventory.md),
+so proposed surfaces such as fidelity calibration, evidence packs, and
+binding evidence do not get mistaken for canonical product artifacts.

--- a/docs/reference/schemas-overview.md
+++ b/docs/reference/schemas-overview.md
@@ -36,4 +36,6 @@ string carries the contract boundary.
 | Index | Role |
 |---|---|
 | [`runner/schemas-overview.md`](runner/schemas-overview.md) | Detailed Runner and Runner-adjacent schema list. |
+| [`artifact-families-inventory.md`](artifact-families-inventory.md) | Canonical, reference, experiment-scoped, and proposed artifact-family inventory. |
 | [`observability/README.md`](observability/README.md) | Observability reference contracts for claim classes and joins. |
+| [`experiments/namespace-governance.md`](experiments/namespace-governance.md) | Naming, promotion, and cross-arc field guidance for experiment-scoped schemas. |


### PR DESCRIPTION
Summary

Plans the next useful experiment line after the completed Runner-vs-OTel overhead arc: fidelity-aware agent observability rather than another broad overhead rerun. This revision also adds the zero-step governance layer requested in review so the upcoming calibration/evidence-pack work does not introduce ad hoc artifact families.

What changed

- Added docs/experiments/agent-observability-fidelity-2026-05.md with a SOTA-informed roadmap for the next slices.
- Added docs/reference/experiments/namespace-governance.md for experiment schema naming, promotion criteria, cross-arc fields, calibration methods, and evidence-pack minimums.
- Added docs/reference/artifact-families-inventory.md to classify current/proposed artifact families as canonical, reference, experiment-scoped, proposed, or historical.
- Reordered the roadmap to: namespace governance -> fidelity calibration -> evidence pack prototype -> semantic-gap experiment -> interop matrix -> optional #1408.
- Adds `fidelity_verdict` as the review-facing rollup over per-measurement `{target, observed, method, agreement}` calibration entries.
- Softens input-binding language to working terms: binding evidence / join receipts, not a committed product line.
- Adds semantic-gap baseline and non-claim language, OpenInference span-kind anchors, and experiment-vs-feature discipline guidance.
- Links the roadmap from docs/reference/observability/README.md and schema/artifact indexes.
- Adds a changelog entry.

Validation

- python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p "test_*.py" -> 38 OK
- local changed-docs markdown link check -> OK
- git diff --check
- pre-commit + pre-push hooks green

Non-claims

- Does not dispatch new measurements.
- Does not commit measurement artifacts.
- Does not reopen the completed default-config overhead arc.
- Does not start the optional #1408 OTel span-limit characterization arc.
- Does not publish product rankings between OTel, OpenInference, or Assay-Runner.
- Does not promote proposed artifact families into canonical product surfaces.