### PR TITLE
feat: group MCP CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Grouped MCP runtime commands under the visible `assay mcp` command
+  family. The canonical forms are now `assay mcp discover`, `assay mcp
+  kill`, and `assay mcp tool ...`; the previous flat `assay discover`,
+  `assay kill`, and `assay tool ...` paths remain available as hidden
+  compatibility shims with stderr deprecation warnings. Output shapes,
+  exit codes, artifacts, and MCP policy behavior are unchanged.
+
 - Added `assay run --format <text|json>`. `text` (default) keeps the
   existing human-readable summary on stderr; `json` prints a
   machine-readable results report to stdout so `assay run --format json >

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Assay does **not** ship a primary aggregate trust score or a `safe/unsafe` badge
               └─► 📊 Trust Basis → Trust Card → SARIF / CI
 ```
 
-> **CLI:** The `mcp` command group is **hidden** from top-level `assay --help` while the surface stabilizes; it is supported. Use `assay mcp --help`, `assay mcp wrap …`, or follow the [MCP Quickstart](examples/mcp-quickstart/).
+> **CLI:** MCP runtime commands live under `assay mcp`. Use `assay mcp --help`,
+> `assay mcp wrap …`, `assay mcp discover`, `assay mcp kill`, or follow the
+> [MCP Quickstart](examples/mcp-quickstart/).
 
 > **Wedge, not category.** “MCP firewall” describes the control plane; **trust compilation** describes the outcome: reviewable claims backed by evidence. See [ADR-033](docs/architecture/ADR-033-OTel-Trust-Compiler-Positioning.md) and [RFC-005](docs/architecture/RFC-005-trust-compiler-mvp-2026q2.md).
 
@@ -285,7 +287,7 @@ PRs that violate policy get blocked; SARIF can surface in the Security tab.
 | **Deterministic** | Same input, same decision — not probabilistic. |
 | **Portable artifacts** | Bundles, Trust Basis, Trust Card, SARIF — for CI, review, audit. |
 | **Bounded claims** | Explicit about what is **verified** vs **visible** vs **absent** — no score-first UX. |
-| **MCP-native wedge** | `assay mcp wrap` is the fast path (the `mcp` group is hidden from `assay --help`; use `assay mcp --help`). Adapters extend the same engine. |
+| **MCP-native wedge** | `assay mcp wrap` is the fast path; `assay mcp discover`, `assay mcp kill`, and `assay mcp tool` keep the runtime surface grouped. Adapters extend the same engine. |
 | **Offline-first** | No backend required for core enforcement and bundle verification. |
 
 <details>

--- a/crates/assay-cli/src/cli/args/mcp.rs
+++ b/crates/assay-cli/src/cli/args/mcp.rs
@@ -1,18 +1,26 @@
+use super::ToolArgs;
+use crate::cli::commands::kill::KillArgs;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-#[derive(Parser, Clone, Debug)]
+#[derive(Parser, Debug)]
 pub struct McpArgs {
     #[command(subcommand)]
     pub cmd: McpSub,
 }
 
-#[derive(Subcommand, Clone, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum McpSub {
     /// Wrap an MCP server process
     Wrap(McpWrapArgs),
     /// Detect config path and generate setup
     ConfigPath(ConfigPathArgs),
+    /// Discover MCP servers on this machine
+    Discover(DiscoverArgs),
+    /// Kill or terminate MCP server processes
+    Kill(KillArgs),
+    /// Sign and verify MCP tool definitions
+    Tool(ToolArgs),
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -77,16 +77,17 @@ pub enum Command {
     InitCi(InitCiArgs),
     /// Apply supported automatic fixes
     Fix(FixArgs),
-    /// Experimental: MCP Process Wrapper
-    #[command(hide = true)]
+    /// MCP runtime, discovery, kill-switch, and tool signing commands
     Mcp(McpArgs),
     /// Print Assay version information
     Version,
     /// Validate, format, and migrate policies
     Policy(PolicyArgs),
     /// Discover MCP servers on this machine (v1.8)
+    #[command(hide = true)]
     Discover(DiscoverArgs),
     /// Kill/Terminate MCP servers (v1.8)
+    #[command(hide = true)]
     Kill(super::commands::kill::KillArgs),
     /// Runtime eBPF Monitor (Linux only)
     Monitor(super::commands::monitor::MonitorArgs),
@@ -114,6 +115,7 @@ pub enum Command {
     /// Interactive installer and environment setup (Phase 2)
     Setup(SetupArgs),
     /// Tool signing and verification
+    #[command(hide = true)]
     Tool(ToolArgs),
     /// Generate canonical trust-basis artifacts from verified evidence bundles
     #[command(name = "trust-basis")]

--- a/crates/assay-cli/src/cli/args/tests.rs
+++ b/crates/assay-cli/src/cli/args/tests.rs
@@ -48,6 +48,59 @@ fn trust_card_command_accepts_canonical_and_legacy_names() {
     assert!(matches!(legacy.cmd, Command::TrustCard(_)));
 }
 
+#[test]
+fn mcp_group_accepts_canonical_paths_and_legacy_shims_are_hidden() {
+    let visible: Vec<_> = Cli::command()
+        .get_subcommands()
+        .filter(|cmd| !cmd.is_hide_set())
+        .map(|cmd| cmd.get_name().to_string())
+        .collect();
+
+    assert!(visible.contains(&"mcp".to_string()));
+    assert!(!visible.contains(&"discover".to_string()));
+    assert!(!visible.contains(&"kill".to_string()));
+    assert!(!visible.contains(&"tool".to_string()));
+
+    let discover = Cli::try_parse_from(["assay", "mcp", "discover", "--format", "json"])
+        .expect("canonical mcp discover command should parse");
+    assert!(matches!(
+        discover.cmd,
+        Command::Mcp(McpArgs {
+            cmd: McpSub::Discover(_)
+        })
+    ));
+
+    let kill = Cli::try_parse_from(["assay", "mcp", "kill", "proc-123"])
+        .expect("canonical mcp kill command should parse");
+    assert!(matches!(
+        kill.cmd,
+        Command::Mcp(McpArgs {
+            cmd: McpSub::Kill(_)
+        })
+    ));
+
+    let tool = Cli::try_parse_from(["assay", "mcp", "tool", "keygen", "--out", "keys"])
+        .expect("canonical mcp tool command should parse");
+    assert!(matches!(
+        tool.cmd,
+        Command::Mcp(McpArgs {
+            cmd: McpSub::Tool(_)
+        })
+    ));
+
+    let legacy_discover = Cli::try_parse_from(["assay", "discover", "--format", "json"])
+        .expect("legacy discover shim should parse");
+    assert!(matches!(legacy_discover.cmd, Command::Discover(_)));
+
+    let legacy_kill =
+        Cli::try_parse_from(["assay", "kill", "proc-123"]).expect("legacy kill shim should parse");
+    assert!(matches!(legacy_kill.cmd, Command::Kill(_)));
+
+    let legacy_tool = Cli::try_parse_from(["assay", "tool", "keygen", "--out", "keys"])
+        .expect("legacy tool shim should parse");
+    assert!(matches!(legacy_tool.cmd, Command::Tool(_)));
+}
+
 #[cfg(feature = "sim")]
 #[test]
 fn sim_soak_parses_with_defaults() {

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -1,6 +1,10 @@
 use super::super::args::*;
 use crate::exit_codes::EXIT_SUCCESS;
 
+fn warn_legacy_mcp_path(old: &str, new: &str) {
+    eprintln!("warning: `assay {old}` is deprecated; use `assay mcp {new}` instead");
+}
+
 pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
     match cli.cmd {
         Command::Init(args) => super::init::run(args).await,
@@ -31,8 +35,14 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         Command::Demo(args) => super::demo::cmd_demo(args).await,
         Command::InitCi(args) => super::init_ci::cmd_init_ci(args),
         Command::Mcp(args) => super::mcp::run(args).await,
-        Command::Discover(args) => super::discover::run(args).await,
-        Command::Kill(args) => super::kill::run(args).await,
+        Command::Discover(args) => {
+            warn_legacy_mcp_path("discover", "discover");
+            super::discover::run(args).await
+        }
+        Command::Kill(args) => {
+            warn_legacy_mcp_path("kill", "kill");
+            super::kill::run(args).await
+        }
         Command::Monitor(args) => super::monitor::run(args).await,
         Command::Policy(args) => super::policy::run(args).await,
         Command::Generate(args) => super::generate::run(args),
@@ -47,7 +57,10 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         #[cfg(feature = "sim")]
         Command::Sim(args) => super::sim::run(args),
         Command::Setup(args) => super::setup::run(args).await,
-        Command::Tool(args) => Ok(super::tool::cmd_tool(args.cmd)),
+        Command::Tool(args) => {
+            warn_legacy_mcp_path("tool", "tool");
+            Ok(super::tool::cmd_tool(args.cmd))
+        }
         Command::TrustBasis(args) => super::trust_basis::run(args),
         Command::TrustCard(args) => super::trust_card::run(args),
         Command::Version => {

--- a/crates/assay-cli/src/cli/commands/mcp.rs
+++ b/crates/assay-cli/src/cli/commands/mcp.rs
@@ -16,6 +16,9 @@ pub async fn run(args: McpArgs) -> anyhow::Result<i32> {
             super::config_path::run(config_args);
             Ok(0)
         }
+        McpSub::Discover(discover_args) => super::discover::run(discover_args).await,
+        McpSub::Kill(kill_args) => super::kill::run(kill_args).await,
+        McpSub::Tool(tool_args) => Ok(super::tool::cmd_tool(tool_args.cmd)),
     }
 }
 

--- a/crates/assay-cli/src/cli/commands/tool/keygen.rs
+++ b/crates/assay-cli/src/cli/commands/tool/keygen.rs
@@ -1,4 +1,4 @@
-//! `assay tool keygen` - Generate ed25519 keypair for signing.
+//! `assay mcp tool keygen` - Generate ed25519 keypair for signing.
 
 use anyhow::{Context, Result};
 use clap::Args;

--- a/crates/assay-cli/src/cli/commands/tool/sign.rs
+++ b/crates/assay-cli/src/cli/commands/tool/sign.rs
@@ -1,4 +1,4 @@
-//! `assay tool sign` - Sign a tool definition.
+//! `assay mcp tool sign` - Sign a tool definition.
 
 use anyhow::{Context, Result};
 use clap::Args;

--- a/crates/assay-cli/src/cli/commands/tool/verify.rs
+++ b/crates/assay-cli/src/cli/commands/tool/verify.rs
@@ -1,4 +1,4 @@
-//! `assay tool verify` - Verify a signed tool definition.
+//! `assay mcp tool verify` - Verify a signed tool definition.
 
 use anyhow::{Context, Result};
 use clap::Args;

--- a/crates/assay-cli/tests/e2e_policy_test.rs
+++ b/crates/assay-cli/tests/e2e_policy_test.rs
@@ -103,7 +103,7 @@ fn test_discovery_respects_policy_fail_on_unmanaged() {
         .env("APPDATA", &appdata)
         // Make XDG lookups deterministic too
         .env("XDG_CONFIG_HOME", &xdg_config_home)
-        .args(["discover", "--policy", policy_path.to_str().unwrap()])
+        .args(["mcp", "discover", "--policy", policy_path.to_str().unwrap()])
         .output()
         .unwrap();
 

--- a/crates/assay-cli/tests/kill_switch_assert_cmd.rs
+++ b/crates/assay-cli/tests/kill_switch_assert_cmd.rs
@@ -21,9 +21,9 @@ fn kill_by_proc_id_works() {
     // On Unix we can send signal 0, but std doesn't expose that easily.
     // relying on `kill` command to succeed is the test.
 
-    // Kill it using assay kill
+    // Kill it using assay mcp kill
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay"));
-    cmd.args(["kill", &format!("proc-{}", pid)]);
+    cmd.args(["mcp", "kill", &format!("proc-{}", pid)]);
 
     // We expect success
     cmd.assert().success();

--- a/crates/assay-cli/tests/mcp_command_grouping_test.rs
+++ b/crates/assay-cli/tests/mcp_command_grouping_test.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+fn assay_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_assay"))
+}
+
+#[test]
+fn mcp_group_is_visible_and_legacy_flat_commands_are_hidden() {
+    let top_help = assay_cmd().arg("--help").output().unwrap();
+    assert!(top_help.status.success());
+    let top_stdout = String::from_utf8_lossy(&top_help.stdout);
+    assert!(top_stdout.contains("  mcp"));
+    assert!(!top_stdout.contains("  discover "));
+    assert!(!top_stdout.contains("  kill "));
+    assert!(!top_stdout.contains("  tool "));
+
+    let mcp_help = assay_cmd().args(["mcp", "--help"]).output().unwrap();
+    assert!(mcp_help.status.success());
+    let mcp_stdout = String::from_utf8_lossy(&mcp_help.stdout);
+    assert!(mcp_stdout.contains("  discover "));
+    assert!(mcp_stdout.contains("  kill "));
+    assert!(mcp_stdout.contains("  tool "));
+}
+
+#[test]
+fn legacy_flat_mcp_command_prints_deprecation_warning() {
+    let output = assay_cmd().arg("kill").output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`assay kill` is deprecated; use `assay mcp kill` instead"),
+        "missing legacy MCP deprecation warning: {stderr}"
+    );
+}

--- a/crates/assay-cli/tests/tool_signing_test.rs
+++ b/crates/assay-cli/tests/tool_signing_test.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `assay tool` signing commands.
+//! Integration tests for `assay mcp tool` signing commands.
 
 use std::process::Command;
 use tempfile::TempDir;
@@ -13,10 +13,10 @@ fn test_keygen_creates_keypair() {
     let out_dir = tmp.path();
 
     let output = assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(out_dir)
         .output()
-        .expect("failed to run assay tool keygen");
+        .expect("failed to run assay mcp tool keygen");
 
     assert!(output.status.success(), "keygen should succeed");
 
@@ -45,7 +45,7 @@ fn test_keygen_refuses_overwrite_without_force() {
 
     // First keygen
     let output = assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(out_dir)
         .output()
         .expect("failed to run first keygen");
@@ -53,7 +53,7 @@ fn test_keygen_refuses_overwrite_without_force() {
 
     // Second keygen without --force should fail
     let output = assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(out_dir)
         .output()
         .expect("failed to run second keygen");
@@ -61,7 +61,7 @@ fn test_keygen_refuses_overwrite_without_force() {
 
     // With --force should succeed
     let output = assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(out_dir)
         .args(["--force"])
         .output()
@@ -77,7 +77,7 @@ fn test_sign_verify_roundtrip() {
 
     // Generate keypair
     let output = assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(&key_dir)
         .output()
         .expect("keygen failed");
@@ -92,7 +92,7 @@ fn test_sign_verify_roundtrip() {
     // Sign
     let signed_path = tmp.path().join("signed.json");
     let output = assay_cmd()
-        .args(["tool", "sign"])
+        .args(["mcp", "tool", "sign"])
         .arg(&tool_path)
         .args(["--key"])
         .arg(key_dir.join("private_key.pem"))
@@ -110,7 +110,7 @@ fn test_sign_verify_roundtrip() {
 
     // Verify
     let output = assay_cmd()
-        .args(["tool", "verify"])
+        .args(["mcp", "tool", "verify"])
         .arg(&signed_path)
         .args(["--pubkey"])
         .arg(key_dir.join("public_key.pem"))
@@ -131,7 +131,7 @@ fn test_verify_unsigned_exits_0() {
 
     // Generate keypair
     assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(&key_dir)
         .output()
         .expect("keygen failed");
@@ -142,7 +142,7 @@ fn test_verify_unsigned_exits_0() {
 
     // Verify unsigned (no policy requiring signature) -> exit 0
     let output = assay_cmd()
-        .args(["tool", "verify"])
+        .args(["mcp", "tool", "verify"])
         .arg(&tool_path)
         .args(["--pubkey"])
         .arg(key_dir.join("public_key.pem"))
@@ -165,12 +165,12 @@ fn test_verify_wrong_key_exits_4() {
     std::fs::create_dir_all(&key2_dir).unwrap();
 
     assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(&key1_dir)
         .output()
         .unwrap();
     assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(&key2_dir)
         .output()
         .unwrap();
@@ -181,7 +181,7 @@ fn test_verify_wrong_key_exits_4() {
 
     let signed_path = tmp.path().join("signed.json");
     assay_cmd()
-        .args(["tool", "sign"])
+        .args(["mcp", "tool", "sign"])
         .arg(&tool_path)
         .args(["--key"])
         .arg(key1_dir.join("private_key.pem"))
@@ -192,7 +192,7 @@ fn test_verify_wrong_key_exits_4() {
 
     // Verify with key2 -> should fail with exit code 4
     let output = assay_cmd()
-        .args(["tool", "verify"])
+        .args(["mcp", "tool", "verify"])
         .arg(&signed_path)
         .args(["--pubkey"])
         .arg(key2_dir.join("public_key.pem"))
@@ -211,7 +211,7 @@ fn test_verify_tampered_exits_4() {
 
     // Generate keypair
     assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(&key_dir)
         .output()
         .unwrap();
@@ -222,7 +222,7 @@ fn test_verify_tampered_exits_4() {
 
     let signed_path = tmp.path().join("signed.json");
     assay_cmd()
-        .args(["tool", "sign"])
+        .args(["mcp", "tool", "sign"])
         .arg(&tool_path)
         .args(["--key"])
         .arg(key_dir.join("private_key.pem"))
@@ -238,7 +238,7 @@ fn test_verify_tampered_exits_4() {
 
     // Verify -> should fail with exit code 4
     let output = assay_cmd()
-        .args(["tool", "verify"])
+        .args(["mcp", "tool", "verify"])
         .arg(&signed_path)
         .args(["--pubkey"])
         .arg(key_dir.join("public_key.pem"))
@@ -259,7 +259,7 @@ fn test_sign_requires_output() {
     std::fs::create_dir_all(&key_dir).unwrap();
 
     assay_cmd()
-        .args(["tool", "keygen", "--out"])
+        .args(["mcp", "tool", "keygen", "--out"])
         .arg(&key_dir)
         .output()
         .unwrap();
@@ -269,7 +269,7 @@ fn test_sign_requires_output() {
 
     // Sign without --out or --in-place should fail
     let output = assay_cmd()
-        .args(["tool", "sign"])
+        .args(["mcp", "tool", "sign"])
         .arg(&tool_path)
         .args(["--key"])
         .arg(key_dir.join("private_key.pem"))

--- a/docs/AIcontext/code-map.md
+++ b/docs/AIcontext/code-map.md
@@ -174,8 +174,8 @@ The GitHub Action lives in this monorepo under `assay-action/` and is referenced
 - **`mcp.rs`**: `assay mcp` command
 - **`monitor.rs`**: `assay monitor` command
 - **`sandbox.rs`**: `assay sandbox` command
-- **`discover.rs`**: `assay discover` command
-- **`kill.rs`**: `assay kill` command
+- **`discover.rs`**: `assay mcp discover` command
+- **`kill.rs`**: `assay mcp kill` command
 - **`quarantine.rs`**: `assay quarantine` command
 - **`calibrate.rs`**: `assay calibrate` command
 - **`profile.rs`**: `assay profile` command
@@ -187,10 +187,10 @@ The GitHub Action lives in this monorepo under `assay-action/` and is referenced
   - **`evidence/push.rs`**: `assay evidence push` - Upload to BYOS storage
   - **`evidence/pull.rs`**: `assay evidence pull` - Download from BYOS storage
   - **`evidence/list.rs`**: `assay evidence list` - List bundles in storage
-- **`tool/mod.rs`**: `assay tool` command with subcommands:
-  - **`tool/keygen.rs`**: `assay tool keygen` - Generate ed25519 keypair
-  - **`tool/sign.rs`**: `assay tool sign` - Sign tool definition
-  - **`tool/verify.rs`**: `assay tool verify` - Verify signature
+- **`tool/mod.rs`**: `assay mcp tool` command with subcommands:
+  - **`tool/keygen.rs`**: `assay mcp tool keygen` - Generate ed25519 keypair
+  - **`tool/sign.rs`**: `assay mcp tool sign` - Sign tool definition
+  - **`tool/verify.rs`**: `assay mcp tool verify` - Verify signature
 - **`demo.rs`**: `assay demo` command
 - **`fix.rs`**: `assay fix` command (agentic policy fixing)
 - **`sim.rs`**: `assay sim` command

--- a/docs/AIcontext/decision-trees.md
+++ b/docs/AIcontext/decision-trees.md
@@ -185,7 +185,7 @@ flowchart TD
 | Export evidence | `assay evidence export` | `--profile`, `--out` |
 | Verify evidence | `assay evidence verify` | `<bundle.tar.gz>` |
 | Lint evidence | `assay evidence lint` | `--format sarif` |
-| Sign tool | `assay tool sign` | `--key`, `--out` |
+| Sign tool | `assay mcp tool sign` | `--key`, `--out` |
 
 ## Decision Table: Output Format Selection
 

--- a/docs/AIcontext/entry-points.md
+++ b/docs/AIcontext/entry-points.md
@@ -186,12 +186,12 @@ All CLI commands are defined in `crates/assay-cli/src/cli/args.rs` and dispatche
 
 **New in v2.10**: `--decision-log`, `--event-source`, `--audit-log` flags for mandate runtime enforcement.
 
-#### `assay discover`
+#### `assay mcp discover`
 **Purpose**: Discover MCP servers on machine
 **Entry**: `crates/assay-cli/src/cli/commands/discover.rs::run()`
 **Flow**: Scan for MCP processes → list servers
 
-#### `assay kill`
+#### `assay mcp kill`
 **Purpose**: Kill/terminate MCP servers
 **Entry**: `crates/assay-cli/src/cli/commands/kill.rs::run()`
 **Flow**: Find MCP processes → terminate
@@ -242,7 +242,7 @@ All CLI commands are defined in `crates/assay-cli/src/cli/args.rs` and dispatche
 - `pull --bundle-id <ID> --store <URI>`: Download from storage
 - `list --store <URI>`: List bundles
 
-#### `assay tool`
+#### `assay mcp tool`
 **Purpose**: Tool signing and verification
 **Entry**: `crates/assay-cli/src/cli/commands/tool/mod.rs::cmd_tool()`
 **Flow**: Generate keys, sign/verify tool definitions

--- a/docs/AIcontext/quick-reference.md
+++ b/docs/AIcontext/quick-reference.md
@@ -209,13 +209,13 @@ assay evidence diff baseline.tar.gz current.tar.gz
 
 ```bash
 # Generate keypair
-assay tool keygen --out keys/
+assay mcp tool keygen --out keys/
 
 # Sign tool definition
-assay tool sign tool.yaml --key keys/private.pem --out tool-signed.yaml
+assay mcp tool sign tool.yaml --key keys/private.pem --out tool-signed.yaml
 
 # Verify signature
-assay tool verify tool-signed.yaml --trust-policy trust.yaml
+assay mcp tool verify tool-signed.yaml --trust-policy trust.yaml
 ```
 
 ## Common Patterns

--- a/docs/DEVELOPER_HANDOFF.md
+++ b/docs/DEVELOPER_HANDOFF.md
@@ -267,9 +267,9 @@ Supported backends: AWS S3, Backblaze B2, Wasabi, Cloudflare R2, MinIO, Azure Bl
 MCP tool definition signing with `x-assay-sig` field:
 
 ```bash
-assay tool keygen --out ~/.assay/keys/    # Generate PKCS#8/SPKI keypair
-assay tool sign tool.json --key priv.pem --out signed.json
-assay tool verify signed.json --pubkey pub.pem  # Exit: 0=ok, 2=unsigned, 3=untrusted, 4=invalid
+assay mcp tool keygen --out ~/.assay/keys/    # Generate PKCS#8/SPKI keypair
+assay mcp tool sign tool.json --key priv.pem --out signed.json
+assay mcp tool verify signed.json --pubkey pub.pem  # Exit: 0=ok, 2=unsigned, 3=untrusted, 4=invalid
 ```
 
 **Key files:**

--- a/docs/architecture/ADR-011-Tool-Signing.md
+++ b/docs/architecture/ADR-011-Tool-Signing.md
@@ -5,7 +5,7 @@
 Proposed (January 2026; boundary sync February 2026)
 
 Open-core boundary note (current `main`):
-- Open-core delivered: local-key signing and verification via `x-assay-sig` (`assay tool sign --key`, `assay tool verify`).
+- Open-core delivered: local-key signing and verification via `x-assay-sig` (`assay mcp tool sign --key`, `assay mcp tool verify`).
 - Enterprise pending: Sigstore keyless + transparency-log verification (Fulcio/Rekor).
 
 ## Context
@@ -87,19 +87,19 @@ We will implement **Sigstore-based keyless signing** as an enterprise extension 
 
 ```bash
 # Keyless signing (enterprise advanced signing)
-assay tool sign --keyless tool-definition.json
+assay mcp tool sign --keyless tool-definition.json
 
 # Local-key signing (open-core)
-assay tool sign --key private.pem tool-definition.json
+assay mcp tool sign --key private.pem tool-definition.json
 
 # Verify a signed tool
-assay tool verify tool-definition.json
+assay mcp tool verify tool-definition.json
 
 # Verify with explicit trust requirements
-assay tool verify tool-definition.json --require-producer-trust policy.yaml
+assay mcp tool verify tool-definition.json --require-producer-trust policy.yaml
 
 # Verify and require Rekor transparency proof (enterprise advanced signing)
-assay tool verify tool-definition.json --rekor-required
+assay mcp tool verify tool-definition.json --rekor-required
 ```
 
 ### Evidence Verification with Producer Trust
@@ -378,13 +378,13 @@ This enables interoperability with other MCP security tools.
 ## Implementation Plan
 
 ### Phase 1: Enterprise Signing CLI (Week 1)
-- [ ] `assay tool sign --keyless` command
+- [ ] `assay mcp tool sign --keyless` command
 - [ ] Fulcio integration for certificate issuance
 - [ ] Rekor integration for transparency logging
 - [ ] `x-assay-sig` serialization
 
 ### Phase 2: Verification (Week 2)
-- [ ] `assay tool verify` command
+- [ ] `assay mcp tool verify` command
 - [ ] Policy-based trust anchors
 - [ ] Integration with existing `ToolIdentity`
 - [ ] Warning mode for gradual rollout

--- a/docs/architecture/ADR-012-Transparency-Log.md
+++ b/docs/architecture/ADR-012-Transparency-Log.md
@@ -334,13 +334,13 @@ impl RekorCache {
 
 ```bash
 # Require Rekor transparency proof for verification (enterprise advanced signing)
-assay tool verify tool.json --rekor-required
+assay mcp tool verify tool.json --rekor-required
 
 # Verify evidence bundle with Rekor check
 assay evidence verify bundle.tar.gz --rekor-required
 
 # Skip Rekor check (offline mode)
-assay tool verify tool.json --offline
+assay mcp tool verify tool.json --offline
 assay evidence verify bundle.tar.gz --offline
 ```
 

--- a/docs/architecture/SPEC-Tool-Signing-v1.md
+++ b/docs/architecture/SPEC-Tool-Signing-v1.md
@@ -152,7 +152,7 @@ Where `spki_bytes` is the DER-encoded SubjectPublicKeyInfo.
 
 ```bash
 # Using assay CLI
-assay tool keygen --out ~/.assay/keys/
+assay mcp tool keygen --out ~/.assay/keys/
 
 # Output:
 #   ~/.assay/keys/private_key.pem (PKCS#8, mode 0600)

--- a/docs/reference/cli/command-grouping-rfc.md
+++ b/docs/reference/cli/command-grouping-rfc.md
@@ -1,6 +1,6 @@
 # CLI Command Grouping RFC
 
-Status: draft proposal
+Status: accepted direction; Tier 1 MCP pilot implemented
 
 Owner: CLI / Product
 
@@ -13,11 +13,11 @@ usable, and the high-frequency commands should stay flat. The useful next step
 is selective noun-verb grouping for families that already behave like resource
 groups:
 
-- `mcp` first
+- `mcp` first (implemented as the Tier 1 pilot)
 - `trust` second only after one more usage/docs check
 - `policy` and `evidence` only if user feedback or maintenance work justifies it
 
-The migration contract should copy the proven `trustcard` to `trust-card`
+The migration contract copies the proven `trustcard` to `trust-card`
 pattern from #1454: new canonical spelling, old spelling kept as a hidden
 compatibility path, a stderr deprecation warning, tests for both paths, and no
 artifact/output-shape changes.
@@ -72,7 +72,7 @@ related actions remain flat.
 | Policy authoring | `policy`, `generate`, `record`, `coverage`, `explain`, `fix`, `migrate`, `calibrate` | Mixed |
 | Trust artifacts | `trust-basis`, `trust-card`, `baseline` | Flat |
 | Evidence and replay | `evidence`, `bundle`, `replay`, `import` | Mixed |
-| MCP runtime | `mcp`, `discover`, `kill`, `tool` | Mixed |
+| MCP runtime | `mcp` with hidden legacy shims for `discover`, `kill`, `tool` | Grouped |
 | Runtime/security | `monitor`, `sandbox`, `quarantine`, `sim` | Mixed |
 | Trace/profile data | `trace`, `profile` | Flat |
 | Meta | `doctor`, `version` | Flat |
@@ -119,6 +119,11 @@ Migration rule:
   hidden compatibility shims.
 - Emit a stderr deprecation warning when a legacy flat path is used.
 - Do not change policy enforcement, output files, exit codes, or JSON shapes.
+
+Status:
+
+- Implemented for `discover`, `kill`, and `tool` as the first grouping pilot.
+- `assay mcp wrap` and `assay mcp config-path` remain in the same family.
 
 ### Tier 1: Consider Trust After MCP
 
@@ -245,10 +250,9 @@ That difference is why this RFC recommends starting with one family at a time.
 
 ## Suggested Sequence
 
-1. Land this RFC as docs-only.
-2. Wait for a concrete reason to touch MCP command code, or schedule a small
-   MCP-only grouping PR.
-3. If MCP grouping lands cleanly, consider a trust grouping PR.
+1. Land this RFC as docs-only. Done.
+2. Land the small MCP-only grouping pilot. Done.
+3. If MCP grouping lands cleanly in a release, consider a trust grouping PR.
 4. Defer policy/evidence grouping until there is user feedback or nearby
    maintenance work.
 5. Do not group core commands.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -3,7 +3,7 @@
 Complete documentation for all Assay commands.
 
 Planning note: see [CLI Command Grouping RFC](command-grouping-rfc.md) for the
-draft noun-verb grouping direction and migration contract.
+selective noun-verb grouping direction and migration contract.
 
 ---
 
@@ -41,8 +41,8 @@ assay --version
 | [`assay doctor`](doctor.md) | Diagnose setup and optionally auto-fix known issues |
 | [`assay watch`](watch.md) | Re-run on config/policy/trace changes |
 | [`assay monitor`](../../guides/runtime-monitor.md) | **Runtime Security** (Linux Kernel Enforcement) |
-| [`assay mcp wrap`](mcp-server.md) | Wrap an MCP process with policy enforcement |
-| [CLI Command Grouping RFC](command-grouping-rfc.md) | Draft command grouping direction and compatibility contract |
+| [`assay mcp`](mcp-server.md) | MCP runtime commands: wrap, discover, kill, config-path, and tool signing |
+| [CLI Command Grouping RFC](command-grouping-rfc.md) | Selective command grouping direction and compatibility contract |
 
 ---
 
@@ -124,7 +124,7 @@ assay validate eval.yaml --trace-file traces/golden.jsonl
 assay validate --config eval.yaml --trace-file traces/golden.jsonl
 ```
 
-### Start MCP Wrapper
+### MCP Runtime
 
 ```bash
 # Enforcing mode
@@ -132,6 +132,12 @@ assay mcp wrap --policy assay.yaml -- <real-mcp-command> [args...]
 
 # Dry-run mode
 assay mcp wrap --policy assay.yaml --dry-run -- <real-mcp-command> [args...]
+
+# Discover local MCP servers
+assay mcp discover --format json
+
+# Sign or verify MCP tool definitions
+assay mcp tool sign tool.json --key private.pem --out signed.json
 ```
 
 ### Diagnose and Watch

--- a/docs/reference/cli/mcp-server.md
+++ b/docs/reference/cli/mcp-server.md
@@ -4,7 +4,24 @@ This page documents the current MCP runtime entry points in Assay.
 
 ---
 
-## 1) `assay mcp wrap` (CLI)
+## 1) `assay mcp` (CLI)
+
+`assay mcp` is the canonical command family for MCP runtime work:
+
+- `assay mcp wrap`
+- `assay mcp discover`
+- `assay mcp kill`
+- `assay mcp config-path`
+- `assay mcp tool keygen|sign|verify`
+
+The previous flat `assay discover`, `assay kill`, and `assay tool ...`
+spellings remain available as hidden compatibility shims and print a
+deprecation warning to stderr. Their stdout, exit codes, artifacts, and output
+formats remain unchanged.
+
+---
+
+## 2) `assay mcp wrap` (CLI)
 
 Wrap a real MCP process and enforce policy decisions inline.
 
@@ -39,7 +56,7 @@ assay mcp wrap --policy assay.yaml --dry-run -- <real-mcp-command> [args...]
 
 ---
 
-## 2) `assay-mcp-server` (separate binary)
+## 3) `assay-mcp-server` (separate binary)
 
 Run the MCP server binary directly.
 

--- a/docs/security/OWASP-MCP-TOP10-MAPPING.md
+++ b/docs/security/OWASP-MCP-TOP10-MAPPING.md
@@ -12,7 +12,7 @@ How Assay addresses the [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top
 | Intent Flow Subversion | MCP06 | Strong | Sequence policies detect tool-call ordering violations. [Memory poisoning experiment](../architecture/RESULTS-EXPERIMENT-MEMORY-POISON-2026q2.md) tested delayed payload reactivation. |
 | Insufficient Authentication & Authorization | MCP07 | Strong | `approval_required` enforcement, mandate system with revocation, auth context validation. |
 | **Lack of Audit and Telemetry** | **MCP08** | **Complete** | **Evidence bundles, decision logs, replay, diff, lint, SARIF output.** This is Assay's primary value proposition. |
-| Shadow MCP Servers | MCP09 | Partial | `assay discover` lists MCP servers on the machine. Policy enforcement only applies to wrapped servers. |
+| Shadow MCP Servers | MCP09 | Partial | `assay mcp discover` lists MCP servers on the machine. Policy enforcement only applies to wrapped servers. |
 | Context Injection & Over-Sharing | MCP10 | Strong | `redact_args` enforcement strips sensitive fields. Context envelope hardening validates completeness. [Protocol evidence experiment](../architecture/RESULTS-EXPERIMENT-PROTOCOL-EVIDENCE-INTERPRETATION-2026q2.md) tested consumer-side interpretation. |
 
 ## Summary


### PR DESCRIPTION
## Summary

Implements the Tier 1 MCP command-grouping pilot from the CLI Command Grouping RFC.

What changed:

- makes `assay mcp` visible in top-level help
- adds canonical nested paths:
  - `assay mcp discover`
  - `assay mcp kill`
  - `assay mcp tool ...`
- keeps legacy flat paths hidden but working:
  - `assay discover`
  - `assay kill`
  - `assay tool ...`
- emits stderr deprecation warnings only on legacy flat paths
- updates tests and user-facing docs to prefer the grouped MCP surface

## Boundary

This PR does not change MCP policy behavior, tool-signing semantics, stdout output shapes, artifact names, exit codes, Trust Basis/Card behavior, or the broader trust/policy/evidence grouping RFC lanes.

Trust grouping remains conditional after this release proves the MCP pilot. Policy/evidence grouping remains deferred.

## Validation

Ran locally:

```bash
cargo check -p assay-cli
cargo fmt --check
cargo clippy -p assay-cli --all-targets -- -D warnings
cargo test -p assay-cli mcp_group_accepts_canonical_paths_and_legacy_shims_are_hidden -- --nocapture
cargo test -p assay-cli --test mcp_command_grouping_test -- --nocapture
cargo test -p assay-cli --test e2e_policy_test test_discovery_respects_policy_fail_on_unmanaged -- --nocapture
cargo test -p assay-cli --test kill_switch_assert_cmd kill_by_proc_id_works -- --nocapture
cargo test -p assay-cli --test tool_signing_test -- --nocapture
git diff --check
```

Manual smoke:

```bash
cargo run -q -p assay-cli -- --help
cargo run -q -p assay-cli -- mcp --help
cargo run -q -p assay-cli -- kill
# expected legacy warning + invalid-args failure because no target was provided
```

Pre-push hooks also passed workspace clippy and the linux compile gate.

Note: `mkdocs` is not installed in this local worktree, so docs strict/local-link checks are left to CI.
