### PR TITLE
chore(release): prepare v3.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.17.0] - 2026-06-06
+
+- Added `assay sandbox --bundle-out`, which emits sandbox observations as a
+  canonical evidence bundle. The bundle projection records observed filesystem,
+  environment, process, and sandbox-degradation facts without promoting them to
+  policy approval, signer trust, application outcome truth, or a broader
+  runtime-safety claim.
+
+- Hardened Runner/eBPF release and CI behavior by documenting unsafe invariants
+  in eBPF and runner Linux code, adding targeted unsafe lint posture, pinning
+  the eBPF toolchain, and making native eBPF builds use the release-optimized
+  path expected by the kernel verifier. These changes keep the runner proof
+  path bounded and do not change the public evidence archive schema.
+
+- Split high-traffic implementation hotspots behind stable facades, including
+  CLI importers and command modules, registry trust/cache/resolver internals,
+  runner path projection, policy tier compilation, metrics argument validation,
+  simulation attack matrices, and mandate core data types. Public module
+  surfaces are preserved through re-exports; the release adds contract and
+  serialization guards where the moved code carries evidence or policy
+  semantics.
+
+- Added and refined technical governance docs for the Assay/Runner/Harness
+  contract seam, sandbox-evidence capture, editor MCP wrapping, OTLP export for
+  observations, evidence-bundle attestation, Inspect claim-support scoring, and
+  the eBPF policy-substrate decision boundary. These are repository contracts
+  and implementation guidance, not separate product claims.
+
+- Replaced historical per-wave refactor artifacts with the durable generic
+  split-wave gate and removed stale split review scripts. Routine refactor
+  waves now keep move maps and review notes in PR bodies plus the rolling
+  refactor status page instead of adding per-wave `SPLIT-*` docs or
+  `review-wave*.sh` scripts.
+
 - Documentation: grouped the coverage-honesty examples under a single
   "Coverage honesty" section in the examples index, with the end-to-end
   walkthrough as the entry point, so the capture → coverage descriptor →

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.16.0"
+version = "3.17.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -73,18 +73,18 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.16.0" }
-assay-common = { path = "crates/assay-common", version = "3.16.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.16.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.16.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.16.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.16.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.16.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.16.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.16.0" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.16.0" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.16.0" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.16.0" }
+assay-core = { path = "crates/assay-core", version = "3.17.0" }
+assay-common = { path = "crates/assay-common", version = "3.17.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.17.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.17.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.17.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.17.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.17.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.17.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.17.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.17.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.17.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.17.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,11 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-06-04, `v3.16.0` release prep):** the `v3.16.0`
-> release line carries the post-`v3.15.0` coverage-aware interpretation batch:
-> the MCP tunnel observed-facts checker, the Runner coverage descriptor helper,
-> coverage-aware side-effect and drift annotation examples, drift comparator
-> claim enforcement, and datagram-aware descriptor mapping for Runner archives
-> that report `sendto`/`sendmsg` peer observations. The Cargo workspace/package
-> version in this release-prep branch is **`3.16.0`**.
+> **Status sync (2026-06-06, `v3.17.0` release prep):** the `v3.17.0`
+> release line carries the post-`v3.16.0` sandbox-evidence bundle projection,
+> Runner/eBPF build and unsafe-invariant hardening, refactor-gate cleanup, and
+> facade splits that keep public module surfaces stable while reducing
+> high-traffic implementation hotspots. The Cargo workspace/package version in
+> this release-prep branch is **`3.17.0`**.
 > The current execution posture is: keep remaining CLI grouping trigger-gated,
 > keep Assay-Runner repository extraction gated, treat Assay-Harness `v3.13.0`
 > compatibility as verified by its release-binary compatibility CI check
@@ -209,7 +208,7 @@ datagram destination sockaddr evidence from `sendto`/`sendmsg`, and the
 cross-runtime experiment comparator treats diagnostic-only endpoint churn as
 inconclusive instead of hard provider/runtime drift.
 
-The `v3.16.0` release-prep line layers coverage-aware interpretation on top of
+The `v3.16.0` release line layers coverage-aware interpretation on top of
 that substrate: consumers can classify effect claims through coverage
 descriptors, drift annotations can be emitted and enforced as sidecars, and
 datagram-aware network descriptors are selected from
@@ -217,6 +216,14 @@ datagram-aware network descriptors are selected from
 network observations beyond connect-only capture, but it still does not claim
 request-level binding, `cf_ray` capture, or authoritative exact QUIC peer
 identity.
+
+The `v3.17.0` release-prep line adds a canonical sandbox-observation evidence
+bundle projection, records the Assay/Runner/Harness contract seam and related
+interop decisions, hardens the Runner/eBPF build and unsafe-invariant posture,
+and closes the split-refactor housekeeping loop with a durable generic gate.
+Those changes are bounded to evidence projection, implementation structure,
+release/CI robustness, and technical contracts; they do not add a scalar trust
+score, hosted dashboard, policy-quality claim, or application-outcome claim.
 
 ### Happy Path (Core Workflow)
 ```bash


### PR DESCRIPTION
## Summary
- bump workspace and internal Assay dependency versions from `3.16.0` to `3.17.0`
- move `CHANGELOG.md` `[Unreleased]` content into `3.17.0` with public-safe, technical release notes
- sync `docs/ROADMAP.md` to the `v3.17.0` release-prep line without claiming crates.io publication before the tag workflow runs

## Changelog sanitization
- interop ADR/RFC items are summarized as technical repository contracts and seams only: contract seam, sandbox-evidence capture, editor MCP wrapping, OTLP export, evidence-bundle attestation, Inspect claim-support scoring, and the eBPF policy-substrate boundary
- no strategy vocabulary or publish-before-release claims are introduced

## Verification
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --workspace`
- `bash scripts/ci/check-public-crate-policy.sh`
- `cargo fmt --check`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets -- -D warnings`
- `uv run --with-requirements docs/requirements-ci.txt mkdocs build --strict`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1` confirms Assay workspace packages are `3.17.0`

## Delegated proof
- gate: all
- head: 67549cf8ef3cc379a075800747c4dbec22c9905c
- run: https://github.com/Rul1an/assay/actions/runs/27064938572

## Release follow-up after merge
- tag `v3.17.0` from updated `main`
- let the existing release workflow publish in dependency order, including the runner crates
- verify the GitHub release and crates.io line after the workflow completes
