### PR TITLE
[codex] honor diagnostic network endpoint scope

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -92,6 +92,8 @@ CLASSIFICATION_PROVIDER = "provider-induced"
 CLASSIFICATION_RUNTIME = "runtime-induced"
 CLASSIFICATION_INCONCLUSIVE = "inconclusive"
 
+NETWORK_ENDPOINT_CLAIM_SCOPE_DIAGNOSTIC_ONLY = "diagnostic_only"
+
 PATH_PROJECTION_SCHEMA = "assay.runner.path_projection.v0"
 NETWORK_PROJECTION_SCHEMA = "assay.runner.network_projection.v0"
 PROJECTION_NOT_APPLIED_SCHEMA = "assay.runner.projection_not_applied.v0"
@@ -1077,6 +1079,46 @@ def _diff_lists(
     )
 
 
+def _network_endpoint_claim_scope(observation: ArchiveObservation) -> str | None:
+    value = observation.observation_health.get("network_endpoint_claim_scope")
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _diagnostic_only_network_endpoint_detail(
+    a: ArchiveObservation,
+    b: ArchiveObservation,
+    previous_detail: str,
+) -> str:
+    scopes = {
+        "arm-a": _network_endpoint_claim_scope(a) or "unspecified",
+        "arm-b": _network_endpoint_claim_scope(b) or "unspecified",
+    }
+    return (
+        "network_endpoints claim scope is diagnostic-only "
+        f"(arm-a={scopes['arm-a']}, arm-b={scopes['arm-b']}); "
+        "raw endpoint churn is not classified as a hard regression. "
+        f"Raw comparison detail: {previous_detail}"
+    )
+
+
+def _network_endpoint_churn_is_diagnostic_only(
+    a: ArchiveObservation,
+    b: ArchiveObservation,
+    only_a: list[str],
+    only_b: list[str],
+) -> bool:
+    if not only_a and not only_b:
+        return False
+    return (
+        _network_endpoint_claim_scope(a)
+        == NETWORK_ENDPOINT_CLAIM_SCOPE_DIAGNOSTIC_ONLY
+        or _network_endpoint_claim_scope(b)
+        == NETWORK_ENDPOINT_CLAIM_SCOPE_DIAGNOSTIC_ONLY
+    )
+
+
 def build_drift_report(
     a: ArchiveObservation,
     b: ArchiveObservation,
@@ -1171,6 +1213,9 @@ def build_drift_report(
         fixture_paths,
         is_network_dimension=True,
     )
+    if _network_endpoint_churn_is_diagnostic_only(a, b, only_a, only_b):
+        cls = CLASSIFICATION_INCONCLUSIVE
+        detail = _diagnostic_only_network_endpoint_detail(a, b, detail)
     rows.append(
         DriftRow(
             dimension="network_endpoints",

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1213,7 +1213,9 @@ def build_drift_report(
         fixture_paths,
         is_network_dimension=True,
     )
-    if _network_endpoint_churn_is_diagnostic_only(a, b, only_a, only_b):
+    if a_net and b_net and _network_endpoint_churn_is_diagnostic_only(
+        a, b, only_a, only_b
+    ):
         cls = CLASSIFICATION_INCONCLUSIVE
         detail = _diagnostic_only_network_endpoint_detail(a, b, detail)
     rows.append(

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -621,6 +621,85 @@ class DriftReportClassificationTests(unittest.TestCase):
         )
         self.assertEqual(row.classification, drift.CLASSIFICATION_PROVIDER)
 
+    def test_diagnostic_only_network_endpoint_churn_is_inconclusive(self) -> None:
+        a = drift.ArchiveObservation(
+            path="a",
+            run_id="a",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:aa",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["198.41.192.107:7844"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+            observation_health={
+                "network_endpoint_claim_scope": "diagnostic_only"
+            },
+        )
+        b = drift.ArchiveObservation(
+            path="b",
+            run_id="b",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:bb",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["198.41.200.43:7844"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+            observation_health={
+                "network_endpoint_claim_scope": "diagnostic_only"
+            },
+        )
+
+        rows = drift.build_drift_report(a, b)
+        row = self._by_dim(rows)["network_endpoints"]
+
+        self.assertEqual(row.classification, drift.CLASSIFICATION_INCONCLUSIVE)
+        self.assertIn("diagnostic-only", row.detail)
+        self.assertIn("not classified as a hard regression", row.detail)
+
+    def test_diagnostic_only_network_endpoint_overlap_remains_task(self) -> None:
+        a = drift.ArchiveObservation(
+            path="a",
+            run_id="a",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:aa",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["198.41.192.107:7844"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+            observation_health={
+                "network_endpoint_claim_scope": "diagnostic_only"
+            },
+        )
+
+        rows = drift.build_drift_report(a, a)
+        row = self._by_dim(rows)["network_endpoints"]
+
+        self.assertEqual(row.classification, drift.CLASSIFICATION_TASK)
+
     def test_kernel_file_operations_task_induced(self) -> None:
         rows = drift.build_drift_report(
             self.a, self.b, fixture_paths=self.fixture_paths

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -672,6 +672,56 @@ class DriftReportClassificationTests(unittest.TestCase):
         self.assertIn("diagnostic-only", row.detail)
         self.assertIn("not classified as a hard regression", row.detail)
 
+    def test_one_sided_diagnostic_network_endpoint_churn_is_inconclusive(
+        self,
+    ) -> None:
+        a = drift.ArchiveObservation(
+            path="a",
+            run_id="a",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:aa",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["198.41.192.107:7844"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+            observation_health={
+                "network_endpoint_claim_scope": "diagnostic_only"
+            },
+        )
+        b = drift.ArchiveObservation(
+            path="b",
+            run_id="b",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:bb",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["198.41.200.43:7844"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+        )
+
+        rows = drift.build_drift_report(a, b)
+        row = self._by_dim(rows)["network_endpoints"]
+
+        self.assertEqual(row.classification, drift.CLASSIFICATION_INCONCLUSIVE)
+        self.assertIn("arm-a=diagnostic_only", row.detail)
+        self.assertIn("arm-b=unspecified", row.detail)
+
     def test_diagnostic_only_network_endpoint_overlap_remains_task(self) -> None:
         a = drift.ArchiveObservation(
             path="a",

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -1124,6 +1124,56 @@ class DriftReportInconclusiveTests(unittest.TestCase):
         )
         self.assertIn("arm-b", row.detail)
 
+    def test_diagnostic_only_one_sided_endpoint_absence_keeps_absence_detail(
+        self,
+    ) -> None:
+        a = drift.ArchiveObservation(
+            path="a",
+            run_id="a",
+            runtime_label="openai-agents",
+            manifest_digest="sha256:aa",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": ["api.openai.com:443"],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+            observation_health={
+                "network_endpoint_claim_scope": "diagnostic_only"
+            },
+        )
+        b = drift.ArchiveObservation(
+            path="b",
+            run_id="b",
+            runtime_label="gemini-genai",
+            manifest_digest="sha256:bb",
+            capability_surface={
+                "filesystem_paths": [],
+                "network_endpoints": [],
+                "process_execs": [],
+                "mcp_tools": [],
+                "policy_decisions": [],
+            },
+            sdk_events=[],
+            sdk_event_count=0,
+            sdk_tools=[],
+            sdk_tool_call_ids=[],
+            sdk_tool_order=[],
+        )
+
+        rows = drift.build_drift_report(a, b)
+        row = next(r for r in rows if r.dimension == "network_endpoints")
+
+        self.assertEqual(row.classification, drift.CLASSIFICATION_INCONCLUSIVE)
+        self.assertIn("dimension absent in arm-b", row.detail)
+        self.assertNotIn("raw endpoint churn", row.detail)
+
 
 class DriftReportFixturePathOverrideTests(unittest.TestCase):
     """An extra fixture path that only one arm touched (e.g. cache file)


### PR DESCRIPTION
## Description
This fixes the Assay cross-runtime comparator portion of #1476 by teaching the drift comparator to honor `network_endpoint_claim_scope=diagnostic_only` from Runner observation health.

When raw `network_endpoints` differ but either archive declares diagnostic-only endpoint scope, the comparator now classifies that row as `inconclusive` instead of provider/runtime-induced drift. Full overlap still remains `task-induced`, and older v0 archives without the field keep their existing behavior.

The within-runtime Assay-Harness Tier-2A comparator gap in `runner_compare.ts` is separate and remains tracked in Rul1an/Assay-Harness#80.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor

## Verification
- [ ] `cargo check` passes
- [x] `cargo test` passes
- [ ] Ran a demo suite (e.g. `examples/rag-grounding`)

Verification used:
- `python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'`
- pre-push gates including `cargo fmt --check`, `cargo clippy`, and linux compile gate

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

Closes #1476
Refs Rul1an/Assay-Harness#80
