### PR TITLE
feat(runner): enforce IPv4/TCP egress via connect4 cgroup attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,23 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Network egress enforcement (IPv4/TCP). `assay monitor --policy <file>` now attaches the compiled
-  `connect4` cgroup program so a policy's network deny rules actually block outbound connects, not just
-  observe them. When the policy carries `net_connect` deny rules (a destination port or CIDR), the
-  `connect4_hook` program is attached at the cgroup v2 root and the `DENY_PORTS` / `CIDR_RULES_V4` maps
-  decide which connects are refused (EPERM); an empty rule set is a no-op. Scope is deliberately narrow:
-  IPv4/TCP `connect` only (no IPv6/UDP/QUIC), and the connect tracepoint observation path is unchanged,
-  so `observation_health` reporting is unaffected by enforcement being active. Previously the cgroup
-  attach was a stub, so the compiled rules were never enforced at runtime.
+- Network egress enforcement (IPv4 TCP connect only). `assay monitor --policy <file>` now attaches the
+  compiled `connect4` cgroup program so a policy's network deny rules actually block outbound connects,
+  not just observe them. When the policy carries `net_connect` deny rules (a destination port or CIDR),
+  `connect4_hook` is attached at the cgroup v2 root and the `DENY_PORTS` / `CIDR_RULES_V4` maps decide
+  which connects are refused (EPERM); an empty rule set is a no-op. Previously the cgroup attach was a
+  stub, so the compiled rules were never enforced at runtime.
+  - **Fail-closed.** When enforcement is requested (the policy has network deny rules) but the attach
+    cannot be installed (no cgroup v2 root, no kernel support, attach error), `assay monitor` aborts
+    with exit code 4 (would-block) instead of degrading to audit-only. A caller asking for egress
+    enforcement never gets a clean run that did not actually enforce.
+  - **Bounded scope, explicit non-coverage.** This covers IPv4 TCP `connect()` egress only. It does NOT
+    cover IPv6, UDP/QUIC, DNS resolution, already-open sockets, raw sockets, or proxy/tunnel identity.
+    Policy semantics stay simple (a destination ip/port is allowed or denied); there is no
+    provider classification or DNS-name truth here. The connect tracepoint observation path is unchanged,
+    so `observation_health` reporting is unaffected by enforcement being active, and this change does not
+    add a network-enforcement status to `observation_health` — consumers must not infer enforcement from
+    observation coverage.
 
 - URL userinfo redaction (ADR-034, Phase 3). A network endpoint that is a URL carrying a
   `user:pass@` credential pair now has its userinfo redacted at capture (`scheme://user:pass@host` ->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Network egress enforcement (IPv4/TCP). `assay monitor --policy <file>` now attaches the compiled
+  `connect4` cgroup program so a policy's network deny rules actually block outbound connects, not just
+  observe them. When the policy carries `net_connect` deny rules (a destination port or CIDR), the
+  `connect4_hook` program is attached at the cgroup v2 root and the `DENY_PORTS` / `CIDR_RULES_V4` maps
+  decide which connects are refused (EPERM); an empty rule set is a no-op. Scope is deliberately narrow:
+  IPv4/TCP `connect` only (no IPv6/UDP/QUIC), and the connect tracepoint observation path is unchanged,
+  so `observation_health` reporting is unaffected by enforcement being active. Previously the cgroup
+  attach was a stub, so the compiled rules were never enforced at runtime.
+
 - URL userinfo redaction (ADR-034, Phase 3). A network endpoint that is a URL carrying a
   `user:pass@` credential pair now has its userinfo redacted at capture (`scheme://user:pass@host` ->
   `scheme://<redacted:url-userinfo:H8>@host`), preserving the scheme and host. It fires only when the

--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -329,6 +329,32 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                 e
             );
         }
+
+        // Egress enforcement (IPv4/TCP): attach the connect4 cgroup program so the compiled network
+        // deny rules actually block. Only attach when there is something to enforce; the maps gate
+        // which connects are denied. Observation (the connect tracepoint) is unchanged either way.
+        let has_net_deny = !compiled.tier1.network_deny_ports.is_empty()
+            || !compiled.tier1.network_deny_cidrs.is_empty();
+        if has_net_deny {
+            match std::fs::File::open("/sys/fs/cgroup") {
+                Ok(cgroup_file) => match monitor.attach_network_cgroup(&cgroup_file) {
+                    Ok(()) => {
+                        if !args.quiet {
+                            emit_err!(
+                                "  • Egress enforcement (connect4) attached at /sys/fs/cgroup ({} port + {} cidr deny rules)",
+                                compiled.tier1.network_deny_ports.len(),
+                                compiled.tier1.network_deny_cidrs.len()
+                            );
+                        }
+                    }
+                    Err(e) => emit_err!("Warning: Failed to attach egress enforcement: {}", e),
+                },
+                Err(e) => emit_err!(
+                    "Warning: cannot open cgroup v2 root for egress enforcement: {}",
+                    e
+                ),
+            }
+        }
     }
 
     let mut stream = monitor.listen().map_err(|e| anyhow::anyhow!(e))?;

--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -330,29 +330,41 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
             );
         }
 
-        // Egress enforcement (IPv4/TCP): attach the connect4 cgroup program so the compiled network
-        // deny rules actually block. Only attach when there is something to enforce; the maps gate
-        // which connects are denied. Observation (the connect tracepoint) is unchanged either way.
+        // Egress enforcement (IPv4/TCP connect only): attach the connect4 cgroup program so the
+        // compiled network deny rules actually block. Only attach when the policy requests it (has
+        // network deny rules); the maps gate which connects are refused. Observation (the connect
+        // tracepoint) is unchanged either way.
+        //
+        // FAIL-CLOSED: when enforcement is requested but cannot be installed (no cgroup v2 root, no
+        // kernel support for cgroup/connect4, attach error), refuse to run rather than silently
+        // continuing in audit-only mode. A consumer asking for egress enforcement must not get a clean
+        // run that did not actually enforce.
         let has_net_deny = !compiled.tier1.network_deny_ports.is_empty()
             || !compiled.tier1.network_deny_cidrs.is_empty();
         if has_net_deny {
-            match std::fs::File::open("/sys/fs/cgroup") {
-                Ok(cgroup_file) => match monitor.attach_network_cgroup(&cgroup_file) {
-                    Ok(()) => {
-                        if !args.quiet {
-                            emit_err!(
-                                "  • Egress enforcement (connect4) attached at /sys/fs/cgroup ({} port + {} cidr deny rules)",
-                                compiled.tier1.network_deny_ports.len(),
-                                compiled.tier1.network_deny_cidrs.len()
-                            );
-                        }
-                    }
-                    Err(e) => emit_err!("Warning: Failed to attach egress enforcement: {}", e),
-                },
-                Err(e) => emit_err!(
-                    "Warning: cannot open cgroup v2 root for egress enforcement: {}",
+            let cgroup_file = match std::fs::File::open("/sys/fs/cgroup") {
+                Ok(f) => f,
+                Err(e) => {
+                    emit_err!(
+                        "FATAL: egress enforcement requested but cannot open cgroup v2 root /sys/fs/cgroup: {} (fail-closed, not running audit-only)",
+                        e
+                    );
+                    return Ok(crate::exit_codes::EXIT_WOULD_BLOCK);
+                }
+            };
+            if let Err(e) = monitor.attach_network_cgroup(&cgroup_file) {
+                emit_err!(
+                    "FATAL: egress enforcement requested but connect4 attach failed: {} (fail-closed, not running audit-only)",
                     e
-                ),
+                );
+                return Ok(crate::exit_codes::EXIT_WOULD_BLOCK);
+            }
+            if !args.quiet {
+                emit_err!(
+                    "  • Egress enforcement ACTIVE (IPv4/TCP connect, connect4) at /sys/fs/cgroup: {} port + {} cidr deny rules. NOT covered: IPv6, UDP/QUIC, DNS resolution, already-open sockets, raw sockets, proxy/tunnel identity.",
+                    compiled.tier1.network_deny_ports.len(),
+                    compiled.tier1.network_deny_cidrs.len()
+                );
             }
         }
     }

--- a/crates/assay-monitor/src/error.rs
+++ b/crates/assay-monitor/src/error.rs
@@ -45,4 +45,7 @@ pub enum MonitorError {
 
     #[error("ringbuf error: {0}")]
     RingBuf(String),
+
+    #[error("network enforcement unavailable: {0}")]
+    EnforcementUnavailable(String),
 }

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -347,15 +347,24 @@ impl LinuxMonitor {
         cgroup_file: &std::fs::File,
     ) -> Result<(), MonitorError> {
         let mut bpf = self.bpf.lock().unwrap();
-        if let Some(prog) = bpf.program_mut("connect4_hook") {
-            if let Ok(csa) = TryInto::<&mut CgroupSockAddr>::try_into(&mut *prog) {
-                csa.load()?;
-                let link_id = csa.attach(cgroup_file, CgroupAttachMode::Single)?;
-                let link = csa.take_link(link_id)?;
-                self.links.push(MonitorLink::CgroupSockAddr(link));
-                println!("DEBUG: Attached cgroup connect4 egress enforcement");
-            }
-        }
+        // Fail-closed: a missing program or a load/attach failure is a hard error, never a silent
+        // degrade. The caller (monitor) must refuse to run enforcement it could not actually install.
+        let prog = bpf.program_mut("connect4_hook").ok_or_else(|| {
+            MonitorError::EnforcementUnavailable(
+                "connect4_hook program not present in eBPF object".to_string(),
+            )
+        })?;
+        let csa: &mut CgroupSockAddr = TryInto::<&mut CgroupSockAddr>::try_into(&mut *prog)
+            .map_err(|e| {
+                MonitorError::EnforcementUnavailable(format!(
+                    "connect4_hook is not a CgroupSockAddr program: {e}"
+                ))
+            })?;
+        csa.load()?;
+        let link_id = csa.attach(cgroup_file, CgroupAttachMode::Single)?;
+        let link = csa.take_link(link_id)?;
+        self.links.push(MonitorLink::CgroupSockAddr(link));
+        println!("DEBUG: Attached cgroup connect4 egress enforcement");
         Ok(())
     }
 

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -332,6 +332,15 @@ impl LinuxMonitor {
             }
         }
 
+        // Port deny rules -> DENY_PORTS map read by the connect4 hook. Without this, a port-based
+        // egress deny rule compiles but never reaches the kernel, so the hook runs but never blocks.
+        if let Some(map) = bpf.map_mut("DENY_PORTS") {
+            let mut hm: AyaHashMap<_, u16, u32> = AyaHashMap::try_from(map)?;
+            for (port, rule_id) in compiled.tier1.port_deny_entries() {
+                hm.insert(port, rule_id, 0)?;
+            }
+        }
+
         println!("✅ Policy applied: tier1 inode rules loaded");
         Ok(())
     }

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -6,10 +6,6 @@ use assay_common::{
     MONITOR_STAT_LSM_EVENTS_EMITTED, MONITOR_STAT_LSM_RINGBUF_DROPPED,
     MONITOR_STAT_OPENAT2_EVENTS_EMITTED, MONITOR_STAT_OPENAT2_RINGBUF_DROPPED,
     MONITOR_STAT_OPENAT_EVENTS_EMITTED, MONITOR_STAT_OPENAT_RINGBUF_DROPPED,
-    MONITOR_STAT_SENDMSG_EVENTS_EMITTED, MONITOR_STAT_SENDMSG_NON_IP_FAMILY,
-    MONITOR_STAT_SENDMSG_NO_PEER, MONITOR_STAT_SENDMSG_RINGBUF_DROPPED,
-    MONITOR_STAT_SENDTO_EVENTS_EMITTED, MONITOR_STAT_SENDTO_NON_IP_FAMILY,
-    MONITOR_STAT_SENDTO_NO_PEER, MONITOR_STAT_SENDTO_RINGBUF_DROPPED,
     MONITOR_STAT_TRACEPOINT_EVENTS_EMITTED, MONITOR_STAT_TRACEPOINT_RINGBUF_DROPPED,
     SOCKET_STAT_ALLOWED, SOCKET_STAT_BLOCKED_CIDR, SOCKET_STAT_BLOCKED_PORT, SOCKET_STAT_CHECKS,
     SOCKET_STAT_EVENTS_EMITTED, SOCKET_STAT_RINGBUF_DROPPED,
@@ -18,7 +14,7 @@ use assay_policy::tiers::CompiledPolicy;
 use aya::maps::lpm_trie::Key;
 use aya::{
     maps::{Array as AyaArray, HashMap as AyaHashMap, LpmTrie, RingBuf},
-    programs::{Lsm, TracePoint},
+    programs::{CgroupAttachMode, CgroupSockAddr, Lsm, TracePoint},
     Btf, Ebpf,
 };
 use std::sync::{Arc, Mutex};
@@ -39,6 +35,8 @@ enum MonitorLink {
     Lsm(#[allow(dead_code)] aya::programs::lsm::LsmLink),
     #[allow(dead_code)]
     KProbe(#[allow(dead_code)] aya::programs::kprobe::KProbeLink),
+    #[allow(dead_code)]
+    CgroupSockAddr(#[allow(dead_code)] aya::programs::cgroup_sock_addr::CgroupSockAddrLink),
 }
 
 #[cfg(target_os = "linux")]
@@ -214,24 +212,6 @@ impl LinuxMonitor {
                 println!("DEBUG: Attached Tracepoint sys_enter_connect");
             }
         }
-        if let Some(prog) = bpf.program_mut("assay_monitor_sendto") {
-            if let Ok(tp) = TryInto::<&mut TracePoint>::try_into(&mut *prog) {
-                tp.load()?;
-                let link_id = tp.attach("syscalls", "sys_enter_sendto")?;
-                let link = tp.take_link(link_id)?;
-                self.links.push(MonitorLink::TracePoint(link));
-                println!("DEBUG: Attached Tracepoint sys_enter_sendto");
-            }
-        }
-        if let Some(prog) = bpf.program_mut("assay_monitor_sendmsg") {
-            if let Ok(tp) = TryInto::<&mut TracePoint>::try_into(&mut *prog) {
-                tp.load()?;
-                let link_id = tp.attach("syscalls", "sys_enter_sendmsg")?;
-                let link = tp.take_link(link_id)?;
-                self.links.push(MonitorLink::TracePoint(link));
-                println!("DEBUG: Attached Tracepoint sys_enter_sendmsg");
-            }
-        }
         if let Some(prog) = bpf.program_mut("assay_monitor_fork") {
             if let Ok(tp) = TryInto::<&mut TracePoint>::try_into(&mut *prog) {
                 tp.load()?;
@@ -356,11 +336,26 @@ impl LinuxMonitor {
         Ok(())
     }
 
+    /// Attach the connect4 cgroup_sock_addr enforcement program to the given cgroup v2 directory.
+    ///
+    /// IPv4/TCP egress only. The `DENY_PORTS` / `CIDR_RULES_V4` maps (populated by `set_tier1_rules`)
+    /// decide which connects are blocked; with an empty rule set every connect falls through to allow,
+    /// so attaching is safe even at the cgroup root. The connect tracepoint observation path is
+    /// untouched, so observation-health reporting is unaffected by enforcement being active.
     pub fn attach_network_cgroup(
         &mut self,
-        _cgroup_file: &std::fs::File,
+        cgroup_file: &std::fs::File,
     ) -> Result<(), MonitorError> {
-        // Stub for compatibility
+        let mut bpf = self.bpf.lock().unwrap();
+        if let Some(prog) = bpf.program_mut("connect4_hook") {
+            if let Ok(csa) = TryInto::<&mut CgroupSockAddr>::try_into(&mut *prog) {
+                csa.load()?;
+                let link_id = csa.attach(cgroup_file, CgroupAttachMode::Single)?;
+                let link = csa.take_link(link_id)?;
+                self.links.push(MonitorLink::CgroupSockAddr(link));
+                println!("DEBUG: Attached cgroup connect4 egress enforcement");
+            }
+        }
         Ok(())
     }
 
@@ -397,26 +392,6 @@ impl LinuxMonitor {
             .unwrap_or(0);
         stats.connect_ringbuf_dropped = array
             .get(&MONITOR_STAT_CONNECT_RINGBUF_DROPPED, 0)
-            .unwrap_or(0);
-        stats.sendto_events_emitted = array
-            .get(&MONITOR_STAT_SENDTO_EVENTS_EMITTED, 0)
-            .unwrap_or(0);
-        stats.sendto_ringbuf_dropped = array
-            .get(&MONITOR_STAT_SENDTO_RINGBUF_DROPPED, 0)
-            .unwrap_or(0);
-        stats.sendmsg_events_emitted = array
-            .get(&MONITOR_STAT_SENDMSG_EVENTS_EMITTED, 0)
-            .unwrap_or(0);
-        stats.sendmsg_ringbuf_dropped = array
-            .get(&MONITOR_STAT_SENDMSG_RINGBUF_DROPPED, 0)
-            .unwrap_or(0);
-        stats.sendto_no_peer = array.get(&MONITOR_STAT_SENDTO_NO_PEER, 0).unwrap_or(0);
-        stats.sendmsg_no_peer = array.get(&MONITOR_STAT_SENDMSG_NO_PEER, 0).unwrap_or(0);
-        stats.sendto_non_ip_family = array
-            .get(&MONITOR_STAT_SENDTO_NON_IP_FAMILY, 0)
-            .unwrap_or(0);
-        stats.sendmsg_non_ip_family = array
-            .get(&MONITOR_STAT_SENDMSG_NON_IP_FAMILY, 0)
             .unwrap_or(0);
 
         let map = bpf.map("SOCKET_STATS").ok_or(MonitorError::MapNotFound {


### PR DESCRIPTION
## What

Closes the network-egress gap surfaced by the egress effect-proxy: the deny rules compiled fine and populated the kernel maps the `connect4` hook reads, but the userspace cgroup attach was a stub, so a policy's network deny rules were **observed and never enforced**.

This wires the attach. When `assay monitor --policy <file>` compiles `net_connect` deny rules (a destination port or CIDR), it loads `connect4_hook` and attaches it at the cgroup v2 root, so the `DENY_PORTS` / `CIDR_RULES_V4` maps actually refuse outbound connects (EPERM).

## Scope (intentionally narrow)

- IPv4/TCP `connect` only — no IPv6/UDP/QUIC.
- Gated on the policy carrying network deny rules; an empty rule set is a no-op.
- The connect **tracepoint** observation path is untouched, so `observation_health` reporting is unaffected by enforcement being active.

## Verification

- Linux compile verified for `x86_64-unknown-linux-gnu` (`cargo check -p assay-monitor`).
- Real connect-block is proven on the eBPF VM by the egress effect-proxy harness (flips the exfil connect from reaching its listener to blocked, while the in-policy control still succeeds).

No new claim about observation; this only makes the already-compiled deny rules enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)