### PR TITLE
chore: prep v3.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.16.0] - 2026-06-04
+
+- Added `assay evidence verify-mcp-tunnel-observed`, a bounded consumer-side
+  checker for MCP tunnel observed-facts fixtures. The command validates the
+  `assay.mcp.tunnel_observed.v0` shape, enforces no-raw-payload and
+  no-raw-authorization boundaries, and classifies whether evidence references
+  support a strong `same_request_instance` join or only diagnostic correlation.
+  It does not prove tunnel mediation, authorization success, policy
+  correctness, tool result truth, application outcome truth, or issuer/key
+  trust.
+
+- Added Runner coverage descriptor helpers and examples for coverage-aware
+  side-effect interpretation. The new `assay.runner.coverage_descriptor.v0`
+  helper gates positive, exhaustive, and bounded-negative effect claims by
+  effect dimension and documented blind spots, so observed positives can remain
+  useful while absence and exact-set claims stay blocked or degraded when the
+  capture method cannot support them.
+
+- Added coverage-aware drift annotation and enforcement support to the
+  cross-runtime drift experiment comparator. The comparator can now emit a
+  sidecar claim annotation, derive measured-positive strength from per-arm
+  observation health, and use `--assert-claim TYPE:DIMENSION` to fail when a
+  requested claim is not permitted by the coverage/fidelity gates. The drift
+  report schema remains unchanged.
+
+- Added datagram-aware network coverage descriptors for Runner archives that
+  report `datagram_peer_observed` or `connect_and_datagram_peer_observed`.
+  Coverage-aware samples now derive the network descriptor from
+  `observation_health.network_protocol_coverage` instead of assuming
+  `connect_only`. Datagram peer evidence strengthens positive network
+  observations, but exact peer-set and bounded-negative network claims remain
+  degraded or blocked while blind spots are declared.
+
+- Updated dependency and CI hygiene patches, including CodeQL, `serial_test`,
+  `uuid`, and `assert_fs` patch bumps.
+
 ## [3.15.0] - 2026-06-03
 
 - Added Runner network-fidelity claim-scope fields so measured-run archives can

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.15.0"
+version = "3.16.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -73,18 +73,18 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.15.0" }
-assay-common = { path = "crates/assay-common", version = "3.15.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.15.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.15.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.15.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.15.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.15.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.15.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.15.0" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.15.0" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.15.0" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.15.0" }
+assay-core = { path = "crates/assay-core", version = "3.16.0" }
+assay-common = { path = "crates/assay-common", version = "3.16.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.16.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.16.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.16.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.16.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.16.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.16.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.16.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.16.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.16.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.16.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,12 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-06-03, `v3.15.0` release prep):** the `v3.15.0`
-> release line carries the post-`v3.14.0` Runner fidelity batch: honest
-> network protocol coverage / endpoint claim-scope fields, datagram peer
-> telemetry for `sendto`/`sendmsg`, the fidelity verdict and declared
-> path-projection helpers, the MCP request-envelope fallback binding slice, and
-> the cross-runtime comparator's diagnostic-only endpoint-churn handling. The
-> Cargo workspace/package version in this release-prep branch is **`3.15.0`**.
+> **Status sync (2026-06-04, `v3.16.0` release prep):** the `v3.16.0`
+> release line carries the post-`v3.15.0` coverage-aware interpretation batch:
+> the MCP tunnel observed-facts checker, the Runner coverage descriptor helper,
+> coverage-aware side-effect and drift annotation examples, drift comparator
+> claim enforcement, and datagram-aware descriptor mapping for Runner archives
+> that report `sendto`/`sendmsg` peer observations. The Cargo workspace/package
+> version in this release-prep branch is **`3.16.0`**.
 > The current execution posture is: keep remaining CLI grouping trigger-gated,
 > keep Assay-Runner repository extraction gated, treat Assay-Harness `v3.13.0`
 > compatibility as verified by its release-binary compatibility CI check
@@ -202,14 +202,21 @@ grouping RFC remains deliberately trigger-gated: `trust` and `replay` should
 move only with a concrete docs/user-maintenance reason, not just to reduce the
 top-level command count.
 
-The `v3.15.0` release-prep line closes the Runner QUIC fidelity follow-up on
-`main`: Runner archives can now state protocol coverage and diagnostic-only
-network endpoint scope separately from capture health, Linux captures can record
-observed datagram destination sockaddr evidence from `sendto`/`sendmsg`, and the
+The `v3.15.0` release line closed the Runner QUIC fidelity follow-up on `main`:
+Runner archives can state protocol coverage and diagnostic-only network endpoint
+scope separately from capture health, Linux captures can record observed
+datagram destination sockaddr evidence from `sendto`/`sendmsg`, and the
 cross-runtime experiment comparator treats diagnostic-only endpoint churn as
-inconclusive instead of hard provider/runtime drift. This strengthens transport
-evidence beyond connect-only capture, but it still does not claim request-level
-binding, `cf_ray` capture, or authoritative exact QUIC peer identity.
+inconclusive instead of hard provider/runtime drift.
+
+The `v3.16.0` release-prep line layers coverage-aware interpretation on top of
+that substrate: consumers can classify effect claims through coverage
+descriptors, drift annotations can be emitted and enforced as sidecars, and
+datagram-aware network descriptors are selected from
+`observation_health.network_protocol_coverage`. This strengthens positive
+network observations beyond connect-only capture, but it still does not claim
+request-level binding, `cf_ray` capture, or authoritative exact QUIC peer
+identity.
 
 ### Happy Path (Core Workflow)
 ```bash


### PR DESCRIPTION
## Summary

- Move the post-v3.15.0 work into a `v3.16.0` changelog section.
- Bump workspace/package versions from `3.15.0` to `3.16.0` in `Cargo.toml` and `Cargo.lock`.
- Sync `docs/ROADMAP.md` to the v3.16.0 release-prep line.

## Release contents covered

- `assay evidence verify-mcp-tunnel-observed` bounded observed-facts checker.
- Runner coverage descriptor helper and coverage-aware side-effect examples.
- Coverage-aware drift annotation sidecar and `--assert-claim` enforcement.
- Datagram-aware network coverage descriptors selected from `observation_health.network_protocol_coverage`.
- Dependency and CI hygiene patch bumps since v3.15.0.

## Verification

- `cargo metadata --no-deps --format-version 1` -> local workspace package versions are `3.16.0`.
- `cargo fmt --check`
- `git diff --check`
- `cargo publish -p assay-common --dry-run --allow-dirty` succeeds.
- `cargo publish -p assay-cli --dry-run --allow-dirty` stops at the expected publish-order boundary because `assay-common ^3.16.0` is not on crates.io until the release sequence publishes dependencies first.

## Boundary

- Release prep only: no feature code, no schema changes, no CLI behavior changes.
- This PR does not tag or publish; it prepares main for the v3.16.0 release cut.


## Delegated runner proof

- head sha: `9d42bdfeac8bb1d23d0371b54d615adcb2d9668d`
- gate: `all`
- delegated run: https://github.com/Rul1an/assay/actions/runs/26956318658 (success)

