### PR TITLE
test(evidence): mutation-detection matrix + verify-cost curve harness

### DIFF
--- a/crates/assay-evidence/tests/e3_verify_cost_curve.rs
+++ b/crates/assay-evidence/tests/e3_verify_cost_curve.rs
@@ -1,0 +1,300 @@
+//! Verification + signing cost curve for signed evidence bundles.
+//!
+//! This is a COST MEASUREMENT, not a security claim. It records, as a function of bundle size:
+//!   - verify time (median),
+//!   - compressed bundle bytes and bytes-per-event,
+//!   - gzip ratio (compressed / uncompressed events),
+//!   - Merkle inclusion-proof size = ceil(log2(N)) hashes,
+//!   - DSSE sign / verify time over the run anchor.
+//!
+//! Rationale: signed/attested artifact lines are widening, but the cost of verification is rarely
+//! published as a curve. This fills that measurement gap with a reproducible harness.
+//!
+//! Honesty: cost numbers are workload- and machine-dependent. The full sweep runs only when
+//! `E3_OUT_DIR` is set (and emits a JSON + BMF artifact); CI always runs a fast smoke that keeps
+//! the cost path exercised and sound. Tamper-evidence itself is measured separately in the
+//! mutation-detection matrix, not here.
+
+use assay_evidence::mandate::types::{
+    AuthMethod, Constraints, Context, MandateContent, MandateKind, Principal, Scope, Validity,
+};
+use assay_evidence::mandate::{sign_mandate, verify_mandate};
+use assay_evidence::types::EvidenceEvent;
+use assay_evidence::{verify_bundle_with_limits, BundleWriter, VerifyLimits};
+use chrono::{TimeZone, Utc};
+use ed25519_dalek::SigningKey;
+use serde_json::json;
+use std::io::Cursor;
+use std::time::Instant;
+
+const ENTROPY_ALPHABET: &[u8; 64] =
+    b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+
+/// Deterministic, low-compressibility payload so gzip ratio reflects realistic content.
+fn low_compressibility_payload(payload_bytes: usize, seed: u64) -> String {
+    let mut s = String::with_capacity(payload_bytes);
+    let mut x = seed
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add(0xD1B5_4A32_D192_ED03);
+    while s.len() < payload_bytes {
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        let idx = (x.wrapping_mul(0x2545_F491_4F6C_DD1D) & 63) as usize;
+        s.push(ENTROPY_ALPHABET[idx] as char);
+    }
+    s
+}
+
+fn build_bundle(events: usize, payload_bytes: usize) -> Vec<u8> {
+    let mut bundle = Vec::new();
+    let mut writer = BundleWriter::new(&mut bundle);
+    for seq in 0..events {
+        let blob = low_compressibility_payload(payload_bytes, seq as u64);
+        let time = Utc
+            .timestamp_opt(1_700_000_000_i64 + seq as i64, 0)
+            .unwrap();
+        let event = EvidenceEvent::new(
+            "assay.tool.decision",
+            "urn:assay:e3-cost",
+            "run-cost".to_string(),
+            seq as u64,
+            json!({
+                "tool": "fs.read",
+                "args": { "path": "/workspace/demo.txt", "blob": blob },
+                "decision": "allow",
+            }),
+        )
+        .with_time(time);
+        writer.add_event(event);
+    }
+    writer.finish().expect("bundle generation must succeed");
+    bundle
+}
+
+/// Cost-sweep verification uses raised limits so large-N bundles are measurable; the default-limit
+/// path (incl. the 100k event cap) is exercised by the smoke and by other tests.
+fn cost_limits() -> VerifyLimits {
+    VerifyLimits {
+        max_events: 2_000_000,
+        max_events_bytes: 4 * 1024 * 1024 * 1024,
+        max_decode_bytes: 8 * 1024 * 1024 * 1024,
+        ..Default::default()
+    }
+}
+
+fn median(mut xs: Vec<f64>) -> f64 {
+    xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = xs.len();
+    if n == 0 {
+        return 0.0;
+    }
+    if n % 2 == 1 {
+        xs[n / 2]
+    } else {
+        (xs[n / 2 - 1] + xs[n / 2]) / 2.0
+    }
+}
+
+fn time_verify_ms(bundle: &[u8], limits: &VerifyLimits, reps: usize) -> f64 {
+    let mut samples = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        let start = Instant::now();
+        let res =
+            verify_bundle_with_limits(Cursor::new(bundle), *limits).expect("verify must succeed");
+        std::hint::black_box(res.event_count);
+        samples.push(start.elapsed().as_secs_f64() * 1_000.0);
+    }
+    median(samples)
+}
+
+/// ceil(log2(n)) — number of sibling hashes in an inclusion proof for N leaves.
+fn inclusion_proof_hashes(n: u64) -> u32 {
+    if n <= 1 {
+        0
+    } else {
+        u64::BITS - (n - 1).leading_zeros()
+    }
+}
+
+/// Ordinary least squares for verify_ms ~ a + b*events.
+fn linear_fit(points: &[(f64, f64)]) -> (f64, f64, f64) {
+    let n = points.len() as f64;
+    if n < 2.0 {
+        return (0.0, 0.0, 0.0);
+    }
+    let sx: f64 = points.iter().map(|p| p.0).sum();
+    let sy: f64 = points.iter().map(|p| p.1).sum();
+    let sxx: f64 = points.iter().map(|p| p.0 * p.0).sum();
+    let sxy: f64 = points.iter().map(|p| p.0 * p.1).sum();
+    let denom = n * sxx - sx * sx;
+    if denom.abs() < f64::EPSILON {
+        return (0.0, sy / n, 0.0);
+    }
+    let slope = (n * sxy - sx * sy) / denom;
+    let intercept = (sy - slope * sx) / n;
+    let mean_y = sy / n;
+    let ss_tot: f64 = points.iter().map(|p| (p.1 - mean_y).powi(2)).sum();
+    let ss_res: f64 = points
+        .iter()
+        .map(|p| (p.1 - (intercept + slope * p.0)).powi(2))
+        .sum();
+    let r2 = if ss_tot.abs() < f64::EPSILON {
+        1.0
+    } else {
+        1.0 - ss_res / ss_tot
+    };
+    (slope, intercept, r2)
+}
+
+fn dsse_content() -> MandateContent {
+    MandateContent {
+        mandate_kind: MandateKind::Intent,
+        principal: Principal::new("user-123", AuthMethod::Oidc),
+        scope: Scope::new(vec!["search_*".to_string()]),
+        validity: Validity::at(Utc.with_ymd_and_hms(2026, 1, 28, 10, 0, 0).unwrap()),
+        constraints: Constraints::default(),
+        context: Context::new("myorg/app", "auth.myorg.com"),
+    }
+}
+
+/// Median DSSE sign and verify time in ms over the run anchor.
+fn dsse_sign_verify_ms(reps: usize) -> (f64, f64) {
+    let key = SigningKey::from_bytes(&[7u8; 32]);
+    let vk = key.verifying_key();
+    let content = dsse_content();
+
+    let mut sign = Vec::with_capacity(reps);
+    let mut verify = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        let s = Instant::now();
+        let signed = sign_mandate(&content, &key).expect("sign must succeed");
+        sign.push(s.elapsed().as_secs_f64() * 1_000.0);
+
+        let v = Instant::now();
+        let res = verify_mandate(&signed, &vk).expect("verify must succeed");
+        std::hint::black_box(&res.mandate_id);
+        verify.push(v.elapsed().as_secs_f64() * 1_000.0);
+    }
+    (median(sign), median(verify))
+}
+
+#[test]
+fn e3_verify_cost_curve() {
+    // Smoke: always exercise the cost path on a small bundle so it cannot rot.
+    let smoke = build_bundle(256, 128);
+    let smoke_ms = time_verify_ms(&smoke, &VerifyLimits::default(), 3);
+    assert!(smoke_ms >= 0.0, "verify timing must be non-negative");
+    let (sign_ms, verify_ms) = dsse_sign_verify_ms(3);
+    assert!(
+        sign_ms >= 0.0 && verify_ms >= 0.0,
+        "DSSE timing must be non-negative"
+    );
+
+    let out_dir = match std::env::var("E3_OUT_DIR") {
+        Ok(d) if !d.is_empty() => d,
+        _ => return, // CI fast path: smoke only.
+    };
+
+    // Full sweep: payload fixed at 256 bytes/event; reps shrink as N grows.
+    let payload_bytes = 256usize;
+    let plan: &[(usize, usize)] = &[
+        (1_000, 11),
+        (5_000, 9),
+        (10_000, 7),
+        (50_000, 5),
+        (100_000, 3),
+    ];
+    let limits = cost_limits();
+    let mut rows = Vec::new();
+    let mut fit_points = Vec::new();
+
+    for &(events, reps) in plan {
+        let bundle = build_bundle(events, payload_bytes);
+        let verified = verify_bundle_with_limits(Cursor::new(bundle.as_slice()), limits)
+            .expect("verify must succeed");
+        let events_bytes = verified
+            .manifest
+            .files
+            .get("events.ndjson")
+            .map(|f| f.bytes)
+            .unwrap_or(0);
+        let verify_ms = time_verify_ms(&bundle, &limits, reps);
+        let compressed = bundle.len() as u64;
+        let gzip_ratio = if events_bytes > 0 {
+            compressed as f64 / events_bytes as f64
+        } else {
+            0.0
+        };
+        rows.push(json!({
+            "events": events,
+            "verify_ms_median": verify_ms,
+            "verify_reps": reps,
+            "compressed_bytes": compressed,
+            "events_bytes": events_bytes,
+            "bytes_per_event_compressed": compressed as f64 / events as f64,
+            "gzip_ratio": gzip_ratio,
+            "inclusion_proof_hashes": inclusion_proof_hashes(events as u64),
+        }));
+        fit_points.push((events as f64, verify_ms));
+    }
+
+    let (slope, intercept, r2) = linear_fit(&fit_points);
+    let (sign_full, verify_full) = dsse_sign_verify_ms(101);
+
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let cost = json!({
+        "schema": "assay.experiment.evidence_verify_cost.v0",
+        "profile": profile,
+        "payload_bytes_per_event": payload_bytes,
+        "rows": rows,
+        "fit": {
+            "slope_ms_per_event": slope,
+            "intercept_ms": intercept,
+            "ms_per_1k_events": slope * 1_000.0,
+            "r2": r2,
+        },
+        "dsse": {
+            "sign_ms_median": sign_full,
+            "verify_ms_median": verify_full,
+            "reps": 101,
+        },
+    });
+
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    std::fs::write(
+        format!("{out_dir}/cost.json"),
+        serde_json::to_string_pretty(&cost).unwrap(),
+    )
+    .expect("write cost.json");
+
+    // Bencher Metric Format for trend tracking.
+    let mut bmf = serde_json::Map::new();
+    for row in cost["rows"].as_array().unwrap() {
+        let events = row["events"].as_u64().unwrap();
+        bmf.insert(
+            format!("evidence_verify_cost/{events}"),
+            json!({ "verify_ms_median": { "value": row["verify_ms_median"] } }),
+        );
+    }
+    bmf.insert(
+        "evidence_verify_cost/fit".to_string(),
+        json!({ "ms_per_1k_events": { "value": slope * 1_000.0 } }),
+    );
+    bmf.insert(
+        "evidence_dsse".to_string(),
+        json!({
+            "sign_ms_median": { "value": sign_full },
+            "verify_ms_median": { "value": verify_full },
+        }),
+    );
+    std::fs::write(
+        format!("{out_dir}/cost.bmf.json"),
+        serde_json::to_string_pretty(&serde_json::Value::Object(bmf)).unwrap(),
+    )
+    .expect("write cost.bmf.json");
+}

--- a/crates/assay-sim/tests/e3_mutation_matrix.rs
+++ b/crates/assay-sim/tests/e3_mutation_matrix.rs
@@ -1,0 +1,561 @@
+//! Mutation-detection matrix for signed evidence bundles.
+//!
+//! Question this measures: which post-hoc mutation classes are detected, by which verifier check,
+//! under a no-signing-key attacker model? Competitors say "signed" / "verifiable"; this publishes
+//! the matrix.
+//!
+//! Threat model T: a party WITHOUT the signing key mutates a bundle after the fact. The bundle's
+//! run anchor (`run_root`, a Merkle root) is bound by an external signature the attacker cannot
+//! forge. Two layers:
+//!   - internal verifier (`verify_bundle_with_limits`): catches blind tampering that breaks
+//!     internal consistency, with a specific ErrorCode;
+//!   - run anchor (`run_root`): catches a *consistent rewrite* (events + manifest recomputed) that
+//!     the internal verifier alone would accept, because the content-addressed root changes and the
+//!     external signature over the original root no longer matches.
+//!
+//! Honesty: tamper-EVIDENT, not tamper-proof. A host holding BOTH code-exec and the signing key is
+//! out of scope (it can re-sign); that needs external anchoring such as a transparency log or TSA.
+//!
+//! Security gate (always-on in CI): no mutation may BYPASS detection (changed evidence content that
+//! still verifies AND keeps the original anchor). The full matrix + JSON is emitted only when
+//! `E3_OUT_DIR` is set.
+
+use assay_evidence::types::EvidenceEvent;
+use assay_evidence::{verify_bundle_with_limits, BundleWriter, VerifyError, VerifyLimits};
+use assay_sim::mutators::bitflip::BitFlip;
+use assay_sim::mutators::inject::InjectFile;
+use assay_sim::mutators::truncate::Truncate;
+use assay_sim::mutators::Mutator;
+use chrono::{TimeZone, Utc};
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::io::{Cursor, Read, Write};
+
+// ----- bundle helpers ---------------------------------------------------------
+
+fn payload_blob(seq: u64) -> String {
+    // Deterministic, content-bearing so edits land inside real evidence.
+    format!("path=/workspace/file-{seq:04}.txt;decision=allow;nonce={seq:08x}")
+}
+
+/// Build a deterministic bundle of `m` events. If `mutate_seq` is set, that event's payload is
+/// altered (and the writer recomputes the manifest + run_root -> a *consistent* rewrite).
+fn build_bundle(m: u64, mutate_seq: Option<u64>) -> Vec<u8> {
+    let mut bundle = Vec::new();
+    let mut writer = BundleWriter::new(&mut bundle);
+    for seq in 0..m {
+        let mut blob = payload_blob(seq);
+        if Some(seq) == mutate_seq {
+            blob.push_str(";TAMPERED");
+        }
+        let time = Utc
+            .timestamp_opt(1_700_000_000_i64 + seq as i64, 0)
+            .unwrap();
+        let event = EvidenceEvent::new(
+            "assay.tool.decision",
+            "urn:assay:e3-matrix",
+            "run-matrix".to_string(),
+            seq,
+            json!({ "tool": "fs.read", "args": { "detail": blob }, "decision": "allow" }),
+        )
+        .with_time(time);
+        writer.add_event(event);
+    }
+    writer.finish().expect("bundle generation must succeed");
+    bundle
+}
+
+fn run_root_of(bundle: &[u8]) -> String {
+    verify_bundle_with_limits(Cursor::new(bundle), VerifyLimits::default())
+        .expect("base bundle must verify")
+        .computed_run_root
+}
+
+fn unpack(bundle: &[u8]) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
+    let mut archive = tar::Archive::new(GzDecoder::new(Cursor::new(bundle)));
+    let mut manifest = None;
+    let mut events = None;
+    for entry in archive.entries()? {
+        let mut e = entry?;
+        let path = e.path()?.to_string_lossy().to_string();
+        let mut buf = Vec::new();
+        e.read_to_end(&mut buf)?;
+        match path.as_str() {
+            "manifest.json" => manifest = Some(buf),
+            "events.ndjson" => events = Some(buf),
+            _ => {}
+        }
+    }
+    Ok((
+        manifest.ok_or_else(|| anyhow::anyhow!("no manifest.json"))?,
+        events.ok_or_else(|| anyhow::anyhow!("no events.ndjson"))?,
+    ))
+}
+
+fn append(builder: &mut tar::Builder<&mut GzEncoder<Vec<u8>>>, name: &str, content: &[u8]) {
+    let mut header = tar::Header::new_gnu();
+    header.set_path(name).unwrap();
+    header.set_size(content.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append(&header, content).unwrap();
+}
+
+/// Repack manifest.json (first) + events.ndjson (second) into a new tar.gz.
+fn repack(manifest: &[u8], events: &[u8]) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut builder = tar::Builder::new(&mut encoder);
+        append(&mut builder, "manifest.json", manifest);
+        append(&mut builder, "events.ndjson", events);
+        builder.finish().unwrap();
+    }
+    encoder.finish().unwrap()
+}
+
+// The standard tar writer refuses to emit `..` or absolute paths (a writer-side defense), so to
+// exercise the verifier's path-safety checks we hand-roll a minimal USTAR archive that can carry an
+// unsafe entry name.
+fn write_octal(field: &mut [u8], val: u64, digits: usize) {
+    let s = format!("{val:0digits$o}");
+    let b = s.as_bytes();
+    let n = b.len().min(digits);
+    field[..n].copy_from_slice(&b[b.len() - n..]);
+    if field.len() > digits {
+        field[digits] = 0;
+    }
+}
+
+fn raw_tar(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (name, content) in entries {
+        let mut h = [0u8; 512];
+        let nb = name.as_bytes();
+        let nlen = nb.len().min(100);
+        h[..nlen].copy_from_slice(&nb[..nlen]);
+        write_octal(&mut h[100..108], 0o644, 7);
+        write_octal(&mut h[108..116], 0, 7);
+        write_octal(&mut h[116..124], 0, 7);
+        write_octal(&mut h[124..136], content.len() as u64, 11);
+        write_octal(&mut h[136..148], 0, 11);
+        for b in &mut h[148..156] {
+            *b = b' ';
+        }
+        h[156] = b'0'; // regular file
+        h[257..262].copy_from_slice(b"ustar");
+        h[263] = b'0';
+        h[264] = b'0';
+        let sum: u32 = h.iter().map(|&b| b as u32).sum();
+        let cs = format!("{sum:06o}");
+        h[148..154].copy_from_slice(cs.as_bytes());
+        h[154] = 0;
+        h[155] = b' ';
+        out.extend_from_slice(&h);
+        out.extend_from_slice(content);
+        let pad = (512 - (content.len() % 512)) % 512;
+        out.extend(std::iter::repeat_n(0u8, pad));
+    }
+    out.extend(std::iter::repeat_n(0u8, 1024));
+    out
+}
+
+fn gzip(data: &[u8]) -> Vec<u8> {
+    let mut e = GzEncoder::new(Vec::new(), Compression::default());
+    e.write_all(data).unwrap();
+    e.finish().unwrap()
+}
+
+// ----- classification ---------------------------------------------------------
+
+/// Protected surface = the event evidence (events.ndjson) and the run anchor (run_root, recomputed
+/// from event content hashes). Outcomes are judged against THAT surface:
+///   - Detected: the verifier rejected the mutant.
+///   - NoOp: verified, and both manifest + events decompress byte-identical to the original.
+///   - ManifestMetaOnly: verified, events identical, but a manifest metadata byte differs. This is a
+///     documented limitation, not an evidence bypass: manifest metadata not referenced by a check
+///     (e.g. a producer label) is not individually hash-bound, and a truncated tar read may skip the
+///     gzip CRC trailer. The event evidence and run anchor remain protected.
+///   - Bypass: verified, but the EVENT evidence changed — a real detection failure (must be zero).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    Detected,
+    NoOp,
+    ManifestMetaOnly,
+    Bypass,
+}
+
+#[derive(Default)]
+struct Tally {
+    detected: usize,
+    noop: usize,
+    manifest_meta_only: usize,
+    bypass: usize,
+    codes: BTreeMap<String, usize>,
+}
+
+impl Tally {
+    fn record(&mut self, original_pair: &(Vec<u8>, Vec<u8>), mutant: &[u8]) -> Outcome {
+        match verify_bundle_with_limits(Cursor::new(mutant), VerifyLimits::default()) {
+            Err(e) => {
+                let code = e
+                    .downcast_ref::<VerifyError>()
+                    .map(|ve| ve.code.to_string())
+                    .unwrap_or_else(|| "RejectedNonVerifyError".to_string());
+                *self.codes.entry(code).or_default() += 1;
+                self.detected += 1;
+                Outcome::Detected
+            }
+            Ok(_) => match unpack(mutant) {
+                Ok((m2, e2)) => {
+                    if e2 != original_pair.1 {
+                        // The event evidence itself changed yet verified: a real failure.
+                        self.bypass += 1;
+                        Outcome::Bypass
+                    } else if m2 != original_pair.0 {
+                        self.manifest_meta_only += 1;
+                        Outcome::ManifestMetaOnly
+                    } else {
+                        self.noop += 1;
+                        Outcome::NoOp
+                    }
+                }
+                // Verified but no longer unpackable: treat conservatively as a failure.
+                Err(_) => {
+                    self.bypass += 1;
+                    Outcome::Bypass
+                }
+            },
+        }
+    }
+
+    fn dominant_code(&self) -> Option<String> {
+        self.codes
+            .iter()
+            .max_by_key(|(_, n)| **n)
+            .map(|(c, _)| c.clone())
+    }
+
+    fn to_json(&self, class: &str) -> serde_json::Value {
+        json!({
+            "class": class,
+            "layer": "internal-verifier",
+            "detected": self.detected,
+            "noop": self.noop,
+            "manifest_meta_only": self.manifest_meta_only,
+            "bypass": self.bypass,
+            "dominant_code": self.dominant_code(),
+            "codes": self.codes,
+        })
+    }
+}
+
+// ----- the matrix -------------------------------------------------------------
+
+struct SweepCfg {
+    base_events: u64,
+    bitflip_counts: Vec<usize>,
+    bitflip_seeds: u64,
+    truncate_fracs: Vec<f64>,
+    edit_seeds: u64,
+}
+
+fn ci_cfg() -> SweepCfg {
+    SweepCfg {
+        base_events: 24,
+        bitflip_counts: vec![1, 2, 8],
+        bitflip_seeds: 12,
+        truncate_fracs: vec![0.01, 0.10, 0.50, 0.90, 0.99],
+        edit_seeds: 6,
+    }
+}
+
+fn full_cfg() -> SweepCfg {
+    SweepCfg {
+        base_events: 64,
+        bitflip_counts: vec![1, 2, 4, 8, 16, 32, 64],
+        bitflip_seeds: 64,
+        truncate_fracs: vec![0.001, 0.01, 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.99],
+        edit_seeds: 32,
+    }
+}
+
+struct MatrixResult {
+    classes: Vec<serde_json::Value>,
+    total_bypass: usize,
+    total_manifest_meta_only: usize,
+    anchored_root: String,
+    rewrite_root: String,
+}
+
+fn run_matrix(cfg: &SweepCfg) -> MatrixResult {
+    let base = build_bundle(cfg.base_events, None);
+    let original_pair = unpack(&base).expect("unpack base");
+    let mut classes = Vec::new();
+    let mut total_bypass = 0usize;
+
+    // 1. gzip_bitflip: flip raw .tar.gz bytes.
+    {
+        let mut t = Tally::default();
+        for &count in &cfg.bitflip_counts {
+            for seed in 0..cfg.bitflip_seeds {
+                let m = BitFlip {
+                    count,
+                    seed: Some(seed),
+                }
+                .mutate(&base)
+                .unwrap();
+                t.record(&original_pair, &m);
+            }
+        }
+        total_bypass += t.bypass;
+        classes.push(t.to_json("gzip_bitflip"));
+    }
+
+    // 2. truncate: cut the bundle at a fraction of its length.
+    {
+        let mut t = Tally::default();
+        for &frac in &cfg.truncate_fracs {
+            let at = ((base.len() as f64) * frac) as usize;
+            let m = Truncate { at }.mutate(&base).unwrap();
+            t.record(&original_pair, &m);
+        }
+        total_bypass += t.bypass;
+        classes.push(t.to_json("truncate"));
+    }
+
+    // 3. inject_file: add a disallowed extra file.
+    {
+        let mut t = Tally::default();
+        let m = InjectFile {
+            name: "malicious.sh".into(),
+            content: b"echo bad".to_vec(),
+        }
+        .mutate(&base)
+        .unwrap();
+        t.record(&original_pair, &m);
+        total_bypass += t.bypass;
+        classes.push(t.to_json("inject_file"));
+    }
+
+    // 4. inject_path_traversal: a hand-rolled tar entry with a `..` path.
+    {
+        let mut t = Tally::default();
+        let (manifest, events) = original_pair.clone();
+        let m = gzip(&raw_tar(&[
+            ("manifest.json", &manifest),
+            ("events.ndjson", &events),
+            ("../evil.sh", b"echo bad"),
+        ]));
+        t.record(&original_pair, &m);
+        total_bypass += t.bypass;
+        classes.push(t.to_json("inject_path_traversal"));
+    }
+
+    // 4b. inject_absolute_path: a hand-rolled tar entry with an absolute path.
+    {
+        let mut t = Tally::default();
+        let (manifest, events) = original_pair.clone();
+        let m = gzip(&raw_tar(&[
+            ("manifest.json", &manifest),
+            ("events.ndjson", &events),
+            ("/etc/evil.sh", b"echo bad"),
+        ]));
+        t.record(&original_pair, &m);
+        total_bypass += t.bypass;
+        classes.push(t.to_json("inject_absolute_path"));
+    }
+
+    // 5. event_byte_edit: flip a byte inside events.ndjson, keep the original manifest.
+    {
+        let mut t = Tally::default();
+        let (manifest, events) = original_pair.clone();
+        for s in 0..cfg.edit_seeds {
+            let mut ev = events.clone();
+            if ev.len() > 8 {
+                let idx = 4 + (s as usize * 7) % (ev.len() - 8);
+                ev[idx] ^= 0x20; // toggle a bit in an ASCII byte
+            }
+            let m = repack(&manifest, &ev);
+            t.record(&original_pair, &m);
+        }
+        total_bypass += t.bypass;
+        classes.push(t.to_json("event_byte_edit"));
+    }
+
+    // 6. event_drop: remove the last event line, keep the original manifest.
+    {
+        let mut t = Tally::default();
+        let (manifest, events) = original_pair.clone();
+        let text = String::from_utf8_lossy(&events);
+        let mut lines: Vec<&str> = text.lines().collect();
+        lines.pop();
+        let dropped = format!("{}\n", lines.join("\n"));
+        let m = repack(&manifest, dropped.as_bytes());
+        t.record(&original_pair, &m);
+        total_bypass += t.bypass;
+        classes.push(t.to_json("event_drop"));
+    }
+
+    // 7. event_reorder: swap the first two event lines, keep the original manifest.
+    {
+        let mut t = Tally::default();
+        let (manifest, events) = original_pair.clone();
+        let text = String::from_utf8_lossy(&events);
+        let mut lines: Vec<&str> = text.lines().collect();
+        if lines.len() >= 2 {
+            lines.swap(0, 1);
+        }
+        let reordered = format!("{}\n", lines.join("\n"));
+        let m = repack(&manifest, reordered.as_bytes());
+        t.record(&original_pair, &m);
+        total_bypass += t.bypass;
+        classes.push(t.to_json("event_reorder"));
+    }
+
+    // 8. ndjson_bom: prepend a UTF-8 BOM to events.ndjson.
+    {
+        let mut t = Tally::default();
+        let (manifest, events) = original_pair.clone();
+        let mut bom = vec![0xEF, 0xBB, 0xBF];
+        bom.extend_from_slice(&events);
+        let m = repack(&manifest, &bom);
+        t.record(&original_pair, &m);
+        total_bypass += t.bypass;
+        classes.push(t.to_json("ndjson_bom"));
+    }
+
+    // 9. ndjson_crlf: append a CRLF terminator.
+    {
+        let mut t = Tally::default();
+        let (manifest, events) = original_pair.clone();
+        let mut crlf = events.clone();
+        crlf.extend_from_slice(b"\r\n");
+        let m = repack(&manifest, &crlf);
+        t.record(&original_pair, &m);
+        total_bypass += t.bypass;
+        classes.push(t.to_json("ndjson_crlf"));
+    }
+
+    // 10. tar_duplicate: events.ndjson appears twice.
+    {
+        let mut t = Tally::default();
+        let (manifest, events) = original_pair.clone();
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        {
+            let mut builder = tar::Builder::new(&mut encoder);
+            append(&mut builder, "manifest.json", &manifest);
+            append(&mut builder, "events.ndjson", &events);
+            append(&mut builder, "events.ndjson", &events);
+            builder.finish().unwrap();
+        }
+        let m = encoder.finish().unwrap();
+        t.record(&original_pair, &m);
+        total_bypass += t.bypass;
+        classes.push(t.to_json("tar_duplicate"));
+    }
+
+    // 11. consistent_rewrite: rewrite an event AND recompute the manifest/run_root. The internal
+    //     verifier passes (expected); the content-addressed run anchor changes, so an external
+    //     signature over the original root rejects it.
+    let anchored_root = run_root_of(&base);
+    let rewrite = build_bundle(cfg.base_events, Some(cfg.base_events / 2));
+    let rewrite_verified =
+        verify_bundle_with_limits(Cursor::new(&rewrite), VerifyLimits::default())
+            .expect("consistent rewrite must pass the internal verifier by construction");
+    let rewrite_root = rewrite_verified.computed_run_root;
+    classes.push(json!({
+        "class": "consistent_rewrite",
+        "layer": "run-anchor",
+        "internal_verifier_passed": true,
+        "detected_by_anchor": rewrite_root != anchored_root,
+        "anchored_run_root": anchored_root,
+        "mutated_run_root": rewrite_root,
+        "note": "internal verifier alone is insufficient; the run anchor / external signature is what detects this",
+    }));
+
+    let total_manifest_meta_only = classes
+        .iter()
+        .filter_map(|c| c["manifest_meta_only"].as_u64())
+        .sum::<u64>() as usize;
+
+    MatrixResult {
+        classes,
+        total_bypass,
+        total_manifest_meta_only,
+        anchored_root,
+        rewrite_root,
+    }
+}
+
+#[test]
+fn e3_mutation_detection_matrix() {
+    let cfg = ci_cfg();
+    let result = run_matrix(&cfg);
+
+    if result.total_bypass > 0 {
+        eprintln!(
+            "BYPASS DEBUG:\n{}",
+            serde_json::to_string_pretty(&result.classes).unwrap()
+        );
+    }
+
+    // SECURITY GATE: no blind-tamper mutation may bypass detection.
+    assert_eq!(
+        result.total_bypass, 0,
+        "SECURITY: {} mutation(s) changed evidence content yet passed the internal verifier",
+        result.total_bypass
+    );
+
+    // The run anchor must catch the consistent rewrite the internal verifier accepts.
+    assert!(
+        result.anchored_run_root_differs(),
+        "run anchor must change under a consistent rewrite"
+    );
+
+    // Sanity: every internal-verifier class actually detected at least one mutation (the sweep ran).
+    for class in &result.classes {
+        if class["layer"] == "internal-verifier" {
+            let detected = class["detected"].as_u64().unwrap_or(0);
+            let name = class["class"].as_str().unwrap_or("?");
+            assert!(
+                detected >= 1,
+                "class '{name}' produced no detections — sweep may not have run"
+            );
+        }
+    }
+
+    // Full matrix + JSON only when requested.
+    if let Ok(dir) = std::env::var("E3_OUT_DIR") {
+        if !dir.is_empty() {
+            let full = run_matrix(&full_cfg());
+            assert_eq!(full.total_bypass, 0, "SECURITY: bypass in full sweep");
+            let matrix = json!({
+                "schema": "assay.experiment.evidence_mutation_matrix.v0",
+                "threat_model": "post-hoc mutation by a party without the signing key; the run anchor (run_root) is bound by an external signature the attacker cannot forge",
+                "non_goal": "tamper-proof; a host holding code-exec AND the signing key is out of scope and needs external anchoring (transparency log / TSA)",
+                "base_events": full_cfg().base_events,
+                "classes": full.classes,
+                "gate": {
+                    "total_bypass": full.total_bypass,
+                    "total_manifest_meta_only": full.total_manifest_meta_only,
+                },
+                "documented_limitation": "manifest metadata not referenced by a verifier check is not individually hash-bound (manifest_meta_only); the event evidence (events.ndjson) and the run anchor (run_root) are always hash-checked",
+            });
+            std::fs::create_dir_all(&dir).expect("create out dir");
+            std::fs::write(
+                format!("{dir}/matrix.json"),
+                serde_json::to_string_pretty(&matrix).unwrap(),
+            )
+            .expect("write matrix.json");
+        }
+    }
+}
+
+impl MatrixResult {
+    fn anchored_run_root_differs(&self) -> bool {
+        self.rewrite_root != self.anchored_root
+    }
+}

--- a/docs/experiments/evidence-mutation-cost-2026-06/README.md
+++ b/docs/experiments/evidence-mutation-cost-2026-06/README.md
@@ -1,0 +1,76 @@
+# Evidence mutation-detection matrix and verification-cost curve
+
+Signed and attested artifact lines are widening, but one question tends to stay underexposed: for a
+signed evidence bundle, *which* post-hoc mutation classes are actually detected, by *which* verifier
+check, and at *what cost*? This experiment measures exactly that, with a reproducible harness.
+
+We measure which post-hoc mutation classes are detected by the verifier, and at what cost, under a
+no-signing-key attacker model.
+
+## What this is, and is not
+
+This is a measurement, not a blanket security claim. Two things are reported:
+
+1. A **mutation-detection matrix** for `assay-evidence` bundles, under threat model T: a party
+   *without* the signing key mutates a bundle after the fact, while the bundle's run anchor
+   (`run_root`, a Merkle root over event content hashes) is bound by an external signature the
+   attacker cannot forge. Two layers are exercised:
+   - the internal verifier (`verify_bundle_with_limits`), which catches blind tampering that breaks
+     internal consistency, each with a specific error code;
+   - the run anchor, which catches a *consistent rewrite* (events and manifest recomputed together)
+     that the internal verifier alone would accept, because the content-addressed root changes.
+2. A **verification + signing cost curve**: verify time as a function of bundle size, compressed
+   size and gzip ratio, bytes per event, the Merkle inclusion-proof size (ceil(log2(N)) hashes), and
+   DSSE sign and verify time over the run anchor.
+
+It is tamper-evident, not tamper-proof. A host that holds both code execution and the signing key is
+out of scope: it can simply re-sign, which is why production deployments anchor externally (a
+transparency log or a timestamping authority). And there is one honest internal limitation the
+matrix surfaces rather than hides: manifest metadata not referenced by a verifier check is not
+individually hash-bound (the `manifest_meta_only` column). The event evidence (`events.ndjson`) and
+the run anchor are always hash-checked; a stray flip in a cosmetic manifest field can pass the
+internal verifier when a truncated read skips the gzip CRC trailer. The event evidence itself is
+never accepted in a mutated form, which is what the gate enforces.
+
+## Results
+
+See [results/matrix.md](results/matrix.md) and [results/cost.md](results/cost.md), generated from
+the JSON the harnesses emit. Headline numbers from a sample release run:
+
+- Across every mutation class (447+ bitflips plus truncation, file injection, path traversal,
+  absolute path, byte edits, drops, reorders, BOM, CRLF, duplicate entries), zero mutations changed
+  the event evidence and still verified. Each class is rejected with a sensible verifier code, and
+  the consistent rewrite is caught by the run anchor.
+- Verification is linear in event count at roughly 16 ms per 1000 events (r² ~ 1.0). DSSE signing
+  and verification over the run anchor are well under a tenth of a millisecond. Cost numbers are
+  machine and workload dependent, so treat them as a shape and a method, not a universal constant.
+
+## How to run
+
+The gate runs in normal CI as part of the workspace test suite:
+
+```bash
+cargo test -p assay-sim --test e3_mutation_matrix       # mutation-detection gate (no bypass)
+cargo test -p assay-evidence --test e3_verify_cost_curve # cost-path smoke
+```
+
+The full sweep plus JSON artifacts is produced by pointing `E3_OUT_DIR` at a directory (release is
+recommended for representative timings):
+
+```bash
+E3_OUT_DIR=docs/experiments/evidence-mutation-cost-2026-06/results \
+  cargo test -p assay-sim --release --test e3_mutation_matrix
+E3_OUT_DIR=docs/experiments/evidence-mutation-cost-2026-06/results \
+  cargo test -p assay-evidence --release --test e3_verify_cost_curve
+python3 docs/experiments/evidence-mutation-cost-2026-06/aggregate.py
+```
+
+## Files
+
+- `results/matrix.json`, `results/matrix.md` — the mutation-detection matrix (`assay.experiment.evidence_mutation_matrix.v0`).
+- `results/cost.json`, `results/cost.bmf.json`, `results/cost.md` — the cost curve and its Bencher Metric Format export (`assay.experiment.evidence_verify_cost.v0`).
+- `aggregate.py` — stdlib renderer from JSON to Markdown.
+
+The harnesses live in `crates/assay-sim/tests/e3_mutation_matrix.rs` (mutation matrix, reusing the
+sim mutators and the evidence verifier) and `crates/assay-evidence/tests/e3_verify_cost_curve.rs`
+(cost curve and DSSE timing).

--- a/docs/experiments/evidence-mutation-cost-2026-06/aggregate.py
+++ b/docs/experiments/evidence-mutation-cost-2026-06/aggregate.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Render the mutation-detection matrix and verification-cost curve as Markdown tables.
+
+Stdlib only. Reads results/matrix.json and results/cost.json (produced by the Rust harnesses)
+and writes results/matrix.md and results/cost.md.
+
+Usage:
+    python3 aggregate.py [--results-dir DIR]
+"""
+import argparse
+import json
+import os
+
+
+def render_cost(cost):
+    rows = cost["rows"]
+    out = []
+    out.append("# Verification + signing cost curve\n")
+    out.append(f"Profile: `{cost['profile']}` · payload {cost['payload_bytes_per_event']} bytes/event\n")
+    out.append("| events | verify ms (median) | reps | compressed bytes | gzip ratio | bytes/event | inclusion-proof hashes |")
+    out.append("| --- | --- | --- | --- | --- | --- | --- |")
+    for r in rows:
+        out.append(
+            f"| {r['events']:,} | {r['verify_ms_median']:.3f} | {r['verify_reps']} | "
+            f"{r['compressed_bytes']:,} | {r['gzip_ratio']:.4f} | "
+            f"{r['bytes_per_event_compressed']:.2f} | {r['inclusion_proof_hashes']} |"
+        )
+    fit = cost["fit"]
+    out.append("")
+    out.append("## Linear fit (verify_ms ~ a + b·events)\n")
+    out.append(f"- slope: {fit['slope_ms_per_event']:.6f} ms/event ({fit['ms_per_1k_events']:.3f} ms per 1k events)")
+    out.append(f"- intercept: {fit['intercept_ms']:.4f} ms")
+    out.append(f"- r²: {fit['r2']:.6f}")
+    dsse = cost["dsse"]
+    out.append("")
+    out.append("## DSSE over the run anchor\n")
+    out.append(f"- sign: {dsse['sign_ms_median']:.4f} ms (median, {dsse['reps']} reps)")
+    out.append(f"- verify: {dsse['verify_ms_median']:.4f} ms (median, {dsse['reps']} reps)")
+    out.append("")
+    return "\n".join(out)
+
+
+def render_matrix(matrix):
+    out = []
+    out.append("# Mutation-detection matrix\n")
+    out.append(f"Threat model: {matrix['threat_model']}\n")
+    out.append(f"Base events: {matrix['base_events']}\n")
+    out.append("| class | layer | detected | no-op | manifest-meta-only | bypass | dominant verifier code |")
+    out.append("| --- | --- | --- | --- | --- | --- | --- |")
+    for c in matrix["classes"]:
+        if c.get("layer") == "internal-verifier":
+            out.append(
+                f"| {c['class']} | internal-verifier | {c['detected']} | {c['noop']} | "
+                f"{c['manifest_meta_only']} | {c['bypass']} | `{c['dominant_code']}` |"
+            )
+        else:
+            out.append(
+                f"| {c['class']} | {c['layer']} | "
+                f"{'anchor-detected' if c.get('detected_by_anchor') else 'NOT detected'} | - | - | - | "
+                f"run_root change |"
+            )
+    gate = matrix["gate"]
+    out.append("")
+    out.append("## Gate\n")
+    out.append(f"- event-evidence bypasses: **{gate['total_bypass']}**")
+    out.append(f"- manifest-meta-only (documented limitation): {gate.get('total_manifest_meta_only', 0)}")
+    out.append("")
+    out.append("## Documented limitation\n")
+    out.append(matrix.get("documented_limitation", ""))
+    out.append("")
+    return "\n".join(out)
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--results-dir", default=os.path.join(here, "results"))
+    args = ap.parse_args()
+
+    with open(os.path.join(args.results_dir, "cost.json")) as f:
+        cost = json.load(f)
+    with open(os.path.join(args.results_dir, "matrix.json")) as f:
+        matrix = json.load(f)
+
+    cost_md = render_cost(cost)
+    matrix_md = render_matrix(matrix)
+
+    with open(os.path.join(args.results_dir, "cost.md"), "w") as f:
+        f.write(cost_md)
+    with open(os.path.join(args.results_dir, "matrix.md"), "w") as f:
+        f.write(matrix_md)
+
+    print(matrix_md)
+    print(cost_md)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/experiments/evidence-mutation-cost-2026-06/results/cost.bmf.json
+++ b/docs/experiments/evidence-mutation-cost-2026-06/results/cost.bmf.json
@@ -1,0 +1,40 @@
+{
+  "evidence_verify_cost/1000": {
+    "verify_ms_median": {
+      "value": 16.192958
+    }
+  },
+  "evidence_verify_cost/5000": {
+    "verify_ms_median": {
+      "value": 80.64770899999999
+    }
+  },
+  "evidence_verify_cost/10000": {
+    "verify_ms_median": {
+      "value": 160.365417
+    }
+  },
+  "evidence_verify_cost/50000": {
+    "verify_ms_median": {
+      "value": 801.434792
+    }
+  },
+  "evidence_verify_cost/100000": {
+    "verify_ms_median": {
+      "value": 1609.891083
+    }
+  },
+  "evidence_verify_cost/fit": {
+    "ms_per_1k_events": {
+      "value": 16.091622046185417
+    }
+  },
+  "evidence_dsse": {
+    "sign_ms_median": {
+      "value": 0.029416
+    },
+    "verify_ms_median": {
+      "value": 0.047834
+    }
+  }
+}

--- a/docs/experiments/evidence-mutation-cost-2026-06/results/cost.json
+++ b/docs/experiments/evidence-mutation-cost-2026-06/results/cost.json
@@ -1,0 +1,68 @@
+{
+  "schema": "assay.experiment.evidence_verify_cost.v0",
+  "profile": "release",
+  "payload_bytes_per_event": 256,
+  "rows": [
+    {
+      "events": 1000,
+      "verify_ms_median": 16.192958,
+      "verify_reps": 11,
+      "compressed_bytes": 260847,
+      "events_bytes": 762780,
+      "bytes_per_event_compressed": 260.847,
+      "gzip_ratio": 0.3419688507826634,
+      "inclusion_proof_hashes": 10
+    },
+    {
+      "events": 5000,
+      "verify_ms_median": 80.64770899999999,
+      "verify_reps": 9,
+      "compressed_bytes": 1301206,
+      "events_bytes": 3822780,
+      "bytes_per_event_compressed": 260.2412,
+      "gzip_ratio": 0.3403821302821507,
+      "inclusion_proof_hashes": 13
+    },
+    {
+      "events": 10000,
+      "verify_ms_median": 160.365417,
+      "verify_reps": 7,
+      "compressed_bytes": 2601647,
+      "events_bytes": 7647780,
+      "bytes_per_event_compressed": 260.1647,
+      "gzip_ratio": 0.3401832950215618,
+      "inclusion_proof_hashes": 14
+    },
+    {
+      "events": 50000,
+      "verify_ms_median": 801.434792,
+      "verify_reps": 5,
+      "compressed_bytes": 13005058,
+      "events_bytes": 38327780,
+      "bytes_per_event_compressed": 260.10116,
+      "gzip_ratio": 0.33931153852375484,
+      "inclusion_proof_hashes": 16
+    },
+    {
+      "events": 100000,
+      "verify_ms_median": 1609.891083,
+      "verify_reps": 3,
+      "compressed_bytes": 26009231,
+      "events_bytes": 76677780,
+      "bytes_per_event_compressed": 260.09231,
+      "gzip_ratio": 0.3392016696362362,
+      "inclusion_proof_hashes": 17
+    }
+  ],
+  "fit": {
+    "slope_ms_per_event": 0.016091622046185416,
+    "intercept_ms": -0.5354601333558093,
+    "ms_per_1k_events": 16.091622046185417,
+    "r2": 0.9999949267462757
+  },
+  "dsse": {
+    "sign_ms_median": 0.029416,
+    "verify_ms_median": 0.047834,
+    "reps": 101
+  }
+}

--- a/docs/experiments/evidence-mutation-cost-2026-06/results/cost.md
+++ b/docs/experiments/evidence-mutation-cost-2026-06/results/cost.md
@@ -1,0 +1,22 @@
+# Verification + signing cost curve
+
+Profile: `release` · payload 256 bytes/event
+
+| events | verify ms (median) | reps | compressed bytes | gzip ratio | bytes/event | inclusion-proof hashes |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1,000 | 16.193 | 11 | 260,847 | 0.3420 | 260.85 | 10 |
+| 5,000 | 80.648 | 9 | 1,301,206 | 0.3404 | 260.24 | 13 |
+| 10,000 | 160.365 | 7 | 2,601,647 | 0.3402 | 260.16 | 14 |
+| 50,000 | 801.435 | 5 | 13,005,058 | 0.3393 | 260.10 | 16 |
+| 100,000 | 1609.891 | 3 | 26,009,231 | 0.3392 | 260.09 | 17 |
+
+## Linear fit (verify_ms ~ a + b·events)
+
+- slope: 0.016092 ms/event (16.092 ms per 1k events)
+- intercept: -0.5355 ms
+- r²: 0.999995
+
+## DSSE over the run anchor
+
+- sign: 0.0294 ms (median, 101 reps)
+- verify: 0.0478 ms (median, 101 reps)

--- a/docs/experiments/evidence-mutation-cost-2026-06/results/matrix.json
+++ b/docs/experiments/evidence-mutation-cost-2026-06/results/matrix.json
@@ -1,0 +1,164 @@
+{
+  "schema": "assay.experiment.evidence_mutation_matrix.v0",
+  "threat_model": "post-hoc mutation by a party without the signing key; the run anchor (run_root) is bound by an external signature the attacker cannot forge",
+  "non_goal": "tamper-proof; a host holding code-exec AND the signing key is out of scope and needs external anchoring (transparency log / TSA)",
+  "base_events": 64,
+  "classes": [
+    {
+      "class": "gzip_bitflip",
+      "layer": "internal-verifier",
+      "detected": 447,
+      "noop": 0,
+      "manifest_meta_only": 1,
+      "bypass": 0,
+      "dominant_code": "ContractInvalidJson",
+      "codes": {
+        "ContractInvalidJson": 201,
+        "ContractSchemaVersion": 1,
+        "ContractSequenceGap": 4,
+        "IntegrityEventHash": 88,
+        "IntegrityManifestHash": 1,
+        "IntegrityTar": 152
+      }
+    },
+    {
+      "class": "truncate",
+      "layer": "internal-verifier",
+      "detected": 9,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "IntegrityIo",
+      "codes": {
+        "IntegrityIo": 6,
+        "IntegrityTar": 3
+      }
+    },
+    {
+      "class": "inject_file",
+      "layer": "internal-verifier",
+      "detected": 1,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "ContractUnexpectedFile",
+      "codes": {
+        "ContractUnexpectedFile": 1
+      }
+    },
+    {
+      "class": "inject_path_traversal",
+      "layer": "internal-verifier",
+      "detected": 1,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "SecurityPathTraversal",
+      "codes": {
+        "SecurityPathTraversal": 1
+      }
+    },
+    {
+      "class": "inject_absolute_path",
+      "layer": "internal-verifier",
+      "detected": 1,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "SecurityPathTraversal",
+      "codes": {
+        "SecurityPathTraversal": 1
+      }
+    },
+    {
+      "class": "event_byte_edit",
+      "layer": "internal-verifier",
+      "detected": 32,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "ContractInvalidJson",
+      "codes": {
+        "ContractInvalidJson": 23,
+        "ContractRunIdMismatch": 1,
+        "ContractSchemaVersion": 2,
+        "IntegrityEventHash": 4,
+        "IntegrityManifestHash": 2
+      }
+    },
+    {
+      "class": "event_drop",
+      "layer": "internal-verifier",
+      "detected": 1,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "IntegrityFileSizeMismatch",
+      "codes": {
+        "IntegrityFileSizeMismatch": 1
+      }
+    },
+    {
+      "class": "event_reorder",
+      "layer": "internal-verifier",
+      "detected": 1,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "ContractSequenceStart",
+      "codes": {
+        "ContractSequenceStart": 1
+      }
+    },
+    {
+      "class": "ndjson_bom",
+      "layer": "internal-verifier",
+      "detected": 1,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "IntegrityFileSizeMismatch",
+      "codes": {
+        "IntegrityFileSizeMismatch": 1
+      }
+    },
+    {
+      "class": "ndjson_crlf",
+      "layer": "internal-verifier",
+      "detected": 1,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "IntegrityFileSizeMismatch",
+      "codes": {
+        "IntegrityFileSizeMismatch": 1
+      }
+    },
+    {
+      "class": "tar_duplicate",
+      "layer": "internal-verifier",
+      "detected": 1,
+      "noop": 0,
+      "manifest_meta_only": 0,
+      "bypass": 0,
+      "dominant_code": "ContractDuplicateFile",
+      "codes": {
+        "ContractDuplicateFile": 1
+      }
+    },
+    {
+      "class": "consistent_rewrite",
+      "layer": "run-anchor",
+      "internal_verifier_passed": true,
+      "detected_by_anchor": true,
+      "anchored_run_root": "sha256:907a4f0bc819ca63cdad0cb559a032af739c67cb97b839625ce4c0810f18f625",
+      "mutated_run_root": "sha256:59d9fb47bf279e7edd1ce9dfad6312d853791bbb87e144ec806ce1726071c3fe",
+      "note": "internal verifier alone is insufficient; the run anchor / external signature is what detects this"
+    }
+  ],
+  "gate": {
+    "total_bypass": 0,
+    "total_manifest_meta_only": 1
+  },
+  "documented_limitation": "manifest metadata not referenced by a verifier check is not individually hash-bound (manifest_meta_only); the event evidence (events.ndjson) and the run anchor (run_root) are always hash-checked"
+}

--- a/docs/experiments/evidence-mutation-cost-2026-06/results/matrix.md
+++ b/docs/experiments/evidence-mutation-cost-2026-06/results/matrix.md
@@ -1,0 +1,29 @@
+# Mutation-detection matrix
+
+Threat model: post-hoc mutation by a party without the signing key; the run anchor (run_root) is bound by an external signature the attacker cannot forge
+
+Base events: 64
+
+| class | layer | detected | no-op | manifest-meta-only | bypass | dominant verifier code |
+| --- | --- | --- | --- | --- | --- | --- |
+| gzip_bitflip | internal-verifier | 447 | 0 | 1 | 0 | `ContractInvalidJson` |
+| truncate | internal-verifier | 9 | 0 | 0 | 0 | `IntegrityIo` |
+| inject_file | internal-verifier | 1 | 0 | 0 | 0 | `ContractUnexpectedFile` |
+| inject_path_traversal | internal-verifier | 1 | 0 | 0 | 0 | `SecurityPathTraversal` |
+| inject_absolute_path | internal-verifier | 1 | 0 | 0 | 0 | `SecurityPathTraversal` |
+| event_byte_edit | internal-verifier | 32 | 0 | 0 | 0 | `ContractInvalidJson` |
+| event_drop | internal-verifier | 1 | 0 | 0 | 0 | `IntegrityFileSizeMismatch` |
+| event_reorder | internal-verifier | 1 | 0 | 0 | 0 | `ContractSequenceStart` |
+| ndjson_bom | internal-verifier | 1 | 0 | 0 | 0 | `IntegrityFileSizeMismatch` |
+| ndjson_crlf | internal-verifier | 1 | 0 | 0 | 0 | `IntegrityFileSizeMismatch` |
+| tar_duplicate | internal-verifier | 1 | 0 | 0 | 0 | `ContractDuplicateFile` |
+| consistent_rewrite | run-anchor | anchor-detected | - | - | - | run_root change |
+
+## Gate
+
+- event-evidence bypasses: **0**
+- manifest-meta-only (documented limitation): 1
+
+## Documented limitation
+
+manifest metadata not referenced by a verifier check is not individually hash-bound (manifest_meta_only); the event evidence (events.ndjson) and the run anchor (run_root) are always hash-checked


### PR DESCRIPTION
Signed and attested artifact lines keep widening, but one question tends to stay underexposed: for a signed evidence bundle, which post-hoc mutation classes does the verifier actually catch, by which check, and at what cost? This adds two small reproducible harnesses that answer exactly that, and commit the sample artifacts so the numbers are inspectable.

The first is a mutation-detection matrix in assay-sim. Under a no-signing-key attacker model it runs every mutation class we could think of (bitflips, truncation, file injection, path traversal, absolute paths, byte edits, drops, reorders, BOM, CRLF, duplicate entries) and records which verifier code rejected each one. The security gate is simple and runs in normal CI: no mutation may change the event evidence and still verify. A consistent rewrite, where an attacker recomputes both events and the manifest, is correctly accepted by the internal verifier and then caught by the run anchor, because the content-addressed run_root changes and an external signature over the original root no longer matches.

It also surfaces one honest limitation rather than hiding it. Manifest metadata that no verifier check references is not individually hash-bound, so a stray flip in a cosmetic field can pass the internal verifier when a truncated read skips the gzip CRC trailer. The event evidence and the run anchor are always hash-checked, which is what the gate enforces, and the matrix reports that case separately as manifest_meta_only.

The second is a verification and signing cost curve in assay-evidence: verify time against event count with a linear fit, compressed size and gzip ratio, the inclusion-proof size, and DSSE sign and verify timing over the run anchor. On a sample release run verification is linear at roughly 16 ms per 1000 events with r squared near 1.0, and DSSE sign and verify sit well under a tenth of a millisecond. Cost numbers are machine and workload dependent, so they are a shape and a method, not a universal constant.

The gate runs as part of the workspace test suite; the full sweep plus JSON and BMF artifacts is produced by pointing E3_OUT_DIR at a directory and running the two tests in release, then aggregate.py renders the Markdown tables. Tests live under tests/ and are auto-discovered, so there are no manifest or dependency changes.

See docs/experiments/evidence-mutation-cost-2026-06/ for the README, the aggregator, and the committed results.