### PR TITLE
examples: add coverage-aware drift annotation sample

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -211,6 +211,10 @@ Map a tiny A2A task lifecycle export into Assay-shaped external evidence.
 Map a tiny UCP checkout/order lifecycle export into Assay-shaped external evidence.
 **Focus**: checkout/order-state observation only, no imported payment, settlement, or merchant truth.
 
+### [Coverage-Aware Drift Annotation](./coverage-aware-drift-annotation)
+Attach per-dimension claim cells to a `runtime_drift.v0.2` report so a full-overlap drift row is not read as exhaustive-equality or bounded-negative.
+**Focus**: comparator-output coverage ceiling, blocked absence claims, no comparator or schema change.
+
 ## 2. [Negation Safety](./negation-safety)
 Ensure model adheres to critical safety instructions (e.g. "Do NOT").
 **Metrics**: `regex`.

--- a/examples/coverage-aware-drift-annotation/README.md
+++ b/examples/coverage-aware-drift-annotation/README.md
@@ -13,7 +13,11 @@ sample. That sample gates claims for one measured run; this one gates the
 
 It is intentionally small and derived-report only:
 
-- reads one frozen `runtime_drift.v0.2` report fixture
+- reads one frozen `runtime_drift.v0.2` report fixture. The checked-in
+  `fixtures/drift_report.json` is a minimized subset for the sample: it carries
+  only the `schema` and `rows` the annotator reads, and intentionally omits
+  v0.2-required fields (`taxonomy`, `provenance`, `summary`, and several per-row
+  fields), so it is not a schema-valid v0.2 report on its own
 - emits an `assay.coverage_aware_drift.annotation.v0` placeholder annotation
 - does not change the comparator, the runtime-drift schema, Runner archives,
   or Trust Basis

--- a/examples/coverage-aware-drift-annotation/README.md
+++ b/examples/coverage-aware-drift-annotation/README.md
@@ -1,0 +1,73 @@
+# Coverage-Aware Drift Annotation (sample)
+
+This sample reads one `assay.runner.runtime_drift.v0.2` report and attaches
+per-dimension claim cells that apply the coverage ceiling at the
+comparator-output level, using the same gate as the shipped
+`assay.runner.coverage_descriptor.v0` helper
+(`crates/assay-runner-schema/src/coverage.rs`).
+
+It is the comparator-level companion to the single-archive
+[`../coverage-aware-side-effect/`](../coverage-aware-side-effect/README.md)
+sample. That sample gates claims for one measured run; this one gates the
+*reading* of a cross-runtime drift row.
+
+It is intentionally small and derived-report only:
+
+- reads one frozen `runtime_drift.v0.2` report fixture
+- emits an `assay.coverage_aware_drift.annotation.v0` placeholder annotation
+- does not change the comparator, the runtime-drift schema, Runner archives,
+  or Trust Basis
+
+## What it shows
+
+The drift comparator classifies each dimension as `task-induced`,
+`runtime-induced`, `inconclusive`, etc. The hazard is reading a `task-induced`
+(full-overlap) filesystem or network row as "these are exhaustively all the
+effects, and they match." Coverage descriptors say otherwise: filesystem
+capture is `open_syscall_only` and network capture is `connect_only`, so neither
+backs an exhaustive-equality or bounded-negative claim. For each measured
+dimension the annotation therefore distinguishes:
+
+- positive drift (this surface was observed) is `partial measured`. It is
+  capped at partial here on purpose: the drift report does not surface per-arm
+  observation health, so this sample will not emit a strong measured claim it
+  cannot back from the report alone. Consult `fidelity_verdict.v0` against the
+  source archives to raise it.
+- exhaustive equality (this is the complete shared effect set) is `weak
+  measured` while the dimension declares blind spots.
+- bounded negative (no effect beyond the observed surface) is blocked, even for
+  an empty or inconclusive row. A zero-observation row is exactly where someone
+  is tempted to claim "no effects happened"; the annotation refuses it.
+
+SDK/trace-reported dimensions (`sdk_tool_events`, `tool_invocation_order`,
+`mcp_tool_surface`) stay `reported` basis with no coverage gate, because they are
+not measured kernel effects.
+
+A `task-induced` classification is also recorded as a caveat, so full overlap is
+read as descriptive surface shape, not as exhaustive-equality proof.
+
+## Files
+
+- `annotate_drift.py`: derived-annotation generator (stdlib only)
+- `fixtures/drift_report.json`: small frozen `runtime_drift.v0.2` report
+- `fixtures/expected_annotation.json`: frozen expected annotation
+- `test_annotate.py`: stdlib tests for the partial / weak / blocked outcomes
+
+## Run
+
+```bash
+python3 examples/coverage-aware-drift-annotation/annotate_drift.py \
+  examples/coverage-aware-drift-annotation/fixtures/drift_report.json
+python3 examples/coverage-aware-drift-annotation/annotate_drift.py \
+  examples/coverage-aware-drift-annotation/fixtures/drift_report.json --format markdown
+python3 examples/coverage-aware-drift-annotation/test_annotate.py
+```
+
+## Boundary
+
+This is a sample annotation generator. It classifies the evidence a drift report
+already carries; it does not change the comparator, certify a runtime, prove
+intent, or claim a complete view of side effects. The canonical gate logic is the
+Rust `coverage_descriptor.v0` helper; this script mirrors its ceiling so the
+pattern is reviewable from a frozen report. Wiring this annotation into the
+comparator itself is a later Runner-crate slice.

--- a/examples/coverage-aware-drift-annotation/README.md
+++ b/examples/coverage-aware-drift-annotation/README.md
@@ -34,7 +34,9 @@ dimension the annotation therefore distinguishes:
   cannot back from the report alone. Consult `fidelity_verdict.v0` against the
   source archives to raise it.
 - exhaustive equality (this is the complete shared effect set) is `weak
-  measured` while the dimension declares blind spots.
+  derived` while the dimension declares blind spots: the exhaustive reading is
+  computed by applying the gate, so its basis is `derived`, not `measured`, and
+  the cell note names the rule.
 - bounded negative (no effect beyond the observed surface) is blocked, even for
   an empty or inconclusive row. A zero-observation row is exactly where someone
   is tempted to claim "no effects happened"; the annotation refuses it.

--- a/examples/coverage-aware-drift-annotation/annotate_drift.py
+++ b/examples/coverage-aware-drift-annotation/annotate_drift.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Coverage-aware drift annotation (sample, derived-report only).
+
+Reads one `assay.runner.runtime_drift.v0.2` report and attaches per-dimension
+claim cells that apply the coverage ceiling at the comparator-output level.
+
+This is the comparator-level companion to the single-archive
+`coverage-aware-side-effect` sample. The single-archive sample gates claims for
+one measured run; this sample gates the *reading* of a cross-runtime drift row,
+so a full-overlap (`task-induced`) row is not mistaken for an exhaustive-equality
+or bounded-negative effect claim.
+
+It is a sample: it produces a placeholder annotation envelope. It does not change
+the comparator, the runtime-drift schema, Runner archives, or Trust Basis. The
+canonical coverage gate lives in `crates/assay-runner-schema/src/coverage.rs`;
+this script mirrors its ceiling so the pattern is reviewable from a frozen
+report fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+ANNOTATION_SCHEMA = "assay.coverage_aware_drift.annotation.v0"
+CLAIM_CELL_SCHEMA = "assay.observability.claim_class_cell.v0"
+DRIFT_SCHEMA = "assay.runner.runtime_drift.v0.2"
+# The gating rule named by every derived claim cell, per claim-classes-v0
+# ("Derived must name the rule").
+GATE_RULE = "coverage_descriptor.v0 + fidelity_verdict.v0"
+
+# Seed coverage descriptors per effect dimension, mirroring coverage.rs. Each
+# names the capture method and documented blind spots, so an exhaustive or
+# bounded-negative reading is never assumed from a drift row.
+SEED_DESCRIPTORS: dict[str, dict[str, Any]] = {
+    "filesystem": {
+        "method": "open/openat/openat2 tracepoints",
+        "known_blind_spots": [
+            "io_uring file operations may bypass syscall tracepoints",
+            "mmap-backed writes are not path-open observations",
+        ],
+        "completeness": "open_syscall_only",
+    },
+    "network": {
+        "method": "connect tracepoint",
+        "known_blind_spots": [
+            "QUIC/datagram peer changes after connect are not an exhaustive peer set",
+            "io_uring network operations may bypass syscall tracepoints",
+        ],
+        "completeness": "connect_only",
+    },
+    "process": {
+        "method": "exec tracepoint",
+        "known_blind_spots": [
+            "fork/clone gaps can make process-tree exhaustiveness kernel-dependent",
+        ],
+        "completeness": "exec_only",
+    },
+}
+
+# Map each runtime-drift dimension to an effect dimension + claim basis.
+# Measured dimensions get the coverage ceiling; reported dimensions do not,
+# because SDK/trace events are reported, not measured kernel effects.
+DIMENSION_MAP: dict[str, dict[str, str]] = {
+    "filesystem_paths_touched": {"effect": "filesystem", "basis": "measured"},
+    "kernel_file_operations": {"effect": "filesystem", "basis": "measured"},
+    "network_endpoints": {"effect": "network", "basis": "measured"},
+    "process_execs": {"effect": "process", "basis": "measured"},
+    "sdk_tool_events": {"effect": None, "basis": "reported"},
+    "tool_invocation_order": {"effect": None, "basis": "reported"},
+    "mcp_tool_surface": {"effect": None, "basis": "reported"},
+}
+
+
+def _blind_spot_summary(descriptor: dict[str, Any]) -> str:
+    spots = descriptor.get("known_blind_spots") or []
+    return "; ".join(spots) if spots else "none declared"
+
+
+def _supports_complete_claims(descriptor: dict[str, Any]) -> bool:
+    # Mirrors coverage.rs: completeness == full AND no blind spots.
+    return descriptor.get("completeness") == "full" and not descriptor.get(
+        "known_blind_spots"
+    )
+
+
+def _row_observed_anything(row: dict[str, Any]) -> bool:
+    return bool(
+        row.get("only_in_a") or row.get("only_in_b") or row.get("in_both")
+    )
+
+
+def annotate(report: dict[str, Any]) -> dict[str, Any]:
+    schema = report.get("schema")
+    if schema != DRIFT_SCHEMA:
+        raise ValueError(
+            f"expected {DRIFT_SCHEMA} report; got {schema!r}"
+        )
+    rows = report.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("report: rows array is required")
+
+    claim_cells: list[dict[str, Any]] = []
+    blocked_claims: list[dict[str, Any]] = []
+    classification_caveats: list[dict[str, Any]] = []
+
+    for row in rows:
+        dimension = row.get("dimension")
+        mapping = DIMENSION_MAP.get(dimension)
+        if mapping is None:
+            continue
+        classification = row.get("classification")
+        observed = _row_observed_anything(row)
+
+        if mapping["basis"] == "reported":
+            # SDK/trace-reported surface: real for control flow, but not a
+            # measured kernel effect. No coverage gate applies; the cell stays
+            # reported so it is never read as a measured exhaustive set.
+            if observed:
+                claim_cells.append(
+                    {
+                        "schema": CLAIM_CELL_SCHEMA,
+                        "claim_type": f"reported_{dimension}",
+                        "artifact_role": "joined_artifacts",
+                        "claim_strength": "partial",
+                        "claim_basis": "reported",
+                        "evidence_refs": ["runtime-drift-report.json"],
+                        "notes": [
+                            "SDK/trace-reported drift surface; not a measured "
+                            "kernel effect, so no coverage ceiling is applied"
+                        ],
+                        "non_claims": [
+                            "does_not_prove_measured_effect",
+                            "does_not_prove_complete_set",
+                        ],
+                    }
+                )
+            continue
+
+        effect = mapping["effect"]
+        descriptor = SEED_DESCRIPTORS[effect]
+
+        if observed:
+            # Positive existence of the observed drift surface. The drift report
+            # does not surface per-arm capture health, so positive strength is
+            # capped at partial: this sample will not emit a strong measured
+            # claim it cannot back from the report alone.
+            claim_cells.append(
+                {
+                    "schema": CLAIM_CELL_SCHEMA,
+                    "claim_type": f"measured_{dimension}_drift",
+                    "artifact_role": "joined_artifacts",
+                    "claim_strength": "partial",
+                    "claim_basis": "measured",
+                    "evidence_refs": ["runtime-drift-report.json"],
+                    "notes": [
+                        "positive strength capped at partial: the drift report "
+                        "does not surface per-arm observation health; consult "
+                        "fidelity_verdict.v0 against the source archives to "
+                        "raise this to strong"
+                    ],
+                    "non_claims": [
+                        "does_not_prove_tool_intent",
+                        "does_not_prove_complete_set",
+                    ],
+                }
+            )
+
+        # Exhaustive equality: the reading that in_both / task-induced means the
+        # complete shared effect set. Only meaningful when something was
+        # observed. Allowed (weak->partial) only when coverage supports complete
+        # claims; otherwise degraded to weak. This mirrors coverage_descriptor.v0,
+        # where exhaustive set is allowed when completeness=full with no blind
+        # spots. Under the seed descriptors the supported branch is never taken;
+        # it is kept so the example represents the full gate, not only its
+        # degraded path.
+        if observed and _supports_complete_claims(descriptor):
+            claim_cells.append(
+                {
+                    "schema": CLAIM_CELL_SCHEMA,
+                    "claim_type": f"exhaustive_{dimension}_equality",
+                    "artifact_role": "joined_artifacts",
+                    "claim_strength": "partial",
+                    "claim_basis": "derived",
+                    "evidence_refs": ["runtime-drift-report.json"],
+                    "notes": [
+                        f"derived by {GATE_RULE}: completeness is full with no "
+                        f"declared blind spots, so exhaustive {effect} equality is "
+                        f"allowed; capped at partial because the drift report does "
+                        f"not surface per-arm health"
+                    ],
+                    "non_claims": ["strong_only_within_cgroup_scope"],
+                }
+            )
+        elif observed:
+            claim_cells.append(
+                {
+                    "schema": CLAIM_CELL_SCHEMA,
+                    "claim_type": f"exhaustive_{dimension}_equality",
+                    "artifact_role": "joined_artifacts",
+                    "claim_strength": "weak",
+                    "claim_basis": "derived",
+                    "evidence_refs": ["runtime-drift-report.json"],
+                    "notes": [
+                        f"derived by {GATE_RULE}: exhaustive {effect} equality "
+                        f"requires completeness=full with no blind spots; "
+                        f"completeness is {descriptor['completeness']}; blind "
+                        f"spots: {_blind_spot_summary(descriptor)}"
+                    ],
+                    "non_claims": [f"does_not_prove_complete_{effect}_set"],
+                }
+            )
+
+        # Bounded negative: "no effect beyond the observed drift surface". The
+        # coverage_descriptor.v0 gate allows this only when completeness=full
+        # with no blind spots; this comparator-level sample additionally never
+        # allows it, because the drift report does not surface per-arm capture
+        # health, so a clean-capture precondition cannot be confirmed here. The
+        # block reason names both gates.
+        blocked_claims.append(
+            {
+                "claim_type": "bounded_negative_claim",
+                "requested_claim": f"no_{dimension}_effect_beyond_observed",
+                "decision": "blocked",
+                "reason": (
+                    f"{effect} absence-beyond-observed claim requires "
+                    f"completeness=full with no blind spots and confirmed clean "
+                    f"capture; completeness is {descriptor['completeness']}; blind "
+                    f"spots: {_blind_spot_summary(descriptor)}; the drift report "
+                    f"does not surface per-arm observation health"
+                ),
+            }
+        )
+
+        # A task-induced (full overlap) classification is descriptive surface
+        # shape, not an exhaustive-equality proof. Make that explicit.
+        if classification == "task-induced":
+            classification_caveats.append(
+                {
+                    "dimension": dimension,
+                    "classification": "task-induced",
+                    "caveat": (
+                        "full overlap of the observed surface; this is not proof "
+                        f"the {effect} effect sets are exhaustively equal, because "
+                        f"{effect} coverage is {descriptor['completeness']}"
+                    ),
+                }
+            )
+
+    return {
+        "schema": ANNOTATION_SCHEMA,
+        "source_report_schema": DRIFT_SCHEMA,
+        "claim_cells": claim_cells,
+        "blocked_claims": blocked_claims,
+        "classification_caveats": classification_caveats,
+    }
+
+
+def render_markdown(annotation: dict[str, Any]) -> str:
+    lines = ["# Coverage-Aware Drift Annotation (sample)", ""]
+    lines.append("## Claims")
+    for cell in annotation["claim_cells"]:
+        lines.append(
+            f"- {cell['claim_type']}: {cell['claim_strength']} {cell['claim_basis']}"
+        )
+    if annotation["blocked_claims"]:
+        lines.append("")
+        lines.append("## Blocked (coverage cannot support)")
+        for blocked in annotation["blocked_claims"]:
+            lines.append(f"- {blocked['requested_claim']}: {blocked['reason']}")
+    if annotation["classification_caveats"]:
+        lines.append("")
+        lines.append("## Classification caveats")
+        for caveat in annotation["classification_caveats"]:
+            lines.append(f"- {caveat['dimension']}: {caveat['caveat']}")
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", help="runtime-drift v0.2 report JSON")
+    parser.add_argument("--format", choices=["json", "markdown"], default="json")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    with open(args.report, "r", encoding="utf-8") as handle:
+        report = json.load(handle)
+    annotation = annotate(report)
+    if args.format == "markdown":
+        sys.stdout.write(render_markdown(annotation))
+    else:
+        sys.stdout.write(json.dumps(annotation, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/coverage-aware-drift-annotation/annotate_drift.py
+++ b/examples/coverage-aware-drift-annotation/annotate_drift.py
@@ -63,7 +63,7 @@ SEED_DESCRIPTORS: dict[str, dict[str, Any]] = {
 # Map each runtime-drift dimension to an effect dimension + claim basis.
 # Measured dimensions get the coverage ceiling; reported dimensions do not,
 # because SDK/trace events are reported, not measured kernel effects.
-DIMENSION_MAP: dict[str, dict[str, str]] = {
+DIMENSION_MAP: dict[str, dict[str, str | None]] = {
     "filesystem_paths_touched": {"effect": "filesystem", "basis": "measured"},
     "kernel_file_operations": {"effect": "filesystem", "basis": "measured"},
     "network_endpoints": {"effect": "network", "basis": "measured"},
@@ -140,6 +140,10 @@ def annotate(report: dict[str, Any]) -> dict[str, Any]:
             continue
 
         effect = mapping["effect"]
+        if effect is None:
+            # Reported dimensions return above; measured ones always map to an
+            # effect. Guard explicitly so the SEED_DESCRIPTORS lookup is safe.
+            continue
         descriptor = SEED_DESCRIPTORS[effect]
 
         if observed:

--- a/examples/coverage-aware-drift-annotation/fixtures/drift_report.json
+++ b/examples/coverage-aware-drift-annotation/fixtures/drift_report.json
@@ -1,0 +1,35 @@
+{
+  "schema": "assay.runner.runtime_drift.v0.2",
+  "archive_a": {"path": "runs/arm-a", "manifest_digest": "sha256:aaaa"},
+  "archive_b": {"path": "runs/arm-b", "manifest_digest": "sha256:bbbb"},
+  "rows": [
+    {
+      "dimension": "filesystem_paths_touched",
+      "classification": "runtime-induced",
+      "only_in_a": ["read:/tmp/run-a/input.txt", "read:/tmp/run-a/cache"],
+      "only_in_b": ["read:/tmp/run-b/input.txt"],
+      "in_both": ["read:/etc/hosts"]
+    },
+    {
+      "dimension": "network_endpoints",
+      "classification": "task-induced",
+      "only_in_a": [],
+      "only_in_b": [],
+      "in_both": ["api.example.com:443"]
+    },
+    {
+      "dimension": "process_execs",
+      "classification": "inconclusive",
+      "only_in_a": [],
+      "only_in_b": [],
+      "in_both": []
+    },
+    {
+      "dimension": "sdk_tool_events",
+      "classification": "task-induced",
+      "only_in_a": [],
+      "only_in_b": [],
+      "in_both": ["search", "fetch"]
+    }
+  ]
+}

--- a/examples/coverage-aware-drift-annotation/fixtures/drift_report.json
+++ b/examples/coverage-aware-drift-annotation/fixtures/drift_report.json
@@ -1,7 +1,7 @@
 {
   "schema": "assay.runner.runtime_drift.v0.2",
-  "archive_a": {"path": "runs/arm-a", "manifest_digest": "sha256:aaaa"},
-  "archive_b": {"path": "runs/arm-b", "manifest_digest": "sha256:bbbb"},
+  "archive_a": {"path": "runs/arm-a", "manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
+  "archive_b": {"path": "runs/arm-b", "manifest_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"},
   "rows": [
     {
       "dimension": "filesystem_paths_touched",

--- a/examples/coverage-aware-drift-annotation/fixtures/expected_annotation.json
+++ b/examples/coverage-aware-drift-annotation/fixtures/expected_annotation.json
@@ -1,0 +1,116 @@
+{
+  "blocked_claims": [
+    {
+      "claim_type": "bounded_negative_claim",
+      "decision": "blocked",
+      "reason": "filesystem absence-beyond-observed claim requires completeness=full with no blind spots and confirmed clean capture; completeness is open_syscall_only; blind spots: io_uring file operations may bypass syscall tracepoints; mmap-backed writes are not path-open observations; the drift report does not surface per-arm observation health",
+      "requested_claim": "no_filesystem_paths_touched_effect_beyond_observed"
+    },
+    {
+      "claim_type": "bounded_negative_claim",
+      "decision": "blocked",
+      "reason": "network absence-beyond-observed claim requires completeness=full with no blind spots and confirmed clean capture; completeness is connect_only; blind spots: QUIC/datagram peer changes after connect are not an exhaustive peer set; io_uring network operations may bypass syscall tracepoints; the drift report does not surface per-arm observation health",
+      "requested_claim": "no_network_endpoints_effect_beyond_observed"
+    },
+    {
+      "claim_type": "bounded_negative_claim",
+      "decision": "blocked",
+      "reason": "process absence-beyond-observed claim requires completeness=full with no blind spots and confirmed clean capture; completeness is exec_only; blind spots: fork/clone gaps can make process-tree exhaustiveness kernel-dependent; the drift report does not surface per-arm observation health",
+      "requested_claim": "no_process_execs_effect_beyond_observed"
+    }
+  ],
+  "claim_cells": [
+    {
+      "artifact_role": "joined_artifacts",
+      "claim_basis": "measured",
+      "claim_strength": "partial",
+      "claim_type": "measured_filesystem_paths_touched_drift",
+      "evidence_refs": [
+        "runtime-drift-report.json"
+      ],
+      "non_claims": [
+        "does_not_prove_tool_intent",
+        "does_not_prove_complete_set"
+      ],
+      "notes": [
+        "positive strength capped at partial: the drift report does not surface per-arm observation health; consult fidelity_verdict.v0 against the source archives to raise this to strong"
+      ],
+      "schema": "assay.observability.claim_class_cell.v0"
+    },
+    {
+      "artifact_role": "joined_artifacts",
+      "claim_basis": "derived",
+      "claim_strength": "weak",
+      "claim_type": "exhaustive_filesystem_paths_touched_equality",
+      "evidence_refs": [
+        "runtime-drift-report.json"
+      ],
+      "non_claims": [
+        "does_not_prove_complete_filesystem_set"
+      ],
+      "notes": [
+        "derived by coverage_descriptor.v0 + fidelity_verdict.v0: exhaustive filesystem equality requires completeness=full with no blind spots; completeness is open_syscall_only; blind spots: io_uring file operations may bypass syscall tracepoints; mmap-backed writes are not path-open observations"
+      ],
+      "schema": "assay.observability.claim_class_cell.v0"
+    },
+    {
+      "artifact_role": "joined_artifacts",
+      "claim_basis": "measured",
+      "claim_strength": "partial",
+      "claim_type": "measured_network_endpoints_drift",
+      "evidence_refs": [
+        "runtime-drift-report.json"
+      ],
+      "non_claims": [
+        "does_not_prove_tool_intent",
+        "does_not_prove_complete_set"
+      ],
+      "notes": [
+        "positive strength capped at partial: the drift report does not surface per-arm observation health; consult fidelity_verdict.v0 against the source archives to raise this to strong"
+      ],
+      "schema": "assay.observability.claim_class_cell.v0"
+    },
+    {
+      "artifact_role": "joined_artifacts",
+      "claim_basis": "derived",
+      "claim_strength": "weak",
+      "claim_type": "exhaustive_network_endpoints_equality",
+      "evidence_refs": [
+        "runtime-drift-report.json"
+      ],
+      "non_claims": [
+        "does_not_prove_complete_network_set"
+      ],
+      "notes": [
+        "derived by coverage_descriptor.v0 + fidelity_verdict.v0: exhaustive network equality requires completeness=full with no blind spots; completeness is connect_only; blind spots: QUIC/datagram peer changes after connect are not an exhaustive peer set; io_uring network operations may bypass syscall tracepoints"
+      ],
+      "schema": "assay.observability.claim_class_cell.v0"
+    },
+    {
+      "artifact_role": "joined_artifacts",
+      "claim_basis": "reported",
+      "claim_strength": "partial",
+      "claim_type": "reported_sdk_tool_events",
+      "evidence_refs": [
+        "runtime-drift-report.json"
+      ],
+      "non_claims": [
+        "does_not_prove_measured_effect",
+        "does_not_prove_complete_set"
+      ],
+      "notes": [
+        "SDK/trace-reported drift surface; not a measured kernel effect, so no coverage ceiling is applied"
+      ],
+      "schema": "assay.observability.claim_class_cell.v0"
+    }
+  ],
+  "classification_caveats": [
+    {
+      "caveat": "full overlap of the observed surface; this is not proof the network effect sets are exhaustively equal, because network coverage is connect_only",
+      "classification": "task-induced",
+      "dimension": "network_endpoints"
+    }
+  ],
+  "schema": "assay.coverage_aware_drift.annotation.v0",
+  "source_report_schema": "assay.runner.runtime_drift.v0.2"
+}

--- a/examples/coverage-aware-drift-annotation/test_annotate.py
+++ b/examples/coverage-aware-drift-annotation/test_annotate.py
@@ -1,0 +1,100 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("annotate_drift.py")
+FIXTURES = Path(__file__).with_name("fixtures")
+REQUIRED_CELL_FIELDS = {
+    "schema",
+    "claim_type",
+    "artifact_role",
+    "claim_strength",
+    "claim_basis",
+    "evidence_refs",
+    "notes",
+    "non_claims",
+}
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("annotate_drift", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _report(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+class CoverageAwareDriftTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.m = _load_module()
+        self.annotation = self.m.annotate(_report("drift_report.json"))
+
+    def _cells(self) -> dict:
+        return {c["claim_type"]: c for c in self.annotation["claim_cells"]}
+
+    def test_positive_drift_is_partial_measured_not_strong(self):
+        cells = self._cells()
+        fs = cells["measured_filesystem_paths_touched_drift"]
+        self.assertEqual(fs["claim_strength"], "partial")
+        self.assertEqual(fs["claim_basis"], "measured")
+        # the report does not surface health, so positive is never strong here
+        self.assertFalse(
+            any(
+                c["claim_strength"] == "strong"
+                for c in self.annotation["claim_cells"]
+            )
+        )
+
+    def test_exhaustive_equality_is_weak_with_blind_spot_note(self):
+        cells = self._cells()
+        net = cells["exhaustive_network_endpoints_equality"]
+        self.assertEqual(net["claim_strength"], "weak")
+        self.assertTrue(any("QUIC" in note for note in net["notes"]))
+
+    def test_bounded_negative_is_blocked_for_measured_dimensions(self):
+        blocked = {b["requested_claim"] for b in self.annotation["blocked_claims"]}
+        self.assertIn("no_filesystem_paths_touched_effect_beyond_observed", blocked)
+        self.assertIn("no_network_endpoints_effect_beyond_observed", blocked)
+        # even the empty/inconclusive process row blocks the absence claim
+        self.assertIn("no_process_execs_effect_beyond_observed", blocked)
+
+    def test_empty_dimension_emits_no_positive_or_exhaustive_cell(self):
+        cells = self._cells()
+        self.assertNotIn("measured_process_execs_drift", cells)
+        self.assertNotIn("exhaustive_process_execs_equality", cells)
+
+    def test_task_induced_is_caveated_not_treated_as_equality(self):
+        caveats = {c["dimension"]: c for c in self.annotation["classification_caveats"]}
+        self.assertIn("network_endpoints", caveats)
+        self.assertIn("not proof", caveats["network_endpoints"]["caveat"])
+
+    def test_reported_dimension_is_reported_basis_no_coverage_gate(self):
+        cells = self._cells()
+        sdk = cells["reported_sdk_tool_events"]
+        self.assertEqual(sdk["claim_basis"], "reported")
+        # no exhaustive/blocked claim is derived for a reported dimension
+        self.assertNotIn("exhaustive_sdk_tool_events_equality", cells)
+        self.assertFalse(
+            any("sdk_tool_events" in b["requested_claim"] for b in self.annotation["blocked_claims"])
+        )
+
+    def test_all_cells_conform_to_required_fields(self):
+        for cell in self.annotation["claim_cells"]:
+            self.assertEqual(REQUIRED_CELL_FIELDS - set(cell), set(), cell["claim_type"])
+
+    def test_wrong_source_schema_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self.m.annotate({"schema": "assay.runner.runtime_drift.v0", "rows": []})
+
+    def test_matches_frozen_expected(self):
+        expected = _report("expected_annotation.json")
+        self.assertEqual(self.annotation, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the comparator-output companion to the `coverage-aware-side-effect` sample.
That sample gates claims for one measured archive; this one gates the *reading*
of a cross-runtime drift row, so a full-overlap (`task-induced`)
`runtime_drift.v0.2` row is not mistaken for an exhaustive-equality or
bounded-negative effect claim.

For each measured dimension the annotation distinguishes:

- positive drift is `partial measured` — capped at partial on purpose, because
  the drift report does not surface per-arm observation health; consult
  `fidelity_verdict.v0` against the source archives to raise it
- exhaustive equality is `weak derived` while the dimension declares blind spots
- bounded negative (no effect beyond the observed surface) is blocked, even for
  an empty or inconclusive row — a zero-observation row is exactly where someone
  is tempted to claim "no effects happened"

SDK/trace-reported dimensions stay `reported` basis with no coverage gate, and a
`task-induced` classification is recorded as a caveat rather than equality proof.

## Scope

Example only. stdlib generator + frozen fixtures + tests. It does not change the
comparator, the runtime-drift schema, Runner archives, or Trust Basis. Wiring
this annotation into the comparator itself is a later Runner-crate slice. The
canonical gate stays the Rust `coverage_descriptor.v0` helper.

## Files

- `examples/coverage-aware-drift-annotation/annotate_drift.py` (stdlib generator)
- `examples/coverage-aware-drift-annotation/fixtures/{drift_report,expected_annotation}.json`
- `examples/coverage-aware-drift-annotation/test_annotate.py` (9 tests)
- `examples/coverage-aware-drift-annotation/README.md`
- `examples/README.md` (index entry)

## Validation

```bash
python3 examples/coverage-aware-drift-annotation/test_annotate.py   # 9 tests OK
python3 examples/coverage-aware-drift-annotation/annotate_drift.py \
  examples/coverage-aware-drift-annotation/fixtures/drift_report.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
