### PR TITLE
docs: sync CLI UX release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file.
   artifacts and the exit-code contract are unchanged. This mirrors the
   existing `assay validate --format` interface for consistency.
 
+- Tightened trace-replay UX: `model: trace` now fails early with
+  `E_INVALID_ARGS` when `--trace-file` is missing instead of falling
+  through to misleading test failures.
+
+- Added the natural positional config form for validation:
+  `assay validate eval.yaml --trace-file traces.jsonl`. The existing
+  `--config eval.yaml` form remains supported.
+
 - Renamed the Trust Card command surface to `assay trust-card` for
   consistency with other hyphenated multi-word commands. The previous
   `assay trustcard` spelling remains available as a deprecated

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ CI: [GitHub Action](https://github.com/marketplace/actions/assay-ai-agent-securi
 
 No hosted backend. No API keys for core flows. Deterministic: same input, same decision.
 
+> **CLI release note:** `main` currently includes a small CLI UX close-out for
+> the next release line: `assay run --format json` emits machine-readable run
+> results to stdout, `model: trace` now errors clearly when `--trace-file` is
+> missing, `assay validate eval.yaml` works beside `--config eval.yaml`, and
+> `assay trust-card` is the canonical Trust Card command spelling. These are
+> merged on `main`; see [CHANGELOG.md](CHANGELOG.md) for release status before
+> assuming crates.io availability.
+
 <details>
 <summary>Evidence levels and non-goals</summary>
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,6 +167,15 @@ Historical close-out note:
 
 To reduce "surface area tax" and improve adoption, CLI commands are positioned in two tiers:
 
+Post-`v3.12.0` CLI UX close-out is merged on `main`: top-level command help is
+covered by regression tests, trace replay reports missing `--trace-file` as an
+argument error, `assay run --format json` provides stdout machine output,
+`assay validate` accepts a positional config path, and `assay trust-card` is the
+canonical Trust Card command spelling with `trustcard` retained as a deprecated
+compatibility alias. This is a discoverability and scripting pass only; it does
+not change scoring, artifact schemas, Trust Basis semantics, or the command
+grouping RFC migration plan.
+
 ### Happy Path (Core Workflow)
 ```bash
 assay run              # Execute with policy enforcement

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -71,6 +71,9 @@ assay run --config eval.yaml --strict
 # Specific trace file
 assay run --config eval.yaml --trace-file traces/golden.jsonl
 
+# Machine-readable run report on stdout
+assay run --config eval.yaml --trace-file traces/golden.jsonl --format json > results.json
+
 # CI reports
 assay ci --config eval.yaml --trace-file traces/golden.jsonl --sarif sarif.json --junit junit.xml
 ```
@@ -109,6 +112,16 @@ assay migrate --config old-eval.yaml
 
 # Preview changes without writing
 assay migrate --config old-eval.yaml --dry-run
+```
+
+### Validate Config And Trace
+
+```bash
+# Positional config path
+assay validate eval.yaml --trace-file traces/golden.jsonl
+
+# Equivalent explicit config flag
+assay validate --config eval.yaml --trace-file traces/golden.jsonl
 ```
 
 ### Start MCP Wrapper


### PR DESCRIPTION
## Summary

Syncs public docs after the small CLI UX close-out that is merged on `main` after `v3.12.0`.

This PR updates:

- `CHANGELOG.md` with the complete CLI UX set: `run --format json`, trace replay missing-`--trace-file` error, positional `validate` config, and canonical `trust-card` naming.
- `README.md` with a bounded release note that says these changes are merged on `main`, not yet assumed available from crates.io.
- `docs/ROADMAP.md` with the CLI UX close-out status and explicit non-claims.
- `docs/reference/cli/index.md` with quick examples for `run --format json` and positional `validate` config.

## Release truth

- Merged on `main`: yes, the CLI UX changes are present after #1451, #1452, #1453, #1454, #1455, and #1456.
- Latest tag: `v3.12.0`.
- crates.io: `assay-cli = 3.12.0`.
- This PR does not claim a new tag or crates.io publication.

## Validation

Ran locally:

```bash
git diff --check
cargo test -q -p assay-cli --test contract_exit_codes core::contract_run_format_json_emits_report_to_stdout -- --nocapture
cargo test -q -p assay-cli --test contract_exit_codes core::contract_run_default_text_keeps_stdout_clean -- --nocapture
cargo test -q -p assay-cli --test contract_init_hello_trace validate_accepts_positional_config_path -- --nocapture
python3 -m venv /tmp/assay-docs-venv
/tmp/assay-docs-venv/bin/pip install --quiet --requirement docs/requirements-ci.txt
/tmp/assay-docs-venv/bin/mkdocs build --strict
```

Also ran the docs-link-check workflow logic against the changed docs files; local links resolved.
