### PR TITLE
fix: tighten CLI help and trace replay error

### DIFF
--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -43,28 +43,46 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Command {
+    /// Run an evaluation suite and write run artifacts
     Run(RunArgs),
+    /// Run the CI gate and emit CI report artifacts
     Ci(CiArgs),
+    /// Create starter Assay config and trace fixtures
     Init(InitArgs),
+    /// Manage quarantined or flaky tests
     Quarantine(QuarantineArgs),
+    /// Inspect or transform trace inputs
     Trace(TraceArgs),
+    /// Calibrate thresholds from previous run artifacts
     Calibrate(CalibrateArgs),
+    /// Record or compare score baselines
     Baseline(BaselineArgs),
+    /// Validate config and trace files without a full run
     Validate(ValidateArgs),
+    /// Diagnose local setup, config, and trace health
     Doctor(DoctorArgs),
     /// Watch config/policy/trace files and rerun on changes
     Watch(WatchArgs),
+    /// Import external artifacts into Assay-compatible data
     Import(ImportArgs),
+    /// Migrate older config or policy formats
     Migrate(MigrateArgs),
+    /// Report policy and trace coverage
     Coverage(CoverageArgs),
+    /// Explain a test result or trace decision
     Explain(super::commands::explain::ExplainArgs),
+    /// Generate and run the local demo project
     Demo(DemoArgs),
+    /// Generate CI workflow scaffolding
     InitCi(InitCiArgs),
+    /// Apply supported automatic fixes
     Fix(FixArgs),
     /// Experimental: MCP Process Wrapper
     #[command(hide = true)]
     Mcp(McpArgs),
+    /// Print Assay version information
     Version,
+    /// Validate, format, and migrate policies
     Policy(PolicyArgs),
     /// Discover MCP servers on this machine (v1.8)
     Discover(DiscoverArgs),

--- a/crates/assay-cli/src/cli/args/tests.rs
+++ b/crates/assay-cli/src/cli/args/tests.rs
@@ -7,6 +7,22 @@ fn cli_debug_assert() {
     Cli::command().debug_assert();
 }
 
+#[test]
+fn visible_top_level_commands_have_descriptions() {
+    let missing: Vec<_> = Cli::command()
+        .get_subcommands()
+        .filter(|cmd| !cmd.is_hide_set())
+        .filter(|cmd| cmd.get_about().is_none())
+        .map(|cmd| cmd.get_name().to_string())
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "visible top-level commands without descriptions: {}",
+        missing.join(", ")
+    );
+}
+
 #[cfg(feature = "sim")]
 #[test]
 fn sim_soak_parses_with_defaults() {

--- a/crates/assay-cli/src/cli/commands/pipeline.rs
+++ b/crates/assay-cli/src/cli/commands/pipeline.rs
@@ -162,6 +162,13 @@ pub(crate) async fn execute_pipeline(
         eprintln!("WARN: {}", msg);
     }
 
+    if cfg.model == "trace" && input.trace_file.is_none() {
+        eprintln!("config error: model: trace requires --trace-file <PATH>");
+        return Err(PipelineError::invalid_args(
+            "config uses model: trace, so --trace-file <PATH> is required",
+        ));
+    }
+
     let store = match assay_core::storage::Store::open(&input.db) {
         Ok(s) => s,
         Err(e) => {

--- a/crates/assay-cli/tests/contract_exit_codes.rs
+++ b/crates/assay-cli/tests/contract_exit_codes.rs
@@ -4,6 +4,7 @@ use assay_core::replay::{
     ReplayManifest,
 };
 use assert_cmd::Command;
+use predicates::prelude::*;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fs;

--- a/crates/assay-cli/tests/exit_codes/core.rs
+++ b/crates/assay-cli/tests/exit_codes/core.rs
@@ -85,6 +85,45 @@ fn contract_run_json_always_written_arg_conflict() {
 }
 
 #[test]
+fn contract_model_trace_requires_trace_file() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("assay.yaml"),
+        r#"version: 1
+suite: trace-requires-input
+model: trace
+tests:
+  - id: t1
+    input: { prompt: "hello" }
+    expected: { type: must_contain, must_contain: ["hello"] }
+"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("assay").unwrap();
+    cmd.current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("run")
+        .arg("--config")
+        .arg("assay.yaml")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "model: trace requires --trace-file <PATH>",
+        ));
+
+    let v = read_run_json(dir.path());
+    assert_schema(&v);
+    assert_eq!(v["exit_code"], 2);
+    assert_eq!(v["reason_code"], "E_INVALID_ARGS");
+    assert!(v["resolution"]["message"]
+        .as_str()
+        .expect("resolution.message must be a string")
+        .contains("--trace-file <PATH> is required"));
+    assert_run_json_seeds_early_exit(&v);
+}
+
+#[test]
 fn contract_reason_code_trace_not_found_v2() {
     let dir = tempdir().unwrap();
     // Valid config schema with ID


### PR DESCRIPTION
Summary
- Adds descriptions for all visible top-level commands that were blank in `assay --help`.
- Adds a regression test so visible top-level command descriptions cannot silently disappear again.
- Returns an explicit `E_INVALID_ARGS` config error when `model: trace` is used without `--trace-file`, instead of running trace-replay tests and reporting assertion failures.

Boundary
- No command rename or `trustcard` / `trust-basis` deprecation path in this PR.
- No run output model redesign.
- No changes to model execution, scoring, storage, or evidence contracts.

Validation
- `cargo fmt --check`
- `cargo test -q -p assay-cli visible_top_level_commands_have_descriptions -- --nocapture`
- `cargo test -q -p assay-cli --test contract_exit_codes -- --nocapture`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- Manual `assay --help` smoke confirmed all visible top-level commands show descriptions.
- Manual `model: trace` without `--trace-file` smoke confirmed exit `2`, stderr config error, and `run.json` with `E_INVALID_ARGS`.
