### PR TITLE
fix(release): install matrix Rust targets explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_NET_RETRY: 5
   RUST_BACKTRACE: 1
 
 jobs:
@@ -91,6 +92,10 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Ensure Rust target is installed
+        shell: bash
+        run: rustup target add "${{ matrix.target }}"
 
       - name: Install cross-compilation tools
         if: matrix.cross
@@ -227,6 +232,10 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Ensure Rust target is installed
+        shell: bash
+        run: rustup target add "${{ matrix.target }}"
 
       - name: Install cross-compilation tools
         if: matrix.cross


### PR DESCRIPTION
## Summary
- add an explicit `rustup target add ${{ matrix.target }}` step in both release binary matrices
- set `CARGO_NET_RETRY=5` for release jobs to reduce transient registry EOF failures during fresh artifact builds

## Root cause from v3.17.0 release run
- `x86_64-apple-darwin` and `aarch64-unknown-linux-gnu` binary builds failed with `error[E0463]: can't find crate for core`, with rustc reporting that the matrix target may not be installed
- `assay-mcp-server aarch64-unknown-linux-gnu` failed while downloading `serde_json` from crates.io with `curl [56] unexpected eof while reading`, which is transient and should be retried
- no crates.io/PyPI/GitHub release publish jobs ran because the release fan-out failed before the `release` job

## Verification
- local commit hooks passed: `check yaml`, `Lint GitHub Actions workflow files`, `cargo fmt --check`, workspace clippy, linux compile gate
- failed release run inspected: https://github.com/Rul1an/assay/actions/runs/27065318720

## Follow-up after merge
- dispatch `Release` manually with `version=v3.17.0` from updated `main`
- keep the existing `v3.17.0` tag; no tag rewrite needed
