### PR TITLE
feat(experiments): add semantic gap MVP harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,12 @@ All notable changes to this project will be documented in this file.
   unless a strong key exists, and Slice 4's MVP gate can be synthetic
   while delegated capture remains required before publishing measured
   findings.
+- Added the Slice 4 semantic-gap MVP harness. The synthetic harness
+  emits `matched_safe_read`, `hidden_write`, and `weak_join_fallback`
+  scenario directories with trace/archive fixtures, join-result rows,
+  claim-class cells, bounded semantic-gap verdicts, and evidence packs
+  without dispatching delegated runs or publishing semantic-gap
+  findings.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/agent-observability-fidelity-2026-05.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05.md
@@ -1,8 +1,9 @@
 # Agent Observability Fidelity Roadmap (2026-05)
 
-> **Status:** plan-only follow-up after the completed
-> Runner-vs-OTel overhead arc. This document ranks the next useful
-> experiments for improving Assay's agent-observability surface. It does
+> **Status:** roadmap plus implemented local harness slices after the
+> completed Runner-vs-OTel overhead arc. This document ranks the next
+> useful experiments for improving Assay's agent-observability surface
+> and links the implemented local guardrail/prototype harnesses. It does
 > not dispatch new runs, does not commit measurement artifacts, and does
 > not open the optional OTel span-limit study tracked in
 > [issue #1408](https://github.com/Rul1an/assay/issues/1408).
@@ -227,11 +228,13 @@ Assay feature: "give me the portable evidence for this agent run."
 **Goal:** prove exactly where trace-reported intent, SDK events, policy
 events, and measured system effects diverge.
 
-> **Status:** scenario-plan-ready. The baseline, scenario matrix, join
-> requirements, claim-class rules, evidence-pack expectations, and
-> Slice 4 exit gate are predeclared in
+> **Status:** MVP synthetic harness-ready. The baseline, scenario
+> matrix, join requirements, claim-class rules, evidence-pack
+> expectations, and Slice 4 exit gate are predeclared in
 > [`agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md`](agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md).
-> This does not add a harness or dispatch measurements.
+> [`agent-observability-fidelity-2026-05/semantic_gap_harness.py`](agent-observability-fidelity-2026-05/semantic_gap_harness.py)
+> now generates the three MVP synthetic scenarios and evidence packs.
+> This does not dispatch delegated measurements.
 
 This is the most strategically valuable new experiment. It extends the
 existing runner-vs-OTel shape comparison and cross-runtime drift work
@@ -264,9 +267,26 @@ join path under real Runner capture before gap findings are published.
 
 The detailed plan pins scenario ids, join requirements, claim rules,
 the canonical `path_rewrite` symlink fixture, runtime-side-effect join
-policy, and the minimum harness exit gate. The first harness should
-prove the baseline, `hidden_write`, and `weak_join_fallback` with
-synthetic fixtures before broadening to all six scenarios.
+policy, and the minimum harness exit gate. The MVP harness proves the
+baseline, `hidden_write`, and `weak_join_fallback` with synthetic
+fixtures before broadening to all six scenarios.
+
+### MVP harness
+
+The Slice 4 MVP harness emits one directory per synthetic scenario:
+
+```bash
+python3 docs/experiments/agent-observability-fidelity-2026-05/semantic_gap_harness.py \
+  --out-dir semantic-gap-runs
+```
+
+Each MVP scenario directory contains `trace.json`,
+`runner-archive.json`, `observation-health.json`, `join-result.json`,
+`claim-class-cells.json`, `scenario-verdict.json`, `summary.md`, and an
+`evidence-pack/` directory. The verdict file uses
+`assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0`.
+The MVP harness is synthetic-only; delegated baseline capture is still
+required before any semantic-gap finding is published.
 
 ### Acceptance rules
 
@@ -282,8 +302,10 @@ synthetic fixtures before broadening to all six scenarios.
 - **Done for Slice 3:** a measured effect mismatch is evidence of
   divergence. It is not by itself evidence of malicious behavior, policy
   failure, or root-cause attribution.
-- **Not done:** harness, synthetic fixtures, delegated sanity run, or
-  committed measurement artifacts.
+- **Done for Slice 4 MVP:** synthetic fixtures and evidence-pack output
+  for `matched_safe_read`, `hidden_write`, and `weak_join_fallback`.
+- **Not done:** delegated sanity run, all six scenario implementations,
+  or committed measurement artifacts.
 
 ### Tool improvement
 
@@ -378,7 +400,7 @@ visible by the overhead and shape-comparison arcs.
 | 1 | Harness-ready | Fidelity calibration fields and summary rendering | One overhead-style fixture proves clean, lossy, and not-applicable calibration states. |
 | 2 | Prototype-ready | Portable evidence-pack prototype | `evidence_pack.py` emits the minimum pack: manifest, summary, archive/ref, optional trace/ref, health, and redaction manifest. |
 | 3 | Scenario-plan-ready | Semantic-gap scenario plan | Baseline plus six predeclared scenarios, claim classes, join requirements, evidence-pack expectations, and Slice 4 minimum harness gate documented before dispatch. |
-| 4 | Planned | Semantic-gap harness | Fake fixtures plus one delegated sanity run prove joined intent/effect rows and evidence-pack output. |
+| 4 | MVP harness-ready | Semantic-gap harness | Synthetic fixtures prove the three exit-gate cases with joined intent/effect rows, bounded verdicts, and evidence-pack output; delegated sanity run remains not done. |
 | 5 | Planned | Interop matrix plan | OTel/OpenInference/Runner coverage axes and non-claims pinned. |
 | 6 | Optional | OTel span-limit study | Only after an external trigger; otherwise remains issue-only. |
 
@@ -399,8 +421,8 @@ is carried or rendered.
 
 Status labels may differ by slice type. `Scenario-plan-ready` means the
 scenario matrix, baseline, claim rules, and next harness gate are pinned
-before implementation. It does not mean the harness exists or that any
-measurement has run.
+before implementation. `MVP harness-ready` means synthetic fixtures
+exercise the minimum gate without publishing delegated measurements.
 
 ## What Not To Do Yet
 

--- a/docs/experiments/agent-observability-fidelity-2026-05/schema/semantic-gap-verdict-v0.schema.json
+++ b/docs/experiments/agent-observability-fidelity-2026-05/schema/semantic-gap-verdict-v0.schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/Rul1an/assay/main/docs/experiments/agent-observability-fidelity-2026-05/schema/semantic-gap-verdict-v0.schema.json",
+  "title": "Assay agent-observability semantic-gap verdict v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "scenario_id",
+    "role",
+    "verdict",
+    "evidence_pack_claim_class",
+    "runner_health_status",
+    "trace_calibration_status",
+    "join_key",
+    "join_grade",
+    "fallback_used",
+    "reason",
+    "non_claims"
+  ],
+  "properties": {
+    "schema": {
+      "const": "assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0"
+    },
+    "scenario_id": {
+      "type": "string",
+      "enum": [
+        "matched_safe_read",
+        "hidden_write",
+        "weak_join_fallback"
+      ]
+    },
+    "role": {
+      "type": "string",
+      "enum": [
+        "baseline",
+        "gap",
+        "fallback"
+      ]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "positive_join",
+        "semantic_gap",
+        "diagnostic_only",
+        "inconclusive"
+      ]
+    },
+    "evidence_pack_claim_class": {
+      "type": "string",
+      "enum": [
+        "diagnostic",
+        "fidelity_boundary",
+        "semantic_gap",
+        "positive_join"
+      ]
+    },
+    "runner_health_status": {
+      "type": "string",
+      "enum": [
+        "clean",
+        "inconclusive"
+      ]
+    },
+    "trace_calibration_status": {
+      "type": "string",
+      "enum": [
+        "clean",
+        "lossy",
+        "inconclusive",
+        "not_applicable"
+      ]
+    },
+    "join_key": {
+      "type": "string",
+      "enum": [
+        "tool_call_id",
+        "run_id",
+        "session_id",
+        "trace_span_id",
+        "timestamp_or_order"
+      ]
+    },
+    "join_grade": {
+      "type": "string",
+      "enum": [
+        "strong",
+        "weak",
+        "diagnostic",
+        "failed"
+      ]
+    },
+    "fallback_used": {
+      "type": "boolean"
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "non_claims": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^[a-z][a-z0-9_]*$"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "positive_join"
+          }
+        },
+        "required": [
+          "verdict"
+        ]
+      },
+      "then": {
+        "properties": {
+          "evidence_pack_claim_class": {
+            "const": "positive_join"
+          },
+          "join_grade": {
+            "const": "strong"
+          },
+          "fallback_used": {
+            "const": false
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "semantic_gap"
+          }
+        },
+        "required": [
+          "verdict"
+        ]
+      },
+      "then": {
+        "properties": {
+          "evidence_pack_claim_class": {
+            "const": "semantic_gap"
+          },
+          "join_grade": {
+            "const": "strong"
+          },
+          "fallback_used": {
+            "const": false
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "diagnostic_only"
+          }
+        },
+        "required": [
+          "verdict"
+        ]
+      },
+      "then": {
+        "properties": {
+          "evidence_pack_claim_class": {
+            "const": "diagnostic"
+          },
+          "join_grade": {
+            "enum": [
+              "weak",
+              "diagnostic",
+              "failed"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "verdict": {
+            "const": "inconclusive"
+          }
+        },
+        "required": [
+          "verdict"
+        ]
+      },
+      "then": {
+        "properties": {
+          "evidence_pack_claim_class": {
+            "const": "diagnostic"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md
@@ -1,10 +1,11 @@
 # Semantic Gap Scenario Plan
 
-> **Status:** plan-only Slice 3 for the
-> agent-observability fidelity roadmap. This document predeclares the
-> baseline, scenarios, join requirements, claim classes, and evidence
-> pack expectations before any semantic-gap harness or delegated run is
-> added.
+> **Status:** scenario-plan-ready plus Slice 4 MVP synthetic
+> harness-ready for the agent-observability fidelity roadmap. This
+> document predeclared the baseline, scenarios, join requirements,
+> claim classes, and evidence pack expectations before harness work; the
+> MVP harness now implements the three minimum exit-gate scenarios
+> without delegated runs.
 >
 > **Last updated:** 2026-05-28
 
@@ -36,6 +37,10 @@ The first harness PR should reuse
 `assay.observability.claim_class_cell.v0`, and
 `assay.experiment.agent_observability_fidelity.evidence_pack.v0` unless
 the implementation proves a version bump is required.
+
+The Slice 4 MVP harness lives in [`semantic_gap_harness.py`](semantic_gap_harness.py).
+It emits the three minimum synthetic scenarios from the exit gate:
+`matched_safe_read`, `hidden_write`, and `weak_join_fallback`.
 
 ## Baseline
 
@@ -117,6 +122,12 @@ Minimum required rows per scenario:
 | Evidence pack | One experiment-scoped evidence pack carrying the trace/archive or references, observation health, redaction manifest, and one-page summary. |
 | Scenario verdict | A bounded verdict: `positive_join`, `semantic_gap`, `diagnostic_only`, or `inconclusive`. |
 
+The MVP harness emits scenario verdicts with
+`assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0`.
+That schema is experiment-scoped and covers the three synthetic
+exit-gate scenarios only; delegated findings or additional scenario
+types require a deliberate schema review before publication.
+
 The evidence pack's `scenario_id` field must equal the scenario id from
 this plan, for example `matched_safe_read`, `hidden_write`, or
 `weak_join_fallback`. The Slice 4 harness can use the existing
@@ -180,7 +191,7 @@ The first findings document should report claim strength and basis using
 
 ## Non-Claims
 
-- This plan does not add a harness or dispatch delegated runs.
+- The MVP harness does not dispatch delegated runs.
 - This plan does not rank OTel, OpenInference, Runner, or Assay.
 - This plan does not claim semantic gaps are malicious.
 - This plan does not promote evidence packs, join results, or claim
@@ -189,8 +200,8 @@ The first findings document should report claim strength and basis using
 
 ## Exit Gate For Slice 4
 
-Slice 4 may start when this document is merged and the harness PR can
-show, using synthetic fixtures first, that:
+Slice 4's MVP synthetic harness is ready when it can show, using
+synthetic fixtures first, that:
 
 1. `matched_safe_read` emits a strong `tool_call_id` join and a
    `positive_join` evidence pack.

--- a/docs/experiments/agent-observability-fidelity-2026-05/semantic_gap_harness.py
+++ b/docs/experiments/agent-observability-fidelity-2026-05/semantic_gap_harness.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Generate synthetic semantic-gap harness outputs for the MVP scenarios."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from evidence_pack import build_pack, utc_now
+
+JOIN_RESULT_SCHEMA = "assay.observability.join_result.v0"
+CLAIM_CLASS_CELL_SCHEMA = "assay.observability.claim_class_cell.v0"
+SEMANTIC_GAP_VERDICT_SCHEMA = (
+    "assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0"
+)
+
+MVP_SCENARIOS = ("matched_safe_read", "hidden_write", "weak_join_fallback")
+
+
+@dataclass(frozen=True)
+class Scenario:
+    scenario_id: str
+    role: str
+    verdict: str
+    evidence_claim_class: str
+    claim_summary: str
+    trace_tool_call: dict[str, Any]
+    measured_effect: dict[str, Any]
+    join: dict[str, Any]
+    joined_claim_strength: str
+    joined_claim_basis: str
+    joined_notes: list[str]
+    non_claims: list[str]
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def clean_health() -> dict[str, Any]:
+    return {
+        "kernel_layer": "complete",
+        "ringbuf_drops": 0,
+        "cgroup_correlation": "clean",
+    }
+
+
+def scenario_definitions() -> dict[str, Scenario]:
+    matched_tool_call_id = "tc_semantic_gap_matched_safe_read"
+    hidden_tool_call_id = "tc_semantic_gap_hidden_write"
+    return {
+        "matched_safe_read": Scenario(
+            scenario_id="matched_safe_read",
+            role="baseline",
+            verdict="positive_join",
+            evidence_claim_class="positive_join",
+            claim_summary=(
+                "Synthetic trace intent and measured archive effect agree for "
+                "safe.txt under a unique tool_call_id."
+            ),
+            trace_tool_call={
+                "tool_call_id": matched_tool_call_id,
+                "tool_name": "read_file",
+                "reported_action": "read",
+                "reported_path": "safe.txt",
+                "order": 1,
+            },
+            measured_effect={
+                "tool_call_id": matched_tool_call_id,
+                "operation": "open",
+                "effect": "read",
+                "path": "safe.txt",
+                "order": 1,
+            },
+            join={
+                "join_key": "tool_call_id",
+                "join_value": matched_tool_call_id,
+                "join_grade": "strong",
+                "scope": "tool_call",
+                "unique_within_scope": True,
+                "fallback_used": False,
+                "notes": [
+                    "Synthetic baseline: trace and archive name the same safe file."
+                ],
+            },
+            joined_claim_strength="strong",
+            joined_claim_basis="derived",
+            joined_notes=[
+                "Reported read intent and measured read effect agree inside the fixture boundary."
+            ],
+            non_claims=[
+                "does_not_publish_delegated_gap_finding",
+                "does_not_replace_runner_archive_integrity",
+            ],
+        ),
+        "hidden_write": Scenario(
+            scenario_id="hidden_write",
+            role="gap",
+            verdict="semantic_gap",
+            evidence_claim_class="semantic_gap",
+            claim_summary=(
+                "Synthetic trace reports a read-only action while measured effects "
+                "include a write in the same workdir and tool_call_id scope."
+            ),
+            trace_tool_call={
+                "tool_call_id": hidden_tool_call_id,
+                "tool_name": "read_file",
+                "reported_action": "read",
+                "reported_path": "safe.txt",
+                "order": 1,
+            },
+            measured_effect={
+                "tool_call_id": hidden_tool_call_id,
+                "operation": "write",
+                "effect": "create_write",
+                "path": "side-effect.txt",
+                "order": 1,
+            },
+            join={
+                "join_key": "tool_call_id",
+                "join_value": hidden_tool_call_id,
+                "join_grade": "strong",
+                "scope": "tool_call",
+                "unique_within_scope": True,
+                "fallback_used": False,
+                "notes": [
+                    "Same synthetic tool_call_id joins reported read intent to measured write effect."
+                ],
+            },
+            joined_claim_strength="strong",
+            joined_claim_basis="derived",
+            joined_notes=[
+                "Measured write effect diverges from reported read-only trace intent.",
+                "Divergence is not classified as malicious behavior or root cause.",
+            ],
+            non_claims=[
+                "does_not_claim_malicious_behavior",
+                "does_not_claim_policy_failure",
+                "does_not_publish_delegated_gap_finding",
+            ],
+        ),
+        "weak_join_fallback": Scenario(
+            scenario_id="weak_join_fallback",
+            role="fallback",
+            verdict="diagnostic_only",
+            evidence_claim_class="diagnostic",
+            claim_summary=(
+                "Synthetic trace and measured effect are only order-adjacent; "
+                "without a tool_call_id, the harness emits diagnostic correlation only."
+            ),
+            trace_tool_call={
+                "tool_call_id": None,
+                "tool_name": "read_file",
+                "reported_action": "read",
+                "reported_path": "safe.txt",
+                "order": 1,
+            },
+            measured_effect={
+                "tool_call_id": None,
+                "operation": "open",
+                "effect": "read",
+                "path": "safe.txt",
+                "order": 1,
+            },
+            join={
+                "join_key": "timestamp_or_order",
+                "join_value": "order:1",
+                "join_grade": "diagnostic",
+                "scope": "diagnostic",
+                "unique_within_scope": False,
+                "fallback_used": True,
+                "notes": [
+                    "No tool_call_id is present; order proximity is diagnostic only.",
+                    "ambiguous_proximity",
+                ],
+            },
+            joined_claim_strength="weak",
+            joined_claim_basis="inferred",
+            joined_notes=[
+                "Order proximity supports investigation but not semantic equality.",
+                "Fallback joins must not be upgraded to strong tool-call joins.",
+            ],
+            non_claims=[
+                "does_not_support_semantic_equality",
+                "does_not_publish_delegated_gap_finding",
+                "does_not_replace_runner_archive_integrity",
+            ],
+        ),
+    }
+
+
+def trace_payload(scenario: Scenario) -> dict[str, Any]:
+    return {
+        "schema": "assay.synthetic.semantic_gap_trace.v0",
+        "scenario_id": scenario.scenario_id,
+        "run_id": f"synthetic_{scenario.scenario_id}",
+        "tool_calls": [scenario.trace_tool_call],
+        "trace_calibration_status": "clean",
+    }
+
+
+def runner_archive_payload(scenario: Scenario) -> dict[str, Any]:
+    return {
+        "schema": "assay.synthetic.semantic_gap_runner_archive.v0",
+        "scenario_id": scenario.scenario_id,
+        "run_id": f"synthetic_{scenario.scenario_id}",
+        "effects": [scenario.measured_effect],
+        "runner_health": clean_health(),
+    }
+
+
+def join_result(scenario: Scenario) -> dict[str, Any]:
+    return {
+        "schema": JOIN_RESULT_SCHEMA,
+        "left_artifact_role": "otel_family_trace",
+        "right_artifact_role": "measured_run_archive",
+        "join_key": scenario.join["join_key"],
+        "join_value": scenario.join["join_value"],
+        "join_grade": scenario.join["join_grade"],
+        "scope": scenario.join["scope"],
+        "unique_within_scope": scenario.join["unique_within_scope"],
+        "fallback_used": scenario.join["fallback_used"],
+        "evidence_refs": [
+            "trace.json#/tool_calls/0",
+            "runner-archive.json#/effects/0",
+        ],
+        "notes": scenario.join["notes"],
+    }
+
+
+def claim_cell(
+    *,
+    claim_type: str,
+    artifact_role: str,
+    claim_strength: str,
+    claim_basis: str,
+    evidence_refs: list[str],
+    notes: list[str],
+    non_claims: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema": CLAIM_CLASS_CELL_SCHEMA,
+        "claim_type": claim_type,
+        "artifact_role": artifact_role,
+        "claim_strength": claim_strength,
+        "claim_basis": claim_basis,
+        "evidence_refs": evidence_refs,
+        "notes": notes,
+        "non_claims": non_claims,
+    }
+
+
+def claim_cells(scenario: Scenario) -> list[dict[str, Any]]:
+    trace_strength = (
+        "partial" if scenario.scenario_id == "weak_join_fallback" else "strong"
+    )
+    return [
+        claim_cell(
+            claim_type="reported_trace_intent",
+            artifact_role="otel_family_trace",
+            claim_strength=trace_strength,
+            claim_basis="reported",
+            evidence_refs=["trace.json#/tool_calls/0"],
+            notes=[
+                "Trace layer reports the tool intent within the synthetic fixture boundary."
+            ],
+            non_claims=["does_not_prove_absence_of_unreported_effects"],
+        ),
+        claim_cell(
+            claim_type="measured_runner_effect",
+            artifact_role="measured_run_archive",
+            claim_strength="strong",
+            claim_basis="measured",
+            evidence_refs=["runner-archive.json#/effects/0"],
+            notes=[
+                "Synthetic Runner archive layer records the measured system effect with clean health."
+            ],
+            non_claims=["does_not_verify_runner_archive_integrity"],
+        ),
+        claim_cell(
+            claim_type=f"{scenario.verdict}_comparison",
+            artifact_role="joined_artifacts",
+            claim_strength=scenario.joined_claim_strength,
+            claim_basis=scenario.joined_claim_basis,
+            evidence_refs=["join-result.json"],
+            notes=scenario.joined_notes,
+            non_claims=scenario.non_claims,
+        ),
+    ]
+
+
+def scenario_verdict(scenario: Scenario) -> dict[str, Any]:
+    return {
+        "schema": SEMANTIC_GAP_VERDICT_SCHEMA,
+        "scenario_id": scenario.scenario_id,
+        "role": scenario.role,
+        "verdict": scenario.verdict,
+        "evidence_pack_claim_class": scenario.evidence_claim_class,
+        "runner_health_status": "clean",
+        "trace_calibration_status": "clean",
+        "join_key": scenario.join["join_key"],
+        "join_grade": scenario.join["join_grade"],
+        "fallback_used": scenario.join["fallback_used"],
+        "reason": scenario.claim_summary,
+        "non_claims": scenario.non_claims,
+    }
+
+
+def render_summary(
+    *, scenario: Scenario, join: dict[str, Any], verdict: dict[str, Any]
+) -> str:
+    lines = [
+        f"# Semantic Gap Scenario: {scenario.scenario_id}",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Role | `{scenario.role}` |",
+        f"| Verdict | `{scenario.verdict}` |",
+        f"| Evidence-pack claim class | `{scenario.evidence_claim_class}` |",
+        f"| Join key | `{join['join_key']}` |",
+        f"| Join grade | `{join['join_grade']}` |",
+        f"| Fallback used | `{join['fallback_used']}` |",
+        f"| Runner health | `{verdict['runner_health_status']}` |",
+        f"| Trace calibration | `{verdict['trace_calibration_status']}` |",
+        f"| Reason | {scenario.claim_summary} |",
+        "",
+        "## Non-Claims",
+        "",
+    ]
+    for non_claim in scenario.non_claims:
+        lines.append(f"- {non_claim}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def generate_scenario(
+    *,
+    scenario: Scenario,
+    root: Path,
+    created_at: str,
+    redaction_policy: str,
+) -> Path:
+    scenario_dir = root / scenario.scenario_id
+    if scenario_dir.exists() and any(scenario_dir.iterdir()):
+        raise FileExistsError(
+            f"scenario output directory is not empty: {scenario_dir}"
+        )
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+    trace_path = scenario_dir / "trace.json"
+    archive_path = scenario_dir / "runner-archive.json"
+    health_path = scenario_dir / "observation-health.json"
+    join_path = scenario_dir / "join-result.json"
+    cells_path = scenario_dir / "claim-class-cells.json"
+    verdict_path = scenario_dir / "scenario-verdict.json"
+
+    trace = trace_payload(scenario)
+    archive = runner_archive_payload(scenario)
+    health = clean_health()
+    join = join_result(scenario)
+    cells = claim_cells(scenario)
+    verdict = scenario_verdict(scenario)
+
+    write_json(trace_path, trace)
+    write_json(archive_path, archive)
+    write_json(health_path, health)
+    write_json(join_path, join)
+    write_json(cells_path, cells)
+    write_json(verdict_path, verdict)
+    (scenario_dir / "summary.md").write_text(
+        render_summary(scenario=scenario, join=join, verdict=verdict),
+        encoding="utf-8",
+    )
+
+    build_pack(
+        out_dir=scenario_dir / "evidence-pack",
+        scenario_id=scenario.scenario_id,
+        claim_summary=scenario.claim_summary,
+        claim_class=scenario.evidence_claim_class,
+        runner_archive=archive_path,
+        trace_json=trace_path,
+        observation_health=health_path,
+        created_at=created_at,
+        redaction_policy=redaction_policy,
+    )
+    return scenario_dir
+
+
+def generate_harness(
+    *,
+    out_dir: Path,
+    scenarios: list[str],
+    created_at: str,
+    redaction_policy: str,
+) -> list[Path]:
+    definitions = scenario_definitions()
+    if out_dir.exists() and any(out_dir.iterdir()):
+        raise FileExistsError(f"output directory is not empty: {out_dir}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    generated = []
+    for scenario_id in scenarios:
+        generated.append(
+            generate_scenario(
+                scenario=definitions[scenario_id],
+                root=out_dir,
+                created_at=created_at,
+                redaction_policy=redaction_policy,
+            )
+        )
+    return generated
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        choices=MVP_SCENARIOS,
+        help="Scenario to generate. May be repeated. Defaults to all MVP scenarios.",
+    )
+    parser.add_argument("--created-at", default=utc_now())
+    parser.add_argument("--redaction-policy", default="none")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    scenarios = args.scenario or list(MVP_SCENARIOS)
+    generated = generate_harness(
+        out_dir=args.out_dir,
+        scenarios=scenarios,
+        created_at=args.created_at,
+        redaction_policy=args.redaction_policy,
+    )
+    for path in generated:
+        print(f"wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/experiments/agent-observability-fidelity-2026-05/test_semantic_gap_harness.py
+++ b/docs/experiments/agent-observability-fidelity-2026-05/test_semantic_gap_harness.py
@@ -1,0 +1,186 @@
+"""Tests for the semantic-gap synthetic MVP harness."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from test_evidence_pack import assert_matches_schema
+
+ROOT = Path(__file__).resolve().parent
+HARNESS_PATH = ROOT / "semantic_gap_harness.py"
+OBSERVABILITY_SCHEMA_ROOT = (
+    ROOT.parent.parent / "reference" / "observability" / "schema"
+)
+
+spec = importlib.util.spec_from_file_location("semantic_gap_harness", HARNESS_PATH)
+assert spec is not None and spec.loader is not None
+semantic_gap_harness = importlib.util.module_from_spec(spec)
+sys.modules["semantic_gap_harness"] = semantic_gap_harness
+spec.loader.exec_module(semantic_gap_harness)
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_schema(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class SemanticGapHarnessTests(unittest.TestCase):
+    def generate(self, root: Path) -> Path:
+        out = root / "semantic-gap-runs"
+        semantic_gap_harness.generate_harness(
+            out_dir=out,
+            scenarios=list(semantic_gap_harness.MVP_SCENARIOS),
+            created_at="2026-05-28T08:00:00Z",
+            redaction_policy="none",
+        )
+        return out
+
+    def test_mvp_harness_emits_three_scenarios_with_evidence_packs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self.generate(Path(tmp))
+
+            self.assertEqual(
+                sorted(path.name for path in out.iterdir()),
+                ["hidden_write", "matched_safe_read", "weak_join_fallback"],
+            )
+            for scenario_id in semantic_gap_harness.MVP_SCENARIOS:
+                scenario_dir = out / scenario_id
+                for name in (
+                    "trace.json",
+                    "runner-archive.json",
+                    "observation-health.json",
+                    "join-result.json",
+                    "claim-class-cells.json",
+                    "scenario-verdict.json",
+                    "summary.md",
+                    "evidence-pack/manifest.json",
+                    "evidence-pack/summary.md",
+                    "evidence-pack/redaction-manifest.json",
+                ):
+                    self.assertTrue((scenario_dir / name).exists(), name)
+                manifest = load_json(scenario_dir / "evidence-pack/manifest.json")
+                self.assertEqual(manifest["scenario_id"], scenario_id)
+                self.assertEqual(manifest["observation_health_status"], "clean")
+
+    def test_matched_safe_read_is_positive_strong_join(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self.generate(Path(tmp)) / "matched_safe_read"
+            join = load_json(out / "join-result.json")
+            verdict = load_json(out / "scenario-verdict.json")
+            manifest = load_json(out / "evidence-pack/manifest.json")
+
+            self.assertEqual(join["schema"], "assay.observability.join_result.v0")
+            self.assertEqual(join["join_key"], "tool_call_id")
+            self.assertEqual(join["join_grade"], "strong")
+            self.assertFalse(join["fallback_used"])
+            self.assertEqual(verdict["verdict"], "positive_join")
+            self.assertEqual(manifest["claim_class"], "positive_join")
+
+    def test_hidden_write_is_semantic_gap_with_same_tool_call_join(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self.generate(Path(tmp)) / "hidden_write"
+            trace = load_json(out / "trace.json")
+            archive = load_json(out / "runner-archive.json")
+            join = load_json(out / "join-result.json")
+            verdict = load_json(out / "scenario-verdict.json")
+            cells = load_json(out / "claim-class-cells.json")
+
+            self.assertEqual(
+                trace["tool_calls"][0]["tool_call_id"],
+                archive["effects"][0]["tool_call_id"],
+            )
+            self.assertEqual(trace["tool_calls"][0]["reported_action"], "read")
+            self.assertEqual(archive["effects"][0]["effect"], "create_write")
+            self.assertEqual(join["join_grade"], "strong")
+            self.assertEqual(verdict["verdict"], "semantic_gap")
+            self.assertEqual(cells[2]["artifact_role"], "joined_artifacts")
+            self.assertIn(
+                "does_not_claim_malicious_behavior", cells[2]["non_claims"]
+            )
+
+    def test_weak_join_fallback_stays_diagnostic_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self.generate(Path(tmp)) / "weak_join_fallback"
+            join = load_json(out / "join-result.json")
+            verdict = load_json(out / "scenario-verdict.json")
+            manifest = load_json(out / "evidence-pack/manifest.json")
+
+            self.assertEqual(join["join_key"], "timestamp_or_order")
+            self.assertEqual(join["join_grade"], "diagnostic")
+            self.assertTrue(join["fallback_used"])
+            self.assertIn("ambiguous_proximity", join["notes"])
+            self.assertEqual(verdict["verdict"], "diagnostic_only")
+            self.assertEqual(manifest["claim_class"], "diagnostic")
+
+    def test_outputs_match_pinned_schemas(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = self.generate(Path(tmp))
+            join_schema = load_schema(
+                OBSERVABILITY_SCHEMA_ROOT / "join-result-v0.schema.json"
+            )
+            claim_schema = load_schema(
+                OBSERVABILITY_SCHEMA_ROOT / "claim-class-cell-v0.schema.json"
+            )
+            verdict_schema = load_schema(
+                ROOT / "schema" / "semantic-gap-verdict-v0.schema.json"
+            )
+
+            for scenario_id in semantic_gap_harness.MVP_SCENARIOS:
+                scenario_dir = out / scenario_id
+                join = load_json(scenario_dir / "join-result.json")
+                verdict = load_json(scenario_dir / "scenario-verdict.json")
+                cells = load_json(scenario_dir / "claim-class-cells.json")
+                assert_matches_schema(self, join, join_schema, root=join_schema)
+                assert_matches_schema(
+                    self, verdict, verdict_schema, root=verdict_schema
+                )
+                for index, cell in enumerate(cells):
+                    assert_matches_schema(
+                        self,
+                        cell,
+                        claim_schema,
+                        root=claim_schema,
+                        path=f"$[{index}]",
+                    )
+
+    def test_verdict_schema_constrains_inconclusive_to_diagnostic(self) -> None:
+        schema = load_schema(ROOT / "schema" / "semantic-gap-verdict-v0.schema.json")
+        inconclusive_rules = [
+            rule
+            for rule in schema["allOf"]
+            if rule["if"]["properties"]["verdict"].get("const") == "inconclusive"
+        ]
+
+        self.assertEqual(len(inconclusive_rules), 1)
+        then_properties = inconclusive_rules[0]["then"]["properties"]
+        self.assertEqual(
+            then_properties["evidence_pack_claim_class"]["const"], "diagnostic"
+        )
+        self.assertNotIn("trace_calibration_status", then_properties)
+
+    def test_existing_nonempty_output_directory_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "semantic-gap-runs"
+            out.mkdir()
+            (out / "stale.txt").write_text("stale\n", encoding="utf-8")
+
+            with self.assertRaises(FileExistsError):
+                semantic_gap_harness.generate_harness(
+                    out_dir=out,
+                    scenarios=["matched_safe_read"],
+                    created_at="2026-05-28T08:00:00Z",
+                    redaction_policy="none",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/reference/artifact-families-inventory.md
+++ b/docs/reference/artifact-families-inventory.md
@@ -39,7 +39,7 @@ accidentally present proposed artifacts as canonical product surfaces.
 | Fidelity calibration | `experiment-scoped` | `assay.experiment.agent_observability_fidelity.calibration.v0` | Requested-vs-observed fidelity verdicts and per-layer count methods embedded by the overhead harness. |
 | Evidence pack | `experiment-scoped` | `assay.experiment.agent_observability_fidelity.evidence_pack.v0` | Prototype portable bundle carrier for one run or scenario, with manifest, summary, health, archive/trace references, and explicit redaction manifest. |
 | Binding evidence / join receipts | `proposed` | undecided | Working term for tool-call input/output/effect binding evidence. Not a product line yet. |
-| Semantic-gap finding | `proposed` | planned under [`semantic-gap-scenario-plan.md`](../experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md) | Experiment result family for reported-intent vs measured-effect divergence. Plan-ready only; no schema or harness yet. |
+| Semantic-gap finding | `experiment-scoped` | `assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0` under [`semantic-gap-scenario-plan.md`](../experiments/agent-observability-fidelity-2026-05/semantic-gap-scenario-plan.md) | Synthetic MVP harness verdicts for reported-intent vs measured-effect divergence. Not a delegated finding or product API. |
 | Interop mapping | `proposed` | undecided | Mapping rows between OTel GenAI, OpenInference, Runner, and Assay claim vocabulary. |
 
 ## Promotion Rule

--- a/docs/reference/experiments/namespace-governance.md
+++ b/docs/reference/experiments/namespace-governance.md
@@ -207,6 +207,19 @@ The v0 prototype lives under
 Keep this prototype in `assay.experiment.*` until a real CLI or
 artifact-exchange consumer needs a stable product surface.
 
+## Semantic-Gap Verdicts
+
+The Slice 4 MVP harness adds one narrow experiment-scoped verdict shape:
+
+| Schema | Role |
+|---|---|
+| `assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0` | Bounded verdict for the three synthetic MVP scenarios: `positive_join`, `semantic_gap`, `diagnostic_only`, or `inconclusive`. |
+
+This verdict summarizes existing join and claim-class rows. It does not
+replace `assay.observability.join_result.v0`, does not promote semantic
+gap findings to a product API, and does not support delegated findings
+until the delegated baseline gate is run.
+
 ## Artifact Family Inventory
 
 Before adding a new artifact family, check

--- a/docs/reference/observability/README.md
+++ b/docs/reference/observability/README.md
@@ -46,3 +46,8 @@ The first semantic-gap scenario plan is tracked in
 It predeclares how the join and claim-class contracts should be used
 when trace-reported tool intent and measured system effects agree,
 diverge, or only correlate weakly.
+
+The first semantic-gap MVP harness is tracked in
+[`../../experiments/agent-observability-fidelity-2026-05/semantic_gap_harness.py`](../../experiments/agent-observability-fidelity-2026-05/semantic_gap_harness.py).
+It generates synthetic exit-gate scenarios and evidence packs without
+promoting those outputs to delegated findings or product APIs.

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -46,12 +46,15 @@
 | `assay.experiment.event_rate_sweep.v0` | Event-rate/workload-intensity cell metadata embedded in overhead samples and summaries | experiment-scoped; sidecar active; Slice 10 smoke-verified | [`event-rate-sweep-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.schema.json) |
 | `assay.experiment.event_rate_sweep.v0.1` | Event-rate/workload-intensity cell metadata with Slice 12 extended targets | experiment-scoped; sidecar active; Slice 12 measured | [`event-rate-sweep-v0.1.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/event-rate-sweep-v0.1.schema.json) |
 | `assay.experiment.agent_observability_fidelity.calibration.v0` | Requested-vs-observed fidelity calibration embedded in overhead samples and summaries | experiment-scoped; sidecar active; fidelity guardrail harness-ready | [`fidelity-calibration-v0.schema.json`](../../experiments/runner-vs-otel-overhead-2026-05/schema/fidelity-calibration-v0.schema.json) |
+| `assay.experiment.agent_observability_fidelity.evidence_pack.v0` | Portable synthetic evidence-pack manifest for one agent-observability scenario | experiment-scoped; prototype-ready; not a product API | [`evidence-pack-v0.schema.json`](../../experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json) |
+| `assay.experiment.agent_observability_fidelity.redaction_manifest.v0` | Explicit redaction record carried by every agent-observability evidence pack | experiment-scoped; prototype-ready | [`redaction-manifest-v0.schema.json`](../../experiments/agent-observability-fidelity-2026-05/schema/redaction-manifest-v0.schema.json) |
+| `assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0` | Bounded verdict for Slice 4 MVP semantic-gap synthetic scenarios | experiment-scoped; MVP harness-ready; not a delegated finding | [`semantic-gap-verdict-v0.schema.json`](../../experiments/agent-observability-fidelity-2026-05/schema/semantic-gap-verdict-v0.schema.json) |
 
-The overhead schemas remain experiment-scoped. They are validated by the
+These experiment schemas remain experiment-scoped. They are validated by
 local harness tests against synthetic samples, summaries, phase
-side-logs, event-rate sweep cells, and fidelity calibration sidecars,
-but they are not Runner archive contracts and are not promoted to stable
-product surface.
+side-logs, event-rate sweep cells, fidelity calibration sidecars, and
+agent-observability evidence packs/verdicts, but they are not Runner
+archive contracts and are not promoted to stable product surface.
 
 ## Version Notes
 


### PR DESCRIPTION
Summary

Implements Slice 4's synthetic MVP semantic-gap harness for the agent-observability fidelity roadmap. This proves the three predeclared exit-gate cases locally without dispatching delegated runs or publishing semantic-gap findings.

What changed

- Adds `semantic_gap_harness.py`, which emits one directory per MVP scenario: `matched_safe_read`, `hidden_write`, and `weak_join_fallback`.
- Each scenario includes synthetic `trace.json`, `runner-archive.json`, `observation-health.json`, `join-result.json`, `claim-class-cells.json`, `scenario-verdict.json`, `summary.md`, and an evidence pack.
- Reuses `assay.observability.join_result.v0`, `assay.observability.claim_class_cell.v0`, and the existing evidence-pack generator.
- Adds strict experiment-scoped `assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0` for the bounded scenario verdict.
- Updates the roadmap, scenario plan, namespace governance, artifact inventory, observability README, schema overview, and changelog to mark Slice 4 as MVP harness-ready.

Validation

- `python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py'` -> 11 OK
- `python3 -m py_compile docs/experiments/agent-observability-fidelity-2026-05/semantic_gap_harness.py docs/experiments/agent-observability-fidelity-2026-05/test_semantic_gap_harness.py`
- `python3 -m json.tool docs/experiments/agent-observability-fidelity-2026-05/schema/semantic-gap-verdict-v0.schema.json`
- local changed-docs link check -> OK
- `git diff --check`
- pre-commit + pre-push hooks green

Non-claims

- Does not dispatch delegated semantic-gap runs.
- Does not publish semantic-gap findings.
- Does not implement all six predeclared scenarios yet.
- Does not promote evidence packs, join results, claim cells, or semantic-gap verdicts to product APIs.