### PR TITLE
feat(runner-schema): effect-class-aware coverage positive-existence gate

### DIFF
--- a/crates/assay-runner-schema/src/coverage.rs
+++ b/crates/assay-runner-schema/src/coverage.rs
@@ -213,7 +213,7 @@ impl CoverageDescriptor {
                 "{} does not list the claimed effect class \"{}\" in observes: {}",
                 dimension_label(descriptor.dimension),
                 effect_class.trim(),
-                descriptor.observes.join("; ")
+                observes_summary(descriptor)
             ),
         }
     }
@@ -260,5 +260,13 @@ fn blind_spot_summary(descriptor: &CoverageDescriptor) -> String {
         "none declared".to_string()
     } else {
         descriptor.known_blind_spots.join("; ")
+    }
+}
+
+fn observes_summary(descriptor: &CoverageDescriptor) -> String {
+    if descriptor.observes.is_empty() {
+        "none declared".to_string()
+    } else {
+        descriptor.observes.join("; ")
     }
 }

--- a/crates/assay-runner-schema/src/coverage.rs
+++ b/crates/assay-runner-schema/src/coverage.rs
@@ -147,7 +147,7 @@ impl CoverageDescriptor {
                     "{} completeness is {}; blind spots: {}",
                     dimension_label(descriptor.dimension),
                     completeness_label(descriptor.completeness),
-                    descriptor.known_blind_spots.join("; ")
+                    blind_spot_summary(descriptor)
                 ),
             },
             CoverageClaimKind::BoundedNegative if descriptor.supports_complete_claims() => {
@@ -169,6 +169,68 @@ impl CoverageDescriptor {
                 ),
             },
         }
+    }
+
+    /// Effect-class-aware variant of [`Self::claim_decision_for`].
+    ///
+    /// This refines only `PositiveExistence`: it first applies the same
+    /// descriptor-presence, schema, and claim-kind gate, and then, when that
+    /// gate would allow the positive claim, additionally checks that the
+    /// caller's `effect_class` is one this descriptor actually observes. A
+    /// positive claim for a class outside `observes` is downgraded to
+    /// `Degraded` rather than blanket-allowed, so callers cannot read a
+    /// present descriptor as permission for an effect class it never captured.
+    ///
+    /// `ExhaustiveSet` and `BoundedNegative` are unaffected: they already gate
+    /// on completeness and blind spots, which are class-independent. The
+    /// existing [`Self::claim_decision_for`] is left unchanged for callers that
+    /// scope the effect class themselves.
+    #[must_use]
+    pub fn claim_decision_for_effect(
+        descriptor: Option<&Self>,
+        claim_kind: CoverageClaimKind,
+        effect_class: &str,
+    ) -> CoverageClaimDecision {
+        let base = Self::claim_decision_for(descriptor, claim_kind);
+        if claim_kind != CoverageClaimKind::PositiveExistence {
+            return base;
+        }
+        // Only refine a positive claim the base gate already allowed; missing
+        // descriptor / schema mismatch are already blocked by `base`.
+        let Some(descriptor) = descriptor else {
+            return base;
+        };
+        if base.decision != ClaimGateDecision::Allowed {
+            return base;
+        }
+        if descriptor.observes_effect_class(effect_class) {
+            return base;
+        }
+        CoverageClaimDecision {
+            decision: ClaimGateDecision::Degraded,
+            rule: "coverage_descriptor_positive_class_not_observed".to_string(),
+            reason: format!(
+                "{} does not list the claimed effect class \"{}\" in observes: {}",
+                dimension_label(descriptor.dimension),
+                effect_class.trim(),
+                descriptor.observes.join("; ")
+            ),
+        }
+    }
+
+    /// Conservative containment check: does any `observes` entry mention this
+    /// effect class? `observes` carries free-text capture descriptions, so the
+    /// match is a case-insensitive substring rather than an enum equality. An
+    /// empty class never matches.
+    #[must_use]
+    pub fn observes_effect_class(&self, effect_class: &str) -> bool {
+        let needle = effect_class.trim().to_ascii_lowercase();
+        if needle.is_empty() {
+            return false;
+        }
+        self.observes
+            .iter()
+            .any(|observed| observed.to_ascii_lowercase().contains(&needle))
     }
 
     fn supports_complete_claims(&self) -> bool {

--- a/crates/assay-runner-schema/tests/coverage_descriptor.rs
+++ b/crates/assay-runner-schema/tests/coverage_descriptor.rs
@@ -129,3 +129,78 @@ fn network_connect_only_is_positive_but_not_an_exhaustive_peer_set() {
     assert_eq!(exhaustive.decision, ClaimGateDecision::Degraded);
     assert!(exhaustive.reason.contains("QUIC"));
 }
+
+#[test]
+fn observes_effect_class_matches_case_insensitive_substring() {
+    let descriptor = CoverageDescriptor::filesystem_open_syscall_only();
+    assert!(descriptor.observes_effect_class("path opens"));
+    assert!(descriptor.observes_effect_class("PATH OPENS"));
+    assert!(!descriptor.observes_effect_class("network connect"));
+    assert!(!descriptor.observes_effect_class("   "));
+}
+
+#[test]
+fn positive_claim_for_observed_class_is_allowed() {
+    let descriptor = CoverageDescriptor::network_connect_only();
+    let decision = CoverageDescriptor::claim_decision_for_effect(
+        Some(&descriptor),
+        CoverageClaimKind::PositiveExistence,
+        "connect-time peer endpoints",
+    );
+    assert_eq!(decision.decision, ClaimGateDecision::Allowed);
+    assert_eq!(
+        decision.rule,
+        "coverage_descriptor_allows_observed_positive_claim"
+    );
+}
+
+#[test]
+fn positive_claim_for_unobserved_class_is_degraded() {
+    let descriptor = CoverageDescriptor::network_connect_only();
+    // connect-only capture does not observe post-connect datagram peers
+    let decision = CoverageDescriptor::claim_decision_for_effect(
+        Some(&descriptor),
+        CoverageClaimKind::PositiveExistence,
+        "datagram peer after connect",
+    );
+    assert_eq!(decision.decision, ClaimGateDecision::Degraded);
+    assert_eq!(
+        decision.rule,
+        "coverage_descriptor_positive_class_not_observed"
+    );
+    assert!(decision.reason.contains("datagram peer after connect"));
+}
+
+#[test]
+fn effect_class_variant_leaves_exhaustive_and_bounded_unchanged() {
+    let descriptor = CoverageDescriptor::filesystem_open_syscall_only();
+    // class argument is irrelevant for non-positive claim kinds
+    let exhaustive = CoverageDescriptor::claim_decision_for_effect(
+        Some(&descriptor),
+        CoverageClaimKind::ExhaustiveSet,
+        "anything",
+    );
+    assert_eq!(exhaustive.decision, ClaimGateDecision::Degraded);
+    assert_eq!(
+        exhaustive.rule,
+        "coverage_descriptor_degrades_exhaustive_claim"
+    );
+
+    let bounded = CoverageDescriptor::claim_decision_for_effect(
+        Some(&descriptor),
+        CoverageClaimKind::BoundedNegative,
+        "anything",
+    );
+    assert_eq!(bounded.decision, ClaimGateDecision::Blocked);
+}
+
+#[test]
+fn missing_descriptor_still_blocks_effect_variant() {
+    let decision = CoverageDescriptor::claim_decision_for_effect(
+        None,
+        CoverageClaimKind::PositiveExistence,
+        "path opens",
+    );
+    assert_eq!(decision.decision, ClaimGateDecision::Blocked);
+    assert_eq!(decision.rule, "coverage_descriptor_required_for_claim");
+}

--- a/crates/assay-runner-schema/tests/coverage_descriptor.rs
+++ b/crates/assay-runner-schema/tests/coverage_descriptor.rs
@@ -204,3 +204,22 @@ fn missing_descriptor_still_blocks_effect_variant() {
     assert_eq!(decision.decision, ClaimGateDecision::Blocked);
     assert_eq!(decision.rule, "coverage_descriptor_required_for_claim");
 }
+
+#[test]
+fn unobserved_class_with_empty_observes_uses_placeholder() {
+    let descriptor = CoverageDescriptor {
+        schema: "assay.runner.coverage_descriptor.v0".to_string(),
+        dimension: EffectDimension::Filesystem,
+        method: "synthetic".to_string(),
+        observes: Vec::new(),
+        known_blind_spots: Vec::new(),
+        completeness: CoverageCompleteness::OpenSyscallOnly,
+    };
+    let decision = CoverageDescriptor::claim_decision_for_effect(
+        Some(&descriptor),
+        CoverageClaimKind::PositiveExistence,
+        "path opens",
+    );
+    assert_eq!(decision.decision, ClaimGateDecision::Degraded);
+    assert!(decision.reason.contains("observes: none declared"));
+}

--- a/docs/reference/runner/coverage-descriptor-v0.md
+++ b/docs/reference/runner/coverage-descriptor-v0.md
@@ -81,15 +81,27 @@ The descriptor gate evaluates the requested claim kind:
 | `exhaustive_set` | "These are all paths or peers." | Degraded when any blind spots are declared. |
 | `bounded_negative` | "No unexpected egress happened." | Blocked when any blind spots are declared. |
 
-M1 is intentionally conservative. The helper does not yet inspect whether
-a particular claimed effect class appears in `observes`, and it does not
-filter blind spots by per-claim relevance. Callers are responsible for
-selecting the descriptor that matches the effect dimension and effect
-class they are interpreting. If a descriptor declares any blind spot, M1
-treats that blind spot as relevant for exhaustive and bounded-negative
-claims. A later descriptor-aware consumer slice can add finer
-effect-class matching and relevance filtering without weakening this
-initial gate.
+The base gate (`claim_decision_for`) is intentionally conservative: it does
+not inspect whether a particular claimed effect class appears in `observes`,
+so callers that use it remain responsible for selecting a descriptor whose
+`observes` covers the effect class they are interpreting.
+
+An additive, effect-class-aware variant `claim_decision_for_effect(descriptor,
+claim_kind, effect_class)` layers that check on top. For `positive_existence`
+it first applies the same presence/schema/claim-kind gate and then, when the
+base gate would allow the positive claim, additionally confirms the
+`effect_class` is one the descriptor observes (a conservative case-insensitive
+containment match against `observes`, also exposed as
+`observes_effect_class`). A positive claim for a class outside `observes` is
+downgraded to `degraded` (`coverage_descriptor_positive_class_not_observed`)
+rather than blanket-allowed. `exhaustive_set` and `bounded_negative` are
+unaffected, because they already gate on completeness and blind spots, which
+are class-independent; the base `claim_decision_for` is left unchanged for
+callers that scope the effect class themselves.
+
+Relevance filtering of individual blind spots per claim remains a later step:
+if a descriptor declares any blind spot, both variants still treat it as
+relevant for exhaustive and bounded-negative claims.
 
 M1 also treats `completeness` as load-bearing, not decorative. Exhaustive
 and bounded-negative claims are allowed only when `completeness = full`


### PR DESCRIPTION
## Summary

Additive, descriptor-aware refinement of the coverage gate — the follow-on the `coverage-descriptor-v0` doc flagged for a later consumer slice.

- `claim_decision_for_effect(descriptor, claim_kind, effect_class)` layers an `observes` check on `positive_existence`: when the base presence/schema gate would allow the positive claim, it additionally confirms the `effect_class` is one the descriptor observes; otherwise it downgrades to `degraded` (`coverage_descriptor_positive_class_not_observed`) rather than blanket-allow.
- `observes_effect_class()` exposes the conservative case-insensitive containment match.
- `exhaustive_set` / `bounded_negative` are unaffected (class-independent); the existing `claim_decision_for` is unchanged for back-compat.
- Consistency: the degraded-exhaustive reason now uses `blind_spot_summary()` like the bounded-negative branch.

## Scope

Runner-crate (`assay-runner-schema`) + its reference doc. Additive only — no signature change to existing APIs; only the crate's own tests called the gate.

## Validation

`cargo test -p assay-runner-schema --test coverage_descriptor` — 11 tests pass (5 new). clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assay-Runner delegated proof: gate: all — head ff44b8b67e99fd99e7a4ab93dc8b5d7af8c4e00b — run https://github.com/Rul1an/assay/actions/runs/26948715968 (success).