### PR TITLE
docs: make the coverage-honesty example chain discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Documentation: grouped the coverage-honesty examples under a single
+  "Coverage honesty" section in the examples index, with the end-to-end
+  walkthrough as the entry point, so the capture → coverage descriptor →
+  annotation → enforcement → aggregation chain is discoverable in one place.
+  Also added Runner reference docs for the address-less and non-IP
+  `sendto`/`sendmsg` send counters. Documentation only; no schema, archive,
+  CLI output, or other contract change.
+
 ## [3.16.0] - 2026-06-04
 
 - Added `assay evidence verify-mcp-tunnel-observed`, a bounded consumer-side

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,38 @@ Ready-to-use examples to get started with Assay.
 Wrap an MCP server with policy enforcement in under 2 minutes.
 See ALLOW/DENY decisions for every tool call.
 
+## Coverage honesty
+
+How Assay keeps a coverage claim no stronger than the observation behind it —
+capture, then a completeness ceiling, then claim cells, then enforcement and
+aggregation. Every stage degrades rather than inflates when evidence is missing.
+Start with the walkthrough; it links the runnable pieces in order.
+
+### [Coverage Honesty Walkthrough](./coverage-honesty-walkthrough)
+The whole chain in one place: capture → coverage descriptor → annotation →
+enforcement → aggregation, plus the synthetic attestation-shape demonstrator.
+A reading guide that points at each runnable example below.
+
+### [Coverage-Aware Side-Effect Report](./coverage-aware-side-effect)
+Single-archive sample that reads a runner archive and reports observed effects
+with the coverage descriptor that bounds them.
+
+### [Coverage-Aware Drift Annotation](./coverage-aware-drift-annotation)
+Turn a cross-runtime drift report into honest claim cells (strength × basis),
+capped by the coverage descriptor.
+
+### [Coverage-Claims Gate](./coverage-claims-gate)
+A dependency-free consumer that mechanically permits or blocks asserted coverage
+claims against an annotation — enforcement, not just documentation.
+
+### [Coverage Fleet Summary](./coverage-fleet-summary)
+Fold many annotations into one fleet-level honesty summary, including the fleet
+floor: the strongest positive claim supportable across *every* run.
+
+### [Attested-Claim Composition Shape](./attested-shape-demo)
+A clearly-labelled synthetic demonstrator of how a verifiable, subject-bound
+claim would compose — degrading unless verified. No real attestation mechanism.
+
 ## Inventory examples
 
 ### [CycloneDX ML-BOM Model Component Evidence](./cyclonedx-mlbom-model-component-evidence)


### PR DESCRIPTION
## What

Adds a single **Coverage honesty** section to `examples/README.md` that groups the existing coverage examples in chain order, with the end-to-end walkthrough as the entry point:

capture → coverage descriptor → annotation → enforcement → aggregation (+ the synthetic attestation-shape demonstrator).

Plus one `[Unreleased]` CHANGELOG line noting the grouping and the new Runner send-counter reference docs (`send-no-recoverable-peer-counter.md`, `send-non-ip-family-counter.md`).

## Why

The pieces existed but were scattered across the index; this makes the whole honesty story findable in one place.

## Scope

Documentation only — no schema, archive member, CLI output, or other contract change. All linked example directories exist on main.