### PR TITLE
docs(refactor): close housekeeping status

### DIFF
--- a/docs/contributing/REFACTOR-WAVE-STATUS.md
+++ b/docs/contributing/REFACTOR-WAVE-STATUS.md
@@ -26,7 +26,7 @@ It answers four questions:
 | Wave18 | Mandate types | `#670`, `#672`, `#674`, `#675` | Closed-loop | mandate types split into facade, core, serde, schema, tests |
 | Wave19 | Coverage command | Step1 landed, `#679`, `#680` | Closed-loop | coverage command split into facade, generate, legacy, IO, supporting modules |
 | Wave64 | Assay sim | `#1526` | Closed-loop | consumer downgrade split into facade + `consumer_downgrade_next/*`; first user of generic `review-split-wave.sh` |
-| Housekeeping | Refactor artifacts | pending PR | In progress | removes historical per-wave `SPLIT-*` docs and `review-wave*.sh` scripts after the durable generic gate landed |
+| Housekeeping | Refactor artifacts | `#1527` | Closed-loop | removed historical per-wave `SPLIT-*` docs and `review-wave*.sh` scripts after the durable generic gate landed |
 
 ## What changed
 The refactor program reduced large single-file hotspots in these areas:


### PR DESCRIPTION
## Summary

Closes the housekeeping row in `docs/contributing/REFACTOR-WAVE-STATUS.md` now that #1527 has merged.

## Verification

- `git diff --check`
- `mkdocs build --strict` via `/tmp/assay-mkdocs-venv` using `docs/requirements-ci.txt`
- `git ls-files 'docs/contributing/SPLIT-*' 'scripts/ci/review-wave*.sh' | wc -l` -> `0`
