### PR TITLE
feat(diagnostics): Landlock-net CONNECT_TCP usability smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to this project will be documented in this file.
   `net_enforce`, `abi_version`) are unchanged. This is preflight / host-eligibility only — it reports
   whether a host can support a future Landlock TCP-connect proof path; it does **not** implement or
   claim enforcement of TCP connects.
+- Landlock-net CONNECT_TCP usability smoke on the diagnostics report: `net_connect_ruleset_probe`
+  (`usable` / `unsupported` / `failed`) and `net_connect_ruleset_errno`. The smoke builds a
+  CONNECT_TCP ruleset with a port rule (landlock crate, hard-requirement compatibility so the right is
+  never silently best-effort-dropped) and applies it via `landlock_restrict_self` in a throwaway
+  forked child that runs only async-signal-safe calls, so the diagnostics process itself is never
+  restricted. This proves the host supports the CONNECT_TCP syscall path needed for a future
+  enforcement proof; it does **not** implement or claim enforcement, and blocks no connection.
 
 ### Changed
 

--- a/crates/assay-cli/src/diagnostics/format.rs
+++ b/crates/assay-cli/src/diagnostics/format.rs
@@ -12,8 +12,10 @@ pub fn format_text(report: &DiagnosticReport) -> String {
     s.push_str("\nSecurity Modules:\n");
     if let Some(abi) = report.landlock.abi_version {
         s.push_str(&format!(
-            "  Landlock:   ✓ ABI v{abi} (FS); net_connect_tcp={}, no_new_privs_settable={}\n",
-            report.landlock.net_connect_tcp_supported, report.landlock.no_new_privs_settable,
+            "  Landlock:   ✓ ABI v{abi} (FS); net_connect_tcp={}, no_new_privs_settable={}, ruleset_probe={:?}\n",
+            report.landlock.net_connect_tcp_supported,
+            report.landlock.no_new_privs_settable,
+            report.landlock.net_connect_ruleset_probe,
         ));
     } else {
         s.push_str(&format!(

--- a/crates/assay-cli/src/diagnostics/landlock_net_smoke.rs
+++ b/crates/assay-cli/src/diagnostics/landlock_net_smoke.rs
@@ -1,0 +1,233 @@
+//! Landlock-net CONNECT_TCP usability smoke (PR2).
+//!
+//! Proves the host can CREATE and APPLY a TCP-connect Landlock ruleset, one step beyond the PR1
+//! ABI probe. This is host-eligibility / diagnostics only: it does NOT implement or claim
+//! enforcement, blocks no real connection, and does not touch the sandbox path (`backend.rs`,
+//! whose `// TODO(landlock-net)` stays untouched).
+//!
+//! Hybrid design (deliberate, per review):
+//! - the parent builds the ruleset with the `landlock` crate (`AccessNet::ConnectTcp`, `NetPort`,
+//!   `add_rule`) under `CompatLevel::HardRequirement` so CONNECT_TCP is never silently
+//!   best-effort-dropped, then extracts the owned ruleset fd;
+//! - a throwaway forked child runs ONLY async-signal-safe operations between fork and exit
+//!   (`prctl(PR_SET_NO_NEW_PRIVS)`, the raw `landlock_restrict_self` syscall on the fd, `_exit`),
+//!   so the diagnostics process itself is never restricted and no allocation/locking happens in
+//!   the child. This mirrors the safe primitive a future enforcement child (PR5) must use.
+
+use super::report::LandlockNetProbeStatus;
+
+/// `LANDLOCK_ACCESS_NET_CONNECT_TCP` is an ABI >= 4 right; below that the smoke cannot run.
+fn abi_supports_connect_tcp(abi_version: Option<u32>) -> bool {
+    abi_version.is_some_and(|v| v >= 4)
+}
+
+/// Pure mapping from the throwaway child's wait result to a smoke status. Unit-tested
+/// cross-platform. `exit_code` is `Some(code)` when the child exited normally (`code` is `0` on
+/// success, otherwise the clamped failure errno written by the child), `None`/`signaled` mean the
+/// child died abnormally.
+///
+/// On non-Linux the only non-test caller (`run_smoke`) is compiled out, so this is test-only there.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn classify_child(exit_code: Option<i32>, signaled: bool) -> (LandlockNetProbeStatus, Option<i32>) {
+    if signaled {
+        return (LandlockNetProbeStatus::Failed, None);
+    }
+    match exit_code {
+        Some(0) => (LandlockNetProbeStatus::Usable, None),
+        Some(code) => (LandlockNetProbeStatus::Failed, Some(code)),
+        None => (LandlockNetProbeStatus::Failed, None),
+    }
+}
+
+/// Run the CONNECT_TCP ruleset usability smoke. Returns the status plus the errno when it failed.
+pub(super) fn probe_net_connect_ruleset(
+    abi_version: Option<u32>,
+) -> (LandlockNetProbeStatus, Option<i32>) {
+    if !abi_supports_connect_tcp(abi_version) {
+        return (LandlockNetProbeStatus::Unsupported, None);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        run_smoke()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // No Landlock off Linux; the ABI gate above already returns `Unsupported` in practice
+        // (the syscall probe returns `None`), this is the belt-and-braces non-Linux arm.
+        (LandlockNetProbeStatus::Unsupported, None)
+    }
+}
+
+/// Walk an error's `source()` chain looking for an `io::Error`, and return its raw OS errno.
+/// The `landlock` crate wraps the failing syscall's `io::Error` as a source on its build errors
+/// (`CreateRulesetCall { source }`, `AddRuleCall { source }`), so this recovers the real errno for
+/// a parent-side build failure.
+#[cfg(target_os = "linux")]
+fn errno_from_error(err: &(dyn std::error::Error + 'static)) -> Option<i32> {
+    let mut cur: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = cur {
+        if let Some(io) = e.downcast_ref::<std::io::Error>() {
+            return io.raw_os_error();
+        }
+        cur = e.source();
+    }
+    None
+}
+
+/// A fixed, non-semantic test port. This smoke only validates that a CONNECT_TCP ruleset carrying
+/// a port rule can be built and applied; it does NOT prove that connects to other ports are
+/// blocked, so the specific port carries no claim.
+#[cfg(target_os = "linux")]
+const SMOKE_TEST_PORT: u16 = 443;
+
+#[cfg(target_os = "linux")]
+fn run_smoke() -> (LandlockNetProbeStatus, Option<i32>) {
+    use landlock::{
+        AccessNet, CompatLevel, Compatible, NetPort, Ruleset, RulesetAttr, RulesetCreatedAttr,
+    };
+    use std::os::fd::{AsRawFd, OwnedFd};
+
+    // --- Parent: build the CONNECT_TCP ruleset (allocations are fine here). ---
+    // HardRequirement => if CONNECT_TCP cannot be handled the build errors instead of silently
+    // degrading to best-effort, which is the honest posture for an evidence-oriented smoke.
+    let built = Ruleset::default()
+        .set_compatibility(CompatLevel::HardRequirement)
+        .handle_access(AccessNet::ConnectTcp)
+        .and_then(|r| r.create())
+        .and_then(|r| r.add_rule(NetPort::new(SMOKE_TEST_PORT, AccessNet::ConnectTcp)));
+
+    let created = match built {
+        Ok(c) => c,
+        Err(e) => return (LandlockNetProbeStatus::Failed, errno_from_error(&e)),
+    };
+
+    // Extract the owned ruleset fd; the child applies it via a raw syscall.
+    let owned_fd: Option<OwnedFd> = created.into();
+    let owned_fd = match owned_fd {
+        Some(fd) => fd,
+        None => return (LandlockNetProbeStatus::Failed, Some(libc::EBADF)),
+    };
+    let ruleset_fd = owned_fd.as_raw_fd();
+
+    // --- Throwaway child: only async-signal-safe calls between fork and exit. ---
+    // SAFETY: the child runs only prctl, the raw landlock_restrict_self syscall, errno reads, and
+    // `_exit` (all async-signal-safe); it performs no allocation and runs no Rust destructors.
+    // The ruleset fd is inherited across fork. The parent never calls restrict_self, so the
+    // diagnostics process itself is never restricted.
+    const PR_SET_NO_NEW_PRIVS: libc::c_int = 38;
+    let pid = unsafe { libc::fork() };
+    if pid == 0 {
+        // Child.
+        if unsafe { libc::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
+            unsafe { libc::_exit(clamp_errno()) };
+        }
+        let ret = unsafe { libc::syscall(libc::SYS_landlock_restrict_self, ruleset_fd, 0) };
+        if ret != 0 {
+            unsafe { libc::_exit(clamp_errno()) };
+        }
+        unsafe { libc::_exit(0) };
+    } else if pid < 0 {
+        // fork failed in the parent.
+        return (
+            LandlockNetProbeStatus::Failed,
+            std::io::Error::last_os_error().raw_os_error(),
+        );
+    }
+
+    // --- Parent: reap the child and map its result. ---
+    let mut status: libc::c_int = 0;
+    let wait = unsafe { libc::waitpid(pid, &mut status, 0) };
+    drop(owned_fd); // close the ruleset fd in the parent now that the child has run.
+    if wait < 0 {
+        return (LandlockNetProbeStatus::Failed, None);
+    }
+    if libc::WIFEXITED(status) {
+        classify_child(Some(libc::WEXITSTATUS(status)), false)
+    } else {
+        // Signaled or otherwise abnormal.
+        classify_child(None, true)
+    }
+}
+
+/// Read `errno` and clamp it to a non-zero child exit code in `1..=255`. A failing syscall always
+/// sets `errno`, but if it is unexpectedly `0` we return `255` so a failure never exits `0`
+/// (which the parent reads as success). Async-signal-safe: a single `errno` read.
+#[cfg(target_os = "linux")]
+fn clamp_errno() -> libc::c_int {
+    let e = unsafe { *libc::__errno_location() };
+    if e <= 0 || e > 255 {
+        255
+    } else {
+        e
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abi_gate_requires_v4() {
+        assert!(!abi_supports_connect_tcp(None));
+        assert!(!abi_supports_connect_tcp(Some(3)));
+        assert!(abi_supports_connect_tcp(Some(4)));
+        assert!(abi_supports_connect_tcp(Some(5)));
+    }
+
+    #[test]
+    fn classify_child_success_is_usable() {
+        assert_eq!(
+            classify_child(Some(0), false),
+            (LandlockNetProbeStatus::Usable, None)
+        );
+    }
+
+    #[test]
+    fn classify_child_nonzero_exit_is_failed_with_errno() {
+        // EACCES and EPERM are the errnos a denied restrict_self / prctl would carry.
+        assert_eq!(
+            classify_child(Some(libc::EACCES), false),
+            (LandlockNetProbeStatus::Failed, Some(libc::EACCES))
+        );
+        assert_eq!(
+            classify_child(Some(libc::EPERM), false),
+            (LandlockNetProbeStatus::Failed, Some(libc::EPERM))
+        );
+    }
+
+    #[test]
+    fn classify_child_signaled_is_failed_no_errno() {
+        assert_eq!(
+            classify_child(None, true),
+            (LandlockNetProbeStatus::Failed, None)
+        );
+    }
+
+    #[test]
+    fn classify_child_no_exit_code_is_failed() {
+        assert_eq!(
+            classify_child(None, false),
+            (LandlockNetProbeStatus::Failed, None)
+        );
+    }
+
+    #[test]
+    fn probe_is_unsupported_below_abi_4() {
+        assert_eq!(
+            probe_net_connect_ruleset(None),
+            (LandlockNetProbeStatus::Unsupported, None)
+        );
+        assert_eq!(
+            probe_net_connect_ruleset(Some(3)),
+            (LandlockNetProbeStatus::Unsupported, None)
+        );
+    }
+
+    #[test]
+    fn probe_returns_without_panic_at_abi_4() {
+        // Cross-platform we only assert it returns a value and never panics. On a non-Linux host
+        // (or a Linux host without Landlock-net) this is `Unsupported`/`Failed`; on an ABI 4 host
+        // it is `Usable`. The value itself is asserted in the VM evidence, not here.
+        let (_status, _errno) = probe_net_connect_ruleset(Some(4));
+    }
+}

--- a/crates/assay-cli/src/diagnostics/mod.rs
+++ b/crates/assay-cli/src/diagnostics/mod.rs
@@ -1,4 +1,5 @@
 pub mod format;
+mod landlock_net_smoke;
 pub mod probes;
 pub mod report;
 

--- a/crates/assay-cli/src/diagnostics/probes.rs
+++ b/crates/assay-cli/src/diagnostics/probes.rs
@@ -105,6 +105,8 @@ fn probe_landlock(lsms: &[String]) -> LandlockStatus {
     let net_connect_tcp_supported = net_connect_tcp_supported(abi_version);
     let net_bind_tcp_supported = net_bind_tcp_supported(abi_version);
     let no_new_privs_settable = probe_no_new_privs_settable();
+    let (net_connect_ruleset_probe, net_connect_ruleset_errno) =
+        super::landlock_net_smoke::probe_net_connect_ruleset(abi_version);
 
     LandlockStatus {
         available,
@@ -121,6 +123,8 @@ fn probe_landlock(lsms: &[String]) -> LandlockStatus {
         net_connect_tcp_supported,
         net_bind_tcp_supported,
         no_new_privs_settable,
+        net_connect_ruleset_probe,
+        net_connect_ruleset_errno,
     }
 }
 
@@ -315,6 +319,8 @@ mod landlock_probe_tests {
             "net_connect_tcp_supported",
             "net_bind_tcp_supported",
             "no_new_privs_settable",
+            "net_connect_ruleset_probe",
+            "net_connect_ruleset_errno",
         ] {
             assert!(v.get(k).is_some(), "missing new field {k}");
         }

--- a/crates/assay-cli/src/diagnostics/report.rs
+++ b/crates/assay-cli/src/diagnostics/report.rs
@@ -34,6 +34,22 @@ pub enum LandlockAbiProbeStatus {
     Error,
 }
 
+/// How the Landlock-net CONNECT_TCP ruleset usability smoke resolved. One step beyond
+/// `LandlockAbiProbeStatus`: it does not just read the ABI, it actually builds a TCP-connect
+/// ruleset and applies it (`landlock_restrict_self`) in a throwaway child. This is
+/// host-eligibility/diagnostics only and does NOT implement or claim enforcement.
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LandlockNetProbeStatus {
+    /// Ruleset created, a port rule added, `no_new_privs` set, and `restrict_self` succeeded
+    /// in the child: the host supports the CONNECT_TCP syscall path needed for future enforcement.
+    Usable,
+    /// ABI < 4 (no `LANDLOCK_ACCESS_NET_CONNECT_TCP`) or non-Linux: the smoke is not applicable.
+    Unsupported,
+    /// Ruleset build, `no_new_privs`, or `restrict_self` failed (errno carried separately).
+    Failed,
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct LandlockStatus {
     /// Landlock present in `/sys/kernel/security/lsm`. Unchanged meaning; kept as an extra observation
@@ -55,6 +71,12 @@ pub struct LandlockStatus {
     /// Whether `PR_SET_NO_NEW_PRIVS` could be set in a throwaway child (prerequisite for unprivileged
     /// `landlock_restrict_self`). Measured in a forked child, never set on the diagnostics process.
     pub no_new_privs_settable: bool,
+    /// Result of the CONNECT_TCP ruleset usability smoke: whether the host can create and apply a
+    /// TCP-connect Landlock ruleset (`restrict_self`) in a throwaway child. Host-eligibility only;
+    /// proves nothing about whether any connection is actually blocked.
+    pub net_connect_ruleset_probe: LandlockNetProbeStatus,
+    /// The errno when `net_connect_ruleset_probe` is `failed`; `None` on `usable`/`unsupported`.
+    pub net_connect_ruleset_errno: Option<i32>,
 }
 
 #[derive(Debug, Serialize, Clone)]


### PR DESCRIPTION
## Landlock-net CONNECT_TCP usability smoke (PR2)

One step beyond the PR1 ABI probe (#1586). PR1 read the ABI; this proves the host can actually **create and apply** a TCP-connect Landlock ruleset.

### Claim
> Host supports the Landlock-net CONNECT_TCP syscall path needed for future enforcement.

This PR proves only that: ABI says CONNECT_TCP exists; a CONNECT_TCP ruleset can be created; a port rule can be added; a child can set `no_new_privs`; `restrict_self` succeeds for that ruleset. It is **host-eligibility / diagnostics only**. It does **not** implement or claim enforcement, blocks no connection, and proves nothing about whether connects to other ports are denied.

### Design (hybrid, fork-safe)
- The **parent** builds the ruleset with the `landlock` crate (`AccessNet::ConnectTcp`, `NetPort`, `add_rule`) under `CompatLevel::HardRequirement`, so CONNECT_TCP is never silently best-effort-dropped, then extracts the owned ruleset fd.
- A **throwaway forked child** runs only async-signal-safe calls between fork and exit (`prctl(PR_SET_NO_NEW_PRIVS)`, the raw `landlock_restrict_self` syscall on the fd, `_exit`). No allocation, no Rust destructors. The diagnostics process itself is never restricted.

### Report fields (additive)
- `net_connect_ruleset_probe`: `usable` | `unsupported` | `failed`
- `net_connect_ruleset_errno`: errno when `failed`, else `null`

Existing fields are unchanged.

### Scope boundary
- Touches `crates/assay-cli/src/diagnostics/` only.
- The sandbox path (`backend.rs`) and its `// TODO(landlock-net)` are untouched.
- No `enforcement_health`, no policy compiler, no `bind`, no Plimsoll — those are later, separate PRs.

### Verification
- 7 cross-platform unit tests (ABI gate, child-result classifier, unsupported-below-ABI-4, no-panic), plus the additive-report test extended with the two new fields.
- Host-eligibility evidence from a real Landlock ABI 4 host attached as a follow-up comment (`assay doctor --format json`), with provenance, before merge. `ubuntu-latest`/macOS/Windows CI give the compile and unit-test coverage.
