### PR TITLE
fix(evidence): validate gzip CRC/ISIZE trailer in verify_bundle

### DIFF
--- a/crates/assay-evidence/src/bundle/writer_next/verify.rs
+++ b/crates/assay-evidence/src/bundle/writer_next/verify.rs
@@ -444,6 +444,33 @@ pub fn verify_bundle_with_limits<R: Read>(reader: R, limits: VerifyLimits) -> Re
         .into());
     }
 
+    // Defense in depth: drain the remaining gzip stream so the decoder validates its CRC32/ISIZE
+    // trailer. The tar reader stops after the expected entries and would otherwise never read the
+    // trailer, so a mutation in the compressed stream that lands in a manifest field not covered by
+    // a specific check (e.g. producer metadata) could slip through. Draining forces the CRC check.
+    let mut tail = archive.into_inner();
+    let mut drain = [0u8; 8192];
+    loop {
+        match tail.read(&mut drain) {
+            Ok(0) => break,
+            Ok(_) => continue,
+            Err(e) => {
+                let mut ve = VerifyError::from(e);
+                if ve.message.contains("LimitDecodeBytes") {
+                    ve.code = ErrorCode::LimitDecodeBytes;
+                    ve.class = ErrorClass::Limits;
+                } else if ve.message.contains("LimitBundleBytes") {
+                    ve.code = ErrorCode::LimitBundleBytes;
+                    ve.class = ErrorClass::Limits;
+                } else {
+                    ve.code = ErrorCode::IntegrityGzip;
+                    ve.class = ErrorClass::Integrity;
+                }
+                return Err(ve.with_context("Gzip trailer").into());
+            }
+        }
+    }
+
     Ok(VerifyResult {
         manifest: manifest.unwrap(),
         event_count: actual_event_count,

--- a/crates/assay-evidence/tests/verify_gzip_trailer_test.rs
+++ b/crates/assay-evidence/tests/verify_gzip_trailer_test.rs
@@ -1,0 +1,59 @@
+//! Regression: the verifier must validate the gzip CRC/ISIZE trailer.
+//!
+//! The tar reader stops after the expected entries, so without an explicit drain the gzip trailer
+//! was never read and a corrupted trailer (or a compressed-stream mutation landing in an unchecked
+//! manifest field) could slip through. These tests pin the post-fix behavior.
+
+use assay_evidence::types::EvidenceEvent;
+use assay_evidence::{
+    verify_bundle_with_limits, BundleWriter, ErrorClass, VerifyError, VerifyLimits,
+};
+use chrono::{TimeZone, Utc};
+use std::io::Cursor;
+
+fn valid_bundle() -> Vec<u8> {
+    let mut bundle = Vec::new();
+    let mut writer = BundleWriter::new(&mut bundle);
+    for seq in 0..3u64 {
+        let mut event = EvidenceEvent::new(
+            "assay.test",
+            "urn:test",
+            "run",
+            seq,
+            serde_json::json!({ "seq": seq }),
+        );
+        event.time = Utc.timestamp_opt(1_700_000_000 + seq as i64, 0).unwrap();
+        writer.add_event(event);
+    }
+    writer.finish().unwrap();
+    bundle
+}
+
+#[test]
+fn valid_bundle_still_verifies() {
+    let bundle = valid_bundle();
+    verify_bundle_with_limits(Cursor::new(&bundle), VerifyLimits::default())
+        .expect("a valid bundle must verify after the trailer drain");
+}
+
+#[test]
+fn corrupted_gzip_trailer_is_rejected() {
+    let mut bundle = valid_bundle();
+    let n = bundle.len();
+    // gzip trailer = last 8 bytes (CRC32 + ISIZE). Corrupting it leaves the deflate stream intact
+    // but invalid at the trailer check; before the drain fix this passed verification.
+    for b in &mut bundle[n - 8..] {
+        *b ^= 0xFF;
+    }
+    let err = verify_bundle_with_limits(Cursor::new(&bundle), VerifyLimits::default())
+        .expect_err("corrupted gzip trailer must be rejected");
+    let ve = err
+        .downcast_ref::<VerifyError>()
+        .expect("expected a typed VerifyError");
+    assert_eq!(
+        ve.class,
+        ErrorClass::Integrity,
+        "trailer corruption must classify as Integrity (got {:?})",
+        ve.code
+    );
+}


### PR DESCRIPTION
The evidence verifier reads manifest.json and events.ndjson and then stops, which means the gzip CRC and ISIZE trailer were never read or checked. The event content and the run root are fully hash-bound, so event tampering was always caught, but a mutation in the compressed stream that happened to land in a manifest field with no dedicated check (producer metadata, for example) could slip through because nothing validated the trailer.

This drains the remaining decoded stream after the entries loop so the decoder validates its CRC/ISIZE, and classifies a failure as Integrity/IntegrityGzip. It is defense in depth: the DSSE attestation already binds the manifest when used, and this makes verify_bundle alone reject the case too.

Surfaced by an evidence mutation-detection sweep, where exactly one bitflip per large run produced a verified-but-changed bundle (a flipped manifest metadata byte). With this change the trailer check catches it.

A regression test corrupts the gzip trailer of an otherwise valid bundle and asserts it is now rejected, while valid bundles still verify. The broader evidence suite (golden vectors, determinism, security, mandate) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
