### PR TITLE
examples: add coverage-aware side-effect report sample

### DIFF
--- a/docs/reference/runner/coverage-descriptor-v0.md
+++ b/docs/reference/runner/coverage-descriptor-v0.md
@@ -95,7 +95,7 @@ M1 also treats `completeness` as load-bearing, not decorative. Exhaustive
 and bounded-negative claims are allowed only when `completeness = full`
 and the descriptor declares no blind spots. A descriptor with
 `completeness = open_syscall_only`, `connect_only`, or `exec_only` still
-degrades or blocks those claim kinds even if its blindspot text is
+degrades or blocks those claim kinds even if its blind spot text is
 accidentally empty.
 
 This composes with `fidelity_verdict.v0`. Fidelity gates capture health

--- a/docs/reference/runner/schemas-overview.md
+++ b/docs/reference/runner/schemas-overview.md
@@ -35,7 +35,7 @@
 | `assay.runner.runtime_noise_taxonomy.v0` | Shared vocabulary for runtime/provider/task/noise classes | vocabulary-only | described in [`runtime-drift-v0.md`](runtime-drift-v0.md) |
 | `assay.runner.drift_report_provenance.v0` | Render and capture provenance embedded in runtime-drift reports | embedded report metadata | described in [`runtime-drift-v0.md`](runtime-drift-v0.md) |
 | `assay.runner.fidelity_verdict.v0` | Derived claim gate from one `observation_health.v0` record | internal helper contract; no archive member or sidecar yet | described in [`fidelity-verdict-v0.md`](fidelity-verdict-v0.md) |
-| `assay.runner.coverage_descriptor.v0` | Per-dimension capture method, blindspot, and claim-kind gate descriptor | internal helper contract; no archive member or sidecar yet | described in [`coverage-descriptor-v0.md`](coverage-descriptor-v0.md) |
+| `assay.runner.coverage_descriptor.v0` | Per-dimension capture method, blind spot, and claim-kind gate descriptor | internal helper contract; no archive member or sidecar yet | described in [`coverage-descriptor-v0.md`](coverage-descriptor-v0.md) |
 | `assay.runner.cross_runtime_diff.v0.clean` | Earlier clean-output cross-runtime diff shape | reference schema | [`cross-runtime-diff-v0-clean.schema.json`](schema/cross-runtime-diff-v0-clean.schema.json) |
 
 ## Experiment Schemas

--- a/examples/README.md
+++ b/examples/README.md
@@ -175,6 +175,14 @@ external evidence.
 **Focus**: tunnel-observed route/upstream facts plus request-envelope binding
 only, no imported tunnel trust, auth correctness, policy outcome, or tool truth.
 
+### [Coverage-Aware Side-Effect Report](./coverage-aware-side-effect)
+Turn a Runner archive's `observation_health` and `capability_surface` into
+per-dimension claim cells plus blocked claims, reusing the shipped
+`coverage_descriptor.v0` claim-kind gate.
+**Focus**: positive existence is strong measured, exhaustive set is weak under
+declared blind spots, and bounded-negative (absence) claims are blocked unless
+coverage is complete and capture is clean. Derived report only, no schema change.
+
 ### [Pydantic Evals Reduced Case-Result Evidence](./pydantic-ai-eval-report-evidence)
 Map one reduced artifact derived from `pydantic_evals` `EvaluationReport.cases[]` into Assay-shaped external evidence or importer-only Pydantic case-result receipts.
 **Focus**: code-first case-result seam, no raw `ReportCase`, report summary, task input/output, tracing truth, or Trust Basis claim.

--- a/examples/coverage-aware-side-effect/README.md
+++ b/examples/coverage-aware-side-effect/README.md
@@ -1,0 +1,54 @@
+# Coverage-Aware Side-Effect Report (sample)
+
+This sample turns a Runner archive's `observation_health` and
+`capability_surface` into per-dimension claim cells plus blocked claims, applying
+the same claim-kind gate as the shipped `assay.runner.coverage_descriptor.v0`
+helper (`crates/assay-runner-schema/src/coverage.rs`).
+
+It is intentionally small and derived-report only:
+
+- reads one frozen archive fixture (observation_health + capability_surface)
+- emits a `assay.coverage_aware_side_effect.report.v0` placeholder report
+- does not register a new archive member, change Runner schemas, or promote
+  anything into Trust Basis
+
+## What it shows
+
+For each observed effect dimension, the report distinguishes claim kinds:
+
+- positive existence (this open / connect / exec happened) is `strong measured`
+  when capture is clean; capture health, not blind spots, gates its strength
+- exhaustive set (these are all the X) is `weak measured` while the dimension's
+  coverage declares blind spots
+- bounded negative (X did not happen) is blocked unless coverage is complete
+  with no blind spots and capture was clean
+
+The point is the last one: absence of an observed effect is not proof that the
+effect did not occur, so the report refuses that claim rather than letting a zero
+read as safety.
+
+## Files
+
+- `report_from_archive.py`: derived-report generator (stdlib only)
+- `fixtures/clean.archive.json`: clean capture, filesystem + connect-only network
+- `fixtures/clipped.archive.json`: ring-buffer drops, so positive claims degrade
+- `fixtures/clean.report.json`: frozen expected report for the clean fixture
+- `test_report.py`: stdlib tests for the strong / weak / blocked outcomes
+
+## Run
+
+```bash
+python3 examples/coverage-aware-side-effect/report_from_archive.py \
+  examples/coverage-aware-side-effect/fixtures/clean.archive.json
+python3 examples/coverage-aware-side-effect/report_from_archive.py \
+  examples/coverage-aware-side-effect/fixtures/clean.archive.json --format markdown
+python3 examples/coverage-aware-side-effect/test_report.py
+```
+
+## Boundary
+
+This is a sample report generator. It classifies the evidence a Runner archive
+already carries; it does not certify a server, prove intent, or claim a complete
+view of side effects. The canonical gate logic is the Rust
+`coverage_descriptor.v0` helper; this script mirrors it so the pattern is
+reviewable from a frozen fixture.

--- a/examples/coverage-aware-side-effect/README.md
+++ b/examples/coverage-aware-side-effect/README.md
@@ -17,9 +17,13 @@ It is intentionally small and derived-report only:
 For each observed effect dimension, the report distinguishes claim kinds:
 
 - positive existence (this open / connect / exec happened) is `strong measured`
-  when capture is clean; capture health, not blind spots, gates its strength
-- exhaustive set (these are all the X) is `weak measured` while the dimension's
-  coverage declares blind spots
+  when capture is clean, `partial` when capture is degraded, and `absent` (with
+  no evidence refs) when the fidelity verdict blocks measured claims entirely
+  (non-Linux, kernel layer absent, or correlation failed); capture health, not
+  blind spots, gates its strength
+- exhaustive set (these are all the X) is `weak derived` while the dimension's
+  coverage declares blind spots: the exhaustive reading is computed by the gate,
+  so its basis is `derived`, and the cell note names the rule
 - bounded negative (X did not happen) is blocked unless coverage is complete
   with no blind spots and capture was clean
 

--- a/examples/coverage-aware-side-effect/README.md
+++ b/examples/coverage-aware-side-effect/README.md
@@ -18,9 +18,10 @@ For each observed effect dimension, the report distinguishes claim kinds:
 
 - positive existence (this open / connect / exec happened) is `strong measured`
   when capture is clean, `partial` when capture is degraded, and `absent` (with
-  no evidence refs) when the fidelity verdict blocks measured claims entirely
-  (non-Linux, kernel layer absent, or correlation failed); capture health, not
-  blind spots, gates its strength
+  no evidence refs) on the not_applicable path, where there is no measured
+  kernel surface (non-Linux, or kernel layer absent); capture health, not blind
+  spots, gates its strength. Out-of-contract health (for example
+  `cgroup_correlation=failed`) is rejected outright rather than interpreted
 - exhaustive set (these are all the X) is `weak derived` while the dimension's
   coverage declares blind spots: the exhaustive reading is computed by the gate,
   so its basis is `derived`, and the cell note names the rule

--- a/examples/coverage-aware-side-effect/fixtures/clean.archive.json
+++ b/examples/coverage-aware-side-effect/fixtures/clean.archive.json
@@ -1,0 +1,24 @@
+{
+  "observation_health": {
+    "schema": "assay.runner.observation_health.v0",
+    "run_id": "run_coverage_aware_clean",
+    "platform": "linux",
+    "kernel_layer": "complete",
+    "ringbuf_drops": 0,
+    "policy_layer": "absent",
+    "sdk_layer": "absent",
+    "cgroup_correlation": "clean",
+    "network_protocol_coverage": "connect_only",
+    "network_endpoint_claim_scope": "diagnostic_only",
+    "notes": ["coverage_aware_sample"]
+  },
+  "capability_surface": {
+    "schema": "assay.runner.capability_surface.v0",
+    "run_id": "run_coverage_aware_clean",
+    "filesystem_paths": ["/etc/ssl/certs/ca-certificates.crt"],
+    "network_endpoints": ["198.41.192.107:7844"],
+    "process_execs": [],
+    "mcp_tools": [],
+    "policy_decisions": []
+  }
+}

--- a/examples/coverage-aware-side-effect/fixtures/clean.report.json
+++ b/examples/coverage-aware-side-effect/fixtures/clean.report.json
@@ -32,7 +32,7 @@
     },
     {
       "artifact_role": "measured_run_archive",
-      "claim_basis": "measured",
+      "claim_basis": "derived",
       "claim_strength": "weak",
       "claim_type": "exhaustive_filesystem_set",
       "evidence_refs": [
@@ -43,7 +43,7 @@
         "does_not_prove_complete_filesystem_set"
       ],
       "notes": [
-        "exhaustive filesystem set requires completeness=full with no blind spots; completeness is open_syscall_only; blind spots: io_uring file operations may bypass syscall tracepoints; mmap-backed writes are not path-open observations"
+        "derived by coverage_descriptor.v0 + fidelity_verdict.v0: exhaustive filesystem set requires completeness=full with no blind spots; completeness is open_syscall_only; blind spots: io_uring file operations may bypass syscall tracepoints; mmap-backed writes are not path-open observations"
       ],
       "schema": "assay.observability.claim_class_cell.v0"
     },
@@ -65,7 +65,7 @@
     },
     {
       "artifact_role": "measured_run_archive",
-      "claim_basis": "measured",
+      "claim_basis": "derived",
       "claim_strength": "weak",
       "claim_type": "exhaustive_network_set",
       "evidence_refs": [
@@ -76,7 +76,7 @@
         "does_not_prove_complete_network_set"
       ],
       "notes": [
-        "exhaustive network set requires completeness=full with no blind spots; completeness is connect_only; blind spots: QUIC/datagram peer changes after connect are not an exhaustive peer set; io_uring network operations may bypass syscall tracepoints"
+        "derived by coverage_descriptor.v0 + fidelity_verdict.v0: exhaustive network set requires completeness=full with no blind spots; completeness is connect_only; blind spots: QUIC/datagram peer changes after connect are not an exhaustive peer set; io_uring network operations may bypass syscall tracepoints"
       ],
       "schema": "assay.observability.claim_class_cell.v0"
     }

--- a/examples/coverage-aware-side-effect/fixtures/clean.report.json
+++ b/examples/coverage-aware-side-effect/fixtures/clean.report.json
@@ -1,0 +1,85 @@
+{
+  "blocked_claims": [
+    {
+      "claim_type": "bounded_negative_claim",
+      "decision": "blocked",
+      "reason": "filesystem absence claim requires completeness=full with no blind spots and clean capture; completeness is open_syscall_only; blind spots: io_uring file operations may bypass syscall tracepoints; mmap-backed writes are not path-open observations; capture_clean=true",
+      "requested_claim": "no_unexpected_filesystem_effect"
+    },
+    {
+      "claim_type": "bounded_negative_claim",
+      "decision": "blocked",
+      "reason": "network absence claim requires completeness=full with no blind spots and clean capture; completeness is connect_only; blind spots: QUIC/datagram peer changes after connect are not an exhaustive peer set; io_uring network operations may bypass syscall tracepoints; capture_clean=true",
+      "requested_claim": "no_unexpected_network_effect"
+    }
+  ],
+  "claim_cells": [
+    {
+      "artifact_role": "measured_run_archive",
+      "claim_basis": "measured",
+      "claim_strength": "strong",
+      "claim_type": "measured_filesystem_effect",
+      "evidence_refs": [
+        "capability-surface.json",
+        "observation-health.json"
+      ],
+      "non_claims": [
+        "does_not_prove_intent",
+        "strong_only_within_cgroup_scope"
+      ],
+      "schema": "assay.observability.claim_class_cell.v0"
+    },
+    {
+      "artifact_role": "measured_run_archive",
+      "claim_basis": "measured",
+      "claim_strength": "weak",
+      "claim_type": "exhaustive_filesystem_set",
+      "evidence_refs": [
+        "capability-surface.json",
+        "observation-health.json"
+      ],
+      "non_claims": [
+        "does_not_prove_complete_filesystem_set"
+      ],
+      "notes": [
+        "exhaustive filesystem set requires completeness=full with no blind spots; completeness is open_syscall_only; blind spots: io_uring file operations may bypass syscall tracepoints; mmap-backed writes are not path-open observations"
+      ],
+      "schema": "assay.observability.claim_class_cell.v0"
+    },
+    {
+      "artifact_role": "measured_run_archive",
+      "claim_basis": "measured",
+      "claim_strength": "strong",
+      "claim_type": "measured_network_effect",
+      "evidence_refs": [
+        "capability-surface.json",
+        "observation-health.json"
+      ],
+      "non_claims": [
+        "does_not_prove_intent",
+        "strong_only_within_cgroup_scope"
+      ],
+      "schema": "assay.observability.claim_class_cell.v0"
+    },
+    {
+      "artifact_role": "measured_run_archive",
+      "claim_basis": "measured",
+      "claim_strength": "weak",
+      "claim_type": "exhaustive_network_set",
+      "evidence_refs": [
+        "capability-surface.json",
+        "observation-health.json"
+      ],
+      "non_claims": [
+        "does_not_prove_complete_network_set"
+      ],
+      "notes": [
+        "exhaustive network set requires completeness=full with no blind spots; completeness is connect_only; blind spots: QUIC/datagram peer changes after connect are not an exhaustive peer set; io_uring network operations may bypass syscall tracepoints"
+      ],
+      "schema": "assay.observability.claim_class_cell.v0"
+    }
+  ],
+  "observation_health_ref": "observation-health.json",
+  "run_id": "run_coverage_aware_clean",
+  "schema": "assay.coverage_aware_side_effect.report.v0"
+}

--- a/examples/coverage-aware-side-effect/fixtures/clean.report.json
+++ b/examples/coverage-aware-side-effect/fixtures/clean.report.json
@@ -24,7 +24,7 @@
         "observation-health.json"
       ],
       "non_claims": [
-        "does_not_prove_intent",
+        "does_not_prove_tool_intent",
         "strong_only_within_cgroup_scope"
       ],
       "notes": [],
@@ -57,7 +57,7 @@
         "observation-health.json"
       ],
       "non_claims": [
-        "does_not_prove_intent",
+        "does_not_prove_tool_intent",
         "strong_only_within_cgroup_scope"
       ],
       "notes": [],

--- a/examples/coverage-aware-side-effect/fixtures/clean.report.json
+++ b/examples/coverage-aware-side-effect/fixtures/clean.report.json
@@ -27,6 +27,7 @@
         "does_not_prove_intent",
         "strong_only_within_cgroup_scope"
       ],
+      "notes": [],
       "schema": "assay.observability.claim_class_cell.v0"
     },
     {
@@ -59,6 +60,7 @@
         "does_not_prove_intent",
         "strong_only_within_cgroup_scope"
       ],
+      "notes": [],
       "schema": "assay.observability.claim_class_cell.v0"
     },
     {

--- a/examples/coverage-aware-side-effect/fixtures/clipped.archive.json
+++ b/examples/coverage-aware-side-effect/fixtures/clipped.archive.json
@@ -1,0 +1,24 @@
+{
+  "observation_health": {
+    "schema": "assay.runner.observation_health.v0",
+    "run_id": "run_coverage_aware_clipped",
+    "platform": "linux",
+    "kernel_layer": "partial_ringbuf_drops",
+    "ringbuf_drops": 4,
+    "policy_layer": "absent",
+    "sdk_layer": "absent",
+    "cgroup_correlation": "clean",
+    "network_protocol_coverage": "connect_only",
+    "network_endpoint_claim_scope": "diagnostic_only",
+    "notes": ["coverage_aware_sample_clipped"]
+  },
+  "capability_surface": {
+    "schema": "assay.runner.capability_surface.v0",
+    "run_id": "run_coverage_aware_clipped",
+    "filesystem_paths": ["/etc/hostname"],
+    "network_endpoints": ["198.41.200.33:7844"],
+    "process_execs": [],
+    "mcp_tools": [],
+    "policy_decisions": []
+  }
+}

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -99,18 +99,18 @@ def _capture_is_clean(health: dict[str, Any]) -> bool:
 def _positive_verdict(health: dict[str, Any]) -> str:
     """Strength a measured positive claim may carry, mirroring fidelity_verdict.v0.
 
-    - blocked -> "absent": there is no measured kernel-effect surface to support
-      the claim (non-Linux/not_applicable, kernel layer absent, or correlation
-      failed). An absent cell carries no evidence_refs.
+    Assumes the record already passed `_validate_health` (so it is a valid,
+    passing observation_health record: no `cgroup_correlation=failed`, cross-field
+    invariants satisfied).
+
+    - not_applicable -> "absent": there is no measured kernel-effect surface to
+      support the claim (non-Linux, or kernel layer absent). An absent cell
+      carries no evidence_refs.
     - clean -> "strong".
     - otherwise -> "partial": measurement exists but is degraded (e.g. drops or
       partial kernel capture).
     """
-    if (
-        health.get("platform") != "linux"
-        or health.get("kernel_layer") == "absent"
-        or health.get("cgroup_correlation") == "failed"
-    ):
+    if health.get("platform") != "linux" or health.get("kernel_layer") == "absent":
         return "absent"
     if _capture_is_clean(health):
         return "strong"
@@ -121,27 +121,50 @@ OBS_HEALTH_SCHEMA = "assay.runner.observation_health.v0"
 CAP_SURFACE_SCHEMA = "assay.runner.capability_surface.v0"
 # Canonical observation_health.v0 enums (see docs/reference/runner/artifacts-v0.md).
 KERNEL_LAYERS = {"complete", "partial_ringbuf_drops", "absent"}
-CGROUP_CORRELATIONS = {"clean", "partial", "failed"}
+# A passing record carries clean or partial correlation. `failed` is a valid
+# enum token in the schema but marks a non-passing record, which
+# ObservationHealth::validate() and fidelity_verdict.v0 (verdict=failed) reject;
+# this sample rejects it rather than interpreting it.
+PASSING_CGROUP_CORRELATIONS = {"clean", "partial"}
 
 
 def _validate_health(health: dict[str, Any]) -> None:
-    """Enforce the observation_health.v0 enum/type invariants before deriving.
+    """Enforce the passing observation_health.v0 invariants before deriving.
 
-    A sample that mirrors fidelity_verdict.v0 must reject out-of-contract health
-    rather than interpret it. This is not a full schema validator; it checks the
-    fields the gate actually reads.
+    Mirrors the contract rules ObservationHealth::validate() enforces so the
+    sample refuses out-of-contract health rather than interpreting it. This is
+    not a byte-for-byte schema validator; it checks the fields the gate reads
+    plus the cross-field invariants documented in artifacts-v0.md.
     """
     if health.get("schema") != OBS_HEALTH_SCHEMA:
         raise ValueError(f"observation_health schema must be {OBS_HEALTH_SCHEMA}")
-    if health.get("kernel_layer") not in KERNEL_LAYERS:
+    run_id = health.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        raise ValueError("observation_health.run_id must be a non-empty string")
+    platform = health.get("platform")
+    if not isinstance(platform, str) or not platform:
+        raise ValueError("observation_health.platform must be a non-empty string")
+    kernel_layer = health.get("kernel_layer")
+    if kernel_layer not in KERNEL_LAYERS:
         raise ValueError(f"kernel_layer must be one of {sorted(KERNEL_LAYERS)}")
-    if health.get("cgroup_correlation") not in CGROUP_CORRELATIONS:
+    correlation = health.get("cgroup_correlation")
+    if correlation not in PASSING_CGROUP_CORRELATIONS:
+        # `failed` reaches here as a non-passing record; reject like the contract.
         raise ValueError(
-            f"cgroup_correlation must be one of {sorted(CGROUP_CORRELATIONS)}"
+            "cgroup_correlation must be one of "
+            f"{sorted(PASSING_CGROUP_CORRELATIONS)} for a passing record "
+            "(cgroup_correlation=failed is an invalid observation_health record)"
         )
     drops = health.get("ringbuf_drops")
     if isinstance(drops, bool) or not isinstance(drops, int) or drops < 0:
         raise ValueError("ringbuf_drops must be a non-negative integer")
+    # Cross-field invariants (artifacts-v0.md).
+    if drops > 0 and kernel_layer != "partial_ringbuf_drops":
+        raise ValueError(
+            "ringbuf_drops > 0 requires kernel_layer=partial_ringbuf_drops"
+        )
+    if platform != "linux" and kernel_layer != "absent":
+        raise ValueError("non-linux platforms require kernel_layer=absent")
 
 
 def build_report(archive: dict[str, Any]) -> dict[str, Any]:

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -117,6 +117,10 @@ def _positive_verdict(health: dict[str, Any]) -> str:
     return "partial"
 
 
+OBS_HEALTH_SCHEMA = "assay.runner.observation_health.v0"
+CAP_SURFACE_SCHEMA = "assay.runner.capability_surface.v0"
+
+
 def build_report(archive: dict[str, Any]) -> dict[str, Any]:
     health = archive.get("observation_health")
     surface = archive.get("capability_surface")
@@ -125,7 +129,27 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(surface, dict):
         raise ValueError("archive: capability_surface object is required")
 
-    run_id = health.get("run_id") or surface.get("run_id") or "unknown"
+    # Validate both records before interpreting them. fidelity_verdict.v0 blocks
+    # measured claims on an invalid health record, so a sample that derives
+    # claims must refuse malformed or mismatched inputs rather than emit cells.
+    if health.get("schema") != OBS_HEALTH_SCHEMA:
+        raise ValueError(
+            f"observation_health schema must be {OBS_HEALTH_SCHEMA}"
+        )
+    if surface.get("schema") != CAP_SURFACE_SCHEMA:
+        raise ValueError(
+            f"capability_surface schema must be {CAP_SURFACE_SCHEMA}"
+        )
+    health_run = health.get("run_id")
+    surface_run = surface.get("run_id")
+    if not health_run or not surface_run:
+        raise ValueError("both records must carry a run_id")
+    if health_run != surface_run:
+        raise ValueError(
+            f"run_id mismatch: health={health_run!r} surface={surface_run!r}"
+        )
+
+    run_id = health_run
     capture_clean = _capture_is_clean(health)
     claim_cells: list[dict[str, Any]] = []
     blocked_claims: list[dict[str, Any]] = []

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -117,9 +117,29 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
             }
         )
 
-        # Exhaustive set: "these are all the X". Allowed only when the descriptor
-        # supports complete claims; otherwise degraded to weak with the reason.
-        if not _supports_complete_claims(descriptor):
+        # Exhaustive set: "these are all the X". Allowed (strong) only when the
+        # descriptor supports complete claims; otherwise degraded to weak with
+        # the reason. This mirrors coverage_descriptor.v0, where exhaustive set
+        # is allowed when completeness=full with no blind spots. Under the seed
+        # descriptors the supported branch is never taken; it is kept so the
+        # example represents the full gate, not only its degraded path.
+        if _supports_complete_claims(descriptor):
+            claim_cells.append(
+                {
+                    "schema": CLAIM_CELL_SCHEMA,
+                    "claim_type": f"exhaustive_{dimension}_set",
+                    "artifact_role": "measured_run_archive",
+                    "claim_strength": "strong" if capture_clean else "partial",
+                    "claim_basis": "measured",
+                    "evidence_refs": ["capability-surface.json", "observation-health.json"],
+                    "notes": [
+                        f"completeness is full with no declared blind spots: "
+                        f"exhaustive {dimension} set allowed"
+                    ],
+                    "non_claims": ["strong_only_within_cgroup_scope"],
+                }
+            )
+        else:
             claim_cells.append(
                 {
                     "schema": CLAIM_CELL_SCHEMA,
@@ -137,9 +157,27 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
                 }
             )
 
-        # Bounded negative: "X did not happen". Blocked unless coverage is
-        # complete with no blind spots AND capture was clean.
-        if not _supports_complete_claims(descriptor) or not capture_clean:
+        # Bounded negative: "X did not happen". Allowed only when coverage is
+        # complete with no blind spots AND capture was clean; otherwise blocked.
+        # As with the exhaustive set, the seed descriptors never satisfy the
+        # allowed branch; it is kept so the gate's allowed outcome is represented.
+        if _supports_complete_claims(descriptor) and capture_clean:
+            claim_cells.append(
+                {
+                    "schema": CLAIM_CELL_SCHEMA,
+                    "claim_type": f"bounded_negative_{dimension}_effect",
+                    "artifact_role": "measured_run_archive",
+                    "claim_strength": "strong",
+                    "claim_basis": "measured",
+                    "evidence_refs": ["capability-surface.json", "observation-health.json"],
+                    "notes": [
+                        f"completeness is full with no declared blind spots and "
+                        f"capture is clean: bounded-negative {dimension} claim allowed"
+                    ],
+                    "non_claims": ["strong_only_within_cgroup_scope"],
+                }
+            )
+        else:
             reason = (
                 f"{dimension} absence claim requires completeness=full with no blind "
                 f"spots and clean capture; completeness is {descriptor['completeness']}; "

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Coverage-aware side-effect report generator (sample, derived-report only).
+
+Reads the observation_health and capability_surface of a Runner archive (as a
+single JSON fixture for this sample) and emits per-dimension claim cells plus
+blocked claims, applying the same claim-kind gate as the shipped
+`assay.runner.coverage_descriptor.v0` helper.
+
+This is a sample: it produces placeholder report envelopes. It does not register
+a new archive member, does not change Runner schemas, and does not promote
+anything into Trust Basis. The canonical gate logic lives in
+`crates/assay-runner-schema/src/coverage.rs`; this script mirrors it so the
+pattern is reviewable from a frozen fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+REPORT_SCHEMA = "assay.coverage_aware_side_effect.report.v0"
+CLAIM_CELL_SCHEMA = "assay.observability.claim_class_cell.v0"
+
+# Seed coverage descriptors per effect dimension, mirroring the shipped
+# coverage.rs seed constructors. Each names the capture method and its
+# documented blind spots, so completeness is never assumed.
+SEED_DESCRIPTORS: dict[str, dict[str, Any]] = {
+    "filesystem": {
+        "method": "open/openat/openat2 tracepoints",
+        "known_blind_spots": [
+            "io_uring file operations may bypass syscall tracepoints",
+            "mmap-backed writes are not path-open observations",
+        ],
+        "completeness": "open_syscall_only",
+    },
+    "network": {
+        "method": "connect tracepoint",
+        "known_blind_spots": [
+            "QUIC/datagram peer changes after connect are not an exhaustive peer set",
+            "io_uring network operations may bypass syscall tracepoints",
+        ],
+        "completeness": "connect_only",
+    },
+    "process": {
+        "method": "exec tracepoint",
+        "known_blind_spots": [
+            "fork/clone gaps can make process-tree exhaustiveness kernel-dependent",
+        ],
+        "completeness": "exec_only",
+    },
+}
+
+# Which capability_surface field carries the observed set for each dimension.
+SURFACE_FIELD = {
+    "filesystem": "filesystem_paths",
+    "network": "network_endpoints",
+    "process": "process_execs",
+}
+
+
+def _blind_spot_summary(descriptor: dict[str, Any]) -> str:
+    spots = descriptor.get("known_blind_spots") or []
+    return "; ".join(spots) if spots else "none declared"
+
+
+def _supports_complete_claims(descriptor: dict[str, Any]) -> bool:
+    # Mirrors coverage.rs: completeness == full AND no blind spots.
+    return descriptor.get("completeness") == "full" and not descriptor.get(
+        "known_blind_spots"
+    )
+
+
+def _capture_is_clean(health: dict[str, Any]) -> bool:
+    return (
+        health.get("kernel_layer") == "complete"
+        and int(health.get("ringbuf_drops", 1)) == 0
+        and health.get("cgroup_correlation") == "clean"
+    )
+
+
+def build_report(archive: dict[str, Any]) -> dict[str, Any]:
+    health = archive.get("observation_health")
+    surface = archive.get("capability_surface")
+    if not isinstance(health, dict):
+        raise ValueError("archive: observation_health object is required")
+    if not isinstance(surface, dict):
+        raise ValueError("archive: capability_surface object is required")
+
+    run_id = health.get("run_id") or surface.get("run_id") or "unknown"
+    capture_clean = _capture_is_clean(health)
+    claim_cells: list[dict[str, Any]] = []
+    blocked_claims: list[dict[str, Any]] = []
+
+    for dimension, descriptor in SEED_DESCRIPTORS.items():
+        observed = surface.get(SURFACE_FIELD[dimension]) or []
+        if not observed:
+            continue
+
+        # Positive existence: an observed effect happened. Capture health gates
+        # strength (clipped capture downgrades positive measured claims), but the
+        # descriptor's blind spots do not weaken a positive observation.
+        claim_cells.append(
+            {
+                "schema": CLAIM_CELL_SCHEMA,
+                "claim_type": f"measured_{dimension}_effect",
+                "artifact_role": "measured_run_archive",
+                "claim_strength": "strong" if capture_clean else "partial",
+                "claim_basis": "measured",
+                "evidence_refs": ["capability-surface.json", "observation-health.json"],
+                "non_claims": [
+                    "does_not_prove_intent",
+                    "strong_only_within_cgroup_scope",
+                ],
+            }
+        )
+
+        # Exhaustive set: "these are all the X". Allowed only when the descriptor
+        # supports complete claims; otherwise degraded to weak with the reason.
+        if not _supports_complete_claims(descriptor):
+            claim_cells.append(
+                {
+                    "schema": CLAIM_CELL_SCHEMA,
+                    "claim_type": f"exhaustive_{dimension}_set",
+                    "artifact_role": "measured_run_archive",
+                    "claim_strength": "weak",
+                    "claim_basis": "measured",
+                    "evidence_refs": ["capability-surface.json", "observation-health.json"],
+                    "notes": [
+                        f"exhaustive {dimension} set requires completeness=full with no "
+                        f"blind spots; completeness is {descriptor['completeness']}; "
+                        f"blind spots: {_blind_spot_summary(descriptor)}"
+                    ],
+                    "non_claims": [f"does_not_prove_complete_{dimension}_set"],
+                }
+            )
+
+        # Bounded negative: "X did not happen". Blocked unless coverage is
+        # complete with no blind spots, or capture was not clean.
+        if not _supports_complete_claims(descriptor) or not capture_clean:
+            reason = (
+                f"{dimension} absence claim requires completeness=full with no blind "
+                f"spots and clean capture; completeness is {descriptor['completeness']}; "
+                f"blind spots: {_blind_spot_summary(descriptor)}; "
+                f"capture_clean={str(capture_clean).lower()}"
+            )
+            blocked_claims.append(
+                {
+                    "claim_type": "bounded_negative_claim",
+                    "requested_claim": f"no_unexpected_{dimension}_effect",
+                    "decision": "blocked",
+                    "reason": reason,
+                }
+            )
+
+    return {
+        "schema": REPORT_SCHEMA,
+        "run_id": run_id,
+        "observation_health_ref": "observation-health.json",
+        "claim_cells": claim_cells,
+        "blocked_claims": blocked_claims,
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = ["# Coverage-Aware Side-Effect Report (sample)", ""]
+    lines.append(f"run id: `{report['run_id']}`")
+    lines.append("")
+    lines.append("## Claims")
+    for cell in report["claim_cells"]:
+        lines.append(
+            f"- {cell['claim_type']}: {cell['claim_strength']} {cell['claim_basis']}"
+        )
+    if report["blocked_claims"]:
+        lines.append("")
+        lines.append("## Blocked (measurement cannot support)")
+        for blocked in report["blocked_claims"]:
+            lines.append(f"- {blocked['requested_claim']}: {blocked['reason']}")
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", help="archive fixture JSON (observation_health + capability_surface)")
+    parser.add_argument("--format", choices=["json", "markdown"], default="json")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    with open(args.archive, "r", encoding="utf-8") as handle:
+        archive = json.load(handle)
+    report = build_report(archive)
+    if args.format == "markdown":
+        sys.stdout.write(render_markdown(report))
+    else:
+        sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -96,6 +96,27 @@ def _capture_is_clean(health: dict[str, Any]) -> bool:
     )
 
 
+def _positive_verdict(health: dict[str, Any]) -> str:
+    """Strength a measured positive claim may carry, mirroring fidelity_verdict.v0.
+
+    - blocked -> "absent": there is no measured kernel-effect surface to support
+      the claim (non-Linux/not_applicable, kernel layer absent, or correlation
+      failed). An absent cell carries no evidence_refs.
+    - clean -> "strong".
+    - otherwise -> "partial": measurement exists but is degraded (e.g. drops or
+      partial kernel capture).
+    """
+    if (
+        health.get("platform") != "linux"
+        or health.get("kernel_layer") == "absent"
+        or health.get("cgroup_correlation") == "failed"
+    ):
+        return "absent"
+    if _capture_is_clean(health):
+        return "strong"
+    return "partial"
+
+
 def build_report(archive: dict[str, Any]) -> dict[str, Any]:
     health = archive.get("observation_health")
     surface = archive.get("capability_surface")
@@ -115,23 +136,43 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
             continue
 
         # Positive existence: an observed effect happened. Capture health gates
-        # strength (clipped capture downgrades positive measured claims), but the
-        # descriptor's blind spots do not weaken a positive observation.
-        claim_cells.append(
-            {
-                "schema": CLAIM_CELL_SCHEMA,
-                "claim_type": POSITIVE_CLAIM_TYPE[dimension],
-                "artifact_role": "measured_run_archive",
-                "claim_strength": "strong" if capture_clean else "partial",
-                "claim_basis": "measured",
-                "evidence_refs": ["capability-surface.json", "observation-health.json"],
-                "notes": [],
-                "non_claims": [
-                    "does_not_prove_tool_intent",
-                    "strong_only_within_cgroup_scope",
-                ],
-            }
-        )
+        # strength: clean -> strong, degraded -> partial, and a blocked verdict
+        # (no measured kernel surface) -> absent rather than overstated partial.
+        # The descriptor's blind spots do not weaken a positive observation.
+        positive = _positive_verdict(health)
+        if positive == "absent":
+            claim_cells.append(
+                {
+                    "schema": CLAIM_CELL_SCHEMA,
+                    "claim_type": POSITIVE_CLAIM_TYPE[dimension],
+                    "artifact_role": "none",
+                    "claim_strength": "absent",
+                    "claim_basis": "measured",
+                    "evidence_refs": [],
+                    "notes": [
+                        "measured positive blocked by fidelity verdict: no measured "
+                        "kernel-effect surface (non-Linux, kernel layer absent, or "
+                        "cgroup correlation failed)"
+                    ],
+                    "non_claims": ["does_not_prove_tool_intent"],
+                }
+            )
+        else:
+            claim_cells.append(
+                {
+                    "schema": CLAIM_CELL_SCHEMA,
+                    "claim_type": POSITIVE_CLAIM_TYPE[dimension],
+                    "artifact_role": "measured_run_archive",
+                    "claim_strength": positive,
+                    "claim_basis": "measured",
+                    "evidence_refs": ["capability-surface.json", "observation-health.json"],
+                    "notes": [],
+                    "non_claims": [
+                        "does_not_prove_tool_intent",
+                        "strong_only_within_cgroup_scope",
+                    ],
+                }
+            )
 
         # Exhaustive set: "these are all the X". Allowed (strong) only when the
         # descriptor supports complete claims; otherwise degraded to weak with

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -22,6 +22,9 @@ from typing import Any
 
 REPORT_SCHEMA = "assay.coverage_aware_side_effect.report.v0"
 CLAIM_CELL_SCHEMA = "assay.observability.claim_class_cell.v0"
+# The gating rule named by every derived claim cell, per claim-classes-v0
+# ("Derived must name the rule").
+GATE_RULE = "coverage_descriptor.v0 + fidelity_verdict.v0"
 
 # Seed coverage descriptors per effect dimension, mirroring the shipped
 # coverage.rs seed constructors. Each names the capture method and its
@@ -143,11 +146,12 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
                     "claim_type": f"exhaustive_{dimension}_set",
                     "artifact_role": "measured_run_archive",
                     "claim_strength": "strong" if capture_clean else "partial",
-                    "claim_basis": "measured",
+                    "claim_basis": "derived",
                     "evidence_refs": ["capability-surface.json", "observation-health.json"],
                     "notes": [
-                        f"completeness is full with no declared blind spots: "
-                        f"exhaustive {dimension} set allowed"
+                        f"derived by {GATE_RULE}: completeness is full with no "
+                        f"declared blind spots, so the exhaustive {dimension} set "
+                        f"is allowed"
                     ],
                     "non_claims": ["strong_only_within_cgroup_scope"],
                 }
@@ -159,12 +163,13 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
                     "claim_type": f"exhaustive_{dimension}_set",
                     "artifact_role": "measured_run_archive",
                     "claim_strength": "weak",
-                    "claim_basis": "measured",
+                    "claim_basis": "derived",
                     "evidence_refs": ["capability-surface.json", "observation-health.json"],
                     "notes": [
-                        f"exhaustive {dimension} set requires completeness=full with no "
-                        f"blind spots; completeness is {descriptor['completeness']}; "
-                        f"blind spots: {_blind_spot_summary(descriptor)}"
+                        f"derived by {GATE_RULE}: exhaustive {dimension} set requires "
+                        f"completeness=full with no blind spots; completeness is "
+                        f"{descriptor['completeness']}; blind spots: "
+                        f"{_blind_spot_summary(descriptor)}"
                     ],
                     "non_claims": [f"does_not_prove_complete_{dimension}_set"],
                 }
@@ -181,11 +186,12 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
                     "claim_type": "bounded_negative_claim",
                     "artifact_role": "measured_run_archive",
                     "claim_strength": "strong",
-                    "claim_basis": "measured",
+                    "claim_basis": "derived",
                     "evidence_refs": ["capability-surface.json", "observation-health.json"],
                     "notes": [
-                        f"{dimension}: completeness is full with no declared blind "
-                        f"spots and capture is clean: bounded-negative claim allowed"
+                        f"{dimension}: derived by {GATE_RULE}: completeness is full "
+                        f"with no declared blind spots and capture is clean, so the "
+                        f"bounded-negative claim is allowed"
                     ],
                     "non_claims": ["strong_only_within_cgroup_scope"],
                 }

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -109,6 +109,7 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
                 "claim_strength": "strong" if capture_clean else "partial",
                 "claim_basis": "measured",
                 "evidence_refs": ["capability-surface.json", "observation-health.json"],
+                "notes": [],
                 "non_claims": [
                     "does_not_prove_intent",
                     "strong_only_within_cgroup_scope",
@@ -137,7 +138,7 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
             )
 
         # Bounded negative: "X did not happen". Blocked unless coverage is
-        # complete with no blind spots, or capture was not clean.
+        # complete with no blind spots AND capture was clean.
         if not _supports_complete_claims(descriptor) or not capture_clean:
             reason = (
                 f"{dimension} absence claim requires completeness=full with no blind "

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -198,7 +198,16 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
     blocked_claims: list[dict[str, Any]] = []
 
     for dimension, descriptor in SEED_DESCRIPTORS.items():
-        observed = surface.get(SURFACE_FIELD[dimension]) or []
+        observed = surface.get(SURFACE_FIELD[dimension])
+        if observed is None:
+            continue
+        if not isinstance(observed, list) or any(
+            not isinstance(value, str) or not value for value in observed
+        ):
+            raise ValueError(
+                f"capability_surface.{SURFACE_FIELD[dimension]} must be a list of "
+                "non-empty strings"
+            )
         if not observed:
             continue
 
@@ -217,9 +226,9 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
                     "claim_basis": "measured",
                     "evidence_refs": [],
                     "notes": [
-                        "measured positive blocked by fidelity verdict: no measured "
-                        "kernel-effect surface (non-Linux, kernel layer absent, or "
-                        "cgroup correlation failed)"
+                        "measured positive blocked on the not_applicable path: no "
+                        "measured kernel-effect surface (non-Linux, or kernel layer "
+                        "absent)"
                     ],
                     "non_claims": ["does_not_prove_tool_intent"],
                 }

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -91,7 +91,7 @@ def _capture_is_clean(health: dict[str, Any]) -> bool:
     return (
         health.get("platform") == "linux"
         and health.get("kernel_layer") == "complete"
-        and int(health.get("ringbuf_drops", 1)) == 0
+        and health.get("ringbuf_drops") == 0
         and health.get("cgroup_correlation") == "clean"
     )
 
@@ -119,6 +119,29 @@ def _positive_verdict(health: dict[str, Any]) -> str:
 
 OBS_HEALTH_SCHEMA = "assay.runner.observation_health.v0"
 CAP_SURFACE_SCHEMA = "assay.runner.capability_surface.v0"
+# Canonical observation_health.v0 enums (see docs/reference/runner/artifacts-v0.md).
+KERNEL_LAYERS = {"complete", "partial_ringbuf_drops", "absent"}
+CGROUP_CORRELATIONS = {"clean", "partial", "failed"}
+
+
+def _validate_health(health: dict[str, Any]) -> None:
+    """Enforce the observation_health.v0 enum/type invariants before deriving.
+
+    A sample that mirrors fidelity_verdict.v0 must reject out-of-contract health
+    rather than interpret it. This is not a full schema validator; it checks the
+    fields the gate actually reads.
+    """
+    if health.get("schema") != OBS_HEALTH_SCHEMA:
+        raise ValueError(f"observation_health schema must be {OBS_HEALTH_SCHEMA}")
+    if health.get("kernel_layer") not in KERNEL_LAYERS:
+        raise ValueError(f"kernel_layer must be one of {sorted(KERNEL_LAYERS)}")
+    if health.get("cgroup_correlation") not in CGROUP_CORRELATIONS:
+        raise ValueError(
+            f"cgroup_correlation must be one of {sorted(CGROUP_CORRELATIONS)}"
+        )
+    drops = health.get("ringbuf_drops")
+    if isinstance(drops, bool) or not isinstance(drops, int) or drops < 0:
+        raise ValueError("ringbuf_drops must be a non-negative integer")
 
 
 def build_report(archive: dict[str, Any]) -> dict[str, Any]:
@@ -132,10 +155,7 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
     # Validate both records before interpreting them. fidelity_verdict.v0 blocks
     # measured claims on an invalid health record, so a sample that derives
     # claims must refuse malformed or mismatched inputs rather than emit cells.
-    if health.get("schema") != OBS_HEALTH_SCHEMA:
-        raise ValueError(
-            f"observation_health schema must be {OBS_HEALTH_SCHEMA}"
-        )
+    _validate_health(health)
     if surface.get("schema") != CAP_SURFACE_SCHEMA:
         raise ValueError(
             f"capability_surface schema must be {CAP_SURFACE_SCHEMA}"

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -59,6 +59,15 @@ SURFACE_FIELD = {
     "process": "process_execs",
 }
 
+# Canonical positive-effect claim_type per dimension, matching the documented
+# vocabulary in docs/reference/observability/claim-classes-v0.md. Note the
+# process dimension uses `process_execution_effect`, not `measured_process_*`.
+POSITIVE_CLAIM_TYPE = {
+    "filesystem": "measured_filesystem_effect",
+    "network": "measured_network_effect",
+    "process": "process_execution_effect",
+}
+
 
 def _blind_spot_summary(descriptor: dict[str, Any]) -> str:
     spots = descriptor.get("known_blind_spots") or []
@@ -73,8 +82,12 @@ def _supports_complete_claims(descriptor: dict[str, Any]) -> bool:
 
 
 def _capture_is_clean(health: dict[str, Any]) -> bool:
+    # Non-Linux records have no measured kernel-effect surface; the canonical
+    # fidelity verdict treats them as not_applicable, never clean, so they must
+    # not upgrade measured claims to strong.
     return (
-        health.get("kernel_layer") == "complete"
+        health.get("platform") == "linux"
+        and health.get("kernel_layer") == "complete"
         and int(health.get("ringbuf_drops", 1)) == 0
         and health.get("cgroup_correlation") == "clean"
     )
@@ -104,14 +117,14 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
         claim_cells.append(
             {
                 "schema": CLAIM_CELL_SCHEMA,
-                "claim_type": f"measured_{dimension}_effect",
+                "claim_type": POSITIVE_CLAIM_TYPE[dimension],
                 "artifact_role": "measured_run_archive",
                 "claim_strength": "strong" if capture_clean else "partial",
                 "claim_basis": "measured",
                 "evidence_refs": ["capability-surface.json", "observation-health.json"],
                 "notes": [],
                 "non_claims": [
-                    "does_not_prove_intent",
+                    "does_not_prove_tool_intent",
                     "strong_only_within_cgroup_scope",
                 ],
             }
@@ -165,14 +178,14 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
             claim_cells.append(
                 {
                     "schema": CLAIM_CELL_SCHEMA,
-                    "claim_type": f"bounded_negative_{dimension}_effect",
+                    "claim_type": "bounded_negative_claim",
                     "artifact_role": "measured_run_archive",
                     "claim_strength": "strong",
                     "claim_basis": "measured",
                     "evidence_refs": ["capability-surface.json", "observation-health.json"],
                     "notes": [
-                        f"completeness is full with no declared blind spots and "
-                        f"capture is clean: bounded-negative {dimension} claim allowed"
+                        f"{dimension}: completeness is full with no declared blind "
+                        f"spots and capture is clean: bounded-negative claim allowed"
                     ],
                     "non_claims": ["strong_only_within_cgroup_scope"],
                 }

--- a/examples/coverage-aware-side-effect/test_report.py
+++ b/examples/coverage-aware-side-effect/test_report.py
@@ -145,6 +145,27 @@ class CoverageAwareReportTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.m.build_report(archive)
 
+    def test_malformed_surface_field_is_rejected(self):
+        # A non-list (or empty-string-containing) capability_surface field is
+        # refused rather than interpreted as observed effects.
+        archive = {
+            "observation_health": {
+                "schema": "assay.runner.observation_health.v0",
+                "run_id": "run_bad_surface",
+                "platform": "linux",
+                "kernel_layer": "complete",
+                "ringbuf_drops": 0,
+                "cgroup_correlation": "clean",
+            },
+            "capability_surface": {
+                "schema": "assay.runner.capability_surface.v0",
+                "run_id": "run_bad_surface",
+                "filesystem_paths": "/etc/hosts",
+            },
+        }
+        with self.assertRaises(ValueError):
+            self.m.build_report(archive)
+
     def test_clean_report_matches_frozen_fixture(self):
         # Golden test: the generator output must equal the frozen expected
         # report, so the fixture and generator cannot drift apart silently.

--- a/examples/coverage-aware-side-effect/test_report.py
+++ b/examples/coverage-aware-side-effect/test_report.py
@@ -77,17 +77,18 @@ class CoverageAwareReportTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.m.build_report({"capability_surface": {"filesystem_paths": []}})
 
-    def test_blocked_fidelity_makes_positive_absent(self):
-        # Non-Linux (or kernel absent / correlation failed) blocks measured
-        # positives: the cell is absent with empty evidence_refs, not partial.
+    def test_not_applicable_makes_positive_absent(self):
+        # A valid not_applicable record (non-Linux, kernel_layer=absent) has no
+        # measured kernel surface: the positive cell is absent with empty
+        # evidence_refs, not an overstated partial.
         archive = {
             "observation_health": {
                 "schema": "assay.runner.observation_health.v0",
                 "run_id": "run_blocked",
-                "platform": "linux",
-                "kernel_layer": "complete",
+                "platform": "darwin",
+                "kernel_layer": "absent",
                 "ringbuf_drops": 0,
-                "cgroup_correlation": "failed",
+                "cgroup_correlation": "clean",
             },
             "capability_surface": {
                 "schema": "assay.runner.capability_surface.v0",
@@ -103,6 +104,27 @@ class CoverageAwareReportTest(unittest.TestCase):
         self.assertEqual(fs["claim_strength"], "absent")
         self.assertEqual(fs["artifact_role"], "none")
         self.assertEqual(fs["evidence_refs"], [])
+
+    def test_failed_cgroup_correlation_is_rejected(self):
+        # cgroup_correlation=failed is a non-passing observation_health record;
+        # the sample rejects it rather than interpreting it.
+        archive = {
+            "observation_health": {
+                "schema": "assay.runner.observation_health.v0",
+                "run_id": "run_failed",
+                "platform": "linux",
+                "kernel_layer": "complete",
+                "ringbuf_drops": 0,
+                "cgroup_correlation": "failed",
+            },
+            "capability_surface": {
+                "schema": "assay.runner.capability_surface.v0",
+                "run_id": "run_failed",
+                "filesystem_paths": ["/etc/hosts"],
+            },
+        }
+        with self.assertRaises(ValueError):
+            self.m.build_report(archive)
 
     def test_mismatched_run_id_is_rejected(self):
         archive = {

--- a/examples/coverage-aware-side-effect/test_report.py
+++ b/examples/coverage-aware-side-effect/test_report.py
@@ -77,6 +77,29 @@ class CoverageAwareReportTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.m.build_report({"capability_surface": {"filesystem_paths": []}})
 
+    def test_blocked_fidelity_makes_positive_absent(self):
+        # Non-Linux (or kernel absent / correlation failed) blocks measured
+        # positives: the cell is absent with empty evidence_refs, not partial.
+        archive = {
+            "observation_health": {
+                "schema": "assay.runner.observation_health.v0",
+                "run_id": "run_blocked",
+                "platform": "darwin",
+                "kernel_layer": "absent",
+                "ringbuf_drops": 0,
+                "cgroup_correlation": "not_applicable",
+            },
+            "capability_surface": {"filesystem_paths": ["read:/etc/hosts"]},
+        }
+        report = self.m.build_report(archive)
+        fs = next(
+            c for c in report["claim_cells"]
+            if c["claim_type"] == "measured_filesystem_effect"
+        )
+        self.assertEqual(fs["claim_strength"], "absent")
+        self.assertEqual(fs["artifact_role"], "none")
+        self.assertEqual(fs["evidence_refs"], [])
+
     def test_clean_report_matches_frozen_fixture(self):
         # Golden test: the generator output must equal the frozen expected
         # report, so the fixture and generator cannot drift apart silently.

--- a/examples/coverage-aware-side-effect/test_report.py
+++ b/examples/coverage-aware-side-effect/test_report.py
@@ -1,0 +1,82 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("report_from_archive.py")
+FIXTURES = Path(__file__).with_name("fixtures")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("coverage_aware_report", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _archive(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+class CoverageAwareReportTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _load_module()
+
+    def test_clean_positive_is_strong_measured(self):
+        report = self.m.build_report(_archive("clean.archive.json"))
+        positives = {
+            c["claim_type"]: c
+            for c in report["claim_cells"]
+            if c["claim_type"].startswith("measured_")
+        }
+        self.assertEqual(positives["measured_filesystem_effect"]["claim_strength"], "strong")
+        self.assertEqual(positives["measured_filesystem_effect"]["claim_basis"], "measured")
+        self.assertEqual(positives["measured_network_effect"]["claim_strength"], "strong")
+
+    def test_clean_exhaustive_network_is_weak(self):
+        report = self.m.build_report(_archive("clean.archive.json"))
+        exhaustive = {
+            c["claim_type"]: c
+            for c in report["claim_cells"]
+            if c["claim_type"].startswith("exhaustive_")
+        }
+        self.assertEqual(exhaustive["exhaustive_network_set"]["claim_strength"], "weak")
+        self.assertTrue(
+            any("QUIC" in note for note in exhaustive["exhaustive_network_set"]["notes"])
+        )
+
+    def test_clean_bounded_negative_is_blocked(self):
+        report = self.m.build_report(_archive("clean.archive.json"))
+        blocked = {b["requested_claim"] for b in report["blocked_claims"]}
+        self.assertIn("no_unexpected_network_effect", blocked)
+        self.assertIn("no_unexpected_filesystem_effect", blocked)
+        # no bounded-negative claim is emitted as an allowed/strong cell
+        self.assertFalse(
+            any(c["claim_type"] == "bounded_negative_claim" for c in report["claim_cells"])
+        )
+
+    def test_clipped_capture_downgrades_positive_to_partial(self):
+        report = self.m.build_report(_archive("clipped.archive.json"))
+        positives = {
+            c["claim_type"]: c
+            for c in report["claim_cells"]
+            if c["claim_type"].startswith("measured_")
+        }
+        # ringbuf drops > 0 -> capture not clean -> positive is partial, not strong
+        self.assertEqual(positives["measured_filesystem_effect"]["claim_strength"], "partial")
+
+    def test_unobserved_dimension_is_absent_not_claimed(self):
+        report = self.m.build_report(_archive("clean.archive.json"))
+        # process_execs is empty -> no process claim cell at all
+        self.assertFalse(
+            any("process" in c["claim_type"] for c in report["claim_cells"])
+        )
+
+    def test_missing_observation_health_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self.m.build_report({"capability_surface": {"filesystem_paths": []}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/coverage-aware-side-effect/test_report.py
+++ b/examples/coverage-aware-side-effect/test_report.py
@@ -89,7 +89,11 @@ class CoverageAwareReportTest(unittest.TestCase):
                 "ringbuf_drops": 0,
                 "cgroup_correlation": "not_applicable",
             },
-            "capability_surface": {"filesystem_paths": ["read:/etc/hosts"]},
+            "capability_surface": {
+                "schema": "assay.runner.capability_surface.v0",
+                "run_id": "run_blocked",
+                "filesystem_paths": ["/etc/hosts"],
+            },
         }
         report = self.m.build_report(archive)
         fs = next(
@@ -99,6 +103,25 @@ class CoverageAwareReportTest(unittest.TestCase):
         self.assertEqual(fs["claim_strength"], "absent")
         self.assertEqual(fs["artifact_role"], "none")
         self.assertEqual(fs["evidence_refs"], [])
+
+    def test_mismatched_run_id_is_rejected(self):
+        archive = {
+            "observation_health": {
+                "schema": "assay.runner.observation_health.v0",
+                "run_id": "run_a",
+                "platform": "linux",
+                "kernel_layer": "complete",
+                "ringbuf_drops": 0,
+                "cgroup_correlation": "clean",
+            },
+            "capability_surface": {
+                "schema": "assay.runner.capability_surface.v0",
+                "run_id": "run_b",
+                "filesystem_paths": ["/etc/hosts"],
+            },
+        }
+        with self.assertRaises(ValueError):
+            self.m.build_report(archive)
 
     def test_clean_report_matches_frozen_fixture(self):
         # Golden test: the generator output must equal the frozen expected

--- a/examples/coverage-aware-side-effect/test_report.py
+++ b/examples/coverage-aware-side-effect/test_report.py
@@ -77,6 +77,13 @@ class CoverageAwareReportTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.m.build_report({"capability_surface": {"filesystem_paths": []}})
 
+    def test_clean_report_matches_frozen_fixture(self):
+        # Golden test: the generator output must equal the frozen expected
+        # report, so the fixture and generator cannot drift apart silently.
+        report = self.m.build_report(_archive("clean.archive.json"))
+        expected = json.loads((FIXTURES / "clean.report.json").read_text(encoding="utf-8"))
+        self.assertEqual(report, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/examples/coverage-aware-side-effect/test_report.py
+++ b/examples/coverage-aware-side-effect/test_report.py
@@ -84,10 +84,10 @@ class CoverageAwareReportTest(unittest.TestCase):
             "observation_health": {
                 "schema": "assay.runner.observation_health.v0",
                 "run_id": "run_blocked",
-                "platform": "darwin",
-                "kernel_layer": "absent",
+                "platform": "linux",
+                "kernel_layer": "complete",
                 "ringbuf_drops": 0,
-                "cgroup_correlation": "not_applicable",
+                "cgroup_correlation": "failed",
             },
             "capability_surface": {
                 "schema": "assay.runner.capability_surface.v0",


### PR DESCRIPTION
## Summary

Adds a derived-report sample that turns a Runner archive's `observation_health`
and `capability_surface` into per-dimension claim cells plus blocked claims,
reusing the shipped `assay.runner.coverage_descriptor.v0` claim-kind gate
(`crates/assay-runner-schema/src/coverage.rs`).

It demonstrates three outcomes from one frozen archive fixture:

- positive existence (an observed open/connect happened): `strong measured` when
  capture is clean; capture health, not blind spots, gates strength
- exhaustive set (these are all the endpoints/paths): `weak measured` while the
  dimension declares blind spots
- bounded negative (no unexpected effect): blocked, because absence of an
  observed effect is not proof none occurred

Docs/example only: no new archive member, no Runner schema change, no Trust Basis
claim. The canonical gate logic stays in `coverage_descriptor.v0`; this script
mirrors it so the pattern is reviewable from a frozen fixture.

Also fixes two `blindspot` -> `blind spot` doc typos in the runner reference.

## Files

- `examples/coverage-aware-side-effect/report_from_archive.py` (stdlib generator)
- `fixtures/clean.archive.json`, `fixtures/clipped.archive.json`, `fixtures/clean.report.json`
- `test_report.py` (stdlib tests)
- examples index entry

## Validation

```bash
python3 examples/coverage-aware-side-effect/test_report.py   # 6 tests OK
python3 examples/coverage-aware-side-effect/report_from_archive.py examples/coverage-aware-side-effect/fixtures/clean.archive.json
```
