### PR TITLE
fix(diagnostics): query Landlock ABI via syscall, add Landlock-net preflight fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Diagnostics now read the Landlock ABI from the canonical `landlock_create_ruleset(NULL, 0,
+  LANDLOCK_CREATE_RULESET_VERSION)` syscall instead of `/sys/kernel/security/landlock/abi_version`,
+  which does not exist on mainline kernels and produced a false-negative `net_enforce` on real hosts
+  (e.g. Ubuntu 24.04, kernel 6.8, Landlock ABI 4). The probe distinguishes `Supported` (ABI returned),
+  `Disabled` (`EOPNOTSUPP`, built in but boot-disabled), and `Unsupported` (`ENOSYS`); the LSM-list
+  membership is kept only as an extra observation, not as the ABI/net source of truth.
+
+### Added
+- Landlock-net preflight fields on the diagnostics report: `abi_probe_status` (`ok` / `unsupported` /
+  `disabled` / `error`), `abi_probe_errno`, `abi_version_source`, `net_connect_tcp_supported` /
+  `net_bind_tcp_supported` (ABI ≥ 4), and `no_new_privs_settable` (measured in a throwaway forked
+  child, never set on the diagnostics process). Existing fields (`available`, `fs_enforce`,
+  `net_enforce`, `abi_version`) are unchanged. This is preflight / host-eligibility only — it reports
+  whether a host can support a future Landlock TCP-connect proof path; it does **not** implement or
+  claim enforcement of TCP connects.
+
 ### Changed
 
 - MCP execution-record verifiers: pin semantics with stable, machine-readable reason codes before the

--- a/crates/assay-cli/src/diagnostics/format.rs
+++ b/crates/assay-cli/src/diagnostics/format.rs
@@ -10,13 +10,16 @@ pub fn format_text(report: &DiagnosticReport) -> String {
     }
 
     s.push_str("\nSecurity Modules:\n");
-    if report.landlock.available {
+    if let Some(abi) = report.landlock.abi_version {
         s.push_str(&format!(
-            "  Landlock:   ✓ ABI v{} (FS)\n",
-            report.landlock.abi_version.unwrap_or(0)
+            "  Landlock:   ✓ ABI v{abi} (FS); net_connect_tcp={}, no_new_privs_settable={}\n",
+            report.landlock.net_connect_tcp_supported, report.landlock.no_new_privs_settable,
         ));
     } else {
-        s.push_str("  Landlock:   ✗ unavailable\n");
+        s.push_str(&format!(
+            "  Landlock:   ✗ {:?} (no usable ABI)\n",
+            report.landlock.abi_probe_status
+        ));
     }
 
     if report.bpf_lsm.available {

--- a/crates/assay-cli/src/diagnostics/probes.rs
+++ b/crates/assay-cli/src/diagnostics/probes.rs
@@ -95,26 +95,124 @@ fn probe_lsms() -> Vec<String> {
 }
 
 fn probe_landlock(lsms: &[String]) -> LandlockStatus {
+    // LSM-list membership is an extra observation only. The source of truth for ABI and net support
+    // is the landlock_create_ruleset(NULL, 0, VERSION) syscall: the sysfs path the old probe read
+    // (/sys/kernel/security/landlock/abi_version) does not exist on mainline kernels and produced a
+    // false-negative net_enforce on real hosts (e.g. Ubuntu 24.04, kernel 6.8, ABI 4).
     let available = lsms.contains(&"landlock".to_string());
 
-    // Read actual ABI version from sysfs (PR5.5 enhancement)
-    let abi_version = if available {
-        std::fs::read_to_string("/sys/kernel/security/landlock/abi_version")
-            .ok()
-            .and_then(|s| s.trim().parse::<u32>().ok())
-    } else {
-        None
-    };
-
-    // Net enforcement requires ABI >= 4
-    let net_enforce = abi_version.map(|v| v >= 4).unwrap_or(false);
+    let (abi_probe_status, abi_version, abi_probe_errno) = query_landlock_abi();
+    let net_connect_tcp_supported = net_connect_tcp_supported(abi_version);
+    let net_bind_tcp_supported = net_bind_tcp_supported(abi_version);
+    let no_new_privs_settable = probe_no_new_privs_settable();
 
     LandlockStatus {
         available,
         fs_enforce: available,
-        net_enforce,
+        net_enforce: net_connect_tcp_supported,
         abi_version,
+        abi_version_source: if abi_version.is_some() {
+            "landlock_create_ruleset_version"
+        } else {
+            "none"
+        },
+        abi_probe_status,
+        abi_probe_errno,
+        net_connect_tcp_supported,
+        net_bind_tcp_supported,
+        no_new_privs_settable,
     }
+}
+
+/// Classify the raw return of `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)`.
+/// Pure logic, unit-tested cross-platform; the actual syscall is Linux-only (below), so on non-Linux
+/// builds this is only reachable from tests.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn classify_abi(ret: i64, errno: i32) -> (LandlockAbiProbeStatus, Option<u32>, Option<i32>) {
+    if ret >= 1 {
+        (LandlockAbiProbeStatus::Ok, Some(ret as u32), None)
+    } else if errno == libc::ENOSYS {
+        (LandlockAbiProbeStatus::Unsupported, None, Some(errno))
+    } else if errno == libc::EOPNOTSUPP {
+        (LandlockAbiProbeStatus::Disabled, None, Some(errno))
+    } else {
+        (LandlockAbiProbeStatus::Error, None, Some(errno))
+    }
+}
+
+/// `LANDLOCK_ACCESS_NET_CONNECT_TCP` is available from ABI 4 (the future Plan 2A connect path).
+fn net_connect_tcp_supported(abi: Option<u32>) -> bool {
+    abi.is_some_and(|v| v >= 4)
+}
+
+/// `LANDLOCK_ACCESS_NET_BIND_TCP` is also available from ABI 4.
+fn net_bind_tcp_supported(abi: Option<u32>) -> bool {
+    abi.is_some_and(|v| v >= 4)
+}
+
+// The ABI query and the no_new_privs probe are raw syscalls. assay-cli already opts into unsafe
+// (`#![allow(unsafe_code)]` in main.rs) for its sandbox path, and backend.rs's enforce() already runs
+// raw prctl + landlock_restrict_self in pre_exec, so this is consistent with the crate's existing
+// policy rather than a new unsafe surface. The landlock crate gives an ABI number (see
+// backend.rs::detect_backend / caps.abi_version) but caps probing at V4 and does not expose the
+// ENOSYS-vs-EOPNOTSUPP distinction, so the canonical VERSION syscall is used directly here.
+#[cfg(target_os = "linux")]
+fn query_landlock_abi() -> (LandlockAbiProbeStatus, Option<u32>, Option<i32>) {
+    // landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION) returns the ABI version.
+    const LANDLOCK_CREATE_RULESET_VERSION: libc::c_long = 1;
+    // SAFETY: a pure version query — NULL attr, 0 size, VERSION flag. Reads no memory, restricts
+    // nothing, has no side effects on this process.
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_landlock_create_ruleset,
+            std::ptr::null::<libc::c_void>(),
+            0usize,
+            LANDLOCK_CREATE_RULESET_VERSION,
+        )
+    };
+    let errno = if ret < 0 {
+        std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+    } else {
+        0
+    };
+    classify_abi(ret as i64, errno)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn query_landlock_abi() -> (LandlockAbiProbeStatus, Option<u32>, Option<i32>) {
+    // No Landlock off Linux.
+    (LandlockAbiProbeStatus::Unsupported, None, None)
+}
+
+/// Whether `PR_SET_NO_NEW_PRIVS` can be set, measured in a throwaway forked child so the diagnostics
+/// process itself is never permanently put into no-new-privs. Only async-signal-safe calls (prctl,
+/// _exit) run between fork and exit.
+#[cfg(target_os = "linux")]
+fn probe_no_new_privs_settable() -> bool {
+    const PR_SET_NO_NEW_PRIVS: libc::c_int = 38;
+    const PR_GET_NO_NEW_PRIVS: libc::c_int = 39;
+    // SAFETY: child runs only prctl + _exit (async-signal-safe); parent only waitpid.
+    unsafe {
+        let pid = libc::fork();
+        if pid == 0 {
+            let set = libc::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+            let get = libc::prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0);
+            libc::_exit(if set == 0 && get == 1 { 0 } else { 1 });
+        } else if pid > 0 {
+            let mut status: libc::c_int = 0;
+            if libc::waitpid(pid, &mut status, 0) < 0 {
+                return false;
+            }
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn probe_no_new_privs_settable() -> bool {
+    false
 }
 
 fn probe_bpf_lsm(lsms: &[String]) -> BpfLsmStatus {
@@ -133,5 +231,92 @@ fn probe_helper() -> HelperStatus {
         version: None,
         socket_exists: socket.exists(),
         socket,
+    }
+}
+
+#[cfg(test)]
+mod landlock_probe_tests {
+    use super::*;
+
+    #[test]
+    fn abi_ok_returns_version_and_no_errno() {
+        assert_eq!(
+            classify_abi(4, 0),
+            (LandlockAbiProbeStatus::Ok, Some(4), None)
+        );
+        assert_eq!(
+            classify_abi(1, 0),
+            (LandlockAbiProbeStatus::Ok, Some(1), None)
+        );
+    }
+
+    #[test]
+    fn abi_enosys_is_unsupported() {
+        assert_eq!(
+            classify_abi(-1, libc::ENOSYS),
+            (
+                LandlockAbiProbeStatus::Unsupported,
+                None,
+                Some(libc::ENOSYS)
+            )
+        );
+    }
+
+    #[test]
+    fn abi_eopnotsupp_is_disabled() {
+        assert_eq!(
+            classify_abi(-1, libc::EOPNOTSUPP),
+            (
+                LandlockAbiProbeStatus::Disabled,
+                None,
+                Some(libc::EOPNOTSUPP)
+            )
+        );
+    }
+
+    #[test]
+    fn abi_other_errno_is_error_with_errno() {
+        assert_eq!(
+            classify_abi(-1, libc::EPERM),
+            (LandlockAbiProbeStatus::Error, None, Some(libc::EPERM))
+        );
+    }
+
+    #[test]
+    fn net_caps_require_abi_4() {
+        assert!(!net_connect_tcp_supported(None));
+        assert!(!net_connect_tcp_supported(Some(3)));
+        assert!(net_connect_tcp_supported(Some(4)));
+        assert!(net_connect_tcp_supported(Some(5)));
+        assert!(!net_bind_tcp_supported(Some(3)));
+        assert!(net_bind_tcp_supported(Some(4)));
+    }
+
+    #[test]
+    fn no_new_privs_probe_returns_without_panic() {
+        // We cannot assert the value cross-platform (true on Linux, false elsewhere), only that the
+        // forked-child probe returns a bool and never panics.
+        let _: bool = probe_no_new_privs_settable();
+    }
+
+    #[test]
+    fn report_is_additive_and_keeps_old_fields() {
+        let status = probe_landlock(&[]);
+        let v = serde_json::to_value(&status).unwrap();
+        // Old fields still present.
+        for k in ["available", "fs_enforce", "net_enforce", "abi_version"] {
+            assert!(v.get(k).is_some(), "missing pre-existing field {k}");
+        }
+        // New preflight fields present.
+        for k in [
+            "abi_version_source",
+            "abi_probe_status",
+            "abi_probe_errno",
+            "net_connect_tcp_supported",
+            "net_bind_tcp_supported",
+            "no_new_privs_settable",
+        ] {
+            assert!(v.get(k).is_some(), "missing new field {k}");
+        }
     }
 }

--- a/crates/assay-cli/src/diagnostics/report.rs
+++ b/crates/assay-cli/src/diagnostics/report.rs
@@ -17,12 +17,44 @@ pub struct DiagnosticReport {
     pub suggestions: Vec<String>,
 }
 
+/// How the Landlock ABI probe resolved. The authoritative query is the
+/// `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)` syscall (per the kernel docs),
+/// NOT the `/sys/kernel/security/landlock/abi_version` path, which does not exist on mainline kernels
+/// and produced a false-negative `net_enforce` on real hosts.
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LandlockAbiProbeStatus {
+    /// Syscall returned an ABI version (>= 1): Landlock is built in and enabled.
+    Ok,
+    /// Syscall returned `ENOSYS`: the kernel has no Landlock support.
+    Unsupported,
+    /// Syscall returned `EOPNOTSUPP`: Landlock is built in but disabled at boot.
+    Disabled,
+    /// Any other errno (or a non-Linux platform): could not be determined.
+    Error,
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct LandlockStatus {
+    /// Landlock present in `/sys/kernel/security/lsm`. Unchanged meaning; kept as an extra observation
+    /// only — it is NOT the source of truth for ABI or net support (the syscall is).
     pub available: bool,
     pub fs_enforce: bool,
+    /// Back-compat alias for `net_connect_tcp_supported` (kept so existing readers do not break).
     pub net_enforce: bool,
     pub abi_version: Option<u32>,
+    /// How `abi_version` was obtained: `landlock_create_ruleset_version` (syscall) or `none`.
+    pub abi_version_source: &'static str,
+    pub abi_probe_status: LandlockAbiProbeStatus,
+    /// The errno from the ABI probe when it did not return a version; `None` on success.
+    pub abi_probe_errno: Option<i32>,
+    /// ABI >= 4 (`LANDLOCK_ACCESS_NET_CONNECT_TCP`). Required for the future Landlock TCP-connect path.
+    pub net_connect_tcp_supported: bool,
+    /// ABI >= 4 (`LANDLOCK_ACCESS_NET_BIND_TCP`).
+    pub net_bind_tcp_supported: bool,
+    /// Whether `PR_SET_NO_NEW_PRIVS` could be set in a throwaway child (prerequisite for unprivileged
+    /// `landlock_restrict_self`). Measured in a forked child, never set on the diagnostics process.
+    pub no_new_privs_settable: bool,
 }
 
 #[derive(Debug, Serialize, Clone)]


### PR DESCRIPTION
Fixes Landlock diagnostics to query the ABI through the canonical syscall path and adds the preflight facts needed for a future Landlock TCP-connect proof path. **This PR does not implement or claim enforcement.**

### Why
- The kernel docs define `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)` as the ABI source of truth.
- The old probe read `/sys/kernel/security/landlock/abi_version`, which does not exist on mainline kernels and produced a **false-negative** `net_enforce` on the proof VM (Ubuntu 24.04, kernel 6.8, Landlock ABI 4).
- This PR fixes diagnostics/preflight only; no enforcement behaviour changes.

### What
- ABI read now uses the `…VERSION` syscall; `abi_probe_status` distinguishes `ok` / `unsupported` (`ENOSYS`) / `disabled` (`EOPNOTSUPP`) / `error`, with `abi_probe_errno` and `abi_version_source`.
- Additive fields: `net_connect_tcp_supported` / `net_bind_tcp_supported` (ABI ≥ 4) and `no_new_privs_settable` — the last measured in a throwaway forked child (only async-signal-safe `prctl` + `_exit` between fork and exit), so the diagnostics process is never put into no-new-privs. Existing fields (`available`, `fs_enforce`, `net_enforce`, `abi_version`) are unchanged; LSM-list membership stays an extra observation, not the ABI source of truth.
- `available`'s meaning is unchanged (Landlock in the LSM list).

On unsafe: `assay-cli` already opts into unsafe (`#![allow(unsafe_code)]` in `main.rs`) for its sandbox path, and `backend.rs` already runs raw `prctl + landlock_restrict_self` in `pre_exec`. The landlock crate exposes an ABI number (`backend.rs::detect_backend` / `caps.abi_version`) but caps probing at V4 and does not expose the `ENOSYS`-vs-`EOPNOTSUPP` distinction, so the canonical `…VERSION` syscall is used directly. No new dependency.

### Tests
7 unit tests: ABI result mapping (`Ok(4)`→supported, `Ok(3)`→net false, `ENOSYS`→unsupported, `EOPNOTSUPP`→disabled, other→error), ABI→capability (≥4), `no_new_privs` probe returns without panic, and serialization is additive (old fields kept, new fields present). Pure logic runs cross-platform; the syscall/fork paths are Linux-only and `cfg`-gated.

### Manual VM preflight
```
VM:                       assay-bpf-runner
Ubuntu:                   24.04 LTS
kernel:                   6.8.0-124-generic
LSM contains landlock:    yes
Landlock ABI via syscall: 4
no_new_privs settable:    yes
```
(The old sysfs path returned no file on this host, which is the false negative this PR fixes.)

### CI/runner validation
- head SHA: `e31faf0d9e62b89c517aad87b5f11c5f8e736108`
- Linux compile + the 7 tests run in regular CI (ubuntu-latest); run URL via the Checks tab on this PR.

### Lane classification: `Gate.NONE`
```
files: CHANGELOG.md, crates/assay-cli/src/diagnostics/{probes.rs,report.rs,format.rs}
Gate: NONE | reasons: (none)
```
Diagnostics only — no runner/eBPF/monitor/xtask, no `runner_spike.rs`/`cgroup.rs`, no `Cargo.toml`/`Cargo.lock`. No delegated proof required.

Next (separate PR2): Landlock-net `CONNECT_TCP` ruleset usability smoke. Enforcement (Plan 2A) is a later PR and is explicitly not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)