### PR TITLE
chore: prep v3.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.13.0] - 2026-06-01
+
+> `v3.13.0` closes the post-`v3.12.0` CLI UX pass and ships the first
+> selective command-grouping pilot. It keeps the core evaluation loop flat,
+> adds machine-readable `run` output, improves trace/validate ergonomics,
+> canonicalizes Trust Card spelling, and groups MCP runtime commands under
+> `assay mcp` while preserving hidden compatibility shims for the previous
+> flat paths.
+
 - Grouped MCP runtime commands under the visible `assay mcp` command
   family. The canonical forms are now `assay mcp discover`, `assay mcp
   kill`, and `assay mcp tool ...`; the previous flat `assay discover`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.12.0"
+version = "3.13.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.12.0"
+version = "3.13.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -73,18 +73,18 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.12.0" }
-assay-common = { path = "crates/assay-common", version = "3.12.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.12.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.12.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.12.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.12.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.12.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.12.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.12.0" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.12.0" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.12.0" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.12.0" }
+assay-core = { path = "crates/assay-core", version = "3.13.0" }
+assay-common = { path = "crates/assay-common", version = "3.13.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.13.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.13.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.13.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.13.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.13.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.13.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.13.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.13.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.13.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.13.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ CI: [GitHub Action](https://github.com/marketplace/actions/assay-ai-agent-securi
 No hosted backend. No API keys for core flows. Deterministic: same input, same decision.
 
 > **CLI release note:** `main` currently includes a small CLI UX close-out for
-> the next release line: `assay run --format json` emits machine-readable run
+> the `v3.13.0` release line: `assay run --format json` emits machine-readable run
 > results to stdout, `model: trace` now errors clearly when `--trace-file` is
 > missing, `assay validate eval.yaml` works beside `--config eval.yaml`, and
-> `assay trust-card` is the canonical Trust Card command spelling. These are
-> merged on `main`; see [CHANGELOG.md](CHANGELOG.md) for release status before
-> assuming crates.io availability.
+> `assay trust-card` is the canonical Trust Card command spelling. MCP runtime
+> commands are grouped under `assay mcp`, with hidden compatibility shims for
+> the previous flat `assay discover`, `assay kill`, and `assay tool ...` paths.
+> These are merged on `main`; see [CHANGELOG.md](CHANGELOG.md) for release
+> status before assuming crates.io availability.
 
 <details>
 <summary>Evidence levels and non-goals</summary>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,14 +167,16 @@ Historical close-out note:
 
 To reduce "surface area tax" and improve adoption, CLI commands are positioned in two tiers:
 
-Post-`v3.12.0` CLI UX close-out is merged on `main`: top-level command help is
+The `v3.13.0` CLI UX close-out is merged on `main`: top-level command help is
 covered by regression tests, trace replay reports missing `--trace-file` as an
 argument error, `assay run --format json` provides stdout machine output,
 `assay validate` accepts a positional config path, and `assay trust-card` is the
 canonical Trust Card command spelling with `trustcard` retained as a deprecated
-compatibility alias. This is a discoverability and scripting pass only; it does
-not change scoring, artifact schemas, Trust Basis semantics, or the command
-grouping RFC migration plan.
+compatibility alias. The first command-grouping pilot is also merged: MCP
+runtime commands now live under `assay mcp`, with hidden compatibility shims for
+the previous flat `assay discover`, `assay kill`, and `assay tool ...` paths.
+This is a discoverability and scripting pass only; it does not change scoring,
+artifact schemas, Trust Basis semantics, or MCP policy behavior.
 
 ### Happy Path (Core Workflow)
 ```bash
@@ -187,7 +189,7 @@ assay evidence explore # Interactive TUI viewer
 ```
 
 ### Power Tools (Advanced/Experimental)
-All other commands (`quarantine`, `fix`, `demo`, `sim`, `discover`, `kill`, `mcp`, etc.) are documented separately as advanced tooling.
+All other commands (`quarantine`, `fix`, `demo`, `sim`, `mcp`, etc.) are documented separately as advanced tooling.
 
 ---
 


### PR DESCRIPTION
## Summary

Prepares the repository for the `v3.13.0` release line after the CLI UX close-out and MCP command-grouping pilot landed on `main`.

What changed:

- bumps the workspace package version and internal workspace dependency versions from `3.12.0` to `3.13.0`
- refreshes `Cargo.lock` to `3.13.0`
- moves the current changelog entries into `## [3.13.0] - 2026-06-01`
- updates README/ROADMAP release-truth wording for the CLI UX close-out and MCP grouping pilot

## Release Truth

- latest shipped tag: `v3.12.0`
- latest crates.io `assay-cli`: `3.12.0`
- target release prep version: `3.13.0`
- #1459 is merged, so the MCP Tier 1 grouping pilot is included in this prep

This PR does not create a tag, publish crates, or claim crates.io availability. It only prepares `main` for the tag/release workflow.

## Validation

Ran locally:

```bash
cargo search assay-cli --limit 1
cargo check --workspace
PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --workspace
bash scripts/ci/check-public-crate-policy.sh
cargo fmt --check
git diff --check
cargo metadata --no-deps --format-version 1
PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets -- -D warnings
```

Note: the first plain `cargo check --workspace` hit the local Python 3.14 / PyO3 0.24.2 guard. The same workspace check passed with `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`, which matches this machine's interpreter reality rather than an Assay source failure.

After merge, the next step is to create and push tag `v3.13.0`, then monitor the release workflow and crates.io publication.
