### PR TITLE
docs: sync roadmap after v3.13

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,11 +1,24 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-03-27, K1 formalized):** Q1 DX/refactor convergence is closed on `main` (RFC-001/002/003/004).
+> **Status sync (2026-06-01, post-`v3.13.0`):** the latest public release is
+> **`v3.13.0`**. The workspace version on `main` is **`3.13.0`**. Post-release
+> `main` currently also contains the MCP execution-record verifier edge-test
+> follow-up and Tier 2a CLI grouping for `assay policy generate` /
+> `assay policy record`; those are merged repository truth, not a separate
+> crates.io release yet.
+> The current execution posture is: keep remaining CLI grouping trigger-gated,
+> keep Assay-Runner repository extraction gated, treat Assay-Harness `v3.13.0`
+> compatibility as verified by its release-binary proof rail
+> ([run 26756652781](https://github.com/Rul1an/Assay-Harness/actions/runs/26756652781)),
+> and use the capability-diff / `assay-action` preview decision as the next
+> product-roadmap checkpoint.
+>
+> **Historical status sync (2026-03-27, K1 formalized):** Q1 DX/refactor convergence is closed on `main` (RFC-001/002/003/004).
 > Evidence-as-a-product (ADR-025), protocol adapters (ADR-026), and MCP governance/enforcement (ADR-032 Wave24-Wave42) are materially implemented on `main`.
 > Governance support ADRs [ADR-027](architecture/ADR-027-Tool-Taxonomy.md) through [ADR-031](architecture/ADR-031-Coverage-v1.1-DX-Polish.md) are implemented on `main` and should be read as delivered contracts, not pending proposals.
 > **BYOS truth (ADR-015):** Phase 1 is complete on `main`: `push`, `pull`, `list`, `store-status`, `.assay/store.yaml` config, and provider quickstart docs (S3, B2, MinIO) are all shipped.
 > Split refactor program is closed loop through Wave7C Step3 on `main` (see [plan](architecture/PLAN-split-refactor-2026q1.md), [report](architecture/REPORT-split-refactor-2026q1.md), [program review pack](contributing/SPLIT-REVIEW-PACK-2026q1-program.md)).
-> `E1`, `G1`, `G2`, `P1`, `T1a`, `T1b`, and `G3` are merged on `main`; workspace version is **`3.9.2`** and OWASP signal-aware pack floors align to `>=3.2.3`.
+> `E1`, `G1`, `G2`, `P1`, `T1a`, `T1b`, and `G3` are merged on `main`; OWASP signal-aware pack floors align to `>=3.2.3`.
 > **Sequence:** `T1a → T1b → G3 → P2a → H1 → P2b` shipped on `main` (**`a2a-signal-followup`** first publicly released in **`v3.3.0`**). **`G4-A` Phase 1** (A2A `payload.discovery` evidence seam), **`P2c`** — built-in **`a2a-discovery-card-followup`** (A2A-DC-001 / A2A-DC-002), and **`K1-A` Phase 1** (`payload.handoff`) are part of the public **`v3.4.0`** line. **`K2-A` Phase 1** (MCP authorization-discovery evidence) first became public in **`v3.5.0`** and is carried forward through **`v3.5.1`**, which also adds the honest official-MCP-Registry publication foundation for `assay-mcp-server`. **`v3.6.0`** added the first external-eval receipt lane for Promptfoo assertion-component results. **`v3.7.0`** makes the first three receipt families claim-visible: eval outcomes, runtime decision details, and inventory/provenance surfaces, starting with Promptfoo, OpenFeature, and CycloneDX ML-BOM. **`v3.8.0`** adds machine-readable receipt/import JSON Schemas for those surfaces plus the importer-only Mastra score receipt lane. **`v3.9.0`** adds the post-schema consolidation surfaces: product-truth alignment, `trust-basis assert`, `evidence schema` CLI access, static Trust Card HTML, policy snapshot digest visibility, and tool-definition digest visibility. **`v3.9.1`** is a release-truth patch that publishes the public three-family evidence receipts note under an immutable tag; **`v3.9.2`** prepares the proof page, assurance mapping note, and P57 seeding pack for release-truth tagging while keeping Pydantic/Mastra lanes importer-only unless a future claim family is explicitly defined. **G4-A** follow-up remains post-merge verification / release-truth hygiene only (no new G4 semantics). **`K1`** remains shipped as the active A2A evidence-first line, adapter-first and explicitly **not** a pack wave. **`K2`** is now the active public MCP authorization-discovery line, still evidence-first and CI-native, and still **not** a pack in the same slice — see [PLAN-K1](architecture/PLAN-K1-A2A-HANDOFF-DELEGATION-ROUTE-EVIDENCE-2026q2.md), [PLAN-K2](architecture/PLAN-K2-MCP-AUTHORIZATION-DISCOVERY-EVIDENCE-2026q2.md), [K1-A freeze](architecture/K1-A-PHASE1-FREEZE.md), [K2-A freeze](architecture/K2-A-PHASE1-FREEZE.md), and [K2-A freeze prep](architecture/K2-A-PHASE1-FREEZE-PREP.md). References: [PLAN-T1b](architecture/PLAN-T1b-TRUST-CARD-2026q2.md), [PLAN-G3](architecture/PLAN-G3-AUTHORIZATION-CONTEXT-EVIDENCE-2026q2.md), [PLAN-H1](architecture/PLAN-H1-TRUST-KERNEL-ALIGNMENT-RELEASE-HARDENING.md), [MIGRATION-TRUST-COMPILER-3.2.md](architecture/MIGRATION-TRUST-COMPILER-3.2.md).
 > **Shipped (trust compiler line):** **`P2a`** **`mcp-signal-followup`**, **`H1`** alignment, **`P2b`** **`a2a-signal-followup`** — see [PLAN-P2b](architecture/PLAN-P2b-A2A-SIGNAL-FOLLOWUP-CLAIM-PACK.md), §Q3 2026, [RFC-005](architecture/RFC-005-trust-compiler-mvp-2026q2.md) §6. Optional small **test-only** follow-ups (e.g. shared `tests/common` bundle builders for H1/P2a parity) do not change product semantics.
 > **Evidence portability (P31-P49):** Prepared for the **`v3.8.0`** trust-compiler line: supported external eval outcomes, runtime decision details, and inventory/provenance surfaces can enter the trust-compiler path as bounded receipts with machine-readable JSON Schema contracts. The first three claim-visible families are Promptfoo assertion-component results, OpenFeature boolean `EvaluationDetails`, and CycloneDX ML-BOM model components. Mastra ScoreEvent receipts are schema-covered but remain importer-only, not a Trust Basis claim family; P14d freezes that score-receipt boundary until any future score-derived claim has explicit semantics, Trust Card impact, and Harness posture. These are downstream evidence-portability lanes, not integration, partnership, correctness, safety, or compliance-truth claims — see the [receipt family matrix](reference/receipt-family-matrix.json), [receipt schema registry](reference/receipt-schemas/README.md), and [From Promptfoo JSONL to Evidence Receipts](notes/FROM-PROMPTFOO-JSONL-TO-EVIDENCE-RECEIPTS.md).
@@ -177,6 +190,14 @@ runtime commands now live under `assay mcp`, with hidden compatibility shims for
 the previous flat `assay discover`, `assay kill`, and `assay tool ...` paths.
 This is a discoverability and scripting pass only; it does not change scoring,
 artifact schemas, Trust Basis semantics, or MCP policy behavior.
+
+After `v3.13.0`, `main` also contains the Tier 2a policy-authoring grouping:
+`assay policy generate` and `assay policy record` are canonical, while the
+previous top-level `assay generate` and `assay record` paths remain hidden
+compatibility shims with stderr deprecation warnings. The rest of the CLI
+grouping RFC remains deliberately trigger-gated: `trust` and `replay` should
+move only with a concrete docs/user-maintenance reason, not just to reduce the
+top-level command count.
 
 ### Happy Path (Core Workflow)
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,10 +2,10 @@
 
 > **Status sync (2026-06-01, post-`v3.13.0`):** the latest public release is
 > **`v3.13.0`**. The workspace version on `main` is **`3.13.0`**. Post-release
-> `main` currently also contains the MCP execution-record verifier edge-test
-> follow-up and Tier 2a CLI grouping for `assay policy generate` /
-> `assay policy record`; those are merged repository truth, not a separate
-> crates.io release yet.
+> `main` currently also contains the new `assay evidence verify-mcp-records`
+> command, its edge-test follow-up, and Tier 2a CLI grouping for
+> `assay policy generate` / `assay policy record`; those are merged repository
+> truth, not a separate crates.io release yet.
 > The current execution posture is: keep remaining CLI grouping trigger-gated,
 > keep Assay-Runner repository extraction gated, treat Assay-Harness `v3.13.0`
 > compatibility as verified by its release-binary proof rail

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,14 +1,15 @@
 # Assay Roadmap 2026
 
 > **Status sync (2026-06-01, post-`v3.13.0`):** the latest public release is
-> **`v3.13.0`**. The workspace version on `main` is **`3.13.0`**. Post-release
+> tagged **`v3.13.0`**; the Cargo workspace/package version on `main` is
+> **`3.13.0`**. Post-release
 > `main` currently also contains the new `assay evidence verify-mcp-records`
 > command, its edge-test follow-up, and Tier 2a CLI grouping for
 > `assay policy generate` / `assay policy record`; those are merged repository
 > truth, not a separate crates.io release yet.
 > The current execution posture is: keep remaining CLI grouping trigger-gated,
 > keep Assay-Runner repository extraction gated, treat Assay-Harness `v3.13.0`
-> compatibility as verified by its release-binary proof rail
+> compatibility as verified by its release-binary compatibility CI check
 > ([run 26756652781](https://github.com/Rul1an/Assay-Harness/actions/runs/26756652781)),
 > and use the capability-diff / `assay-action` preview decision as the next
 > product-roadmap checkpoint.
@@ -194,7 +195,7 @@ artifact schemas, Trust Basis semantics, or MCP policy behavior.
 After `v3.13.0`, `main` also contains the Tier 2a policy-authoring grouping:
 `assay policy generate` and `assay policy record` are canonical, while the
 previous top-level `assay generate` and `assay record` paths remain hidden
-compatibility shims with stderr deprecation warnings. The rest of the CLI
+compatibility shims with `stderr` deprecation warnings. The rest of the CLI
 grouping RFC remains deliberately trigger-gated: `trust` and `replay` should
 move only with a concrete docs/user-maintenance reason, not just to reduce the
 top-level command count.


### PR DESCRIPTION
Summary

Updates the public roadmap head after the v3.13.0 release and the post-release main merges.

What changed:
- records v3.13.0 as the latest public Assay release and 3.13.0 as the current main workspace version
- separates post-release main truth from released/crates.io truth for MCP execution-record verifier follow-up and Tier 2a policy grouping
- records the current roadmap posture: remaining CLI grouping is trigger-gated, Runner extraction remains gated, Harness v3.13 compatibility is verified, and capability-diff / assay-action preview is the next roadmap checkpoint
- updates the CLI surface section to include the post-v3.13 `assay policy generate` / `assay policy record` grouping on main

Validation

- `git diff --check`
- local `mkdocs` was not installed in this environment; docs CI should run mkdocs-strict

Assay-Harness note

Assay-Harness compatibility against Assay v3.13.0 was verified via Harness CI run 26756652781.
