### PR TITLE
feat: add runner coverage descriptor gate

### DIFF
--- a/crates/assay-runner-schema/src/coverage.rs
+++ b/crates/assay-runner-schema/src/coverage.rs
@@ -111,6 +111,17 @@ impl CoverageDescriptor {
             };
         };
 
+        if descriptor.schema != COVERAGE_DESCRIPTOR_SCHEMA {
+            return CoverageClaimDecision {
+                decision: ClaimGateDecision::Blocked,
+                rule: "coverage_descriptor_schema_mismatch".to_string(),
+                reason: format!(
+                    "coverage descriptor schema must be {}, found {}",
+                    COVERAGE_DESCRIPTOR_SCHEMA, descriptor.schema
+                ),
+            };
+        }
+
         match claim_kind {
             CoverageClaimKind::PositiveExistence => CoverageClaimDecision {
                 decision: ClaimGateDecision::Allowed,
@@ -121,11 +132,12 @@ impl CoverageDescriptor {
                     dimension_label(descriptor.dimension)
                 ),
             },
-            CoverageClaimKind::ExhaustiveSet if descriptor.known_blind_spots.is_empty() => {
+            CoverageClaimKind::ExhaustiveSet if descriptor.supports_complete_claims() => {
                 CoverageClaimDecision {
                     decision: ClaimGateDecision::Allowed,
                     rule: "coverage_descriptor_allows_exhaustive_claim".to_string(),
-                    reason: "descriptor declares no blind spots for this dimension".to_string(),
+                    reason: "descriptor completeness is full and declares no blind spots"
+                        .to_string(),
                 }
             }
             CoverageClaimKind::ExhaustiveSet => CoverageClaimDecision {
@@ -138,23 +150,29 @@ impl CoverageDescriptor {
                     descriptor.known_blind_spots.join("; ")
                 ),
             },
-            CoverageClaimKind::BoundedNegative if descriptor.known_blind_spots.is_empty() => {
+            CoverageClaimKind::BoundedNegative if descriptor.supports_complete_claims() => {
                 CoverageClaimDecision {
                     decision: ClaimGateDecision::Allowed,
                     rule: "coverage_descriptor_allows_absence_claim".to_string(),
-                    reason: "descriptor declares no blind spots for this dimension".to_string(),
+                    reason: "descriptor completeness is full and declares no blind spots"
+                        .to_string(),
                 }
             }
             CoverageClaimKind::BoundedNegative => CoverageClaimDecision {
                 decision: ClaimGateDecision::Blocked,
                 rule: "coverage_descriptor_blocks_absence_claim".to_string(),
                 reason: format!(
-                    "{} blind spots can hide the requested absence: {}",
+                    "{} completeness is {}; blind spots can hide the requested absence: {}",
                     dimension_label(descriptor.dimension),
-                    descriptor.known_blind_spots.join("; ")
+                    completeness_label(descriptor.completeness),
+                    blind_spot_summary(descriptor)
                 ),
             },
         }
+    }
+
+    fn supports_complete_claims(&self) -> bool {
+        self.completeness == CoverageCompleteness::Full && self.known_blind_spots.is_empty()
     }
 }
 
@@ -172,5 +190,13 @@ fn completeness_label(completeness: CoverageCompleteness) -> &'static str {
         CoverageCompleteness::OpenSyscallOnly => "open_syscall_only",
         CoverageCompleteness::ConnectOnly => "connect_only",
         CoverageCompleteness::ExecOnly => "exec_only",
+    }
+}
+
+fn blind_spot_summary(descriptor: &CoverageDescriptor) -> String {
+    if descriptor.known_blind_spots.is_empty() {
+        "none declared".to_string()
+    } else {
+        descriptor.known_blind_spots.join("; ")
     }
 }

--- a/crates/assay-runner-schema/src/coverage.rs
+++ b/crates/assay-runner-schema/src/coverage.rs
@@ -1,0 +1,178 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ClaimGateDecision;
+
+pub const COVERAGE_DESCRIPTOR_SCHEMA: &str = "assay.runner.coverage_descriptor.v0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectDimension {
+    Filesystem,
+    Network,
+    Process,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageCompleteness {
+    Full,
+    OpenSyscallOnly,
+    ConnectOnly,
+    ExecOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageClaimKind {
+    PositiveExistence,
+    ExhaustiveSet,
+    BoundedNegative,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoverageDescriptor {
+    pub schema: String,
+    pub dimension: EffectDimension,
+    pub method: String,
+    pub observes: Vec<String>,
+    pub known_blind_spots: Vec<String>,
+    pub completeness: CoverageCompleteness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoverageClaimDecision {
+    pub decision: ClaimGateDecision,
+    pub rule: String,
+    pub reason: String,
+}
+
+impl CoverageDescriptor {
+    #[must_use]
+    pub fn filesystem_open_syscall_only() -> Self {
+        Self {
+            schema: COVERAGE_DESCRIPTOR_SCHEMA.to_string(),
+            dimension: EffectDimension::Filesystem,
+            method: "open/openat/openat2 tracepoints".to_string(),
+            observes: vec!["path opens through syscall tracepoints".to_string()],
+            known_blind_spots: vec![
+                "io_uring file operations may bypass syscall tracepoints".to_string(),
+                "mmap-backed writes are not path-open observations".to_string(),
+            ],
+            completeness: CoverageCompleteness::OpenSyscallOnly,
+        }
+    }
+
+    #[must_use]
+    pub fn network_connect_only() -> Self {
+        Self {
+            schema: COVERAGE_DESCRIPTOR_SCHEMA.to_string(),
+            dimension: EffectDimension::Network,
+            method: "connect tracepoint".to_string(),
+            observes: vec!["connect-time peer endpoints".to_string()],
+            known_blind_spots: vec![
+                "QUIC/datagram peer changes after connect are not an exhaustive peer set"
+                    .to_string(),
+                "io_uring network operations may bypass syscall tracepoints".to_string(),
+            ],
+            completeness: CoverageCompleteness::ConnectOnly,
+        }
+    }
+
+    #[must_use]
+    pub fn process_exec_only() -> Self {
+        Self {
+            schema: COVERAGE_DESCRIPTOR_SCHEMA.to_string(),
+            dimension: EffectDimension::Process,
+            method: "exec tracepoint".to_string(),
+            observes: vec!["process exec targets".to_string()],
+            known_blind_spots: vec![
+                "fork/clone gaps can make process-tree exhaustiveness kernel-dependent".to_string(),
+            ],
+            completeness: CoverageCompleteness::ExecOnly,
+        }
+    }
+
+    #[must_use]
+    pub fn claim_decision(&self, claim_kind: CoverageClaimKind) -> CoverageClaimDecision {
+        Self::claim_decision_for(Some(self), claim_kind)
+    }
+
+    #[must_use]
+    pub fn claim_decision_for(
+        descriptor: Option<&Self>,
+        claim_kind: CoverageClaimKind,
+    ) -> CoverageClaimDecision {
+        let Some(descriptor) = descriptor else {
+            return CoverageClaimDecision {
+                decision: ClaimGateDecision::Blocked,
+                rule: "coverage_descriptor_required_for_claim".to_string(),
+                reason: "missing coverage descriptor blocks coverage-aware side-effect claims"
+                    .to_string(),
+            };
+        };
+
+        match claim_kind {
+            CoverageClaimKind::PositiveExistence => CoverageClaimDecision {
+                decision: ClaimGateDecision::Allowed,
+                rule: "coverage_descriptor_allows_observed_positive_claim".to_string(),
+                reason: format!(
+                    "{} observes positive {} effects",
+                    descriptor.method,
+                    dimension_label(descriptor.dimension)
+                ),
+            },
+            CoverageClaimKind::ExhaustiveSet if descriptor.known_blind_spots.is_empty() => {
+                CoverageClaimDecision {
+                    decision: ClaimGateDecision::Allowed,
+                    rule: "coverage_descriptor_allows_exhaustive_claim".to_string(),
+                    reason: "descriptor declares no relevant blind spots for this dimension"
+                        .to_string(),
+                }
+            }
+            CoverageClaimKind::ExhaustiveSet => CoverageClaimDecision {
+                decision: ClaimGateDecision::Degraded,
+                rule: "coverage_descriptor_degrades_exhaustive_claim".to_string(),
+                reason: format!(
+                    "{} completeness is {}; blind spots: {}",
+                    dimension_label(descriptor.dimension),
+                    completeness_label(descriptor.completeness),
+                    descriptor.known_blind_spots.join("; ")
+                ),
+            },
+            CoverageClaimKind::BoundedNegative if descriptor.known_blind_spots.is_empty() => {
+                CoverageClaimDecision {
+                    decision: ClaimGateDecision::Allowed,
+                    rule: "coverage_descriptor_allows_absence_claim".to_string(),
+                    reason: "descriptor declares no relevant blind spots for this dimension"
+                        .to_string(),
+                }
+            }
+            CoverageClaimKind::BoundedNegative => CoverageClaimDecision {
+                decision: ClaimGateDecision::Blocked,
+                rule: "coverage_descriptor_blocks_absence_claim".to_string(),
+                reason: format!(
+                    "{} blind spots can hide the requested absence: {}",
+                    dimension_label(descriptor.dimension),
+                    descriptor.known_blind_spots.join("; ")
+                ),
+            },
+        }
+    }
+}
+
+fn dimension_label(dimension: EffectDimension) -> &'static str {
+    match dimension {
+        EffectDimension::Filesystem => "filesystem",
+        EffectDimension::Network => "network",
+        EffectDimension::Process => "process",
+    }
+}
+
+fn completeness_label(completeness: CoverageCompleteness) -> &'static str {
+    match completeness {
+        CoverageCompleteness::Full => "full",
+        CoverageCompleteness::OpenSyscallOnly => "open_syscall_only",
+        CoverageCompleteness::ConnectOnly => "connect_only",
+        CoverageCompleteness::ExecOnly => "exec_only",
+    }
+}

--- a/crates/assay-runner-schema/src/coverage.rs
+++ b/crates/assay-runner-schema/src/coverage.rs
@@ -125,8 +125,7 @@ impl CoverageDescriptor {
                 CoverageClaimDecision {
                     decision: ClaimGateDecision::Allowed,
                     rule: "coverage_descriptor_allows_exhaustive_claim".to_string(),
-                    reason: "descriptor declares no relevant blind spots for this dimension"
-                        .to_string(),
+                    reason: "descriptor declares no blind spots for this dimension".to_string(),
                 }
             }
             CoverageClaimKind::ExhaustiveSet => CoverageClaimDecision {
@@ -143,8 +142,7 @@ impl CoverageDescriptor {
                 CoverageClaimDecision {
                     decision: ClaimGateDecision::Allowed,
                     rule: "coverage_descriptor_allows_absence_claim".to_string(),
-                    reason: "descriptor declares no relevant blind spots for this dimension"
-                        .to_string(),
+                    reason: "descriptor declares no blind spots for this dimension".to_string(),
                 }
             }
             CoverageClaimKind::BoundedNegative => CoverageClaimDecision {

--- a/crates/assay-runner-schema/src/lib.rs
+++ b/crates/assay-runner-schema/src/lib.rs
@@ -8,6 +8,8 @@
 //! - `assay.runner.capability_surface.v0`
 //! - `assay.runner.correlation_report.v0`
 //! - `assay.runner.sdk_event.v0`
+//! - `assay.runner.coverage_descriptor.v0` (internal helper contract; not an
+//!   archive member yet)
 //! - `assay.runner.archive_manifest.v0` (manifest semantics only; archive
 //!   assembly mechanics live in `assay-runner-core` since Phase 2D Slice 2)
 //!
@@ -17,6 +19,7 @@
 
 mod archive_manifest;
 mod correlation;
+mod coverage;
 mod fidelity;
 mod health;
 mod sdk_event;
@@ -30,6 +33,10 @@ pub use archive_manifest::{
 pub use correlation::{
     BindingWindow, CorrelationBinding, CorrelationReport, CorrelationReportError,
     CorrelationStatus, CORRELATION_REPORT_SCHEMA,
+};
+pub use coverage::{
+    CoverageClaimDecision, CoverageClaimKind, CoverageCompleteness, CoverageDescriptor,
+    EffectDimension, COVERAGE_DESCRIPTOR_SCHEMA,
 };
 pub use fidelity::{
     ClaimGateDecision, RunnerClaimGate, RunnerFidelityReason, RunnerFidelityVerdict,

--- a/crates/assay-runner-schema/tests/coverage_descriptor.rs
+++ b/crates/assay-runner-schema/tests/coverage_descriptor.rs
@@ -1,0 +1,96 @@
+use assay_runner_schema::{
+    ClaimGateDecision, CoverageClaimKind, CoverageCompleteness, CoverageDescriptor, EffectDimension,
+};
+use serde_json::json;
+
+#[test]
+fn filesystem_descriptor_serializes_blindspots_as_data() {
+    let descriptor = CoverageDescriptor::filesystem_open_syscall_only();
+
+    assert_eq!(descriptor.schema, "assay.runner.coverage_descriptor.v0");
+    assert_eq!(descriptor.dimension, EffectDimension::Filesystem);
+    assert_eq!(
+        descriptor.completeness,
+        CoverageCompleteness::OpenSyscallOnly
+    );
+    assert!(descriptor
+        .known_blind_spots
+        .iter()
+        .any(|blindspot| blindspot.contains("io_uring")));
+
+    let value = serde_json::to_value(&descriptor).expect("descriptor serializes");
+    assert_eq!(
+        value,
+        json!({
+            "schema": "assay.runner.coverage_descriptor.v0",
+            "dimension": "filesystem",
+            "method": "open/openat/openat2 tracepoints",
+            "observes": ["path opens through syscall tracepoints"],
+            "known_blind_spots": [
+                "io_uring file operations may bypass syscall tracepoints",
+                "mmap-backed writes are not path-open observations"
+            ],
+            "completeness": "open_syscall_only"
+        })
+    );
+}
+
+#[test]
+fn partial_filesystem_coverage_allows_positive_but_blocks_absence() {
+    let descriptor = CoverageDescriptor::filesystem_open_syscall_only();
+
+    assert_eq!(
+        descriptor
+            .claim_decision(CoverageClaimKind::PositiveExistence)
+            .decision,
+        ClaimGateDecision::Allowed
+    );
+    assert_eq!(
+        descriptor
+            .claim_decision(CoverageClaimKind::ExhaustiveSet)
+            .decision,
+        ClaimGateDecision::Degraded
+    );
+
+    let bounded_negative = descriptor.claim_decision(CoverageClaimKind::BoundedNegative);
+    assert_eq!(bounded_negative.decision, ClaimGateDecision::Blocked);
+    assert_eq!(
+        bounded_negative.rule,
+        "coverage_descriptor_blocks_absence_claim"
+    );
+    assert!(bounded_negative.reason.contains("io_uring"));
+}
+
+#[test]
+fn missing_descriptor_blocks_exhaustive_and_bounded_negative_claims() {
+    assert_eq!(
+        CoverageDescriptor::claim_decision_for(None, CoverageClaimKind::PositiveExistence).decision,
+        ClaimGateDecision::Blocked
+    );
+    assert_eq!(
+        CoverageDescriptor::claim_decision_for(None, CoverageClaimKind::ExhaustiveSet).decision,
+        ClaimGateDecision::Blocked
+    );
+    assert_eq!(
+        CoverageDescriptor::claim_decision_for(None, CoverageClaimKind::BoundedNegative).decision,
+        ClaimGateDecision::Blocked
+    );
+}
+
+#[test]
+fn network_connect_only_is_positive_but_not_an_exhaustive_peer_set() {
+    let descriptor = CoverageDescriptor::network_connect_only();
+
+    assert_eq!(descriptor.dimension, EffectDimension::Network);
+    assert_eq!(descriptor.completeness, CoverageCompleteness::ConnectOnly);
+    assert_eq!(
+        descriptor
+            .claim_decision(CoverageClaimKind::PositiveExistence)
+            .decision,
+        ClaimGateDecision::Allowed
+    );
+
+    let exhaustive = descriptor.claim_decision(CoverageClaimKind::ExhaustiveSet);
+    assert_eq!(exhaustive.decision, ClaimGateDecision::Degraded);
+    assert!(exhaustive.reason.contains("QUIC"));
+}

--- a/crates/assay-runner-schema/tests/coverage_descriptor.rs
+++ b/crates/assay-runner-schema/tests/coverage_descriptor.rs
@@ -78,6 +78,41 @@ fn missing_descriptor_blocks_all_claim_kinds() {
 }
 
 #[test]
+fn malformed_descriptor_schema_blocks_claim_decisions() {
+    let mut descriptor = CoverageDescriptor::filesystem_open_syscall_only();
+    descriptor.schema = "assay.runner.coverage_descriptor.v_next".to_string();
+
+    let decision = CoverageDescriptor::claim_decision_for(
+        Some(&descriptor),
+        CoverageClaimKind::PositiveExistence,
+    );
+
+    assert_eq!(decision.decision, ClaimGateDecision::Blocked);
+    assert_eq!(decision.rule, "coverage_descriptor_schema_mismatch");
+}
+
+#[test]
+fn non_full_completeness_blocks_absence_even_without_blindspot_text() {
+    let mut descriptor = CoverageDescriptor::filesystem_open_syscall_only();
+    descriptor.known_blind_spots.clear();
+
+    let exhaustive = descriptor.claim_decision(CoverageClaimKind::ExhaustiveSet);
+    assert_eq!(exhaustive.decision, ClaimGateDecision::Degraded);
+    assert_eq!(
+        exhaustive.rule,
+        "coverage_descriptor_degrades_exhaustive_claim"
+    );
+
+    let bounded_negative = descriptor.claim_decision(CoverageClaimKind::BoundedNegative);
+    assert_eq!(bounded_negative.decision, ClaimGateDecision::Blocked);
+    assert_eq!(
+        bounded_negative.rule,
+        "coverage_descriptor_blocks_absence_claim"
+    );
+    assert!(bounded_negative.reason.contains("open_syscall_only"));
+}
+
+#[test]
 fn network_connect_only_is_positive_but_not_an_exhaustive_peer_set() {
     let descriptor = CoverageDescriptor::network_connect_only();
 

--- a/crates/assay-runner-schema/tests/coverage_descriptor.rs
+++ b/crates/assay-runner-schema/tests/coverage_descriptor.rs
@@ -62,7 +62,7 @@ fn partial_filesystem_coverage_allows_positive_but_blocks_absence() {
 }
 
 #[test]
-fn missing_descriptor_blocks_exhaustive_and_bounded_negative_claims() {
+fn missing_descriptor_blocks_all_claim_kinds() {
     assert_eq!(
         CoverageDescriptor::claim_decision_for(None, CoverageClaimKind::PositiveExistence).decision,
         ClaimGateDecision::Blocked

--- a/docs/reference/runner/coverage-descriptor-v0.md
+++ b/docs/reference/runner/coverage-descriptor-v0.md
@@ -1,0 +1,130 @@
+# Runner Coverage Descriptor v0
+
+> **Status:** internal helper contract. This page defines the
+> `assay.runner.coverage_descriptor.v0` vocabulary and the first
+> descriptor-driven claim-kind gate. It does not add a Runner archive
+> member, CLI output, Trust Basis claim, or stable report schema.
+
+## Purpose
+
+Runner observation health answers whether the capture was healthy. A
+coverage descriptor answers a different question:
+
+```text
+For this effect dimension, what did this capture method observe, and what can it miss?
+```
+
+That distinction matters because an observed positive event can remain
+useful while an exhaustive or negative claim is unsafe. For example, a
+file open observed by an `openat` tracepoint is still a measured positive
+event, but `openat`-only capture does not prove that no other file
+activity happened.
+
+## Schema String
+
+```text
+assay.runner.coverage_descriptor.v0
+```
+
+The current Rust helper lives in `assay-runner-schema`. The schema string
+is an internal helper/contract label at this stage; no JSON Schema
+sidecar or archive member is frozen yet.
+
+## Descriptor Shape
+
+```json
+{
+  "schema": "assay.runner.coverage_descriptor.v0",
+  "dimension": "filesystem",
+  "method": "open/openat/openat2 tracepoints",
+  "observes": ["path opens through syscall tracepoints"],
+  "known_blind_spots": [
+    "io_uring file operations may bypass syscall tracepoints",
+    "mmap-backed writes are not path-open observations"
+  ],
+  "completeness": "open_syscall_only"
+}
+```
+
+Fields:
+
+| Field | Meaning |
+|---|---|
+| `dimension` | Effect dimension: `filesystem`, `network`, or `process`. |
+| `method` | Capture method being described. |
+| `observes` | Positive effect classes this method can report. |
+| `known_blind_spots` | Documented ways this method may miss effects. |
+| `completeness` | The claim ceiling for exhaustive and negative claims. |
+
+`known_blind_spots` is data, not prose decoration. Downstream claim gates
+must consult it before interpreting absence or exhaustiveness.
+
+## Seed Descriptors
+
+| Dimension | Helper | Completeness | Initial blind spots |
+|---|---|---|---|
+| filesystem | `filesystem_open_syscall_only()` | `open_syscall_only` | io_uring file operations; mmap-backed writes |
+| network | `network_connect_only()` | `connect_only` | QUIC/datagram peer changes after connect; io_uring network operations |
+| process | `process_exec_only()` | `exec_only` | fork/clone gaps that affect process-tree exhaustiveness |
+
+The seed descriptors intentionally describe the current capture ceiling.
+Future capture improvements can narrow or remove blind spots by changing
+descriptor data; until then, the gate must not silently upgrade claims.
+
+## Claim Kinds
+
+The descriptor gate evaluates the requested claim kind:
+
+| Claim kind | Example | Descriptor rule |
+|---|---|---|
+| `positive_existence` | "This path open happened." | Allowed when the method observes that positive event class. |
+| `exhaustive_set` | "These are all paths or peers." | Degraded when relevant blind spots are present. |
+| `bounded_negative` | "No unexpected egress happened." | Blocked when relevant blind spots are present. |
+
+This composes with `fidelity_verdict.v0`. Fidelity gates capture health
+such as drops and cgroup correlation. Coverage descriptors gate the
+dimension-specific ceiling even when fidelity is otherwise `clean`.
+
+## Derived Decisions
+
+The helper emits a small `CoverageClaimDecision`:
+
+```json
+{
+  "decision": "blocked",
+  "rule": "coverage_descriptor_blocks_absence_claim",
+  "reason": "filesystem blind spots can hide the requested absence: io_uring file operations may bypass syscall tracepoints; mmap-backed writes are not path-open observations"
+}
+```
+
+Initial rules:
+
+- Missing descriptor blocks coverage-aware side-effect claims.
+- Positive existence is `allowed` for a present descriptor.
+- Exhaustive set is `allowed` only when the descriptor has no known blind
+  spots; otherwise it is `degraded`.
+- Bounded negative is `allowed` only when the descriptor has no known
+  blind spots; otherwise it is `blocked`.
+
+## Non-Claims
+
+- The descriptor does not prove runtime safety.
+- The descriptor does not close the blind spot it names.
+- The descriptor does not replace `observation_health.v0`.
+- The descriptor does not convert `connect_only` network capture into an
+  exact peer set.
+- The descriptor does not make self-reported SDK or trace evidence
+  measured.
+
+## Wiring Boundary
+
+This slice adds only the contract and helper. It intentionally does not:
+
+- add a Runner archive member;
+- add CLI output;
+- add comparator wiring;
+- add Trust Basis claims;
+- add capture enhancements for io_uring, QUIC/datagram, or fork/clone.
+
+Report and comparator wiring should wait for the next descriptor-aware
+consumer slice.

--- a/docs/reference/runner/coverage-descriptor-v0.md
+++ b/docs/reference/runner/coverage-descriptor-v0.md
@@ -77,9 +77,19 @@ The descriptor gate evaluates the requested claim kind:
 
 | Claim kind | Example | Descriptor rule |
 |---|---|---|
-| `positive_existence` | "This path open happened." | Allowed when the method observes that positive event class. |
-| `exhaustive_set` | "These are all paths or peers." | Degraded when relevant blind spots are present. |
-| `bounded_negative` | "No unexpected egress happened." | Blocked when relevant blind spots are present. |
+| `positive_existence` | "This path open happened." | Allowed for the caller-scoped effect class when a descriptor is present. |
+| `exhaustive_set` | "These are all paths or peers." | Degraded when any blind spots are declared. |
+| `bounded_negative` | "No unexpected egress happened." | Blocked when any blind spots are declared. |
+
+M1 is intentionally conservative. The helper does not yet inspect whether
+a particular claimed effect class appears in `observes`, and it does not
+filter blind spots by per-claim relevance. Callers are responsible for
+selecting the descriptor that matches the effect dimension and effect
+class they are interpreting. If a descriptor declares any blind spot, M1
+treats that blind spot as relevant for exhaustive and bounded-negative
+claims. A later descriptor-aware consumer slice can add finer
+effect-class matching and relevance filtering without weakening this
+initial gate.
 
 This composes with `fidelity_verdict.v0`. Fidelity gates capture health
 such as drops and cgroup correlation. Coverage descriptors gate the
@@ -100,7 +110,8 @@ The helper emits a small `CoverageClaimDecision`:
 Initial rules:
 
 - Missing descriptor blocks coverage-aware side-effect claims.
-- Positive existence is `allowed` for a present descriptor.
+- Positive existence is `allowed` for a present descriptor, scoped by the
+  caller to an effect class that descriptor observes.
 - Exhaustive set is `allowed` only when the descriptor has no known blind
   spots; otherwise it is `degraded`.
 - Bounded negative is `allowed` only when the descriptor has no known

--- a/docs/reference/runner/coverage-descriptor-v0.md
+++ b/docs/reference/runner/coverage-descriptor-v0.md
@@ -91,6 +91,13 @@ claims. A later descriptor-aware consumer slice can add finer
 effect-class matching and relevance filtering without weakening this
 initial gate.
 
+M1 also treats `completeness` as load-bearing, not decorative. Exhaustive
+and bounded-negative claims are allowed only when `completeness = full`
+and the descriptor declares no blind spots. A descriptor with
+`completeness = open_syscall_only`, `connect_only`, or `exec_only` still
+degrades or blocks those claim kinds even if its blindspot text is
+accidentally empty.
+
 This composes with `fidelity_verdict.v0`. Fidelity gates capture health
 such as drops and cgroup correlation. Coverage descriptors gate the
 dimension-specific ceiling even when fidelity is otherwise `clean`.
@@ -110,12 +117,13 @@ The helper emits a small `CoverageClaimDecision`:
 Initial rules:
 
 - Missing descriptor blocks coverage-aware side-effect claims.
+- Schema mismatch blocks coverage-aware side-effect claims.
 - Positive existence is `allowed` for a present descriptor, scoped by the
   caller to an effect class that descriptor observes.
-- Exhaustive set is `allowed` only when the descriptor has no known blind
-  spots; otherwise it is `degraded`.
-- Bounded negative is `allowed` only when the descriptor has no known
-  blind spots; otherwise it is `blocked`.
+- Exhaustive set is `allowed` only when `completeness = full` and the
+  descriptor has no known blind spots; otherwise it is `degraded`.
+- Bounded negative is `allowed` only when `completeness = full` and the
+  descriptor has no known blind spots; otherwise it is `blocked`.
 
 ## Non-Claims
 

--- a/docs/reference/runner/fidelity-verdict-v0.md
+++ b/docs/reference/runner/fidelity-verdict-v0.md
@@ -135,6 +135,31 @@ claim to a specific run/cgroup/tool identity, it must also consult
 This keeps `claim_gate` as a guardrail over existing claim levels instead
 of introducing a second independent claim hierarchy.
 
+## Composition With Coverage Descriptors
+
+`fidelity_verdict.v0` gates capture health. `coverage_descriptor.v0`
+gates the per-dimension visibility ceiling. Consumers must apply both
+when interpreting measured side effects.
+
+Example:
+
+- A clean health record may allow `bounded_negative_claims` at the
+  fidelity layer.
+- A filesystem descriptor with `completeness = open_syscall_only` still
+  blocks a bounded-negative file-activity claim because io_uring or
+  mmap-backed writes can hide effects from the capture method.
+
+So the combined decision is the stricter of:
+
+```text
+fidelity claim gate
+coverage descriptor claim-kind decision
+```
+
+This keeps positive observed effects useful while preventing a clean
+capture-health verdict from becoming a universal absence or completeness
+claim.
+
 ## Derived Shape
 
 Example clean verdict:

--- a/docs/reference/runner/index.md
+++ b/docs/reference/runner/index.md
@@ -29,6 +29,7 @@ Phase 2B capability-diff planning slice.
 - [Runner projection roadmap](projection-roadmap.md)
 - [Runner path projection Slice 1 plan (declared-rule only)](path-projection-slice1-plan.md)
 - [Runner fidelity verdict v0](fidelity-verdict-v0.md)
+- [Runner coverage descriptor v0](coverage-descriptor-v0.md)
 - [Runner schema overview](schemas-overview.md)
 - [Runner runtime drift projection v0/v0.2 contract](runtime-drift-v0.md)
 - [Runner cross-runtime diff v0 clean-output JSON Schema](schema/cross-runtime-diff-v0-clean.schema.json)

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -35,6 +35,7 @@
 | `assay.runner.runtime_noise_taxonomy.v0` | Shared vocabulary for runtime/provider/task/noise classes | vocabulary-only | described in [`runtime-drift-v0.md`](runtime-drift-v0.md) |
 | `assay.runner.drift_report_provenance.v0` | Render and capture provenance embedded in runtime-drift reports | embedded report metadata | described in [`runtime-drift-v0.md`](runtime-drift-v0.md) |
 | `assay.runner.fidelity_verdict.v0` | Derived claim gate from one `observation_health.v0` record | internal helper contract; no archive member or sidecar yet | described in [`fidelity-verdict-v0.md`](fidelity-verdict-v0.md) |
+| `assay.runner.coverage_descriptor.v0` | Per-dimension capture method, blindspot, and claim-kind gate descriptor | internal helper contract; no archive member or sidecar yet | described in [`coverage-descriptor-v0.md`](coverage-descriptor-v0.md) |
 | `assay.runner.cross_runtime_diff.v0.clean` | Earlier clean-output cross-runtime diff shape | reference schema | [`cross-runtime-diff-v0-clean.schema.json`](schema/cross-runtime-diff-v0-clean.schema.json) |
 
 ## Experiment Schemas


### PR DESCRIPTION
Summary

Adds the first M1 slice for coverage-aware side-effect verification: a small Runner schema helper for `assay.runner.coverage_descriptor.v0` plus a descriptor-driven claim-kind gate.

What changed:

- adds `CoverageDescriptor`, `EffectDimension`, `CoverageCompleteness`, `CoverageClaimKind`, and `CoverageClaimDecision` in `assay-runner-schema`
- adds seed descriptors for filesystem/open-syscall-only, network/connect-only, and process/exec-only coverage
- distinguishes claim kinds:
  - positive existence: allowed for the caller-scoped effect class when a descriptor is present
  - exhaustive set: allowed only when `completeness = full` and no blind spots are declared; otherwise degraded
  - bounded negative: allowed only when `completeness = full` and no blind spots are declared; otherwise blocked
- blocks malformed descriptor schemas before making claim decisions
- treats missing descriptors as blocking coverage-aware side-effect claims
- documents composition with `fidelity_verdict.v0`: fidelity gates capture health; coverage descriptors gate per-dimension visibility ceilings

Boundary

This PR intentionally does not:

- add a Runner archive member
- add CLI/report output
- add comparator wiring
- add Trust Basis claims
- add capture enhancements for io_uring, QUIC/datagram, sendmsg/sendto, or fork/clone

Validation

Ran locally:

```bash
cargo fmt --check -p assay-runner-schema
cargo test -p assay-runner-schema
cargo clippy -p assay-runner-schema --all-targets -- -D warnings
cargo check -p assay-runner-core -p assay-cli
git diff --check
```

Next

The next slice should be descriptor-aware consumer wiring: either a small derived report/fixture or comparator consultation that applies the stricter of fidelity gate and coverage-descriptor claim decision.


## Delegated runner proof
- gate: all
- head sha: 1cfe04d50f564f08c7947c1e883bd32d171f81fb
- Runner Spike Delegated run: success
