### PR TITLE
chore(infra): runner assay-freshness updater + release-line version gate

### DIFF
--- a/assay-action/action.yml
+++ b/assay-action/action.yml
@@ -1,13 +1,6 @@
-# Assay GitHub Action v3.0.0
-# Verify, lint, and diff evidence bundles from AI agent runs, plus coding-agent
-# sandbox governance and in-toto/DSSE bundle attestation.
-#
-# v3.0.0 is a new major. It carries the v2.1 "AI Agent Security" feature set
-# (compliance packs, BYOS push, artifact attestation, coverage badges) and adds
-# `sandbox-command` (run a coding agent under `assay sandbox` and verify the
-# resulting evidence bundle) and `attest-key` (`assay evidence attest`,
-# in-toto/DSSE). It does NOT carry the legacy marketplace v2 "Evidence Artifacts"
-# `mode`/`run` inputs; pin `@v2` if you depend on those.
+# Assay GitHub Action v2.1
+# Verify, lint, and diff evidence bundles from AI agent runs.
+# v2.1 adds: Compliance packs, BYOS push with OIDC, artifact attestation, coverage badges.
 #
 # Spec: https://github.com/Rul1an/assay/blob/main/docs/architecture/SPEC-GitHub-Action-v2.1.md
 # ADR:  https://github.com/Rul1an/assay/blob/main/docs/architecture/ADR-018-GitHub-Action-v2.1.md
@@ -148,20 +141,6 @@ inputs:
       Only used when badge_gist is set.
     required: false
     default: ''
-  sandbox-command:
-    description: |
-      Optional. A command to run under `assay sandbox` (Landlock) so the action
-      records the coding agent's observed effects as an evidence bundle and
-      verifies/lints it. Requires a Linux runner. Empty disables the step.
-    required: false
-    default: ''
-  attest-key:
-    description: |
-      Optional. Ed25519 private key (PKCS#8 PEM) used to sign the evidence
-      bundle's manifest as an in-toto/DSSE attestation via `assay evidence
-      attest`. Pass via a secret. Empty disables the step.
-    required: false
-    default: ''
 
 outputs:
   verified:
@@ -223,9 +202,6 @@ outputs:
   coverage_percent:
     description: 'Evidence coverage percentage (tools with policy / total tools)'
     value: ${{ steps.coverage.outputs.coverage_percent }}
-  attestation_envelope:
-    description: 'Local path to the in-toto/DSSE attestation envelope (if attest-key set)'
-    value: ${{ steps.assay-attest.outputs.envelope_path }}
 
 runs:
   using: 'composite'
@@ -234,15 +210,47 @@ runs:
     # E1: Foundation - Platform detection, caching, binary installation
     # =========================================================================
 
-    - name: Check if Assay already in PATH
+    - name: Resolve requested Assay version
       id: check-existing
       shell: bash
+      env:
+        ASSAY_VERSION_INPUT: ${{ inputs.version }}
       run: |
-        if command -v assay &> /dev/null; then
-          echo "Assay already installed: $(assay --version)"
-          echo "skip_install=true" >> $GITHUB_OUTPUT
-        else
+        set -euo pipefail
+
+        VERSION="$ASSAY_VERSION_INPUT"
+        REPO="Rul1an/assay"
+
+        if [ "$VERSION" = "latest" ]; then
+          VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to fetch latest Assay version"
+            exit 1
+          fi
+        fi
+
+        case "$VERSION" in
+          v*) ;;
+          *) VERSION="v${VERSION}" ;;
+        esac
+
+        echo "resolved_version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "resolved_version_plain=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+        if ! command -v assay &> /dev/null; then
           echo "skip_install=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        INSTALLED_VERSION="$(assay --version 2>/dev/null | awk '{print $2}' || true)"
+        echo "installed_version=$INSTALLED_VERSION" >> "$GITHUB_OUTPUT"
+        echo "Assay already installed: ${INSTALLED_VERSION:-unknown}"
+
+        if [ "$INSTALLED_VERSION" = "${VERSION#v}" ]; then
+          echo "skip_install=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "::notice::Installed Assay ${INSTALLED_VERSION:-unknown} does not match requested ${VERSION}; reinstalling"
+          echo "skip_install=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Detect platform
@@ -281,13 +289,13 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.assay/bin
-        key: assay-${{ inputs.version }}-${{ steps.platform.outputs.target }}
+        key: assay-${{ steps.check-existing.outputs.resolved_version }}-${{ steps.platform.outputs.target }}
 
     - name: Install Assay CLI
       if: steps.check-existing.outputs.skip_install != 'true' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       env:
-        ASSAY_VERSION: ${{ inputs.version }}
+        ASSAY_VERSION: ${{ steps.check-existing.outputs.resolved_version }}
         ASSAY_TARGET: ${{ steps.platform.outputs.target }}
       run: |
         set -euo pipefail
@@ -296,15 +304,6 @@ runs:
         VERSION="$ASSAY_VERSION"
         TARGET="$ASSAY_TARGET"
         REPO="Rul1an/assay"
-
-        # Resolve 'latest' to actual version
-        if [ "$VERSION" = "latest" ]; then
-          VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
-          if [ -z "$VERSION" ]; then
-            echo "::error::Failed to fetch latest version"
-            exit 1
-          fi
-        fi
 
         DOWNLOAD_URL="https://github.com/$REPO/releases/download/${VERSION}/assay-${VERSION}-${TARGET}.tar.gz"
         CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
@@ -373,16 +372,21 @@ runs:
       id: verify-install
       if: steps.check-existing.outputs.skip_install != 'true'
       shell: bash
+      env:
+        EXPECTED_VERSION: ${{ steps.check-existing.outputs.resolved_version_plain }}
       run: | # zizmor: ignore[github-env] v2 compatibility exports a literal install dir for later caller steps
         # v2 compatibility: later caller steps may invoke `assay` directly.
         # Keep exporting this literal install directory until a major-version contract change.
         printf '%s\n' "$HOME/.assay/bin" >> "$GITHUB_PATH"
         export PATH="$HOME/.assay/bin:$PATH"
 
-        if ! ~/.assay/bin/assay --version; then
+        INSTALLED_VERSION="$(~/.assay/bin/assay --version | awk '{print $2}')"
+        if [ "$INSTALLED_VERSION" != "$EXPECTED_VERSION" ]; then
+          echo "::error::Assay installation verification failed: expected ${EXPECTED_VERSION}, got ${INSTALLED_VERSION:-unknown}"
           echo "::error::Assay installation verification failed"
           exit 1
         fi
+        ~/.assay/bin/assay --version
 
         echo "installed=true" >> $GITHUB_OUTPUT
 
@@ -390,27 +394,6 @@ runs:
     # E2: Evidence Processing - Discovery, verify, lint
     # (Placeholder - will be implemented in Epic 2)
     # =========================================================================
-
-    - name: Coding-agent sandbox governance
-      id: sandbox-governance
-      if: inputs.sandbox-command != ''
-      shell: bash
-      env:
-        SANDBOX_COMMAND: ${{ inputs.sandbox-command }}
-        RUNNER_TEMP: ${{ runner.temp }}
-      run: |
-        set -euo pipefail
-        TMP="${RUNNER_TEMP:-/tmp}"
-        BUNDLE="$TMP/assay-coding-agent.tar.gz"
-        echo "Running coding agent under assay sandbox (observe + record)"
-        assay sandbox \
-          --profile "$TMP/assay-coding-agent.profile.yaml" \
-          --bundle "$BUNDLE" \
-          --dry-run \
-          -- bash -lc "$SANDBOX_COMMAND"
-        echo "coding_agent_bundle=$BUNDLE" >> "$GITHUB_OUTPUT"
-        echo "Linting the coding-agent evidence bundle"
-        assay evidence lint "$BUNDLE"
 
     - name: Discover evidence bundles
       id: discover
@@ -1211,36 +1194,6 @@ runs:
     # =========================================================================
     # v2.1: P4 - Coverage Badge
     # =========================================================================
-
-    - name: In-toto attestation
-      id: assay-attest
-      if: inputs.attest-key != ''
-      shell: bash
-      env:
-        ATTEST_KEY: ${{ inputs.attest-key }}
-        RUNNER_TEMP: ${{ runner.temp }}
-        CODING_AGENT_BUNDLE: ${{ steps.sandbox-governance.outputs.coding_agent_bundle }}
-        BUNDLES_PATTERN: ${{ inputs.bundles }}
-      run: |
-        set -euo pipefail
-        TMP="${RUNNER_TEMP:-/tmp}"
-        KEY="$TMP/assay-attest-key.pem"
-        printf '%s\n' "$ATTEST_KEY" > "$KEY"
-        chmod 600 "$KEY"
-        BUNDLE="${CODING_AGENT_BUNDLE:-}"
-        if [ -z "$BUNDLE" ] && [ -n "${BUNDLES_PATTERN:-}" ]; then
-          BUNDLE="$(ls -1 $BUNDLES_PATTERN 2>/dev/null | head -n1 || true)"
-        fi
-        if [ -z "$BUNDLE" ] || [ ! -f "$BUNDLE" ]; then
-          echo "::warning::attest-key set but no bundle found to attest; skipping"
-          rm -f "$KEY"
-          exit 0
-        fi
-        OUT="$TMP/assay-attestation.json"
-        assay evidence attest --bundle "$BUNDLE" --key "$KEY" --out "$OUT"
-        rm -f "$KEY"
-        echo "envelope_path=$OUT" >> "$GITHUB_OUTPUT"
-        echo "Wrote in-toto/DSSE attestation: $OUT"
 
     - name: Update coverage badge
       if: |

--- a/assay-action/action.yml
+++ b/assay-action/action.yml
@@ -1,6 +1,13 @@
-# Assay GitHub Action v2.1
-# Verify, lint, and diff evidence bundles from AI agent runs.
-# v2.1 adds: Compliance packs, BYOS push with OIDC, artifact attestation, coverage badges.
+# Assay GitHub Action v3.0.0
+# Verify, lint, and diff evidence bundles from AI agent runs, plus coding-agent
+# sandbox governance and in-toto/DSSE bundle attestation.
+#
+# v3.0.0 is a new major. It carries the v2.1 "AI Agent Security" feature set
+# (compliance packs, BYOS push, artifact attestation, coverage badges) and adds
+# `sandbox-command` (run a coding agent under `assay sandbox` and verify the
+# resulting evidence bundle) and `attest-key` (`assay evidence attest`,
+# in-toto/DSSE). It does NOT carry the legacy marketplace v2 "Evidence Artifacts"
+# `mode`/`run` inputs; pin `@v2` if you depend on those.
 #
 # Spec: https://github.com/Rul1an/assay/blob/main/docs/architecture/SPEC-GitHub-Action-v2.1.md
 # ADR:  https://github.com/Rul1an/assay/blob/main/docs/architecture/ADR-018-GitHub-Action-v2.1.md
@@ -141,6 +148,20 @@ inputs:
       Only used when badge_gist is set.
     required: false
     default: ''
+  sandbox-command:
+    description: |
+      Optional. A command to run under `assay sandbox` (Landlock) so the action
+      records the coding agent's observed effects as an evidence bundle and
+      verifies/lints it. Requires a Linux runner. Empty disables the step.
+    required: false
+    default: ''
+  attest-key:
+    description: |
+      Optional. Ed25519 private key (PKCS#8 PEM) used to sign the evidence
+      bundle's manifest as an in-toto/DSSE attestation via `assay evidence
+      attest`. Pass via a secret. Empty disables the step.
+    required: false
+    default: ''
 
 outputs:
   verified:
@@ -202,6 +223,9 @@ outputs:
   coverage_percent:
     description: 'Evidence coverage percentage (tools with policy / total tools)'
     value: ${{ steps.coverage.outputs.coverage_percent }}
+  attestation_envelope:
+    description: 'Local path to the in-toto/DSSE attestation envelope (if attest-key set)'
+    value: ${{ steps.assay-attest.outputs.envelope_path }}
 
 runs:
   using: 'composite'
@@ -394,6 +418,27 @@ runs:
     # E2: Evidence Processing - Discovery, verify, lint
     # (Placeholder - will be implemented in Epic 2)
     # =========================================================================
+
+    - name: Coding-agent sandbox governance
+      id: sandbox-governance
+      if: inputs.sandbox-command != ''
+      shell: bash
+      env:
+        SANDBOX_COMMAND: ${{ inputs.sandbox-command }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      run: |
+        set -euo pipefail
+        TMP="${RUNNER_TEMP:-/tmp}"
+        BUNDLE="$TMP/assay-coding-agent.tar.gz"
+        echo "Running coding agent under assay sandbox (observe + record)"
+        assay sandbox \
+          --profile "$TMP/assay-coding-agent.profile.yaml" \
+          --bundle "$BUNDLE" \
+          --dry-run \
+          -- bash -lc "$SANDBOX_COMMAND"
+        echo "coding_agent_bundle=$BUNDLE" >> "$GITHUB_OUTPUT"
+        echo "Linting the coding-agent evidence bundle"
+        assay evidence lint "$BUNDLE"
 
     - name: Discover evidence bundles
       id: discover
@@ -1194,6 +1239,36 @@ runs:
     # =========================================================================
     # v2.1: P4 - Coverage Badge
     # =========================================================================
+
+    - name: In-toto attestation
+      id: assay-attest
+      if: inputs.attest-key != ''
+      shell: bash
+      env:
+        ATTEST_KEY: ${{ inputs.attest-key }}
+        RUNNER_TEMP: ${{ runner.temp }}
+        CODING_AGENT_BUNDLE: ${{ steps.sandbox-governance.outputs.coding_agent_bundle }}
+        BUNDLES_PATTERN: ${{ inputs.bundles }}
+      run: |
+        set -euo pipefail
+        TMP="${RUNNER_TEMP:-/tmp}"
+        KEY="$TMP/assay-attest-key.pem"
+        printf '%s\n' "$ATTEST_KEY" > "$KEY"
+        chmod 600 "$KEY"
+        BUNDLE="${CODING_AGENT_BUNDLE:-}"
+        if [ -z "$BUNDLE" ] && [ -n "${BUNDLES_PATTERN:-}" ]; then
+          BUNDLE="$(ls -1 $BUNDLES_PATTERN 2>/dev/null | head -n1 || true)"
+        fi
+        if [ -z "$BUNDLE" ] || [ ! -f "$BUNDLE" ]; then
+          echo "::warning::attest-key set but no bundle found to attest; skipping"
+          rm -f "$KEY"
+          exit 0
+        fi
+        OUT="$TMP/assay-attestation.json"
+        assay evidence attest --bundle "$BUNDLE" --key "$KEY" --out "$OUT"
+        rm -f "$KEY"
+        echo "envelope_path=$OUT" >> "$GITHUB_OUTPUT"
+        echo "Wrote in-toto/DSSE attestation: $OUT"
 
     - name: Update coverage badge
       if: |

--- a/infra/bpf-runner/README.md
+++ b/infra/bpf-runner/README.md
@@ -32,6 +32,7 @@ The `health_check.sh` script monitors the runner and auto-recovers from common f
 - Runner online status at GitHub
 - Runner service status in VM
 - Queued jobs waiting for the runner
+- Assay CLI release drift on the VM (`assay` in PATH must match the latest GitHub release)
 
 **What it auto-fixes:**
 - VM clock drift (NTP sync) — most common cause of "token expired"
@@ -39,6 +40,7 @@ The `health_check.sh` script monitors the runner and auto-recovers from common f
 - Deleted runner registrations on GitHub (fresh config + service reinstall)
 - Stopped services (restarts runner service)
 - Stale configuration (full reconfiguration if needed)
+- Stale Assay CLI binary (runs `/usr/local/sbin/update-assay-latest` and verifies the runner user sees the latest version)
 
 **Label contract:**
 - Configure only the custom labels: `bpf-lsm,assay-bpf-runner`
@@ -81,6 +83,26 @@ If the **Kernel Matrix (5.15)** or **(6.6)** job fails with `Error: No space lef
   multipass exec assay-bpf-runner -- sudo bash -c '(crontab -l 2>/dev/null | grep -q free_disk) || (crontab -l 2>/dev/null; echo "0 * * * * /opt/actions-runner/scripts/free_disk.sh >> /var/log/assay-free_disk.log 2>&1") | crontab -'
   ```
 
+## Assay CLI freshness on the VM
+
+New runner setups install `/usr/local/sbin/update-assay-latest` plus the
+`assay-update.timer` systemd timer. The timer checks hourly for the latest
+`Rul1an/assay` release, verifies the release asset checksum, and replaces the
+global `/usr/local/bin/assay` binary atomically.
+
+For an **existing** Multipass VM, install or refresh the updater once from the
+host:
+
+```bash
+multipass exec assay-bpf-runner -- sudo tee /usr/local/sbin/update-assay-latest < infra/bpf-runner/update_assay_latest.sh >/dev/null
+multipass exec assay-bpf-runner -- sudo chmod +x /usr/local/sbin/update-assay-latest
+multipass exec assay-bpf-runner -- sudo tee /etc/systemd/system/assay-update.service < infra/bpf-runner/assay-update.service >/dev/null
+multipass exec assay-bpf-runner -- sudo tee /etc/systemd/system/assay-update.timer < infra/bpf-runner/assay-update.timer >/dev/null
+multipass exec assay-bpf-runner -- sudo systemctl daemon-reload
+multipass exec assay-bpf-runner -- sudo systemctl enable --now assay-update.timer
+multipass exec assay-bpf-runner -- sudo /usr/local/sbin/update-assay-latest
+```
+
 ## Files
 
 | File | Purpose |
@@ -91,3 +113,5 @@ If the **Kernel Matrix (5.15)** or **(6.6)** job fails with `Error: No space lef
 | `register_local.sh` | Register/update runner using a token. |
 | `health_check.sh` | Health monitoring and auto-recovery (install via `--install-cron`). |
 | `free_disk.sh` | Free disk on the runner VM (run when you see "No space left on device"). |
+| `update_assay_latest.sh` | Install/update the latest released Assay CLI on the runner VM. |
+| `assay-update.service` / `assay-update.timer` | systemd unit and hourly timer for Assay CLI freshness. |

--- a/infra/bpf-runner/assay-update.service
+++ b/infra/bpf-runner/assay-update.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Update assay CLI to the latest GitHub release
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/update-assay-latest

--- a/infra/bpf-runner/assay-update.timer
+++ b/infra/bpf-runner/assay-update.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Check hourly for the latest assay CLI release
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1h
+RandomizedDelaySec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/bpf-runner/health_check.sh
+++ b/infra/bpf-runner/health_check.sh
@@ -33,6 +33,7 @@ GH_TOKEN_FILE="${GH_TOKEN_FILE:-${GITHUB_TOKEN_FILE:-}}"
 LOG_FILE="${LOG_FILE:-/tmp/runner-health-check.log}"
 MAX_LOG_SIZE=1048576  # 1MB
 RUNNER_FATAL_PATTERNS="${RUNNER_FATAL_PATTERNS:-registration has been deleted from the server|Failed to create a session|token expired|Authentication failed}"
+ASSAY_UPDATE_SCRIPT="${ASSAY_UPDATE_SCRIPT:-/usr/local/sbin/update-assay-latest}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -121,6 +122,50 @@ check_vm_running() {
         fi
         return 1
     fi
+    return 0
+}
+
+latest_assay_tag() {
+    curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | jq -r '.tag_name // empty' 2>/dev/null || true
+}
+
+runner_user_assay_version() {
+    multipass exec "$VM_NAME" -- sudo -u "$RUNNER_USER" bash -lc \
+        'command -v assay >/dev/null 2>&1 && assay --version | awk "{print \$2}"' 2>/dev/null || true
+}
+
+ensure_assay_cli_current() {
+    local latest_tag latest_version current_version update_output
+    latest_tag=$(latest_assay_tag)
+
+    if [[ -z "$latest_tag" || "$latest_tag" == "null" ]]; then
+        log_error "Could not determine latest Assay release for $REPO"
+        return 1
+    fi
+    latest_version="${latest_tag#v}"
+
+    log_info "Checking Assay CLI freshness on VM (latest: $latest_tag)..."
+
+    update_output=$(multipass exec "$VM_NAME" -- bash -lc "
+        set -euo pipefail
+        if [ ! -x '$ASSAY_UPDATE_SCRIPT' ]; then
+            echo 'missing updater: $ASSAY_UPDATE_SCRIPT' >&2
+            exit 42
+        fi
+        sudo '$ASSAY_UPDATE_SCRIPT'
+    " 2>&1) || {
+        log_error "Assay CLI updater failed: $update_output"
+        return 1
+    }
+    log_info "$update_output"
+
+    current_version=$(runner_user_assay_version)
+    if [[ "$current_version" != "$latest_version" ]]; then
+        log_error "Assay CLI drift detected: runner user sees '${current_version:-missing}', expected '$latest_version'"
+        return 1
+    fi
+
+    log_ok "Assay CLI current for runner user: $current_version"
     return 0
 }
 
@@ -593,6 +638,7 @@ health_check() {
     # Pre-flight checks
     check_gh_auth || return 1
     check_vm_running || return 1
+    ensure_assay_cli_current || return 1
 
     # Get current status
     local status
@@ -704,6 +750,19 @@ show_status() {
         echo "Runner Log Health: fatal registration/session error detected"
     else
         echo "Runner Log Health: no fatal registration/session error detected"
+    fi
+
+    echo ""
+    echo "=== Assay CLI ==="
+    local latest_tag current_version
+    latest_tag=$(latest_assay_tag)
+    current_version=$(runner_user_assay_version)
+    echo "Latest Release: ${latest_tag:-unknown}"
+    echo "Runner PATH Version: ${current_version:-missing}"
+    if [[ -n "$latest_tag" && "$current_version" == "${latest_tag#v}" ]]; then
+        echo "Assay CLI Health: current"
+    else
+        echo "Assay CLI Health: stale or unknown (run /usr/local/sbin/update-assay-latest on the VM)"
     fi
 
     echo ""

--- a/infra/bpf-runner/health_check.sh
+++ b/infra/bpf-runner/health_check.sh
@@ -130,6 +130,7 @@ latest_assay_tag() {
 }
 
 runner_user_assay_version() {
+    # shellcheck disable=SC2016 # awk expansion must happen inside the VM shell.
     multipass exec "$VM_NAME" -- sudo -u "$RUNNER_USER" bash -lc \
         'command -v assay >/dev/null 2>&1 && assay --version | awk "{print \$2}"' 2>/dev/null || true
 }

--- a/infra/bpf-runner/setup.sh
+++ b/infra/bpf-runner/setup.sh
@@ -11,7 +11,7 @@
 #
 # FEATURES:
 # - Kernel Hardening: Enables BPF LSM via boot parameters.
-# - Dependency Management: Rust (via rustup), native bpf-linker, Docker, LLVM/Clang.
+# - Dependency Management: Rust (via rustup), Docker, LLVM/Clang.
 # - Runner Security: Runs as non-root 'github-runner' user, standard Docker group.
 # ==============================================================================
 
@@ -23,8 +23,7 @@ apt-get update
 apt-get install -y \
     curl git build-essential \
     linux-tools-common linux-tools-generic linux-headers-generic \
-    llvm llvm-dev clang libclang-dev \
-    pkg-config libssl-dev libsqlite3-dev \
+    llvm clang libclang-dev \
     jq
 
 # 2. Configure Kernel for BPF LSM
@@ -56,7 +55,7 @@ else
 fi
 
 # 4. Install Rust Toolchain (System-wide for Runner)
-echo "🦀 [4/5] Installing Rust Toolchain and native eBPF linker..."
+echo "🦀 [4/5] Installing Rust Toolchain..."
 export RUSTUP_HOME=/opt/rust
 export CARGO_HOME=/opt/rust
 if [ ! -d "/opt/rust" ]; then
@@ -65,25 +64,9 @@ if [ ! -d "/opt/rust" ]; then
 else
     echo "   -> Rust already installed in /opt/rust."
 fi
-# Add to global path and keep rustup proxies pointed at the system toolchain.
-cat > /etc/profile.d/rust.sh <<'EOF'
-export RUSTUP_HOME=/opt/rust
-export CARGO_HOME=/opt/rust
-export PATH=/opt/rust/bin:$PATH
-EOF
-# shellcheck disable=SC1091
+# Add to global path
+echo 'export PATH=/opt/rust/bin:$PATH' > /etc/profile.d/rust.sh
 source /etc/profile.d/rust.sh
-rustup toolchain install nightly-2026-01-01 --profile minimal
-rustup component add rust-src --toolchain nightly-2026-01-01
-if ! command -v bpf-linker &> /dev/null || ! bpf-linker --version | grep -Fq "bpf-linker 0.10.3"; then
-    rustup run nightly-2026-01-01 cargo install bpf-linker --version 0.10.3 --locked --force
-else
-    echo "   -> bpf-linker 0.10.3 already installed."
-fi
-ln -sf /opt/rust/bin/cargo /usr/local/bin/cargo
-ln -sf /opt/rust/bin/rustc /usr/local/bin/rustc
-ln -sf /opt/rust/bin/rustup /usr/local/bin/rustup
-ln -sf /opt/rust/bin/bpf-linker /usr/local/bin/bpf-linker
 
 # 5. Connect GitHub Runner
 echo "🏃 [5/5] Configuring GitHub Action Runner..."
@@ -97,13 +80,6 @@ if ! id "$RUNNER_USER" &>/dev/null; then
     # but verify_lsm_docker.sh needs host privileges for BPF)
     echo "$RUNNER_USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/github-runner
 fi
-for rust_home in .cargo .rustup; do
-    rust_home_path="/home/$RUNNER_USER/$rust_home"
-    if [ ! -e "$rust_home_path" ]; then
-        ln -s /opt/rust "$rust_home_path"
-        chown -h "$RUNNER_USER":"$RUNNER_USER" "$rust_home_path"
-    fi
-done
 
 mkdir -p "$RUNNER_DIR"
 chown "$RUNNER_USER":"$RUNNER_USER" "$RUNNER_DIR"
@@ -117,6 +93,14 @@ if ! (crontab -l 2>/dev/null | grep -q "free_disk.sh"); then
     (crontab -l 2>/dev/null; echo "0 * * * * $RUNNER_DIR/scripts/free_disk.sh >> /var/log/assay-free_disk.log 2>&1") | crontab -
     echo "   -> Installed hourly cron: $RUNNER_DIR/scripts/free_disk.sh"
 fi
+
+# 5b. Install Assay latest-release updater (keeps global PATH binary current)
+install -m 0755 "$SCRIPT_DIR/update_assay_latest.sh" /usr/local/sbin/update-assay-latest
+install -m 0644 "$SCRIPT_DIR/assay-update.service" /etc/systemd/system/assay-update.service
+install -m 0644 "$SCRIPT_DIR/assay-update.timer" /etc/systemd/system/assay-update.timer
+systemctl daemon-reload
+systemctl enable --now assay-update.timer
+/usr/local/sbin/update-assay-latest
 
 if [ ! -f "$RUNNER_DIR/.runner" ]; then
     echo "   -> Downloading Runner Agent..."

--- a/infra/bpf-runner/setup.sh
+++ b/infra/bpf-runner/setup.sh
@@ -11,7 +11,7 @@
 #
 # FEATURES:
 # - Kernel Hardening: Enables BPF LSM via boot parameters.
-# - Dependency Management: Rust (via rustup), Docker, LLVM/Clang.
+# - Dependency Management: Rust (via rustup), native bpf-linker, Docker, LLVM/Clang.
 # - Runner Security: Runs as non-root 'github-runner' user, standard Docker group.
 # ==============================================================================
 
@@ -23,7 +23,8 @@ apt-get update
 apt-get install -y \
     curl git build-essential \
     linux-tools-common linux-tools-generic linux-headers-generic \
-    llvm clang libclang-dev \
+    llvm llvm-dev clang libclang-dev \
+    pkg-config libssl-dev libsqlite3-dev \
     jq
 
 # 2. Configure Kernel for BPF LSM
@@ -55,7 +56,7 @@ else
 fi
 
 # 4. Install Rust Toolchain (System-wide for Runner)
-echo "🦀 [4/5] Installing Rust Toolchain..."
+echo "🦀 [4/5] Installing Rust Toolchain and native eBPF linker..."
 export RUSTUP_HOME=/opt/rust
 export CARGO_HOME=/opt/rust
 if [ ! -d "/opt/rust" ]; then
@@ -64,9 +65,25 @@ if [ ! -d "/opt/rust" ]; then
 else
     echo "   -> Rust already installed in /opt/rust."
 fi
-# Add to global path
-echo 'export PATH=/opt/rust/bin:$PATH' > /etc/profile.d/rust.sh
+# Add to global path and keep rustup proxies pointed at the system toolchain.
+cat > /etc/profile.d/rust.sh <<'EOF'
+export RUSTUP_HOME=/opt/rust
+export CARGO_HOME=/opt/rust
+export PATH=/opt/rust/bin:$PATH
+EOF
+# shellcheck disable=SC1091
 source /etc/profile.d/rust.sh
+rustup toolchain install nightly-2026-01-01 --profile minimal
+rustup component add rust-src --toolchain nightly-2026-01-01
+if ! command -v bpf-linker &> /dev/null || ! bpf-linker --version | grep -Fq "bpf-linker 0.10.3"; then
+    rustup run nightly-2026-01-01 cargo install bpf-linker --version 0.10.3 --locked --force
+else
+    echo "   -> bpf-linker 0.10.3 already installed."
+fi
+ln -sf /opt/rust/bin/cargo /usr/local/bin/cargo
+ln -sf /opt/rust/bin/rustc /usr/local/bin/rustc
+ln -sf /opt/rust/bin/rustup /usr/local/bin/rustup
+ln -sf /opt/rust/bin/bpf-linker /usr/local/bin/bpf-linker
 
 # 5. Connect GitHub Runner
 echo "🏃 [5/5] Configuring GitHub Action Runner..."
@@ -80,6 +97,13 @@ if ! id "$RUNNER_USER" &>/dev/null; then
     # but verify_lsm_docker.sh needs host privileges for BPF)
     echo "$RUNNER_USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/github-runner
 fi
+for rust_home in .cargo .rustup; do
+    rust_home_path="/home/$RUNNER_USER/$rust_home"
+    if [ ! -e "$rust_home_path" ]; then
+        ln -s /opt/rust "$rust_home_path"
+        chown -h "$RUNNER_USER":"$RUNNER_USER" "$rust_home_path"
+    fi
+done
 
 mkdir -p "$RUNNER_DIR"
 chown "$RUNNER_USER":"$RUNNER_USER" "$RUNNER_DIR"

--- a/infra/bpf-runner/setup_local_multipass.sh
+++ b/infra/bpf-runner/setup_local_multipass.sh
@@ -78,7 +78,18 @@ multipass exec "$VM_NAME" -- sudo chmod +x /opt/actions-runner/scripts/free_disk
 multipass exec "$VM_NAME" -- bash -c '(crontab -l 2>/dev/null | grep -q free_disk.sh) || (crontab -l 2>/dev/null; echo "0 * * * * /opt/actions-runner/scripts/free_disk.sh >> /var/log/assay-free_disk.log 2>&1") | crontab -'
 echo "   -> Hourly free_disk cron installed."
 
-# 5. Final Instructions
+# 5. Install Assay release updater (keeps PATH binary current for action smoke tests)
+echo "📋 Installing Assay latest-release updater on VM..."
+multipass exec "$VM_NAME" -- sudo tee /usr/local/sbin/update-assay-latest < infra/bpf-runner/update_assay_latest.sh >/dev/null
+multipass exec "$VM_NAME" -- sudo chmod +x /usr/local/sbin/update-assay-latest
+multipass exec "$VM_NAME" -- sudo tee /etc/systemd/system/assay-update.service < infra/bpf-runner/assay-update.service >/dev/null
+multipass exec "$VM_NAME" -- sudo tee /etc/systemd/system/assay-update.timer < infra/bpf-runner/assay-update.timer >/dev/null
+multipass exec "$VM_NAME" -- sudo systemctl daemon-reload
+multipass exec "$VM_NAME" -- sudo systemctl enable --now assay-update.timer
+multipass exec "$VM_NAME" -- sudo /usr/local/sbin/update-assay-latest
+echo "   -> Assay updater installed and timer enabled."
+
+# 6. Final Instructions
 IP=$(multipass info "$VM_NAME" | grep IPv4 | awk '{print $2}')
 echo ""
 echo "========================================================================"

--- a/infra/bpf-runner/update_assay_latest.sh
+++ b/infra/bpf-runner/update_assay_latest.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${ASSAY_REPO:-Rul1an/assay}"
+INSTALL_DIR="${ASSAY_INSTALL_DIR:-/usr/local/bin}"
+INSTALL_OWNER="${ASSAY_INSTALL_OWNER:-root:root}"
+COMPAT_SYMLINKS="${ASSAY_COMPAT_SYMLINKS:-/home/ubuntu/.cargo/bin/assay /home/github-runner/.cargo/bin/assay}"
+
+case "$(uname -m)" in
+  aarch64|arm64)
+    TARGET="aarch64-unknown-linux-gnu"
+    ;;
+  x86_64|amd64)
+    TARGET="x86_64-unknown-linux-gnu"
+    ;;
+  *)
+    echo "unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to update assay" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to update assay" >&2
+  exit 1
+fi
+
+api_url="https://api.github.com/repos/${REPO}/releases/latest"
+tag="$(curl -fsSL "$api_url" | jq -r '.tag_name // empty')"
+if [[ -z "$tag" || "$tag" == "null" ]]; then
+  echo "could not determine latest release tag for ${REPO}" >&2
+  exit 1
+fi
+
+ensure_compat_symlinks() {
+  for link_path in $COMPAT_SYMLINKS; do
+    if [[ "$link_path" == "${INSTALL_DIR}/assay" ]]; then
+      continue
+    fi
+    link_dir="$(dirname "$link_path")"
+    if [[ -d "$link_dir" ]]; then
+      ln -sfn "${INSTALL_DIR}/assay" "$link_path"
+    fi
+  done
+}
+
+version="${tag#v}"
+asset="assay-${tag}-${TARGET}.tar.gz"
+base_url="https://github.com/${REPO}/releases/download/${tag}"
+
+current_version=""
+if [[ -x "${INSTALL_DIR}/assay" ]]; then
+  current_version="$("${INSTALL_DIR}/assay" --version 2>/dev/null | awk '{print $2}' || true)"
+elif command -v assay >/dev/null 2>&1; then
+  current_version="$(assay --version 2>/dev/null | awk '{print $2}' || true)"
+fi
+
+if [[ "${ASSAY_FORCE_UPDATE:-0}" != "1" && "$current_version" == "$version" ]]; then
+  ensure_compat_symlinks
+  echo "assay is already current: ${version}"
+  exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+cd "$tmpdir"
+
+curl -fsSLO "${base_url}/${asset}"
+curl -fsSLO "${base_url}/${asset}.sha256"
+sha256sum -c "${asset}.sha256"
+
+tar -xzf "$asset"
+extracted_dir="${asset%.tar.gz}"
+if [[ ! -x "${extracted_dir}/assay" ]]; then
+  echo "release archive did not contain executable assay binary" >&2
+  exit 1
+fi
+
+install -d -m 0755 "$INSTALL_DIR"
+install -m 0755 "${extracted_dir}/assay" "${INSTALL_DIR}/assay.new"
+mv "${INSTALL_DIR}/assay.new" "${INSTALL_DIR}/assay"
+chown "${INSTALL_OWNER}" "${INSTALL_DIR}/assay"
+
+ensure_compat_symlinks
+
+echo "updated assay to ${version} at ${INSTALL_DIR}/assay"

--- a/scripts/ci/check-assay-version-line.sh
+++ b/scripts/ci/check-assay-version-line.sh
@@ -56,6 +56,7 @@ vm_assay_version() {
     return 0
   fi
 
+  # shellcheck disable=SC2016 # awk expansion must happen inside the VM shell.
   multipass exec "$VM_NAME" -- sudo -u github-runner bash -lc \
     'assay --version 2>/dev/null | awk "{print \$2}"' 2>/dev/null || true
 }

--- a/scripts/ci/check-assay-version-line.sh
+++ b/scripts/ci/check-assay-version-line.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${REPO:-Rul1an/assay}"
+VM_NAME="${VM_NAME:-assay-bpf-runner}"
+HARNESS_DIR="${HARNESS_DIR:-../Assay-Harness}"
+CHECK_VM="${CHECK_VM:-1}"
+
+failures=0
+
+note() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  failures=$((failures + 1))
+  note "FAIL: $*"
+}
+
+latest_tag() {
+  curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" |
+    sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+    head -n 1
+}
+
+workspace_version() {
+  awk '
+    $0 == "[workspace.package]" { in_workspace_package = 1; next }
+    /^\[/ && $0 != "[workspace.package]" { in_workspace_package = 0 }
+    in_workspace_package && $1 == "version" {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+  ' Cargo.toml
+}
+
+harness_version() {
+  local workflow="${HARNESS_DIR}/.github/workflows/harness-ci.yml"
+  if [[ ! -f "$workflow" ]]; then
+    return 0
+  fi
+
+  awk '
+    $1 == "default:" {
+      value = $2
+      gsub(/"/, "", value)
+      print value
+      exit
+    }
+  ' "$workflow"
+}
+
+vm_assay_version() {
+  if ! command -v multipass >/dev/null 2>&1; then
+    return 0
+  fi
+
+  multipass exec "$VM_NAME" -- sudo -u github-runner bash -lc \
+    'assay --version 2>/dev/null | awk "{print \$2}"' 2>/dev/null || true
+}
+
+latest="$(latest_tag)"
+if [[ -z "$latest" ]]; then
+  fail "could not resolve latest ${REPO} release"
+else
+  note "latest_release=${latest}"
+fi
+
+workspace="$(workspace_version)"
+if [[ -z "$workspace" ]]; then
+  fail "could not read workspace.package.version from Cargo.toml"
+else
+  note "workspace_version=${workspace}"
+fi
+
+harness="$(harness_version)"
+if [[ -z "$harness" ]]; then
+  fail "could not read Harness CI assay_version default from ${HARNESS_DIR}"
+else
+  note "harness_assay_version=${harness}"
+fi
+
+vm_version=""
+if [[ "$CHECK_VM" == "1" ]]; then
+  vm_version="$(vm_assay_version)"
+  if [[ -z "$vm_version" ]]; then
+    fail "could not read assay version from Multipass VM ${VM_NAME}"
+  else
+    note "vm_assay_version=${vm_version}"
+  fi
+else
+  note "vm_assay_version=skipped"
+fi
+
+if [[ -n "$latest" && -n "$workspace" && "v${workspace}" != "$latest" ]]; then
+  fail "workspace version v${workspace} does not match latest release ${latest}"
+fi
+
+if [[ -n "$latest" && -n "$harness" && "$harness" != "$latest" ]]; then
+  fail "Harness compatibility default ${harness} does not match latest release ${latest}"
+fi
+
+if [[ "$CHECK_VM" == "1" && -n "$latest" && -n "$vm_version" && "v${vm_version}" != "$latest" ]]; then
+  fail "VM assay version v${vm_version} does not match latest release ${latest}"
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  note "version_line_status=failed"
+  exit 1
+fi
+
+note "version_line_status=ok"


### PR DESCRIPTION
This lifts the runner-freshness and version-line work onto a clean main so the release-line gate passes, rather than failing on a stale branch that still read 3.12.0. main is already on the 3.19.0 line, so this is purely the infra and the gate, no version bump games.

A few related pieces travel together. The action no longer trusts whatever assay happens to be on PATH; it reuses only the exact requested or latest version and otherwise reinstalls, so a run can't silently grade against a stale binary. The Multipass runner gets a repo-versioned updater plus a systemd timer that keeps /usr/local/bin/assay pinned to the latest release, and the setup scripts wire it in. health_check.sh now surfaces and monitors CLI freshness against the latest GitHub release. And scripts/ci/check-assay-version-line.sh ties it together: it compares the latest release, the workspace version, the VM binary, and the Harness compatibility default, and fails loudly on any divergence.

Verified on the clean line: latest v3.19.0, workspace 3.19.0, harness v3.19.0, vm 3.19.0, version_line_status ok. Shell syntax, YAML parse, shellcheck, and typos all pass.

One open choice left to you: whether to wire the version-line gate into a CI workflow. It checks the VM binary via multipass by default, which a hosted CI runner can't reach, so in CI it would run with CHECK_VM=0 (release vs workspace vs harness only). I left the wiring out so you can decide where it should run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
