### PR TITLE
docs(observability): define fidelity calibration reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added an observability fidelity calibration reference note that generalizes
+  the closed overhead and fidelity arcs' requested-vs-observed
+  calibration lesson. The note frames retained signal as a prerequisite
+  for timing, throughput, and absence claims without opening a new
+  experiment arc, defining a schema, or promoting experiment-scoped
+  calibration artifacts to product APIs.
 - Removed the legacy `assay-runner-spike` compatibility wrapper crate
   from the workspace and release pipeline. The runner substrate publish
   contract now includes only `assay-runner-schema`,

--- a/docs/reference/observability/README.md
+++ b/docs/reference/observability/README.md
@@ -16,6 +16,7 @@ governance.
 | [`claim-boundary-positioning.md`](claim-boundary-positioning.md) | Post-arc positioning and public selection discipline for claim-boundary and evidence-fidelity work. |
 | [`claim-classes-v0.md`](claim-classes-v0.md) | Vocabulary for saying what a trace, archive, or joined artifact can honestly claim. |
 | [`join-contract-v0.md`](join-contract-v0.md) | Vocabulary for joining trace, SDK, policy, and measured-run evidence without silently upgrading weak keys. |
+| [`observability-fidelity-calibration.md`](observability-fidelity-calibration.md) | Reference note for reading requested-vs-observed signal retention before timing, throughput, or absence claims. |
 
 These contracts are intentionally separate from Runner archive schemas.
 Runner artifacts remain the primary measured-run evidence. The
@@ -40,6 +41,12 @@ turns the closed overhead and fidelity findings into a public
 positioning statement and next-arc selection rule. It intentionally does
 not publish outreach targets, comment drafts, adjacent-whitespace
 shortlists, competitive analysis, or private sequencing notes.
+
+The observability fidelity calibration note is
+[`observability-fidelity-calibration.md`](observability-fidelity-calibration.md). It
+extracts the closed arcs' requested-vs-observed calibration lesson into
+a public reference category: measure retained signal before interpreting
+timing, throughput, or absence claims.
 
 Experiment-scoped schema naming and promotion rules for that roadmap are
 tracked in

--- a/docs/reference/observability/observability-fidelity-calibration.md
+++ b/docs/reference/observability/observability-fidelity-calibration.md
@@ -1,0 +1,158 @@
+# Observability Fidelity Calibration
+
+> **Status:** reference note. Last updated: 2026-05-28.
+> This document does not open a new experiment arc, define a schema, or
+> promote any `assay.experiment.*` artifact to a product API.
+
+## Position
+
+Observability fidelity calibration is a review discipline for deciding
+whether an observation path retained enough of the requested signal for
+downstream claims to be interpreted.
+
+It is not a user-facing product SLO, SLA, uptime promise, support
+promise, or vendor comparison. It answers a narrower question:
+
+> Did the observation layer preserve the evidence it was asked to
+> preserve, and if not, do we know why?
+
+The closed Runner-vs-OTel overhead arc exposed the motivating failure
+mode: an observation path can look cheap because a requested signal was
+clipped before the measurement reached the layer being analyzed. The
+agent-observability fidelity arc turned that warning into a mechanical
+calibration discipline.
+
+## Minimum Record Shape
+
+A fidelity calibration record should be able to state, at minimum:
+
+| Field | Role |
+|---|---|
+| `signal` | The requested observable, such as kernel worker files or span events. |
+| `target` | The expected count, predicate, or retention target. |
+| `observed` | The measured count or predicate result. |
+| `method` | How the observed value was counted. |
+| `agreement` | `match`, `clipped`, `drift`, `failed`, or `not_applicable`. |
+| `effective_limit` | The known limit when clipping is explained. |
+| `health` | Capture-layer health gates that affect interpretation. |
+| `safe_claim` | The strongest claim the record supports. |
+
+`effective_limit` is required when `agreement = clipped`. Without a
+known effective limit, a lossy retained signal collapses to `drift`.
+
+This is a reference shape, not a new schema. The experiment-scoped
+implementation that proved the pattern is
+`assay.experiment.agent_observability_fidelity.calibration.v0`.
+
+## Agreement Semantics
+
+The central vocabulary is the agreement field:
+
+- `match`: the requested signal is present and retained at the required
+  level by the named method, and the recorded health gates do not
+  contradict the retention claim.
+- `clipped`: the signal existed or was requested, but the observation
+  system truncated, dropped, sampled, or limited it for a known effective
+  limit.
+- `drift`: a usable artifact exists, but the count, shape, key, or
+  category changed in a way that makes comparison unreliable and no
+  known effective limit explains the change.
+- `failed`: the capture path did not produce a usable artifact or
+  measurement for the stated purpose.
+- `not_applicable`: the signal is outside the measurement surface of the
+  current layer, host, workload, or observation arm.
+
+The important boundary is `clipped` versus `drift`. `clipped` is still a
+lossy sample, but it is an explained lossy sample. `drift` is an
+unexplained lossy sample and should block timing, throughput, and
+absence claims until investigated.
+
+The second important boundary is `drift` versus `failed`. `drift` leaves
+a reviewable artifact, but makes comparison or interpretation unsafe for
+the stated claim. `failed` means the measurement is not usable for that
+purpose at all.
+
+## Reading Rules
+
+1. **Do not read speed from loss.** A sample that retained fewer events
+   than requested may look faster because it did less observation work.
+2. **Do not read absence from clipped capture.** If a trace path clipped
+   at a known limit, missing later events do not prove absent behavior.
+3. **Do not broaden absence claims.** Even `match` only authorizes
+   negative claims inside the recorded capture layer, health state,
+   configured limits, and measurement method.
+4. **Do not upgrade drift into efficiency.** An unexplained count drop is
+   a fidelity problem before it is a performance result.
+5. **Do not hide health gates.** Ring-buffer drops, archive
+   completeness, correlation health, and trace exporter health must stay
+   visible because they can bound the safe claim.
+6. **Attach the method.** A retained count is only reviewable when the
+   record says how the count was produced.
+
+## Worked Examples
+
+| Scenario | Agreement | Why |
+|---|---|---|
+| Span events are capped by an exporter or SDK limit. | `clipped` | The signal was requested, but a known limit truncated the retained events. |
+| A Runner archive reports `ringbuf_drops > 0` for the signal under review. | `failed` | Capture health contradicts a complete-retention claim for that purpose; absence or timing claims need a rerun or a narrower bound. |
+| A tool span exists but the required cross-layer join key is missing. | `drift` | The trace artifact exists, but joined comparison has lost reliability. |
+| Kernel-only capture is requested on an unsupported non-Linux host. | `not_applicable` | The signal is outside the current capture surface. |
+| The expected worker-file count equals the observed archive count with clean health gates. | `match` | The requested signal was retained by the named method within the recorded health state. |
+
+## Closed-Arc Examples
+
+The overhead arc found that Runner kernel capture stayed healthy through
+the widened event-rate cells, while the default OTel span-event path
+retained exactly `128` events per span in cells that requested `500` or
+`1000` events. The local repro with
+`OTEL_SPAN_EVENT_COUNT_LIMIT=1000` retained all requested events, so the
+safe classification was a known default-limit boundary rather than an
+unknown throughput failure.
+
+The fidelity arc converted that lesson into calibration rows with
+per-measurement `{target, observed, method, agreement}` values and a
+review-facing rollup. That made lossy capture visible before semantic
+gap, interop, or timing claims were interpreted.
+
+## What This Enables
+
+Observability fidelity calibration lets a reviewer distinguish four
+cases that otherwise collapse into one vague "we observed fewer events"
+statement:
+
+| Case | Safe interpretation |
+|---|---|
+| `target=1000`, `observed=1000`, `agreement=match` | Retention target was met. |
+| `target=1000`, `observed=128`, `agreement=clipped` | Retention failed for a known limit. |
+| `target=1000`, `observed=128`, `agreement=drift` | Retention failed for an unknown reason. |
+| `target=1000`, `observed=None`, `agreement=failed` | Measurement failed; no retention claim is safe. |
+
+The category is useful because the second and third rows require
+different action. A clipped sample can support a configuration-boundary
+finding. A drift sample requires investigation before it can support any
+downstream measurement claim.
+
+## Non-Claims
+
+- This note does not define a product SLO, SLA, support promise, or
+  availability surface.
+- This note does not claim OTel, OpenInference, Runner, or Assay is
+  better than another observation layer.
+- This note does not publish new benchmark numbers.
+- This note does not open the optional span-limit characterization issue
+  as an active experiment.
+- This note does not promote experiment-scoped calibration artifacts to
+  product APIs.
+- This note does not cover the separate evidence-pack discipline where a
+  portable carrier must not strengthen the underlying claim.
+
+## Source Anchors
+
+- Runner-vs-OTel overhead findings:
+  [`../../experiments/runner-vs-otel-overhead-2026-05/findings-summary.md`](../../experiments/runner-vs-otel-overhead-2026-05/findings-summary.md)
+- Agent-observability fidelity findings:
+  [`../../experiments/agent-observability-fidelity-2026-05/findings-summary.md`](../../experiments/agent-observability-fidelity-2026-05/findings-summary.md)
+- Agent-observability fidelity roadmap and calibration fields:
+  [`../../experiments/agent-observability-fidelity-2026-05.md`](../../experiments/agent-observability-fidelity-2026-05.md)
+- Optional future span-limit characterization:
+  [issue #1408](https://github.com/Rul1an/assay/issues/1408)

--- a/docs/reference/schemas-overview.md
+++ b/docs/reference/schemas-overview.md
@@ -39,5 +39,6 @@ string carries the contract boundary.
 | [`artifact-families-inventory.md`](artifact-families-inventory.md) | Canonical, reference, experiment-scoped, and proposed artifact-family inventory. |
 | [`observability/README.md`](observability/README.md) | Observability reference contracts for claim classes and joins. |
 | [`observability/claim-boundary-positioning.md`](observability/claim-boundary-positioning.md) | Post-arc positioning and public next-arc selection discipline for claim-boundary and evidence-fidelity work. |
+| [`observability/observability-fidelity-calibration.md`](observability/observability-fidelity-calibration.md) | Reference note for requested-vs-observed signal retention before timing, throughput, or absence claims. |
 | [`experiments/namespace-governance.md`](experiments/namespace-governance.md) | Naming, promotion, and cross-arc field guidance for experiment-scoped schemas. |
 | [`experiments/arc-lifecycle-guide.md`](experiments/arc-lifecycle-guide.md) | Plan, harness, delegated-gate, and findings-summary lifecycle guidance for experiment arcs. |


### PR DESCRIPTION
Summary

Adds an observability fidelity calibration reference note that turns the closed overhead and agent-observability fidelity findings into a small public reading discipline: verify retained signal before interpreting timing, throughput, or absence claims.

What changed

- Adds `docs/reference/observability/observability-fidelity-calibration.md`.
- Defines agreement categories: `match`, `clipped`, `drift`, `failed`, and `not_applicable`.
- Makes `effective_limit` required for `clipped`; without a known effective limit, a lossy retained signal collapses to `drift`.
- Adds reading rules that bound speed, absence, drift, health-gate, and method claims.
- Adds worked examples for exporter/SDK clipping, Runner health drops, missing join keys, unsupported capture surfaces, and clean worker-file retention.
- Links the note from the observability reference README and schema namespace overview, and records it in the changelog.

Non-claims

- Does not open the optional span-limit characterization issue as an active experiment.
- Does not define a product SLO, SLA, support promise, or availability surface.
- Does not publish new benchmark numbers.
- Does not promote experiment-scoped calibration artifacts to product APIs.
- Does not cover the separate evidence-pack carrier discipline.

Validation

- `git diff --check`
- changed-docs local link check
- `mkdocs build --strict`
- commit hooks green, including clippy and linux compile gate