### PR TITLE
fix(monitor): fail when requested enforcement health cannot be written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- `assay monitor` no longer exits 0 when a requested `--enforcement-health` artifact cannot be
+  written. A consumer reads a missing artifact as "not requested" (absent), so an active run whose
+  artifact write failed would have been misread as making no enforcement claim; the command now exits
+  with an infra error instead. The fail-closed abort paths (attach failure) already exit non-zero and
+  are unchanged.
 - Diagnostics now read the Landlock ABI from the canonical `landlock_create_ruleset(NULL, 0,
   LANDLOCK_CREATE_RULESET_VERSION)` syscall instead of `/sys/kernel/security/landlock/abi_version`,
   which does not exist on mainline kernels and produced a false-negative `net_enforce` on real hosts

--- a/crates/assay-cli/src/cli/commands/monitor_next/enforcement_health.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/enforcement_health.rs
@@ -136,4 +136,37 @@ mod tests {
         assert_eq!(back.network_enforcement, NetworkEnforcement::Failed);
         assert!(!back.attach_confirmed);
     }
+
+    // write_to failure modes use a directory-as-path and a missing parent: both are portable and
+    // deterministic, unlike permission bits which differ per OS/CI. A requested artifact that cannot
+    // be written must surface as an error so the caller can refuse exit 0 (a missing file would
+    // otherwise be read as "not requested").
+    #[test]
+    fn write_to_fails_when_path_is_a_directory() {
+        let h = EnforcementHealth::active(SCOPE_IPV4_TCP_CONNECT, 1, 1);
+        assert!(h.write_to(&std::env::temp_dir()).is_err());
+    }
+
+    #[test]
+    fn write_to_fails_when_parent_dir_is_missing() {
+        let h = EnforcementHealth::active(SCOPE_IPV4_TCP_CONNECT, 1, 1);
+        let path = std::env::temp_dir()
+            .join(format!("assay-eh-missing-{}", std::process::id()))
+            .join("nested")
+            .join("enforcement_health.json");
+        assert!(h.write_to(&path).is_err());
+    }
+
+    #[test]
+    fn write_to_succeeds_and_round_trips_from_disk() {
+        let h = EnforcementHealth::active(SCOPE_IPV4_TCP_CONNECT, 2, 3);
+        let path = std::env::temp_dir().join(format!("assay-eh-{}.json", std::process::id()));
+        h.write_to(&path).unwrap();
+        let back: EnforcementHealth =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(back.network_enforcement, NetworkEnforcement::Active);
+        assert_eq!(back.blocked_count, 2);
+        assert_eq!(back.allowed_count, 3);
+    }
 }

--- a/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/mod.rs
@@ -359,7 +359,8 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                     );
                     // Honesty: a requested-but-failed enforcement must record `failed`, never look
                     // like `absent` (not requested), so write the artifact BEFORE the fail-closed exit.
-                    write_enforcement_health(
+                    // A write failure here is already covered by the non-zero exit below.
+                    let _ = write_enforcement_health(
                         &args,
                         EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT),
                     );
@@ -371,7 +372,10 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
                     "FATAL: egress enforcement requested but connect4 attach failed: {} (fail-closed, not running audit-only)",
                     e
                 );
-                write_enforcement_health(&args, EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT));
+                let _ = write_enforcement_health(
+                    &args,
+                    EnforcementHealth::failed(SCOPE_IPV4_TCP_CONNECT),
+                );
                 return Ok(crate::exit_codes::EXIT_WOULD_BLOCK);
             }
             enforcement_active = true;
@@ -465,30 +469,48 @@ async fn run_linux(args: super::MonitorArgs) -> anyhow::Result<i32> {
         } else {
             EnforcementHealth::absent(SCOPE_IPV4_TCP_CONNECT)
         };
-        write_enforcement_health(&args, health);
+        if !write_enforcement_health(&args, health) {
+            // A requested artifact that cannot be written must not exit 0: a consumer reads a
+            // missing file as "not requested" (absent), which would misreport an active run.
+            // Enforcement itself worked, so this is an infra error, not a would-block.
+            emit_err!(
+                "FATAL: enforcement_health artifact was requested but could not be written; refusing exit 0 so a missing artifact is never read as not-requested"
+            );
+            return Ok(exit_codes::EXIT_INFRA_ERROR);
+        }
     }
 
     Ok(exit_codes::OK)
 }
 
 /// Write the enforcement_health.v0 artifact to `--enforcement-health <path>` if set. No-op otherwise.
+/// Returns `false` only when the artifact was requested but could not be written; on the fail-closed
+/// abort paths the caller already exits non-zero, on the success path the caller must not exit 0.
 #[cfg(target_os = "linux")]
 fn write_enforcement_health(
     args: &super::MonitorArgs,
     health: enforcement_health::EnforcementHealth,
-) {
+) -> bool {
     if let Some(path) = args.enforcement_health.as_ref() {
         match health.write_to(path) {
-            Ok(()) => output::err(format!(
-                "  • enforcement_health.v0 written: {} ({:?})",
-                path.display(),
-                health.network_enforcement
-            )),
-            Err(e) => output::err(format!(
-                "Warning: failed to write enforcement_health artifact to {}: {}",
-                path.display(),
-                e
-            )),
+            Ok(()) => {
+                output::err(format!(
+                    "  • enforcement_health.v0 written: {} ({:?})",
+                    path.display(),
+                    health.network_enforcement
+                ));
+                true
+            }
+            Err(e) => {
+                output::err(format!(
+                    "ERROR: failed to write enforcement_health artifact to {}: {}",
+                    path.display(),
+                    e
+                ));
+                false
+            }
         }
+    } else {
+        true
     }
 }


### PR DESCRIPTION
## What

When `--enforcement-health <path>` is requested and the artifact cannot be written, `assay monitor` now exits with an infra error (3) instead of 0.

**Acceptance sentence:** When enforcement health output is requested, failure to write the artifact is itself a command failure; Assay no longer exits successfully in a state where active enforcement evidence was produced in memory but absent on disk.

## Why

The artifact's own contract is that absent = not requested. The previous behavior logged a warning on write failure and still exited 0, so an *active* run whose write failed produced no file, and a consumer (e.g. the harness or a downstream reviewer) would read that as "no enforcement requested". That is the inverse of the carefully handled failed-vs-absent distinction the artifact exists for.

## How

- `write_enforcement_health` now returns whether the requested write succeeded (no-op when the flag is unset returns true).
- Success path: write failure → `EXIT_INFRA_ERROR` (3). Enforcement itself worked, so this is an evidence-output/IO failure, not a would-block; no schema change, no new exit code.
- Fail-closed abort paths (cgroup open / connect4 attach failure): unchanged, they already exit 4 and the write result is explicitly ignored there (`let _ =`) since the exit is already non-zero.

## Tests

- `write_to_fails_when_path_is_a_directory` (portable, deterministic failure)
- `write_to_fails_when_parent_dir_is_missing`
- `write_to_succeeds_and_round_trips_from_disk`
- Existing constructor/serde tests unchanged (7/7 green).
- stderr carries the path and the OS error, never the artifact content.

## Scope boundary

No schema change, no v1, no Landlock, no proof-harness, no lane-gate design. One behavior fix plus tests.

## Lane classification

Classifier output (`scripts/ci/assay_runner_lane_check.py` `classify_files` on the changed files):

```
classification gate: none
  crates/assay-cli/src/cli/commands/monitor_next/mod.rs -> none
  crates/assay-cli/src/cli/commands/monitor_next/enforcement_health.rs -> none
  CHANGELOG.md -> none
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
