### PR TITLE
docs: mark v3.13 CLI UX as released

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,13 @@ CI: [GitHub Action](https://github.com/marketplace/actions/assay-ai-agent-securi
 
 No hosted backend. No API keys for core flows. Deterministic: same input, same decision.
 
-> **CLI release note:** `main` currently includes a small CLI UX close-out for
-> the `v3.13.0` release line: `assay run --format json` emits machine-readable run
-> results to stdout, `model: trace` now errors clearly when `--trace-file` is
+> **v3.13.0 CLI UX:** `assay run --format json` emits machine-readable run
+> results to stdout, `model: trace` errors clearly when `--trace-file` is
 > missing, `assay validate eval.yaml` works beside `--config eval.yaml`, and
 > `assay trust-card` is the canonical Trust Card command spelling. MCP runtime
 > commands are grouped under `assay mcp`, with hidden compatibility shims for
 > the previous flat `assay discover`, `assay kill`, and `assay tool ...` paths.
-> These are merged on `main`; see [CHANGELOG.md](CHANGELOG.md) for release
-> status before assuming crates.io availability.
+> See [CHANGELOG.md](CHANGELOG.md) for the full release notes.
 
 <details>
 <summary>Evidence levels and non-goals</summary>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,12 +167,12 @@ Historical close-out note:
 
 To reduce "surface area tax" and improve adoption, CLI commands are positioned in two tiers:
 
-The `v3.13.0` CLI UX close-out is merged on `main`: top-level command help is
-covered by regression tests, trace replay reports missing `--trace-file` as an
-argument error, `assay run --format json` provides stdout machine output,
-`assay validate` accepts a positional config path, and `assay trust-card` is the
+The `v3.13.0` CLI UX close-out is released: top-level command help is covered
+by regression tests, trace replay reports missing `--trace-file` as an argument
+error, `assay run --format json` provides stdout machine output, `assay
+validate` accepts a positional config path, and `assay trust-card` is the
 canonical Trust Card command spelling with `trustcard` retained as a deprecated
-compatibility alias. The first command-grouping pilot is also merged: MCP
+compatibility alias. The first command-grouping pilot is also released: MCP
 runtime commands now live under `assay mcp`, with hidden compatibility shims for
 the previous flat `assay discover`, `assay kill`, and `assay tool ...` paths.
 This is a discoverability and scripting pass only; it does not change scoring,


### PR DESCRIPTION
## Summary

Cleans up the temporary CLI UX release note now that `v3.13.0` is tagged and published.

- removes the README hedge that said the CLI UX work was only merged on `main`
- marks the CLI UX close-out and MCP grouping pilot as released in the roadmap
- keeps the feature list aligned with the `v3.13.0` changelog

Closes #1458.

## Validation

- `git diff --check`
- `uv run --with-requirements docs/requirements-ci.txt mkdocs build --strict`
