### PR TITLE
chore(ebpf): document unsafe invariants

### DIFF
--- a/crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs
@@ -281,6 +281,9 @@ fn spawn_child_in_cgroup(
     command.args(&spec.command[1..]);
     apply_kernel_capture_child_env(&mut command, spec);
 
+    // SAFETY: `pre_exec` runs after fork and before exec. The closure only
+    // writes the child pid to the precomputed cgroup.procs path using libc
+    // open/write/close helpers below and does not touch shared Rust state.
     unsafe {
         command.pre_exec(move || write_self_to_cgroup(&procs_path));
     }
@@ -350,10 +353,13 @@ async fn drain_kernel_events(
 fn write_self_to_cgroup(procs_path: &std::ffi::CStr) -> std::io::Result<()> {
     let fd = retry_open_write_only(procs_path)?;
 
+    // SAFETY: `getpid` is async-signal-safe and returns the current child pid in
+    // the pre-exec path; the scalar result is only formatted into a stack buffer.
     let pid = unsafe { libc::getpid() } as u32;
     let mut buf = [0_u8; 32];
     let len = write_u32_decimal(pid, &mut buf);
     let write_result = retry_write_all(fd, &buf[..len]);
+    // SAFETY: `fd` was returned by `open` and is no longer used after this close.
     let close_result = unsafe { libc::close(fd) };
 
     match (write_result.err(), close_result) {
@@ -366,6 +372,8 @@ fn write_self_to_cgroup(procs_path: &std::ffi::CStr) -> std::io::Result<()> {
 #[cfg(target_os = "linux")]
 fn retry_open_write_only(path: &std::ffi::CStr) -> std::io::Result<i32> {
     loop {
+        // SAFETY: `path` is a NUL-terminated cgroup.procs path prepared before
+        // `pre_exec`; the returned fd is checked before use and retried on EINTR.
         let fd = unsafe { libc::open(path.as_ptr(), libc::O_WRONLY | libc::O_CLOEXEC) };
         if fd >= 0 {
             return Ok(fd);
@@ -380,6 +388,8 @@ fn retry_open_write_only(path: &std::ffi::CStr) -> std::io::Result<i32> {
 #[cfg(target_os = "linux")]
 fn retry_write_all(fd: i32, mut bytes: &[u8]) -> std::io::Result<()> {
     while !bytes.is_empty() {
+        // SAFETY: `fd` is an open cgroup.procs descriptor and `bytes` points to
+        // the stack-formatted pid slice for the duration of the write call.
         let written = unsafe { libc::write(fd, bytes.as_ptr().cast(), bytes.len()) };
         if written < 0 {
             let error = std::io::Error::last_os_error();

--- a/crates/assay-ebpf/Cargo.toml
+++ b/crates/assay-ebpf/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [lints.rust]
 unsafe_code = "allow"
+unsafe_op_in_unsafe_fn = "warn"
 missing_docs = "allow"
 rust_2018_idioms = { level = "warn", priority = -1 }
 unused_lifetimes = "warn"
@@ -13,6 +14,7 @@ unused_lifetimes = "warn"
 [lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "allow", priority = -1 }
+undocumented_unsafe_blocks = "warn"
 unwrap_used = "allow"
 print_stdout = "allow"
 missing_errors_doc = "allow"

--- a/crates/assay-ebpf/src/connect_events.rs
+++ b/crates/assay-ebpf/src/connect_events.rs
@@ -14,10 +14,14 @@ pub(super) fn try_connect(ctx: TracePointContext) -> Result<u32, u32> {
     }
 
     // Dynamic offset resolution
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the tracepoint ABI default below.
     let sockaddr_offset = unsafe { CONFIG.get(&KEY_OFFSET_SOCKADDR) }
         .map(|v| *v as usize)
         .unwrap_or(DEFAULT_OFFSET as usize);
 
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads are converted into the existing error path.
     let sockaddr_ptr: u64 = unsafe { ctx.read_at(sockaddr_offset).map_err(|_| 1u32)? };
     emit_sockaddr_event(
         sockaddr_ptr,
@@ -33,9 +37,13 @@ pub(super) fn try_sendto(ctx: TracePointContext) -> Result<u32, u32> {
         return Ok(0);
     }
 
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the tracepoint ABI default below.
     let sockaddr_offset = unsafe { CONFIG.get(&KEY_OFFSET_SENDTO_SOCKADDR) }
         .map(|v| *v as usize)
         .unwrap_or(48);
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads are converted into the existing error path.
     let sockaddr_ptr: u64 = unsafe { ctx.read_at(sockaddr_offset).map_err(|_| 1u32)? };
     if sockaddr_ptr == 0 {
         // Address-less send (e.g. a connected socket): no destination sockaddr in
@@ -58,14 +66,20 @@ pub(super) fn try_sendmsg(ctx: TracePointContext) -> Result<u32, u32> {
         return Ok(0);
     }
 
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the tracepoint ABI default below.
     let msghdr_offset = unsafe { CONFIG.get(&KEY_OFFSET_SENDMSG_MSGHDR) }
         .map(|v| *v as usize)
         .unwrap_or(DEFAULT_OFFSET as usize);
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads are converted into the existing error path.
     let msghdr_ptr: u64 = unsafe { ctx.read_at(msghdr_offset).map_err(|_| 1u32)? };
     if msghdr_ptr == 0 {
         return Ok(0);
     }
 
+    // SAFETY: `msghdr_ptr` is the user pointer carried by the tracepoint. Probe
+    // read failures are converted into the existing error path.
     let msghdr = unsafe {
         aya_ebpf::helpers::bpf_probe_read_user(msghdr_ptr as *const UserMsghdrHead)
             .map_err(|_| 1u32)?
@@ -106,6 +120,8 @@ fn emit_sockaddr_event(
     // We can't easily read indefinite structs, so we read a fixed chunk (e.g. 128 bytes)
     // to cover sockaddr_in / sockaddr_in6.
     let mut raw_sockaddr = [0u8; 128];
+    // SAFETY: `sockaddr_ptr` is a user sockaddr pointer from the syscall
+    // tracepoint. Failed probe reads leave the zeroed stack buffer in place.
     unsafe {
         let _ = aya_ebpf::helpers::bpf_probe_read_user(sockaddr_ptr as *const [u8; 128])
             .map(|x| raw_sockaddr = x);
@@ -125,7 +141,9 @@ fn emit_sockaddr_event(
     }
 
     if let Some(mut entry) = EVENTS.reserve::<MonitorEvent>(0) {
-        let ev = entry.as_mut_ptr() as *mut MonitorEvent;
+        let ev = entry.as_mut_ptr();
+        // SAFETY: `ev` points to a reserved `MonitorEvent` ring-buffer entry.
+        // Header and copied sockaddr payload are initialized before submit.
         unsafe {
             write_event_header(ev, current_tgid(), event_type);
 

--- a/crates/assay-ebpf/src/fork_events.rs
+++ b/crates/assay-ebpf/src/fork_events.rs
@@ -9,19 +9,29 @@ pub(super) fn try_fork(ctx: TracePointContext) -> Result<u32, u32> {
         return Ok(0);
     }
 
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the fork tracepoint ABI defaults below.
     let parent_offset = unsafe { CONFIG.get(&KEY_OFFSET_FORK_PARENT) }
         .map(|v| *v as usize)
         .unwrap_or(24); // Common default for parent_pid
 
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the fork tracepoint ABI defaults below.
     let child_offset = unsafe { CONFIG.get(&KEY_OFFSET_FORK_CHILD) }
         .map(|v| *v as usize)
         .unwrap_or(44); // Common default for child_pid
 
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads are converted into the existing error path.
     let parent_pid: u32 = unsafe { ctx.read_at(parent_offset).map_err(|_| 1u32)? };
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads are converted into the existing error path.
     let child_pid: u32 = unsafe { ctx.read_at(child_offset).map_err(|_| 1u32)? };
 
     if let Some(mut entry) = EVENTS.reserve::<MonitorEvent>(0) {
-        let ev = entry.as_mut_ptr() as *mut MonitorEvent;
+        let ev = entry.as_mut_ptr();
+        // SAFETY: `ev` points to a reserved `MonitorEvent` ring-buffer entry.
+        // Header and child pid payload are initialized before submit.
         unsafe {
             use assay_common::EVENT_FORK;
             write_event_header(ev, parent_pid, EVENT_FORK);

--- a/crates/assay-ebpf/src/lsm.rs
+++ b/crates/assay-ebpf/src/lsm.rs
@@ -9,7 +9,7 @@ use assay_common::{
 use aya_ebpf::{
     helpers::{bpf_get_current_cgroup_id, bpf_get_current_pid_tgid, bpf_probe_read_kernel},
     macros::{lsm, map},
-    maps::{Array, HashMap, RingBuf},
+    maps::HashMap,
     programs::LsmContext,
 };
 use aya_log_ebpf::info;
@@ -47,6 +47,8 @@ fn emit_event(
 ) {
     if let Some(mut entry) = LSM_EVENTS.reserve::<[u8; 520]>(0) {
         let buf = entry.as_mut_ptr() as *mut u8;
+        // SAFETY: `buf` points to a reserved LSM event ring-buffer entry. The
+        // fixed header and bounded payload bytes are initialized before submit.
         unsafe {
             // Write PID
             let pid = (bpf_get_current_pid_tgid() >> 32) as u32;
@@ -86,30 +88,42 @@ fn emit_event(
 pub fn file_open_lsm(ctx: LsmContext) -> i32 {
     match try_file_open_lsm(ctx) {
         Ok(ret) => ret,
-        Err(ret) => ret as i32,
+        Err(ret) => ret,
     }
 }
 
 fn try_file_open_lsm(ctx: LsmContext) -> Result<i32, i32> {
     // 0. Mark Hit (Absolute proof kernel reached here)
     if let Some(hits) = LSM_HIT.get_ptr_mut(0) {
+        // SAFETY: `hits` points to a mutable counter returned by the eBPF map;
+        // the verifier checks the map access for the constant key.
         unsafe { *hits += 1 };
     }
 
+    // SAFETY: `bpf_get_current_cgroup_id` returns a scalar cgroup id from the
+    // verifier-provided helper; the result is not dereferenced.
     let cgroup_id = unsafe { bpf_get_current_cgroup_id() };
 
     // Validates that we have a file pointer (arg 0)
+    // SAFETY: The LSM hook supplies argument 0 as a kernel `file` pointer. The
+    // pointer is checked for null before any typed field access.
     let file_ptr: *const c_void = unsafe { ctx.arg(0) };
     if file_ptr.is_null() {
         return Ok(0);
     }
 
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys use the
+    // existing monitor-all disabled default.
     let monitor_val = unsafe { CONFIG.get(&KEY_MONITOR_ALL).copied().unwrap_or(0) };
     let monitor_all = monitor_val != 0;
 
     // Optimization: avoid heavy logic if not monitored
+    // SAFETY: MONITORED_CGROUPS is an eBPF map owned by this program. A missing
+    // cgroup key means this task is outside the monitored set.
     if !monitor_all && unsafe { MONITORED_CGROUPS.get(&cgroup_id).is_none() } {
         if let Some(x) = LSM_BYPASS.get_ptr_mut(0) {
+            // SAFETY: `x` points to a mutable bypass counter returned by the
+            // eBPF map for the constant key.
             unsafe { *x += 1 };
         }
         return Ok(0);
@@ -120,6 +134,8 @@ fn try_file_open_lsm(ctx: LsmContext) -> Result<i32, i32> {
     // The "CO-RE" magic happens because we are casting to pointers of `vmlinux::file`/`inode`
     // which are generated with BTF relocations enabled.
     let f = file_ptr as *const file;
+    // SAFETY: `f` is the non-null kernel file pointer from the LSM hook. Probe
+    // read failures return a null inode pointer and are handled below.
     let inode_ptr: *mut inode = unsafe {
         bpf_probe_read_kernel(&((*f).f_inode) as *const *mut inode).unwrap_or(core::ptr::null_mut())
     };
@@ -130,12 +146,18 @@ fn try_file_open_lsm(ctx: LsmContext) -> Result<i32, i32> {
     }
 
     // Read i_ino
+    // SAFETY: `inode_ptr` was probe-read from the file and checked for null.
+    // Failed reads use the existing zero sentinel.
     let i_ino = unsafe { bpf_probe_read_kernel(&((*inode_ptr).i_ino) as *const u64).unwrap_or(0) };
 
     // Read i_generation (SOTA)
+    // SAFETY: `inode_ptr` was probe-read from the file and checked for null.
+    // Failed reads use the existing zero generation sentinel.
     let i_gen =
         unsafe { bpf_probe_read_kernel(&((*inode_ptr).i_generation) as *const u32).unwrap_or(0) };
 
+    // SAFETY: `inode_ptr` was probe-read from the file and checked for null.
+    // Failed reads return a null super_block pointer and are handled below.
     let sb_ptr: *mut super_block = unsafe {
         bpf_probe_read_kernel(&((*inode_ptr).i_sb) as *const *mut super_block)
             .unwrap_or(core::ptr::null_mut())
@@ -143,6 +165,8 @@ fn try_file_open_lsm(ctx: LsmContext) -> Result<i32, i32> {
 
     let mut s_dev = 0u32;
     if !sb_ptr.is_null() {
+        // SAFETY: `sb_ptr` was probe-read from the inode and checked for null.
+        // Failed reads use the existing zero device sentinel.
         s_dev = unsafe { bpf_probe_read_kernel(&((*sb_ptr).s_dev) as *const u32).unwrap_or(0) };
     }
 
@@ -156,7 +180,11 @@ fn try_file_open_lsm(ctx: LsmContext) -> Result<i32, i32> {
             dev: s_dev,
             gen: i_gen,
         };
+        // SAFETY: DENY_INO is an eBPF map owned by this program. The key is
+        // fully initialized from probe-read inode fields.
         if let Some(rule_id) = unsafe { DENY_INO.get(&key_exact) } {
+            // SAFETY: `bpf_printk!` emits scalar diagnostic values only; no
+            // pointer arguments are passed to the helper.
             unsafe {
                 aya_ebpf::helpers::bpf_printk!(
                     b"LSM: BLOCKED %llu:%llu (Exact Gen %u) rule=%u\0",
@@ -168,10 +196,14 @@ fn try_file_open_lsm(ctx: LsmContext) -> Result<i32, i32> {
             }
 
             if let Some(denies) = LSM_DENY.get_ptr_mut(0) {
+                // SAFETY: `denies` points to a mutable deny counter returned by
+                // the eBPF map for the constant key.
                 unsafe { *denies += 1 };
             }
 
             let mut alert_data = [0u8; 64];
+            // SAFETY: `alert_data` is a 64-byte stack buffer and the fixed
+            // offsets/lengths below fit within it.
             unsafe {
                 core::ptr::copy_nonoverlapping(
                     (s_dev as u64).to_ne_bytes().as_ptr(),
@@ -205,7 +237,11 @@ fn try_file_open_lsm(ctx: LsmContext) -> Result<i32, i32> {
         gen: 0,
     };
 
+    // SAFETY: DENY_INO is an eBPF map owned by this program. The fallback key is
+    // fully initialized from probe-read inode fields.
     if let Some(rule_id) = unsafe { DENY_INO.get(&key_fallback) } {
+        // SAFETY: `bpf_printk!` emits scalar diagnostic values only; no pointer
+        // arguments are passed to the helper.
         unsafe {
             aya_ebpf::helpers::bpf_printk!(
                 b"LSM: BLOCKED %llu:%llu (Fallback Gen) rule=%u\0",
@@ -216,10 +252,14 @@ fn try_file_open_lsm(ctx: LsmContext) -> Result<i32, i32> {
         }
 
         if let Some(denies) = LSM_DENY.get_ptr_mut(0) {
+            // SAFETY: `denies` points to a mutable deny counter returned by the
+            // eBPF map for the constant key.
             unsafe { *denies += 1 };
         }
 
         let mut alert_data = [0u8; 64];
+        // SAFETY: `alert_data` is a 64-byte stack buffer and the fixed
+        // offsets/lengths below fit within it.
         unsafe {
             core::ptr::copy_nonoverlapping(
                 (s_dev as u64).to_ne_bytes().as_ptr(),
@@ -246,6 +286,8 @@ fn try_file_open_lsm(ctx: LsmContext) -> Result<i32, i32> {
     // Event 112: Inode Resolved (Telemetry). It is enabled by default for the
     // monitor CLI, but runner-spike disables it because it is not attribution
     // evidence and can flood the LSM ring buffer on tiny fixtures.
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys use the
+    // existing default that emits inode-resolved telemetry.
     let emit_inode_resolved = unsafe { CONFIG.get(&KEY_EMIT_INODE_RESOLVED) }
         .copied()
         .unwrap_or(1)

--- a/crates/assay-ebpf/src/main.rs
+++ b/crates/assay-ebpf/src/main.rs
@@ -16,6 +16,7 @@ pub mod socket_lsm;
 #[allow(non_camel_case_types)]
 #[allow(non_upper_case_globals)]
 #[allow(clippy::all)]
+#[allow(clippy::undocumented_unsafe_blocks, unsafe_op_in_unsafe_fn)]
 pub mod vmlinux;
 
 use assay_common::{
@@ -47,6 +48,8 @@ fn current_tgid() -> u32 {
 #[inline(always)]
 pub(crate) fn inc_stat(index: u32) {
     if let Some(val) = STATS.get_ptr_mut(index) {
+        // SAFETY: `val` points to a mutable entry returned by the eBPF stats
+        // array for this program; the verifier checks map bounds for the index.
         unsafe { *val += 1 };
     }
 }
@@ -129,6 +132,8 @@ const MAX_ANCESTOR_DEPTH_HARD: usize = 16;
 
 #[inline(always)]
 fn max_ancestor_depth() -> usize {
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys are
+    // handled by the fallback default and the value is clamped below.
     let v = unsafe { CONFIG.get(&KEY_MAX_ANCESTOR_DEPTH) }
         .copied()
         .unwrap_or(8);
@@ -143,6 +148,8 @@ fn max_ancestor_depth() -> usize {
 #[inline(always)]
 fn is_monitored() -> bool {
     // 0. Global Monitor-All Override
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys are
+    // handled by the default disabled monitor-all setting.
     if unsafe { CONFIG.get(&KEY_MONITOR_ALL) }
         .copied()
         .unwrap_or(0)
@@ -152,12 +159,18 @@ fn is_monitored() -> bool {
     }
 
     // 1. Check PID (Legacy/Override)
+    // SAFETY: MONITORED_PIDS is an eBPF map owned by this program. The scalar
+    // current TGID key is local and a missing key simply means not monitored.
     if unsafe { MONITORED_PIDS.get(&current_tgid()) }.is_some() {
         return true;
     }
 
     // 2. Check current cgroup
+    // SAFETY: `bpf_get_current_cgroup_id` returns a scalar cgroup id from the
+    // verifier-provided helper; the result is not dereferenced.
     let current_id = unsafe { bpf_get_current_cgroup_id() };
+    // SAFETY: MONITORED_CGROUPS is an eBPF map owned by this program. A missing
+    // current cgroup key simply means this task is outside the monitored set.
     if unsafe { MONITORED_CGROUPS.get(&current_id) }.is_some() {
         return true;
     }
@@ -169,11 +182,15 @@ fn is_monitored() -> bool {
             break;
         }
 
+        // SAFETY: The helper returns a scalar ancestor cgroup id for the
+        // current task. The result is only compared and used as a map key.
         let ancestor_id = unsafe { bpf_get_current_ancestor_cgroup_id(i as i32) };
         if ancestor_id == 0 {
             break;
         } // Root or error
 
+        // SAFETY: MONITORED_CGROUPS is an eBPF map owned by this program. A
+        // missing ancestor key simply means this task is outside the monitored set.
         if unsafe { MONITORED_CGROUPS.get(&ancestor_id) }.is_some() {
             return true;
         }
@@ -186,14 +203,18 @@ const DATA_LEN: usize = 512;
 
 #[inline(always)]
 unsafe fn write_event_header(ev: *mut MonitorEvent, pid: u32, event_type: u32) {
-    (*ev).pid = pid;
-    (*ev).event_type = event_type;
-    (*ev).flags = 0;
-    (*ev).mode = 0;
-    (*ev).resolve = 0;
-    (*ev).return_value = 0;
-    // Zero payload in-place
-    core::ptr::write_bytes((*ev).data.as_mut_ptr(), 0, (*ev).data.len());
+    // SAFETY: Callers pass a non-null pointer to a reserved `MonitorEvent`
+    // ring-buffer entry. This initializes the fixed header and zeros the
+    // payload before the caller submits the event.
+    unsafe {
+        (*ev).pid = pid;
+        (*ev).event_type = event_type;
+        (*ev).flags = 0;
+        (*ev).mode = 0;
+        (*ev).resolve = 0;
+        (*ev).return_value = 0;
+        core::ptr::write_bytes((*ev).data.as_mut_ptr(), 0, (*ev).data.len());
+    }
 }
 
 #[tracepoint]
@@ -263,6 +284,8 @@ pub fn assay_monitor_sendmsg(ctx: TracePointContext) -> u32 {
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+    // SAFETY: eBPF programs in this crate use abort-style panic semantics and
+    // cannot recover in-kernel. Reaching this handler is treated as unreachable.
     unsafe { core::hint::unreachable_unchecked() }
 }
 

--- a/crates/assay-ebpf/src/open_events.rs
+++ b/crates/assay-ebpf/src/open_events.rs
@@ -2,19 +2,29 @@ use super::{path_filter, *};
 
 pub(super) fn try_openat2(ctx: TracePointContext) -> Result<u32, u32> {
     if let Some(hits) = TP_HIT.get_ptr_mut(0) {
+        // SAFETY: `hits` points to a mutable counter returned by the eBPF map;
+        // the verifier checks the map access for the constant key.
         unsafe { *hits += 1 };
     }
 
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the tracepoint ABI default below.
     let how_offset = unsafe { CONFIG.get(&KEY_OFFSET_OPENAT2_HOW) }
         .map(|v| *v as usize)
         .unwrap_or(32);
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads are converted into the existing error path.
     let how_ptr: u64 = unsafe { ctx.read_at(how_offset).map_err(|_| 1u32)? };
     let mut flags = 0u64;
     let mut mode = 0u64;
     let mut resolve = 0u64;
     if how_ptr != 0 {
         if let Ok(how) =
-            unsafe { aya_ebpf::helpers::bpf_probe_read_user(how_ptr as *const vmlinux::open_how) }
+            // SAFETY: `how_ptr` is the user pointer carried by the tracepoint. Probe
+            // read failures are ignored and leave the default openat2 metadata.
+            unsafe {
+                aya_ebpf::helpers::bpf_probe_read_user(how_ptr as *const vmlinux::open_how)
+            }
         {
             flags = how.flags;
             mode = how.mode;
@@ -27,16 +37,26 @@ pub(super) fn try_openat2(ctx: TracePointContext) -> Result<u32, u32> {
 
 pub(super) fn try_openat(ctx: TracePointContext) -> Result<u32, u32> {
     if let Some(hits) = TP_HIT.get_ptr_mut(0) {
+        // SAFETY: `hits` points to a mutable counter returned by the eBPF map;
+        // the verifier checks the map access for the constant key.
         unsafe { *hits += 1 };
     }
 
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the tracepoint ABI default below.
     let flags_offset = unsafe { CONFIG.get(&KEY_OFFSET_OPENAT_FLAGS) }
         .map(|v| *v as usize)
         .unwrap_or(32);
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the tracepoint ABI default below.
     let mode_offset = unsafe { CONFIG.get(&KEY_OFFSET_OPENAT_MODE) }
         .map(|v| *v as usize)
         .unwrap_or(40);
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads use the existing safe default.
     let flags: i32 = unsafe { ctx.read_at(flags_offset).unwrap_or(0) };
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads use the existing safe default.
     let mode: u64 = unsafe { ctx.read_at::<u64>(mode_offset).unwrap_or(0) };
 
     store_open_pending(ctx, KEY_OFFSET_FILENAME, flags as u64, mode, 0)
@@ -54,10 +74,14 @@ fn store_open_pending(
         return Ok(0);
     }
 
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the tracepoint ABI default below.
     let filename_offset = unsafe { CONFIG.get(&offset_key) }
         .map(|v| *v as usize)
         .unwrap_or(DEFAULT_OFFSET as usize);
 
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads are converted into the existing error path.
     let filename_ptr: u64 = unsafe { ctx.read_at(filename_offset).map_err(|_| 1u32)? };
     if filename_ptr == 0 {
         return Ok(0);
@@ -67,12 +91,16 @@ fn store_open_pending(
         Some(pending) => pending,
         None => return Ok(0),
     };
+    // SAFETY: `pending` points to this CPU's scratch `PendingOpen` slot returned
+    // by the PerCpuArray; all fields are initialized before the slot is used.
     unsafe {
         core::ptr::write_bytes((*pending).data.as_mut_ptr(), 0, DATA_LEN);
         (*pending).flags = flags;
         (*pending).mode = mode;
         (*pending).resolve = resolve;
     }
+    // SAFETY: `filename_ptr` is the user pointer carried by the tracepoint. The
+    // destination is the initialized scratch buffer and read errors are handled.
     let read_result = unsafe {
         aya_ebpf::helpers::bpf_probe_read_user_str_bytes(
             filename_ptr as *const u8,
@@ -82,6 +110,8 @@ fn store_open_pending(
     if read_result.is_err() {
         return Ok(0);
     }
+    // SAFETY: `pending` remains the valid scratch slot returned above. The data
+    // field was zeroed before the user string probe read.
     let path = unsafe { &(*pending).data };
     if path_filter::is_loader_telemetry_open_path(path) {
         return Ok(0);
@@ -91,6 +121,8 @@ fn store_open_pending(
     }
 
     let key = bpf_get_current_pid_tgid();
+    // SAFETY: PENDING_OPEN is an eBPF map owned by this program. `pending` is
+    // copied into the map value before the scratch slot can be reused.
     let _ = unsafe { PENDING_OPEN.insert(&key, &*pending, 0) };
 
     Ok(0)
@@ -103,19 +135,27 @@ pub(super) fn try_open_exit(
     dropped_stat: u32,
 ) -> Result<u32, u32> {
     let key = bpf_get_current_pid_tgid();
+    // SAFETY: PENDING_OPEN is an eBPF map owned by this program. A missing key
+    // means the entry probe did not record a path for this pid/tgid.
     let pending = match unsafe { PENDING_OPEN.get(&key) } {
         Some(pending) => pending,
         None => return Ok(0),
     };
     let _ = PENDING_OPEN.remove(&key);
 
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys fall
+    // back to the syscall-exit tracepoint ABI default below.
     let ret_offset = unsafe { CONFIG.get(&KEY_OFFSET_SYSCALL_EXIT_RET) }
         .map(|v| *v as usize)
         .unwrap_or(16);
+    // SAFETY: The offset comes from configured tracepoint ABI state; failed
+    // reads use the existing safe default return value.
     let ret: i64 = unsafe { ctx.read_at(ret_offset).unwrap_or(0) };
 
     if let Some(mut entry) = EVENTS.reserve::<MonitorEvent>(0) {
-        let ev = entry.as_mut_ptr() as *mut MonitorEvent;
+        let ev = entry.as_mut_ptr();
+        // SAFETY: `ev` points to a reserved `MonitorEvent` ring-buffer entry.
+        // Header and payload fields are initialized before submit.
         unsafe {
             write_event_header(ev, current_tgid(), EVENT_OPENAT);
             (*ev).flags = pending.flags;
@@ -141,6 +181,8 @@ pub(super) fn try_open_exit(
 
 #[inline(always)]
 fn should_dedup_open_path(path: &[u8; DATA_LEN], flags: u64) -> bool {
+    // SAFETY: CONFIG is an eBPF map owned by this program. Missing keys disable
+    // deduplication through the existing fallback default.
     let dedup = unsafe { CONFIG.get(&KEY_DEDUP_OPEN_PATHS) }
         .copied()
         .unwrap_or(0)
@@ -150,6 +192,8 @@ fn should_dedup_open_path(path: &[u8; DATA_LEN], flags: u64) -> bool {
     }
 
     let key = hash_open_path(path, flags);
+    // SAFETY: OPEN_PATH_SEEN is an eBPF map owned by this program. A missing key
+    // means the path hash has not been emitted yet.
     if unsafe { OPEN_PATH_SEEN.get(&key) }.is_some() {
         return true;
     }

--- a/crates/assay-ebpf/src/socket_lsm.rs
+++ b/crates/assay-ebpf/src/socket_lsm.rs
@@ -69,10 +69,16 @@ pub fn connect4_hook(ctx: SockAddrContext) -> i32 {
 fn try_connect4(ctx: &SockAddrContext) -> Result<bool, i64> {
     inc_stat(SOCKET_STAT_CHECKS);
 
+    // SAFETY: `bpf_get_current_cgroup_id` returns a scalar cgroup id from the
+    // verifier-provided helper; the result is not dereferenced.
     let cgroup_id = unsafe { bpf_get_current_cgroup_id() };
+    // SAFETY: `ctx.as_ptr()` is provided by the cgroup sockaddr hook and points
+    // to a `bpf_sock_addr` for the duration of this hook invocation.
     let sock_addr = unsafe { &*(ctx.as_ptr() as *const bpf_sock_addr) };
     let dst_port = u16::from_be(sock_addr.user_port as u16);
 
+    // SAFETY: DENY_PORTS is an eBPF map owned by this program. The destination
+    // port key is a scalar copied from the hook context.
     if let Some(&rule_id) = unsafe { DENY_PORTS.get(&dst_port) } {
         emit_socket_event(
             EVENT_CONNECT_BLOCKED,
@@ -88,6 +94,8 @@ fn try_connect4(ctx: &SockAddrContext) -> Result<bool, i64> {
         return Ok(false);
     }
 
+    // SAFETY: ALLOW_PORTS is an eBPF map owned by this program. A missing key
+    // means no explicit allow rule matched this destination port.
     if unsafe { ALLOW_PORTS.get(&dst_port).is_some() } {
         inc_stat(SOCKET_STAT_ALLOWED);
         return Ok(true);
@@ -170,19 +178,28 @@ pub fn connect6_hook(ctx: SockAddrContext) -> i32 {
 fn try_connect6(ctx: &SockAddrContext) -> Result<bool, i64> {
     inc_stat(SOCKET_STAT_CHECKS);
 
+    // SAFETY: `bpf_get_current_cgroup_id` returns a scalar cgroup id from the
+    // verifier-provided helper; the result is not dereferenced.
     let cgroup_id = unsafe { bpf_get_current_cgroup_id() };
+    // SAFETY: `ctx.as_ptr()` is provided by the cgroup sockaddr hook and points
+    // to a `bpf_sock_addr` for the duration of this hook invocation.
     let sock_addr = unsafe { &*(ctx.as_ptr() as *const bpf_sock_addr) };
     let dst_port = u16::from_be(sock_addr.user_port as u16);
     let dst_addr = sock_addr.user_ip6;
 
+    // SAFETY: DENY_PORTS is an eBPF map owned by this program. The destination
+    // port key is a scalar copied from the hook context.
     if let Some(&rule_id) = unsafe { DENY_PORTS.get(&dst_port) } {
+        // SAFETY: `[u32; 4]` and `[u8; 16]` have the same size, and every byte
+        // pattern is valid for `u8`; the bytes are copied into the event payload.
+        let dst_addr_bytes = unsafe { core::mem::transmute::<[u32; 4], [u8; 16]>(dst_addr) };
         emit_socket_event(
             EVENT_CONNECT_BLOCKED,
             cgroup_id,
             10, // IPv6
             dst_port,
             0,
-            &unsafe { core::mem::transmute::<[u32; 4], [u8; 16]>(dst_addr) },
+            &dst_addr_bytes,
             rule_id,
             0,
         );
@@ -190,11 +207,15 @@ fn try_connect6(ctx: &SockAddrContext) -> Result<bool, i64> {
         return Ok(false);
     }
 
+    // SAFETY: ALLOW_PORTS is an eBPF map owned by this program. A missing key
+    // means no explicit allow rule matched this destination port.
     if unsafe { ALLOW_PORTS.get(&dst_port).is_some() } {
         inc_stat(SOCKET_STAT_ALLOWED);
         return Ok(true);
     }
 
+    // SAFETY: `[u32; 4]` and `[u8; 16]` have the same size, and every byte
+    // pattern is valid for `u8`; the bytes are used immediately as an LPM key.
     let ip6_bytes = unsafe { core::mem::transmute::<[u32; 4], [u8; 16]>(dst_addr) };
     let key = Key::new(128, ip6_bytes);
     if let Some(&action) = CIDR_RULES_V6.get(&key) {
@@ -221,6 +242,8 @@ fn try_connect6(ctx: &SockAddrContext) -> Result<bool, i64> {
 #[inline(always)]
 fn inc_stat(index: u32) {
     if let Some(val) = SOCKET_STATS.get_ptr_mut(index) {
+        // SAFETY: `val` points to a mutable counter returned by the eBPF stats
+        // array; the verifier checks map bounds for the supplied index.
         unsafe { *val += 1 };
     }
 }
@@ -237,9 +260,13 @@ fn emit_socket_event(
     action: u32,
 ) {
     if let Some(mut event) = SOCKET_EVENTS.reserve::<SocketEvent>(0) {
+        // SAFETY: `event.as_mut_ptr()` points to a reserved `SocketEvent`
+        // ring-buffer entry initialized below before submit.
         let ev = unsafe { &mut *event.as_mut_ptr() };
         ev.event_type = event_type;
         ev.pid = (bpf_get_current_pid_tgid() >> 32) as u32;
+        // SAFETY: `bpf_ktime_get_ns` returns a scalar timestamp from the
+        // verifier-provided helper; the result is not dereferenced.
         ev.timestamp_ns = unsafe { bpf_ktime_get_ns() };
         ev.cgroup_id = cgroup_id;
         ev.family = family;
@@ -248,9 +275,7 @@ fn emit_socket_event(
         ev.rule_id = rule_id;
         ev.action = action;
 
-        for i in 0..16 {
-            ev.addr_v6[i] = addr_v6[i];
-        }
+        ev.addr_v6.copy_from_slice(addr_v6);
         event.submit(0);
         inc_stat(SOCKET_STAT_EVENTS_EMITTED);
     } else {

--- a/docs/contributing/SAFETY-MAP-wave54-ebpf-unsafe.md
+++ b/docs/contributing/SAFETY-MAP-wave54-ebpf-unsafe.md
@@ -1,0 +1,43 @@
+# SAFETY MAP - Wave54 eBPF Unsafe Documentation
+
+## Intent
+
+Document the invariant classes for hand-written unsafe code in the eBPF kernel path and runner cgroup assignment path.
+
+## Non-Goals
+
+- Do not edit `crates/assay-ebpf/src/vmlinux.rs`; it is generated bindgen output.
+- Do not migrate the workspace to edition 2024.
+- Do not change map capacities, tracepoint entrypoints, event schemas, filtering behavior, cgroup assignment behavior, or LSM decisions.
+- Do not make `assay-ebpf` full `clippy -D warnings` clean in this PR; unrelated Clippy cleanup belongs in a separate PR.
+
+## eBPF
+
+| File | Baseline unsafe lines | Safety classes |
+| --- | ---: | --- |
+| `crates/assay-ebpf/src/main.rs` | 10 | map access, BPF helper calls, event header raw pointer writes, panic handler, generated `vmlinux` exemption |
+| `crates/assay-ebpf/src/open_events.rs` | 21 | tracepoint reads, map access, ring buffer writes, pending-open raw pointer access |
+| `crates/assay-ebpf/src/connect_events.rs` | 9 | tracepoint reads, msghdr probe reads, ring buffer writes |
+| `crates/assay-ebpf/src/fork_events.rs` | 5 | tracepoint reads, ring buffer writes |
+| `crates/assay-ebpf/src/lsm.rs` | 21 | LSM hook args, kernel pointer reads, map access, ring buffer writes |
+| `crates/assay-ebpf/src/socket_lsm.rs` | 13 | BPF helpers, socket hook args, map access, byte reinterpretation, ring buffer writes |
+
+## Runner Cgroup
+
+| File | Baseline unsafe lines | Safety classes |
+| --- | ---: | --- |
+| `crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs` | 5 | `pre_exec`, `getpid`, `open`, `write`, `close` for cgroup assignment |
+
+## Safety Invariant Classes
+
+- eBPF map access: unsafe because Aya exposes map operations through unsafe APIs; key lifetimes are local and missing keys are handled.
+- Tracepoint reads: unsafe because kernel tracepoint context reads depend on configured offsets; read failures return an error or safe default.
+- Ring buffer writes: unsafe because reserved ring-buffer memory is written through raw pointers; entries are initialized before submit.
+- Kernel pointer reads: unsafe because LSM hook pointers come from kernel context; null and probe-read failures are handled before use.
+- BPF helpers: unsafe because helper calls cross the verifier boundary; scalar results are not dereferenced.
+- Byte reinterpretation: unsafe only when source and target layouts are same-size byte representations with no invalid `u8` bit patterns.
+- Pre-exec cgroup assignment: unsafe because `pre_exec` runs after fork and before exec; the closure only calls async-signal-safe libc operations.
+
+## Generated Non-Target
+
+`crates/assay-ebpf/src/vmlinux.rs` is generated bindgen output and is excluded from this wave. It is exempted through the module declaration in `crates/assay-ebpf/src/main.rs`, not by editing generated code.

--- a/scripts/ci/review-wave54-ebpf-safety.sh
+++ b/scripts/ci/review-wave54-ebpf-safety.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
+export CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
+
+base_ref="${BASE_REF:-origin/main}"
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  echo "FAIL: cannot resolve base ref: $base_ref"
+  echo "Set BASE_REF to the intended Wave54 base ref."
+  exit 1
+fi
+
+base_changed="$(git diff --name-only "$base_ref"...HEAD)"
+worktree_changed="$(
+  {
+    git diff --name-only
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  } | sort -u
+)"
+changed="$(printf '%s\n%s\n' "$base_changed" "$worktree_changed" | sed '/^$/d' | sort -u)"
+
+allowed_pattern='^(docs/contributing/SAFETY-MAP-wave54-ebpf-unsafe\.md|scripts/ci/review-wave54-ebpf-safety\.sh|crates/assay-ebpf/Cargo\.toml|crates/assay-ebpf/src/main\.rs|crates/assay-ebpf/src/open_events\.rs|crates/assay-ebpf/src/connect_events\.rs|crates/assay-ebpf/src/fork_events\.rs|crates/assay-ebpf/src/lsm\.rs|crates/assay-ebpf/src/socket_lsm\.rs|crates/assay-cli/src/cli/commands/runner_spike/cgroup\.rs)$'
+unexpected="$(printf '%s\n' "$changed" | rg -v "$allowed_pattern" || true)"
+if [[ -n "$unexpected" ]]; then
+  echo "FAIL: Wave54 changed files outside the allowlist:"
+  printf '%s\n' "$unexpected"
+  exit 1
+fi
+
+if printf '%s\n' "$changed" | rg '^crates/assay-ebpf/src/vmlinux\.rs$' >/dev/null; then
+  echo "FAIL: generated vmlinux.rs is out of scope for Wave54"
+  exit 1
+fi
+
+required=(
+  "docs/contributing/SAFETY-MAP-wave54-ebpf-unsafe.md"
+  "scripts/ci/review-wave54-ebpf-safety.sh"
+  "crates/assay-ebpf/Cargo.toml"
+  "crates/assay-ebpf/src/main.rs"
+  "crates/assay-ebpf/src/open_events.rs"
+  "crates/assay-ebpf/src/connect_events.rs"
+  "crates/assay-ebpf/src/fork_events.rs"
+  "crates/assay-ebpf/src/lsm.rs"
+  "crates/assay-ebpf/src/socket_lsm.rs"
+  "crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs"
+)
+
+for file in "${required[@]}"; do
+  test -f "$file" || {
+    echo "FAIL: missing required file: $file"
+    exit 1
+  }
+done
+
+require_marker() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if ! rg -q "$pattern" "$file"; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+require_marker '^unsafe_op_in_unsafe_fn = "warn"$' \
+  "crates/assay-ebpf/Cargo.toml" \
+  "assay-ebpf must warn on unsafe ops inside unsafe fn"
+require_marker '^undocumented_unsafe_blocks = "warn"$' \
+  "crates/assay-ebpf/Cargo.toml" \
+  "assay-ebpf must warn on undocumented unsafe blocks"
+require_marker '#\[allow\(clippy::undocumented_unsafe_blocks, unsafe_op_in_unsafe_fn\)\]' \
+  "crates/assay-ebpf/src/main.rs" \
+  "generated vmlinux module must be exempted without editing vmlinux.rs"
+
+while IFS=: read -r line _text; do
+  start=$(( line > 4 ? line - 4 : 1 ))
+  if ! sed -n "${start},$((line - 1))p" \
+    "crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs" | rg -q 'SAFETY:'; then
+    echo "FAIL: runner_spike/cgroup.rs unsafe block at line ${line} lacks preceding SAFETY comment"
+    exit 1
+  fi
+done < <(rg -n 'unsafe[[:space:]]*\{' \
+  "crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs" || true)
+
+cargo fmt --check
+cargo check -p assay-ebpf --features ebpf --bin assay-ebpf
+cargo clippy -p assay-ebpf --features ebpf --bin assay-ebpf -- \
+  -D clippy::undocumented_unsafe_blocks \
+  -D unsafe_op_in_unsafe_fn
+cargo check -p assay-cli --features runner
+cargo test -q -p assay-cli --features runner -- runner_spike
+git diff --check "$base_ref"...HEAD
+git diff --check
+git diff --cached --check
+
+echo "PASS: Wave54 eBPF safety lint gate"


### PR DESCRIPTION
# SAFETY REVIEW PACK - Wave54 eBPF Unsafe Documentation

## Scope

This PR documents hand-written unsafe blocks in eBPF and runner cgroup assignment code. It also adds targeted unsafe lint gates. It does not change runtime behavior.

## Reviewer Focus

- Verify each `SAFETY:` comment states a concrete invariant, not a restatement of the code.
- Verify `crates/assay-ebpf/src/vmlinux.rs` is unchanged and only exempted at the module declaration.
- Verify eBPF entrypoints, map declarations, event schemas, and LSM decisions are unchanged.
- Verify the review script enforces targeted unsafe linting without broadening into unrelated Clippy cleanup.

## Checklist

- [ ] `crates/assay-ebpf/src/vmlinux.rs` is unchanged.
- [ ] No tracepoint entrypoint names changed.
- [ ] No eBPF map names, key types, value types, or capacities changed.
- [ ] No event schema fields changed.
- [ ] No LSM allow/deny behavior changed.
- [ ] Hand-written eBPF unsafe blocks are covered by targeted Clippy.
- [ ] `runner_spike/cgroup.rs` unsafe blocks have `SAFETY:` comments.
- [ ] Local review gate passed.
- [ ] Delegated Runner Spike `gates=all` proof passed before ready-for-review.

## Verification

```bash
BASE_REF=origin/main bash scripts/ci/review-wave54-ebpf-safety.sh
```

Local result: `PASS: Wave54 eBPF safety lint gate`.

Before ready-for-review, dispatch Runner Spike Delegated with `gates=all` and paste the run URL plus head SHA into the PR.
