### PR TITLE
docs(guides): correct sandbox report artifact filename (Codex #1542)

### DIFF
--- a/docs/guides/coding-agent-governance.md
+++ b/docs/guides/coding-agent-governance.md
@@ -25,7 +25,8 @@ This produces three artifacts:
   containment degradations), with a deterministic run id of the form
   `sandbox_<sha256-prefix>`. Re-running the same command over the same behavior
   yields the same run id.
-- `run.profile.report.md` — a human-readable summary.
+- `run.report.md` — a human-readable summary (the path passed to `--profile-report`;
+  if that flag is omitted it defaults to `run.profile.yaml.report.md`).
 
 Use `--profile-format json` for JSON instead of YAML.
 


### PR DESCRIPTION
Addresses the [P2] Codex review on #1542: the coding-agent-governance guide listed the report artifact as `run.profile.report.md`, but the example command passes `--profile-report run.report.md` so the file is `run.report.md`. Corrects the bullet and documents the default (`run.profile.yaml.report.md`) when the flag is omitted. Docs only, Gate.NONE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)