### PR TITLE
feat(experiments): add agent evidence pack prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,13 @@ All notable changes to this project will be documented in this file.
   methods, per-layer agreement, and a compact `fidelity_verdict`.
   Fidelity calibration now moves from `proposed` to `experiment-scoped`
   in the artifact-families inventory.
+- Added the first agent-observability evidence-pack prototype. The
+  experiment-scoped `evidence_pack.py` generator emits a strict v0 pack
+  manifest, one-page Markdown summary, observation-health artifact,
+  optional trace JSON, Runner archive/reference copy, and explicit
+  redaction manifest without promoting evidence packs to a product API.
+  Evidence packs now move from `proposed` to `experiment-scoped` in the
+  artifact-families inventory.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/agent-observability-fidelity-2026-05.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05.md
@@ -158,6 +158,13 @@ observed-count fields and summary-level calibration gates.
 **Goal:** turn one interesting or failing agent run into a compact,
 portable, reviewable bundle.
 
+> **Status:** prototype-ready in the agent-observability fidelity
+> package. The repo now includes
+> `docs/experiments/agent-observability-fidelity-2026-05/evidence_pack.py`
+> and strict v0 schemas for the pack manifest and redaction manifest.
+> The prototype is experiment-scoped and does not promote evidence packs
+> to a product API.
+
 This is the first tool-facing slice after calibration because every
 later experiment should be able to hand reviewers a bounded evidence
 pack instead of a pile of raw artifacts. The first prototype should
@@ -176,16 +183,39 @@ incident.
 | Nice-to-have v1 | Expanded manifest/provenance table |
 | Nice-to-have v1 | Derived measured-effects summary |
 
+### Prototype layout
+
+The v0 generator writes a directory with stable filenames:
+
+```text
+manifest.json
+summary.md
+redaction-manifest.json
+artifacts/<runner archive filename>
+artifacts/observation-health.json
+artifacts/trace.json          # only when a trace layer exists
+```
+
+The manifest uses
+`assay.experiment.agent_observability_fidelity.evidence_pack.v0`. The
+redaction manifest uses
+`assay.experiment.agent_observability_fidelity.redaction_manifest.v0`.
+`pack_id` is a deterministic digest over the carried input artifacts and
+redaction manifest; rendered summaries are listed as artifacts but do
+not create a circular pack-id dependency.
+
 ### Acceptance rules
 
-- The pack must never strengthen a claim beyond the underlying join and
-  calibration grades.
-- Redaction must be explicit: omitted content is named as omitted, not
-  silently removed.
-- The pack must be reproducible from input artifacts by a command, not
-  hand-curated.
-- The first pack should target one known scenario and produce stable
-  filenames, so later semantic-gap scenarios can reuse the same carrier.
+- **Done:** the pack never strengthens a claim beyond the underlying
+  join and calibration grades; v0 emits that as an explicit non-claim.
+- **Done:** redaction is explicit. Even no-redaction packs include
+  `redaction-manifest.json`.
+- **Done:** the pack is reproducible from input artifacts by command,
+  not hand-curated.
+- **Done:** the first prototype uses stable filenames so later
+  semantic-gap scenarios can reuse the same carrier.
+- **Not done:** promotion into a canonical Assay bundle or evidence
+  receipt family. That still requires a consumer and a promotion PR.
 
 ### Tool improvement
 
@@ -328,8 +358,8 @@ visible by the overhead and shape-comparison arcs.
 | Slice | Status | Purpose | Exit gate |
 |---:|---|---|---|
 | 0 | Done in this plan | Namespace governance for experiment artifacts | Naming, promotion, cross-arc field, calibration-method, and evidence-pack minimum rules are documented. |
-| 1 | Planned | Fidelity calibration fields and summary rendering | One overhead-style fixture proves clean, lossy, and not-applicable calibration states. |
-| 2 | Planned | Portable evidence-pack prototype | One controlled scenario emits the minimum pack: summary, archive/ref, trace/ref, health, and redaction manifest. |
+| 1 | Harness-ready | Fidelity calibration fields and summary rendering | One overhead-style fixture proves clean, lossy, and not-applicable calibration states. |
+| 2 | Prototype-ready | Portable evidence-pack prototype | `evidence_pack.py` emits the minimum pack: manifest, summary, archive/ref, optional trace/ref, health, and redaction manifest. |
 | 3 | Planned | Semantic-gap scenario plan | Baseline plus six predeclared scenarios, claim classes, and join requirements documented before dispatch. |
 | 4 | Planned | Semantic-gap harness | Fake fixtures plus one delegated sanity run prove joined intent/effect rows and evidence-pack output. |
 | 5 | Planned | Interop matrix plan | OTel/OpenInference/Runner coverage axes and non-claims pinned. |

--- a/docs/experiments/agent-observability-fidelity-2026-05/evidence_pack.py
+++ b/docs/experiments/agent-observability-fidelity-2026-05/evidence_pack.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Build experiment-scoped agent observability evidence packs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shlex
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+EVIDENCE_PACK_SCHEMA = "assay.experiment.agent_observability_fidelity.evidence_pack.v0"
+REDACTION_MANIFEST_SCHEMA = (
+    "assay.experiment.agent_observability_fidelity.redaction_manifest.v0"
+)
+EXPERIMENT = "agent-observability-fidelity-2026-05"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def copy_artifact(
+    *,
+    source: Path,
+    destination: Path,
+    role: str,
+    required: bool,
+) -> dict[str, Any]:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)
+    return {
+        "role": role,
+        "path": str(destination),
+        "required": required,
+        "bytes": destination.stat().st_size,
+        "sha256": sha256_file(destination),
+        "redaction_state": "unredacted",
+    }
+
+
+def artifact_row(
+    *,
+    pack_dir: Path,
+    path: Path,
+    role: str,
+    required: bool,
+    redaction_state: str,
+) -> dict[str, Any]:
+    return {
+        "role": role,
+        "path": str(path.relative_to(pack_dir)),
+        "required": required,
+        "bytes": path.stat().st_size,
+        "sha256": sha256_file(path),
+        "redaction_state": redaction_state,
+    }
+
+
+def relative_artifact_rows(
+    pack_dir: Path, rows: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    relative_rows = []
+    for row in rows:
+        rel = dict(row)
+        rel["path"] = str(Path(row["path"]).relative_to(pack_dir))
+        relative_rows.append(rel)
+    return relative_rows
+
+
+def validate_source(path: Path, label: str) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"{label} does not exist: {path}")
+    if not path.is_file():
+        raise ValueError(f"{label} is not a file: {path}")
+
+
+def load_observation_health(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "kernel_layer": payload.get("kernel_layer", "unknown"),
+        "ringbuf_drops": int(payload.get("ringbuf_drops", -1)),
+        "cgroup_correlation": payload.get("cgroup_correlation", "unknown"),
+    }
+
+
+def health_status(health: dict[str, Any]) -> str:
+    if (
+        health.get("kernel_layer") == "complete"
+        and health.get("ringbuf_drops") == 0
+        and health.get("cgroup_correlation") == "clean"
+    ):
+        return "clean"
+    return "inconclusive"
+
+
+def pack_id_from_rows(rows: list[dict[str, Any]]) -> str:
+    material = json.dumps(
+        [
+            {
+                "role": row["role"],
+                "path": row["path"],
+                "sha256": row["sha256"],
+                "bytes": row["bytes"],
+            }
+            for row in rows
+        ],
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(material).hexdigest()}"
+
+
+def redaction_manifest(*, created_at: str, policy: str) -> dict[str, Any]:
+    return {
+        "schema": REDACTION_MANIFEST_SCHEMA,
+        "created_at": created_at,
+        "policy": policy,
+        "redaction_applied": False,
+        "omitted_content": [],
+        "notes": [
+            "Prototype pack records redaction explicitly; no redaction was applied."
+        ],
+    }
+
+
+def reproduction_command(
+    *,
+    out_dir: Path,
+    scenario_id: str,
+    claim_summary: str,
+    claim_class: str,
+    runner_archive: Path,
+    trace_json: Path | None,
+    observation_health: Path,
+    created_at: str,
+    redaction_policy: str,
+) -> str:
+    args = [
+        "python3",
+        "docs/experiments/agent-observability-fidelity-2026-05/evidence_pack.py",
+        "create",
+        "--out-dir",
+        str(out_dir),
+        "--scenario-id",
+        scenario_id,
+        "--claim-class",
+        claim_class,
+        "--claim-summary",
+        claim_summary,
+        "--runner-archive",
+        str(runner_archive),
+        "--observation-health",
+        str(observation_health),
+        "--created-at",
+        created_at,
+        "--redaction-policy",
+        redaction_policy,
+    ]
+    if trace_json is not None:
+        args.extend(["--trace-json", str(trace_json)])
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def summary_markdown(manifest: dict[str, Any]) -> str:
+    health = manifest["observation_health"]
+    lines = [
+        "# Agent Observability Evidence Pack",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Pack ID | `{manifest['pack_id']}` |",
+        f"| Scenario | `{manifest['scenario_id']}` |",
+        f"| Claim class | `{manifest['claim_class']}` |",
+        f"| Claim summary | {manifest['claim_summary']} |",
+        f"| Observation health | `{manifest['observation_health_status']}` |",
+        f"| Kernel layer | `{health['kernel_layer']}` |",
+        f"| Ringbuf drops | `{health['ringbuf_drops']}` |",
+        f"| Cgroup correlation | `{health['cgroup_correlation']}` |",
+        f"| Redaction applied | `{manifest['redaction']['redaction_applied']}` |",
+        "",
+        "## Artifacts",
+        "",
+        "| Role | Path | Required | SHA-256 |",
+        "|---|---|---:|---|",
+    ]
+    for artifact in manifest["artifacts"]:
+        lines.append(
+            f"| `{artifact['role']}` | `{artifact['path']}` | "
+            f"`{artifact['required']}` | `{artifact['sha256']}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Non-Claims",
+            "",
+        ]
+    )
+    for non_claim in manifest["non_claims"]:
+        lines.append(f"- {non_claim}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_pack(
+    *,
+    out_dir: Path,
+    scenario_id: str,
+    claim_summary: str,
+    claim_class: str,
+    runner_archive: Path,
+    trace_json: Path | None,
+    observation_health: Path,
+    created_at: str,
+    redaction_policy: str,
+) -> dict[str, Any]:
+    if out_dir.exists() and any(out_dir.iterdir()):
+        raise FileExistsError(f"output directory is not empty: {out_dir}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    artifacts_dir = out_dir / "artifacts"
+    rows = [
+        copy_artifact(
+            source=runner_archive,
+            destination=artifacts_dir / runner_archive.name,
+            role="runner_archive",
+            required=True,
+        ),
+        copy_artifact(
+            source=observation_health,
+            destination=artifacts_dir / "observation-health.json",
+            role="observation_health",
+            required=True,
+        ),
+    ]
+    if trace_json is not None:
+        rows.append(
+            copy_artifact(
+                source=trace_json,
+                destination=artifacts_dir / "trace.json",
+                role="trace_json",
+                required=False,
+            )
+        )
+    redaction = redaction_manifest(created_at=created_at, policy=redaction_policy)
+    write_json(out_dir / "redaction-manifest.json", redaction)
+    rows.append(
+        {
+            "role": "redaction_manifest",
+            "path": str(out_dir / "redaction-manifest.json"),
+            "required": True,
+            "bytes": (out_dir / "redaction-manifest.json").stat().st_size,
+            "sha256": sha256_file(out_dir / "redaction-manifest.json"),
+            "redaction_state": "manifest",
+        }
+    )
+    relative_rows = relative_artifact_rows(out_dir, rows)
+    health = load_observation_health(observation_health)
+    manifest = {
+        "schema": EVIDENCE_PACK_SCHEMA,
+        "experiment": EXPERIMENT,
+        "pack_id": pack_id_from_rows(relative_rows),
+        "scenario_id": scenario_id,
+        "created_at": created_at,
+        "claim_class": claim_class,
+        "claim_summary": claim_summary,
+        "observation_health_status": health_status(health),
+        "observation_health": health,
+        "artifacts": relative_rows,
+        "redaction": redaction,
+        "reproduction": {
+            "command": reproduction_command(
+                out_dir=out_dir,
+                scenario_id=scenario_id,
+                claim_summary=claim_summary,
+                claim_class=claim_class,
+                runner_archive=runner_archive,
+                trace_json=trace_json,
+                observation_health=observation_health,
+                created_at=created_at,
+                redaction_policy=redaction_policy,
+            ),
+            "inputs": {
+                "runner_archive": str(runner_archive),
+                "trace_json": str(trace_json) if trace_json is not None else None,
+                "observation_health": str(observation_health),
+            },
+        },
+        "non_claims": [
+            "does_not_strengthen_underlying_claims",
+            "does_not_verify_runner_archive_integrity",
+            "does_not_promote_evidence_pack_to_product_api",
+        ],
+    }
+    summary_path = out_dir / "summary.md"
+    summary_path.write_text(summary_markdown(manifest), encoding="utf-8")
+    manifest["artifacts"].append(
+        artifact_row(
+            pack_dir=out_dir,
+            path=summary_path,
+            role="summary_markdown",
+            required=True,
+            redaction_state="rendered",
+        )
+    )
+    write_json(out_dir / "manifest.json", manifest)
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    create = subparsers.add_parser("create", help="Create an evidence pack directory")
+    create.add_argument("--out-dir", type=Path, required=True)
+    create.add_argument("--scenario-id", required=True)
+    create.add_argument("--claim-summary", required=True)
+    create.add_argument(
+        "--claim-class",
+        choices=("diagnostic", "fidelity_boundary", "semantic_gap", "positive_join"),
+        default="diagnostic",
+    )
+    create.add_argument("--runner-archive", type=Path, required=True)
+    create.add_argument("--trace-json", type=Path)
+    create.add_argument("--observation-health", type=Path, required=True)
+    create.add_argument("--created-at", default=utc_now())
+    create.add_argument("--redaction-policy", default="none")
+    args = parser.parse_args(argv)
+    validate_source(args.runner_archive, "runner archive")
+    validate_source(args.observation_health, "observation health")
+    if args.trace_json is not None:
+        validate_source(args.trace_json, "trace JSON")
+
+    build_pack(
+        out_dir=args.out_dir,
+        scenario_id=args.scenario_id,
+        claim_summary=args.claim_summary,
+        claim_class=args.claim_class,
+        runner_archive=args.runner_archive,
+        trace_json=args.trace_json,
+        observation_health=args.observation_health,
+        created_at=args.created_at,
+        redaction_policy=args.redaction_policy,
+    )
+    print(f"wrote {args.out_dir / 'manifest.json'}")
+    print(f"wrote {args.out_dir / 'summary.md'}")
+    print(f"wrote {args.out_dir / 'redaction-manifest.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json
+++ b/docs/experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json
@@ -28,6 +28,7 @@
     },
     "pack_id": {
       "type": "string",
+      "description": "Digest over the carried evidence inputs and redaction manifest: runner_archive, observation_health, optional trace_json, and redaction_manifest. The rendered summary_markdown artifact is listed for review but is not part of the pack_id digest to avoid a circular dependency.",
       "pattern": "^sha256:[0-9a-f]{64}$"
     },
     "scenario_id": {

--- a/docs/experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json
+++ b/docs/experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://assay.dev/schemas/experiments/agent-observability-fidelity/evidence-pack-v0.schema.json",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json",
   "title": "Agent Observability Evidence Pack v0",
   "type": "object",
   "additionalProperties": false,

--- a/docs/experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json
+++ b/docs/experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.dev/schemas/experiments/agent-observability-fidelity/evidence-pack-v0.schema.json",
+  "title": "Agent Observability Evidence Pack v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "experiment",
+    "pack_id",
+    "scenario_id",
+    "created_at",
+    "claim_class",
+    "claim_summary",
+    "observation_health_status",
+    "observation_health",
+    "artifacts",
+    "redaction",
+    "reproduction",
+    "non_claims"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.experiment.agent_observability_fidelity.evidence_pack.v0"
+    },
+    "experiment": {
+      "const": "agent-observability-fidelity-2026-05"
+    },
+    "pack_id": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "scenario_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "claim_class": {
+      "enum": [
+        "diagnostic",
+        "fidelity_boundary",
+        "semantic_gap",
+        "positive_join"
+      ]
+    },
+    "claim_summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "observation_health_status": {
+      "enum": [
+        "clean",
+        "inconclusive"
+      ]
+    },
+    "observation_health": {
+      "$ref": "#/$defs/observation_health"
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    },
+    "redaction": {
+      "$ref": "#/$defs/redaction_manifest"
+    },
+    "reproduction": {
+      "$ref": "#/$defs/reproduction"
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role",
+        "path",
+        "required",
+        "bytes",
+        "sha256",
+        "redaction_state"
+      ],
+      "properties": {
+        "role": {
+          "enum": [
+            "runner_archive",
+            "trace_json",
+            "observation_health",
+            "redaction_manifest",
+            "summary_markdown"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "redaction_state": {
+          "enum": [
+            "unredacted",
+            "manifest",
+            "rendered"
+          ]
+        }
+      }
+    },
+    "observation_health": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kernel_layer",
+        "ringbuf_drops",
+        "cgroup_correlation"
+      ],
+      "properties": {
+        "kernel_layer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ringbuf_drops": {
+          "type": "integer",
+          "minimum": -1
+        },
+        "cgroup_correlation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "redaction_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "created_at",
+        "policy",
+        "redaction_applied",
+        "omitted_content",
+        "notes"
+      ],
+      "properties": {
+        "schema": {
+          "const": "assay.experiment.agent_observability_fidelity.redaction_manifest.v0"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "policy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "redaction_applied": {
+          "type": "boolean"
+        },
+        "omitted_content": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "reproduction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "inputs"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "inputs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "runner_archive",
+            "trace_json",
+            "observation_health"
+          ],
+          "properties": {
+            "runner_archive": {
+              "type": "string",
+              "minLength": 1
+            },
+            "trace_json": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "observation_health": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/experiments/agent-observability-fidelity-2026-05/schema/redaction-manifest-v0.schema.json
+++ b/docs/experiments/agent-observability-fidelity-2026-05/schema/redaction-manifest-v0.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://assay.dev/schemas/experiments/agent-observability-fidelity/redaction-manifest-v0.schema.json",
+  "title": "Agent Observability Redaction Manifest v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "created_at",
+    "policy",
+    "redaction_applied",
+    "omitted_content",
+    "notes"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.experiment.agent_observability_fidelity.redaction_manifest.v0"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "policy": {
+      "type": "string",
+      "minLength": 1
+    },
+    "redaction_applied": {
+      "type": "boolean"
+    },
+    "omitted_content": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/experiments/agent-observability-fidelity-2026-05/schema/redaction-manifest-v0.schema.json
+++ b/docs/experiments/agent-observability-fidelity-2026-05/schema/redaction-manifest-v0.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://assay.dev/schemas/experiments/agent-observability-fidelity/redaction-manifest-v0.schema.json",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/agent-observability-fidelity-2026-05/schema/redaction-manifest-v0.schema.json",
   "title": "Agent Observability Redaction Manifest v0",
   "type": "object",
   "additionalProperties": false,

--- a/docs/experiments/agent-observability-fidelity-2026-05/test_evidence_pack.py
+++ b/docs/experiments/agent-observability-fidelity-2026-05/test_evidence_pack.py
@@ -1,0 +1,298 @@
+"""Tests for the agent-observability evidence-pack prototype."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+PACK_PATH = ROOT / "evidence_pack.py"
+
+spec = importlib.util.spec_from_file_location("evidence_pack", PACK_PATH)
+assert spec is not None and spec.loader is not None
+evidence_pack = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(evidence_pack)
+
+
+def load_schema(name: str) -> dict[str, Any]:
+    return json.loads((ROOT / "schema" / name).read_text(encoding="utf-8"))
+
+
+def resolve_ref(schema: dict[str, Any], ref: str) -> dict[str, Any]:
+    if not ref.startswith("#/$defs/"):
+        raise AssertionError(f"unsupported $ref: {ref}")
+    target: Any = schema
+    for part in ref.removeprefix("#/").split("/"):
+        target = target[part]
+    if not isinstance(target, dict):
+        raise AssertionError(f"$ref did not resolve to object: {ref}")
+    return target
+
+
+def assert_matches_schema(
+    test: unittest.TestCase,
+    payload: Any,
+    node: dict[str, Any],
+    *,
+    root: dict[str, Any],
+    path: str = "$",
+) -> None:
+    if "$ref" in node:
+        return assert_matches_schema(
+            test, payload, resolve_ref(root, node["$ref"]), root=root, path=path
+        )
+
+    expected_type = node.get("type")
+    if expected_type is not None:
+        types = expected_type if isinstance(expected_type, list) else [expected_type]
+        if "null" in types and payload is None:
+            return
+        type_ok = False
+        for typ in types:
+            if typ == "object":
+                type_ok = isinstance(payload, dict)
+            elif typ == "array":
+                type_ok = isinstance(payload, list)
+            elif typ == "string":
+                type_ok = isinstance(payload, str)
+            elif typ == "integer":
+                type_ok = isinstance(payload, int) and not isinstance(payload, bool)
+            elif typ == "boolean":
+                type_ok = isinstance(payload, bool)
+            elif typ == "null":
+                type_ok = payload is None
+            else:
+                raise AssertionError(f"{path}: unsupported type {typ!r}")
+            if type_ok:
+                break
+        test.assertTrue(type_ok, f"{path}: expected {types}, got {type(payload)}")
+
+    if "const" in node:
+        test.assertEqual(payload, node["const"], path)
+    if "enum" in node:
+        test.assertIn(payload, node["enum"], path)
+    if "pattern" in node and isinstance(payload, str):
+        test.assertRegex(payload, node["pattern"], path)
+    if "minLength" in node and isinstance(payload, str):
+        test.assertGreaterEqual(len(payload), node["minLength"], path)
+    if node.get("format") == "date-time":
+        datetime.fromisoformat(payload.replace("Z", "+00:00"))
+    if "minimum" in node and payload is not None:
+        test.assertGreaterEqual(payload, node["minimum"], path)
+
+    if isinstance(payload, list):
+        if "minItems" in node:
+            test.assertGreaterEqual(len(payload), node["minItems"], path)
+        item_node = node.get("items")
+        if item_node is not None:
+            for index, item in enumerate(payload):
+                assert_matches_schema(
+                    test, item, item_node, root=root, path=f"{path}[{index}]"
+                )
+
+    if isinstance(payload, dict):
+        required = node.get("required", [])
+        for key in required:
+            test.assertIn(key, payload, f"{path}: missing {key}")
+        properties = node.get("properties", {})
+        if node.get("additionalProperties") is False:
+            test.assertLessEqual(set(payload), set(properties), path)
+        for key, value in payload.items():
+            if key in properties:
+                assert_matches_schema(
+                    test, value, properties[key], root=root, path=f"{path}.{key}"
+                )
+
+
+def write_inputs(root: Path, *, ringbuf_drops: int = 0) -> tuple[Path, Path, Path]:
+    runner_archive = root / "runner-archive.tar.gz"
+    trace_json = root / "trace.json"
+    health = root / "observation-health.json"
+    runner_archive.write_bytes(b"runner archive bytes\n")
+    trace_json.write_text(
+        json.dumps({"resourceSpans": [{"scopeSpans": [{"spans": []}]}]}) + "\n",
+        encoding="utf-8",
+    )
+    health.write_text(
+        json.dumps(
+            {
+                "kernel_layer": "complete",
+                "ringbuf_drops": ringbuf_drops,
+                "cgroup_correlation": "clean",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return runner_archive, trace_json, health
+
+
+class EvidencePackTests(unittest.TestCase):
+    def assert_valid_pack(self, pack_dir: Path) -> dict[str, Any]:
+        manifest = json.loads((pack_dir / "manifest.json").read_text(encoding="utf-8"))
+        redaction = json.loads(
+            (pack_dir / "redaction-manifest.json").read_text(encoding="utf-8")
+        )
+        pack_schema = load_schema("evidence-pack-v0.schema.json")
+        redaction_schema = load_schema("redaction-manifest-v0.schema.json")
+        assert_matches_schema(self, manifest, pack_schema, root=pack_schema)
+        assert_matches_schema(
+            self, redaction, redaction_schema, root=redaction_schema
+        )
+        return manifest
+
+    def test_create_pack_with_trace_and_clean_health(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive, trace, health = write_inputs(root)
+            out = root / "pack"
+
+            evidence_pack.build_pack(
+                out_dir=out,
+                scenario_id="matched-safe-read",
+                claim_class="positive_join",
+                claim_summary="Trace and archive agree for safe.txt.",
+                runner_archive=archive,
+                trace_json=trace,
+                observation_health=health,
+                created_at="2026-05-28T08:00:00Z",
+                redaction_policy="none",
+            )
+
+            manifest = self.assert_valid_pack(out)
+            self.assertEqual(
+                manifest["schema"],
+                "assay.experiment.agent_observability_fidelity.evidence_pack.v0",
+            )
+            self.assertEqual(manifest["scenario_id"], "matched-safe-read")
+            self.assertEqual(manifest["claim_class"], "positive_join")
+            self.assertEqual(manifest["observation_health_status"], "clean")
+            self.assertFalse(manifest["redaction"]["redaction_applied"])
+            self.assertIn(
+                "does_not_strengthen_underlying_claims", manifest["non_claims"]
+            )
+            roles = {row["role"]: row for row in manifest["artifacts"]}
+            self.assertEqual(
+                roles["runner_archive"]["path"], "artifacts/runner-archive.tar.gz"
+            )
+            self.assertEqual(roles["trace_json"]["path"], "artifacts/trace.json")
+            self.assertEqual(
+                roles["observation_health"]["path"],
+                "artifacts/observation-health.json",
+            )
+            self.assertEqual(
+                roles["redaction_manifest"]["path"],
+                "redaction-manifest.json",
+            )
+            self.assertEqual(roles["summary_markdown"]["path"], "summary.md")
+            for row in manifest["artifacts"]:
+                self.assertRegex(row["sha256"], r"^sha256:[0-9a-f]{64}$")
+                self.assertFalse(Path(row["path"]).is_absolute())
+                self.assertTrue((out / row["path"]).exists())
+
+            summary = (out / "summary.md").read_text(encoding="utf-8")
+            self.assertIn("Trace and archive agree for safe.txt.", summary)
+            self.assertIn("does_not_promote_evidence_pack_to_product_api", summary)
+
+    def test_pack_without_trace_keeps_trace_input_null(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive, _trace, health = write_inputs(root)
+            out = root / "pack"
+
+            evidence_pack.build_pack(
+                out_dir=out,
+                scenario_id="archive-only-diagnostic",
+                claim_class="diagnostic",
+                claim_summary="Archive-only health diagnostic.",
+                runner_archive=archive,
+                trace_json=None,
+                observation_health=health,
+                created_at="2026-05-28T08:00:00Z",
+                redaction_policy="none",
+            )
+
+            manifest = self.assert_valid_pack(out)
+            self.assertNotIn(
+                "trace_json", {row["role"] for row in manifest["artifacts"]}
+            )
+            self.assertIsNone(manifest["reproduction"]["inputs"]["trace_json"])
+
+    def test_health_with_drops_is_inconclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive, trace, health = write_inputs(root, ringbuf_drops=3)
+            out = root / "pack"
+
+            evidence_pack.build_pack(
+                out_dir=out,
+                scenario_id="drop-diagnostic",
+                claim_class="diagnostic",
+                claim_summary="Kernel drops make this diagnostic-only.",
+                runner_archive=archive,
+                trace_json=trace,
+                observation_health=health,
+                created_at="2026-05-28T08:00:00Z",
+                redaction_policy="none",
+            )
+
+            manifest = self.assert_valid_pack(out)
+            self.assertEqual(manifest["observation_health_status"], "inconclusive")
+            self.assertEqual(manifest["observation_health"]["ringbuf_drops"], 3)
+
+    def test_missing_input_fails_before_writing_pack(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive, _trace, health = write_inputs(root)
+            missing_trace = root / "missing-trace.json"
+
+            with self.assertRaises(FileNotFoundError):
+                evidence_pack.main(
+                    [
+                        "create",
+                        "--out-dir",
+                        str(root / "pack"),
+                        "--scenario-id",
+                        "missing-input",
+                        "--claim-summary",
+                        "missing input should fail",
+                        "--runner-archive",
+                        str(archive),
+                        "--trace-json",
+                        str(missing_trace),
+                        "--observation-health",
+                        str(health),
+                    ]
+                )
+
+            self.assertFalse((root / "pack").exists())
+
+    def test_existing_nonempty_output_directory_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive, trace, health = write_inputs(root)
+            out = root / "pack"
+            out.mkdir()
+            (out / "stale.txt").write_text("stale\n", encoding="utf-8")
+
+            with self.assertRaises(FileExistsError):
+                evidence_pack.build_pack(
+                    out_dir=out,
+                    scenario_id="stale-output",
+                    claim_class="diagnostic",
+                    claim_summary="stale output should fail",
+                    runner_archive=archive,
+                    trace_json=trace,
+                    observation_health=health,
+                    created_at="2026-05-28T08:00:00Z",
+                    redaction_policy="none",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/reference/artifact-families-inventory.md
+++ b/docs/reference/artifact-families-inventory.md
@@ -37,7 +37,7 @@ accidentally present proposed artifacts as canonical product surfaces.
 | Overhead experiment sidecars | `experiment-scoped` | `assay.experiment.*` under `runner-vs-otel-overhead-2026-05/` | Samples, summaries, phase timings, paired sequences, and event-rate sweep cells. |
 | Cross-runtime drift outputs | `experiment-scoped` | `cross-runtime-drift-2026-05/` | Runtime capability-surface drift comparisons. |
 | Fidelity calibration | `experiment-scoped` | `assay.experiment.agent_observability_fidelity.calibration.v0` | Requested-vs-observed fidelity verdicts and per-layer count methods embedded by the overhead harness. |
-| Evidence pack | `proposed` | `assay.experiment.agent_observability_fidelity.evidence_pack.v0` | Portable bundle carrier for one run or scenario. |
+| Evidence pack | `experiment-scoped` | `assay.experiment.agent_observability_fidelity.evidence_pack.v0` | Prototype portable bundle carrier for one run or scenario, with manifest, summary, health, archive/trace references, and explicit redaction manifest. |
 | Binding evidence / join receipts | `proposed` | undecided | Working term for tool-call input/output/effect binding evidence. Not a product line yet. |
 | Semantic-gap finding | `proposed` | undecided | Experiment result family for reported-intent vs measured-effect divergence. |
 | Interop mapping | `proposed` | undecided | Mapping rows between OTel GenAI, OpenInference, Runner, and Assay claim vocabulary. |

--- a/docs/reference/experiments/namespace-governance.md
+++ b/docs/reference/experiments/namespace-governance.md
@@ -196,6 +196,17 @@ The pack must not strengthen a claim beyond the underlying calibration
 and join grades. It is a carrier for evidence, not a new source of
 truth.
 
+The v0 prototype lives under
+`docs/experiments/agent-observability-fidelity-2026-05/` and uses:
+
+| Schema | Role |
+|---|---|
+| `assay.experiment.agent_observability_fidelity.evidence_pack.v0` | Pack manifest with scenario, claim class, carried artifacts, health, reproduction, and non-claims. |
+| `assay.experiment.agent_observability_fidelity.redaction_manifest.v0` | Required redaction record, even when no redaction was applied. |
+
+Keep this prototype in `assay.experiment.*` until a real CLI or
+artifact-exchange consumer needs a stable product surface.
+
 ## Artifact Family Inventory
 
 Before adding a new artifact family, check

--- a/docs/reference/observability/README.md
+++ b/docs/reference/observability/README.md
@@ -34,3 +34,9 @@ Artifact-family status is tracked in
 [`../artifact-families-inventory.md`](../artifact-families-inventory.md),
 so proposed surfaces such as fidelity calibration, evidence packs, and
 binding evidence do not get mistaken for canonical product artifacts.
+
+The first experiment-scoped evidence-pack prototype is tracked in
+[`../../experiments/agent-observability-fidelity-2026-05.md`](../../experiments/agent-observability-fidelity-2026-05.md).
+It renders a portable manifest, one-page summary, observation-health
+record, optional trace, Runner archive/reference, and explicit redaction
+manifest without promoting that carrier to a product API.


### PR DESCRIPTION
Summary

Adds the first experiment-scoped agent-observability evidence-pack prototype after the fidelity calibration guardrail. This turns the roadmap's portable-evidence step into a reproducible carrier without promoting evidence packs to a product API.

What changed

- Adds `docs/experiments/agent-observability-fidelity-2026-05/evidence_pack.py` with a `create` command that builds a stable pack directory from a Runner archive/reference, observation-health JSON, and optional trace JSON.
- Adds strict v0 JSON Schemas for `assay.experiment.agent_observability_fidelity.evidence_pack.v0` and `assay.experiment.agent_observability_fidelity.redaction_manifest.v0`.
- Emits `manifest.json`, `summary.md`, `redaction-manifest.json`, and copied artifacts under `artifacts/`, with explicit non-claims and deterministic pack id over the carried input artifacts plus redaction manifest.
- Adds tests for clean packs, trace-optional packs, inconclusive health, missing-input failure, stale output rejection, and schema validation.
- Updates the fidelity roadmap, namespace governance, observability references, artifact-family inventory, and changelog to mark evidence packs experiment-scoped/prototype-ready.

Validation

- `python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py'` -> 5 OK
- `python3 -m unittest discover -s docs/experiments/runner-vs-otel-overhead-2026-05 -p 'test_*.py'` -> 44 OK
- `python3 -m json.tool docs/experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json`
- `python3 -m json.tool docs/experiments/agent-observability-fidelity-2026-05/schema/redaction-manifest-v0.schema.json`
- local changed-docs link check -> OK
- `git diff --check`
- pre-commit + pre-push hooks green, including linux compile gate

Local note

- `mkdocs build --strict` was not run locally because `mkdocs` is not installed on this machine; CI should cover mkdocs-strict.

Non-claims

- Does not promote evidence packs to a product API, canonical Assay bundle, Trust Card claim, or receipt family.
- Does not verify Runner archive integrity beyond carrying and hashing the supplied artifact.
- Does not add semantic-gap scenarios or dispatch new measurements.
- Does not strengthen claims beyond underlying join, calibration, and health evidence.
