### PR TITLE
docs(examples): attested-claim composition shape (synthetic demonstrator)

### DIFF
--- a/examples/attested-shape-demo/README.md
+++ b/examples/attested-shape-demo/README.md
@@ -1,0 +1,64 @@
+# Attested-claim composition shape (SYNTHETIC DEMONSTRATOR)
+
+> **This is a synthetic demonstrator.** It does not implement, verify, or assert
+> any real attestation mechanism. Every envelope and digest in the fixtures is
+> fabricated demo data, and "verification" is decided by a flag in the synthetic
+> envelope — no cryptography is performed. Nothing here is a commitment or a
+> stable contract.
+
+## What it explores
+
+The current claim-class schema (`assay.observability.claim_class_cell.v0`)
+recognises four claim bases: `reported`, `measured`, `derived`, `inferred`. This
+demonstrator explores the *shape* a fifth, `attested`, basis could take — purely
+so the idea can be reasoned about on engineering merit. It is **not** in the
+schema and this demonstrator does not add it.
+
+The teaching point is the composition rule, which follows the same evidence-first
+discipline the measured/derived cells already use: **absence of verifiable
+evidence degrades a claim; it never silently upgrades it.**
+
+A claim cell that cites an attestation is composed with an attestation envelope:
+
+| Envelope state | Effective result |
+|----------------|------------------|
+| none supplied | degrade to `inferred`, strength capped at `weak` |
+| present, not verified | degrade to `inferred`, capped at `weak` (an unverifiable envelope is not evidence) |
+| verified, subject digest mismatches the cell | degrade to `inferred`, capped at `weak` (the attestation does not cover this subject) |
+| verified, subject digest matches | declared strength stands (basis `attested`) |
+
+Composition can cap a claim but never inflate it: a cell that only declared a
+`weak` claim stays `weak` even with a verified, matching envelope.
+
+## Usage
+
+```bash
+# No envelope -> the no-evidence degrade
+python3 compose_attested.py fixtures/cell.json
+
+# A synthetic verified envelope that binds to the cited subject
+python3 compose_attested.py fixtures/cell.json --envelope fixtures/envelope_verified.json
+
+# Synthetic failure shapes
+python3 compose_attested.py fixtures/cell.json --envelope fixtures/envelope_wrong_subject.json
+python3 compose_attested.py fixtures/cell.json --envelope fixtures/envelope_unverified.json
+
+# JSON output
+python3 compose_attested.py fixtures/cell.json \
+    --envelope fixtures/envelope_verified.json --format json
+```
+
+## Fixtures (all fabricated demo data)
+
+- `fixtures/cell.json` — a synthetic claim cell declaring an `attested` basis.
+- `fixtures/envelope_verified.json` — verifies and binds to the cell's subject.
+- `fixtures/envelope_wrong_subject.json` — verifies but binds to a different subject.
+- `fixtures/envelope_unverified.json` — present but not verified.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s examples/attested-shape-demo -p 'test_*.py'
+```
+
+Stdlib only — no third-party dependencies.

--- a/examples/attested-shape-demo/compose_attested.py
+++ b/examples/attested-shape-demo/compose_attested.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Attested-claim composition SHAPE — SYNTHETIC DEMONSTRATOR ONLY.
+
+================================ READ THIS FIRST ===============================
+This file is a synthetic demonstrator. It does NOT implement, verify, or assert
+any real attestation mechanism. The "attested" claim basis it explores is NOT a
+basis recognised by the current claim-class schema
+(`assay.observability.claim_class_cell.v0` defines: reported, measured, derived,
+inferred). Nothing here is a commitment, a stable contract, or a statement that
+such a basis will be added. It exists purely to illustrate the *shape* a
+consumer-side composition rule could take if an attested basis were ever
+explored — so the idea can be reasoned about on engineering merit alone.
+
+Every envelope and digest below is fabricated demo data. The verification result
+is decided by a flag in the synthetic envelope, not by any cryptographic check.
+===============================================================================
+
+What it shows: a claim cell that cites an attestation is only as strong as the
+attestation it can actually bind to. The composition rule here degrades an
+"attested" cell to a conservative basis unless a verifiable envelope is present
+AND that envelope binds to the same subject digest the cell refers to. This is
+the same evidence-first discipline the measured/derived cells already use:
+absence of verifiable evidence degrades the claim; it never silently upgrades it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+DEMO_BANNER = "SYNTHETIC DEMONSTRATOR — not a real attestation mechanism"
+
+# Strength lattice, weakest first. The composed strength can never exceed what
+# the synthetic evidence supports.
+_STRENGTH_ORDER = ("absent", "weak", "partial", "strong")
+
+
+def _at_most(declared: str, ceiling: str) -> str:
+    di = _STRENGTH_ORDER.index(declared) if declared in _STRENGTH_ORDER else 0
+    ci = _STRENGTH_ORDER.index(ceiling) if ceiling in _STRENGTH_ORDER else 0
+    return declared if di <= ci else ceiling
+
+
+def compose(cell: dict[str, Any], envelope: dict[str, Any] | None) -> dict[str, Any]:
+    """Compose a (synthetic) attested cell with a (synthetic) attestation envelope.
+
+    Rules (illustrative, evidence-first):
+    - No envelope -> the attested claim cannot be supported; basis degrades to
+      `inferred` and strength is capped at `weak`.
+    - Envelope present but not verified (synthetic flag) -> same conservative
+      degrade; an unverifiable envelope is not evidence.
+    - Envelope verified but bound to a different subject digest than the cell
+      cites -> degrade: the attestation does not actually cover this subject.
+    - Envelope verified AND subject digest matches -> the declared strength is
+      allowed to stand (still capped by the lattice).
+    """
+    declared = cell.get("claim_strength", "absent")
+    cited_digest = cell.get("subject_digest")
+    result = {
+        "demo": DEMO_BANNER,
+        "claim_type": cell.get("claim_type"),
+        "declared_strength": declared,
+        "declared_basis": cell.get("claim_basis"),
+    }
+
+    if envelope is None:
+        result.update(
+            effective_strength=_at_most(declared, "weak"),
+            effective_basis="inferred",
+            reason="no attestation envelope supplied; cannot support an attested claim",
+        )
+        return result
+
+    verified = envelope.get("verification", {}).get("status") == "verified"
+    env_digest = envelope.get("subject_digest")
+
+    if not verified:
+        result.update(
+            effective_strength=_at_most(declared, "weak"),
+            effective_basis="inferred",
+            reason=(
+                "envelope present but verification status is "
+                f"{envelope.get('verification', {}).get('status')!r}; "
+                "an unverifiable envelope is not evidence"
+            ),
+        )
+        return result
+
+    if env_digest != cited_digest:
+        result.update(
+            effective_strength=_at_most(declared, "weak"),
+            effective_basis="inferred",
+            reason=(
+                "envelope verifies but its subject digest does not match the "
+                "digest the claim cites; the attestation does not cover this subject"
+            ),
+        )
+        return result
+
+    result.update(
+        effective_strength=declared,
+        effective_basis="attested",
+        reason=(
+            "envelope verifies (synthetic) and binds to the cited subject digest; "
+            "declared strength stands"
+        ),
+    )
+    return result
+
+
+def render_text(report: dict[str, Any]) -> str:
+    return (
+        f"[{report['demo']}]\n"
+        f"claim: {report['claim_type']}\n"
+        f"declared: {report['declared_strength']} ({report['declared_basis']})\n"
+        f"effective: {report['effective_strength']} ({report['effective_basis']})\n"
+        f"reason: {report['reason']}\n"
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cell", help="synthetic attested claim cell JSON")
+    parser.add_argument(
+        "--envelope",
+        help="synthetic attestation envelope JSON (omit to show the no-evidence degrade)",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    return parser.parse_args()
+
+
+def _run(args: argparse.Namespace) -> int:
+    with open(args.cell, "r", encoding="utf-8") as handle:
+        cell = json.load(handle)
+    envelope = None
+    if args.envelope:
+        with open(args.envelope, "r", encoding="utf-8") as handle:
+            envelope = json.load(handle)
+    report = compose(cell, envelope)
+    if args.format == "json":
+        sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(render_text(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run(_parse_args()))

--- a/examples/attested-shape-demo/fixtures/cell.json
+++ b/examples/attested-shape-demo/fixtures/cell.json
@@ -1,0 +1,12 @@
+{
+  "_demo": "SYNTHETIC DEMONSTRATOR — fabricated data, not a real attestation",
+  "schema": "assay.observability.claim_class_cell.v0",
+  "claim_type": "measured_filesystem_paths_touched_drift",
+  "artifact_role": "joined_artifacts",
+  "claim_strength": "strong",
+  "claim_basis": "attested",
+  "subject_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+  "evidence_refs": ["synthetic-attestation-envelope.json"],
+  "notes": ["synthetic cell exploring the shape of an attested-basis claim"],
+  "non_claims": ["not_a_real_attestation", "demonstrator_only"]
+}

--- a/examples/attested-shape-demo/fixtures/envelope_unverified.json
+++ b/examples/attested-shape-demo/fixtures/envelope_unverified.json
@@ -1,0 +1,13 @@
+{
+  "_demo": "SYNTHETIC DEMONSTRATOR — envelope present but not verified",
+  "envelope_type": "synthetic-demo",
+  "subject_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+  "statement": {
+    "predicate": "synthetic-coverage-attestation",
+    "note": "illustrative only"
+  },
+  "verification": {
+    "status": "unverified",
+    "note": "decided by this flag, not by any real verification"
+  }
+}

--- a/examples/attested-shape-demo/fixtures/envelope_verified.json
+++ b/examples/attested-shape-demo/fixtures/envelope_verified.json
@@ -1,0 +1,13 @@
+{
+  "_demo": "SYNTHETIC DEMONSTRATOR — fabricated envelope, no cryptography performed",
+  "envelope_type": "synthetic-demo",
+  "subject_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+  "statement": {
+    "predicate": "synthetic-coverage-attestation",
+    "note": "illustrative only; binds a fabricated subject digest to a fabricated statement"
+  },
+  "verification": {
+    "status": "verified",
+    "note": "decided by this flag, not by any real verification"
+  }
+}

--- a/examples/attested-shape-demo/fixtures/envelope_wrong_subject.json
+++ b/examples/attested-shape-demo/fixtures/envelope_wrong_subject.json
@@ -1,0 +1,13 @@
+{
+  "_demo": "SYNTHETIC DEMONSTRATOR — verifies but binds to a different subject",
+  "envelope_type": "synthetic-demo",
+  "subject_digest": "sha256:00000000000000000000000000000000000000000000000000000000000000ff",
+  "statement": {
+    "predicate": "synthetic-coverage-attestation",
+    "note": "illustrative only; subject digest deliberately does not match the cell"
+  },
+  "verification": {
+    "status": "verified",
+    "note": "decided by this flag, not by any real verification"
+  }
+}

--- a/examples/attested-shape-demo/test_compose_attested.py
+++ b/examples/attested-shape-demo/test_compose_attested.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Stdlib unittest suite for the attested-shape synthetic demonstrator.
+
+Run: python3 -m unittest discover -s examples/attested-shape-demo -p 'test_*.py'
+
+Reminder: the subject under test is a SYNTHETIC DEMONSTRATOR. These tests assert
+the composition SHAPE, not any real attestation behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+
+import compose_attested as ca
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIXTURES = os.path.join(HERE, "fixtures")
+
+
+def _load(name: str) -> dict:
+    with open(os.path.join(FIXTURES, name), "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+class AtMostTests(unittest.TestCase):
+    def test_caps_to_ceiling(self) -> None:
+        self.assertEqual(ca._at_most("strong", "weak"), "weak")
+
+    def test_keeps_lower(self) -> None:
+        self.assertEqual(ca._at_most("absent", "strong"), "absent")
+
+    def test_equal(self) -> None:
+        self.assertEqual(ca._at_most("partial", "partial"), "partial")
+
+
+class ComposeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cell = _load("cell.json")
+
+    def test_no_envelope_degrades(self) -> None:
+        report = ca.compose(self.cell, None)
+        self.assertEqual(report["effective_strength"], "weak")
+        self.assertEqual(report["effective_basis"], "inferred")
+
+    def test_verified_matching_subject_stands(self) -> None:
+        report = ca.compose(self.cell, _load("envelope_verified.json"))
+        self.assertEqual(report["effective_strength"], "strong")
+        self.assertEqual(report["effective_basis"], "attested")
+
+    def test_verified_wrong_subject_degrades(self) -> None:
+        report = ca.compose(self.cell, _load("envelope_wrong_subject.json"))
+        self.assertEqual(report["effective_strength"], "weak")
+        self.assertEqual(report["effective_basis"], "inferred")
+        self.assertIn("does not cover this subject", report["reason"])
+
+    def test_unverified_envelope_degrades(self) -> None:
+        report = ca.compose(self.cell, _load("envelope_unverified.json"))
+        self.assertEqual(report["effective_strength"], "weak")
+        self.assertEqual(report["effective_basis"], "inferred")
+        self.assertIn("not evidence", report["reason"])
+
+    def test_declared_weak_never_upgraded(self) -> None:
+        # A verified, matching envelope must not upgrade a cell that only
+        # declared a weak claim — composition can cap but never inflate.
+        weak_cell = dict(self.cell, claim_strength="weak")
+        report = ca.compose(weak_cell, _load("envelope_verified.json"))
+        self.assertEqual(report["effective_strength"], "weak")
+
+    def test_report_always_carries_demo_banner(self) -> None:
+        for env in (None, _load("envelope_verified.json")):
+            report = ca.compose(self.cell, env)
+            self.assertEqual(report["demo"], ca.DEMO_BANNER)
+
+
+class RenderTests(unittest.TestCase):
+    def test_text_render_includes_banner(self) -> None:
+        out = ca.render_text(ca.compose(_load("cell.json"), None))
+        self.assertIn(ca.DEMO_BANNER, out)
+        self.assertIn("effective:", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds `examples/attested-shape-demo/` — a **clearly-labelled synthetic demonstrator** exploring the shape a fifth claim basis (`attested`) could take. It implements no real attestation mechanism, adds nothing to the schema, and all fixtures are fabricated demo data ("verification" is decided by a flag, no cryptography).

## Why

So the idea can be reasoned about on engineering merit. The teaching point is the composition rule, which follows the same evidence-first discipline the measured/derived cells already use: an attested claim is only as strong as a verifiable envelope that binds to the same subject digest — otherwise it degrades to `inferred`/`weak`. Composition can cap a claim but never inflate it.

| Envelope state | Effective result |
|---|---|
| none | degrade to `inferred`, capped at `weak` |
| present, not verified | degrade (unverifiable envelope is not evidence) |
| verified, subject mismatch | degrade (does not cover this subject) |
| verified, subject match | declared strength stands |

## Scope

Demonstrator only — no Runner/contract/schema change. Stdlib `unittest` suite (10 tests) + synthetic fixtures + heavily-labelled README.

```
python3 -m unittest discover -s examples/attested-shape-demo -p 'test_*.py'
```