### PR TITLE
feat: group policy authoring commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Grouped policy authoring under `assay policy generate` and
+  `assay policy record`. The previous top-level `assay generate` and
+  `assay record` commands remain available as hidden compatibility shims with
+  stderr deprecation warnings; output shapes, exit codes, and generated policy
+  behavior are unchanged.
+
 ## [3.13.0] - 2026-06-01
 
 > `v3.13.0` closes the post-`v3.12.0` CLI UX pass and ships the first

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -92,8 +92,10 @@ pub enum Command {
     /// Runtime eBPF Monitor (Linux only)
     Monitor(super::commands::monitor::MonitorArgs),
     /// Learning Mode: Generate policy from trace or profile
+    #[command(hide = true)]
     Generate(super::commands::generate::GenerateArgs),
     /// Learning Mode: Capture and Generate in one flow
+    #[command(hide = true)]
     Record(super::commands::record::RecordArgs),
     /// Internal Assay-Runner Phase 1 spike command
     #[cfg(feature = "runner")]

--- a/crates/assay-cli/src/cli/args/policy.rs
+++ b/crates/assay-cli/src/cli/args/policy.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 
+use crate::cli::commands::{generate::GenerateArgs, record::RecordArgs};
+
 #[derive(Args, Clone, Debug)]
 pub struct PolicyArgs {
     #[command(subcommand)]
@@ -12,6 +14,12 @@ pub struct PolicyArgs {
 
 #[derive(Subcommand, Clone, Debug)]
 pub enum PolicyCommand {
+    /// Generate policy from trace or profile input
+    Generate(GenerateArgs),
+
+    /// Capture runtime behavior and generate a policy
+    Record(RecordArgs),
+
     /// Validate policy syntax and (v2) JSON Schemas
     Validate(PolicyValidateArgs),
 

--- a/crates/assay-cli/src/cli/args/tests.rs
+++ b/crates/assay-cli/src/cli/args/tests.rs
@@ -101,6 +101,53 @@ fn mcp_group_accepts_canonical_paths_and_legacy_shims_are_hidden() {
     assert!(matches!(legacy_tool.cmd, Command::Tool(_)));
 }
 
+#[test]
+fn policy_group_accepts_authoring_paths_and_legacy_shims_are_hidden() {
+    let visible: Vec<_> = Cli::command()
+        .get_subcommands()
+        .filter(|cmd| !cmd.is_hide_set())
+        .map(|cmd| cmd.get_name().to_string())
+        .collect();
+
+    assert!(visible.contains(&"policy".to_string()));
+    assert!(!visible.contains(&"generate".to_string()));
+    assert!(!visible.contains(&"record".to_string()));
+
+    let generate = Cli::try_parse_from([
+        "assay",
+        "policy",
+        "generate",
+        "--input",
+        "trace.jsonl",
+        "--dry-run",
+    ])
+    .expect("canonical policy generate command should parse");
+    assert!(matches!(
+        generate.cmd,
+        Command::Policy(PolicyArgs {
+            cmd: PolicyCommand::Generate(_)
+        })
+    ));
+
+    let record = Cli::try_parse_from(["assay", "policy", "record", "--", "echo", "hello"])
+        .expect("canonical policy record command should parse");
+    assert!(matches!(
+        record.cmd,
+        Command::Policy(PolicyArgs {
+            cmd: PolicyCommand::Record(_)
+        })
+    ));
+
+    let legacy_generate =
+        Cli::try_parse_from(["assay", "generate", "--input", "trace.jsonl", "--dry-run"])
+            .expect("legacy generate shim should parse");
+    assert!(matches!(legacy_generate.cmd, Command::Generate(_)));
+
+    let legacy_record = Cli::try_parse_from(["assay", "record", "--", "echo", "hello"])
+        .expect("legacy record shim should parse");
+    assert!(matches!(legacy_record.cmd, Command::Record(_)));
+}
+
 #[cfg(feature = "sim")]
 #[test]
 fn sim_soak_parses_with_defaults() {

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -5,6 +5,10 @@ fn warn_legacy_mcp_path(old: &str, new: &str) {
     eprintln!("warning: `assay {old}` is deprecated; use `assay mcp {new}` instead");
 }
 
+fn warn_legacy_policy_path(old: &str, new: &str) {
+    eprintln!("warning: `assay {old}` is deprecated; use `assay policy {new}` instead");
+}
+
 pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
     match cli.cmd {
         Command::Init(args) => super::init::run(args).await,
@@ -45,8 +49,14 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         }
         Command::Monitor(args) => super::monitor::run(args).await,
         Command::Policy(args) => super::policy::run(args).await,
-        Command::Generate(args) => super::generate::run(args),
-        Command::Record(args) => super::record::run(args).await,
+        Command::Generate(args) => {
+            warn_legacy_policy_path("generate", "generate");
+            super::generate::run(args)
+        }
+        Command::Record(args) => {
+            warn_legacy_policy_path("record", "record");
+            super::record::run(args).await
+        }
         #[cfg(feature = "runner")]
         Command::RunnerSpike(args) => super::runner_spike::run(args).await,
         Command::Profile(args) => super::profile::run(args),

--- a/crates/assay-cli/src/cli/commands/policy/mod.rs
+++ b/crates/assay-cli/src/cli/commands/policy/mod.rs
@@ -6,6 +6,8 @@ use crate::cli::args::{PolicyArgs, PolicyCommand};
 
 pub async fn run(args: PolicyArgs) -> anyhow::Result<i32> {
     match args.cmd {
+        PolicyCommand::Generate(a) => super::generate::run(a),
+        PolicyCommand::Record(a) => super::record::run(a).await,
         PolicyCommand::Validate(a) => validate::run(a).await,
         PolicyCommand::Migrate(a) => migrate::run(a).await,
         PolicyCommand::Fmt(a) => fmt::run(a).await,

--- a/crates/assay-cli/tests/contract_docs_generate_explain.rs
+++ b/crates/assay-cli/tests/contract_docs_generate_explain.rs
@@ -15,18 +15,25 @@ fn docs_reference_includes_generate_and_explain_contract_flags() {
     let index = fs::read_to_string(root.join("docs/reference/cli/index.md")).expect("read index");
     let explain =
         fs::read_to_string(root.join("docs/reference/cli/explain.md")).expect("read explain doc");
+    let policy =
+        fs::read_to_string(root.join("docs/reference/cli/policy.md")).expect("read policy doc");
     let generate =
         fs::read_to_string(root.join("docs/reference/cli/generate.md")).expect("read generate doc");
 
     assert!(
-        index.contains("[`assay generate`](generate.md)"),
-        "CLI index must link to assay generate"
+        index.contains("[`assay policy`](policy.md)"),
+        "CLI index must link to assay policy"
     );
     assert!(
         index.contains("[`assay explain`](explain.md)"),
         "CLI index must link to assay explain"
     );
 
+    assert!(
+        policy.contains("[`assay policy generate`](generate.md)")
+            && policy.contains("`assay policy record`"),
+        "policy docs must include policy authoring commands"
+    );
     assert!(
         explain.contains("--compliance-pack"),
         "explain docs must include compliance-pack option"
@@ -42,6 +49,7 @@ fn cli_help_exposes_generate_diff_and_explain_compliance_pack() {
     #[allow(deprecated)]
     let mut generate_help = Command::cargo_bin("assay").expect("assay binary");
     let generate_output = generate_help
+        .arg("policy")
         .arg("generate")
         .arg("--help")
         .assert()

--- a/crates/assay-cli/tests/contract_generate_g1.rs
+++ b/crates/assay-cli/tests/contract_generate_g1.rs
@@ -37,7 +37,7 @@ fn normalize_text(raw: &str, tmp_root: &Path) -> String {
 
 fn run_generate(args: &[&str]) -> std::process::Output {
     let mut cmd = Command::cargo_bin("assay").expect("assay binary");
-    cmd.arg("generate");
+    cmd.arg("policy").arg("generate");
     for arg in args {
         cmd.arg(arg);
     }
@@ -99,7 +99,8 @@ fn generate_contract_read_events_all_invalid_is_hard_error() {
     write_file(&input, "not-json\n{\n#comment\n");
 
     let mut cmd = Command::cargo_bin("assay").expect("assay binary");
-    cmd.arg("generate")
+    cmd.arg("policy")
+        .arg("generate")
         .arg("--input")
         .arg(&input)
         .arg("--dry-run")
@@ -137,6 +138,7 @@ entries:
 
     let mut none_cmd = Command::cargo_bin("assay").expect("assay binary");
     none_cmd
+        .arg("policy")
         .arg("generate")
         .arg("--dry-run")
         .assert()
@@ -148,6 +150,7 @@ entries:
 
     let mut both_cmd = Command::cargo_bin("assay").expect("assay binary");
     both_cmd
+        .arg("policy")
         .arg("generate")
         .arg("--input")
         .arg(&input)

--- a/crates/assay-cli/tests/generate_golden.rs
+++ b/crates/assay-cli/tests/generate_golden.rs
@@ -1,4 +1,4 @@
-//! Golden tests for assay generate (Phase 3)
+//! Golden tests for assay policy generate (Phase 3)
 
 #![allow(deprecated)] // cargo_bin is deprecated but still works
 
@@ -21,9 +21,10 @@ fn run_golden(name: &str, use_heuristics: bool) {
     let input_path = dir.join("input.jsonl");
     let expected_path = dir.join("expected.yaml");
 
-    // We run the binary "assay" with the "generate" subcommand
+    // We run the binary "assay" with the canonical "policy generate" subcommand.
     let mut cmd = Command::cargo_bin("assay").unwrap();
-    cmd.arg("generate")
+    cmd.arg("policy")
+        .arg("generate")
         .arg("--input")
         .arg(&input_path)
         .arg("--name")

--- a/crates/assay-cli/tests/policy_command_grouping_test.rs
+++ b/crates/assay-cli/tests/policy_command_grouping_test.rs
@@ -1,0 +1,35 @@
+use std::process::Command;
+
+fn assay_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_assay"))
+}
+
+#[test]
+fn policy_group_exposes_authoring_commands_and_legacy_flat_commands_are_hidden() {
+    let top_help = assay_cmd().arg("--help").output().unwrap();
+    assert!(top_help.status.success());
+    let top_stdout = String::from_utf8_lossy(&top_help.stdout);
+    assert!(top_stdout.contains("  policy"));
+    assert!(!top_stdout.contains("  generate "));
+    assert!(!top_stdout.contains("  record "));
+
+    let policy_help = assay_cmd().args(["policy", "--help"]).output().unwrap();
+    assert!(policy_help.status.success());
+    let policy_stdout = String::from_utf8_lossy(&policy_help.stdout);
+    assert!(policy_stdout.contains("  generate "));
+    assert!(policy_stdout.contains("  record "));
+    assert!(policy_stdout.contains("  validate "));
+    assert!(policy_stdout.contains("  migrate "));
+    assert!(policy_stdout.contains("  fmt "));
+}
+
+#[test]
+fn legacy_flat_policy_generate_prints_deprecation_warning() {
+    let output = assay_cmd().arg("generate").output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`assay generate` is deprecated; use `assay policy generate` instead"),
+        "missing legacy policy deprecation warning: {stderr}"
+    );
+}

--- a/docs/reference/cli/command-grouping-rfc.md
+++ b/docs/reference/cli/command-grouping-rfc.md
@@ -1,10 +1,10 @@
 # CLI Command Grouping RFC
 
-Status: accepted direction; Tier 1 MCP pilot implemented
+Status: accepted direction; Tier 1 MCP pilot and Tier 2a policy authoring implemented
 
 Owner: CLI / Product
 
-Last updated: 2026-06-01 (Tier 2 revised)
+Last updated: 2026-06-01 (Tier 2a policy authoring implemented)
 
 ## Summary
 
@@ -16,8 +16,9 @@ groups:
 - `mcp` first (implemented as the Tier 1 pilot)
 - `trust` second only after one more usage/docs check
 - a narrowed `policy` grouping (`generate`/`record`, not the full set first
-  drafted) and a corrected `replay` grouping (not `evidence`) only if user
-  feedback or nearby maintenance work justifies it
+  drafted), now implemented as Tier 2a
+- a corrected `replay` grouping (not `evidence`) only if user feedback or
+  nearby maintenance work justifies it
 
 Tier 2 was revised after checking the real command tree: the earlier
 `policy generate/coverage/explain/fix` and `evidence bundle/replay/import`
@@ -188,6 +189,9 @@ assay policy generate   # was: generate  ("Learning Mode: Generate policy from t
 assay policy record     # was: record    ("Learning Mode: Capture and Generate in one flow")
 ```
 
+Status: implemented. The old top-level `assay generate` and `assay record`
+paths remain hidden compatibility shims with stderr deprecation warnings.
+
 Optional, weaker fit:
 
 ```text
@@ -298,15 +302,14 @@ That difference is why this RFC recommends starting with one family at a time.
 1. Land this RFC as docs-only. Done.
 2. Land the small MCP-only grouping pilot. Done.
 3. If MCP grouping lands cleanly in a release, consider a trust grouping PR.
-4. Defer the narrowed Tier 2 work until there is user feedback or nearby
-   maintenance work:
-   - Tier 2a: `policy generate` / `policy record` (only `generate`/`record`,
-     plus optional `coverage`). Do not move `migrate`/`explain`/`fix`/
-     `calibrate`.
-   - Tier 2b: a `replay` noun (`replay bundle`, `replay run`). Not `evidence`.
-     Leave top-level `import` flat (collides with `evidence import`).
-5. Do not group core commands.
-6. Treat each Tier 2 family as its own PR; the collisions found while drafting
+4. Tier 2a `policy generate` / `policy record` is implemented. Keep
+   `coverage` flat for now, and do not move `migrate`/`explain`/`fix`/
+   `calibrate`.
+5. Defer Tier 2b until there is user feedback or nearby replay maintenance:
+   a `replay` noun (`replay bundle`, `replay run`). Not `evidence`. Leave
+   top-level `import` flat (collides with `evidence import`).
+6. Do not group core commands.
+7. Treat each Tier 2 family as its own PR; the collisions found while drafting
    Tier 2 are exactly why a bundled restructure is unsafe.
 
 ## Review Checklist For Future Grouping PRs

--- a/docs/reference/cli/generate.md
+++ b/docs/reference/cli/generate.md
@@ -1,20 +1,24 @@
-# assay generate
+# assay policy generate
 
 Generate policy scaffolding from trace or profile inputs.
+
+The legacy top-level form `assay generate` remains available as a hidden
+compatibility shim and prints a deprecation warning. New usage should prefer
+`assay policy generate`.
 
 ---
 
 ## Synopsis
 
 ```bash
-assay generate [OPTIONS]
+assay policy generate [OPTIONS]
 ```
 
 ---
 
 ## Description
 
-`assay generate` supports two modes:
+`assay policy generate` supports two modes:
 
 - single-run mode from `--input` trace events
 - profile mode from `--profile` stability data
@@ -50,19 +54,19 @@ For parity hardening, the key reviewer-facing surface is `--diff`: it previews h
 ### Trace input
 
 ```bash
-assay generate --input traces/session.jsonl --output policy.yaml
+assay policy generate --input traces/session.jsonl --output policy.yaml
 ```
 
 ### Diff preview (no write)
 
 ```bash
-assay generate --input traces/session.jsonl --output policy.yaml --diff --dry-run
+assay policy generate --input traces/session.jsonl --output policy.yaml --diff --dry-run
 ```
 
 ### Profile input
 
 ```bash
-assay generate --profile .assay/profile.json --min-stability 0.8 --new-is-risky
+assay policy generate --profile .assay/profile.json --min-stability 0.8 --new-is-risky
 ```
 
 ---

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -29,7 +29,7 @@ assay --version
 | Command | Description |
 |---------|-------------|
 | [`assay run`](run.md) | Run tests against traces |
-| [`assay generate`](generate.md) | Generate policy scaffolding from trace/profile input |
+| [`assay policy`](policy.md) | Author, validate, format, and migrate policies |
 | [`assay explain`](explain.md) | Explain why trace steps were allowed/blocked |
 | [`assay bundle`](bundle.md) | Create/verify replay bundles |
 | [`assay replay`](replay.md) | Replay from a replay bundle |
@@ -82,10 +82,10 @@ assay ci --config eval.yaml --trace-file traces/golden.jsonl --sarif sarif.json 
 
 ```bash
 # Generate policy from trace
-assay generate --input traces/session.jsonl --output policy.yaml
+assay policy generate --input traces/session.jsonl --output policy.yaml
 
 # Preview changes against existing policy file
-assay generate --input traces/session.jsonl --output policy.yaml --diff --dry-run
+assay policy generate --input traces/session.jsonl --output policy.yaml --diff --dry-run
 ```
 
 ### Replay Bundles
@@ -217,13 +217,13 @@ See [Configuration](../config/index.md) for full reference.
 
     [:octicons-arrow-right-24: Full reference](explain.md)
 
--   :material-source-branch:{ .lg .middle } __assay generate__
+-   :material-source-branch:{ .lg .middle } __assay policy__
 
     ---
 
-    Generate policy scaffolding from traces/profiles and preview diffs.
+    Author, validate, format, and migrate policies.
 
-    [:octicons-arrow-right-24: Full reference](generate.md)
+    [:octicons-arrow-right-24: Full reference](policy.md)
 
 -   :material-import:{ .lg .middle } __assay import__
 

--- a/docs/reference/cli/policy.md
+++ b/docs/reference/cli/policy.md
@@ -1,0 +1,60 @@
+# assay policy
+
+Policy authoring, validation, formatting, and migration commands.
+
+The policy family now owns policy-authoring commands. The legacy top-level
+forms `assay generate` and `assay record` remain available as hidden
+compatibility shims and print deprecation warnings.
+
+---
+
+## Synopsis
+
+```bash
+assay policy <COMMAND> [OPTIONS]
+```
+
+---
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| [`assay policy generate`](generate.md) | Generate policy scaffolding from trace/profile input. |
+| `assay policy record` | Capture runtime behavior and generate a policy. |
+| `assay policy validate` | Validate policy syntax and v2 JSON Schemas. |
+| `assay policy migrate` | Migrate v1.x constraints policies to v2.0 schemas. |
+| `assay policy fmt` | Format policy YAML. |
+
+---
+
+## Examples
+
+### Generate From A Trace
+
+```bash
+assay policy generate --input traces/session.jsonl --output policy.yaml
+```
+
+### Capture And Generate
+
+```bash
+assay policy record --output policy.yaml -- npm test
+```
+
+### Validate A Policy
+
+```bash
+assay policy validate --input policy.yaml
+```
+
+---
+
+## Compatibility
+
+- `assay generate ...` still runs as a hidden compatibility shim for
+  `assay policy generate ...`.
+- `assay record ...` still runs as a hidden compatibility shim for
+  `assay policy record ...`.
+- Output shapes, exit codes, generated policy behavior, and policy schema
+  semantics are unchanged.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,7 +192,8 @@ nav:
     - assay init: reference/cli/init.md
     - assay validate: reference/cli/validate.md
     - assay run: reference/cli/run.md
-    - assay generate: reference/cli/generate.md
+    - assay policy: reference/cli/policy.md
+    - assay policy generate: reference/cli/generate.md
     - assay explain: reference/cli/explain.md
     - assay doctor: reference/cli/doctor.md
     - assay watch: reference/cli/watch.md


### PR DESCRIPTION
## Summary

Starts the corrected Tier 2a CLI grouping from the command-grouping RFC by making policy authoring canonical under `assay policy`.

What changed:

- adds `assay policy generate` and `assay policy record`
- keeps legacy `assay generate` and `assay record` as hidden compatibility shims with stderr deprecation warnings
- reuses the existing generate/record handlers directly, with no policy-generation behavior changes
- adds parser and binary help/deprecation regression tests
- updates CLI docs, mkdocs nav, RFC status, and the changelog

## Boundary

This PR intentionally does not move `coverage`, `migrate`, `explain`, `fix`, or `calibrate` under `policy`.

It also does not change generated policy output, exit codes, policy schemas, Trust Basis behavior, evidence schemas, or replay/bundle grouping.

## Validation

Ran locally:

```bash
cargo fmt --check
cargo test -p assay-cli cli::args::tests::policy_group_accepts_authoring_paths_and_legacy_shims_are_hidden -- --nocapture
cargo test -p assay-cli --test policy_command_grouping_test -- --nocapture
cargo test -p assay-cli --test contract_docs_generate_explain -- --nocapture
cargo test -p assay-cli --test contract_generate_g1 -- --nocapture
cargo test -p assay-cli --test generate_golden -- --nocapture
cargo clippy -p assay-cli --all-targets -- -D warnings
uv run --with-requirements docs/requirements-ci.txt mkdocs build --strict
git diff --check
```

Pre-push hooks also passed, including workspace clippy and linux compile gate.
