### PR TITLE
chore(mcp): add stable fallback/supersession reason codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- MCP execution-record verifiers: pin semantics with stable, machine-readable reason codes before the
+  new verifiers are used as a contract (no new capability, no mode change, no schema bump).
+  `verify-mcp-supersession` now exposes a stable `groups[].reason_code`
+  (`supersession_resolved_*` / `supersession_ambiguous_*`) instead of only prose; the named fallback
+  in `verify-mcp-records` distinguishes `fallback_projection_missing_authorization_binding` from
+  `fallback_projection_invalid_meta` (both fail-closed). Tests now pin that the projection id is part
+  of the digest preimage (changing it breaks the back-link) and that the whole `authorization_binding`
+  object is bound (no allowlist inside the block). `--fallback-projection whole-envelope` is documented
+  as the legacy compatibility mode and `named` as the named projection mode (default unchanged). The
+  supersession report documents that `sequence` is asserted canonical-content ordering, not an
+  independently verified ordering (Assay verifies no signatures). Docs:
+  `docs/reference/cli/mcp-execution-record-fallback-plan.md`.
+
 ### Added
 
 - `assay evidence verify-mcp-supersession`: independent-consumer evaluation of decision-record

--- a/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs
@@ -30,12 +30,12 @@ pub struct McpExecutionRecordArgs {
     pub outcome: Option<PathBuf>,
 
     /// For the no-attestation fallback, how the request-envelope binding digest is computed.
-    /// `whole-envelope` (default) digests the full JCS envelope; `named` digests only a named
-    /// projection (the `tools/call` params plus a named `_meta` binding block), so transport-local
-    /// or observation-local `_meta` fields a gateway/provider can legitimately add or strip do not
-    /// change the digest. Named mode is allowlist + fail-closed: if the binding block is absent the
-    /// fallback case is non-conformant rather than silently hashing the whole envelope. Ignored for
-    /// the SEP-2787 attestation path.
+    /// `whole-envelope` (default) is the legacy compatibility mode: it digests the full JCS envelope.
+    /// `named` is the named fallback projection mode: it digests only the `tools/call` params plus the
+    /// `_meta.authorization_binding` block, so transport-local or observation-local `_meta` fields a
+    /// gateway/provider can legitimately add or strip do not change the digest. Named mode is
+    /// allowlist + fail-closed: if the binding block cannot be resolved the fallback case is
+    /// non-conformant rather than silently hashing the whole envelope. Ignored for the SEP-2787 path.
     #[arg(long, value_enum, default_value_t = FallbackProjection::WholeEnvelope)]
     pub fallback_projection: FallbackProjection,
 
@@ -51,9 +51,10 @@ const FALLBACK_PROJECTION_V0: &str = "assay.fallback_projection.v0";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum FallbackProjection {
-    /// Digest the full JCS-canonical request envelope (matches the shipped SEP-2828 fallback text).
+    /// Legacy compatibility mode: digest the full JCS-canonical request envelope.
     WholeEnvelope,
-    /// Digest only the named projection: `tools/call` params plus the `_meta` binding block.
+    /// Named fallback projection mode: digest only the `tools/call` params plus the
+    /// `_meta.authorization_binding` block (allowlist + fail-closed).
     Named,
 }
 
@@ -173,9 +174,11 @@ struct BindingExpectation {
     digest: String,
     digest_source: &'static str,
     projection: Option<&'static str>,
-    /// `Some(false)` when named projection was requested but the binding block was absent
+    /// `Some(false)` when named projection was requested but the binding block could not be resolved
     /// (fail-closed); `None` when not applicable (whole-envelope / attestation).
     binding_block_present: Option<bool>,
+    /// Stable reason code for the named-projection fail-closed case (None when present / N/A).
+    named_fail_code: Option<&'static str>,
     nonce: Option<String>,
     nonce_source: &'static str,
 }
@@ -192,23 +195,26 @@ fn build_report(
     let expectation = binding_expectation(binding_input, &decision_backlink, fallback_projection)?;
 
     let mut checks = Vec::new();
-    // Fail-closed: named projection requested but the binding block was absent is non-conformant,
-    // never a silent fall-back to hashing the whole envelope.
-    if expectation.binding_block_present == Some(false) {
-        checks.push(CheckReport {
-            id: "fallback_binding_block_present",
-            ok: false,
-            detail:
-                "named fallback projection requested but _meta.authorization_binding is absent; \
-                     failing closed instead of hashing the whole envelope"
-                    .to_string(),
-        });
-    } else if expectation.binding_block_present == Some(true) {
-        checks.push(CheckReport {
-            id: "fallback_binding_block_present",
+    // Fail-closed: named projection requested but the binding block could not be resolved is
+    // non-conformant, never a silent fall-back to hashing the whole envelope. The check id is the
+    // stable reason code (invalid `_meta` vs missing `authorization_binding`).
+    match (
+        expectation.binding_block_present,
+        expectation.named_fail_code,
+    ) {
+        (Some(true), _) => checks.push(CheckReport {
+            id: "fallback_projection_binding_present",
             ok: true,
             detail: "named fallback projection binding block present".to_string(),
-        });
+        }),
+        (Some(false), Some(code)) => checks.push(CheckReport {
+            id: code,
+            ok: false,
+            detail: "named fallback projection requested but the binding block could not be \
+                     resolved; failing closed instead of hashing the whole envelope"
+                .to_string(),
+        }),
+        _ => {}
     }
     push_decision_binding_checks(&mut checks, &decision_backlink, &expectation);
     checks.push(check_enum(
@@ -314,6 +320,7 @@ fn binding_expectation(
             digest_source: "sep2787_attestation_jcs",
             projection: None,
             binding_block_present: None,
+            named_fail_code: None,
             nonce: string_at(attestation, &["issuerAsserted", "nonce"]),
             nonce_source: "issuerAsserted.nonce",
         }),
@@ -325,37 +332,49 @@ fn binding_expectation(
                 digest_source: "request_envelope_jcs",
                 projection: None,
                 binding_block_present: None,
+                named_fail_code: None,
                 nonce: decision_backlink.attestation_nonce.clone(),
                 nonce_source: "record_backlink_consistency",
             }),
             FallbackProjection::Named => {
-                // Allowlist: the preimage is exactly the named params plus the named binding block,
-                // everything else under _meta is excluded by construction. Fail-closed when the
-                // binding block is absent — never fall back to hashing the whole envelope.
-                let binding_block = request_envelope
-                    .get("_meta")
-                    .and_then(|m| m.get("authorization_binding"));
-                let (digest, present) = match binding_block {
+                // Allowlist: the preimage is exactly the named params plus the whole named binding
+                // block, everything else under _meta is excluded by construction. Fail-closed with a
+                // stable reason when the binding cannot be resolved — never hash the whole envelope.
+                // `_meta` absent or not an object -> invalid_meta; object but no binding -> missing.
+                let meta = request_envelope.get("_meta");
+                let (named_fail_code, binding): (Option<&'static str>, Option<&Value>) = match meta
+                {
+                    None => (Some("fallback_projection_invalid_meta"), None),
+                    Some(m) if !m.is_object() => (Some("fallback_projection_invalid_meta"), None),
+                    Some(m) => match m.get("authorization_binding") {
+                        Some(b) => (None, Some(b)),
+                        None => (
+                            Some("fallback_projection_missing_authorization_binding"),
+                            None,
+                        ),
+                    },
+                };
+                let digest = match binding {
                     Some(binding) => {
+                        // The whole authorization_binding object is bound (bind-all); any field
+                        // inside it is part of the preimage. The projection id is bound too.
                         let projected = serde_json::json!({
                             "projection": FALLBACK_PROJECTION_V0,
                             "params": request_envelope.get("params").unwrap_or(&Value::Null),
                             "binding": binding,
                         });
-                        (
-                            jcs_digest(&projected)
-                                .context("failed to digest named fallback projection")?,
-                            true,
-                        )
+                        jcs_digest(&projected)
+                            .context("failed to digest named fallback projection")?
                     }
-                    None => ("sha256:unresolved-binding-block".to_string(), false),
+                    None => "sha256:unresolved-binding-block".to_string(),
                 };
                 Ok(BindingExpectation {
                     mode: "request_envelope",
                     digest,
                     digest_source: "request_envelope_named_projection_jcs",
                     projection: Some(FALLBACK_PROJECTION_V0),
-                    binding_block_present: Some(present),
+                    binding_block_present: Some(binding.is_some()),
+                    named_fail_code,
                     nonce: decision_backlink.attestation_nonce.clone(),
                     nonce_source: "record_backlink_consistency",
                 })

--- a/crates/assay-cli/src/cli/commands/evidence/mcp_supersession.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/mcp_supersession.rs
@@ -59,6 +59,8 @@ struct GroupReport {
     backlink_key: String,
     count: usize,
     verdict: &'static str,
+    /// Stable, machine-readable reason; CI consumers key on this, not on `detail` prose.
+    reason_code: &'static str,
     effective_decided_at: Option<String>,
     effective_decision: Option<String>,
     detail: String,
@@ -97,6 +99,10 @@ pub fn cmd_verify_mcp_supersession(args: McpSupersessionArgs) -> Result<i32> {
             "signature_verification",
             "issuer_key_trust",
             "decided_at_clock_truth",
+            // `sequence` is read from the canonical decisionDerived content; Assay verifies no
+            // signatures, so a sequence-resolved ordering is asserted-content, not independently
+            // verified ordering.
+            "sequence_ordering_is_asserted_content_not_verified",
             "policy_correctness",
             "runtime_side_effect_truth",
         ],
@@ -116,6 +122,7 @@ fn evaluate_group(key: String, records: &[&Value]) -> GroupReport {
             backlink_key: key,
             count,
             verdict: "resolved",
+            reason_code: "supersession_resolved_single",
             effective_decided_at: decided_at(records[0]),
             effective_decision: decision_value(records[0]),
             detail: "single decision for this call binding".to_string(),
@@ -128,6 +135,7 @@ fn evaluate_group(key: String, records: &[&Value]) -> GroupReport {
         return ambiguous(
             key,
             count,
+            "supersession_ambiguous_missing_decided_at",
             "a decision record is missing decidedAt; cannot order",
         );
     }
@@ -143,6 +151,7 @@ fn evaluate_group(key: String, records: &[&Value]) -> GroupReport {
             backlink_key: key,
             count,
             verdict: "resolved",
+            reason_code: "supersession_resolved_latest_decided_at",
             effective_decided_at: Some(max_time),
             effective_decision: decision_value(leaders[0]),
             detail: "latest decidedAt is unique".to_string(),
@@ -162,14 +171,18 @@ fn evaluate_group(key: String, records: &[&Value]) -> GroupReport {
                 backlink_key: key,
                 count,
                 verdict: "resolved",
+                reason_code: "supersession_resolved_sequence",
                 effective_decided_at: Some(max_time),
                 effective_decision: decision_value(seq_leaders[0]),
-                detail: format!("equal decidedAt resolved by explicit sequence {max_seq}"),
+                detail: format!(
+                    "equal decidedAt resolved by explicit (asserted) sequence {max_seq}"
+                ),
             };
         }
         return ambiguous(
             key,
             count,
+            "supersession_ambiguous_duplicate_sequence",
             "equal decidedAt and equal sequence; no deterministic winner",
         );
     }
@@ -177,15 +190,17 @@ fn evaluate_group(key: String, records: &[&Value]) -> GroupReport {
     ambiguous(
         key,
         count,
+        "supersession_ambiguous_missing_sequence",
         "equal decidedAt and no explicit ordering field; a nonce is not an ordering field",
     )
 }
 
-fn ambiguous(key: String, count: usize, detail: &str) -> GroupReport {
+fn ambiguous(key: String, count: usize, reason_code: &'static str, detail: &str) -> GroupReport {
     GroupReport {
         backlink_key: key,
         count,
         verdict: "ambiguous",
+        reason_code,
         effective_decided_at: None,
         effective_decision: None,
         detail: detail.to_string(),
@@ -242,8 +257,8 @@ fn print_table(report: &SupersessionReport) {
     println!();
     for group in &report.groups {
         println!(
-            "{:<10} count={} {}",
-            group.verdict, group.count, group.backlink_key
+            "{:<10} {:<44} count={} {}",
+            group.verdict, group.reason_code, group.count, group.backlink_key
         );
         println!("           {}", group.detail);
     }

--- a/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_execution_records.rs
@@ -672,8 +672,114 @@ fn fallback_named_projection_fails_closed_when_binding_block_absent() {
         ])
         .assert()
         .code(2)
-        .stdout(predicate::str::contains("fallback_binding_block_present"))
+        .stdout(predicate::str::contains(
+            "fallback_projection_missing_authorization_binding",
+        ))
         .stdout(predicate::str::contains("failing closed"));
+}
+
+#[test]
+fn fallback_named_projection_invalid_meta_fails_closed() {
+    let dir = tempdir().unwrap();
+    // `_meta` present but not an object -> invalid, distinct reason code from a missing binding.
+    let envelope =
+        serde_json::json!({ "params": sample_params(), "_meta": "not-an-object" }).to_string();
+    let digest = named_digest(&sample_params(), &sample_binding());
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&env_path, envelope).unwrap();
+    fs::write(&decision, decision_json(&digest)).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--fallback-projection",
+            "named",
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("fallback_projection_invalid_meta"));
+}
+
+#[test]
+fn fallback_named_projection_id_is_bound_in_the_digest() {
+    // Changing the projection id changes the digest: a decision whose backLink was computed with a
+    // DIFFERENT projection id must not pair, proving the projection id is part of the preimage.
+    let dir = tempdir().unwrap();
+    let params = sample_params();
+    let binding = sample_binding();
+    let envelope = named_envelope(&params, Some(&binding), &[]);
+    // Digest computed with a WRONG projection id; the verifier uses the real id, so they differ.
+    let wrong = jcs_digest_value(&serde_json::json!({
+        "projection": "assay.fallback_projection.v0-WRONG",
+        "params": params,
+        "binding": binding,
+    }));
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&env_path, envelope).unwrap();
+    fs::write(&decision, decision_json(&wrong)).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--fallback-projection",
+            "named",
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains(
+            "decision_request_envelope_digest_match",
+        ))
+        .stdout(predicate::str::contains("fail mismatch"));
+}
+
+#[test]
+fn fallback_named_projection_binds_whole_authorization_binding() {
+    // Bind-all: an extra field inside authorization_binding is part of the preimage, so a decision
+    // built without that field does not pair. (Documents that there is no allowlist *inside* the
+    // binding block; the whole object is bound.)
+    let dir = tempdir().unwrap();
+    let params = sample_params();
+    let binding_without = sample_binding();
+    let mut binding_with = sample_binding();
+    binding_with["extra_inner_field"] = serde_json::json!("x");
+    let envelope = named_envelope(&params, Some(&binding_with), &[]);
+    let digest_without = named_digest(&params, &binding_without);
+    let env_path = dir.path().join("request-envelope.json");
+    let decision = dir.path().join("decision.json");
+    fs::write(&env_path, envelope).unwrap();
+    fs::write(&decision, decision_json(&digest_without)).unwrap();
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "evidence",
+            "verify-mcp-records",
+            "--request-envelope",
+            env_path.to_str().unwrap(),
+            "--decision",
+            decision.to_str().unwrap(),
+            "--fallback-projection",
+            "named",
+        ])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains(
+            "decision_request_envelope_digest_match",
+        ));
 }
 
 #[test]

--- a/crates/assay-cli/tests/evidence_test/mcp_supersession.rs
+++ b/crates/assay-cli/tests/evidence_test/mcp_supersession.rs
@@ -64,6 +64,10 @@ fn single_decision_resolves() {
     let report: Value = serde_json::from_slice(&out).unwrap();
     assert_eq!(report["ok"], true);
     assert_eq!(report["groups"][0]["verdict"], "resolved");
+    assert_eq!(
+        report["groups"][0]["reason_code"],
+        "supersession_resolved_single"
+    );
 }
 
 #[test]
@@ -79,6 +83,10 @@ fn distinct_decided_at_latest_wins() {
     let report: Value = serde_json::from_slice(&out).unwrap();
     assert_eq!(report["ok"], true);
     assert_eq!(report["groups"][0]["verdict"], "resolved");
+    assert_eq!(
+        report["groups"][0]["reason_code"],
+        "supersession_resolved_latest_decided_at"
+    );
     assert_eq!(report["groups"][0]["effective_decision"], "allow");
     assert_eq!(
         report["groups"][0]["effective_decided_at"],
@@ -95,8 +103,9 @@ fn equal_decided_at_without_ordering_is_ambiguous() {
         decision("sha256:aa", "n1", "2026-06-09T10:00:00Z", "allow", None),
     ])
     .code(2)
-    .stdout(predicate::str::contains("ambiguous"))
-    .stdout(predicate::str::contains("no explicit ordering field"));
+    .stdout(predicate::str::contains(
+        "supersession_ambiguous_missing_sequence",
+    ));
 }
 
 #[test]
@@ -118,6 +127,10 @@ fn equal_decided_at_with_sequence_resolves() {
     let report: Value = serde_json::from_slice(&out).unwrap();
     assert_eq!(report["ok"], true);
     assert_eq!(report["groups"][0]["verdict"], "resolved");
+    assert_eq!(
+        report["groups"][0]["reason_code"],
+        "supersession_resolved_sequence"
+    );
     assert_eq!(report["groups"][0]["effective_decision"], "allow");
 }
 
@@ -134,8 +147,9 @@ fn equal_decided_at_and_equal_sequence_is_ambiguous() {
         decision("sha256:aa", "n1", "2026-06-09T10:00:00Z", "allow", Some(5)),
     ])
     .code(2)
-    .stdout(predicate::str::contains("ambiguous"))
-    .stdout(predicate::str::contains("equal sequence"));
+    .stdout(predicate::str::contains(
+        "supersession_ambiguous_duplicate_sequence",
+    ));
 }
 
 #[test]

--- a/docs/reference/cli/mcp-execution-record-fallback-plan.md
+++ b/docs/reference/cli/mcp-execution-record-fallback-plan.md
@@ -250,3 +250,30 @@ Everything else under `_meta` is excluded by construction. The rules, in code an
 - Matching the named projection digest does not prove the server observed the envelope honestly, nor
   that the omitted `_meta` was irrelevant to anything other than the binding.
 - `whole-envelope` mode remains for interop with current external fixtures that bind the full envelope.
+
+## Reason Codes and Semantics (hardening)
+
+Stable, machine-readable reason codes (CI consumers key on these, not on prose `detail`):
+
+- fallback (named mode, in `verify-mcp-records` check ids): `fallback_projection_binding_present`,
+  `fallback_projection_missing_authorization_binding`, `fallback_projection_invalid_meta`; a digest
+  mismatch surfaces through the existing `decision_request_envelope_digest_match` check.
+- supersession (`verify-mcp-supersession` `groups[].reason_code`):
+  `supersession_resolved_single`, `supersession_resolved_latest_decided_at`,
+  `supersession_resolved_sequence`, `supersession_ambiguous_missing_sequence`,
+  `supersession_ambiguous_duplicate_sequence`, `supersession_ambiguous_missing_decided_at`.
+
+Pinned semantics:
+
+- **Projection id is bound.** The named projection digest is `sha256(jcs({projection, params, binding}))`,
+  so the projection id is part of the preimage; changing it changes the digest. A rename or rule change
+  is an explicit version bump.
+- **Bind-all inside the binding block.** Extra non-binding `_meta` fields are excluded from the digest,
+  but the `authorization_binding` object is included as a whole — there is no allowlist *inside* the
+  binding block, so any field within it is bound. (A closed schema for `authorization_binding` is a
+  possible later policy step, not part of this hardening.)
+- **`whole-envelope` is legacy compatibility.** `named` is the mode used for the `_meta`
+  authorization-binding allowlist behavior. The default is unchanged here.
+- **Asserted sequence ordering.** `sequence` is read from the canonical `decisionDerived` content.
+  Assay verifies no signatures or issuer trust for these records, so a sequence-resolved ordering is
+  asserted-content ordering, not an independently verified ordering (stated in `claims_not_made`).


### PR DESCRIPTION
Pins the new MCP execution-record verifier semantics with stable, machine-readable reason codes before anyone uses them as a contract. No new capability, no mode change, no external corpus, no schema bump, no refactor.

**Reason codes (CI keys on these, not prose `detail`):**
- `verify-mcp-supersession` → `groups[].reason_code`: `supersession_resolved_single` / `_latest_decided_at` / `_sequence`, and `supersession_ambiguous_missing_sequence` / `_duplicate_sequence` / `_missing_decided_at`.
- `verify-mcp-records` named fallback (check ids): `fallback_projection_binding_present`, `fallback_projection_missing_authorization_binding`, `fallback_projection_invalid_meta`; digest mismatch stays on `decision_request_envelope_digest_match`.

**Closes the review's key question in code:** a test proves the projection id is part of the digest preimage — a decision computed with a different projection id does not pair. A second test pins bind-all: an extra field inside `authorization_binding` changes the digest (no allowlist *inside* the block; the whole object is bound).

**Honest framing:**
- `--fallback-projection whole-envelope` is documented as the legacy compatibility mode; `named` as the named projection mode. Default unchanged (no flip here).
- `sequence` is documented as asserted canonical-content ordering, not an independently verified ordering (Assay verifies no signatures), and added to `claims_not_made`.

Tests: projection-id-bound; invalid-`_meta` vs missing-binding distinct fail-closed codes; bind-all inside the binding block; supersession reason codes for resolved/ambiguous cases. 40 evidence tests pass.

### Lane classification: `Gate.NONE`

```
files: CHANGELOG.md, crates/assay-cli/src/cli/commands/evidence/mcp_execution_records.rs,
       crates/assay-cli/src/cli/commands/evidence/mcp_supersession.rs,
       crates/assay-cli/tests/evidence_test/mcp_execution_records.rs,
       crates/assay-cli/tests/evidence_test/mcp_supersession.rs,
       docs/reference/cli/mcp-execution-record-fallback-plan.md
Gate: NONE | reasons: (none)
```

assay-cli evidence command/docs/tests only; no `runner_spike.rs`/`cgroup.rs`, no runner/ebpf/monitor, no `Cargo.toml`/`Cargo.lock`. No delegated proof.

This closes the MCP block; the rest is upstream/external-corpus dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)