### PR TITLE
Verify SEP-2828 outcome decision digest

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
@@ -68,6 +68,7 @@ struct DecisionReport {
 struct OutcomeReport {
     status: Option<String>,
     completed_at: Option<String>,
+    decision_digest: Option<String>,
     backlink: BackLinkReport,
     signature_present: bool,
 }
@@ -113,6 +114,7 @@ fn build_report(
     outcome: Option<&Value>,
 ) -> Result<PairingReport> {
     let attestation_digest = jcs_digest(attestation).context("failed to digest attestation")?;
+    let decision_digest = jcs_digest(decision).context("failed to digest decision")?;
     let attestation_nonce = string_at(attestation, &["issuerAsserted", "nonce"]);
     let decision_backlink = backlink_report(decision)?;
     let outcome_backlink = outcome.map(backlink_report).transpose()?;
@@ -151,9 +153,15 @@ fn build_report(
         ));
         checks.push(check_eq(
             "decision_outcome_backlink_match",
-            outcome_backlink.attestation_digest.as_deref(),
-            decision_backlink.attestation_digest.as_deref(),
+            backlink_pair_key(outcome_backlink).as_deref(),
+            backlink_pair_key(&decision_backlink).as_deref(),
             "decision and outcome describe the same call instance",
+        ));
+        checks.push(check_eq(
+            "outcome_decision_digest_match",
+            outcome.and_then(outcome_decision_digest).as_deref(),
+            Some(decision_digest.as_str()),
+            "outcomeDerived.decisionDigest matches the signed decision record digest",
         ));
         checks.push(check_enum(
             "outcome_status_enum",
@@ -178,6 +186,7 @@ fn build_report(
         (Some(outcome), Some(backlink)) => Some(OutcomeReport {
             status: outcome_status(outcome),
             completed_at: string_at(outcome, &["outcomeDerived", "completedAt"]),
+            decision_digest: outcome_decision_digest(outcome),
             backlink,
             signature_present: outcome.get("signature").and_then(Value::as_str).is_some(),
         }),
@@ -237,6 +246,19 @@ fn decision_value(record: &Value) -> Option<String> {
 fn outcome_status(record: &Value) -> Option<String> {
     string_at(record, &["outcomeDerived", "status"])
         .or_else(|| string_at(record, &["outcome_derived", "status"]))
+}
+
+fn outcome_decision_digest(record: &Value) -> Option<String> {
+    string_at(record, &["outcomeDerived", "decisionDigest"])
+        .or_else(|| string_at(record, &["outcome_derived", "decision_digest"]))
+}
+
+fn backlink_pair_key(backlink: &BackLinkReport) -> Option<String> {
+    Some(format!(
+        "attestationDigest={};attestationNonce={}",
+        backlink.attestation_digest.as_deref()?,
+        backlink.attestation_nonce.as_deref()?
+    ))
 }
 
 fn string_at(value: &Value, path: &[&str]) -> Option<String> {

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
@@ -1,6 +1,7 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::fs;
 use tempfile::tempdir;
 
@@ -69,7 +70,7 @@ fn decision_json_with_value(digest: &str, decision: &str) -> String {
     )
 }
 
-fn outcome_json(digest: &str) -> String {
+fn outcome_json(digest: &str, decision_digest: &str) -> String {
     format!(
         r#"{{
   "version": 1,
@@ -80,7 +81,8 @@ fn outcome_json(digest: &str) -> String {
   }},
   "outcomeDerived": {{
     "status": "executed",
-    "completedAt": "2026-06-01T00:00:02Z"
+    "completedAt": "2026-06-01T00:00:02Z",
+    "decisionDigest": "{decision_digest}"
   }},
   "receiptAsserted": {{
     "iss": "server",
@@ -95,15 +97,23 @@ fn outcome_json(digest: &str) -> String {
     )
 }
 
+fn jcs_digest_json(body: &str) -> String {
+    let value: Value = serde_json::from_str(body).unwrap();
+    let canonical = assay_core::mcp::jcs::to_vec(&value).unwrap();
+    format!("sha256:{}", hex::encode(Sha256::digest(&canonical)))
+}
+
 #[test]
 fn verify_mcp_records_reports_pairing_as_independent_consumer() {
     let dir = tempdir().unwrap();
     let attestation = dir.path().join("attestation.json");
     let decision = dir.path().join("decision.json");
     let outcome = dir.path().join("outcome.json");
+    let decision_body = decision_json(ATTESTATION_DIGEST);
+    let decision_digest = jcs_digest_json(&decision_body);
     fs::write(&attestation, attestation_json()).unwrap();
-    fs::write(&decision, decision_json(ATTESTATION_DIGEST)).unwrap();
-    fs::write(&outcome, outcome_json(ATTESTATION_DIGEST)).unwrap();
+    fs::write(&decision, decision_body).unwrap();
+    fs::write(&outcome, outcome_json(ATTESTATION_DIGEST, &decision_digest)).unwrap();
 
     let output = Command::cargo_bin("assay")
         .unwrap()
@@ -131,11 +141,44 @@ fn verify_mcp_records_reports_pairing_as_independent_consumer() {
     assert_eq!(report["attestation"]["digest"], ATTESTATION_DIGEST);
     assert_eq!(report["decision"]["decision"], "allow");
     assert_eq!(report["outcome"]["status"], "executed");
+    assert_eq!(report["outcome"]["decision_digest"], decision_digest);
     assert!(report["claims_not_made"]
         .as_array()
         .unwrap()
         .iter()
         .any(|claim| claim == "signature_verification"));
+}
+
+#[test]
+fn verify_mcp_records_fails_when_outcome_binds_different_decision() {
+    let dir = tempdir().unwrap();
+    let attestation = dir.path().join("attestation.json");
+    let decision = dir.path().join("decision.json");
+    let outcome = dir.path().join("outcome.json");
+    fs::write(&attestation, attestation_json()).unwrap();
+    fs::write(&decision, decision_json(ATTESTATION_DIGEST)).unwrap();
+    fs::write(
+        &outcome,
+        outcome_json(ATTESTATION_DIGEST, "sha256:0000000000000000"),
+    )
+    .unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--attestation",
+            attestation.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--outcome",
+            outcome.to_str().unwrap(),
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("outcome_decision_digest_match"))
+        .stdout(predicate::str::contains("fail mismatch"));
 }
 
 #[test]

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -80,7 +80,8 @@ assay evidence verify-mcp-records \
 
 This command emits an `assay.mcp.execution-record-pairing.report.v0` report. It
 computes the SEP-2787 JCS digest, checks the decision and optional outcome
-`backLink` fields, and verifies the narrow decision/outcome enum surface.
+`backLink` fields, verifies the outcome's `decisionDigest` commitment to the
+signed decision record, and verifies the narrow decision/outcome enum surface.
 
 The command is deliberately not an MCP proxy, issuer, policy engine, or runtime
 truth oracle. It does not verify signatures, establish issuer key trust, prove


### PR DESCRIPTION
## Summary

- add Check B validation for MCP execution records by comparing `outcomeDerived.decisionDigest` to the JCS digest of the signed decision record
- tighten decision/outcome instance pairing so the shared backLink check includes both attestation digest and nonce
- cover the substituted-decision-under-shared-attestation negative case and document the new decision digest check

## Verification

- `cargo test -p assay-cli --test evidence_test mcp_execution_records -- --nocapture`
- Vaara SEP-2828 `decision_pairing_v0` single-decision fixtures:
  - `valid_pair_allow_executed`: exit 0
  - `decision_only_escalate`: exit 0
  - `substituted_attestation_backlink`: exit 2
  - `substituted_pairing_nonce`: exit 2
  - `substituted_decision_under_shared_attestation`: exit 2 via `outcome_decision_digest_match`
