### PR TITLE
feat: support MCP request-envelope fallback binding

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use clap::{Args, ValueEnum};
+use clap::{ArgGroup, Args, ValueEnum};
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -7,10 +7,19 @@ use std::fs;
 use std::path::PathBuf;
 
 #[derive(Debug, Args, Clone)]
+#[command(group(
+    ArgGroup::new("binding_input")
+        .required(true)
+        .args(["attestation", "request_envelope"])
+))]
 pub struct McpExecutionRecordArgs {
     /// SEP-2787 attestation JSON fixture
     #[arg(long)]
-    pub attestation: PathBuf,
+    pub attestation: Option<PathBuf>,
+
+    /// Observed tools/call request envelope JSON fixture for no-attestation fallback
+    #[arg(long)]
+    pub request_envelope: Option<PathBuf>,
 
     /// Server-side decision record JSON fixture
     #[arg(long)]
@@ -37,7 +46,8 @@ struct PairingReport {
     ok: bool,
     canonicalization: &'static str,
     verification_scope: VerificationScope,
-    attestation: AttestationReport,
+    binding: BindingReport,
+    attestation: Option<AttestationReport>,
     decision: DecisionReport,
     outcome: Option<OutcomeReport>,
     checks: Vec<CheckReport>,
@@ -54,6 +64,15 @@ struct VerificationScope {
 struct AttestationReport {
     digest: String,
     nonce: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct BindingReport {
+    mode: &'static str,
+    digest: String,
+    digest_source: &'static str,
+    nonce: Option<String>,
+    nonce_source: &'static str,
 }
 
 #[derive(Debug, Serialize)]
@@ -87,11 +106,17 @@ struct CheckReport {
 }
 
 pub fn cmd_verify_mcp_records(args: McpExecutionRecordArgs) -> Result<i32> {
-    let attestation = read_json(&args.attestation)?;
+    let binding_input = match (&args.attestation, &args.request_envelope) {
+        (Some(attestation), None) => BindingInput::Attestation(read_json(attestation)?),
+        (None, Some(request_envelope)) => {
+            BindingInput::RequestEnvelope(read_json(request_envelope)?)
+        }
+        _ => anyhow::bail!("exactly one of --attestation or --request-envelope is required"),
+    };
     let decision = read_json(&args.decision)?;
     let outcome = args.outcome.as_ref().map(read_json).transpose()?;
 
-    let report = build_report(&attestation, &decision, outcome.as_ref())?;
+    let report = build_report(&binding_input, &decision, outcome.as_ref())?;
     match args.format {
         McpExecutionRecordFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&report)?);
@@ -108,30 +133,31 @@ fn read_json(path: &PathBuf) -> Result<Value> {
     serde_json::from_str(&body).with_context(|| format!("failed to parse {}", path.display()))
 }
 
+enum BindingInput {
+    Attestation(Value),
+    RequestEnvelope(Value),
+}
+
+struct BindingExpectation {
+    mode: &'static str,
+    digest: String,
+    digest_source: &'static str,
+    nonce: Option<String>,
+    nonce_source: &'static str,
+}
+
 fn build_report(
-    attestation: &Value,
+    binding_input: &BindingInput,
     decision: &Value,
     outcome: Option<&Value>,
 ) -> Result<PairingReport> {
-    let attestation_digest = jcs_digest(attestation).context("failed to digest attestation")?;
     let decision_digest = jcs_digest(decision).context("failed to digest decision")?;
-    let attestation_nonce = string_at(attestation, &["issuerAsserted", "nonce"]);
     let decision_backlink = backlink_report(decision)?;
     let outcome_backlink = outcome.map(backlink_report).transpose()?;
+    let expectation = binding_expectation(binding_input, &decision_backlink)?;
 
     let mut checks = Vec::new();
-    checks.push(check_eq(
-        "decision_attestation_digest_match",
-        decision_backlink.attestation_digest.as_deref(),
-        Some(attestation_digest.as_str()),
-        "decision backLink.attestationDigest matches SEP-2787 JCS digest",
-    ));
-    checks.push(check_eq(
-        "decision_attestation_nonce_match",
-        decision_backlink.attestation_nonce.as_deref(),
-        attestation_nonce.as_deref(),
-        "decision backLink.attestationNonce matches issuerAsserted.nonce",
-    ));
+    push_decision_binding_checks(&mut checks, &decision_backlink, &expectation);
     checks.push(check_enum(
         "decision_enum",
         decision_value(decision).as_deref(),
@@ -139,24 +165,14 @@ fn build_report(
     ));
 
     if let Some(outcome_backlink) = &outcome_backlink {
-        checks.push(check_eq(
-            "outcome_attestation_digest_match",
-            outcome_backlink.attestation_digest.as_deref(),
-            Some(attestation_digest.as_str()),
-            "outcome backLink.attestationDigest matches SEP-2787 JCS digest",
-        ));
-        checks.push(check_eq(
-            "outcome_attestation_nonce_match",
-            outcome_backlink.attestation_nonce.as_deref(),
-            attestation_nonce.as_deref(),
-            "outcome backLink.attestationNonce matches issuerAsserted.nonce",
-        ));
+        push_outcome_binding_checks(&mut checks, outcome_backlink, &expectation);
         checks.push(check_eq(
             "decision_outcome_backlink_match",
             backlink_pair_key(outcome_backlink).as_deref(),
             backlink_pair_key(&decision_backlink).as_deref(),
             "decision and outcome describe the same call instance",
         ));
+        // SEP-2828 Check B digests the full signed decision record.
         checks.push(check_eq(
             "outcome_decision_digest_match",
             outcome.and_then(outcome_decision_digest).as_deref(),
@@ -202,21 +218,138 @@ fn build_report(
             role: "independent-consumer",
             note: "Assay verifies fixture pairing and digest commitments only; it does not emit records or act as a proxy.",
         },
-        attestation: AttestationReport {
-            digest: attestation_digest,
-            nonce: attestation_nonce,
+        binding: BindingReport {
+            mode: expectation.mode,
+            digest: expectation.digest.clone(),
+            digest_source: expectation.digest_source,
+            nonce: expectation.nonce.clone(),
+            nonce_source: expectation.nonce_source,
         },
+        attestation: attestation_report(binding_input, &expectation),
         decision: decision_report,
         outcome: outcome_report,
         checks,
-        claims_not_made: vec![
-            "signature_verification",
-            "issuer_key_trust",
-            "policy_correctness",
-            "runtime_side_effect_truth",
-            "payload_or_result_disclosure",
-        ],
+        claims_not_made: claims_not_made(&expectation),
     })
+}
+
+fn claims_not_made(expectation: &BindingExpectation) -> Vec<&'static str> {
+    let mut claims = vec![
+        "signature_verification",
+        "issuer_key_trust",
+        "policy_correctness",
+        "runtime_side_effect_truth",
+        "payload_or_result_disclosure",
+    ];
+    if expectation.mode == "request_envelope" {
+        claims.push("fallback_server_observation_truth");
+        claims.push("fallback_nonce_freshness_or_uniqueness");
+    }
+    claims
+}
+
+fn binding_expectation(
+    binding_input: &BindingInput,
+    decision_backlink: &BackLinkReport,
+) -> Result<BindingExpectation> {
+    match binding_input {
+        BindingInput::Attestation(attestation) => Ok(BindingExpectation {
+            mode: "sep2787_attestation",
+            digest: jcs_digest(attestation).context("failed to digest attestation")?,
+            digest_source: "sep2787_attestation_jcs",
+            nonce: string_at(attestation, &["issuerAsserted", "nonce"]),
+            nonce_source: "issuerAsserted.nonce",
+        }),
+        BindingInput::RequestEnvelope(request_envelope) => Ok(BindingExpectation {
+            mode: "request_envelope",
+            digest: jcs_digest(request_envelope).context("failed to digest request envelope")?,
+            digest_source: "request_envelope_jcs",
+            nonce: decision_backlink.attestation_nonce.clone(),
+            nonce_source: "record_backlink_consistency",
+        }),
+    }
+}
+
+fn attestation_report(
+    binding_input: &BindingInput,
+    expectation: &BindingExpectation,
+) -> Option<AttestationReport> {
+    match binding_input {
+        BindingInput::Attestation(_) => Some(AttestationReport {
+            digest: expectation.digest.clone(),
+            nonce: expectation.nonce.clone(),
+        }),
+        BindingInput::RequestEnvelope(_) => None,
+    }
+}
+
+fn push_decision_binding_checks(
+    checks: &mut Vec<CheckReport>,
+    decision_backlink: &BackLinkReport,
+    expectation: &BindingExpectation,
+) {
+    match expectation.mode {
+        "sep2787_attestation" => {
+            checks.push(check_eq(
+                "decision_attestation_digest_match",
+                decision_backlink.attestation_digest.as_deref(),
+                Some(expectation.digest.as_str()),
+                "decision backLink.attestationDigest matches SEP-2787 JCS digest",
+            ));
+            checks.push(check_eq(
+                "decision_attestation_nonce_match",
+                decision_backlink.attestation_nonce.as_deref(),
+                expectation.nonce.as_deref(),
+                "decision backLink.attestationNonce matches issuerAsserted.nonce",
+            ));
+        }
+        "request_envelope" => {
+            checks.push(check_eq(
+                "decision_request_envelope_digest_match",
+                decision_backlink.attestation_digest.as_deref(),
+                Some(expectation.digest.as_str()),
+                "decision backLink.attestationDigest matches request-envelope JCS digest",
+            ));
+            checks.push(check_present(
+                "decision_request_envelope_nonce_present",
+                decision_backlink.attestation_nonce.as_deref(),
+                "decision backLink.attestationNonce is present for fallback binding",
+            ));
+        }
+        _ => unreachable!("unknown binding mode"),
+    }
+}
+
+fn push_outcome_binding_checks(
+    checks: &mut Vec<CheckReport>,
+    outcome_backlink: &BackLinkReport,
+    expectation: &BindingExpectation,
+) {
+    match expectation.mode {
+        "sep2787_attestation" => {
+            checks.push(check_eq(
+                "outcome_attestation_digest_match",
+                outcome_backlink.attestation_digest.as_deref(),
+                Some(expectation.digest.as_str()),
+                "outcome backLink.attestationDigest matches SEP-2787 JCS digest",
+            ));
+            checks.push(check_eq(
+                "outcome_attestation_nonce_match",
+                outcome_backlink.attestation_nonce.as_deref(),
+                expectation.nonce.as_deref(),
+                "outcome backLink.attestationNonce matches issuerAsserted.nonce",
+            ));
+        }
+        "request_envelope" => {
+            checks.push(check_eq(
+                "outcome_request_envelope_digest_match",
+                outcome_backlink.attestation_digest.as_deref(),
+                Some(expectation.digest.as_str()),
+                "outcome backLink.attestationDigest matches request-envelope JCS digest",
+            ));
+        }
+        _ => unreachable!("unknown binding mode"),
+    }
 }
 
 fn jcs_digest(value: &Value) -> Result<String> {
@@ -305,15 +438,28 @@ fn check_enum(id: &'static str, value: Option<&str>, allowed: &[&str]) -> CheckR
     }
 }
 
+fn check_present(id: &'static str, value: Option<&str>, description: &str) -> CheckReport {
+    CheckReport {
+        id,
+        ok: value.is_some(),
+        detail: if value.is_some() {
+            description.to_string()
+        } else {
+            "missing value".to_string()
+        },
+    }
+}
+
 fn print_table_report(report: &PairingReport) {
     println!("MCP Execution Record Pairing Report");
     println!("===================================");
     println!("OK:               {}", if report.ok { "yes" } else { "no" });
     println!("Role:             {}", report.verification_scope.role);
-    println!("Attestation:      {}", report.attestation.digest);
+    println!("Binding:          {}", report.binding.mode);
+    println!("Binding digest:   {}", report.binding.digest);
     println!(
-        "Nonce:            {}",
-        report.attestation.nonce.as_deref().unwrap_or("-")
+        "Binding nonce:    {}",
+        report.binding.nonce.as_deref().unwrap_or("-")
     );
     println!(
         "Decision:         {}",

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
@@ -44,13 +44,17 @@ fn decision_json(digest: &str) -> String {
 }
 
 fn decision_json_with_value(digest: &str, decision: &str) -> String {
+    decision_json_with_backlink(digest, "nonce-1", decision)
+}
+
+fn decision_json_with_backlink(digest: &str, nonce: &str, decision: &str) -> String {
     format!(
         r#"{{
   "version": 1,
   "alg": "ES256",
   "backLink": {{
     "attestationDigest": "{digest}",
-    "attestationNonce": "nonce-1"
+    "attestationNonce": "{nonce}"
   }},
   "decisionDerived": {{
     "decision": "{decision}",
@@ -71,13 +75,17 @@ fn decision_json_with_value(digest: &str, decision: &str) -> String {
 }
 
 fn outcome_json(digest: &str, decision_digest: &str) -> String {
+    outcome_json_with_backlink(digest, "nonce-1", decision_digest)
+}
+
+fn outcome_json_with_backlink(digest: &str, nonce: &str, decision_digest: &str) -> String {
     format!(
         r#"{{
   "version": 1,
   "alg": "ES256",
   "backLink": {{
     "attestationDigest": "{digest}",
-    "attestationNonce": "nonce-1"
+    "attestationNonce": "{nonce}"
   }},
   "outcomeDerived": {{
     "status": "executed",
@@ -95,6 +103,19 @@ fn outcome_json(digest: &str, decision_digest: &str) -> String {
   "signature": "outcome-sig"
 }}"#
     )
+}
+
+fn request_envelope_json() -> &'static str {
+    r#"{
+  "name": "tools/call",
+  "arguments": {
+    "processInstanceKey": "2251799813685249"
+  },
+  "_meta": {
+    "callId": "call-001",
+    "requestSource": "mcp"
+  }
+}"#
 }
 
 fn jcs_digest_json(body: &str) -> String {
@@ -138,6 +159,10 @@ fn verify_mcp_records_reports_pairing_as_independent_consumer() {
     let report: Value = serde_json::from_slice(&output).unwrap();
     assert_eq!(report["ok"], true);
     assert_eq!(report["verification_scope"]["role"], "independent-consumer");
+    assert_eq!(report["binding"]["mode"], "sep2787_attestation");
+    assert_eq!(report["binding"]["digest"], ATTESTATION_DIGEST);
+    assert_eq!(report["binding"]["nonce"], "nonce-1");
+    assert_eq!(report["binding"]["nonce_source"], "issuerAsserted.nonce");
     assert_eq!(report["attestation"]["digest"], ATTESTATION_DIGEST);
     assert_eq!(report["decision"]["decision"], "allow");
     assert_eq!(report["outcome"]["status"], "executed");
@@ -147,6 +172,11 @@ fn verify_mcp_records_reports_pairing_as_independent_consumer() {
         .unwrap()
         .iter()
         .any(|claim| claim == "signature_verification"));
+    assert!(!report["claims_not_made"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|claim| claim == "fallback_nonce_freshness_or_uniqueness"));
 }
 
 #[test]
@@ -205,6 +235,204 @@ fn verify_mcp_records_fails_on_substituted_backlink() {
             "decision_attestation_digest_match",
         ))
         .stdout(predicate::str::contains("fail mismatch"));
+}
+
+#[test]
+fn verify_mcp_records_accepts_request_envelope_fallback_pairing() {
+    let dir = tempdir().unwrap();
+    let request_envelope = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    let outcome = dir.path().join("outcome.json");
+    let envelope_digest = jcs_digest_json(request_envelope_json());
+    let decision_body = decision_json(&envelope_digest);
+    let decision_digest = jcs_digest_json(&decision_body);
+    fs::write(&request_envelope, request_envelope_json()).unwrap();
+    fs::write(&decision, decision_body).unwrap();
+    fs::write(&outcome, outcome_json(&envelope_digest, &decision_digest)).unwrap();
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            request_envelope.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--outcome",
+            outcome.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["binding"]["mode"], "request_envelope");
+    assert_eq!(report["binding"]["digest"], envelope_digest);
+    assert_eq!(report["binding"]["digest_source"], "request_envelope_jcs");
+    assert_eq!(report["binding"]["nonce"], "nonce-1");
+    assert_eq!(
+        report["binding"]["nonce_source"],
+        "record_backlink_consistency"
+    );
+    assert_eq!(report["attestation"], Value::Null);
+    assert!(report["claims_not_made"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|claim| claim == "fallback_nonce_freshness_or_uniqueness"));
+}
+
+#[test]
+fn verify_mcp_records_fallback_fails_on_decision_envelope_digest_substitution() {
+    let dir = tempdir().unwrap();
+    let request_envelope = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    let outcome = dir.path().join("outcome.json");
+    let envelope_digest = jcs_digest_json(request_envelope_json());
+    let decision_body = decision_json("sha256:0000");
+    let decision_digest = jcs_digest_json(&decision_body);
+    fs::write(&request_envelope, request_envelope_json()).unwrap();
+    fs::write(&decision, decision_body).unwrap();
+    fs::write(&outcome, outcome_json(&envelope_digest, &decision_digest)).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            request_envelope.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--outcome",
+            outcome.to_str().unwrap(),
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains(
+            "decision_request_envelope_digest_match",
+        ))
+        .stdout(predicate::str::contains("fail mismatch"));
+}
+
+#[test]
+fn verify_mcp_records_fallback_fails_on_outcome_envelope_digest_substitution() {
+    let dir = tempdir().unwrap();
+    let request_envelope = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    let outcome = dir.path().join("outcome.json");
+    let envelope_digest = jcs_digest_json(request_envelope_json());
+    let decision_body = decision_json(&envelope_digest);
+    let decision_digest = jcs_digest_json(&decision_body);
+    fs::write(&request_envelope, request_envelope_json()).unwrap();
+    fs::write(&decision, decision_body).unwrap();
+    fs::write(&outcome, outcome_json("sha256:0000", &decision_digest)).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            request_envelope.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--outcome",
+            outcome.to_str().unwrap(),
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains(
+            "outcome_request_envelope_digest_match",
+        ))
+        .stdout(predicate::str::contains("fail mismatch"));
+}
+
+#[test]
+fn verify_mcp_records_fallback_fails_on_outcome_nonce_substitution() {
+    let dir = tempdir().unwrap();
+    let request_envelope = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    let outcome = dir.path().join("outcome.json");
+    let envelope_digest = jcs_digest_json(request_envelope_json());
+    let decision_body = decision_json(&envelope_digest);
+    let decision_digest = jcs_digest_json(&decision_body);
+    fs::write(&request_envelope, request_envelope_json()).unwrap();
+    fs::write(&decision, decision_body).unwrap();
+    fs::write(
+        &outcome,
+        outcome_json_with_backlink(&envelope_digest, "nonce-2", &decision_digest),
+    )
+    .unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            request_envelope.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--outcome",
+            outcome.to_str().unwrap(),
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("decision_outcome_backlink_match"))
+        .stdout(predicate::str::contains("fail mismatch"));
+}
+
+#[test]
+fn verify_mcp_records_requires_exactly_one_binding_input() {
+    let dir = tempdir().unwrap();
+    let request_envelope = dir.path().join("request-envelope.json");
+    let attestation = dir.path().join("attestation.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&request_envelope, request_envelope_json()).unwrap();
+    fs::write(&attestation, attestation_json()).unwrap();
+    fs::write(&decision, decision_json(ATTESTATION_DIGEST)).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--decision",
+            decision.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "<--attestation <ATTESTATION>|--request-envelope <REQUEST_ENVELOPE>>",
+        ))
+        .stderr(predicate::str::contains(
+            "Usage: assay evidence verify-mcp-records",
+        ));
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--attestation",
+            attestation.to_str().unwrap(),
+            "--request-envelope",
+            request_envelope.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "the argument '--attestation <ATTESTATION>' cannot be used with '--request-envelope <REQUEST_ENVELOPE>'",
+        ));
 }
 
 #[test]

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -67,8 +67,8 @@ Schema names can be the registry name, known alias, source path, or JSON Schema
 
 ## MCP Execution Record Pairing
 
-Verify that SEP-2787 attestation and server execution-record fixtures pair up
-from the consumer side:
+Verify that request binding material and server execution-record fixtures pair
+up from the consumer side:
 
 ```bash
 assay evidence verify-mcp-records \
@@ -78,15 +78,35 @@ assay evidence verify-mcp-records \
   --format json
 ```
 
+For deployments without SEP-2787 attestation, supply the observed
+`tools/call` params plus `_meta` request envelope instead:
+
+```bash
+assay evidence verify-mcp-records \
+  --request-envelope tools-call-envelope.json \
+  --decision server-decision-record.json \
+  --outcome server-outcome-record.json \
+  --format json
+```
+
+`--attestation` and `--request-envelope` are mutually exclusive. Exactly one is
+required.
+
 This command emits an `assay.mcp.execution-record-pairing.report.v0` report. It
-computes the SEP-2787 JCS digest, checks the decision and optional outcome
+computes the binding digest, checks the decision and optional outcome
 `backLink` fields, verifies the outcome's `decisionDigest` commitment to the
-signed decision record, and verifies the narrow decision/outcome enum surface.
+full signed decision record, and verifies the narrow decision/outcome enum
+surface. In SEP-2787 mode the binding digest is the attestation JCS digest and
+the nonce comes from `issuerAsserted.nonce`. In request-envelope mode the
+binding digest is the JCS digest of the supplied envelope, while the nonce is
+only checked for decision/outcome record consistency.
 
 The command is deliberately not an MCP proxy, issuer, policy engine, or runtime
 truth oracle. It does not verify signatures, establish issuer key trust, prove
 policy correctness, prove side effects, or disclose payload/result bodies. It is
 for downstream verifier fixtures and reviewer-visible pairing diagnostics.
+Request-envelope fallback does not prove the server observed that envelope
+honestly, or that the server-chosen nonce was unique or fresh for the call.
 
 If `--outcome` is omitted, Assay reports a valid decision-only pairing check.
 Pairing or enum mismatches produce a report and exit `2`.

--- a/docs/reference/cli/mcp-execution-record-fallback-plan.md
+++ b/docs/reference/cli/mcp-execution-record-fallback-plan.md
@@ -115,24 +115,30 @@ add a binding block that names the mode:
 {
   "schema": "assay.mcp.execution-record-pairing.report.v0",
   "binding": {
-    "kind": "request_envelope_fallback",
+    "mode": "request_envelope",
     "digest": "sha256:...",
-    "nonce": "server-chosen-nonce-001"
+    "digest_source": "request_envelope_jcs",
+    "nonce": "server-chosen-nonce-001",
+    "nonce_source": "record_backlink_consistency"
   }
 }
 ```
 
-For the SEP-2787 path, `binding.kind` should be
-`sep2787_attestation`. The existing `attestation` report field can stay
-for compatibility when an attestation input is supplied. The `binding`
-block is additive; existing v0 consumers that ignore unknown fields
-should still be able to parse the report.
+For the SEP-2787 path, `binding.mode` should be
+`sep2787_attestation`, with `digest_source` set to
+`sep2787_attestation_jcs` and `nonce_source` set to
+`issuerAsserted.nonce`. The existing `attestation` report field can stay
+for compatibility when an attestation input is supplied, and should be
+`null` in request-envelope mode. The `binding` block is additive;
+existing v0 consumers that ignore unknown fields should still be able to
+parse the report.
 
 Fallback-specific check ids should say what was verified:
 
 | Check id | Meaning |
 |---|---|
 | `decision_request_envelope_digest_match` | Decision backLink digest matches the request-envelope digest |
+| `decision_request_envelope_nonce_present` | Decision backLink carries the server-chosen nonce used for fallback pairing |
 | `outcome_request_envelope_digest_match` | Outcome backLink digest matches the request-envelope digest |
 | `decision_outcome_backlink_match` | Decision and outcome describe the same call instance through digest + nonce |
 | `outcome_decision_digest_match` | Outcome commits to this full signed decision record |
@@ -195,7 +201,7 @@ Review-ready when:
 
 - `verify-mcp-records` accepts exactly one of `--attestation` or
   `--request-envelope`
-- both modes produce an explicit `binding.kind`
+- both modes produce an explicit `binding.mode`
 - SEP-2787-backed behavior is unchanged
 - fallback digest and nonce checks are covered by CLI tests
 - Check B remains shared across both modes


### PR DESCRIPTION
## Summary

- add `--request-envelope` as the no-attestation binding input for `assay evidence verify-mcp-records`
- emit an additive `binding` block with mode, digest, digest source, nonce, and nonce source
- keep SEP-2787 behavior intact while sharing Check B across attestation and request-envelope modes
- document request-envelope fallback non-claims and keep the fallback plan in sync with the shipped report shape

## Validation

- `cargo test -p assay-cli --test evidence_test mcp_execution_records -- --nocapture`
- `git diff --check`
- `cargo clippy -p assay-cli --tests -- -D warnings`
- push hooks: merge-conflict check, formatting, token hygiene, typos, workspace clippy, linux compile gate
- Vaara fixture smoke from a fresh clone: valid pair and decision-only cases exit 0; substituted attestation, nonce, and Check B cases exit 2 as expected

## Notes

The Vaara `fallback_envelope_binding` fixture is still not independently evaluable by Assay because it does not commit the observed request envelope artifact. This PR adds the Assay-side no-attestation input path and local fallback coverage; the external fallback fixture can be consumed once that envelope material exists.

`mkdocs build --strict` was not run locally because `mkdocs` is not installed in this environment.
