### PR TITLE
docs(runner): scope path projection Slice 1 (declared-rule only)

### DIFF
--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -27,6 +27,7 @@ Phase 2B capability-diff planning slice.
 - [Runner cross-runtime diff Phase 2C decisions (A1+B3+C1)](cross-runtime-diff-decisions.md)
 - [Runner cross-runtime diff v0 contract](cross-runtime-diff-v0.md)
 - [Runner projection roadmap](projection-roadmap.md)
+- [Runner path projection Slice 1 plan (declared-rule only)](path-projection-slice1-plan.md)
 - [Runner schema overview](schemas-overview.md)
 - [Runner runtime drift projection v0/v0.2 contract](runtime-drift-v0.md)
 - [Runner cross-runtime diff v0 clean-output JSON Schema](schema/cross-runtime-diff-v0-clean.schema.json)

--- a/docs/reference/runner/path-projection-slice1-plan.md
+++ b/docs/reference/runner/path-projection-slice1-plan.md
@@ -1,0 +1,102 @@
+# Runner Path Projection — Slice 1 Plan (declared-rule only)
+
+> **Status:** slice-scoping plan, not a shipped contract. This narrows
+> the path-projection work already described in
+> [`projection-roadmap.md`](projection-roadmap.md) into the smallest
+> buildable first slice. It does not change the Runner archive v0
+> contracts, add a public CLI surface, infer heuristic classes, touch
+> network projection, or promote projection output to primary evidence.
+
+## Why a slice, not a new plan
+
+The projection roadmap already defines the path classes, the network
+taxonomy, the confidence levels, and the acceptance criteria. The
+cross-runtime drift comparator already carries that taxonomy as
+**vocabulary-only** metadata: it validates declared projection classes
+and preserves `unknown`, but it does **not yet infer** a class from a raw
+path or endpoint.
+
+So the gap is not more planning. It is one bounded implementation step:
+turn the documented taxonomy into a computed projection for the
+highest-confidence case only. This slice scopes that step.
+
+## Slice 1 scope
+
+Implement path projection for **declared-rule mappings only**:
+
+- workload-contract paths (declared input / output / scratch), and
+- the run-workdir prefix when it is declared by workflow or artifact
+  metadata.
+
+Everything else stays `unknown`. No heuristics, no network, no taxonomy
+inference beyond declared rules.
+
+In scope:
+
+```text
+raw filesystem_paths (unchanged, still source of truth)
+  + projected rows for declared matches only:
+      raw_path, projected_path, path_class, rule, confidence=declared
+  + unmatched raw paths summarized by count + samples, class=unknown
+```
+
+Explicitly **out of this slice** (later slices, same engine):
+
+- Slice 2: heuristic path classes (`runtime_package`, `provider_sdk`,
+  `loader`, `cache`) at `confidence=heuristic`.
+- Slice 3: network endpoint projection (`provider_api`, `dns`,
+  `telemetry`, `package_fetch`) reusing the same projection engine and
+  confidence model.
+
+## Output shape (extends the roadmap example)
+
+```json
+{
+  "raw_path": "/opt/actions-runner/_work/assay/.../workdir/fixture-input.txt",
+  "projected_path": "workdir/input",
+  "path_class": "workload_fixture",
+  "rule": "workload_contract_input_path",
+  "confidence": "declared",
+  "relation": "inside_run_workdir"
+}
+```
+
+The raw `filesystem_paths` set is unchanged. Projected rows are additive.
+
+## Acceptance rules
+
+1. Raw path sets remain present and unchanged; projection is additive.
+2. Every projected row carries `rule` and `confidence`.
+3. Slice 1 emits `confidence=declared` only. A row that would require a
+   prefix/substring heuristic is left `unknown`, not guessed.
+4. Workdir-prefix stripping is allowed only when the prefix is declared
+   by workflow or artifact metadata; an undeclared prefix stays raw.
+5. Unmatched raw paths are summarized by count and samples; `unknown` is
+   not a failure.
+6. Projection is idempotent: projecting a projected report is a no-op.
+7. Projection emits no policy verdict. `path_class` is reviewer
+   vocabulary, not an allow/deny or safety judgment.
+8. A report can show "raw paths differ, projected paths match" without
+   asserting the workloads are semantically equivalent.
+
+## Non-claims
+
+- This slice does not classify a path as safe, malicious, expected, or
+  policy-relevant. Class strings are reviewer vocabulary only.
+- This slice does not infer heuristic classes; only declared rules
+  produce a class in Slice 1.
+- This slice does not change the Runner archive v0 schema, add a CLI
+  surface, or promote projection to primary evidence.
+- A projected match is not a claim of behavioral equivalence between two
+  runs; raw rows remain the source of truth.
+- `unknown` is an honest absence of a declared rule, not a finding.
+
+## Slice gate (review-ready when)
+
+- Declared-rule path projection emits additive rows with
+  `confidence=declared` for the workload-contract and declared-workdir
+  cases.
+- Raw `filesystem_paths` round-trip unchanged.
+- Idempotence and `unknown`-preservation are covered by tests.
+- A fixture shows "raw differs / projected matches" with the
+  non-equivalence non-claim attached.

--- a/docs/reference/runner/projection-roadmap.md
+++ b/docs/reference/runner/projection-roadmap.md
@@ -79,6 +79,10 @@ Path projection is the highest-leverage next step. Current drift reports
 show too much absolute run-directory noise. The fix is not to remove raw
 paths; it is to add a logical path layer above them.
 
+> The smallest buildable first slice of this phase — declared-rule
+> projection only, no heuristics, no network — is scoped in
+> [`path-projection-slice1-plan.md`](path-projection-slice1-plan.md).
+
 ### Shape
 
 ```json


### PR DESCRIPTION
## Summary

Plan-only, docs-only. Narrows **Phase 1** of the existing
[`projection-roadmap.md`](docs/reference/runner/projection-roadmap.md)
into the smallest buildable first slice.

The projection roadmap already specifies path classes, the network taxonomy, confidence levels, and acceptance criteria, and the cross-runtime drift comparator already carries that taxonomy as **vocabulary-only** metadata (it validates declared classes and preserves `unknown`, but does **not yet infer** a class from a raw path/endpoint). The gap is one bounded implementation step, not more planning.

## What this scopes

**Slice 1 = declared-rule path projection only:**
- workload-contract paths + the declared run-workdir prefix → additive projected rows at `confidence=declared`
- everything else stays `unknown` (no heuristics, no network)
- raw `filesystem_paths` unchanged and authoritative
- projection is additive, idempotent, and emits reviewer vocabulary — not policy verdicts

**Explicitly deferred (later slices, same engine):**
- Slice 2: heuristic path classes (`runtime_package`, `provider_sdk`, `loader`, `cache`) at `confidence=heuristic`
- Slice 3: network endpoint projection (`provider_api`, `dns`, …)

## Boundary

- No Runner archive v0 schema change, no CLI surface, no evidence-contract change.
- Projection output stays secondary to raw rows; `path_class` is not a safety/allow/deny judgment.
- `unknown` is an honest absence of a declared rule, not a finding.

## Files

- `docs/reference/runner/path-projection-slice1-plan.md` (new)
- linked from `projection-roadmap.md` (Phase 1) and the runner `index.md`

## Validation

- `git diff --check`: clean
- Links resolve locally; mkdocs-strict left to CI