### PR TITLE
docs(experiments): clarify MCP transport context boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Clarified that the MCP tool evidence-binding harness's synthetic
+  tunnel/proxy transport fixture is context-only metadata and does not
+  prove tool intent, upstream MCP authentication, poisoning, or stronger
+  description/call/effect claims.
 - Added a synthetic MCP tool evidence-binding harness that emits
   experiment-scoped `binding_cell.v0` rows for description/call/effect
   scenarios, including plural visible tool-description sets and one

--- a/docs/experiments/mcp-tool-evidence-binding-2026-05.md
+++ b/docs/experiments/mcp-tool-evidence-binding-2026-05.md
@@ -159,6 +159,13 @@ It emits `assay.experiment.mcp_tool_evidence_binding.binding_cell.v0`
 rows for the MVP scenarios without contacting live MCP servers,
 deploying tunnels, or promoting the shape to a product API.
 
+The harness includes one synthetic MCP tunnel/proxy transport-context
+fixture. That fixture records where MCP traffic would have flowed
+through an outbound-only tunnel and proxy boundary, but it is context
+only: transport metadata does not prove tool intent, authenticate the
+upstream MCP server, classify poisoning, or strengthen any
+description/call/effect claim.
+
 A harness PR is review-ready when it can emit stable synthetic outputs
 for the MVP scenarios with:
 


### PR DESCRIPTION
Summary
- Clarifies that the MCP tool evidence-binding harness includes one synthetic tunnel/proxy transport-context fixture.
- Bounds that fixture as context-only metadata: it does not prove tool intent, upstream MCP authentication, poisoning, or stronger description/call/effect claims.
- Adds a matching changelog note.

Validation
- git diff --check
- mkdocs build --strict --no-directory-urls via /tmp/assay-docs-venv
- commit and pre-push hooks green, including workspace clippy and linux compile gate

Non-claims
- Does not change the harness, schema, tests, or emitted evidence rows.
- Does not contact live MCP servers or deploy tunnels.
- Does not promote MCP binding evidence to a product API or receipt family.
- Does not classify poisoning, maliciousness, upstream auth, or vendor quality.