### PR TITLE
docs(experiments): plan delegated semantic-gap expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added a post-closure delegated semantic-gap expansion plan for the
+  agent-observability fidelity arc. The plan selects `hidden_write` as
+  the first delegated gap candidate after the smoke-verified
+  `matched_safe_read` baseline, pins same-head baseline revalidation,
+  clean-health, strong `tool_call_id` join, workdir-boundary, and
+  non-claim gates, and does not dispatch a run, publish delegated gap
+  findings, define schemas, or promote experiment artifacts.
 - Added an observability fidelity calibration reference note that generalizes
   the closed overhead and fidelity arcs' requested-vs-observed
   calibration lesson. The note frames retained signal as a prerequisite

--- a/docs/experiments/agent-observability-fidelity-2026-05.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05.md
@@ -36,7 +36,10 @@ Priority order:
    under real Runner capture before any gap finding is published.
 6. **Fidelity arc findings summary** - close the arc with bounded,
    citation-ready statements after the delegated baseline gate.
-7. **Optional OTel span-limit characterization** - only when an external
+7. **Delegated semantic-gap expansion** - only after the positive
+   baseline, predeclare the first delegated gap candidate and review
+   gate before any measured gap row is cited.
+8. **Optional OTel span-limit characterization** - only when an external
    consumer needs behavior above the default 128 span-event limit.
 
 ## Why This Direction
@@ -504,7 +507,42 @@ roadmap and plan files.
   APIs.
 - The summary does not recommend one trace vocabulary over another.
 
-## Experiment 7 - Optional OTel Span-Limit Characterization
+## Post-Closure Follow-Up A - Delegated Semantic-Gap Expansion
+
+**Goal:** predeclare the first delegated gap scenario after the positive
+baseline without reopening the whole fidelity arc.
+
+> **Status:** plan-ready. The post-closure expansion gate is in
+> [`agent-observability-fidelity-2026-05/delegated-semantic-gap-expansion-plan.md`](agent-observability-fidelity-2026-05/delegated-semantic-gap-expansion-plan.md).
+> It selects `hidden_write` as the first delegated gap candidate and
+> keeps the follow-up bounded to one same-tool-call gap row. It does not
+> dispatch a delegated run, publish a gap finding, add a schema, or
+> promote experiment artifacts.
+
+The positive `matched_safe_read` baseline is already
+smoke-verified. That makes a narrow delegated gap expansion technically
+possible, but it does not make every synthetic gap scenario publishable.
+The first useful follow-up is `hidden_write`: one reported read-like
+tool call, one measured workdir-bounded write effect, one strong
+`tool_call_id` join, and explicit non-claims around maliciousness,
+policy failure, and root cause.
+
+### Acceptance rules
+
+- Keep the first delegated gap expansion to `hidden_write` only.
+- If fixture code, acceptance scripts, cgroup handling, SDK
+  normalization, policy normalization, or kernel extraction changes,
+  rerun the positive baseline on the same head SHA before citing the
+  gap row.
+- Require clean Runner health and a unique strong `tool_call_id` join.
+- Require the measured write/create effect to remain inside the
+  delegated fixture workdir.
+- Classify missing artifacts, unclean health, or ambiguous joins as
+  `inconclusive`, not as semantic gaps.
+- Preserve the existing semantic-gap verdict, join-result, claim-class,
+  evidence-pack, and redaction vocabularies.
+
+## Experiment 8 - Optional OTel Span-Limit Characterization
 
 **Goal:** characterize span-event throughput/fidelity only after raising
 the OTel SDK limit above the requested target.
@@ -556,7 +594,8 @@ visible by the overhead and shape-comparison arcs.
 
 Arc status: closed at Slice 8 with
 [`agent-observability-fidelity-2026-05/findings-summary.md`](agent-observability-fidelity-2026-05/findings-summary.md).
-Slice 9 remains optional and trigger-only.
+Post-closure Follow-up A is plan-ready for a narrow delegated
+`hidden_write` expansion. Slice 9 remains optional and trigger-only.
 
 | Slice | Status | Purpose | Exit gate |
 |---:|---|---|---|
@@ -569,6 +608,7 @@ Slice 9 remains optional and trigger-only.
 | 6 | Harness-ready | Interop matrix harness | Five synthetic starter cells emit strict `interop_coverage_cell.v0` rows, join-result refs, claim-class refs, source snapshots, partial/absent rows, and stable output directories without delegated publication. |
 | 7 | Delegated-baseline-smoke-verified | Delegated semantic-gap baseline | Run `26571739019` passed the `openai-agents-kernel-policy` delegated gate, uploaded proof pack `assay-runner-delegated-proof-pack-26571739019`, and validated clean health plus strong `tool_call_id` positive baseline join without promoting delegated gap scenarios. |
 | 8 | Done | Fidelity arc findings summary | Citation-friendly summary closes the arc across calibration, evidence-pack, semantic-gap, interop, and delegated-baseline outcomes without promoting product APIs or publishing delegated gap findings. |
+| Follow-up A | Delegated-gap-expansion-plan-ready | Delegated semantic-gap expansion | `hidden_write` is selected as the first delegated gap candidate with same-head positive-baseline revalidation, clean-health, strong-join, workdir-boundary, and non-claim gates pinned before dispatch. |
 | 9 | Optional | OTel span-limit study | Only after an external trigger; otherwise remains issue-only. |
 
 ## Experiment vs Feature Boundary
@@ -602,13 +642,17 @@ non-claims are pinned before dispatch. `Delegated-baseline-smoke-verified`
 means the delegated positive baseline ran, produced the required proof
 pack or references, and satisfied the predeclared health and join
 invariants without promoting delegated gap scenarios.
+`Delegated-gap-expansion-plan-ready` means one delegated gap candidate,
+same-head baseline revalidation rules, health gates, join invariants,
+review artifacts, and non-claims are pinned before any delegated gap
+dispatch.
 
 ## What Not To Do Yet
 
 - Do not dispatch delegated gap scenarios as part of this baseline
   smoke. The delegated `matched_safe_read` gate is clean; any delegated
-  gap scenario still needs its own dispatch plan, non-claims, and review
-  gate before it is cited as measured evidence.
+  gap scenario still needs its own accepted dispatch follow-up,
+  non-claims, and review gate before it is cited as measured evidence.
 - Do not turn the Interop Matrix into product ranking. It is now
   harness-ready, but it remains a coverage and claim-strength map.
 - Do not turn the required product-development list into one epic. Each

--- a/docs/experiments/agent-observability-fidelity-2026-05/delegated-semantic-gap-expansion-plan.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05/delegated-semantic-gap-expansion-plan.md
@@ -1,0 +1,177 @@
+# Delegated Semantic-Gap Expansion Plan
+
+> **Status:** delegated-gap-expansion-plan-ready. This note predeclares
+> the smallest post-closure delegated gap expansion after the successful
+> `matched_safe_read` smoke. It does not dispatch a delegated run, add a
+> new schema, promote experiment artifacts, or publish delegated
+> semantic-gap findings.
+>
+> **Last updated:** 2026-05-29
+
+## Goal
+
+The delegated expansion asks one narrow question:
+
+```text
+After the positive matched_safe_read path is smoke-verified under real
+Runner capture, can one same-tool-call gap scenario be repeated on the
+delegated runner while preserving clean health, strong tool_call_id
+joining, and bounded non-claims?
+```
+
+This is a technical publication gate for one future measured gap row,
+not a new observability strategy and not a broad semantic-gap campaign.
+The first delegated gap candidate is `hidden_write` because it keeps
+the same single-call, strong-join shape as the positive baseline while
+changing only the measured effect side.
+
+## Prerequisites
+
+| Prerequisite | Status | Why it matters |
+|---|---|---|
+| Positive delegated baseline | Done: [`runs/slice7-delegated-baseline/summary.md`](runs/slice7-delegated-baseline/summary.md) | Gap publication needs evidence that the non-gap join path works on the delegated host. |
+| Full synthetic matrix | Done: [`semantic_gap_harness.py`](semantic_gap_harness.py) | The delegated scenario must map back to an already predeclared synthetic scenario id and verdict. |
+| Existing delegated runner lane | Existing workflow: [`.github/workflows/runner-spike-delegated.yml`](../../../.github/workflows/runner-spike-delegated.yml) | The expansion should reuse the Linux/eBPF proof-pack mechanism instead of creating a parallel lane. |
+| Join and claim-class references | Reference-ready | Delegated rows must reuse `assay.observability.join_result.v0` and `assay.observability.claim_class_cell.v0`. |
+| Evidence-pack/proof-pack carrier | Prototype-ready | Reviewers need a stable directory or proof-pack reference, not loose logs. |
+
+## First Candidate
+
+`hidden_write` is the first delegated gap candidate.
+
+| Property | Required value |
+|---|---|
+| Scenario id | `hidden_write` |
+| Expected verdict | `semantic_gap` |
+| Expected evidence-pack claim class | `semantic_gap` |
+| Join key | `tool_call_id` |
+| Join grade | `strong` |
+| Reported layer | one `read_file` tool call with reported read intent |
+| Measured layer | one workdir-bounded write/create effect in the same run window |
+| Claim boundary | effect divergence at the same tool call; no maliciousness, policy-failure, or root-cause claim |
+
+This is intentionally narrower than "run every gap scenario delegated."
+It avoids the extra ambiguity in `path_rewrite` path projection, the
+cardinality change in `retry_self_correction`, the run-scope
+attribution problem in `runtime_side_effect`, and the intentionally weak
+join in `weak_join_fallback`.
+
+## Implementation Shape
+
+The implementation PR should prefer a small fixture extension over a
+new workflow surface. A suitable shape is:
+
+```text
+runner-fixtures/openai-agents/
+  fixture-agent.js                    # existing deterministic fixture
+scripts/ci/
+  runner-spike-openai-agents-...sh    # existing delegated acceptance path
+```
+
+The future implementation may add a scenario selector or a narrow
+acceptance wrapper, but it should keep these constraints:
+
+- preserve the existing `matched_safe_read` delegated acceptance path;
+- keep `hidden_write` opt-in so the existing baseline gate does not
+  silently change behavior;
+- keep the fixture deterministic across three delegated runs;
+- emit the same proof-pack families already used by the baseline:
+  selected JSON, SDK NDJSON, policy NDJSON, Runner archive tarballs,
+  gate log, and proof-pack manifest;
+- reuse the semantic-gap review rows rather than inventing a
+  delegated-only verdict vocabulary.
+
+If the fixture or acceptance script changes, the implementation PR must
+rerun the positive baseline on the same head SHA. A delegated gap row is
+not citeable if the positive baseline only passed on an older fixture
+shape.
+
+## Required Review Output
+
+A future delegated `hidden_write` follow-up should produce one stable
+review directory, for example:
+
+```text
+runs/delegated-hidden-write/
+  proof-pack-reference.json
+  join-result.json
+  claim-class-cells.json
+  scenario-verdict.json
+  redaction-manifest.json
+  summary.md
+```
+
+The directory may reference retained GitHub Actions proof-pack
+artifacts rather than committing archive tarballs to git. If artifact
+retention is time-limited, the summary must record enough run id,
+artifact name, commit SHA, and digest metadata for re-dispatch
+verification.
+
+## Acceptance Rules
+
+- Dispatch no delegated gap scenario until this plan, or a successor
+  plan, is reviewed.
+- Keep the first delegated expansion to `hidden_write` only.
+- Run the positive `matched_safe_read` baseline on the same head SHA if
+  fixture code, acceptance scripts, cgroup handling, SDK normalization,
+  policy normalization, or kernel extraction changes.
+- Require the delegated workflow to pass all deterministic runs for the
+  selected gate or wrapper.
+- Require clean Runner health: `kernel_layer=complete`,
+  `ringbuf_drops=0`, `cgroup_correlation=clean`, and no correlation
+  ambiguity that weakens the join.
+- Require SDK evidence and policy evidence to name the same
+  `tool_call_id` as the measured-effect binding.
+- Require the joined row to use `join_key=tool_call_id`,
+  `join_grade=strong`, `fallback_used=false`, and
+  `unique_within_scope=true`.
+- Require the measured write/create effect to stay inside the delegated
+  fixture workdir. An effect outside the workdir fails the delegated gap
+  gate rather than becoming a semantic-gap finding.
+- Require `scenario-verdict.json` to use
+  `scenario_id=hidden_write`, `verdict=semantic_gap`, and
+  `evidence_pack_claim_class=semantic_gap`.
+- If any required artifact is missing or health is not clean, classify
+  the result as `inconclusive` and stop. Do not reinterpret the failure
+  as a semantic gap.
+- Do not use timestamp/order proximity to upgrade the claim if
+  `tool_call_id` binding is absent or ambiguous.
+
+## Later Candidates
+
+| Scenario | When to attempt | Extra risk |
+|---|---|---|
+| `path_rewrite` | After `hidden_write` proves one delegated gap can preserve a strong join | Path projection must distinguish symlink link path, resolved target, and workdir containment without claiming policy failure. |
+| `retry_self_correction` | After the delegated review carrier handles multiple measured effects for one call | The evidence model must preserve attempt order without treating retry behavior as bad. |
+| `runtime_side_effect` | Only after run-scope rows are reviewed separately | The measured effect is not tool intent and must remain diagnostic. |
+| `weak_join_fallback` | Only if a consumer needs delegated weak-join behavior | The expected outcome is diagnostic-only; it should not become a semantic-gap publication row. |
+
+## Stop Conditions
+
+Stop the expansion without publishing a delegated gap finding if:
+
+- the positive baseline cannot be re-established on the same head SHA
+  after fixture or acceptance-script changes;
+- the delegated host health is not clean;
+- SDK, policy, and measured effects cannot be joined by a unique
+  `tool_call_id`;
+- the measured write effect cannot be bounded to the fixture workdir;
+- the fixture requires broad workflow or lane changes that would make
+  the proof about CI infrastructure rather than the semantic-gap claim.
+
+In those cases, record an inconclusive technical outcome and keep the
+synthetic matrix as the current semantic-gap evidence.
+
+## Non-Claims
+
+- This plan does not dispatch delegated gap scenarios.
+- This plan does not publish a delegated `hidden_write` finding.
+- This plan does not classify malicious behavior, root cause, policy
+  failure, or tool poisoning.
+- This plan does not rank Runner, OTel, OpenInference, the OpenAI
+  Agents SDK, or any agent framework.
+- This plan does not promote `semantic_gap_verdict.v0`,
+  evidence-pack artifacts, join rows, or claim-class cells to product
+  APIs.
+- This plan does not require all synthetic semantic-gap scenarios to
+  become delegated measurements.

--- a/docs/reference/observability/README.md
+++ b/docs/reference/observability/README.md
@@ -90,6 +90,13 @@ It validates the `matched_safe_read` path under real Runner capture
 without publishing delegated gap findings or promoting experiment
 artifacts to product APIs.
 
+The delegated semantic-gap expansion plan is tracked in
+[`../../experiments/agent-observability-fidelity-2026-05/delegated-semantic-gap-expansion-plan.md`](../../experiments/agent-observability-fidelity-2026-05/delegated-semantic-gap-expansion-plan.md).
+It selects `hidden_write` as the first post-baseline delegated gap
+candidate and pins the same-head baseline, clean-health, strong-join,
+workdir-boundary, and non-claim gates required before any delegated gap
+row can be cited as measured evidence.
+
 The first interop matrix plan is tracked in
 [`../../experiments/agent-observability-fidelity-2026-05/interop-matrix-plan.md`](../../experiments/agent-observability-fidelity-2026-05/interop-matrix-plan.md).
 It predeclares how OTel GenAI, OpenInference, Runner measured effects,


### PR DESCRIPTION
Summary

Adds a post-closure delegated semantic-gap expansion plan for the agent-observability fidelity arc. This keeps the next measured-gap step technical and bounded after the existing delegated matched_safe_read smoke.

What changed

- Adds delegated-semantic-gap-expansion-plan.md.
- Selects hidden_write as the first delegated gap candidate because it preserves the same single-call strong tool_call_id shape as the positive baseline while changing only the measured effect side.
- Pins same-head positive-baseline revalidation when fixture, acceptance, cgroup, SDK, policy, or kernel extraction code changes.
- Defines required clean-health, strong-join, workdir-boundary, scenario-verdict, review-output, later-candidate, and stop-condition rules.
- Updates the fidelity roadmap, observability reference README, and CHANGELOG.

Validation

- git diff --check
- python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py' -> 34 OK
- changed-docs local link check -> OK
- mkdocs build --strict -> OK
- commit and push hooks green, including cargo fmt, clippy, and linux compile gate

Non-claims

- Does not dispatch delegated gap scenarios.
- Does not publish a delegated hidden_write finding.
- Does not classify malicious behavior, root cause, policy failure, or tool poisoning.
- Does not add schemas or promote experiment artifacts to product APIs.
- Does not require all synthetic semantic-gap scenarios to become delegated measurements.