### PR TITLE
refactor(cli): split evidence schema facade

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/schema.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/schema.rs
@@ -1,51 +1,14 @@
+mod registry;
+mod reports;
+mod validate;
+mod write;
+
 use crate::cli::args::OutputFormat;
 use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_SUCCESS, EXIT_TEST_FAILURE};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 use jsonschema::Draft;
-use serde::Serialize;
-use serde_json::Value;
-use std::fmt;
 use std::path::PathBuf;
-
-const SCHEMA_LIST_REPORT: &str = "assay.evidence.schema.list.v1";
-const SCHEMA_SHOW_REPORT: &str = "assay.evidence.schema.show.v1";
-const SCHEMA_VALIDATION_REPORT: &str = "assay.evidence.schema.validation.v1";
-
-macro_rules! include_packaged_schema {
-    ($relative_path:literal) => {
-        include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/receipt-schemas/",
-            $relative_path
-        ))
-    };
-}
-
-const PROMPTFOO_RECEIPT_SCHEMA: &str =
-    include_packaged_schema!("receipts/promptfoo.assertion-component.v1.schema.json");
-const OPENFEATURE_RECEIPT_SCHEMA: &str =
-    include_packaged_schema!("receipts/openfeature.evaluation-details.v1.schema.json");
-const CYCLONEDX_RECEIPT_SCHEMA: &str =
-    include_packaged_schema!("receipts/cyclonedx.mlbom-model-component.v1.schema.json");
-const MASTRA_RECEIPT_SCHEMA: &str =
-    include_packaged_schema!("receipts/mastra.score-event.v1.schema.json");
-const PYDANTIC_RECEIPT_SCHEMA: &str =
-    include_packaged_schema!("receipts/pydantic.case-result.v1.schema.json");
-const LIVEKIT_RECEIPT_SCHEMA: &str =
-    include_packaged_schema!("receipts/livekit.tool-action.v1.schema.json");
-const PROMPTFOO_INPUT_SCHEMA: &str =
-    include_packaged_schema!("inputs/promptfoo-cli-jsonl-component-result.v1.schema.json");
-const OPENFEATURE_INPUT_SCHEMA: &str =
-    include_packaged_schema!("inputs/openfeature-evaluation-details-export.v1.schema.json");
-const CYCLONEDX_INPUT_SCHEMA: &str =
-    include_packaged_schema!("inputs/cyclonedx-mlbom-model-component-input.v1.schema.json");
-const MASTRA_INPUT_SCHEMA: &str =
-    include_packaged_schema!("inputs/mastra-score-event-export.v1.schema.json");
-const PYDANTIC_INPUT_SCHEMA: &str =
-    include_packaged_schema!("inputs/pydantic-case-result-export.v1.schema.json");
-const LIVEKIT_INPUT_SCHEMA: &str =
-    include_packaged_schema!("inputs/livekit-function-tools-executed-export.v1.schema.json");
 
 /// Inspect and validate supported receipt schema contracts.
 #[derive(Debug, Args, Clone)]
@@ -105,271 +68,6 @@ pub struct SchemaValidateArgs {
     pub format: OutputFormat,
 }
 
-#[derive(Clone, Copy, Debug, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum SchemaKind {
-    Receipt,
-    Input,
-}
-
-impl fmt::Display for SchemaKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Receipt => f.write_str("receipt"),
-            Self::Input => f.write_str("input"),
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-struct SchemaDescriptor {
-    name: &'static str,
-    aliases: &'static [&'static str],
-    kind: SchemaKind,
-    status: &'static str,
-    family: &'static str,
-    source_path: &'static str,
-    description: &'static str,
-    trust_basis_claim: Option<&'static str>,
-    importer_only: bool,
-    schema_json: &'static str,
-}
-
-impl SchemaDescriptor {
-    fn json_schema_value(&self) -> Result<Value> {
-        serde_json::from_str(self.schema_json)
-            .with_context(|| format!("failed to parse embedded schema {}", self.name))
-    }
-
-    fn json_schema_id(&self) -> Result<String> {
-        Ok(self
-            .json_schema_value()?
-            .get("$id")
-            .and_then(Value::as_str)
-            .unwrap_or(self.name)
-            .to_string())
-    }
-
-    fn matches(&self, needle: &str) -> Result<bool> {
-        if self.name == needle || self.source_path == needle || self.aliases.contains(&needle) {
-            return Ok(true);
-        }
-        Ok(self.json_schema_id()? == needle)
-    }
-}
-
-const SCHEMAS: &[SchemaDescriptor] = &[
-    SchemaDescriptor {
-        name: "promptfoo.assertion-component.v1",
-        aliases: &["assay.receipt.promptfoo.assertion-component.v1"],
-        kind: SchemaKind::Receipt,
-        status: "stable",
-        family: "external_eval_receipts",
-        source_path: "docs/reference/receipt-schemas/receipts/promptfoo.assertion-component.v1.schema.json",
-        description: "Assay receipt payload for one selected Promptfoo assertion component result.",
-        trust_basis_claim: Some("external_eval_receipt_boundary_visible"),
-        importer_only: false,
-        schema_json: PROMPTFOO_RECEIPT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "openfeature.evaluation-details.v1",
-        aliases: &["assay.receipt.openfeature.evaluation_details.v1"],
-        kind: SchemaKind::Receipt,
-        status: "stable",
-        family: "external_decision_receipts",
-        source_path: "docs/reference/receipt-schemas/receipts/openfeature.evaluation-details.v1.schema.json",
-        description: "Assay receipt payload for one bounded OpenFeature boolean EvaluationDetails decision.",
-        trust_basis_claim: Some("external_decision_receipt_boundary_visible"),
-        importer_only: false,
-        schema_json: OPENFEATURE_RECEIPT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "cyclonedx.mlbom-model-component.v1",
-        aliases: &["assay.receipt.cyclonedx.mlbom-model-component.v1"],
-        kind: SchemaKind::Receipt,
-        status: "stable",
-        family: "external_inventory_receipts",
-        source_path: "docs/reference/receipt-schemas/receipts/cyclonedx.mlbom-model-component.v1.schema.json",
-        description: "Assay receipt payload for one selected CycloneDX ML-BOM machine-learning-model component.",
-        trust_basis_claim: Some("external_inventory_receipt_boundary_visible"),
-        importer_only: false,
-        schema_json: CYCLONEDX_RECEIPT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "mastra.score-event.v1",
-        aliases: &["assay.receipt.mastra.score_event.v1"],
-        kind: SchemaKind::Receipt,
-        status: "experimental",
-        family: "score_receipts",
-        source_path: "docs/reference/receipt-schemas/receipts/mastra.score-event.v1.schema.json",
-        description: "Assay receipt payload for one bounded Mastra ScoreEvent-derived score artifact.",
-        trust_basis_claim: None,
-        importer_only: true,
-        schema_json: MASTRA_RECEIPT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "pydantic.case-result.v1",
-        aliases: &["assay.receipt.pydantic.case_result.v1"],
-        kind: SchemaKind::Receipt,
-        status: "experimental",
-        family: "case_result_receipts",
-        source_path: "docs/reference/receipt-schemas/receipts/pydantic.case-result.v1.schema.json",
-        description: "Assay receipt payload for one bounded Pydantic Evals reduced case-result artifact.",
-        trust_basis_claim: None,
-        importer_only: true,
-        schema_json: PYDANTIC_RECEIPT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "livekit.tool-action.v1",
-        aliases: &["assay.receipt.livekit.tool-action.v1"],
-        kind: SchemaKind::Receipt,
-        status: "experimental",
-        family: "acted_receipts_candidate",
-        source_path: "docs/reference/receipt-schemas/receipts/livekit.tool-action.v1.schema.json",
-        description: "Assay receipt payload for one bounded LiveKit function tool action artifact.",
-        trust_basis_claim: None,
-        importer_only: true,
-        schema_json: LIVEKIT_RECEIPT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "promptfoo-cli-jsonl-component-result.v1",
-        aliases: &[],
-        kind: SchemaKind::Input,
-        status: "stable",
-        family: "external_eval_receipts",
-        source_path: "docs/reference/receipt-schemas/inputs/promptfoo-cli-jsonl-component-result.v1.schema.json",
-        description: "Supported Promptfoo CLI JSONL row shape containing assertion component results.",
-        trust_basis_claim: Some("external_eval_receipt_boundary_visible"),
-        importer_only: false,
-        schema_json: PROMPTFOO_INPUT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "openfeature-evaluation-details-export.v1",
-        aliases: &[],
-        kind: SchemaKind::Input,
-        status: "stable",
-        family: "external_decision_receipts",
-        source_path: "docs/reference/receipt-schemas/inputs/openfeature-evaluation-details-export.v1.schema.json",
-        description: "Supported reduced OpenFeature boolean EvaluationDetails JSONL row shape.",
-        trust_basis_claim: Some("external_decision_receipt_boundary_visible"),
-        importer_only: false,
-        schema_json: OPENFEATURE_INPUT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "cyclonedx-mlbom-model-component-input.v1",
-        aliases: &[],
-        kind: SchemaKind::Input,
-        status: "stable",
-        family: "external_inventory_receipts",
-        source_path: "docs/reference/receipt-schemas/inputs/cyclonedx-mlbom-model-component-input.v1.schema.json",
-        description: "Supported CycloneDX ML-BOM input shape for selecting one machine-learning-model component.",
-        trust_basis_claim: Some("external_inventory_receipt_boundary_visible"),
-        importer_only: false,
-        schema_json: CYCLONEDX_INPUT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "mastra-score-event-export.v1",
-        aliases: &[],
-        kind: SchemaKind::Input,
-        status: "experimental",
-        family: "score_receipts",
-        source_path: "docs/reference/receipt-schemas/inputs/mastra-score-event-export.v1.schema.json",
-        description: "Supported reduced Mastra ScoreEvent JSONL row shape.",
-        trust_basis_claim: None,
-        importer_only: true,
-        schema_json: MASTRA_INPUT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "pydantic-case-result-export.v1",
-        aliases: &[],
-        kind: SchemaKind::Input,
-        status: "experimental",
-        family: "case_result_receipts",
-        source_path: "docs/reference/receipt-schemas/inputs/pydantic-case-result-export.v1.schema.json",
-        description: "Supported reduced Pydantic Evals case-result JSONL row shape.",
-        trust_basis_claim: None,
-        importer_only: true,
-        schema_json: PYDANTIC_INPUT_SCHEMA,
-    },
-    SchemaDescriptor {
-        name: "livekit-function-tools-executed-export.v1",
-        aliases: &[],
-        kind: SchemaKind::Input,
-        status: "experimental",
-        family: "acted_receipts_candidate",
-        source_path: "docs/reference/receipt-schemas/inputs/livekit-function-tools-executed-export.v1.schema.json",
-        description: "Supported reduced LiveKit FunctionToolsExecutedEvent artifact shape.",
-        trust_basis_claim: None,
-        importer_only: true,
-        schema_json: LIVEKIT_INPUT_SCHEMA,
-    },
-];
-
-#[derive(Debug, Serialize)]
-struct SchemaListReport {
-    schema: &'static str,
-    schemas: Vec<SchemaMetadata>,
-}
-
-#[derive(Debug, Serialize)]
-struct SchemaShowReport {
-    schema: &'static str,
-    metadata: SchemaMetadata,
-}
-
-#[derive(Debug, Serialize)]
-struct SchemaMetadata {
-    name: String,
-    kind: SchemaKind,
-    status: String,
-    family: String,
-    json_schema_id: String,
-    source_path: String,
-    description: String,
-    trust_basis_claim: Option<String>,
-    importer_only: bool,
-    aliases: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct SchemaValidationReport {
-    schema: &'static str,
-    schema_name: String,
-    schema_kind: SchemaKind,
-    input: String,
-    jsonl: bool,
-    valid: bool,
-    documents: usize,
-    errors: Vec<SchemaValidationError>,
-}
-
-#[derive(Debug, Serialize)]
-struct SchemaValidationError {
-    document: usize,
-    kind: SchemaValidationErrorKind,
-    instance_path: String,
-    message: String,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum SchemaValidationErrorKind {
-    Parse,
-    EmptyInput,
-    Schema,
-}
-
-impl SchemaValidationReport {
-    fn has_input_errors(&self) -> bool {
-        self.errors.iter().any(|error| {
-            matches!(
-                error.kind,
-                SchemaValidationErrorKind::Parse | SchemaValidationErrorKind::EmptyInput
-            )
-        })
-    }
-}
-
 pub fn cmd_schema(args: SchemaArgs) -> Result<i32> {
     match args.cmd {
         SchemaCmd::List(args) => cmd_list(args),
@@ -379,41 +77,40 @@ pub fn cmd_schema(args: SchemaArgs) -> Result<i32> {
 }
 
 fn cmd_list(args: SchemaListArgs) -> Result<i32> {
-    let report = SchemaListReport {
-        schema: SCHEMA_LIST_REPORT,
-        schemas: SCHEMAS
+    let report = reports::SchemaListReport {
+        schema: reports::SCHEMA_LIST_REPORT,
+        schemas: registry::SCHEMAS
             .iter()
-            .map(schema_metadata)
+            .map(registry::schema_metadata)
             .collect::<Result<Vec<_>>>()?,
     };
 
     match args.format {
-        OutputFormat::Text => write_list_text(&report),
-        OutputFormat::Json => write_json(&report),
+        OutputFormat::Text => write::write_list_text(&report),
+        OutputFormat::Json => write::write_json(&report),
     }
 }
 
 fn cmd_show(args: SchemaShowArgs) -> Result<i32> {
-    let descriptor = find_schema(&args.schema)?;
+    let descriptor = registry::find_schema(&args.schema)?;
     if args.raw {
         let raw = descriptor.json_schema_value()?;
-        println!("{}", serde_json::to_string_pretty(&raw)?);
-        return Ok(EXIT_SUCCESS);
+        return write::write_json(&raw);
     }
 
-    let report = SchemaShowReport {
-        schema: SCHEMA_SHOW_REPORT,
-        metadata: schema_metadata(descriptor)?,
+    let report = reports::SchemaShowReport {
+        schema: reports::SCHEMA_SHOW_REPORT,
+        metadata: registry::schema_metadata(descriptor)?,
     };
 
     match args.format {
-        OutputFormat::Text => write_show_text(&report),
-        OutputFormat::Json => write_json(&report),
+        OutputFormat::Text => write::write_show_text(&report),
+        OutputFormat::Json => write::write_json(&report),
     }
 }
 
 fn cmd_validate(args: SchemaValidateArgs) -> Result<i32> {
-    let descriptor = find_schema(&args.schema)?;
+    let descriptor = registry::find_schema(&args.schema)?;
     let input = std::fs::read_to_string(&args.input).with_context(|| {
         format!(
             "failed to read schema validation input {}",
@@ -425,11 +122,11 @@ fn cmd_validate(args: SchemaValidateArgs) -> Result<i32> {
         .with_draft(Draft::Draft202012)
         .build(&schema_value)
         .with_context(|| format!("failed to compile schema {}", descriptor.name))?;
-    let report = validate_input(descriptor, &args.input, args.jsonl, &input, &validator);
+    let report = validate::validate_input(descriptor, &args.input, args.jsonl, &input, &validator);
 
     match args.format {
-        OutputFormat::Text => write_validation_text(&report),
-        OutputFormat::Json => write_json(&report),
+        OutputFormat::Text => write::write_validation_text(&report),
+        OutputFormat::Json => write::write_json(&report),
     }?;
 
     if report.valid {
@@ -439,189 +136,4 @@ fn cmd_validate(args: SchemaValidateArgs) -> Result<i32> {
     } else {
         Ok(EXIT_TEST_FAILURE)
     }
-}
-
-fn find_schema(raw: &str) -> Result<&'static SchemaDescriptor> {
-    let needle = raw.trim();
-    if needle.is_empty() {
-        bail!("schema name is empty");
-    }
-
-    for descriptor in SCHEMAS {
-        if descriptor.matches(needle)? {
-            return Ok(descriptor);
-        }
-    }
-
-    bail!("unknown schema {needle:?}; run `assay evidence schema list` for supported schemas");
-}
-
-fn schema_metadata(descriptor: &SchemaDescriptor) -> Result<SchemaMetadata> {
-    Ok(SchemaMetadata {
-        name: descriptor.name.to_string(),
-        kind: descriptor.kind,
-        status: descriptor.status.to_string(),
-        family: descriptor.family.to_string(),
-        json_schema_id: descriptor.json_schema_id()?,
-        source_path: descriptor.source_path.to_string(),
-        description: descriptor.description.to_string(),
-        trust_basis_claim: descriptor.trust_basis_claim.map(str::to_string),
-        importer_only: descriptor.importer_only,
-        aliases: descriptor
-            .aliases
-            .iter()
-            .map(|alias| (*alias).to_string())
-            .collect(),
-    })
-}
-
-fn validate_input(
-    descriptor: &SchemaDescriptor,
-    input_path: &std::path::Path,
-    jsonl: bool,
-    input: &str,
-    validator: &jsonschema::Validator,
-) -> SchemaValidationReport {
-    let mut errors = Vec::new();
-    let mut documents = 0usize;
-
-    if jsonl {
-        for (idx, line) in input.lines().enumerate() {
-            let line_number = idx + 1;
-            if line.trim().is_empty() {
-                continue;
-            }
-            documents += 1;
-            match serde_json::from_str::<Value>(line) {
-                Ok(value) => collect_validation_errors(line_number, &value, validator, &mut errors),
-                Err(err) => errors.push(SchemaValidationError {
-                    document: line_number,
-                    kind: SchemaValidationErrorKind::Parse,
-                    instance_path: "$".to_string(),
-                    message: format!("invalid JSON: {err}"),
-                }),
-            }
-        }
-    } else {
-        documents = 1;
-        match serde_json::from_str::<Value>(input) {
-            Ok(value) => collect_validation_errors(1, &value, validator, &mut errors),
-            Err(err) => errors.push(SchemaValidationError {
-                document: 1,
-                kind: SchemaValidationErrorKind::Parse,
-                instance_path: "$".to_string(),
-                message: format!("invalid JSON: {err}"),
-            }),
-        }
-    }
-
-    if documents == 0 {
-        errors.push(SchemaValidationError {
-            document: 0,
-            kind: SchemaValidationErrorKind::EmptyInput,
-            instance_path: "$".to_string(),
-            message: "no JSON documents found".to_string(),
-        });
-    }
-
-    SchemaValidationReport {
-        schema: SCHEMA_VALIDATION_REPORT,
-        schema_name: descriptor.name.to_string(),
-        schema_kind: descriptor.kind,
-        input: input_path.display().to_string(),
-        jsonl,
-        valid: errors.is_empty(),
-        documents,
-        errors,
-    }
-}
-
-fn collect_validation_errors(
-    document: usize,
-    value: &Value,
-    validator: &jsonschema::Validator,
-    errors: &mut Vec<SchemaValidationError>,
-) {
-    errors.extend(
-        validator
-            .iter_errors(value)
-            .map(|err| SchemaValidationError {
-                document,
-                kind: SchemaValidationErrorKind::Schema,
-                instance_path: err.instance_path().to_string(),
-                message: err.to_string(),
-            }),
-    );
-}
-
-fn write_list_text(report: &SchemaListReport) -> Result<i32> {
-    println!("Assay Evidence Schema Registry");
-    println!("Schema: {}", report.schema);
-    for schema in &report.schemas {
-        println!(
-            "- {} [{}; {}; family: {}]",
-            schema.name, schema.kind, schema.status, schema.family
-        );
-        println!("  id: {}", schema.json_schema_id);
-        println!("  source: {}", schema.source_path);
-        println!("  description: {}", schema.description);
-        if let Some(claim) = &schema.trust_basis_claim {
-            println!("  trust_basis_claim: {claim}");
-        } else if schema.importer_only {
-            println!("  trust_basis_claim: none (importer-only)");
-        }
-    }
-    Ok(EXIT_SUCCESS)
-}
-
-fn write_show_text(report: &SchemaShowReport) -> Result<i32> {
-    let schema = &report.metadata;
-    println!("Schema: {}", schema.name);
-    println!("Kind: {}", schema.kind);
-    println!("Status: {}", schema.status);
-    println!("Family: {}", schema.family);
-    println!("JSON Schema $id: {}", schema.json_schema_id);
-    println!("Source: {}", schema.source_path);
-    println!("Description: {}", schema.description);
-    if let Some(claim) = &schema.trust_basis_claim {
-        println!("Trust Basis claim: {claim}");
-    } else if schema.importer_only {
-        println!("Trust Basis claim: none (importer-only)");
-    } else {
-        println!("Trust Basis claim: none");
-    }
-    if !schema.aliases.is_empty() {
-        println!("Aliases:");
-        for alias in &schema.aliases {
-            println!("- {alias}");
-        }
-    }
-    Ok(EXIT_SUCCESS)
-}
-
-fn write_validation_text(report: &SchemaValidationReport) -> Result<i32> {
-    if report.valid {
-        println!(
-            "Schema validation passed: {} matches {} ({} document(s))",
-            report.input, report.schema_name, report.documents
-        );
-        return Ok(EXIT_SUCCESS);
-    }
-
-    println!(
-        "Schema validation failed: {} does not match {}",
-        report.input, report.schema_name
-    );
-    for error in &report.errors {
-        println!(
-            "- document {} at {}: {}",
-            error.document, error.instance_path, error.message
-        );
-    }
-    Ok(EXIT_SUCCESS)
-}
-
-fn write_json<T: Serialize>(value: &T) -> Result<i32> {
-    println!("{}", serde_json::to_string_pretty(value)?);
-    Ok(EXIT_SUCCESS)
 }

--- a/crates/assay-cli/src/cli/commands/evidence/schema/registry.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/schema/registry.rs
@@ -1,0 +1,256 @@
+use super::reports::{SchemaKind, SchemaMetadata};
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+
+macro_rules! include_packaged_schema {
+    ($relative_path:literal) => {
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/receipt-schemas/",
+            $relative_path
+        ))
+    };
+}
+
+const PROMPTFOO_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/promptfoo.assertion-component.v1.schema.json");
+const OPENFEATURE_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/openfeature.evaluation-details.v1.schema.json");
+const CYCLONEDX_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/cyclonedx.mlbom-model-component.v1.schema.json");
+const MASTRA_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/mastra.score-event.v1.schema.json");
+const PYDANTIC_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/pydantic.case-result.v1.schema.json");
+const LIVEKIT_RECEIPT_SCHEMA: &str =
+    include_packaged_schema!("receipts/livekit.tool-action.v1.schema.json");
+const PROMPTFOO_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/promptfoo-cli-jsonl-component-result.v1.schema.json");
+const OPENFEATURE_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/openfeature-evaluation-details-export.v1.schema.json");
+const CYCLONEDX_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/cyclonedx-mlbom-model-component-input.v1.schema.json");
+const MASTRA_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/mastra-score-event-export.v1.schema.json");
+const PYDANTIC_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/pydantic-case-result-export.v1.schema.json");
+const LIVEKIT_INPUT_SCHEMA: &str =
+    include_packaged_schema!("inputs/livekit-function-tools-executed-export.v1.schema.json");
+
+#[derive(Clone, Copy)]
+pub(super) struct SchemaDescriptor {
+    pub(super) name: &'static str,
+    aliases: &'static [&'static str],
+    pub(super) kind: SchemaKind,
+    status: &'static str,
+    family: &'static str,
+    source_path: &'static str,
+    description: &'static str,
+    trust_basis_claim: Option<&'static str>,
+    importer_only: bool,
+    schema_json: &'static str,
+}
+
+impl SchemaDescriptor {
+    pub(super) fn json_schema_value(&self) -> Result<Value> {
+        serde_json::from_str(self.schema_json)
+            .with_context(|| format!("failed to parse embedded schema {}", self.name))
+    }
+
+    fn json_schema_id(&self) -> Result<String> {
+        Ok(self
+            .json_schema_value()?
+            .get("$id")
+            .and_then(Value::as_str)
+            .unwrap_or(self.name)
+            .to_string())
+    }
+
+    fn matches(&self, needle: &str) -> Result<bool> {
+        if self.name == needle || self.source_path == needle || self.aliases.contains(&needle) {
+            return Ok(true);
+        }
+        Ok(self.json_schema_id()? == needle)
+    }
+}
+
+pub(super) const SCHEMAS: &[SchemaDescriptor] = &[
+    SchemaDescriptor {
+        name: "promptfoo.assertion-component.v1",
+        aliases: &["assay.receipt.promptfoo.assertion-component.v1"],
+        kind: SchemaKind::Receipt,
+        status: "stable",
+        family: "external_eval_receipts",
+        source_path: "docs/reference/receipt-schemas/receipts/promptfoo.assertion-component.v1.schema.json",
+        description: "Assay receipt payload for one selected Promptfoo assertion component result.",
+        trust_basis_claim: Some("external_eval_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: PROMPTFOO_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "openfeature.evaluation-details.v1",
+        aliases: &["assay.receipt.openfeature.evaluation_details.v1"],
+        kind: SchemaKind::Receipt,
+        status: "stable",
+        family: "external_decision_receipts",
+        source_path: "docs/reference/receipt-schemas/receipts/openfeature.evaluation-details.v1.schema.json",
+        description: "Assay receipt payload for one bounded OpenFeature boolean EvaluationDetails decision.",
+        trust_basis_claim: Some("external_decision_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: OPENFEATURE_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "cyclonedx.mlbom-model-component.v1",
+        aliases: &["assay.receipt.cyclonedx.mlbom-model-component.v1"],
+        kind: SchemaKind::Receipt,
+        status: "stable",
+        family: "external_inventory_receipts",
+        source_path: "docs/reference/receipt-schemas/receipts/cyclonedx.mlbom-model-component.v1.schema.json",
+        description: "Assay receipt payload for one selected CycloneDX ML-BOM machine-learning-model component.",
+        trust_basis_claim: Some("external_inventory_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: CYCLONEDX_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "mastra.score-event.v1",
+        aliases: &["assay.receipt.mastra.score_event.v1"],
+        kind: SchemaKind::Receipt,
+        status: "experimental",
+        family: "score_receipts",
+        source_path: "docs/reference/receipt-schemas/receipts/mastra.score-event.v1.schema.json",
+        description: "Assay receipt payload for one bounded Mastra ScoreEvent-derived score artifact.",
+        trust_basis_claim: None,
+        importer_only: true,
+        schema_json: MASTRA_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "pydantic.case-result.v1",
+        aliases: &["assay.receipt.pydantic.case_result.v1"],
+        kind: SchemaKind::Receipt,
+        status: "experimental",
+        family: "case_result_receipts",
+        source_path: "docs/reference/receipt-schemas/receipts/pydantic.case-result.v1.schema.json",
+        description: "Assay receipt payload for one bounded Pydantic Evals reduced case-result artifact.",
+        trust_basis_claim: None,
+        importer_only: true,
+        schema_json: PYDANTIC_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "livekit.tool-action.v1",
+        aliases: &["assay.receipt.livekit.tool-action.v1"],
+        kind: SchemaKind::Receipt,
+        status: "experimental",
+        family: "acted_receipts_candidate",
+        source_path: "docs/reference/receipt-schemas/receipts/livekit.tool-action.v1.schema.json",
+        description: "Assay receipt payload for one bounded LiveKit function tool action artifact.",
+        trust_basis_claim: None,
+        importer_only: true,
+        schema_json: LIVEKIT_RECEIPT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "promptfoo-cli-jsonl-component-result.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "stable",
+        family: "external_eval_receipts",
+        source_path: "docs/reference/receipt-schemas/inputs/promptfoo-cli-jsonl-component-result.v1.schema.json",
+        description: "Supported Promptfoo CLI JSONL row shape containing assertion component results.",
+        trust_basis_claim: Some("external_eval_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: PROMPTFOO_INPUT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "openfeature-evaluation-details-export.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "stable",
+        family: "external_decision_receipts",
+        source_path: "docs/reference/receipt-schemas/inputs/openfeature-evaluation-details-export.v1.schema.json",
+        description: "Supported reduced OpenFeature boolean EvaluationDetails JSONL row shape.",
+        trust_basis_claim: Some("external_decision_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: OPENFEATURE_INPUT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "cyclonedx-mlbom-model-component-input.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "stable",
+        family: "external_inventory_receipts",
+        source_path: "docs/reference/receipt-schemas/inputs/cyclonedx-mlbom-model-component-input.v1.schema.json",
+        description: "Supported CycloneDX ML-BOM input shape for selecting one machine-learning-model component.",
+        trust_basis_claim: Some("external_inventory_receipt_boundary_visible"),
+        importer_only: false,
+        schema_json: CYCLONEDX_INPUT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "mastra-score-event-export.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "experimental",
+        family: "score_receipts",
+        source_path: "docs/reference/receipt-schemas/inputs/mastra-score-event-export.v1.schema.json",
+        description: "Supported reduced Mastra ScoreEvent JSONL row shape.",
+        trust_basis_claim: None,
+        importer_only: true,
+        schema_json: MASTRA_INPUT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "pydantic-case-result-export.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "experimental",
+        family: "case_result_receipts",
+        source_path: "docs/reference/receipt-schemas/inputs/pydantic-case-result-export.v1.schema.json",
+        description: "Supported reduced Pydantic Evals case-result JSONL row shape.",
+        trust_basis_claim: None,
+        importer_only: true,
+        schema_json: PYDANTIC_INPUT_SCHEMA,
+    },
+    SchemaDescriptor {
+        name: "livekit-function-tools-executed-export.v1",
+        aliases: &[],
+        kind: SchemaKind::Input,
+        status: "experimental",
+        family: "acted_receipts_candidate",
+        source_path: "docs/reference/receipt-schemas/inputs/livekit-function-tools-executed-export.v1.schema.json",
+        description: "Supported reduced LiveKit FunctionToolsExecutedEvent artifact shape.",
+        trust_basis_claim: None,
+        importer_only: true,
+        schema_json: LIVEKIT_INPUT_SCHEMA,
+    },
+];
+
+pub(super) fn find_schema(raw: &str) -> Result<&'static SchemaDescriptor> {
+    let needle = raw.trim();
+    if needle.is_empty() {
+        bail!("schema name is empty");
+    }
+
+    for descriptor in SCHEMAS {
+        if descriptor.matches(needle)? {
+            return Ok(descriptor);
+        }
+    }
+
+    bail!("unknown schema {needle:?}; run `assay evidence schema list` for supported schemas");
+}
+
+pub(super) fn schema_metadata(descriptor: &SchemaDescriptor) -> Result<SchemaMetadata> {
+    Ok(SchemaMetadata {
+        name: descriptor.name.to_string(),
+        kind: descriptor.kind,
+        status: descriptor.status.to_string(),
+        family: descriptor.family.to_string(),
+        json_schema_id: descriptor.json_schema_id()?,
+        source_path: descriptor.source_path.to_string(),
+        description: descriptor.description.to_string(),
+        trust_basis_claim: descriptor.trust_basis_claim.map(str::to_string),
+        importer_only: descriptor.importer_only,
+        aliases: descriptor
+            .aliases
+            .iter()
+            .map(|alias| (*alias).to_string())
+            .collect(),
+    })
+}

--- a/crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/schema/reports.rs
@@ -1,0 +1,87 @@
+use serde::Serialize;
+use std::fmt;
+
+pub(super) const SCHEMA_LIST_REPORT: &str = "assay.evidence.schema.list.v1";
+pub(super) const SCHEMA_SHOW_REPORT: &str = "assay.evidence.schema.show.v1";
+pub(super) const SCHEMA_VALIDATION_REPORT: &str = "assay.evidence.schema.validation.v1";
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum SchemaKind {
+    Receipt,
+    Input,
+}
+
+impl fmt::Display for SchemaKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Receipt => f.write_str("receipt"),
+            Self::Input => f.write_str("input"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct SchemaListReport {
+    pub(super) schema: &'static str,
+    pub(super) schemas: Vec<SchemaMetadata>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct SchemaShowReport {
+    pub(super) schema: &'static str,
+    pub(super) metadata: SchemaMetadata,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct SchemaMetadata {
+    pub(super) name: String,
+    pub(super) kind: SchemaKind,
+    pub(super) status: String,
+    pub(super) family: String,
+    pub(super) json_schema_id: String,
+    pub(super) source_path: String,
+    pub(super) description: String,
+    pub(super) trust_basis_claim: Option<String>,
+    pub(super) importer_only: bool,
+    pub(super) aliases: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct SchemaValidationReport {
+    pub(super) schema: &'static str,
+    pub(super) schema_name: String,
+    pub(super) schema_kind: SchemaKind,
+    pub(super) input: String,
+    pub(super) jsonl: bool,
+    pub(super) valid: bool,
+    pub(super) documents: usize,
+    pub(super) errors: Vec<SchemaValidationError>,
+}
+
+impl SchemaValidationReport {
+    pub(super) fn has_input_errors(&self) -> bool {
+        self.errors.iter().any(|error| {
+            matches!(
+                error.kind,
+                SchemaValidationErrorKind::Parse | SchemaValidationErrorKind::EmptyInput
+            )
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct SchemaValidationError {
+    pub(super) document: usize,
+    pub(super) kind: SchemaValidationErrorKind,
+    pub(super) instance_path: String,
+    pub(super) message: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum SchemaValidationErrorKind {
+    Parse,
+    EmptyInput,
+    Schema,
+}

--- a/crates/assay-cli/src/cli/commands/evidence/schema/validate.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/schema/validate.rs
@@ -1,0 +1,86 @@
+use super::registry::SchemaDescriptor;
+use super::reports::{
+    SchemaValidationError, SchemaValidationErrorKind, SchemaValidationReport,
+    SCHEMA_VALIDATION_REPORT,
+};
+use serde_json::Value;
+use std::path::Path;
+
+pub(super) fn validate_input(
+    descriptor: &SchemaDescriptor,
+    input_path: &Path,
+    jsonl: bool,
+    input: &str,
+    validator: &jsonschema::Validator,
+) -> SchemaValidationReport {
+    let mut errors = Vec::new();
+    let mut documents = 0usize;
+
+    if jsonl {
+        for (idx, line) in input.lines().enumerate() {
+            let line_number = idx + 1;
+            if line.trim().is_empty() {
+                continue;
+            }
+            documents += 1;
+            match serde_json::from_str::<Value>(line) {
+                Ok(value) => collect_validation_errors(line_number, &value, validator, &mut errors),
+                Err(err) => errors.push(SchemaValidationError {
+                    document: line_number,
+                    kind: SchemaValidationErrorKind::Parse,
+                    instance_path: "$".to_string(),
+                    message: format!("invalid JSON: {err}"),
+                }),
+            }
+        }
+    } else {
+        documents = 1;
+        match serde_json::from_str::<Value>(input) {
+            Ok(value) => collect_validation_errors(1, &value, validator, &mut errors),
+            Err(err) => errors.push(SchemaValidationError {
+                document: 1,
+                kind: SchemaValidationErrorKind::Parse,
+                instance_path: "$".to_string(),
+                message: format!("invalid JSON: {err}"),
+            }),
+        }
+    }
+
+    if documents == 0 {
+        errors.push(SchemaValidationError {
+            document: 0,
+            kind: SchemaValidationErrorKind::EmptyInput,
+            instance_path: "$".to_string(),
+            message: "no JSON documents found".to_string(),
+        });
+    }
+
+    SchemaValidationReport {
+        schema: SCHEMA_VALIDATION_REPORT,
+        schema_name: descriptor.name.to_string(),
+        schema_kind: descriptor.kind,
+        input: input_path.display().to_string(),
+        jsonl,
+        valid: errors.is_empty(),
+        documents,
+        errors,
+    }
+}
+
+fn collect_validation_errors(
+    document: usize,
+    value: &Value,
+    validator: &jsonschema::Validator,
+    errors: &mut Vec<SchemaValidationError>,
+) {
+    errors.extend(
+        validator
+            .iter_errors(value)
+            .map(|err| SchemaValidationError {
+                document,
+                kind: SchemaValidationErrorKind::Schema,
+                instance_path: err.instance_path().to_string(),
+                message: err.to_string(),
+            }),
+    );
+}

--- a/crates/assay-cli/src/cli/commands/evidence/schema/write.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/schema/write.rs
@@ -1,0 +1,76 @@
+use super::reports::{SchemaListReport, SchemaShowReport, SchemaValidationReport};
+use crate::exit_codes::EXIT_SUCCESS;
+use anyhow::Result;
+use serde::Serialize;
+
+pub(super) fn write_list_text(report: &SchemaListReport) -> Result<i32> {
+    println!("Assay Evidence Schema Registry");
+    println!("Schema: {}", report.schema);
+    for schema in &report.schemas {
+        println!(
+            "- {} [{}; {}; family: {}]",
+            schema.name, schema.kind, schema.status, schema.family
+        );
+        println!("  id: {}", schema.json_schema_id);
+        println!("  source: {}", schema.source_path);
+        println!("  description: {}", schema.description);
+        if let Some(claim) = &schema.trust_basis_claim {
+            println!("  trust_basis_claim: {claim}");
+        } else if schema.importer_only {
+            println!("  trust_basis_claim: none (importer-only)");
+        }
+    }
+    Ok(EXIT_SUCCESS)
+}
+
+pub(super) fn write_show_text(report: &SchemaShowReport) -> Result<i32> {
+    let schema = &report.metadata;
+    println!("Schema: {}", schema.name);
+    println!("Kind: {}", schema.kind);
+    println!("Status: {}", schema.status);
+    println!("Family: {}", schema.family);
+    println!("JSON Schema $id: {}", schema.json_schema_id);
+    println!("Source: {}", schema.source_path);
+    println!("Description: {}", schema.description);
+    if let Some(claim) = &schema.trust_basis_claim {
+        println!("Trust Basis claim: {claim}");
+    } else if schema.importer_only {
+        println!("Trust Basis claim: none (importer-only)");
+    } else {
+        println!("Trust Basis claim: none");
+    }
+    if !schema.aliases.is_empty() {
+        println!("Aliases:");
+        for alias in &schema.aliases {
+            println!("- {alias}");
+        }
+    }
+    Ok(EXIT_SUCCESS)
+}
+
+pub(super) fn write_validation_text(report: &SchemaValidationReport) -> Result<i32> {
+    if report.valid {
+        println!(
+            "Schema validation passed: {} matches {} ({} document(s))",
+            report.input, report.schema_name, report.documents
+        );
+        return Ok(EXIT_SUCCESS);
+    }
+
+    println!(
+        "Schema validation failed: {} does not match {}",
+        report.input, report.schema_name
+    );
+    for error in &report.errors {
+        println!(
+            "- document {} at {}: {}",
+            error.document, error.instance_path, error.message
+        );
+    }
+    Ok(EXIT_SUCCESS)
+}
+
+pub(super) fn write_json<T: Serialize>(value: &T) -> Result<i32> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(EXIT_SUCCESS)
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave55-evidence-contract-schema-step1.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave55-evidence-contract-schema-step1.md
@@ -1,0 +1,13 @@
+# Wave55 Step1 Checklist - Evidence Schema Facade Split
+
+- [ ] Step1 is based on `origin/main`
+- [ ] `schema.rs` remains the public `assay evidence schema` command facade
+- [ ] Schema registry descriptors live in `schema/registry.rs`
+- [ ] Report/metadata/error DTOs live in `schema/reports.rs`
+- [ ] JSON/JSONL validation lives in `schema/validate.rs`
+- [ ] Text/JSON rendering lives in `schema/write.rs`
+- [ ] No receipt schema JSON files are changed
+- [ ] No importer command files are changed
+- [ ] No docs/reference schema contract files are changed
+- [ ] No `.github/workflows/**` files are changed
+- [ ] `bash scripts/ci/review-wave55-evidence-contract-schema-step1.sh` passes

--- a/docs/contributing/SPLIT-MOVE-MAP-wave55-evidence-contract-schema-step1.md
+++ b/docs/contributing/SPLIT-MOVE-MAP-wave55-evidence-contract-schema-step1.md
@@ -1,0 +1,43 @@
+# SPLIT MOVE MAP - Wave55 Step1 - Evidence Schema Facade Split
+
+## Base
+
+- base: `origin/main`
+- head: `codex/wave55-evidence-contract-split`
+
+## Mechanical Movement
+
+Facade:
+
+- `crates/assay-cli/src/cli/commands/evidence/schema.rs`
+
+New internal modules:
+
+- `crates/assay-cli/src/cli/commands/evidence/schema/registry.rs`
+- `crates/assay-cli/src/cli/commands/evidence/schema/reports.rs`
+- `crates/assay-cli/src/cli/commands/evidence/schema/validate.rs`
+- `crates/assay-cli/src/cli/commands/evidence/schema/write.rs`
+
+## Explicit Non-Movement
+
+- No edits to `crates/assay-cli/src/cli/commands/evidence/*_result.rs`.
+- No edits to `crates/assay-cli/src/cli/commands/evidence/cyclonedx_mlbom_model.rs`.
+- No edits to `crates/assay-cli/src/cli/commands/evidence/mastra_score_event.rs`.
+- No edits to `crates/assay-cli/receipt-schemas/**`.
+- No edits to `docs/reference/receipt-schemas/**`.
+- No edits to `.github/workflows/**`.
+
+## LOC Snapshot
+
+| Area | Before LOC | After LOC |
+| --- | ---: | ---: |
+| `schema.rs` facade | 627 | 139 |
+
+Moved code now lives in:
+
+| File | LOC |
+| --- | ---: |
+| `schema/registry.rs` | 256 |
+| `schema/reports.rs` | 87 |
+| `schema/validate.rs` | 86 |
+| `schema/write.rs` | 76 |

--- a/docs/contributing/SPLIT-PLAN-wave55-evidence-contract-schema.md
+++ b/docs/contributing/SPLIT-PLAN-wave55-evidence-contract-schema.md
@@ -1,0 +1,34 @@
+# Wave55 Evidence Contract Schema Split Plan
+
+## Scope
+
+Wave55 starts the post-Wave54 evidence-contract refactor line with one narrow target:
+
+- `crates/assay-cli/src/cli/commands/evidence/schema.rs`
+
+This file owns the `assay evidence schema` CLI contract for listing, showing, and validating
+receipt/input schemas. Because the surface is a serialized CLI contract, this wave preserves behavior
+and output shape before considering any importer-model splits.
+
+## Step 1 Target
+
+Split `schema.rs` behind its existing public command facade:
+
+- keep `SchemaArgs`, `SchemaCmd`, subcommand args, and `cmd_schema` in `schema.rs`
+- move embedded schema descriptors and lookup to `schema/registry.rs`
+- move serializable report and validation error types to `schema/reports.rs`
+- move JSON/JSONL validation to `schema/validate.rs`
+- move text/JSON rendering to `schema/write.rs`
+
+## Non-Goals
+
+- No schema ID, alias, path, family, status, or Trust Basis claim changes.
+- No importer behavior changes.
+- No receipt JSON Schema file changes.
+- No docs/reference content changes.
+- No `.github/workflows/**` edits.
+
+## Review Rule
+
+Review this as a mechanical split against `origin/main`. The contract tests in
+`crates/assay-cli/tests/receipt_schema_registry_test*` are the behavior freeze.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave55-evidence-contract-schema-step1.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave55-evidence-contract-schema-step1.md
@@ -1,0 +1,71 @@
+# SPLIT REVIEW PACK - Wave55 Step1 - Evidence Schema Facade Split
+
+## Scope
+
+Step1 mechanically splits the `assay evidence schema` CLI implementation behind the stable
+`schema.rs` facade.
+
+## Files
+
+- `docs/contributing/SPLIT-PLAN-wave55-evidence-contract-schema.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave55-evidence-contract-schema-step1.md`
+- `docs/contributing/SPLIT-MOVE-MAP-wave55-evidence-contract-schema-step1.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave55-evidence-contract-schema-step1.md`
+- `scripts/ci/review-wave55-evidence-contract-schema-step1.sh`
+- `crates/assay-cli/src/cli/commands/evidence/schema.rs`
+- `crates/assay-cli/src/cli/commands/evidence/schema/registry.rs`
+- `crates/assay-cli/src/cli/commands/evidence/schema/reports.rs`
+- `crates/assay-cli/src/cli/commands/evidence/schema/validate.rs`
+- `crates/assay-cli/src/cli/commands/evidence/schema/write.rs`
+
+## Verification
+
+Run:
+
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave55-evidence-contract-schema-step1.sh
+```
+
+The gate runs:
+
+```bash
+cargo fmt --check
+cargo check -p assay-cli
+cargo test -q -p assay-cli --test receipt_schema_registry_test
+cargo clippy -p assay-cli --all-targets -- -D warnings
+git diff --check
+```
+
+## Reviewer Focus
+
+- Confirm `schema.rs` still owns the CLI args and `cmd_schema` dispatch.
+- Confirm descriptor names, aliases, schema IDs, paths, status, family, and Trust Basis claim fields
+  are mechanically preserved in `schema/registry.rs`.
+- Confirm JSON/JSONL validation preserves parse/config/schema exit-code behavior.
+- Confirm text and JSON report output contracts remain covered by `receipt_schema_registry_test`.
+- Confirm importer command behavior is untouched.
+
+## LOC Deltas
+
+| File | Before LOC | After LOC |
+| --- | ---: | ---: |
+| `crates/assay-cli/src/cli/commands/evidence/schema.rs` | 627 | 139 |
+
+Moved modules:
+
+| File | LOC |
+| --- | ---: |
+| `crates/assay-cli/src/cli/commands/evidence/schema/registry.rs` | 256 |
+| `crates/assay-cli/src/cli/commands/evidence/schema/reports.rs` | 87 |
+| `crates/assay-cli/src/cli/commands/evidence/schema/validate.rs` | 86 |
+| `crates/assay-cli/src/cli/commands/evidence/schema/write.rs` | 76 |
+
+## Next Candidates
+
+After this PR lands, the next evidence-contract candidates are the importer model files:
+
+- `pydantic_case_result.rs`
+- `cyclonedx_mlbom_model.rs`
+- `mastra_score_event.rs`
+
+Each should get its own contract-preserving split, not a combined broad cleanup.

--- a/scripts/ci/review-wave55-evidence-contract-schema-step1.sh
+++ b/scripts/ci/review-wave55-evidence-contract-schema-step1.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
+export CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
+
+base_ref="${BASE_REF:-origin/main}"
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  echo "FAIL: cannot resolve Wave55 Step1 base ref: $base_ref"
+  echo "Set BASE_REF to the main ref used for this review."
+  exit 1
+fi
+
+base_changed="$(git diff --name-only "$base_ref"...HEAD)"
+worktree_changed="$(
+  {
+    git diff --name-only
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  } | sort -u
+)"
+changed="$(printf '%s\n%s\n' "$base_changed" "$worktree_changed" | sed '/^$/d' | sort -u)"
+
+allowed_pattern='^(docs/contributing/SPLIT-PLAN-wave55-evidence-contract-schema\.md|docs/contributing/SPLIT-CHECKLIST-wave55-evidence-contract-schema-step1\.md|docs/contributing/SPLIT-MOVE-MAP-wave55-evidence-contract-schema-step1\.md|docs/contributing/SPLIT-REVIEW-PACK-wave55-evidence-contract-schema-step1\.md|scripts/ci/review-wave55-evidence-contract-schema-step1\.sh|crates/assay-cli/src/cli/commands/evidence/schema\.rs|crates/assay-cli/src/cli/commands/evidence/schema/(registry|reports|validate|write)\.rs)$'
+unexpected="$(printf '%s\n' "$changed" | rg -v "$allowed_pattern" || true)"
+if [[ -n "$unexpected" ]]; then
+  echo "FAIL: Wave55 Step1 changed files outside the allowlist:"
+  printf '%s\n' "$unexpected"
+  exit 1
+fi
+
+for forbidden in \
+  '^\.github/workflows/' \
+  '^crates/assay-cli/receipt-schemas/' \
+  '^docs/reference/receipt-schemas/' \
+  '^crates/assay-cli/src/cli/commands/evidence/(pydantic_case_result|cyclonedx_mlbom_model|mastra_score_event)\.rs$'
+do
+  if printf '%s\n' "$changed" | rg "$forbidden" >/dev/null; then
+    echo "FAIL: forbidden Wave55 Step1 path matched: $forbidden"
+    exit 1
+  fi
+done
+
+required=(
+  "docs/contributing/SPLIT-PLAN-wave55-evidence-contract-schema.md"
+  "docs/contributing/SPLIT-CHECKLIST-wave55-evidence-contract-schema-step1.md"
+  "docs/contributing/SPLIT-MOVE-MAP-wave55-evidence-contract-schema-step1.md"
+  "docs/contributing/SPLIT-REVIEW-PACK-wave55-evidence-contract-schema-step1.md"
+  "scripts/ci/review-wave55-evidence-contract-schema-step1.sh"
+  "crates/assay-cli/src/cli/commands/evidence/schema.rs"
+  "crates/assay-cli/src/cli/commands/evidence/schema/registry.rs"
+  "crates/assay-cli/src/cli/commands/evidence/schema/reports.rs"
+  "crates/assay-cli/src/cli/commands/evidence/schema/validate.rs"
+  "crates/assay-cli/src/cli/commands/evidence/schema/write.rs"
+)
+
+for path in "${required[@]}"; do
+  test -f "$path" || {
+    echo "FAIL: missing required file: $path"
+    exit 1
+  }
+done
+
+require_marker() {
+  local pattern="$1"
+  local path="$2"
+  local message="$3"
+  if ! rg -q "$pattern" "$path"; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+forbid_marker() {
+  local pattern="$1"
+  local path="$2"
+  local message="$3"
+  if rg -q "$pattern" "$path"; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+for module in registry reports validate write; do
+  require_marker "^mod ${module};$" "crates/assay-cli/src/cli/commands/evidence/schema.rs" "schema facade must declare ${module} module"
+done
+require_marker '^pub fn cmd_schema\b' "crates/assay-cli/src/cli/commands/evidence/schema.rs" "schema facade must keep cmd_schema entrypoint"
+require_marker '^pub struct SchemaArgs\b' "crates/assay-cli/src/cli/commands/evidence/schema.rs" "schema facade must keep CLI args"
+require_marker '^pub enum SchemaCmd\b' "crates/assay-cli/src/cli/commands/evidence/schema.rs" "schema facade must keep CLI subcommands"
+forbid_marker '^const SCHEMAS\b|^struct SchemaDescriptor\b|^fn validate_input\b|^fn collect_validation_errors\b|^fn write_list_text\b' "crates/assay-cli/src/cli/commands/evidence/schema.rs" "schema facade must not own moved registry/validation/rendering internals"
+
+require_marker '^pub\(super\) const SCHEMAS\b' "crates/assay-cli/src/cli/commands/evidence/schema/registry.rs" "registry module must own SCHEMAS"
+require_marker '^pub\(super\) fn find_schema\b' "crates/assay-cli/src/cli/commands/evidence/schema/registry.rs" "registry module must own lookup"
+require_marker '^pub\(super\) struct SchemaMetadata\b' "crates/assay-cli/src/cli/commands/evidence/schema/reports.rs" "reports module must own metadata DTO"
+require_marker '^pub\(super\) fn validate_input\b' "crates/assay-cli/src/cli/commands/evidence/schema/validate.rs" "validate module must own validation"
+require_marker '^pub\(super\) fn write_list_text\b' "crates/assay-cli/src/cli/commands/evidence/schema/write.rs" "write module must own text rendering"
+require_marker '^pub\(super\) fn write_json\b' "crates/assay-cli/src/cli/commands/evidence/schema/write.rs" "write module must own JSON rendering"
+
+check_loc_max() {
+  local path="$1"
+  local max="$2"
+  local loc
+  loc="$(wc -l < "$path" | tr -d ' ')"
+  if (( loc > max )); then
+    echo "FAIL: $path has $loc LOC, expected <= $max"
+    exit 1
+  fi
+}
+
+check_loc_max "crates/assay-cli/src/cli/commands/evidence/schema.rs" 160
+check_loc_max "crates/assay-cli/src/cli/commands/evidence/schema/registry.rs" 300
+check_loc_max "crates/assay-cli/src/cli/commands/evidence/schema/reports.rs" 120
+check_loc_max "crates/assay-cli/src/cli/commands/evidence/schema/validate.rs" 120
+check_loc_max "crates/assay-cli/src/cli/commands/evidence/schema/write.rs" 120
+
+cargo fmt --check
+cargo check -p assay-cli
+cargo test -q -p assay-cli --test receipt_schema_registry_test
+cargo clippy -p assay-cli --all-targets -- -D warnings
+git diff --check "$base_ref"...HEAD
+git diff --check
+git diff --cached --check
+
+echo "PASS: Wave55 Step1 evidence schema facade split gate"


### PR DESCRIPTION
## Summary

Wave55 Step1 mechanically splits the `assay evidence schema` CLI hotspot behind the existing `schema.rs` facade.

- keep CLI args and `cmd_schema` dispatch in `schema.rs`
- move embedded descriptor registry/lookup to `schema/registry.rs`
- move report DTOs to `schema/reports.rs`
- move JSON/JSONL validation to `schema/validate.rs`
- move text/JSON rendering to `schema/write.rs`
- add Wave55 split plan/checklist/move-map/review-pack plus a scoped reviewer gate

## Contract / Behavior

No schema IDs, aliases, source paths, families, statuses, Trust Basis claim mappings, receipt schema JSON files, importer behavior, or workflow topology changed.

## LOC

- `schema.rs`: 627 -> 139 LOC
- moved modules: `registry.rs` 256, `reports.rs` 87, `validate.rs` 86, `write.rs` 76

## Verification

Local committed HEAD:

```bash
BASE_REF=origin/main bash scripts/ci/review-wave55-evidence-contract-schema-step1.sh
```

Gate includes:

- `cargo fmt --check`
- `cargo check -p assay-cli`
- `cargo test -q -p assay-cli --test receipt_schema_registry_test`
- `cargo clippy -p assay-cli --all-targets -- -D warnings`
- scope/LOC/diff checks

Result: PASS.

## Reviewer Focus

- Confirm `schema.rs` remains the public command facade.
- Confirm registry descriptors were moved without contract drift.
- Confirm validation exit-code behavior remains covered by receipt schema registry tests.
- Confirm importer files and schema JSON files are untouched.