### PR TITLE
feat(runner): URL userinfo redaction preserving host (ADR-034 Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- URL userinfo redaction (ADR-034, Phase 3). A network endpoint that is a URL carrying a
+  `user:pass@` credential pair now has its userinfo redacted at capture (`scheme://user:pass@host` ->
+  `scheme://<redacted:url-userinfo:H8>@host`), preserving the scheme and host. It fires only when the
+  userinfo contains a `:` pair (a token-as-username is already caught by the shape pass), is
+  idempotent, and is a runner-side capture-hygiene transform rather than a shared detection rule.
+
 - Secret-rule contract fixture (ADR-034, Phase 2). The runner Redactor's curated rules are now
   published as `secret-rules.v1.json` (the canonical name->pattern table), with a parity test
   asserting the built-in rules match it exactly; the same fixture is shared with the Plimsoll detector

--- a/crates/assay-runner-core/src/archive.rs
+++ b/crates/assay-runner-core/src/archive.rs
@@ -167,7 +167,7 @@ impl RunnerSpikeArchive {
             redactor,
             &mut tally,
         );
-        redact_set(
+        redact_endpoint_set(
             &mut self.capability_surface.network_endpoints,
             "network_endpoints",
             redactor,
@@ -222,6 +222,27 @@ fn redact_set(
     let redacted: BTreeSet<String> = set
         .iter()
         .map(|v| redactor.redact_value(field, v, tally).into_owned())
+        .collect();
+    *set = redacted;
+}
+
+/// A network endpoint can be a URL carrying a `user:pass@` credential pair whose password is not
+/// shape-matchable, so it first gets the structural userinfo transform (which preserves scheme +
+/// host) and then the normal shape pass.
+fn redact_endpoint_set(
+    set: &mut BTreeSet<String>,
+    field: &str,
+    redactor: &Redactor,
+    tally: &mut RedactionTally,
+) {
+    let redacted: BTreeSet<String> = set
+        .iter()
+        .map(|v| {
+            let after_userinfo = redactor.redact_url_userinfo(field, v, tally);
+            redactor
+                .redact_value(field, &after_userinfo, tally)
+                .into_owned()
+        })
         .collect();
     *set = redacted;
 }

--- a/crates/assay-runner-core/src/redact.rs
+++ b/crates/assay-runner-core/src/redact.rs
@@ -142,6 +142,32 @@ impl Redactor {
         self.shape_pass(field, input, tally)
     }
 
+    /// Redact the userinfo credential pair in a URL (`scheme://user:pass@host` ->
+    /// `scheme://<redacted:url-userinfo:H8>@host`), preserving the scheme and host. Only fires when
+    /// the userinfo contains a `:` (a `user:pass` pair): a token-as-username is already caught by the
+    /// shape pass, while a bare username is not a credential. This is a runner-side capture-hygiene
+    /// transform, not a shared detection rule (the password is not shape-matchable), so it is not in
+    /// `secret-rules.v1.json`. Idempotent: an already-redacted placeholder is left untouched.
+    pub fn redact_url_userinfo<'a>(
+        &self,
+        field: &str,
+        input: &'a str,
+        tally: &mut RedactionTally,
+    ) -> Cow<'a, str> {
+        if !self.mode.is_active() {
+            return Cow::Borrowed(input);
+        }
+        url_userinfo_re().replace_all(input, |caps: &regex::Captures<'_>| {
+            let scheme = &caps["scheme"];
+            let userinfo = &caps["userinfo"];
+            if userinfo.starts_with("<redacted:") || self.is_allowlisted(userinfo) {
+                return caps[0].to_string();
+            }
+            tally.record(field, "url-userinfo");
+            format!("{scheme}{}@", self.placeholder("url-userinfo", userinfo))
+        })
+    }
+
     /// Redact an argv vector: flag-aware (a value following a known credential flag is redacted
     /// regardless of shape, in `ShapeAndFlag` mode) plus a shape pass on every token. `argv[0]` is
     /// treated as a binary path (shape pass only, never as a flag value).
@@ -291,6 +317,18 @@ fn placeholder_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(r"<redacted:[a-z-]+:[0-9a-f]{8}>").expect("placeholder pattern must compile")
+    })
+}
+
+/// Matches `scheme://userinfo@` where the userinfo contains a `user:pass` pair. Captures the scheme
+/// and the userinfo so the replacement can keep the scheme and host while redacting only the
+/// credential pair.
+fn url_userinfo_re() -> &'static Regex {
+    use std::sync::OnceLock;
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)(?P<userinfo>[^/?#@\s]*:[^/?#@\s]*)@")
+            .expect("url userinfo pattern must compile")
     })
 }
 
@@ -550,6 +588,48 @@ mod tests {
         // host/path are preserved; only the credential params (key=value) are replaced.
         assert!(out.starts_with("https://api.example.com/cb?"));
         assert!(out.contains("<redacted:sensitive-query-param:"));
+    }
+
+    #[test]
+    fn url_userinfo_redacted_preserving_host() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let pw = format!("s3cr3t{}", "pass");
+        let url = format!("https://svcuser:{pw}@db.internal.example.com:5432/app");
+        let out = r.redact_url_userinfo("network_endpoints", &url, &mut t);
+        assert!(out.starts_with("https://<redacted:url-userinfo:"));
+        assert!(out.ends_with("@db.internal.example.com:5432/app"));
+        assert!(!out.contains(&pw));
+        assert!(!out.contains("svcuser"));
+        assert_eq!(t.by_rule.get("url-userinfo"), Some(&1));
+    }
+
+    #[test]
+    fn url_userinfo_leaves_bare_username_and_hostport() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        // bare username (no password pair) and a plain host:port are not credential pairs
+        assert_eq!(
+            r.redact_url_userinfo("f", "https://justuser@host.com/x", &mut t),
+            "https://justuser@host.com/x"
+        );
+        assert_eq!(
+            r.redact_url_userinfo("f", "10.0.0.1:53", &mut t),
+            "10.0.0.1:53"
+        );
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn url_userinfo_is_idempotent() {
+        let r = redactor(RedactMode::ShapeAndFlag);
+        let mut t = RedactionTally::default();
+        let url = "https://u:pw1234@host.com/p";
+        let once = r.redact_url_userinfo("f", url, &mut t).into_owned();
+        let mut t2 = RedactionTally::default();
+        let twice = r.redact_url_userinfo("f", &once, &mut t2);
+        assert_eq!(twice, once);
+        assert!(t2.is_empty());
     }
 
     #[test]

--- a/crates/assay-runner-core/tests/redaction_integration.rs
+++ b/crates/assay-runner-core/tests/redaction_integration.rs
@@ -62,6 +62,34 @@ fn no_raw_planted_secret_in_serialized_archive() {
 }
 
 #[test]
+fn url_userinfo_in_endpoint_is_redacted_preserving_host() {
+    let pw = format!("s3cr3t{}", "pass");
+    let mut archive = RunnerSpikeArchive::empty("run_url", "linux");
+    archive
+        .capability_surface
+        .add_network_endpoint(format!("postgres://svc:{pw}@db.internal:5432/app"));
+
+    let r = redactor();
+    let tally = archive.redact_in_place(&r);
+    assert!(tally.total >= 1);
+    let eps: Vec<String> = archive
+        .capability_surface
+        .network_endpoints
+        .iter()
+        .cloned()
+        .collect();
+    let joined = eps.join(" ");
+    assert!(!joined.contains(&pw), "raw password leaked: {joined}");
+    assert!(
+        joined.contains("@db.internal:5432/app"),
+        "host should be preserved: {joined}"
+    );
+    archive
+        .assert_no_unredacted(&r)
+        .expect("no unredacted secret after redaction");
+}
+
+#[test]
 fn fail_closed_sweep_catches_a_missed_funnel() {
     let tok = gh_token();
     let mut archive = RunnerSpikeArchive::empty("run_leak", "linux");

--- a/docs/architecture/ADR-034-Evidence-Redaction-At-Capture.md
+++ b/docs/architecture/ADR-034-Evidence-Redaction-At-Capture.md
@@ -299,15 +299,21 @@ scanned length per value; avoid allocation when there is no hit (`Cow::Borrowed`
 
 ## Rollout plan
 
-1. Phase 1: `Redactor`, shape pass on argv and capability-surface fields, the `observation_health.
-   redaction` block, the fail-closed assertion sweep before hashing, env keys-only invariant test,
-   `--unsafe-disable-redaction` escape hatch, default-on, and the installation-secret salt plumbing.
-   Minor version bump.
-2. Phase 2: flag-aware argv value redaction (catches non-shaped secrets like short passwords).
-3. Phase 3: URL userinfo and sensitive query-param redaction for `network_endpoints`.
-4. Phase 4: shared `secret-rules.v1.json` fixture and parity tests in both repos; Plimsoll consumes
-   `observation_health.redaction` to downgrade `PLIMSOLL-POSSIBLE-SECRET` to a "redacted at capture"
-   informational note when the runner already handled it.
+1. Phase 1 (DONE, #1563): `Redactor`, shape pass on argv and capability-surface fields, the
+   `observation_health.redaction` block, the fail-closed assertion sweep before hashing, env
+   keys-only invariant test, `--unsafe-disable-redaction` escape hatch, default-on, and the
+   installation-secret salt plumbing. Flag-aware argv value redaction (the original Phase 2 item) was
+   folded in here.
+2. Phase 2 (DONE, #1564 + plimsoll #13): shared `secret-rules.v1.json` fixture and parity tests in
+   both repos; the `sensitive-query-param` rule (covers `access_token=`/`sig=`/`signature=` query
+   credentials the assignment rule misses); Plimsoll consumes `observation_health.redaction` to turn
+   `PLIMSOLL-POSSIBLE-SECRET` into a "redacted at capture" receipt when the runner already handled it.
+3. Phase 3 (DONE): URL userinfo redaction for `network_endpoints` (`scheme://user:pass@host`),
+   preserving the host. Limited to the `user:pass` pair because a token-as-username is already caught
+   by the shape pass and a bare username is not a credential.
+4. Later refinement (deferred): broader URL structural handling if a real need appears (e.g.
+   non-`:`-delimited userinfo schemes); the shape + query-param rules already cover recognized
+   credentials in URLs, so this is not currently necessary.
 
 ## Decisions (resolved in review, June 2026)
 


### PR DESCRIPTION
ADR-034 Phase 3: close the last URL gap — a `user:pass@` credential pair in a network endpoint, whose password is not shape-matchable and so escapes the existing rules.

## What lands

- `Redactor::redact_url_userinfo` — `scheme://user:pass@host` becomes `scheme://<redacted:url-userinfo:H8>@host`, preserving scheme + host via capture-group replacement (no lookbehind needed). Fires only when the userinfo contains a `:` pair: a token-as-username is already caught by the shape pass, and a bare username is not a credential. Idempotent and allowlist-aware.
- It is a **runner-side capture-hygiene transform, not a shared detection rule** (the password is not shape-matchable), so it is deliberately NOT in `secret-rules.v1.json`. An already-redacted `<redacted:...>` placeholder is stripped by the consumer, so Plimsoll won't re-flag it.
- `network_endpoints` now runs userinfo redaction, then the shape pass.

## Scope

This is the userinfo piece of the original Phase 3. Sensitive query/fragment params were already handled in Phase 2 (`sensitive-query-param` + the assignment rule match `token=`/`access_token=` anywhere). The ADR rollout is updated to mark Phases 1–3 done; broader structural URL handling is deferred unless a real need appears.

## Tests

95 runner-core unit (incl. userinfo redacted/host-preserved, bare-username + host:port left alone, idempotency) + 5 integration (incl. an end-to-end endpoint userinfo case through `redact_in_place`). clippy + fmt clean.