### PR TITLE
feat(runner): shared secret-rule contract fixture + parity (ADR-034 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Secret-rule contract fixture (ADR-034, Phase 2). The runner Redactor's curated rules are now
+  published as `secret-rules.v1.json` (the canonical name->pattern table), with a parity test
+  asserting the built-in rules match it exactly; the same fixture is shared with the Plimsoll detector
+  so the Rust and Python implementations cannot drift. Adds a `sensitive-query-param` rule covering
+  URL/query credentials the assignment rule misses (`access_token=`, `sig=`, `signature=`).
+
 - Runner evidence redaction at capture (ADR-034, Phase 1). The runner-spike run now redacts
   secret-shaped values (provider tokens, PEM keys, JWTs, bearer tokens, `key=value` credentials, and
   flag values such as `--token X`) out of argv and the capability surface before the bundle is

--- a/crates/assay-runner-core/src/lib.rs
+++ b/crates/assay-runner-core/src/lib.rs
@@ -29,7 +29,7 @@ pub use path_projection::{
     PathProjectionMapping, UnmatchedPathSummary, PATH_PROJECTION_SCHEMA,
 };
 pub use policy::{PolicyLayerCapture, PolicyLayerError, PolicyLayerEvent, POLICY_EVENT_SCHEMA};
-pub use redact::{RedactMode, RedactionTally, Redactor};
+pub use redact::{rule_specs, RedactMode, RedactionTally, Redactor};
 pub use redaction_key::{KeyScope, RedactionKey, ENV_KEY_FILE, KEY_FILE_PREFIX};
 pub use run::{RunExecutionError, RunOutcome, RunSpec, RunSpecError, RUN_EVENT_SCHEMA};
 pub use sdk::{SdkLayerCapture, SdkLayerError};

--- a/crates/assay-runner-core/src/redact.rs
+++ b/crates/assay-runner-core/src/redact.rs
@@ -308,7 +308,7 @@ pub fn rule_specs() -> &'static [(&'static str, &'static str)] {
         ("github-token", r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"),
         ("openai-key", r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b"),
         ("slack-token", r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
-        ("google-api-key", r"\bAIza[0-9A-Za-z_-]{35}"),
+        ("google-api-key", r"\bAIza[0-9A-Za-z_-]{35}\b"),
         ("stripe-key", r"\b[sp]k_(?:live|test)_[0-9A-Za-z]{16,}\b"),
         ("private-key-pem", r"-----BEGIN (?:[A-Z ]*)PRIVATE KEY-----"),
         (

--- a/crates/assay-runner-core/src/redact.rs
+++ b/crates/assay-runner-core/src/redact.rs
@@ -298,16 +298,17 @@ fn is_cred_flag(flag: &str) -> bool {
     CRED_FLAGS.iter().any(|f| f.eq_ignore_ascii_case(flag))
 }
 
-/// The curated rule set. Shared vocabulary with the Plimsoll detector (`secret-rules.v1`).
-fn build_rules() -> Vec<Rule> {
-    // (name, pattern). Order matters only for which placeholder wins on overlap; provider tokens
-    // first, the broad credential-assignment rule last.
-    let specs: &[(&str, &str)] = &[
+/// Canonical curated rule set: `(name, pattern)`, shared vocabulary with the Plimsoll detector. This
+/// is the single source of truth behind the `secret-rules.v1.json` contract fixture; a parity test
+/// asserts the two stay in lockstep. Order matters only for which placeholder wins on overlap:
+/// provider tokens first, then URL/structural credential shapes, then the broad assignment rule last.
+pub fn rule_specs() -> &'static [(&'static str, &'static str)] {
+    &[
         ("aws-access-key-id", r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"),
         ("github-token", r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"),
         ("openai-key", r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b"),
         ("slack-token", r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
-        ("google-api-key", r"\bAIza[0-9A-Za-z_-]{35}\b"),
+        ("google-api-key", r"\bAIza[0-9A-Za-z_-]{35}"),
         ("stripe-key", r"\b[sp]k_(?:live|test)_[0-9A-Za-z]{16,}\b"),
         ("private-key-pem", r"-----BEGIN (?:[A-Z ]*)PRIVATE KEY-----"),
         (
@@ -315,12 +316,22 @@ fn build_rules() -> Vec<Rule> {
             r"\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b",
         ),
         ("bearer-token", r"(?i)\bbearer\s+[A-Za-z0-9._~+/-]{20,}=*"),
+        // URL/query credential params that the assignment rule misses because the credential word is
+        // glued to another token by an underscore (e.g. `access_token`) or is not a keyword (`sig`).
+        (
+            "sensitive-query-param",
+            r#"(?i)\b(?:access[_-]?token|refresh[_-]?token|sig|signature)=[^&\s#"']{6,}"#,
+        ),
         (
             "credential-assignment",
             r#"(?i)\b(?:api[_-]?key|secret|token|password|passwd|access[_-]?key|client[_-]?secret)\b\s*[=:]\s*[^\s'"]{6,}"#,
         ),
-    ];
-    specs
+    ]
+}
+
+/// The compiled curated rule set.
+fn build_rules() -> Vec<Rule> {
+    rule_specs()
         .iter()
         .map(|(name, pat)| Rule {
             name,
@@ -523,6 +534,22 @@ mod tests {
         let _ = r.redact_value("process_execs", &assignment, &mut t);
         assert_eq!(t.by_rule.get("aws-access-key-id"), Some(&1));
         assert_eq!(t.by_rule.get("credential-assignment"), Some(&1));
+    }
+
+    #[test]
+    fn sensitive_query_param_catches_assignment_gaps() {
+        // access_token / sig / signature are glued or non-keyword, so the credential-assignment rule
+        // misses them; the sensitive-query-param rule covers the URL/query case.
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let url = "https://api.example.com/cb?access_token=abcdef123456&sig=deadbeefcafe";
+        let out = r.redact_value("network_endpoints", url, &mut t);
+        assert!(!out.contains("abcdef123456"));
+        assert!(!out.contains("deadbeefcafe"));
+        assert_eq!(t.by_rule.get("sensitive-query-param"), Some(&2));
+        // host/path are preserved; only the credential params (key=value) are replaced.
+        assert!(out.starts_with("https://api.example.com/cb?"));
+        assert!(out.contains("<redacted:sensitive-query-param:"));
     }
 
     #[test]

--- a/crates/assay-runner-core/tests/fixtures/secret-rules.v1.json
+++ b/crates/assay-runner-core/tests/fixtures/secret-rules.v1.json
@@ -6,7 +6,7 @@
     { "name": "github-token", "pattern": "\\bgh[pousr]_[A-Za-z0-9]{36,}\\b" },
     { "name": "openai-key", "pattern": "\\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\\b" },
     { "name": "slack-token", "pattern": "\\bxox[baprs]-[A-Za-z0-9-]{10,}\\b" },
-    { "name": "google-api-key", "pattern": "\\bAIza[0-9A-Za-z_-]{35}" },
+    { "name": "google-api-key", "pattern": "\\bAIza[0-9A-Za-z_-]{35}\\b" },
     { "name": "stripe-key", "pattern": "\\b[sp]k_(?:live|test)_[0-9A-Za-z]{16,}\\b" },
     { "name": "private-key-pem", "pattern": "-----BEGIN (?:[A-Z ]*)PRIVATE KEY-----" },
     { "name": "jwt", "pattern": "\\beyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\b" },

--- a/crates/assay-runner-core/tests/fixtures/secret-rules.v1.json
+++ b/crates/assay-runner-core/tests/fixtures/secret-rules.v1.json
@@ -1,0 +1,17 @@
+{
+  "schema": "assay.secret-rules.v1",
+  "description": "Canonical secret-shape rule contract shared by the assay runner Redactor (Rust) and the Plimsoll detector (Python). Each side compiles these patterns natively and a parity test asserts its built-in rules match this table exactly, so the two implementations cannot drift. Curated, low-false-positive; no generic entropy rule. The patterns themselves contain no secrets.",
+  "rules": [
+    { "name": "aws-access-key-id", "pattern": "\\b(?:AKIA|ASIA)[0-9A-Z]{16}\\b" },
+    { "name": "github-token", "pattern": "\\bgh[pousr]_[A-Za-z0-9]{36,}\\b" },
+    { "name": "openai-key", "pattern": "\\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\\b" },
+    { "name": "slack-token", "pattern": "\\bxox[baprs]-[A-Za-z0-9-]{10,}\\b" },
+    { "name": "google-api-key", "pattern": "\\bAIza[0-9A-Za-z_-]{35}" },
+    { "name": "stripe-key", "pattern": "\\b[sp]k_(?:live|test)_[0-9A-Za-z]{16,}\\b" },
+    { "name": "private-key-pem", "pattern": "-----BEGIN (?:[A-Z ]*)PRIVATE KEY-----" },
+    { "name": "jwt", "pattern": "\\beyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\b" },
+    { "name": "bearer-token", "pattern": "(?i)\\bbearer\\s+[A-Za-z0-9._~+/-]{20,}=*" },
+    { "name": "sensitive-query-param", "pattern": "(?i)\\b(?:access[_-]?token|refresh[_-]?token|sig|signature)=[^&\\s#\"']{6,}" },
+    { "name": "credential-assignment", "pattern": "(?i)\\b(?:api[_-]?key|secret|token|password|passwd|access[_-]?key|client[_-]?secret)\\b\\s*[=:]\\s*[^\\s'\"]{6,}" }
+  ]
+}

--- a/crates/assay-runner-core/tests/secret_rules_parity.rs
+++ b/crates/assay-runner-core/tests/secret_rules_parity.rs
@@ -1,0 +1,41 @@
+//! Parity test: the runner's built-in secret rules must match the shared `secret-rules.v1.json`
+//! contract fixture exactly (ADR-034 Phase 2). The same fixture is committed to the Plimsoll repo
+//! with its own parity test, so the Rust runner and the Python detector cannot drift apart.
+
+use std::collections::BTreeMap;
+
+use assay_runner_core::rule_specs;
+
+#[test]
+fn builtin_rules_match_the_shared_contract_fixture() {
+    let raw = include_str!("fixtures/secret-rules.v1.json");
+    let doc: serde_json::Value = serde_json::from_str(raw).expect("fixture is valid json");
+
+    assert_eq!(
+        doc["schema"], "assay.secret-rules.v1",
+        "fixture schema tag changed unexpectedly"
+    );
+
+    let fixture: BTreeMap<String, String> = doc["rules"]
+        .as_array()
+        .expect("rules is an array")
+        .iter()
+        .map(|r| {
+            (
+                r["name"].as_str().unwrap().to_string(),
+                r["pattern"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+
+    let builtin: BTreeMap<String, String> = rule_specs()
+        .iter()
+        .map(|(name, pat)| (name.to_string(), pat.to_string()))
+        .collect();
+
+    assert_eq!(
+        builtin, fixture,
+        "runner secret rules drifted from secret-rules.v1.json; update the fixture AND the Plimsoll \
+         detector together so the two implementations stay in lockstep"
+    );
+}


### PR DESCRIPTION
ADR-034 Phase 2 (assay side): lock the secret-rule vocabulary so the Rust runner `Redactor` and the Python Plimsoll detector cannot drift.

## What lands

- **`secret-rules.v1.json`** — the canonical `name -> pattern` contract fixture (no secrets in it; patterns only). `redact::rule_specs()` is now the single source of truth behind both `build_rules()` and the fixture.
- **Parity test** — asserts the runner's built-in rules match the fixture exactly. The same fixture is committed to the Plimsoll repo with its own parity test (follow-up PR), so the two implementations stay in lockstep.
- **`sensitive-query-param` rule** — covers URL/query credentials the `credential-assignment` rule misses (`access_token=`, `refresh_token=`, `sig=`, `signature=`), which are glued by underscores or are non-keyword and so escape the `\btoken\b`-style match.
- `google-api-key` pattern aligned to the canonical (no trailing `\b`) to match the already-shipped Plimsoll detector.

## Scope

Deliberately bounded. Full structural URL handling (preserving host while redacting only `user:pass@` userinfo) needs lookbehind/URL parsing the `regex` crate doesn't offer cleanly; the shape + query-param rules already cover recognized credentials in URLs, so the structural userinfo case is left for a later refinement rather than bloating this slice.

## Tests

92 runner-core unit + 4 redaction integration + 1 parity. clippy + fmt clean. Fixture patterns contain no secret literals.