### PR TITLE
test(registry): freeze resolver contracts

### DIFF
--- a/crates/assay-registry/tests/resolver_contracts.rs
+++ b/crates/assay-registry/tests/resolver_contracts.rs
@@ -1,0 +1,156 @@
+use assay_registry::{
+    compute_digest, FetchResult, PackCache, PackHeaders, PackResolver, RegistryClient,
+    RegistryConfig, ResolveSource, ResolverConfig, TrustStore,
+};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn resolver_config(mock_server: &MockServer) -> ResolverConfig {
+    ResolverConfig {
+        registry: RegistryConfig::default()
+            .with_url(mock_server.uri())
+            .with_token("test-token"),
+        no_cache: false,
+        allow_unsigned: true,
+        bundled_packs_dir: None,
+    }
+}
+
+fn fetch_result(content: &str, etag: Option<&str>) -> FetchResult {
+    let digest = compute_digest(content);
+    FetchResult {
+        content: content.to_string(),
+        headers: PackHeaders {
+            digest: Some(digest.clone()),
+            signature: None,
+            key_id: None,
+            etag: etag.map(str::to_string),
+            cache_control: Some("max-age=3600".to_string()),
+            content_length: Some(content.len() as u64),
+        },
+        computed_digest: digest,
+    }
+}
+
+fn resolver_with_cache(
+    mock_server: &MockServer,
+    cache: PackCache,
+) -> assay_registry::RegistryResult<PackResolver> {
+    let config = resolver_config(mock_server);
+    let client = RegistryClient::new(config.registry.clone())?;
+    Ok(PackResolver::with_components(
+        client,
+        cache,
+        TrustStore::new(),
+        config,
+    ))
+}
+
+#[tokio::test]
+async fn resolver_uses_fresh_cache_before_network() -> Result<(), Box<dyn std::error::Error>> {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new()?;
+    let cache = PackCache::with_dir(temp_dir.path().join("cache"));
+    let cached_content = "name: cached-pack\nversion: \"1.0.0\"\n";
+    cache
+        .put(
+            "cached-pack",
+            "1.0.0",
+            &fetch_result(cached_content, Some("\"cache-etag\"")),
+            Some("https://cache.example.test"),
+        )
+        .await?;
+
+    let resolver = resolver_with_cache(&mock_server, cache)?;
+    let resolved = resolver.resolve("cached-pack@1.0.0").await?;
+
+    assert_eq!(resolved.source, ResolveSource::Cache);
+    assert_eq!(resolved.content, cached_content);
+    assert_eq!(resolved.digest, compute_digest(cached_content));
+    Ok(())
+}
+
+#[tokio::test]
+async fn resolver_evicts_pinned_cache_mismatch_and_refetches(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new()?;
+    let cache = PackCache::with_dir(temp_dir.path().join("cache"));
+    let stale_content = "name: pinned-pack\nversion: \"1.0.0\"\nstate: stale\n";
+    let fresh_content = "name: pinned-pack\nversion: \"1.0.0\"\nstate: fresh\n";
+    let fresh_digest = compute_digest(fresh_content);
+
+    cache
+        .put(
+            "pinned-pack",
+            "1.0.0",
+            &fetch_result(stale_content, Some("\"stale-etag\"")),
+            Some("https://cache.example.test"),
+        )
+        .await?;
+
+    Mock::given(method("GET"))
+        .and(path("/packs/pinned-pack/1.0.0"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(fresh_content)
+                .insert_header("x-pack-digest", fresh_digest.as_str()),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let resolver = resolver_with_cache(&mock_server, cache)?;
+    let resolved = resolver
+        .resolve(&format!("pinned-pack@1.0.0#{}", fresh_digest))
+        .await?;
+
+    assert!(matches!(resolved.source, ResolveSource::Registry(_)));
+    assert_eq!(resolved.content, fresh_content);
+    assert_eq!(resolved.digest, fresh_digest);
+    Ok(())
+}
+
+#[tokio::test]
+async fn resolver_no_cache_skips_cached_entry_and_fetches_registry(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new()?;
+    let cache = PackCache::with_dir(temp_dir.path().join("cache"));
+    let cached_content = "name: no-cache-pack\nversion: \"1.0.0\"\nstate: cached\n";
+    let fresh_content = "name: no-cache-pack\nversion: \"1.0.0\"\nstate: fresh\n";
+    let fresh_digest = compute_digest(fresh_content);
+    cache
+        .put(
+            "no-cache-pack",
+            "1.0.0",
+            &fetch_result(cached_content, Some("\"cache-etag\"")),
+            Some("https://cache.example.test"),
+        )
+        .await?;
+
+    Mock::given(method("GET"))
+        .and(path("/packs/no-cache-pack/1.0.0"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(fresh_content)
+                .insert_header("x-pack-digest", fresh_digest.as_str()),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let config = ResolverConfig {
+        no_cache: true,
+        ..resolver_config(&mock_server)
+    };
+    let client = RegistryClient::new(config.registry.clone())?;
+    let resolver = PackResolver::with_components(client, cache, TrustStore::new(), config);
+    let resolved = resolver.resolve("no-cache-pack@1.0.0").await?;
+
+    assert!(matches!(resolved.source, ResolveSource::Registry(_)));
+    assert_eq!(resolved.content, fresh_content);
+    assert_eq!(resolved.digest, fresh_digest);
+    Ok(())
+}

--- a/docs/contributing/SPLIT-CHECKLIST-wave57-registry-resolver-contracts.md
+++ b/docs/contributing/SPLIT-CHECKLIST-wave57-registry-resolver-contracts.md
@@ -1,0 +1,25 @@
+# Wave57 Registry Resolver Contracts Checklist
+
+Scope:
+- Add external resolver characterization tests.
+- Add review gate for the pre-split resolver contract step.
+- Do not edit `resolver.rs` in this PR.
+
+Required contracts:
+- `resolver_uses_fresh_cache_before_network`
+- `resolver_evicts_pinned_cache_mismatch_and_refetches`
+- `resolver_no_cache_skips_cached_entry_and_fetches_registry`
+
+Required checks:
+- `cargo fmt --check`
+- `cargo check -p assay-registry`
+- `cargo test -p assay-registry resolver`
+- `cargo test -p assay-registry --test resolver_contracts`
+- `cargo clippy -p assay-registry --all-targets -- -D warnings`
+- `BASE_REF=origin/main bash scripts/ci/review-wave57-registry-resolver-contracts.sh`
+
+Non-goals:
+- No `resolver_next` module creation.
+- No `resolver.rs` code movement.
+- No cache, trust, client, or verification behavior changes.
+- No dependency or workflow changes.

--- a/docs/contributing/SPLIT-PLAN-wave57-registry-resolver.md
+++ b/docs/contributing/SPLIT-PLAN-wave57-registry-resolver.md
@@ -1,0 +1,25 @@
+# Wave57 Registry Resolver Contract Plan
+
+Goal:
+- Add resolver characterization tests before any resolver split.
+- Keep `resolver.rs` behavior and public API unchanged in this step.
+- Make the later `resolver_next` split reviewable by pinning cache, pinned-digest, and `no_cache` contracts first.
+
+Observed baseline:
+- `crates/assay-registry/src/resolver.rs`: 589 LOC on `origin/main`.
+- Existing inline resolver tests cover local/bundled paths, source display, and production-root bootstrap.
+- Existing external resolver tests cover production-root signature accept/reject.
+- Registry-client tests cover HTTP fetch/304 behavior at the client layer, not resolver closure behavior.
+
+Contracts added in this step:
+- Fresh cache entries win before network fetch.
+- Pinned digest mismatch in cache evicts the stale entry and refetches from registry.
+- `no_cache` skips a cached entry and fetches from registry.
+
+Explicit deferred gap:
+- Resolver-level `304 Not Modified` behavior is not claimed as a green contract in this step. Current control flow returns a valid cache entry before network revalidation, while an unusable cache entry cannot safely satisfy the later `304` branch. Treat that as a future behavior/design PR, not as part of a mechanical split.
+
+Next split prerequisites:
+- Keep these contract tests green.
+- Add a move-map for `resolver_next` only after deciding module boundaries for local/bundled, registry/cache, BYOS, and prefetch.
+- Do not combine resolver behavior changes with the mechanical split.

--- a/docs/contributing/SPLIT-REVIEW-PACK-wave57-registry-resolver-contracts.md
+++ b/docs/contributing/SPLIT-REVIEW-PACK-wave57-registry-resolver-contracts.md
@@ -1,0 +1,23 @@
+# Wave57 Registry Resolver Contracts Review Pack
+
+Review intent:
+- Freeze resolver behavior before the later `resolver_next` split.
+- Increase confidence around the cache/registry decision boundary without changing runtime code.
+
+Changed files expected:
+- `crates/assay-registry/tests/resolver_contracts.rs`
+- `docs/contributing/SPLIT-PLAN-wave57-registry-resolver.md`
+- `docs/contributing/SPLIT-CHECKLIST-wave57-registry-resolver-contracts.md`
+- `docs/contributing/SPLIT-REVIEW-PACK-wave57-registry-resolver-contracts.md`
+- `scripts/ci/review-wave57-registry-resolver-contracts.sh`
+
+Primary review questions:
+- Do the tests assert externally observable resolver behavior rather than private implementation details?
+- Are cache-first, pinned-digest refetch, and `no_cache` behavior all covered?
+- Does the PR avoid edits to `resolver.rs` and other runtime code?
+- Is the deferred 304 resolver behavior called out rather than accidentally normalized?
+
+Verification:
+```bash
+BASE_REF=origin/main bash scripts/ci/review-wave57-registry-resolver-contracts.sh
+```

--- a/scripts/ci/review-wave57-registry-resolver-contracts.sh
+++ b/scripts/ci/review-wave57-registry-resolver-contracts.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+BASE_REF="${BASE_REF:-origin/main}"
+TEST_FILE="crates/assay-registry/tests/resolver_contracts.rs"
+
+allowed_regex='^(crates/assay-registry/tests/resolver_contracts\.rs|docs/contributing/SPLIT-(PLAN-wave57-registry-resolver|CHECKLIST-wave57-registry-resolver-contracts|REVIEW-PACK-wave57-registry-resolver-contracts)\.md|scripts/ci/review-wave57-registry-resolver-contracts\.sh)$'
+
+assert_rg() {
+  local pattern="$1"
+  local file="$2"
+  local message="$3"
+  if ! rg -n "$pattern" "$file" >/dev/null; then
+    echo "FAIL: $message"
+    exit 1
+  fi
+}
+
+echo "[review] scope allowlist"
+changed_files="$(
+  {
+    git diff --name-only "$BASE_REF" --
+    git ls-files --others --exclude-standard -- \
+      "$TEST_FILE" \
+      docs/contributing/SPLIT-PLAN-wave57-registry-resolver.md \
+      docs/contributing/SPLIT-CHECKLIST-wave57-registry-resolver-contracts.md \
+      docs/contributing/SPLIT-REVIEW-PACK-wave57-registry-resolver-contracts.md \
+      scripts/ci/review-wave57-registry-resolver-contracts.sh
+  } | sort -u
+)"
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  if [[ ! "$file" =~ $allowed_regex ]]; then
+    echo "FAIL: out-of-scope path changed: $file"
+    exit 1
+  fi
+done <<EOF
+$changed_files
+EOF
+
+echo "[review] forbidden runtime surfaces"
+if ! git diff --quiet "$BASE_REF" -- crates/assay-registry/src/resolver.rs crates/assay-registry/src/cache.rs crates/assay-registry/src/trust.rs crates/assay-registry/src/client crates/assay-registry/src/verify.rs; then
+  echo "FAIL: Wave57 resolver contracts must not edit runtime resolver/cache/trust/client/verify code"
+  exit 1
+fi
+if ! git diff --quiet "$BASE_REF" -- Cargo.toml Cargo.lock .github/workflows; then
+  echo "FAIL: Wave57 resolver contracts must not touch Cargo files or workflows"
+  exit 1
+fi
+
+echo "[review] contract coverage"
+assert_rg 'async fn resolver_uses_fresh_cache_before_network' "$TEST_FILE" "cache-first resolver contract missing"
+assert_rg 'async fn resolver_evicts_pinned_cache_mismatch_and_refetches' "$TEST_FILE" "pinned digest refetch contract missing"
+assert_rg 'async fn resolver_no_cache_skips_cached_entry_and_fetches_registry' "$TEST_FILE" "no_cache registry fetch contract missing"
+assert_rg 'PackResolver::with_components' "$TEST_FILE" "resolver contracts must use public component injection"
+assert_rg 'ResolveSource::Cache' "$TEST_FILE" "cache source assertion missing"
+assert_rg 'ResolveSource::Registry' "$TEST_FILE" "registry source assertion missing"
+
+echo "[review] repo checks"
+cargo fmt --check
+cargo check -p assay-registry
+cargo test -p assay-registry resolver
+cargo test -p assay-registry --test resolver_contracts
+cargo clippy -p assay-registry --all-targets -- -D warnings
+git diff --check "$BASE_REF" --
+
+echo "[review] PASS"


### PR DESCRIPTION
Summary:
- Add resolver characterization tests before creating resolver_next or moving resolver code.
- Cover cache-first resolution, pinned-digest cache mismatch evict/refetch, and no_cache registry fetch behavior.
- Add Wave57 resolver contract plan, checklist, review pack, and scoped review gate.

Verification:
- BASE_REF=origin/main bash scripts/ci/review-wave57-registry-resolver-contracts.sh
- Pre-commit hooks passed.
- Pre-push hooks passed, including workspace clippy and Linux compile gate.

Review focus:
- Test-only runtime safety net; resolver.rs is intentionally unchanged.
- 304 resolver behavior is explicitly deferred because current control flow does not make that a clean green contract.