### PR TITLE
feat(cli): assay evidence attest (in-toto/DSSE bundle attestation, ADR-039)

### DIFF
--- a/crates/assay-cli/src/cli/commands/evidence/attest.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/attest.rs
@@ -1,0 +1,143 @@
+//! `assay evidence attest` — sign a bundle's manifest as an in-toto/DSSE attestation.
+//!
+//! Wraps `assay_evidence::attestation` (ADR-039): opens and verifies an evidence
+//! bundle, builds an in-toto v1 Statement over its integrity root, and signs it
+//! as a DSSE envelope with an Ed25519 key (PKCS#8 PEM, as produced by
+//! `assay mcp tool keygen`). The anchor (transparency log / timestamp) stays
+//! external. Attestation binds who-said-it and the bundle content; it does not
+//! upgrade observed support.
+
+use anyhow::{Context, Result};
+use assay_evidence::attestation::{sign_statement, statement_from_manifest};
+use assay_evidence::bundle::BundleReader;
+use clap::Args;
+use ed25519_dalek::pkcs8::DecodePrivateKey;
+use ed25519_dalek::SigningKey;
+use std::fs::File;
+use std::path::PathBuf;
+
+#[derive(Debug, Args, Clone)]
+pub struct AttestArgs {
+    /// Path to the evidence bundle (.tar.gz) to attest.
+    #[arg(long)]
+    pub bundle: PathBuf,
+    /// Path to the Ed25519 private key (PKCS#8 PEM; see `assay mcp tool keygen`).
+    #[arg(long)]
+    pub key: PathBuf,
+    /// Optional JSON file used as the attestation predicate (default: a minimal summary).
+    #[arg(long)]
+    pub predicate: Option<PathBuf>,
+    /// Write the DSSE envelope here (default: stdout).
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+}
+
+pub fn cmd_attest(args: AttestArgs) -> Result<i32> {
+    run(args)?;
+    Ok(0)
+}
+
+fn run(args: AttestArgs) -> Result<()> {
+    // 1. Open + verify the bundle, take its manifest.
+    let file = File::open(&args.bundle)
+        .with_context(|| format!("open bundle {}", args.bundle.display()))?;
+    let reader = BundleReader::open(file).context("verify/open bundle")?;
+    let manifest = reader.manifest().clone();
+
+    // 2. Load the Ed25519 signing key (PKCS#8 PEM).
+    let pem = std::fs::read_to_string(&args.key)
+        .with_context(|| format!("read key {}", args.key.display()))?;
+    let key = SigningKey::from_pkcs8_pem(&pem).context("parse Ed25519 PKCS#8 PEM key")?;
+
+    // 3. Predicate: from file, or a minimal default summarizing the bundle.
+    let predicate = match &args.predicate {
+        Some(p) => {
+            let raw = std::fs::read_to_string(p)
+                .with_context(|| format!("read predicate {}", p.display()))?;
+            serde_json::from_str(&raw).context("parse predicate JSON")?
+        }
+        None => serde_json::json!({
+            "run_id": manifest.run_id,
+            "event_count": manifest.event_count,
+        }),
+    };
+
+    // 4. Build + sign the in-toto statement.
+    let statement = statement_from_manifest(&manifest, predicate);
+    let envelope = sign_statement(&statement, &key).context("sign in-toto statement")?;
+    let json = serde_json::to_string_pretty(&envelope).context("serialize DSSE envelope")?;
+
+    // 5. Write the DSSE envelope.
+    match &args.out {
+        Some(p) => {
+            std::fs::write(p, format!("{json}\n"))
+                .with_context(|| format!("write {}", p.display()))?;
+            eprintln!("Attestation: {}", p.display());
+        }
+        None => println!("{json}"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_evidence::attestation::{verify_envelope, DsseEnvelope};
+    use assay_evidence::bundle::BundleWriter;
+    use assay_evidence::types::{EvidenceEvent, ProducerMeta};
+    use ed25519_dalek::pkcs8::{spki::der::pem::LineEnding, EncodePrivateKey};
+
+    #[test]
+    fn attest_produces_a_verifiable_envelope() {
+        let dir = std::env::temp_dir().join(format!("assay-attest-cli-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bundle_path = dir.join("bundle.tar.gz");
+        let key_path = dir.join("private_key.pem");
+        let out_path = dir.join("attestation.json");
+
+        // Write a small bundle.
+        let producer = ProducerMeta {
+            name: "assay-cli".into(),
+            version: "test".into(),
+            git: None,
+        };
+        let file = File::create(&bundle_path).unwrap();
+        let mut writer = BundleWriter::new(file).with_producer(producer.clone());
+        writer.add_event(
+            EvidenceEvent::new(
+                "assay.test.event",
+                "urn:assay:test",
+                "attest_run",
+                0,
+                serde_json::json!({}),
+            )
+            .with_producer(&producer),
+        );
+        writer.finish().unwrap();
+
+        // Write a key.
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        std::fs::write(
+            &key_path,
+            signing.to_pkcs8_pem(LineEnding::LF).unwrap().as_bytes(),
+        )
+        .unwrap();
+
+        // Attest.
+        run(AttestArgs {
+            bundle: bundle_path,
+            key: key_path,
+            predicate: None,
+            out: Some(out_path.clone()),
+        })
+        .expect("attest");
+
+        // The produced envelope verifies under the signer's public key.
+        let raw = std::fs::read_to_string(&out_path).unwrap();
+        let envelope: DsseEnvelope = serde_json::from_str(&raw).unwrap();
+        let statement = verify_envelope(&envelope, &signing.verifying_key()).expect("verify");
+        assert_eq!(statement.type_, "https://in-toto.io/Statement/v1");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -1,3 +1,4 @@
+pub mod attest;
 pub mod cyclonedx_mlbom_model;
 pub mod diff;
 pub mod lint;
@@ -44,6 +45,8 @@ pub enum EvidenceCmd {
     Lint(lint::LintArgs),
     /// Diff two bundles and report changes
     Diff(diff::DiffArgs),
+    /// Sign a bundle's manifest as an in-toto/DSSE attestation
+    Attest(attest::AttestArgs),
     /// Upload a bundle to remote storage (BYOS)
     Push(push::PushArgs),
     /// Download a bundle from remote storage (BYOS)
@@ -135,6 +138,7 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
         EvidenceCmd::Schema(a) => schema::cmd_schema(a),
         EvidenceCmd::Lint(a) => lint::cmd_lint(a),
         EvidenceCmd::Diff(a) => diff::cmd_diff(a),
+        EvidenceCmd::Attest(a) => attest::cmd_attest(a),
         EvidenceCmd::Push(a) => push::cmd_push(a).await,
         EvidenceCmd::Pull(a) => pull::cmd_pull(a).await,
         EvidenceCmd::List(a) => list::cmd_list(a).await,


### PR DESCRIPTION
Adds the `assay evidence attest` CLI surface over the ADR-039 attestation library (which shipped library-only in v3.18.0):

```bash
assay evidence attest --bundle b.tar.gz --key private_key.pem [--predicate p.json] [--out env.json]
```

Opens and verifies the bundle, builds an in-toto v1 Statement over its integrity root (default predicate summarizes run_id + event_count), and signs it as a DSSE envelope with an Ed25519 PKCS#8 PEM key (as produced by `assay mcp tool keygen`). The anchor (transparency log / timestamp) stays external; attestation binds who-said-it and the bundle content, it does not upgrade observed support.

This is the CLI the planned assay-action v2.2 attestation output depends on. New `evidence::attest` module + enum variant + dispatch; unit test builds a bundle, attests it, and confirms the envelope verifies under the signer's public key. fmt/clippy clean, Gate.NONE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)