### PR TITLE
chore(runner): pin eBPF toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,9 +465,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             build-essential libssl-dev pkg-config llvm-dev libclang-dev clang libsqlite3-dev
 
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo install bpf-linker --locked
-          fi
+          scripts/ci/install-ebpf-toolchain.sh
 
       - name: Verify LSM blocking (CI Mode - Ubuntu soft skip)
         shell: bash
@@ -631,9 +629,7 @@ jobs:
             build-essential libssl-dev pkg-config llvm-dev libclang-dev clang libsqlite3-dev
 
           sudo chown -R "$(whoami)":"$(id -gn)" ~/.cargo || true
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo install bpf-linker --locked
-          fi
+          scripts/ci/install-ebpf-toolchain.sh
 
       - name: Ensure Docker context excludes target
         shell: bash

--- a/.github/workflows/cross-runtime-drift-experiment.yml
+++ b/.github/workflows/cross-runtime-drift-experiment.yml
@@ -123,10 +123,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install nightly --profile minimal --component rust-src
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo install bpf-linker --locked
-          fi
+          scripts/ci/install-ebpf-toolchain.sh
           cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
@@ -283,10 +280,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install nightly --profile minimal --component rust-src
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo install bpf-linker --locked
-          fi
+          scripts/ci/install-ebpf-toolchain.sh
           cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 

--- a/.github/workflows/kernel-matrix.yml
+++ b/.github/workflows/kernel-matrix.yml
@@ -224,39 +224,32 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             llvm-dev libclang-dev build-essential libbpf-dev pkg-config
 
-      - name: Install Rust Toolchain (nightly)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Install rust-src for eBPF (explicit for ARM)
+      - name: Install pinned eBPF toolchain
         run: |
-          rustup component add rust-src --toolchain nightly
-          # Verify rust-src is installed
-          ls -la "$(rustup run nightly rustc --print sysroot)/lib/rustlib/src/rust/library/Cargo.lock" || {
-            echo "ERROR: rust-src not found after install"
-            rustup show
-            exit 1
-          }
+          scripts/ci/install-ebpf-toolchain.sh
 
       - name: Swatinem/rust-cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true
 
-      - name: Install bpf-linker (nightly)
+      - name: Verify bpf-linker
         run: |
           set -euo pipefail
-          cargo +nightly install bpf-linker --locked
           command -v bpf-linker
 
       - name: Build eBPF (Release)
         run: |
           set -euo pipefail
-          cargo +nightly xtask build-ebpf --release
+          cargo xtask build-ebpf --release
 
       - name: Build CLI (Release)
         run: |
           set -euo pipefail
-          cargo +nightly build --release --package assay-cli --bin assay
+          cargo build --release --package assay-cli --bin assay
 
       - name: Prepare Artifacts
         run: |

--- a/.github/workflows/runner-otel-experiment.yml
+++ b/.github/workflows/runner-otel-experiment.yml
@@ -111,10 +111,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install nightly --profile minimal --component rust-src
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo install bpf-linker --locked
-          fi
+          scripts/ci/install-ebpf-toolchain.sh
           cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 

--- a/.github/workflows/runner-otel-overhead-experiment.yml
+++ b/.github/workflows/runner-otel-overhead-experiment.yml
@@ -163,10 +163,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install nightly --profile minimal --component rust-src
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo install bpf-linker --locked
-          fi
+          scripts/ci/install-ebpf-toolchain.sh
           cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
@@ -339,10 +336,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install nightly --profile minimal --component rust-src
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo install bpf-linker --locked
-          fi
+          scripts/ci/install-ebpf-toolchain.sh
           cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 
@@ -502,10 +496,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install nightly --profile minimal --component rust-src
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo install bpf-linker --locked
-          fi
+          scripts/ci/install-ebpf-toolchain.sh
           cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 

--- a/.github/workflows/runner-spike-delegated.yml
+++ b/.github/workflows/runner-spike-delegated.yml
@@ -170,10 +170,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install nightly --profile minimal --component rust-src
-          if ! command -v bpf-linker >/dev/null 2>&1; then
-            cargo install bpf-linker --locked
-          fi
+          scripts/ci/install-ebpf-toolchain.sh
           cargo xtask build-ebpf --release --no-docker
           test -f target/assay-ebpf.o
 

--- a/crates/assay-xtask/src/main.rs
+++ b/crates/assay-xtask/src/main.rs
@@ -4,6 +4,9 @@ use std::fmt::Write as _;
 use std::path::PathBuf;
 use std::process::Command;
 
+const DEFAULT_EBPF_RUST_TOOLCHAIN: &str = "nightly-2026-01-01";
+const DEFAULT_BPF_LINKER_VERSION: &str = "0.10.3";
+
 #[derive(Parser)]
 struct Opts {
     #[clap(subcommand)]
@@ -81,6 +84,31 @@ fn has_cmd(cmd: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn ebpf_rust_toolchain() -> String {
+    std::env::var("ASSAY_EBPF_RUST_TOOLCHAIN")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_EBPF_RUST_TOOLCHAIN.to_string())
+}
+
+fn bpf_linker_version() -> String {
+    std::env::var("ASSAY_BPF_LINKER_VERSION")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_BPF_LINKER_VERSION.to_string())
+}
+
+fn has_pinned_bpf_linker() -> bool {
+    let expected = format!("bpf-linker {}", bpf_linker_version());
+    Command::new("bpf-linker")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|stdout| stdout.contains(&expected))
+        .unwrap_or(false)
+}
+
 fn docker_allowed(opts: &BuildEbpfOpts) -> bool {
     // explicit override flags win
     if opts.no_docker {
@@ -102,23 +130,26 @@ fn build_ebpf(opts: BuildEbpfOpts) -> anyhow::Result<()> {
 
 fn build_ebpf_local(root: &PathBuf, opts: &BuildEbpfOpts) -> anyhow::Result<()> {
     // Auto-fallback only when allowed and docker exists
-    if !has_cmd("bpf-linker") {
+    if !has_pinned_bpf_linker() {
         if docker_allowed(opts) && has_cmd("docker") {
-            eprintln!("bpf-linker not found; falling back to docker build...");
+            eprintln!("pinned bpf-linker not found; falling back to docker build...");
             return build_ebpf_docker(root.as_path(), opts);
         }
 
         anyhow::bail!(
-            "bpf-linker not found.\n\
-             Install it with: cargo install bpf-linker --locked\n\
-             Or rerun with --docker (or omit --no-docker to allow fallback)."
+            "pinned bpf-linker not found.\n\
+             Install it with: cargo install bpf-linker --version {} --locked\n\
+             Or rerun with --docker (or omit --no-docker to allow fallback).",
+            bpf_linker_version()
         );
     }
 
     let target_flag = format!("--target={}", opts.target);
+    let toolchain = ebpf_rust_toolchain();
+    let toolchain_arg = format!("+{toolchain}");
 
     let mut args = vec![
-        "+nightly",
+        toolchain_arg.as_str(),
         "build",
         "--package",
         "assay-ebpf",
@@ -248,15 +279,23 @@ fn build_ebpf_docker(root: &std::path::Path, opts: &BuildEbpfOpts) -> anyhow::Re
     // Ensure cargo is in PATH (standard rust image location)
     script.push_str("export PATH=\"/usr/local/cargo/bin:$PATH\"; ");
 
+    let toolchain = ebpf_rust_toolchain();
+    let bpf_linker_version = bpf_linker_version();
+
     // Setup dependencies (using cache) - SKIP if using builder image
     if !opts.docker_image.contains("assay-ebpf-builder") {
-        // We need nightly for -Z build-std, so install it first
-        script.push_str("rustup toolchain install nightly; ");
-        script.push_str(
-            "rustup component add rust-src --toolchain nightly >/dev/null 2>&1 || true; ",
+        // We need a pinned nightly for -Z build-std, so install it first.
+        let _ = write!(
+            script,
+            "rustup toolchain install {toolchain} --profile minimal; "
         );
-        script.push_str(
-            "if ! command -v bpf-linker > /dev/null; then echo 'Installing bpf-linker...'; ",
+        let _ = write!(
+            script,
+            "rustup component add rust-src --toolchain {toolchain} >/dev/null 2>&1 || true; "
+        );
+        let _ = write!(
+            script,
+            "if ! command -v bpf-linker > /dev/null || ! bpf-linker --version | grep -Fq 'bpf-linker {bpf_linker_version}'; then echo 'Installing bpf-linker...'; "
         );
 
         // Install dependencies for bpf-linker
@@ -264,11 +303,17 @@ fn build_ebpf_docker(root: &std::path::Path, opts: &BuildEbpfOpts) -> anyhow::Re
             "apt-get update && apt-get install -y llvm-dev libclang-dev build-essential git; ",
         );
 
-        script.push_str("cargo install bpf-linker --locked; fi; ");
+        let _ = write!(
+            script,
+            "rustup run {toolchain} cargo install bpf-linker --version {bpf_linker_version} --locked; fi; "
+        );
     }
 
     // Always ensure bpf-linker exists in-container (builder should already have it)
-    script.push_str("if ! command -v bpf-linker >/dev/null 2>&1; then ");
+    let _ = write!(
+        script,
+        "if ! command -v bpf-linker >/dev/null 2>&1 || ! bpf-linker --version | grep -Fq 'bpf-linker {bpf_linker_version}'; then "
+    );
     if opts.docker_image.contains("assay-ebpf-builder") {
         script.push_str("echo 'ERROR: bpf-linker missing in builder image'; exit 1; ");
     } else {
@@ -276,13 +321,16 @@ fn build_ebpf_docker(root: &std::path::Path, opts: &BuildEbpfOpts) -> anyhow::Re
         script.push_str(
             "apt-get update && apt-get install -y llvm-dev libclang-dev build-essential git; ",
         );
-        script.push_str("cargo install bpf-linker --locked; ");
+        let _ = write!(
+            script,
+            "rustup run {toolchain} cargo install bpf-linker --version {bpf_linker_version} --locked; "
+        );
     }
     script.push_str("fi; ");
 
     script.push_str(r#"export RUSTFLAGS="${RUSTFLAGS:-} -C linker=bpf-linker"; "#);
 
-    script.push_str("cargo +nightly build --package assay-ebpf ");
+    let _ = write!(script, "cargo +{toolchain} build --package assay-ebpf ");
     script.push_str(&format!("--target {} ", opts.target));
     script.push_str("--release "); // Force release build for eBPF (LLVM strictness)
     script.push_str("-Z build-std=core ");

--- a/docker/Dockerfile.ebpf-builder
+++ b/docker/Dockerfile.ebpf-builder
@@ -5,14 +5,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     llvm-dev libclang-dev build-essential git pkg-config ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-# Install Rust nightly toolchain (pinned for stability)
+# Install Rust eBPF toolchain (pinned for verifier stability)
 RUN rustup toolchain install nightly-2026-01-01 --profile minimal \
- && rustup component add rust-src --toolchain nightly-2026-01-01 \
- && rustup toolchain install nightly --profile minimal \
- && rustup component add rust-src --toolchain nightly
+ && rustup component add rust-src --toolchain nightly-2026-01-01
 
-# Install bpf-linker
-RUN cargo install bpf-linker --locked
+# Install pinned bpf-linker
+RUN rustup run nightly-2026-01-01 cargo install bpf-linker --version 0.10.3 --locked
 
 # FIX: Replace rustup's libLLVM linker script with a symlink so bpf-linker can load it
 RUN find /usr/local/rustup/toolchains -name "libLLVM-*.so" -type f -exec sh -c 'if grep -q "INPUT" "$1"; then ln -sf "$(grep -o "libLLVM.so[^)]*" "$1")" "$1"; echo "Fixed $1"; fi' -- {} \;

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -10,9 +10,9 @@
 Assay's delegated runner path uses native `bpf-linker` builds so cold Docker image builds stay out of the proof hot path.
 
 ```bash
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
-cargo install bpf-linker --locked
+rustup toolchain install nightly-2026-01-01 --profile minimal
+rustup component add rust-src --toolchain nightly-2026-01-01
+rustup run nightly-2026-01-01 cargo install bpf-linker --version 0.10.3 --locked
 ```
 
 ## 3. Build & Verify

--- a/docs/guides/runtime-monitor.md
+++ b/docs/guides/runtime-monitor.md
@@ -48,9 +48,9 @@ eBPF development requires a specific toolchain (LLVM, nightly Rust, bpf-linker).
 
 ```bash
 # 1. Install the native eBPF toolchain
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
-cargo install bpf-linker --locked
+rustup toolchain install nightly-2026-01-01 --profile minimal
+rustup component add rust-src --toolchain nightly-2026-01-01
+rustup run nightly-2026-01-01 cargo install bpf-linker --version 0.10.3 --locked
 
 # 2. Compile eBPF bytecode
 cargo xtask build-ebpf --release --no-docker

--- a/infra/bpf-runner/cloud-init.yaml
+++ b/infra/bpf-runner/cloud-init.yaml
@@ -47,9 +47,9 @@ runcmd:
   - ln -sf /opt/rust/bin/cargo /usr/local/bin/cargo
   - ln -sf /opt/rust/bin/rustc /usr/local/bin/rustc
   - ln -sf /opt/rust/bin/rustup /usr/local/bin/rustup
-  - /opt/rust/bin/rustup toolchain install nightly
-  - /opt/rust/bin/rustup component add rust-src --toolchain nightly
-  - /opt/rust/bin/cargo install bpf-linker --locked
+  - /opt/rust/bin/rustup toolchain install nightly-2026-01-01 --profile minimal
+  - /opt/rust/bin/rustup component add rust-src --toolchain nightly-2026-01-01
+  - /opt/rust/bin/rustup run nightly-2026-01-01 cargo install bpf-linker --version 0.10.3 --locked --force
   - ln -sf /opt/rust/bin/bpf-linker /usr/local/bin/bpf-linker
 
   # 4. Prepare Runner User

--- a/infra/bpf-runner/setup.sh
+++ b/infra/bpf-runner/setup.sh
@@ -71,13 +71,14 @@ export RUSTUP_HOME=/opt/rust
 export CARGO_HOME=/opt/rust
 export PATH=/opt/rust/bin:$PATH
 EOF
+# shellcheck disable=SC1091
 source /etc/profile.d/rust.sh
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
-if ! command -v bpf-linker &> /dev/null; then
-    cargo install bpf-linker --locked
+rustup toolchain install nightly-2026-01-01 --profile minimal
+rustup component add rust-src --toolchain nightly-2026-01-01
+if ! command -v bpf-linker &> /dev/null || ! bpf-linker --version | grep -Fq "bpf-linker 0.10.3"; then
+    rustup run nightly-2026-01-01 cargo install bpf-linker --version 0.10.3 --locked --force
 else
-    echo "   -> bpf-linker already installed."
+    echo "   -> bpf-linker 0.10.3 already installed."
 fi
 ln -sf /opt/rust/bin/cargo /usr/local/bin/cargo
 ln -sf /opt/rust/bin/rustc /usr/local/bin/rustc

--- a/scripts/ci/install-ebpf-toolchain.sh
+++ b/scripts/ci/install-ebpf-toolchain.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+toolchain="${ASSAY_EBPF_RUST_TOOLCHAIN:-nightly-2026-01-01}"
+bpf_linker_version="${ASSAY_BPF_LINKER_VERSION:-0.10.3}"
+
+rustup toolchain install "${toolchain}" --profile minimal --component rust-src
+
+if ! command -v bpf-linker >/dev/null 2>&1 \
+    || ! bpf-linker --version | grep -Fq "bpf-linker ${bpf_linker_version}"; then
+    rustup run "${toolchain}" cargo install \
+        bpf-linker \
+        --version "${bpf_linker_version}" \
+        --locked \
+        --force
+fi
+
+echo "eBPF toolchain: ${toolchain}"
+echo "bpf-linker: $(bpf-linker --version)"


### PR DESCRIPTION
## Summary
- pin the eBPF Rust toolchain to `nightly-2026-01-01` and `bpf-linker` to `0.10.3`
- make `cargo xtask build-ebpf` use the pinned toolchain by default, with env overrides for emergency/debug use
- centralize CI native eBPF toolchain bootstrap in `scripts/ci/install-ebpf-toolchain.sh`
- align Docker builder, runner provisioning, kernel matrix, delegated workflows, and docs with the same pins

## Why
PR #1524 removed Docker from the delegated hot path. This follow-up removes the remaining floating `nightly`/latest `bpf-linker` drift so native and Docker eBPF builds do not silently diverge when upstream toolchains move.

## Delegated proof
- gate: all
- head SHA: 6b08733316f873cba1523fe8b89830ee2d399477
- head prefix: 6b08733316f8
- status: green `Runner Spike Delegated` workflow_dispatch
- proof: https://github.com/Rul1an/assay/actions/runs/27058962085

## Verification
- `bash -n scripts/ci/install-ebpf-toolchain.sh infra/bpf-runner/setup.sh`
- `shellcheck scripts/ci/install-ebpf-toolchain.sh infra/bpf-runner/setup.sh`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/runner-spike-delegated.yml .github/workflows/runner-otel-experiment.yml .github/workflows/cross-runtime-drift-experiment.yml .github/workflows/runner-otel-overhead-experiment.yml .github/workflows/kernel-matrix.yml .github/workflows/ci.yml infra/bpf-runner/cloud-init.yaml`
- `cargo fmt --check`
- `cargo check -p assay-xtask`
- grep proof: no floating eBPF `+nightly`/unpinned `bpf-linker` install-sites in checked runner/eBPF paths
- pre-push hooks: workflow lint, shellcheck, cargo fmt, cargo clippy, linux compile gate

## Merge discipline
Merge only after CI/delegated runner proof is green and review comments are addressed.
