### PR TITLE
docs(experiments): define post-closure follow-up discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Added a post-closure delegated semantic-gap expansion plan for the
-  agent-observability fidelity arc. The plan selects `hidden_write` as
-  the first delegated gap candidate after the smoke-verified
-  `matched_safe_read` baseline, pins same-head baseline revalidation,
-  clean-health, strong `tool_call_id` join, workdir-boundary, and
-  non-claim gates, and does not dispatch a run, publish delegated gap
-  findings, define schemas, or promote experiment artifacts.
+- Added a post-closure delegated semantic-gap expansion plan for
+  `hidden_write` after the smoke-verified `matched_safe_read` baseline.
+  The plan pins the technical review gate without dispatching a run,
+  publishing a gap finding, defining schemas, or promoting artifacts.
+- Clarified the experiment arc lifecycle rules for post-closure
+  follow-up plans: they must keep findings summaries closed, land any
+  new finding as a sidecar, and avoid hidden arc reopening.
 - Added an observability fidelity calibration reference note that generalizes
   the closed overhead and fidelity arcs' requested-vs-observed
   calibration lesson. The note frames retained signal as a prerequisite

--- a/docs/experiments/agent-observability-fidelity-2026-05/delegated-semantic-gap-expansion-plan.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05/delegated-semantic-gap-expansion-plan.md
@@ -25,6 +25,12 @@ The first delegated gap candidate is `hidden_write` because it keeps
 the same single-call, strong-join shape as the positive baseline while
 changing only the measured effect side.
 
+This plan follows the post-closure follow-up rules in the
+[`arc-lifecycle-guide`](../../reference/experiments/arc-lifecycle-guide.md#post-closure-follow-up-rules):
+the arc-level findings summary stays closed, any successful delegated
+gap result lands as a sidecar, and the follow-up remains bounded to one
+predeclared technical gate.
+
 ## Prerequisites
 
 | Prerequisite | Status | Why it matters |
@@ -107,6 +113,12 @@ retention is time-limited, the summary must record enough run id,
 artifact name, commit SHA, and digest metadata for re-dispatch
 verification.
 
+A successful delegated gap result should land as a sidecar finding, for
+example `delegated-hidden-write-finding.md`, next to the review
+directory. The existing arc-level
+[`findings-summary.md`](findings-summary.md) remains closed and should
+not be appended merely because one delegated gap row passes.
+
 ## Acceptance Rules
 
 - Dispatch no delegated gap scenario until this plan, or a successor
@@ -132,19 +144,18 @@ verification.
   `scenario_id=hidden_write`, `verdict=semantic_gap`, and
   `evidence_pack_claim_class=semantic_gap`.
 - If any required artifact is missing or health is not clean, classify
-  the result as `inconclusive` and stop. Do not reinterpret the failure
-  as a semantic gap.
+  the result as `inconclusive` with
+  `evidence_pack_claim_class=diagnostic` and stop. Do not reinterpret
+  the failure as a semantic gap.
 - Do not use timestamp/order proximity to upgrade the claim if
   `tool_call_id` binding is absent or ambiguous.
 
 ## Later Candidates
 
-| Scenario | When to attempt | Extra risk |
-|---|---|---|
-| `path_rewrite` | After `hidden_write` proves one delegated gap can preserve a strong join | Path projection must distinguish symlink link path, resolved target, and workdir containment without claiming policy failure. |
-| `retry_self_correction` | After the delegated review carrier handles multiple measured effects for one call | The evidence model must preserve attempt order without treating retry behavior as bad. |
-| `runtime_side_effect` | Only after run-scope rows are reviewed separately | The measured effect is not tool intent and must remain diagnostic. |
-| `weak_join_fallback` | Only if a consumer needs delegated weak-join behavior | The expected outcome is diagnostic-only; it should not become a semantic-gap publication row. |
+Other synthetic gap scenarios remain in scope of the synthetic matrix.
+Each delegated expansion beyond `hidden_write` requires its own
+predeclared gate, review output, stop conditions, and non-claims before
+dispatch.
 
 ## Stop Conditions
 

--- a/docs/reference/experiments/arc-lifecycle-guide.md
+++ b/docs/reference/experiments/arc-lifecycle-guide.md
@@ -177,8 +177,33 @@ Good stop outcomes:
 - **Carrier/prototype complete:** feature-like carrier has enough shape
   for the next consumer to test.
 
-Follow-up questions should become trigger-only issues or a new arc with
-their own plan, not hidden extensions of the closed arc.
+Follow-up questions should usually become trigger-only issues or a new
+arc with their own plan, not hidden extensions of the closed arc. A
+closed arc may host a post-closure follow-up only when the follow-up
+keeps the original findings summary closed and satisfies the rules
+below.
+
+## Post-Closure Follow-Up Rules
+
+A post-closure follow-up is allowed when a closed arc already contains
+the substrate needed for one narrow technical gate and a separate new
+arc would hide more context than it clarifies.
+
+Before adding one, pin:
+
+- why the follow-up belongs to the closed arc's evidence substrate;
+- the single candidate, scenario, or gate being extended;
+- where any successful new finding will live as a sidecar, not as an
+  append to the closed `findings-summary.md`;
+- the health, calibration, join, or artifact-retention rules that can
+  stop the follow-up as inconclusive;
+- the non-claims that prevent the follow-up from reopening the whole
+  arc.
+
+Post-closure follow-ups should appear as explicitly labeled follow-up
+rows or sidecar plans, not as new numbered slices inside the closed
+arc. They must not promote schemas, broaden the closed findings
+summary, or imply that all remaining tail items are now active.
 
 ## Non-Claims
 


### PR DESCRIPTION
Summary

Addresses the discipline follow-up from PR #1438 by formalizing when a closed experiment arc may host a post-closure follow-up, and tightening the delegated semantic-gap expansion plan accordingly.

What changed

- Adds explicit Post-Closure Follow-Up Rules to the arc lifecycle guide.
- Clarifies that successful delegated hidden_write evidence should land as a sidecar finding, not an append to the closed fidelity findings-summary.
- Pins inconclusive delegated gap outcomes to evidence_pack_claim_class=diagnostic.
- Replaces the later-candidates table with a narrower rule that each future delegated gap requires its own predeclared gate.
- Shortens the CHANGELOG wording.

Validation

- git diff --check
- python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py' -> 34 OK
- changed-docs local link check -> OK
- mkdocs build --strict -> OK
- commit/push hooks green

Non-claims

- Does not dispatch delegated gap scenarios.
- Does not reopen the closed fidelity findings-summary.
- Does not publish a delegated hidden_write finding.
- Does not add schemas or promote experiment artifacts.