### PR TITLE
ci: pin actions/checkout in monitor attach smoke

### DIFF
--- a/.github/workflows/monitor-attach-smoke.yml
+++ b/.github/workflows/monitor-attach-smoke.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Build assay-cli
         run: cargo build -p assay-cli --release


### PR DESCRIPTION
Follow-up to #1571: the smoke workflow used actions/checkout@v4 but the repo requires actions pinned to a full-length SHA, so the first dispatch failed at setup before running the monitor. Pin to the repo's canonical checkout SHA (v5.0.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)