### PR TITLE
perf(policy): compile-once PolicyState for tool-arg schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- `policy_engine::PolicyState`: compile a policy's per-tool JSON Schema validators ONCE and reuse them
+  across calls, instead of recompiling per call. The `args_valid` metric evaluator now compiles once
+  per evaluation and reuses the validators across every tool call in the response (previously each call
+  recompiled the matched tool's schema). `evaluate_tool_args` stays as the one-shot convenience and is
+  unchanged; the MCP proxy already compiled at policy load. Verdicts are identical (parity-tested);
+  this is a hot-loop performance change, not a behaviour change.
+
 ## [3.20.0] - 2026-06-09
 
 ### Added

--- a/crates/assay-core/src/policy_engine.rs
+++ b/crates/assay-core/src/policy_engine.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
@@ -93,6 +94,66 @@ pub fn evaluate_schema(compiled: &jsonschema::Validator, tool_args: &Value) -> V
         details: serde_json::json!({
             "violations": violations
         }),
+    }
+}
+
+/// A policy whose per-tool JSON Schema validators are compiled ONCE, so a caller evaluating many tool
+/// calls against the same policy does not recompile per call (`jsonschema::validator_for` is the
+/// expensive step). `evaluate_tool_args` stays the one-shot convenience that compiles on the fly; this
+/// is the compile-once path for hot loops, matching how the MCP proxy compiles all schemas at policy
+/// load. Verdicts are identical to `evaluate_tool_args` for the same policy and call.
+pub struct PolicyState {
+    validators: HashMap<String, Result<jsonschema::Validator, String>>,
+    tool_names: Vec<String>,
+}
+
+impl PolicyState {
+    /// Compile every tool schema in the policy once. A tool whose schema fails to compile is recorded
+    /// as an error and only surfaces (as `E_SCHEMA_COMPILE`) if that tool is later evaluated, matching
+    /// the one-shot `evaluate_tool_args` behavior of only compiling the requested tool's schema.
+    pub fn compile(policy: &Value) -> Self {
+        let mut validators = HashMap::new();
+        let mut tool_names = Vec::new();
+        if let Some(obj) = policy.as_object() {
+            for (tool, schema_val) in obj {
+                tool_names.push(tool.clone());
+                validators.insert(
+                    tool.clone(),
+                    jsonschema::validator_for(schema_val).map_err(|e| e.to_string()),
+                );
+            }
+        }
+        Self {
+            validators,
+            tool_names,
+        }
+    }
+
+    /// Evaluate one tool call against the pre-compiled validators.
+    pub fn evaluate(&self, tool_name: &str, tool_args: &Value) -> Verdict {
+        match self.validators.get(tool_name) {
+            None => {
+                let mut message = format!("Tool '{}' not defined in policy", tool_name);
+                if let Some(match_) =
+                    crate::errors::similarity::closest_prompt(tool_name, self.tool_names.iter())
+                {
+                    message.push_str(&format!(". Did you mean '{}'?", match_.prompt));
+                }
+                Verdict {
+                    status: VerdictStatus::Blocked,
+                    reason_code: "E_POLICY_MISSING_TOOL".to_string(),
+                    details: serde_json::json!({ "message": message }),
+                }
+            }
+            Some(Err(e)) => Verdict {
+                status: VerdictStatus::Blocked,
+                reason_code: "E_SCHEMA_COMPILE".to_string(),
+                details: serde_json::json!({
+                    "message": format!("Invalid schema for tool '{}': {}", tool_name, e)
+                }),
+            },
+            Some(Ok(compiled)) => evaluate_schema(compiled, tool_args),
+        }
     }
 }
 

--- a/crates/assay-core/tests/policy_state_cache.rs
+++ b/crates/assay-core/tests/policy_state_cache.rs
@@ -1,0 +1,117 @@
+//! `PolicyState` (compile-once) must produce verdicts identical to the one-shot `evaluate_tool_args`,
+//! so switching a hot loop to compile-once changes performance, never behaviour.
+
+use assay_core::policy_engine::{evaluate_tool_args, PolicyState, VerdictStatus};
+use serde_json::json;
+
+fn policy() -> serde_json::Value {
+    json!({
+        "send_money": {
+            "type": "object",
+            "properties": {
+                "recipient": { "type": "string", "enum": ["acc_alice"] },
+                "amount": { "type": "number", "maximum": 1000 }
+            },
+            "required": ["recipient", "amount"]
+        },
+        // an intentionally broken schema for one tool, to exercise E_SCHEMA_COMPILE parity
+        "broken": { "type": "not-a-real-type" }
+    })
+}
+
+fn assert_parity(tool: &str, args: &serde_json::Value) {
+    let p = policy();
+    let state = PolicyState::compile(&p);
+    let cached = state.evaluate(tool, args);
+    let one_shot = evaluate_tool_args(&p, tool, args);
+    assert_eq!(cached.status, one_shot.status, "status differs for {tool}");
+    assert_eq!(
+        cached.reason_code, one_shot.reason_code,
+        "reason_code differs for {tool}"
+    );
+}
+
+#[test]
+fn allowed_call_parity() {
+    assert_parity(
+        "send_money",
+        &json!({ "recipient": "acc_alice", "amount": 100 }),
+    );
+}
+
+#[test]
+fn blocked_over_ceiling_parity() {
+    let p = policy();
+    let v = PolicyState::compile(&p).evaluate(
+        "send_money",
+        &json!({ "recipient": "acc_alice", "amount": 9999 }),
+    );
+    assert_eq!(v.status, VerdictStatus::Blocked);
+    assert_eq!(v.reason_code, "E_ARG_SCHEMA");
+    assert_parity(
+        "send_money",
+        &json!({ "recipient": "acc_alice", "amount": 9999 }),
+    );
+}
+
+#[test]
+fn off_allowlist_recipient_parity() {
+    assert_parity(
+        "send_money",
+        &json!({ "recipient": "acc_attacker", "amount": 10 }),
+    );
+}
+
+#[test]
+fn missing_tool_parity() {
+    // A tool not in the policy: both paths return E_POLICY_MISSING_TOOL (incl. the did-you-mean path).
+    let p = policy();
+    let v = PolicyState::compile(&p).evaluate("send_monye", &json!({}));
+    assert_eq!(v.status, VerdictStatus::Blocked);
+    assert_eq!(v.reason_code, "E_POLICY_MISSING_TOOL");
+    assert_parity("send_monye", &json!({}));
+}
+
+#[test]
+fn broken_schema_only_surfaces_when_that_tool_is_evaluated() {
+    let p = policy();
+    let state = PolicyState::compile(&p);
+    // The broken schema is compiled eagerly but must not affect an unrelated tool's verdict.
+    let ok = state.evaluate(
+        "send_money",
+        &json!({ "recipient": "acc_alice", "amount": 1 }),
+    );
+    assert_eq!(ok.status, VerdictStatus::Allowed);
+    // Evaluating the broken tool surfaces the compile error, same as the one-shot path.
+    let broken = state.evaluate("broken", &json!({}));
+    assert_eq!(broken.status, VerdictStatus::Blocked);
+    assert_eq!(broken.reason_code, "E_SCHEMA_COMPILE");
+    assert_parity("broken", &json!({}));
+}
+
+#[test]
+fn compile_once_reused_across_many_calls() {
+    // The point of the cache: one compile, many evaluations, stable verdicts.
+    let p = policy();
+    let state = PolicyState::compile(&p);
+    for _ in 0..50 {
+        assert_eq!(
+            state
+                .evaluate(
+                    "send_money",
+                    &json!({ "recipient": "acc_alice", "amount": 100 })
+                )
+                .status,
+            VerdictStatus::Allowed
+        );
+        assert_eq!(
+            state
+                .evaluate(
+                    "send_money",
+                    &json!({ "recipient": "acc_alice", "amount": 5000 })
+                )
+                .status,
+            VerdictStatus::Blocked
+        );
+    }
+}

--- a/crates/assay-metrics/src/args_valid_next/evaluator.rs
+++ b/crates/assay-metrics/src/args_valid_next/evaluator.rs
@@ -63,13 +63,12 @@ impl Metric for ArgsValidMetric {
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),
                 );
+                // Compile each tool schema once and reuse it across every tool call, instead of
+                // recompiling per call via evaluate_tool_args.
+                let state = assay_core::policy_engine::PolicyState::compile(&policy_val);
 
                 for call in tool_calls {
-                    let verdict = assay_core::policy_engine::evaluate_tool_args(
-                        &policy_val,
-                        &call.tool_name,
-                        &call.args,
-                    );
+                    let verdict = state.evaluate(&call.tool_name, &call.args);
 
                     if verdict.status == assay_core::policy_engine::VerdictStatus::Blocked {
                         // Legacy compat: schema-only mode ignores missing tools.
@@ -99,6 +98,8 @@ impl Metric for ArgsValidMetric {
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),
                 );
+                // Compile each tool schema once and reuse it across every tool call.
+                let state = assay_core::policy_engine::PolicyState::compile(&policy_val);
 
                 for call in tool_calls {
                     if policy
@@ -139,11 +140,7 @@ impl Metric for ArgsValidMetric {
                         continue;
                     }
 
-                    let verdict = assay_core::policy_engine::evaluate_tool_args(
-                        &policy_val,
-                        &call.tool_name,
-                        &call.args,
-                    );
+                    let verdict = state.evaluate(&call.tool_name, &call.args);
                     if verdict.status == assay_core::policy_engine::VerdictStatus::Blocked {
                         if verdict.reason_code == "E_ARG_SCHEMA" {
                             if let Some(violations) =


### PR DESCRIPTION
`evaluate_tool_args` compiles the JSON Schema validator on every call (`jsonschema::validator_for` is the expensive step). The `args_valid` metric evaluator loops over a response's tool calls and recompiled the matched tool's schema each time. This pays off the known "compile on the fly" debt without changing behaviour.

- Adds `policy_engine::PolicyState`: compile every tool schema once, then `evaluate(tool, args)` per call, reusing the compiled validators.
- Switches the `args_valid` evaluator (schema-map and structured branches) to build `PolicyState` once per evaluation and reuse it across the loop.
- `evaluate_tool_args` is unchanged (the one-shot convenience). The MCP proxy already compiled all schemas at policy load (`compile_all_schemas`).

Verdicts are identical: a parity test asserts `PolicyState.evaluate` matches `evaluate_tool_args` for allowed / blocked-over-ceiling / off-allowlist / missing-tool (incl. did-you-mean) / broken-schema cases, plus a 50x-reuse stability check. Behaviour-neutral; this is a hot-loop performance change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)