### PR TITLE
feat(evidence): named fallback projection for verify-mcp-records (the _meta allowlist point)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `assay evidence verify-mcp-records --fallback-projection named`: a no-attestation fallback binding
+  computed over a named projection (the `tools/call` `params` plus the `_meta.authorization_binding`
+  block) instead of the whole request envelope, so transport- or observation-local `_meta` fields a
+  gateway/provider can legitimately add or strip do not change the binding digest. Allowlist (only the
+  named fields are in the preimage) and fail-closed (a missing binding block is non-conformant, never a
+  silent fall-back to hashing the whole envelope). The report carries a self-describing
+  `binding.projection = "assay.fallback_projection.v0"`, so the rule is versioned and a change is an
+  explicit bump; it tracks the in-progress SEP-2828 fallback-binding discussion. Default stays
+  `whole-envelope`, so existing behavior is unchanged. Docs:
+  `docs/reference/cli/mcp-execution-record-fallback-plan.md`.
 - `assay project-otel` CLI: a read-only wrapper around the `otel::projection` library that emits
   `assay.otel_projection.v0` from files. `--capability-surface` is required; `--observation-health`
   and `--enforcement-health` are optional (following the library signature); `--out` writes to a file

--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
@@ -29,9 +29,32 @@ pub struct McpExecutionRecordArgs {
     #[arg(long)]
     pub outcome: Option<PathBuf>,
 
+    /// For the no-attestation fallback, how the request-envelope binding digest is computed.
+    /// `whole-envelope` (default) digests the full JCS envelope; `named` digests only a named
+    /// projection (the `tools/call` params plus a named `_meta` binding block), so transport-local
+    /// or observation-local `_meta` fields a gateway/provider can legitimately add or strip do not
+    /// change the digest. Named mode is allowlist + fail-closed: if the binding block is absent the
+    /// fallback case is non-conformant rather than silently hashing the whole envelope. Ignored for
+    /// the SEP-2787 attestation path.
+    #[arg(long, value_enum, default_value_t = FallbackProjection::WholeEnvelope)]
+    pub fallback_projection: FallbackProjection,
+
     /// Output format
     #[arg(long, value_enum, default_value_t = McpExecutionRecordFormat::Table)]
     pub format: McpExecutionRecordFormat,
+}
+
+/// Self-describing id of the named fallback projection. A rename or rule change is an explicit
+/// version bump (it tracks the in-progress SEP-2828 fallback-binding discussion), never a silent
+/// reinterpretation. The binding block is read at `_meta.authorization_binding`.
+const FALLBACK_PROJECTION_V0: &str = "assay.fallback_projection.v0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum FallbackProjection {
+    /// Digest the full JCS-canonical request envelope (matches the shipped SEP-2828 fallback text).
+    WholeEnvelope,
+    /// Digest only the named projection: `tools/call` params plus the `_meta` binding block.
+    Named,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -71,6 +94,8 @@ struct BindingReport {
     mode: &'static str,
     digest: String,
     digest_source: &'static str,
+    /// Self-describing projection id for the named fallback; `None` for whole-envelope / attestation.
+    projection: Option<&'static str>,
     nonce: Option<String>,
     nonce_source: &'static str,
 }
@@ -116,7 +141,12 @@ pub fn cmd_verify_mcp_records(args: McpExecutionRecordArgs) -> Result<i32> {
     let decision = read_json(&args.decision)?;
     let outcome = args.outcome.as_ref().map(read_json).transpose()?;
 
-    let report = build_report(&binding_input, &decision, outcome.as_ref())?;
+    let report = build_report(
+        &binding_input,
+        &decision,
+        outcome.as_ref(),
+        args.fallback_projection,
+    )?;
     match args.format {
         McpExecutionRecordFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&report)?);
@@ -142,6 +172,10 @@ struct BindingExpectation {
     mode: &'static str,
     digest: String,
     digest_source: &'static str,
+    projection: Option<&'static str>,
+    /// `Some(false)` when named projection was requested but the binding block was absent
+    /// (fail-closed); `None` when not applicable (whole-envelope / attestation).
+    binding_block_present: Option<bool>,
     nonce: Option<String>,
     nonce_source: &'static str,
 }
@@ -150,13 +184,32 @@ fn build_report(
     binding_input: &BindingInput,
     decision: &Value,
     outcome: Option<&Value>,
+    fallback_projection: FallbackProjection,
 ) -> Result<PairingReport> {
     let decision_digest = jcs_digest(decision).context("failed to digest decision")?;
     let decision_backlink = backlink_report(decision)?;
     let outcome_backlink = outcome.map(backlink_report).transpose()?;
-    let expectation = binding_expectation(binding_input, &decision_backlink)?;
+    let expectation = binding_expectation(binding_input, &decision_backlink, fallback_projection)?;
 
     let mut checks = Vec::new();
+    // Fail-closed: named projection requested but the binding block was absent is non-conformant,
+    // never a silent fall-back to hashing the whole envelope.
+    if expectation.binding_block_present == Some(false) {
+        checks.push(CheckReport {
+            id: "fallback_binding_block_present",
+            ok: false,
+            detail:
+                "named fallback projection requested but _meta.authorization_binding is absent; \
+                     failing closed instead of hashing the whole envelope"
+                    .to_string(),
+        });
+    } else if expectation.binding_block_present == Some(true) {
+        checks.push(CheckReport {
+            id: "fallback_binding_block_present",
+            ok: true,
+            detail: "named fallback projection binding block present".to_string(),
+        });
+    }
     push_decision_binding_checks(&mut checks, &decision_backlink, &expectation);
     checks.push(check_enum(
         "decision_enum",
@@ -222,6 +275,7 @@ fn build_report(
             mode: expectation.mode,
             digest: expectation.digest.clone(),
             digest_source: expectation.digest_source,
+            projection: expectation.projection,
             nonce: expectation.nonce.clone(),
             nonce_source: expectation.nonce_source,
         },
@@ -251,22 +305,62 @@ fn claims_not_made(expectation: &BindingExpectation) -> Vec<&'static str> {
 fn binding_expectation(
     binding_input: &BindingInput,
     decision_backlink: &BackLinkReport,
+    fallback_projection: FallbackProjection,
 ) -> Result<BindingExpectation> {
     match binding_input {
         BindingInput::Attestation(attestation) => Ok(BindingExpectation {
             mode: "sep2787_attestation",
             digest: jcs_digest(attestation).context("failed to digest attestation")?,
             digest_source: "sep2787_attestation_jcs",
+            projection: None,
+            binding_block_present: None,
             nonce: string_at(attestation, &["issuerAsserted", "nonce"]),
             nonce_source: "issuerAsserted.nonce",
         }),
-        BindingInput::RequestEnvelope(request_envelope) => Ok(BindingExpectation {
-            mode: "request_envelope",
-            digest: jcs_digest(request_envelope).context("failed to digest request envelope")?,
-            digest_source: "request_envelope_jcs",
-            nonce: decision_backlink.attestation_nonce.clone(),
-            nonce_source: "record_backlink_consistency",
-        }),
+        BindingInput::RequestEnvelope(request_envelope) => match fallback_projection {
+            FallbackProjection::WholeEnvelope => Ok(BindingExpectation {
+                mode: "request_envelope",
+                digest: jcs_digest(request_envelope)
+                    .context("failed to digest request envelope")?,
+                digest_source: "request_envelope_jcs",
+                projection: None,
+                binding_block_present: None,
+                nonce: decision_backlink.attestation_nonce.clone(),
+                nonce_source: "record_backlink_consistency",
+            }),
+            FallbackProjection::Named => {
+                // Allowlist: the preimage is exactly the named params plus the named binding block,
+                // everything else under _meta is excluded by construction. Fail-closed when the
+                // binding block is absent — never fall back to hashing the whole envelope.
+                let binding_block = request_envelope
+                    .get("_meta")
+                    .and_then(|m| m.get("authorization_binding"));
+                let (digest, present) = match binding_block {
+                    Some(binding) => {
+                        let projected = serde_json::json!({
+                            "projection": FALLBACK_PROJECTION_V0,
+                            "params": request_envelope.get("params").unwrap_or(&Value::Null),
+                            "binding": binding,
+                        });
+                        (
+                            jcs_digest(&projected)
+                                .context("failed to digest named fallback projection")?,
+                            true,
+                        )
+                    }
+                    None => ("sha256:unresolved-binding-block".to_string(), false),
+                };
+                Ok(BindingExpectation {
+                    mode: "request_envelope",
+                    digest,
+                    digest_source: "request_envelope_named_projection_jcs",
+                    projection: Some(FALLBACK_PROJECTION_V0),
+                    binding_block_present: Some(present),
+                    nonce: decision_backlink.attestation_nonce.clone(),
+                    nonce_source: "record_backlink_consistency",
+                })
+            }
+        },
     }
 }
 

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
@@ -500,3 +500,246 @@ fn verify_mcp_records_fails_on_unknown_decision_enum() {
             "defer is not one of allow, block, escalate",
         ));
 }
+
+// ---- named fallback projection (the _meta allowlist point) ----------------------------------
+//
+// In `--fallback-projection named`, the binding digest is computed over a named projection
+// (`params` plus the `_meta.authorization_binding` block) rather than the whole envelope, so
+// transport/observation-local `_meta` fields do not change it. Allowlist + fail-closed.
+
+fn jcs_digest_value(value: &Value) -> String {
+    let canonical = assay_core::mcp::jcs::to_vec(value).unwrap();
+    format!("sha256:{}", hex::encode(Sha256::digest(&canonical)))
+}
+
+fn named_digest(params: &Value, binding: &Value) -> String {
+    jcs_digest_value(&serde_json::json!({
+        "projection": "assay.fallback_projection.v0",
+        "params": params,
+        "binding": binding,
+    }))
+}
+
+fn named_envelope(params: &Value, binding: Option<&Value>, extra_meta: &[(&str, Value)]) -> String {
+    let mut meta = serde_json::Map::new();
+    if let Some(b) = binding {
+        meta.insert("authorization_binding".to_string(), b.clone());
+    }
+    for (k, v) in extra_meta {
+        meta.insert((*k).to_string(), v.clone());
+    }
+    serde_json::json!({ "params": params, "_meta": Value::Object(meta) }).to_string()
+}
+
+fn sample_params() -> Value {
+    serde_json::json!({ "name": "tools/call", "arguments": { "processInstanceKey": "2251799813685249" } })
+}
+
+fn sample_binding() -> Value {
+    serde_json::json!({ "tenant": "acme", "resource": "provider/customer/cus_123" })
+}
+
+#[test]
+fn fallback_named_projection_excludes_nonbinding_meta() {
+    let dir = tempdir().unwrap();
+    let params = sample_params();
+    let binding = sample_binding();
+    // Envelope carries extra, non-binding _meta the digest must NOT depend on.
+    let envelope = named_envelope(
+        &params,
+        Some(&binding),
+        &[
+            ("progress_token", serde_json::json!("p-001")),
+            (
+                "trace_context",
+                serde_json::json!({ "traceparent": "00-abc" }),
+            ),
+        ],
+    );
+    // The expected digest is computed from params + binding only.
+    let digest = named_digest(&params, &binding);
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&env_path, envelope).unwrap();
+    fs::write(&decision, decision_json(&digest)).unwrap();
+
+    let output = Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--fallback-projection",
+            "named",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let report: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["binding"]["mode"], "request_envelope");
+    assert_eq!(report["binding"]["digest"], digest);
+    assert_eq!(
+        report["binding"]["digest_source"],
+        "request_envelope_named_projection_jcs"
+    );
+    assert_eq!(
+        report["binding"]["projection"],
+        "assay.fallback_projection.v0"
+    );
+}
+
+#[test]
+fn fallback_named_projection_same_digest_for_different_nonbinding_meta() {
+    // Two envelopes that differ only in non-binding _meta must produce the same binding digest.
+    let dir = tempdir().unwrap();
+    let params = sample_params();
+    let binding = sample_binding();
+    let digest = named_digest(&params, &binding);
+    let decision = dir.path().join("decision.json");
+    fs::write(&decision, decision_json(&digest)).unwrap();
+
+    for (i, extra) in [
+        ("gateway", serde_json::json!("gw-token")),
+        ("provider", serde_json::json!("pv-trace")),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let env_path = dir.path().join(format!("env-{i}.json"));
+        fs::write(
+            &env_path,
+            named_envelope(&params, Some(&binding), &[(extra.0, extra.1)]),
+        )
+        .unwrap();
+        let output = Command::cargo_bin("assay")
+            .unwrap()
+            .args([
+                "evidence",
+                "verify-mcp-records",
+                "--request-envelope",
+                env_path.to_str().unwrap(),
+                "--decision",
+                decision.to_str().unwrap(),
+                "--fallback-projection",
+                "named",
+                "--format",
+                "json",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let report: Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(
+            report["binding"]["digest"], digest,
+            "non-binding _meta must not change the digest"
+        );
+    }
+}
+
+#[test]
+fn fallback_named_projection_fails_closed_when_binding_block_absent() {
+    let dir = tempdir().unwrap();
+    let params = sample_params();
+    // Envelope with NO _meta.authorization_binding.
+    let envelope = named_envelope(&params, None, &[("progress_token", serde_json::json!("p"))]);
+    let digest = named_digest(&params, &sample_binding());
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&env_path, envelope).unwrap();
+    fs::write(&decision, decision_json(&digest)).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--fallback-projection",
+            "named",
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("fallback_binding_block_present"))
+        .stdout(predicate::str::contains("failing closed"));
+}
+
+#[test]
+fn fallback_named_projection_breaks_on_changed_binding_block() {
+    let dir = tempdir().unwrap();
+    let params = sample_params();
+    // Decision binds the ORIGINAL binding; the envelope carries a DIFFERENT binding.
+    let digest = named_digest(&params, &sample_binding());
+    let other_binding =
+        serde_json::json!({ "tenant": "acme", "resource": "provider/customer/cus_999" });
+    let envelope = named_envelope(&params, Some(&other_binding), &[]);
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&env_path, envelope).unwrap();
+    fs::write(&decision, decision_json(&digest)).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--fallback-projection",
+            "named",
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains(
+            "decision_request_envelope_digest_match",
+        ))
+        .stdout(predicate::str::contains("fail mismatch"));
+}
+
+#[test]
+fn fallback_named_projection_breaks_on_changed_bound_param() {
+    let dir = tempdir().unwrap();
+    let binding = sample_binding();
+    // Decision binds the ORIGINAL params; the envelope carries DIFFERENT params.
+    let digest = named_digest(&sample_params(), &binding);
+    let other_params =
+        serde_json::json!({ "name": "tools/call", "arguments": { "processInstanceKey": "9999" } });
+    let envelope = named_envelope(&other_params, Some(&binding), &[]);
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&env_path, envelope).unwrap();
+    fs::write(&decision, decision_json(&digest)).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--fallback-projection",
+            "named",
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains(
+            "decision_request_envelope_digest_match",
+        ))
+        .stdout(predicate::str::contains("fail mismatch"));
+}

--- a/docs/reference/cli/mcp-execution-record-fallback-plan.md
+++ b/docs/reference/cli/mcp-execution-record-fallback-plan.md
@@ -208,3 +208,45 @@ Review-ready when:
 - docs state the request-envelope shape and the fallback non-claims
 - no supersession, signature verification, or issuer-trust behavior is
   introduced in this slice
+
+## Named Projection Follow-up (shipped)
+
+The slice above hashes the whole request envelope. A follow-up adds an opt-in named projection so
+transport-local or observation-local `_meta` fields a gateway or provider can legitimately add or
+strip do not change the binding digest.
+
+```bash
+assay evidence verify-mcp-records \
+  --request-envelope tools-call-envelope.json \
+  --decision server-decision-record.json \
+  --fallback-projection named \
+  --format json
+```
+
+In `--fallback-projection named` (default stays `whole-envelope`, so existing behavior is unchanged),
+the binding digest is computed over an **allowlist** projection, not the whole envelope:
+
+```text
+sha256( jcs( { "projection": "assay.fallback_projection.v0",
+               "params":     <tools/call params>,
+               "binding":    <_meta.authorization_binding> } ) )
+```
+
+Everything else under `_meta` is excluded by construction. The rules, in code and pinned by tests:
+
+- **Allowlist, not denylist.** Only the named `params` and the named binding block are in the
+  preimage; unrelated `_meta` (progress tokens, trace context, other SEP blocks) is excluded, so two
+  views that differ only in non-binding `_meta` produce the same digest.
+- **Fail-closed.** If `_meta.authorization_binding` is absent, the fallback case is non-conformant
+  (`fallback_binding_block_present` fails, exit `2`) rather than silently hashing the whole envelope.
+- **Self-describing version.** The report carries `binding.projection = "assay.fallback_projection.v0"`.
+  This tracks the in-progress SEP-2828 fallback-binding discussion; a rename or rule change is an
+  explicit version bump, never a silent reinterpretation.
+
+### Non-claims (named projection)
+
+- The named field set (`params` + `_meta.authorization_binding`) is a proposed shape tracking the
+  upstream discussion, not a finalized SEP contract; it is versioned so it can change explicitly.
+- Matching the named projection digest does not prove the server observed the envelope honestly, nor
+  that the omitted `_meta` was irrelevant to anything other than the binding.
+- `whole-envelope` mode remains for interop with current external fixtures that bind the full envelope.


### PR DESCRIPTION
First of two slices delivering on the MCP #2852/#2867 commitment to extend Assay's consumer verifier to the no-attestation fallback path. This one realizes the `_meta` allowlist point in code.

The existing `--request-envelope` fallback hashes the **whole** envelope, so a gateway and a provider that legitimately see slightly different `_meta` (progress tokens, trace context, other SEP blocks) compute different digests — the scope-drift-that-is-really-a-hashing-bug. This adds an opt-in named projection:

```bash
assay evidence verify-mcp-records \
  --request-envelope tools-call-envelope.json \
  --decision server-decision-record.json \
  --fallback-projection named --format json
```

In `named` mode the binding digest is computed over an allowlist:

```
sha256( jcs( { "projection": "assay.fallback_projection.v0",
               "params": <tools/call params>,
               "binding": <_meta.authorization_binding> } ) )
```

The three rules from the #2867 discussion, in code and pinned by tests:
- **allowlist, not denylist** — only the named fields are in the preimage; two views differing only in non-binding `_meta` produce the same digest;
- **fail-closed** — a missing `_meta.authorization_binding` is non-conformant (`fallback_binding_block_present` fails, exit `2`), never a silent fall-back to hashing the whole envelope;
- **self-describing version** — `binding.projection = "assay.fallback_projection.v0"`, so a rename/rule change is an explicit bump (it tracks the in-progress SEP-2828 discussion, it is not a finalized contract).

Default stays `whole-envelope`, so existing behavior and current external-fixture interop are unchanged. Five new tests (named match excludes non-binding `_meta`; same digest across differing non-binding `_meta`; fail-closed on missing block; break on changed binding; break on changed param); the existing 10 pass unchanged.

### Lane classification: `Gate.NONE`

```
files: CHANGELOG.md, crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs,
       crates/assay-cli/tests/evidence_test/mcp_execution_records.rs,
       docs/reference/cli/mcp-execution-record-fallback-plan.md
Gate: NONE | reasons: (none)
```

(`evidence/mcp_execution_records.rs` is not `runner_spike.rs`/`cgroup.rs`; no runner/ebpf/monitor/xtask, no `Cargo.toml`/`Cargo.lock`.) No delegated proof required.

Next slice (separate thin PR, per one-capability discipline): supersession evaluation — equal-`decidedAt` ambiguity treated as non-conformant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)