### PR TITLE
fix: make trustcard deprecation check argv-safe

### DIFF
--- a/crates/assay-cli/src/cli/commands/trust_card.rs
+++ b/crates/assay-cli/src/cli/commands/trust_card.rs
@@ -7,6 +7,7 @@ use assay_evidence::{
     generate_trust_basis, trust_basis_to_trust_card, trust_card_to_canonical_json_bytes,
     trust_card_to_html, trust_card_to_markdown, TrustBasisOptions, VerifyLimits,
 };
+use std::ffi::OsStr;
 use std::fs::File;
 
 pub fn run(args: TrustCardArgs) -> Result<i32> {
@@ -20,7 +21,7 @@ pub fn run(args: TrustCardArgs) -> Result<i32> {
 }
 
 fn invoked_via_legacy_trustcard() -> bool {
-    std::env::args().nth(1).as_deref() == Some("trustcard")
+    std::env::args_os().nth(1).as_deref() == Some(OsStr::new("trustcard"))
 }
 
 fn cmd_generate(args: TrustCardGenerateArgs) -> Result<i32> {


### PR DESCRIPTION
Summary

- Addresses Copilot's review note from #1454.
- Switches the legacy `assay trustcard` deprecation detection from `std::env::args()` to `std::env::args_os()`.
- Compares against `OsStr` so non-UTF-8 argv on Unix cannot panic in the warning path.

Boundary

- No command behavior change.
- No artifact, schema, output, or warning text change.
- Keeps `assay trust-card` canonical and `assay trustcard` as the compatibility alias.

Validation

- `cargo fmt --check`
- `cargo test -q -p assay-cli --test trustcard_test -- --nocapture`
- `cargo test -q -p assay-cli trust_card_command_accepts_canonical_and_legacy_names -- --nocapture`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- `git diff --check`
- pre-push hooks, including fmt, workspace clippy, and linux compile gate
