### PR TITLE
[codex] Freeze Wave53 hotspot refactor

### DIFF
--- a/docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md
@@ -1,0 +1,12 @@
+# Wave53 Step1 Checklist - Top 2-9 Hotspot Freeze
+
+- [ ] Plan exists: `docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md`
+- [ ] Move-map exists: `docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md`
+- [ ] Review pack exists: `docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md`
+- [ ] Review script exists: `scripts/ci/review-wave53-hotspot-top2-9-step1.sh`
+- [ ] Wave53 scope is fixed to the selected top 2-9 snapshot, not dynamic current LOC order
+- [ ] `crates/assay-ebpf/src/vmlinux.rs` is explicitly out of scope
+- [ ] Step1 has no Rust source edits in the Wave53 target files
+- [ ] Step1 has no test edits
+- [ ] Step1 has no workflow edits
+- [ ] `bash scripts/ci/review-wave53-hotspot-top2-9-step1.sh` passes

--- a/docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md
@@ -1,0 +1,40 @@
+# SPLIT MOVE MAP - Wave53 Step1 - Top 2-9 Hotspot Freeze
+
+## Step1 Movement
+
+Step1 moves no Rust code.
+
+The only allowed Step1 changes are planning and review-gate artifacts:
+
+- `docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md`
+- `scripts/ci/review-wave53-hotspot-top2-9-step1.sh`
+
+## Frozen Target Files
+
+Wave53 freezes these selected hotspot files for later mechanical splits:
+
+- `crates/assay-runner-core/src/kernel.rs`
+- `crates/assay-cli/src/cli/commands/runner_spike.rs`
+- `crates/assay-ebpf/src/main.rs`
+- `crates/assay-registry/src/lockfile.rs`
+- `crates/assay-core/src/mcp/policy/mod.rs`
+- `crates/assay-cli/src/cli/commands/bundle.rs`
+- `crates/assay-core/src/report/summary.rs`
+- `crates/assay-cli/src/cli/commands/doctor.rs`
+
+## Explicit Non-Movement
+
+- No edits under `crates/**/src/**/*.rs` in Step1.
+- No edits under `crates/**/tests/**` in Step1.
+- No edits under `.github/workflows/**`.
+- No edits to `crates/assay-ebpf/src/vmlinux.rs`.
+
+## Later Mechanical Direction
+
+Step2 starts with the high-readiness files: `lockfile.rs`, `summary.rs`, and `bundle.rs`.
+Step3 handles CLI command splits for `runner_spike.rs` and `doctor.rs`.
+Step4 handles runner/eBPF boundaries for `kernel.rs` and `assay-ebpf/src/main.rs`.
+Step5 handles the high-risk policy facade in `mcp/policy/mod.rs`.

--- a/docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md
+++ b/docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md
@@ -1,0 +1,368 @@
+# SPLIT PLAN - Wave53 Top 2-9 Rust Hotspot Refactor
+
+## Intent
+
+Refactor the selected top 2 through 9 handwritten Rust hotspots behind stable facades in one
+coordinated wave.
+
+This wave follows the user-selected top 2 through 9 set from the prior hotspot snapshot, excluding
+generated `crates/assay-ebpf/src/vmlinux.rs`. Later repo-root inventories may move other files above
+or below this set; Wave53 scope must not drift just because a later branch changes LOC ordering. The
+goal is reviewability and ownership clarity, not feature work.
+
+## Scope
+
+| Rank | File | Baseline LOC | Crate | Readiness | Target shape |
+| ---: | --- | ---: | --- | --- | --- |
+| 2 | `crates/assay-runner-core/src/kernel.rs` | 992 | `assay-runner-core` | Medium | stable `kernel.rs` facade over `kernel/*` |
+| 3 | `crates/assay-cli/src/cli/commands/runner_spike.rs` | 686 | `assay-cli` | Medium | command facade over `runner_spike/*` |
+| 4 | `crates/assay-ebpf/src/main.rs` | 559 | `assay-ebpf` | Low | conservative eBPF helpers split, tracepoint names unchanged |
+| 5 | `crates/assay-registry/src/lockfile.rs` | 649 | `assay-registry` | High | finish thin facade over existing `lockfile_next/*` |
+| 6 | `crates/assay-core/src/mcp/policy/mod.rs` | 636 | `assay-core` | Low | policy public surface facade, no policy behavior drift |
+| 7 | `crates/assay-cli/src/cli/commands/bundle.rs` | 632 | `assay-cli` | High | command facade over `bundle/*` |
+| 8 | `crates/assay-core/src/report/summary.rs` | 629 | `assay-core` | High | report facade over `summary/*` |
+| 9 | `crates/assay-cli/src/cli/commands/doctor.rs` | 629 | `assay-cli` | Medium | command facade over `doctor/*` |
+
+`crates/assay-ebpf/src/vmlinux.rs` remains out of scope because it is generated kernel binding
+surface.
+
+Current repo-root inventory on `codex/runner-otel-slice12-harness` shows additional large files
+above `crates/assay-ebpf/src/main.rs`, including evidence schema-generation files. Those are not
+added to Wave53 without a separate scope decision.
+
+## Relation To Existing Waves
+
+Wave51 covers different large hotspots:
+
+- `crates/assay-core/src/engine/runner.rs`
+- `crates/assay-cli/src/cli/commands/sandbox.rs`
+- `crates/assay-core/src/mcp/proxy.rs`
+- `crates/assay-evidence/src/trust_basis.rs`
+
+Wave53 must not take over Wave51 scope. Wave53 may reuse its gate style: freeze first, keep facades,
+move bodies mechanically, and close with review artifacts.
+
+Older waves already touched two Wave53 files:
+
+- `lockfile.rs` has an existing `lockfile_next/*` direction from Wave4. Wave53 should finish facade
+  thinning and closure only.
+- `mcp/policy/mod.rs` has existing policy-engine and MCP policy history. Wave53 must treat it as a
+  contract file, not a cleanup target.
+
+## Standing Rules
+
+1. Preserve public APIs, command names, exit codes, JSON output, CloudEvent/MCP shapes, reason codes,
+   policy semantics, and eBPF tracepoint names.
+2. Keep the current top-level files as stable facades.
+3. Move implementation bodies 1:1 before any cleanup.
+4. Keep module visibility crate-private unless an existing public API already requires broader
+   visibility.
+5. Do not edit `.github/workflows/`.
+6. Do not change generated `vmlinux.rs`.
+7. Do not mix performance tuning, dependency changes, formatting churn, or behavior cleanup into
+   mechanical split commits.
+8. Every step gets a checklist, move-map, review-pack, and `scripts/ci/review-wave53-...sh` gate.
+
+## Frozen Public Surface
+
+Wave53 freezes the following surfaces.
+
+For `kernel.rs`:
+
+- `KernelLayerEvent`
+- `KernelLayerCapture`
+- `KernelLayerError`
+- `KernelLayerBuilder`
+- event decoding and health-note meaning
+
+For `runner_spike.rs`:
+
+- `RunnerSpikeArgs`
+- `RunnerSpikeCommand`
+- `RunnerSpikeRunArgs`
+- CLI output, bundle output paths, cgroup behavior, kernel-capture env wiring, and exit-status
+  mapping
+
+For `assay-ebpf/src/main.rs`:
+
+- tracepoint program names
+- map names and event struct compatibility
+- open/connect/fork event meaning
+- loader-path filtering and dedup semantics
+
+For `lockfile.rs`:
+
+- `Lockfile`
+- `LockedPack`
+- `LockSource`
+- `LockSignature`
+- `VerifyLockResult`
+- `LockMismatch`
+- parse, format, digest, load, save, check, update behavior
+
+For `mcp/policy/mod.rs`:
+
+- `McpPolicy`
+- `EnforcementSettings`
+- `ToolPolicy`
+- `PolicyEvaluation`
+- `PolicyDecision`
+- `TypedPolicyDecision`
+- `PolicyObligation`
+- `ApprovalArtifact`
+- contract structs, reason-code strings, deserialization compatibility, and pattern matching
+
+For `bundle.rs`:
+
+- `bundle create` and `bundle verify` behavior
+- run-id and seed extraction
+- input-coverage enforcement
+- source-root/path selection
+- archive contents and missing-input handling
+
+For `summary.rs`:
+
+- `Summary`
+- `SarifOutputInfo`
+- `Seeds`
+- `JudgeMetrics`
+- `Provenance`
+- `ResultsSummary`
+- `PerformanceMetrics`
+- `SlowestTest`
+- `PhaseTimings`
+- `judge_metrics_from_results`
+- `write_summary`
+
+For `doctor.rs`:
+
+- diagnostics rendering
+- fix preview/apply behavior
+- suggested-patch matching
+- trace fix targets
+- YAML unknown-field repair behavior
+
+## Planned Layout
+
+Step2 high-readiness split:
+
+```text
+crates/assay-registry/src/lockfile.rs
+crates/assay-registry/src/lockfile_next/
+  mod.rs
+  model.rs
+  source.rs
+  signature.rs
+  verify.rs
+
+crates/assay-core/src/report/summary.rs
+crates/assay-core/src/report/summary/
+  types.rs
+  metrics.rs
+  writer.rs
+
+crates/assay-cli/src/cli/commands/bundle.rs
+crates/assay-cli/src/cli/commands/bundle/
+  create.rs
+  verify.rs
+  paths.rs
+  coverage.rs
+```
+
+Step3 CLI medium-readiness split:
+
+```text
+crates/assay-cli/src/cli/commands/runner_spike.rs
+crates/assay-cli/src/cli/commands/runner_spike/
+  args.rs
+  spec.rs
+  phases.rs
+  cgroup.rs
+  logs.rs
+  exit_status.rs
+
+crates/assay-cli/src/cli/commands/doctor.rs
+crates/assay-cli/src/cli/commands/doctor/
+  fixes.rs
+  patching.rs
+  parse_error.rs
+  preview.rs
+```
+
+Step4 runner/eBPF split:
+
+```text
+crates/assay-runner-core/src/kernel.rs
+crates/assay-runner-core/src/kernel/
+  decode.rs
+  stats.rs
+  health.rs
+  notes.rs
+
+crates/assay-ebpf/src/main.rs
+crates/assay-ebpf/src/
+  open_events.rs
+  connect_events.rs
+  fork_events.rs
+  path_filter.rs
+```
+
+Step5 policy-mod split:
+
+```text
+crates/assay-core/src/mcp/policy/mod.rs
+crates/assay-core/src/mcp/policy/
+  types.rs
+  deserialize.rs
+  matcher.rs
+  contracts.rs
+```
+
+Existing directories such as `engine_next/*` remain in place. Step5 is about thinning
+`mcp/policy/mod.rs`, not redesigning the policy engine.
+
+For files that already exist as `foo.rs`, the split modules live under `foo/*.rs` and are declared
+from the facade with `mod child;`. Do not add a sibling `foo/mod.rs`, because that would conflict
+with the existing facade module.
+
+## Step Structure
+
+### Step1 - Freeze and gates
+
+Docs and gate only.
+
+Deliverables:
+
+- `docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md`
+- `scripts/ci/review-wave53-hotspot-top2-9-step1.sh`
+
+Step1 constraints:
+
+- no edits under `crates/**/src/**/*.rs`
+- no edits under `crates/**/tests/**`
+- no workflow edits
+- no generated-file edits
+
+### Step2 - High-readiness mechanical split
+
+Targets:
+
+- `crates/assay-registry/src/lockfile.rs`
+- `crates/assay-core/src/report/summary.rs`
+- `crates/assay-cli/src/cli/commands/bundle.rs`
+
+Acceptance:
+
+- facade files delegate to internal modules
+- no output or serialization drift
+- `lockfile.rs` keeps existing public data types stable
+- `summary.rs` keeps summary JSON stable
+- `bundle.rs` keeps archive and coverage behavior stable
+
+### Step3 - CLI command split
+
+Targets:
+
+- `crates/assay-cli/src/cli/commands/runner_spike.rs`
+- `crates/assay-cli/src/cli/commands/doctor.rs`
+
+Acceptance:
+
+- command enum wiring is unchanged
+- exit codes and stdout/stderr behavior are unchanged
+- cgroup and kernel-capture behavior are unchanged
+- doctor fix preview/apply behavior is unchanged
+
+### Step4 - Runner and eBPF split
+
+Targets:
+
+- `crates/assay-runner-core/src/kernel.rs`
+- `crates/assay-ebpf/src/main.rs`
+
+Acceptance:
+
+- kernel event decoding is unchanged
+- health-note strings and cgroup correlation behavior are unchanged
+- eBPF tracepoint names, map names, and event payloads are unchanged
+- no changes to `vmlinux.rs`
+
+### Step5 - Policy facade split and closure
+
+Target:
+
+- `crates/assay-core/src/mcp/policy/mod.rs`
+
+Acceptance:
+
+- YAML/JSON deserialization compatibility is unchanged
+- policy decision semantics are unchanged
+- reason-code strings are unchanged
+- existing `engine_next/*` behavior is untouched
+- final review pack lists LOC deltas and residual hotspots
+
+## Required Gates
+
+Every step:
+
+```bash
+cargo fmt --check
+git diff --check
+```
+
+Per-crate gates:
+
+```bash
+cargo check -p assay-registry
+cargo test -q -p assay-registry
+
+cargo check -p assay-core
+cargo test -q -p assay-core --test policy_engine_test
+cargo test -q -p assay-core --lib report::summary
+
+cargo check -p assay-cli
+cargo test -q -p assay-cli
+
+cargo check -p assay-runner-core
+cargo test -q -p assay-runner-core
+
+cargo check -p assay-ebpf
+```
+
+Medium and high-risk shared-code steps also run:
+
+```bash
+cargo clippy -p assay-registry --all-targets -- -D warnings
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo clippy -p assay-cli --all-targets -- -D warnings
+cargo clippy -p assay-runner-core --all-targets -- -D warnings
+```
+
+The eBPF step must use the crate's existing supported check path. If `cargo check -p assay-ebpf`
+requires host/kernel prerequisites that are unavailable on the reviewer machine, the review pack must
+show the exact failing prerequisite and the fallback command that was run.
+
+## Reviewer Failure Modes
+
+- changing policy behavior while moving policy types
+- changing CLI output or exit codes while splitting command files
+- changing summary JSON or bundle archive contents while moving helpers
+- widening visibility to make moves compile faster
+- touching generated `vmlinux.rs`
+- using the one-wave label to batch unrelated cleanup
+
+## Promotion Shape
+
+The preferred stacked PR order is:
+
+1. Step1 freeze and gates
+2. Step2 high-readiness split
+3. Step3 CLI split
+4. Step4 runner/eBPF split
+5. Step5 policy facade split and closure
+
+Each step can merge independently after its review script passes. The final closure PR should update
+the review pack with actual LOC deltas and any deferred follow-up work.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md
@@ -1,0 +1,51 @@
+# SPLIT REVIEW PACK - Wave53 Step1 - Top 2-9 Hotspot Freeze
+
+## Scope
+
+Step1 freezes the Wave53 selected hotspot scope and adds the reviewer gate. It is docs plus script
+only.
+
+## Files
+
+- `docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md`
+- `scripts/ci/review-wave53-hotspot-top2-9-step1.sh`
+
+## Baseline Note
+
+The active repo-root inventory currently puts additional files above `crates/assay-ebpf/src/main.rs`.
+Wave53 intentionally keeps the earlier selected 2-9 snapshot instead of expanding scope mid-wave.
+Evidence schema-generation files and `coverage.rs` are not part of this wave.
+
+## Verification
+
+```bash
+bash scripts/ci/review-wave53-hotspot-top2-9-step1.sh
+```
+
+For a clean Step1 PR branch, run the same gate with an explicit base ref:
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave53-hotspot-top2-9-step1.sh
+```
+
+The default local mode is intentionally tolerant of unrelated dirty Rust files because this branch
+already contains work outside Wave53. Explicit `BASE_REF` mode keeps the stricter full
+`cargo fmt --check` path for clean review branches.
+
+## Reviewer Focus
+
+- Confirm the wave does not overlap Wave51 scope.
+- Confirm generated `crates/assay-ebpf/src/vmlinux.rs` stays out of scope.
+- Confirm Step1 contains no Rust source, test, or workflow edits.
+- Confirm later steps preserve stable facades before moving implementation bodies.
+
+## Follow-Up
+
+Step2 should create the high-readiness mechanical split for:
+
+- `crates/assay-registry/src/lockfile.rs`
+- `crates/assay-core/src/report/summary.rs`
+- `crates/assay-cli/src/cli/commands/bundle.rs`

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md
@@ -32,8 +32,8 @@ BASE_REF=origin/main bash scripts/ci/review-wave53-hotspot-top2-9-step1.sh
 ```
 
 The default local mode is intentionally tolerant of unrelated dirty Rust files because this branch
-already contains work outside Wave53. Explicit `BASE_REF` mode keeps the stricter full
-`cargo fmt --check` path for clean review branches.
+already contains work outside Wave53. Explicit `BASE_REF` mode keeps strict Step1 diff scope checks;
+the script runs full `cargo fmt --check` only when the local Rust worktree is clean.
 
 ## Reviewer Focus
 

--- a/docs/superpowers/plans/2026-06-05-assay-wave53-hotspot-top2-9-refactor.md
+++ b/docs/superpowers/plans/2026-06-05-assay-wave53-hotspot-top2-9-refactor.md
@@ -1,0 +1,531 @@
+# Assay Wave53 Hotspot Top 2-9 Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Execute Wave53 as one coordinated refactor wave for the selected top 2 through 9 handwritten Rust hotspot files while preserving all public behavior.
+
+**Architecture:** Keep each current hotspot file as the stable facade and move implementation bodies into private modules. Use Step1 to freeze behavior and gates, then split by readiness: high-readiness pure/data paths first, CLI orchestration next, runner/eBPF paths next, and policy facade last.
+
+**Tech Stack:** Rust workspace, Cargo, Bash reviewer scripts, existing Assay SPLIT-* documentation pattern.
+
+---
+
+## File Structure
+
+Create during Step1:
+
+- `docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md`
+- `scripts/ci/review-wave53-hotspot-top2-9-step1.sh`
+
+Create during Step2:
+
+- `crates/assay-registry/src/lockfile_next/model.rs`
+- `crates/assay-registry/src/lockfile_next/source.rs`
+- `crates/assay-registry/src/lockfile_next/signature.rs`
+- `crates/assay-registry/src/lockfile_next/verify.rs`
+- `crates/assay-core/src/report/summary/types.rs`
+- `crates/assay-core/src/report/summary/metrics.rs`
+- `crates/assay-core/src/report/summary/writer.rs`
+- `crates/assay-cli/src/cli/commands/bundle/create.rs`
+- `crates/assay-cli/src/cli/commands/bundle/verify.rs`
+- `crates/assay-cli/src/cli/commands/bundle/paths.rs`
+- `crates/assay-cli/src/cli/commands/bundle/coverage.rs`
+
+Create during Step3:
+
+- `crates/assay-cli/src/cli/commands/runner_spike/args.rs`
+- `crates/assay-cli/src/cli/commands/runner_spike/spec.rs`
+- `crates/assay-cli/src/cli/commands/runner_spike/phases.rs`
+- `crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs`
+- `crates/assay-cli/src/cli/commands/runner_spike/logs.rs`
+- `crates/assay-cli/src/cli/commands/runner_spike/exit_status.rs`
+- `crates/assay-cli/src/cli/commands/doctor/fixes.rs`
+- `crates/assay-cli/src/cli/commands/doctor/patching.rs`
+- `crates/assay-cli/src/cli/commands/doctor/parse_error.rs`
+- `crates/assay-cli/src/cli/commands/doctor/preview.rs`
+
+Create during Step4:
+
+- `crates/assay-runner-core/src/kernel/decode.rs`
+- `crates/assay-runner-core/src/kernel/stats.rs`
+- `crates/assay-runner-core/src/kernel/health.rs`
+- `crates/assay-runner-core/src/kernel/notes.rs`
+- `crates/assay-ebpf/src/open_events.rs`
+- `crates/assay-ebpf/src/connect_events.rs`
+- `crates/assay-ebpf/src/fork_events.rs`
+- `crates/assay-ebpf/src/path_filter.rs`
+
+Create during Step5:
+
+- `crates/assay-core/src/mcp/policy/types.rs`
+- `crates/assay-core/src/mcp/policy/deserialize.rs`
+- `crates/assay-core/src/mcp/policy/matcher.rs`
+- `crates/assay-core/src/mcp/policy/contracts.rs`
+
+Each step also creates its own checklist, move-map, review-pack, and review script following the
+Step1 naming pattern with `step2`, `step3`, `step4`, or `step5`.
+
+For existing facade files such as `summary.rs`, `bundle.rs`, `runner_spike.rs`, `doctor.rs`, and
+`kernel.rs`, declare child modules directly from the facade with `mod types;`, `mod create;`, and
+similar names. Do not add `summary/mod.rs`, `bundle/mod.rs`, `runner_spike/mod.rs`, `doctor/mod.rs`,
+or `kernel/mod.rs`.
+
+### Task 1: Step1 Freeze And Review Gate
+
+**Files:**
+
+- Modify: `docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md`
+- Create: `docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md`
+- Create: `docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md`
+- Create: `docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md`
+- Create: `scripts/ci/review-wave53-hotspot-top2-9-step1.sh`
+
+- [ ] **Step 1: Record baseline inventory**
+
+Run:
+
+```bash
+rg --files -g '*.rs' | xargs wc -l | sort -nr | sed -n '1,12p'
+```
+
+Expected: the inventory is recorded for context. If current LOC order differs from the selected
+Wave53 snapshot, keep Wave53 scope fixed to the plan and do not substitute new files mid-wave.
+
+- [ ] **Step 2: Write Step1 checklist**
+
+Create a checklist with these entries:
+
+```markdown
+# Wave53 Step1 Checklist - Top 2-9 Hotspot Freeze
+
+- [ ] Plan exists: `docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md`
+- [ ] Move-map exists: `docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md`
+- [ ] Review pack exists: `docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md`
+- [ ] Review script exists: `scripts/ci/review-wave53-hotspot-top2-9-step1.sh`
+- [ ] No Rust source files changed in Step1
+- [ ] No test files changed in Step1
+- [ ] No workflow files changed in Step1
+- [ ] `bash scripts/ci/review-wave53-hotspot-top2-9-step1.sh` passes
+```
+
+- [ ] **Step 3: Write Step1 move-map**
+
+Create a move-map that states Step1 moves no Rust code and freezes the target files listed in the
+Wave53 plan.
+
+- [ ] **Step 4: Write Step1 review pack**
+
+Include:
+
+````markdown
+# SPLIT REVIEW PACK - Wave53 Step1 - Top 2-9 Hotspot Freeze
+
+## Scope
+
+Docs and gate only for Wave53.
+
+## Verification
+
+```bash
+bash scripts/ci/review-wave53-hotspot-top2-9-step1.sh
+```
+
+## Reviewer Focus
+
+- Confirm the wave does not overlap Wave51 scope.
+- Confirm generated `vmlinux.rs` is out of scope.
+- Confirm Step2 through Step5 preserve stable facades.
+````
+
+- [ ] **Step 5: Write Step1 review script**
+
+Use this script body:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-origin/main}"
+
+changed="$(git diff --name-only "$base_ref"...HEAD)"
+
+if printf '%s\n' "$changed" | rg '^\.github/workflows/' >/dev/null; then
+  echo "FAIL: workflow edits are out of scope for Wave53 Step1"
+  exit 1
+fi
+
+if printf '%s\n' "$changed" | rg '^crates/.+\.rs$|^crates/.+/tests/' >/dev/null; then
+  echo "FAIL: Rust source/test edits are out of scope for Wave53 Step1"
+  exit 1
+fi
+
+required=(
+  "docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md"
+  "scripts/ci/review-wave53-hotspot-top2-9-step1.sh"
+)
+
+for path in "${required[@]}"; do
+  test -f "$path" || {
+    echo "FAIL: missing required file: $path"
+    exit 1
+  }
+done
+
+rg -n 'vmlinux\.rs.*out of scope|generated `vmlinux\.rs`' \
+  docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md >/dev/null
+
+cargo fmt --check
+git diff --check
+
+echo "PASS: Wave53 Step1 freeze gate"
+```
+
+- [ ] **Step 6: Verify Step1**
+
+Run:
+
+```bash
+chmod +x scripts/ci/review-wave53-hotspot-top2-9-step1.sh
+bash scripts/ci/review-wave53-hotspot-top2-9-step1.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Step1**
+
+Run:
+
+```bash
+git add docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md \
+  docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md \
+  docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md \
+  docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md \
+  scripts/ci/review-wave53-hotspot-top2-9-step1.sh
+git commit -m "docs: freeze wave53 hotspot refactor"
+```
+
+### Task 2: Step2 High-Readiness Split
+
+**Files:**
+
+- Modify: `crates/assay-registry/src/lockfile.rs`
+- Modify: `crates/assay-registry/src/lockfile_next/mod.rs`
+- Create/modify: `crates/assay-registry/src/lockfile_next/{model,source,signature,verify}.rs`
+- Modify: `crates/assay-core/src/report/summary.rs`
+- Create: `crates/assay-core/src/report/summary/{mod,types,metrics,writer}.rs`
+- Modify: `crates/assay-cli/src/cli/commands/bundle.rs`
+- Create: `crates/assay-cli/src/cli/commands/bundle/{mod,create,verify,paths,coverage}.rs`
+- Create: Step2 checklist, move-map, review-pack, review script
+
+- [ ] **Step 1: Write or identify contract tests**
+
+Run:
+
+```bash
+cargo test -q -p assay-registry
+cargo test -q -p assay-core --lib report::summary
+cargo test -q -p assay-cli -- bundle
+```
+
+Expected: existing tests pass or the failing selector is replaced in the review pack with the exact
+available test selectors that cover lockfile, summary, and bundle behavior.
+
+- [ ] **Step 2: Split `summary.rs`**
+
+Move public structs into `summary/types.rs`, `judge_metrics_from_results` into `summary/metrics.rs`,
+and `write_summary` into `summary/writer.rs`. Keep `summary.rs` as facade:
+
+```rust
+mod metrics;
+mod types;
+mod writer;
+
+pub use metrics::judge_metrics_from_results;
+pub use types::{
+    JudgeMetrics, PerformanceMetrics, PhaseTimings, Provenance, ResultsSummary, SarifOutputInfo,
+    Seeds, SlowestTest, Summary,
+};
+pub use writer::write_summary;
+```
+
+- [ ] **Step 3: Split `bundle.rs`**
+
+Move `cmd_create` and run-json extraction helpers into `bundle/create.rs`, `cmd_verify` into
+`bundle/verify.rs`, path selection helpers into `bundle/paths.rs`, and replay coverage helpers into
+`bundle/coverage.rs`. Keep `bundle.rs` as the command facade and preserve existing command entrypoint
+names.
+
+- [ ] **Step 4: Finish `lockfile.rs` facade thinning**
+
+Use existing `lockfile_next/*` where present. Move remaining model/source/signature/verify helper
+bodies into the new modules only when the move is 1:1 and public types remain re-exported from
+`lockfile.rs`.
+
+- [ ] **Step 5: Verify Step2**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo check -p assay-registry
+cargo test -q -p assay-registry
+cargo clippy -p assay-registry --all-targets -- -D warnings
+cargo check -p assay-core
+cargo test -q -p assay-core --lib report::summary
+cargo clippy -p assay-core --all-targets -- -D warnings
+cargo check -p assay-cli
+cargo test -q -p assay-cli -- bundle
+cargo clippy -p assay-cli --all-targets -- -D warnings
+git diff --check
+bash scripts/ci/review-wave53-hotspot-top2-9-step2.sh
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit Step2**
+
+Run:
+
+```bash
+git add crates/assay-registry/src/lockfile.rs crates/assay-registry/src/lockfile_next \
+  crates/assay-core/src/report/summary.rs crates/assay-core/src/report/summary \
+  crates/assay-cli/src/cli/commands/bundle.rs crates/assay-cli/src/cli/commands/bundle \
+  docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step2.md \
+  docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step2.md \
+  docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step2.md \
+  scripts/ci/review-wave53-hotspot-top2-9-step2.sh
+git commit -m "refactor: split wave53 high-readiness hotspots"
+```
+
+### Task 3: Step3 CLI Command Split
+
+**Files:**
+
+- Modify: `crates/assay-cli/src/cli/commands/runner_spike.rs`
+- Create: `crates/assay-cli/src/cli/commands/runner_spike/{mod,args,spec,phases,cgroup,logs,exit_status}.rs`
+- Modify: `crates/assay-cli/src/cli/commands/doctor.rs`
+- Create: `crates/assay-cli/src/cli/commands/doctor/{mod,fixes,patching,parse_error,preview}.rs`
+- Create: Step3 checklist, move-map, review-pack, review script
+
+- [ ] **Step 1: Characterize CLI behavior**
+
+Run:
+
+```bash
+cargo test -q -p assay-cli -- runner_spike
+cargo test -q -p assay-cli -- doctor
+```
+
+Expected: existing selectors pass, or the review pack records exact available selectors for these
+commands.
+
+- [ ] **Step 2: Split `runner_spike.rs`**
+
+Move argument/spec helpers into `args.rs` and `spec.rs`, phase timing into `phases.rs`, cgroup
+helpers into `cgroup.rs`, log decision helpers into `logs.rs`, and exit-status mapping into
+`exit_status.rs`. Keep public command structs visible through the facade.
+
+- [ ] **Step 3: Split `doctor.rs`**
+
+Move fix operation selection into `fixes.rs`, patch application/diff rendering into `patching.rs`,
+parse-error repair helpers into `parse_error.rs`, and preview output into `preview.rs`.
+
+- [ ] **Step 4: Verify Step3**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo check -p assay-cli
+cargo test -q -p assay-cli -- runner_spike
+cargo test -q -p assay-cli -- doctor
+cargo clippy -p assay-cli --all-targets -- -D warnings
+git diff --check
+bash scripts/ci/review-wave53-hotspot-top2-9-step3.sh
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit Step3**
+
+Run:
+
+```bash
+git add crates/assay-cli/src/cli/commands/runner_spike.rs \
+  crates/assay-cli/src/cli/commands/runner_spike \
+  crates/assay-cli/src/cli/commands/doctor.rs \
+  crates/assay-cli/src/cli/commands/doctor \
+  docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step3.md \
+  docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step3.md \
+  docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step3.md \
+  scripts/ci/review-wave53-hotspot-top2-9-step3.sh
+git commit -m "refactor: split wave53 cli hotspots"
+```
+
+### Task 4: Step4 Runner And eBPF Split
+
+**Files:**
+
+- Modify: `crates/assay-runner-core/src/kernel.rs`
+- Create: `crates/assay-runner-core/src/kernel/{mod,decode,stats,health,notes}.rs`
+- Modify: `crates/assay-ebpf/src/main.rs`
+- Create: `crates/assay-ebpf/src/{open_events,connect_events,fork_events,path_filter}.rs`
+- Create: Step4 checklist, move-map, review-pack, review script
+
+- [ ] **Step 1: Characterize runner kernel behavior**
+
+Run:
+
+```bash
+cargo test -q -p assay-runner-core
+cargo check -p assay-runner-core
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Split `kernel.rs`**
+
+Move monitor-event decoding into `kernel/decode.rs`, stats delta/breakdown helpers into
+`kernel/stats.rs`, health classification into `kernel/health.rs`, and note rendering into
+`kernel/notes.rs`. Keep `KernelLayerBuilder` and public structs re-exported from `kernel.rs`.
+
+- [ ] **Step 3: Characterize eBPF build path**
+
+Run:
+
+```bash
+cargo check -p assay-ebpf
+```
+
+Expected: pass on configured eBPF hosts. If host prerequisites fail, record the exact stderr in the
+review pack and run the repo-supported fallback eBPF check from the existing CI scripts.
+
+- [ ] **Step 4: Split `assay-ebpf/src/main.rs` conservatively**
+
+Move open tracepoint helpers into `open_events.rs`, connect helpers into `connect_events.rs`, fork
+helpers into `fork_events.rs`, and loader/dedup path helpers into `path_filter.rs`. Keep tracepoint
+entry functions and map declarations in `main.rs` unless moving them is required by the existing eBPF
+crate pattern.
+
+- [ ] **Step 5: Verify Step4**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo check -p assay-runner-core
+cargo test -q -p assay-runner-core
+cargo clippy -p assay-runner-core --all-targets -- -D warnings
+cargo check -p assay-ebpf
+git diff --check
+bash scripts/ci/review-wave53-hotspot-top2-9-step4.sh
+```
+
+Expected: all configured checks pass, with any eBPF host prerequisite limitation recorded.
+
+- [ ] **Step 6: Commit Step4**
+
+Run:
+
+```bash
+git add crates/assay-runner-core/src/kernel.rs crates/assay-runner-core/src/kernel \
+  crates/assay-ebpf/src/main.rs crates/assay-ebpf/src/open_events.rs \
+  crates/assay-ebpf/src/connect_events.rs crates/assay-ebpf/src/fork_events.rs \
+  crates/assay-ebpf/src/path_filter.rs \
+  docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step4.md \
+  docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step4.md \
+  docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step4.md \
+  scripts/ci/review-wave53-hotspot-top2-9-step4.sh
+git commit -m "refactor: split wave53 runner and ebpf hotspots"
+```
+
+### Task 5: Step5 Policy Facade Split And Closure
+
+**Files:**
+
+- Modify: `crates/assay-core/src/mcp/policy/mod.rs`
+- Create: `crates/assay-core/src/mcp/policy/{types,deserialize,matcher,contracts}.rs`
+- Create: Step5 checklist, move-map, review-pack, review script
+
+- [ ] **Step 1: Freeze policy behavior**
+
+Run:
+
+```bash
+cargo test -q -p assay-core --test policy_engine_test
+cargo test -q -p assay-core --lib mcp::tests
+cargo test -q -p assay-cli --test e2e_policy_test
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Split policy public surface**
+
+Move public data types into `types.rs`, custom deserializers into `deserialize.rs`, pattern matching
+helpers into `matcher.rs`, and decision contract structs/helpers into `contracts.rs`. Keep
+`mcp/policy/mod.rs` as the stable public facade with `pub use` exports for existing consumers.
+
+- [ ] **Step 3: Verify no policy drift**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo check -p assay-core
+cargo test -q -p assay-core --test policy_engine_test
+cargo test -q -p assay-core --lib mcp::tests
+cargo test -q -p assay-cli --test e2e_policy_test
+cargo clippy -p assay-core --all-targets -- -D warnings
+git diff --check
+bash scripts/ci/review-wave53-hotspot-top2-9-step5.sh
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Update closure review pack**
+
+Record actual LOC deltas for all eight files:
+
+```bash
+wc -l crates/assay-runner-core/src/kernel.rs \
+  crates/assay-cli/src/cli/commands/runner_spike.rs \
+  crates/assay-ebpf/src/main.rs \
+  crates/assay-registry/src/lockfile.rs \
+  crates/assay-core/src/mcp/policy/mod.rs \
+  crates/assay-cli/src/cli/commands/bundle.rs \
+  crates/assay-core/src/report/summary.rs \
+  crates/assay-cli/src/cli/commands/doctor.rs
+```
+
+Expected: review pack includes before/after LOC and lists any remaining file above 500 LOC.
+
+- [ ] **Step 5: Commit Step5**
+
+Run:
+
+```bash
+git add crates/assay-core/src/mcp/policy/mod.rs \
+  crates/assay-core/src/mcp/policy/types.rs \
+  crates/assay-core/src/mcp/policy/deserialize.rs \
+  crates/assay-core/src/mcp/policy/matcher.rs \
+  crates/assay-core/src/mcp/policy/contracts.rs \
+  docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step5.md \
+  docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step5.md \
+  docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step5.md \
+  scripts/ci/review-wave53-hotspot-top2-9-step5.sh
+git commit -m "refactor: split wave53 policy facade"
+```
+
+## Self-Review
+
+- Spec coverage: covered all eight target files from ranks 2 through 9 and excluded generated
+  `vmlinux.rs`.
+- Scope control: Step1 is docs/gate only; Step2 through Step5 are ordered by readiness and crate risk.
+- Type consistency: public facade names match the Wave53 plan.
+- Verification: each task includes crate checks, targeted tests, review script execution, and commit
+  boundaries.

--- a/scripts/ci/review-wave53-hotspot-top2-9-step1.sh
+++ b/scripts/ci/review-wave53-hotspot-top2-9-step1.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_mode="working-tree"
+if [[ -n "${BASE_REF:-}" ]]; then
+  base_ref="$BASE_REF"
+fi
+
+if [[ -n "${base_ref:-}" ]] && git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  base_mode="base-ref"
+  changed="$(git diff --name-only "$base_ref"...HEAD)"
+else
+  changed="$(git status --short --untracked-files=all | sed -E 's/^...//')"
+fi
+
+if printf '%s\n' "$changed" | rg '^\.github/workflows/' >/dev/null; then
+  echo "FAIL: workflow edits are out of scope for Wave53 Step1"
+  exit 1
+fi
+
+required=(
+  "docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave53-hotspot-top2-9-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave53-hotspot-top2-9-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md"
+  "scripts/ci/review-wave53-hotspot-top2-9-step1.sh"
+)
+
+for path in "${required[@]}"; do
+  test -f "$path" || {
+    echo "FAIL: missing required file: $path"
+    exit 1
+  }
+done
+
+targets=(
+  "crates/assay-runner-core/src/kernel.rs"
+  "crates/assay-cli/src/cli/commands/runner_spike.rs"
+  "crates/assay-ebpf/src/main.rs"
+  "crates/assay-registry/src/lockfile.rs"
+  "crates/assay-core/src/mcp/policy/mod.rs"
+  "crates/assay-cli/src/cli/commands/bundle.rs"
+  "crates/assay-core/src/report/summary.rs"
+  "crates/assay-cli/src/cli/commands/doctor.rs"
+)
+
+for path in "${targets[@]}"; do
+  test -f "$path" || {
+    echo "FAIL: missing Wave53 target file: $path"
+    exit 1
+  }
+done
+
+if [[ "$base_mode" == "base-ref" ]]; then
+  if printf '%s\n' "$changed" | rg '^crates/.+\.rs$|^crates/.+/tests/' >/dev/null; then
+    echo "FAIL: Rust source/test edits are out of scope for Wave53 Step1"
+    exit 1
+  fi
+else
+  target_pattern="$(printf '%s\n' "${targets[@]}" | sed 's/[.[\*^$()+?{}|]/\\&/g' | paste -sd '|' -)"
+  if printf '%s\n' "$changed" | rg "^(${target_pattern})$" >/dev/null; then
+    echo "FAIL: Wave53 target Rust files changed in local Step1 scope"
+    exit 1
+  fi
+fi
+
+rg -n 'vmlinux\.rs.*out of scope|generated `crates/assay-ebpf/src/vmlinux\.rs`' \
+  docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md \
+  docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md >/dev/null
+
+rg -n 'selected top 2 through 9|selected 2-9 snapshot|selected top 2-9 snapshot' \
+  docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md \
+  docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md >/dev/null
+
+if [[ "$base_mode" == "base-ref" ]]; then
+  cargo fmt --check
+else
+  dirty_rust="$(git status --short --untracked-files=all | sed -E 's/^...//' | rg '^crates/.+\.rs$' || true)"
+  if [[ -n "$dirty_rust" ]]; then
+    echo "WARN: skipping workspace cargo fmt --check in local dirty mode; dirty Rust exists outside Wave53 Step1:"
+    printf '%s\n' "$dirty_rust"
+  else
+    cargo fmt --check
+  fi
+fi
+git diff --check
+
+echo "PASS: Wave53 Step1 freeze gate"

--- a/scripts/ci/review-wave53-hotspot-top2-9-step1.sh
+++ b/scripts/ci/review-wave53-hotspot-top2-9-step1.sh
@@ -72,16 +72,12 @@ rg -n 'selected top 2 through 9|selected 2-9 snapshot|selected top 2-9 snapshot'
   docs/contributing/SPLIT-PLAN-wave53-hotspot-top2-9.md \
   docs/contributing/SPLIT-REVIEW-PACK-wave53-hotspot-top2-9-step1.md >/dev/null
 
-if [[ "$base_mode" == "base-ref" ]]; then
-  cargo fmt --check
+dirty_rust="$(git status --short --untracked-files=all | sed -E 's/^...//' | rg '^crates/.+\.rs$' || true)"
+if [[ -n "$dirty_rust" ]]; then
+  echo "WARN: skipping workspace cargo fmt --check; dirty Rust exists outside Wave53 Step1:"
+  printf '%s\n' "$dirty_rust"
 else
-  dirty_rust="$(git status --short --untracked-files=all | sed -E 's/^...//' | rg '^crates/.+\.rs$' || true)"
-  if [[ -n "$dirty_rust" ]]; then
-    echo "WARN: skipping workspace cargo fmt --check in local dirty mode; dirty Rust exists outside Wave53 Step1:"
-    printf '%s\n' "$dirty_rust"
-  else
-    cargo fmt --check
-  fi
+  cargo fmt --check
 fi
 git diff --check
 


### PR DESCRIPTION
## Description
Freeze Wave53 for the selected top 2-9 Rust hotspot refactor. This adds the wave plan, Step1 checklist, move-map, review pack, implementation plan, and Step1 review gate. No Rust implementation code changes are included.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactor

## Verification
- [ ] `cargo check` passes
- [ ] `cargo test` passes
- [ ] Ran a demo suite (e.g. `examples/rag-grounding`)
- [x] `BASE_REF=origin/main bash scripts/ci/review-wave53-hotspot-top2-9-step1.sh` passes
- [x] Push hooks passed: merge-conflict check, shellcheck, cargo fmt, workspace clippy, linux compile gate

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

## PR strategy
Open Step1 now as its own draft PR against `main`. Open Step2 as a stacked draft PR after its high-readiness split passes the Step2 review gate, with Step1 as the base branch. Do not open Step3+ PRs until the previous step is green or merged.