### PR TITLE
feat(experiment): fidelity-derived strength + claim enforcement in drift comparator

### DIFF
--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -110,6 +110,20 @@ python3 "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/drift.p
 # effect claim. The canonical gate is crates/assay-runner-schema/src/coverage.rs;
 # see also examples/coverage-aware-drift-annotation/.
 #   ... --coverage-annotation-out /tmp/drift.coverage-annotation.json
+#
+# Positive measured drift strength is derived from per-arm observation_health
+# (already parsed from both archives): strong only when BOTH arms are clean,
+# partial when capture is degraded, absent when either arm has no valid measured
+# surface (fidelity_verdict not_applicable/failed). The drift report contract is
+# not changed.
+#
+# Enforcement: --assert-claim TYPE:DIMENSION makes the honesty layer
+# afdwingbaar. The comparator exits 1 if the coverage gate does not permit an
+# asserted claim (e.g. a bounded-negative or a blind-spot-degraded exhaustive
+# claim), and 0 when all asserted claims are permitted. TYPE is positive,
+# exhaustive, or bounded_negative.
+#   ... --assert-claim bounded_negative:network_endpoints   # exits 1 (blocked)
+#   ... --assert-claim positive:filesystem_paths_touched    # exits 0 if observed+clean
 
 # Tests (no API keys required):
 python3 -m unittest discover \

--- a/docs/experiments/cross-runtime-drift-2026-05/README.md
+++ b/docs/experiments/cross-runtime-drift-2026-05/README.md
@@ -112,18 +112,20 @@ python3 "$REPO_ROOT/docs/experiments/cross-runtime-drift-2026-05/compare/drift.p
 #   ... --coverage-annotation-out /tmp/drift.coverage-annotation.json
 #
 # Positive measured drift strength is derived from per-arm observation_health
-# (already parsed from both archives): strong only when BOTH arms are clean,
-# partial when capture is degraded, absent when either arm has no valid measured
-# surface (fidelity_verdict not_applicable/failed). The drift report contract is
-# not changed.
+# when both archives carry it: strong only when BOTH arms are clean, partial
+# when capture is degraded, absent when either arm has no valid measured surface
+# (fidelity_verdict not_applicable/failed). When either archive lacks
+# observation-health.json (no health supplied), it falls back to the
+# conservative partial. The drift report contract is not changed.
 #
 # Enforcement: --assert-claim TYPE:DIMENSION makes the honesty layer
-# afdwingbaar. The comparator exits 1 if the coverage gate does not permit an
+# enforceable. The comparator exits 1 if the coverage gate does not permit an
 # asserted claim (e.g. a bounded-negative or a blind-spot-degraded exhaustive
 # claim), and 0 when all asserted claims are permitted. TYPE is positive,
 # exhaustive, or bounded_negative.
 #   ... --assert-claim bounded_negative:network_endpoints   # exits 1 (blocked)
-#   ... --assert-claim positive:filesystem_paths_touched    # exits 0 if observed+clean
+#   ... --assert-claim positive:filesystem_paths_touched    # exits 0 if observed
+#                                                           # (strong or partial)
 
 # Tests (no API keys required):
 python3 -m unittest discover \

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1755,6 +1755,7 @@ def coverage_annotation_for_report(
     classification_caveats: list[dict[str, Any]] = []
     # Cross-arm fidelity drives measured positive strength (dimension-independent).
     pos_strength, pos_reason = _combined_positive_strength(health_a, health_b)
+    pos_derived = health_a is not None and health_b is not None
 
     for row in rows:
         dimension = row.get("dimension")
@@ -1814,7 +1815,11 @@ def coverage_annotation_for_report(
                         "claim_strength": pos_strength,
                         "claim_basis": "measured",
                         "evidence_refs": ["runtime-drift-report.json"],
-                        "notes": [f"positive strength derived from {COVERAGE_GATE_RULE}: {pos_reason}"],
+                        "notes": [
+                            f"positive strength derived from {COVERAGE_GATE_RULE}: {pos_reason}"
+                            if pos_derived
+                            else pos_reason
+                        ],
                         "non_claims": [
                             "does_not_prove_tool_intent",
                             "does_not_prove_complete_set",
@@ -2233,7 +2238,7 @@ def main(argv: list[str] | None = None) -> int:
             "coverage gate does not permit it. TYPE is positive, exhaustive, or "
             "bounded_negative; DIMENSION is a drift dimension (e.g. "
             "network_endpoints). Repeatable. Makes the honesty layer "
-            "afdwingbaar rather than only documentable."
+            "enforceable rather than only documentable."
         ),
     )
     parser.add_argument("--workflow-url", help="GitHub Actions run URL, if any.")

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1596,14 +1596,17 @@ def fidelity_verdict(health: Any) -> str:
         readers may gate per-binding claims differently).
       - "clipped": measurement exists but is otherwise degraded (drops / partial
         kernel capture).
-    A non-dict / empty record is treated as "not_applicable". An
+    A non-dict / empty record is "failed": a record that is present but invalid.
+    "not_applicable" is reserved for *valid* records that simply have no measured
+    kernel surface (non-Linux / kernel_layer=absent). The "no record supplied"
+    case is handled by the caller (None -> conservative fallback), not here. An
     out-of-contract record (bad enum, or a violated cross-field invariant such
     as non-Linux without kernel_layer=absent, or ringbuf_drops>0 without
-    kernel_layer=partial_ringbuf_drops) is "failed" per fidelity_verdict.v0,
-    so an invalid record can never be misread as clean/clipped/not_applicable.
+    kernel_layer=partial_ringbuf_drops) is also "failed", so an invalid record
+    can never be misread as clean/clipped/not_applicable.
     """
     if not isinstance(health, dict) or not health:
-        return "not_applicable"
+        return "failed"
     # Out-of-contract records -> failed (checked before any other verdict).
     if health.get("schema") != "assay.runner.observation_health.v0":
         return "failed"
@@ -1647,21 +1650,26 @@ def _combined_positive_strength(
 ) -> tuple[str, str]:
     """Cross-arm strength for a measured positive drift claim, with a reason.
 
-    Both arms clean -> strong. Any arm not_applicable/failed -> absent (no
-    measured surface to back the cross-arm positive). Otherwise -> partial.
-    Returns (strength, reason). When either health record is missing, falls back
-    to the conservative "partial" used before per-arm health was wired in.
+    Evidence-first: any *supplied* arm that classifies as not_applicable/failed
+    blocks the cross-arm positive (-> absent), even if the other arm's health is
+    missing, because there is positive evidence of no valid measured surface.
+    If no supplied arm is absent-class: both arms clean -> strong; a missing arm
+    -> conservative partial; otherwise (degraded but valid) -> partial.
+    Returns (strength, reason).
     """
-    if health_a is None or health_b is None:
-        return "partial", (
-            "per-arm observation health not supplied; positive strength capped "
-            "at partial"
-        )
-    va, vb = fidelity_verdict(health_a), fidelity_verdict(health_b)
-    if va in ("not_applicable", "failed") or vb in ("not_applicable", "failed"):
+    va = fidelity_verdict(health_a) if health_a is not None else None
+    vb = fidelity_verdict(health_b) if health_b is not None else None
+    present = [v for v in (va, vb) if v is not None]
+
+    if any(v in ("not_applicable", "failed") for v in present):
         return "absent", (
             f"measured positive blocked: arm fidelity a={va}, b={vb}; at least "
-            "one arm has no valid measured kernel surface"
+            "one supplied arm has no valid measured kernel surface"
+        )
+    if health_a is None or health_b is None:
+        return "partial", (
+            f"per-arm observation health not supplied for at least one arm "
+            f"(a={va}, b={vb}); positive strength capped at partial"
         )
     if va == "clean" and vb == "clean":
         return "strong", "both arms clean (fidelity_verdict=clean)"

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1633,6 +1633,10 @@ def fidelity_verdict(health: Any) -> str:
         return "not_applicable"
     if kernel == "complete" and drops == 0 and correlation == "clean":
         return "clean"
+    # Clipping (ring-buffer drops / partial kernel capture) takes precedence over
+    # correlation_partial, matching fidelity_verdict.v0 ordering.
+    if drops > 0 or kernel == "partial_ringbuf_drops":
+        return "clipped"
     if correlation == "partial":
         return "correlation_partial"
     return "clipped"

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1591,8 +1591,11 @@ def fidelity_verdict(health: Any) -> str:
       - "failed": cgroup_correlation failed -> invalid for measured claims.
       - "clean": Linux, kernel_layer complete, zero ring-buffer drops, clean
         cgroup correlation.
-      - "clipped": measurement exists but is degraded (drops / partial kernel /
-        partial correlation).
+      - "correlation_partial": valid measurement but cgroup_correlation=partial
+        (kept distinct from clipped per fidelity_verdict.v0, since downstream
+        readers may gate per-binding claims differently).
+      - "clipped": measurement exists but is otherwise degraded (drops / partial
+        kernel capture).
     A non-dict / empty record is treated as "not_applicable". An
     out-of-contract record (bad enum, or a violated cross-field invariant such
     as non-Linux without kernel_layer=absent, or ringbuf_drops>0 without
@@ -1617,6 +1620,8 @@ def fidelity_verdict(health: Any) -> str:
         return "failed"
     if isinstance(drops, bool) or not isinstance(drops, int) or drops < 0:
         return "failed"
+    if not isinstance(platform, str) or not platform:
+        return "failed"  # platform is a required field
     if platform != "linux" and kernel != "absent":
         return "failed"  # non-Linux must have kernel_layer=absent
     if drops > 0 and kernel != "partial_ringbuf_drops":
@@ -1628,6 +1633,8 @@ def fidelity_verdict(health: Any) -> str:
         return "not_applicable"
     if kernel == "complete" and drops == 0 and correlation == "clean":
         return "clean"
+    if correlation == "partial":
+        return "correlation_partial"
     return "clipped"
 
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1593,19 +1593,35 @@ def fidelity_verdict(health: Any) -> str:
         cgroup correlation.
       - "clipped": measurement exists but is degraded (drops / partial kernel /
         partial correlation).
-    A non-dict / empty record is treated as "not_applicable".
+    A non-dict / empty record is treated as "not_applicable". An
+    out-of-contract record (bad enum, or a violated cross-field invariant such
+    as non-Linux without kernel_layer=absent, or ringbuf_drops>0 without
+    kernel_layer=partial_ringbuf_drops) is "failed" per fidelity_verdict.v0,
+    so an invalid record can never be misread as clean/clipped/not_applicable.
     """
     if not isinstance(health, dict) or not health:
         return "not_applicable"
-    if health.get("platform") != "linux" or health.get("kernel_layer") == "absent":
-        return "not_applicable"
-    if health.get("cgroup_correlation") == "failed":
+    platform = health.get("platform")
+    kernel = health.get("kernel_layer")
+    correlation = health.get("cgroup_correlation")
+    drops = health.get("ringbuf_drops")
+    # Invalid records -> failed (checked before any other verdict).
+    if kernel not in ("complete", "partial_ringbuf_drops", "absent"):
         return "failed"
-    if (
-        health.get("kernel_layer") == "complete"
-        and health.get("ringbuf_drops") == 0
-        and health.get("cgroup_correlation") == "clean"
-    ):
+    if correlation not in ("clean", "partial", "failed"):
+        return "failed"
+    if isinstance(drops, bool) or not isinstance(drops, int) or drops < 0:
+        return "failed"
+    if platform != "linux" and kernel != "absent":
+        return "failed"  # non-Linux must have kernel_layer=absent
+    if drops > 0 and kernel != "partial_ringbuf_drops":
+        return "failed"  # drops require partial_ringbuf_drops
+    if correlation == "failed":
+        return "failed"
+    # Valid records.
+    if platform != "linux" or kernel == "absent":
+        return "not_applicable"
+    if kernel == "complete" and drops == 0 and correlation == "clean":
         return "clean"
     return "clipped"
 
@@ -2273,10 +2289,13 @@ def main(argv: list[str] | None = None) -> int:
 
     annotation: dict[str, Any] | None = None
     if args.coverage_annotation_out or args.assert_claim:
+        # parse_archive leaves observation_health as {} when the archive has no
+        # observation-health.json. Treat that as "no health supplied" (-> the
+        # conservative partial fallback) rather than a not_applicable arm.
         annotation = coverage_annotation_for_report(
             payload,
-            health_a=a.observation_health,
-            health_b=b.observation_health,
+            health_a=a.observation_health or None,
+            health_b=b.observation_health or None,
         )
 
     if args.coverage_annotation_out and annotation is not None:
@@ -2329,6 +2348,13 @@ def main(argv: list[str] | None = None) -> int:
             claim_type, _, dimension = raw.partition(":")
             claim_type = claim_type.strip()
             dimension = dimension.strip()
+            if not dimension:
+                print(
+                    f"--assert-claim must be TYPE:DIMENSION with a non-empty "
+                    f"dimension, got {raw!r}",
+                    file=sys.stderr,
+                )
+                return 2
             if claim_type not in ASSERTABLE_CLAIM_TYPES:
                 print(
                     f"--assert-claim TYPE must be one of {ASSERTABLE_CLAIM_TYPES}; "

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1601,11 +1601,16 @@ def fidelity_verdict(health: Any) -> str:
     """
     if not isinstance(health, dict) or not health:
         return "not_applicable"
+    # Out-of-contract records -> failed (checked before any other verdict).
+    if health.get("schema") != "assay.runner.observation_health.v0":
+        return "failed"
+    run_id = health.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        return "failed"
     platform = health.get("platform")
     kernel = health.get("kernel_layer")
     correlation = health.get("cgroup_correlation")
     drops = health.get("ringbuf_drops")
-    # Invalid records -> failed (checked before any other verdict).
     if kernel not in ("complete", "partial_ringbuf_drops", "absent"):
         return "failed"
     if correlation not in ("clean", "partial", "failed"):
@@ -1685,6 +1690,16 @@ def evaluate_asserted_claim(
             return True, "exhaustive equality allowed (partial)"
         return False, f"exhaustive equality is {strength} (degraded by coverage)"
     if claim_type == "bounded_negative":
+        mapping = COVERAGE_DIMENSION_MAP.get(dimension)
+        if mapping is None or mapping[0] is None:
+            # Reported (effect None) or unknown dimensions never produce a
+            # measured bounded-negative; the assertion is not evaluable here, so
+            # it is not permitted rather than vacuously true.
+            return (
+                False,
+                f"bounded-negative not evaluable for non-measured dimension "
+                f"{dimension!r}",
+            )
         blocked = {
             b.get("requested_claim") for b in annotation.get("blocked_claims", [])
         }

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -1581,7 +1581,109 @@ def _coverage_supports_complete(descriptor: dict[str, Any]) -> bool:
     )
 
 
-def coverage_annotation_for_report(report: dict[str, Any]) -> dict[str, Any]:
+def fidelity_verdict(health: Any) -> str:
+    """Derive a fidelity verdict from one observation_health record.
+
+    Mirrors the runner fidelity_verdict.v0 buckets that matter for measured
+    positive strength:
+      - "not_applicable": no measured kernel-effect surface (non-Linux, or
+        kernel_layer absent).
+      - "failed": cgroup_correlation failed -> invalid for measured claims.
+      - "clean": Linux, kernel_layer complete, zero ring-buffer drops, clean
+        cgroup correlation.
+      - "clipped": measurement exists but is degraded (drops / partial kernel /
+        partial correlation).
+    A non-dict / empty record is treated as "not_applicable".
+    """
+    if not isinstance(health, dict) or not health:
+        return "not_applicable"
+    if health.get("platform") != "linux" or health.get("kernel_layer") == "absent":
+        return "not_applicable"
+    if health.get("cgroup_correlation") == "failed":
+        return "failed"
+    if (
+        health.get("kernel_layer") == "complete"
+        and health.get("ringbuf_drops") == 0
+        and health.get("cgroup_correlation") == "clean"
+    ):
+        return "clean"
+    return "clipped"
+
+
+def _combined_positive_strength(
+    health_a: Any, health_b: Any
+) -> tuple[str, str]:
+    """Cross-arm strength for a measured positive drift claim, with a reason.
+
+    Both arms clean -> strong. Any arm not_applicable/failed -> absent (no
+    measured surface to back the cross-arm positive). Otherwise -> partial.
+    Returns (strength, reason). When either health record is missing, falls back
+    to the conservative "partial" used before per-arm health was wired in.
+    """
+    if health_a is None or health_b is None:
+        return "partial", (
+            "per-arm observation health not supplied; positive strength capped "
+            "at partial"
+        )
+    va, vb = fidelity_verdict(health_a), fidelity_verdict(health_b)
+    if va in ("not_applicable", "failed") or vb in ("not_applicable", "failed"):
+        return "absent", (
+            f"measured positive blocked: arm fidelity a={va}, b={vb}; at least "
+            "one arm has no valid measured kernel surface"
+        )
+    if va == "clean" and vb == "clean":
+        return "strong", "both arms clean (fidelity_verdict=clean)"
+    return "partial", f"degraded capture: arm fidelity a={va}, b={vb}"
+
+
+ASSERTABLE_CLAIM_TYPES = ("positive", "exhaustive", "bounded_negative")
+
+
+def evaluate_asserted_claim(
+    annotation: dict[str, Any], claim_type: str, dimension: str
+) -> tuple[bool, str]:
+    """Return (permitted, detail) for one asserted claim against an annotation.
+
+    Enforcement contract:
+      - positive:DIM permitted iff a measured_{DIM}_drift cell exists with
+        strength strong or partial (absent / missing -> not permitted).
+      - exhaustive:DIM permitted iff exhaustive_{DIM}_equality is allowed
+        (strength partial); a degraded weak cell or a missing cell is not.
+      - bounded_negative:DIM permitted iff it is NOT in blocked_claims.
+    """
+    cells = {c.get("claim_type"): c for c in annotation.get("claim_cells", [])}
+    if claim_type == "positive":
+        cell = cells.get(f"measured_{dimension}_drift")
+        if cell is None:
+            return False, f"no measured_{dimension}_drift cell (nothing observed)"
+        strength = cell.get("claim_strength")
+        if strength in ("strong", "partial"):
+            return True, f"measured positive is {strength}"
+        return False, f"measured positive is {strength}"
+    if claim_type == "exhaustive":
+        cell = cells.get(f"exhaustive_{dimension}_equality")
+        if cell is None:
+            return False, f"no exhaustive_{dimension}_equality cell"
+        strength = cell.get("claim_strength")
+        if strength == "partial":
+            return True, "exhaustive equality allowed (partial)"
+        return False, f"exhaustive equality is {strength} (degraded by coverage)"
+    if claim_type == "bounded_negative":
+        blocked = {
+            b.get("requested_claim") for b in annotation.get("blocked_claims", [])
+        }
+        if f"no_{dimension}_effect_beyond_observed" in blocked:
+            return False, "bounded-negative blocked by coverage descriptor"
+        return True, "bounded-negative not blocked"
+    return False, f"unknown claim type {claim_type!r}"
+
+
+def coverage_annotation_for_report(
+    report: dict[str, Any],
+    *,
+    health_a: Any = None,
+    health_b: Any = None,
+) -> dict[str, Any]:
     """Derive a coverage annotation from a runtime_drift.v0.2 report.
 
     Separate companion document to the drift report (it is emitted as its own
@@ -1591,6 +1693,13 @@ def coverage_annotation_for_report(report: dict[str, Any]) -> dict[str, Any]:
     row is not read as exhaustive-equality or bounded-negative. Mirrors
     examples/coverage-aware-drift-annotation/; the canonical gate is the Rust
     helper in crates/assay-runner-schema/src/coverage.rs.
+
+    When `health_a` / `health_b` (the two source archives' observation_health
+    records) are supplied, a measured positive drift claim is raised to `strong`
+    only when both arms are clean, degraded to `partial` when capture is
+    degraded, and downgraded to `absent` when either arm has no valid measured
+    surface (fidelity_verdict not_applicable/failed). Without them it stays the
+    conservative `partial`. The drift report contract is never changed by this.
     """
     if report.get("schema") != DRIFT_REPORT_SCHEMA:
         raise ValueError(
@@ -1602,6 +1711,8 @@ def coverage_annotation_for_report(report: dict[str, Any]) -> dict[str, Any]:
     claim_cells: list[dict[str, Any]] = []
     blocked_claims: list[dict[str, Any]] = []
     classification_caveats: list[dict[str, Any]] = []
+    # Cross-arm fidelity drives measured positive strength (dimension-independent).
+    pos_strength, pos_reason = _combined_positive_strength(health_a, health_b)
 
     for row in rows:
         dimension = row.get("dimension")
@@ -1637,25 +1748,37 @@ def coverage_annotation_for_report(report: dict[str, Any]) -> dict[str, Any]:
 
         descriptor = COVERAGE_SEED_DESCRIPTORS[effect]
         if observed:
-            claim_cells.append(
-                {
-                    "schema": COVERAGE_CLAIM_CELL_SCHEMA,
-                    "claim_type": f"measured_{dimension}_drift",
-                    "artifact_role": "joined_artifacts",
-                    "claim_strength": "partial",
-                    "claim_basis": "measured",
-                    "evidence_refs": ["runtime-drift-report.json"],
-                    "notes": [
-                        "positive strength capped at partial: the drift report "
-                        "does not surface per-arm observation health; consult "
-                        "fidelity_verdict.v0 against the source archives to raise it"
-                    ],
-                    "non_claims": [
-                        "does_not_prove_tool_intent",
-                        "does_not_prove_complete_set",
-                    ],
-                }
-            )
+            if pos_strength == "absent":
+                # No valid measured surface on at least one arm: the cross-arm
+                # positive cannot be supported. Absent cells carry no evidence.
+                claim_cells.append(
+                    {
+                        "schema": COVERAGE_CLAIM_CELL_SCHEMA,
+                        "claim_type": f"measured_{dimension}_drift",
+                        "artifact_role": "none",
+                        "claim_strength": "absent",
+                        "claim_basis": "measured",
+                        "evidence_refs": [],
+                        "notes": [pos_reason],
+                        "non_claims": ["does_not_prove_tool_intent"],
+                    }
+                )
+            else:
+                claim_cells.append(
+                    {
+                        "schema": COVERAGE_CLAIM_CELL_SCHEMA,
+                        "claim_type": f"measured_{dimension}_drift",
+                        "artifact_role": "joined_artifacts",
+                        "claim_strength": pos_strength,
+                        "claim_basis": "measured",
+                        "evidence_refs": ["runtime-drift-report.json"],
+                        "notes": [f"positive strength derived from {COVERAGE_GATE_RULE}: {pos_reason}"],
+                        "non_claims": [
+                            "does_not_prove_tool_intent",
+                            "does_not_prove_complete_set",
+                        ],
+                    }
+                )
             if _coverage_supports_complete(descriptor):
                 # Gate allows the exhaustive set; still capped at partial here
                 # because the drift report carries no per-arm capture health.
@@ -2058,6 +2181,19 @@ def main(argv: list[str] | None = None) -> int:
             "stays valid against the additionalProperties:false v0.2 schema."
         ),
     )
+    parser.add_argument(
+        "--assert-claim",
+        action="append",
+        default=[],
+        metavar="TYPE:DIMENSION",
+        help=(
+            "Enforcement: assert a coverage claim and fail (exit 1) if the "
+            "coverage gate does not permit it. TYPE is positive, exhaustive, or "
+            "bounded_negative; DIMENSION is a drift dimension (e.g. "
+            "network_endpoints). Repeatable. Makes the honesty layer "
+            "afdwingbaar rather than only documentable."
+        ),
+    )
     parser.add_argument("--workflow-url", help="GitHub Actions run URL, if any.")
     parser.add_argument("--runner-label", help="Runner label or host class.")
     parser.add_argument("--kernel-os", help="Kernel OS for the capture host.")
@@ -2135,8 +2271,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     payload = report_to_json(a, b, rows, provenance)
 
-    if args.coverage_annotation_out:
-        annotation = coverage_annotation_for_report(payload)
+    annotation: dict[str, Any] | None = None
+    if args.coverage_annotation_out or args.assert_claim:
+        annotation = coverage_annotation_for_report(
+            payload,
+            health_a=a.observation_health,
+            health_b=b.observation_health,
+        )
+
+    if args.coverage_annotation_out and annotation is not None:
         try:
             args.coverage_annotation_out.parent.mkdir(parents=True, exist_ok=True)
             args.coverage_annotation_out.write_text(
@@ -2172,6 +2315,41 @@ def main(argv: list[str] | None = None) -> int:
         except OSError as exc:
             print(f"failed to write --out-md: {exc}", file=sys.stderr)
             return 2
+
+    if args.assert_claim and annotation is not None:
+        violations: list[str] = []
+        for spec in args.assert_claim:
+            raw = str(spec)
+            if ":" not in raw:
+                print(
+                    f"--assert-claim must be TYPE:DIMENSION, got {raw!r}",
+                    file=sys.stderr,
+                )
+                return 2
+            claim_type, _, dimension = raw.partition(":")
+            claim_type = claim_type.strip()
+            dimension = dimension.strip()
+            if claim_type not in ASSERTABLE_CLAIM_TYPES:
+                print(
+                    f"--assert-claim TYPE must be one of {ASSERTABLE_CLAIM_TYPES}; "
+                    f"got {claim_type!r}",
+                    file=sys.stderr,
+                )
+                return 2
+            permitted, detail = evaluate_asserted_claim(
+                annotation, claim_type, dimension
+            )
+            verdict = "PERMIT" if permitted else "BLOCK"
+            print(f"assert-claim {raw}: {verdict} ({detail})", file=sys.stderr)
+            if not permitted:
+                violations.append(raw)
+        if violations:
+            print(
+                "coverage enforcement failed: "
+                + ", ".join(violations),
+                file=sys.stderr,
+            )
+            return 1
 
     return 0
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -2219,7 +2219,8 @@ class FidelityAndEnforcementTest(unittest.TestCase):
         self.assertEqual(drift.fidelity_verdict(self.CLIPPED), "clipped")
         self.assertEqual(drift.fidelity_verdict(self.NOT_APPLICABLE), "not_applicable")
         self.assertEqual(drift.fidelity_verdict(self.FAILED), "failed")
-        self.assertEqual(drift.fidelity_verdict({}), "not_applicable")
+        # empty/invalid record is a present-but-invalid record -> failed
+        self.assertEqual(drift.fidelity_verdict({}), "failed")
 
     def test_both_clean_makes_positive_strong(self):
         ann = drift.coverage_annotation_for_report(
@@ -2398,6 +2399,22 @@ class FidelityAndEnforcementTest(unittest.TestCase):
             "ringbuf_drops": 0, "cgroup_correlation": "partial",
         }
         self.assertEqual(drift.fidelity_verdict(only_corr), "correlation_partial")
+
+    def test_one_arm_missing_health_paths(self):
+        # both missing -> conservative partial
+        ann = drift.coverage_annotation_for_report(self.REPORT)
+        self.assertEqual(self._net_cell(ann)["claim_strength"], "partial")
+        # one arm clean, other missing -> partial (cannot be strong; not absent)
+        ann = drift.coverage_annotation_for_report(self.REPORT, health_a=self.CLEAN)
+        self.assertEqual(self._net_cell(ann)["claim_strength"], "partial")
+        # one arm not_applicable, other missing -> absent (evidence of no surface)
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT, health_b=self.NOT_APPLICABLE
+        )
+        self.assertEqual(self._net_cell(ann)["claim_strength"], "absent")
+        # one arm failed, other missing -> absent
+        ann = drift.coverage_annotation_for_report(self.REPORT, health_a=self.FAILED)
+        self.assertEqual(self._net_cell(ann)["claim_strength"], "absent")
 
 
 

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -2376,6 +2376,29 @@ class FidelityAndEnforcementTest(unittest.TestCase):
         }
         self.assertEqual(drift.fidelity_verdict(no_platform), "failed")
 
+    def test_clipping_takes_precedence_over_correlation_partial(self):
+        # both clipped (drops>0 / partial kernel) AND correlation=partial -> clipped
+        both = {
+            "schema": "assay.runner.observation_health.v0", "run_id": "r",
+            "platform": "linux", "kernel_layer": "partial_ringbuf_drops",
+            "ringbuf_drops": 5, "cgroup_correlation": "partial",
+        }
+        self.assertEqual(drift.fidelity_verdict(both), "clipped")
+        # partial kernel, zero drops, partial correlation -> still clipped (partial kernel)
+        partial_kernel = {
+            "schema": "assay.runner.observation_health.v0", "run_id": "s",
+            "platform": "linux", "kernel_layer": "partial_ringbuf_drops",
+            "ringbuf_drops": 0, "cgroup_correlation": "partial",
+        }
+        self.assertEqual(drift.fidelity_verdict(partial_kernel), "clipped")
+        # complete kernel, zero drops, partial correlation -> correlation_partial
+        only_corr = {
+            "schema": "assay.runner.observation_health.v0", "run_id": "t",
+            "platform": "linux", "kernel_layer": "complete",
+            "ringbuf_drops": 0, "cgroup_correlation": "partial",
+        }
+        self.assertEqual(drift.fidelity_verdict(only_corr), "correlation_partial")
+
 
 
 if __name__ == "__main__":

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -2356,6 +2356,26 @@ class FidelityAndEnforcementTest(unittest.TestCase):
         ok, _ = drift.evaluate_asserted_claim(ann, "bounded_negative", "no_such_dim")
         self.assertFalse(ok)
 
+    def test_correlation_partial_distinct_and_degrades_to_partial(self):
+        corr_partial = {
+            "schema": "assay.runner.observation_health.v0", "run_id": "p",
+            "platform": "linux", "kernel_layer": "complete",
+            "ringbuf_drops": 0, "cgroup_correlation": "partial",
+        }
+        self.assertEqual(drift.fidelity_verdict(corr_partial), "correlation_partial")
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT, health_a=self.CLEAN, health_b=corr_partial
+        )
+        self.assertEqual(self._net_cell(ann)["claim_strength"], "partial")
+
+    def test_missing_platform_is_failed(self):
+        no_platform = {
+            "schema": "assay.runner.observation_health.v0", "run_id": "q",
+            "kernel_layer": "absent", "ringbuf_drops": 0,
+            "cgroup_correlation": "clean",
+        }
+        self.assertEqual(drift.fidelity_verdict(no_platform), "failed")
+
 
 
 if __name__ == "__main__":

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -2338,6 +2338,24 @@ class FidelityAndEnforcementTest(unittest.TestCase):
         )
         self.assertEqual(rc, 2)
 
+    def test_missing_schema_or_runid_is_failed(self):
+        no_schema = {"run_id": "x", "platform": "linux", "kernel_layer": "complete",
+                     "ringbuf_drops": 0, "cgroup_correlation": "clean"}
+        self.assertEqual(drift.fidelity_verdict(no_schema), "failed")
+        empty_runid = {"schema": "assay.runner.observation_health.v0", "run_id": "",
+                       "platform": "linux", "kernel_layer": "complete",
+                       "ringbuf_drops": 0, "cgroup_correlation": "clean"}
+        self.assertEqual(drift.fidelity_verdict(empty_runid), "failed")
+
+    def test_bounded_negative_not_evaluable_for_reported_dimension(self):
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT, health_a=self.CLEAN, health_b=self.CLEAN
+        )
+        ok, _ = drift.evaluate_asserted_claim(ann, "bounded_negative", "sdk_tool_events")
+        self.assertFalse(ok)
+        ok, _ = drift.evaluate_asserted_claim(ann, "bounded_negative", "no_such_dim")
+        self.assertFalse(ok)
+
 
 
 if __name__ == "__main__":

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -2160,6 +2160,151 @@ class CoverageAnnotationTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             drift.coverage_annotation_for_report({"schema": "assay.runner.runtime_drift.v0.2", "rows": {}})
 
+class FidelityAndEnforcementTest(unittest.TestCase):
+    """F3: per-arm fidelity drives positive strength; --assert-claim enforces."""
+
+    CLEAN = {
+        "schema": "assay.runner.observation_health.v0",
+        "run_id": "a",
+        "platform": "linux",
+        "kernel_layer": "complete",
+        "ringbuf_drops": 0,
+        "cgroup_correlation": "clean",
+    }
+    CLIPPED = {
+        "schema": "assay.runner.observation_health.v0",
+        "run_id": "b",
+        "platform": "linux",
+        "kernel_layer": "partial_ringbuf_drops",
+        "ringbuf_drops": 4,
+        "cgroup_correlation": "clean",
+    }
+    NOT_APPLICABLE = {
+        "schema": "assay.runner.observation_health.v0",
+        "run_id": "c",
+        "platform": "darwin",
+        "kernel_layer": "absent",
+        "ringbuf_drops": 0,
+        "cgroup_correlation": "clean",
+    }
+    FAILED = {
+        "schema": "assay.runner.observation_health.v0",
+        "run_id": "d",
+        "platform": "linux",
+        "kernel_layer": "complete",
+        "ringbuf_drops": 0,
+        "cgroup_correlation": "failed",
+    }
+    REPORT = {
+        "schema": "assay.runner.runtime_drift.v0.2",
+        "rows": [
+            {
+                "dimension": "network_endpoints",
+                "classification": "task-induced",
+                "only_in_a": [],
+                "only_in_b": [],
+                "in_both": ["api.example.com:443"],
+            }
+        ],
+    }
+
+    def _net_cell(self, ann):
+        for c in ann["claim_cells"]:
+            if c["claim_type"] == "measured_network_endpoints_drift":
+                return c
+        return None
+
+    def test_fidelity_verdict_mapping(self):
+        self.assertEqual(drift.fidelity_verdict(self.CLEAN), "clean")
+        self.assertEqual(drift.fidelity_verdict(self.CLIPPED), "clipped")
+        self.assertEqual(drift.fidelity_verdict(self.NOT_APPLICABLE), "not_applicable")
+        self.assertEqual(drift.fidelity_verdict(self.FAILED), "failed")
+        self.assertEqual(drift.fidelity_verdict({}), "not_applicable")
+
+    def test_both_clean_makes_positive_strong(self):
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT, health_a=self.CLEAN, health_b=self.CLEAN
+        )
+        self.assertEqual(self._net_cell(ann)["claim_strength"], "strong")
+
+    def test_clipped_arm_makes_positive_partial(self):
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT, health_a=self.CLEAN, health_b=self.CLIPPED
+        )
+        self.assertEqual(self._net_cell(ann)["claim_strength"], "partial")
+
+    def test_not_applicable_arm_makes_positive_absent(self):
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT, health_a=self.CLEAN, health_b=self.NOT_APPLICABLE
+        )
+        cell = self._net_cell(ann)
+        self.assertEqual(cell["claim_strength"], "absent")
+        self.assertEqual(cell["artifact_role"], "none")
+        self.assertEqual(cell["evidence_refs"], [])
+
+    def test_failed_arm_makes_positive_absent(self):
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT, health_a=self.FAILED, health_b=self.CLEAN
+        )
+        self.assertEqual(self._net_cell(ann)["claim_strength"], "absent")
+
+    def test_no_health_falls_back_to_partial(self):
+        ann = drift.coverage_annotation_for_report(self.REPORT)
+        self.assertEqual(self._net_cell(ann)["claim_strength"], "partial")
+
+    def test_evaluate_asserted_claim_outcomes(self):
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT, health_a=self.CLEAN, health_b=self.CLEAN
+        )
+        ok, _ = drift.evaluate_asserted_claim(ann, "positive", "network_endpoints")
+        self.assertTrue(ok)
+        ok, _ = drift.evaluate_asserted_claim(ann, "bounded_negative", "network_endpoints")
+        self.assertFalse(ok)
+        ok, _ = drift.evaluate_asserted_claim(ann, "exhaustive", "network_endpoints")
+        self.assertFalse(ok)  # degraded to weak under seed blind spots
+
+    def test_cli_assert_bounded_negative_fails(self):
+        rc = drift.main(
+            [
+                "--archive-a", str(ARM_A),
+                "--archive-b", str(ARM_B),
+                "--out-json", "/dev/null",
+                "--assert-claim", "bounded_negative:network_endpoints",
+            ]
+        )
+        self.assertEqual(rc, 1)
+
+    def test_cli_malformed_assert_claim_is_usage_error(self):
+        rc = drift.main(
+            [
+                "--archive-a", str(ARM_A),
+                "--archive-b", str(ARM_B),
+                "--out-json", "/dev/null",
+                "--assert-claim", "bogus",
+            ]
+        )
+        self.assertEqual(rc, 2)
+
+    def test_cli_coverage_annotation_sidecar_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "ann.json"
+            rc = drift.main(
+                [
+                    "--archive-a", str(ARM_A),
+                    "--archive-b", str(ARM_B),
+                    "--out-json", str(Path(tmp) / "drift.json"),
+                    "--coverage-annotation-out", str(out),
+                ]
+            )
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.is_file())
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(doc["schema"], "assay.coverage_aware_drift.annotation.v0")
+            # the drift report itself must NOT carry the annotation key
+            report = json.loads((Path(tmp) / "drift.json").read_text(encoding="utf-8"))
+            self.assertNotIn("coverage_annotation", report)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -2304,6 +2304,40 @@ class FidelityAndEnforcementTest(unittest.TestCase):
             report = json.loads((Path(tmp) / "drift.json").read_text(encoding="utf-8"))
             self.assertNotIn("coverage_annotation", report)
 
+    def test_invalid_health_is_failed(self):
+        # non-Linux must have kernel_layer=absent; complete -> invalid -> failed
+        bad_platform = {
+            "schema": "assay.runner.observation_health.v0", "run_id": "x",
+            "platform": "darwin", "kernel_layer": "complete",
+            "ringbuf_drops": 0, "cgroup_correlation": "clean",
+        }
+        self.assertEqual(drift.fidelity_verdict(bad_platform), "failed")
+        # ringbuf_drops>0 requires partial_ringbuf_drops
+        bad_drops = {
+            "schema": "assay.runner.observation_health.v0", "run_id": "y",
+            "platform": "linux", "kernel_layer": "complete",
+            "ringbuf_drops": 3, "cgroup_correlation": "clean",
+        }
+        self.assertEqual(drift.fidelity_verdict(bad_drops), "failed")
+        # out-of-enum cgroup_correlation -> failed
+        bad_enum = {
+            "schema": "assay.runner.observation_health.v0", "run_id": "z",
+            "platform": "linux", "kernel_layer": "complete",
+            "ringbuf_drops": 0, "cgroup_correlation": "weird",
+        }
+        self.assertEqual(drift.fidelity_verdict(bad_enum), "failed")
+
+    def test_cli_empty_dimension_is_usage_error(self):
+        rc = drift.main(
+            [
+                "--archive-a", str(ARM_A),
+                "--archive-b", str(ARM_B),
+                "--out-json", "/dev/null",
+                "--assert-claim", "positive:",
+            ]
+        )
+        self.assertEqual(rc, 2)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

F3 "wiring + hardening" for the cross-runtime drift coverage annotation (`docs/experiments/cross-runtime-drift-2026-05/compare/drift.py`). Experiment-scoped — **no runner-crate change, no `runtime_drift.v0.2` contract change**.

**Wiring — fidelity-derived positive strength.** `fidelity_verdict(health)` derives a per-arm verdict (`clean` / `clipped` / `not_applicable` / `failed`) from the `observation_health` the comparator already parses. `coverage_annotation_for_report` now accepts `health_a`/`health_b` and sets measured positive drift to:
- `strong` only when **both** arms are clean,
- `partial` when capture is degraded,
- `absent` (`artifact_role: none`, empty `evidence_refs`) when either arm has no valid measured surface.

Without health it stays the conservative `partial` (back-compat). This resolves the stale "capped at partial" note from #1492.

**Hardening — enforcement.** `--assert-claim TYPE:DIMENSION` makes the honesty layer afdwingbaar: the comparator exits `1` when the coverage gate does not permit an asserted claim (e.g. a blocked bounded-negative, or a blind-spot-degraded exhaustive), and `0` when all asserted claims are permitted. `TYPE` ∈ `positive` / `exhaustive` / `bounded_negative`. `evaluate_asserted_claim` is the reusable check.

## Scope / non-goals

Experiment Python only → lane-check `Gate.NONE`, no `gates=all`. The drift report is never modified and stays valid against the strict v0.2 schema. Promotion to a shipped product surface (runner-crate / CLI / new report version) stays out of scope.

## Validation

`python3 -m unittest discover -s docs/experiments/cross-runtime-drift-2026-05/compare -p 'test_*.py'` — 115 tests pass (new fidelity mapping, cross-arm strength, enforcement evaluator, and CLI exit-code tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)