### PR TITLE
chore(runner-linux): document pidfd unsafe and add crate unsafe-lint posture

### DIFF
--- a/crates/assay-runner-linux/src/cgroup.rs
+++ b/crates/assay-runner-linux/src/cgroup.rs
@@ -189,6 +189,11 @@ impl SessionCgroup {
             }
 
             #[cfg(target_os = "linux")]
+            // SAFETY: pidfd_open and pidfd_send_signal are raw libc syscalls.
+            // `pid` is validated above, the returned fd is checked before use,
+            // and the only pointer passed to the kernel is a null siginfo
+            // pointer. Failures fall back to classic kill; nothing is
+            // dereferenced through a Rust reference.
             unsafe {
                 // syscall(SYS_pidfd_open, pid, 0)
                 let fd = libc::syscall(libc::SYS_pidfd_open, pid, 0) as i32;

--- a/crates/assay-runner-linux/src/lib.rs
+++ b/crates/assay-runner-linux/src/lib.rs
@@ -4,6 +4,8 @@
 // remains `unsafe_code = "deny"`; this crate is the platform adapter where
 // such syscalls are intentional and unavoidable.
 #![allow(unsafe_code)]
+#![warn(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 //! Linux-only platform adapter for the Assay-Runner candidate.
 //!


### PR DESCRIPTION
## Summary

Wave54.1 closes the runner-linux unsafe documentation gap found after Wave54:

- add crate-local warn posture for `unsafe_op_in_unsafe_fn` and `clippy::undocumented_unsafe_blocks` in `assay-runner-linux`
- document the Linux pidfd graceful-kill unsafe block with a concrete `SAFETY:` invariant
- keep behavior unchanged: signal order, fallback path, pid validation, syscalls, and Cargo lint inheritance stay intact

## Scope

Changed only:

- `crates/assay-runner-linux/src/lib.rs`
- `crates/assay-runner-linux/src/cgroup.rs`

No Cargo.toml changes, no workspace lint widening, no edition migration, no runner behavior changes.

## Verification

Local:

- `cargo fmt --check`
- `cargo check -p assay-runner-linux`
- `cargo clippy -p assay-runner-linux --all-targets -- -D clippy::undocumented_unsafe_blocks -D unsafe_op_in_unsafe_fn`
- commit hooks: merge conflicts, EOF/trailing whitespace, MCP token hygiene, typos, shellcheck, cargo fmt
- push hooks: merge conflicts, EOF/trailing whitespace, typos, shellcheck, cargo fmt, workspace clippy deny warnings, linux compile gate

Important caveat: the pidfd block is behind `#[cfg(target_os = "linux")]`, so macOS clippy does not prove the unsafe lint on that block. This PR should only be marked ready after the Linux Runner Spike delegated `gates=all` proof is green and matched by lane-check.

## Runner Proof

Assay-Runner delegated proof:
- gate: all
- run: https://github.com/Rul1an/assay/actions/runs/27041455470
- sha: c41ca0b7878dd2b7a5f3a01acecd98e0f9119ddb
- status: success