### PR TITLE
docs(observability): map claim-boundary whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added a post-arc claim-boundary positioning note for agent
+  observability work. The note records Assay's post-overhead and
+  post-fidelity position as a claim-boundary and evidence-fidelity layer,
+  not an observability replacement. It maps lifecycle-conform next steps
+  as upstream comments, citation updates, research notes, and
+  trigger-only watches rather than opening new experiment arcs or
+  promoting experiment-scoped artifacts.
 - Added an experiment arc lifecycle guide that captures the shared
   plan-to-harness-to-findings-summary pattern proven by the overhead and
   agent-observability fidelity arcs. The guide documents delegated gate

--- a/docs/reference/observability/README.md
+++ b/docs/reference/observability/README.md
@@ -13,6 +13,7 @@ governance.
 
 | Contract | Role |
 |---|---|
+| [`claim-boundary-positioning.md`](claim-boundary-positioning.md) | Post-arc positioning and adjacent whitespace map for claim-boundary and evidence-fidelity work. |
 | [`claim-classes-v0.md`](claim-classes-v0.md) | Vocabulary for saying what a trace, archive, or joined artifact can honestly claim. |
 | [`join-contract-v0.md`](join-contract-v0.md) | Vocabulary for joining trace, SDK, policy, and measured-run evidence without silently upgrading weak keys. |
 
@@ -32,6 +33,14 @@ The citation-oriented result of that arc is
 It summarizes the calibration, evidence-pack, semantic-gap, interop, and
 delegated-baseline findings without promoting experiment-scoped schemas
 to product APIs.
+
+The post-arc positioning note is
+[`claim-boundary-positioning.md`](claim-boundary-positioning.md). It
+turns the closed overhead and fidelity findings into a next-arc
+selection rule and lifecycle-conform outreach map: MCP tool-evidence
+comments, an AgentSight citation update, a fidelity-SLO research note,
+and trigger-only watches for identity, real trace interop, and causal
+graph work.
 
 Experiment-scoped schema naming and promotion rules for that roadmap are
 tracked in

--- a/docs/reference/observability/claim-boundary-positioning.md
+++ b/docs/reference/observability/claim-boundary-positioning.md
@@ -1,0 +1,305 @@
+# Claim-Boundary Positioning
+
+> **Status:** reference positioning note. Last updated: 2026-05-28.
+> This document does not open a new experiment arc, define a schema, or
+> promote any `assay.experiment.*` artifact to a product API.
+
+## Position
+
+Assay is not an observability replacement, trace viewer, vendor ranking,
+or general agent dashboard. Assay's strongest post-arc position is a
+claim-boundary and evidence-fidelity layer for agent systems.
+
+The closed Runner-vs-OTel overhead arc and agent-observability fidelity
+arc support one shared statement:
+
+> Assay helps determine what an agent run proves, not just what it
+> emitted.
+
+The useful boundary is not "Runner versus OTel" or "OpenInference versus
+OTel GenAI." It is the boundary between reported intent, measured
+effect, calibration health, join strength, and the claim a reviewer may
+safely make.
+
+## Methodology Anchor
+
+Future agent-observability work should start from the pattern proven by
+the two closed arcs:
+
+1. **Calibrate before timing.** Requested signals must be compared with
+   observed signals before throughput, timing, or absence claims are
+   interpreted.
+2. **Respect evidence boundaries.** In-process traces, OpenInference or
+   OTel vocabularies, Runner archives, policy evidence, and kernel
+   effects carry different claim surfaces.
+3. **Classify claims.** A trace/archive mismatch is a measured
+   divergence, not automatically malicious behavior, policy failure, or
+   root cause.
+4. **Carry bounded evidence.** A portable carrier should make review
+   easier without strengthening the underlying evidence.
+5. **Use delegated gates sparingly.** Real infrastructure should verify
+   a specific publication gate, not broaden a synthetic experiment by
+   accident.
+
+This is the product-facing form of the experiment lifecycle documented
+in [`../experiments/arc-lifecycle-guide.md`](../experiments/arc-lifecycle-guide.md).
+
+## Adjacent Whitespace
+
+This map is not a backlog of arcs. The experiment lifecycle guide makes
+arc closure a stop condition, not permission to open every adjacent
+question. The default next gate for a whitespace direction is an
+upstream comment, a short research note, or a watch trigger. A new arc
+requires a named consumer, upstream response, or concrete contract ask.
+
+### 1. Protocol Tool-Evidence Assurance
+
+**Question:** When a protocol-exposed tool is selected and invoked, can
+Assay bind the tool metadata visible to the model, the tool call, policy
+context, and measured runtime effect?
+
+**Why now:** MCP has become a major tool-integration surface. The MCP
+tools specification makes tools discoverable and model-controlled, while
+recent work such as MCPTox and MCP-TDP shows that tool metadata and
+descriptions are active attack surfaces.
+
+**Assay angle:** Produce bounded evidence for "the model saw this tool
+description, selected this tool, sent these arguments, and the system
+measured these effects." Do not claim that every poisoned tool is
+malicious or that every mismatch is an exploit.
+
+**Lifecycle-conform next step:** write an upstream comment trilogy, not
+an Assay arc:
+
+- one comment on MCPTox or its follow-up discussion;
+- one comment on MCP-TDP or its benchmark surface;
+- one comment or issue on the MCP tools specification/discussion.
+
+Each comment should reuse the same bounded evidence shape:
+`tool_manifest_digest -> model-visible description -> tool_call ->
+runtime_effect`. Do not promise an Assay schema, evidence-pack product,
+or delegated experiment in those comments.
+
+**Trigger to open an arc:** a maintainer, benchmark author, or downstream
+consumer asks for concrete Assay evidence over a tool-poisoning case.
+
+### 2. AgentSight Semantic-Gap Citation
+
+**Question:** Can the closed fidelity arc cite an external formulation of
+the same reported-intent versus measured-effect gap without reopening
+the arc?
+
+**Why now:** AgentSight explicitly frames the need to correlate
+high-level agent intent with low-level system actions. That is the same
+conceptual gap the fidelity arc made executable with semantic-gap
+scenarios, join rows, and claim classes.
+
+**Assay angle:** Use AgentSight as an external citation anchor for the
+already-closed fidelity finding. Do not dispatch new `hidden_write` or
+`path_rewrite` delegated captures just because the citation exists.
+
+**Lifecycle-conform next step:** a narrow findings-summary citation
+update or research note that says AgentSight names the same semantic-gap
+class that Assay bounds through claim-strength and join evidence.
+
+**Trigger to open an arc:** an external reader asks Assay to validate one
+of the semantic-gap scenarios under a specific real agent framework.
+
+### 3. Observability Fidelity SLOs
+
+**Question:** Can "observability that looks cheap because it clipped the
+requested signal" become a reusable category without reopening the OTel
+span-limit study?
+
+**Why now:** The overhead arc showed that the OTel
+`SpanLimits.EventCountLimit=128` behavior is a configuration boundary,
+not a throughput boundary. That makes it a clean example of a broader
+fidelity-SLO problem: retention target, observed count, effective limit,
+method, agreement, and safe claim class.
+
+**Assay angle:** Turn Slice 12 into a vocabulary for observability
+fidelity, not an OTel benchmark. The safe thesis is "measure fidelity
+before timing," not "OTel is limited."
+
+**Lifecycle-conform next step:** write a positioning blogpost or research
+note. Keep issue #1408 trigger-only.
+
+**Trigger to open an arc:** a concrete consumer asks "can Assay measure
+this fidelity SLO for my trace path?"
+
+### 4. Agent Identity And Delegation
+
+**Question:** When an agent acts on behalf of a user or another agent,
+what evidence would be needed to bind identity, delegation,
+authorization, tool intent, and measured effect?
+
+**Why now:** NIST's 2026 AI Agent Standards Initiative and AI-agent
+identity work point at authentication, authorization, auditing, and
+non-repudiation as open agent-system problems. Recent identity research
+also highlights semantic intent verification and recursive delegation
+accountability as unresolved gaps.
+
+**Assay angle:** Treat identity and authorization as claim inputs, not
+as generic metadata. A delegated action should be reviewable as "who or
+what delegated the action, under which policy, through which key, and
+with which measured effect."
+
+**Lifecycle-conform next step:** one public comment on the NIST concept
+paper or related standards discussion. The comment should introduce the
+bounded-evidence vocabulary and then wait for response. Do not predeclare
+a delegation receipt schema.
+
+**Trigger to open an arc:** NIST, a standards participant, or a real
+downstream consumer asks for a concrete Assay receipt shape.
+
+### 5. Real Trace Interop Imports
+
+**Question:** Given a real OTel GenAI or OpenInference trace and a
+Runner proof pack for the same run, which claims map fully, partially,
+or not at all?
+
+**Why now:** OTel GenAI semantic conventions remain in Development, with
+explicit opt-in transition behavior for latest experimental emission.
+OpenInference uses a richer AI-specific span-kind vocabulary, including
+`AGENT`, `LLM`, `TOOL`, `RETRIEVER`, `GUARDRAIL`, `EVALUATOR`, and
+`PROMPT`.
+
+**Assay angle:** The synthetic interop matrix is enough for now. OTel's
+Development status is a reason to track the surface, not a reason to
+build an importer before a stable target or consumer exists.
+
+**Lifecycle-conform next step:** watch OTel GenAI and OpenInference
+surface changes and keep the interop matrix citation-ready. Do not build
+a translator or importer as a speculative product surface.
+
+**Trigger to open an arc:** a stable upstream field surface or external
+consumer asks Assay to map a specific real trace against Runner evidence.
+
+### 6. Causal Claim Graphs
+
+**Question:** Can Assay produce causal graph rows that state what is
+known, weakly joined, absent, or inconclusive without asking an LLM to
+invent root cause?
+
+**Why now:** 2026 work on causal tracing, trace-to-graph analysis, and
+multi-agent root-cause localization shows growing demand for structured
+diagnosis over long agent traces. Assay can contribute a stricter
+evidence-bounded graph layer.
+
+**Assay angle:** The graph is not "the explanation." It is a typed view
+of evidence, joins, health, calibration, and safe claim classes.
+
+**Lifecycle-conform next step:** a research note only. Do not define
+`causal_claim_cell.v0` or promote a graph schema until a concrete
+consumer asks for graph output.
+
+**Trigger to open an arc:** a paper, benchmark, or downstream integration
+needs graph-shaped evidence rather than the existing join and claim-class
+rows.
+
+## Explicit Non-Directions
+
+Do not build a public synthetic trace corpus now. A 20 to 50 run corpus
+would require curation, hosting, contribution policy, and ongoing
+maintenance. It also competes with AgentSim, Agentic CLEAR, and related
+corpus work where Assay's advantage is not scale. Assay's advantage is
+the narrowness of the claim and the evidence boundary around it.
+
+Do not treat NIST identity work as an invitation to start a standards
+arc. Standards engagement can become a time sink for a solo maintainer.
+The right unit of work is one well-timed public comment, then waiting
+for a concrete response.
+
+Do not treat OTel GenAI Development status as an importer trigger. A
+moving surface is a reason to track source snapshots and wait for a
+stable or requested mapping target.
+
+## Selection Rule
+
+Open a new arc only when the question can be stated as:
+
+> Which claim can we not safely make today because trace, protocol,
+> policy, identity, or runtime evidence is not yet bound tightly enough?
+
+Prefer future arcs that:
+
+- create or validate a bounded claim class;
+- bind two or more evidence layers that currently drift apart;
+- make absence, partial coverage, clipping, or weak joins first-class;
+- produce a carrier a reviewer can inspect;
+- have a delegated baseline or a concrete downstream consumer.
+
+Defer arcs that:
+
+- mainly rank tools, vendors, vocabularies, or frameworks;
+- add another dashboard without changing claim strength;
+- expand a synthetic matrix without a new claim boundary;
+- require schema promotion before a consumer exists;
+- duplicate OTel/OpenInference trace viewing instead of binding traces
+  to measured effects.
+
+## Near-Term Priority
+
+The near-term program is outreach and positioning, not new experiments:
+
+1. **MCP comment trilogy.** One bounded-evidence comment each for
+   MCPTox, MCP-TDP, and the MCP tools specification or discussion.
+2. **AgentSight citation update.** Use AgentSight as an external
+   formulation of the semantic gap already closed by the fidelity arc.
+3. **Fidelity-SLO research note.** Reframe Slice 12 as "observability
+   fidelity before timing" without opening #1408.
+4. **NIST identity watch.** Make at most one public comment, then wait
+   for response.
+5. **Interop import watch.** Track OTel/OpenInference surface stability,
+   but do not build a speculative importer.
+6. **Causal graph watch.** Keep as a paper-tier possibility after a
+   consumer asks for graph-shaped evidence.
+
+## Source Anchors
+
+- Assay overhead arc:
+  [`../../experiments/runner-vs-otel-overhead-2026-05/findings-summary.md`](../../experiments/runner-vs-otel-overhead-2026-05/findings-summary.md)
+- Assay fidelity arc:
+  [`../../experiments/agent-observability-fidelity-2026-05/findings-summary.md`](../../experiments/agent-observability-fidelity-2026-05/findings-summary.md)
+- Assay arc lifecycle:
+  [`../experiments/arc-lifecycle-guide.md`](../experiments/arc-lifecycle-guide.md)
+- OpenTelemetry GenAI semantic conventions:
+  <https://opentelemetry.io/docs/specs/semconv/gen-ai/>
+- OpenTelemetry GenAI agent spans:
+  <https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/>
+- OpenInference semantic conventions:
+  <https://arize-ai.github.io/openinference/spec/semantic_conventions.html>
+- Model Context Protocol tools:
+  <https://modelcontextprotocol.io/specification/2025-06-18/server/tools>
+- MCPTox:
+  <https://ojs.aaai.org/index.php/AAAI/article/view/40895>
+- MCP-TDP:
+  <https://arxiv.org/abs/2605.24069>
+- NIST AI Agent Standards Initiative:
+  <https://www.nist.gov/artificial-intelligence/ai-agent-standards-initiative>
+- NIST AI agent identity concept paper:
+  <https://csrc.nist.gov/pubs/other/2026/02/05/accelerating-the-adoption-of-software-and-ai-agent/ipd>
+- AI Identity survey:
+  <https://arxiv.org/abs/2604.23280>
+- AgentSight:
+  <https://arxiv.org/abs/2508.02736>
+- AgentTrace causal tracing:
+  <https://arxiv.org/abs/2603.14688>
+- AgentSim:
+  <https://arxiv.org/abs/2604.26653>
+- AgentGraph:
+  <https://ojs.aaai.org/index.php/AAAI/article/view/42393>
+- Agentic CLEAR:
+  <https://ibm.github.io/CLEAR/>
+
+## Non-Claims
+
+- This document does not open the MCP/tool-evidence, identity,
+  interop-import, corpus, causal-graph, or fidelity-SLO arcs.
+- This document does not promote evidence packs, calibration verdicts,
+  interop rows, semantic-gap verdicts, or future binding evidence to
+  product APIs.
+- This document does not rank OTel, OpenInference, MCP, A2A, Runner, or
+  Assay as products.
+- This document does not claim that every protocol, trace, or
+  trace/kernel mismatch is a security issue.

--- a/docs/reference/schemas-overview.md
+++ b/docs/reference/schemas-overview.md
@@ -38,5 +38,6 @@ string carries the contract boundary.
 | [`runner/schemas-overview.md`](runner/schemas-overview.md) | Detailed Runner and Runner-adjacent schema list. |
 | [`artifact-families-inventory.md`](artifact-families-inventory.md) | Canonical, reference, experiment-scoped, and proposed artifact-family inventory. |
 | [`observability/README.md`](observability/README.md) | Observability reference contracts for claim classes and joins. |
+| [`observability/claim-boundary-positioning.md`](observability/claim-boundary-positioning.md) | Post-arc positioning and next-arc selection guidance for claim-boundary and evidence-fidelity work. |
 | [`experiments/namespace-governance.md`](experiments/namespace-governance.md) | Naming, promotion, and cross-arc field guidance for experiment-scoped schemas. |
 | [`experiments/arc-lifecycle-guide.md`](experiments/arc-lifecycle-guide.md) | Plan, harness, delegated-gate, and findings-summary lifecycle guidance for experiment arcs. |


### PR DESCRIPTION
## Summary

Adds a post-arc observability positioning note that turns the closed overhead and agent-observability fidelity findings into a claim-boundary strategy and lifecycle-conform outreach map.

## What changed

- Adds `docs/reference/observability/claim-boundary-positioning.md`.
- Positions Assay as a claim-boundary and evidence-fidelity layer, not an observability replacement, trace viewer, translator, or vendor ranking surface.
- Captures the reusable methodology from the two closed arcs: calibration before timing, evidence-boundary respect, bounded claim classification, portable evidence, and narrow delegated gates.
- Converts adjacent whitespace into non-arc first gates:
  - MCP tool-evidence assurance as an upstream comment trilogy
  - AgentSight semantic-gap citation as a findings-summary/research-note update
  - observability fidelity SLOs as a positioning note, with #1408 still trigger-only
  - NIST identity, real trace interop imports, and causal claim graphs as trigger-only watches
- Explicitly rejects a public synthetic trace corpus as a near-term direction.
- Links the note from the observability reference README, schema namespace overview, and changelog.

## Non-claims

- Does not open the MCP/tool-evidence, identity, interop-import, corpus, causal-graph, or fidelity-SLO arcs.
- Does not define a schema or promote experiment-scoped artifacts to product APIs.
- Does not promise evidence packs, delegation receipts, importers, graph schemas, or delegated experiments.
- Does not rank OTel, OpenInference, MCP, A2A, Runner, or Assay as products.
- Does not claim that every protocol, trace, or trace/kernel mismatch is a security issue.

## Validation

- `git diff --check`
- local changed-docs link check
- `mkdocs build --strict` via the existing temporary docs venv
- pre-commit and pre-push hooks green, including workspace clippy and linux compile gate
