### PR TITLE
docs(guides): coding-agent governance + editor MCP recipe (ADR-035, ADR-036)

### DIFF
--- a/docs/architecture/ADR-035-sandbox-the-agent-evidence.md
+++ b/docs/architecture/ADR-035-sandbox-the-agent-evidence.md
@@ -1,0 +1,66 @@
+# ADR-035: Sandbox-the-Agent Evidence Path
+
+## Status
+Proposed (June 2026)
+
+Depends on ADR-034 (Assay / Runner / Harness contract seam).
+
+## Context
+
+Coding agents and other autonomous agents run shell commands, edit files, and reach
+the network with broad blast radius. Editor-native permission prompts are
+self-reported and editor-specific, so they do not give an independent, portable
+record of what an agent actually did.
+
+Assay already ships `assay sandbox` (Landlock-based), which runs a command under
+containment and, with `--profile`, emits a content-addressed evidence profile of the
+observed effects (filesystem operations, executed programs, counters, containment
+degradations) with a deterministic `sandbox_<sha256-prefix>` run id, plus a suggested
+policy and a human report.
+
+## Decision
+
+Document and support running a coding agent under `assay sandbox -- <agent command>`
+as a first-class governance path that produces an independent, deterministic record
+of the agent's observed effects, with optional inline enforcement (`--enforce`,
+`--fail-closed`) and an observe-only mode (`--dry-run`).
+
+Frame the evidence dimensions around the three controls that matter most for an
+autonomous agent: network egress, file writes, and configuration protection.
+
+Consume the record via the contract seam (ADR-034). Promoting the evidence profile
+into the canonical evidence bundle consumed by `assay evidence lint` / `diff`, and a
+matching Assay-Harness recipe, gate, and report, is the next slice; until then the
+evidence profile is consumed directly.
+
+## Consequences
+
+- An independent, cross-editor, deterministic record of an agent run, most valuable
+  in CI and cloud-autonomous runs where an audit trail beats an interactive prompt.
+- A documented governance workflow over already-shipping code; no new subsystem.
+- A follow-up is needed to converge the evidence-profile artifact with the canonical
+  evidence-bundle format behind the contract seam.
+
+## Best-practice basis (2026)
+
+- Landlock / seccomp for lightweight unprivileged in-process containment.
+- microVM / gVisor for isolating genuinely untrusted code; Assay composes on top.
+- Independent observation as the cross-check on self-reported permissions.
+- The three mandatory controls for autonomous agents: network egress, file-write
+  restrictions, configuration protection.
+
+## Non-claims
+
+- Landlock is not VM-level isolation. For untrusted code, run the agent inside a
+  microVM or gVisor and use Assay for the record and the gate on top.
+- Assay does not prevent prompt injection. There is no deterministic prevention for
+  prompt injection; the only provable defense is environment isolation. Assay
+  observes, records, and gates.
+- The evidence profile records observed effects from Assay's vantage; it is not a
+  proof of intent.
+
+## References
+
+- `crates/assay-cli/src/cli/commands/sandbox.rs`
+- `docs/guides/coding-agent-governance.md`
+- ADR-034 (contract seam)

--- a/docs/architecture/ADR-036-editor-mcp-wrap-recipe.md
+++ b/docs/architecture/ADR-036-editor-mcp-wrap-recipe.md
@@ -1,0 +1,57 @@
+# ADR-036: Editor MCP Wrap Recipe
+
+## Status
+Proposed (June 2026; remote/OAuth section finalises after the 28 July 2026 MCP spec)
+
+Depends on ADR-034 (Assay / Runner / Harness contract seam).
+
+## Context
+
+Coding agents (Claude Code, Cursor, Codex) are MCP clients and use standard MCP
+client configuration as their extension point. Assay ships `assay mcp wrap`, which
+wraps a real MCP server process and enforces policy decisions inline, plus
+`assay mcp config-path` to locate the active config. There is no documented recipe
+for inserting Assay into an agent's MCP setup.
+
+The MCP specification finalising on 28 July 2026 brings a stateless HTTP core, server
+UIs rendered in a sandboxed iframe (every UI action routed through the same JSON-RPC
+audit and consent path as a direct tool call), a Tasks extension, and authorization
+aligned to OAuth 2.1 / OIDC (PKCE, scoped tokens, consent).
+
+## Decision
+
+Provide a one-page recipe to route an agent's MCP servers through
+`assay mcp wrap --policy <file> -- <real-server> [args]` using each host's standard
+MCP client config: Claude Code project config, Cursor `.cursor/mcp.json`, and Codex
+`AGENTS.md` / MCP config. Recommend `--dry-run` first, then enforce. Use standard MCP
+client config; do not build a bespoke per-editor plugin.
+
+Write the recipe against the 2026-07-28 release candidate. For remote servers, align
+the wrapped server to the OAuth 2.1 flow with least-privilege scopes and consent;
+mark that section provisional and finalise it once the spec is final. The local
+stdio wrap is stable and is the primary path.
+
+## Consequences
+
+- Any MCP-client coding agent can run its tool calls through an Assay policy gate
+  with a one-line config change. Low cost (docs + a quickstart).
+- The recipe must track the 2026-07-28 spec and each host's MCP config conventions.
+
+## Best-practice basis (2026)
+
+- MCP 2026-07-28 spec: OAuth 2.1 / OIDC authorization, sandboxed-iframe UIs, unified
+  audit and consent path.
+- MCP security guidance: least privilege, run servers sandboxed with restricted
+  filesystem and network, explicit privilege grants.
+
+## Non-claims
+
+- `assay mcp wrap` enforces policy at the MCP protocol boundary (which tools, which
+  arguments). It is the protocol-level complement to kernel-level containment, not a
+  replacement, and not a prompt-injection defense.
+
+## References
+
+- `docs/reference/cli/mcp-server.md`
+- `docs/guides/editor-mcp-recipe.md`
+- ADR-034 (contract seam)

--- a/docs/guides/coding-agent-governance.md
+++ b/docs/guides/coding-agent-governance.md
@@ -1,0 +1,78 @@
+# Coding-Agent Governance: an independent record of what the agent did
+
+Coding agents (Claude Code, Cursor, Codex, and cloud-autonomous runners) run shell,
+edit files, and reach the network with broad blast radius. Their editor-native
+permission prompts are self-reported and editor-specific. Assay gives you an
+independent, deterministic record of what an agent actually did, plus an optional
+policy gate, by running the agent under `assay sandbox`.
+
+## What you get
+
+Run any command (including a coding-agent CLI) under the sandbox with profiling on:
+
+```bash
+assay sandbox \
+  --profile run.profile.yaml \
+  --profile-report run.report.md \
+  -- <your coding-agent command> [args...]
+```
+
+This produces three artifacts:
+
+- `run.profile.yaml` — a suggested policy derived from the observed behavior.
+- `run.profile.evidence.yaml` — a content-addressed **evidence profile** of the
+  observed effects (filesystem operations, executed programs, counters, and any
+  containment degradations), with a deterministic run id of the form
+  `sandbox_<sha256-prefix>`. Re-running the same command over the same behavior
+  yields the same run id.
+- `run.profile.report.md` — a human-readable summary.
+
+Use `--profile-format json` for JSON instead of YAML.
+
+## Enforcement modes
+
+The sandbox uses Landlock when available:
+
+- default: containment is active when Landlock is present.
+- `--dry-run`: observe and log only, never block (exits 4 if an unauthorized action
+  occurs). Best for the first run while you learn the agent's footprint.
+- `--enforce`: require active enforcement; combine with `--fail-closed` to make an
+  unenforceable policy fatal (exit 2) rather than degrading to audit.
+
+Pass a policy with `--policy assay.yaml`; without one, a minimal default applies.
+Environment scrubbing is on by default (`--env-strict`, `--env-strip-exec`,
+`--env-allow a,b`, `--env-safe-path` to tune; `--env-passthrough` is the unsafe
+escape hatch).
+
+## The three controls
+
+The observed effects map to the three controls that matter most for an autonomous
+agent:
+
+- **Network egress** — NET allow/deny rules; observed connection attempts.
+- **File writes** — FS allow/deny rules; observed filesystem operations in the
+  evidence profile.
+- **Configuration protection** — deny rules over sensitive paths.
+
+## Honest limits (read this)
+
+- Landlock is a lightweight in-kernel containment layer. It is **not** VM-level
+  isolation. For genuinely untrusted code, run the agent inside a microVM or gVisor
+  and use Assay for the independent record and policy gate on top of that isolation.
+- Assay does **not** prevent prompt injection. There is no deterministic prevention
+  for prompt injection; the only provable defense is isolating the environment. Assay
+  observes, records, and gates; it does not make an injected instruction safe.
+- The evidence profile is the agent's observed effects from Assay's vantage, not a
+  proof of intent.
+
+Most useful in CI and cloud-autonomous runs, where an independent audit trail beats
+an interactive permission prompt.
+
+## Consuming the record
+
+Today the sandbox emits the evidence-profile artifact described above. Promoting that
+into the canonical evidence bundle consumed by `assay evidence lint` / `diff`, and a
+matching Assay-Harness recipe, gate, and report, is tracked as the next slice (see
+ADR-035 and ADR-034). Until then, consume `run.profile.evidence.yaml` directly.
+
+See also: [Editor MCP recipe](editor-mcp-recipe.md), [ADR-035](../architecture/ADR-035-sandbox-the-agent-evidence.md).

--- a/docs/guides/editor-mcp-recipe.md
+++ b/docs/guides/editor-mcp-recipe.md
@@ -1,0 +1,80 @@
+# Editor MCP Recipe: policy-enforcing MCP in Claude Code, Cursor, Codex
+
+Coding agents are MCP clients. You can put Assay between the agent and the MCP
+servers it uses by wrapping each server with `assay mcp wrap`, so every tool call is
+checked against your policy inline. No bespoke plugin is needed; you only change the
+server command in the agent's standard MCP config.
+
+## The wrap command
+
+```bash
+assay mcp wrap --policy assay.yaml -- <real-mcp-server-command> [args...]
+```
+
+Key options:
+
+| Option | Effect |
+|--------|--------|
+| `--policy <PATH>` | Policy file (default `assay.yaml`) |
+| `--dry-run` | Log decisions, do not block (start here) |
+| `--verbose` | Print decisions to stderr |
+
+Recommended path: run with `--dry-run` first to see decisions, then drop it to
+enforce.
+
+## Claude Code
+
+In your project MCP config, set the server's command to the wrapped form:
+
+```json
+{
+  "mcpServers": {
+    "files": {
+      "command": "assay",
+      "args": ["mcp", "wrap", "--policy", "assay.yaml", "--",
+               "<real-mcp-server>", "<server-args>"]
+    }
+  }
+}
+```
+
+## Cursor
+
+In `.cursor/mcp.json`, same shape:
+
+```json
+{
+  "mcpServers": {
+    "files": {
+      "command": "assay",
+      "args": ["mcp", "wrap", "--policy", "assay.yaml", "--",
+               "<real-mcp-server>", "<server-args>"]
+    }
+  }
+}
+```
+
+## Codex
+
+In your `AGENTS.md` / Codex MCP config, register the same wrapped command as the
+server entry. Use `assay mcp config-path` to locate the active config.
+
+## Remote servers (provisional, MCP 2026-07-28)
+
+The MCP specification finalising on 28 July 2026 aligns remote authorization with
+OAuth 2.1 / OIDC (PKCE, scoped tokens, consent), and renders server UIs in a
+sandboxed iframe with every UI action going through the same audit and consent path
+as a direct tool call. For remote MCP servers, align the wrapped server to that
+OAuth 2.1 flow and keep scopes least-privilege. This section is provisional against
+the release candidate and will be finalised once the spec is final; the local
+stdio wrap above is stable today.
+
+## Honest limits
+
+- `assay mcp wrap` enforces policy at the MCP protocol boundary (which tools, which
+  arguments). It is the protocol-level complement to kernel-level containment, not a
+  replacement for it, and not a prompt-injection defense.
+- Least privilege still applies: scope the wrapped server's filesystem and network
+  access, and grant more only when needed.
+
+See also: [Coding-Agent Governance](coding-agent-governance.md), [ADR-036](../architecture/ADR-036-editor-mcp-wrap-recipe.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -228,6 +228,8 @@ nav:
   - Guides:
     - guides/index.md
     - Sandbox Security: guides/sandbox-security.md
+    - Coding-Agent Governance: guides/coding-agent-governance.md
+    - Editor MCP Recipe: guides/editor-mcp-recipe.md
     - Gateway Pattern: guides/gateway-pattern.md
     - OpenTelemetry & Langfuse: guides/otel-langfuse.md
 


### PR DESCRIPTION
## Summary
Phase 1 of the interop program (depends on ADR-034 contract seam, merged in #1536), built over already-shipping code:

- **guides/coding-agent-governance.md** — run a coding agent under `assay sandbox -- <agent>` to get a deterministic, content-addressed evidence profile of observed filesystem/exec/degradation effects, with optional inline enforcement (`--enforce`/`--fail-closed`) and observe-only `--dry-run`. Maps the evidence to the three controls (network egress, file write, config protection).
- **guides/editor-mcp-recipe.md** — route a coding agent's MCP servers through `assay mcp wrap` (Claude Code, Cursor `.cursor/mcp.json`, Codex), for an inline policy gate. Remote/OAuth section provisional against the 2026-07-28 MCP spec.
- **ADR-035** (sandbox-the-agent evidence) and **ADR-036** (editor MCP wrap recipe), both depending on ADR-034.
- Both guides added to the mkdocs Guides nav.

## Honest limits (carried in the docs and ADRs)
- Landlock is not VM-level isolation and does not prevent prompt injection; compose on top of microVM/gVisor for untrusted code.
- `assay mcp wrap` enforces at the MCP protocol boundary, not a substitute for kernel containment.
- Documents current behavior: the sandbox emits an evidence profile today; promoting it to the canonical evidence bundle (`assay evidence lint`) + a matching Assay-Harness recipe is tracked as the next slice.

## Scope
Docs only. No code or behavior change. Verified against the real `assay sandbox` flags and `assay mcp wrap` surface.

## Verification
- pre-commit hooks green (yaml, typos, fmt, end-of-files, whitespace)
- guides added to mkdocs nav; mkdocs-strict should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)