### PR TITLE
[codex] tighten runner network fidelity claims

### DIFF
--- a/crates/assay-runner-core/src/kernel.rs
+++ b/crates/assay-runner-core/src/kernel.rs
@@ -4,7 +4,10 @@ use assay_common::{
     EVENT_INODE_RESOLVED, EVENT_OPENAT,
 };
 use assay_monitor::MonitorStatsSnapshot;
-use assay_runner_schema::{CapabilitySurface, CgroupCorrelationStatus, KernelLayerStatus};
+use assay_runner_schema::{
+    CapabilitySurface, CgroupCorrelationStatus, KernelLayerStatus, NetworkEndpointClaimScope,
+    NetworkProtocolCoverageStatus,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -231,10 +234,25 @@ impl KernelLayerCapture {
             archive.observation_health.kernel_layer =
                 kernel_layer_for(ringbuf_drops, cgroup_correlation);
             archive.observation_health.cgroup_correlation = cgroup_correlation;
+            if archive.observation_health.kernel_layer == KernelLayerStatus::Absent {
+                archive.observation_health.network_protocol_coverage =
+                    NetworkProtocolCoverageStatus::Absent;
+                archive.observation_health.network_endpoint_claim_scope =
+                    NetworkEndpointClaimScope::NotApplicable;
+            } else {
+                archive.observation_health.network_protocol_coverage =
+                    NetworkProtocolCoverageStatus::ConnectOnly;
+                archive.observation_health.network_endpoint_claim_scope =
+                    NetworkEndpointClaimScope::DiagnosticOnly;
+            }
         } else {
             archive.observation_health.ringbuf_drops = 0;
             archive.observation_health.kernel_layer = KernelLayerStatus::Absent;
             archive.observation_health.cgroup_correlation = CgroupCorrelationStatus::Partial;
+            archive.observation_health.network_protocol_coverage =
+                NetworkProtocolCoverageStatus::Absent;
+            archive.observation_health.network_endpoint_claim_scope =
+                NetworkEndpointClaimScope::NotApplicable;
         }
         archive.observation_health.notes.retain(|note| {
             !note.starts_with("contract_only_mode:") && !note.starts_with("s2_kernel_capture:")
@@ -555,7 +573,9 @@ fn kernel_capture_note(input: KernelCaptureNote) -> String {
 
     match cgroup_correlation {
         CgroupCorrelationStatus::Clean if ringbuf_drops == 0 => {
-            format!("s2_kernel_capture: monitor_events={event_count} ringbuf_drops={ringbuf_drops}")
+            format!(
+                "s2_kernel_capture: monitor_events={event_count} ringbuf_drops={ringbuf_drops} network_protocol_coverage=connect_only network_endpoint_claim_scope=diagnostic_only"
+            )
         }
         CgroupCorrelationStatus::Clean => {
             let filtered_top = filtered_loader_top
@@ -564,7 +584,7 @@ fn kernel_capture_note(input: KernelCaptureNote) -> String {
                 .collect::<Vec<_>>()
                 .join(",");
             format!(
-                "s2_kernel_capture: monitor_events={event_count} ringbuf_drops={ringbuf_drops} drop_breakdown=tracepoint:{} lsm:{} socket:{} emitted=tracepoint:{} lsm:{} socket:{} tracepoint_hooks=openat:{}/{} openat2:{}/{} connect:{}/{} filtered_loader_events={filtered_loader_events} filtered_loader_top=[{filtered_top}]",
+                "s2_kernel_capture: monitor_events={event_count} ringbuf_drops={ringbuf_drops} network_protocol_coverage=connect_only network_endpoint_claim_scope=diagnostic_only drop_breakdown=tracepoint:{} lsm:{} socket:{} emitted=tracepoint:{} lsm:{} socket:{} tracepoint_hooks=openat:{}/{} openat2:{}/{} connect:{}/{} filtered_loader_events={filtered_loader_events} filtered_loader_top=[{filtered_top}]",
                 drop_breakdown.tracepoint,
                 drop_breakdown.lsm,
                 drop_breakdown.socket,
@@ -848,6 +868,14 @@ mod tests {
             KernelLayerStatus::PartialRingbufDrops
         );
         assert_eq!(archive.observation_health.ringbuf_drops, 4);
+        assert_eq!(
+            archive.observation_health.network_protocol_coverage,
+            NetworkProtocolCoverageStatus::ConnectOnly
+        );
+        assert_eq!(
+            archive.observation_health.network_endpoint_claim_scope,
+            NetworkEndpointClaimScope::DiagnosticOnly
+        );
         archive.observation_health.validate().unwrap();
     }
 
@@ -875,11 +903,19 @@ mod tests {
             archive.observation_health.cgroup_correlation,
             CgroupCorrelationStatus::Clean
         );
+        assert_eq!(
+            archive.observation_health.network_protocol_coverage,
+            NetworkProtocolCoverageStatus::ConnectOnly
+        );
+        assert_eq!(
+            archive.observation_health.network_endpoint_claim_scope,
+            NetworkEndpointClaimScope::DiagnosticOnly
+        );
         assert!(archive
             .observation_health
             .notes
             .iter()
-            .any(|note| note.starts_with("s2_kernel_capture:")));
+            .any(|note| note.contains("network_protocol_coverage=connect_only")));
     }
 
     #[test]
@@ -903,6 +939,14 @@ mod tests {
             CgroupCorrelationStatus::Partial
         );
         assert_eq!(archive.observation_health.ringbuf_drops, 0);
+        assert_eq!(
+            archive.observation_health.network_protocol_coverage,
+            NetworkProtocolCoverageStatus::Absent
+        );
+        assert_eq!(
+            archive.observation_health.network_endpoint_claim_scope,
+            NetworkEndpointClaimScope::NotApplicable
+        );
         assert!(archive
             .observation_health
             .notes
@@ -987,6 +1031,14 @@ mod tests {
             CgroupCorrelationStatus::Partial
         );
         assert_eq!(archive.observation_health.ringbuf_drops, 0);
+        assert_eq!(
+            archive.observation_health.network_protocol_coverage,
+            NetworkProtocolCoverageStatus::Absent
+        );
+        assert_eq!(
+            archive.observation_health.network_endpoint_claim_scope,
+            NetworkEndpointClaimScope::NotApplicable
+        );
         archive.observation_health.validate().unwrap();
     }
 }

--- a/crates/assay-runner-schema/src/fidelity.rs
+++ b/crates/assay-runner-schema/src/fidelity.rs
@@ -274,6 +274,8 @@ mod tests {
             .with_sdk_layer(SdkLayerStatus::SelfReported)
             .with_cgroup_correlation(CgroupCorrelationStatus::Clean);
         health.kernel_layer = KernelLayerStatus::Complete;
+        health.network_protocol_coverage = crate::NetworkProtocolCoverageStatus::ConnectOnly;
+        health.network_endpoint_claim_scope = crate::NetworkEndpointClaimScope::DiagnosticOnly;
         health
     }
 

--- a/crates/assay-runner-schema/src/health.rs
+++ b/crates/assay-runner-schema/src/health.rs
@@ -34,6 +34,27 @@ pub enum CgroupCorrelationStatus {
     Failed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkProtocolCoverageStatus {
+    #[default]
+    Unknown,
+    Absent,
+    ConnectOnly,
+    DatagramPeerObserved,
+    ConnectAndDatagramPeerObserved,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkEndpointClaimScope {
+    #[default]
+    Unknown,
+    NotApplicable,
+    DiagnosticOnly,
+    PeerSet,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObservationHealth {
     pub schema: String,
@@ -44,6 +65,10 @@ pub struct ObservationHealth {
     pub policy_layer: PolicyLayerStatus,
     pub sdk_layer: SdkLayerStatus,
     pub cgroup_correlation: CgroupCorrelationStatus,
+    #[serde(default)]
+    pub network_protocol_coverage: NetworkProtocolCoverageStatus,
+    #[serde(default)]
+    pub network_endpoint_claim_scope: NetworkEndpointClaimScope,
     pub notes: Vec<String>,
 }
 
@@ -72,6 +97,8 @@ impl ObservationHealth {
             policy_layer: PolicyLayerStatus::Absent,
             sdk_layer: SdkLayerStatus::Absent,
             cgroup_correlation: CgroupCorrelationStatus::Partial,
+            network_protocol_coverage: NetworkProtocolCoverageStatus::Absent,
+            network_endpoint_claim_scope: NetworkEndpointClaimScope::NotApplicable,
             notes: Vec::new(),
         }
         .normalized()
@@ -136,6 +163,10 @@ impl ObservationHealth {
         if self.platform != "linux" {
             self.kernel_layer = KernelLayerStatus::Absent;
         }
+        if self.platform != "linux" || self.kernel_layer == KernelLayerStatus::Absent {
+            self.network_protocol_coverage = NetworkProtocolCoverageStatus::Absent;
+            self.network_endpoint_claim_scope = NetworkEndpointClaimScope::NotApplicable;
+        }
         // The SDK layer is intentionally not derived from the declared shim.
         // A shim can crash before emitting events, which legitimately leaves
         // sdk_layer=absent even when the requested shim was not "none".
@@ -152,6 +183,10 @@ mod tests {
 
         assert_eq!(health.kernel_layer, KernelLayerStatus::PartialRingbufDrops);
         assert_eq!(health.ringbuf_drops, 2);
+        assert_eq!(
+            health.network_protocol_coverage,
+            NetworkProtocolCoverageStatus::Absent
+        );
     }
 
     #[test]
@@ -160,6 +195,10 @@ mod tests {
 
         assert_eq!(health.kernel_layer, KernelLayerStatus::Absent);
         assert_eq!(health.cgroup_correlation, CgroupCorrelationStatus::Partial);
+        assert_eq!(
+            health.network_endpoint_claim_scope,
+            NetworkEndpointClaimScope::NotApplicable
+        );
     }
 
     #[test]
@@ -167,6 +206,10 @@ mod tests {
         let health = ObservationHealth::new("run_001", "macos");
 
         assert_eq!(health.kernel_layer, KernelLayerStatus::Absent);
+        assert_eq!(
+            health.network_protocol_coverage,
+            NetworkProtocolCoverageStatus::Absent
+        );
     }
 
     #[test]

--- a/crates/assay-runner-schema/src/lib.rs
+++ b/crates/assay-runner-schema/src/lib.rs
@@ -38,8 +38,9 @@ pub use fidelity::{
     RUNNER_FIDELITY_VERDICT_SCHEMA,
 };
 pub use health::{
-    CgroupCorrelationStatus, KernelLayerStatus, ObservationHealth, ObservationHealthError,
-    PolicyLayerStatus, SdkLayerStatus, OBSERVATION_HEALTH_SCHEMA,
+    CgroupCorrelationStatus, KernelLayerStatus, NetworkEndpointClaimScope,
+    NetworkProtocolCoverageStatus, ObservationHealth, ObservationHealthError, PolicyLayerStatus,
+    SdkLayerStatus, OBSERVATION_HEALTH_SCHEMA,
 };
 pub use sdk_event::{SdkLayerEvent, SDK_EVENT_SCHEMA};
 pub use surface::{CapabilitySurface, CapabilitySurfaceError, CAPABILITY_SURFACE_SCHEMA};

--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -179,6 +179,8 @@ Fields:
 | `policy_layer` | enum | yes | `present` or `absent` |
 | `sdk_layer` | enum | yes | `present`, `self_reported`, or `absent` |
 | `cgroup_correlation` | enum | yes | `clean`, `partial`, or `failed` |
+| `network_protocol_coverage` | enum | yes | Network protocol coverage scope for this run's kernel evidence |
+| `network_endpoint_claim_scope` | enum | yes | Claim boundary for interpreting `network_endpoints` |
 | `notes` | array[string] | yes | Stable code-prefixed capture notes used by delegated determinism |
 
 `sdk_layer=self_reported` is the accepted v0 value for the OpenAI Agents SDK
@@ -200,6 +202,16 @@ Validation rules:
 - non-`linux` platforms require `kernel_layer=absent`.
 - `cgroup_correlation=failed` is not valid for a passing Phase 1 run.
 
+Interpretation rules:
+
+- `kernel_layer=complete` means capture health was clean for the attached hooks;
+  it does not, by itself, prove protocol-complete network coverage.
+- `network_protocol_coverage=connect_only` means the current Runner observed
+  `connect()`-level network evidence only.
+- `network_endpoint_claim_scope=diagnostic_only` means `network_endpoints`
+  are useful for coarse/diagnostic review, not for exact peer-set claims on
+  datagram protocols such as QUIC.
+
 Passing Linux/eBPF example:
 
 ```json
@@ -212,8 +224,10 @@ Passing Linux/eBPF example:
   "policy_layer": "present",
   "sdk_layer": "self_reported",
   "cgroup_correlation": "clean",
+  "network_protocol_coverage": "connect_only",
+  "network_endpoint_claim_scope": "diagnostic_only",
   "notes": [
-    "s2_kernel_capture: monitor_events=4 ringbuf_drops=0",
+    "s2_kernel_capture: monitor_events=4 ringbuf_drops=0 network_protocol_coverage=connect_only network_endpoint_claim_scope=diagnostic_only",
     "s4_policy_capture: policy_events=1",
     "s5_sdk_capture: sdk_events=3 sdk_tool_calls=1"
   ]
@@ -235,7 +249,7 @@ Fields:
 | `schema` | string | yes | Must equal `assay.runner.capability_surface.v0` |
 | `run_id` | string | yes | Non-empty run identifier shared by all archive artifacts |
 | `filesystem_paths` | array[string] | yes | Stable sorted set of observed filesystem evidence values |
-| `network_endpoints` | array[string] | yes | Stable sorted set of observed network endpoints |
+| `network_endpoints` | array[string] | yes | Stable sorted set of observed network endpoint values under the coverage and claim-scope limits declared in `observation_health` |
 | `process_execs` | array[string] | yes | Stable sorted set of observed process execution values |
 | `mcp_tools` | array[string] | yes | Stable sorted set of observed MCP/tool names |
 | `policy_decisions` | array[string] | yes | Stable sorted set of policy decision summaries |
@@ -245,6 +259,11 @@ projections. During Phase 2A consolidation this field was renamed from the
 earlier internal `filesystem_prefixes` label because the old name implied a
 projection the artifact never provided. Prefix projection remains a later
 capability-diff transformation, not part of this artifact contract.
+
+For current Linux kernel capture, `network_endpoints` is populated from
+`EVENT_CONNECT` / `EVENT_CONNECT_BLOCKED` sockaddr values. For datagram
+protocols, especially QUIC, this is a connect-attempt surface, not a proven
+actual peer-set surface.
 
 Example:
 

--- a/docs/reference/runner/examples/measured-run-proof-bundle.md
+++ b/docs/reference/runner/examples/measured-run-proof-bundle.md
@@ -88,8 +88,10 @@ Canonical golden, from
   "policy_layer": "present",
   "sdk_layer": "self_reported",
   "cgroup_correlation": "clean",
+  "network_protocol_coverage": "connect_only",
+  "network_endpoint_claim_scope": "diagnostic_only",
   "notes": [
-    "s2_kernel_capture: monitor_events=4 ringbuf_drops=0",
+    "s2_kernel_capture: monitor_events=4 ringbuf_drops=0 network_protocol_coverage=connect_only network_endpoint_claim_scope=diagnostic_only",
     "s4_policy_capture: policy_events=1",
     "s5_sdk_capture: sdk_events=3 sdk_tool_calls=1"
   ]
@@ -102,6 +104,12 @@ How to read this:
   not lose any events the eBPF ring buffer handed us. If it had, this
   would say `degraded` and the count would be non-zero, and the rest of
   the bundle would have to be interpreted in that light.
+- `network_protocol_coverage: connect_only` is the honesty boundary for
+  the current Runner network surface: clean capture does not imply
+  protocol-complete QUIC peer attribution.
+- `network_endpoint_claim_scope: diagnostic_only` means any
+  `network_endpoints` values are coarse/diagnostic evidence, not an
+  exact datagram peer set.
 - `policy_layer: present` means MCP policy decisions were captured.
 - `sdk_layer: self_reported` is the honest framing: SDK events come from
   the SDK itself, so we record them but never call them

--- a/docs/reference/runner/fidelity-verdict-v0.md
+++ b/docs/reference/runner/fidelity-verdict-v0.md
@@ -16,6 +16,8 @@ signals:
 - `policy_layer`
 - `sdk_layer`
 - `cgroup_correlation`
+- `network_protocol_coverage`
+- `network_endpoint_claim_scope`
 
 Those fields are the source of truth. The fidelity verdict is a small
 derived read-model that answers one narrower question:
@@ -94,6 +96,11 @@ Observed positive events can remain useful under `clipped`; missing
 events cannot prove absence. This is why `clipped` degrades positive
 measured claims but blocks bounded negative claims.
 
+`clean` is capture-health clean, not protocol-universal. A record may be
+`clean` while still declaring `network_protocol_coverage = connect_only`
+and `network_endpoint_claim_scope = diagnostic_only`. Downstream code
+must not stretch that into an exact QUIC/datagram peer-set claim.
+
 ## Composition With Projection `claim_level`
 
 Projection helpers such as path projection carry `claim_level` values
@@ -171,6 +178,11 @@ The v0 helper derives the verdict only from one
 5. `kernel_layer = complete`, `ringbuf_drops = 0`, and
    `cgroup_correlation = clean` produces `clean`.
 
+The helper intentionally does not upgrade or reinterpret
+`network_protocol_coverage` or `network_endpoint_claim_scope`. Those
+fields remain an explicit honesty boundary on top of the capture-health
+verdict.
+
 If more than one degradation is present, the helper preserves specific
 reasons and applies the stricter gate where needed. For example,
 partial cgroup correlation blocks per-binding claims even when the
@@ -185,6 +197,8 @@ top-level verdict is driven by clipping.
 - The verdict does not provide probabilistic confidence.
 - The verdict does not validate reported traces, spans, tool calls, or
   SDK events as true.
+- The verdict does not convert connect-only network capture into an exact
+  datagram/QUIC peer-binding claim.
 
 ## Wiring Boundary
 

--- a/docs/reference/runner/golden/observation-health-openai-agents-kernel-policy-v0.json
+++ b/docs/reference/runner/golden/observation-health-openai-agents-kernel-policy-v0.json
@@ -7,8 +7,10 @@
   "policy_layer": "present",
   "sdk_layer": "self_reported",
   "cgroup_correlation": "clean",
+  "network_protocol_coverage": "connect_only",
+  "network_endpoint_claim_scope": "diagnostic_only",
   "notes": [
-    "s2_kernel_capture: monitor_events=4 ringbuf_drops=0",
+    "s2_kernel_capture: monitor_events=4 ringbuf_drops=0 network_protocol_coverage=connect_only network_endpoint_claim_scope=diagnostic_only",
     "s4_policy_capture: policy_events=1",
     "s5_sdk_capture: sdk_events=3 sdk_tool_calls=1"
   ]


### PR DESCRIPTION
## Description
This tightens the Runner's network fidelity claims so QUIC and other datagram traffic are not overclaimed as exact peer bindings.

The patch adds explicit network coverage metadata to `observation_health`, sets current Linux kernel capture to `connect_only` plus `diagnostic_only`, and updates the Runner docs/golden artifact to explain that `network_endpoints` is currently a `connect()`-level surface rather than a proven QUIC peer set.

This addresses the product honesty gap surfaced by the recent QUIC tunnel runs: `kernel_layer=complete` reflected hook/ringbuf/cgroup health, but not protocol-complete network coverage.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor

## Verification
- [ ] `cargo check` passes
- [x] `cargo test` passes
- [ ] Ran a demo suite (e.g. `examples/rag-grounding`)

Verification used:
- `cargo test -p assay-runner-schema -p assay-runner-core`
- pre-push gates including `cargo fmt --check`, `cargo clippy`, and linux compile gate

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Why This Matters
Recent MCP-tunnel / Runner exploration showed a consistent pattern:
- payload-free transport and kernel evidence can support coarse binding,
- but instance-precise semantic accountability still requires explicit content-bound decision/outcome records,
- and the current Runner network surface is only a lower bound for QUIC/datagram egress.

In the measured QUIC runs, kernel-observed `:7844` peers and connector self-reported registered peers were reproducibly disjoint, agreeing only at provider subnet + port. That makes the current `connect()`-derived endpoint set diagnostic, not an exact binding key.

## Delegated Gate Proof
- head sha: `8f655bd6e179276ceb888eb32f53cab7dbc57504`
- gate: all
- delegated run: https://github.com/Rul1an/assay/actions/runs/26875521698

## Follow-up
This PR is the honesty patch. The next product work should be a separate implementation PR with three concrete steps:
1. Add `sendmsg` / `sendto` telemetry so QUIC/datagram peer evidence is not limited to `connect()` attempts.
2. Keep `observation_health` split between capture health and protocol coverage so clean ringbuf/cgroup state cannot overstate network fidelity.
3. Improve `correlation_report` from run-coarse whole-window attribution toward per-window or per-event attribution, so decision-to-effect binding can become more instance-level.
