### PR TITLE
feat(cli): sandbox --bundle emits a canonical evidence bundle (ADR-035)

### DIFF
--- a/crates/assay-cli/src/cli/args/runtime.rs
+++ b/crates/assay-cli/src/cli/args/runtime.rs
@@ -196,6 +196,11 @@ pub struct SandboxArgs {
     #[arg(long)]
     pub profile_report: Option<PathBuf>,
 
+    /// Emit observed effects as a canonical evidence bundle (.tar.gz) at this path.
+    /// Requires --profile (the bundle is built from the profiled observations).
+    #[arg(long, requires = "profile")]
+    pub bundle: Option<PathBuf>,
+
     /// Show detailed sandbox setup
     #[arg(long, short)]
     pub verbose: bool,

--- a/crates/assay-cli/src/cli/commands/sandbox.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox.rs
@@ -5,6 +5,7 @@ use crate::metrics;
 
 use crate::profile::{events::ProfileEvent, ProfileCollector};
 
+mod bundle;
 mod child;
 mod degradation;
 mod env;
@@ -264,6 +265,7 @@ mod tests {
             profile: None,
             profile_format: "yaml".into(),
             profile_report: None,
+            bundle: None,
             verbose: false,
             quiet: true,
         }

--- a/crates/assay-cli/src/cli/commands/sandbox/bundle.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox/bundle.rs
@@ -1,0 +1,175 @@
+//! Emit sandbox observations as a canonical evidence bundle.
+//!
+//! Builds CloudEvents-style `EvidenceEvent`s from the profiled observations
+//! (filesystem operations, executed programs, containment degradations) and
+//! writes them as a `.tar.gz` evidence bundle consumable by `assay evidence
+//! lint` / `diff`. The run id is the deterministic profile run id; event
+//! timestamps reflect emission time, matching the receipt-importer convention.
+
+use crate::profile::ProfileReport;
+use anyhow::Context;
+use assay_evidence::bundle::BundleWriter;
+use assay_evidence::types::{EvidenceEvent, ProducerMeta};
+use chrono::{DateTime, Utc};
+use std::fs::File;
+use std::path::Path;
+
+const EVENT_SOURCE: &str = "urn:assay:sandbox";
+
+pub(super) fn emit_bundle(
+    report: &ProfileReport,
+    command: &[String],
+    run_id: &str,
+    out: &Path,
+) -> anyhow::Result<()> {
+    let producer = ProducerMeta {
+        name: "assay-cli".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        git: option_env!("ASSAY_GIT_SHA").map(|s| s.to_string()),
+    };
+    let emit_time = Utc::now();
+    let agg = &report.agg;
+    let mut events: Vec<EvidenceEvent> = Vec::new();
+
+    // Summary event: command and aggregate counts.
+    let summary = serde_json::json!({
+        "command": command,
+        "counters": agg.counters,
+        "notes": agg.notes,
+        "fs_count": agg.fs.len(),
+        "exec_count": agg.execs.len(),
+        "degradation_count": agg.sandbox_degradations.len(),
+    });
+    push_event(
+        &mut events,
+        "assay.sandbox.summary",
+        run_id,
+        summary,
+        None,
+        emit_time,
+        &producer,
+    );
+
+    // Filesystem observations (deterministic order: agg.fs is collected in order).
+    for (op, path, backend) in &agg.fs {
+        let payload = serde_json::json!({
+            "op": op.as_str(),
+            "path": path,
+            "backend": backend.as_str(),
+        });
+        push_event(
+            &mut events,
+            "assay.sandbox.fs",
+            run_id,
+            payload,
+            Some(path.clone()),
+            emit_time,
+            &producer,
+        );
+    }
+
+    // Executed programs (BTreeMap iterates in sorted, deterministic order).
+    for (argv0, hits) in &agg.execs {
+        let payload = serde_json::json!({ "argv0": argv0, "hits": hits });
+        push_event(
+            &mut events,
+            "assay.sandbox.exec",
+            run_id,
+            payload,
+            Some(argv0.clone()),
+            emit_time,
+            &producer,
+        );
+    }
+
+    // Containment degradations that weakened enforcement while execution continued.
+    for degradation in &agg.sandbox_degradations {
+        let payload =
+            serde_json::to_value(degradation).context("serialize sandbox degradation payload")?;
+        push_event(
+            &mut events,
+            "assay.sandbox.degraded",
+            run_id,
+            payload,
+            None,
+            emit_time,
+            &producer,
+        );
+    }
+
+    let file = File::create(out)
+        .with_context(|| format!("create evidence bundle at {}", out.display()))?;
+    let mut writer = BundleWriter::new(file).with_producer(producer);
+    for event in events {
+        writer.add_event(event);
+    }
+    writer.finish().context("write sandbox evidence bundle")?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_event(
+    events: &mut Vec<EvidenceEvent>,
+    type_: &str,
+    run_id: &str,
+    payload: serde_json::Value,
+    subject: Option<String>,
+    time: DateTime<Utc>,
+    producer: &ProducerMeta,
+) {
+    let seq = events.len() as u64;
+    let mut event = EvidenceEvent::new(type_, EVENT_SOURCE, run_id, seq, payload)
+        .with_time(time)
+        .with_producer(producer);
+    if let Some(subject) = subject {
+        event = event.with_subject(subject);
+    }
+    events.push(event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::events::{BackendHint, FsOp};
+    use crate::profile::{ProfileAgg, ProfileConfig, ProfileReport};
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    #[test]
+    fn emit_bundle_produces_a_verifiable_bundle() {
+        let mut execs = BTreeMap::new();
+        execs.insert("sh".to_string(), 2);
+        let agg = ProfileAgg {
+            fs: vec![(
+                FsOp::Write,
+                "/tmp/out.txt".to_string(),
+                BackendHint::Landlock,
+            )],
+            execs,
+            ..Default::default()
+        };
+        let report = ProfileReport {
+            version: 1,
+            config: ProfileConfig {
+                cwd: PathBuf::from("/tmp"),
+                home: None,
+                assay_tmp: None,
+            },
+            agg,
+        };
+        let command = vec!["echo".to_string(), "hi".to_string()];
+        let out = std::env::temp_dir().join(format!(
+            "assay-sbx-bundle-test-{}.tar.gz",
+            std::process::id()
+        ));
+
+        emit_bundle(&report, &command, "sandbox_testrun", &out).expect("emit bundle");
+
+        let file = File::open(&out).expect("open bundle");
+        let result = assay_evidence::bundle::verify_bundle(file).expect("verify bundle");
+        // summary + 1 fs op + 1 exec entry = 3 events.
+        assert_eq!(result.event_count, 3);
+
+        std::fs::remove_file(&out).ok();
+    }
+}

--- a/crates/assay-cli/src/cli/commands/sandbox/profile.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox/profile.rs
@@ -46,6 +46,16 @@ pub(super) fn maybe_profile_finish(
     let evidence_profile = report.to_evidence_profile(&evidence_profile_name, &run_id);
     crate::cli::commands::profile_types::save_profile(&evidence_profile, &evidence_profile_path)?;
 
+    // Optionally emit the observed effects as a canonical evidence bundle
+    // (consumable by `assay evidence lint` / `diff`). `--bundle` requires
+    // `--profile`, enforced by clap, so the report exists here.
+    if let Some(bundle_path) = args.bundle.as_ref() {
+        super::bundle::emit_bundle(&report, &args.command, &run_id, bundle_path)?;
+        if !args.quiet {
+            eprintln!("Evidence Bundle: {}", bundle_path.display());
+        }
+    }
+
     let report_path = args.profile_report.clone().unwrap_or_else(|| {
         let mut p = out_path.clone();
         if let Some(fname) = p.file_name() {

--- a/docs/guides/coding-agent-governance.md
+++ b/docs/guides/coding-agent-governance.md
@@ -68,11 +68,25 @@ agent:
 Most useful in CI and cloud-autonomous runs, where an independent audit trail beats
 an interactive permission prompt.
 
-## Consuming the record
+## Canonical evidence bundle
 
-Today the sandbox emits the evidence-profile artifact described above. Promoting that
-into the canonical evidence bundle consumed by `assay evidence lint` / `diff`, and a
-matching Assay-Harness recipe, gate, and report, is tracked as the next slice (see
-ADR-035 and ADR-034). Until then, consume `run.profile.evidence.yaml` directly.
+Add `--bundle <path>` (alongside `--profile`) to also emit a canonical evidence
+bundle (`.tar.gz`, manifest + events) of the observed effects, consumable by
+`assay evidence lint` / `diff`:
+
+```bash
+assay sandbox \
+  --profile run.profile.yaml \
+  --bundle run.bundle.tar.gz \
+  -- <your coding-agent command> [args...]
+
+assay evidence lint run.bundle.tar.gz
+```
+
+The bundle carries one CloudEvents-style event per observed filesystem operation,
+executed program, and containment degradation, plus a summary event, under the
+deterministic profile run id (event timestamps reflect emission time). A matching
+Assay-Harness recipe, gate, and report over this bundle is tracked next (see ADR-035
+and ADR-034).
 
 See also: [Editor MCP recipe](editor-mcp-recipe.md), [ADR-035](../architecture/ADR-035-sandbox-the-agent-evidence.md).


### PR DESCRIPTION
## Summary
Implements the first code slice of the interop program: `assay sandbox --bundle <path>` (requires `--profile`) emits the observed effects as a canonical evidence bundle (`.tar.gz`, manifest + NDJSON events) consumable by `assay evidence lint` / `diff`.

This completes the sandbox-the-agent evidence path described in **ADR-035** and unlocks the Inspect scorer (ADR-040) and a matching Assay-Harness recipe, which consume the bundle through the **ADR-034** contract shapes.

## What it does
Mirrors the existing receipt-importer pattern (promptfoo/mastra/etc.): from the profiled `ProfileReport.agg`, build one CloudEvents-style `EvidenceEvent` per observation and write them with `BundleWriter`:
- `assay.sandbox.summary` — command + aggregate counts
- `assay.sandbox.fs` — each filesystem operation (op/path/backend), subject = path
- `assay.sandbox.exec` — each executed program (argv0/hits), subject = argv0
- `assay.sandbox.degraded` — each containment degradation

Run id is the deterministic profile run id; event timestamps reflect emission time (receipt-importer convention).

## Scope / safety
- New `crates/assay-cli/src/cli/commands/sandbox/bundle.rs`; `--bundle` flag with clap `requires = "profile"`; emission wired in `maybe_profile_finish`.
- No change to Landlock enforcement, the profiler, or the existing profile/evidence-profile outputs.
- `docs/guides/coding-agent-governance.md` updated to document `--bundle`.
- Gate.NONE (no runner-lane files).

## Verification
- `cargo fmt --check`, `cargo clippy -p assay-cli --all-targets` clean
- new unit test `emit_bundle_produces_a_verifiable_bundle`: builds a bundle from a sample report and asserts `verify_bundle` accepts it (event_count == 3) — passing locally
- pre-commit hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)