### PR TITLE
feat(cli): add `run --format json` for machine-readable stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added `assay run --format <text|json>`. `text` (default) keeps the
+  existing human-readable summary on stderr; `json` prints a
+  machine-readable results report to stdout so `assay run --format json >
+  results.json` composes with CI pipelines. The `run.json`/`summary.json`
+  artifacts and the exit-code contract are unchanged. This mirrors the
+  existing `assay validate --format` interface for consistency.
+
 - Surfaced the synthetic MCP tool evidence-binding quickstart from the
   observability reference, the research note, and the root README
   research section. Discoverability only: no new schema, no top-level

--- a/crates/assay-cli/src/cli/args/run.rs
+++ b/crates/assay-cli/src/cli/args/run.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
-use super::JudgeArgs;
+use super::{JudgeArgs, OutputFormat};
 
 #[derive(Parser, Clone)]
 pub struct RunArgs {
@@ -84,6 +84,12 @@ pub struct RunArgs {
     /// Disable signature verification (UNSAFE); recorded in summary.json as verify_enabled: false
     #[arg(long)]
     pub no_verify: bool,
+
+    /// Output format for results: text (human report on stderr) or json
+    /// (machine-readable report on stdout). The run.json/summary.json
+    /// artifacts are always written regardless of this flag.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
 }
 
 impl Default for RunArgs {
@@ -110,6 +116,7 @@ impl Default for RunArgs {
             deny_deprecations: false,
             exit_codes: crate::exit_codes::ExitCodeVersion::default(),
             no_verify: false,
+            format: OutputFormat::Text,
         }
     }
 }

--- a/crates/assay-cli/src/cli/commands/run.rs
+++ b/crates/assay-cli/src/cli/commands/run.rs
@@ -33,7 +33,20 @@ pub(crate) async fn run(args: RunArgs, legacy_mode: bool) -> anyhow::Result<i32>
     let mut summary =
         build_summary_from_artifacts(&outcome, !args.no_verify, &artifacts, Some(&timings), None);
 
-    print_pipeline_summary(&artifacts, args.explain_skip, &summary);
+    // Output model:
+    // - text: human-readable summary on stderr (default; unchanged behavior).
+    // - json: machine-readable report on stdout, so `assay run --format json
+    //   > results.json` composes with CI pipelines.
+    // The run.json / summary.json artifacts are written regardless, so the
+    // exit-code contract is unaffected by the chosen display format.
+    match args.format {
+        super::super::args::OutputFormat::Text => {
+            print_pipeline_summary(&artifacts, args.explain_skip, &summary);
+        }
+        super::super::args::OutputFormat::Json => {
+            println!("{}", assay_core::report::json::render_json(&artifacts)?);
+        }
+    }
 
     maybe_export_baseline(&args.export_baseline, &args.config, &cfg, &artifacts);
 

--- a/crates/assay-cli/tests/exit_codes/core.rs
+++ b/crates/assay-cli/tests/exit_codes/core.rs
@@ -304,3 +304,73 @@ tests:
     let run = read_run_json(dir.path());
     assert_eq!(run["reason_code"], "E_CFG_PARSE");
 }
+
+#[test]
+fn contract_run_format_json_emits_report_to_stdout() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("assay.yaml"),
+        "suite: test\nmodel: dummy\ntests:\n  - id: pass\n    input: hello",
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("run")
+        .arg("--config")
+        .arg("assay.yaml")
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    // stdout carries a valid, parseable JSON report (the CI piping contract).
+    let stdout = String::from_utf8(out.stdout).expect("stdout utf8");
+    let report: Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be valid JSON for --format json");
+    assert!(report.get("run_id").is_some(), "report missing run_id");
+    assert!(report.get("suite").is_some(), "report missing suite");
+    assert!(
+        report.get("results").and_then(|r| r.as_array()).is_some(),
+        "report missing results array"
+    );
+
+    // The run.json artifact is still written and schema-valid regardless of format.
+    let run = read_run_json(dir.path());
+    assert_schema(&run);
+    assert_eq!(run["exit_code"], 0);
+}
+
+#[test]
+fn contract_run_default_text_keeps_stdout_clean() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("assay.yaml"),
+        "suite: test\nmodel: dummy\ntests:\n  - id: pass\n    input: hello",
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .current_dir(dir.path())
+        .env("ASSAY_EXIT_CODES", "v2")
+        .arg("run")
+        .arg("--config")
+        .arg("assay.yaml")
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    // Default text format leaves stdout empty (human report goes to stderr),
+    // so `--format json` is the only thing that writes machine output to stdout.
+    assert!(
+        out.stdout.is_empty(),
+        "default text run must not write to stdout, got: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}

--- a/crates/assay-core/src/report/json.rs
+++ b/crates/assay-core/src/report/json.rs
@@ -1,12 +1,21 @@
 use crate::report::RunArtifacts;
 use std::path::Path;
 
-pub fn write_json(artifacts: &RunArtifacts, out: &Path) -> anyhow::Result<()> {
+/// Render the run results report as a pretty-printed JSON string.
+///
+/// Single source of truth for the JSON report shape: both the file writer
+/// ([`write_json`]) and stdout emission (`assay run --format json`) use it,
+/// so the on-disk and piped representations never diverge.
+pub fn render_json(artifacts: &RunArtifacts) -> anyhow::Result<String> {
     let v = serde_json::json!({
         "run_id": artifacts.run_id,
         "suite": artifacts.suite,
         "results": artifacts.results,
     });
-    std::fs::write(out, serde_json::to_string_pretty(&v)?)?;
+    Ok(serde_json::to_string_pretty(&v)?)
+}
+
+pub fn write_json(artifacts: &RunArtifacts, out: &Path) -> anyhow::Result<()> {
+    std::fs::write(out, render_json(artifacts)?)?;
     Ok(())
 }

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -17,6 +17,7 @@ assay run [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `--config <PATH>` | Config file (default: `eval.yaml`) |
+| `--format <text\|json>` | Output format. `text` (default) prints a human report to stderr; `json` prints a machine-readable report to stdout. The `run.json`/`summary.json` artifacts are always written regardless. |
 | `--db <PATH>` | SQLite DB path (default: `.eval/eval.db`) |
 | `--trace-file <PATH>` | Trace file source for replay/validation |
 | `--strict` | Treat blocking results as failing exit status |


### PR DESCRIPTION
## Summary

Audit **defect 4**: `assay run` had no machine-readable stdout output. The human summary went to stderr and structured data only landed in `.eval/eval.db` + `run.json`, so the canonical CI pattern `assay run --format json > results.json` was impossible — the largest structural UX gap for a CI-native tool.

This adds `assay run --format <text|json>`, mirroring the existing `assay validate --format` interface for internal consistency.

## Changes

- **`assay-core/src/report/json.rs`**: extract `render_json()` as the single source of truth for the JSON report shape; `write_json()` becomes a thin wrapper over it. No existing caller changes.
- **`assay run`**: gains `--format <text|json>` (reuses the existing `OutputFormat` enum).
  - `text` (default): human summary on **stderr**, exactly as before.
  - `json`: results report on **stdout**, so it composes with pipelines.
- The `run.json` / `summary.json` artifacts and the exit-code contract are written **regardless** of `--format`.

## Boundary (non-goals)

- **No SARIF on `run`** — run results are not findings; `validate --format sarif` already covers code-scanning, and `run.rs` already documented "no SARIF in run command".
- No change to model execution, scoring, storage, or evidence contracts.
- Text output stays on stderr — scripts that ignore stderr are unaffected.

## Best-practice basis (May 2026)

CLI consensus (clig.dev; `gh`/`cargo`/`kubectl`/`terraform`): machine-readable output belongs behind a `--format`/`--json` flag emitted to **stdout**, composable with redirects. Internal consistency with the existing `validate --format` is itself a least-surprise win.

## Validation

- `cargo fmt --check` ✓
- `cargo clippy -p assay-cli -p assay-core --all-targets -- -D warnings` ✓
- `cargo test -p assay-cli --test contract_exit_codes` → 16 passed (2 new: json-to-stdout, default-text-stdout-clean)
- `cargo test -p assay-cli --bin assay` → 187 passed (clap `debug_assert` and the `visible_top_level_commands_have_descriptions` regression test from #1451 unaffected)
- Manual: `run --format json` emits ~10 KB valid JSON to stdout with `run.json` unchanged; default text leaves stdout empty.

## Follow-ups (separate PRs, not bundled)

- Defect 2: `trust-basis`/`trustcard` naming consistency (rename + hidden alias).
- Overzicht #3: move `profile_simulation_test.rs` out of `src/commands/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)