### PR TITLE
chore(runner): prefer native eBPF builds

### DIFF
--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -123,12 +123,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v docker >/dev/null 2>&1; then
-            cargo xtask build-image
-            cargo xtask build-ebpf --docker
-          else
-            cargo xtask build-ebpf
+          rustup toolchain install nightly --profile minimal --component rust-src
+          if ! command -v bpf-linker >/dev/null 2>&1; then
+            cargo install bpf-linker --locked
           fi
+          cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
       - name: Verify eBPF artifact present
@@ -284,12 +283,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v docker >/dev/null 2>&1; then
-            cargo xtask build-image
-            cargo xtask build-ebpf --docker
-          else
-            cargo xtask build-ebpf
+          rustup toolchain install nightly --profile minimal --component rust-src
+          if ! command -v bpf-linker >/dev/null 2>&1; then
+            cargo install bpf-linker --locked
           fi
+          cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
       - name: Verify eBPF artifact present

--- a/.github/workflows/runner-otel-experiment.yml
+++ b/.github/workflows/runner-otel-experiment.yml
@@ -111,12 +111,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v docker >/dev/null 2>&1; then
-            cargo xtask build-image
-            cargo xtask build-ebpf --docker
-          else
-            cargo xtask build-ebpf
+          rustup toolchain install nightly --profile minimal --component rust-src
+          if ! command -v bpf-linker >/dev/null 2>&1; then
+            cargo install bpf-linker --locked
           fi
+          cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
       - name: Verify eBPF artifact present

--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -163,12 +163,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v docker >/dev/null 2>&1; then
-            cargo xtask build-image
-            cargo xtask build-ebpf --docker
-          else
-            cargo xtask build-ebpf
+          rustup toolchain install nightly --profile minimal --component rust-src
+          if ! command -v bpf-linker >/dev/null 2>&1; then
+            cargo install bpf-linker --locked
           fi
+          cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
       - name: Verify eBPF artifact present
@@ -340,12 +339,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v docker >/dev/null 2>&1; then
-            cargo xtask build-image
-            cargo xtask build-ebpf --docker
-          else
-            cargo xtask build-ebpf
+          rustup toolchain install nightly --profile minimal --component rust-src
+          if ! command -v bpf-linker >/dev/null 2>&1; then
+            cargo install bpf-linker --locked
           fi
+          cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
       - name: Verify eBPF artifact present
@@ -504,12 +502,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v docker >/dev/null 2>&1; then
-            cargo xtask build-image
-            cargo xtask build-ebpf --docker
-          else
-            cargo xtask build-ebpf
+          rustup toolchain install nightly --profile minimal --component rust-src
+          if ! command -v bpf-linker >/dev/null 2>&1; then
+            cargo install bpf-linker --locked
           fi
+          cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
       - name: Verify eBPF artifact present

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -170,12 +170,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v docker >/dev/null 2>&1; then
-            cargo xtask build-image
-            cargo xtask build-ebpf --docker
-          else
-            cargo xtask build-ebpf
+          rustup toolchain install nightly --profile minimal --component rust-src
+          if ! command -v bpf-linker >/dev/null 2>&1; then
+            cargo install bpf-linker --locked
           fi
+          cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
       - name: Verify eBPF artifact

--- a/docs/DEVELOPER_HANDOFF.md
+++ b/docs/DEVELOPER_HANDOFF.md
@@ -581,6 +581,6 @@ cargo test -p assay-evidence -- --nocapture verify_bundle
 # Check what would be published
 cargo publish -p assay-evidence --dry-run
 
-# Build eBPF (Linux/Docker only)
-cargo xtask build-ebpf --docker
+# Build eBPF (native bpf-linker path)
+cargo xtask build-ebpf --release --no-docker
 ```

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -2,22 +2,25 @@
 
 ## 1. Prerequisites
 - **Rust**: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-- **Docker**: (Required for non-Linux hosts)
+- **Native eBPF toolchain**: LLVM/Clang, nightly Rust, `rust-src`, and `bpf-linker`
+- **Docker**: Optional fallback for non-Linux hosts
 - **Repo**: `git clone git@github.com:Rul1an/assay.git && cd assay`
 
 ## 2. Prepare the Toolchain
-Assay uses a custom builder image to ensure consistent eBPF bytecode generation.
+Assay's delegated runner path uses native `bpf-linker` builds so cold Docker image builds stay out of the proof hot path.
 
 ```bash
-cargo xtask build-image
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+cargo install bpf-linker --locked
 ```
 
 ## 3. Build & Verify
 Build the host binary and the eBPF kernel module, then run the verification suite.
 
 ```bash
-# Build eBPF (using Docker)
-cargo xtask build-ebpf --docker
+# Build eBPF (native bpf-linker path)
+cargo xtask build-ebpf --release --no-docker
 
 # Build Host
 cargo build --workspace
@@ -25,6 +28,8 @@ cargo build --workspace
 # Run E2E Verification (requires sudo/root/lima)
 ./scripts/verify_lsm_docker.sh
 ```
+
+If the native toolchain is not available on a local machine, the Docker fallback remains: `cargo xtask build-image && cargo xtask build-ebpf --docker`.
 
 ## 4. Quality Gates
 Before pushing a PR, ensure these pass:

--- a/docs/guides/runtime-monitor.md
+++ b/docs/guides/runtime-monitor.md
@@ -44,15 +44,19 @@ Uses Cgroup `connect4` and `connect6` hooks to enforce:
 ## 3. Developer Workflow
 
 ### Environment Setup
-eBPF development requires a specific toolchain (LLVM, nightly Rust, bpf-linker). Assay automates this via Docker:
+eBPF development requires a specific toolchain (LLVM, nightly Rust, bpf-linker). The delegated runner path uses native `bpf-linker` builds so cold Docker image builds stay out of the proof hot path:
 
 ```bash
-# 1. Build the builder image (one-time)
-cargo xtask build-image
+# 1. Install the native eBPF toolchain
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+cargo install bpf-linker --locked
 
 # 2. Compile eBPF bytecode
-cargo xtask build-ebpf --docker
+cargo xtask build-ebpf --release --no-docker
 ```
+
+Docker remains available as a fallback for machines that cannot host the native toolchain: `cargo xtask build-image && cargo xtask build-ebpf --docker`.
 
 ### Verification
 Local verification is best done via **Lima VM** on macOS or directly on **Linux**:

--- a/infra/bpf-runner/cloud-init.yaml
+++ b/infra/bpf-runner/cloud-init.yaml
@@ -15,8 +15,12 @@ packages:
   - linux-tools-generic
   - linux-headers-generic
   - llvm
+  - llvm-dev
   - clang
   - libclang-dev
+  - pkg-config
+  - libssl-dev
+  - libsqlite3-dev
   - jq
   - docker.io
 
@@ -39,12 +43,21 @@ runcmd:
   - export CARGO_HOME=/opt/rust
   - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
   - chmod -R 777 /opt/rust
-  - ln -s /opt/rust/bin/cargo /usr/local/bin/cargo
-  - ln -s /opt/rust/bin/rustc /usr/local/bin/rustc
+  - printf 'export RUSTUP_HOME=/opt/rust\nexport CARGO_HOME=/opt/rust\nexport PATH=/opt/rust/bin:$PATH\n' > /etc/profile.d/rust.sh
+  - ln -sf /opt/rust/bin/cargo /usr/local/bin/cargo
+  - ln -sf /opt/rust/bin/rustc /usr/local/bin/rustc
+  - ln -sf /opt/rust/bin/rustup /usr/local/bin/rustup
+  - /opt/rust/bin/rustup toolchain install nightly
+  - /opt/rust/bin/rustup component add rust-src --toolchain nightly
+  - /opt/rust/bin/cargo install bpf-linker --locked
+  - ln -sf /opt/rust/bin/bpf-linker /usr/local/bin/bpf-linker
 
   # 4. Prepare Runner User
   - useradd -m -s /bin/bash github-runner
   - usermod -aG docker github-runner
+  - ln -sfn /opt/rust /home/github-runner/.cargo
+  - ln -sfn /opt/rust /home/github-runner/.rustup
+  - chown -h github-runner:github-runner /home/github-runner/.cargo /home/github-runner/.rustup
   - echo "github-runner ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/github-runner
 
   # 5. NOTE: runner registration requires secrets (GITHUB_TOKEN)

--- a/infra/bpf-runner/setup.sh
+++ b/infra/bpf-runner/setup.sh
@@ -11,7 +11,7 @@
 #
 # FEATURES:
 # - Kernel Hardening: Enables BPF LSM via boot parameters.
-# - Dependency Management: Rust (via rustup), Docker, LLVM/Clang.
+# - Dependency Management: Rust (via rustup), native bpf-linker, Docker, LLVM/Clang.
 # - Runner Security: Runs as non-root 'github-runner' user, standard Docker group.
 # ==============================================================================
 
@@ -23,7 +23,8 @@ apt-get update
 apt-get install -y \
     curl git build-essential \
     linux-tools-common linux-tools-generic linux-headers-generic \
-    llvm clang libclang-dev \
+    llvm llvm-dev clang libclang-dev \
+    pkg-config libssl-dev libsqlite3-dev \
     jq
 
 # 2. Configure Kernel for BPF LSM
@@ -55,7 +56,7 @@ else
 fi
 
 # 4. Install Rust Toolchain (System-wide for Runner)
-echo "🦀 [4/5] Installing Rust Toolchain..."
+echo "🦀 [4/5] Installing Rust Toolchain and native eBPF linker..."
 export RUSTUP_HOME=/opt/rust
 export CARGO_HOME=/opt/rust
 if [ ! -d "/opt/rust" ]; then
@@ -64,9 +65,24 @@ if [ ! -d "/opt/rust" ]; then
 else
     echo "   -> Rust already installed in /opt/rust."
 fi
-# Add to global path
-echo 'export PATH=/opt/rust/bin:$PATH' > /etc/profile.d/rust.sh
+# Add to global path and keep rustup proxies pointed at the system toolchain.
+cat > /etc/profile.d/rust.sh <<'EOF'
+export RUSTUP_HOME=/opt/rust
+export CARGO_HOME=/opt/rust
+export PATH=/opt/rust/bin:$PATH
+EOF
 source /etc/profile.d/rust.sh
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+if ! command -v bpf-linker &> /dev/null; then
+    cargo install bpf-linker --locked
+else
+    echo "   -> bpf-linker already installed."
+fi
+ln -sf /opt/rust/bin/cargo /usr/local/bin/cargo
+ln -sf /opt/rust/bin/rustc /usr/local/bin/rustc
+ln -sf /opt/rust/bin/rustup /usr/local/bin/rustup
+ln -sf /opt/rust/bin/bpf-linker /usr/local/bin/bpf-linker
 
 # 5. Connect GitHub Runner
 echo "🏃 [5/5] Configuring GitHub Action Runner..."
@@ -80,6 +96,13 @@ if ! id "$RUNNER_USER" &>/dev/null; then
     # but verify_lsm_docker.sh needs host privileges for BPF)
     echo "$RUNNER_USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/github-runner
 fi
+for rust_home in .cargo .rustup; do
+    rust_home_path="/home/$RUNNER_USER/$rust_home"
+    if [ ! -e "$rust_home_path" ]; then
+        ln -s /opt/rust "$rust_home_path"
+        chown -h "$RUNNER_USER":"$RUNNER_USER" "$rust_home_path"
+    fi
+done
 
 mkdir -p "$RUNNER_DIR"
 chown "$RUNNER_USER":"$RUNNER_USER" "$RUNNER_DIR"


### PR DESCRIPTION
## Summary
- switch delegated runner eBPF artifact builds to `cargo xtask build-ebpf --release --no-docker`
- provision native eBPF tooling on the BPF runner image (`nightly`, `rust-src`, `bpf-linker`, LLVM dev libs)
- make delegated eBPF workflow steps self-heal by installing minimal nightly + `rust-src` and `bpf-linker` when absent
- update runner docs to describe native-first release builds with Docker as a local fallback

## Why
The delegated proof path was Docker-first whenever Docker was installed, which forced a cold image/eBPF build through the heaviest path on the self-hosted runner. The xtask already supports a native `bpf-linker` path; this PR makes that path explicit and fail-fast in delegated workflows while preserving the old Docker-builder release-mode artifact semantics.

## Delegated proof
- gate: all
- head SHA: 9e7b7085031e14aec76ae6d5b09ae1e110cde114
- head prefix: 9e7b7085031e
- status: green `Runner Spike Delegated` workflow_dispatch
- proof: https://github.com/Rul1an/assay/actions/runs/27058549427

## Verification
- `bash -n infra/bpf-runner/setup.sh`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' infra/bpf-runner/cloud-init.yaml .github/workflows/runner-spike-delegated.yml .github/workflows/runner-otel-experiment.yml .github/workflows/cross-runtime-drift-experiment.yml .github/workflows/runner-otel-overhead-experiment.yml`
- `rg -n "cargo xtask build-image|cargo xtask build-ebpf --docker" .github/workflows/runner-spike-delegated.yml .github/workflows/runner-otel-experiment.yml .github/workflows/cross-runtime-drift-experiment.yml .github/workflows/runner-otel-overhead-experiment.yml` returned no matches
- `git diff --check`
- `cargo fmt --check`
- `cargo check -p assay-xtask`
- pre-push hooks: workflow lint, shellcheck, cargo fmt, cargo clippy, linux compile gate

## Follow-up
- Pin native eBPF toolchain versions (nightly date, `bpf-linker`, LLVM) in a separate PR; this PR only removes Docker from the delegated hot path and keeps release-mode semantics.

## Merge discipline
Merge only after CI/delegated runner proof is green and review comments are addressed.
