### PR TITLE
docs(experiments): add MCP binding stable outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added checked-in starter outputs for the synthetic MCP tool
+  evidence-binding harness and a regression test that regenerates them
+  to catch harness/output drift.
 - Clarified that the MCP tool evidence-binding harness's synthetic
   tunnel/proxy transport fixture is context-only metadata and does not
   prove tool intent, upstream MCP authentication, poisoning, or stronger

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/README.md
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/README.md
@@ -60,6 +60,11 @@ Each scenario directory contains:
 - `transport-context.json` only for the synthetic tunnel fixture;
 - `summary.md`.
 
+The checked-in starter outputs are indexed from
+[`runs/README.md`](runs/README.md). The harness tests regenerate the
+`runs/starter-synthetic/` directory and fail if the committed outputs
+drift from the generator.
+
 ## Non-Claims
 
 - This harness does not detect tool poisoning.

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/README.md
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/README.md
@@ -1,0 +1,22 @@
+# MCP Tool Evidence Binding Harness Runs
+
+This directory contains checked-in synthetic outputs for the MCP tool
+evidence-binding harness.
+
+## Starter Synthetic
+
+`starter-synthetic/` contains the six starter scenario outputs generated
+by:
+
+```bash
+python3 ../mcp_tool_binding_harness.py \
+  --out-dir starter-synthetic \
+  --assay-commit synthetic-starter-output \
+  --created-at 2026-05-29T00:00:00Z
+```
+
+The harness test suite regenerates this directory and compares it
+byte-for-byte against the committed files. These outputs are synthetic
+review artifacts only: they do not contact live MCP servers, deploy MCP
+tunnels, detect poisoned tools, classify maliciousness, or promote a
+receipt family.

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/binding-cell.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/binding-cell.json
@@ -1,0 +1,68 @@
+{
+  "assay_commit": "synthetic-starter-output",
+  "call_observed": true,
+  "called_tool_description_digest": "sha256:933d4192f09bc1cb704f00d711c0462c1761fe82504024a424dcffcdd9ef9556",
+  "called_tool_manifest_digest": "sha256:bbe1e428ff1f2a9ae3f493fbb1664c77308de9f8be464bc4506284b19fd3bcee",
+  "called_tool_name": "read_file",
+  "claim_outcome": "bound_tool_evidence",
+  "co_visible_tool_names": [
+    "read_file"
+  ],
+  "context_descriptor_set_digest": "sha256:02f88a7f166da5e1a9109d9f8cc4e5bc61fffbe272d2452340f1aa46856488a6",
+  "context_descriptor_set_ref": "context-descriptor-set.json",
+  "created_at": "2026-05-29T00:00:00Z",
+  "description_matches_manifest": true,
+  "effect_capture_status": "observed",
+  "effect_within_declared_boundary": true,
+  "join_grade": "strong",
+  "join_key": "tool_call_id",
+  "mapping_notes": [
+    "Visible description, called tool, and measured effect align inside the declared boundary.",
+    "Tunnel transport metadata is retained as context only and does not authenticate or explain the tool call."
+  ],
+  "measured_effect_kind": "filesystem_read",
+  "measured_effect_ref": "measured-effect.json",
+  "model_visible_tool_description_refs": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "digest": "sha256:933d4192f09bc1cb704f00d711c0462c1761fe82504024a424dcffcdd9ef9556",
+      "ref": "context-descriptor-set.json#/tools/0",
+      "source_surface": "synthetic_mcp_tools_list",
+      "tool_name": "read_file"
+    }
+  ],
+  "non_claims": [
+    "does_not_detect_tool_poisoning",
+    "does_not_classify_malicious_intent",
+    "does_not_rank_mcp_clients_servers_or_providers",
+    "does_not_define_mcp_spec_changes",
+    "does_not_promote_experiment_schema_to_product_api",
+    "does_not_treat_tunnel_routing_as_tool_intent",
+    "does_not_claim_tunnel_authenticates_upstream_mcp_server"
+  ],
+  "required_links_complete": true,
+  "role": "baseline",
+  "scenario_id": "benign_tool_call_bound",
+  "schema": "assay.experiment.mcp_tool_evidence_binding.binding_cell.v0",
+  "tool_call_id": "mcp_call_001",
+  "tool_call_ref": "tool-call.json",
+  "transport_context": {
+    "connection_direction": "outbound_only",
+    "kind": "synthetic_mcp_tunnel_transport_context",
+    "metadata_visible_to_transport_provider": [
+      "egress_ip",
+      "host_fingerprint",
+      "connection_timing",
+      "byte_volume",
+      "tunnel_subdomain"
+    ],
+    "payload_tls_boundary": "inner_tls_to_proxy",
+    "proxy_role": "routes_to_private_mcp_server",
+    "transport_claim": "transport_context_only",
+    "transport_profile": "mcp_tunnel_synthetic",
+    "upstream_authentication": "independent_oauth_or_bearer_token"
+  },
+  "transport_profile": "mcp_tunnel_synthetic"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/context-descriptor-set.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/context-descriptor-set.json
@@ -1,0 +1,13 @@
+{
+  "kind": "synthetic_mcp_context_descriptor_set",
+  "tools": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "name": "read_file",
+      "source_surface": "synthetic_mcp_tools_list",
+      "visible_description": "Read a file under /workspace/allowed."
+    }
+  ]
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/measured-effect.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/measured-effect.json
@@ -1,0 +1,6 @@
+{
+  "effect_kind": "filesystem_read",
+  "kind": "synthetic_measured_runtime_effect",
+  "path": "/workspace/allowed/safe.txt",
+  "status": "success"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/summary.md
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/summary.md
@@ -1,0 +1,17 @@
+# benign_tool_call_bound
+
+- Claim outcome: `bound_tool_evidence`
+- Visible tools: read_file
+- Called tool: `read_file`
+- Effect capture: `observed`
+- Transport profile: `mcp_tunnel_synthetic`
+
+## Non-Claims
+
+- `does_not_detect_tool_poisoning`
+- `does_not_classify_malicious_intent`
+- `does_not_rank_mcp_clients_servers_or_providers`
+- `does_not_define_mcp_spec_changes`
+- `does_not_promote_experiment_schema_to_product_api`
+- `does_not_treat_tunnel_routing_as_tool_intent`
+- `does_not_claim_tunnel_authenticates_upstream_mcp_server`

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/tool-call.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/tool-call.json
@@ -1,0 +1,6 @@
+{
+  "arguments_digest": "sha256:d1a022e88fed4ac804978a70abccbb2c0cedc8bf6473b336c01060c9bf68eea7",
+  "kind": "synthetic_mcp_tool_call",
+  "tool_call_id": "mcp_call_001",
+  "tool_name": "read_file"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/transport-context.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/benign_tool_call_bound/transport-context.json
@@ -1,0 +1,16 @@
+{
+  "connection_direction": "outbound_only",
+  "kind": "synthetic_mcp_tunnel_transport_context",
+  "metadata_visible_to_transport_provider": [
+    "egress_ip",
+    "host_fingerprint",
+    "connection_timing",
+    "byte_volume",
+    "tunnel_subdomain"
+  ],
+  "payload_tls_boundary": "inner_tls_to_proxy",
+  "proxy_role": "routes_to_private_mcp_server",
+  "transport_claim": "transport_context_only",
+  "transport_profile": "mcp_tunnel_synthetic",
+  "upstream_authentication": "independent_oauth_or_bearer_token"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_no_measurable_effect/binding-cell.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_no_measurable_effect/binding-cell.json
@@ -1,0 +1,51 @@
+{
+  "assay_commit": "synthetic-starter-output",
+  "call_observed": true,
+  "called_tool_description_digest": "sha256:933d4192f09bc1cb704f00d711c0462c1761fe82504024a424dcffcdd9ef9556",
+  "called_tool_manifest_digest": "sha256:bbe1e428ff1f2a9ae3f493fbb1664c77308de9f8be464bc4506284b19fd3bcee",
+  "called_tool_name": "read_file",
+  "claim_outcome": "inconclusive",
+  "co_visible_tool_names": [
+    "read_file"
+  ],
+  "context_descriptor_set_digest": "sha256:02f88a7f166da5e1a9109d9f8cc4e5bc61fffbe272d2452340f1aa46856488a6",
+  "context_descriptor_set_ref": "context-descriptor-set.json",
+  "created_at": "2026-05-29T00:00:00Z",
+  "description_matches_manifest": true,
+  "effect_capture_status": "unavailable",
+  "effect_within_declared_boundary": null,
+  "join_grade": "diagnostic",
+  "join_key": "none",
+  "mapping_notes": [
+    "The call exists, but the measured-effect layer is unavailable, so the chain cannot support an effect claim."
+  ],
+  "measured_effect_kind": "none",
+  "measured_effect_ref": null,
+  "model_visible_tool_description_refs": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "digest": "sha256:933d4192f09bc1cb704f00d711c0462c1761fe82504024a424dcffcdd9ef9556",
+      "ref": "context-descriptor-set.json#/tools/0",
+      "source_surface": "synthetic_mcp_tools_list",
+      "tool_name": "read_file"
+    }
+  ],
+  "non_claims": [
+    "does_not_detect_tool_poisoning",
+    "does_not_classify_malicious_intent",
+    "does_not_rank_mcp_clients_servers_or_providers",
+    "does_not_define_mcp_spec_changes",
+    "does_not_promote_experiment_schema_to_product_api",
+    "does_not_claim_absence_of_effect"
+  ],
+  "required_links_complete": false,
+  "role": "effect_boundary",
+  "scenario_id": "call_made_no_measurable_effect",
+  "schema": "assay.experiment.mcp_tool_evidence_binding.binding_cell.v0",
+  "tool_call_id": "mcp_call_001",
+  "tool_call_ref": "tool-call.json",
+  "transport_context": null,
+  "transport_profile": "local_synthetic"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_no_measurable_effect/context-descriptor-set.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_no_measurable_effect/context-descriptor-set.json
@@ -1,0 +1,13 @@
+{
+  "kind": "synthetic_mcp_context_descriptor_set",
+  "tools": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "name": "read_file",
+      "source_surface": "synthetic_mcp_tools_list",
+      "visible_description": "Read a file under /workspace/allowed."
+    }
+  ]
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_no_measurable_effect/summary.md
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_no_measurable_effect/summary.md
@@ -1,0 +1,16 @@
+# call_made_no_measurable_effect
+
+- Claim outcome: `inconclusive`
+- Visible tools: read_file
+- Called tool: `read_file`
+- Effect capture: `unavailable`
+- Transport profile: `local_synthetic`
+
+## Non-Claims
+
+- `does_not_detect_tool_poisoning`
+- `does_not_classify_malicious_intent`
+- `does_not_rank_mcp_clients_servers_or_providers`
+- `does_not_define_mcp_spec_changes`
+- `does_not_promote_experiment_schema_to_product_api`
+- `does_not_claim_absence_of_effect`

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_no_measurable_effect/tool-call.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_no_measurable_effect/tool-call.json
@@ -1,0 +1,6 @@
+{
+  "arguments_digest": "sha256:d1a022e88fed4ac804978a70abccbb2c0cedc8bf6473b336c01060c9bf68eea7",
+  "kind": "synthetic_mcp_tool_call",
+  "tool_call_id": "mcp_call_001",
+  "tool_name": "read_file"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/binding-cell.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/binding-cell.json
@@ -1,0 +1,62 @@
+{
+  "assay_commit": "synthetic-starter-output",
+  "call_observed": true,
+  "called_tool_description_digest": "sha256:933d4192f09bc1cb704f00d711c0462c1761fe82504024a424dcffcdd9ef9556",
+  "called_tool_manifest_digest": "sha256:bbe1e428ff1f2a9ae3f493fbb1664c77308de9f8be464bc4506284b19fd3bcee",
+  "called_tool_name": "read_file",
+  "claim_outcome": "call_isolated_in_visible_context",
+  "co_visible_tool_names": [
+    "read_file",
+    "write_file"
+  ],
+  "context_descriptor_set_digest": "sha256:cd7e6646a2432fb05476d810f4112ca498f5ff433d0416c72698a91051cffc76",
+  "context_descriptor_set_ref": "context-descriptor-set.json",
+  "created_at": "2026-05-29T00:00:00Z",
+  "description_matches_manifest": true,
+  "effect_capture_status": "observed",
+  "effect_within_declared_boundary": true,
+  "join_grade": "strong",
+  "join_key": "tool_call_id",
+  "mapping_notes": [
+    "The called tool is bound while preserving the complete co-visible tool description set.",
+    "The row records co-visibility without claiming causation between other visible descriptions and the call."
+  ],
+  "measured_effect_kind": "filesystem_read",
+  "measured_effect_ref": "measured-effect.json",
+  "model_visible_tool_description_refs": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "digest": "sha256:933d4192f09bc1cb704f00d711c0462c1761fe82504024a424dcffcdd9ef9556",
+      "ref": "context-descriptor-set.json#/tools/0",
+      "source_surface": "synthetic_mcp_tools_list",
+      "tool_name": "read_file"
+    },
+    {
+      "declared_boundary": [
+        "filesystem_write:/workspace/out/*"
+      ],
+      "digest": "sha256:6d1a29b3d081c1575ed6d624edf6a53344cd76d696250a22ad2c50a426fd92fa",
+      "ref": "context-descriptor-set.json#/tools/1",
+      "source_surface": "synthetic_mcp_tools_list",
+      "tool_name": "write_file"
+    }
+  ],
+  "non_claims": [
+    "does_not_detect_tool_poisoning",
+    "does_not_classify_malicious_intent",
+    "does_not_rank_mcp_clients_servers_or_providers",
+    "does_not_define_mcp_spec_changes",
+    "does_not_promote_experiment_schema_to_product_api",
+    "does_not_claim_co_visible_description_caused_call"
+  ],
+  "required_links_complete": true,
+  "role": "context_boundary",
+  "scenario_id": "call_made_with_other_descriptions_visible",
+  "schema": "assay.experiment.mcp_tool_evidence_binding.binding_cell.v0",
+  "tool_call_id": "mcp_call_001",
+  "tool_call_ref": "tool-call.json",
+  "transport_context": null,
+  "transport_profile": "local_synthetic"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/context-descriptor-set.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/context-descriptor-set.json
@@ -1,0 +1,21 @@
+{
+  "kind": "synthetic_mcp_context_descriptor_set",
+  "tools": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "name": "read_file",
+      "source_surface": "synthetic_mcp_tools_list",
+      "visible_description": "Read a file under /workspace/allowed."
+    },
+    {
+      "declared_boundary": [
+        "filesystem_write:/workspace/out/*"
+      ],
+      "name": "write_file",
+      "source_surface": "synthetic_mcp_tools_list",
+      "visible_description": "Write generated output under /workspace/out."
+    }
+  ]
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/measured-effect.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/measured-effect.json
@@ -1,0 +1,6 @@
+{
+  "effect_kind": "filesystem_read",
+  "kind": "synthetic_measured_runtime_effect",
+  "path": "/workspace/allowed/safe.txt",
+  "status": "success"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/summary.md
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/summary.md
@@ -1,0 +1,16 @@
+# call_made_with_other_descriptions_visible
+
+- Claim outcome: `call_isolated_in_visible_context`
+- Visible tools: read_file, write_file
+- Called tool: `read_file`
+- Effect capture: `observed`
+- Transport profile: `local_synthetic`
+
+## Non-Claims
+
+- `does_not_detect_tool_poisoning`
+- `does_not_classify_malicious_intent`
+- `does_not_rank_mcp_clients_servers_or_providers`
+- `does_not_define_mcp_spec_changes`
+- `does_not_promote_experiment_schema_to_product_api`
+- `does_not_claim_co_visible_description_caused_call`

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/tool-call.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/call_made_with_other_descriptions_visible/tool-call.json
@@ -1,0 +1,6 @@
+{
+  "arguments_digest": "sha256:d1a022e88fed4ac804978a70abccbb2c0cedc8bf6473b336c01060c9bf68eea7",
+  "kind": "synthetic_mcp_tool_call",
+  "tool_call_id": "mcp_call_001",
+  "tool_name": "read_file"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/binding-cell.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/binding-cell.json
@@ -1,0 +1,51 @@
+{
+  "assay_commit": "synthetic-starter-output",
+  "call_observed": true,
+  "called_tool_description_digest": "sha256:327d554ca048a3264c7c025082d80f21906b225b5420839360dd30edc925edd2",
+  "called_tool_manifest_digest": "sha256:bbe1e428ff1f2a9ae3f493fbb1664c77308de9f8be464bc4506284b19fd3bcee",
+  "called_tool_name": "read_file",
+  "claim_outcome": "description_drift",
+  "co_visible_tool_names": [
+    "read_file"
+  ],
+  "context_descriptor_set_digest": "sha256:6b641a270a65d60bd59a3186060eae050b8815b0a643531aa90e66fae5eac639",
+  "context_descriptor_set_ref": "context-descriptor-set.json",
+  "created_at": "2026-05-29T00:00:00Z",
+  "description_matches_manifest": false,
+  "effect_capture_status": "observed",
+  "effect_within_declared_boundary": true,
+  "join_grade": "strong",
+  "join_key": "tool_call_id",
+  "mapping_notes": [
+    "The called tool manifest digest differs from the model-visible description digest before the call."
+  ],
+  "measured_effect_kind": "filesystem_read",
+  "measured_effect_ref": "measured-effect.json",
+  "model_visible_tool_description_refs": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "digest": "sha256:327d554ca048a3264c7c025082d80f21906b225b5420839360dd30edc925edd2",
+      "ref": "context-descriptor-set.json#/tools/0",
+      "source_surface": "synthetic_mcp_tools_list",
+      "tool_name": "read_file"
+    }
+  ],
+  "non_claims": [
+    "does_not_detect_tool_poisoning",
+    "does_not_classify_malicious_intent",
+    "does_not_rank_mcp_clients_servers_or_providers",
+    "does_not_define_mcp_spec_changes",
+    "does_not_promote_experiment_schema_to_product_api",
+    "does_not_claim_the_drift_was_malicious"
+  ],
+  "required_links_complete": true,
+  "role": "drift",
+  "scenario_id": "description_changed_before_call",
+  "schema": "assay.experiment.mcp_tool_evidence_binding.binding_cell.v0",
+  "tool_call_id": "mcp_call_001",
+  "tool_call_ref": "tool-call.json",
+  "transport_context": null,
+  "transport_profile": "local_synthetic"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/context-descriptor-set.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/context-descriptor-set.json
@@ -1,0 +1,13 @@
+{
+  "kind": "synthetic_mcp_context_descriptor_set",
+  "tools": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "name": "read_file",
+      "source_surface": "synthetic_mcp_tools_list",
+      "visible_description": "Read any file path provided by the user."
+    }
+  ]
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/measured-effect.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/measured-effect.json
@@ -1,0 +1,6 @@
+{
+  "effect_kind": "filesystem_read",
+  "kind": "synthetic_measured_runtime_effect",
+  "path": "/workspace/allowed/safe.txt",
+  "status": "success"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/summary.md
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/summary.md
@@ -1,0 +1,16 @@
+# description_changed_before_call
+
+- Claim outcome: `description_drift`
+- Visible tools: read_file
+- Called tool: `read_file`
+- Effect capture: `observed`
+- Transport profile: `local_synthetic`
+
+## Non-Claims
+
+- `does_not_detect_tool_poisoning`
+- `does_not_classify_malicious_intent`
+- `does_not_rank_mcp_clients_servers_or_providers`
+- `does_not_define_mcp_spec_changes`
+- `does_not_promote_experiment_schema_to_product_api`
+- `does_not_claim_the_drift_was_malicious`

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/tool-call.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_changed_before_call/tool-call.json
@@ -1,0 +1,6 @@
+{
+  "arguments_digest": "sha256:d1a022e88fed4ac804978a70abccbb2c0cedc8bf6473b336c01060c9bf68eea7",
+  "kind": "synthetic_mcp_tool_call",
+  "tool_call_id": "mcp_call_001",
+  "tool_name": "read_file"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_visible_no_call/binding-cell.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_visible_no_call/binding-cell.json
@@ -1,0 +1,51 @@
+{
+  "assay_commit": "synthetic-starter-output",
+  "call_observed": false,
+  "called_tool_description_digest": null,
+  "called_tool_manifest_digest": null,
+  "called_tool_name": null,
+  "claim_outcome": "diagnostic_only",
+  "co_visible_tool_names": [
+    "read_file"
+  ],
+  "context_descriptor_set_digest": "sha256:02f88a7f166da5e1a9109d9f8cc4e5bc61fffbe272d2452340f1aa46856488a6",
+  "context_descriptor_set_ref": "context-descriptor-set.json",
+  "created_at": "2026-05-29T00:00:00Z",
+  "description_matches_manifest": null,
+  "effect_capture_status": "unobserved",
+  "effect_within_declared_boundary": null,
+  "join_grade": "diagnostic",
+  "join_key": "none",
+  "mapping_notes": [
+    "A tool definition is visible, but no call to that tool is observed inside the bounded call surface."
+  ],
+  "measured_effect_kind": "none",
+  "measured_effect_ref": null,
+  "model_visible_tool_description_refs": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "digest": "sha256:933d4192f09bc1cb704f00d711c0462c1761fe82504024a424dcffcdd9ef9556",
+      "ref": "context-descriptor-set.json#/tools/0",
+      "source_surface": "synthetic_mcp_tools_list",
+      "tool_name": "read_file"
+    }
+  ],
+  "non_claims": [
+    "does_not_detect_tool_poisoning",
+    "does_not_classify_malicious_intent",
+    "does_not_rank_mcp_clients_servers_or_providers",
+    "does_not_define_mcp_spec_changes",
+    "does_not_promote_experiment_schema_to_product_api",
+    "does_not_claim_no_runtime_activity_occurred"
+  ],
+  "required_links_complete": true,
+  "role": "absence_boundary",
+  "scenario_id": "description_visible_no_call",
+  "schema": "assay.experiment.mcp_tool_evidence_binding.binding_cell.v0",
+  "tool_call_id": null,
+  "tool_call_ref": null,
+  "transport_context": null,
+  "transport_profile": "local_synthetic"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_visible_no_call/context-descriptor-set.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_visible_no_call/context-descriptor-set.json
@@ -1,0 +1,13 @@
+{
+  "kind": "synthetic_mcp_context_descriptor_set",
+  "tools": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "name": "read_file",
+      "source_surface": "synthetic_mcp_tools_list",
+      "visible_description": "Read a file under /workspace/allowed."
+    }
+  ]
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_visible_no_call/summary.md
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/description_visible_no_call/summary.md
@@ -1,0 +1,16 @@
+# description_visible_no_call
+
+- Claim outcome: `diagnostic_only`
+- Visible tools: read_file
+- Called tool: `None`
+- Effect capture: `unobserved`
+- Transport profile: `local_synthetic`
+
+## Non-Claims
+
+- `does_not_detect_tool_poisoning`
+- `does_not_classify_malicious_intent`
+- `does_not_rank_mcp_clients_servers_or_providers`
+- `does_not_define_mcp_spec_changes`
+- `does_not_promote_experiment_schema_to_product_api`
+- `does_not_claim_no_runtime_activity_occurred`

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/binding-cell.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/binding-cell.json
@@ -1,0 +1,52 @@
+{
+  "assay_commit": "synthetic-starter-output",
+  "call_observed": true,
+  "called_tool_description_digest": "sha256:933d4192f09bc1cb704f00d711c0462c1761fe82504024a424dcffcdd9ef9556",
+  "called_tool_manifest_digest": "sha256:bbe1e428ff1f2a9ae3f493fbb1664c77308de9f8be464bc4506284b19fd3bcee",
+  "called_tool_name": "read_file",
+  "claim_outcome": "effect_outside_declared_tool_boundary",
+  "co_visible_tool_names": [
+    "read_file"
+  ],
+  "context_descriptor_set_digest": "sha256:02f88a7f166da5e1a9109d9f8cc4e5bc61fffbe272d2452340f1aa46856488a6",
+  "context_descriptor_set_ref": "context-descriptor-set.json",
+  "created_at": "2026-05-29T00:00:00Z",
+  "description_matches_manifest": true,
+  "effect_capture_status": "observed",
+  "effect_within_declared_boundary": false,
+  "join_grade": "strong",
+  "join_key": "tool_call_id",
+  "mapping_notes": [
+    "The measured write exceeds the visible read-only boundary without proving malicious intent."
+  ],
+  "measured_effect_kind": "filesystem_write",
+  "measured_effect_ref": "measured-effect.json",
+  "model_visible_tool_description_refs": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "digest": "sha256:933d4192f09bc1cb704f00d711c0462c1761fe82504024a424dcffcdd9ef9556",
+      "ref": "context-descriptor-set.json#/tools/0",
+      "source_surface": "synthetic_mcp_tools_list",
+      "tool_name": "read_file"
+    }
+  ],
+  "non_claims": [
+    "does_not_detect_tool_poisoning",
+    "does_not_classify_malicious_intent",
+    "does_not_rank_mcp_clients_servers_or_providers",
+    "does_not_define_mcp_spec_changes",
+    "does_not_promote_experiment_schema_to_product_api",
+    "does_not_claim_policy_failure",
+    "does_not_claim_root_cause"
+  ],
+  "required_links_complete": true,
+  "role": "gap",
+  "scenario_id": "effect_outside_declared_tool_boundary",
+  "schema": "assay.experiment.mcp_tool_evidence_binding.binding_cell.v0",
+  "tool_call_id": "mcp_call_001",
+  "tool_call_ref": "tool-call.json",
+  "transport_context": null,
+  "transport_profile": "local_synthetic"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/context-descriptor-set.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/context-descriptor-set.json
@@ -1,0 +1,13 @@
+{
+  "kind": "synthetic_mcp_context_descriptor_set",
+  "tools": [
+    {
+      "declared_boundary": [
+        "filesystem_read:/workspace/allowed/*"
+      ],
+      "name": "read_file",
+      "source_surface": "synthetic_mcp_tools_list",
+      "visible_description": "Read a file under /workspace/allowed."
+    }
+  ]
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/measured-effect.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/measured-effect.json
@@ -1,0 +1,6 @@
+{
+  "effect_kind": "filesystem_write",
+  "kind": "synthetic_measured_runtime_effect",
+  "path": "/workspace/outside/hidden.txt",
+  "status": "success"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/summary.md
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/summary.md
@@ -1,0 +1,17 @@
+# effect_outside_declared_tool_boundary
+
+- Claim outcome: `effect_outside_declared_tool_boundary`
+- Visible tools: read_file
+- Called tool: `read_file`
+- Effect capture: `observed`
+- Transport profile: `local_synthetic`
+
+## Non-Claims
+
+- `does_not_detect_tool_poisoning`
+- `does_not_classify_malicious_intent`
+- `does_not_rank_mcp_clients_servers_or_providers`
+- `does_not_define_mcp_spec_changes`
+- `does_not_promote_experiment_schema_to_product_api`
+- `does_not_claim_policy_failure`
+- `does_not_claim_root_cause`

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/tool-call.json
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/runs/starter-synthetic/effect_outside_declared_tool_boundary/tool-call.json
@@ -1,0 +1,6 @@
+{
+  "arguments_digest": "sha256:d1a022e88fed4ac804978a70abccbb2c0cedc8bf6473b336c01060c9bf68eea7",
+  "kind": "synthetic_mcp_tool_call",
+  "tool_call_id": "mcp_call_001",
+  "tool_name": "read_file"
+}

--- a/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/test_mcp_tool_binding_harness.py
+++ b/docs/experiments/mcp-tool-evidence-binding-harness-2026-05/test_mcp_tool_binding_harness.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).resolve().parent
 HARNESS_PATH = ROOT / "mcp_tool_binding_harness.py"
 FIDELITY_ROOT = ROOT.parent / "agent-observability-fidelity-2026-05"
 SCHEMA_PATH = ROOT / "schema" / "mcp-tool-binding-cell-v0.schema.json"
+STABLE_RUNS = ROOT / "runs" / "starter-synthetic"
 
 schema_spec = importlib.util.spec_from_file_location(
     "fidelity_test_evidence_pack",
@@ -219,6 +220,35 @@ class McpToolBindingHarnessTests(unittest.TestCase):
                     out_dir=out,
                     scenarios=["benign_tool_call_bound"],
                     assay_commit="test",
+                )
+
+    def test_checked_in_starter_outputs_match_harness(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            generated = Path(tmp) / "starter-synthetic"
+            mcp_tool_binding_harness.generate_harness(
+                out_dir=generated,
+                scenarios=list(mcp_tool_binding_harness.STARTER_SCENARIOS),
+                assay_commit="synthetic-starter-output",
+                created_at="2026-05-29T00:00:00Z",
+            )
+
+            checked_in_files = sorted(
+                path.relative_to(STABLE_RUNS)
+                for path in STABLE_RUNS.rglob("*")
+                if path.is_file()
+            )
+            generated_files = sorted(
+                path.relative_to(generated)
+                for path in generated.rglob("*")
+                if path.is_file()
+            )
+
+            self.assertEqual(generated_files, checked_in_files)
+            for relative_path in checked_in_files:
+                self.assertEqual(
+                    (generated / relative_path).read_text(encoding="utf-8"),
+                    (STABLE_RUNS / relative_path).read_text(encoding="utf-8"),
+                    f"stable output drifted: {relative_path}",
                 )
 
 


### PR DESCRIPTION
Summary
- Adds checked-in starter outputs for the synthetic MCP tool evidence-binding harness.
- Adds a runs index and links it from the harness README.
- Adds a regression test that regenerates the starter output directory and compares it byte-for-byte against the committed files.

Validation
- python3 -m unittest discover -s docs/experiments/mcp-tool-evidence-binding-harness-2026-05 -p test_*.py -> 11 OK
- python3 -m unittest discover -s docs/experiments/agent-observability-fidelity-2026-05 -p test_*.py -> 39 OK
- git diff --check
- mkdocs build --strict --no-directory-urls via /tmp/assay-docs-venv
- commit and pre-push hooks green, including workspace clippy and linux compile gate

Non-claims
- Does not change the harness schema or claim vocabulary.
- Does not contact live MCP servers or deploy tunnels.
- Does not classify poisoning, malicious intent, upstream authentication, or vendor quality.
- Does not promote MCP binding evidence to a product API or receipt family.