### PR TITLE
ci: build eBPF in release in monitor attach smoke (root cause of #1570)

### DIFF
--- a/.github/workflows/monitor-attach-smoke.yml
+++ b/.github/workflows/monitor-attach-smoke.yml
@@ -34,7 +34,13 @@ jobs:
 
       - name: Build eBPF object
         if: ${{ github.event.inputs.build_ebpf != 'false' }}
-        run: cargo xtask build-ebpf
+        # Build the eBPF object exactly like the delegated runner-spike gate: install the eBPF
+        # toolchain and build in release with --no-docker. A debug-mode build produces programs the
+        # verifier rejects (empty / "last insn is not an exit or jmp"), which is what made an earlier
+        # smoke run mislook like an assay monitor attach bug.
+        run: |
+          scripts/ci/install-ebpf-toolchain.sh
+          cargo xtask build-ebpf --release --no-docker
 
       - name: Smoke - assay monitor must attach its observation probes
         run: |


### PR DESCRIPTION
The `assay monitor` verifier failure in #1570 was a build artifact, not a kernel or source bug. The smoke gate (and the egress proof) built the eBPF with a bare `cargo xtask build-ebpf` — debug mode, no toolchain install — which produces programs the verifier rejects (`last insn is not an exit or jmp`, `processed 0 insns`).

The delegated runner-spike gate, which attaches the same programs and is green, builds with `scripts/ci/install-ebpf-toolchain.sh` + `cargo xtask build-ebpf --release --no-docker`. This matches that.

Expected: the re-dispatched smoke now reaches `Assay Monitor running` (SMOKE PASS), confirming `assay monitor` attaches fine with a correctly-built object — which unblocks the egress real-block proof in #1569.

Related: #1570, #1569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)