### PR TITLE
feat(runner): emit assay.enforcement_health.v0 (enforcement truth, separate carrier)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Enforcement health artifact (`assay.enforcement_health.v0`). `assay monitor --enforcement-health
+  <path>` writes an explicit enforcement-truth artifact, deliberately SEPARATE from
+  `observation_health`: observation_health answers "how complete was observation?", this answers "was
+  enforcement active, and did it block?". The two are orthogonal (a run can have complete observation
+  and absent enforcement, or vice versa), so they are not conflated into one blob. Fields:
+  `network_enforcement` (`active` / `absent` / `failed` / `not_applicable`), `attach_confirmed`,
+  `blocked_count`, `allowed_count`, `scope` (`ipv4_tcp_connect`). It is a written artifact, never parsed
+  from stdout. Crucially, on the fail-closed abort path (egress enforcement requested but the connect4
+  attach could not be installed) it writes `failed` BEFORE exiting, so a requested-but-failed
+  enforcement is never mistaken for an un-requested one (`absent`). v0 is intentionally small; rule IDs,
+  policy refs, timestamps, provenance, and enforcement receipts are follow-ups. The schema is
+  producer-agnostic so future enforcement paths emit the same shape; a second enforcement domain becomes
+  an explicit `v1`, never a silent reinterpretation of `v0`.
+
 - Network egress enforcement (IPv4 TCP connect only). `assay monitor --policy <file>` now attaches the
   compiled `connect4` cgroup program so a policy's network deny rules actually block outbound connects,
   not just observe them. When the policy carries `net_connect` deny rules (a destination port or CIDR),

--- a/crates/assay-cli/src/cli/commands/monitor.rs
+++ b/crates/assay-cli/src/cli/commands/monitor.rs
@@ -58,6 +58,11 @@ pub struct MonitorArgs {
     /// Monitor ALL cgroups (bypass filtering, useful for debugging)
     #[arg(long)]
     pub monitor_all: bool,
+
+    /// Write an `assay.enforcement_health.v0` artifact (enforcement truth: active/failed/absent +
+    /// block counts) to this path. Explicit artifact, not parsed from stdout.
+    #[arg(long)]
+    pub enforcement_health: Option<PathBuf>,
 }
 
 pub async fn run(args: MonitorArgs) -> anyhow::Result<i32> {

--- a/crates/assay-cli/src/cli/commands/monitor_next/enforcement_health.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/enforcement_health.rs
@@ -1,0 +1,139 @@
+//! `assay.enforcement_health.v0` — the enforcement-truth artifact.
+//!
+//! Deliberately a SEPARATE carrier from `observation_health`. observation_health answers "how complete
+//! was observation?"; this answers "was enforcement active, and did it block?". They are orthogonal: a
+//! run can have complete observation and absent enforcement, or vice versa. Conflating them would let an
+//! observation artifact claim something it never produced.
+//!
+//! Modelled as enforcement truth, not monitor output: an *enforcement run* produces it. Today the only
+//! producer is `assay monitor` (the connect4 egress path), but the schema is producer-agnostic so future
+//! enforcement paths (landlock, argument constraints, tool-decision) emit the same shape.
+//!
+//! Truth carrier, not a log derivative: it is written as an explicit artifact (`--enforcement-health
+//! <path>`), never parsed back out of stdout. stdout stays diagnostic; this file is the contract.
+//!
+//! v0 is intentionally small. Rule IDs, policy refs, timestamps, provenance, and enforcement receipts
+//! are follow-ups, not v0.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+pub const SCHEMA_V0: &str = "assay.enforcement_health.v0";
+
+/// The enforcement domain this artifact reports on. For now the only producer is connect4 IPv4/TCP
+/// egress. A second domain (e.g. landlock filesystem, argument constraints) is a new `scope` value, and
+/// a multi-domain shape would be an explicit `v1` bump, never a silent reinterpretation of `v0`.
+pub const SCOPE_IPV4_TCP_CONNECT: &str = "ipv4_tcp_connect";
+
+/// The enforcement status. The carrier vocabulary is the full set; a given producer emits only the
+/// states that can actually occur for it (the connect4 producer emits Active / Failed / Absent —
+/// NotApplicable is reserved for scopes where the channel does not apply).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkEnforcement {
+    /// Requested and installed (the program is attached and the deny rules are loaded).
+    Active,
+    /// Not requested (no network deny rules in the policy, or no policy).
+    Absent,
+    /// Requested but could NOT be installed (attach failed / no kernel support). Emitted on the
+    /// fail-closed abort path BEFORE exit, so a requested-but-failed enforcement is never mistaken for
+    /// an un-requested one.
+    Failed,
+    /// Network enforcement does not apply to this scope/producer (reserved; not emitted by connect4).
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnforcementHealth {
+    pub schema: String,
+    pub scope: String,
+    pub network_enforcement: NetworkEnforcement,
+    pub attach_confirmed: bool,
+    pub blocked_count: u64,
+    pub allowed_count: u64,
+}
+
+impl EnforcementHealth {
+    fn new(scope: &str, status: NetworkEnforcement, attach_confirmed: bool) -> Self {
+        Self {
+            schema: SCHEMA_V0.to_string(),
+            scope: scope.to_string(),
+            network_enforcement: status,
+            attach_confirmed,
+            blocked_count: 0,
+            allowed_count: 0,
+        }
+    }
+
+    /// Enforcement was requested and installed; carries the observed block/allow counts.
+    pub fn active(scope: &str, blocked_count: u64, allowed_count: u64) -> Self {
+        Self {
+            blocked_count,
+            allowed_count,
+            ..Self::new(scope, NetworkEnforcement::Active, true)
+        }
+    }
+
+    /// Enforcement was requested but could not be installed (fail-closed abort).
+    pub fn failed(scope: &str) -> Self {
+        Self::new(scope, NetworkEnforcement::Failed, false)
+    }
+
+    /// Enforcement was not requested for this run.
+    pub fn absent(scope: &str) -> Self {
+        Self::new(scope, NetworkEnforcement::Absent, false)
+    }
+
+    pub fn write_to(&self, path: &Path) -> std::io::Result<()> {
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        std::fs::write(path, json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_carries_counts_and_confirmed_attach() {
+        let h = EnforcementHealth::active(SCOPE_IPV4_TCP_CONNECT, 1, 1);
+        assert_eq!(h.network_enforcement, NetworkEnforcement::Active);
+        assert!(h.attach_confirmed);
+        assert_eq!(h.blocked_count, 1);
+        assert_eq!(h.allowed_count, 1);
+        assert_eq!(h.schema, SCHEMA_V0);
+    }
+
+    #[test]
+    fn failed_is_distinct_from_absent() {
+        // The whole point of the artifact: requested-but-failed must not look like not-requested.
+        let failed = EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT);
+        let absent = EnforcementHealth::absent(SCOPE_IPV4_TCP_CONNECT);
+        assert_eq!(failed.network_enforcement, NetworkEnforcement::Failed);
+        assert!(!failed.attach_confirmed);
+        assert_eq!(absent.network_enforcement, NetworkEnforcement::Absent);
+        assert_ne!(failed.network_enforcement, absent.network_enforcement);
+    }
+
+    #[test]
+    fn serializes_snake_case_status() {
+        let json = serde_json::to_string(&EnforcementHealth::active(SCOPE_IPV4_TCP_CONNECT, 2, 3))
+            .unwrap();
+        assert!(json.contains("\"schema\":\"assay.enforcement_health.v0\""));
+        assert!(json.contains("\"network_enforcement\":\"active\""));
+        assert!(json.contains("\"scope\":\"ipv4_tcp_connect\""));
+        assert!(json.contains("\"blocked_count\":2"));
+        assert!(json.contains("\"allowed_count\":3"));
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let h = EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT);
+        let back: EnforcementHealth =
+            serde_json::from_str(&serde_json::to_string(&h).unwrap()).unwrap();
+        assert_eq!(back.network_enforcement, NetworkEnforcement::Failed);
+        assert!(!back.attach_confirmed);
+    }
+}

--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -19,6 +19,10 @@ pub(crate) mod errors;
 pub(crate) mod events;
 #[cfg(target_os = "linux")]
 pub(crate) mod normalize;
+// Cross-platform carrier; its only emitter (run_linux) is Linux-gated, so on other targets the
+// constructors are unused outside the unit tests.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) mod enforcement_health;
 pub(crate) mod output;
 #[cfg(target_os = "linux")]
 pub(crate) mod rules;
@@ -152,6 +156,10 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
     }
 
     let rules = rules::compile_active_rules(runtime_config.as_ref());
+
+    // Enforcement truth for the enforcement_health.v0 artifact: did egress enforcement actually attach?
+    use enforcement_health::{EnforcementHealth, SCOPE_IPV4_TCP_CONNECT};
+    let mut enforcement_active = false;
 
     if let Some(cfg) = &runtime_config {
         let mut t1_policy = assay_policy::tiers::Policy::default();
@@ -349,6 +357,12 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                         "FATAL: egress enforcement requested but cannot open cgroup v2 root /sys/fs/cgroup: {} (fail-closed, not running audit-only)",
                         e
                     );
+                    // Honesty: a requested-but-failed enforcement must record `failed`, never look
+                    // like `absent` (not requested), so write the artifact BEFORE the fail-closed exit.
+                    write_enforcement_health(
+                        &args,
+                        EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT),
+                    );
                     return Ok(crate::exit_codes::EXIT_WOULD_BLOCK);
                 }
             };
@@ -357,8 +371,10 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                     "FATAL: egress enforcement requested but connect4 attach failed: {} (fail-closed, not running audit-only)",
                     e
                 );
+                write_enforcement_health(&args, EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT));
                 return Ok(crate::exit_codes::EXIT_WOULD_BLOCK);
             }
+            enforcement_active = true;
             if !args.quiet {
                 emit_err!(
                     "  • Egress enforcement ACTIVE (IPv4/TCP connect, connect4) at /sys/fs/cgroup: {} port + {} cidr deny rules. NOT covered: IPv6, UDP/QUIC, DNS resolution, already-open sockets, raw sockets, proxy/tunnel identity.",
@@ -403,6 +419,9 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         }
     }
 
+    // Enforcement block/allow counts for the enforcement_health artifact (from the kernel stats).
+    let mut blocked_count = 0u64;
+    let mut allowed_count = 0u64;
     match monitor.snapshot_stats() {
         Ok(stats) => {
             emit_err!("Monitor summary:");
@@ -425,6 +444,8 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                 stats.socket_events_emitted,
                 stats.socket_ringbuf_dropped
             );
+            blocked_count = stats.socket_blocked_port + stats.socket_blocked_cidr;
+            allowed_count = stats.socket_allowed;
             if stats.has_ringbuf_pressure() {
                 emit_err!(
                     "  ⚠️  Ring buffer pressure detected: {} dropped event(s)",
@@ -435,5 +456,39 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         Err(e) => emit_err!("Warning: Failed to read monitor stats: {}", e),
     }
 
+    // enforcement_health.v0 artifact (explicit, never parsed from stdout). active when enforcement
+    // attached; absent when it was not requested. The `failed` case is written on the fail-closed abort
+    // path above, before exit, so requested-but-failed never reads as not-requested.
+    if args.enforcement_health.is_some() {
+        let health = if enforcement_active {
+            EnforcementHealth::active(SCOPE_IPV4_TCP_CONNECT, blocked_count, allowed_count)
+        } else {
+            EnforcementHealth::absent(SCOPE_IPV4_TCP_CONNECT)
+        };
+        write_enforcement_health(&args, health);
+    }
+
     Ok(exit_codes::OK)
+}
+
+/// Write the enforcement_health.v0 artifact to `--enforcement-health <path>` if set. No-op otherwise.
+#[cfg(target_os = "linux")]
+fn write_enforcement_health(
+    args: &super::MonitorArgs,
+    health: enforcement_health::EnforcementHealth,
+) {
+    if let Some(path) = args.enforcement_health.as_ref() {
+        match health.write_to(path) {
+            Ok(()) => output::err(format!(
+                "  • enforcement_health.v0 written: {} ({:?})",
+                path.display(),
+                health.network_enforcement
+            )),
+            Err(e) => output::err(format!(
+                "Warning: failed to write enforcement_health artifact to {}: {}",
+                path.display(),
+                e
+            )),
+        }
+    }
 }


### PR DESCRIPTION
Closes the artifact-honesty gap the egress-enforcement arc (#1569) left open: enforcement was proven on the runner, but nothing in an artifact said so. This adds a SEPARATE carrier for enforcement truth.

## Why separate from observation_health
`observation_health` answers "how complete was observation?"; this answers "was enforcement active, and did it block?". They are orthogonal — a run can have complete observation and absent enforcement, or vice versa. Bolting enforcement status onto observation_health would let an observation artifact claim something it never produced.

## What
`assay monitor --enforcement-health <path>` writes `assay.enforcement_health.v0`:
```json
{ "schema": "assay.enforcement_health.v0", "scope": "ipv4_tcp_connect",
  "network_enforcement": "active", "attach_confirmed": true,
  "blocked_count": 1, "allowed_count": 1 }
```
- Explicit artifact, never parsed from stdout (stdout stays diagnostic, the file is the contract).
- Fail-closed honesty: on the abort path (egress requested but the connect4 attach is unavailable) it writes `failed` BEFORE exit 4, so requested-but-failed is never mistaken for not-requested (`absent`). `absent` = not requested, `failed` = requested-but-not-installed, `active` = installed — all three reachable.
- v0 is intentionally small. Rule IDs, policy refs, timestamps, provenance, enforcement receipts are follow-ups.
- Producer-agnostic schema: future enforcement paths (landlock, argument constraints, tool-decision) emit the same shape; a second enforcement domain is an explicit `v1`, never a silent reinterpretation of `v0`.

## Verification
Cross-platform carrier + serde round-trip unit tests pass natively (4 tests). The `run_linux` wiring is cfg-gated; ubuntu Build+Test and the delegated runner-spike proof type-check it on real Linux.

Follow-ups (separate): plimsoll consumes enforcement_health.v0; the egress effect-proxy harness reads the artifact instead of parsing monitor stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)