### PR TITLE
ci: emit eBPF build provenance in monitor attach smoke

### DIFF
--- a/.github/workflows/monitor-attach-smoke.yml
+++ b/.github/workflows/monitor-attach-smoke.yml
@@ -41,6 +41,13 @@ jobs:
         run: |
           scripts/ci/install-ebpf-toolchain.sh
           cargo xtask build-ebpf --release --no-docker
+          # Build provenance, so the canonical eBPF build path is self-documenting in the run log and
+          # nobody has to reconstruct in three months why this path is the right one (see #1570).
+          {
+            echo "ebpf_build_mode=release"
+            echo "ebpf_build_path=xtask --release --no-docker"
+            echo "toolchain_install=present"
+          } | tee "$RUNNER_TEMP/ebpf-build-provenance.txt"
 
       - name: Smoke - assay monitor must attach its observation probes
         run: |


### PR DESCRIPTION
Self-documents the canonical eBPF build path in the smoke run log (`ebpf_build_mode=release`, `ebpf_build_path=xtask --release --no-docker`, `toolchain_install=present`) so the reason this path is canonical does not have to be reconstructed later. Follow-up to #1570 / the egress proof in #1569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)