### PR TITLE
feat(runner): evidence redaction at capture (ADR-034 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Runner evidence redaction at capture (ADR-034, Phase 1). The runner-spike run now redacts
+  secret-shaped values (provider tokens, PEM keys, JWTs, bearer tokens, `key=value` credentials, and
+  flag values such as `--token X`) out of argv and the capability surface before the bundle is
+  serialized, hashed, or signed, replacing each with a value-free `<redacted:RULE:H8>` placeholder
+  keyed by an installation-local key. `observation_health` gains an additive, value-free `redaction`
+  block (mode, counts by rule and field, `key_scope`, `key_id`). A fail-closed assertion sweep aborts
+  bundle creation if a secret-shaped value survives. Redaction is on by default; it can be disabled
+  only with the deliberately named `--unsafe-disable-redaction` (recorded as `disabled_unsafe`). The
+  redaction key resolves from `ASSAY_REDACTION_KEY_FILE`, else a generated host-local key file, else
+  `--redaction-key ephemeral`. Note: default-on redaction changes the recorded bytes of bundles that
+  contained secret-shaped values; clean bundles are byte-identical and all existing bundles remain
+  valid. This is a runner behavior change and should ship with a minor version bump.
+
 ## [3.19.1] - 2026-06-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "assay-runner-schema",
  "flate2",
  "hex",
+ "regex",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/assay-cli/src/cli/commands/runner_spike.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike.rs
@@ -6,6 +6,7 @@ mod exit_status;
 mod implementation;
 mod logs;
 mod phases;
+mod redaction;
 mod spec;
 
 #[allow(unused_imports)]

--- a/crates/assay-cli/src/cli/commands/runner_spike/args.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike/args.rs
@@ -1,5 +1,28 @@
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use std::path::PathBuf;
+
+/// Redaction mode for evidence captured by this run (ADR-034).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
+#[value(rename_all = "snake_case")]
+pub enum RedactArg {
+    /// Curated shape rules plus flag-aware argv value redaction (default).
+    #[default]
+    ShapeAndFlag,
+    /// Curated shape rules only.
+    ShapeOnly,
+}
+
+/// Where the redaction key (placeholder salt) comes from (ADR-034).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
+#[value(rename_all = "kebab-case")]
+pub enum RedactionKeyArg {
+    /// Runner-local key file (ASSAY_REDACTION_KEY_FILE env, else the default host path, generated
+    /// once). Tokens correlate across runs on the same host (default).
+    #[default]
+    HostLocal,
+    /// In-memory throwaway key, never persisted. Tokens do not correlate with any other run.
+    Ephemeral,
+}
 
 #[derive(Debug, Clone, Args)]
 pub struct RunnerSpikeArgs {
@@ -50,6 +73,20 @@ pub struct RunnerSpikeRunArgs {
     /// Hidden overhead experiment path: write runner phase timing diagnostics.
     #[arg(long, hide = true)]
     pub phase_timing_log: Option<PathBuf>,
+
+    /// Evidence redaction mode (ADR-034). Secret-shaped values in argv and the capability surface are
+    /// replaced with a value-free placeholder before the bundle is hashed.
+    #[arg(long, value_enum, default_value_t = RedactArg::ShapeAndFlag)]
+    pub redact: RedactArg,
+
+    /// Where the redaction key comes from. host-local persists a per-host key; ephemeral is throwaway.
+    #[arg(long, value_enum, default_value_t = RedactionKeyArg::HostLocal)]
+    pub redaction_key: RedactionKeyArg,
+
+    /// DANGER: write raw, un-redacted evidence. The bundle may contain credentials and must not be
+    /// shared or retained. Recorded in observation_health as disabled_unsafe.
+    #[arg(long)]
+    pub unsafe_disable_redaction: bool,
 
     /// Command to run.
     #[arg(allow_hyphen_values = true, required = true, trailing_var_arg = true)]

--- a/crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike/cgroup.rs
@@ -248,6 +248,8 @@ pub(super) async fn cmd_run_with_kernel_capture(args: RunnerSpikeRunArgs) -> any
     spec.append_run_finished(&mut archive, 1, &status, clock.elapsed())?;
     record_phase(&mut phases, "event_flush_ms", event_flush_start);
 
+    // Redact secret-shaped values and run the fail-closed sweep before writing (and hashing).
+    super::redaction::finalize_redaction(&args, &mut archive)?;
     let archive_write_start = Instant::now();
     let mut file = File::create(&output)?;
     archive.write(&mut file)?;

--- a/crates/assay-cli/src/cli/commands/runner_spike/implementation.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike/implementation.rs
@@ -26,6 +26,8 @@ fn cmd_run_contract_only(args: RunnerSpikeRunArgs) -> anyhow::Result<i32> {
 
     let mut outcome = spec.run_contract_only()?;
     apply_policy_then_sdk_logs_if_requested(&spec, &args, &mut outcome.archive)?;
+    // Redact secret-shaped values and run the fail-closed sweep before writing (and hashing).
+    super::redaction::finalize_redaction(&args, &mut outcome.archive)?;
     let mut file = File::create(&output)?;
     outcome.archive.write(&mut file)?;
     let exit_status = exit_status_label(outcome.exit_code, outcome.signal);

--- a/crates/assay-cli/src/cli/commands/runner_spike/redaction.rs
+++ b/crates/assay-cli/src/cli/commands/runner_spike/redaction.rs
@@ -1,0 +1,98 @@
+//! Capture-side redaction finalization for the runner-spike command (ADR-034).
+//!
+//! Order is load-bearing: `capture -> redact -> serialize -> assert clean -> hash/sign`. This runs
+//! after the archive is assembled and BEFORE it is written (which is where the manifest hashes are
+//! computed), so a raw secret never reaches the serialized bytes, the hash input, or the signature.
+//!
+//! The assertion sweep only asserts: if a secret-shaped value survives, bundle creation fails hard
+//! (the caller propagates the error to a non-zero exit). It never rewrites bytes, so a missed capture
+//! funnel is surfaced as a bug rather than silently patched. No raw value is ever placed in an error,
+//! a log line, or the health block.
+
+use std::path::PathBuf;
+
+use assay_runner_core::{RedactMode, RedactionKey, Redactor, RunnerSpikeArchive, ENV_KEY_FILE};
+use assay_runner_schema::Redaction;
+
+use super::args::{RedactArg, RedactionKeyArg, RunnerSpikeRunArgs};
+
+/// Redact the assembled archive in place, record the value-free `observation_health.redaction`
+/// summary, and run the fail-closed assertion sweep. Must be called before the archive is written.
+pub(super) fn finalize_redaction(
+    args: &RunnerSpikeRunArgs,
+    archive: &mut RunnerSpikeArchive,
+) -> anyhow::Result<()> {
+    if args.unsafe_disable_redaction {
+        eprintln!(
+            "WARNING: --unsafe-disable-redaction is set. This bundle may contain raw credentials in \
+             argv, filesystem paths, or tool names. Do not share or retain it."
+        );
+        archive.observation_health.redaction = Some(Redaction {
+            mode: "disabled_unsafe".to_string(),
+            redacted_count: 0,
+            by_rule: Default::default(),
+            by_field: Default::default(),
+            key_scope: "ephemeral".to_string(),
+            key_id: "none".to_string(),
+        });
+        return Ok(());
+    }
+
+    let mode = match args.redact {
+        RedactArg::ShapeAndFlag => RedactMode::ShapeAndFlag,
+        RedactArg::ShapeOnly => RedactMode::ShapeOnly,
+    };
+    let key = resolve_key(args)?;
+    let redactor = Redactor::new(mode, key.salt(), Vec::new());
+
+    let tally = archive.redact_in_place(&redactor);
+    archive.observation_health.redaction = Some(Redaction {
+        mode: mode.as_health_str().to_string(),
+        redacted_count: tally.total,
+        by_rule: tally.by_rule,
+        by_field: tally.by_field,
+        key_scope: key.scope().as_str().to_string(),
+        key_id: key.key_id().to_string(),
+    });
+
+    // Hard fail-closed: a surviving secret-shaped value aborts bundle creation.
+    archive.assert_no_unredacted(&redactor)?;
+    Ok(())
+}
+
+fn resolve_key(args: &RunnerSpikeRunArgs) -> anyhow::Result<RedactionKey> {
+    match args.redaction_key {
+        RedactionKeyArg::Ephemeral => {
+            eprintln!(
+                "WARNING: --redaction-key ephemeral. Redaction tokens in this bundle do not correlate \
+                 with any other run."
+            );
+            Ok(RedactionKey::ephemeral())
+        }
+        RedactionKeyArg::HostLocal => {
+            let env = std::env::var_os(ENV_KEY_FILE).map(PathBuf::from);
+            match RedactionKey::resolve_host_local(env.as_deref(), &default_key_path()) {
+                Ok(key) => Ok(key),
+                // System path not writable and no explicit env override: fall back to a user-mode path.
+                Err(_) if env.is_none() => {
+                    Ok(RedactionKey::resolve_host_local(None, &user_key_path())?)
+                }
+                Err(err) => Err(err.into()),
+            }
+        }
+    }
+}
+
+fn default_key_path() -> PathBuf {
+    PathBuf::from("/var/lib/assay/redaction.key")
+}
+
+fn user_key_path() -> PathBuf {
+    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+        PathBuf::from(xdg).join("assay/redaction.key")
+    } else if let Some(home) = std::env::var_os("HOME") {
+        PathBuf::from(home).join(".local/share/assay/redaction.key")
+    } else {
+        std::env::temp_dir().join("assay/redaction.key")
+    }
+}

--- a/crates/assay-runner-core/Cargo.toml
+++ b/crates/assay-runner-core/Cargo.toml
@@ -14,6 +14,7 @@ assay-monitor = { workspace = true }
 assay-runner-schema = { workspace = true }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
+regex = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/assay-runner-core/src/archive.rs
+++ b/crates/assay-runner-core/src/archive.rs
@@ -1,3 +1,4 @@
+use crate::redact::{RedactionTally, Redactor};
 use assay_runner_schema::{
     ArchiveFile, ArchiveManifest, CapabilitySurface, CapabilitySurfaceError, CorrelationReport,
     CorrelationReportError, ObservationHealth, ObservationHealthError, ARCHIVE_MANIFEST_SCHEMA,
@@ -6,8 +7,9 @@ use assay_runner_schema::{
 };
 use flate2::write::GzEncoder;
 use flate2::{Compression, GzBuilder};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use tar::{Builder, Header};
 use thiserror::Error;
@@ -44,6 +46,14 @@ pub enum RunnerSpikeArchiveError {
     Json(#[from] serde_json::Error),
     #[error("archive io failed: {0}")]
     Io(#[from] std::io::Error),
+    #[error(
+        "fail-closed redaction sweep found an unredacted {rule}-shaped value in {file}; \
+         a capture funnel was missed (runner bug)"
+    )]
+    UnredactedSecret {
+        rule: &'static str,
+        file: &'static str,
+    },
 }
 
 impl RunnerSpikeArchive {
@@ -142,6 +152,191 @@ impl RunnerSpikeArchive {
             ArchiveFileContent::Owned(serde_json::to_vec(&self.correlation_report)?),
         );
         Ok(files)
+    }
+
+    /// Redact secret-shaped values across the in-memory archive (ADR-034), before any hashing or
+    /// serialization to disk. Rewrites the capability surface string sets and the structured JSON of
+    /// the event/kernel/policy/sdk ndjson streams (a clean line is left byte-identical; only a line
+    /// carrying a secret is reparsed and re-emitted). Returns the value-free tally for the
+    /// `observation_health.redaction` block. The raw value never reaches a hashed or stored artifact.
+    pub fn redact_in_place(&mut self, redactor: &Redactor) -> RedactionTally {
+        let mut tally = RedactionTally::default();
+        redact_set(
+            &mut self.capability_surface.filesystem_paths,
+            "filesystem_paths",
+            redactor,
+            &mut tally,
+        );
+        redact_set(
+            &mut self.capability_surface.network_endpoints,
+            "network_endpoints",
+            redactor,
+            &mut tally,
+        );
+        redact_command_set(
+            &mut self.capability_surface.process_execs,
+            "process_execs",
+            redactor,
+            &mut tally,
+        );
+        redact_set(
+            &mut self.capability_surface.mcp_tools,
+            "mcp_tools",
+            redactor,
+            &mut tally,
+        );
+        redact_set(
+            &mut self.capability_surface.policy_decisions,
+            "policy_decisions",
+            redactor,
+            &mut tally,
+        );
+        self.events_ndjson = redact_ndjson(&self.events_ndjson, redactor, &mut tally);
+        self.kernel_layer_ndjson = redact_ndjson(&self.kernel_layer_ndjson, redactor, &mut tally);
+        self.policy_layer_ndjson = redact_ndjson(&self.policy_layer_ndjson, redactor, &mut tally);
+        self.sdk_layer_ndjson = redact_ndjson(&self.sdk_layer_ndjson, redactor, &mut tally);
+        tally
+    }
+
+    /// Fail-closed assertion sweep (ADR-034): after redaction, no archive file may still carry a
+    /// secret-shaped value. This never rewrites bytes; it asserts. A hit means a capture funnel was
+    /// missed, so bundle creation must fail rather than ship a raw secret. Runs before hashing.
+    pub fn assert_no_unredacted(&self, redactor: &Redactor) -> Result<(), RunnerSpikeArchiveError> {
+        let files = self.archive_files()?;
+        for (path, content) in &files {
+            let text = String::from_utf8_lossy(content.as_slice());
+            if let Some(rule) = redactor.find_unredacted(&text) {
+                return Err(RunnerSpikeArchiveError::UnredactedSecret { rule, file: path });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn redact_set(
+    set: &mut BTreeSet<String>,
+    field: &str,
+    redactor: &Redactor,
+    tally: &mut RedactionTally,
+) {
+    let redacted: BTreeSet<String> = set
+        .iter()
+        .map(|v| redactor.redact_value(field, v, tally).into_owned())
+        .collect();
+    *set = redacted;
+}
+
+/// A process-exec value can be a full invocation (`python script.py --token X`), so it gets the
+/// flag-aware argv treatment, not just a shape pass. Tokenized on whitespace; a value that changed is
+/// rejoined with single spaces (process-exec strings are heuristic capture, exact spacing is not
+/// load-bearing), a clean value is left exactly as is.
+fn redact_command_set(
+    set: &mut BTreeSet<String>,
+    field: &str,
+    redactor: &Redactor,
+    tally: &mut RedactionTally,
+) {
+    let redacted: BTreeSet<String> = set
+        .iter()
+        .map(|v| {
+            let argv: Vec<String> = v.split_whitespace().map(str::to_string).collect();
+            if argv.is_empty() {
+                return v.clone();
+            }
+            let before = tally.total;
+            let out = redactor.redact_argv(field, &argv, tally);
+            if tally.total > before {
+                out.join(" ")
+            } else {
+                v.clone()
+            }
+        })
+        .collect();
+    *set = redacted;
+}
+
+fn redact_ndjson(bytes: &[u8], redactor: &Redactor, tally: &mut RedactionTally) -> Vec<u8> {
+    if bytes.is_empty() {
+        return Vec::new();
+    }
+    let text = String::from_utf8_lossy(bytes);
+    let mut out = String::with_capacity(text.len());
+    for segment in text.split_inclusive('\n') {
+        let (content, newline) = match segment.strip_suffix('\n') {
+            Some(c) => (c, "\n"),
+            None => (segment, ""),
+        };
+        if content.trim().is_empty() {
+            out.push_str(segment);
+            continue;
+        }
+        match serde_json::from_str::<Value>(content) {
+            Ok(mut value) => {
+                let before = tally.total;
+                redact_json_value("", &mut value, redactor, tally);
+                if tally.total > before {
+                    // Only a line that actually carried a secret is re-emitted.
+                    match serde_json::to_string(&value) {
+                        Ok(s) => {
+                            out.push_str(&s);
+                            out.push_str(newline);
+                        }
+                        Err(_) => out.push_str(segment),
+                    }
+                } else {
+                    out.push_str(segment);
+                }
+            }
+            // Non-JSON line (should not happen for these streams): leave untouched. The assertion
+            // sweep is the backstop if a raw secret somehow survives here.
+            Err(_) => out.push_str(segment),
+        }
+    }
+    out.into_bytes()
+}
+
+fn redact_json_value(
+    field: &str,
+    value: &mut Value,
+    redactor: &Redactor,
+    tally: &mut RedactionTally,
+) {
+    match value {
+        Value::String(s) => {
+            let owned = match redactor.redact_value(field, s, tally) {
+                std::borrow::Cow::Borrowed(_) => None,
+                std::borrow::Cow::Owned(o) => Some(o),
+            };
+            if let Some(o) = owned {
+                *s = o;
+            }
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                redact_json_value(field, item, redactor, tally);
+            }
+        }
+        Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                // An argv array ("command") gets the flag-aware treatment, so a value following a
+                // credential flag is redacted even when it is not shape-matchable.
+                if key == "command" {
+                    if let Value::Array(items) = val {
+                        if !items.is_empty() && items.iter().all(Value::is_string) {
+                            let argv: Vec<String> = items
+                                .iter()
+                                .map(|i| i.as_str().unwrap_or_default().to_string())
+                                .collect();
+                            let redacted = redactor.redact_argv("command", &argv, tally);
+                            *val = Value::Array(redacted.into_iter().map(Value::String).collect());
+                            continue;
+                        }
+                    }
+                }
+                redact_json_value(key, val, redactor, tally);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/assay-runner-core/src/lib.rs
+++ b/crates/assay-runner-core/src/lib.rs
@@ -17,6 +17,8 @@ mod archive;
 mod kernel;
 mod path_projection;
 mod policy;
+mod redact;
+mod redaction_key;
 mod run;
 mod sdk;
 
@@ -27,5 +29,7 @@ pub use path_projection::{
     PathProjectionMapping, UnmatchedPathSummary, PATH_PROJECTION_SCHEMA,
 };
 pub use policy::{PolicyLayerCapture, PolicyLayerError, PolicyLayerEvent, POLICY_EVENT_SCHEMA};
+pub use redact::{RedactMode, RedactionTally, Redactor};
+pub use redaction_key::{KeyScope, RedactionKey, ENV_KEY_FILE, KEY_FILE_PREFIX};
 pub use run::{RunExecutionError, RunOutcome, RunSpec, RunSpecError, RUN_EVENT_SCHEMA};
 pub use sdk::{SdkLayerCapture, SdkLayerError};

--- a/crates/assay-runner-core/src/redact.rs
+++ b/crates/assay-runner-core/src/redact.rs
@@ -1,0 +1,538 @@
+//! Evidence redaction at capture (ADR-034).
+//!
+//! Keeps secret-shaped values out of an evidence bundle at the capture boundary, before the archive
+//! is hashed and signed, rather than detecting them after they are already persisted. This is the
+//! runner-side companion to the consumer-side detector.
+//!
+//! Design notes (see ADR-034):
+//! - Curated provider/structural rules, shared vocabulary with the Plimsoll detector. No generic
+//!   entropy rule (digests, UUIDs, and signatures are legitimately high-entropy).
+//! - A matched span is replaced by `<redacted:RULE:H8>` where `H8` is the first 8 hex chars of
+//!   `HMAC-SHA256(installation_secret, value)`. Deterministic and replay-stable, stable within an
+//!   installation (so secret reuse stays visible across runs), and not reversible.
+//! - The runner records rule + count only, never the matched value and never its length.
+//! - Redaction is a pure transform; it must run before hashing/signing.
+
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
+use regex::Regex;
+use sha2::{Digest, Sha256};
+
+/// Redaction mode. Controls how aggressively values are scrubbed at capture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedactMode {
+    /// Default: shape rules plus flag-aware argv value redaction.
+    ShapeAndFlag,
+    /// Shape rules only (no flag-aware argv value redaction).
+    ShapeOnly,
+    /// Redaction disabled. Only reachable via `--unsafe-disable-redaction`; the bundle may carry
+    /// raw credentials. Recorded in observation_health so a reviewer can see it was not sanitized.
+    DisabledUnsafe,
+}
+
+impl RedactMode {
+    /// The string written into `observation_health.redaction.mode`.
+    pub fn as_health_str(self) -> &'static str {
+        match self {
+            RedactMode::ShapeAndFlag => "shape_and_flag",
+            RedactMode::ShapeOnly => "shape_only",
+            RedactMode::DisabledUnsafe => "disabled_unsafe",
+        }
+    }
+
+    fn is_active(self) -> bool {
+        !matches!(self, RedactMode::DisabledUnsafe)
+    }
+}
+
+/// Value-free running totals of what was redacted, for `observation_health.redaction`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RedactionTally {
+    pub total: u64,
+    pub by_rule: BTreeMap<String, u64>,
+    pub by_field: BTreeMap<String, u64>,
+}
+
+impl RedactionTally {
+    fn record(&mut self, field: &str, rule: &str) {
+        self.total += 1;
+        *self.by_rule.entry(rule.to_string()).or_insert(0) += 1;
+        *self.by_field.entry(field.to_string()).or_insert(0) += 1;
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total == 0
+    }
+}
+
+/// Argv flag names whose following value is a credential regardless of shape (so a short password,
+/// which no shape rule would catch, is still redacted). Case-insensitive compare.
+const CRED_FLAGS: &[&str] = &[
+    "--token",
+    "--api-key",
+    "--apikey",
+    "--api_key",
+    "--key",
+    "--secret",
+    "--client-secret",
+    "--password",
+    "--passwd",
+    "--pass",
+    "-p",
+    "--access-key",
+    "--access-token",
+    "--auth",
+    "--authorization",
+    "--bearer",
+];
+
+/// One curated rule: a name (shared with the Plimsoll detector) and a compiled pattern.
+struct Rule {
+    name: &'static str,
+    re: Regex,
+}
+
+/// The capture-boundary redactor. Constructed once per run.
+pub struct Redactor {
+    mode: RedactMode,
+    rules: Vec<Rule>,
+    allow: Vec<Regex>,
+    salt: Vec<u8>,
+}
+
+impl Redactor {
+    /// Build a redactor. `salt` is the installation/org secret used to key the placeholder hash;
+    /// `allow` are regexes for known-safe values that should never be redacted (false-positive
+    /// suppression). The rule patterns are fixed and shared with the Plimsoll detector.
+    pub fn new(mode: RedactMode, salt: &[u8], allow: Vec<Regex>) -> Self {
+        Self {
+            mode,
+            rules: build_rules(),
+            allow,
+            salt: salt.to_vec(),
+        }
+    }
+
+    pub fn mode(&self) -> RedactMode {
+        self.mode
+    }
+
+    fn is_allowlisted(&self, value: &str) -> bool {
+        self.allow.iter().any(|re| re.is_match(value))
+    }
+
+    fn placeholder(&self, rule: &str, matched: &str) -> String {
+        let mac = hmac_sha256(&self.salt, matched.as_bytes());
+        let h8 = hex::encode(&mac[..4]);
+        format!("<redacted:{rule}:{h8}>")
+    }
+
+    /// Redact secret-shaped spans in a free-form value (a path, endpoint, tool name, decision).
+    /// Returns the (possibly unchanged) value and records any hits in `tally`.
+    pub fn redact_value<'a>(
+        &self,
+        field: &str,
+        input: &'a str,
+        tally: &mut RedactionTally,
+    ) -> Cow<'a, str> {
+        if !self.mode.is_active() {
+            return Cow::Borrowed(input);
+        }
+        self.shape_pass(field, input, tally)
+    }
+
+    /// Redact an argv vector: flag-aware (a value following a known credential flag is redacted
+    /// regardless of shape, in `ShapeAndFlag` mode) plus a shape pass on every token. `argv[0]` is
+    /// treated as a binary path (shape pass only, never as a flag value).
+    pub fn redact_argv(
+        &self,
+        field: &str,
+        argv: &[String],
+        tally: &mut RedactionTally,
+    ) -> Vec<String> {
+        if !self.mode.is_active() {
+            return argv.to_vec();
+        }
+        let flag_aware = matches!(self.mode, RedactMode::ShapeAndFlag);
+        let mut out = Vec::with_capacity(argv.len());
+        let mut redact_next_as_value = false;
+        for (idx, token) in argv.iter().enumerate() {
+            if redact_next_as_value {
+                redact_next_as_value = false;
+                if !self.is_allowlisted(token) {
+                    tally.record(field, "credential-flag-value");
+                    out.push(self.placeholder("credential-flag-value", token));
+                    continue;
+                }
+            }
+
+            // `--flag=value` inline form: redact the value half regardless of shape.
+            if flag_aware && idx > 0 {
+                if let Some((flag, value)) = token.split_once('=') {
+                    if is_cred_flag(flag) && !value.is_empty() && !self.is_allowlisted(token) {
+                        tally.record(field, "credential-flag-value");
+                        out.push(format!(
+                            "{flag}={}",
+                            self.placeholder("credential-flag-value", value)
+                        ));
+                        continue;
+                    }
+                }
+                if is_cred_flag(token) {
+                    // The credential value is the next token.
+                    redact_next_as_value = true;
+                    out.push(token.clone());
+                    continue;
+                }
+            }
+
+            out.push(self.shape_pass(field, token, tally).into_owned());
+        }
+        out
+    }
+
+    fn shape_pass<'a>(
+        &self,
+        field: &str,
+        input: &'a str,
+        tally: &mut RedactionTally,
+    ) -> Cow<'a, str> {
+        if self.is_allowlisted(input) {
+            return Cow::Borrowed(input);
+        }
+        // Single left-to-right scan: at each position take the earliest match across all rules
+        // (longest on a tie), emit prefix + placeholder, and advance PAST the matched span in the
+        // original input. Emitted placeholders are never re-scanned. Existing `<redacted:...>`
+        // placeholders already present in the input are copied through untouched, so the pass is
+        // idempotent (re-running over redacted text is a no-op) and a placeholder's internal text
+        // (e.g. the word "token" in a rule name) cannot trip a later rule.
+        let placeholders: Vec<(usize, usize)> = placeholder_re()
+            .find_iter(input)
+            .map(|m| (m.start(), m.end()))
+            .collect();
+        let placeholder_end_at = |p: usize| -> Option<usize> {
+            placeholders
+                .iter()
+                .find(|(s, e)| p >= *s && p < *e)
+                .map(|(_, e)| *e)
+        };
+
+        let mut out = String::new();
+        let mut pos = 0usize;
+        let mut changed = false;
+        while pos <= input.len() {
+            let mut best: Option<(usize, usize, &'static str)> = None;
+            for rule in &self.rules {
+                if let Some(m) = rule.re.find_at(input, pos) {
+                    let cand = (m.start(), m.end(), rule.name);
+                    best = match best {
+                        None => Some(cand),
+                        Some(b) if cand.0 < b.0 || (cand.0 == b.0 && cand.1 > b.1) => Some(cand),
+                        Some(b) => Some(b),
+                    };
+                }
+            }
+            match best {
+                Some((start, end, name)) => {
+                    // If the match begins inside an existing placeholder, copy through the
+                    // placeholder untouched and keep scanning after it.
+                    if let Some(ph_end) = placeholder_end_at(start) {
+                        out.push_str(&input[pos..ph_end]);
+                        pos = ph_end;
+                        continue;
+                    }
+                    let matched = &input[start..end];
+                    if self.is_allowlisted(matched) {
+                        // Leave this span as is and continue scanning after it.
+                        out.push_str(&input[pos..end]);
+                        pos = end;
+                        continue;
+                    }
+                    out.push_str(&input[pos..start]);
+                    out.push_str(&self.placeholder(name, matched));
+                    tally.record(field, name);
+                    changed = true;
+                    pos = end;
+                }
+                None => {
+                    out.push_str(&input[pos..]);
+                    break;
+                }
+            }
+        }
+        if changed {
+            Cow::Owned(out)
+        } else {
+            Cow::Borrowed(input)
+        }
+    }
+
+    /// Backstop for the fail-closed assertion sweep: returns the first rule name that still matches
+    /// a non-allowlisted span in `text` (i.e. an unredacted secret slipped through a capture funnel).
+    /// `None` means clean. Already-emitted `<redacted:...>` placeholders are stripped before scanning,
+    /// so a correctly redacted value is never mistaken for an unredacted one.
+    pub fn find_unredacted(&self, text: &str) -> Option<&'static str> {
+        let stripped = placeholder_re().replace_all(text, " ");
+        for rule in &self.rules {
+            for m in rule.re.find_iter(&stripped) {
+                if !self.is_allowlisted(m.as_str()) {
+                    return Some(rule.name);
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Matches an emitted redaction placeholder `<redacted:RULE:H8>`.
+fn placeholder_re() -> &'static Regex {
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"<redacted:[a-z-]+:[0-9a-f]{8}>").expect("placeholder pattern must compile")
+    })
+}
+
+fn is_cred_flag(flag: &str) -> bool {
+    CRED_FLAGS.iter().any(|f| f.eq_ignore_ascii_case(flag))
+}
+
+/// The curated rule set. Shared vocabulary with the Plimsoll detector (`secret-rules.v1`).
+fn build_rules() -> Vec<Rule> {
+    // (name, pattern). Order matters only for which placeholder wins on overlap; provider tokens
+    // first, the broad credential-assignment rule last.
+    let specs: &[(&str, &str)] = &[
+        ("aws-access-key-id", r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"),
+        ("github-token", r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"),
+        ("openai-key", r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b"),
+        ("slack-token", r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+        ("google-api-key", r"\bAIza[0-9A-Za-z_-]{35}\b"),
+        ("stripe-key", r"\b[sp]k_(?:live|test)_[0-9A-Za-z]{16,}\b"),
+        ("private-key-pem", r"-----BEGIN (?:[A-Z ]*)PRIVATE KEY-----"),
+        (
+            "jwt",
+            r"\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b",
+        ),
+        ("bearer-token", r"(?i)\bbearer\s+[A-Za-z0-9._~+/-]{20,}=*"),
+        (
+            "credential-assignment",
+            r#"(?i)\b(?:api[_-]?key|secret|token|password|passwd|access[_-]?key|client[_-]?secret)\b\s*[=:]\s*[^\s'"]{6,}"#,
+        ),
+    ];
+    specs
+        .iter()
+        .map(|(name, pat)| Rule {
+            name,
+            re: Regex::new(pat).expect("static redaction pattern must compile"),
+        })
+        .collect()
+}
+
+/// HMAC-SHA256 on top of the already-vendored `sha2` crate (avoids a new dependency for a single
+/// keyed hash). Standard construction; used only as a non-reversible redaction salt and key id.
+pub(crate) fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
+    const BLOCK: usize = 64;
+    let mut k = [0u8; BLOCK];
+    if key.len() > BLOCK {
+        let digest = Sha256::digest(key);
+        k[..32].copy_from_slice(&digest);
+    } else {
+        k[..key.len()].copy_from_slice(key);
+    }
+    let mut ipad = [0x36u8; BLOCK];
+    let mut opad = [0x5cu8; BLOCK];
+    for i in 0..BLOCK {
+        ipad[i] ^= k[i];
+        opad[i] ^= k[i];
+    }
+    let mut inner = Sha256::new();
+    inner.update(ipad);
+    inner.update(msg);
+    let inner_digest = inner.finalize();
+    let mut outer = Sha256::new();
+    outer.update(opad);
+    outer.update(inner_digest);
+    let out = outer.finalize();
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&out);
+    arr
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Secret SHAPES assembled from fragments at runtime, so no whole-token literal is committed and
+    // the repo secret scanner does not flag this test file (same pattern as the Plimsoll tests).
+    fn gh() -> String {
+        format!("gh{}_{}{}", "p", "0123456789abcdef".repeat(2), "0123")
+    }
+    fn aws() -> String {
+        format!("AK{}{}{}", "IA", "IOSFODNN7", "EXAMPLE")
+    }
+    // Weak/synthetic credential strings, assembled at runtime so the repo secret scanner does not
+    // flag this test file.
+    fn pw_short() -> String {
+        format!("{}{}", "hunter2", "short")
+    }
+
+    fn redactor(mode: RedactMode) -> Redactor {
+        Redactor::new(mode, b"installation-secret-key", Vec::new())
+    }
+
+    #[test]
+    fn clean_value_is_borrowed_unchanged() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let out = r.redact_value("filesystem_paths", "/workspace/src/main.py", &mut t);
+        assert_eq!(out, "/workspace/src/main.py");
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn shape_pass_redacts_and_never_echoes_value() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let token = gh();
+        let input = format!("/tmp/cfg/{token}.json");
+        let out = r.redact_value("filesystem_paths", &input, &mut t);
+        assert!(out.contains("<redacted:github-token:"));
+        assert!(!out.contains(&token));
+        assert_eq!(t.total, 1);
+        assert_eq!(t.by_rule.get("github-token"), Some(&1));
+        assert_eq!(t.by_field.get("filesystem_paths"), Some(&1));
+    }
+
+    #[test]
+    fn deterministic_same_secret_same_placeholder() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let token = gh();
+        let mut t = RedactionTally::default();
+        let a = r.redact_value("a", &token, &mut t).into_owned();
+        let b = r.redact_value("b", &token, &mut t).into_owned();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn salt_changes_placeholder() {
+        let token = gh();
+        let mut t = RedactionTally::default();
+        let r1 = Redactor::new(RedactMode::ShapeAndFlag, b"salt-one", Vec::new());
+        let r2 = Redactor::new(RedactMode::ShapeAndFlag, b"salt-two", Vec::new());
+        let a = r1.redact_value("f", &token, &mut t).into_owned();
+        let b = r2.redact_value("f", &token, &mut t).into_owned();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn idempotent_placeholder_not_rematched() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let once = r.redact_value("f", &gh(), &mut t).into_owned();
+        let mut t2 = RedactionTally::default();
+        let twice = r.redact_value("f", &once, &mut t2);
+        assert_eq!(twice, once);
+        assert!(t2.is_empty());
+    }
+
+    #[test]
+    fn argv_flag_aware_redacts_value_token() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let pw = pw_short();
+        let argv = vec!["agent".to_string(), "--password".to_string(), pw.clone()];
+        let out = r.redact_argv("command", &argv, &mut t);
+        assert_eq!(out[0], "agent");
+        assert_eq!(out[1], "--password");
+        assert!(out[2].starts_with("<redacted:credential-flag-value:"));
+        assert!(!out[2].contains(&pw));
+    }
+
+    #[test]
+    fn argv_inline_flag_value_redacted() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let pw = pw_short();
+        let argv = vec!["agent".to_string(), format!("--token={pw}")];
+        let out = r.redact_argv("command", &argv, &mut t);
+        assert!(out[1].starts_with("--token=<redacted:credential-flag-value:"));
+        assert!(!out[1].contains(&pw));
+    }
+
+    #[test]
+    fn argv_zero_is_not_treated_as_flag_value() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        // argv[0] resembling a flag must not consume a value; it is the binary.
+        let argv = vec!["--password".to_string(), "/bin/agent".to_string()];
+        let out = r.redact_argv("command", &argv, &mut t);
+        assert_eq!(out[0], "--password");
+        assert_eq!(out[1], "/bin/agent");
+    }
+
+    #[test]
+    fn shape_only_skips_flag_value() {
+        let r = redactor(RedactMode::ShapeOnly);
+        let mut t = RedactionTally::default();
+        let pw = pw_short();
+        let argv = vec!["agent".to_string(), "--password".to_string(), pw.clone()];
+        let out = r.redact_argv("command", &argv, &mut t);
+        assert_eq!(out[2], pw); // not shape-matchable, and flag-aware is off
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn disabled_unsafe_passes_through() {
+        let r = redactor(RedactMode::DisabledUnsafe);
+        let mut t = RedactionTally::default();
+        let token = gh();
+        let out = r.redact_value("f", &token, &mut t);
+        assert_eq!(out, token);
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn allowlist_suppresses_match() {
+        let token = gh();
+        let allow = vec![Regex::new(&regex::escape(&token)).unwrap()];
+        let r = Redactor::new(RedactMode::ShapeAndFlag, b"k", allow);
+        let mut t = RedactionTally::default();
+        let out = r.redact_value("f", &token, &mut t);
+        assert_eq!(out, token);
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn high_entropy_digest_not_flagged() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let digest = format!("sha256:{}", "a1b2c3d4".repeat(8));
+        let out = r.redact_value("mcp_tools", &digest, &mut t);
+        assert_eq!(out, digest);
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn aws_and_credential_assignment_detected() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let _ = r.redact_value("filesystem_paths", &format!("/etc/{}.conf", aws()), &mut t);
+        let assignment = format!("run --opt password={}{}", "hunter2", "supersecret");
+        let _ = r.redact_value("process_execs", &assignment, &mut t);
+        assert_eq!(t.by_rule.get("aws-access-key-id"), Some(&1));
+        assert_eq!(t.by_rule.get("credential-assignment"), Some(&1));
+    }
+
+    #[test]
+    fn find_unredacted_backstop() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        assert_eq!(r.find_unredacted("/clean/path"), None);
+        assert_eq!(r.find_unredacted(&gh()), Some("github-token"));
+        // a placeholder is clean
+        let mut t = RedactionTally::default();
+        let red = r.redact_value("f", &gh(), &mut t).into_owned();
+        assert_eq!(r.find_unredacted(&red), None);
+    }
+}

--- a/crates/assay-runner-core/src/redaction_key.rs
+++ b/crates/assay-runner-core/src/redaction_key.rs
@@ -1,0 +1,308 @@
+//! Redaction key resolution (ADR-034).
+//!
+//! The redaction placeholder hash is keyed by an installation/org-scoped secret so that the same
+//! credential redacts to the same `<redacted:RULE:H8>` token across runs (reuse stays visible), while
+//! staying non-reversible and not globally correlatable. The key is a runner-local file, generated
+//! once, with an env override for CI/ephemeral runners.
+//!
+//! Resolution order (see `resolve`):
+//! 1. `ASSAY_REDACTION_KEY_FILE` env var, a path to an existing key file.
+//! 2. The default host-local key file, generated once (0600) if absent.
+//! 3. Ephemeral: an in-memory random key, only when explicitly requested. Never persisted.
+//!
+//! The key itself is never written into the bundle and never logged. Evidence records only a
+//! non-reversible `key_id` and the `key_scope`.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use uuid::Uuid;
+
+use crate::redact::hmac_sha256;
+
+/// File content prefix / version tag for a redaction key file.
+pub const KEY_FILE_PREFIX: &str = "assay-redaction-key-v1:";
+/// Env var holding an explicit path to a redaction key file (CI / mounted secret).
+pub const ENV_KEY_FILE: &str = "ASSAY_REDACTION_KEY_FILE";
+
+/// Where a redaction key came from, recorded in `observation_health.redaction.key_scope`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyScope {
+    /// A persisted host-local key file (default path or env-provided). Tokens correlate across runs.
+    HostLocal,
+    /// An in-memory throwaway key. Tokens do not correlate with any other run.
+    Ephemeral,
+}
+
+impl KeyScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            KeyScope::HostLocal => "host_local",
+            KeyScope::Ephemeral => "ephemeral",
+        }
+    }
+}
+
+/// A resolved redaction key: the salt bytes plus the value-free metadata recorded in evidence.
+#[derive(Debug, Clone)]
+pub struct RedactionKey {
+    bytes: Vec<u8>,
+    scope: KeyScope,
+    key_id: String,
+}
+
+impl RedactionKey {
+    fn from_bytes(bytes: Vec<u8>, scope: KeyScope) -> Self {
+        let key_id = compute_key_id(&bytes);
+        Self {
+            bytes,
+            scope,
+            key_id,
+        }
+    }
+
+    /// The salt bytes for the redactor. Never logged, never serialized.
+    pub fn salt(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn scope(&self) -> KeyScope {
+        self.scope
+    }
+
+    /// Non-reversible key id (`hmac-sha256:<8 hex>`), safe to record in evidence. Lets a reviewer tell
+    /// whether two bundles share a redaction domain without ever seeing the key.
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+
+    /// An in-memory ephemeral key (explicit `--redaction-key ephemeral`).
+    pub fn ephemeral() -> Self {
+        Self::from_bytes(generate_key_bytes().to_vec(), KeyScope::Ephemeral)
+    }
+
+    /// Resolve a host-local key: read `ASSAY_REDACTION_KEY_FILE` if set, else read the default path,
+    /// generating and persisting (0600) a fresh key there if it does not yet exist. `env_override` and
+    /// `default_path` are passed in (not read from globals) so this is testable.
+    pub fn resolve_host_local(
+        env_override: Option<&Path>,
+        default_path: &Path,
+    ) -> io::Result<Self> {
+        if let Some(path) = env_override {
+            let bytes = read_key_file(path)?;
+            return Ok(Self::from_bytes(bytes, KeyScope::HostLocal));
+        }
+        if default_path.exists() {
+            let bytes = read_key_file(default_path)?;
+            return Ok(Self::from_bytes(bytes, KeyScope::HostLocal));
+        }
+        let bytes = generate_key_bytes().to_vec();
+        write_key_file(default_path, &bytes)?;
+        Ok(Self::from_bytes(bytes, KeyScope::HostLocal))
+    }
+}
+
+/// 32 random bytes, sourced from two v4 UUIDs (CSPRNG-backed via the already-vendored `uuid` crate,
+/// so no new randomness dependency). Ample entropy for a redaction salt.
+pub fn generate_key_bytes() -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[..16].copy_from_slice(Uuid::new_v4().as_bytes());
+    out[16..].copy_from_slice(Uuid::new_v4().as_bytes());
+    out
+}
+
+fn compute_key_id(bytes: &[u8]) -> String {
+    // Keyed self-digest: HMAC-SHA256(key, fixed label), first 8 hex. Non-reversible.
+    let mac = hmac_sha256(bytes, b"assay-redaction-key-id");
+    format!("hmac-sha256:{}", hex::encode(&mac[..4]))
+}
+
+/// Encode a key file body: `assay-redaction-key-v1:<base64url(bytes)>`.
+pub fn encode_key_file(bytes: &[u8]) -> String {
+    format!("{KEY_FILE_PREFIX}{}", base64url_encode(bytes))
+}
+
+/// Parse a key file body, validating the version prefix.
+pub fn parse_key_file(content: &str) -> io::Result<Vec<u8>> {
+    let trimmed = content.trim();
+    let b64 = trimmed.strip_prefix(KEY_FILE_PREFIX).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "redaction key file missing expected version prefix",
+        )
+    })?;
+    base64url_decode(b64)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "redaction key is not base64url"))
+}
+
+fn read_key_file(path: &Path) -> io::Result<Vec<u8>> {
+    let content = fs::read_to_string(path)?;
+    parse_key_file(&content)
+}
+
+fn write_key_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, encode_key_file(bytes))?;
+    set_owner_only_perms(path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_owner_only_perms(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_perms(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+// --- base64url (URL-safe, no padding). Hand-rolled to avoid a new dependency. ---
+
+const B64URL: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+fn base64url_encode(input: &[u8]) -> String {
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(B64URL[((n >> 18) & 0x3f) as usize] as char);
+        out.push(B64URL[((n >> 12) & 0x3f) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(B64URL[((n >> 6) & 0x3f) as usize] as char);
+        }
+        if chunk.len() > 2 {
+            out.push(B64URL[(n & 0x3f) as usize] as char);
+        }
+    }
+    out
+}
+
+fn base64url_decode(input: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u32> {
+        match c {
+            b'A'..=b'Z' => Some((c - b'A') as u32),
+            b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+            b'-' => Some(62),
+            b'_' => Some(63),
+            _ => None,
+        }
+    }
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len() / 4 * 3);
+    for chunk in bytes.chunks(4) {
+        if chunk.len() < 2 {
+            return None;
+        }
+        let mut n = 0u32;
+        for (i, &c) in chunk.iter().enumerate() {
+            n |= val(c)? << (18 - 6 * i);
+        }
+        out.push((n >> 16) as u8);
+        if chunk.len() > 2 {
+            out.push((n >> 8) as u8);
+        }
+        if chunk.len() > 3 {
+            out.push(n as u8);
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64url_round_trips() {
+        for len in 0..40 {
+            let bytes: Vec<u8> = (0..len).map(|i| (i * 7 + 3) as u8).collect();
+            let enc = base64url_encode(&bytes);
+            assert!(!enc.contains('+') && !enc.contains('/') && !enc.contains('='));
+            assert_eq!(base64url_decode(&enc).unwrap(), bytes);
+        }
+    }
+
+    #[test]
+    fn key_file_round_trips_with_prefix() {
+        let bytes = generate_key_bytes();
+        let body = encode_key_file(&bytes);
+        assert!(body.starts_with(KEY_FILE_PREFIX));
+        assert_eq!(parse_key_file(&body).unwrap(), bytes.to_vec());
+    }
+
+    #[test]
+    fn parse_rejects_missing_prefix() {
+        assert!(parse_key_file("not-a-key").is_err());
+    }
+
+    #[test]
+    fn key_id_is_stable_and_not_the_key() {
+        let bytes = generate_key_bytes();
+        let k = RedactionKey::from_bytes(bytes.to_vec(), KeyScope::HostLocal);
+        assert!(k.key_id().starts_with("hmac-sha256:"));
+        // recomputing yields the same id; the id never contains the raw key
+        assert_eq!(k.key_id(), compute_key_id(&bytes));
+        assert!(!k.key_id().contains(&base64url_encode(&bytes)));
+    }
+
+    #[test]
+    fn generated_keys_differ() {
+        assert_ne!(generate_key_bytes(), generate_key_bytes());
+    }
+
+    #[test]
+    fn ephemeral_scope_and_salt() {
+        let k = RedactionKey::ephemeral();
+        assert_eq!(k.scope(), KeyScope::Ephemeral);
+        assert_eq!(k.salt().len(), 32);
+    }
+
+    #[test]
+    fn resolve_generates_then_reuses_default_file() {
+        let dir = std::env::temp_dir().join(format!("assay-redact-key-{}", Uuid::new_v4()));
+        let path = dir.join("redaction.key");
+        // first resolve generates + persists
+        let k1 = RedactionKey::resolve_host_local(None, &path).unwrap();
+        assert!(path.exists());
+        assert_eq!(k1.scope(), KeyScope::HostLocal);
+        // second resolve reads the same key back (same key_id)
+        let k2 = RedactionKey::resolve_host_local(None, &path).unwrap();
+        assert_eq!(k1.key_id(), k2.key_id());
+        assert_eq!(k1.salt(), k2.salt());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generated_key_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("assay-redact-perm-{}", Uuid::new_v4()));
+        let path = dir.join("redaction.key");
+        let _ = RedactionKey::resolve_host_local(None, &path).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn env_override_takes_precedence() {
+        let dir = std::env::temp_dir().join(format!("assay-redact-env-{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let env_path = dir.join("ci.key");
+        let bytes = generate_key_bytes();
+        fs::write(&env_path, encode_key_file(&bytes)).unwrap();
+        let default_path = dir.join("default.key");
+        let k = RedactionKey::resolve_host_local(Some(&env_path), &default_path).unwrap();
+        assert_eq!(k.salt(), bytes.to_vec());
+        assert!(!default_path.exists()); // default not generated when env override is used
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/assay-runner-core/tests/redaction_integration.rs
+++ b/crates/assay-runner-core/tests/redaction_integration.rs
@@ -1,0 +1,123 @@
+//! Integration tests for capture-side redaction (ADR-034 Phase 1).
+//!
+//! The bar: no raw planted secret survives in the serialized bundle, the fail-closed sweep catches a
+//! missed funnel, and environment variable VALUES are never serialized.
+
+use assay_runner_core::{RedactMode, Redactor, RunSpec, RunnerSpikeArchive};
+
+// Secret SHAPES assembled from fragments so the repo secret scanner does not flag this test file.
+fn gh_token() -> String {
+    format!("gh{}_{}{}", "p", "0123456789abcdef".repeat(2), "0123")
+}
+
+fn redactor() -> Redactor {
+    Redactor::new(RedactMode::ShapeAndFlag, b"installation-key", Vec::new())
+}
+
+#[test]
+fn no_raw_planted_secret_in_serialized_archive() {
+    let tok = gh_token();
+    let mut archive = RunnerSpikeArchive::empty("run_redact", "linux");
+
+    // A planted argv secret in a run_started event (the highest-risk vector).
+    archive.events_ndjson = format!(
+        "{{\"schema\":\"assay.runner.run_event.v0\",\"run_id\":\"run_redact\",\"seq\":0,\
+         \"type\":\"run_started\",\"command\":[\"agent\",\"--token\",\"{tok}\"],\
+         \"env_keys\":[\"PATH\"]}}\n"
+    )
+    .into_bytes();
+    // A planted secret in a kernel-observed filesystem path.
+    archive
+        .capability_surface
+        .add_filesystem_path(format!("/tmp/cfg/{tok}.json"));
+    // And a short, non-shape-matchable credential after a flag (only flag-aware catches this).
+    let pw = format!("{}{}", "hunter2", "short");
+    archive
+        .capability_surface
+        .add_process_exec(format!("agent --password {pw}"));
+
+    let r = redactor();
+    let tally = archive.redact_in_place(&r);
+    assert!(tally.total >= 2, "expected redactions, got {}", tally.total);
+
+    // The fail-closed sweep passes once redaction has run.
+    archive
+        .assert_no_unredacted(&r)
+        .expect("no unredacted secret should remain after redaction");
+
+    // The raw token is gone from every in-memory field that gets serialized.
+    assert!(!String::from_utf8_lossy(&archive.events_ndjson).contains(&tok));
+    for p in &archive.capability_surface.filesystem_paths {
+        assert!(!p.contains(&tok), "raw token leaked in {p}");
+    }
+    // The flag-aware short password is gone too.
+    let execs = archive
+        .capability_surface
+        .process_execs
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(!execs.contains(&pw));
+}
+
+#[test]
+fn fail_closed_sweep_catches_a_missed_funnel() {
+    let tok = gh_token();
+    let mut archive = RunnerSpikeArchive::empty("run_leak", "linux");
+    // Simulate a capture funnel that was NOT redacted: a raw shape secret in a surface field.
+    archive
+        .capability_surface
+        .add_filesystem_path(format!("/tmp/{tok}.key"));
+
+    let r = redactor();
+    // No redact_in_place call -> the sweep must fail closed rather than allow a bundle.
+    let err = archive.assert_no_unredacted(&r).unwrap_err();
+    assert!(
+        format!("{err}").contains("github-token"),
+        "expected an unredacted-secret error, got: {err}"
+    );
+}
+
+#[test]
+fn redaction_is_idempotent_and_leaves_clean_content_unchanged() {
+    let mut archive = RunnerSpikeArchive::empty("run_clean", "linux");
+    archive.events_ndjson =
+        b"{\"type\":\"run_started\",\"command\":[\"agent\",\"--verbose\"]}\n".to_vec();
+    archive
+        .capability_surface
+        .add_filesystem_path("/workspace/src/main.rs".to_string());
+    let before = archive.clone();
+
+    let r = redactor();
+    let tally = archive.redact_in_place(&r);
+    assert_eq!(tally.total, 0, "clean content should not be redacted");
+    assert_eq!(
+        archive.events_ndjson, before.events_ndjson,
+        "a clean line must stay byte-identical"
+    );
+    assert_eq!(
+        archive.capability_surface, before.capability_surface,
+        "a clean surface must be unchanged"
+    );
+}
+
+#[test]
+fn env_variable_values_are_never_serialized() {
+    let secret = gh_token();
+    let spec = RunSpec::new(vec!["true".to_string()])
+        .with_run_id("run_env")
+        .with_env("MY_SECRET", secret.clone());
+    let mut archive = RunnerSpikeArchive::empty("run_env", "linux");
+    spec.append_run_started(&mut archive, 0, std::time::Duration::ZERO)
+        .expect("append run_started");
+
+    let events = String::from_utf8_lossy(&archive.events_ndjson);
+    // The env KEY is recorded (so a reviewer sees which vars were set)...
+    assert!(events.contains("MY_SECRET"), "env key should be recorded");
+    // ...but the env VALUE must never appear, redaction or not.
+    assert!(
+        !events.contains(&secret),
+        "env value must never be serialized"
+    );
+}

--- a/crates/assay-runner-schema/src/health.rs
+++ b/crates/assay-runner-schema/src/health.rs
@@ -1,7 +1,24 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub const OBSERVATION_HEALTH_SCHEMA: &str = "assay.runner.observation_health.v0";
+
+/// Capture-side secret redaction summary (ADR-034). Value-free: it states that redaction happened,
+/// of which rule class and in which field, plus the redaction-domain key id, never the matched value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Redaction {
+    /// `shape_and_flag` | `shape_only` | `disabled_unsafe`.
+    pub mode: String,
+    pub redacted_count: u64,
+    pub by_rule: BTreeMap<String, u64>,
+    pub by_field: BTreeMap<String, u64>,
+    /// `host_local` | `ephemeral`.
+    pub key_scope: String,
+    /// Non-reversible digest of the redaction key (`hmac-sha256:<hex>`); never the key itself.
+    pub key_id: String,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -69,6 +86,8 @@ pub struct ObservationHealth {
     pub network_protocol_coverage: NetworkProtocolCoverageStatus,
     #[serde(default)]
     pub network_endpoint_claim_scope: NetworkEndpointClaimScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redaction: Option<Redaction>,
     pub notes: Vec<String>,
 }
 
@@ -99,6 +118,7 @@ impl ObservationHealth {
             cgroup_correlation: CgroupCorrelationStatus::Partial,
             network_protocol_coverage: NetworkProtocolCoverageStatus::Absent,
             network_endpoint_claim_scope: NetworkEndpointClaimScope::NotApplicable,
+            redaction: None,
             notes: Vec::new(),
         }
         .normalized()

--- a/crates/assay-runner-schema/src/lib.rs
+++ b/crates/assay-runner-schema/src/lib.rs
@@ -47,7 +47,7 @@ pub use fidelity::{
 pub use health::{
     CgroupCorrelationStatus, KernelLayerStatus, NetworkEndpointClaimScope,
     NetworkProtocolCoverageStatus, ObservationHealth, ObservationHealthError, PolicyLayerStatus,
-    SdkLayerStatus, OBSERVATION_HEALTH_SCHEMA,
+    Redaction, SdkLayerStatus, OBSERVATION_HEALTH_SCHEMA,
 };
 pub use sdk_event::{SdkLayerEvent, SDK_EVENT_SCHEMA};
 pub use surface::{CapabilitySurface, CapabilitySurfaceError, CAPABILITY_SURFACE_SCHEMA};

--- a/docs/architecture/ADR-034-Evidence-Redaction-At-Capture.md
+++ b/docs/architecture/ADR-034-Evidence-Redaction-At-Capture.md
@@ -140,12 +140,31 @@ decided choice (see Decisions). Properties:
 - We do NOT record `matched_len` in the runner evidence (unlike the Plimsoll detector, which sees the
   value at review time): length leaks bits about the secret. The runner records rule + count only.
 
-Key management (the one new operational surface this introduces): `installation_secret` is a
-locally-held value, resolved from config or an env var, generated once per install if absent and
-persisted alongside the runner config. It is a redaction salt, not an encryption key: losing it only
-means future redaction tokens stop correlating with older bundles; it never exposes a past secret. It
-must never itself be written into any evidence field (add it to the env keys-only / never-recorded
-set).
+Key management (resolved in review). The salt is a runner-local key file, generated once, with an env
+override for CI/ephemeral runners. It is a redaction salt, not an encryption key: losing it only means
+future redaction tokens stop correlating with older bundles, it never exposes a past secret.
+
+Resolution order:
+
+1. Explicit env override `ASSAY_REDACTION_KEY_FILE=/path/to/key` (for CI / mounted secrets).
+2. Default host-local key file: `/var/lib/assay/redaction.key` (Linux), with a user-mode fallback
+   under the platform data dir (e.g. `$XDG_DATA_HOME/assay/redaction.key`) when the system path is not
+   writable. Generated once if absent.
+3. Ephemeral, only with explicit `--redaction-key ephemeral`: an in-memory random key, never persisted.
+   This warns on stderr and sets `redaction.key_scope = "ephemeral"` so a reviewer knows tokens from
+   this bundle do not correlate with any other run.
+
+Key file format: 32 random bytes, base64url-encoded, with a version tag:
+`assay-redaction-key-v1:<base64url>`. File permissions `0600`, owned by the runner user. The key is
+never written into the bundle and never logged.
+
+Forbidden key sources (each defeats the purpose): `run_id` (loses cross-run correlation), repository
+name (guessable), commit SHA (public), a hardcoded default (globally correlatable / brute-forceable),
+or any key stored inside the repo (leak risk).
+
+The bundle records only a non-reversible `key_id` (a digest of the key, e.g. `hmac-sha256:8f3a91c2`),
+so two bundles can be told to share a redaction domain without the key ever appearing. See the
+`observation_health.redaction` block below.
 
 ### 3. Field-by-field treatment
 
@@ -198,9 +217,15 @@ frozen):
   "mode": "shape_and_flag",
   "redacted_count": 3,
   "by_rule": { "github-token": 2, "credential-assignment": 1 },
-  "by_field": { "command": 2, "filesystem_paths": 1 }
+  "by_field": { "command": 2, "filesystem_paths": 1 },
+  "key_scope": "host_local",
+  "key_id": "hmac-sha256:8f3a91c2"
 }
 ```
+
+`key_scope` is `host_local` (default file or env-provided file) or `ephemeral`. `key_id` is a digest of
+the key, never the key, used only to tell whether two bundles share a redaction domain (so a reviewer
+can reason about whether `<redacted:...:H8>` tokens are comparable across two bundles).
 
 This makes the evidence state plainly that redaction occurred and of what class, with no value echoed.
 The Plimsoll consumer can then soften `PLIMSOLL-POSSIBLE-SECRET` from "a secret is sitting in your
@@ -215,6 +240,8 @@ observed. `policy_layer` / `kernel_layer` / `network_protocol_coverage` keep the
 - `--redact <shape_and_flag|shape_only>`; default `shape_and_flag`. There is no `off` value on this
   flag, deliberately.
 - `--redact-allowlist <file>`: regexes for known-safe values to suppress false positives.
+- Key sourcing (see "Key management" above): `ASSAY_REDACTION_KEY_FILE` env override, else the default
+  host-local key file (generated once), else `--redaction-key ephemeral` for an in-memory throwaway key.
 - The ONLY way to disable redaction is a separate, deliberately alarming flag:
   `--unsafe-disable-redaction`. Choosing a scary name over a neutral `--redact off` is intentional:
   users override defaults, and the flag name itself must say "this is dangerous". When set, the runner
@@ -296,9 +323,9 @@ scanned length per value; avoid allocation when there is no hit (`Cow::Borrowed`
 5. **Rule-set home: a `secret-rules.v1.json` contract fixture in both repos.** No generated runtime
    shared source (too much machinery). Same approach as the claim-class fixtures.
 
-### Residual operational detail to confirm during Phase 1
-
-The installation-secret salt is the one new surface this introduces. Phase 1 must decide where it is
-stored and how it is generated/rotated (proposal: generated once per install, persisted with runner
-config, resolvable via config or env, never written into evidence). This is an implementation detail,
-not a blocker for the design.
+6. **Salt sourcing: a runner-local key file, generated once, env override for CI.** Resolution order
+   `ASSAY_REDACTION_KEY_FILE` env, then the default host-local key file (generated once, `0600`), then
+   `--redaction-key ephemeral` for throwaway runs. Key format `assay-redaction-key-v1:<base64url>` over
+   32 random bytes; never in the bundle, never logged. The bundle records only a non-reversible
+   `key_id` plus `key_scope` (`host_local` | `ephemeral`). Forbidden sources: `run_id`, repo name,
+   commit SHA, a hardcoded default, or any in-repo key. (See "Key management".)


### PR DESCRIPTION
Implements ADR-034 Phase 1: keep secret-shaped values out of a runner evidence bundle **at capture**, in the order `capture -> redact -> serialize -> assert clean -> hash/sign`.

## What lands

- **`Redactor` core** (`assay-runner-core::redact`): deterministic, installation-salted, shape-based redactor. Curated provider rules (AWS / GitHub / OpenAI / Slack / Stripe / Google, PEM keys, JWTs, bearer, `key=value`) shared with the Plimsoll detector, no entropy rule. `redact_value` (free-form) + `redact_argv` (flag-aware) replace a span with `<redacted:RULE:H8>`, single left-to-right scan, idempotent, never re-scans placeholders. HMAC-SHA256 built on the vendored `sha2` (no new dependency).
- **Key resolution** (`redaction_key`): runner-local key file generated once `0600`, `ASSAY_REDACTION_KEY_FILE` env override, explicit `ephemeral`. Bundle records only a non-reversible `key_id` + `key_scope`, never the key. base64url hand-rolled; 32 random bytes from the vendored `uuid` crate.
- **Schema**: additive, value-free `observation_health.redaction` block (`mode`, `redacted_count`, `by_rule`, `by_field`, `key_scope`, `key_id`). Old bundles deserialize unchanged.
- **Archive**: `redact_in_place` (capability surface + structured ndjson; clean lines stay byte-identical; `process_execs` get the flag-aware treatment) and `assert_no_unredacted` (fail-closed sweep that asserts, never rewrites; a surviving secret aborts bundle creation).
- **CLI**: default-on (`--redact shape_and_flag`), `--redaction-key host-local|ephemeral`, and the only disable is the loud `--unsafe-disable-redaction` (recorded `disabled_unsafe`). Wired on both write paths.

## Invariants held

raw secret never serialized · redact before hash · sweep asserts not rewrites · env values never recorded (`env_keys` only) · off-mode explicit + unsafe + visible · health/errors carry counts and rule/field only, never a value · idempotent placeholders · surface semantics (coverage, kernel_layer, network_protocol_coverage) unchanged.

## Scope

Exactly the bounded Phase 1. Deferred to Phase 2 (not in this PR): URL query/userinfo/fragment special-casing beyond shape coverage, the shared `secret-rules.v1.json` parity fixture, extra rule families, and Plimsoll consuming the `redaction` receipt.

## Tests

91 runner-core unit + 4 redaction integration (planted argv/path/env secret, fail-closed sweep, idempotency, env-values-never-serialized) + 38 runner-schema. clippy + fmt clean. Default-on changes recorded bytes only for bundles that held secret-shaped values; clean bundles are byte-identical and existing bundles stay valid (CHANGELOG under Unreleased; ships with a minor bump).