### PR TITLE
feat: add MCP tunnel observed facts checker

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/mcp_tunnel_observed.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_tunnel_observed.rs
@@ -1,0 +1,525 @@
+use anyhow::{Context, Result};
+use clap::{Args, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+
+const SCHEMA: &str = "assay.mcp.tunnel_observed.v0";
+
+const REQUIRED_NON_CLAIMS: &[&str] = &[
+    "agent_identity_not_verified_by_tunnel_observation",
+    "authorization_not_proven_by_tunnel_observation",
+    "policy_outcome_not_inferred_from_transport",
+    "tool_result_truth_not_proven",
+    "application_outcome_not_proven",
+    "upstream_server_trust_not_proven",
+    "token_freshness_not_proven",
+    "observed_facts_trust_depends_on_observation_point_integrity",
+    "route_facts_may_be_asserted_not_mediation_proven",
+];
+
+const CLAIMS_NOT_MADE: &[&str] = &[
+    "agent_identity_verification",
+    "authorization_proof",
+    "policy_outcome_proof",
+    "route_or_transport_mediation_proof",
+    "tool_result_truth",
+    "application_outcome_truth",
+    "raw_payload_or_raw_auth_retention",
+];
+
+#[derive(Debug, Args, Clone)]
+pub struct McpTunnelObservedArgs {
+    /// MCP tunnel observed-facts artifact JSON fixture
+    #[arg(long)]
+    pub artifact: PathBuf,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = McpTunnelObservedFormat::Table)]
+    pub format: McpTunnelObservedFormat,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum McpTunnelObservedFormat {
+    Json,
+    Table,
+}
+
+#[derive(Debug, Serialize)]
+struct TunnelObservedReport {
+    schema: &'static str,
+    ok: bool,
+    verification_scope: VerificationScope,
+    request_binding: RequestBindingReport,
+    join_summary: JoinSummary,
+    checks: Vec<CheckReport>,
+    claims_not_made: Vec<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct VerificationScope {
+    role: &'static str,
+    note: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct RequestBindingReport {
+    request_envelope_digest: Option<String>,
+    request_envelope_canonicalization: Option<String>,
+}
+
+#[derive(Debug, Serialize, Default)]
+struct JoinSummary {
+    strong_same_request_instance: usize,
+    diagnostic_correlation: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckReport {
+    id: &'static str,
+    ok: bool,
+    detail: String,
+}
+
+pub fn cmd_verify_mcp_tunnel_observed(args: McpTunnelObservedArgs) -> Result<i32> {
+    let artifact = read_json(&args.artifact)?;
+    let report = build_report(&artifact);
+    match args.format {
+        McpTunnelObservedFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        McpTunnelObservedFormat::Table => print_table_report(&report),
+    }
+    Ok(if report.ok { 0 } else { 2 })
+}
+
+fn read_json(path: &PathBuf) -> Result<Value> {
+    let body =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&body).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn build_report(artifact: &Value) -> TunnelObservedReport {
+    let request_digest = string_at(artifact, &["request_instance", "request_envelope_digest"]);
+    let request_canonicalization = string_at(
+        artifact,
+        &["request_instance", "request_envelope_canonicalization"],
+    );
+    let mut checks = Vec::new();
+    let mut join_summary = JoinSummary::default();
+
+    checks.push(check_eq(
+        "schema",
+        string_at(artifact, &["schema"]).as_deref(),
+        Some(SCHEMA),
+        "artifact schema is the MCP tunnel observed-facts v0 contract",
+    ));
+    checks.push(check_sha256(
+        "request_envelope_digest_shape",
+        request_digest.as_deref(),
+        "request_instance.request_envelope_digest is a sha256 digest",
+    ));
+    checks.push(check_present(
+        "request_envelope_canonicalization_present",
+        request_canonicalization.as_deref(),
+        "request_instance.request_envelope_canonicalization is present",
+    ));
+
+    push_visibility_checks(artifact, &mut checks);
+    push_auth_context_checks(artifact, &mut checks);
+    push_inspector_ref_checks(artifact, &mut checks);
+    push_non_claim_checks(artifact, &mut checks);
+    push_evidence_ref_checks(
+        artifact,
+        request_digest.as_deref(),
+        request_canonicalization.as_deref(),
+        &mut checks,
+        &mut join_summary,
+    );
+
+    let ok = checks.iter().all(|check| check.ok);
+    TunnelObservedReport {
+        schema: "assay.mcp.tunnel-observed.report.v0",
+        ok,
+        verification_scope: VerificationScope {
+            role: "independent-consumer",
+            note: "Assay validates bounded observed facts and join classification only; it does not prove mediation, authorization, identity, policy correctness, or runtime truth.",
+        },
+        request_binding: RequestBindingReport {
+            request_envelope_digest: request_digest,
+            request_envelope_canonicalization: request_canonicalization,
+        },
+        join_summary,
+        checks,
+        claims_not_made: CLAIMS_NOT_MADE.to_vec(),
+    }
+}
+
+fn push_visibility_checks(artifact: &Value, checks: &mut Vec<CheckReport>) {
+    let visibility = object_at(artifact, &["visibility"]);
+    checks.push(CheckReport {
+        id: "visibility_object_present",
+        ok: visibility.is_some(),
+        detail: if visibility.is_some() {
+            "visibility object is present".to_string()
+        } else {
+            "missing visibility object".to_string()
+        },
+    });
+    let Some(visibility) = visibility else {
+        return;
+    };
+
+    for key in [
+        "tool_result_visible",
+        "policy_decision_visible",
+        "raw_payload_retained",
+    ] {
+        checks.push(CheckReport {
+            id: match key {
+                "tool_result_visible" => "tool_result_visible_boolean",
+                "policy_decision_visible" => "policy_decision_visible_boolean",
+                "raw_payload_retained" => "raw_payload_retained_boolean",
+                _ => unreachable!(),
+            },
+            ok: visibility.get(key).is_some_and(Value::is_boolean),
+            detail: format!("visibility.{key} must be a JSON boolean"),
+        });
+    }
+
+    let raw_payload_retained = visibility
+        .get("raw_payload_retained")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    checks.push(CheckReport {
+        id: "raw_payload_not_retained",
+        ok: !raw_payload_retained,
+        detail: "visibility.raw_payload_retained must be false".to_string(),
+    });
+
+    for key in ["request_payload_mode", "response_payload_mode"] {
+        let value = visibility.get(key).and_then(Value::as_str);
+        let allowed = ["not_observed", "digest_only", "redacted_projection"];
+        checks.push(CheckReport {
+            id: match key {
+                "request_payload_mode" => "request_payload_mode_enum",
+                "response_payload_mode" => "response_payload_mode_enum",
+                _ => unreachable!(),
+            },
+            ok: value.is_some_and(|mode| allowed.contains(&mode)),
+            detail: match value {
+                Some(value) if allowed.contains(&value) => format!("{value} is allowed"),
+                Some(value) => format!("{value} is not one of {}", allowed.join(", ")),
+                None => "missing value".to_string(),
+            },
+        });
+    }
+}
+
+fn push_auth_context_checks(artifact: &Value, checks: &mut Vec<CheckReport>) {
+    let Some(auth) = object_at(artifact, &["auth_context"]) else {
+        checks.push(CheckReport {
+            id: "auth_context_absent",
+            ok: true,
+            detail: "no auth_context supplied".to_string(),
+        });
+        return;
+    };
+
+    let allowed = [
+        "authorization_header_visible",
+        "authorization_header_stored",
+        "authorization_header_digest",
+        "mcp_oauth_metadata_visible",
+        "client_mtls_configured",
+    ];
+    let unsupported: Vec<_> = auth
+        .keys()
+        .filter(|key| !allowed.contains(&key.as_str()))
+        .cloned()
+        .collect();
+    checks.push(CheckReport {
+        id: "auth_context_key_allowlist",
+        ok: unsupported.is_empty(),
+        detail: if unsupported.is_empty() {
+            "auth_context contains only bounded keys".to_string()
+        } else {
+            format!("unsupported auth_context keys: {}", unsupported.join(", "))
+        },
+    });
+
+    let stored = auth
+        .get("authorization_header_stored")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    checks.push(CheckReport {
+        id: "raw_authorization_not_stored",
+        ok: !stored,
+        detail: "authorization_header_stored must be false".to_string(),
+    });
+
+    for key in [
+        "authorization_header_visible",
+        "authorization_header_stored",
+        "mcp_oauth_metadata_visible",
+        "client_mtls_configured",
+    ] {
+        if auth.get(key).is_some() {
+            checks.push(CheckReport {
+                id: match key {
+                    "authorization_header_visible" => "authorization_header_visible_boolean",
+                    "authorization_header_stored" => "authorization_header_stored_boolean",
+                    "mcp_oauth_metadata_visible" => "mcp_oauth_metadata_visible_boolean",
+                    "client_mtls_configured" => "client_mtls_configured_boolean",
+                    _ => unreachable!(),
+                },
+                ok: auth.get(key).is_some_and(Value::is_boolean),
+                detail: format!("auth_context.{key} must be a JSON boolean"),
+            });
+        }
+    }
+
+    if auth.get("authorization_header_digest").is_some() {
+        checks.push(check_sha256(
+            "authorization_header_digest_shape",
+            auth.get("authorization_header_digest")
+                .and_then(Value::as_str),
+            "authorization_header_digest is a sha256 digest",
+        ));
+    }
+}
+
+fn push_inspector_ref_checks(artifact: &Value, checks: &mut Vec<CheckReport>) {
+    let Some(refs) = artifact
+        .get("inspector_event_refs")
+        .and_then(Value::as_array)
+    else {
+        checks.push(CheckReport {
+            id: "inspector_event_refs_absent",
+            ok: true,
+            detail: "no inspector_event_refs supplied".to_string(),
+        });
+        return;
+    };
+
+    for (index, reference) in refs.iter().enumerate() {
+        let Some(object) = reference.as_object() else {
+            checks.push(CheckReport {
+                id: "inspector_event_ref_shape",
+                ok: false,
+                detail: format!("inspector_event_refs[{index}] must be an object"),
+            });
+            continue;
+        };
+        let unsupported: Vec<_> = object
+            .keys()
+            .filter(|key| !["kind", "digest", "ref"].contains(&key.as_str()))
+            .cloned()
+            .collect();
+        checks.push(CheckReport {
+            id: "inspector_event_ref_key_allowlist",
+            ok: unsupported.is_empty(),
+            detail: if unsupported.is_empty() {
+                format!("inspector_event_refs[{index}] contains only bounded keys")
+            } else {
+                format!(
+                    "inspector_event_refs[{index}] unsupported keys: {}",
+                    unsupported.join(", ")
+                )
+            },
+        });
+        checks.push(check_sha256(
+            "inspector_event_ref_digest_shape",
+            object.get("digest").and_then(Value::as_str),
+            "inspector_event_refs[].digest is a sha256 digest",
+        ));
+    }
+}
+
+fn push_non_claim_checks(artifact: &Value, checks: &mut Vec<CheckReport>) {
+    let supplied: Vec<&str> = artifact
+        .get("non_claims")
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    let missing: Vec<_> = REQUIRED_NON_CLAIMS
+        .iter()
+        .copied()
+        .filter(|claim| !supplied.contains(claim))
+        .collect();
+    checks.push(CheckReport {
+        id: "required_non_claims_present",
+        ok: missing.is_empty(),
+        detail: if missing.is_empty() {
+            "all required non-claims are present".to_string()
+        } else {
+            format!("missing non-claims: {}", missing.join(", "))
+        },
+    });
+}
+
+fn push_evidence_ref_checks(
+    artifact: &Value,
+    request_digest: Option<&str>,
+    request_canonicalization: Option<&str>,
+    checks: &mut Vec<CheckReport>,
+    join_summary: &mut JoinSummary,
+) {
+    let Some(refs) = artifact.get("evidence_refs").and_then(Value::as_array) else {
+        checks.push(CheckReport {
+            id: "evidence_refs_absent",
+            ok: true,
+            detail: "no evidence_refs supplied".to_string(),
+        });
+        return;
+    };
+
+    for (index, reference) in refs.iter().enumerate() {
+        let relationship = string_at(reference, &["relationship"]);
+        let join_strength = string_at(reference, &["join_strength"]);
+        let ref_digest = string_at(reference, &["request_envelope_digest"]);
+        let ref_canonicalization = string_at(reference, &["request_envelope_canonicalization"]);
+        let is_strong_same_request = relationship.as_deref() == Some("same_request_instance")
+            && join_strength.as_deref() == Some("strong");
+
+        if is_strong_same_request {
+            join_summary.strong_same_request_instance += 1;
+            let ok = ref_digest.as_deref() == request_digest
+                && ref_canonicalization.as_deref() == request_canonicalization
+                && request_digest.is_some()
+                && request_canonicalization.is_some();
+            checks.push(CheckReport {
+                id: "same_request_instance_strong_join",
+                ok,
+                detail: if ok {
+                    format!(
+                        "evidence_refs[{index}] binds the same request envelope digest and canonicalization"
+                    )
+                } else {
+                    format!(
+                        "evidence_refs[{index}] strong join requires matching request_envelope_digest and request_envelope_canonicalization"
+                    )
+                },
+            });
+        } else {
+            join_summary.diagnostic_correlation += 1;
+            checks.push(CheckReport {
+                id: "diagnostic_correlation_boundary",
+                ok: true,
+                detail: format!(
+                    "evidence_refs[{index}] is diagnostic because it is not a strong shared request-envelope join"
+                ),
+            });
+        }
+    }
+}
+
+fn object_at<'a>(value: &'a Value, path: &[&str]) -> Option<&'a serde_json::Map<String, Value>> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_object()
+}
+
+fn string_at(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str().map(ToOwned::to_owned)
+}
+
+fn check_present(id: &'static str, value: Option<&str>, description: &str) -> CheckReport {
+    CheckReport {
+        id,
+        ok: value.is_some(),
+        detail: if value.is_some() {
+            description.to_string()
+        } else {
+            "missing value".to_string()
+        },
+    }
+}
+
+fn check_eq(
+    id: &'static str,
+    left: Option<&str>,
+    right: Option<&str>,
+    description: &str,
+) -> CheckReport {
+    let ok = left.is_some() && right.is_some() && left == right;
+    let detail = match (left, right) {
+        (Some(left), Some(right)) if left == right => description.to_string(),
+        (Some(left), Some(right)) => format!("mismatch: got {left}, expected {right}"),
+        (None, _) => "missing observed value".to_string(),
+        (_, None) => "missing expected value".to_string(),
+    };
+    CheckReport { id, ok, detail }
+}
+
+fn check_sha256(id: &'static str, value: Option<&str>, description: &str) -> CheckReport {
+    let ok = value.is_some_and(is_sha256_digest);
+    let detail = match value {
+        Some(value) if is_sha256_digest(value) => description.to_string(),
+        Some(value) => format!("{value} is not sha256:<64 lowercase hex chars>"),
+        None => "missing value".to_string(),
+    };
+    CheckReport { id, ok, detail }
+}
+
+fn is_sha256_digest(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return false;
+    };
+    hex.len() == 64
+        && hex
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn print_table_report(report: &TunnelObservedReport) {
+    println!("MCP Tunnel Observed-Facts Report");
+    println!("================================");
+    println!(
+        "OK:                  {}",
+        if report.ok { "yes" } else { "no" }
+    );
+    println!("Role:                {}", report.verification_scope.role);
+    println!(
+        "Request digest:      {}",
+        report
+            .request_binding
+            .request_envelope_digest
+            .as_deref()
+            .unwrap_or("-")
+    );
+    println!(
+        "Request canon:       {}",
+        report
+            .request_binding
+            .request_envelope_canonicalization
+            .as_deref()
+            .unwrap_or("-")
+    );
+    println!(
+        "Strong joins:        {}",
+        report.join_summary.strong_same_request_instance
+    );
+    println!(
+        "Diagnostic joins:    {}",
+        report.join_summary.diagnostic_correlation
+    );
+    println!();
+    for check in &report.checks {
+        println!(
+            "{:<42} {:<4} {}",
+            check.id,
+            if check.ok { "ok" } else { "fail" },
+            check.detail
+        );
+    }
+    println!();
+    println!("Claims not made: {}", report.claims_not_made.join(", "));
+}

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -6,6 +6,7 @@ pub mod livekit_tool_action;
 pub mod mapping;
 pub mod mastra_score_event;
 pub mod mcp_execution_records;
+pub mod mcp_tunnel_observed;
 pub mod openfeature_details;
 pub mod promptfoo_jsonl;
 pub mod pull;
@@ -30,6 +31,9 @@ pub enum EvidenceCmd {
     /// Verify SEP-2787/server execution-record fixture pairing
     #[command(name = "verify-mcp-records")]
     VerifyMcpRecords(mcp_execution_records::McpExecutionRecordArgs),
+    /// Verify MCP tunnel observed-facts fixture boundaries and join classification
+    #[command(name = "verify-mcp-tunnel-observed")]
+    VerifyMcpTunnelObserved(mcp_tunnel_observed::McpTunnelObservedArgs),
     /// Inspect a bundle's contents (verify + show table)
     Show(EvidenceShowArgs),
     /// Import external evidence into an Assay evidence bundle
@@ -123,6 +127,9 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
         EvidenceCmd::Export(a) => cmd_export(a),
         EvidenceCmd::Verify(a) => cmd_verify(a),
         EvidenceCmd::VerifyMcpRecords(a) => mcp_execution_records::cmd_verify_mcp_records(a),
+        EvidenceCmd::VerifyMcpTunnelObserved(a) => {
+            mcp_tunnel_observed::cmd_verify_mcp_tunnel_observed(a)
+        }
         EvidenceCmd::Show(a) => cmd_show(a),
         EvidenceCmd::Import(a) => cmd_import(a),
         EvidenceCmd::Schema(a) => schema::cmd_schema(a),

--- a/crates/assay-cli/tests/evidence_test.rs
+++ b/crates/assay-cli/tests/evidence_test.rs
@@ -19,3 +19,5 @@ mod flow_and_eval_receipts;
 mod importer_receipts;
 #[path = "evidence_test/mcp_execution_records.rs"]
 mod mcp_execution_records;
+#[path = "evidence_test/mcp_tunnel_observed.rs"]
+mod mcp_tunnel_observed;

--- a/crates/assay-cli/tests/evidence_test/mcp_tunnel_observed.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_tunnel_observed.rs
@@ -1,0 +1,157 @@
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::{tempdir, TempDir};
+
+const VALID_TUNNEL: &str = "examples/mcp-tunnel-observed-evidence/fixtures/valid.tunnel.json";
+
+fn repo_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
+fn read_valid_tunnel() -> Value {
+    let body = fs::read_to_string(repo_path(VALID_TUNNEL)).unwrap();
+    serde_json::from_str(&body).unwrap()
+}
+
+fn write_fixture(value: &Value, name: &str) -> (TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(name);
+    fs::write(&path, serde_json::to_string_pretty(value).unwrap()).unwrap();
+    (dir, path)
+}
+
+#[test]
+fn verify_mcp_tunnel_observed_reports_strong_join_boundary() {
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-tunnel-observed",
+            "--artifact",
+            repo_path(VALID_TUNNEL).to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["schema"], "assay.mcp.tunnel-observed.report.v0");
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["verification_scope"]["role"], "independent-consumer");
+    assert_eq!(
+        report["request_binding"]["request_envelope_digest"],
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    );
+    assert!(report["request_binding"].get("route").is_none());
+    assert!(report["request_binding"].get("upstream").is_none());
+    assert_eq!(report["join_summary"]["strong_same_request_instance"], 1);
+    assert_eq!(report["join_summary"]["diagnostic_correlation"], 0);
+    assert!(report["claims_not_made"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|claim| claim == "route_or_transport_mediation_proof"));
+}
+
+#[test]
+fn verify_mcp_tunnel_observed_rejects_raw_payload_retention() {
+    let mut artifact = read_valid_tunnel();
+    artifact["visibility"]["raw_payload_retained"] = Value::Bool(true);
+    let (_dir, path) = write_fixture(&artifact, "raw-payload-retained.tunnel.json");
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-tunnel-observed",
+            "--artifact",
+            path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .code(2)
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["ok"], false);
+    assert!(report["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|check| check["id"] == "raw_payload_not_retained" && check["ok"] == false));
+}
+
+#[test]
+fn verify_mcp_tunnel_observed_classifies_route_only_ref_as_diagnostic() {
+    let mut artifact = read_valid_tunnel();
+    let refs = artifact["evidence_refs"].as_array_mut().unwrap();
+    refs[0] = serde_json::json!({
+        "kind": "mcp.execution_record",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "relationship": "route_label_only",
+        "join_strength": "diagnostic"
+    });
+    let (_dir, path) = write_fixture(&artifact, "route-only-diagnostic.tunnel.json");
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-tunnel-observed",
+            "--artifact",
+            path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["join_summary"]["strong_same_request_instance"], 0);
+    assert_eq!(report["join_summary"]["diagnostic_correlation"], 1);
+}
+
+#[test]
+fn verify_mcp_tunnel_observed_rejects_mismatched_strong_join() {
+    let mut artifact = read_valid_tunnel();
+    artifact["evidence_refs"][0]["request_envelope_canonicalization"] =
+        Value::String("json:mcp_request_envelope.unstable".to_string());
+    let (_dir, path) = write_fixture(&artifact, "mismatched-strong-join.tunnel.json");
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-tunnel-observed",
+            "--artifact",
+            path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .code(2)
+        .get_output()
+        .stdout
+        .clone();
+
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert!(report["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|check| check["id"] == "same_request_instance_strong_join" && check["ok"] == false));
+}

--- a/docs/reference/cli/evidence.md
+++ b/docs/reference/cli/evidence.md
@@ -113,6 +113,33 @@ Pairing or enum mismatches produce a report and exit `2`.
 
 ---
 
+## MCP Tunnel Observed-Facts Check
+
+Validate one bounded MCP tunnel observed-facts fixture and classify its join
+evidence from the consumer side:
+
+```bash
+assay evidence verify-mcp-tunnel-observed \
+  --artifact examples/mcp-tunnel-observed-evidence/fixtures/valid.tunnel.json \
+  --format json
+```
+
+This command emits an `assay.mcp.tunnel-observed.report.v0` report. It checks
+the provider-neutral `assay.mcp.tunnel_observed.v0` fixture shape, enforces the
+no-raw-payload and no-raw-authorization boundaries, and reports whether
+`evidence_refs` form a strong `same_request_instance` join or only diagnostic
+correlation.
+
+A strong join requires the referenced evidence to bind the same
+`request_envelope_digest` and `request_envelope_canonicalization` as the tunnel
+artifact. Route, upstream, request id, timestamp, or provider request id alone
+remain diagnostic correlation. The command deliberately does not prove tunnel
+mediation, agent identity, authorization success, policy correctness, tool
+result truth, application outcome truth, or issuer/key trust. Boundary
+violations produce a JSON/table report and exit `2`.
+
+---
+
 ## CycloneDX ML-BOM Model Import
 
 Import one selected CycloneDX ML-BOM `machine-learning-model` component into a

--- a/examples/mcp-tunnel-observed-evidence/README.md
+++ b/examples/mcp-tunnel-observed-evidence/README.md
@@ -60,6 +60,21 @@ python3 examples/mcp-tunnel-observed-evidence/map_to_assay.py \
   --overwrite
 ```
 
+## Verify the observed-facts fixture
+
+```bash
+assay evidence verify-mcp-tunnel-observed \
+  --artifact examples/mcp-tunnel-observed-evidence/fixtures/valid.tunnel.json \
+  --format json
+```
+
+This checker is the reference fixture path for the sample. It validates the
+bounded `assay.mcp.tunnel_observed.v0` shape, keeps raw payload/auth material
+out, and classifies `evidence_refs` as either strong `same_request_instance`
+joins or diagnostic correlation. Strong joins require a shared
+`request_envelope_digest` and `request_envelope_canonicalization`; route,
+upstream, request id, timestamp, or provider request id alone stay diagnostic.
+
 ## Map the substituted-upstream artifact
 
 ```bash
@@ -114,4 +129,5 @@ strengthen that, but this first sample keeps the consumer boundary explicit.
 
 ```bash
 python3 -m unittest examples/mcp-tunnel-observed-evidence/test_map_to_assay.py
+cargo test -p assay-cli --test evidence_test mcp_tunnel_observed
 ```


### PR DESCRIPTION
## Description
Adds a first-class consumer-side checker for the P57 MCP tunnel observed-facts sample:

- introduces `assay evidence verify-mcp-tunnel-observed`
- validates the bounded `assay.mcp.tunnel_observed.v0` fixture boundary
- keeps route/upstream outside the request binding key
- classifies `evidence_refs` as strong `same_request_instance` joins only when both request envelope digest and canonicalization match; otherwise diagnostic
- preserves no-raw-payload/no-raw-auth and observed-vs-proven non-claim discipline

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor

## Verification
- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] Ran a demo suite (e.g. `examples/rag-grounding`)

Commands run:

```bash
cargo fmt
cargo test -p assay-cli --test evidence_test mcp_tunnel_observed -- --nocapture
python3 -m unittest examples/mcp-tunnel-observed-evidence/test_map_to_assay.py
target/debug/assay evidence verify-mcp-tunnel-observed --artifact examples/mcp-tunnel-observed-evidence/fixtures/valid.tunnel.json --format json | python3 -m json.tool >/tmp/p57-tunnel-valid-report-clean.json
target/debug/assay evidence verify-mcp-tunnel-observed --artifact examples/mcp-tunnel-observed-evidence/fixtures/raw-auth-leak.tunnel.json --format json >/tmp/p57-tunnel-raw-auth-report-clean.json
python3 -m json.tool /tmp/p57-tunnel-raw-auth-report-clean.json >/dev/null
cargo clippy -p assay-cli --tests -- -D warnings
git diff --check
```

The raw-auth fixture exits `2` as expected while still producing a parseable JSON report.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
