### PR TITLE
fix(runner): mark empty network coverage absent

### DIFF
--- a/crates/assay-runner-core/src/kernel.rs
+++ b/crates/assay-runner-core/src/kernel.rs
@@ -17,7 +17,10 @@ mod stats;
 mod tests;
 
 use decode::{decode_monitor_event, is_loader_telemetry_path};
-use health::{health_ringbuf_drops, kernel_layer_for, network_protocol_coverage_for};
+use health::{
+    health_ringbuf_drops, kernel_layer_for, network_endpoint_claim_scope_for,
+    network_protocol_coverage_for,
+};
 use notes::{kernel_capture_note, KernelCaptureNote};
 use stats::{
     ringbuf_drop_breakdown, ringbuf_drop_delta, ringbuf_emitted_breakdown,
@@ -209,7 +212,8 @@ impl KernelLayerCapture {
             filtered_loader_events,
             filtered_loader_top,
         } = self;
-        let network_protocol_coverage = network_protocol_coverage_for(tracepoint_hook_breakdown);
+        let mut network_protocol_coverage =
+            network_protocol_coverage_for(tracepoint_hook_breakdown);
 
         if archive.run_id != run_id {
             return Err(KernelLayerError::RunIdMismatch {
@@ -232,9 +236,14 @@ impl KernelLayerCapture {
                 archive.observation_health.network_endpoint_claim_scope =
                     NetworkEndpointClaimScope::NotApplicable;
             } else {
+                if archive.observation_health.kernel_layer == KernelLayerStatus::PartialRingbufDrops
+                    && network_protocol_coverage == NetworkProtocolCoverageStatus::Absent
+                {
+                    network_protocol_coverage = NetworkProtocolCoverageStatus::Unknown;
+                }
                 archive.observation_health.network_protocol_coverage = network_protocol_coverage;
                 archive.observation_health.network_endpoint_claim_scope =
-                    NetworkEndpointClaimScope::DiagnosticOnly;
+                    network_endpoint_claim_scope_for(network_protocol_coverage);
             }
         } else {
             archive.observation_health.ringbuf_drops = 0;
@@ -261,6 +270,9 @@ impl KernelLayerCapture {
                 filtered_loader_top,
                 cgroup_correlation,
                 network_protocol_coverage,
+                network_endpoint_claim_scope: archive
+                    .observation_health
+                    .network_endpoint_claim_scope,
             }));
         Ok(())
     }

--- a/crates/assay-runner-core/src/kernel/health.rs
+++ b/crates/assay-runner-core/src/kernel/health.rs
@@ -1,5 +1,6 @@
 use assay_runner_schema::{
-    CgroupCorrelationStatus, KernelLayerStatus, NetworkProtocolCoverageStatus,
+    CgroupCorrelationStatus, KernelLayerStatus, NetworkEndpointClaimScope,
+    NetworkProtocolCoverageStatus,
 };
 
 use super::stats::TracepointHookBreakdown;
@@ -9,10 +10,31 @@ pub(super) fn network_protocol_coverage_for(
 ) -> NetworkProtocolCoverageStatus {
     let has_connect = tracepoints.connect_emitted > 0;
     let has_datagram_peer = tracepoints.sendto_emitted > 0 || tracepoints.sendmsg_emitted > 0;
+    let has_network_hook_drop = tracepoints.connect_dropped > 0
+        || tracepoints.sendto_dropped > 0
+        || tracepoints.sendmsg_dropped > 0;
+    if !has_connect && !has_datagram_peer && has_network_hook_drop {
+        return NetworkProtocolCoverageStatus::Unknown;
+    }
     match (has_connect, has_datagram_peer) {
         (true, true) => NetworkProtocolCoverageStatus::ConnectAndDatagramPeerObserved,
+        (true, false) => NetworkProtocolCoverageStatus::ConnectOnly,
         (false, true) => NetworkProtocolCoverageStatus::DatagramPeerObserved,
-        _ => NetworkProtocolCoverageStatus::ConnectOnly,
+        (false, false) => NetworkProtocolCoverageStatus::Absent,
+    }
+}
+
+pub(super) fn network_endpoint_claim_scope_for(
+    network_protocol_coverage: NetworkProtocolCoverageStatus,
+) -> NetworkEndpointClaimScope {
+    match network_protocol_coverage {
+        NetworkProtocolCoverageStatus::Unknown => NetworkEndpointClaimScope::Unknown,
+        NetworkProtocolCoverageStatus::Absent => NetworkEndpointClaimScope::NotApplicable,
+        NetworkProtocolCoverageStatus::ConnectOnly
+        | NetworkProtocolCoverageStatus::DatagramPeerObserved
+        | NetworkProtocolCoverageStatus::ConnectAndDatagramPeerObserved => {
+            NetworkEndpointClaimScope::DiagnosticOnly
+        }
     }
 }
 

--- a/crates/assay-runner-core/src/kernel/notes.rs
+++ b/crates/assay-runner-core/src/kernel/notes.rs
@@ -1,4 +1,6 @@
-use assay_runner_schema::{CgroupCorrelationStatus, NetworkProtocolCoverageStatus};
+use assay_runner_schema::{
+    CgroupCorrelationStatus, NetworkEndpointClaimScope, NetworkProtocolCoverageStatus,
+};
 
 use super::stats::{RingbufDropBreakdown, RingbufEmittedBreakdown, TracepointHookBreakdown};
 
@@ -12,6 +14,7 @@ pub(super) struct KernelCaptureNote {
     pub(super) filtered_loader_top: Vec<(String, u64)>,
     pub(super) cgroup_correlation: CgroupCorrelationStatus,
     pub(super) network_protocol_coverage: NetworkProtocolCoverageStatus,
+    pub(super) network_endpoint_claim_scope: NetworkEndpointClaimScope,
 }
 
 pub(super) fn kernel_capture_note(input: KernelCaptureNote) -> String {
@@ -25,8 +28,11 @@ pub(super) fn kernel_capture_note(input: KernelCaptureNote) -> String {
         filtered_loader_top,
         cgroup_correlation,
         network_protocol_coverage,
+        network_endpoint_claim_scope,
     } = input;
     let network_protocol_coverage = network_protocol_coverage_label(network_protocol_coverage);
+    let network_endpoint_claim_scope =
+        network_endpoint_claim_scope_label(network_endpoint_claim_scope);
 
     // Surfaced only when a sendto/sendmsg with no recoverable peer address was
     // actually observed, so runs that never hit this path produce a
@@ -62,7 +68,7 @@ pub(super) fn kernel_capture_note(input: KernelCaptureNote) -> String {
     match cgroup_correlation {
         CgroupCorrelationStatus::Clean if ringbuf_drops == 0 => {
             format!(
-                "s2_kernel_capture: monitor_events={event_count} ringbuf_drops={ringbuf_drops} network_protocol_coverage={network_protocol_coverage} network_endpoint_claim_scope=diagnostic_only{no_peer_suffix}{non_ip_suffix}"
+                "s2_kernel_capture: monitor_events={event_count} ringbuf_drops={ringbuf_drops} network_protocol_coverage={network_protocol_coverage} network_endpoint_claim_scope={network_endpoint_claim_scope}{no_peer_suffix}{non_ip_suffix}"
             )
         }
         CgroupCorrelationStatus::Clean => {
@@ -72,7 +78,7 @@ pub(super) fn kernel_capture_note(input: KernelCaptureNote) -> String {
                 .collect::<Vec<_>>()
                 .join(",");
             format!(
-                "s2_kernel_capture: monitor_events={event_count} ringbuf_drops={ringbuf_drops} network_protocol_coverage={network_protocol_coverage} network_endpoint_claim_scope=diagnostic_only drop_breakdown=tracepoint:{} lsm:{} socket:{} emitted=tracepoint:{} lsm:{} socket:{} tracepoint_hooks=openat:{}/{} openat2:{}/{} connect:{}/{} sendto:{}/{} sendmsg:{}/{} filtered_loader_events={filtered_loader_events} filtered_loader_top=[{filtered_top}]{no_peer_suffix}{non_ip_suffix}",
+                "s2_kernel_capture: monitor_events={event_count} ringbuf_drops={ringbuf_drops} network_protocol_coverage={network_protocol_coverage} network_endpoint_claim_scope={network_endpoint_claim_scope} drop_breakdown=tracepoint:{} lsm:{} socket:{} emitted=tracepoint:{} lsm:{} socket:{} tracepoint_hooks=openat:{}/{} openat2:{}/{} connect:{}/{} sendto:{}/{} sendmsg:{}/{} filtered_loader_events={filtered_loader_events} filtered_loader_top=[{filtered_top}]{no_peer_suffix}{non_ip_suffix}",
                 drop_breakdown.tracepoint,
                 drop_breakdown.lsm,
                 drop_breakdown.socket,
@@ -94,6 +100,15 @@ pub(super) fn kernel_capture_note(input: KernelCaptureNote) -> String {
         CgroupCorrelationStatus::Partial | CgroupCorrelationStatus::Failed => format!(
             "s2_kernel_capture: monitor_events={event_count} cgroup_correlation={cgroup_correlation:?} kernel_layer downgraded to absent"
         ),
+    }
+}
+
+fn network_endpoint_claim_scope_label(status: NetworkEndpointClaimScope) -> &'static str {
+    match status {
+        NetworkEndpointClaimScope::Unknown => "unknown",
+        NetworkEndpointClaimScope::NotApplicable => "not_applicable",
+        NetworkEndpointClaimScope::DiagnosticOnly => "diagnostic_only",
+        NetworkEndpointClaimScope::PeerSet => "peer_set",
     }
 }
 

--- a/crates/assay-runner-core/src/kernel/tests.rs
+++ b/crates/assay-runner-core/src/kernel/tests.rs
@@ -514,11 +514,11 @@ fn ringbuf_drop_delta_marks_partial_health_when_applied() {
     assert_eq!(archive.observation_health.ringbuf_drops, 4);
     assert_eq!(
         archive.observation_health.network_protocol_coverage,
-        NetworkProtocolCoverageStatus::ConnectOnly
+        NetworkProtocolCoverageStatus::Unknown
     );
     assert_eq!(
         archive.observation_health.network_endpoint_claim_scope,
-        NetworkEndpointClaimScope::DiagnosticOnly
+        NetworkEndpointClaimScope::Unknown
     );
     archive.observation_health.validate().unwrap();
 }
@@ -549,17 +549,54 @@ fn clean_capture_can_mark_kernel_complete() {
     );
     assert_eq!(
         archive.observation_health.network_protocol_coverage,
-        NetworkProtocolCoverageStatus::ConnectOnly
+        NetworkProtocolCoverageStatus::Absent
     );
     assert_eq!(
         archive.observation_health.network_endpoint_claim_scope,
-        NetworkEndpointClaimScope::DiagnosticOnly
+        NetworkEndpointClaimScope::NotApplicable
     );
     assert!(archive
         .observation_health
         .notes
         .iter()
-        .any(|note| note.contains("network_protocol_coverage=connect_only")));
+        .any(|note| note.contains("network_protocol_coverage=absent")
+            && note.contains("network_endpoint_claim_scope=not_applicable")));
+}
+
+#[test]
+fn network_hook_drop_without_network_emit_marks_unknown_coverage() {
+    let before = MonitorStatsSnapshot::default();
+    let after = MonitorStatsSnapshot {
+        connect_ringbuf_dropped: 1,
+        ..Default::default()
+    };
+    let capture = KernelLayerBuilder::new("run_001")
+        .unwrap()
+        .finish(&before, &after);
+    let mut archive = RunnerSpikeArchive::empty("run_001", "linux");
+
+    capture
+        .apply_to_archive(&mut archive, CgroupCorrelationStatus::Clean)
+        .unwrap();
+
+    assert_eq!(
+        archive.observation_health.kernel_layer,
+        KernelLayerStatus::Complete
+    );
+    assert_eq!(
+        archive.observation_health.network_protocol_coverage,
+        NetworkProtocolCoverageStatus::Unknown
+    );
+    assert_eq!(
+        archive.observation_health.network_endpoint_claim_scope,
+        NetworkEndpointClaimScope::Unknown
+    );
+    assert!(archive
+        .observation_health
+        .notes
+        .iter()
+        .any(|note| note.contains("network_protocol_coverage=unknown")
+            && note.contains("network_endpoint_claim_scope=unknown")));
 }
 
 #[test]

--- a/docs/reference/runner/artifacts-v0.md
+++ b/docs/reference/runner/artifacts-v0.md
@@ -206,6 +206,11 @@ Interpretation rules:
 
 - `kernel_layer=complete` means capture health was clean for the attached hooks;
   it does not, by itself, prove protocol-complete network coverage.
+- `network_protocol_coverage=absent` means Runner observed no network protocol
+  events in the capture window. It is not a positive network coverage claim.
+- `network_protocol_coverage=unknown` means network protocol coverage cannot be
+  interpreted, for example because relevant network hook events may have been
+  dropped.
 - `network_protocol_coverage=connect_only` means Runner observed
   `connect()`-level network evidence only.
 - `network_protocol_coverage=datagram_peer_observed` means Runner observed
@@ -217,6 +222,10 @@ Interpretation rules:
 - `network_endpoint_claim_scope=diagnostic_only` means `network_endpoints`
   are useful for coarse/diagnostic review, not for exact peer-set claims on
   datagram protocols such as QUIC.
+- `network_endpoint_claim_scope=not_applicable` means no network endpoint claim
+  is available for this run.
+- `network_endpoint_claim_scope=unknown` means no bounded endpoint claim should
+  be inferred because network coverage is not interpretable.
 - Datagram peer evidence is stronger than `connect_only` for QUIC-style
   capture, but v0 still keeps `network_endpoint_claim_scope=diagnostic_only`
   unless a future layer can make a bounded exact peer-set claim.

--- a/docs/reference/runner/fidelity-verdict-v0.md
+++ b/docs/reference/runner/fidelity-verdict-v0.md
@@ -97,14 +97,18 @@ events cannot prove absence. This is why `clipped` degrades positive
 measured claims but blocks bounded negative claims.
 
 `clean` is capture-health clean, not protocol-universal. A record may be
-`clean` while still declaring `network_protocol_coverage = connect_only`
-and `network_endpoint_claim_scope = diagnostic_only`. Downstream code
-must not stretch that into an exact QUIC/datagram peer-set claim.
-When Runner observes `sendto` or `sendmsg` destination sockaddr events it
-may upgrade `network_protocol_coverage` to `datagram_peer_observed` or
+`clean` while still declaring `network_protocol_coverage = absent` and
+`network_endpoint_claim_scope = not_applicable` when no network protocol
+events were observed. A record with observed connect activity may instead
+declare `network_protocol_coverage = connect_only` and
+`network_endpoint_claim_scope = diagnostic_only`; downstream code must not
+stretch that into an exact QUIC/datagram peer-set claim. When Runner observes
+`sendto` or `sendmsg` destination sockaddr events it may upgrade
+`network_protocol_coverage` to `datagram_peer_observed` or
 `connect_and_datagram_peer_observed`; that is a stronger transport signal,
 but still not a request-level or exact peer-set binding while
-`network_endpoint_claim_scope = diagnostic_only`.
+`network_endpoint_claim_scope = diagnostic_only`. If network events may have
+been dropped before any network event was emitted, coverage is `unknown`.
 
 ## Composition With Projection `claim_level`
 


### PR DESCRIPTION
## Summary
- split empty network observations from `connect_only`: zero connect/sendto/sendmsg events now report `network_protocol_coverage=absent`
- derive `network_endpoint_claim_scope` from the network coverage status so absent coverage becomes `not_applicable` and uninterpretable coverage becomes `unknown`
- keep partial/drop cases honest: if no network event was emitted but network hook drops or partial kernel drops leave ambiguity, coverage is `unknown`
- update runner reference docs for `absent`, `unknown`, and endpoint claim scope semantics

## Verification
- RED first: `cargo test -p assay-runner-core kernel::tests` failed on `clean_capture_can_mark_kernel_complete` and `network_hook_drop_without_network_emit_marks_unknown_coverage` before the fix
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p assay-runner-core`
- `cargo test -p assay-runner-schema`
- `cargo clippy -p assay-runner-core --all-targets -- -D warnings`
- `cargo clippy -p assay-runner-schema --all-targets -- -D warnings`

Note: the workspace-wide pre-push clippy hook timed out during a cold build, then appeared to hang after retry. I ran targeted clippy for the changed Rust packages successfully and pushed with only the timeout-prone workspace clippy hook skipped; the remaining pre-push hooks, including the Linux compile gate, passed.

Closes #1560