### PR TITLE
[codex] prepare v3.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.15.0] - 2026-06-03
+
+- Added Runner network-fidelity claim-scope fields so measured-run archives can
+  distinguish capture health from protocol coverage. `network_protocol_coverage`
+  now records whether evidence is connect-only, datagram-peer-only, or both, and
+  `network_endpoint_claim_scope` keeps raw network endpoints diagnostic-only
+  when Assay cannot make an exact peer-set claim.
+
+- Added Runner datagram peer telemetry for Linux captures by attaching
+  `sys_enter_sendto` and `sys_enter_sendmsg` tracepoints alongside the existing
+  `connect()` hook. Assay now records observed datagram destination sockaddr
+  evidence when the kernel exposes it, while still avoiding request-level,
+  `cf_ray`, or authoritative exact-QUIC-peer binding claims.
+
+- Added Runner fidelity helpers for low-level archive consumers, including the
+  fidelity verdict helper and declared path-projection helper used by measured
+  run proof bundles and runner documentation.
+
+- Improved MCP execution-record verification by adding outcome decision-digest
+  verification and a request-envelope fallback binding path for supported MCP
+  execution-record pairing fixtures.
+
+- Updated the cross-runtime drift experiment comparator so raw
+  `network_endpoints` churn is classified as inconclusive when either archive
+  declares diagnostic-only network endpoint scope. This prevents experiment
+  tooling from turning deliberately weak Runner transport evidence into a hard
+  provider/runtime drift claim.
+
+- Added interop joinability summaries for the agent-observability fidelity
+  experiment docs, keeping those artifacts experiment-scoped and non-product
+  API.
+
 ## [3.14.0] - 2026-06-01
 
 - Added `assay evidence verify-mcp-records`, a downstream consumer verifier

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.14.0"
+version = "3.15.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.14.0"
+version = "3.15.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -73,18 +73,18 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.14.0" }
-assay-common = { path = "crates/assay-common", version = "3.14.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.14.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.14.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.14.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.14.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.14.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.14.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.14.0" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.14.0" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.14.0" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.14.0" }
+assay-core = { path = "crates/assay-core", version = "3.15.0" }
+assay-common = { path = "crates/assay-common", version = "3.15.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.15.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.15.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.15.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.15.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.15.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.15.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.15.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.15.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.15.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.15.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,15 +1,16 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-06-01, `v3.14.0` release prep):** the `v3.14.0`
-> release line carries the new `assay evidence verify-mcp-records` command,
-> its edge-test follow-up, and Tier 2a CLI grouping for
-> `assay policy generate` / `assay policy record`. The Cargo
-> workspace/package version on `main` is **`3.14.0`** for this release cut.
+> **Status sync (2026-06-03, `v3.15.0` release prep):** the `v3.15.0`
+> release line carries the post-`v3.14.0` Runner fidelity batch: honest
+> network protocol coverage / endpoint claim-scope fields, datagram peer
+> telemetry for `sendto`/`sendmsg`, the fidelity verdict and declared
+> path-projection helpers, the MCP request-envelope fallback binding slice, and
+> the cross-runtime comparator's diagnostic-only endpoint-churn handling. The
+> Cargo workspace/package version in this release-prep branch is **`3.15.0`**.
 > The current execution posture is: keep remaining CLI grouping trigger-gated,
 > keep Assay-Runner repository extraction gated, treat Assay-Harness `v3.13.0`
 > compatibility as verified by its release-binary compatibility CI check
 > ([run 26756652781](https://github.com/Rul1an/Assay-Harness/actions/runs/26756652781)),
-> refresh Assay-Harness compatibility to `v3.14.0` after the Assay tag,
 > and use the capability-diff / `assay-action` preview decision as the next
 > product-roadmap checkpoint.
 >
@@ -200,6 +201,15 @@ attestation and server execution-record fixture pairing. The rest of the CLI
 grouping RFC remains deliberately trigger-gated: `trust` and `replay` should
 move only with a concrete docs/user-maintenance reason, not just to reduce the
 top-level command count.
+
+The `v3.15.0` release-prep line closes the Runner QUIC fidelity follow-up on
+`main`: Runner archives can now state protocol coverage and diagnostic-only
+network endpoint scope separately from capture health, Linux captures can record
+observed datagram destination sockaddr evidence from `sendto`/`sendmsg`, and the
+cross-runtime experiment comparator treats diagnostic-only endpoint churn as
+inconclusive instead of hard provider/runtime drift. This strengthens transport
+evidence beyond connect-only capture, but it still does not claim request-level
+binding, `cf_ray` capture, or authoritative exact QUIC peer identity.
 
 ### Happy Path (Core Workflow)
 ```bash


### PR DESCRIPTION
## Description
Prepares the v3.15.0 release line from current main.

This is release-prep only: it bumps the workspace/package version from 3.14.0 to 3.15.0, updates Cargo.lock, and adds bounded release notes for the post-v3.14.0 batch now merged on main.

## Release truth
- latest tag: v3.14.0
- latest crates.io line observed: 3.14.0
- this PR prepares v3.15.0; it does not tag or publish crates

## Included main changes
- Runner network fidelity honesty fields: network_protocol_coverage and network_endpoint_claim_scope.
- Runner sendto/sendmsg datagram peer telemetry.
- Runner fidelity verdict and declared path-projection helpers.
- MCP execution-record outcome decision digest verification and request-envelope fallback binding.
- Cross-runtime drift comparator handling for diagnostic-only network endpoint churn.
- Agent-observability interop joinability docs.

## Claim boundary
The v3.15.0 notes keep QUIC/datagram claims transport-scoped. They do not claim request-level binding, cf_ray capture, or authoritative exact QUIC peer identity.

## Verification
- cargo search confirmed assay-cli, assay-runner-core, and assay-runner-schema are currently at 3.14.0 on crates.io.
- cargo metadata --locked --no-deps --format-version 1
- git diff --check
- uvx --with mkdocs-material==9.5.28 --with mkdocs-minify-plugin==0.8.0 mkdocs build --strict
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --workspace --locked
- commit hooks: cargo fmt --check, cargo deny
- pre-push hooks: cargo fmt --check, cargo audit, workspace clippy, linux compile gate

## After merge
Tag v3.15.0 and run the existing release workflow/publish path. Do not describe v3.15.0 as released or published until that completes.
