### PR TITLE
feat(cli): add `assay project-otel` — read-only wrapper over the otel projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `assay project-otel` CLI: a read-only wrapper around the `otel::projection` library that emits
+  `assay.otel_projection.v0` from files. `--capability-surface` is required; `--observation-health`
+  and `--enforcement-health` are optional (following the library signature); `--out` writes to a file
+  and leaves stdout empty. The CLI is transport only — it reads files, parses JSON, calls
+  `assay_core::otel::projection::project`, and writes JSON; all projection semantics stay in the
+  library. On a read/parse error it writes to stderr and exits `2` with empty stdout, without echoing
+  raw artifact content. Not a telemetry pipeline: no OTLP export, no network, no runtime-proof claim.
+  Docs: `docs/reference/otel-projection.md`.
 - OTel GenAI + OpenInference projection (`otel::projection`, schema `assay.otel_projection.v0`): a
   read-only, one-directional, lossy view of assay runtime evidence (capability surface, observation
   health, enforcement health) as OpenTelemetry GenAI attributes plus an OpenInference `span.kind`, so

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -8,6 +8,7 @@ pub mod evidence;
 pub mod import;
 pub mod mcp;
 pub mod policy;
+pub mod project_otel;
 pub mod replay;
 pub mod run;
 pub mod runtime;
@@ -23,6 +24,7 @@ pub use evidence::*;
 pub use import::*;
 pub use mcp::*;
 pub use policy::*;
+pub use project_otel::*;
 pub use replay::*;
 pub use run::*;
 pub use runtime::*;
@@ -69,6 +71,8 @@ pub enum Command {
     Migrate(MigrateArgs),
     /// Report policy and trace coverage
     Coverage(CoverageArgs),
+    /// Project assay evidence into the OTel GenAI + OpenInference view (`assay.otel_projection.v0`)
+    ProjectOtel(ProjectOtelArgs),
     /// Explain a test result or trace decision
     Explain(super::commands::explain::ExplainArgs),
     /// Generate and run the local demo project

--- a/crates/assay-cli/src/cli/args/project_otel.rs
+++ b/crates/assay-cli/src/cli/args/project_otel.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+/// Project assay runtime evidence into the OTel GenAI + OpenInference attribute view.
+///
+/// Read-only, one-directional, lossy: assay artifacts are the source of truth and the output is a
+/// standards-shaped view of them. The CLI only reads files, deserializes JSON, and calls the library
+/// projector; all projection semantics live in `assay_core::otel::projection`. See
+/// `docs/reference/otel-projection.md`.
+#[derive(clap::Args, Debug, Clone)]
+pub struct ProjectOtelArgs {
+    /// Path to an `assay.runner.capability_surface.v0` JSON file (required).
+    #[arg(long = "capability-surface")]
+    pub capability_surface: PathBuf,
+
+    /// Optional path to an `assay.runner.observation_health.v0` JSON file.
+    #[arg(long = "observation-health")]
+    pub observation_health: Option<PathBuf>,
+
+    /// Optional path to an `assay.enforcement_health.v0` JSON file. Absent means no enforcement
+    /// claim is made (it does NOT assert that enforcement was absent — that lives in the carrier).
+    #[arg(long = "enforcement-health")]
+    pub enforcement_health: Option<PathBuf>,
+
+    /// Write the projection JSON here instead of stdout. On success stdout stays empty.
+    #[arg(long = "out")]
+    pub out: Option<PathBuf>,
+}

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -35,6 +35,7 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         },
         Command::Migrate(args) => super::migrate::cmd_migrate(args),
         Command::Coverage(args) => super::coverage::cmd_coverage(args).await,
+        Command::ProjectOtel(args) => super::project_otel::run(args),
         Command::Explain(args) => super::explain::run(args).await,
         Command::Demo(args) => super::demo::cmd_demo(args).await,
         Command::InitCi(args) => super::init_ci::cmd_init_ci(args),

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -32,6 +32,7 @@ pub mod profile;
 #[cfg(test)]
 mod profile_simulation_test;
 pub mod profile_types;
+pub mod project_otel;
 pub(crate) mod quarantine;
 pub mod record;
 pub(crate) mod reporting;

--- a/crates/assay-cli/src/cli/commands/project_otel.rs
+++ b/crates/assay-cli/src/cli/commands/project_otel.rs
@@ -1,0 +1,76 @@
+//! `assay project-otel` — read-only projection of assay evidence into the OTel GenAI + OpenInference
+//! view.
+//!
+//! Guardrail: this command must never be smarter than the library projector. It reads files,
+//! deserializes JSON, calls `assay_core::otel::projection::project`, and writes the result. All
+//! projection semantics live in `assay_core`, so there is exactly one projection truth — never a
+//! second, divergent CLI projection.
+
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::cli::args::ProjectOtelArgs;
+use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_SUCCESS};
+
+fn read_json(path: &Path) -> anyhow::Result<Value> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", path.display()))?;
+    serde_json::from_str(&text)
+        .map_err(|e| anyhow::anyhow!("invalid JSON in {}: {e}", path.display()))
+}
+
+/// Project the supplied artifacts. Input/IO errors are reported on stderr and return
+/// `EXIT_CONFIG_ERROR`, leaving stdout empty; on success the projection is the only thing written to
+/// stdout (or to `--out`), as pure JSON.
+pub fn run(args: ProjectOtelArgs) -> anyhow::Result<i32> {
+    let capability_surface = match read_json(&args.capability_surface) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+    let observation_health = match args
+        .observation_health
+        .as_deref()
+        .map(read_json)
+        .transpose()
+    {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+    let enforcement_health = match args
+        .enforcement_health
+        .as_deref()
+        .map(read_json)
+        .transpose()
+    {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+
+    let projection = assay_core::otel::projection::project(
+        &capability_surface,
+        observation_health.as_ref(),
+        enforcement_health.as_ref(),
+    );
+    let json = serde_json::to_string_pretty(&projection)?;
+
+    match &args.out {
+        Some(path) => {
+            if let Err(e) = std::fs::write(path, format!("{json}\n")) {
+                eprintln!("error: cannot write {}: {e}", path.display());
+                return Ok(EXIT_CONFIG_ERROR);
+            }
+        }
+        None => println!("{json}"),
+    }
+    Ok(EXIT_SUCCESS)
+}

--- a/crates/assay-cli/tests/project_otel_cli.rs
+++ b/crates/assay-cli/tests/project_otel_cli.rs
@@ -1,0 +1,155 @@
+//! Contract tests for `assay project-otel`.
+//!
+//! The CLI is transport only: it reads files, parses JSON, calls
+//! `assay_core::otel::projection::project`, and writes JSON. These tests pin that contract — the
+//! happy path reproduces the committed golden projection, and the error paths return a non-zero exit
+//! with an empty stdout, a message on stderr, no panic/backtrace, and no raw artifact content echoed
+//! back. JSON is compared as `serde_json::Value`, not byte-for-byte.
+
+use std::fs;
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../assay-core/tests/fixtures/otel_projection"
+    ))
+}
+
+/// Split the committed wrapper `input.json` into the three separate artifact files the CLI takes,
+/// written under a unique per-test dir in CARGO_TARGET_TMPDIR. Returns (dir, cap, obs, enf).
+fn write_split_inputs(case: &str) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let input: Value =
+        serde_json::from_str(&fs::read_to_string(fixtures_dir().join("input.json")).unwrap())
+            .unwrap();
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(format!("project_otel_{case}"));
+    fs::create_dir_all(&dir).unwrap();
+    let cap = dir.join("capability-surface.json");
+    let obs = dir.join("observation-health.json");
+    let enf = dir.join("enforcement-health.json");
+    fs::write(
+        &cap,
+        serde_json::to_string(&input["capability_surface"]).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        &obs,
+        serde_json::to_string(&input["observation_health"]).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        &enf,
+        serde_json::to_string(&input["enforcement_health"]).unwrap(),
+    )
+    .unwrap();
+    (dir, cap, obs, enf)
+}
+
+fn expected() -> Value {
+    serde_json::from_str(&fs::read_to_string(fixtures_dir().join("expected.json")).unwrap())
+        .unwrap()
+}
+
+#[test]
+fn happy_path_matches_golden_projection() {
+    let (_dir, cap, obs, enf) = write_split_inputs("happy");
+    let out = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "project-otel",
+            "--capability-surface",
+            cap.to_str().unwrap(),
+            "--observation-health",
+            obs.to_str().unwrap(),
+            "--enforcement-health",
+            enf.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let got: Value = serde_json::from_slice(&out).expect("stdout is parseable JSON");
+    assert_eq!(
+        got,
+        expected(),
+        "CLI stdout must match the committed golden projection"
+    );
+}
+
+#[test]
+fn missing_file_fails_clean() {
+    let missing = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("does-not-exist.json");
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "project-otel",
+            "--capability-surface",
+            missing.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("cannot read"));
+}
+
+#[test]
+fn malformed_json_fails_without_panic_or_content_leak() {
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("project_otel_malformed");
+    fs::create_dir_all(&dir).unwrap();
+    let cap = dir.join("capability-surface.json");
+    // A unique body string so we can assert it is NOT echoed back in the error.
+    let body = "{ this_is_not_valid_json_sentinel ";
+    fs::write(&cap, body).unwrap();
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "project-otel",
+            "--capability-surface",
+            cap.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("invalid JSON"))
+        // no panic/backtrace in normal error output
+        .stderr(predicate::str::contains("panicked").not())
+        .stderr(predicate::str::contains("RUST_BACKTRACE").not())
+        // no raw artifact content echoed into the error
+        .stderr(predicate::str::contains("not_valid_json_sentinel").not());
+}
+
+#[test]
+fn out_flag_writes_file_and_leaves_stdout_empty() {
+    let (dir, cap, obs, enf) = write_split_inputs("out");
+    let out_path = dir.join("projection.json");
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "project-otel",
+            "--capability-surface",
+            cap.to_str().unwrap(),
+            "--observation-health",
+            obs.to_str().unwrap(),
+            "--enforcement-health",
+            enf.to_str().unwrap(),
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+    let written: Value =
+        serde_json::from_str(&fs::read_to_string(&out_path).unwrap()).expect("--out file is JSON");
+    assert_eq!(
+        written,
+        expected(),
+        "--out file must match the committed golden projection"
+    );
+}

--- a/docs/reference/otel-projection.md
+++ b/docs/reference/otel-projection.md
@@ -66,7 +66,29 @@ The projection carries its own `non_claims`, and they are the point of doing it 
 - absence of an enforcement span is not a claim that enforcement was absent;
 - the version is pinned and a bump is explicit.
 
+## CLI
+
+`assay project-otel` emits `assay.otel_projection.v0`, a lossy, read-only projection of assay evidence
+into selected OTel GenAI / OpenInference-shaped fields. It reads files, parses JSON, calls the library
+projector, and writes JSON — it is transport only, with no projection logic of its own.
+
+```bash
+assay project-otel \
+  --capability-surface capability-surface.json \
+  --observation-health observation-health.json \
+  --enforcement-health enforcement-health.json
+# or write to a file (stdout stays empty on success):
+assay project-otel --capability-surface capability-surface.json --out projection.json
+```
+
+Only `--capability-surface` is required; `--observation-health` and `--enforcement-health` are
+optional and follow the library signature (an absent enforcement-health makes no enforcement claim).
+On a read or parse error the command writes a message to stderr and exits non-zero (`2`) with an empty
+stdout, and never echoes raw artifact content. It is not a telemetry pipeline: it produces a
+projection JSON document, it does not export OTLP, open a network connection, or emit runtime proof.
+
 ## Scope
 
-This is the projection function and its fixtures. There is no OTLP exporter and no CLI subcommand yet;
-those are later slices, kept separate so the contract and its fixtures stand on their own first.
+This is the projection function, its fixtures, and the read-only `assay project-otel` CLI wrapper.
+There is no OTLP exporter and no live telemetry path yet; those are later slices, kept separate so the
+contract and its fixtures stand on their own first.


### PR DESCRIPTION
Gives the `otel::projection` library (landed in #1581) a usable CLI entry. The command is **transport only**: it reads files, parses JSON, calls `assay_core::otel::projection::project`, and writes JSON. No projection logic lives in the CLI, so there remains exactly one projection truth — the library.

```bash
assay project-otel \
  --capability-surface capability-surface.json \
  --observation-health observation-health.json \
  --enforcement-health enforcement-health.json
# or write to a file (stdout stays empty on success):
assay project-otel --capability-surface capability-surface.json --out projection.json
```

`--capability-surface` is required; `--observation-health` and `--enforcement-health` are optional, following the library signature (an absent enforcement-health makes no enforcement claim). It emits `assay.otel_projection.v0`, a lossy, read-only projection of assay evidence into selected OTel GenAI / OpenInference-shaped fields. It is **not** a telemetry pipeline: no OTLP export, no network, no runtime-proof claim.

### Tests (4, `assert_cmd` — already a dev-dep, no `Cargo.toml` change)
- **happy path** reuses the committed golden fixtures (`crates/assay-core/tests/fixtures/otel_projection/`), exit `0`, stdout parseable JSON equal to `expected.json`;
- **missing file** → exit `2`, empty stdout, stderr message;
- **malformed JSON** → exit `2`, empty stdout, stderr message, no panic/backtrace, and the raw artifact body is not echoed back;
- **`--out`** writes valid JSON equal to the golden projection and leaves stdout empty.

JSON is compared as `serde_json::Value`, not byte-for-byte.

### Lane classification: `Gate.NONE`

Run of the source-of-truth classifier (`scripts/ci/assay_runner_lane_check.py::classify_files`) over this PR's changed files:

```
Gate: NONE
reasons: (none)
```

Reason:
- no `Cargo.toml` / `Cargo.lock` changes
- no `assay-monitor` / `assay-ebpf` / `assay-runner-*` / `assay-xtask` paths
- no `crates/assay-cli/src/cli/commands/runner_spike.rs` / `crates/assay-cli/src/cgroup.rs` changes
- read-only CLI wrapper around the existing `assay_core::otel::projection::project`

So this does not require a delegated `Runner Spike (gates=all)` proof. (Pinning this explicitly because an earlier heuristic over-broadly treated "any CLI change" as gates=all; the classifier is path-specific.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)