### PR TITLE
chore: prep v3.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.14.0] - 2026-06-01
+
+- Added `assay evidence verify-mcp-records`, a downstream consumer verifier
+  for SEP-2787 attestation and server execution-record fixture pairing. The
+  command computes the SEP-2787 JCS digest, checks decision/outcome `backLink`
+  fields, and emits an `assay.mcp.execution-record-pairing.report.v0` report.
+  It does not verify signatures, establish issuer key trust, proxy MCP, prove
+  policy correctness, prove side effects, or claim runtime truth.
+
 - Grouped policy authoring under `assay policy generate` and
   `assay policy record`. The previous top-level `assay generate` and
   `assay record` commands remain available as hidden compatibility shims with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.13.0"
+version = "3.14.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.13.0"
+version = "3.14.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -73,18 +73,18 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.13.0" }
-assay-common = { path = "crates/assay-common", version = "3.13.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.13.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.13.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.13.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.13.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.13.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.13.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.13.0" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.13.0" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.13.0" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.13.0" }
+assay-core = { path = "crates/assay-core", version = "3.14.0" }
+assay-common = { path = "crates/assay-common", version = "3.14.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.14.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.14.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.14.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.14.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.14.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.14.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.14.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.14.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.14.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.14.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,16 +1,15 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-06-01, post-`v3.13.0`):** the latest public release is
-> tagged **`v3.13.0`**; the Cargo workspace/package version on `main` is
-> **`3.13.0`**. Post-release
-> `main` currently also contains the new `assay evidence verify-mcp-records`
-> command, its edge-test follow-up, and Tier 2a CLI grouping for
-> `assay policy generate` / `assay policy record`; those are merged repository
-> truth, not a separate crates.io release yet.
+> **Status sync (2026-06-01, `v3.14.0` release prep):** the `v3.14.0`
+> release line carries the new `assay evidence verify-mcp-records` command,
+> its edge-test follow-up, and Tier 2a CLI grouping for
+> `assay policy generate` / `assay policy record`. The Cargo
+> workspace/package version on `main` is **`3.14.0`** for this release cut.
 > The current execution posture is: keep remaining CLI grouping trigger-gated,
 > keep Assay-Runner repository extraction gated, treat Assay-Harness `v3.13.0`
 > compatibility as verified by its release-binary compatibility CI check
 > ([run 26756652781](https://github.com/Rul1an/Assay-Harness/actions/runs/26756652781)),
+> refresh Assay-Harness compatibility to `v3.14.0` after the Assay tag,
 > and use the capability-diff / `assay-action` preview decision as the next
 > product-roadmap checkpoint.
 >
@@ -192,10 +191,12 @@ the previous flat `assay discover`, `assay kill`, and `assay tool ...` paths.
 This is a discoverability and scripting pass only; it does not change scoring,
 artifact schemas, Trust Basis semantics, or MCP policy behavior.
 
-After `v3.13.0`, `main` also contains the Tier 2a policy-authoring grouping:
+The `v3.14.0` release line also includes the Tier 2a policy-authoring grouping:
 `assay policy generate` and `assay policy record` are canonical, while the
 previous top-level `assay generate` and `assay record` paths remain hidden
-compatibility shims with `stderr` deprecation warnings. The rest of the CLI
+compatibility shims with `stderr` deprecation warnings. It also adds
+`assay evidence verify-mcp-records` as a downstream verifier for SEP-2787
+attestation and server execution-record fixture pairing. The rest of the CLI
 grouping RFC remains deliberately trigger-gated: `trust` and `replay` should
 move only with a concrete docs/user-maintenance reason, not just to reduce the
 top-level command count.


### PR DESCRIPTION
## Summary

Prepares the `v3.14.0` release cut after the post-`v3.13.0` main-only work landed.

This PR:

- bumps the Cargo workspace version and internal workspace dependency pins from `3.13.0` to `3.14.0`
- updates `Cargo.lock` package versions to `3.14.0`
- cuts the changelog section for `3.14.0` on `2026-06-01`
- adds the missing release note for `assay evidence verify-mcp-records`
- flips the roadmap from post-`v3.13.0` main-only wording to the `v3.14.0` release-prep line
- records that Assay-Harness compatibility should be refreshed to `v3.14.0` after the Assay tag

## Boundary

No feature code, schema behavior, CLI routing, Trust Basis semantics, capability-diff Scope B work, LiveKit Trust Basis claims, or additional CLI grouping changes.

## Validation

Ran locally:

```bash
cargo check -p assay-cli
cargo fmt --check
git diff --check
cargo test -p assay-cli --test evidence_test mcp_execution_records -- --nocapture
cargo publish --dry-run -p assay-common --allow-dirty --locked
```

Also ran:

```bash
cargo publish --dry-run -p assay-cli --allow-dirty --locked
```

That fails at the expected publish-order precondition because `assay-cli v3.14.0` depends on internal `assay-common ^3.14.0`, which is not on crates.io until the release sequence publishes internal crates first. The leaf `assay-common` dry-run passes.

## Next After Merge

- tag `v3.14.0` from main
- run the release workflow / crates.io publish sequence in dependency order
- refresh Assay-Harness compatibility to `v3.14.0` after the Assay release asset exists
