### PR TITLE
docs(experiments): plan semantic gap scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,12 @@ All notable changes to this project will be documented in this file.
   redaction manifest without promoting evidence packs to a product API.
   Evidence packs now move from `proposed` to `experiment-scoped` in the
   artifact-families inventory.
+- Planned the first semantic-gap scenario matrix for the
+  agent-observability fidelity roadmap. The plan predeclares a
+  deterministic safe-read baseline, five divergence/fallback scenarios,
+  join-grade requirements, claim-class rules, evidence-pack output
+  expectations, and the minimum Slice 4 harness exit gate without adding
+  a harness or dispatching measurements.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/agent-observability-fidelity-2026-05.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05.md
@@ -7,7 +7,7 @@
 > not open the optional OTel span-limit study tracked in
 > [issue #1408](https://github.com/Rul1an/assay/issues/1408).
 >
-> **Last updated:** 2026-05-27
+> **Last updated:** 2026-05-28
 
 ## Executive Decision
 
@@ -227,6 +227,12 @@ Assay feature: "give me the portable evidence for this agent run."
 **Goal:** prove exactly where trace-reported intent, SDK events, policy
 events, and measured system effects diverge.
 
+> **Status:** scenario-plan-ready. The baseline, scenario matrix, join
+> requirements, claim-class rules, evidence-pack expectations, and
+> Slice 4 exit gate are predeclared in
+> [`agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md`](agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md).
+> This does not add a harness or dispatch measurements.
+
 This is the most strategically valuable new experiment. It extends the
 existing runner-vs-OTel shape comparison and cross-runtime drift work
 from "can we join layers?" to "what can the joined layers honestly
@@ -247,28 +253,36 @@ join path under real Runner capture before gap findings are published.
 
 ### Scenarios
 
-| Scenario | Reported trace intent | Measured effect | Expected claim |
-|---|---|---|---|
-| Matched safe read | tool call reports reading `safe.txt` | kernel observes read of `safe.txt` | strong positive join |
-| Argument/path rewrite | tool call reports `safe.txt` | kernel observes normalized alternate path | semantic mismatch at same tool call |
-| Hidden write | tool call reports read-only action | kernel observes create/write in workdir | L1 underreports side effect |
-| Retry/self-correction | trace records final successful action | kernel/archive records failed prior attempts | trace summary loses temporal evidence |
-| Runtime side effect | no tool-level trace event | archive records runtime loader/config/probe path | runtime-induced surface |
-| Weak join fallback | missing `tool_call_id`, only order/timestamp | effects are plausible but not strongly joinable | diagnostic-only claim |
+| Scenario | Role | Reported trace intent | Measured effect | Expected claim |
+|---|---|---|---|---|
+| Matched safe read | baseline | tool call reports reading `safe.txt` | kernel observes read of `safe.txt` | strong positive join |
+| Argument/path rewrite | gap | tool call reports `safe.txt` | kernel observes normalized alternate path | semantic mismatch at same tool call |
+| Hidden write | gap | tool call reports read-only action | kernel observes create/write in workdir | reported intent under-describes measured side effect |
+| Retry/self-correction | gap | trace records final successful action | kernel/archive records failed prior attempts | trace summary loses temporal evidence |
+| Runtime side effect | gap | no tool-level trace event | archive records runtime loader/config/probe path | runtime-induced surface |
+| Weak join fallback | fallback | missing `tool_call_id`, only order/timestamp | effects are plausible but not strongly joinable | diagnostic-only claim |
+
+The detailed plan pins scenario ids, join requirements, claim rules, and
+the minimum harness exit gate. The first harness should prove the
+baseline, `hidden_write`, and `weak_join_fallback` before broadening to
+all six scenarios.
 
 ### Acceptance rules
 
-- Every row must emit an `assay.observability.join_result.v0` entry or a
-  newer successor.
-- Strong findings require unique `tool_call_id` or an explicitly
-  equivalent key.
-- Timestamp/order joins remain diagnostic and may not support semantic
-  equality claims.
-- The output must classify each scenario by claim class: reported
-  intent, measured effect, joined evidence, or inconclusive.
-- A measured effect mismatch is evidence of divergence. It is not by
-  itself evidence of malicious behavior, policy failure, or root-cause
-  attribution.
+- **Done for Slice 3:** every planned row must emit an
+  `assay.observability.join_result.v0` entry or a newer successor.
+- **Done for Slice 3:** strong findings require unique `tool_call_id`
+  or an explicitly equivalent key.
+- **Done for Slice 3:** timestamp/order joins remain diagnostic and may
+  not support semantic equality claims.
+- **Done for Slice 3:** the output must classify each scenario by claim
+  class: reported intent, measured effect, joined evidence, or
+  inconclusive.
+- **Done for Slice 3:** a measured effect mismatch is evidence of
+  divergence. It is not by itself evidence of malicious behavior, policy
+  failure, or root-cause attribution.
+- **Not done:** harness, synthetic fixtures, delegated sanity run, or
+  committed measurement artifacts.
 
 ### Tool improvement
 
@@ -360,7 +374,7 @@ visible by the overhead and shape-comparison arcs.
 | 0 | Done in this plan | Namespace governance for experiment artifacts | Naming, promotion, cross-arc field, calibration-method, and evidence-pack minimum rules are documented. |
 | 1 | Harness-ready | Fidelity calibration fields and summary rendering | One overhead-style fixture proves clean, lossy, and not-applicable calibration states. |
 | 2 | Prototype-ready | Portable evidence-pack prototype | `evidence_pack.py` emits the minimum pack: manifest, summary, archive/ref, optional trace/ref, health, and redaction manifest. |
-| 3 | Planned | Semantic-gap scenario plan | Baseline plus six predeclared scenarios, claim classes, and join requirements documented before dispatch. |
+| 3 | Scenario-plan-ready | Semantic-gap scenario plan | Baseline plus six predeclared scenarios, claim classes, join requirements, evidence-pack expectations, and Slice 4 minimum harness gate documented before dispatch. |
 | 4 | Planned | Semantic-gap harness | Fake fixtures plus one delegated sanity run prove joined intent/effect rows and evidence-pack output. |
 | 5 | Planned | Interop matrix plan | OTel/OpenInference/Runner coverage axes and non-claims pinned. |
 | 6 | Optional | OTel span-limit study | Only after an external trigger; otherwise remains issue-only. |
@@ -379,6 +393,11 @@ Not every follow-up needs full experiment-arc discipline:
 Use the heavier slice discipline when the result will be interpreted as
 evidence. Use feature iteration when the task is improving how evidence
 is carried or rendered.
+
+Status labels may differ by slice type. `Scenario-plan-ready` means the
+scenario matrix, baseline, claim rules, and next harness gate are pinned
+before implementation. It does not mean the harness exists or that any
+measurement has run.
 
 ## What Not To Do Yet
 

--- a/docs/experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md
@@ -1,0 +1,181 @@
+# Semantic Gap Scenario Plan
+
+> **Status:** plan-only Slice 3 for the
+> agent-observability fidelity roadmap. This document predeclares the
+> baseline, scenarios, join requirements, claim classes, and evidence
+> pack expectations before any semantic-gap harness or delegated run is
+> added.
+>
+> **Last updated:** 2026-05-28
+
+## Goal
+
+The semantic-gap experiment asks one narrow question:
+
+```text
+When a trace reports one tool-call intent and Runner measures a system
+effect, what claim is safe if those layers agree, disagree, or can only
+be joined weakly?
+```
+
+This is not an overhead benchmark. It is a fidelity and claim-boundary
+experiment that uses the completed calibration guardrail and evidence
+pack prototype as prerequisites.
+
+## Prerequisites
+
+| Prerequisite | Status | Why it matters |
+|---|---|---|
+| Fidelity calibration | Done for the overhead harness | A trace/archive comparison cannot interpret missing retained signal as efficient or safe behavior. |
+| Evidence pack carrier | Prototype-ready | Every scenario should be reviewable as a small pack rather than a loose artifact pile. |
+| Join contract | Reference-ready | Strong findings require an explicit join key and grade, not timestamp proximity. |
+| Claim classes | Reference-ready | Reported intent, measured effects, derived joins, and inferred diagnostics must stay separate. |
+
+The first harness PR should reuse
+`assay.observability.join_result.v0`,
+`assay.observability.claim_class_cell.v0`, and
+`assay.experiment.agent_observability_fidelity.evidence_pack.v0` unless
+the implementation proves a version bump is required.
+
+## Baseline
+
+The baseline is a deterministic safe tool call:
+
+| Field | Value |
+|---|---|
+| Scenario id | `matched_safe_read` |
+| Tool call id | stable unique id, for example `tc_semantic_gap_001` |
+| Reported intent | read `safe.txt` |
+| Measured effect | kernel/archive observes read/open of `safe.txt` inside the workdir |
+| Expected join | `tool_call_id`, `strong`, `tool_call`, `unique_within_scope=true` |
+| Expected claim | positive joined evidence: reported intent and measured effect agree inside the measurement boundary |
+
+This baseline is not optional. Every gap scenario is interpreted against
+the same fixture contract and the same join path. Synthetic fixtures are
+acceptable for unit tests, but at least one delegated sanity run must
+prove this baseline under real Runner capture before any gap finding is
+published.
+
+## Scenario Matrix
+
+| ID | Role | Reported trace intent | Measured system effect | Join requirement | Expected safe claim |
+|---|---|---|---|---|---|
+| `matched_safe_read` | baseline | tool reports reading `safe.txt` | archive observes read/open of `safe.txt` | unique `tool_call_id` | strong positive join |
+| `path_rewrite` | gap | tool reports `safe.txt` | archive observes normalized alternate path that resolves inside the same fixture boundary | same unique `tool_call_id` | semantic mismatch or projection ambiguity, not unsafe behavior |
+| `hidden_write` | gap | tool reports read-only action | archive observes create/write of `side-effect.txt` in workdir | same unique `tool_call_id` | reported intent under-describes measured side effect |
+| `retry_self_correction` | gap | trace summary records final successful read | archive records prior failed attempts before the final read | same unique `tool_call_id` plus ordered attempt index if available | trace summary loses temporal evidence |
+| `runtime_side_effect` | gap | no tool-level event reports the runtime/config/probe path | archive observes runtime loader/config/probe path inside capture boundary | run-level join only unless a tool id exists | runtime-induced measured surface; diagnostic unless scoped to runtime setup |
+| `weak_join_fallback` | fallback | tool event is missing `tool_call_id` | archive observes plausible matching effect near the same order/timestamp | timestamp/order only | diagnostic-only correlation, not semantic equality |
+
+### Scenario Notes
+
+- `path_rewrite` should distinguish benign projection mismatch from
+  dangerous target drift. A normalized path inside the fixture boundary
+  is still a gap between reported and measured representation, not
+  automatically a policy failure.
+- `hidden_write` is the sharpest same-tool-call divergence. It needs a
+  clean Runner health gate and a unique tool-call join before it can
+  support a strong joined-evidence claim.
+- `retry_self_correction` should keep prior failed attempts visible even
+  when the final trace span reports success. The point is temporal
+  loss, not whether retry behavior is good or bad.
+- `runtime_side_effect` is intentionally not framed as agent intent. It
+  tests whether Assay can separate tool effects from runtime/framework
+  effects.
+- `weak_join_fallback` exists to prove the negative case: plausible
+  timing is useful for investigation but must not become a strong claim.
+
+## Required Outputs
+
+The harness slice should produce one output directory per scenario with
+stable names:
+
+```text
+semantic-gap-runs/<scenario-id>/
+  join-result.json
+  claim-class-cells.json
+  evidence-pack/
+    manifest.json
+    summary.md
+    redaction-manifest.json
+    artifacts/...
+```
+
+Minimum required rows per scenario:
+
+| Row | Requirement |
+|---|---|
+| Join result | One `assay.observability.join_result.v0` row naming the key, grade, scope, uniqueness, fallback usage, and evidence refs. |
+| Claim cells | At least one trace/reported cell, one archive/measured cell, and one joined-artifacts cell. |
+| Evidence pack | One experiment-scoped evidence pack carrying the trace/archive or references, observation health, redaction manifest, and one-page summary. |
+| Scenario verdict | A bounded verdict: `positive_join`, `semantic_gap`, `diagnostic_only`, or `inconclusive`. |
+
+Evidence-pack `claim_class` should map verdicts conservatively:
+
+| Scenario verdict | Evidence-pack `claim_class` |
+|---|---|
+| `positive_join` | `positive_join` |
+| `semantic_gap` | `semantic_gap` |
+| `diagnostic_only` | `diagnostic` |
+| `inconclusive` | `diagnostic` |
+
+## Claim Rules
+
+| Condition | Maximum safe claim |
+|---|---|
+| Unique `tool_call_id`, clean Runner health, and matching reported/measured target | `positive_join` |
+| Unique `tool_call_id`, clean Runner health, and measured effect differs from reported intent | `semantic_gap` |
+| Clean Runner health but only run-level join | measured effect exists in the run; no per-tool semantic equality |
+| Timestamp/order fallback only | diagnostic-only |
+| Runner health not clean | inconclusive for measured-effect claims |
+| Trace calibration lossy or inconclusive | no claim that absent trace fields prove absence of intent |
+
+The first findings document should report claim strength and basis using
+`assay.observability.claim_class_cell.v0` vocabulary:
+
+| Layer | Typical basis | Typical strength |
+|---|---|---|
+| Trace intent | `reported` | strong inside trace boundary, absent for unreported effects |
+| Runner archive effect | `measured` | strong only when health is clean |
+| Joined comparison | `derived` | bounded by join grade and the weaker source layer |
+| Fallback/order correlation | `inferred` | weak or diagnostic only |
+
+## Acceptance Rules
+
+- Do not dispatch or publish measurements from this plan-only slice.
+- Every scenario must have a role: `baseline`, `gap`, or `fallback`.
+- Strong semantic-gap findings require a unique same-scenario
+  `tool_call_id`; timestamp/order fallback remains diagnostic.
+- Every measured-effect claim must state Runner health and evidence refs.
+- Every trace absence claim must state trace retention/calibration
+  status. Missing trace fields do not prove missing behavior.
+- Each scenario evidence pack must preserve the non-claim that it does
+  not strengthen underlying join/calibration grades.
+- Redaction must remain explicit even for synthetic fixtures.
+- Mismatches are divergence evidence, not proof of malicious behavior,
+  policy failure, or root cause.
+
+## Non-Claims
+
+- This plan does not add a harness or dispatch delegated runs.
+- This plan does not rank OTel, OpenInference, Runner, or Assay.
+- This plan does not claim semantic gaps are malicious.
+- This plan does not promote evidence packs, join results, or claim
+  cells to product APIs.
+- This plan does not replace Runner archive integrity or health gates.
+
+## Exit Gate For Slice 4
+
+Slice 4 may start when this document is merged and the harness PR can
+show, using synthetic fixtures first, that:
+
+1. `matched_safe_read` emits a strong `tool_call_id` join and a
+   `positive_join` evidence pack.
+2. `hidden_write` emits a strong join but a `semantic_gap` verdict.
+3. `weak_join_fallback` emits only a diagnostic join and cannot be
+   rendered as semantic equality.
+
+Those three cases are the minimum useful harness. The remaining
+scenarios can be added after the shape is proven, but the harness should
+not publish delegated findings until all predeclared scenarios have
+either run or been explicitly scoped out.

--- a/docs/reference/artifact-families-inventory.md
+++ b/docs/reference/artifact-families-inventory.md
@@ -39,7 +39,7 @@ accidentally present proposed artifacts as canonical product surfaces.
 | Fidelity calibration | `experiment-scoped` | `assay.experiment.agent_observability_fidelity.calibration.v0` | Requested-vs-observed fidelity verdicts and per-layer count methods embedded by the overhead harness. |
 | Evidence pack | `experiment-scoped` | `assay.experiment.agent_observability_fidelity.evidence_pack.v0` | Prototype portable bundle carrier for one run or scenario, with manifest, summary, health, archive/trace references, and explicit redaction manifest. |
 | Binding evidence / join receipts | `proposed` | undecided | Working term for tool-call input/output/effect binding evidence. Not a product line yet. |
-| Semantic-gap finding | `proposed` | undecided | Experiment result family for reported-intent vs measured-effect divergence. |
+| Semantic-gap finding | `proposed` | planned under [`semantic-gap-scenario-plan.md`](../experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md) | Experiment result family for reported-intent vs measured-effect divergence. Plan-ready only; no schema or harness yet. |
 | Interop mapping | `proposed` | undecided | Mapping rows between OTel GenAI, OpenInference, Runner, and Assay claim vocabulary. |
 
 ## Promotion Rule

--- a/docs/reference/observability/README.md
+++ b/docs/reference/observability/README.md
@@ -40,3 +40,9 @@ The first experiment-scoped evidence-pack prototype is tracked in
 It renders a portable manifest, one-page summary, observation-health
 record, optional trace, Runner archive/reference, and explicit redaction
 manifest without promoting that carrier to a product API.
+
+The first semantic-gap scenario plan is tracked in
+[`../../experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md`](../../experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md).
+It predeclares how the join and claim-class contracts should be used
+when trace-reported tool intent and measured system effects agree,
+diverge, or only correlate weakly.


### PR DESCRIPTION
Summary

Plans Slice 3 of the agent-observability fidelity roadmap: the semantic-gap / intent-vs-effect scenario matrix. This keeps the next harness work predeclared before adding fixtures, dispatching delegated runs, or publishing any gap findings.

What changed

- Adds `docs/experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md` with the baseline, six scenario roles, join requirements, claim rules, required outputs, non-claims, and Slice 4 minimum harness gate.
- Updates the roadmap to mark Slice 3 as scenario-plan-ready and to define that status as plan/exit-gate ready, not harness-ready.
- Adds a role column to the scenario table: baseline / gap / fallback.
- Pins the minimum Slice 4 harness proof set: `matched_safe_read`, `hidden_write`, and `weak_join_fallback`.
- Cross-links the plan from observability references and keeps semantic-gap findings `proposed` in the artifact-family inventory.

Validation

- `python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py'` -> 5 OK
- local changed-docs link check -> OK
- `git diff --check`
- pre-commit + pre-push hooks green, including linux compile gate

Local note

- `mkdocs build --strict` was not run locally because `mkdocs` is not installed on this machine; CI should cover mkdocs-strict.

Non-claims

- Does not add a semantic-gap harness or fixtures.
- Does not dispatch delegated runs or commit measurement artifacts.
- Does not claim any scenario is malicious, a policy failure, or root cause.
- Does not promote evidence packs, join results, claim cells, or semantic-gap findings to product APIs.
