### PR TITLE
docs(experiments): surface MCP binding quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Surfaced the synthetic MCP tool evidence-binding quickstart from the
+  observability reference, the research note, and the root README
+  research section. Discoverability only: no new schema, no top-level
+  example, no poisoning-detection or product-API claim.
 - Added a boundary-first quickstart for the synthetic MCP tool
   evidence-binding harness. It demonstrates bounded
   `description -> call -> effect -> claim` reading without promoting the

--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ No release commitment. No timeline. No external demand has been measured.
 - [OWASP MCP Top 10 Mapping](docs/security/OWASP-MCP-TOP10-MAPPING.md) — how Assay relates to each risk category (coverage is **not** a scalar guarantee).
 - Third-party survey: popular MCP servers often show weak defaults — Assay adds policy + evidence; see discussion in the mapping doc.
 - [Security experiments](docs/architecture/SYNTHESIS-TRUST-CHAIN-TRIFECTA-2026q2.md) — attack vectors and harness notes (methodology matters more than headline counts).
+- [MCP tool evidence-binding quickstart](docs/experiments/mcp-tool-evidence-binding-harness-2026-05/QUICKSTART.md) —
+  synthetic description→call→effect binding with bounded claims.
+  Experiment-scoped; **not** a poisoning detector, and distinct from
+  the supported [MCP policy quickstart](examples/mcp-quickstart/) above.
 
 ## Contributing
 

--- a/docs/experiments/mcp-tool-evidence-binding-2026-05.md
+++ b/docs/experiments/mcp-tool-evidence-binding-2026-05.md
@@ -158,6 +158,10 @@ The synthetic harness lives in
 It emits `assay.experiment.mcp_tool_evidence_binding.binding_cell.v0`
 rows for the MVP scenarios without contacting live MCP servers,
 deploying tunnels, or promoting the shape to a product API.
+A runnable quickstart is now available at
+[`mcp-tool-evidence-binding-harness-2026-05/QUICKSTART.md`](mcp-tool-evidence-binding-harness-2026-05/QUICKSTART.md):
+it walks the out-of-boundary and co-visible-context scenarios as golden
+examples with their non-claims.
 
 The harness includes one synthetic MCP tunnel/proxy transport-context
 fixture. That fixture records where MCP traffic would have flowed

--- a/docs/reference/observability/README.md
+++ b/docs/reference/observability/README.md
@@ -53,6 +53,11 @@ The MCP tool evidence binding research note is
 It asks what bounded evidence is needed to connect a model-visible MCP
 tool context, a tool call, and a measured runtime effect without
 claiming to detect poisoned tools or creating a new receipt family.
+A runnable, synthetic quickstart for that note lives in
+[`../../experiments/mcp-tool-evidence-binding-harness-2026-05/QUICKSTART.md`](../../experiments/mcp-tool-evidence-binding-harness-2026-05/QUICKSTART.md).
+It demonstrates bounded description→call→effect reading with non-claims
+as first-class output. It is experiment-scoped and is not a poisoning
+detector.
 
 Experiment-scoped schema naming and promotion rules for that roadmap are
 tracked in


### PR DESCRIPTION
Summary
- Surfaces the synthetic MCP tool evidence-binding quickstart from three bounded discoverability surfaces: root README research section, observability reference index, and the MCP evidence-binding research note.
- Uses collision-safe naming: evidence-binding quickstart for the experiment-scoped synthetic demo, distinct from the supported MCP policy quickstart.
- Keeps the quickstart out of top-level examples and away from hero/See It Work surfaces.

Validation
- local changed-docs link check for the two changed docs markdown files -> OK
- mkdocs build --strict --no-directory-urls via /tmp/assay-docs-venv -> OK
- git diff --check
- pre-commit/pre-push hooks green, including workspace clippy and linux compile gate

Non-claims
- Does not add a top-level example.
- Does not change harness code, schemas, tests, or generated outputs.
- Does not promote the experiment-scoped quickstart to a product API or supported MCP policy quickstart.
- Does not claim poisoning detection, malicious intent classification, or live MCP coverage.