### PR TITLE
feat(runner): carry datagram-aware network coverage descriptors

### DIFF
--- a/crates/assay-runner-schema/src/coverage.rs
+++ b/crates/assay-runner-schema/src/coverage.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::ClaimGateDecision;
+use crate::{ClaimGateDecision, NetworkProtocolCoverageStatus};
 
 pub const COVERAGE_DESCRIPTOR_SCHEMA: &str = "assay.runner.coverage_descriptor.v0";
 
@@ -18,6 +18,8 @@ pub enum CoverageCompleteness {
     Full,
     OpenSyscallOnly,
     ConnectOnly,
+    DatagramPeerObserved,
+    ConnectAndDatagramPeerObserved,
     ExecOnly,
 }
 
@@ -75,6 +77,52 @@ impl CoverageDescriptor {
                 "io_uring network operations may bypass syscall tracepoints".to_string(),
             ],
             completeness: CoverageCompleteness::ConnectOnly,
+        }
+    }
+
+    #[must_use]
+    pub fn network_datagram_peer_observed() -> Self {
+        Self {
+            schema: COVERAGE_DESCRIPTOR_SCHEMA.to_string(),
+            dimension: EffectDimension::Network,
+            method: "sendto/sendmsg tracepoints".to_string(),
+            observes: vec!["datagram peer endpoints from explicit sockaddr arguments".to_string()],
+            known_blind_spots: vec![
+                "connected datagram sends without an explicit sockaddr require connect evidence to recover the peer".to_string(),
+                "io_uring network operations may bypass syscall tracepoints".to_string(),
+            ],
+            completeness: CoverageCompleteness::DatagramPeerObserved,
+        }
+    }
+
+    #[must_use]
+    pub fn network_connect_and_datagram_peer_observed() -> Self {
+        Self {
+            schema: COVERAGE_DESCRIPTOR_SCHEMA.to_string(),
+            dimension: EffectDimension::Network,
+            method: "connect/sendto/sendmsg tracepoints".to_string(),
+            observes: vec![
+                "connect-time peer endpoints".to_string(),
+                "datagram peer endpoints from explicit sockaddr arguments".to_string(),
+            ],
+            known_blind_spots: vec![
+                "io_uring network operations may bypass syscall tracepoints".to_string()
+            ],
+            completeness: CoverageCompleteness::ConnectAndDatagramPeerObserved,
+        }
+    }
+
+    #[must_use]
+    pub fn network_for_protocol_coverage(coverage: NetworkProtocolCoverageStatus) -> Option<Self> {
+        match coverage {
+            NetworkProtocolCoverageStatus::ConnectOnly => Some(Self::network_connect_only()),
+            NetworkProtocolCoverageStatus::DatagramPeerObserved => {
+                Some(Self::network_datagram_peer_observed())
+            }
+            NetworkProtocolCoverageStatus::ConnectAndDatagramPeerObserved => {
+                Some(Self::network_connect_and_datagram_peer_observed())
+            }
+            NetworkProtocolCoverageStatus::Unknown | NetworkProtocolCoverageStatus::Absent => None,
         }
     }
 
@@ -251,6 +299,10 @@ fn completeness_label(completeness: CoverageCompleteness) -> &'static str {
         CoverageCompleteness::Full => "full",
         CoverageCompleteness::OpenSyscallOnly => "open_syscall_only",
         CoverageCompleteness::ConnectOnly => "connect_only",
+        CoverageCompleteness::DatagramPeerObserved => "datagram_peer_observed",
+        CoverageCompleteness::ConnectAndDatagramPeerObserved => {
+            "connect_and_datagram_peer_observed"
+        }
         CoverageCompleteness::ExecOnly => "exec_only",
     }
 }

--- a/crates/assay-runner-schema/tests/coverage_descriptor.rs
+++ b/crates/assay-runner-schema/tests/coverage_descriptor.rs
@@ -1,5 +1,6 @@
 use assay_runner_schema::{
-    ClaimGateDecision, CoverageClaimKind, CoverageCompleteness, CoverageDescriptor, EffectDimension,
+    ClaimGateDecision, CoverageClaimKind, CoverageCompleteness, CoverageDescriptor,
+    EffectDimension, NetworkProtocolCoverageStatus,
 };
 use serde_json::json;
 
@@ -128,6 +129,104 @@ fn network_connect_only_is_positive_but_not_an_exhaustive_peer_set() {
     let exhaustive = descriptor.claim_decision(CoverageClaimKind::ExhaustiveSet);
     assert_eq!(exhaustive.decision, ClaimGateDecision::Degraded);
     assert!(exhaustive.reason.contains("QUIC"));
+}
+
+#[test]
+fn network_datagram_descriptor_serializes_sendto_sendmsg_surface() {
+    let descriptor = CoverageDescriptor::network_datagram_peer_observed();
+
+    assert_eq!(descriptor.dimension, EffectDimension::Network);
+    assert_eq!(
+        descriptor.completeness,
+        CoverageCompleteness::DatagramPeerObserved
+    );
+    assert!(descriptor.observes_effect_class("datagram peer endpoints"));
+    assert!(descriptor
+        .known_blind_spots
+        .iter()
+        .any(|blindspot| blindspot.contains("io_uring")));
+
+    let value = serde_json::to_value(&descriptor).expect("descriptor serializes");
+    assert_eq!(
+        value,
+        json!({
+            "schema": "assay.runner.coverage_descriptor.v0",
+            "dimension": "network",
+            "method": "sendto/sendmsg tracepoints",
+            "observes": ["datagram peer endpoints from explicit sockaddr arguments"],
+            "known_blind_spots": [
+                "connected datagram sends without an explicit sockaddr require connect evidence to recover the peer",
+                "io_uring network operations may bypass syscall tracepoints"
+            ],
+            "completeness": "datagram_peer_observed"
+        })
+    );
+}
+
+#[test]
+fn network_descriptor_tracks_observation_health_protocol_coverage() {
+    let connect = CoverageDescriptor::network_for_protocol_coverage(
+        NetworkProtocolCoverageStatus::ConnectOnly,
+    )
+    .expect("connect-only descriptor");
+    assert_eq!(connect.completeness, CoverageCompleteness::ConnectOnly);
+
+    let datagram = CoverageDescriptor::network_for_protocol_coverage(
+        NetworkProtocolCoverageStatus::DatagramPeerObserved,
+    )
+    .expect("datagram descriptor");
+    assert_eq!(
+        datagram.completeness,
+        CoverageCompleteness::DatagramPeerObserved
+    );
+    assert!(datagram.observes_effect_class("datagram peer endpoints"));
+
+    let combined = CoverageDescriptor::network_for_protocol_coverage(
+        NetworkProtocolCoverageStatus::ConnectAndDatagramPeerObserved,
+    )
+    .expect("combined descriptor");
+    assert_eq!(
+        combined.completeness,
+        CoverageCompleteness::ConnectAndDatagramPeerObserved
+    );
+    assert!(combined.observes_effect_class("connect-time peer endpoints"));
+    assert!(combined.observes_effect_class("datagram peer endpoints"));
+
+    assert!(CoverageDescriptor::network_for_protocol_coverage(
+        NetworkProtocolCoverageStatus::Absent
+    )
+    .is_none());
+    assert!(CoverageDescriptor::network_for_protocol_coverage(
+        NetworkProtocolCoverageStatus::Unknown
+    )
+    .is_none());
+}
+
+#[test]
+fn datagram_network_descriptor_allows_observed_datagram_positive_only() {
+    let descriptor = CoverageDescriptor::network_datagram_peer_observed();
+
+    let positive = CoverageDescriptor::claim_decision_for_effect(
+        Some(&descriptor),
+        CoverageClaimKind::PositiveExistence,
+        "datagram peer endpoints",
+    );
+    assert_eq!(positive.decision, ClaimGateDecision::Allowed);
+
+    let connect_positive = CoverageDescriptor::claim_decision_for_effect(
+        Some(&descriptor),
+        CoverageClaimKind::PositiveExistence,
+        "connect-time peer endpoints",
+    );
+    assert_eq!(connect_positive.decision, ClaimGateDecision::Degraded);
+
+    let bounded_negative = CoverageDescriptor::claim_decision_for_effect(
+        Some(&descriptor),
+        CoverageClaimKind::BoundedNegative,
+        "datagram peer endpoints",
+    );
+    assert_eq!(bounded_negative.decision, ClaimGateDecision::Blocked);
+    assert!(bounded_negative.reason.contains("datagram_peer_observed"));
 }
 
 #[test]

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/drift.py
@@ -126,6 +126,19 @@ COVERAGE_SEED_DESCRIPTORS: dict[str, dict[str, Any]] = {
             "io_uring network operations may bypass syscall tracepoints",
         ],
     },
+    "network_datagram_peer_observed": {
+        "completeness": "datagram_peer_observed",
+        "known_blind_spots": [
+            "connected datagram sends without an explicit sockaddr require connect evidence to recover the peer",
+            "io_uring network operations may bypass syscall tracepoints",
+        ],
+    },
+    "network_connect_and_datagram_peer_observed": {
+        "completeness": "connect_and_datagram_peer_observed",
+        "known_blind_spots": [
+            "io_uring network operations may bypass syscall tracepoints",
+        ],
+    },
     "process": {
         "completeness": "exec_only",
         "known_blind_spots": [
@@ -1581,6 +1594,52 @@ def _coverage_supports_complete(descriptor: dict[str, Any]) -> bool:
     )
 
 
+def _network_descriptor_for_protocol_coverage(status: Any) -> dict[str, Any] | None:
+    if status == "connect_only":
+        return COVERAGE_SEED_DESCRIPTORS["network"]
+    if status == "datagram_peer_observed":
+        return COVERAGE_SEED_DESCRIPTORS["network_datagram_peer_observed"]
+    if status == "connect_and_datagram_peer_observed":
+        return COVERAGE_SEED_DESCRIPTORS["network_connect_and_datagram_peer_observed"]
+    return None
+
+
+def _coverage_descriptor_for_effect(
+    effect: str,
+    *,
+    health_a: Any = None,
+    health_b: Any = None,
+) -> dict[str, Any]:
+    if effect != "network":
+        return COVERAGE_SEED_DESCRIPTORS[effect]
+    if health_a is None and health_b is None:
+        return COVERAGE_SEED_DESCRIPTORS["network"]
+
+    statuses = []
+    descriptors = []
+    for health in (health_a, health_b):
+        if isinstance(health, dict):
+            status = health.get("network_protocol_coverage")
+        else:
+            status = None
+        statuses.append(status)
+        descriptors.append(_network_descriptor_for_protocol_coverage(status))
+
+    # Cross-runtime annotations use the common ceiling across both arms. If one
+    # arm is weaker or unknown, keep the connect-only descriptor rather than
+    # allowing the stronger arm to speak for the pair.
+    if any(descriptor is None for descriptor in descriptors):
+        return COVERAGE_SEED_DESCRIPTORS["network"]
+    if any(status != "connect_and_datagram_peer_observed" for status in statuses):
+        if all(
+            status in ("datagram_peer_observed", "connect_and_datagram_peer_observed")
+            for status in statuses
+        ):
+            return COVERAGE_SEED_DESCRIPTORS["network_datagram_peer_observed"]
+        return COVERAGE_SEED_DESCRIPTORS["network"]
+    return COVERAGE_SEED_DESCRIPTORS["network_connect_and_datagram_peer_observed"]
+
+
 def fidelity_verdict(health: Any) -> str:
     """Derive a fidelity verdict from one observation_health record.
 
@@ -1797,7 +1856,9 @@ def coverage_annotation_for_report(
                 )
             continue
 
-        descriptor = COVERAGE_SEED_DESCRIPTORS[effect]
+        descriptor = _coverage_descriptor_for_effect(
+            effect, health_a=health_a, health_b=health_b
+        )
         if observed:
             if pos_strength == "absent":
                 # No valid measured surface on at least one arm: the cross-arm
@@ -1873,8 +1934,15 @@ def coverage_annotation_for_report(
                     }
                 )
 
-        # Bounded negative is always blocked here: the drift report carries no
-        # per-arm capture health, and the seed descriptors declare blind spots.
+        health_reason = (
+            "per-arm observation health supplied; coverage completeness still "
+            "blocks this bounded-negative claim"
+            if health_a is not None and health_b is not None
+            else "the drift report does not surface per-arm observation health"
+        )
+        # Bounded negative is always blocked here: the seed descriptors declare
+        # blind spots, so no current network/filesystem/process descriptor can
+        # prove absence-beyond-observed.
         blocked_claims.append(
             {
                 "claim_type": "bounded_negative_claim",
@@ -1884,8 +1952,8 @@ def coverage_annotation_for_report(
                     f"{effect} absence-beyond-observed claim requires "
                     f"completeness=full with no blind spots and confirmed clean "
                     f"capture; completeness is {descriptor['completeness']}; blind "
-                    f"spots: {_coverage_blind_spot_summary(descriptor)}; the drift "
-                    f"report does not surface per-arm observation health"
+                    f"spots: {_coverage_blind_spot_summary(descriptor)}; "
+                    f"{health_reason}"
                 ),
             }
         )

--- a/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
+++ b/docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py
@@ -2214,6 +2214,17 @@ class FidelityAndEnforcementTest(unittest.TestCase):
                 return c
         return None
 
+    def _net_exhaustive_cell(self, ann):
+        for c in ann["claim_cells"]:
+            if c["claim_type"] == "exhaustive_network_endpoints_equality":
+                return c
+        return None
+
+    def _network_health(self, status: str) -> dict:
+        health = dict(self.CLEAN)
+        health["network_protocol_coverage"] = status
+        return health
+
     def test_fidelity_verdict_mapping(self):
         self.assertEqual(drift.fidelity_verdict(self.CLEAN), "clean")
         self.assertEqual(drift.fidelity_verdict(self.CLIPPED), "clipped")
@@ -2415,6 +2426,38 @@ class FidelityAndEnforcementTest(unittest.TestCase):
         # one arm failed, other missing -> absent
         ann = drift.coverage_annotation_for_report(self.REPORT, health_a=self.FAILED)
         self.assertEqual(self._net_cell(ann)["claim_strength"], "absent")
+
+    def test_network_descriptor_uses_common_datagram_coverage_when_both_arms_observe_it(self):
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT,
+            health_a=self._network_health("connect_and_datagram_peer_observed"),
+            health_b=self._network_health("connect_and_datagram_peer_observed"),
+        )
+        exhaustive = self._net_exhaustive_cell(ann)
+        self.assertIn("connect_and_datagram_peer_observed", exhaustive["notes"][0])
+        caveat = ann["classification_caveats"][0]["caveat"]
+        self.assertIn("connect_and_datagram_peer_observed", caveat)
+
+    def test_network_descriptor_downgrades_to_datagram_when_one_arm_lacks_connect(self):
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT,
+            health_a=self._network_health("datagram_peer_observed"),
+            health_b=self._network_health("connect_and_datagram_peer_observed"),
+        )
+        exhaustive = self._net_exhaustive_cell(ann)
+        self.assertIn("datagram_peer_observed", exhaustive["notes"][0])
+        self.assertNotIn("connect_and_datagram_peer_observed", exhaustive["notes"][0])
+
+    def test_network_descriptor_keeps_connect_only_when_one_arm_is_connect_only(self):
+        ann = drift.coverage_annotation_for_report(
+            self.REPORT,
+            health_a=self._network_health("connect_only"),
+            health_b=self._network_health("connect_and_datagram_peer_observed"),
+        )
+        exhaustive = self._net_exhaustive_cell(ann)
+        self.assertIn("connect_only", exhaustive["notes"][0])
+        blocked = ann["blocked_claims"][0]["reason"]
+        self.assertIn("coverage completeness still blocks", blocked)
 
 
 

--- a/docs/reference/observability/claim-semantics-overview.md
+++ b/docs/reference/observability/claim-semantics-overview.md
@@ -69,7 +69,7 @@ ceiling. The descriptor gate evaluates the requested claim kind:
 
 | Claim kind | Descriptor rule |
 |---|---|
-| `positive_existence` | Allowed when a descriptor is present; strength then comes from gate one. The shipped helper keys this on descriptor presence and does not yet validate that the claimed class appears in `observes` — the caller is responsible for selecting a descriptor whose `observes` covers the effect class. |
+| `positive_existence` | Allowed when a descriptor is present and, for callers using `claim_decision_for_effect`, the claimed class appears in `observes`; strength then comes from gate one. |
 | `exhaustive_set` | Degraded to `weak` whenever the descriptor declares any blind spot or `completeness` is not `full`. |
 | `bounded_negative` | Blocked whenever the descriptor declares any blind spot or `completeness` is not `full`. |
 
@@ -77,13 +77,15 @@ A missing or schema-mismatched descriptor is not the same as a present
 one: the helper blocks coverage-aware claims outright when no valid
 descriptor is supplied, rather than treating absence as permission.
 
-The seed descriptors describe today's capture ceiling: filesystem capture
-is `open_syscall_only` (io_uring and mmap-backed writes are blind spots),
-network capture is `connect_only` (QUIC/datagram and io_uring are blind
-spots), process capture is `exec_only` (fork/clone gaps). None of them
-support complete claims yet, so every exhaustive set degrades and every
-bounded-negative claim blocks under the current seeds. That is the point:
-the gate must not silently upgrade a claim the method cannot back.
+The seed descriptors describe today's capture ceilings: filesystem capture
+is `open_syscall_only` (io_uring and mmap-backed writes are blind spots);
+network capture can be `connect_only`, `datagram_peer_observed`, or
+`connect_and_datagram_peer_observed` depending on whether the run observed
+`connect`, `sendto`, and/or `sendmsg` peers; process capture is `exec_only`
+(fork/clone gaps). None of the seed descriptors support complete claims yet,
+so every exhaustive set degrades and every bounded-negative claim blocks under
+the current seeds. That is the point: the gate must not silently upgrade a
+claim the method cannot back.
 
 ## Composition order
 
@@ -128,7 +130,8 @@ endpoint it emits:
   not `measured`.
 - `measured_network_effect` — `strong` / `measured`.
 - `exhaustive_network_set` — `weak` / `derived`, naming the gating rule
-  and the `connect_only` ceiling.
+  and the run's network coverage ceiling (`connect_only`,
+  `datagram_peer_observed`, or `connect_and_datagram_peer_observed`).
 - `no_unexpected_filesystem_effect` and `no_unexpected_network_effect` —
   **blocked**, recorded in `blocked_claims` rather than emitted as cells.
 

--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -206,7 +206,7 @@ Interpretation rules:
 
 - `kernel_layer=complete` means capture health was clean for the attached hooks;
   it does not, by itself, prove protocol-complete network coverage.
-- `network_protocol_coverage=connect_only` means the current Runner observed
+- `network_protocol_coverage=connect_only` means Runner observed
   `connect()`-level network evidence only.
 - `network_protocol_coverage=datagram_peer_observed` means Runner observed
   datagram peer evidence from `sendto` or `sendmsg`, without a matching

--- a/docs/reference/runner/coverage-descriptor-v0.md
+++ b/docs/reference/runner/coverage-descriptor-v0.md
@@ -65,11 +65,19 @@ must consult it before interpreting absence or exhaustiveness.
 |---|---|---|---|
 | filesystem | `filesystem_open_syscall_only()` | `open_syscall_only` | io_uring file operations; mmap-backed writes |
 | network | `network_connect_only()` | `connect_only` | QUIC/datagram peer changes after connect; io_uring network operations |
+| network | `network_datagram_peer_observed()` | `datagram_peer_observed` | connected datagram sends without explicit sockaddr; io_uring network operations |
+| network | `network_connect_and_datagram_peer_observed()` | `connect_and_datagram_peer_observed` | io_uring network operations |
 | process | `process_exec_only()` | `exec_only` | fork/clone gaps that affect process-tree exhaustiveness |
 
 The seed descriptors intentionally describe the current capture ceiling.
 Future capture improvements can narrow or remove blind spots by changing
 descriptor data; until then, the gate must not silently upgrade claims.
+`network_for_protocol_coverage(status)` maps
+`observation_health.network_protocol_coverage` into the matching network
+descriptor when the run reported `connect_only`, `datagram_peer_observed`,
+or `connect_and_datagram_peer_observed`. `unknown` and `absent` return no
+descriptor, so coverage-aware network claims remain blocked rather than
+silently assuming a method.
 
 ## Claim Kinds
 
@@ -142,20 +150,24 @@ Initial rules:
 - The descriptor does not prove runtime safety.
 - The descriptor does not close the blind spot it names.
 - The descriptor does not replace `observation_health.v0`.
-- The descriptor does not convert `connect_only` network capture into an
-  exact peer set.
+- The descriptor does not convert `connect_only` or datagram-aware network
+  capture into an exact peer set.
 - The descriptor does not make self-reported SDK or trace evidence
   measured.
 
-## Wiring Boundary
+## Wiring Status
 
-This slice adds only the contract and helper. It intentionally does not:
+The Rust helper remains an internal contract in `assay-runner-schema`.
+Experiment surfaces may mirror it for sidecar annotations and enforcement, but
+the Runner archive contract is unchanged. This helper still does not:
 
 - add a Runner archive member;
 - add CLI output;
-- add comparator wiring;
+- add a stable report schema;
 - add Trust Basis claims;
-- add capture enhancements for io_uring, QUIC/datagram, or fork/clone.
+- add capture enhancements for io_uring or fork/clone.
 
-Report and comparator wiring should wait for the next descriptor-aware
-consumer slice.
+Any consumer that mirrors the gate should preserve the same ceiling: datagram
+peer observations can strengthen positive network evidence, but they do not
+permit exact peer-set or bounded-negative network claims while blind spots
+remain declared.

--- a/examples/coverage-aware-side-effect/report_from_archive.py
+++ b/examples/coverage-aware-side-effect/report_from_archive.py
@@ -46,6 +46,21 @@ SEED_DESCRIPTORS: dict[str, dict[str, Any]] = {
         ],
         "completeness": "connect_only",
     },
+    "network_datagram_peer_observed": {
+        "method": "sendto/sendmsg tracepoints",
+        "known_blind_spots": [
+            "connected datagram sends without an explicit sockaddr require connect evidence to recover the peer",
+            "io_uring network operations may bypass syscall tracepoints",
+        ],
+        "completeness": "datagram_peer_observed",
+    },
+    "network_connect_and_datagram_peer_observed": {
+        "method": "connect/sendto/sendmsg tracepoints",
+        "known_blind_spots": [
+            "io_uring network operations may bypass syscall tracepoints",
+        ],
+        "completeness": "connect_and_datagram_peer_observed",
+    },
     "process": {
         "method": "exec tracepoint",
         "known_blind_spots": [
@@ -82,6 +97,21 @@ def _supports_complete_claims(descriptor: dict[str, Any]) -> bool:
     return descriptor.get("completeness") == "full" and not descriptor.get(
         "known_blind_spots"
     )
+
+
+def _network_descriptor_for_health(health: dict[str, Any]) -> dict[str, Any]:
+    status = health.get("network_protocol_coverage")
+    if status == "datagram_peer_observed":
+        return SEED_DESCRIPTORS["network_datagram_peer_observed"]
+    if status == "connect_and_datagram_peer_observed":
+        return SEED_DESCRIPTORS["network_connect_and_datagram_peer_observed"]
+    return SEED_DESCRIPTORS["network"]
+
+
+def _descriptor_for_dimension(dimension: str, health: dict[str, Any]) -> dict[str, Any]:
+    if dimension == "network":
+        return _network_descriptor_for_health(health)
+    return SEED_DESCRIPTORS[dimension]
 
 
 def _capture_is_clean(health: dict[str, Any]) -> bool:
@@ -197,7 +227,8 @@ def build_report(archive: dict[str, Any]) -> dict[str, Any]:
     claim_cells: list[dict[str, Any]] = []
     blocked_claims: list[dict[str, Any]] = []
 
-    for dimension, descriptor in SEED_DESCRIPTORS.items():
+    for dimension in SURFACE_FIELD:
+        descriptor = _descriptor_for_dimension(dimension, health)
         observed = surface.get(SURFACE_FIELD[dimension])
         if observed is None:
             continue

--- a/examples/coverage-aware-side-effect/test_report.py
+++ b/examples/coverage-aware-side-effect/test_report.py
@@ -166,6 +166,30 @@ class CoverageAwareReportTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.m.build_report(archive)
 
+    def test_datagram_network_coverage_updates_descriptor_ceiling(self):
+        archive = _archive("clean.archive.json")
+        archive["observation_health"][
+            "network_protocol_coverage"
+        ] = "connect_and_datagram_peer_observed"
+        report = self.m.build_report(archive)
+        exhaustive = next(
+            c
+            for c in report["claim_cells"]
+            if c["claim_type"] == "exhaustive_network_set"
+        )
+        self.assertTrue(
+            any(
+                "connect_and_datagram_peer_observed" in note
+                for note in exhaustive["notes"]
+            )
+        )
+        blocked = next(
+            b
+            for b in report["blocked_claims"]
+            if b["requested_claim"] == "no_unexpected_network_effect"
+        )
+        self.assertIn("connect_and_datagram_peer_observed", blocked["reason"])
+
     def test_clean_report_matches_frozen_fixture(self):
         # Golden test: the generator output must equal the frozen expected
         # report, so the fixture and generator cannot drift apart silently.


### PR DESCRIPTION
## Summary

- Add datagram-aware network coverage descriptor variants for `sendto` / `sendmsg` peer observations.
- Map `observation_health.network_protocol_coverage` to the matching network descriptor (`connect_only`, `datagram_peer_observed`, or `connect_and_datagram_peer_observed`).
- Wire the coverage-aware side-effect sample and runtime-drift annotation sidecar to select the network descriptor from observation health instead of always using `connect_only`.
- Update runner/observability reference docs so the descriptor layer matches the existing Runner datagram telemetry.

## Boundary

- No eBPF or monitor hook changes in this PR.
- No Runner archive member change.
- No stable report schema change.
- Datagram peer evidence can strengthen positive network observations, but exact peer-set and bounded-negative network claims remain degraded/blocked while blind spots are declared.

## Verification

- `cargo fmt --check`
- `cargo test -p assay-runner-schema --test coverage_descriptor`
- `cargo test -p assay-runner-core kernel::tests --lib`
- `python3 examples/coverage-aware-side-effect/test_report.py`
- `python3 docs/experiments/cross-runtime-drift-2026-05/compare/test_drift.py`
- `git diff --check`


## Delegated runner proof

- head sha: `7c6eb46c39a51dc09e0e83e33dd6e88cdfd830a6`
- gate: `all`
- delegated run: https://github.com/Rul1an/assay/actions/runs/26955238871 (success)

