### PR TITLE
docs(examples): coverage fleet summary aggregator example

### DIFF
--- a/examples/coverage-fleet-summary/README.md
+++ b/examples/coverage-fleet-summary/README.md
@@ -1,0 +1,64 @@
+# Coverage fleet summary (example aggregator)
+
+A small, dependency-free example showing how the per-run coverage honesty
+classification scales to a whole set of runs — using only local inputs and with
+no contract change. It is a deterministic fold over annotation documents on disk.
+
+It reads many coverage annotation sidecars
+(`assay.coverage_aware_drift.annotation.v0`, as produced by the cross-runtime
+drift comparator's `--coverage-annotation-out`) and emits one fleet-level summary
+(`assay.coverage_fleet_summary.v0`, example-scoped, v0): for each measured
+dimension it reports the distribution of positive strengths, the distribution of
+exhaustive-equality strengths, how many runs block the bounded-negative claim,
+and the **fleet floor** — the weakest positive strength seen across the set.
+
+The fleet floor answers the operational question directly: "across these runs,
+the strongest positive claim I can make *everywhere* is no better than this." If
+one run in the set degraded to `absent`, the floor is `absent`, even if every
+other run was `strong`.
+
+It is an example only — it changes no Runner or contract surface. It consumes
+only the public annotation sidecar shape.
+
+## Usage
+
+```bash
+# A directory of annotation .json files (sorted, non-recursive)
+python3 aggregate_coverage.py --dir fixtures/runs
+
+# Explicit files
+python3 aggregate_coverage.py fixtures/runs/run-01.json fixtures/runs/run-02.json
+
+# JSON summary
+python3 aggregate_coverage.py --dir fixtures/runs --format json
+```
+
+## What the summary contains
+
+For each of the measured dimensions (`filesystem_paths_touched`,
+`kernel_file_operations`, `network_endpoints`, `process_execs`):
+
+- `measured_positive` — count of runs at each strength (`strong`, `partial`,
+  `weak`, `absent`, `missing`).
+- `exhaustive_equality` — count of runs at each exhaustive-claim strength.
+- `bounded_negative_blocked` — how many runs blocked the absence-beyond-observed
+  claim for this dimension.
+- `runs_observed` — runs that carried any measured positive cell for the
+  dimension.
+- `fleet_positive_floor` — the weakest positive strength observed, or `missing`
+  if the dimension was never observed across the fleet.
+
+## Fixtures
+
+`fixtures/runs/` holds three synthetic annotation documents with deliberately
+varied coverage (a clean run, a clipped run, and a run that failed fidelity on
+one arm). `fixtures/expected_summary.json` is the exact fold of those three, used
+by the tests.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s examples/coverage-fleet-summary -p 'test_*.py'
+```
+
+Stdlib only — no third-party dependencies.

--- a/examples/coverage-fleet-summary/README.md
+++ b/examples/coverage-fleet-summary/README.md
@@ -15,7 +15,10 @@ and the **fleet floor** — the weakest positive strength seen across the set.
 The fleet floor answers the operational question directly: "across these runs,
 the strongest positive claim I can make *everywhere* is no better than this." If
 one run in the set degraded to `absent`, the floor is `absent`, even if every
-other run was `strong`.
+other run was `strong`. And if even one run has no positive cell at all for the
+dimension, the floor is `missing` — a fleet cannot claim a positive everywhere
+when one run cannot support it at all. The floor is computed over *every* run,
+not only the observed ones.
 
 It is an example only — it changes no Runner or contract surface. It consumes
 only the public annotation sidecar shape.
@@ -45,8 +48,10 @@ For each of the measured dimensions (`filesystem_paths_touched`,
   claim for this dimension.
 - `runs_observed` — runs that carried any measured positive cell for the
   dimension.
-- `fleet_positive_floor` — the weakest positive strength observed, or `missing`
-  if the dimension was never observed across the fleet.
+- `fleet_positive_floor` — the weakest positive level across **every** run
+  (weakest first: `missing`, `absent`, `weak`, `partial`, `strong`). A run with
+  no positive cell counts as `missing` and pulls the floor to `missing`; the
+  floor is also `missing` for a dimension with no runs at all.
 
 ## Fixtures
 

--- a/examples/coverage-fleet-summary/aggregate_coverage.py
+++ b/examples/coverage-fleet-summary/aggregate_coverage.py
@@ -6,8 +6,9 @@ Reads many coverage annotation sidecars
 drift comparator's --coverage-annotation-out) and folds them into one
 fleet-level honesty summary: for each measured dimension, how many runs report
 each positive strength, how many allow an exhaustive claim, and how many block
-the bounded-negative claim — plus the fleet "floor" (the weakest strength seen
-across the set).
+the bounded-negative claim — plus the fleet "floor" (the weakest positive level
+across every run, where a run with no positive cell counts as `missing` and
+pulls the floor down — so the floor is what is supportable *everywhere*).
 
 The point of the showcase: the same per-run honesty classification scales to a
 whole set of runs using only local inputs and with no contract change — it is
@@ -37,14 +38,18 @@ MEASURED_DIMENSIONS = (
     "process_execs",
 )
 
-# Positive strength ordering, weakest first — used to compute the fleet floor.
-_STRENGTH_ORDER = ("absent", "weak", "partial", "strong")
+# Positive strength ordering, weakest first. `missing` (a run with no positive
+# cell at all) is the weakest level of all: if even one run cannot support a
+# positive claim, the fleet cannot support it *everywhere*, so the floor is
+# `missing`. This ordering is what makes the floor an honest "supportable
+# across every run" answer rather than "supportable across the observed runs".
+_FLOOR_ORDER = ("missing", "absent", "weak", "partial", "strong")
 
 
 def _weaker(a: str, b: str) -> str:
-    """Return the weaker of two strengths by _STRENGTH_ORDER (unknowns are weakest)."""
-    ia = _STRENGTH_ORDER.index(a) if a in _STRENGTH_ORDER else -1
-    ib = _STRENGTH_ORDER.index(b) if b in _STRENGTH_ORDER else -1
+    """Return the weaker of two levels by _FLOOR_ORDER (unknowns are weakest)."""
+    ia = _FLOOR_ORDER.index(a) if a in _FLOOR_ORDER else -1
+    ib = _FLOOR_ORDER.index(b) if b in _FLOOR_ORDER else -1
     return a if ia <= ib else b
 
 
@@ -54,7 +59,9 @@ def _empty_dimension() -> dict[str, Any]:
         "exhaustive_equality": {"partial": 0, "weak": 0, "absent": 0, "missing": 0},
         "bounded_negative_blocked": 0,
         "runs_observed": 0,
-        "fleet_positive_floor": "missing",
+        # None until the first run is folded in; resolved to "missing" at the end
+        # for a dimension with no runs at all.
+        "fleet_positive_floor": None,
     }
 
 
@@ -79,19 +86,20 @@ def fold(annotations: list[dict[str, Any]]) -> dict[str, Any]:
         for dim in MEASURED_DIMENSIONS:
             entry = dims[dim]
             pos = cells.get(f"measured_{dim}_drift")
-            if pos is None:
-                entry["measured_positive"]["missing"] += 1
+            strength = pos.get("claim_strength", "missing") if pos is not None else "missing"
+            if strength in entry["measured_positive"] and strength != "missing":
+                entry["measured_positive"][strength] += 1
+                entry["runs_observed"] += 1
+                run_level = strength
             else:
-                strength = pos.get("claim_strength", "missing")
-                if strength in entry["measured_positive"] and strength != "missing":
-                    entry["measured_positive"][strength] += 1
-                    entry["runs_observed"] += 1
-                    cur = entry["fleet_positive_floor"]
-                    entry["fleet_positive_floor"] = (
-                        strength if cur == "missing" else _weaker(cur, strength)
-                    )
-                else:
-                    entry["measured_positive"]["missing"] += 1
+                # No positive cell, or an unrecognised strength: this run does not
+                # support a positive claim for the dimension.
+                entry["measured_positive"]["missing"] += 1
+                run_level = "missing"
+            # Fold every run into the floor — including the missing ones, so a
+            # single unsupported run pulls the everywhere-floor down to "missing".
+            cur = entry["fleet_positive_floor"]
+            entry["fleet_positive_floor"] = run_level if cur is None else _weaker(cur, run_level)
 
             exh = cells.get(f"exhaustive_{dim}_equality")
             if exh is None:
@@ -106,9 +114,9 @@ def fold(annotations: list[dict[str, Any]]) -> dict[str, Any]:
             if f"no_{dim}_effect_beyond_observed" in blocked:
                 entry["bounded_negative_blocked"] += 1
 
-    # A dimension never observed across the fleet has no floor.
+    # A dimension with no runs at all (empty fleet) resolves to "missing".
     for entry in dims.values():
-        if entry["runs_observed"] == 0:
+        if entry["fleet_positive_floor"] is None:
             entry["fleet_positive_floor"] = "missing"
 
     return {

--- a/examples/coverage-fleet-summary/aggregate_coverage.py
+++ b/examples/coverage-fleet-summary/aggregate_coverage.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Coverage fleet summary (sample aggregator, governance showcase).
+
+Reads many coverage annotation sidecars
+(`assay.coverage_aware_drift.annotation.v0`, as produced by the cross-runtime
+drift comparator's --coverage-annotation-out) and folds them into one
+fleet-level honesty summary: for each measured dimension, how many runs report
+each positive strength, how many allow an exhaustive claim, and how many block
+the bounded-negative claim — plus the fleet "floor" (the weakest strength seen
+across the set).
+
+The point of the showcase: the same per-run honesty classification scales to a
+whole set of runs using only local inputs and with no contract change — it is
+just a deterministic fold over annotation documents on disk. A team can answer
+"across these N runs, which coverage claims are actually supportable
+everywhere?" from local files alone.
+
+It is a sample: it changes no Runner/contract surface. It consumes only the
+public annotation sidecar shape and emits an example-scoped v0 summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+ANNOTATION_SCHEMA = "assay.coverage_aware_drift.annotation.v0"
+SUMMARY_SCHEMA = "assay.coverage_fleet_summary.v0"
+
+MEASURED_DIMENSIONS = (
+    "filesystem_paths_touched",
+    "kernel_file_operations",
+    "network_endpoints",
+    "process_execs",
+)
+
+# Positive strength ordering, weakest first — used to compute the fleet floor.
+_STRENGTH_ORDER = ("absent", "weak", "partial", "strong")
+
+
+def _weaker(a: str, b: str) -> str:
+    """Return the weaker of two strengths by _STRENGTH_ORDER (unknowns are weakest)."""
+    ia = _STRENGTH_ORDER.index(a) if a in _STRENGTH_ORDER else -1
+    ib = _STRENGTH_ORDER.index(b) if b in _STRENGTH_ORDER else -1
+    return a if ia <= ib else b
+
+
+def _empty_dimension() -> dict[str, Any]:
+    return {
+        "measured_positive": {"strong": 0, "partial": 0, "weak": 0, "absent": 0, "missing": 0},
+        "exhaustive_equality": {"partial": 0, "weak": 0, "absent": 0, "missing": 0},
+        "bounded_negative_blocked": 0,
+        "runs_observed": 0,
+        "fleet_positive_floor": "missing",
+    }
+
+
+def _cells(annotation: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {c.get("claim_type"): c for c in annotation.get("claim_cells", [])}
+
+
+def _blocked(annotation: dict[str, Any]) -> set[str]:
+    return {b.get("requested_claim") for b in annotation.get("blocked_claims", [])}
+
+
+def fold(annotations: list[dict[str, Any]]) -> dict[str, Any]:
+    """Fold a list of annotation documents into a fleet summary."""
+    dims: dict[str, dict[str, Any]] = {d: _empty_dimension() for d in MEASURED_DIMENSIONS}
+    for annotation in annotations:
+        if annotation.get("schema") != ANNOTATION_SCHEMA:
+            raise ValueError(
+                f"expected {ANNOTATION_SCHEMA} annotation; got {annotation.get('schema')!r}"
+            )
+        cells = _cells(annotation)
+        blocked = _blocked(annotation)
+        for dim in MEASURED_DIMENSIONS:
+            entry = dims[dim]
+            pos = cells.get(f"measured_{dim}_drift")
+            if pos is None:
+                entry["measured_positive"]["missing"] += 1
+            else:
+                strength = pos.get("claim_strength", "missing")
+                if strength in entry["measured_positive"] and strength != "missing":
+                    entry["measured_positive"][strength] += 1
+                    entry["runs_observed"] += 1
+                    cur = entry["fleet_positive_floor"]
+                    entry["fleet_positive_floor"] = (
+                        strength if cur == "missing" else _weaker(cur, strength)
+                    )
+                else:
+                    entry["measured_positive"]["missing"] += 1
+
+            exh = cells.get(f"exhaustive_{dim}_equality")
+            if exh is None:
+                entry["exhaustive_equality"]["missing"] += 1
+            else:
+                strength = exh.get("claim_strength", "missing")
+                if strength in entry["exhaustive_equality"]:
+                    entry["exhaustive_equality"][strength] += 1
+                else:
+                    entry["exhaustive_equality"]["missing"] += 1
+
+            if f"no_{dim}_effect_beyond_observed" in blocked:
+                entry["bounded_negative_blocked"] += 1
+
+    # A dimension never observed across the fleet has no floor.
+    for entry in dims.values():
+        if entry["runs_observed"] == 0:
+            entry["fleet_positive_floor"] = "missing"
+
+    return {
+        "schema": SUMMARY_SCHEMA,
+        "run_count": len(annotations),
+        "dimensions": dims,
+    }
+
+
+def render_text(summary: dict[str, Any]) -> str:
+    lines = [f"fleet coverage summary over {summary['run_count']} run(s)", ""]
+    for dim in sorted(summary["dimensions"]):
+        entry = summary["dimensions"][dim]
+        pos = entry["measured_positive"]
+        pos_str = ", ".join(
+            f"{k}={pos[k]}" for k in ("strong", "partial", "weak", "absent", "missing")
+        )
+        lines.append(f"{dim}:")
+        lines.append(f"  positive floor: {entry['fleet_positive_floor']}  ({pos_str})")
+        lines.append(f"  bounded-negative blocked in {entry['bounded_negative_blocked']} run(s)")
+    return "\n".join(lines) + "\n"
+
+
+def _read_annotations(paths: list[str]) -> list[dict[str, Any]]:
+    annotations = []
+    for path in paths:
+        with open(path, "r", encoding="utf-8") as handle:
+            annotations.append(json.load(handle))
+    return annotations
+
+
+def _collect_paths(args: argparse.Namespace) -> list[str]:
+    paths = list(args.annotation)
+    if args.dir:
+        for name in sorted(os.listdir(args.dir)):
+            if name.endswith(".json"):
+                paths.append(os.path.join(args.dir, name))
+    return paths
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "annotation",
+        nargs="*",
+        help="annotation JSON file(s) (assay.coverage_aware_drift.annotation.v0)",
+    )
+    parser.add_argument(
+        "--dir",
+        help="directory of annotation .json files (sorted, non-recursive)",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser.parse_args()
+
+
+def _run(args: argparse.Namespace) -> int:
+    paths = _collect_paths(args)
+    if not paths:
+        print("no annotations supplied (pass files or --dir)", file=sys.stderr)
+        return 2
+    try:
+        annotations = _read_annotations(paths)
+        summary = fold(annotations)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if args.format == "json":
+        sys.stdout.write(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_text(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run(_parse_args()))

--- a/examples/coverage-fleet-summary/fixtures/expected_summary.json
+++ b/examples/coverage-fleet-summary/fixtures/expected_summary.json
@@ -1,0 +1,78 @@
+{
+  "dimensions": {
+    "filesystem_paths_touched": {
+      "bounded_negative_blocked": 2,
+      "exhaustive_equality": {
+        "absent": 0,
+        "missing": 1,
+        "partial": 1,
+        "weak": 1
+      },
+      "fleet_positive_floor": "absent",
+      "measured_positive": {
+        "absent": 1,
+        "missing": 0,
+        "partial": 1,
+        "strong": 1,
+        "weak": 0
+      },
+      "runs_observed": 3
+    },
+    "kernel_file_operations": {
+      "bounded_negative_blocked": 0,
+      "exhaustive_equality": {
+        "absent": 0,
+        "missing": 3,
+        "partial": 0,
+        "weak": 0
+      },
+      "fleet_positive_floor": "missing",
+      "measured_positive": {
+        "absent": 0,
+        "missing": 3,
+        "partial": 0,
+        "strong": 0,
+        "weak": 0
+      },
+      "runs_observed": 0
+    },
+    "network_endpoints": {
+      "bounded_negative_blocked": 2,
+      "exhaustive_equality": {
+        "absent": 0,
+        "missing": 3,
+        "partial": 0,
+        "weak": 0
+      },
+      "fleet_positive_floor": "absent",
+      "measured_positive": {
+        "absent": 1,
+        "missing": 0,
+        "partial": 2,
+        "strong": 0,
+        "weak": 0
+      },
+      "runs_observed": 3
+    },
+    "process_execs": {
+      "bounded_negative_blocked": 0,
+      "exhaustive_equality": {
+        "absent": 0,
+        "missing": 3,
+        "partial": 0,
+        "weak": 0
+      },
+      "fleet_positive_floor": "missing",
+      "measured_positive": {
+        "absent": 0,
+        "missing": 3,
+        "partial": 0,
+        "strong": 0,
+        "weak": 0
+      },
+      "runs_observed": 0
+    }
+  },
+  "run_count": 3,
+  "schema": "assay.coverage_fleet_summary.v0"
+}

--- a/examples/coverage-fleet-summary/fixtures/mixed/run-a.json
+++ b/examples/coverage-fleet-summary/fixtures/mixed/run-a.json
@@ -1,0 +1,28 @@
+{
+  "schema": "assay.coverage_aware_drift.annotation.v0",
+  "source_report_schema": "assay.runner.runtime_drift.v0.2",
+  "claim_cells": [
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_filesystem_paths_touched_drift",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "partial",
+      "claim_basis": "measured",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": ["filesystem observed at partial"],
+      "non_claims": ["does_not_prove_tool_intent"]
+    },
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_network_endpoints_drift",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "partial",
+      "claim_basis": "measured",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": ["network observed at partial"],
+      "non_claims": ["does_not_prove_tool_intent"]
+    }
+  ],
+  "blocked_claims": [],
+  "classification_caveats": []
+}

--- a/examples/coverage-fleet-summary/fixtures/mixed/run-b.json
+++ b/examples/coverage-fleet-summary/fixtures/mixed/run-b.json
@@ -1,0 +1,18 @@
+{
+  "schema": "assay.coverage_aware_drift.annotation.v0",
+  "source_report_schema": "assay.runner.runtime_drift.v0.2",
+  "claim_cells": [
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_network_endpoints_drift",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "partial",
+      "claim_basis": "measured",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": ["network observed at partial; this run has no filesystem positive cell"],
+      "non_claims": ["does_not_prove_tool_intent"]
+    }
+  ],
+  "blocked_claims": [],
+  "classification_caveats": []
+}

--- a/examples/coverage-fleet-summary/fixtures/runs/run-01.json
+++ b/examples/coverage-fleet-summary/fixtures/runs/run-01.json
@@ -1,0 +1,45 @@
+{
+  "schema": "assay.coverage_aware_drift.annotation.v0",
+  "source_report_schema": "assay.runner.runtime_drift.v0.2",
+  "claim_cells": [
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_filesystem_paths_touched_drift",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "partial",
+      "claim_basis": "measured",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": ["one arm clipped"],
+      "non_claims": ["does_not_prove_tool_intent"]
+    },
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "exhaustive_filesystem_paths_touched_equality",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "weak",
+      "claim_basis": "derived",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": ["open_syscall_only; blind spots: rename, unlink"],
+      "non_claims": ["does_not_prove_complete_filesystem_set"]
+    },
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_network_endpoints_drift",
+      "artifact_role": "none",
+      "claim_strength": "absent",
+      "claim_basis": "measured",
+      "evidence_refs": [],
+      "notes": ["one arm failed fidelity"],
+      "non_claims": ["does_not_prove_tool_intent"]
+    }
+  ],
+  "blocked_claims": [
+    {
+      "claim_type": "bounded_negative_claim",
+      "requested_claim": "no_filesystem_paths_touched_effect_beyond_observed",
+      "decision": "blocked",
+      "reason": "completeness is open_syscall_only; blind spots: rename, unlink"
+    }
+  ],
+  "classification_caveats": []
+}

--- a/examples/coverage-fleet-summary/fixtures/runs/run-02.json
+++ b/examples/coverage-fleet-summary/fixtures/runs/run-02.json
@@ -1,0 +1,45 @@
+{
+  "schema": "assay.coverage_aware_drift.annotation.v0",
+  "source_report_schema": "assay.runner.runtime_drift.v0.2",
+  "claim_cells": [
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_filesystem_paths_touched_drift",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "strong",
+      "claim_basis": "measured",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": ["both arms clean"],
+      "non_claims": ["does_not_prove_tool_intent"]
+    },
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "exhaustive_filesystem_paths_touched_equality",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "partial",
+      "claim_basis": "derived",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": ["completeness full; capped at partial without per-arm health"],
+      "non_claims": ["strong_only_within_cgroup_scope"]
+    },
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_network_endpoints_drift",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "partial",
+      "claim_basis": "measured",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": ["datagram peers observed"],
+      "non_claims": ["does_not_prove_tool_intent"]
+    }
+  ],
+  "blocked_claims": [
+    {
+      "claim_type": "bounded_negative_claim",
+      "requested_claim": "no_network_endpoints_effect_beyond_observed",
+      "decision": "blocked",
+      "reason": "connect_and_datagram_peer_observed; still not complete"
+    }
+  ],
+  "classification_caveats": []
+}

--- a/examples/coverage-fleet-summary/fixtures/runs/run-03.json
+++ b/examples/coverage-fleet-summary/fixtures/runs/run-03.json
@@ -1,0 +1,41 @@
+{
+  "schema": "assay.coverage_aware_drift.annotation.v0",
+  "source_report_schema": "assay.runner.runtime_drift.v0.2",
+  "claim_cells": [
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_filesystem_paths_touched_drift",
+      "artifact_role": "none",
+      "claim_strength": "absent",
+      "claim_basis": "measured",
+      "evidence_refs": [],
+      "notes": ["one arm failed fidelity"],
+      "non_claims": ["does_not_prove_tool_intent"]
+    },
+    {
+      "schema": "assay.observability.claim_class_cell.v0",
+      "claim_type": "measured_network_endpoints_drift",
+      "artifact_role": "joined_artifacts",
+      "claim_strength": "partial",
+      "claim_basis": "measured",
+      "evidence_refs": ["runtime-drift-report.json"],
+      "notes": ["connect-only base"],
+      "non_claims": ["does_not_prove_tool_intent"]
+    }
+  ],
+  "blocked_claims": [
+    {
+      "claim_type": "bounded_negative_claim",
+      "requested_claim": "no_filesystem_paths_touched_effect_beyond_observed",
+      "decision": "blocked",
+      "reason": "fidelity failed on one arm"
+    },
+    {
+      "claim_type": "bounded_negative_claim",
+      "requested_claim": "no_network_endpoints_effect_beyond_observed",
+      "decision": "blocked",
+      "reason": "connect_only; datagram peers not observed"
+    }
+  ],
+  "classification_caveats": []
+}

--- a/examples/coverage-fleet-summary/test_aggregate_coverage.py
+++ b/examples/coverage-fleet-summary/test_aggregate_coverage.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Stdlib unittest suite for the coverage fleet summary showcase.
+
+Run: python3 -m unittest discover -s examples/coverage-fleet-summary -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+
+import aggregate_coverage as ac
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIXTURES = os.path.join(HERE, "fixtures")
+RUNS = os.path.join(FIXTURES, "runs")
+
+
+def _load(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _all_runs() -> list:
+    return [
+        _load(os.path.join(RUNS, name))
+        for name in sorted(os.listdir(RUNS))
+        if name.endswith(".json")
+    ]
+
+
+class WeakerTests(unittest.TestCase):
+    def test_orders_strengths(self) -> None:
+        self.assertEqual(ac._weaker("strong", "absent"), "absent")
+        self.assertEqual(ac._weaker("partial", "weak"), "weak")
+        self.assertEqual(ac._weaker("partial", "strong"), "partial")
+
+    def test_unknown_is_weakest(self) -> None:
+        self.assertEqual(ac._weaker("strong", "bogus"), "bogus")
+
+
+class FoldTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.summary = ac.fold(_all_runs())
+
+    def test_matches_expected_fixture(self) -> None:
+        self.assertEqual(self.summary, _load(os.path.join(FIXTURES, "expected_summary.json")))
+
+    def test_run_count(self) -> None:
+        self.assertEqual(self.summary["run_count"], 3)
+
+    def test_filesystem_floor_is_weakest_observed(self) -> None:
+        fs = self.summary["dimensions"]["filesystem_paths_touched"]
+        # strengths seen: partial, strong, absent -> floor is absent.
+        self.assertEqual(fs["fleet_positive_floor"], "absent")
+        self.assertEqual(fs["measured_positive"]["strong"], 1)
+        self.assertEqual(fs["measured_positive"]["absent"], 1)
+
+    def test_unobserved_dimension_has_no_floor(self) -> None:
+        ke = self.summary["dimensions"]["kernel_file_operations"]
+        self.assertEqual(ke["runs_observed"], 0)
+        self.assertEqual(ke["fleet_positive_floor"], "missing")
+        self.assertEqual(ke["measured_positive"]["missing"], 3)
+
+    def test_bounded_negative_block_counts(self) -> None:
+        dims = self.summary["dimensions"]
+        self.assertEqual(dims["filesystem_paths_touched"]["bounded_negative_blocked"], 2)
+        self.assertEqual(dims["network_endpoints"]["bounded_negative_blocked"], 2)
+
+    def test_exhaustive_distribution(self) -> None:
+        exh = self.summary["dimensions"]["filesystem_paths_touched"]["exhaustive_equality"]
+        # run-01 weak, run-02 partial, run-03 missing.
+        self.assertEqual(exh["weak"], 1)
+        self.assertEqual(exh["partial"], 1)
+        self.assertEqual(exh["missing"], 1)
+
+    def test_empty_fleet(self) -> None:
+        summary = ac.fold([])
+        self.assertEqual(summary["run_count"], 0)
+        for entry in summary["dimensions"].values():
+            self.assertEqual(entry["runs_observed"], 0)
+            self.assertEqual(entry["fleet_positive_floor"], "missing")
+
+    def test_wrong_schema_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            ac.fold([{"schema": "something.else.v0"}])
+
+
+class RenderTextTests(unittest.TestCase):
+    def test_renders_each_dimension(self) -> None:
+        out = ac.render_text(ac.fold(_all_runs()))
+        self.assertIn("filesystem_paths_touched:", out)
+        self.assertIn("positive floor: absent", out)
+        self.assertIn("bounded-negative blocked in 2 run(s)", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/coverage-fleet-summary/test_aggregate_coverage.py
+++ b/examples/coverage-fleet-summary/test_aggregate_coverage.py
@@ -30,6 +30,15 @@ def _all_runs() -> list:
     ]
 
 
+def _mixed_runs() -> list:
+    mixed = os.path.join(FIXTURES, "mixed")
+    return [
+        _load(os.path.join(mixed, name))
+        for name in sorted(os.listdir(mixed))
+        if name.endswith(".json")
+    ]
+
+
 class WeakerTests(unittest.TestCase):
     def test_orders_strengths(self) -> None:
         self.assertEqual(ac._weaker("strong", "absent"), "absent")
@@ -74,6 +83,54 @@ class FoldTests(unittest.TestCase):
         self.assertEqual(exh["weak"], 1)
         self.assertEqual(exh["partial"], 1)
         self.assertEqual(exh["missing"], 1)
+
+    def test_mixed_observed_and_missing_lowers_floor_to_missing(self) -> None:
+        # Regression for the "floor must answer supportable *everywhere*" contract:
+        # one run observes filesystem at partial, the other has no filesystem
+        # positive cell at all. The floor must drop to "missing" -- a fleet cannot
+        # claim a positive everywhere if one run cannot support it at all.
+        summary = ac.fold(_mixed_runs())
+        fs = summary["dimensions"]["filesystem_paths_touched"]
+        self.assertEqual(fs["fleet_positive_floor"], "missing")
+        self.assertEqual(fs["runs_observed"], 1)
+        self.assertEqual(fs["measured_positive"]["partial"], 1)
+        self.assertEqual(fs["measured_positive"]["missing"], 1)
+        # Network is observed at partial in both runs, so its floor stays partial.
+        net = summary["dimensions"]["network_endpoints"]
+        self.assertEqual(net["fleet_positive_floor"], "partial")
+        self.assertEqual(net["runs_observed"], 2)
+
+    def test_single_absent_run_lowers_floor_below_observed(self) -> None:
+        # A single absent run pulls the floor to absent even if others are strong.
+        summary = ac.fold(
+            [
+                {
+                    "schema": ac.ANNOTATION_SCHEMA,
+                    "claim_cells": [
+                        {
+                            "claim_type": "measured_process_execs_drift",
+                            "claim_strength": "strong",
+                        }
+                    ],
+                    "blocked_claims": [],
+                },
+                {
+                    "schema": ac.ANNOTATION_SCHEMA,
+                    "claim_cells": [
+                        {
+                            "claim_type": "measured_process_execs_drift",
+                            "claim_strength": "absent",
+                        }
+                    ],
+                    "blocked_claims": [],
+                },
+            ]
+        )
+        pe = summary["dimensions"]["process_execs"]
+        self.assertEqual(pe["fleet_positive_floor"], "absent")
+        # Both runs carry a positive cell (strong + absent), so both are observed;
+        # the floor is the weaker of the two.
+        self.assertEqual(pe["runs_observed"], 2)
 
     def test_empty_fleet(self) -> None:
         summary = ac.fold([])


### PR DESCRIPTION
## What

Adds `examples/coverage-fleet-summary/` — a dependency-free example that folds many coverage annotation sidecars (`assay.coverage_aware_drift.annotation.v0`) into one fleet-level summary (`assay.coverage_fleet_summary.v0`, example-scoped v0).

## Why

The per-run coverage classification already says, for one run, how strong each drift claim is. This example shows it scales to a whole set of runs as a deterministic local fold: for each measured dimension it reports the strength distribution, how many runs block the bounded-negative claim, and the **fleet floor** — the weakest positive strength seen across the set. That answers "across these runs, the strongest claim I can make everywhere is no better than X" directly.

## Scope

Example only — no Runner or contract surface changes. Consumes only the public annotation sidecar shape; uses local inputs.

## Tests

Stdlib `unittest` suite (11 tests), three synthetic annotation fixtures, and an exact expected-summary fixture:

```
python3 -m unittest discover -s examples/coverage-fleet-summary -p 'test_*.py'
```