### PR TITLE
feat(runner): add fidelity verdict helper

### DIFF
--- a/crates/assay-runner-schema/src/fidelity.rs
+++ b/crates/assay-runner-schema/src/fidelity.rs
@@ -1,0 +1,450 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CgroupCorrelationStatus, KernelLayerStatus, ObservationHealth, ObservationHealthError,
+    OBSERVATION_HEALTH_SCHEMA,
+};
+
+pub const RUNNER_FIDELITY_VERDICT_SCHEMA: &str = "assay.runner.fidelity_verdict.v0";
+
+pub const PROJECTION_CLAIM_LEVEL_RAW_OBSERVED: &str = "raw_observed";
+pub const PROJECTION_CLAIM_LEVEL_PROJECTED_EQUIVALENT: &str = "projected_equivalent";
+pub const PROJECTION_CLAIM_LEVEL_INCONCLUSIVE: &str = "inconclusive";
+
+const NON_CLAIMS: &[&str] = &[
+    "fidelity_no_observation_health_replacement",
+    "fidelity_no_policy_correctness_verdict",
+    "fidelity_no_runtime_safety_verdict",
+    "fidelity_no_agent_quality_score",
+    "fidelity_no_probabilistic_confidence_score",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerFidelityVerdict {
+    Clean,
+    Clipped,
+    CorrelationPartial,
+    Failed,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimGateDecision {
+    Allowed,
+    Degraded,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunnerClaimGate {
+    pub reported_claims: ClaimGateDecision,
+    pub measured_positive_claims: ClaimGateDecision,
+    pub bounded_negative_claims: ClaimGateDecision,
+    pub per_binding_claims: ClaimGateDecision,
+}
+
+impl RunnerClaimGate {
+    #[must_use]
+    pub fn for_verdict(verdict: RunnerFidelityVerdict) -> Self {
+        match verdict {
+            RunnerFidelityVerdict::Clean => Self {
+                reported_claims: ClaimGateDecision::Allowed,
+                measured_positive_claims: ClaimGateDecision::Allowed,
+                bounded_negative_claims: ClaimGateDecision::Allowed,
+                per_binding_claims: ClaimGateDecision::Allowed,
+            },
+            RunnerFidelityVerdict::Clipped => Self {
+                reported_claims: ClaimGateDecision::Allowed,
+                measured_positive_claims: ClaimGateDecision::Degraded,
+                bounded_negative_claims: ClaimGateDecision::Blocked,
+                per_binding_claims: ClaimGateDecision::Allowed,
+            },
+            RunnerFidelityVerdict::CorrelationPartial => Self {
+                reported_claims: ClaimGateDecision::Allowed,
+                measured_positive_claims: ClaimGateDecision::Degraded,
+                bounded_negative_claims: ClaimGateDecision::Blocked,
+                per_binding_claims: ClaimGateDecision::Blocked,
+            },
+            RunnerFidelityVerdict::NotApplicable => Self {
+                reported_claims: ClaimGateDecision::Allowed,
+                measured_positive_claims: ClaimGateDecision::Blocked,
+                bounded_negative_claims: ClaimGateDecision::Blocked,
+                per_binding_claims: ClaimGateDecision::Blocked,
+            },
+            RunnerFidelityVerdict::Failed => Self {
+                reported_claims: ClaimGateDecision::Blocked,
+                measured_positive_claims: ClaimGateDecision::Blocked,
+                bounded_negative_claims: ClaimGateDecision::Blocked,
+                per_binding_claims: ClaimGateDecision::Blocked,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunnerFidelityReason {
+    pub field: String,
+    pub observed: String,
+    pub rule: String,
+}
+
+impl RunnerFidelityReason {
+    fn new(field: &str, observed: impl ToString, rule: &str) -> Self {
+        Self {
+            field: field.to_string(),
+            observed: observed.to_string(),
+            rule: rule.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunnerFidelityVerdictReport {
+    pub schema: String,
+    pub source_schema: String,
+    pub run_id: String,
+    pub verdict: RunnerFidelityVerdict,
+    pub claim_gate: RunnerClaimGate,
+    pub reasons: Vec<RunnerFidelityReason>,
+    pub non_claims: Vec<String>,
+}
+
+impl RunnerFidelityVerdictReport {
+    #[must_use]
+    pub fn from_observation_health(health: &ObservationHealth) -> Self {
+        let mut reasons = Vec::new();
+        let verdict = classify_observation_health(health, &mut reasons);
+        let mut claim_gate = RunnerClaimGate::for_verdict(verdict);
+
+        if health.cgroup_correlation == CgroupCorrelationStatus::Partial
+            && verdict != RunnerFidelityVerdict::Failed
+        {
+            claim_gate.per_binding_claims = ClaimGateDecision::Blocked;
+        }
+
+        Self {
+            schema: RUNNER_FIDELITY_VERDICT_SCHEMA.to_string(),
+            source_schema: OBSERVATION_HEALTH_SCHEMA.to_string(),
+            run_id: health.run_id.clone(),
+            verdict,
+            claim_gate,
+            reasons,
+            non_claims: NON_CLAIMS
+                .iter()
+                .map(|non_claim| (*non_claim).to_string())
+                .collect(),
+        }
+    }
+
+    #[must_use]
+    pub fn projection_claim_level_decision(&self, claim_level: &str) -> ClaimGateDecision {
+        if self.verdict == RunnerFidelityVerdict::Failed {
+            return ClaimGateDecision::Blocked;
+        }
+
+        match claim_level {
+            PROJECTION_CLAIM_LEVEL_RAW_OBSERVED | PROJECTION_CLAIM_LEVEL_PROJECTED_EQUIVALENT => {
+                self.claim_gate.measured_positive_claims
+            }
+            PROJECTION_CLAIM_LEVEL_INCONCLUSIVE => ClaimGateDecision::Allowed,
+            _ => ClaimGateDecision::Blocked,
+        }
+    }
+}
+
+fn classify_observation_health(
+    health: &ObservationHealth,
+    reasons: &mut Vec<RunnerFidelityReason>,
+) -> RunnerFidelityVerdict {
+    if let Err(error) = health.validate() {
+        reasons.push(reason_for_health_error(error, health));
+        return RunnerFidelityVerdict::Failed;
+    }
+
+    if health.platform != "linux" {
+        reasons.push(RunnerFidelityReason::new(
+            "platform",
+            &health.platform,
+            "non_linux_platform_has_no_kernel_measurement_surface",
+        ));
+        return RunnerFidelityVerdict::NotApplicable;
+    }
+
+    if health.kernel_layer == KernelLayerStatus::Absent {
+        reasons.push(RunnerFidelityReason::new(
+            "kernel_layer",
+            "absent",
+            "absent_kernel_layer_blocks_measured_kernel_effect_claims",
+        ));
+        return RunnerFidelityVerdict::NotApplicable;
+    }
+
+    let is_clipped = if health.ringbuf_drops > 0 {
+        reasons.push(RunnerFidelityReason::new(
+            "ringbuf_drops",
+            health.ringbuf_drops,
+            "ringbuf_drops_block_bounded_negative_claims",
+        ));
+        true
+    } else if health.kernel_layer == KernelLayerStatus::PartialRingbufDrops {
+        reasons.push(RunnerFidelityReason::new(
+            "kernel_layer",
+            "partial_ringbuf_drops",
+            "partial_kernel_layer_blocks_bounded_negative_claims",
+        ));
+        true
+    } else {
+        false
+    };
+
+    let is_correlation_partial = health.cgroup_correlation == CgroupCorrelationStatus::Partial;
+    if is_correlation_partial {
+        reasons.push(RunnerFidelityReason::new(
+            "cgroup_correlation",
+            "partial",
+            "partial_cgroup_correlation_blocks_per_binding_claims",
+        ));
+    }
+
+    if is_clipped {
+        return RunnerFidelityVerdict::Clipped;
+    }
+
+    if is_correlation_partial {
+        return RunnerFidelityVerdict::CorrelationPartial;
+    }
+
+    reasons.push(RunnerFidelityReason::new(
+        "observation_health",
+        "clean",
+        "complete_kernel_layer_zero_drops_clean_cgroup_correlation",
+    ));
+    RunnerFidelityVerdict::Clean
+}
+
+fn reason_for_health_error(
+    error: ObservationHealthError,
+    health: &ObservationHealth,
+) -> RunnerFidelityReason {
+    match error {
+        ObservationHealthError::InvalidSchema => RunnerFidelityReason::new(
+            "schema",
+            &health.schema,
+            "observation_health_schema_must_match_source_schema",
+        ),
+        ObservationHealthError::EmptyRunId => {
+            RunnerFidelityReason::new("run_id", "", "run_id_required_for_fidelity_verdict")
+        }
+        ObservationHealthError::RingbufDropsRequirePartialKernelLayer => RunnerFidelityReason::new(
+            "ringbuf_drops",
+            health.ringbuf_drops,
+            "ringbuf_drops_require_partial_kernel_layer",
+        ),
+        ObservationHealthError::NonLinuxRequiresAbsentKernelLayer => RunnerFidelityReason::new(
+            "kernel_layer",
+            kernel_layer_label(health.kernel_layer),
+            "non_linux_platform_requires_absent_kernel_layer",
+        ),
+        ObservationHealthError::FailedCgroupCorrelation => RunnerFidelityReason::new(
+            "cgroup_correlation",
+            "failed",
+            "failed_cgroup_correlation_blocks_runner_measured_claims",
+        ),
+    }
+}
+
+fn kernel_layer_label(status: KernelLayerStatus) -> &'static str {
+    match status {
+        KernelLayerStatus::Complete => "complete",
+        KernelLayerStatus::PartialRingbufDrops => "partial_ringbuf_drops",
+        KernelLayerStatus::Absent => "absent",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PolicyLayerStatus, SdkLayerStatus};
+
+    fn clean_health() -> ObservationHealth {
+        let mut health = ObservationHealth::new("run_001", "linux")
+            .with_policy_layer(PolicyLayerStatus::Present)
+            .with_sdk_layer(SdkLayerStatus::SelfReported)
+            .with_cgroup_correlation(CgroupCorrelationStatus::Clean);
+        health.kernel_layer = KernelLayerStatus::Complete;
+        health
+    }
+
+    #[test]
+    fn clean_health_allows_measured_and_bounded_negative_claims() {
+        let report = RunnerFidelityVerdictReport::from_observation_health(&clean_health());
+
+        assert_eq!(report.schema, RUNNER_FIDELITY_VERDICT_SCHEMA);
+        assert_eq!(report.source_schema, OBSERVATION_HEALTH_SCHEMA);
+        assert_eq!(report.verdict, RunnerFidelityVerdict::Clean);
+        assert_eq!(
+            report.claim_gate.measured_positive_claims,
+            ClaimGateDecision::Allowed
+        );
+        assert_eq!(
+            report.claim_gate.bounded_negative_claims,
+            ClaimGateDecision::Allowed
+        );
+        assert_eq!(
+            report.projection_claim_level_decision(PROJECTION_CLAIM_LEVEL_PROJECTED_EQUIVALENT),
+            ClaimGateDecision::Allowed
+        );
+    }
+
+    #[test]
+    fn ringbuf_drops_clip_measurement_and_block_negative_claims() {
+        let report = RunnerFidelityVerdictReport::from_observation_health(
+            &clean_health().with_ringbuf_drops(4),
+        );
+
+        assert_eq!(report.verdict, RunnerFidelityVerdict::Clipped);
+        assert_eq!(
+            report.claim_gate.measured_positive_claims,
+            ClaimGateDecision::Degraded
+        );
+        assert_eq!(
+            report.claim_gate.bounded_negative_claims,
+            ClaimGateDecision::Blocked
+        );
+        assert_eq!(
+            report.projection_claim_level_decision(PROJECTION_CLAIM_LEVEL_RAW_OBSERVED),
+            ClaimGateDecision::Degraded
+        );
+        assert!(report
+            .reasons
+            .iter()
+            .any(|reason| reason.rule == "ringbuf_drops_block_bounded_negative_claims"));
+    }
+
+    #[test]
+    fn partial_cgroup_correlation_blocks_per_binding_claims() {
+        let mut health = clean_health();
+        health.cgroup_correlation = CgroupCorrelationStatus::Partial;
+
+        let report = RunnerFidelityVerdictReport::from_observation_health(&health);
+
+        assert_eq!(report.verdict, RunnerFidelityVerdict::CorrelationPartial);
+        assert_eq!(
+            report.claim_gate.measured_positive_claims,
+            ClaimGateDecision::Degraded
+        );
+        assert_eq!(
+            report.claim_gate.per_binding_claims,
+            ClaimGateDecision::Blocked
+        );
+    }
+
+    #[test]
+    fn clipped_health_with_partial_correlation_preserves_both_degradation_reasons() {
+        let mut health = clean_health().with_ringbuf_drops(3);
+        health.cgroup_correlation = CgroupCorrelationStatus::Partial;
+
+        let report = RunnerFidelityVerdictReport::from_observation_health(&health);
+
+        assert_eq!(report.verdict, RunnerFidelityVerdict::Clipped);
+        assert_eq!(
+            report.claim_gate.bounded_negative_claims,
+            ClaimGateDecision::Blocked
+        );
+        assert_eq!(
+            report.claim_gate.per_binding_claims,
+            ClaimGateDecision::Blocked
+        );
+        assert!(report
+            .reasons
+            .iter()
+            .any(|reason| reason.rule == "ringbuf_drops_block_bounded_negative_claims"));
+        assert!(report
+            .reasons
+            .iter()
+            .any(|reason| reason.rule == "partial_cgroup_correlation_blocks_per_binding_claims"));
+    }
+
+    #[test]
+    fn non_linux_kernel_measurement_is_not_applicable_but_reported_claims_can_remain() {
+        let report = RunnerFidelityVerdictReport::from_observation_health(&ObservationHealth::new(
+            "run_macos",
+            "macos",
+        ));
+
+        assert_eq!(report.verdict, RunnerFidelityVerdict::NotApplicable);
+        assert_eq!(
+            report.claim_gate.reported_claims,
+            ClaimGateDecision::Allowed
+        );
+        assert_eq!(
+            report.claim_gate.measured_positive_claims,
+            ClaimGateDecision::Blocked
+        );
+    }
+
+    #[test]
+    fn failed_correlation_blocks_all_claims_from_this_health_record() {
+        let mut health = clean_health();
+        health.cgroup_correlation = CgroupCorrelationStatus::Failed;
+
+        let report = RunnerFidelityVerdictReport::from_observation_health(&health);
+
+        assert_eq!(report.verdict, RunnerFidelityVerdict::Failed);
+        assert_eq!(
+            report.claim_gate.reported_claims,
+            ClaimGateDecision::Blocked
+        );
+        assert_eq!(
+            report.claim_gate.measured_positive_claims,
+            ClaimGateDecision::Blocked
+        );
+        assert_eq!(
+            report.claim_gate.bounded_negative_claims,
+            ClaimGateDecision::Blocked
+        );
+        assert_eq!(
+            report.claim_gate.per_binding_claims,
+            ClaimGateDecision::Blocked
+        );
+    }
+
+    #[test]
+    fn invalid_non_linux_kernel_reason_uses_contract_vocabulary() {
+        let mut health = ObservationHealth::new("run_macos", "macos");
+        health.kernel_layer = KernelLayerStatus::Complete;
+
+        let report = RunnerFidelityVerdictReport::from_observation_health(&health);
+
+        assert_eq!(report.verdict, RunnerFidelityVerdict::Failed);
+        assert!(report.reasons.iter().any(|reason| {
+            reason.field == "kernel_layer"
+                && reason.observed == "complete"
+                && reason.rule == "non_linux_platform_requires_absent_kernel_layer"
+        }));
+    }
+
+    #[test]
+    fn serialization_uses_runner_verdict_vocabulary() {
+        let mut health = clean_health();
+        health.cgroup_correlation = CgroupCorrelationStatus::Partial;
+
+        let report = RunnerFidelityVerdictReport::from_observation_health(&health);
+        let json = serde_json::to_value(&report).expect("serializes");
+
+        assert_eq!(json["verdict"], "correlation_partial");
+        assert_eq!(json["claim_gate"]["per_binding_claims"], "blocked");
+    }
+
+    #[test]
+    fn unknown_projection_claim_level_is_blocked() {
+        let report = RunnerFidelityVerdictReport::from_observation_health(&clean_health());
+
+        assert_eq!(
+            report.projection_claim_level_decision("semantic_truth"),
+            ClaimGateDecision::Blocked
+        );
+    }
+}

--- a/crates/assay-runner-schema/src/lib.rs
+++ b/crates/assay-runner-schema/src/lib.rs
@@ -17,6 +17,7 @@
 
 mod archive_manifest;
 mod correlation;
+mod fidelity;
 mod health;
 mod sdk_event;
 mod surface;
@@ -29,6 +30,12 @@ pub use archive_manifest::{
 pub use correlation::{
     BindingWindow, CorrelationBinding, CorrelationReport, CorrelationReportError,
     CorrelationStatus, CORRELATION_REPORT_SCHEMA,
+};
+pub use fidelity::{
+    ClaimGateDecision, RunnerClaimGate, RunnerFidelityReason, RunnerFidelityVerdict,
+    RunnerFidelityVerdictReport, PROJECTION_CLAIM_LEVEL_INCONCLUSIVE,
+    PROJECTION_CLAIM_LEVEL_PROJECTED_EQUIVALENT, PROJECTION_CLAIM_LEVEL_RAW_OBSERVED,
+    RUNNER_FIDELITY_VERDICT_SCHEMA,
 };
 pub use health::{
     CgroupCorrelationStatus, KernelLayerStatus, ObservationHealth, ObservationHealthError,

--- a/docs/reference/observability/observability-fidelity-calibration.md
+++ b/docs/reference/observability/observability-fidelity-calibration.md
@@ -44,6 +44,14 @@ This is a reference shape, not a new schema. The experiment-scoped
 implementation that proved the pattern is
 `assay.experiment.agent_observability_fidelity.calibration.v0`.
 
+For the separate Runner per-run measurement-health gate, see
+[`../runner/fidelity-verdict-v0.md`](../runner/fidelity-verdict-v0.md).
+That contract derives `clean`, `clipped`, `correlation_partial`,
+`failed`, or `not_applicable` from one `observation_health.v0` record.
+It is not this calibration `agreement` vocabulary: calibration compares
+requested versus observed signals, while Runner fidelity gates what
+claim types may be interpreted from a run's measurement health.
+
 ## Agreement Semantics
 
 The central vocabulary is the agreement field:

--- a/docs/reference/runner/fidelity-verdict-v0.md
+++ b/docs/reference/runner/fidelity-verdict-v0.md
@@ -1,0 +1,201 @@
+# Runner Fidelity Verdict v0
+
+> **Status:** internal derived helper contract. This page defines the
+> `assay.runner.fidelity_verdict.v0` vocabulary and claim gate derived
+> from `assay.runner.observation_health.v0`. It does not wire the verdict
+> into Runner archives, CLI output, Trust Basis, or any stable public
+> report schema.
+
+## Purpose
+
+Runner observation health already records the raw measurement-health
+signals:
+
+- `kernel_layer`
+- `ringbuf_drops`
+- `policy_layer`
+- `sdk_layer`
+- `cgroup_correlation`
+
+Those fields are the source of truth. The fidelity verdict is a small
+derived read-model that answers one narrower question:
+
+```text
+Which Runner measured-effect claims may downstream projection/report code
+interpret from this observation health record?
+```
+
+It is a gate before interpretation, not a new capture layer.
+
+## Schema String
+
+```text
+assay.runner.fidelity_verdict.v0
+```
+
+The current Rust helper lives in `assay-runner-schema`. The schema string
+is an internal helper/contract label at this stage; no JSON Schema
+sidecar or archive member is frozen yet.
+
+## Vocabulary Boundary
+
+Do not confuse this verdict with the experiment-scoped observability
+calibration `agreement` vocabulary.
+
+| Surface | Scope | Vocabulary | Meaning |
+|---|---|---|---|
+| Observability calibration | Requested signal vs observed retained signal | `match`, `clipped`, `drift`, `failed`, `not_applicable` | Did a requested comparison/retention target match, clip, drift, fail, or fall outside the measurement surface? |
+| Runner fidelity verdict | One Runner `observation_health.v0` record | `clean`, `clipped`, `correlation_partial`, `failed`, `not_applicable` | May measured-effect claims be interpreted from this run's measurement health? |
+
+The calibration vocabulary uses `match` and `drift` because it compares a
+requested target with an observed artifact. Runner fidelity deliberately
+does not use those words: a health record can be clean without proving
+the workload content "matched" anything, and drift is a cross-state
+comparison, not per-run measurement quality.
+
+The shared words `clipped`, `failed`, and `not_applicable` are allowed
+because they describe measurement states in both contexts. Consumers must
+still use the schema namespace to decide which semantics apply.
+
+## Verdicts
+
+| Verdict | Meaning |
+|---|---|
+| `clean` | Kernel measurement is available, no ring-buffer drops are reported, and cgroup correlation is clean. |
+| `clipped` | Measurement ran, but known event loss or partial kernel capture blocks absence/bounded-negative claims. |
+| `correlation_partial` | Measurement exists, but the binding between observed effects and the run/cgroup/tool boundary is incomplete. |
+| `failed` | The health record is invalid for measured Runner claims, or cgroup correlation failed. |
+| `not_applicable` | The platform or layer does not provide the measured kernel-effect surface. Reported claims may still exist, but they are not measured kernel-effect claims. |
+
+## Claim Gate
+
+The helper emits a `claim_gate` with explicit decisions for every
+verdict:
+
+| Verdict | `reported_claims` | `measured_positive_claims` | `bounded_negative_claims` | `per_binding_claims` |
+|---|---|---|---|---|
+| `clean` | `allowed` | `allowed` | `allowed` | `allowed` |
+| `clipped` | `allowed` | `degraded` | `blocked` | `allowed` |
+| `correlation_partial` | `allowed` | `degraded` | `blocked` | `blocked` |
+| `not_applicable` | `allowed` | `blocked` | `blocked` | `blocked` |
+| `failed` | `blocked` | `blocked` | `blocked` | `blocked` |
+
+`failed` blocks claims authorized by this fidelity verdict. It does not
+erase separately validated SDK, trace, or external receipt artifacts; it
+means this Runner health record cannot safely authorize those claims.
+
+The load-bearing rule is:
+
+```text
+ringbuf_drops > 0 => clipped => bounded_negative_claims = blocked
+```
+
+Observed positive events can remain useful under `clipped`; missing
+events cannot prove absence. This is why `clipped` degrades positive
+measured claims but blocks bounded negative claims.
+
+## Composition With Projection `claim_level`
+
+Projection helpers such as path projection carry `claim_level` values
+like:
+
+- `raw_observed`
+- `projected_equivalent`
+- `inconclusive`
+
+The fidelity verdict does not replace that vocabulary. It gates which
+projection claim levels may be interpreted as measured-effect claims.
+
+Initial composition rule:
+
+| Projection `claim_level` | Fidelity gate consulted |
+|---|---|
+| `raw_observed` | `claim_gate.measured_positive_claims` |
+| `projected_equivalent` | `claim_gate.measured_positive_claims` |
+| `inconclusive` | Allowed to remain inconclusive unless the verdict is `failed` |
+| unknown value | Blocked |
+
+If a projection or report wants to make a bounded-negative claim, it must
+also consult `claim_gate.bounded_negative_claims`. If it wants to bind a
+claim to a specific run/cgroup/tool identity, it must also consult
+`claim_gate.per_binding_claims`.
+
+This keeps `claim_gate` as a guardrail over existing claim levels instead
+of introducing a second independent claim hierarchy.
+
+## Derived Shape
+
+Example clean verdict:
+
+```json
+{
+  "schema": "assay.runner.fidelity_verdict.v0",
+  "source_schema": "assay.runner.observation_health.v0",
+  "run_id": "run-001",
+  "verdict": "clean",
+  "claim_gate": {
+    "reported_claims": "allowed",
+    "measured_positive_claims": "allowed",
+    "bounded_negative_claims": "allowed",
+    "per_binding_claims": "allowed"
+  },
+  "reasons": [
+    {
+      "field": "observation_health",
+      "observed": "clean",
+      "rule": "complete_kernel_layer_zero_drops_clean_cgroup_correlation"
+    }
+  ],
+  "non_claims": [
+    "fidelity_no_observation_health_replacement",
+    "fidelity_no_policy_correctness_verdict",
+    "fidelity_no_runtime_safety_verdict",
+    "fidelity_no_agent_quality_score",
+    "fidelity_no_probabilistic_confidence_score"
+  ]
+}
+```
+
+## Classification Rules
+
+The v0 helper derives the verdict only from one
+`ObservationHealth` value:
+
+1. Invalid observation-health records or `cgroup_correlation = failed`
+   produce `failed`.
+2. Non-Linux platforms or absent kernel layers produce
+   `not_applicable`.
+3. `ringbuf_drops > 0` or `kernel_layer = partial_ringbuf_drops`
+   produces `clipped`.
+4. `cgroup_correlation = partial` produces `correlation_partial`.
+5. `kernel_layer = complete`, `ringbuf_drops = 0`, and
+   `cgroup_correlation = clean` produces `clean`.
+
+If more than one degradation is present, the helper preserves specific
+reasons and applies the stricter gate where needed. For example,
+partial cgroup correlation blocks per-binding claims even when the
+top-level verdict is driven by clipping.
+
+## Non-Claims
+
+- The verdict does not replace `observation_health.v0`.
+- The verdict does not prove policy correctness.
+- The verdict does not prove runtime safety.
+- The verdict does not score agent quality.
+- The verdict does not provide probabilistic confidence.
+- The verdict does not validate reported traces, spans, tool calls, or
+  SDK events as true.
+
+## Wiring Boundary
+
+This slice adds only the contract and helper. It intentionally does not:
+
+- add a Runner archive member;
+- add CLI output;
+- add Trust Basis claims;
+- add capability-diff gating;
+- add cross-runtime report wiring;
+- add path/network projection Slice 2 or Slice 3.
+
+Report wiring should wait for a concrete consumer or review surface that
+needs the derived verdict.

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -28,6 +28,7 @@ Phase 2B capability-diff planning slice.
 - [Runner cross-runtime diff v0 contract](cross-runtime-diff-v0.md)
 - [Runner projection roadmap](projection-roadmap.md)
 - [Runner path projection Slice 1 plan (declared-rule only)](path-projection-slice1-plan.md)
+- [Runner fidelity verdict v0](fidelity-verdict-v0.md)
 - [Runner schema overview](schemas-overview.md)
 - [Runner runtime drift projection v0/v0.2 contract](runtime-drift-v0.md)
 - [Runner cross-runtime diff v0 clean-output JSON Schema](schema/cross-runtime-diff-v0-clean.schema.json)

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -34,6 +34,7 @@
 | `assay.runner.network_projection.v0` | Additive network projection block embedded in runtime-drift reports | embedded projection vocabulary | described in [`runtime-drift-v0.md`](runtime-drift-v0.md) |
 | `assay.runner.runtime_noise_taxonomy.v0` | Shared vocabulary for runtime/provider/task/noise classes | vocabulary-only | described in [`runtime-drift-v0.md`](runtime-drift-v0.md) |
 | `assay.runner.drift_report_provenance.v0` | Render and capture provenance embedded in runtime-drift reports | embedded report metadata | described in [`runtime-drift-v0.md`](runtime-drift-v0.md) |
+| `assay.runner.fidelity_verdict.v0` | Derived claim gate from one `observation_health.v0` record | internal helper contract; no archive member or sidecar yet | described in [`fidelity-verdict-v0.md`](fidelity-verdict-v0.md) |
 | `assay.runner.cross_runtime_diff.v0.clean` | Earlier clean-output cross-runtime diff shape | reference schema | [`cross-runtime-diff-v0-clean.schema.json`](schema/cross-runtime-diff-v0-clean.schema.json) |
 
 ## Experiment Schemas


### PR DESCRIPTION
## Summary

Adds a small derived Runner fidelity verdict helper over existing `assay.runner.observation_health.v0` records.

What changed:

- adds `assay.runner.fidelity_verdict.v0` Rust helper types in `assay-runner-schema`
- derives `clean`, `clipped`, `correlation_partial`, `failed`, or `not_applicable` from `ObservationHealth`
- emits an explicit `claim_gate` for reported, measured-positive, bounded-negative, and per-binding claims
- adds `projection_claim_level_decision()` so existing projection `claim_level` values are gated instead of replaced
- documents the vocabulary boundary versus experiment calibration `agreement = match|clipped|drift|failed|not_applicable`

## Boundary

This PR intentionally does not:

- add a Runner archive member
- add CLI output
- add Trust Basis claims
- add capability-diff gating
- add cross-runtime report wiring
- add path/network projection Slice 2 or Slice 3
- replace `observation_health.v0`

## Validation

Ran locally:

```bash
cargo fmt --check
cargo test -p assay-runner-schema fidelity -- --nocapture
cargo clippy -p assay-runner-schema --all-targets -- -D warnings
git diff --check
```

Targeted docs-link sanity for the new relative links also passed. Local `mkdocs` is not installed in the temp clone, so CI remains the full mkdocs-strict proof.
