### PR TITLE
fix: accept positional config for validate

### DIFF
--- a/crates/assay-cli/src/cli/args/replay.rs
+++ b/crates/assay-cli/src/cli/args/replay.rs
@@ -5,6 +5,10 @@ use super::ValidateOutputFormat;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct ValidateArgs {
+    /// Path to config (same as --config)
+    #[arg(value_name = "CONFIG", conflicts_with = "config")]
+    pub config_path: Option<std::path::PathBuf>,
+
     #[arg(long, default_value = "assay.yaml")]
     pub config: std::path::PathBuf,
 
@@ -26,6 +30,12 @@ pub struct ValidateArgs {
     /// Fail if deprecated v1 policy format is detected
     #[arg(long)]
     pub deny_deprecations: bool,
+}
+
+impl ValidateArgs {
+    pub fn resolved_config(&self) -> &std::path::PathBuf {
+        self.config_path.as_ref().unwrap_or(&self.config)
+    }
 }
 
 #[derive(Parser, Clone)]

--- a/crates/assay-cli/src/cli/commands/validate.rs
+++ b/crates/assay-cli/src/cli/commands/validate.rs
@@ -12,8 +12,10 @@ pub async fn run(args: ValidateArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
     }
 
+    let config_path = args.resolved_config();
+
     // 1. Load Config
-    let cfg = match load_config(&args.config, legacy_mode, true) {
+    let cfg = match load_config(config_path, legacy_mode, true) {
         Ok(c) => c,
         Err(e) => {
             let diag = Diagnostic::new(
@@ -22,7 +24,7 @@ pub async fn run(args: ValidateArgs, legacy_mode: bool) -> anyhow::Result<i32> {
             )
             .with_source("config")
             .with_context(json!({
-                "file": args.config,
+                "file": config_path,
             }));
 
             let report = ValidateReport {
@@ -35,7 +37,7 @@ pub async fn run(args: ValidateArgs, legacy_mode: bool) -> anyhow::Result<i32> {
         }
     };
 
-    let resolver = PathResolver::new(&args.config);
+    let resolver = PathResolver::new(config_path);
 
     // 2. Prepare Options
     let opts = ValidateOptions {
@@ -140,6 +142,7 @@ fn build_validate_json(
     args: &ValidateArgs,
     exit_code: i32,
 ) -> serde_json::Value {
+    let config_path = args.resolved_config();
     let mut diags: Vec<&Diagnostic> = report.diagnostics.iter().collect();
 
     // Deterministic sort: severity_rank > code > message > file
@@ -166,7 +169,7 @@ fn build_validate_json(
 
     let mut args_list: Vec<String> = vec![
         "--config".into(),
-        args.config.display().to_string(),
+        config_path.display().to_string(),
         "--format".into(),
         match args.format {
             ValidateOutputFormat::Text => "text",
@@ -193,12 +196,12 @@ fn build_validate_json(
     }
 
     // Agentic Contract Integration
-    let inferred_policy = infer_policy_path(&args.config);
+    let inferred_policy = infer_policy_path(config_path);
     let (suggested_actions, suggested_patches) = build_suggestions(
         &report.diagnostics,
         &AgenticCtx {
             policy_path: inferred_policy,
-            config_path: Some(args.config.clone()),
+            config_path: Some(config_path.clone()),
         },
     );
 
@@ -215,7 +218,7 @@ fn build_validate_json(
         "command": {
             "name": "validate",
             "args": args_list,
-            "config_file": args.config.display().to_string(),
+            "config_file": config_path.display().to_string(),
             "trace_file": args.trace_file.as_ref().map(|p| p.display().to_string()),
             "baseline_file": args.baseline.as_ref().map(|p| p.display().to_string())
         },

--- a/crates/assay-cli/tests/contract_init_hello_trace.rs
+++ b/crates/assay-cli/tests/contract_init_hello_trace.rs
@@ -1,5 +1,6 @@
 use assay_core::config::load_config;
 use assert_cmd::Command;
+use predicates::prelude::*;
 use std::fs;
 use tempfile::tempdir;
 
@@ -41,6 +42,42 @@ fn test_init_hello_trace_contract() {
         .arg("traces/hello.jsonl")
         .assert()
         .success();
+}
+
+#[test]
+fn test_validate_accepts_positional_config_path() {
+    let temp = tempdir().expect("temp dir");
+
+    #[allow(deprecated)]
+    let mut init = Command::cargo_bin("assay").expect("assay binary");
+    init.current_dir(temp.path())
+        .arg("init")
+        .arg("--hello-trace")
+        .assert()
+        .success();
+
+    #[allow(deprecated)]
+    let mut validate = Command::cargo_bin("assay").expect("assay binary");
+    validate
+        .current_dir(temp.path())
+        .arg("validate")
+        .arg("eval.yaml")
+        .arg("--trace-file")
+        .arg("traces/hello.jsonl")
+        .assert()
+        .success();
+
+    #[allow(deprecated)]
+    let mut conflict = Command::cargo_bin("assay").expect("assay binary");
+    conflict
+        .current_dir(temp.path())
+        .arg("validate")
+        .arg("eval.yaml")
+        .arg("--config")
+        .arg("eval.yaml")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
 }
 
 #[test]

--- a/docs/reference/cli/validate.md
+++ b/docs/reference/cli/validate.md
@@ -7,7 +7,7 @@ Validate agent traces against your policy. The standard CI gate.
 ## Synopsis
 
 ```bash
-assay validate [OPTIONS]
+assay validate [OPTIONS] [CONFIG]
 ```
 
 ## Description
@@ -21,7 +21,8 @@ Unlike `assay run`, which can perform active replay and LLM-as-a-Judge evaluatio
 ### Input
 | Option | Description |
 |--------|-------------|
-| `--config <FILE>` | Path to config. Default: `assay.yaml`. |
+| `[CONFIG]` | Optional positional config path. |
+| `--config <FILE>` | Path to config. Default: `assay.yaml`. Mutually exclusive with `[CONFIG]`. |
 | `--trace-file <FILE>` | Trace file to validate (JSONL). |
 | `--baseline <FILE>` | Compare against a baseline trace. |
 
@@ -67,4 +68,11 @@ Use `--format sarif` to integrate directly with GitHub Code Scanning.
 
 ```bash
 assay validate --trace-file traces.jsonl --format sarif --output results.sarif
+```
+
+Equivalent config path forms:
+
+```bash
+assay validate eval.yaml --trace-file traces.jsonl
+assay validate --config eval.yaml --trace-file traces.jsonl
 ```


### PR DESCRIPTION
Summary
- Allows `assay validate <config>` as a natural shorthand for `assay validate --config <config>`.
- Keeps `--config` as the existing canonical option and rejects using both forms together.
- Resolves the selected config path consistently for config loading, path resolution, JSON output, and agentic suggestions.
- Updates the validate CLI docs and adds a contract test covering positional success plus the conflict path.

Boundary
- No command rename or trust command deprecation path.
- No `assay run` output model changes.
- No validate behavior changes beyond config-path argument resolution.

Validation
- `cargo fmt --check`
- `cargo test -q -p assay-cli test_validate_accepts_positional_config_path -- --nocapture`
- `cargo test -q -p assay-cli cli_debug_assert -- --nocapture`
- `cargo test -q -p assay-cli visible_top_level_commands_have_descriptions -- --nocapture`
- `cargo test -q -p assay-cli --test contract_init_hello_trace -- --nocapture`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- Manual smoke: `assay validate <absolute eval.yaml> --trace-file <trace> --format json` reports `ok=true`, `exit_code=0`, and the resolved `command.config_file`.
