### PR TITLE
docs(refactor): close wave66 auth status

### DIFF
--- a/docs/contributing/REFACTOR-WAVE-STATUS.md
+++ b/docs/contributing/REFACTOR-WAVE-STATUS.md
@@ -27,7 +27,7 @@ It answers four questions:
 | Wave19 | Coverage command | Step1 landed, `#679`, `#680` | Closed-loop | coverage command split into facade, generate, legacy, IO, supporting modules |
 | Wave64 | Assay sim | `#1526` | Closed-loop | consumer downgrade split into facade + `consumer_downgrade_next/*`; first user of generic `review-split-wave.sh` |
 | Wave65 | Registry lockfile | `#1530` | Closed-loop | moved inline lockfile tests behind existing `lockfile_next/tests.rs`; kept lockfile facade/API behavior stable |
-| Wave66 | Registry auth | `#1531` | In review | moved inline auth/OIDC tests behind existing `auth_next/tests.rs`; kept `TokenProvider`/`OidcProvider` facade/API behavior stable |
+| Wave66 | Registry auth | `#1531` | Closed-loop | moved inline auth/OIDC tests behind existing `auth_next/tests.rs`; kept `TokenProvider`/`OidcProvider` facade/API behavior stable |
 | Housekeeping | Refactor artifacts | `#1527` | Closed-loop | removed historical per-wave `SPLIT-*` docs and `review-wave*.sh` scripts after the durable generic gate landed |
 | Housekeeping | Stale review scripts | `#1529` | Closed-loop | removed non-wave review scripts that still referenced deleted `SPLIT-*` docs |
 


### PR DESCRIPTION
## Summary
- Marks Wave66 as `Closed-loop` after #1531 merged.
- No code changes; status-only closure.

## Verification
- `uv run --with-requirements docs/requirements-ci.txt mkdocs build --strict`
