### PR TITLE
chore(release): assay v3.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.20.0] - 2026-06-09
+
 ### Added
 
 - Enforcement health artifact (`assay.enforcement_health.v0`). `assay monitor --enforcement-health

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.19.1"
+version = "3.20.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.19.1"
+version = "3.20.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Minor release. Bumps the workspace version 3.19.1 -> 3.20.0 and finalizes the CHANGELOG. All additive and backward-compatible.

Carries since v3.19.1:
- Runtime network egress enforcement (IPv4/TCP `connect()` via the connect4 cgroup program), fail-closed, bounded scope (no IPv6/UDP/QUIC/DNS/already-open/raw/proxy).
- `assay.enforcement_health.v0` artifact: enforcement truth as a separate carrier from observation_health (`assay monitor --enforcement-health <path>`), `failed` written before the fail-closed exit.
- ADR-034 evidence redaction at capture (Phase 1 redactor, Phase 2 shared `secret-rules.v1.json` contract, Phase 3 URL userinfo), plus the now-live network observation-health producer that was previously main-only.

After merge: tag `v3.20.0` from main to trigger the release workflow (crates.io publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)