### PR TITLE
feat(diagnostics): add schema id to doctor JSON report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `assay doctor --format json` now carries a top-level `schema` id (`assay.doctor_report.v0`), making
+  the report self-describing so a future field-shape change is an explicit version bump rather than
+  silent drift. Additive; existing fields unchanged.
 - Host-capability proof gate (CI): changes under `crates/assay-cli/src/diagnostics/` now require a
   validated `workflow_dispatch` run of the `host-capability-proof` workflow on the PR head SHA
   (event, SHA, conclusion, and workflow validated via the Actions API; doctor JSON read from the

--- a/crates/assay-cli/src/diagnostics/probes.rs
+++ b/crates/assay-cli/src/diagnostics/probes.rs
@@ -58,6 +58,7 @@ pub fn probe_system() -> DiagnosticReport {
     }
 
     DiagnosticReport {
+        schema: DOCTOR_REPORT_SCHEMA,
         assay_version: env!("CARGO_PKG_VERSION").to_string(),
         platform,
         kernel,
@@ -324,5 +325,16 @@ mod landlock_probe_tests {
         ] {
             assert!(v.get(k).is_some(), "missing new field {k}");
         }
+    }
+
+    #[test]
+    fn report_is_self_describing_with_schema_id() {
+        let report = probe_system();
+        let v = serde_json::to_value(&report).unwrap();
+        assert_eq!(
+            v.get("schema").and_then(|s| s.as_str()),
+            Some(DOCTOR_REPORT_SCHEMA),
+            "doctor report must carry its schema id so the shape is an explicit version, not silent drift"
+        );
     }
 }

--- a/crates/assay-cli/src/diagnostics/report.rs
+++ b/crates/assay-cli/src/diagnostics/report.rs
@@ -1,8 +1,16 @@
 use serde::Serialize;
 use std::path::PathBuf;
 
+/// Schema id for the `assay doctor --format json` report. Makes the artifact self-describing so a
+/// future field-shape change is an explicit version bump rather than silent drift (the same
+/// append-only discipline as the other assay carriers). The host-capability proof gate consumes
+/// this report, so a stable id lets a consumer pin the shape it reconstructs.
+pub const DOCTOR_REPORT_SCHEMA: &str = "assay.doctor_report.v0";
+
 #[derive(Debug, Serialize, Clone)]
 pub struct DiagnosticReport {
+    /// Schema id (`assay.doctor_report.v0`); always first so the JSON stays self-describing.
+    pub schema: &'static str,
     pub assay_version: String,
     pub platform: String,
     pub kernel: Option<String>,


### PR DESCRIPTION
## Summary

Adds a top-level `schema` id (`assay.doctor_report.v0`) to the `assay doctor --format json` report so the artifact is self-describing. A future field-shape change becomes an explicit version bump rather than silent drift, the same append-only discipline as the other assay carriers. Additive only: existing fields and the `landlock` block are unchanged.

Diagnostics / host-eligibility only. No enforcement claim.

## Why now

This is the first PR touching `crates/assay-cli/src/diagnostics/**` since the host-capability proof gate landed (#1590), so it is the intended trigger exercise for that gate before it is made a required check.

## Lane classification

- Runner lane check: `Gate.NONE` (no runner-spike/eBPF/monitor/cgroup paths).
- Host-capability check: **required** (diagnostics path changed). This PR will fail the host-capability check until a `host-capability-proof` workflow run on the head SHA is referenced below.

## Tests

`cargo test -p assay-cli --bin assay diagnostics::` — 15 passed, including a new `report_is_self_describing_with_schema_id`.