### PR TITLE
feat(otel): read-only GenAI + OpenInference projection of assay evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@ All notable changes to this project will be documented in this file.
   read-only, one-directional, lossy view of assay runtime evidence (capability surface, observation
   health, enforcement health) as OpenTelemetry GenAI attributes plus an OpenInference `span.kind`, so
   an OTel/OpenInference backend can read assay evidence without learning assay's vocabulary. assay
-  artifacts stay the source of truth; the standard fields are a projection, never the authority. Three
-  honesty invariants are pinned by tests: every standard field that could be over-read carries a paired
-  `assay.*` qualifier; enforcement is its own attribute set and is never folded into an (observed) tool
-  span, and is absent when no `enforcement_health` is supplied (absence makes no claim); observed sets
-  the standard vocabulary cannot express (egress endpoints, paths) stay under `assay.*`. Pinned to GenAI
-  semantic conventions 1.28.0, so a version bump is an explicit change, never a silent reinterpretation.
-  Projection function and fixtures only; no exporter and no CLI wiring (those are a later slice).
+  artifacts stay the source of truth; the output carries `lossy: true` and `source_of_truth` so the
+  view cannot be mistaken for the record. Honesty invariants pinned by tests: every standard field that
+  could be over-read carries a paired `assay.*` qualifier; enforcement is its OWN guardrail-style span
+  (`assay.claim_class=enforcement`), never attributes hung next to an observed tool span, and absent
+  when no `enforcement_health` is supplied (absence makes no claim); observed sets the standard
+  vocabulary cannot express (egress endpoints, paths) stay under `assay.*`. Pinned to OTel GenAI semconv
+  `1.28.0-development` (flagged Development) and OpenInference `pinned`, so a bump is explicit. Ships a
+  contract doc (`docs/reference/otel-projection.md`) and a committed golden fixture (input plus expected
+  projection) so an external reader sees the contract concretely. Projection function and fixtures only;
+  no exporter and no CLI wiring (those are a later slice).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- OTel GenAI + OpenInference projection (`otel::projection`, schema `assay.otel_projection.v0`): a
+  read-only, one-directional, lossy view of assay runtime evidence (capability surface, observation
+  health, enforcement health) as OpenTelemetry GenAI attributes plus an OpenInference `span.kind`, so
+  an OTel/OpenInference backend can read assay evidence without learning assay's vocabulary. assay
+  artifacts stay the source of truth; the standard fields are a projection, never the authority. Three
+  honesty invariants are pinned by tests: every standard field that could be over-read carries a paired
+  `assay.*` qualifier; enforcement is its own attribute set and is never folded into an (observed) tool
+  span, and is absent when no `enforcement_health` is supplied (absence makes no claim); observed sets
+  the standard vocabulary cannot express (egress endpoints, paths) stay under `assay.*`. Pinned to GenAI
+  semantic conventions 1.28.0, so a version bump is an explicit change, never a silent reinterpretation.
+  Projection function and fixtures only; no exporter and no CLI wiring (those are a later slice).
+
 ### Changed
 
 - `policy_engine::PolicyState`: compile a policy's per-tool JSON Schema validators ONCE and reuse them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ All notable changes to this project will be documented in this file.
   (`assay.claim_class=enforcement`), never attributes hung next to an observed tool span, and absent
   when no `enforcement_health` is supplied (absence makes no claim); observed sets the standard
   vocabulary cannot express (egress endpoints, paths) stay under `assay.*`. Pinned to OTel GenAI semconv
-  `1.28.0-development` (flagged Development) and OpenInference `pinned`, so a bump is explicit. Ships a
+  `1.37.0-development` (the agent/tool-span surface where `execute_tool` lives, distinct from the
+  LLM-client-span surface the module pins at 1.28.0; both Development upstream) and OpenInference
+  `pinned`, so a bump is explicit. Ships a
   contract doc (`docs/reference/otel-projection.md`) and a committed golden fixture (input plus expected
   projection) so an external reader sees the contract concretely. Projection function and fixtures only;
   no exporter and no CLI wiring (those are a later slice).

--- a/crates/assay-core/src/otel/mod.rs
+++ b/crates/assay-core/src/otel/mod.rs
@@ -2,6 +2,7 @@ use crate::model::TestResultRow;
 
 pub mod genai;
 pub mod metrics;
+pub mod projection;
 pub mod redaction;
 pub mod semconv;
 

--- a/crates/assay-core/src/otel/projection.rs
+++ b/crates/assay-core/src/otel/projection.rs
@@ -1,0 +1,215 @@
+//! Read-only projection of assay runtime evidence into OpenTelemetry GenAI + OpenInference
+//! attributes.
+//!
+//! This is a one-directional, lossy projection: assay artifacts are the source of truth, and this
+//! emits a standards-shaped *view* of them so an OTel/OpenInference backend can read assay evidence
+//! without learning assay's vocabulary. It never reverses: nothing here is parsed back, and the
+//! standard fields are a projection, never the authority.
+//!
+//! Three rules make the projection honest, which is the whole point of doing it this way:
+//!
+//! 1. Every standard field that a consumer could over-read carries a paired `assay.*` qualifier
+//!    (`assay.claim_class`, the observation fields, the enforcement fields), so a backend that only
+//!    knows `gen_ai.*` gets a familiar trace and a backend that reads `assay.*` keeps observed-vs-
+//!    enforced and asserted-vs-verified intact.
+//! 2. Enforcement is projected as its own attribute set and is **never** folded into a tool span
+//!    (which is observed, not enforced). Enforcement truth comes from its own carrier
+//!    (`assay.enforcement_health.v0`) and is absent when not supplied: absence makes no claim.
+//! 3. Things the standard vocabulary cannot express (observed egress endpoints, filesystem paths)
+//!    stay in `assay.*`. That is the lossy part, stated rather than hidden.
+//!
+//! Pinned to a specific GenAI semantic-conventions version. Both OTel GenAI and OpenInference are
+//! still evolving, so the projection pins a version and a later bump is an explicit change, never a
+//! silent reinterpretation.
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+/// Schema id of this projection artifact.
+pub const PROJECTION_SCHEMA: &str = "assay.otel_projection.v0";
+
+/// Pinned OTel GenAI semantic-conventions version this projection targets. Matches the version the
+/// rest of the `otel` module pins (see `semconv::V1_28_0`). A bump is an explicit, separate change.
+pub const SEMCONV_VERSION: &str = "1.28.0";
+
+/// A single projected span (OTel span shape with OpenInference `span.kind` carried as an attribute,
+/// since OpenInference is built on OTel and the two coexist).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectedSpan {
+    pub name: String,
+    /// OTel span kind. Tool execution and guardrail decisions are application-owned, so `INTERNAL`.
+    pub kind: String,
+    pub attributes: Map<String, Value>,
+}
+
+/// The full projection: run-level resource attributes, per-event spans, and the explicit non-claims.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Projection {
+    pub schema: String,
+    pub semconv_version: String,
+    pub resource_attributes: Map<String, Value>,
+    pub spans: Vec<ProjectedSpan>,
+    /// Stated boundaries that travel with the projection so a consumer cannot over-read it.
+    pub non_claims: Vec<String>,
+}
+
+fn str_field(v: &Value, key: &str) -> Option<String> {
+    v.get(key).and_then(|x| x.as_str()).map(|s| s.to_string())
+}
+
+fn str_array(v: &Value, key: &str) -> Vec<String> {
+    v.get(key)
+        .and_then(|x| x.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|e| e.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Project assay artifacts into the OTel GenAI + OpenInference attribute view.
+///
+/// `capability_surface` is an `assay.runner.capability_surface.v0` value. `observation_health` and
+/// `enforcement_health` are optional and read from their own artifacts; an absent enforcement_health
+/// means no enforcement claim is made (not "enforcement was absent" — that distinction lives in the
+/// carrier itself).
+pub fn project(
+    capability_surface: &Value,
+    observation_health: Option<&Value>,
+    enforcement_health: Option<&Value>,
+) -> Projection {
+    let mut resource: Map<String, Value> = Map::new();
+    resource.insert("service.name".into(), Value::String("assay".into()));
+    resource.insert(
+        "assay.otel_projection.schema".into(),
+        Value::String(PROJECTION_SCHEMA.into()),
+    );
+    resource.insert(
+        "assay.semconv.version".into(),
+        Value::String(SEMCONV_VERSION.into()),
+    );
+
+    // ---- capability surface: tools and decisions become spans; raw sets stay in assay.* ----
+    let mut spans: Vec<ProjectedSpan> = Vec::new();
+
+    for tool in str_array(capability_surface, "mcp_tools") {
+        let mut attrs = Map::new();
+        attrs.insert(
+            "gen_ai.operation.name".into(),
+            Value::String("execute_tool".into()),
+        );
+        attrs.insert("gen_ai.tool.name".into(), Value::String(tool.clone()));
+        // OpenInference span kind, carried alongside gen_ai.* (the two coexist).
+        attrs.insert(
+            "openinference.span.kind".into(),
+            Value::String("TOOL".into()),
+        );
+        attrs.insert("tool.name".into(), Value::String(tool.clone()));
+        // Honesty qualifier: a capability-surface tool is OBSERVED, not proven-enforced.
+        attrs.insert("assay.claim_class".into(), Value::String("observed".into()));
+        spans.push(ProjectedSpan {
+            name: format!("execute_tool {tool}"),
+            kind: "INTERNAL".into(),
+            attributes: attrs,
+        });
+    }
+
+    // `policy_decisions` entries follow `<decision>:<key>` (e.g. "allow:read_file", "deny:write_file").
+    for decision in str_array(capability_surface, "policy_decisions") {
+        let (verdict, key) = match decision.split_once(':') {
+            Some((v, k)) => (v.to_string(), k.to_string()),
+            None => (decision.clone(), String::new()),
+        };
+        let mut attrs = Map::new();
+        // A policy decision maps to an OpenInference GUARDRAIL span (the gating step).
+        attrs.insert(
+            "openinference.span.kind".into(),
+            Value::String("GUARDRAIL".into()),
+        );
+        attrs.insert("assay.decision".into(), Value::String(verdict));
+        if !key.is_empty() {
+            attrs.insert("assay.tool".into(), Value::String(key.clone()));
+        }
+        attrs.insert("assay.claim_class".into(), Value::String("observed".into()));
+        spans.push(ProjectedSpan {
+            name: format!("guardrail {key}"),
+            kind: "INTERNAL".into(),
+            attributes: attrs,
+        });
+    }
+
+    // Observed sets the standard vocabulary has no field for stay in assay.* (the lossy part).
+    for (src_key, attr_key) in [
+        ("network_endpoints", "assay.capability.network_endpoints"),
+        ("filesystem_paths", "assay.capability.filesystem_paths"),
+        ("process_execs", "assay.capability.process_execs"),
+    ] {
+        let set = str_array(capability_surface, src_key);
+        if !set.is_empty() {
+            resource.insert(
+                attr_key.into(),
+                Value::Array(set.into_iter().map(Value::String).collect()),
+            );
+        }
+    }
+
+    // ---- observation_health: how complete the observation was (not whether it was enforced) ----
+    if let Some(oh) = observation_health {
+        for (src_key, attr_key) in [
+            ("kernel_layer", "assay.observation.kernel_layer"),
+            (
+                "network_protocol_coverage",
+                "assay.observation.network_protocol_coverage",
+            ),
+            ("policy_layer", "assay.observation.policy_layer"),
+        ] {
+            if let Some(v) = str_field(oh, src_key) {
+                resource.insert(attr_key.into(), Value::String(v));
+            }
+        }
+    }
+
+    // ---- enforcement_health: its OWN attribute set, never folded into a tool span ----
+    // Absent enforcement_health => no enforcement attributes at all => no enforcement claim.
+    if let Some(eh) = enforcement_health {
+        if let Some(v) = str_field(eh, "network_enforcement") {
+            resource.insert("assay.enforcement.network".into(), Value::String(v));
+        }
+        if let Some(v) = eh.get("attach_confirmed").and_then(|x| x.as_bool()) {
+            resource.insert("assay.enforcement.attach_confirmed".into(), Value::Bool(v));
+        }
+        if let Some(v) = str_field(eh, "scope") {
+            resource.insert("assay.enforcement.scope".into(), Value::String(v));
+        }
+        for (src_key, attr_key) in [
+            ("blocked_count", "assay.enforcement.blocked_count"),
+            ("allowed_count", "assay.enforcement.allowed_count"),
+        ] {
+            if let Some(n) = eh.get(src_key).and_then(|x| x.as_u64()) {
+                resource.insert(attr_key.into(), Value::Number(n.into()));
+            }
+        }
+    }
+
+    let non_claims = vec![
+        "This projection is a one-directional, lossy view; the assay artifacts remain authoritative."
+            .to_string(),
+        "gen_ai.* and openinference.* fields are a projection, not the source of truth.".to_string(),
+        "Observed is not enforced: capability-surface tools carry assay.claim_class=observed, and \
+         enforcement is a separate attribute set read only from assay.enforcement_health.v0."
+            .to_string(),
+        "Absence of enforcement attributes means no enforcement_health was supplied, not that \
+         enforcement was absent."
+            .to_string(),
+        format!("Pinned to GenAI semantic conventions {SEMCONV_VERSION}; a version bump is explicit."),
+    ];
+
+    Projection {
+        schema: PROJECTION_SCHEMA.to_string(),
+        semconv_version: SEMCONV_VERSION.to_string(),
+        resource_attributes: resource,
+        spans,
+        non_claims,
+    }
+}

--- a/crates/assay-core/src/otel/projection.rs
+++ b/crates/assay-core/src/otel/projection.rs
@@ -28,9 +28,11 @@ use serde_json::{Map, Value};
 /// Schema id of this projection artifact.
 pub const PROJECTION_SCHEMA: &str = "assay.otel_projection.v0";
 
-/// Pinned OTel GenAI semconv target, flagged Development to match upstream status. Matches the
-/// version the rest of the `otel` module pins (`semconv::V1_28_0`). A bump is an explicit change.
-pub const OTEL_GENAI_SEMCONV: &str = "1.28.0-development";
+/// Pinned OTel GenAI semconv target, flagged Development to match upstream status. This projection
+/// targets the GenAI *agent/tool* span surface (`execute_tool`, `gen_ai.tool.*`), which is newer than
+/// the LLM-*client* span surface the rest of the `otel` module pins at 1.28.0 (`semconv::V1_28_0`):
+/// `execute_tool` did not exist in 1.28.0. Both surfaces are Development upstream. A bump is explicit.
+pub const OTEL_GENAI_SEMCONV: &str = "1.37.0-development";
 
 /// OpenInference is pinned (its span-kind set is stable enough to target by name).
 pub const OPENINFERENCE_SEMCONV: &str = "pinned";

--- a/crates/assay-core/src/otel/projection.rs
+++ b/crates/assay-core/src/otel/projection.rs
@@ -3,24 +3,24 @@
 //!
 //! This is a one-directional, lossy projection: assay artifacts are the source of truth, and this
 //! emits a standards-shaped *view* of them so an OTel/OpenInference backend can read assay evidence
-//! without learning assay's vocabulary. It never reverses: nothing here is parsed back, and the
-//! standard fields are a projection, never the authority.
+//! without learning assay's vocabulary. Nothing here is parsed back; the standard fields are a
+//! projection, never the authority. The output carries `lossy: true` and `source_of_truth` so a
+//! consumer cannot mistake the view for the record.
 //!
-//! Three rules make the projection honest, which is the whole point of doing it this way:
+//! Rules that make the projection honest, which is the whole point of doing it this way:
 //!
-//! 1. Every standard field that a consumer could over-read carries a paired `assay.*` qualifier
-//!    (`assay.claim_class`, the observation fields, the enforcement fields), so a backend that only
-//!    knows `gen_ai.*` gets a familiar trace and a backend that reads `assay.*` keeps observed-vs-
-//!    enforced and asserted-vs-verified intact.
-//! 2. Enforcement is projected as its own attribute set and is **never** folded into a tool span
-//!    (which is observed, not enforced). Enforcement truth comes from its own carrier
-//!    (`assay.enforcement_health.v0`) and is absent when not supplied: absence makes no claim.
-//! 3. Things the standard vocabulary cannot express (observed egress endpoints, filesystem paths)
-//!    stay in `assay.*`. That is the lossy part, stated rather than hidden.
+//! 1. Every standard field a consumer could over-read carries a paired `assay.*` qualifier
+//!    (`assay.claim_class`, the observation fields), so a backend that only knows `gen_ai.*` gets a
+//!    familiar trace and a backend that reads `assay.*` keeps observed-vs-enforced intact.
+//! 2. Enforcement is its OWN span (a guardrail-style enforcement span), never attributes hung next to
+//!    an (observed) tool span. Otherwise a downstream tool reads "tool ran" and misses that the
+//!    load-bearing claim was "enforcement was active / blocked / failed". Enforcement is absent when
+//!    no `enforcement_health` is supplied: absence makes no claim.
+//! 3. Things the standard vocabulary cannot express (observed egress endpoints, paths) stay in
+//!    `assay.*`. That is the lossy part, stated rather than hidden.
 //!
-//! Pinned to a specific GenAI semantic-conventions version. Both OTel GenAI and OpenInference are
-//! still evolving, so the projection pins a version and a later bump is an explicit change, never a
-//! silent reinterpretation.
+//! Both OTel GenAI and OpenInference are still evolving upstream (GenAI semconv is Development), so the
+//! projection pins versions and a bump is an explicit change, never a silent reinterpretation.
 
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -28,27 +28,43 @@ use serde_json::{Map, Value};
 /// Schema id of this projection artifact.
 pub const PROJECTION_SCHEMA: &str = "assay.otel_projection.v0";
 
-/// Pinned OTel GenAI semantic-conventions version this projection targets. Matches the version the
-/// rest of the `otel` module pins (see `semconv::V1_28_0`). A bump is an explicit, separate change.
-pub const SEMCONV_VERSION: &str = "1.28.0";
+/// Pinned OTel GenAI semconv target, flagged Development to match upstream status. Matches the
+/// version the rest of the `otel` module pins (`semconv::V1_28_0`). A bump is an explicit change.
+pub const OTEL_GENAI_SEMCONV: &str = "1.28.0-development";
+
+/// OpenInference is pinned (its span-kind set is stable enough to target by name).
+pub const OPENINFERENCE_SEMCONV: &str = "pinned";
+
+/// The authoritative source the projection is a lossy view of.
+pub const SOURCE_OF_TRUTH: &str = "assay artifacts";
+
+/// Pinned semantic-convention targets for the projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Semconv {
+    pub otel_genai: String,
+    pub openinference: String,
+}
 
 /// A single projected span (OTel span shape with OpenInference `span.kind` carried as an attribute,
 /// since OpenInference is built on OTel and the two coexist).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ProjectedSpan {
     pub name: String,
-    /// OTel span kind. Tool execution and guardrail decisions are application-owned, so `INTERNAL`.
+    /// OTel span kind. Tool, guardrail, and enforcement spans are application-owned, so `INTERNAL`.
     pub kind: String,
     pub attributes: Map<String, Value>,
 }
 
-/// The full projection: run-level resource attributes, per-event spans, and the explicit non-claims.
+/// The full projection. `lossy` and `source_of_truth` are not decoration: they are the contract that
+/// the standard fields are a view and the assay artifacts are the record.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Projection {
     pub schema: String,
-    pub semconv_version: String,
-    pub resource_attributes: Map<String, Value>,
+    pub semconv: Semconv,
     pub spans: Vec<ProjectedSpan>,
+    pub resource_attributes: Map<String, Value>,
+    pub lossy: bool,
+    pub source_of_truth: String,
     /// Stated boundaries that travel with the projection so a consumer cannot over-read it.
     pub non_claims: Vec<String>,
 }
@@ -81,18 +97,10 @@ pub fn project(
 ) -> Projection {
     let mut resource: Map<String, Value> = Map::new();
     resource.insert("service.name".into(), Value::String("assay".into()));
-    resource.insert(
-        "assay.otel_projection.schema".into(),
-        Value::String(PROJECTION_SCHEMA.into()),
-    );
-    resource.insert(
-        "assay.semconv.version".into(),
-        Value::String(SEMCONV_VERSION.into()),
-    );
 
-    // ---- capability surface: tools and decisions become spans; raw sets stay in assay.* ----
     let mut spans: Vec<ProjectedSpan> = Vec::new();
 
+    // ---- capability surface: tools become TOOL spans, decisions become GUARDRAIL spans ----
     for tool in str_array(capability_surface, "mcp_tools") {
         let mut attrs = Map::new();
         attrs.insert(
@@ -100,7 +108,6 @@ pub fn project(
             Value::String("execute_tool".into()),
         );
         attrs.insert("gen_ai.tool.name".into(), Value::String(tool.clone()));
-        // OpenInference span kind, carried alongside gen_ai.* (the two coexist).
         attrs.insert(
             "openinference.span.kind".into(),
             Value::String("TOOL".into()),
@@ -122,7 +129,6 @@ pub fn project(
             None => (decision.clone(), String::new()),
         };
         let mut attrs = Map::new();
-        // A policy decision maps to an OpenInference GUARDRAIL span (the gating step).
         attrs.insert(
             "openinference.span.kind".into(),
             Value::String("GUARDRAIL".into()),
@@ -134,6 +140,45 @@ pub fn project(
         attrs.insert("assay.claim_class".into(), Value::String("observed".into()));
         spans.push(ProjectedSpan {
             name: format!("guardrail {key}"),
+            kind: "INTERNAL".into(),
+            attributes: attrs,
+        });
+    }
+
+    // ---- enforcement_health: its OWN guardrail-style span, never folded onto a tool span ----
+    // Absent enforcement_health => no enforcement span => no enforcement claim.
+    if let Some(eh) = enforcement_health {
+        let scope = str_field(eh, "scope").unwrap_or_else(|| "unknown".into());
+        let mut attrs = Map::new();
+        attrs.insert(
+            "openinference.span.kind".into(),
+            Value::String("GUARDRAIL".into()),
+        );
+        // claim_class marks this as enforcement-truth, distinct from an observed tool.
+        attrs.insert(
+            "assay.claim_class".into(),
+            Value::String("enforcement".into()),
+        );
+        if let Some(v) = str_field(eh, "network_enforcement") {
+            attrs.insert("assay.enforcement.network".into(), Value::String(v));
+        }
+        if let Some(v) = eh.get("attach_confirmed").and_then(|x| x.as_bool()) {
+            attrs.insert("assay.enforcement.attach_confirmed".into(), Value::Bool(v));
+        }
+        attrs.insert(
+            "assay.enforcement.scope".into(),
+            Value::String(scope.clone()),
+        );
+        for (src_key, attr_key) in [
+            ("blocked_count", "assay.enforcement.blocked_count"),
+            ("allowed_count", "assay.enforcement.allowed_count"),
+        ] {
+            if let Some(n) = eh.get(src_key).and_then(|x| x.as_u64()) {
+                attrs.insert(attr_key.into(), Value::Number(n.into()));
+            }
+        }
+        spans.push(ProjectedSpan {
+            name: format!("enforcement {scope}"),
             kind: "INTERNAL".into(),
             attributes: attrs,
         });
@@ -154,7 +199,7 @@ pub fn project(
         }
     }
 
-    // ---- observation_health: how complete the observation was (not whether it was enforced) ----
+    // ---- observation_health: how complete the observation was (run-level context, not a span) ----
     if let Some(oh) = observation_health {
         for (src_key, attr_key) in [
             ("kernel_layer", "assay.observation.kernel_layer"),
@@ -170,46 +215,32 @@ pub fn project(
         }
     }
 
-    // ---- enforcement_health: its OWN attribute set, never folded into a tool span ----
-    // Absent enforcement_health => no enforcement attributes at all => no enforcement claim.
-    if let Some(eh) = enforcement_health {
-        if let Some(v) = str_field(eh, "network_enforcement") {
-            resource.insert("assay.enforcement.network".into(), Value::String(v));
-        }
-        if let Some(v) = eh.get("attach_confirmed").and_then(|x| x.as_bool()) {
-            resource.insert("assay.enforcement.attach_confirmed".into(), Value::Bool(v));
-        }
-        if let Some(v) = str_field(eh, "scope") {
-            resource.insert("assay.enforcement.scope".into(), Value::String(v));
-        }
-        for (src_key, attr_key) in [
-            ("blocked_count", "assay.enforcement.blocked_count"),
-            ("allowed_count", "assay.enforcement.allowed_count"),
-        ] {
-            if let Some(n) = eh.get(src_key).and_then(|x| x.as_u64()) {
-                resource.insert(attr_key.into(), Value::Number(n.into()));
-            }
-        }
-    }
-
     let non_claims = vec![
         "This projection is a one-directional, lossy view; the assay artifacts remain authoritative."
             .to_string(),
         "gen_ai.* and openinference.* fields are a projection, not the source of truth.".to_string(),
         "Observed is not enforced: capability-surface tools carry assay.claim_class=observed, and \
-         enforcement is a separate attribute set read only from assay.enforcement_health.v0."
+         enforcement is a separate span read only from assay.enforcement_health.v0."
             .to_string(),
-        "Absence of enforcement attributes means no enforcement_health was supplied, not that \
+        "Absence of an enforcement span means no enforcement_health was supplied, not that \
          enforcement was absent."
             .to_string(),
-        format!("Pinned to GenAI semantic conventions {SEMCONV_VERSION}; a version bump is explicit."),
+        format!(
+            "Pinned to OTel GenAI semconv {OTEL_GENAI_SEMCONV} and OpenInference {OPENINFERENCE_SEMCONV}; \
+             a version bump is explicit."
+        ),
     ];
 
     Projection {
         schema: PROJECTION_SCHEMA.to_string(),
-        semconv_version: SEMCONV_VERSION.to_string(),
-        resource_attributes: resource,
+        semconv: Semconv {
+            otel_genai: OTEL_GENAI_SEMCONV.to_string(),
+            openinference: OPENINFERENCE_SEMCONV.to_string(),
+        },
         spans,
+        resource_attributes: resource,
+        lossy: true,
+        source_of_truth: SOURCE_OF_TRUTH.to_string(),
         non_claims,
     }
 }

--- a/crates/assay-core/tests/fixtures/otel_projection/expected.json
+++ b/crates/assay-core/tests/fixtures/otel_projection/expected.json
@@ -1,0 +1,74 @@
+{
+  "schema": "assay.otel_projection.v0",
+  "semconv": {
+    "otel_genai": "1.28.0-development",
+    "openinference": "pinned"
+  },
+  "spans": [
+    {
+      "name": "execute_tool read_file",
+      "kind": "INTERNAL",
+      "attributes": {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "read_file",
+        "openinference.span.kind": "TOOL",
+        "tool.name": "read_file",
+        "assay.claim_class": "observed"
+      }
+    },
+    {
+      "name": "guardrail read_file",
+      "kind": "INTERNAL",
+      "attributes": {
+        "openinference.span.kind": "GUARDRAIL",
+        "assay.decision": "allow",
+        "assay.tool": "read_file",
+        "assay.claim_class": "observed"
+      }
+    },
+    {
+      "name": "guardrail write_file",
+      "kind": "INTERNAL",
+      "attributes": {
+        "openinference.span.kind": "GUARDRAIL",
+        "assay.decision": "deny",
+        "assay.tool": "write_file",
+        "assay.claim_class": "observed"
+      }
+    },
+    {
+      "name": "enforcement ipv4_tcp_connect",
+      "kind": "INTERNAL",
+      "attributes": {
+        "openinference.span.kind": "GUARDRAIL",
+        "assay.claim_class": "enforcement",
+        "assay.enforcement.network": "active",
+        "assay.enforcement.attach_confirmed": true,
+        "assay.enforcement.scope": "ipv4_tcp_connect",
+        "assay.enforcement.blocked_count": 1,
+        "assay.enforcement.allowed_count": 2
+      }
+    }
+  ],
+  "resource_attributes": {
+    "service.name": "assay",
+    "assay.capability.network_endpoints": [
+      "203.0.113.10:443"
+    ],
+    "assay.capability.filesystem_paths": [
+      "/workspace/app"
+    ],
+    "assay.observation.kernel_layer": "complete",
+    "assay.observation.network_protocol_coverage": "connect_only",
+    "assay.observation.policy_layer": "present"
+  },
+  "lossy": true,
+  "source_of_truth": "assay artifacts",
+  "non_claims": [
+    "This projection is a one-directional, lossy view; the assay artifacts remain authoritative.",
+    "gen_ai.* and openinference.* fields are a projection, not the source of truth.",
+    "Observed is not enforced: capability-surface tools carry assay.claim_class=observed, and enforcement is a separate span read only from assay.enforcement_health.v0.",
+    "Absence of an enforcement span means no enforcement_health was supplied, not that enforcement was absent.",
+    "Pinned to OTel GenAI semconv 1.28.0-development and OpenInference pinned; a version bump is explicit."
+  ]
+}

--- a/crates/assay-core/tests/fixtures/otel_projection/expected.json
+++ b/crates/assay-core/tests/fixtures/otel_projection/expected.json
@@ -1,7 +1,7 @@
 {
   "schema": "assay.otel_projection.v0",
   "semconv": {
-    "otel_genai": "1.28.0-development",
+    "otel_genai": "1.37.0-development",
     "openinference": "pinned"
   },
   "spans": [
@@ -69,6 +69,6 @@
     "gen_ai.* and openinference.* fields are a projection, not the source of truth.",
     "Observed is not enforced: capability-surface tools carry assay.claim_class=observed, and enforcement is a separate span read only from assay.enforcement_health.v0.",
     "Absence of an enforcement span means no enforcement_health was supplied, not that enforcement was absent.",
-    "Pinned to OTel GenAI semconv 1.28.0-development and OpenInference pinned; a version bump is explicit."
+    "Pinned to OTel GenAI semconv 1.37.0-development and OpenInference pinned; a version bump is explicit."
   ]
 }

--- a/crates/assay-core/tests/fixtures/otel_projection/input.json
+++ b/crates/assay-core/tests/fixtures/otel_projection/input.json
@@ -1,0 +1,24 @@
+{
+  "capability_surface": {
+    "schema": "assay.runner.capability_surface.v0",
+    "filesystem_paths": ["/workspace/app"],
+    "network_endpoints": ["203.0.113.10:443"],
+    "process_execs": [],
+    "mcp_tools": ["read_file"],
+    "policy_decisions": ["allow:read_file", "deny:write_file"]
+  },
+  "observation_health": {
+    "schema": "assay.runner.observation_health.v0",
+    "kernel_layer": "complete",
+    "network_protocol_coverage": "connect_only",
+    "policy_layer": "present"
+  },
+  "enforcement_health": {
+    "schema": "assay.enforcement_health.v0",
+    "network_enforcement": "active",
+    "attach_confirmed": true,
+    "blocked_count": 1,
+    "allowed_count": 2,
+    "scope": "ipv4_tcp_connect"
+  }
+}

--- a/crates/assay-core/tests/otel_projection.rs
+++ b/crates/assay-core/tests/otel_projection.rs
@@ -1,9 +1,11 @@
 //! The OTel/OpenInference projection is a one-directional, lossy view of assay evidence. These tests
 //! pin the mapping and the honesty invariants: a tool span is observed (never carries enforcement),
-//! enforcement lives in its own attribute set, absence of enforcement makes no claim, and the
-//! standards fields coexist with the assay.* qualifiers.
+//! enforcement is its OWN span (never folded onto a tool span), absence of enforcement makes no
+//! claim, and the output declares itself lossy with the assay artifacts as the source of truth.
 
-use assay_core::otel::projection::{project, PROJECTION_SCHEMA, SEMCONV_VERSION};
+use assay_core::otel::projection::{
+    project, OPENINFERENCE_SEMCONV, OTEL_GENAI_SEMCONV, PROJECTION_SCHEMA, SOURCE_OF_TRUTH,
+};
 use serde_json::json;
 
 fn surface() -> serde_json::Value {
@@ -38,10 +40,14 @@ fn enforcement() -> serde_json::Value {
 }
 
 #[test]
-fn schema_and_version_are_pinned() {
+fn header_pins_schema_versions_and_lossy_contract() {
     let p = project(&surface(), None, None);
     assert_eq!(p.schema, PROJECTION_SCHEMA);
-    assert_eq!(p.semconv_version, SEMCONV_VERSION);
+    assert_eq!(p.semconv.otel_genai, OTEL_GENAI_SEMCONV);
+    assert_eq!(p.semconv.openinference, OPENINFERENCE_SEMCONV);
+    // The whole point: the view declares itself lossy and names the record.
+    assert!(p.lossy);
+    assert_eq!(p.source_of_truth, SOURCE_OF_TRUTH);
     assert!(!p.non_claims.is_empty());
 }
 
@@ -65,14 +71,12 @@ fn tool_span_carries_genai_and_openinference_and_is_observed() {
             .and_then(|v| v.as_str()),
         Some("execute_tool")
     );
-    // OpenInference span.kind coexists with gen_ai.*
     assert_eq!(
         tool.attributes
             .get("openinference.span.kind")
             .and_then(|v| v.as_str()),
         Some("TOOL")
     );
-    // Honesty: a capability-surface tool is observed.
     assert_eq!(
         tool.attributes
             .get("assay.claim_class")
@@ -82,51 +86,92 @@ fn tool_span_carries_genai_and_openinference_and_is_observed() {
 }
 
 #[test]
-fn enforcement_is_never_folded_into_a_tool_span() {
-    // The load-bearing invariant: enforcement truth must not ride on an observed tool span.
+fn enforcement_is_its_own_span_never_on_a_tool_span() {
+    // The load-bearing invariant: enforcement truth is a separate span, not attributes hung next to
+    // an observed tool, so a downstream reader cannot read "tool ran" and miss "enforcement active".
     let p = project(&surface(), Some(&observation()), Some(&enforcement()));
     for span in &p.spans {
+        let is_enforcement_span = span
+            .attributes
+            .get("assay.claim_class")
+            .and_then(|v| v.as_str())
+            == Some("enforcement");
         for key in span.attributes.keys() {
-            assert!(
-                !key.starts_with("assay.enforcement."),
-                "span {} leaked an enforcement attribute: {key}",
-                span.name
-            );
+            if key.starts_with("assay.enforcement.") {
+                assert!(
+                    is_enforcement_span,
+                    "enforcement attribute {key} leaked onto non-enforcement span {}",
+                    span.name
+                );
+            }
         }
     }
-    // Enforcement lives only in the run-level resource attributes.
+    let enf = p
+        .spans
+        .iter()
+        .find(|s| {
+            s.attributes
+                .get("assay.claim_class")
+                .and_then(|v| v.as_str())
+                == Some("enforcement")
+        })
+        .expect("a separate enforcement span exists");
     assert_eq!(
-        p.resource_attributes
+        enf.attributes
+            .get("openinference.span.kind")
+            .and_then(|v| v.as_str()),
+        Some("GUARDRAIL")
+    );
+    assert_eq!(
+        enf.attributes
             .get("assay.enforcement.network")
             .and_then(|v| v.as_str()),
         Some("active")
     );
     assert_eq!(
-        p.resource_attributes
-            .get("assay.enforcement.attach_confirmed")
-            .and_then(|v| v.as_bool()),
-        Some(true)
-    );
-    assert_eq!(
-        p.resource_attributes
+        enf.attributes
             .get("assay.enforcement.scope")
             .and_then(|v| v.as_str()),
         Some("ipv4_tcp_connect")
     );
+    // And no tool span carries an enforcement attribute.
+    let tool = p
+        .spans
+        .iter()
+        .find(|s| {
+            s.attributes
+                .get("openinference.span.kind")
+                .and_then(|v| v.as_str())
+                == Some("TOOL")
+        })
+        .unwrap();
+    assert!(tool
+        .attributes
+        .keys()
+        .all(|k| !k.starts_with("assay.enforcement.")));
 }
 
 #[test]
 fn absent_enforcement_makes_no_enforcement_claim() {
     let p = project(&surface(), Some(&observation()), None);
-    let leaked: Vec<_> = p
-        .resource_attributes
-        .keys()
-        .filter(|k| k.starts_with("assay.enforcement."))
-        .collect();
-    assert!(
-        leaked.is_empty(),
-        "absent enforcement_health must emit no enforcement attrs: {leaked:?}"
+    let enforcement_spans = p
+        .spans
+        .iter()
+        .filter(|s| {
+            s.attributes
+                .get("assay.claim_class")
+                .and_then(|v| v.as_str())
+                == Some("enforcement")
+        })
+        .count();
+    assert_eq!(
+        enforcement_spans, 0,
+        "absent enforcement_health must emit no enforcement span"
     );
+    assert!(p.spans.iter().all(|s| s
+        .attributes
+        .keys()
+        .all(|k| !k.starts_with("assay.enforcement."))));
 }
 
 #[test]
@@ -153,7 +198,6 @@ fn guardrail_decision_projects_with_verdict() {
 
 #[test]
 fn observed_sets_with_no_standard_field_stay_in_assay_namespace() {
-    // The lossy part, stated: egress endpoints have no gen_ai/openinference home, so they stay assay.*
     let p = project(&surface(), Some(&observation()), None);
     let endpoints = p
         .resource_attributes
@@ -183,9 +227,60 @@ fn network_not_observed_is_carried_without_asserting_enforcement() {
             .and_then(|v| v.as_str()),
         Some("absent")
     );
-    // Observation says network was not seen; the projection must not invent an enforcement claim.
-    assert!(p
-        .resource_attributes
-        .keys()
-        .all(|k| !k.starts_with("assay.enforcement.")));
+    assert!(p.spans.iter().all(|s| s
+        .attributes
+        .get("assay.claim_class")
+        .and_then(|v| v.as_str())
+        != Some("enforcement")));
+}
+
+#[test]
+fn golden_fixture_roundtrip() {
+    // A committed input + expected projection, so an external reader sees the contract concretely
+    // (and a drift in the mapping is caught here, not in prose).
+    let dir = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/otel_projection"
+    );
+    let input: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(format!("{dir}/input.json")).unwrap())
+            .unwrap();
+    let expected: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(format!("{dir}/expected.json")).unwrap())
+            .unwrap();
+    let got = serde_json::to_value(project(
+        &input["capability_surface"],
+        input.get("observation_health"),
+        input.get("enforcement_health"),
+    ))
+    .unwrap();
+    assert_eq!(
+        got, expected,
+        "projection drifted from the committed golden fixture"
+    );
+}
+
+#[test]
+fn bless_golden_fixture() {
+    if std::env::var("BLESS").is_err() {
+        return;
+    }
+    let dir = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/otel_projection"
+    );
+    let input: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(format!("{dir}/input.json")).unwrap())
+            .unwrap();
+    let got = serde_json::to_value(project(
+        &input["capability_surface"],
+        input.get("observation_health"),
+        input.get("enforcement_health"),
+    ))
+    .unwrap();
+    std::fs::write(
+        format!("{dir}/expected.json"),
+        serde_json::to_string_pretty(&got).unwrap(),
+    )
+    .unwrap();
 }

--- a/crates/assay-core/tests/otel_projection.rs
+++ b/crates/assay-core/tests/otel_projection.rs
@@ -1,0 +1,191 @@
+//! The OTel/OpenInference projection is a one-directional, lossy view of assay evidence. These tests
+//! pin the mapping and the honesty invariants: a tool span is observed (never carries enforcement),
+//! enforcement lives in its own attribute set, absence of enforcement makes no claim, and the
+//! standards fields coexist with the assay.* qualifiers.
+
+use assay_core::otel::projection::{project, PROJECTION_SCHEMA, SEMCONV_VERSION};
+use serde_json::json;
+
+fn surface() -> serde_json::Value {
+    json!({
+        "schema": "assay.runner.capability_surface.v0",
+        "filesystem_paths": ["/workspace/app"],
+        "network_endpoints": ["203.0.113.10:443"],
+        "process_execs": [],
+        "mcp_tools": ["search"],
+        "policy_decisions": ["allow:read_file", "deny:write_file"]
+    })
+}
+
+fn observation() -> serde_json::Value {
+    json!({
+        "schema": "assay.runner.observation_health.v0",
+        "kernel_layer": "complete",
+        "network_protocol_coverage": "connect_only",
+        "policy_layer": "present"
+    })
+}
+
+fn enforcement() -> serde_json::Value {
+    json!({
+        "schema": "assay.enforcement_health.v0",
+        "network_enforcement": "active",
+        "attach_confirmed": true,
+        "blocked_count": 1,
+        "allowed_count": 2,
+        "scope": "ipv4_tcp_connect"
+    })
+}
+
+#[test]
+fn schema_and_version_are_pinned() {
+    let p = project(&surface(), None, None);
+    assert_eq!(p.schema, PROJECTION_SCHEMA);
+    assert_eq!(p.semconv_version, SEMCONV_VERSION);
+    assert!(!p.non_claims.is_empty());
+}
+
+#[test]
+fn tool_span_carries_genai_and_openinference_and_is_observed() {
+    let p = project(&surface(), Some(&observation()), Some(&enforcement()));
+    let tool = p
+        .spans
+        .iter()
+        .find(|s| {
+            s.attributes
+                .get("gen_ai.tool.name")
+                .and_then(|v| v.as_str())
+                == Some("search")
+        })
+        .expect("tool span present");
+    assert_eq!(tool.kind, "INTERNAL");
+    assert_eq!(
+        tool.attributes
+            .get("gen_ai.operation.name")
+            .and_then(|v| v.as_str()),
+        Some("execute_tool")
+    );
+    // OpenInference span.kind coexists with gen_ai.*
+    assert_eq!(
+        tool.attributes
+            .get("openinference.span.kind")
+            .and_then(|v| v.as_str()),
+        Some("TOOL")
+    );
+    // Honesty: a capability-surface tool is observed.
+    assert_eq!(
+        tool.attributes
+            .get("assay.claim_class")
+            .and_then(|v| v.as_str()),
+        Some("observed")
+    );
+}
+
+#[test]
+fn enforcement_is_never_folded_into_a_tool_span() {
+    // The load-bearing invariant: enforcement truth must not ride on an observed tool span.
+    let p = project(&surface(), Some(&observation()), Some(&enforcement()));
+    for span in &p.spans {
+        for key in span.attributes.keys() {
+            assert!(
+                !key.starts_with("assay.enforcement."),
+                "span {} leaked an enforcement attribute: {key}",
+                span.name
+            );
+        }
+    }
+    // Enforcement lives only in the run-level resource attributes.
+    assert_eq!(
+        p.resource_attributes
+            .get("assay.enforcement.network")
+            .and_then(|v| v.as_str()),
+        Some("active")
+    );
+    assert_eq!(
+        p.resource_attributes
+            .get("assay.enforcement.attach_confirmed")
+            .and_then(|v| v.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        p.resource_attributes
+            .get("assay.enforcement.scope")
+            .and_then(|v| v.as_str()),
+        Some("ipv4_tcp_connect")
+    );
+}
+
+#[test]
+fn absent_enforcement_makes_no_enforcement_claim() {
+    let p = project(&surface(), Some(&observation()), None);
+    let leaked: Vec<_> = p
+        .resource_attributes
+        .keys()
+        .filter(|k| k.starts_with("assay.enforcement."))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "absent enforcement_health must emit no enforcement attrs: {leaked:?}"
+    );
+}
+
+#[test]
+fn guardrail_decision_projects_with_verdict() {
+    let p = project(&surface(), None, None);
+    let deny = p
+        .spans
+        .iter()
+        .find(|s| {
+            s.attributes
+                .get("openinference.span.kind")
+                .and_then(|v| v.as_str())
+                == Some("GUARDRAIL")
+                && s.attributes.get("assay.tool").and_then(|v| v.as_str()) == Some("write_file")
+        })
+        .expect("deny guardrail span present");
+    assert_eq!(
+        deny.attributes
+            .get("assay.decision")
+            .and_then(|v| v.as_str()),
+        Some("deny")
+    );
+}
+
+#[test]
+fn observed_sets_with_no_standard_field_stay_in_assay_namespace() {
+    // The lossy part, stated: egress endpoints have no gen_ai/openinference home, so they stay assay.*
+    let p = project(&surface(), Some(&observation()), None);
+    let endpoints = p
+        .resource_attributes
+        .get("assay.capability.network_endpoints")
+        .and_then(|v| v.as_array())
+        .expect("network endpoints projected under assay.*");
+    assert_eq!(endpoints.len(), 1);
+    assert_eq!(
+        p.resource_attributes
+            .get("assay.observation.network_protocol_coverage")
+            .and_then(|v| v.as_str()),
+        Some("connect_only")
+    );
+}
+
+#[test]
+fn network_not_observed_is_carried_without_asserting_enforcement() {
+    let oh = json!({
+        "schema": "assay.runner.observation_health.v0",
+        "kernel_layer": "complete",
+        "network_protocol_coverage": "absent"
+    });
+    let p = project(&surface(), Some(&oh), None);
+    assert_eq!(
+        p.resource_attributes
+            .get("assay.observation.network_protocol_coverage")
+            .and_then(|v| v.as_str()),
+        Some("absent")
+    );
+    // Observation says network was not seen; the projection must not invent an enforcement claim.
+    assert!(p
+        .resource_attributes
+        .keys()
+        .all(|k| !k.starts_with("assay.enforcement.")));
+}

--- a/docs/reference/otel-projection.md
+++ b/docs/reference/otel-projection.md
@@ -1,0 +1,64 @@
+# OTel GenAI + OpenInference projection (`assay.otel_projection.v0`)
+
+A read-only, one-directional, lossy view of assay runtime evidence as OpenTelemetry GenAI attributes
+plus an OpenInference `span.kind`, so an OTel/OpenInference backend can read assay evidence without
+learning assay's vocabulary.
+
+This is a **mapping, not a rewrite**. assay artifacts are the source of truth; the standard fields are
+a projection of them. Nothing is parsed back. The output declares this with two top-level fields that
+are part of the contract, not decoration:
+
+- `lossy: true` — the standard fields do not carry everything the assay artifacts do.
+- `source_of_truth: "assay artifacts"` — the record is the assay artifact, not this view.
+
+Implemented by `assay_core::otel::projection::project`. Golden fixtures (a committed input and its
+expected projection) live in `crates/assay-core/tests/fixtures/otel_projection/`, so an external
+reader sees the contract concretely and a mapping drift is caught by a test rather than by prose.
+
+## Versioning
+
+```json
+"semconv": { "otel_genai": "1.28.0-development", "openinference": "pinned" }
+```
+
+OTel GenAI semantic conventions are still Development upstream, so the projection pins a version and
+flags it. A bump is an explicit change, never a silent reinterpretation. `openinference` is pinned by
+name (its span-kind set is stable enough to target).
+
+## Mapping
+
+| assay input | projected as | honesty qualifier |
+| --- | --- | --- |
+| `capability_surface.mcp_tools[]` | OTel `execute_tool` span (`gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`) + OpenInference `span.kind=TOOL` | `assay.claim_class=observed` |
+| `capability_surface.policy_decisions[]` (`<verdict>:<key>`) | OpenInference `span.kind=GUARDRAIL` span + `assay.decision` | `assay.claim_class=observed` |
+| `enforcement_health.v0` | a **separate** `span.kind=GUARDRAIL` enforcement span with `assay.enforcement.*` | `assay.claim_class=enforcement` |
+| `observation_health.v0` | run-level `resource_attributes` (`assay.observation.*`) | (context, not a claim) |
+| `capability_surface` raw sets (endpoints, paths, execs) | run-level `resource_attributes` under `assay.*` | the lossy part, stated |
+| declared-vs-observed findings (when supplied) | `span.kind=EVALUATOR` or `GUARDRAIL` | *next slice* |
+
+## The load-bearing rule: enforcement is its own span, never on a tool span
+
+Enforcement is projected as a separate span, not as attributes hung next to a tool span. If a tool
+span carried `tool ran` and the enforcement attributes together, a downstream tool reads "tool
+executed successfully" and misses that the load-bearing claim was "enforcement was active / blocked /
+failed". So enforcement gets its own guardrail-style span carrying `assay.claim_class=enforcement` and
+the `assay.enforcement.*` attributes, and **no tool span ever carries an `assay.enforcement.*`
+attribute**. This is asserted by a test.
+
+Absence of an enforcement span means no `enforcement_health` was supplied. It does **not** mean
+enforcement was absent; that distinction lives in the carrier itself
+(`network_enforcement: absent | active | failed | not_applicable`).
+
+## Non-claims
+
+The projection carries its own `non_claims`, and they are the point of doing it this way:
+
+- the standard fields are a view, not the source of truth;
+- observed is not enforced (tools are `observed`, enforcement is a separate span);
+- absence of an enforcement span is not a claim that enforcement was absent;
+- the version is pinned and a bump is explicit.
+
+## Scope
+
+This is the projection function and its fixtures. There is no OTLP exporter and no CLI subcommand yet;
+those are later slices, kept separate so the contract and its fixtures stand on their own first.

--- a/docs/reference/otel-projection.md
+++ b/docs/reference/otel-projection.md
@@ -18,12 +18,20 @@ reader sees the contract concretely and a mapping drift is caught by a test rath
 ## Versioning
 
 ```json
-"semconv": { "otel_genai": "1.28.0-development", "openinference": "pinned" }
+"semconv": { "otel_genai": "1.37.0-development", "openinference": "pinned" }
 ```
 
-OTel GenAI semantic conventions are still Development upstream, so the projection pins a version and
-flags it. A bump is an explicit change, never a silent reinterpretation. `openinference` is pinned by
-name (its span-kind set is stable enough to target).
+OTel GenAI semantic conventions are still Development upstream (as are the MCP conventions), so the
+projection pins a version and flags it. A bump is an explicit change, never a silent reinterpretation.
+`openinference` is pinned by name (its span-kind set is stable enough to target).
+
+The pinned version targets the GenAI **agent/tool** span surface (`execute_tool`, `gen_ai.tool.*`),
+which is newer than the LLM-**client** span surface the rest of the `otel` module pins at 1.28.0:
+`execute_tool` did not exist in 1.28.0, so the two surfaces are pinned independently.
+
+A future slice may also emit the OTel **MCP** semantic conventions (`mcp.*`) for these spans, since
+assay's `mcp_tools` are MCP tool calls; the MCP conventions are Development today, so that is a
+deliberate later addition, not part of v0.
 
 ## Mapping
 


### PR DESCRIPTION
The natural next step now that observation, enforcement, and declared-vs-observed are in place: project assay's vocabulary outward so the rest of the world can read it, without changing the core. Mapping, not rewrite.

`otel::projection` (schema `assay.otel_projection.v0`) takes the capability surface, `observation_health`, and `enforcement_health` and emits a standards-shaped view: OpenTelemetry GenAI attributes (`gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, ...) with an OpenInference `span.kind` carried alongside (the two coexist), plus run-level resource attributes. It builds on the existing `otel` module and keeps its pinned semconv version (1.28.0).

One-directional and lossy on purpose: assay artifacts are the source of truth, the standard fields are a projection. Three honesty invariants are pinned by tests:
- every standard field a consumer could over-read carries a paired `assay.*` qualifier (`assay.claim_class`, the observation fields, the enforcement fields);
- enforcement is its own attribute set, never folded into an observed tool span, and absent when no `enforcement_health` is supplied (absence makes no claim, matching the carrier's own semantics);
- observed sets the standard vocabulary has no home for (egress endpoints, paths) stay under `assay.*`, which is the lossy part stated rather than hidden.

Scope: projection function + 7 fixture tests only. No OTLP exporter and no CLI subcommand yet (a later slice), so this is an `assay-core` change with no runner/monitor surface. Both OTel GenAI and OpenInference are still evolving upstream, so the version is pinned and a bump is an explicit change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)