### PR TITLE
feat(experiments): add fidelity calibration guardrail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,14 @@ All notable changes to this project will be documented in this file.
   roadmap now starts with experiment namespace-governance rules for
   naming, promotion, artifact-family inventory, calibration verdicts and
   methods, and evidence-pack minimums.
+- Added the first agent-observability fidelity guardrail to the
+  Runner-vs-OTel overhead harness. Non-baseline sweep samples and
+  summaries now embed
+  `assay.experiment.agent_observability_fidelity.calibration.v0` with
+  requested-vs-observed kernel/span counts, kernel-layer path matching
+  methods, per-layer agreement, and a compact `fidelity_verdict`.
+  Fidelity calibration now moves from `proposed` to `experiment-scoped`
+  in the artifact-families inventory.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/agent-observability-fidelity-2026-05.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05.md
@@ -94,6 +94,12 @@ and does not rename historical overhead artifacts.
 **Goal:** make every measurement artifact self-report whether the
 declared signal reached the observed layer.
 
+> **Status:** harness-ready in the Runner-vs-OTel overhead package. The
+> overhead harness now embeds
+> `assay.experiment.agent_observability_fidelity.calibration.v0` in
+> non-baseline sweep samples and summaries. It does not promote the
+> calibration shape to a product API.
+
 This is the immediate next code slice because it turns the Slice 12
 lesson into a general guardrail. The overhead harness already records
 `span_event_limit_effective`, `span_event_limit_source`, and
@@ -105,7 +111,7 @@ observed-count fields and summary-level calibration gates.
 | Field | Meaning | Layer |
 |---|---|---|
 | `target_kernel_events` | Requested kernel worker-file pressure | workload config |
-| `observed_kernel_worker_files` | Unique `event-rate-sweep/worker-*` files observed in extracted archive contents | Runner archive |
+| `observed_kernel_worker_files` | Unique `event-rate-sweep/worker-*` paths observed in `layers/kernel.ndjson` | Runner archive |
 | `target_span_events` | Requested OTel span events | workload config |
 | `retained_span_events` | Span events retained in trace JSON | OTel trace |
 | `dropped_span_events_estimate` | `target_span_events - retained_span_events` when both are known | derived diagnostic |
@@ -127,9 +133,9 @@ observed-count fields and summary-level calibration gates.
 - Arm A remains asymmetric: OTel span fields are `not_applicable` rather
   than zero-throughput evidence.
 - Every observed count must name its method. Example methods:
-  `archive_contents_worker_files_count`,
-  `kernel_ndjson_path_match_count`, `otel_trace_json_events_count`, and
-  `fixture_side_log_count`.
+  `kernel_ndjson_path_match_count`,
+  `archive_contents_worker_files_count`, `otel_trace_json_events_count`,
+  and `fixture_side_log_count`.
 - The first schema should expose per-layer agreement, not only one
   summary boolean. A mixed cell can be `match` for kernel events and
   `clipped` for span events.
@@ -139,11 +145,13 @@ observed-count fields and summary-level calibration gates.
 
 ### Output
 
-- New experiment-scoped calibration sidecar under the overhead package,
-  or promotion into `assay.observability.*` if it applies beyond the
-  overhead harness.
-- Unit tests covering default OTel limit, raised limit, Arm A
-  not-applicable behavior, and kernel worker-file counting.
+- **Done:** new experiment-scoped calibration sidecar under the overhead
+  package.
+- **Done:** unit tests covering sample/summary schema validation, OTel
+  span-event counting, Arm A not-applicable behavior, span-limit
+  clipping, and kernel worker-file counting.
+- **Not done:** promotion into `assay.observability.*`. That still
+  requires a non-overhead consumer or a later evidence-pack renderer.
 
 ## Experiment 2 - Portable Incident Evidence Pack
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/README.md
@@ -281,6 +281,15 @@ interpret span-event timing above the limit unless
 `OTEL_SPAN_EVENT_COUNT_LIMIT` was raised and retained event counts were
 verified first.
 
+The harness now also embeds
+`assay.experiment.agent_observability_fidelity.calibration.v0` in
+non-baseline sweep samples and summaries. That calibration records the
+requested target, observed count, counting method, and agreement for
+Runner kernel worker paths in `layers/kernel.ndjson` and OTel span
+events in trace JSON. Summary Markdown surfaces the resulting
+`fidelity_verdict` so timing or throughput claims cannot be read before
+target-vs-observed fidelity is checked.
+
 That boundary-finding sweep has now been dispatched and summarized in
 [`findings.md`](findings.md):
 

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py
@@ -30,6 +30,9 @@ SUMMARY_SCHEMA = "assay.experiment.overhead_summary.v0"
 PAIRED_SEQUENCE_SCHEMA = "assay.experiment.paired_sequence.v0"
 EVENT_RATE_SWEEP_SCHEMA = "assay.experiment.event_rate_sweep.v0"
 EVENT_RATE_SWEEP_SCHEMA_V0_1 = "assay.experiment.event_rate_sweep.v0.1"
+FIDELITY_CALIBRATION_SCHEMA = (
+    "assay.experiment.agent_observability_fidelity.calibration.v0"
+)
 OTEL_SPAN_EVENT_COUNT_LIMIT_ENV = "OTEL_SPAN_EVENT_COUNT_LIMIT"
 DEFAULT_OTEL_SPAN_EVENT_COUNT_LIMIT = 128
 DEFAULT_ARM = "arm-b-otel"
@@ -69,6 +72,19 @@ SWEEP_PAYLOAD_BYTES = {
     "small": 128,
     "medium": 4096,
     "large": 65536,
+}
+AGREEMENT_ORDER = {
+    "not_applicable": 0,
+    "match": 1,
+    "clipped": 2,
+    "drift": 3,
+    "failed": 4,
+}
+STATUS_ORDER = {
+    "not_applicable": 0,
+    "clean": 1,
+    "lossy": 2,
+    "inconclusive": 3,
 }
 
 
@@ -201,6 +217,195 @@ def load_phase_timings(path: Path) -> dict[str, float] | None:
         if key in PHASE_TIMING_KEYS and isinstance(value, (int, float)):
             parsed[key] = float(value)
     return parsed or None
+
+
+def iter_json_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        strings: list[str] = []
+        for item in value:
+            strings.extend(iter_json_strings(item))
+        return strings
+    if isinstance(value, dict):
+        strings = []
+        for item in value.values():
+            strings.extend(iter_json_strings(item))
+        return strings
+    return []
+
+
+def count_kernel_worker_paths(archive_contents: Path) -> int | None:
+    kernel_path = archive_contents / "layers" / "kernel.ndjson"
+    if not kernel_path.exists():
+        return None
+    workers: set[str] = set()
+    pattern = re.compile(r"event-rate-sweep/worker-[^\"'\s]+\.txt")
+    for line in kernel_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            workers.update(pattern.findall(line))
+            continue
+        for value in iter_json_strings(payload):
+            workers.update(pattern.findall(value))
+    return len(workers)
+
+
+def iter_otel_spans(payload: Any) -> list[dict[str, Any]]:
+    spans: list[dict[str, Any]] = []
+    if not isinstance(payload, dict):
+        return spans
+    for resource_span in payload.get("resourceSpans", []):
+        if not isinstance(resource_span, dict):
+            continue
+        scope_spans = resource_span.get("scopeSpans")
+        if scope_spans is None:
+            scope_spans = resource_span.get("instrumentationLibrarySpans", [])
+        for scope_span in scope_spans:
+            if not isinstance(scope_span, dict):
+                continue
+            for span in scope_span.get("spans", []):
+                if isinstance(span, dict):
+                    spans.append(span)
+    return spans
+
+
+def count_otel_sweep_span_events(trace_path: Path) -> int | None:
+    if not trace_path.exists():
+        return None
+    try:
+        payload = json.loads(trace_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    count = 0
+    for span in iter_otel_spans(payload):
+        for event in span.get("events", []):
+            if isinstance(event, dict) and event.get("name") == "assay.sweep.span_event":
+                count += 1
+    return count
+
+
+def agreement_status(agreement: str) -> str:
+    if agreement == "match":
+        return "clean"
+    if agreement == "clipped":
+        return "lossy"
+    if agreement in {"drift", "failed"}:
+        return "inconclusive"
+    return "not_applicable"
+
+
+def worst_status(values: list[str]) -> str:
+    if not values:
+        return "not_applicable"
+    return max(values, key=lambda value: STATUS_ORDER[value])
+
+
+def worst_agreement(values: list[str]) -> str:
+    if not values:
+        return "not_applicable"
+    return max(values, key=lambda value: AGREEMENT_ORDER[value])
+
+
+def build_count_calibration(
+    *,
+    target: int,
+    observed: int | None,
+    method: str | None,
+    applicable: bool,
+    effective_limit: int | None = None,
+    effective_limit_source: str | None = None,
+) -> dict[str, Any]:
+    if not applicable:
+        agreement = "not_applicable"
+    elif observed is None:
+        agreement = "failed"
+    elif observed == target:
+        agreement = "match"
+    elif (
+        effective_limit is not None
+        and target > effective_limit
+        and observed == effective_limit
+    ):
+        agreement = "clipped"
+    else:
+        agreement = "drift"
+
+    payload: dict[str, Any] = {
+        "target": target,
+        "observed": observed,
+        "method": method,
+        "agreement": agreement,
+    }
+    if effective_limit is not None:
+        payload["effective_limit"] = effective_limit
+    if effective_limit_source is not None:
+        payload["effective_limit_source"] = effective_limit_source
+    if target is not None and observed is not None and target > observed:
+        payload["dropped_estimate"] = target - observed
+    return payload
+
+
+def fidelity_verdict(
+    *,
+    kernel_agreement: str,
+    span_agreement: str,
+) -> dict[str, str]:
+    runner_capture = agreement_status(kernel_agreement)
+    otel_capture = agreement_status(span_agreement)
+    return {
+        "runner_capture": runner_capture,
+        "otel_capture": otel_capture,
+        "overall": worst_status([runner_capture, otel_capture]),
+    }
+
+
+def build_fidelity_calibration(
+    *,
+    arm: str,
+    event_rate_sweep: dict[str, Any] | None,
+    archive_contents: Path,
+    trace_path: Path,
+) -> dict[str, Any] | None:
+    if event_rate_sweep is None:
+        return None
+
+    kernel_applicable = arm in {ARM_A, ARM_C} and (
+        event_rate_sweep["target_kernel_events"] > 0
+    )
+    kernel_events = build_count_calibration(
+        target=int(event_rate_sweep["target_kernel_events"]),
+        observed=count_kernel_worker_paths(archive_contents)
+        if kernel_applicable
+        else None,
+        method="kernel_ndjson_path_match_count" if kernel_applicable else None,
+        applicable=kernel_applicable,
+    )
+
+    span_applicable = arm in {ARM_B, ARM_C} and (
+        event_rate_sweep["target_span_events"] > 0
+    )
+    span_events = build_count_calibration(
+        target=int(event_rate_sweep["target_span_events"]),
+        observed=count_otel_sweep_span_events(trace_path) if span_applicable else None,
+        method="otel_trace_json_events_count" if span_applicable else None,
+        applicable=span_applicable,
+        effective_limit=event_rate_sweep.get("span_event_limit_effective"),
+        effective_limit_source=event_rate_sweep.get("span_event_limit_source"),
+    )
+    verdict = fidelity_verdict(
+        kernel_agreement=str(kernel_events["agreement"]),
+        span_agreement=str(span_events["agreement"]),
+    )
+    return {
+        "schema": FIDELITY_CALIBRATION_SCHEMA,
+        "kind": "sample",
+        "calibration_status": verdict["overall"],
+        "fidelity_verdict": verdict,
+        "kernel_events": kernel_events,
+        "span_events": span_events,
+    }
 
 
 def event_rate_sweep_config(args: argparse.Namespace) -> dict[str, Any] | None:
@@ -547,6 +752,12 @@ def one_sample(
         extract_archive(archive_path, archive_contents)
         health = load_archive_health(archive_contents)
         archive_extracted = directory_size(archive_contents)
+    fidelity_calibration = build_fidelity_calibration(
+        arm=arm,
+        event_rate_sweep=sample_event_rate_sweep,
+        archive_contents=archive_contents,
+        trace_path=trace_path,
+    )
 
     return {
         "schema": SAMPLE_SCHEMA,
@@ -564,6 +775,7 @@ def one_sample(
         "health": health,
         "phase_timings_ms": load_phase_timings(phase_timing_path),
         "event_rate_sweep": sample_event_rate_sweep,
+        "fidelity_calibration": fidelity_calibration,
         "artifact_bytes": {
             "trace_json": file_size(trace_path),
             "archive_targz": archive_targz,
@@ -629,6 +841,7 @@ def summarize(
     wall_median = median(wall)
     wall_p99 = percentile(wall, 99)
     phase_timings = summarize_phase_timings(valid)
+    fidelity_calibration = summarize_fidelity_calibrations(valid)
     first = samples[0] if samples else {}
     return {
         "schema": SUMMARY_SCHEMA,
@@ -662,6 +875,7 @@ def summarize(
         },
         "phase_timings_ms": phase_timings,
         "event_rate_sweep": first.get("event_rate_sweep"),
+        "fidelity_calibration": fidelity_calibration,
     }
 
 
@@ -683,6 +897,93 @@ def summarize_phase_timings(
                 "p99": percentile(values, 99),
             }
     return summary or None
+
+
+def summarize_count_calibration(
+    samples: list[dict[str, Any]],
+    key: str,
+) -> dict[str, Any] | None:
+    rows = [
+        sample["fidelity_calibration"][key]
+        for sample in samples
+        if isinstance(sample.get("fidelity_calibration"), dict)
+        and isinstance(sample["fidelity_calibration"].get(key), dict)
+    ]
+    if not rows:
+        return None
+    observed_values = [
+        int(row["observed"])
+        for row in rows
+        if isinstance(row.get("observed"), int)
+    ]
+    agreement_counts = {
+        agreement: sum(1 for row in rows if row.get("agreement") == agreement)
+        for agreement in AGREEMENT_ORDER
+        if any(row.get("agreement") == agreement for row in rows)
+    }
+    target_values = [
+        int(row["target"])
+        for row in rows
+        if isinstance(row.get("target"), int)
+    ]
+    summary: dict[str, Any] = {
+        "target": target_values[0] if target_values else None,
+        "observed_min": min(observed_values) if observed_values else None,
+        "observed_max": max(observed_values) if observed_values else None,
+        "method": rows[0].get("method"),
+        "agreement": worst_agreement(
+            [str(row.get("agreement", "not_applicable")) for row in rows]
+        ),
+        "agreement_counts": agreement_counts,
+    }
+    effective_limits = [
+        int(row["effective_limit"])
+        for row in rows
+        if isinstance(row.get("effective_limit"), int)
+    ]
+    if effective_limits:
+        summary["effective_limit"] = effective_limits[0]
+    effective_limit_source = next(
+        (
+            row.get("effective_limit_source")
+            for row in rows
+            if row.get("effective_limit_source") is not None
+        ),
+        None,
+    )
+    if effective_limit_source is not None:
+        summary["effective_limit_source"] = effective_limit_source
+    return summary
+
+
+def summarize_fidelity_calibrations(
+    samples: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    calibrations = [
+        sample["fidelity_calibration"]
+        for sample in samples
+        if isinstance(sample.get("fidelity_calibration"), dict)
+    ]
+    if not calibrations:
+        return None
+    kernel_events = summarize_count_calibration(samples, "kernel_events")
+    span_events = summarize_count_calibration(samples, "span_events")
+    kernel_agreement = (
+        str(kernel_events["agreement"]) if kernel_events else "not_applicable"
+    )
+    span_agreement = str(span_events["agreement"]) if span_events else "not_applicable"
+    verdict = fidelity_verdict(
+        kernel_agreement=kernel_agreement,
+        span_agreement=span_agreement,
+    )
+    return {
+        "schema": FIDELITY_CALIBRATION_SCHEMA,
+        "kind": "summary",
+        "calibration_status": verdict["overall"],
+        "fidelity_verdict": verdict,
+        "kernel_events": kernel_events,
+        "span_events": span_events,
+    }
 
 
 def bmf_export(summary: dict[str, Any]) -> dict[str, dict[str, float | int]]:
@@ -775,6 +1076,17 @@ def write_run_outputs(
                 sample["phase_timings_ms"]
                 for sample in samples
                 if sample.get("phase_timings_ms") is not None
+            ],
+        },
+    )
+    write_json(
+        artifacts_dir / f"fidelity-calibration{artifact_suffix}.json",
+        {
+            "arm": arm,
+            "fidelity_calibration": [
+                sample["fidelity_calibration"]
+                for sample in samples
+                if sample.get("fidelity_calibration") is not None
             ],
         },
     )
@@ -917,6 +1229,7 @@ def summary_markdown(summary: dict[str, Any], *, artifact_name: str | None = Non
     artifacts = summary["artifact_bytes"]
     phase_timings = summary.get("phase_timings_ms")
     event_rate_sweep = summary.get("event_rate_sweep")
+    fidelity_calibration = summary.get("fidelity_calibration")
     tail_ratio = wall["p99_over_median"]
     lines = [
         "## Runner-vs-OTel Overhead Summary",
@@ -959,6 +1272,36 @@ def summary_markdown(summary: dict[str, Any], *, artifact_name: str | None = Non
             lines.append(
                 "| OTel span event warning | "
                 f"`{event_rate_sweep['span_event_limit_warning']}` |"
+            )
+    if isinstance(fidelity_calibration, dict):
+        verdict = fidelity_calibration.get("fidelity_verdict", {})
+        lines.append(
+            "| Fidelity calibration | "
+            f"`{fidelity_calibration.get('calibration_status')}` |"
+        )
+        if isinstance(verdict, dict):
+            lines.append(
+                "| Fidelity verdict | "
+                f"`runner={verdict.get('runner_capture')}; "
+                f"otel={verdict.get('otel_capture')}; "
+                f"overall={verdict.get('overall')}` |"
+            )
+        for label, key in (
+            ("Kernel event calibration", "kernel_events"),
+            ("Span event calibration", "span_events"),
+        ):
+            row = fidelity_calibration.get(key)
+            if not isinstance(row, dict):
+                continue
+            observed = (
+                f"{row.get('observed_min')}..{row.get('observed_max')}"
+                if row.get("observed_min") != row.get("observed_max")
+                else str(row.get("observed_min"))
+            )
+            lines.append(
+                f"| {label} | "
+                f"`target={row.get('target')}; observed={observed}; "
+                f"agreement={row.get('agreement')}; method={row.get('method')}` |"
             )
     if isinstance(phase_timings, dict) and phase_timings:
         lines.extend(

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/fidelity-calibration-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/fidelity-calibration-v0.schema.json
@@ -1,0 +1,271 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/runner-vs-otel-overhead-2026-05/schema/fidelity-calibration-v0.schema.json",
+  "title": "Agent observability fidelity calibration v0",
+  "description": "Experiment-scoped requested-vs-observed calibration sidecar for agent observability fidelity work. This is not a Runner archive contract.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/sample_calibration"
+    },
+    {
+      "$ref": "#/$defs/summary_calibration"
+    }
+  ],
+  "$defs": {
+    "calibration_status": {
+      "enum": [
+        "clean",
+        "lossy",
+        "inconclusive",
+        "not_applicable"
+      ]
+    },
+    "calibration_agreement": {
+      "enum": [
+        "match",
+        "clipped",
+        "drift",
+        "failed",
+        "not_applicable"
+      ]
+    },
+    "calibration_method": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "enum": [
+            "archive_contents_worker_files_count",
+            "kernel_ndjson_path_match_count",
+            "otel_trace_json_events_count",
+            "fixture_side_log_count"
+          ]
+        }
+      ]
+    },
+    "fidelity_verdict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runner_capture",
+        "otel_capture",
+        "overall"
+      ],
+      "properties": {
+        "runner_capture": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "otel_capture": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "overall": {
+          "$ref": "#/$defs/calibration_status"
+        }
+      }
+    },
+    "sample_count": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "observed",
+        "method",
+        "agreement"
+      ],
+      "properties": {
+        "target": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "observed": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "method": {
+          "$ref": "#/$defs/calibration_method"
+        },
+        "agreement": {
+          "$ref": "#/$defs/calibration_agreement"
+        },
+        "effective_limit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "effective_limit_source": {
+          "enum": [
+            "default",
+            "env",
+            "invalid-env"
+          ]
+        },
+        "dropped_estimate": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "agreement_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "match": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "clipped": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "drift": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "not_applicable": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "summary_count": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "observed_min",
+        "observed_max",
+        "method",
+        "agreement",
+        "agreement_counts"
+      ],
+      "properties": {
+        "target": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "observed_min": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "observed_max": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "method": {
+          "$ref": "#/$defs/calibration_method"
+        },
+        "agreement": {
+          "$ref": "#/$defs/calibration_agreement"
+        },
+        "agreement_counts": {
+          "$ref": "#/$defs/agreement_counts"
+        },
+        "effective_limit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "effective_limit_source": {
+          "enum": [
+            "default",
+            "env",
+            "invalid-env"
+          ]
+        }
+      }
+    },
+    "sample_calibration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "kind",
+        "calibration_status",
+        "fidelity_verdict",
+        "kernel_events",
+        "span_events"
+      ],
+      "properties": {
+        "schema": {
+          "const": "assay.experiment.agent_observability_fidelity.calibration.v0"
+        },
+        "kind": {
+          "const": "sample"
+        },
+        "calibration_status": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "fidelity_verdict": {
+          "$ref": "#/$defs/fidelity_verdict"
+        },
+        "kernel_events": {
+          "$ref": "#/$defs/sample_count"
+        },
+        "span_events": {
+          "$ref": "#/$defs/sample_count"
+        }
+      }
+    },
+    "summary_calibration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "kind",
+        "calibration_status",
+        "fidelity_verdict",
+        "kernel_events",
+        "span_events"
+      ],
+      "properties": {
+        "schema": {
+          "const": "assay.experiment.agent_observability_fidelity.calibration.v0"
+        },
+        "kind": {
+          "const": "summary"
+        },
+        "calibration_status": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "fidelity_verdict": {
+          "$ref": "#/$defs/fidelity_verdict"
+        },
+        "kernel_events": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/summary_count"
+            }
+          ]
+        },
+        "span_events": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/summary_count"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-sample-v0.schema.json
@@ -170,6 +170,16 @@
         }
       ]
     },
+    "fidelity_calibration": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/fidelity_calibration_sample"
+        }
+      ]
+    },
     "artifact_bytes": {
       "type": "object",
       "additionalProperties": false,
@@ -312,6 +322,134 @@
         "span_event_limit_warning": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "fidelity_verdict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runner_capture",
+        "otel_capture",
+        "overall"
+      ],
+      "properties": {
+        "runner_capture": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "otel_capture": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "overall": {
+          "$ref": "#/$defs/calibration_status"
+        }
+      }
+    },
+    "calibration_status": {
+      "enum": [
+        "clean",
+        "lossy",
+        "inconclusive",
+        "not_applicable"
+      ]
+    },
+    "calibration_agreement": {
+      "enum": [
+        "match",
+        "clipped",
+        "drift",
+        "failed",
+        "not_applicable"
+      ]
+    },
+    "calibration_method": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "enum": [
+            "archive_contents_worker_files_count",
+            "kernel_ndjson_path_match_count",
+            "otel_trace_json_events_count",
+            "fixture_side_log_count"
+          ]
+        }
+      ]
+    },
+    "count_calibration_sample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "observed",
+        "method",
+        "agreement"
+      ],
+      "properties": {
+        "target": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "observed": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "method": {
+          "$ref": "#/$defs/calibration_method"
+        },
+        "agreement": {
+          "$ref": "#/$defs/calibration_agreement"
+        },
+        "effective_limit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "effective_limit_source": {
+          "enum": [
+            "default",
+            "env",
+            "invalid-env"
+          ]
+        },
+        "dropped_estimate": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "fidelity_calibration_sample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "kind",
+        "calibration_status",
+        "fidelity_verdict",
+        "kernel_events",
+        "span_events"
+      ],
+      "properties": {
+        "schema": {
+          "const": "assay.experiment.agent_observability_fidelity.calibration.v0"
+        },
+        "kind": {
+          "const": "sample"
+        },
+        "calibration_status": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "fidelity_verdict": {
+          "$ref": "#/$defs/fidelity_verdict"
+        },
+        "kernel_events": {
+          "$ref": "#/$defs/count_calibration_sample"
+        },
+        "span_events": {
+          "$ref": "#/$defs/count_calibration_sample"
         }
       }
     }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/schema/overhead-summary-v0.schema.json
@@ -95,6 +95,16 @@
           "$ref": "#/$defs/event_rate_sweep"
         }
       ]
+    },
+    "fidelity_calibration": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/fidelity_calibration_summary"
+        }
+      ]
     }
   },
   "$defs": {
@@ -296,6 +306,185 @@
         "span_event_limit_warning": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "fidelity_verdict": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runner_capture",
+        "otel_capture",
+        "overall"
+      ],
+      "properties": {
+        "runner_capture": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "otel_capture": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "overall": {
+          "$ref": "#/$defs/calibration_status"
+        }
+      }
+    },
+    "calibration_status": {
+      "enum": [
+        "clean",
+        "lossy",
+        "inconclusive",
+        "not_applicable"
+      ]
+    },
+    "calibration_agreement": {
+      "enum": [
+        "match",
+        "clipped",
+        "drift",
+        "failed",
+        "not_applicable"
+      ]
+    },
+    "calibration_method": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "enum": [
+            "archive_contents_worker_files_count",
+            "kernel_ndjson_path_match_count",
+            "otel_trace_json_events_count",
+            "fixture_side_log_count"
+          ]
+        }
+      ]
+    },
+    "agreement_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "match": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "clipped": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "drift": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "not_applicable": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "count_calibration_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target",
+        "observed_min",
+        "observed_max",
+        "method",
+        "agreement",
+        "agreement_counts"
+      ],
+      "properties": {
+        "target": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "observed_min": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "observed_max": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "method": {
+          "$ref": "#/$defs/calibration_method"
+        },
+        "agreement": {
+          "$ref": "#/$defs/calibration_agreement"
+        },
+        "agreement_counts": {
+          "$ref": "#/$defs/agreement_counts"
+        },
+        "effective_limit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "effective_limit_source": {
+          "enum": [
+            "default",
+            "env",
+            "invalid-env"
+          ]
+        }
+      }
+    },
+    "fidelity_calibration_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "kind",
+        "calibration_status",
+        "fidelity_verdict",
+        "kernel_events",
+        "span_events"
+      ],
+      "properties": {
+        "schema": {
+          "const": "assay.experiment.agent_observability_fidelity.calibration.v0"
+        },
+        "kind": {
+          "const": "summary"
+        },
+        "calibration_status": {
+          "$ref": "#/$defs/calibration_status"
+        },
+        "fidelity_verdict": {
+          "$ref": "#/$defs/fidelity_verdict"
+        },
+        "kernel_events": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/count_calibration_summary"
+            }
+          ]
+        },
+        "span_events": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/count_calibration_summary"
+            }
+          ]
         }
       }
     }

--- a/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
+++ b/docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py
@@ -139,9 +139,21 @@ const get = (name) => {
 };
 const traceOut = get("trace-out");
 const workDir = get("work-dir");
+const sweepSpanEvents = Number.parseInt(get("sweep-span-events") ?? "0", 10);
 fs.mkdirSync(path.dirname(traceOut), { recursive: true });
 fs.mkdirSync(workDir, { recursive: true });
-fs.writeFileSync(traceOut, JSON.stringify({ resourceSpans: [] }) + "\\n");
+fs.writeFileSync(traceOut, JSON.stringify({
+  resourceSpans: [{
+    scopeSpans: [{
+      spans: [{
+        events: Array.from({ length: sweepSpanEvents }, (_, index) => ({
+          name: "assay.sweep.span_event",
+          attributes: [{ key: "assay.sweep.index", value: { intValue: String(index) } }]
+        }))
+      }]
+    }]
+  }]
+}) + "\\n");
 """.strip()
         + "\n",
         encoding="utf-8",
@@ -154,6 +166,7 @@ def write_fake_assay(root: Path) -> Path:
         """
 #!/usr/bin/env python3
 import json
+import os
 import sys
 import tarfile
 import tempfile
@@ -169,9 +182,29 @@ if "--" in args:
     child = args[args.index("--") + 1:]
     if "--trace-out" in child:
         trace = Path(child[child.index("--trace-out") + 1])
+    sweep_span_events = 0
+    if "--sweep-span-events" in child:
+        sweep_span_events = int(child[child.index("--sweep-span-events") + 1])
+    work_dir = None
+    if "--work-dir" in child:
+        work_dir = Path(child[child.index("--work-dir") + 1])
+else:
+    sweep_span_events = 0
+    work_dir = None
 if trace is not None:
     trace.parent.mkdir(parents=True, exist_ok=True)
-    trace.write_text(json.dumps({"resourceSpans": []}) + "\\n", encoding="utf-8")
+    trace.write_text(json.dumps({
+        "resourceSpans": [{
+            "scopeSpans": [{
+                "spans": [{
+                    "events": [
+                        {"name": "assay.sweep.span_event", "attributes": []}
+                        for _ in range(sweep_span_events)
+                    ]
+                }]
+            }]
+        }]
+    }) + "\\n", encoding="utf-8")
 if phase_timing is not None:
     phase_timing.parent.mkdir(parents=True, exist_ok=True)
     phase_timing.write_text(json.dumps({
@@ -203,8 +236,21 @@ with tempfile.TemporaryDirectory() as tmp:
         }) + "\\n",
         encoding="utf-8",
     )
+    kernel_events = int(os.environ.get("ASSAY_SWEEP_KERNEL_EVENTS", "0"))
+    if kernel_events > 0:
+        kernel = root / "layers" / "kernel.ndjson"
+        kernel.parent.mkdir(parents=True, exist_ok=True)
+        lines = []
+        for index in range(kernel_events):
+            lines.append(json.dumps({
+                "kind": "openat",
+                "path": f"/tmp/work/event-rate-sweep/worker-0-{index}.txt"
+            }))
+        kernel.write_text("\\n".join(lines) + "\\n", encoding="utf-8")
     with tarfile.open(output, "w:gz") as tar:
-        tar.add(root / "observation-health.json", arcname="observation-health.json")
+        for child in root.rglob("*"):
+            if child.is_file():
+                tar.add(child, arcname=str(child.relative_to(root)))
 """.lstrip(),
         encoding="utf-8",
     )
@@ -238,6 +284,7 @@ class OverheadHarnessTests(unittest.TestCase):
             "health": None,
             "phase_timings_ms": None,
             "event_rate_sweep": None,
+            "fidelity_calibration": None,
             "artifact_bytes": {
                 "trace_json": 123,
                 "archive_targz": None,
@@ -327,6 +374,232 @@ class OverheadHarnessTests(unittest.TestCase):
             ),
         }
         assert_matches_schema(self, payload, schema, root=schema)
+
+    def test_fidelity_calibration_schema_accepts_sample_and_summary(self) -> None:
+        schema = load_schema("fidelity-calibration-v0.schema.json")
+        sample = {
+            "schema": overhead_harness.FIDELITY_CALIBRATION_SCHEMA,
+            "kind": "sample",
+            "calibration_status": "lossy",
+            "fidelity_verdict": {
+                "runner_capture": "clean",
+                "otel_capture": "lossy",
+                "overall": "lossy",
+            },
+            "kernel_events": {
+                "target": 1000,
+                "observed": 1000,
+                "method": "kernel_ndjson_path_match_count",
+                "agreement": "match",
+            },
+            "span_events": {
+                "target": 500,
+                "observed": 128,
+                "method": "otel_trace_json_events_count",
+                "agreement": "clipped",
+                "effective_limit": 128,
+                "effective_limit_source": "default",
+                "dropped_estimate": 372,
+            },
+        }
+        summary = {
+            "schema": overhead_harness.FIDELITY_CALIBRATION_SCHEMA,
+            "kind": "summary",
+            "calibration_status": "clean",
+            "fidelity_verdict": {
+                "runner_capture": "clean",
+                "otel_capture": "not_applicable",
+                "overall": "clean",
+            },
+            "kernel_events": {
+                "target": 1000,
+                "observed_min": 1000,
+                "observed_max": 1000,
+                "method": "kernel_ndjson_path_match_count",
+                "agreement": "match",
+                "agreement_counts": {"match": 5},
+            },
+            "span_events": {
+                "target": 0,
+                "observed_min": None,
+                "observed_max": None,
+                "method": None,
+                "agreement": "not_applicable",
+                "agreement_counts": {"not_applicable": 5},
+                "effective_limit": 128,
+                "effective_limit_source": "default",
+            },
+        }
+        assert_matches_schema(self, sample, schema, root=schema)
+        assert_matches_schema(self, summary, schema, root=schema)
+
+    def test_fidelity_count_helpers_count_kernel_paths_and_trace_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            kernel = root / "archive" / "layers" / "kernel.ndjson"
+            kernel.parent.mkdir(parents=True)
+            kernel.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "path": "/tmp/work/event-rate-sweep/worker-0-0.txt"
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "args": [
+                                    "/tmp/work/event-rate-sweep/worker-1-1.txt"
+                                ]
+                            }
+                        ),
+                        "raw event-rate-sweep/worker-1-1.txt duplicate",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            trace = root / "trace.json"
+            trace.write_text(
+                json.dumps(
+                    {
+                        "resourceSpans": [
+                            {
+                                "scopeSpans": [
+                                    {
+                                        "spans": [
+                                            {
+                                                "events": [
+                                                    {"name": "assay.sweep.span_event"},
+                                                    {"name": "other"},
+                                                    {"name": "assay.sweep.span_event"},
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                overhead_harness.count_kernel_worker_paths(root / "archive"),
+                2,
+            )
+            self.assertEqual(overhead_harness.count_otel_sweep_span_events(trace), 2)
+
+    def test_fidelity_trace_counter_accepts_legacy_instrumentation_library_spans(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trace = Path(tmp) / "trace.json"
+            trace.write_text(
+                json.dumps(
+                    {
+                        "resourceSpans": [
+                            {
+                                "instrumentationLibrarySpans": [
+                                    {
+                                        "spans": [
+                                            {
+                                                "events": [
+                                                    {"name": "assay.sweep.span_event"}
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(overhead_harness.count_otel_sweep_span_events(trace), 1)
+
+    def test_build_fidelity_calibration_marks_span_limit_clipping(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            trace = root / "trace.json"
+            trace.write_text(
+                json.dumps(
+                    {
+                        "resourceSpans": [
+                            {
+                                "scopeSpans": [
+                                    {
+                                        "spans": [
+                                            {
+                                                "events": [
+                                                    {"name": "assay.sweep.span_event"}
+                                                    for _ in range(128)
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            config = {
+                "target_kernel_events": 0,
+                "target_span_events": 500,
+                "span_event_limit_effective": 128,
+                "span_event_limit_source": "default",
+            }
+
+            calibration = overhead_harness.build_fidelity_calibration(
+                arm=overhead_harness.ARM_C,
+                event_rate_sweep=config,
+                archive_contents=root / "archive",
+                trace_path=trace,
+            )
+
+        self.assertEqual(calibration["span_events"]["observed"], 128)
+        self.assertEqual(calibration["span_events"]["agreement"], "clipped")
+        self.assertEqual(calibration["calibration_status"], "lossy")
+
+    def test_build_fidelity_calibration_marks_under_limit_loss_as_drift(self) -> None:
+        span = overhead_harness.build_count_calibration(
+            target=500,
+            observed=0,
+            method="otel_trace_json_events_count",
+            applicable=True,
+            effective_limit=128,
+            effective_limit_source="default",
+        )
+
+        self.assertEqual(span["agreement"], "drift")
+
+    def test_build_fidelity_calibration_marks_arm_a_span_not_applicable(self) -> None:
+        config = {
+            "target_kernel_events": 0,
+            "target_span_events": 0,
+            "span_event_limit_effective": 128,
+            "span_event_limit_source": "default",
+        }
+        calibration = overhead_harness.build_fidelity_calibration(
+            arm=overhead_harness.ARM_A,
+            event_rate_sweep=config,
+            archive_contents=Path("/does/not/exist"),
+            trace_path=Path("/does/not/exist"),
+        )
+
+        self.assertEqual(calibration["span_events"]["agreement"], "not_applicable")
+        self.assertEqual(
+            calibration["fidelity_verdict"]["otel_capture"],
+            "not_applicable",
+        )
 
     def test_event_rate_sweep_config_maps_levels_to_targets(self) -> None:
         args = type(
@@ -820,7 +1093,19 @@ class OverheadHarnessTests(unittest.TestCase):
                 "span_event_limit_warning",
                 sample["event_rate_sweep"],
             )
+            self.assertEqual(
+                sample["fidelity_calibration"]["span_events"]["agreement"],
+                "match",
+            )
+            self.assertEqual(
+                sample["fidelity_calibration"]["fidelity_verdict"]["overall"],
+                "clean",
+            )
             self.assertEqual(summary["event_rate_sweep"], sample["event_rate_sweep"])
+            self.assertEqual(
+                summary["fidelity_calibration"]["calibration_status"],
+                "clean",
+            )
 
     def test_harness_records_warmup_samples_outside_summary(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/reference/artifact-families-inventory.md
+++ b/docs/reference/artifact-families-inventory.md
@@ -36,7 +36,7 @@ accidentally present proposed artifacts as canonical product surfaces.
 | Observability join rows | `reference` | [`observability/join-contract-v0.md`](observability/join-contract-v0.md) | Join-grade rows for trace/archive/receipt comparisons. |
 | Overhead experiment sidecars | `experiment-scoped` | `assay.experiment.*` under `runner-vs-otel-overhead-2026-05/` | Samples, summaries, phase timings, paired sequences, and event-rate sweep cells. |
 | Cross-runtime drift outputs | `experiment-scoped` | `cross-runtime-drift-2026-05/` | Runtime capability-surface drift comparisons. |
-| Fidelity calibration | `proposed` | `assay.experiment.agent_observability_fidelity.calibration.v0` | Requested-vs-observed fidelity verdicts and per-layer count methods. |
+| Fidelity calibration | `experiment-scoped` | `assay.experiment.agent_observability_fidelity.calibration.v0` | Requested-vs-observed fidelity verdicts and per-layer count methods embedded by the overhead harness. |
 | Evidence pack | `proposed` | `assay.experiment.agent_observability_fidelity.evidence_pack.v0` | Portable bundle carrier for one run or scenario. |
 | Binding evidence / join receipts | `proposed` | undecided | Working term for tool-call input/output/effect binding evidence. Not a product line yet. |
 | Semantic-gap finding | `proposed` | undecided | Experiment result family for reported-intent vs measured-effect divergence. |

--- a/docs/reference/experiments/namespace-governance.md
+++ b/docs/reference/experiments/namespace-governance.md
@@ -13,7 +13,8 @@ Assay experiments now emit several useful but local artifact families:
   event-rate sweep cells;
 - cross-runtime drift reports and fixtures;
 - observability join and claim-class reference rows;
-- planned fidelity-calibration and evidence-pack artifacts.
+- active fidelity-calibration sidecars and planned evidence-pack
+  artifacts.
 
 Without a naming and promotion rule, each new slice can create a locally
 reasonable schema that is hard to compare across arcs later. This doc
@@ -116,6 +117,8 @@ Recommended nested shape:
 ```json
 {
   "schema": "assay.experiment.agent_observability_fidelity.calibration.v0",
+  "kind": "sample",
+  "calibration_status": "lossy",
   "fidelity_verdict": {
     "runner_capture": "clean",
     "otel_capture": "clipped",
@@ -124,7 +127,7 @@ Recommended nested shape:
   "kernel_events": {
     "target": 1000,
     "observed": 1000,
-    "method": "archive_contents_worker_files_count",
+    "method": "kernel_ndjson_path_match_count",
     "agreement": "match"
   },
   "span_events": {
@@ -133,7 +136,7 @@ Recommended nested shape:
     "method": "otel_trace_json_events_count",
     "agreement": "clipped",
     "effective_limit": 128,
-    "effective_limit_source": "otel_sdk_default"
+    "effective_limit_source": "default"
   }
 }
 ```
@@ -142,6 +145,18 @@ Recommended nested shape:
 objects are the reproducibility layer. Keep both: a reviewer should see
 the verdict quickly, while an auditor can still see how every count was
 produced.
+
+### Vocabulary Alignment
+
+The calibration shape uses two vocabulary levels. Per-measurement
+`agreement` uses `match`, `clipped`, `drift`, `failed`, or
+`not_applicable`. The per-layer `fidelity_verdict` and top-level
+`calibration_status` use `clean`, `lossy`, `inconclusive`, or
+`not_applicable`. Agreement rolls up to status as follows:
+`match -> clean`, `clipped -> lossy`, `drift` or `failed ->
+inconclusive`, and `not_applicable -> not_applicable`. Layer statuses
+roll up to the overall status by worst case:
+`not_applicable < clean < lossy < inconclusive`.
 
 Allowed `agreement` values:
 

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -45,11 +45,13 @@
 | `assay.experiment.runner_phase_timing.v0` | Phase-timing side-log emitted by `assay runner-spike run --phase-timing-log` | experiment-scoped; sidecar active | [`runner-phase-timing-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/runner-phase-timing-v0.schema.json) |
 | `assay.experiment.event_rate_sweep.v0` | Event-rate/workload-intensity cell metadata embedded in overhead samples and summaries | experiment-scoped; sidecar active; Slice 10 smoke-verified | [`event-rate-sweep-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json) |
 | `assay.experiment.event_rate_sweep.v0.1` | Event-rate/workload-intensity cell metadata with Slice 12 extended targets | experiment-scoped; sidecar active; Slice 12 measured | [`event-rate-sweep-v0.1.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json) |
+| `assay.experiment.agent_observability_fidelity.calibration.v0` | Requested-vs-observed fidelity calibration embedded in overhead samples and summaries | experiment-scoped; sidecar active; fidelity guardrail harness-ready | [`fidelity-calibration-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/fidelity-calibration-v0.schema.json) |
 
 The overhead schemas remain experiment-scoped. They are validated by the
 local harness tests against synthetic samples, summaries, phase
-side-logs, and event-rate sweep cells, but they are not Runner archive contracts and are not
-promoted to stable product surface.
+side-logs, event-rate sweep cells, and fidelity calibration sidecars,
+but they are not Runner archive contracts and are not promoted to stable
+product surface.
 
 ## Version Notes
 


### PR DESCRIPTION
Summary

Implements the first agent-observability fidelity guardrail from the post-overhead roadmap. Non-baseline Runner-vs-OTel sweep samples and summaries now make target-vs-observed fidelity explicit before timing or throughput can be interpreted.

What changed

- Adds experiment-scoped `assay.experiment.agent_observability_fidelity.calibration.v0` schema support.
- Embeds `fidelity_calibration` in overhead samples and summaries for non-baseline sweep cells.
- Records per-layer kernel/span target, observed count, counting method, agreement, and a compact `fidelity_verdict`.
- Counts Runner worker-file evidence from extracted archive contents and OTel sweep span events from trace JSON, including current `scopeSpans` and legacy `instrumentationLibrarySpans` trace shapes.
- Writes `artifacts/fidelity-calibration*.json` alongside existing review artifacts and surfaces the verdict in `summary.md`.
- Documents the `agreement -> status` vocabulary rollup in namespace governance and marks fidelity calibration as experiment-scoped in the artifact-family inventory.
- Updates the roadmap, README, schema overview, artifact-family inventory, namespace guidance, and changelog.

Validation

- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 44 OK\n- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` -> 92 OK\n- schema JSON parse checks -> OK\n- `python3 -m py_compile docs/experiments/runner-vs-otel-overhead-2026-05/overhead_harness.py docs/experiments/runner-vs-otel-overhead-2026-05/test_overhead_harness.py`\n- local changed-docs link check -> OK\n- `git diff --check`\n- pre-commit and pre-push hooks passed, including cargo fmt, clippy, and linux compile gate\n\nLocal note\n\n- `mkdocs` was not available on PATH in the local worktree, so mkdocs-strict is left to CI.\n\nNon-claims\n\n- Does not dispatch new measurements.\n- Does not commit benchmark artifacts.\n- Does not promote the calibration shape to `assay.observability.*` or a product API.\n- Does not reopen the closed overhead wall-clock decomposition arc.\n