### PR TITLE
chore(release): prepare v3.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.19.0] - 2026-06-06
+
+### Added
+
+- `assay evidence attest` — sign an evidence bundle's manifest as an in-toto v1
+  Statement, emitted as a DSSE envelope (Ed25519 over the JCS-canonicalized
+  statement), using a PKCS#8 PEM key from `assay mcp tool keygen`. Builds on the
+  ADR-039 attestation library (shipped library-only in 3.18.0). The anchor
+  (transparency log / timestamp) stays external; an attestation binds who-said-it
+  and the bundle content and does not upgrade observed support. Predicate type is
+  a non-committal `v0`.
+
 ## [3.18.0] - 2026-06-06
 
 - Added OTel GenAI `execute_tool` emission helpers in `assay-core` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.18.0"
+version = "3.19.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.18.0"
+version = "3.19.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"
@@ -73,18 +73,18 @@ codegen-units = 1
 
 [workspace.dependencies]
 # Internal crates
-assay-core = { path = "crates/assay-core", version = "3.18.0" }
-assay-common = { path = "crates/assay-common", version = "3.18.0", default-features = false }
-assay-monitor = { path = "crates/assay-monitor", version = "3.18.0" }
-assay-metrics = { path = "crates/assay-metrics", version = "3.18.0" }
-assay-policy = { path = "crates/assay-policy", version = "3.18.0" }
-assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.18.0" }
-assay-evidence = { path = "crates/assay-evidence", version = "3.18.0" }
-assay-sim = { path = "crates/assay-sim", version = "3.18.0" }
-assay-registry = { path = "crates/assay-registry", version = "3.18.0" }
-assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.18.0" }
-assay-runner-core = { path = "crates/assay-runner-core", version = "3.18.0" }
-assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.18.0" }
+assay-core = { path = "crates/assay-core", version = "3.19.0" }
+assay-common = { path = "crates/assay-common", version = "3.19.0", default-features = false }
+assay-monitor = { path = "crates/assay-monitor", version = "3.19.0" }
+assay-metrics = { path = "crates/assay-metrics", version = "3.19.0" }
+assay-policy = { path = "crates/assay-policy", version = "3.19.0" }
+assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.19.0" }
+assay-evidence = { path = "crates/assay-evidence", version = "3.19.0" }
+assay-sim = { path = "crates/assay-sim", version = "3.19.0" }
+assay-registry = { path = "crates/assay-registry", version = "3.19.0" }
+assay-runner-schema = { path = "crates/assay-runner-schema", version = "3.19.0" }
+assay-runner-core = { path = "crates/assay-runner-core", version = "3.19.0" }
+assay-runner-linux = { path = "crates/assay-runner-linux", version = "3.19.0" }
 
 # Common dependencies
 anyhow = "1"


### PR DESCRIPTION
Cuts assay v3.19.0 (minor). Bumps the workspace 3.18.0 -> 3.19.0 and adds the CHANGELOG [3.19.0] entry for `assay evidence attest` (in-toto/DSSE bundle attestation CLI over the ADR-039 library; anchor external; predicate v0).

After merge, tag v3.19.0 to trigger the release workflow (crates.io + GitHub release + assay-python-sdk).

Assay-Runner delegated proof:
- gate: all
- run: https://github.com/Rul1an/assay/actions/runs/27071411171
- sha: af2655eaf688e8ed0abda08cf9e7e2bca7a409b2

🤖 Generated with [Claude Code](https://claude.com/claude-code)