### PR TITLE
feat: add MCP execution record verifier

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
@@ -1,0 +1,319 @@
+use anyhow::{Context, Result};
+use clap::{Args, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Args, Clone)]
+pub struct McpExecutionRecordArgs {
+    /// SEP-2787 attestation JSON fixture
+    #[arg(long)]
+    pub attestation: PathBuf,
+
+    /// Server-side decision record JSON fixture
+    #[arg(long)]
+    pub decision: PathBuf,
+
+    /// Optional server-side outcome record JSON fixture
+    #[arg(long)]
+    pub outcome: Option<PathBuf>,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = McpExecutionRecordFormat::Table)]
+    pub format: McpExecutionRecordFormat,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum McpExecutionRecordFormat {
+    Json,
+    Table,
+}
+
+#[derive(Debug, Serialize)]
+struct PairingReport {
+    schema: &'static str,
+    ok: bool,
+    canonicalization: &'static str,
+    verification_scope: VerificationScope,
+    attestation: AttestationReport,
+    decision: DecisionReport,
+    outcome: Option<OutcomeReport>,
+    checks: Vec<CheckReport>,
+    claims_not_made: Vec<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct VerificationScope {
+    role: &'static str,
+    note: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct AttestationReport {
+    digest: String,
+    nonce: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DecisionReport {
+    decision: Option<String>,
+    decided_at: Option<String>,
+    backlink: BackLinkReport,
+    signature_present: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct OutcomeReport {
+    status: Option<String>,
+    completed_at: Option<String>,
+    backlink: BackLinkReport,
+    signature_present: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct BackLinkReport {
+    attestation_digest: Option<String>,
+    attestation_nonce: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckReport {
+    id: &'static str,
+    ok: bool,
+    detail: String,
+}
+
+pub fn cmd_verify_mcp_records(args: McpExecutionRecordArgs) -> Result<i32> {
+    let attestation = read_json(&args.attestation)?;
+    let decision = read_json(&args.decision)?;
+    let outcome = args.outcome.as_ref().map(read_json).transpose()?;
+
+    let report = build_report(&attestation, &decision, outcome.as_ref())?;
+    match args.format {
+        McpExecutionRecordFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        McpExecutionRecordFormat::Table => print_table_report(&report),
+    }
+
+    Ok(if report.ok { 0 } else { 2 })
+}
+
+fn read_json(path: &PathBuf) -> Result<Value> {
+    let body =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&body).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn build_report(
+    attestation: &Value,
+    decision: &Value,
+    outcome: Option<&Value>,
+) -> Result<PairingReport> {
+    let attestation_digest = jcs_digest(attestation).context("failed to digest attestation")?;
+    let attestation_nonce = string_at(attestation, &["issuerAsserted", "nonce"]);
+    let decision_backlink = backlink_report(decision)?;
+    let outcome_backlink = outcome.map(backlink_report).transpose()?;
+
+    let mut checks = Vec::new();
+    checks.push(check_eq(
+        "decision_attestation_digest_match",
+        decision_backlink.attestation_digest.as_deref(),
+        Some(attestation_digest.as_str()),
+        "decision backLink.attestationDigest matches SEP-2787 JCS digest",
+    ));
+    checks.push(check_eq(
+        "decision_attestation_nonce_match",
+        decision_backlink.attestation_nonce.as_deref(),
+        attestation_nonce.as_deref(),
+        "decision backLink.attestationNonce matches issuerAsserted.nonce",
+    ));
+    checks.push(check_enum(
+        "decision_enum",
+        decision_value(decision).as_deref(),
+        &["allow", "block", "escalate"],
+    ));
+
+    if let Some(outcome_backlink) = &outcome_backlink {
+        checks.push(check_eq(
+            "outcome_attestation_digest_match",
+            outcome_backlink.attestation_digest.as_deref(),
+            Some(attestation_digest.as_str()),
+            "outcome backLink.attestationDigest matches SEP-2787 JCS digest",
+        ));
+        checks.push(check_eq(
+            "outcome_attestation_nonce_match",
+            outcome_backlink.attestation_nonce.as_deref(),
+            attestation_nonce.as_deref(),
+            "outcome backLink.attestationNonce matches issuerAsserted.nonce",
+        ));
+        checks.push(check_eq(
+            "decision_outcome_backlink_match",
+            outcome_backlink.attestation_digest.as_deref(),
+            decision_backlink.attestation_digest.as_deref(),
+            "decision and outcome describe the same call instance",
+        ));
+        checks.push(check_enum(
+            "outcome_status_enum",
+            outcome.and_then(outcome_status).as_deref(),
+            &["executed", "refused", "errored"],
+        ));
+    } else {
+        checks.push(CheckReport {
+            id: "outcome_absent",
+            ok: true,
+            detail: "no outcome record supplied; report is decision-only".to_string(),
+        });
+    }
+
+    let decision_report = DecisionReport {
+        decision: decision_value(decision),
+        decided_at: string_at(decision, &["decisionDerived", "decidedAt"]),
+        backlink: decision_backlink,
+        signature_present: decision.get("signature").and_then(Value::as_str).is_some(),
+    };
+    let outcome_report = match (outcome, outcome_backlink) {
+        (Some(outcome), Some(backlink)) => Some(OutcomeReport {
+            status: outcome_status(outcome),
+            completed_at: string_at(outcome, &["outcomeDerived", "completedAt"]),
+            backlink,
+            signature_present: outcome.get("signature").and_then(Value::as_str).is_some(),
+        }),
+        _ => None,
+    };
+
+    let ok = checks.iter().all(|check| check.ok);
+    Ok(PairingReport {
+        schema: "assay.mcp.execution-record-pairing.report.v0",
+        ok,
+        canonicalization: "jcs/rfc8785",
+        verification_scope: VerificationScope {
+            role: "independent-consumer",
+            note: "Assay verifies fixture pairing and digest commitments only; it does not emit records or act as a proxy.",
+        },
+        attestation: AttestationReport {
+            digest: attestation_digest,
+            nonce: attestation_nonce,
+        },
+        decision: decision_report,
+        outcome: outcome_report,
+        checks,
+        claims_not_made: vec![
+            "signature_verification",
+            "issuer_key_trust",
+            "policy_correctness",
+            "runtime_side_effect_truth",
+            "payload_or_result_disclosure",
+        ],
+    })
+}
+
+fn jcs_digest(value: &Value) -> Result<String> {
+    let canonical = assay_core::mcp::jcs::to_vec(value)?;
+    let hash = Sha256::digest(&canonical);
+    Ok(format!("sha256:{}", hex::encode(hash)))
+}
+
+fn backlink_report(record: &Value) -> Result<BackLinkReport> {
+    let backlink = record
+        .get("backLink")
+        .or_else(|| record.get("back_link"))
+        .ok_or_else(|| anyhow::anyhow!("record missing backLink"))?;
+    Ok(BackLinkReport {
+        attestation_digest: string_at(backlink, &["attestationDigest"])
+            .or_else(|| string_at(backlink, &["attestation_digest"])),
+        attestation_nonce: string_at(backlink, &["attestationNonce"])
+            .or_else(|| string_at(backlink, &["attestation_nonce"])),
+    })
+}
+
+fn decision_value(record: &Value) -> Option<String> {
+    string_at(record, &["decisionDerived", "decision"])
+        .or_else(|| string_at(record, &["decision_derived", "decision"]))
+}
+
+fn outcome_status(record: &Value) -> Option<String> {
+    string_at(record, &["outcomeDerived", "status"])
+        .or_else(|| string_at(record, &["outcome_derived", "status"]))
+}
+
+fn string_at(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str().map(ToOwned::to_owned)
+}
+
+fn check_eq(
+    id: &'static str,
+    left: Option<&str>,
+    right: Option<&str>,
+    description: &str,
+) -> CheckReport {
+    let ok = left.is_some() && right.is_some() && left == right;
+    let detail = match (left, right) {
+        (Some(left), Some(right)) if left == right => description.to_string(),
+        (Some(left), Some(right)) => format!("mismatch: got {left}, expected {right}"),
+        (None, _) => "missing observed value".to_string(),
+        (_, None) => "missing expected value".to_string(),
+    };
+    CheckReport { id, ok, detail }
+}
+
+fn check_enum(id: &'static str, value: Option<&str>, allowed: &[&str]) -> CheckReport {
+    match value {
+        Some(value) if allowed.contains(&value) => CheckReport {
+            id,
+            ok: true,
+            detail: format!("{value} is allowed"),
+        },
+        Some(value) => CheckReport {
+            id,
+            ok: false,
+            detail: format!("{value} is not one of {}", allowed.join(", ")),
+        },
+        None => CheckReport {
+            id,
+            ok: false,
+            detail: "missing value".to_string(),
+        },
+    }
+}
+
+fn print_table_report(report: &PairingReport) {
+    println!("MCP Execution Record Pairing Report");
+    println!("===================================");
+    println!("OK:               {}", if report.ok { "yes" } else { "no" });
+    println!("Role:             {}", report.verification_scope.role);
+    println!("Attestation:      {}", report.attestation.digest);
+    println!(
+        "Nonce:            {}",
+        report.attestation.nonce.as_deref().unwrap_or("-")
+    );
+    println!(
+        "Decision:         {}",
+        report.decision.decision.as_deref().unwrap_or("-")
+    );
+    if let Some(outcome) = &report.outcome {
+        println!(
+            "Outcome:          {}",
+            outcome.status.as_deref().unwrap_or("-")
+        );
+    } else {
+        println!("Outcome:          -");
+    }
+    println!();
+    for check in &report.checks {
+        println!(
+            "{:<36} {:<4} {}",
+            check.id,
+            if check.ok { "ok" } else { "fail" },
+            check.detail
+        );
+    }
+    println!();
+    println!("Claims not made: {}", report.claims_not_made.join(", "));
+}

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -5,6 +5,7 @@ pub mod list;
 pub mod livekit_tool_action;
 pub mod mapping;
 pub mod mastra_score_event;
+pub mod mcp_execution_records;
 pub mod openfeature_details;
 pub mod promptfoo_jsonl;
 pub mod pull;
@@ -26,6 +27,9 @@ pub enum EvidenceCmd {
     Export(EvidenceExportArgs),
     /// Verify a bundle's integrity and provenance
     Verify(EvidenceVerifyArgs),
+    /// Verify SEP-2787/server execution-record fixture pairing
+    #[command(name = "verify-mcp-records")]
+    VerifyMcpRecords(mcp_execution_records::McpExecutionRecordArgs),
     /// Inspect a bundle's contents (verify + show table)
     Show(EvidenceShowArgs),
     /// Import external evidence into an Assay evidence bundle
@@ -118,6 +122,7 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
     match args.cmd {
         EvidenceCmd::Export(a) => cmd_export(a),
         EvidenceCmd::Verify(a) => cmd_verify(a),
+        EvidenceCmd::VerifyMcpRecords(a) => mcp_execution_records::cmd_verify_mcp_records(a),
         EvidenceCmd::Show(a) => cmd_show(a),
         EvidenceCmd::Import(a) => cmd_import(a),
         EvidenceCmd::Schema(a) => schema::cmd_schema(a),

--- a/crates/assay-cli/tests/evidence_test.rs
+++ b/crates/assay-cli/tests/evidence_test.rs
@@ -17,3 +17,5 @@ mod deterministic_and_guardrails;
 mod flow_and_eval_receipts;
 #[path = "evidence_test/importer_receipts.rs"]
 mod importer_receipts;
+#[path = "evidence_test/mcp_execution_records.rs"]
+mod mcp_execution_records;

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
@@ -1,0 +1,161 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use std::fs;
+use tempfile::tempdir;
+
+const ATTESTATION_DIGEST: &str =
+    "sha256:eb86c33e0905be8dad78dbd2d795711631a2f893ed48c2942679b94c24e9dfc1";
+
+fn attestation_json() -> &'static str {
+    r#"{
+  "version": 1,
+  "alg": "ES256",
+  "issuerAsserted": {
+    "iss": "issuer",
+    "sub": "agent:test",
+    "iat": "2026-06-01T00:00:00Z",
+    "nonce": "nonce-1",
+    "secretVersion": "test",
+    "alg": "ES256"
+  },
+  "plannerDeclared": {
+    "intent": "test"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "name": "tools/call",
+        "serverFingerprint": "srv",
+        "argsProjection": {
+          "projection": "{\"digest\":\"sha256:abc\"}",
+          "projectionDigest": "sha256:def"
+        }
+      }
+    ]
+  },
+  "signature": "sig"
+}"#
+}
+
+fn decision_json(digest: &str) -> String {
+    format!(
+        r#"{{
+  "version": 1,
+  "alg": "ES256",
+  "backLink": {{
+    "attestationDigest": "{digest}",
+    "attestationNonce": "nonce-1"
+  }},
+  "decisionDerived": {{
+    "decision": "allow",
+    "policyId": "policy:test",
+    "decidedAt": "2026-06-01T00:00:01Z"
+  }},
+  "issuerAsserted": {{
+    "iss": "server",
+    "sub": "agent:test",
+    "iat": "2026-06-01T00:00:01Z",
+    "nonce": "decision-1",
+    "secretVersion": "test",
+    "alg": "ES256"
+  }},
+  "signature": "decision-sig"
+}}"#
+    )
+}
+
+fn outcome_json(digest: &str) -> String {
+    format!(
+        r#"{{
+  "version": 1,
+  "alg": "ES256",
+  "backLink": {{
+    "attestationDigest": "{digest}",
+    "attestationNonce": "nonce-1"
+  }},
+  "outcomeDerived": {{
+    "status": "executed",
+    "completedAt": "2026-06-01T00:00:02Z"
+  }},
+  "receiptAsserted": {{
+    "iss": "server",
+    "sub": "agent:test",
+    "iat": "2026-06-01T00:00:02Z",
+    "nonce": "outcome-1",
+    "secretVersion": "test",
+    "alg": "ES256"
+  }},
+  "signature": "outcome-sig"
+}}"#
+    )
+}
+
+#[test]
+fn verify_mcp_records_reports_pairing_as_independent_consumer() {
+    let dir = tempdir().unwrap();
+    let attestation = dir.path().join("attestation.json");
+    let decision = dir.path().join("decision.json");
+    let outcome = dir.path().join("outcome.json");
+    fs::write(&attestation, attestation_json()).unwrap();
+    fs::write(&decision, decision_json(ATTESTATION_DIGEST)).unwrap();
+    fs::write(&outcome, outcome_json(ATTESTATION_DIGEST)).unwrap();
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--attestation",
+            attestation.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--outcome",
+            outcome.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["verification_scope"]["role"], "independent-consumer");
+    assert_eq!(report["attestation"]["digest"], ATTESTATION_DIGEST);
+    assert_eq!(report["decision"]["decision"], "allow");
+    assert_eq!(report["outcome"]["status"], "executed");
+    assert!(report["claims_not_made"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|claim| claim == "signature_verification"));
+}
+
+#[test]
+fn verify_mcp_records_fails_on_substituted_backlink() {
+    let dir = tempdir().unwrap();
+    let attestation = dir.path().join("attestation.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&attestation, attestation_json()).unwrap();
+    fs::write(&decision, decision_json("sha256:0000")).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--attestation",
+            attestation.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains(
+            "decision_attestation_digest_match",
+        ))
+        .stdout(predicate::str::contains("fail mismatch"));
+}

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -65,6 +65,33 @@ Schema names can be the registry name, known alias, source path, or JSON Schema
 
 ---
 
+## MCP Execution Record Pairing
+
+Verify that SEP-2787 attestation and server execution-record fixtures pair up
+from the consumer side:
+
+```bash
+assay evidence verify-mcp-records \
+  --attestation sep2787-attestation.json \
+  --decision server-decision-record.json \
+  --outcome server-outcome-record.json \
+  --format json
+```
+
+This command emits an `assay.mcp.execution-record-pairing.report.v0` report. It
+computes the SEP-2787 JCS digest, checks the decision and optional outcome
+`backLink` fields, and verifies the narrow decision/outcome enum surface.
+
+The command is deliberately not an MCP proxy, issuer, policy engine, or runtime
+truth oracle. It does not verify signatures, establish issuer key trust, prove
+policy correctness, prove side effects, or disclose payload/result bodies. It is
+for downstream verifier fixtures and reviewer-visible pairing diagnostics.
+
+If `--outcome` is omitted, Assay reports a valid decision-only pairing check.
+Pairing or enum mismatches produce a report and exit `2`.
+
+---
+
 ## CycloneDX ML-BOM Model Import
 
 Import one selected CycloneDX ML-BOM `machine-learning-model` component into a


### PR DESCRIPTION
Summary

Adds a small independent consumer verifier for SEP-2787 / MCP server execution-record fixture pairing.

What changed:

- adds `assay evidence verify-mcp-records`
- verifies SEP-2787 attestation JCS digest pairing against server decision records
- optionally verifies outcome records against the same attestation backlink
- emits `assay.mcp.execution-record-pairing.report.v0` as table or JSON
- documents explicit non-claims: no MCP proxy, no issuer role, no signature/key trust, no policy-correctness proof, no runtime side-effect proof, no payload/result disclosure

Scope

This is intentionally separate from the CLI grouping Tier 2 work. It adds one bounded evidence verifier under the existing `evidence` namespace and does not restructure command families.

Validation

Ran locally:

```bash
cargo fmt --check
cargo clippy -p assay-cli --all-targets -- -D warnings
cargo test -p assay-cli --test evidence_test mcp_execution_records -- --nocapture
cargo test -p assay-cli --test evidence_test -- --nocapture
uv run --with-requirements docs/requirements-ci.txt mkdocs build --strict
git diff --check
```
