### PR TITLE
test(experiments): tighten semantic gap harness polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,11 @@ All notable changes to this project will be documented in this file.
   claim-class cells, bounded semantic-gap verdicts, and evidence packs
   without dispatching delegated runs or publishing semantic-gap
   findings.
+- Tightened the semantic-gap MVP harness after review by keeping
+  synthetic fixture schema strings under
+  `assay.experiment.agent_observability_fidelity.*`, adding schema
+  conditional coverage for `inconclusive` verdicts, and pinning the
+  scenario-id enum/CLI generation paths in tests.
 
 ## [3.12.0] - 2026-05-25
 

--- a/docs/experiments/agent-observability-fidelity-2026-05/semantic_gap_harness.py
+++ b/docs/experiments/agent-observability-fidelity-2026-05/semantic_gap_harness.py
@@ -16,6 +16,12 @@ CLAIM_CLASS_CELL_SCHEMA = "assay.observability.claim_class_cell.v0"
 SEMANTIC_GAP_VERDICT_SCHEMA = (
     "assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0"
 )
+SYNTHETIC_TRACE_SCHEMA = (
+    "assay.experiment.agent_observability_fidelity.synthetic_trace.v0"
+)
+SYNTHETIC_RUNNER_ARCHIVE_SCHEMA = (
+    "assay.experiment.agent_observability_fidelity.synthetic_runner_archive.v0"
+)
 
 MVP_SCENARIOS = ("matched_safe_read", "hidden_write", "weak_join_fallback")
 
@@ -198,7 +204,7 @@ def scenario_definitions() -> dict[str, Scenario]:
 
 def trace_payload(scenario: Scenario) -> dict[str, Any]:
     return {
-        "schema": "assay.synthetic.semantic_gap_trace.v0",
+        "schema": SYNTHETIC_TRACE_SCHEMA,
         "scenario_id": scenario.scenario_id,
         "run_id": f"synthetic_{scenario.scenario_id}",
         "tool_calls": [scenario.trace_tool_call],
@@ -208,7 +214,7 @@ def trace_payload(scenario: Scenario) -> dict[str, Any]:
 
 def runner_archive_payload(scenario: Scenario) -> dict[str, Any]:
     return {
-        "schema": "assay.synthetic.semantic_gap_runner_archive.v0",
+        "schema": SYNTHETIC_RUNNER_ARCHIVE_SCHEMA,
         "scenario_id": scenario.scenario_id,
         "run_id": f"synthetic_{scenario.scenario_id}",
         "effects": [scenario.measured_effect],

--- a/docs/experiments/agent-observability-fidelity-2026-05/test_evidence_pack.py
+++ b/docs/experiments/agent-observability-fidelity-2026-05/test_evidence_pack.py
@@ -34,6 +34,59 @@ def resolve_ref(schema: dict[str, Any], ref: str) -> dict[str, Any]:
     return target
 
 
+def condition_matches(
+    payload: Any,
+    node: dict[str, Any],
+    *,
+    root: dict[str, Any],
+) -> bool:
+    if "$ref" in node:
+        return condition_matches(payload, resolve_ref(root, node["$ref"]), root=root)
+
+    if "const" in node and payload != node["const"]:
+        return False
+    if "enum" in node and payload not in node["enum"]:
+        return False
+
+    expected_type = node.get("type")
+    if expected_type is not None:
+        types = expected_type if isinstance(expected_type, list) else [expected_type]
+        type_ok = False
+        for typ in types:
+            if typ == "object":
+                type_ok = isinstance(payload, dict)
+            elif typ == "array":
+                type_ok = isinstance(payload, list)
+            elif typ == "string":
+                type_ok = isinstance(payload, str)
+            elif typ == "integer":
+                type_ok = isinstance(payload, int) and not isinstance(payload, bool)
+            elif typ == "boolean":
+                type_ok = isinstance(payload, bool)
+            elif typ == "null":
+                type_ok = payload is None
+            else:
+                raise AssertionError(f"unsupported type {typ!r}")
+            if type_ok:
+                break
+        if not type_ok:
+            return False
+
+    if isinstance(payload, dict):
+        for key in node.get("required", []):
+            if key not in payload:
+                return False
+        for key, child in node.get("properties", {}).items():
+            if key in payload and not condition_matches(
+                payload[key],
+                child,
+                root=root,
+            ):
+                return False
+
+    return True
+
+
 def assert_matches_schema(
     test: unittest.TestCase,
     payload: Any,
@@ -107,6 +160,25 @@ def assert_matches_schema(
                 assert_matches_schema(
                     test, value, properties[key], root=root, path=f"{path}.{key}"
                 )
+
+    for index, child in enumerate(node.get("allOf", [])):
+        if "if" in child and "then" in child:
+            if condition_matches(payload, child["if"], root=root):
+                assert_matches_schema(
+                    test,
+                    payload,
+                    child["then"],
+                    root=root,
+                    path=f"{path}.allOf[{index}].then",
+                )
+        else:
+            assert_matches_schema(
+                test,
+                payload,
+                child,
+                root=root,
+                path=f"{path}.allOf[{index}]",
+            )
 
 
 def write_inputs(root: Path, *, ringbuf_drops: int = 0) -> tuple[Path, Path, Path]:

--- a/docs/experiments/agent-observability-fidelity-2026-05/test_semantic_gap_harness.py
+++ b/docs/experiments/agent-observability-fidelity-2026-05/test_semantic_gap_harness.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Any
 
@@ -95,6 +97,14 @@ class SemanticGapHarnessTests(unittest.TestCase):
             cells = load_json(out / "claim-class-cells.json")
 
             self.assertEqual(
+                trace["schema"],
+                semantic_gap_harness.SYNTHETIC_TRACE_SCHEMA,
+            )
+            self.assertEqual(
+                archive["schema"],
+                semantic_gap_harness.SYNTHETIC_RUNNER_ARCHIVE_SCHEMA,
+            )
+            self.assertEqual(
                 trace["tool_calls"][0]["tool_call_id"],
                 archive["effects"][0]["tool_call_id"],
             )
@@ -166,6 +176,64 @@ class SemanticGapHarnessTests(unittest.TestCase):
             then_properties["evidence_pack_claim_class"]["const"], "diagnostic"
         )
         self.assertNotIn("trace_calibration_status", then_properties)
+
+    def test_inconclusive_verdict_validates_only_as_diagnostic(self) -> None:
+        schema = load_schema(ROOT / "schema" / "semantic-gap-verdict-v0.schema.json")
+        payload = {
+            "schema": semantic_gap_harness.SEMANTIC_GAP_VERDICT_SCHEMA,
+            "scenario_id": "matched_safe_read",
+            "role": "baseline",
+            "verdict": "inconclusive",
+            "evidence_pack_claim_class": "diagnostic",
+            "runner_health_status": "inconclusive",
+            "trace_calibration_status": "lossy",
+            "join_key": "tool_call_id",
+            "join_grade": "failed",
+            "fallback_used": False,
+            "reason": "Lossy calibration prevents a semantic claim.",
+            "non_claims": ["does_not_publish_delegated_gap_finding"],
+        }
+
+        assert_matches_schema(self, payload, schema, root=schema)
+        payload["evidence_pack_claim_class"] = "positive_join"
+        with self.assertRaises(AssertionError):
+            assert_matches_schema(self, payload, schema, root=schema)
+
+    def test_mvp_scenarios_match_verdict_schema_enum(self) -> None:
+        schema = load_schema(ROOT / "schema" / "semantic-gap-verdict-v0.schema.json")
+
+        self.assertEqual(
+            sorted(schema["properties"]["scenario_id"]["enum"]),
+            sorted(semantic_gap_harness.MVP_SCENARIOS),
+        )
+        self.assertEqual(
+            sorted(semantic_gap_harness.scenario_definitions()),
+            sorted(semantic_gap_harness.MVP_SCENARIOS),
+        )
+
+    def test_cli_generates_selected_scenario(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "semantic-gap-runs"
+            stdout = io.StringIO()
+
+            with redirect_stdout(stdout):
+                exit_code = semantic_gap_harness.main(
+                    [
+                        "--out-dir",
+                        str(out),
+                        "--scenario",
+                        "matched_safe_read",
+                        "--created-at",
+                        "2026-05-28T08:00:00Z",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("matched_safe_read", stdout.getvalue())
+            self.assertTrue(
+                (out / "matched_safe_read" / "scenario-verdict.json").exists()
+            )
+            self.assertFalse((out / "hidden_write").exists())
 
     def test_existing_nonempty_output_directory_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/reference/experiments/namespace-governance.md
+++ b/docs/reference/experiments/namespace-governance.md
@@ -220,6 +220,18 @@ replace `assay.observability.join_result.v0`, does not promote semantic
 gap findings to a product API, and does not support delegated findings
 until the delegated baseline gate is run.
 
+Synthetic fixture payloads emitted by this harness also stay under the
+same experiment namespace:
+
+| Schema | Role |
+|---|---|
+| `assay.experiment.agent_observability_fidelity.synthetic_trace.v0` | Synthetic trace fixture used by the local MVP harness. |
+| `assay.experiment.agent_observability_fidelity.synthetic_runner_archive.v0` | Synthetic Runner-archive fixture used by the local MVP harness. |
+
+These fixture payloads are intentionally schema-string-only in v0. They
+are not delegated capture artifacts, not Runner archive contracts, and
+not a new `assay.synthetic.*` namespace.
+
 ## Artifact Family Inventory
 
 Before adding a new artifact family, check

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -49,6 +49,8 @@
 | `assay.experiment.agent_observability_fidelity.evidence_pack.v0` | Portable synthetic evidence-pack manifest for one agent-observability scenario | experiment-scoped; prototype-ready; not a product API | [`evidence-pack-v0.schema.json`](../../experiments/agent-observability-fidelity-2026-05/schema/evidence-pack-v0.schema.json) |
 | `assay.experiment.agent_observability_fidelity.redaction_manifest.v0` | Explicit redaction record carried by every agent-observability evidence pack | experiment-scoped; prototype-ready | [`redaction-manifest-v0.schema.json`](../../experiments/agent-observability-fidelity-2026-05/schema/redaction-manifest-v0.schema.json) |
 | `assay.experiment.agent_observability_fidelity.semantic_gap_verdict.v0` | Bounded verdict for Slice 4 MVP semantic-gap synthetic scenarios | experiment-scoped; MVP harness-ready; not a delegated finding | [`semantic-gap-verdict-v0.schema.json`](../../experiments/agent-observability-fidelity-2026-05/schema/semantic-gap-verdict-v0.schema.json) |
+| `assay.experiment.agent_observability_fidelity.synthetic_trace.v0` | Synthetic trace fixture used by the local semantic-gap MVP harness | experiment-scoped; schema-string only; not delegated evidence | none |
+| `assay.experiment.agent_observability_fidelity.synthetic_runner_archive.v0` | Synthetic Runner-archive fixture used by the local semantic-gap MVP harness | experiment-scoped; schema-string only; not a Runner archive contract | none |
 
 These experiment schemas remain experiment-scoped. They are validated by
 local harness tests against synthetic samples, summaries, phase


### PR DESCRIPTION
Summary

Follow-up polish for the merged Slice 4 semantic-gap MVP harness (#1418), addressing the small review gaps without expanding the scenario set or dispatching delegated runs.

What changed

- Keeps synthetic fixture schema strings inside the existing experiment namespace:
  - `assay.experiment.agent_observability_fidelity.synthetic_trace.v0`
  - `assay.experiment.agent_observability_fidelity.synthetic_runner_archive.v0`
- Documents those synthetic fixture schema strings in namespace governance and the schema overview as schema-string-only experiment fixtures, not delegated evidence or Runner contracts.
- Extends the local schema-test helper to exercise `allOf` / `if` / `then` conditionals.
- Adds tests that an `inconclusive` verdict validates only with `evidence_pack_claim_class=diagnostic`.
- Pins drift prevention between `MVP_SCENARIOS`, `scenario_definitions()`, and the verdict schema enum.
- Adds a CLI smoke test for generating one selected scenario.

Validation

- `python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py'` -> 15 OK
- `python3 -m py_compile docs/experiments/agent-observability-fidelity-2026-05/semantic_gap_harness.py docs/experiments/agent-observability-fidelity-2026-05/test_semantic_gap_harness.py docs/experiments/agent-observability-fidelity-2026-05/test_evidence_pack.py`
- `python3 -m json.tool docs/experiments/agent-observability-fidelity-2026-05/schema/semantic-gap-verdict-v0.schema.json`
- local changed-docs link check -> OK
- `git diff --check`
- git commit/push hooks green, including cargo fmt, cargo clippy workspace, and linux compile gate

Non-claims

- Does not add new semantic-gap scenarios.
- Does not dispatch delegated runs.
- Does not promote synthetic fixtures, semantic-gap verdicts, or evidence packs to product APIs.
- Does not introduce an `assay.synthetic.*` namespace.
