### PR TITLE
docs(experiments): clarify semantic gap harness gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,9 +151,10 @@ All notable changes to this project will be documented in this file.
   a harness or dispatching measurements.
 - Clarified the semantic-gap pre-harness contract before implementation:
   the `path_rewrite` fixture uses a symlink-resolution pattern, runtime
-  side effects remain run-scope or ambiguous-proximity unless a strong
-  key exists, and Slice 4's MVP gate can be synthetic while delegated
-  capture remains required before publishing measured findings.
+  side effects remain run-scope or `timestamp_or_order` diagnostic joins
+  unless a strong key exists, and Slice 4's MVP gate can be synthetic
+  while delegated capture remains required before publishing measured
+  findings.
 
 ## [3.12.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,11 @@ All notable changes to this project will be documented in this file.
   join-grade requirements, claim-class rules, evidence-pack output
   expectations, and the minimum Slice 4 harness exit gate without adding
   a harness or dispatching measurements.
+- Clarified the semantic-gap pre-harness contract before implementation:
+  the `path_rewrite` fixture uses a symlink-resolution pattern, runtime
+  side effects remain run-scope or ambiguous-proximity unless a strong
+  key exists, and Slice 4's MVP gate can be synthetic while delegated
+  capture remains required before publishing measured findings.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/agent-observability-fidelity-2026-05.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05.md
@@ -262,10 +262,11 @@ join path under real Runner capture before gap findings are published.
 | Runtime side effect | gap | no tool-level trace event | archive records runtime loader/config/probe path | runtime-induced surface |
 | Weak join fallback | fallback | missing `tool_call_id`, only order/timestamp | effects are plausible but not strongly joinable | diagnostic-only claim |
 
-The detailed plan pins scenario ids, join requirements, claim rules, and
-the minimum harness exit gate. The first harness should prove the
-baseline, `hidden_write`, and `weak_join_fallback` before broadening to
-all six scenarios.
+The detailed plan pins scenario ids, join requirements, claim rules,
+the canonical `path_rewrite` symlink fixture, runtime-side-effect join
+policy, and the minimum harness exit gate. The first harness should
+prove the baseline, `hidden_write`, and `weak_join_fallback` with
+synthetic fixtures before broadening to all six scenarios.
 
 ### Acceptance rules
 
@@ -286,9 +287,11 @@ all six scenarios.
 
 ### Tool improvement
 
-This experiment should drive product work on input-binding receipts and
-per-tool evidence rows. If the tool cannot clearly say "same tool call,
-different effect," the observability story is not strong enough yet.
+This experiment may drive product work on binding evidence or per-tool
+input/output/effect carriers, still tracked as `proposed` in the
+artifact-families inventory. If the tool cannot clearly say "same tool
+call, different effect," the observability story is not strong enough
+yet.
 
 ## Experiment 4 - OTel / OpenInference / Runner Interop Matrix
 

--- a/docs/experiments/agent-observability-fidelity-2026-05.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05.md
@@ -256,7 +256,7 @@ join path under real Runner capture before gap findings are published.
 | Scenario | Role | Reported trace intent | Measured effect | Expected claim |
 |---|---|---|---|---|
 | Matched safe read | baseline | tool call reports reading `safe.txt` | kernel observes read of `safe.txt` | strong positive join |
-| Argument/path rewrite | gap | tool call reports `safe.txt` | kernel observes normalized alternate path | semantic mismatch at same tool call |
+| Argument/path rewrite | gap | tool call reports `safe-link.txt` | kernel observes symlink target `safe.txt` or both paths inside the workdir | semantic mismatch at same tool call |
 | Hidden write | gap | tool call reports read-only action | kernel observes create/write in workdir | reported intent under-describes measured side effect |
 | Retry/self-correction | gap | trace records final successful action | kernel/archive records failed prior attempts | trace summary loses temporal evidence |
 | Runtime side effect | gap | no tool-level trace event | archive records runtime loader/config/probe path | runtime-induced surface |

--- a/docs/experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md
@@ -28,8 +28,8 @@ pack prototype as prerequisites.
 |---|---|---|
 | Fidelity calibration | Done for the overhead harness | A trace/archive comparison cannot interpret missing retained signal as efficient or safe behavior. |
 | Evidence pack carrier | Prototype-ready | Every scenario should be reviewable as a small pack rather than a loose artifact pile. |
-| Join contract | Reference-ready | Strong findings require an explicit join key and grade, not timestamp proximity. |
-| Claim classes | Reference-ready | Reported intent, measured effects, derived joins, and inferred diagnostics must stay separate. |
+| Join contract | Reference-ready: [`join-result-v0.schema.json`](../../reference/observability/schema/join-result-v0.schema.json) exists | Strong findings require an explicit join key and grade, not timestamp proximity. |
+| Claim classes | Reference-ready: [`claim-class-cell-v0.schema.json`](../../reference/observability/schema/claim-class-cell-v0.schema.json) exists | Reported intent, measured effects, derived joins, and inferred diagnostics must stay separate. |
 
 The first harness PR should reuse
 `assay.observability.join_result.v0`,
@@ -61,7 +61,7 @@ published.
 | ID | Role | Reported trace intent | Measured system effect | Join requirement | Expected safe claim |
 |---|---|---|---|---|---|
 | `matched_safe_read` | baseline | tool reports reading `safe.txt` | archive observes read/open of `safe.txt` | unique `tool_call_id` | strong positive join |
-| `path_rewrite` | gap | tool reports `safe.txt` | archive observes normalized alternate path that resolves inside the same fixture boundary | same unique `tool_call_id` | semantic mismatch or projection ambiguity, not unsafe behavior |
+| `path_rewrite` | gap | tool reports `safe-link.txt` | archive observes the symlink target `safe.txt` inside the same fixture boundary | same unique `tool_call_id` | semantic mismatch or projection ambiguity, not unsafe behavior |
 | `hidden_write` | gap | tool reports read-only action | archive observes create/write of `side-effect.txt` in workdir | same unique `tool_call_id` | reported intent under-describes measured side effect |
 | `retry_self_correction` | gap | trace summary records final successful read | archive records prior failed attempts before the final read | same unique `tool_call_id` plus ordered attempt index if available | trace summary loses temporal evidence |
 | `runtime_side_effect` | gap | no tool-level event reports the runtime/config/probe path | archive observes runtime loader/config/probe path inside capture boundary | run-level join only unless a tool id exists | runtime-induced measured surface; diagnostic unless scoped to runtime setup |
@@ -69,10 +69,12 @@ published.
 
 ### Scenario Notes
 
-- `path_rewrite` should distinguish benign projection mismatch from
-  dangerous target drift. A normalized path inside the fixture boundary
-  is still a gap between reported and measured representation, not
-  automatically a policy failure.
+- `path_rewrite` uses one canonical rewrite pattern for Slice 4: the
+  fixture creates `safe-link.txt -> safe.txt`, the trace reports
+  `safe-link.txt`, and the measured archive is expected to observe the
+  resolved target `safe.txt` or both paths depending on kernel event
+  shape. Both paths must remain inside the scenario workdir. This is a
+  representation/projection gap, not automatically a policy failure.
 - `hidden_write` is the sharpest same-tool-call divergence. It needs a
   clean Runner health gate and a unique tool-call join before it can
   support a strong joined-evidence claim.
@@ -81,7 +83,10 @@ published.
   loss, not whether retry behavior is good or bad.
 - `runtime_side_effect` is intentionally not framed as agent intent. It
   tests whether Assay can separate tool effects from runtime/framework
-  effects.
+  effects. Runtime events emitted before the first tool-call event are
+  run-scope only by definition. Runtime events near a tool call by
+  timestamp/order alone must be flagged as `ambiguous_proximity`, not
+  upgraded to a strong tool-call join.
 - `weak_join_fallback` exists to prove the negative case: plausible
   timing is useful for investigation but must not become a strong claim.
 
@@ -110,6 +115,13 @@ Minimum required rows per scenario:
 | Evidence pack | One experiment-scoped evidence pack carrying the trace/archive or references, observation health, redaction manifest, and one-page summary. |
 | Scenario verdict | A bounded verdict: `positive_join`, `semantic_gap`, `diagnostic_only`, or `inconclusive`. |
 
+The evidence pack's `scenario_id` field must equal the scenario id from
+this plan, for example `matched_safe_read`, `hidden_write`, or
+`weak_join_fallback`. The Slice 4 harness can use the existing
+`evidence_pack.py create --out-dir
+semantic-gap-runs/<scenario-id>/evidence-pack` command; no evidence-pack
+CLI change is required for the planned directory layout.
+
 Evidence-pack `claim_class` should map verdicts conservatively:
 
 | Scenario verdict | Evidence-pack `claim_class` |
@@ -129,6 +141,11 @@ Evidence-pack `claim_class` should map verdicts conservatively:
 | Timestamp/order fallback only | diagnostic-only |
 | Runner health not clean | inconclusive for measured-effect claims |
 | Trace calibration lossy or inconclusive | no claim that absent trace fields prove absence of intent |
+
+If fidelity calibration for a scenario is `lossy` or `inconclusive`,
+the scenario verdict becomes `inconclusive` regardless of the
+intent/effect comparison. That sample may still be cited as calibration
+evidence, but not as a semantic-gap finding.
 
 The first findings document should report claim strength and basis using
 `assay.observability.claim_class_cell.v0` vocabulary:
@@ -179,3 +196,9 @@ Those three cases are the minimum useful harness. The remaining
 scenarios can be added after the shape is proven, but the harness should
 not publish delegated findings until all predeclared scenarios have
 either run or been explicitly scoped out.
+
+The three MVP cases may all be synthetic-fixture-only at harness gate
+time. A delegated `matched_safe_read` sanity run is required before any
+semantic-gap finding is published. Delegated runs for `hidden_write` and
+`weak_join_fallback` are required only when their findings are promoted
+from harness behavior to measured results.

--- a/docs/experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md
@@ -85,8 +85,9 @@ published.
   tests whether Assay can separate tool effects from runtime/framework
   effects. Runtime events emitted before the first tool-call event are
   run-scope only by definition. Runtime events near a tool call by
-  timestamp/order alone must be flagged as `ambiguous_proximity`, not
-  upgraded to a strong tool-call join.
+  timestamp/order alone must use the existing `timestamp_or_order` join
+  key with `diagnostic` grade and may add `ambiguous_proximity` only as
+  a freeform note. They must not be upgraded to a strong tool-call join.
 - `weak_join_fallback` exists to prove the negative case: plausible
   timing is useful for investigation but must not become a strong claim.
 
@@ -118,9 +119,13 @@ Minimum required rows per scenario:
 The evidence pack's `scenario_id` field must equal the scenario id from
 this plan, for example `matched_safe_read`, `hidden_write`, or
 `weak_join_fallback`. The Slice 4 harness can use the existing
-`evidence_pack.py create --out-dir
-semantic-gap-runs/<scenario-id>/evidence-pack` command; no evidence-pack
-CLI change is required for the planned directory layout.
+evidence-pack command; no evidence-pack CLI change is required for the
+planned directory layout.
+
+```bash
+python3 docs/experiments/agent-observability-fidelity-2026-05/evidence_pack.py create \
+  --out-dir semantic-gap-runs/<scenario-id>/evidence-pack
+```
 
 Evidence-pack `claim_class` should map verdicts conservatively:
 


### PR DESCRIPTION
Summary

Tightens the post-merge Slice 3 semantic-gap plan before Slice 4 harness work starts. This is a docs-only clarification PR: it does not add harness code, fixtures, dispatches, or measurement artifacts.

What changed

- Verifies the Slice 4 prerequisites by linking the existing `join-result-v0` and `claim-class-cell-v0` schemas from the semantic-gap plan.
- Pins the canonical `path_rewrite` fixture as a symlink-resolution case: trace reports `safe-link.txt`, measured archive observes `safe.txt` or both paths inside the workdir.
- Pins runtime side-effect join policy: pre-tool runtime events are run-scope only; timestamp-adjacent runtime events are `ambiguous_proximity`, not strong tool-call joins.
- Requires evidence-pack `scenario_id` to equal the scenario id from the plan and notes the existing `evidence_pack.py --out-dir semantic-gap-runs/<scenario-id>/evidence-pack` flow needs no CLI change.
- Clarifies that lossy/inconclusive fidelity calibration downgrades scenario verdicts to `inconclusive` regardless of apparent intent/effect divergence.
- Clarifies that Slice 4's MVP harness gate may use synthetic fixtures, while delegated baseline confirmation is required before publishing measured gap findings.

Validation

- `python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py'` -> 5 OK
- local changed-docs link check -> OK
- `git diff --check`
- pre-commit + pre-push hooks green, including linux compile gate

Local note

- `mkdocs build --strict` was not run locally because `mkdocs` is not installed on this machine; CI should cover mkdocs-strict.

Non-claims

- Does not add the Slice 4 harness, fixtures, or delegated workflow.
- Does not dispatch runs or commit measurement artifacts.
- Does not publish semantic-gap findings.
- Does not promote semantic-gap findings, evidence packs, join rows, or claim cells to product APIs.
