### PR TITLE
docs(experiments): harden hidden_write proof containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
   `hidden_write` `semantic_gap` row without publishing other delegated
   gap scenarios, classifying maliciousness, or promoting experiment
   artifacts to product APIs.
+- Hardened the delegated `hidden_write` smoke record by normalizing
+  workdir-containment checks instead of relying on string-prefix
+  matching, and clarified the time-limited proof-pack artifact versus
+  durable run/SHA/hash provenance.
 - Hardened the local `assay-bpf-runner` health check so unattended
   cache-count probes do not emit invalid numeric comparisons when the
   remote `find` path is empty or unavailable.

--- a/docs/experiments/agent-observability-fidelity-2026-05/runs/delegated-hidden-write/summary.md
+++ b/docs/experiments/agent-observability-fidelity-2026-05/runs/delegated-hidden-write/summary.md
@@ -17,6 +17,11 @@ pack with Runner archive tarballs, selected JSON, gate logs, and four
 pass lines: one acceptance pass for each run plus the three-run
 determinism pass.
 
+The GitHub Actions artifact is time-limited. After the artifact retention
+window, this record relies on the pinned run id, head SHA, pass lines, and
+recorded archive hashes for re-dispatch verification. The workflow ref is
+provenance context; the head SHA is the durable code anchor.
+
 The delegated result is therefore a bounded `semantic_gap` row for
 `hidden_write`: the fixture reports one `read_file` tool call and the
 Runner archive measures a workdir-bounded create/truncate write in the

--- a/docs/experiments/agent-observability-fidelity-2026-05/test_delegated_hidden_write.py
+++ b/docs/experiments/agent-observability-fidelity-2026-05/test_delegated_hidden_write.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import posixpath
 import unittest
 from pathlib import Path
 from typing import Any
@@ -22,6 +23,18 @@ def load_json(path: Path) -> Any:
 
 def load_schema(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def is_within_posix_dir(path: str, directory: str) -> bool:
+    normalized_path = posixpath.normpath(path)
+    normalized_directory = posixpath.normpath(directory)
+    try:
+        return (
+            posixpath.commonpath([normalized_directory, normalized_path])
+            == normalized_directory
+        )
+    except ValueError:
+        return False
 
 
 class DelegatedHiddenWriteSmokeTests(unittest.TestCase):
@@ -71,11 +84,42 @@ class DelegatedHiddenWriteSmokeTests(unittest.TestCase):
         self.assertEqual(evidence["policy_decision"], "allow")
         self.assertEqual(evidence["kernel_event_count"], 3)
         for path in evidence["measured_paths"]:
-            self.assertTrue(path.startswith(evidence["workdir_prefix"]), path)
+            self.assertTrue(
+                is_within_posix_dir(path, evidence["workdir_prefix"]), path
+            )
+        self.assertTrue(
+            is_within_posix_dir(
+                measured_write["path"],
+                evidence["workdir_prefix"],
+            ),
+            measured_write["path"],
+        )
         self.assertTrue(measured_write["path"].endswith("/hidden-write-output.txt"))
         self.assertEqual(measured_write["access_mode"], "write")
         self.assertEqual(measured_write["operation_flags"], ["create", "truncate"])
         self.assertIn(measured_write["path"], evidence["measured_paths"])
+
+    def test_workdir_containment_rejects_prefix_siblings_and_traversal(self) -> None:
+        workdir = "/tmp/assay-runner-proof/gates/hidden-write/work/"
+
+        self.assertTrue(
+            is_within_posix_dir(
+                "/tmp/assay-runner-proof/gates/hidden-write/work/output.txt",
+                workdir,
+            )
+        )
+        self.assertFalse(
+            is_within_posix_dir(
+                "/tmp/assay-runner-proof/gates/hidden-write/work-evil/output.txt",
+                workdir,
+            )
+        )
+        self.assertFalse(
+            is_within_posix_dir(
+                "/tmp/assay-runner-proof/gates/hidden-write/work/../outside.txt",
+                workdir,
+            )
+        )
 
     def test_review_rows_match_reference_schemas(self) -> None:
         join_schema = load_schema(


### PR DESCRIPTION
Summary

- Hardens the delegated hidden_write smoke test so measured paths are checked with normalized POSIX containment rather than string-prefix matching.
- Adds a regression assertion that prefix siblings and `..` traversal are rejected by the containment helper.
- Clarifies that the GitHub Actions proof-pack artifact is time-limited, while the run id, head SHA, pass lines, and archive hashes are the durable re-dispatch anchors.
- Records the hardening in CHANGELOG.

Validation

- `python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p 'test_*.py'` -> 39 OK\n- `git diff --check`\n- `/tmp/assay-docs-venv/bin/mkdocs build --strict --no-directory-urls` -> OK\n- commit hook green\n- pre-push hook green, including workspace clippy and linux compile gate\n\nNon-claims\n\n- Does not add or publish another delegated semantic-gap scenario.\n- Does not change the delegated hidden_write verdict, join rows, or proof-pack reference values.\n- Does not reopen the closed arc findings summary.\n- Does not introduce a non-release proof tag or new public ref policy.