### PR TITLE
docs(experiments): close agent observability fidelity arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Closed the agent-observability fidelity arc with a citation-oriented
+  findings summary. The summary bounds five claims: calibration as a
+  mechanical guardrail, evidence packs as non-strengthening carriers,
+  the six-scenario synthetic semantic-gap matrix, the five-cell interop
+  coverage matrix, and the delegated `matched_safe_read` positive
+  baseline smoke. It does not publish delegated gap findings, rank trace
+  vocabularies or products, or promote experiment-scoped schemas to
+  product APIs.
 - Smoke-verified Slice 7 of the agent-observability fidelity roadmap
   with a delegated `matched_safe_read` baseline. GitHub Actions run
   `26571739019` passed the existing `openai-agents-kernel-policy`

--- a/docs/experiments/agent-observability-fidelity-2026-05.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05.md
@@ -1,11 +1,13 @@
 # Agent Observability Fidelity Roadmap (2026-05)
 
 > **Status:** roadmap plus implemented local harness slices after the
-> completed Runner-vs-OTel overhead arc. This document ranks the next
-> useful experiments for improving Assay's agent-observability surface
-> and links the implemented local guardrail/prototype harnesses. It does
-> not dispatch new runs, does not commit measurement artifacts, and does
-> not open the optional OTel span-limit study tracked in
+> completed Runner-vs-OTel overhead arc. The citation-oriented closure
+> point is
+> [`agent-observability-fidelity-2026-05/findings-summary.md`](agent-observability-fidelity-2026-05/findings-summary.md).
+> This document keeps the longer slice history and links the implemented
+> local guardrail/prototype harnesses. It does not dispatch new runs,
+> does not commit measurement artifacts, and does not open the optional
+> OTel span-limit study tracked in
 > [issue #1408](https://github.com/Rul1an/assay/issues/1408).
 >
 > **Last updated:** 2026-05-28
@@ -388,14 +390,16 @@ docs around what Assay can honestly consume.
 **Goal:** prove the semantic-gap positive baseline under real Runner
 capture before publishing any delegated gap finding.
 
-> **Status:** delegated-baseline-smoke-verified. The delegated baseline
+> **Status:** done. The delegated baseline
 > source, artifact expectations, join invariants, acceptance rules, and
 > follow-up dispatch/conversion gate were predeclared in
 > [`agent-observability-fidelity-2026-05/delegated-baseline-plan.md`](agent-observability-fidelity-2026-05/delegated-baseline-plan.md).
 > The successful smoke record is in
 > [`agent-observability-fidelity-2026-05/runs/slice7-delegated-baseline/summary.md`](agent-observability-fidelity-2026-05/runs/slice7-delegated-baseline/summary.md).
-> This publishes only the positive baseline gate, not delegated gap
-> findings.
+> The citation-oriented closure summary is in
+> [`agent-observability-fidelity-2026-05/findings-summary.md`](agent-observability-fidelity-2026-05/findings-summary.md).
+> This slice is done for the positive baseline only; delegated gap
+> scenarios remain not dispatched and are not findings.
 
 The full synthetic semantic-gap matrix is useful, but it is still local
 ground truth. Before any semantic-gap result is described as delegated
@@ -470,32 +474,35 @@ non-leaf domain cgroup before creating session cgroups.
 summary after the delegated baseline gate has either passed or been
 classified as inconclusive.
 
-This should mirror the overhead arc's `findings-summary.md` discipline:
-one citation-friendly document, with slice history kept in the longer
+> **Status:** done. The citation-oriented result is in
+> [`agent-observability-fidelity-2026-05/findings-summary.md`](agent-observability-fidelity-2026-05/findings-summary.md).
+
+This mirrors the overhead arc's `findings-summary.md` discipline: one
+citation-friendly document, with slice history kept in the longer
 roadmap and plan files.
 
-### Expected statements
+### Statements
 
-- **Calibration discipline:** requested-vs-observed signal counts are a
+- **Done:** requested-vs-observed signal counts are a
   mechanical guardrail, not a reviewer memory exercise.
-- **Portable evidence:** evidence packs and proof-pack references carry
+- **Done:** evidence packs and proof-pack references carry
   bounded claims without strengthening the underlying artifacts.
-- **Semantic gap:** six synthetic scenario shapes exercise positive
+- **Done:** six synthetic scenario shapes exercise positive
   join, same-tool-call divergence, fallback diagnostics, and runtime
   surface boundaries.
-- **Interop:** five starter cells map OTel GenAI, OpenInference, and
+- **Done:** five starter cells map OTel GenAI, OpenInference, and
   Runner observation profiles as coverage/claim-strength rows, not
   product rankings.
-- **Delegated baseline:** the positive join path is either verified by
-  a real Runner capture or explicitly inconclusive.
+- **Done:** the positive join path is verified by a real Runner capture
+  before delegated gap findings are published.
 
 ### Non-claims
 
-- The summary should not publish delegated gap-scenario findings unless
+- The summary does not publish delegated gap-scenario findings unless
   those scenarios have their own delegated gates.
-- The summary should not promote experiment-scoped schemas to product
+- The summary does not promote experiment-scoped schemas to product
   APIs.
-- The summary should not recommend one trace vocabulary over another.
+- The summary does not recommend one trace vocabulary over another.
 
 ## Experiment 7 - Optional OTel Span-Limit Characterization
 
@@ -547,6 +554,10 @@ visible by the overhead and shape-comparison arcs.
 
 ## Recommended Slice Order
 
+Arc status: closed at Slice 8 with
+[`agent-observability-fidelity-2026-05/findings-summary.md`](agent-observability-fidelity-2026-05/findings-summary.md).
+Slice 9 remains optional and trigger-only.
+
 | Slice | Status | Purpose | Exit gate |
 |---:|---|---|---|
 | 0 | Done in this plan | Namespace governance for experiment artifacts | Naming, promotion, cross-arc field, calibration-method, and evidence-pack minimum rules are documented. |
@@ -557,7 +568,7 @@ visible by the overhead and shape-comparison arcs.
 | 5 | Matrix-plan-ready | Interop matrix plan | OTel/OpenInference/Runner coverage axes, starter cells, row shape, source snapshots, and non-claims pinned before harness work. |
 | 6 | Harness-ready | Interop matrix harness | Five synthetic starter cells emit strict `interop_coverage_cell.v0` rows, join-result refs, claim-class refs, source snapshots, partial/absent rows, and stable output directories without delegated publication. |
 | 7 | Delegated-baseline-smoke-verified | Delegated semantic-gap baseline | Run `26571739019` passed the `openai-agents-kernel-policy` delegated gate, uploaded proof pack `assay-runner-delegated-proof-pack-26571739019`, and validated clean health plus strong `tool_call_id` positive baseline join without promoting delegated gap scenarios. |
-| 8 | Planned | Fidelity arc findings summary | After the delegated baseline gate, write a citation-friendly summary of calibration, evidence-pack, semantic-gap, interop, and delegated-baseline outcomes without promoting product APIs. |
+| 8 | Done | Fidelity arc findings summary | Citation-friendly summary closes the arc across calibration, evidence-pack, semantic-gap, interop, and delegated-baseline outcomes without promoting product APIs or publishing delegated gap findings. |
 | 9 | Optional | OTel span-limit study | Only after an external trigger; otherwise remains issue-only. |
 
 ## Experiment vs Feature Boundary
@@ -602,8 +613,9 @@ invariants without promoting delegated gap scenarios.
   harness-ready, but it remains a coverage and claim-strength map.
 - Do not turn the required product-development list into one epic. Each
   item belongs to a different dependency chain.
-- Do not open a new paper arc yet. The argument is strong, but the
-  delegated baseline and findings-summary closure should land first.
+- Do not open a new paper arc without a concrete consumer. The
+  fidelity-arc summary now gives the argument a stable cite point; a
+  paper arc still needs its own question and acceptance rules.
 - Do not start #1408 unless an external trigger appears.
 
 ## Closure Criterion

--- a/docs/experiments/agent-observability-fidelity-2026-05/findings-summary.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05/findings-summary.md
@@ -1,0 +1,159 @@
+# Agent Observability Fidelity Findings Summary (2026-05)
+
+> Last updated: 2026-05-28.
+
+This is the citation-oriented summary of the agent-observability
+fidelity arc. The full slice history, scenario plans, harness details,
+and delegated baseline record remain in
+[`../agent-observability-fidelity-2026-05.md`](../agent-observability-fidelity-2026-05.md).
+Generated synthetic outputs and delegated proof packs are review
+artifacts; they are not promoted to product APIs by this summary.
+
+## Scope
+
+These findings are methodology and claim-boundary findings for Assay's
+agent-observability layer. They cover experiment-scoped schemas,
+synthetic harnesses, and one delegated positive-baseline smoke on the
+existing `openai-agents-kernel-policy` Runner gate.
+
+They do not rank Runner, OTel GenAI, OpenInference, or the OpenAI
+Agents SDK as products. They also do not publish delegated semantic-gap
+measurements: only the positive `matched_safe_read` join path has been
+smoke-verified under real Runner capture.
+
+The relevant layers are:
+
+- **Trace layer:** reported agent/tool intent from OTel-style or
+  OpenInference-style records.
+- **Runner layer:** measured SDK, policy, cgroup, and kernel evidence in
+  Runner proof packs or synthetic archive fixtures.
+- **Join layer:** `assay.observability.join_result.v0` and
+  `assay.observability.claim_class_cell.v0` rows that bound what a
+  reviewer may claim from the trace/archive comparison.
+- **Experiment carrier:** `assay.experiment.agent_observability_fidelity.*`
+  artifacts that remain experiment-scoped unless a later promotion PR
+  names a real consumer.
+
+## Findings
+
+### 1. Fidelity calibration is now a mechanical guardrail
+
+The overhead arc's main warning was that an observability path can look
+cheap when it silently stops retaining the requested signal. Slice 1
+turns that warning into a reusable harness discipline: requested and
+observed counts are represented as
+`assay.experiment.agent_observability_fidelity.calibration.v0`, with
+per-measurement `{target, observed, method, agreement}` entries and a
+rollup `fidelity_verdict`.
+
+The important distinction is `clipped` versus `drift`. `clipped` means a
+known effective limit explains the loss, such as the OTel default
+`SpanLimits.EventCountLimit=128`. `drift` means the observed count is
+below target without a known clipping reason and needs investigation
+before timing, throughput, or semantic absence claims are read from the
+sample. That distinction moves calibration from reviewer memory into
+schema-validated output.
+
+### 2. Evidence packs carry claims without strengthening them
+
+Slice 2 adds an experiment-scoped evidence-pack prototype with stable
+filenames, a manifest, one-page summary, observation-health record,
+optional trace, Runner archive/reference, and an explicit redaction
+manifest. The pack records its own reproduction command and non-claims.
+
+The key finding is not that evidence packs are now a product format.
+They are not. The finding is that an Assay experiment can package a
+bounded claim together with the artifacts needed to inspect it, while
+stating that the carrier does not strengthen the underlying join,
+health, calibration, or redaction evidence.
+
+### 3. The semantic-gap matrix exercises bounded claim classes
+
+Slices 3 and 4 define and implement six synthetic semantic-gap
+scenarios: `matched_safe_read`, `path_rewrite`, `hidden_write`,
+`retry_self_correction`, `runtime_side_effect`, and
+`weak_join_fallback`. Together they exercise the important claim
+classes: positive join, same-tool-call divergence, diagnostic fallback,
+runtime-surface-only evidence, and inconclusive downgrade when health or
+calibration is not clean.
+
+The matrix is synthetic by design. Its value is that it makes the claim
+rules executable: a strong `tool_call_id` join can support
+`positive_join` or `semantic_gap`, while timestamp/order fallback stays
+diagnostic. A measured effect mismatch is evidence of divergence between
+reported intent and measured effect; it is not evidence of malicious
+behavior, policy failure, or root cause by itself.
+
+### 4. The interop matrix maps coverage, not product quality
+
+Slices 5 and 6 add a synthetic interop matrix for OTel GenAI,
+OpenInference, and Runner measured effects. The five starter cells emit
+strict `interop_coverage_cell.v0` rows with source snapshots, mapping
+basis, coverage status, claim strength, join-result references, and
+claim-class references.
+
+This makes absence first-class. A row with `coverage_status=absent` is
+not a failed test when the vocabulary genuinely does not model the
+behavior; it is a bounded coverage finding. Likewise, `partial` rows
+document overlap without claiming semantic equivalence. The matrix is a
+coverage and claim-strength map, not a translator and not a vendor
+comparison.
+
+### 5. The delegated positive baseline is smoke-verified
+
+Slice 7 verifies the `matched_safe_read` positive baseline under real
+Runner capture. GitHub Actions run
+[`26571739019`](https://github.com/Rul1an/assay/actions/runs/26571739019)
+passed the existing `openai-agents-kernel-policy` delegated gate,
+uploaded proof pack `assay-runner-delegated-proof-pack-26571739019`,
+and recorded clean Runner health: `kernel_layer=complete`,
+`ringbuf_drops=0`, and `cgroup_correlation=clean`.
+
+The delegated proof pack showed the expected
+`tool_call_id=tc_runner_policy_001` path across SDK evidence, policy
+evidence, workdir-bounded kernel read/open effects, a clean correlation
+report, a strong join result, and a `positive_join` scenario verdict.
+This verifies the positive join path before any delegated gap scenario
+is published.
+
+The delegated smoke also found and fixed an infrastructure bug:
+systemd `.service` cgroups can be unsafe Assay session roots when their
+cgroup type is threaded, so Runner now skips `.service` leaf units like
+`.scope` units before creating session cgroups. That engineering
+compliance proof is separate from the narrow Slice 7 research evidence.
+
+## What The Findings Mean Together
+
+Assay's useful whitespace is not "more overhead numbers." It is the
+ability to say, for one agent run, what the trace reported, what the
+system measured, which key joined those layers, whether the requested
+signal was retained, what claim class is safe, and what portable
+evidence a reviewer can inspect.
+
+The defensible position is therefore not "Runner is better than OTel" or
+"OpenInference is more complete than OTel GenAI." It is: Assay can
+separate reported intent from measured effect, keep calibration and
+health gates visible before claims are interpreted, and map external
+trace vocabularies to bounded claim classes without pretending the
+vocabularies or evidence boundaries are equivalent.
+
+## Reproduction Pointers
+
+- Full roadmap and slice history:
+  [`../agent-observability-fidelity-2026-05.md`](../agent-observability-fidelity-2026-05.md)
+- Semantic-gap scenario plan:
+  [`semantic-gap-scenario-plan.md`](semantic-gap-scenario-plan.md)
+- Synthetic semantic-gap harness:
+  [`semantic_gap_harness.py`](semantic_gap_harness.py)
+- Interop matrix plan:
+  [`interop-matrix-plan.md`](interop-matrix-plan.md)
+- Synthetic interop harness:
+  [`interop_harness.py`](interop_harness.py)
+- Delegated baseline smoke record:
+  [`runs/slice7-delegated-baseline/summary.md`](runs/slice7-delegated-baseline/summary.md)
+- Experiment schema governance:
+  [`../../reference/experiments/namespace-governance.md`](../../reference/experiments/namespace-governance.md)
+- Cross-namespace schema index:
+  [`../../reference/runner/schemas-overview.md`](../../reference/runner/schemas-overview.md)
+- Optional future OTel span-limit study:
+  [issue #1408](https://github.com/Rul1an/assay/issues/1408)

--- a/docs/reference/observability/README.md
+++ b/docs/reference/observability/README.md
@@ -21,11 +21,17 @@ Runner artifacts remain the primary measured-run evidence. The
 observability contracts describe comparison and interpretation output
 above those artifacts.
 
-The next planned experiment line for this layer is
+The agent-observability fidelity arc for this layer is
 [`agent-observability-fidelity-2026-05`](../../experiments/agent-observability-fidelity-2026-05.md).
-It turns the completed overhead findings into a prioritized roadmap for
-calibration guardrails, semantic-gap scenarios, portable evidence packs,
-and OTel/OpenInference/Runner interoperability checks.
+It turns the completed overhead findings into calibration guardrails,
+semantic-gap scenarios, portable evidence packs, and
+OTel/OpenInference/Runner interoperability checks.
+
+The citation-oriented result of that arc is
+[`findings-summary.md`](../../experiments/agent-observability-fidelity-2026-05/findings-summary.md).
+It summarizes the calibration, evidence-pack, semantic-gap, interop, and
+delegated-baseline findings without promoting experiment-scoped schemas
+to product APIs.
 
 Experiment-scoped schema naming and promotion rules for that roadmap are
 tracked in


### PR DESCRIPTION
## Summary

Closes Slice 8 of the agent-observability fidelity roadmap with a citation-oriented findings summary. The summary keeps the detailed slice history in the roadmap and plan docs, while giving future README/paper/review work one bounded entry point.

## What changed

- Adds `docs/experiments/agent-observability-fidelity-2026-05/findings-summary.md`.
- Summarizes five bounded findings: fidelity calibration, evidence packs, synthetic semantic-gap matrix, synthetic interop matrix, and the delegated `matched_safe_read` positive baseline.
- Updates the fidelity roadmap so Slice 8 is `Done` and links the summary as the arc closure point.
- Links the summary from the observability reference README.
- Adds a CHANGELOG entry for the closure.

## Non-claims

- Does not publish delegated semantic-gap findings.
- Does not dispatch or add new measurement artifacts.
- Does not rank Runner, OTel GenAI, OpenInference, or the OpenAI Agents SDK.
- Does not promote any `assay.experiment.agent_observability_fidelity.*` schema to a product API.
- Does not open the optional OTel span-limit characterization issue.

## Validation

- `python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py'` -> 34 OK
- `git diff --check`
- `git diff --cached --check`
- changed-docs local link check -> OK
- `mkdocs build --strict` -> OK, with existing repo INFO warnings only
- commit/push hooks green, including workspace clippy and linux compile gate
