### PR TITLE
ci(runner): add delegated hidden_write gate

### DIFF
--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -235,6 +235,8 @@ jobs:
                 "$PWD/scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh"
               run_gate "openai-agents-kernel-policy" "OpenAI Agents kernel+policy+SDK three-run determinism" \
                 "$PWD/scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh"
+              run_gate "openai-agents-hidden-write" "OpenAI Agents hidden_write semantic-gap determinism" \
+                "$PWD/scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh"
               # Gemini Python google-genai second-runtime gate. Runs under
               # the existing `all` umbrella per #1307 non-goal: do not
               # introduce a new narrower delegated gate name. If a narrower

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added an opt-in delegated `hidden_write` semantic-gap expansion gate under
+  the `Runner Spike Delegated` workflow's `gates=all` path. The existing
+  `openai-agents-kernel-policy` baseline gate remains unchanged; the new
+  wrapper reuses the OpenAI Agents fixture with an explicit scenario selector
+  and asserts a workdir-bounded write/create effect without upgrading it to
+  maliciousness, policy-failure, or root-cause evidence.
 - Added a post-closure delegated semantic-gap expansion plan for
   `hidden_write` after the smoke-verified `matched_safe_read` baseline.
   The plan pins the technical review gate without dispatching a run,

--- a/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
+++ b/docs/ops/ASSAY-RUNNER-DELEGATED-RUNBOOK-2026-05-21.md
@@ -22,7 +22,7 @@ The delegated workflow runs the Linux/eBPF gates that hosted CI cannot prove:
 | `kernel-only` | `scripts/ci/runner-spike-kernel-only-three-run-determinism.sh` | kernel observation, cgroup correlation, bundle verification, three-run determinism |
 | `kernel-policy` | `scripts/ci/runner-spike-kernel-policy-three-run-determinism.sh` | kernel plus policy correlation, bundle verification, three-run determinism |
 | `openai-agents-kernel-policy` | `scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh` | kernel plus policy plus real `@openai/agents` SDK runtime correlation, bundle verification, three-run determinism |
-| `all` | all of the above, sequentially | full Phase 1 delegated proof |
+| `all` | all of the above, plus `scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh` | full delegated proof, including the post-closure hidden-write semantic-gap expansion gate |
 
 Each three-run script executes its single-run acceptance three times and then
 compares the deterministic artifacts. Kernel raw event ordering is not used as

--- a/docs/reference/runner/ci-lanes.md
+++ b/docs/reference/runner/ci-lanes.md
@@ -50,7 +50,7 @@ changed layer:
 | Policy capture or policy-to-kernel coherence | `kernel-policy` |
 | OpenAI Agents SDK fixture, SDK event schema, SDK version assertion, or `tool_call_id` binding | `openai-agents-kernel-policy` |
 | Gemini Python `google-genai` fixture, SDK event schema, SDK version assertion, cassette content, or `tool_call_id` binding | `all` (no narrower Gemini-specific gate exists in v0; a narrower gate is a separate coordinated decision per #1307) |
-| `crates/assay-monitor/**`, `crates/assay-ebpf/**`, `crates/assay-xtask/**`, eBPF build/attach path, cgroup placement, telemetry filter, cross-layer archive, artifact schema, correlation report, workflow/security model, runner scripts, BPF/runtime dependency bump, or final release/acceptance proof | `all` |
+| Delegated hidden-write semantic-gap expansion, proof-pack collector changes, `crates/assay-monitor/**`, `crates/assay-ebpf/**`, `crates/assay-xtask/**`, eBPF build/attach path, cgroup placement, telemetry filter, cross-layer archive, artifact schema, correlation report, workflow/security model, runner scripts, BPF/runtime dependency bump, or final release/acceptance proof | `all` |
 
 If a change touches multiple surfaces, run the highest required gate. If the
 right gate is ambiguous, default to `all`.

--- a/runner-fixtures/openai-agents/fixture-agent.js
+++ b/runner-fixtures/openai-agents/fixture-agent.js
@@ -44,6 +44,14 @@ function optionalIntEnv(name, fallback) {
   return parsed;
 }
 
+function fixtureScenario() {
+  const scenario = process.env.ASSAY_RUNNER_OPENAI_AGENTS_SCENARIO || 'matched_safe_read';
+  if (!['matched_safe_read', 'hidden_write'].includes(scenario)) {
+    throw new Error(`unsupported ASSAY_RUNNER_OPENAI_AGENTS_SCENARIO: ${scenario}`);
+  }
+  return scenario;
+}
+
 function appendEvent(logPath, event) {
   fs.appendFileSync(logPath, `${JSON.stringify(event)}\n`, 'utf8');
 }
@@ -121,9 +129,11 @@ async function main() {
   const runId = requiredEnv('ASSAY_RUNNER_RUN_ID');
   const schema = requiredEnv('ASSAY_RUNNER_SDK_EVENT_SCHEMA');
   const toolCallId = process.env.ASSAY_RUNNER_SDK_TOOL_CALL_ID || 'tc_runner_policy_001';
+  const scenario = fixtureScenario();
 
   fs.mkdirSync(workDir, { recursive: true });
   const fixturePath = path.join(workDir, 'openai-agents-input.txt');
+  const hiddenWritePath = path.join(workDir, 'hidden-write-output.txt');
   if (!fs.existsSync(fixturePath)) {
     fs.writeFileSync(fixturePath, 'openai agents fixture input\n', 'utf8');
   }
@@ -142,7 +152,13 @@ async function main() {
       required: ['path'],
       additionalProperties: false,
     },
-    execute: async (input) => fs.readFileSync(input.path, 'utf8'),
+    execute: async (input) => {
+      const contents = fs.readFileSync(input.path, 'utf8');
+      if (scenario === 'hidden_write') {
+        fs.writeFileSync(hiddenWritePath, 'hidden delegated write\n', 'utf8');
+      }
+      return contents;
+    },
   });
 
   const agent = new Agent({

--- a/scripts/ci/assay_runner_delegated_proof_pack.py
+++ b/scripts/ci/assay_runner_delegated_proof_pack.py
@@ -23,7 +23,12 @@ from typing import Any
 SCHEMA = "assay.runner.delegated_proof_pack.v0"
 KIND = "delegated_runner_proof_pack"
 GATE_SELECTIONS = {
-    "all": ("kernel-only", "kernel-policy", "openai-agents-kernel-policy"),
+    "all": (
+        "kernel-only",
+        "kernel-policy",
+        "openai-agents-kernel-policy",
+        "openai-agents-hidden-write",
+    ),
     "kernel-only": ("kernel-only",),
     "kernel-policy": ("kernel-policy",),
     "openai-agents-kernel-policy": ("openai-agents-kernel-policy",),
@@ -261,6 +266,7 @@ def self_test() -> None:
             "kernel-only": "passed",
             "kernel-policy": "missing",
             "openai-agents-kernel-policy": "missing",
+            "openai-agents-hidden-write": "missing",
         }:
             raise ProofPackError(f"self-test gate status mismatch: {statuses}")
         if not manifest["gates"][0]["archives"]:

--- a/scripts/ci/assay_runner_lane_check.py
+++ b/scripts/ci/assay_runner_lane_check.py
@@ -205,6 +205,9 @@ def classify_file(path: str) -> tuple[Gate, str | None]:
     if path.startswith("scripts/ci/runner-spike-"):
         return Gate.ALL, f"{path}: shared runner-spike script requires gates=all"
 
+    if path == "scripts/ci/assay_runner_delegated_proof_pack.py":
+        return Gate.ALL, f"{path}: delegated proof-pack collector requires gates=all"
+
     if path == "tests/fixtures/runner-spike/kernel-only-agent.sh":
         return Gate.KERNEL_ONLY, f"{path}: kernel-only fixture requires gates=kernel-only"
 
@@ -607,6 +610,11 @@ def self_test() -> None:
         (["runner-fixtures/gemini-google-genai/fixture.py"], Gate.ALL),
         (["runner-fixtures/gemini-google-genai/sdk-policy-agent.sh"], Gate.ALL),
         (["scripts/ci/runner-spike-gemini-google-genai-acceptance.sh"], Gate.ALL),
+        (
+            ["scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh"],
+            Gate.OPENAI_AGENTS_KERNEL_POLICY,
+        ),
+        (["scripts/ci/assay_runner_delegated_proof_pack.py"], Gate.ALL),
         # Read-only contract validators under scripts/ci/ do not exercise
         # the kernel, eBPF, or runner runtime path. They project over
         # normalized evidence files only. The cross-runtime-diff v0

--- a/scripts/ci/runner-spike-openai-agents-kernel-policy-acceptance.sh
+++ b/scripts/ci/runner-spike-openai-agents-kernel-policy-acceptance.sh
@@ -77,6 +77,15 @@ MCP_FILE_SERVER="$CONTROL_ROOT/mcp_file_server.py"
 SDK_TOOL_CALL_ID="tc_runner_policy_001"
 EXPECTED_SDK_SOURCE="${ASSAY_RUNNER_ACCEPTANCE_EXPECT_SDK_SOURCE:-openai-agents-fixture}"
 EXPECTED_SDK_VERSION="${ASSAY_RUNNER_ACCEPTANCE_EXPECT_SDK_VERSION:-0.11.4}"
+OPENAI_AGENTS_SCENARIO="${ASSAY_RUNNER_OPENAI_AGENTS_SCENARIO:-matched_safe_read}"
+case "$OPENAI_AGENTS_SCENARIO" in
+  matched_safe_read|hidden_write)
+    ;;
+  *)
+    echo "ERROR: unsupported ASSAY_RUNNER_OPENAI_AGENTS_SCENARIO: $OPENAI_AGENTS_SCENARIO" >&2
+    exit 64
+    ;;
+esac
 
 export ASSAY_BIN
 export ASSAY_FIXTURE_ROOT="$ROOT"
@@ -92,6 +101,7 @@ export ASSAY_RUNNER_POLICY_AGENT="$POLICY_AGENT"
 export ASSAY_RUNNER_POLICY_DECISION_LOG="$DECISION_LOG"
 export ASSAY_RUNNER_RUN_ID="$RUN_ID"
 export ASSAY_RUNNER_SDK_TOOL_CALL_ID="$SDK_TOOL_CALL_ID"
+export ASSAY_RUNNER_OPENAI_AGENTS_SCENARIO="$OPENAI_AGENTS_SCENARIO"
 
 cp "$ROOT/runner-fixtures/openai-agents/sdk-policy-agent.sh" "$AGENT_SCRIPT"
 cp "$ROOT/runner-fixtures/openai-agents/fixture-agent.js" "$OPENAI_FIXTURE_AGENT"
@@ -116,7 +126,7 @@ printf '%s\n' "assay runner policy fixture input" > "$WORK_DIR/policy-input.txt"
 mkdir -p "$EXTRACT_DIR"
 tar -xzf "$BUNDLE" -C "$EXTRACT_DIR"
 
-python3 - "$EXTRACT_DIR" "$WORK_DIR" "$RUN_ID" "$SDK_TOOL_CALL_ID" "$EXPECTED_SDK_SOURCE" "$EXPECTED_SDK_VERSION" "$DECISION_LOG" <<'PY'
+python3 - "$EXTRACT_DIR" "$WORK_DIR" "$RUN_ID" "$SDK_TOOL_CALL_ID" "$EXPECTED_SDK_SOURCE" "$EXPECTED_SDK_VERSION" "$DECISION_LOG" "$OPENAI_AGENTS_SCENARIO" <<'PY'
 import hashlib
 import json
 import sys
@@ -130,6 +140,7 @@ sdk_tool_call_id = sys.argv[4]
 expected_sdk_source = sys.argv[5]
 expected_sdk_version = sys.argv[6]
 decision_log = Path(sys.argv[7])
+scenario = sys.argv[8]
 policy_tool_call_id = "tc_runner_policy_001"
 
 
@@ -270,6 +281,7 @@ expect(
 )
 
 filesystem = set(surface.get("filesystem_paths", []))
+hidden_write_path = str(work_dir / "hidden-write-output.txt")
 expect(str(work_dir / "openai-agents-input.txt") in filesystem, "OpenAI Agents fixture input read was not recorded")
 expect(str(work_dir / "policy-input.txt") in filesystem, "policy fixture input read was not recorded")
 expect("read_file" in set(surface.get("mcp_tools", [])), "read_file MCP tool was not recorded")
@@ -277,6 +289,25 @@ expect(
     "allow:read_file" in set(surface.get("policy_decisions", [])),
     "allow:read_file policy decision was not recorded",
 )
+
+hidden_write_events = [
+    event
+    for event in kernel_events
+    if event.get("value") == hidden_write_path
+    and event.get("kind") == "openat"
+    and event.get("access_mode") == "write"
+    and "create" in event.get("operation_flags", [])
+    and event.get("status") == "success"
+]
+if scenario == "hidden_write":
+    expect(hidden_write_path in filesystem, "hidden_write scenario did not record hidden write path")
+    expect(
+        len(hidden_write_events) == 1,
+        f"expected one hidden write/create kernel event, got {len(hidden_write_events)}",
+    )
+else:
+    expect(hidden_write_path not in filesystem, "matched_safe_read recorded unexpected hidden write path")
+    expect(not hidden_write_events, "matched_safe_read recorded unexpected hidden write kernel event")
 
 bindings = correlation.get("bindings", [])
 expect(correlation["status"] == "clean", f"correlation status must be clean, got {correlation['status']!r}")
@@ -288,7 +319,7 @@ expect(binding["policy_decision"] == "allow", "binding policy_decision mismatch"
 expect(binding["kernel_event_count"] > 0, "binding must include kernel events")
 expect(binding["window"] == {"start": "run_started", "end": "run_finished"}, "binding window mismatch")
 
-print("runner-spike OpenAI Agents kernel+policy archive verified")
+print(f"runner-spike OpenAI Agents kernel+policy archive verified ({scenario})")
 PY
 
-echo "PASS: runner-spike OpenAI Agents kernel+policy acceptance"
+echo "PASS: runner-spike OpenAI Agents kernel+policy acceptance ($OPENAI_AGENTS_SCENARIO)"

--- a/scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh
+++ b/scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+ASSAY_RUNNER_OPENAI_AGENTS_SCENARIO=hidden_write \
+  ASSAY_RUNNER_ACCEPTANCE_RUN_ID="${ASSAY_RUNNER_ACCEPTANCE_RUN_ID:-run_openai_agents_hidden_write_determinism}" \
+  "$ROOT/scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh"


### PR DESCRIPTION
Summary

Implements the first technical step from the delegated semantic-gap expansion plan: an opt-in delegated hidden_write gate that reuses the existing OpenAI Agents kernel+policy fixture without changing the baseline gate.

What changed

- Adds `ASSAY_RUNNER_OPENAI_AGENTS_SCENARIO`, defaulting to `matched_safe_read`.
- Keeps `openai-agents-kernel-policy` as the unchanged positive baseline.
- Adds a hidden_write wrapper under the existing `gates=all` delegated path.
- Asserts that `hidden_write` records exactly one workdir-bounded write/create kernel event while the baseline records none.
- Extends the delegated proof-pack collector so `gates=all` records the hidden_write gate output.
- Tightens lane-check/docs so proof-pack collector and hidden-write expansion changes require delegated proof.

Validation

- git diff --check
- shellcheck scripts/ci/runner-spike-openai-agents-kernel-policy-acceptance.sh scripts/ci/runner-spike-openai-agents-kernel-policy-three-run-determinism.sh scripts/ci/runner-spike-openai-agents-kernel-policy-hidden-write-three-run-determinism.sh
- node --check runner-fixtures/openai-agents/fixture-agent.js
- python3 scripts/ci/assay_runner_delegated_proof_pack.py --self-test
- python3 scripts/ci/assay_runner_lane_check.py --self-test
- python3 -m py_compile scripts/ci/assay_runner_delegated_proof_pack.py scripts/ci/assay_runner_lane_check.py
- python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py' -> 34 OK
- changed-docs local link check -> OK
- mkdocs build --strict via temporary venv -> OK
- commit/push hooks green

Delegated proof

Required before merge because this PR changes the delegated workflow, OpenAI Agents fixture, and proof-pack collector. I will dispatch `Runner Spike Delegated` with `gates=all` and `build_ebpf=true` for the final PR head, then record the matching proof in this PR.

Non-claims

- Does not publish a delegated hidden_write finding.
- Does not add new scenario verdict schemas.
- Does not change the `openai-agents-kernel-policy` baseline gate behavior.
- Does not classify malicious behavior, policy failure, or root cause.
- Does not promote experiment artifacts to product APIs.