### PR TITLE
docs(adr): interop ADR set 037-041 (records + gates)

### DIFF
--- a/docs/architecture/ADR-037-runner-standalone-boundary.md
+++ b/docs/architecture/ADR-037-runner-standalone-boundary.md
@@ -1,0 +1,38 @@
+# ADR-037: Runner Standalone Boundary
+
+## Status
+Accepted (June 2026) — records existing discipline; pointer ADR.
+
+Depends on ADR-034 (contract seam).
+
+## Context
+
+The runner crates (`assay-runner-schema`, `assay-runner-core`, `assay-runner-linux`)
+publish to crates.io and are standalone-useful. The standalone-versus-extraction
+question is already governed by `docs/reference/runner/extraction-roadmap.md`, which
+sequences the extraction slices, gates the repository split, defines kill criteria,
+and states explicitly that standalone usefulness is not the same as repository
+extraction.
+
+## Decision
+
+This ADR does not re-decide the extraction question. It records the invariant the
+rest of the interop program must preserve: every interop slice consumes the Runner
+through its published schema (ADR-034 contract seam) and keeps it standalone-useful,
+so the options in the extraction roadmap stay open. Any move to make the Runner its
+own product follows that roadmap's gates and kill criteria, not this ADR.
+
+## Consequences
+
+- Interop work cannot accidentally re-couple the Runner into core.
+- The extraction decision stays in the document that owns it.
+
+## Non-claims
+
+- This ADR makes no product, packaging, or repository-split claim. It only protects
+  the option by fixing the consume-via-contract invariant.
+
+## References
+
+- `docs/reference/runner/extraction-roadmap.md`
+- ADR-034 (contract seam)

--- a/docs/architecture/ADR-038-otlp-exporter-for-observations.md
+++ b/docs/architecture/ADR-038-otlp-exporter-for-observations.md
@@ -1,0 +1,55 @@
+# ADR-038: OTLP Exporter for Assay Observations
+
+## Status
+Proposed (June 2026) — decision recorded; code lands as a tracked slice.
+
+Depends on ADR-034 (contract seam).
+
+## Context
+
+`assay-core` already ingests OTel-shaped traces and models the GenAI semantic
+conventions (`assay-core/src/otel/`, `trace/otel_ingest.rs`, `config/otel.rs`), but
+emits nothing over OTLP. Assay observations therefore cannot be viewed next to the
+self-reported spans in a user's existing telemetry backend. As of mid-2026 the OTel
+GenAI semantic conventions are still in Development status with no published
+stabilisation timeline; agent spans (create/invoke agent, execute tool) and MCP
+tool-execution instrumentation exist but will churn.
+
+## Decision
+
+Add an opt-in, feature-gated OTLP/HTTP exporter that maps Assay observations and the
+claim-class outcome onto the OTel GenAI agent-spans and execute-tool conventions. Off
+by default; no OTLP dependency in the default build. Pin the semconv version Assay
+maps to and gate behind `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`.
+Emit the claim-class outcome (supported / degraded / blocked / not_evaluable) as span
+attributes on the execute-tool span so the declared (server-returned, SEP-2448) and
+the observed views sit in one trace.
+
+## Implementation slice
+
+Code lands in `assay-core/src/otel/` together with this ADR, sequenced after the
+in-flight evidence-crate refactor waves to avoid churn. This ADR records the
+decision; it is not satisfied until the exporter ships.
+
+## Consequences
+
+- Assay observations land in any OTLP collector (Phoenix, Langfuse, vendor), making
+  claimed-versus-actual a single trace view.
+- Adds a feature-gated dependency and a semconv-mapping surface to re-pin as the
+  conventions move toward stable.
+
+## Best-practice basis (2026)
+
+- OTel GenAI semconv (still Development): target agent-spans + execute-tool, pin the
+  version, use the stability opt-in flag, expect churn.
+- Additive, opt-in instrumentation over an OTLP-compatible backend.
+
+## Non-claims
+
+- Assay does not stabilise OTel semconv; it pins to an experimental version and the
+  mapping is expected to change until the conventions are stable.
+
+## References
+
+- `assay-core/src/otel/semconv.rs`, `trace/otel_ingest.rs`
+- ADR-034 (contract seam)

--- a/docs/architecture/ADR-039-evidence-bundle-attestation.md
+++ b/docs/architecture/ADR-039-evidence-bundle-attestation.md
@@ -1,0 +1,53 @@
+# ADR-039: Evidence Bundle as in-toto / SCITT Attestation
+
+## Status
+Proposed (June 2026) — trigger-gated.
+
+Depends on ADR-034 (contract seam).
+
+## Context
+
+The evidence bundle has a manifest, Merkle root, and content-addressed events, but is
+not emitted as an attestation statement. DSSE signing already exists, scoped to the
+mandate subsystem (`assay-evidence/src/mandate/signing.rs`), and CI emits SLSA
+build-provenance for the binary. The bundle itself cannot be anchored or verified
+offline as a portable claim. As of 2026 the in-toto Attestation Framework (ITE-6) is
+the common envelope that Sigstore and SLSA already use, and SCITT continues through
+the IETF, synergising with RATS and WIMSE.
+
+## Decision
+
+Emit the bundle manifest and the coverage/claim verdict as an in-toto v1 Statement
+under a named custom predicate type (mirroring how SLSA defines its predicate),
+wrapped in a DSSE envelope, reusing the mandate signing path. Keep the anchor
+pluggable (SCITT statement or OpenTimestamps); do not build a transparency log or
+trust root. The per-fact claim-state (basis) is a first-class predicate field.
+
+## Gate
+
+Publish the predicate type and ship the emitter only once an independent consumer
+evaluates or consumes it. Until that trigger, this ADR records the decision and the
+shape; it is intentionally not built, to avoid freezing a predicate no one consumes.
+
+## Consequences
+
+- An Assay coverage/claim verdict becomes a portable attestation other systems can
+  anchor and verify offline, composable under a SCITT statement or content-addressed
+  record.
+- Adds a predicate schema to version and keep stable once published.
+
+## Best-practice basis (2026)
+
+- in-toto ITE-6 as the common envelope; SLSA provenance is an in-toto attestation
+  with a named predicate; SCITT in the IETF with RATS + WIMSE.
+
+## Non-claims
+
+- Attestation binds who-said-it and the content; it does not upgrade observed support
+  (proven in the attested-observed work) and provides no trust root or transparency
+  log.
+
+## References
+
+- `assay-evidence/src/mandate/signing.rs`
+- ADR-034 (contract seam)

--- a/docs/architecture/ADR-040-inspect-claim-support-scorer.md
+++ b/docs/architecture/ADR-040-inspect-claim-support-scorer.md
@@ -1,0 +1,46 @@
+# ADR-040: Public Inspect Scorer for Claim Support
+
+## Status
+Proposed (June 2026) — depends on the sandbox evidence slice (ADR-035).
+
+Depends on ADR-034 (contract seam).
+
+## Context
+
+Assay ingests structured outputs from promptfoo, mastra, pydantic, livekit,
+openfeature, and cyclonedx through a receipt-importer pattern. The one high-value
+eval host not yet wired is Inspect (UK AISI and Meridian). As of 2026 Inspect runs
+arbitrary external agents (Claude Code, Codex CLI, Gemini CLI) as agents-under-test,
+packages scorers as standard Python packages, and registers community evals through a
+`/register/` folder `.yaml` submission pointing to external repositories.
+
+## Decision
+
+Ship the claim-support scorer as a standard Python package and register it through the
+`/register/` flow, not as a fork or a core-repo change. Be a scorer inside Inspect; do
+not build a competing eval harness. The scorer and any other consumer share the same
+claim-class contract (ADR-034); the vocabulary is not forked. Because Inspect can
+drive a coding agent as the agent-under-test, the scorer grades a coding-agent run
+observed by `assay sandbox` (ADR-035), giving one end-to-end demo.
+
+## Implementation slice
+
+Lands as a Python package after the sandbox evidence record is consumable as the
+scorer's observed-evidence source. This ADR records the decision and the integration
+shape.
+
+## Consequences
+
+- Inspect users score claim-support without leaving Inspect, and can score
+  coding-agent runs end to end.
+- Adds a Python package to publish and keep in step with the Inspect scorer API and
+  the register flow.
+
+## Best-practice basis (2026)
+
+- Inspect is the de-facto safety-eval framework; integrate as a first-class scorer via
+  `/register/`. Inspect natively drives Claude Code / Codex CLI / Gemini CLI.
+
+## References
+
+- ADR-034 (contract seam), ADR-035 (sandbox evidence)

--- a/docs/architecture/ADR-041-ebpf-policy-substrate-vs-bespoke.md
+++ b/docs/architecture/ADR-041-ebpf-policy-substrate-vs-bespoke.md
@@ -1,0 +1,56 @@
+# ADR-041: eBPF and Policy, Substrate-versus-Bespoke
+
+## Status
+Proposed (June 2026) — decision recorded; default posture set.
+
+Depends on ADR-034 (contract seam); read with `docs/reference/runner/extraction-roadmap.md`.
+
+## Context
+
+Assay's eBPF security stack (`assay-ebpf`, `assay-monitor`, `assay-policy`) and its
+two-tier policy compilation are entirely bespoke; there is zero interop code with
+Falco, Tetragon, or bpfman, or with OPA or Cedar. Maintaining a parallel kernel stack
+carries an operational cost, including self-hosted runner stability. As of 2026 the
+niche has named occupants: Tetragon 1.4 (February 2026) is production-ready with
+inline enforcement, and AgentSight and ActPlane already do independent eBPF
+observation and enforcement below the agent harness. The incumbents (Falco, Tetragon,
+bpfman for eBPF; OPA, Cedar for policy) are mature.
+
+## Decision
+
+Own only the agent-semantic mapping: kernel event to MCP tool call to policy-as-code
+to claim-class. That layer is Assay's distinct contribution and is not provided by
+raw kernel observation or by a general policy engine. Default posture, set now:
+
+- Do not out-build Falco, Tetragon, or OPA. Prefer interop over a parallel
+  general-purpose product.
+- Evaluate running the agent-semantic layer on Tetragon 1.4 enforcement plus bpfman
+  management rather than the parallel `assay-ebpf` stack.
+- For generic rules, prefer compiling to or interoperating with Cedar or OPA; keep
+  the bespoke language only for the agent-specific parts (tool sequences, argument
+  validation, claim-class) those engines do not express natively.
+- Staying bespoke for a given surface is acceptable only when justified in writing.
+
+## Consequences
+
+- Either path keeps Assay's distinct layer and avoids competing with mature
+  incumbents and the new named neighbours.
+- The substrate decision and the runner extraction decision are the same fork seen
+  from two documents; they move together.
+
+## Best-practice basis (2026)
+
+- Falco / Tetragon / bpfman for eBPF, OPA / Cedar for policy are the incumbents;
+  AgentSight and ActPlane occupy the agent-eBPF niche; the defensible position is the
+  agent-semantic layer above kernel ground truth.
+
+## Non-claims
+
+- Assay's eBPF layer does not replace Falco or Tetragon and inherits the limits
+  documented for kernel-level AI-agent enforcement (what it catches and what it
+  misses).
+
+## References
+
+- `docs/reference/runner/extraction-roadmap.md`
+- ADR-034 (contract seam), ADR-037 (runner standalone boundary)


### PR DESCRIPTION
## Summary
Lifts the remaining interop-program decisions as public ADRs on top of ADR-034 (contract seam, merged #1536) and alongside ADR-035/036 (PR #1542):

- **ADR-037 Runner standalone boundary** — pointer + invariant: interop slices consume the Runner via its published schema and keep it standalone-useful; extraction stays governed by `docs/reference/runner/extraction-roadmap.md`.
- **ADR-038 OTLP exporter** — feature-gated emit mapping observations + claim-class onto GenAI agent/execute-tool spans; pins semconv (still Development); code is a tracked slice after the in-flight evidence waves.
- **ADR-039 Evidence bundle as in-toto/SCITT attestation** — named predicate, DSSE-wrapped, pluggable anchor; trigger-gated on an independent consumer.
- **ADR-040 Public Inspect scorer** — ship via `/register`, share the claim-class contract; depends on the ADR-035 sandbox evidence slice.
- **ADR-041 eBPF/policy substrate-vs-bespoke** — own the agent-semantic mapping, prefer interop (Tetragon/bpfman, Cedar/OPA) over a parallel stack.

## Best practices
Each ADR carries Status, Context, Decision, Consequences, a 2026 best-practice basis, and explicit Non-claims. Code-bearing ADRs (038 OTLP, 040 Inspect) record the decision and shape; the implementation is a tracked follow-up slice, not force-built. ADR-039 is trigger-gated (publish the predicate only once an independent consumer evaluates it). No empty skeletons: ADR-041 sets a concrete default posture (own the semantic layer, prefer interop).

## Scope
Docs only. No code or behavior change.

## Verification
- pre-commit hooks green (typos, fmt, end-of-files, whitespace)
- `docs/architecture/` pages do not require nav entries (consistent with ADR-034 on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)