### PR TITLE
docs(examples): coverage-claims gate example consumer

### DIFF
--- a/examples/coverage-claims-gate/README.md
+++ b/examples/coverage-claims-gate/README.md
@@ -1,0 +1,73 @@
+# Coverage-claims gate (example consumer)
+
+A small, dependency-free example showing how a downstream gate can **mechanically
+enforce** coverage claims instead of merely documenting them.
+
+It reads a coverage annotation sidecar
+(`assay.coverage_aware_drift.annotation.v0`, as produced by the cross-runtime
+drift comparator's `--coverage-annotation-out`) and a set of asserted claims, then
+returns a deterministic pass/fail report:
+
+- every asserted claim permitted → exit `0`
+- any claim blocked → exit `1`
+- usage / schema error → exit `2`
+
+This is the consumer side of the honesty layer. The annotation already classifies
+each drift dimension by claim strength and basis; this checker turns that
+classification into an enforceable decision, so a CI step can refuse to assert a
+claim the annotation does not support — rather than silently treating absence or
+trace-reported signal as if it were measured evidence.
+
+It is an example only. It does not change any Runner or contract surface. The
+canonical gate semantics live in `crates/assay-runner-schema/src/coverage.rs`;
+this checker mirrors the same claim-kind rules over a frozen annotation document.
+
+## Claim kinds
+
+| Claim spec | Permitted when |
+|------------|----------------|
+| `positive:DIM` | a `measured_DIM_drift` cell exists with strength `strong` or `partial` |
+| `exhaustive:DIM` | an `exhaustive_DIM_equality` cell is allowed (strength `partial`); a coverage-degraded `weak` cell is not |
+| `bounded_negative:DIM` | `DIM` is a measured dimension **and** is not present in `blocked_claims`; on a reported/unknown dimension the claim is not evaluable, so not permitted |
+
+Measured dimensions: `filesystem_paths_touched`, `kernel_file_operations`,
+`network_endpoints`, `process_execs`. Reported dimensions (e.g. `tool_calls`)
+carry no measured ceiling, so bounded-negative claims over them are never
+evaluable.
+
+## Usage
+
+```bash
+# Inline claims
+python3 check_claims.py fixtures/annotation.json \
+    --assert-claim positive:filesystem_paths_touched
+
+# Claims from a policy file (JSON array of TYPE:DIMENSION strings)
+python3 check_claims.py fixtures/annotation.json --policy fixtures/policy_pass.json
+
+# JSON report instead of text
+python3 check_claims.py fixtures/annotation.json \
+    --policy fixtures/policy_blocked.json --format json
+```
+
+`--assert-claim` and `--policy` combine; at least one claim must be supplied.
+
+## Fixtures
+
+- `fixtures/annotation.json` — a sample annotation with a partial measured
+  filesystem positive, a coverage-degraded (`weak`) exhaustive cell, an `absent`
+  network positive, a reported `tool_calls` cell, and one blocked bounded-negative
+  claim.
+- `fixtures/policy_pass.json` — a policy that the annotation permits (exit `0`).
+- `fixtures/policy_blocked.json` — a policy mixing permitted and blocked claims
+  (exit `1`).
+- `fixtures/expected_pass.json`, `fixtures/expected_blocked.json` — the exact JSON
+  reports for those two runs, used by the tests.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s examples/coverage-claims-gate -p 'test_*.py'
+```
+
+Stdlib only — no third-party dependencies.

--- a/examples/coverage-claims-gate/check_claims.py
+++ b/examples/coverage-claims-gate/check_claims.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Coverage-claims gate (sample consumer, enforcement showcase).
+
+Reads a coverage annotation sidecar (`assay.coverage_aware_drift.annotation.v0`,
+as produced by the cross-runtime drift comparator's --coverage-annotation-out)
+and a set of asserted coverage claims, then mechanically decides pass/fail:
+
+    permitted  -> exit 0
+    any blocked -> exit 1
+
+This is the consumer side of the honesty layer: it shows that a downstream gate
+(e.g. a CI step) can refuse to assert a coverage claim the annotation does not
+permit, instead of silently treating absence or reported signal as evidence.
+
+It is a sample: it does not change any Runner/contract surface. The canonical
+gate semantics live in crates/assay-runner-schema/src/coverage.rs; this checker
+mirrors the same claim-kind rules over a frozen annotation document.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+ANNOTATION_SCHEMA = "assay.coverage_aware_drift.annotation.v0"
+ASSERTABLE_CLAIM_TYPES = ("positive", "exhaustive", "bounded_negative")
+
+# Which drift dimensions are measured (effect-bearing) vs reported. A
+# bounded-negative claim is only evaluable for a measured dimension; on a
+# reported/unknown dimension it is not evaluable and therefore not permitted.
+MEASURED_DIMENSIONS = {
+    "filesystem_paths_touched",
+    "kernel_file_operations",
+    "network_endpoints",
+    "process_execs",
+}
+
+
+def _cells(annotation: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {c.get("claim_type"): c for c in annotation.get("claim_cells", [])}
+
+
+def evaluate_claim(
+    annotation: dict[str, Any], claim_type: str, dimension: str
+) -> tuple[bool, str]:
+    """Return (permitted, detail) for one asserted claim against an annotation.
+
+    - positive:DIM permitted iff a measured_{DIM}_drift cell exists with strength
+      strong or partial (absent / missing -> not permitted).
+    - exhaustive:DIM permitted iff exhaustive_{DIM}_equality is allowed
+      (strength partial); a degraded weak cell or a missing cell is not.
+    - bounded_negative:DIM permitted iff DIM is a measured dimension AND it is
+      not present in blocked_claims. Reported/unknown dimensions are not
+      evaluable -> not permitted.
+    """
+    cells = _cells(annotation)
+    if claim_type == "positive":
+        cell = cells.get(f"measured_{dimension}_drift")
+        if cell is None:
+            return False, f"no measured_{dimension}_drift cell (nothing observed)"
+        strength = cell.get("claim_strength")
+        if strength in ("strong", "partial"):
+            return True, f"measured positive is {strength}"
+        return False, f"measured positive is {strength}"
+    if claim_type == "exhaustive":
+        cell = cells.get(f"exhaustive_{dimension}_equality")
+        if cell is None:
+            return False, f"no exhaustive_{dimension}_equality cell"
+        strength = cell.get("claim_strength")
+        if strength == "partial":
+            return True, "exhaustive equality allowed (partial)"
+        return False, f"exhaustive equality is {strength} (degraded by coverage)"
+    if claim_type == "bounded_negative":
+        if dimension not in MEASURED_DIMENSIONS:
+            return (
+                False,
+                f"bounded-negative not evaluable for non-measured dimension "
+                f"{dimension!r}",
+            )
+        blocked = {
+            b.get("requested_claim") for b in annotation.get("blocked_claims", [])
+        }
+        if f"no_{dimension}_effect_beyond_observed" in blocked:
+            return False, "bounded-negative blocked by coverage descriptor"
+        return True, "bounded-negative not blocked"
+    return False, f"unknown claim type {claim_type!r}"
+
+
+def parse_claim_spec(spec: str) -> tuple[str, str]:
+    raw = str(spec)
+    if ":" not in raw:
+        raise ValueError(f"claim must be TYPE:DIMENSION, got {raw!r}")
+    claim_type, _, dimension = raw.partition(":")
+    claim_type = claim_type.strip()
+    dimension = dimension.strip()
+    if claim_type not in ASSERTABLE_CLAIM_TYPES:
+        raise ValueError(
+            f"claim TYPE must be one of {ASSERTABLE_CLAIM_TYPES}; got {claim_type!r}"
+        )
+    if not dimension:
+        raise ValueError(f"claim must have a non-empty dimension, got {raw!r}")
+    return claim_type, dimension
+
+
+def gate(annotation: dict[str, Any], specs: list[str]) -> dict[str, Any]:
+    """Evaluate all asserted claims; return a deterministic report."""
+    if annotation.get("schema") != ANNOTATION_SCHEMA:
+        raise ValueError(
+            f"expected {ANNOTATION_SCHEMA} annotation; got {annotation.get('schema')!r}"
+        )
+    results = []
+    for spec in specs:
+        claim_type, dimension = parse_claim_spec(spec)
+        permitted, detail = evaluate_claim(annotation, claim_type, dimension)
+        results.append(
+            {
+                "claim": f"{claim_type}:{dimension}",
+                "permitted": permitted,
+                "detail": detail,
+            }
+        )
+    passed = all(r["permitted"] for r in results)
+    return {"passed": passed, "results": results}
+
+
+def render_text(report: dict[str, Any]) -> str:
+    lines = []
+    for r in report["results"]:
+        mark = "PERMIT" if r["permitted"] else "BLOCK "
+        lines.append(f"[{mark}] {r['claim']}: {r['detail']}")
+    lines.append("PASS" if report["passed"] else "FAIL")
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "annotation",
+        help="coverage annotation JSON (assay.coverage_aware_drift.annotation.v0)",
+    )
+    parser.add_argument(
+        "--assert-claim",
+        action="append",
+        default=[],
+        metavar="TYPE:DIMENSION",
+        help="A coverage claim to assert (positive|exhaustive|bounded_negative:DIM). Repeatable.",
+    )
+    parser.add_argument(
+        "--policy",
+        help="Optional JSON file with an array of TYPE:DIMENSION claim strings.",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser.parse_args()
+
+
+def _run(args: argparse.Namespace) -> int:
+    with open(args.annotation, "r", encoding="utf-8") as handle:
+        annotation = json.load(handle)
+    specs = list(args.assert_claim)
+    if args.policy:
+        with open(args.policy, "r", encoding="utf-8") as handle:
+            policy = json.load(handle)
+        if not isinstance(policy, list):
+            print("--policy file must contain a JSON array of claim strings", file=sys.stderr)
+            return 2
+        specs.extend(str(item) for item in policy)
+    if not specs:
+        print("no claims asserted (use --assert-claim or --policy)", file=sys.stderr)
+        return 2
+    try:
+        report = gate(annotation, specs)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if args.format == "json":
+        sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_text(report))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run(_parse_args()))

--- a/examples/coverage-claims-gate/fixtures/annotation.json
+++ b/examples/coverage-claims-gate/fixtures/annotation.json
@@ -1,0 +1,69 @@
+{
+  "schema": "assay.coverage_aware_drift.annotation.v0",
+  "source_report_schema": "assay.runner.runtime_drift.v0.2",
+  "claim_cells": [
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_filesystem_paths_touched_drift",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "partial",
+      "claim_basis": "measured",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": [
+        "positive strength derived from coverage_descriptor.v0 gate: one arm reported clipped capture health"
+      ],
+      "non_claims": [
+        "does_not_prove_tool_intent",
+        "does_not_prove_complete_set"
+      ]
+    },
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "exhaustive_filesystem_paths_touched_equality",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "weak",
+      "claim_basis": "derived",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": [
+        "derived by coverage_descriptor.v0 gate: exhaustive filesystem equality requires completeness=full with no blind spots; completeness is open_syscall_only; blind spots: rename, unlink"
+      ],
+      "non_claims": ["does_not_prove_complete_filesystem_set"]
+    },
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_network_endpoints_drift",
+      "artifact_role": "none",
+      "claim_strength": "absent",
+      "claim_basis": "measured",
+      "evidence_refs": [],
+      "notes": [
+        "one arm reported a failed fidelity verdict; the cross-arm positive cannot be supported"
+      ],
+      "non_claims": ["does_not_prove_tool_intent"]
+    },
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "reported_tool_calls",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "partial",
+      "claim_basis": "reported",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": [
+        "SDK/trace-reported drift surface; not a measured kernel effect, so no coverage ceiling is applied"
+      ],
+      "non_claims": [
+        "does_not_prove_measured_effect",
+        "does_not_prove_complete_set"
+      ]
+    }
+  ],
+  "blocked_claims": [
+    {
+      "claim_type": "bounded_negative_claim",
+      "requested_claim": "no_filesystem_paths_touched_effect_beyond_observed",
+      "decision": "blocked",
+      "reason": "filesystem absence-beyond-observed claim requires completeness=full with no blind spots and confirmed clean capture; completeness is open_syscall_only; blind spots: rename, unlink; the drift report does not surface per-arm observation health"
+    }
+  ],
+  "classification_caveats": []
+}

--- a/examples/coverage-claims-gate/fixtures/expected_blocked.json
+++ b/examples/coverage-claims-gate/fixtures/expected_blocked.json
@@ -1,0 +1,25 @@
+{
+  "passed": false,
+  "results": [
+    {
+      "claim": "positive:filesystem_paths_touched",
+      "detail": "measured positive is partial",
+      "permitted": true
+    },
+    {
+      "claim": "positive:network_endpoints",
+      "detail": "measured positive is absent",
+      "permitted": false
+    },
+    {
+      "claim": "exhaustive:filesystem_paths_touched",
+      "detail": "exhaustive equality is weak (degraded by coverage)",
+      "permitted": false
+    },
+    {
+      "claim": "bounded_negative:filesystem_paths_touched",
+      "detail": "bounded-negative blocked by coverage descriptor",
+      "permitted": false
+    }
+  ]
+}

--- a/examples/coverage-claims-gate/fixtures/expected_pass.json
+++ b/examples/coverage-claims-gate/fixtures/expected_pass.json
@@ -1,0 +1,10 @@
+{
+  "passed": true,
+  "results": [
+    {
+      "claim": "positive:filesystem_paths_touched",
+      "detail": "measured positive is partial",
+      "permitted": true
+    }
+  ]
+}

--- a/examples/coverage-claims-gate/fixtures/policy_blocked.json
+++ b/examples/coverage-claims-gate/fixtures/policy_blocked.json
@@ -1,0 +1,6 @@
+[
+  "positive:filesystem_paths_touched",
+  "positive:network_endpoints",
+  "exhaustive:filesystem_paths_touched",
+  "bounded_negative:filesystem_paths_touched"
+]

--- a/examples/coverage-claims-gate/fixtures/policy_pass.json
+++ b/examples/coverage-claims-gate/fixtures/policy_pass.json
@@ -1,0 +1,3 @@
+[
+  "positive:filesystem_paths_touched"
+]

--- a/examples/coverage-claims-gate/test_check_claims.py
+++ b/examples/coverage-claims-gate/test_check_claims.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Stdlib unittest suite for the coverage-claims gate showcase.
+
+Run: python3 -m unittest discover -s examples/coverage-claims-gate -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+
+import check_claims as cc
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIXTURES = os.path.join(HERE, "fixtures")
+
+
+def _load(name: str) -> dict:
+    with open(os.path.join(FIXTURES, name), "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+class ParseClaimSpecTests(unittest.TestCase):
+    def test_valid_spec(self) -> None:
+        self.assertEqual(
+            cc.parse_claim_spec("positive:network_endpoints"),
+            ("positive", "network_endpoints"),
+        )
+
+    def test_strips_whitespace(self) -> None:
+        self.assertEqual(
+            cc.parse_claim_spec("  exhaustive : filesystem_paths_touched "),
+            ("exhaustive", "filesystem_paths_touched"),
+        )
+
+    def test_missing_colon(self) -> None:
+        with self.assertRaises(ValueError):
+            cc.parse_claim_spec("positive")
+
+    def test_unknown_type(self) -> None:
+        with self.assertRaises(ValueError):
+            cc.parse_claim_spec("definitely:filesystem_paths_touched")
+
+    def test_empty_dimension(self) -> None:
+        with self.assertRaises(ValueError):
+            cc.parse_claim_spec("positive:")
+
+
+class EvaluateClaimTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.annotation = _load("annotation.json")
+
+    def test_positive_partial_permitted(self) -> None:
+        permitted, _ = cc.evaluate_claim(
+            self.annotation, "positive", "filesystem_paths_touched"
+        )
+        self.assertTrue(permitted)
+
+    def test_positive_absent_blocked(self) -> None:
+        permitted, detail = cc.evaluate_claim(
+            self.annotation, "positive", "network_endpoints"
+        )
+        self.assertFalse(permitted)
+        self.assertIn("absent", detail)
+
+    def test_positive_missing_cell_blocked(self) -> None:
+        permitted, detail = cc.evaluate_claim(
+            self.annotation, "positive", "process_execs"
+        )
+        self.assertFalse(permitted)
+        self.assertIn("nothing observed", detail)
+
+    def test_exhaustive_weak_blocked(self) -> None:
+        permitted, detail = cc.evaluate_claim(
+            self.annotation, "exhaustive", "filesystem_paths_touched"
+        )
+        self.assertFalse(permitted)
+        self.assertIn("weak", detail)
+
+    def test_bounded_negative_blocked_by_descriptor(self) -> None:
+        permitted, detail = cc.evaluate_claim(
+            self.annotation, "bounded_negative", "filesystem_paths_touched"
+        )
+        self.assertFalse(permitted)
+        self.assertIn("blocked", detail)
+
+    def test_bounded_negative_not_evaluable_for_reported_dimension(self) -> None:
+        # tool_calls is a reported dimension, not a measured one -> not evaluable.
+        permitted, detail = cc.evaluate_claim(
+            self.annotation, "bounded_negative", "tool_calls"
+        )
+        self.assertFalse(permitted)
+        self.assertIn("non-measured", detail)
+
+    def test_bounded_negative_permitted_when_measured_and_unblocked(self) -> None:
+        # A measured dimension with no matching blocked_claims entry -> permitted.
+        permitted, _ = cc.evaluate_claim(
+            self.annotation, "bounded_negative", "network_endpoints"
+        )
+        self.assertTrue(permitted)
+
+
+class GateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.annotation = _load("annotation.json")
+
+    def test_pass_policy(self) -> None:
+        report = cc.gate(self.annotation, ["positive:filesystem_paths_touched"])
+        self.assertTrue(report["passed"])
+        self.assertEqual(report, _load("expected_pass.json"))
+
+    def test_blocked_policy(self) -> None:
+        specs = [
+            "positive:filesystem_paths_touched",
+            "positive:network_endpoints",
+            "exhaustive:filesystem_paths_touched",
+            "bounded_negative:filesystem_paths_touched",
+        ]
+        report = cc.gate(self.annotation, specs)
+        self.assertFalse(report["passed"])
+        self.assertEqual(report, _load("expected_blocked.json"))
+
+    def test_wrong_schema_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            cc.gate({"schema": "something.else.v0"}, ["positive:x"])
+
+    def test_single_block_fails_whole_gate(self) -> None:
+        report = cc.gate(
+            self.annotation,
+            ["positive:filesystem_paths_touched", "positive:network_endpoints"],
+        )
+        self.assertFalse(report["passed"])
+        self.assertTrue(report["results"][0]["permitted"])
+        self.assertFalse(report["results"][1]["permitted"])
+
+
+class RenderTextTests(unittest.TestCase):
+    def test_pass_render(self) -> None:
+        report = {
+            "passed": True,
+            "results": [
+                {"claim": "positive:fs", "permitted": True, "detail": "ok"}
+            ],
+        }
+        out = cc.render_text(report)
+        self.assertIn("[PERMIT] positive:fs: ok", out)
+        self.assertTrue(out.rstrip().endswith("PASS"))
+
+    def test_fail_render(self) -> None:
+        report = {
+            "passed": False,
+            "results": [
+                {"claim": "positive:net", "permitted": False, "detail": "absent"}
+            ],
+        }
+        out = cc.render_text(report)
+        self.assertIn("[BLOCK ] positive:net: absent", out)
+        self.assertTrue(out.rstrip().endswith("FAIL"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `examples/coverage-claims-gate/` — a small, dependency-free example consumer that reads a coverage annotation sidecar (`assay.coverage_aware_drift.annotation.v0`, as produced by the cross-runtime drift comparator's `--coverage-annotation-out`) plus a set of asserted claims, and emits a deterministic pass/fail report.

## Why

The annotation already classifies each drift dimension by claim strength and basis. This example shows the consumer side: a downstream CI step can mechanically refuse to assert a claim the annotation does not support, instead of silently treating absence or trace-reported signal as if it were measured evidence. It is the enforcement counterpart to the producer-side annotation work.

## Claim kinds

- `positive:DIM` — permitted iff a `measured_DIM_drift` cell exists with strength `strong`/`partial`.
- `exhaustive:DIM` — permitted iff `exhaustive_DIM_equality` is allowed (`partial`); a coverage-degraded `weak` cell is not.
- `bounded_negative:DIM` — permitted iff `DIM` is a measured dimension and not present in `blocked_claims`; not evaluable on a reported/unknown dimension.

## Scope

Example only — no Runner or contract surface changes. The canonical gate semantics stay in `crates/assay-runner-schema/src/coverage.rs`; this checker mirrors the same claim-kind rules over a frozen annotation document.

## Tests

Stdlib `unittest` suite (18 tests):

```
python3 -m unittest discover -s examples/coverage-claims-gate -p 'test_*.py'
```

Exit codes: `0` all claims permitted, `1` any blocked, `2` usage/schema error.