### PR TITLE
chore(release): prepare v3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.18.0] - 2026-06-06
+
+- Added OTel GenAI `execute_tool` emission helpers in `assay-core` and
+  `assay sandbox --otel-jsonl`. The emitted records carry bounded
+  claim-class outcome fields for sandbox observations and keep OTel as an
+  export/interchange surface, not the authoritative evidence or policy truth
+  layer.
+
+- Added in-toto/DSSE attestation support over evidence bundle manifests in
+  `assay-evidence`. The attestation helper signs the bundle manifest digest and
+  records the envelope material needed by downstream verifiers without
+  promoting issuer trust, application outcome truth, or bundle-content
+  correctness beyond the signed manifest boundary.
+
+- Added the `assay-it` Python claim-support scorer for Inspect-oriented
+  consumers. The helper aggregates observed claim support into bounded
+  categories that downstream harnesses can consume, while leaving policy
+  enforcement, signer trust, and application correctness decisions outside the
+  scorer.
+
+- Updated coding-agent governance docs and README discoverability for the
+  sandbox evidence bundle, OTel JSONL export, bundle attestation, and Inspect
+  claim-support scorer. These notes describe the technical contract seam and
+  artifact flow for downstream consumers; they do not add a broader runtime
+  safety, sandbox correctness, or governance-status claim.
+
+- Fixed the release workflow's cross-target binary build setup by installing
+  each matrix Rust target explicitly before building. This keeps the release
+  artifact path aligned across the CLI, MCP server, wheels, proof kit, and the
+  existing crates.io publish order.
+
 ## [3.17.0] - 2026-06-06
 
 - Added `assay sandbox --bundle-out`, which emits sandbox observations as a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.17.0"
+version = "3.18.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -73,18 +73,18 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.17.0" }
-assay-common = { path = "crates/assay-common", version = "3.17.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.17.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.17.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.17.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.17.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.17.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.17.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.17.0" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.17.0" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.17.0" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.17.0" }
+assay-core = { path = "crates/assay-core", version = "3.18.0" }
+assay-common = { path = "crates/assay-common", version = "3.18.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.18.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.18.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.18.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.18.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.18.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.18.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.18.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.18.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.18.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.18.0" }
 
 # Common dependencies
 anyhow = "1"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,11 +1,11 @@
 # Assay Roadmap 2026
 
-> **Status sync (2026-06-06, `v3.17.0` release prep):** the `v3.17.0`
-> release line carries the post-`v3.16.0` sandbox-evidence bundle projection,
-> Runner/eBPF build and unsafe-invariant hardening, refactor-gate cleanup, and
-> facade splits that keep public module surfaces stable while reducing
-> high-traffic implementation hotspots. The Cargo workspace/package version in
-> this release-prep branch is **`3.17.0`**.
+> **Status sync (2026-06-06, `v3.18.0` release prep):** the `v3.18.0`
+> release line carries the post-`v3.17.0` interop surfaces for coding-agent
+> governance docs, OTel `execute_tool` JSONL export, in-toto/DSSE evidence
+> bundle manifest attestation, and the `assay-it` Python claim-support scorer
+> for Inspect-oriented consumers. The Cargo workspace/package version in this
+> release-prep branch is **`3.18.0`**.
 > The current execution posture is: keep remaining CLI grouping trigger-gated,
 > keep Assay-Runner repository extraction gated, treat Assay-Harness `v3.13.0`
 > compatibility as verified by its release-binary compatibility CI check


### PR DESCRIPTION
gate: all
head: a05513bd24c2c07604fd31aa3375ddd066fa68df

## Summary
- bump workspace and lockfile from 3.17.0 to 3.18.0, including assay-it
- move CHANGELOG [Unreleased] content into 3.18.0 with bounded technical wording
- update roadmap release-prep status for the v3.18.0 interop surface

## Sanitization
- describes coding-agent governance docs, OTel execute_tool export, in-toto/DSSE bundle-manifest attestation, and Inspect claim-support scorer as technical surfaces
- avoids strategy vocabulary and avoids broader runtime-safety, sandbox-correctness, issuer-trust, or application-outcome claims

## Verification
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --workspace
- bash scripts/ci/check-public-crate-policy.sh
- cargo fmt --check
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets -- -D warnings
- uv run --with-requirements docs/requirements-ci.txt mkdocs build --strict
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv run --with maturin --with pytest --with pyyaml maturin develop --release
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv run --with pytest --with pyyaml python -m pytest python/tests (from assay-python-sdk)
- git diff --check

## Release note
After merge, tag v3.18.0 and run the release workflow before starting Harness v0.8.0 consumer updates.

Delegated gates=all proof: https://github.com/Rul1an/assay/actions/runs/27068061111
