### PR TITLE
feat(evidence): add verify-mcp-supersession (latest decidedAt wins; equal time is ambiguous)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `assay evidence verify-mcp-supersession`: independent-consumer evaluation of decision-record
+  supersession for SEP-2828-style execution records. Given decision records that share a call binding
+  (`backLink`), the latest `decidedAt` wins; an equal-`decidedAt` tie with no explicit ordering field
+  (`decisionDerived.sequence`) is reported as `ambiguous` / non-conformant (exit `2`) rather than
+  resolved from file order, arrival order, or the record nonce, because a nonce is unique per record,
+  not an ordering field, and an arbitrary-but-deterministic winner can mask a producer that emitted two
+  records that should never have tied. An explicit `sequence` resolves a tie deterministically.
+  Consumer side only: no signature, issuer-trust, freshness, or runtime-truth claims.
 - `assay evidence verify-mcp-records --fallback-projection named`: a no-attestation fallback binding
   computed over a named projection (the `tools/call` `params` plus the `_meta.authorization_binding`
   block) instead of the whole request envelope, so transport- or observation-local `_meta` fields a

--- a/crates/assay-cli/src/cli/commands/evidence/mcp_supersession.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_supersession.rs
@@ -1,0 +1,252 @@
+//! `assay evidence verify-mcp-supersession` — independent-consumer evaluation of decision-record
+//! supersession for SEP-2828-style execution records.
+//!
+//! Given several decision records that share a call binding (`backLink`), it reports which decision
+//! is effective. The contract, matching the upstream SEP-2828 discussion:
+//!
+//! - the latest `decidedAt` wins;
+//! - if two records share the same `decidedAt` and there is no explicit ordering field
+//!   (`decisionDerived.sequence`), the supersession is **ambiguous / non-conformant** — the verifier
+//!   does not guess from file order, arrival order, or the record nonce, because a nonce is unique
+//!   per record, not an ordering field, and an arbitrary-but-deterministic winner can mask a producer
+//!   that emitted two records that should never have tied.
+//!
+//! This is the consumer side only: it reads committed records and does not verify signatures, issuer
+//! trust, freshness, or runtime truth.
+
+use anyhow::{Context, Result};
+use clap::{Args, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Args, Clone)]
+pub struct McpSupersessionArgs {
+    /// JSON array of server-side decision records that may share a call binding.
+    #[arg(long)]
+    pub decisions: PathBuf,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = SupersessionFormat::Table)]
+    pub format: SupersessionFormat,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum SupersessionFormat {
+    Json,
+    Table,
+}
+
+#[derive(Debug, Serialize)]
+struct SupersessionReport {
+    schema: &'static str,
+    ok: bool,
+    verification_scope: VerificationScope,
+    groups: Vec<GroupReport>,
+    claims_not_made: Vec<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct VerificationScope {
+    role: &'static str,
+    note: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct GroupReport {
+    backlink_key: String,
+    count: usize,
+    verdict: &'static str,
+    effective_decided_at: Option<String>,
+    effective_decision: Option<String>,
+    detail: String,
+}
+
+pub fn cmd_verify_mcp_supersession(args: McpSupersessionArgs) -> Result<i32> {
+    let body = fs::read_to_string(&args.decisions)
+        .with_context(|| format!("failed to read {}", args.decisions.display()))?;
+    let parsed: Value = serde_json::from_str(&body)
+        .with_context(|| format!("failed to parse {}", args.decisions.display()))?;
+    let records = parsed
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("--decisions must be a JSON array of decision records"))?;
+
+    // Group by backLink pair key. Records with no backLink are reported as their own ungrouped entry.
+    let mut groups: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
+    for record in records {
+        groups.entry(backlink_key(record)).or_default().push(record);
+    }
+
+    let group_reports: Vec<GroupReport> = groups
+        .into_iter()
+        .map(|(key, records)| evaluate_group(key, &records))
+        .collect();
+
+    let ok = group_reports.iter().all(|g| g.verdict == "resolved");
+    let report = SupersessionReport {
+        schema: "assay.mcp.execution-record-supersession.report.v0",
+        ok,
+        verification_scope: VerificationScope {
+            role: "independent-consumer",
+            note: "Assay evaluates supersession ordering from committed decision records only; it does not verify signatures, issuer trust, freshness, or runtime truth.",
+        },
+        groups: group_reports,
+        claims_not_made: vec![
+            "signature_verification",
+            "issuer_key_trust",
+            "decided_at_clock_truth",
+            "policy_correctness",
+            "runtime_side_effect_truth",
+        ],
+    };
+
+    match args.format {
+        SupersessionFormat::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        SupersessionFormat::Table => print_table(&report),
+    }
+    Ok(if report.ok { 0 } else { 2 })
+}
+
+fn evaluate_group(key: String, records: &[&Value]) -> GroupReport {
+    let count = records.len();
+    if count == 1 {
+        return GroupReport {
+            backlink_key: key,
+            count,
+            verdict: "resolved",
+            effective_decided_at: decided_at(records[0]),
+            effective_decision: decision_value(records[0]),
+            detail: "single decision for this call binding".to_string(),
+        };
+    }
+
+    // Latest decidedAt wins. RFC 3339 UTC timestamps compare lexicographically; a missing decidedAt
+    // cannot be ordered, so a group with any missing decidedAt is ambiguous.
+    if records.iter().any(|r| decided_at(r).is_none()) {
+        return ambiguous(
+            key,
+            count,
+            "a decision record is missing decidedAt; cannot order",
+        );
+    }
+    let max_time = records.iter().filter_map(|r| decided_at(r)).max().unwrap();
+    let leaders: Vec<&Value> = records
+        .iter()
+        .copied()
+        .filter(|r| decided_at(r).as_deref() == Some(max_time.as_str()))
+        .collect();
+
+    if leaders.len() == 1 {
+        return GroupReport {
+            backlink_key: key,
+            count,
+            verdict: "resolved",
+            effective_decided_at: Some(max_time),
+            effective_decision: decision_value(leaders[0]),
+            detail: "latest decidedAt is unique".to_string(),
+        };
+    }
+
+    // Tie on decidedAt: only an explicit ordering field resolves it; the nonce does not.
+    if leaders.iter().all(|r| sequence(r).is_some()) {
+        let max_seq = leaders.iter().filter_map(|r| sequence(r)).max().unwrap();
+        let seq_leaders: Vec<&Value> = leaders
+            .iter()
+            .copied()
+            .filter(|r| sequence(r) == Some(max_seq))
+            .collect();
+        if seq_leaders.len() == 1 {
+            return GroupReport {
+                backlink_key: key,
+                count,
+                verdict: "resolved",
+                effective_decided_at: Some(max_time),
+                effective_decision: decision_value(seq_leaders[0]),
+                detail: format!("equal decidedAt resolved by explicit sequence {max_seq}"),
+            };
+        }
+        return ambiguous(
+            key,
+            count,
+            "equal decidedAt and equal sequence; no deterministic winner",
+        );
+    }
+
+    ambiguous(
+        key,
+        count,
+        "equal decidedAt and no explicit ordering field; a nonce is not an ordering field",
+    )
+}
+
+fn ambiguous(key: String, count: usize, detail: &str) -> GroupReport {
+    GroupReport {
+        backlink_key: key,
+        count,
+        verdict: "ambiguous",
+        effective_decided_at: None,
+        effective_decision: None,
+        detail: detail.to_string(),
+    }
+}
+
+fn backlink_key(record: &Value) -> String {
+    let backlink = record.get("backLink").or_else(|| record.get("back_link"));
+    match backlink {
+        Some(b) => format!(
+            "attestationDigest={};attestationNonce={}",
+            string_at(b, &["attestationDigest"])
+                .or_else(|| string_at(b, &["attestation_digest"]))
+                .unwrap_or_else(|| "-".to_string()),
+            string_at(b, &["attestationNonce"])
+                .or_else(|| string_at(b, &["attestation_nonce"]))
+                .unwrap_or_else(|| "-".to_string()),
+        ),
+        None => "no-backlink".to_string(),
+    }
+}
+
+fn decided_at(record: &Value) -> Option<String> {
+    string_at(record, &["decisionDerived", "decidedAt"])
+        .or_else(|| string_at(record, &["decision_derived", "decided_at"]))
+}
+
+fn decision_value(record: &Value) -> Option<String> {
+    string_at(record, &["decisionDerived", "decision"])
+        .or_else(|| string_at(record, &["decision_derived", "decision"]))
+}
+
+fn sequence(record: &Value) -> Option<i64> {
+    record
+        .get("decisionDerived")
+        .or_else(|| record.get("decision_derived"))
+        .and_then(|d| d.get("sequence"))
+        .and_then(Value::as_i64)
+}
+
+fn string_at(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str().map(ToOwned::to_owned)
+}
+
+fn print_table(report: &SupersessionReport) {
+    println!("MCP Execution Record Supersession Report");
+    println!("========================================");
+    println!("OK:    {}", if report.ok { "yes" } else { "no" });
+    println!("Role:  {}", report.verification_scope.role);
+    println!();
+    for group in &report.groups {
+        println!(
+            "{:<10} count={} {}",
+            group.verdict, group.count, group.backlink_key
+        );
+        println!("           {}", group.detail);
+    }
+    println!();
+    println!("Claims not made: {}", report.claims_not_made.join(", "));
+}

--- a/crates/assay-cli/src/cli/commands/evidence/mod.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mod.rs
@@ -7,6 +7,7 @@ pub mod livekit_tool_action;
 pub mod mapping;
 pub mod mastra_score_event;
 pub mod mcp_execution_records;
+pub mod mcp_supersession;
 pub mod mcp_tunnel_observed;
 pub mod openfeature_details;
 pub mod promptfoo_jsonl;
@@ -32,6 +33,9 @@ pub enum EvidenceCmd {
     /// Verify SEP-2787/server execution-record fixture pairing
     #[command(name = "verify-mcp-records")]
     VerifyMcpRecords(mcp_execution_records::McpExecutionRecordArgs),
+    /// Evaluate decision-record supersession (latest decidedAt wins; equal time is ambiguous)
+    #[command(name = "verify-mcp-supersession")]
+    VerifyMcpSupersession(mcp_supersession::McpSupersessionArgs),
     /// Verify MCP tunnel observed-facts fixture boundaries and join classification
     #[command(name = "verify-mcp-tunnel-observed")]
     VerifyMcpTunnelObserved(mcp_tunnel_observed::McpTunnelObservedArgs),
@@ -130,6 +134,7 @@ pub async fn run(args: crate::cli::args::EvidenceArgs) -> Result<i32> {
         EvidenceCmd::Export(a) => cmd_export(a),
         EvidenceCmd::Verify(a) => cmd_verify(a),
         EvidenceCmd::VerifyMcpRecords(a) => mcp_execution_records::cmd_verify_mcp_records(a),
+        EvidenceCmd::VerifyMcpSupersession(a) => mcp_supersession::cmd_verify_mcp_supersession(a),
         EvidenceCmd::VerifyMcpTunnelObserved(a) => {
             mcp_tunnel_observed::cmd_verify_mcp_tunnel_observed(a)
         }

--- a/crates/assay-cli/tests/evidence_test.rs
+++ b/crates/assay-cli/tests/evidence_test.rs
@@ -19,5 +19,7 @@ mod flow_and_eval_receipts;
 mod importer_receipts;
 #[path = "evidence_test/mcp_execution_records.rs"]
 mod mcp_execution_records;
+#[path = "evidence_test/mcp_supersession.rs"]
+mod mcp_supersession;
 #[path = "evidence_test/mcp_tunnel_observed.rs"]
 mod mcp_tunnel_observed;

--- a/crates/assay-cli/tests/evidence_test/mcp_supersession.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_supersession.rs
@@ -1,0 +1,154 @@
+//! Contract tests for `assay evidence verify-mcp-supersession`.
+//!
+//! Latest `decidedAt` wins; an equal-`decidedAt` tie with no explicit ordering field is ambiguous /
+//! non-conformant (the verifier refuses to guess from order or nonce). An explicit `sequence` field
+//! resolves a tie deterministically.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use std::fs;
+use tempfile::tempdir;
+
+fn decision(
+    digest: &str,
+    nonce: &str,
+    decided_at: &str,
+    decision: &str,
+    sequence: Option<i64>,
+) -> Value {
+    let mut derived = serde_json::json!({ "decidedAt": decided_at, "decision": decision });
+    if let Some(s) = sequence {
+        derived["sequence"] = serde_json::json!(s);
+    }
+    serde_json::json!({
+        "backLink": { "attestationDigest": digest, "attestationNonce": nonce },
+        "decisionDerived": derived,
+    })
+}
+
+fn run(records: &[Value]) -> assert_cmd::assert::Assert {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("decisions.json");
+    fs::write(
+        &path,
+        serde_json::to_string(&Value::Array(records.to_vec())).unwrap(),
+    )
+    .unwrap();
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-supersession",
+            "--decisions",
+            path.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+}
+
+#[test]
+fn single_decision_resolves() {
+    let out = run(&[decision(
+        "sha256:aa",
+        "n1",
+        "2026-06-09T10:00:00Z",
+        "allow",
+        None,
+    )])
+    .success()
+    .get_output()
+    .stdout
+    .clone();
+    let report: Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["groups"][0]["verdict"], "resolved");
+}
+
+#[test]
+fn distinct_decided_at_latest_wins() {
+    let out = run(&[
+        decision("sha256:aa", "n1", "2026-06-09T10:00:00Z", "escalate", None),
+        decision("sha256:aa", "n1", "2026-06-09T11:00:00Z", "allow", None),
+    ])
+    .success()
+    .get_output()
+    .stdout
+    .clone();
+    let report: Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["groups"][0]["verdict"], "resolved");
+    assert_eq!(report["groups"][0]["effective_decision"], "allow");
+    assert_eq!(
+        report["groups"][0]["effective_decided_at"],
+        "2026-06-09T11:00:00Z"
+    );
+}
+
+#[test]
+fn equal_decided_at_without_ordering_is_ambiguous() {
+    // The headline case: a tie with no ordering field must not be silently resolved.
+    // Same call binding (same digest AND nonce), same decidedAt, no ordering field.
+    run(&[
+        decision("sha256:aa", "n1", "2026-06-09T10:00:00Z", "escalate", None),
+        decision("sha256:aa", "n1", "2026-06-09T10:00:00Z", "allow", None),
+    ])
+    .code(2)
+    .stdout(predicate::str::contains("ambiguous"))
+    .stdout(predicate::str::contains("no explicit ordering field"));
+}
+
+#[test]
+fn equal_decided_at_with_sequence_resolves() {
+    let out = run(&[
+        decision(
+            "sha256:aa",
+            "n1",
+            "2026-06-09T10:00:00Z",
+            "escalate",
+            Some(1),
+        ),
+        decision("sha256:aa", "n1", "2026-06-09T10:00:00Z", "allow", Some(2)),
+    ])
+    .success()
+    .get_output()
+    .stdout
+    .clone();
+    let report: Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["groups"][0]["verdict"], "resolved");
+    assert_eq!(report["groups"][0]["effective_decision"], "allow");
+}
+
+#[test]
+fn equal_decided_at_and_equal_sequence_is_ambiguous() {
+    run(&[
+        decision(
+            "sha256:aa",
+            "n1",
+            "2026-06-09T10:00:00Z",
+            "escalate",
+            Some(5),
+        ),
+        decision("sha256:aa", "n1", "2026-06-09T10:00:00Z", "allow", Some(5)),
+    ])
+    .code(2)
+    .stdout(predicate::str::contains("ambiguous"))
+    .stdout(predicate::str::contains("equal sequence"));
+}
+
+#[test]
+fn distinct_backlinks_each_resolve_independently() {
+    let out = run(&[
+        decision("sha256:aa", "n1", "2026-06-09T10:00:00Z", "allow", None),
+        decision("sha256:bb", "n2", "2026-06-09T10:00:00Z", "block", None),
+    ])
+    .success()
+    .get_output()
+    .stdout
+    .clone();
+    let report: Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["groups"].as_array().unwrap().len(), 2);
+}


### PR DESCRIPTION
Second of the two slices delivering on the MCP #2852/#2867 commitment to extend Assay's consumer verifier to the fallback path. The first (#1583) did the named-projection `_meta` point; this adds supersession evaluation, the equal-`decidedAt` rule the upstream thread pinned.

```bash
assay evidence verify-mcp-supersession --decisions decisions.json --format json
```

Given decision records that share a call binding (`backLink`), it reports which decision is effective:
- the latest `decidedAt` wins;
- an equal-`decidedAt` tie with no explicit ordering field (`decisionDerived.sequence`) is `ambiguous` / non-conformant (exit `2`), not resolved from file order, arrival order, or the record nonce — a nonce is unique per record, not an ordering field, and an arbitrary-but-deterministic winner can mask a producer that emitted two records that should never have tied;
- an explicit `sequence` resolves a tie deterministically.

Consumer side only: no signature, issuer-trust, freshness, or runtime-truth claims (all stated in `claims_not_made`). Six CLI tests: single, distinct-time-latest-wins, equal-time-ambiguous (the headline), equal-time-with-sequence-resolves, equal-time-equal-sequence-ambiguous, distinct-backlinks-group-independently.

### Lane classification: `Gate.NONE`

```
files: CHANGELOG.md, crates/assay-cli/src/cli/commands/evidence/mcp_supersession.rs,
       crates/assay-cli/src/cli/commands/evidence/mod.rs,
       crates/assay-cli/tests/evidence_test.rs,
       crates/assay-cli/tests/evidence_test/mcp_supersession.rs
Gate: NONE | reasons: (none)
```

New evidence command; no `runner_spike.rs`/`cgroup.rs`, no runner/ebpf/monitor, no `Cargo.toml`/`Cargo.lock`. No delegated proof required.

With this and #1583, both of the two fallback-path cases Assay's consumer "could not judge before" — the no-attestation fallback binding and equal-`decidedAt` supersession — are now evaluable from committed records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)