### PR TITLE
feat(sandbox): Landlock TCP-connect egress enforcement (Plan 2 PR5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Landlock TCP-connect egress enforcement for `assay sandbox` (`--enforce-net`, requires
+  `--enforce`): builds a combined FS+NET Landlock ruleset that allows only the explicit TCP
+  ports in `net.allow` and denies all other TCP connects, applied via `restrict_self` in the
+  enforcing child. A non-expressible network policy fails closed before spawn. With
+  `--enforcement-health <path>` it writes the `assay.enforcement_health.v1` artifact (`active`
+  when the ruleset is applied, `failed` with a machine-readable reason otherwise); a requested
+  artifact that cannot be written is a command failure. FS-only sandboxing is unchanged.
 - `assay doctor --format json` now carries a top-level `schema` id (`assay.doctor_report.v0`), making
   the report self-describing so a future field-shape change is an explicit version bump rather than
   silent drift. Additive; existing fields unchanged.

--- a/crates/assay-cli/src/backend.rs
+++ b/crates/assay-cli/src/backend.rs
@@ -92,14 +92,16 @@ impl LandlockEnforcer {
     }
 }
 
-/// Prepare Landlock ruleset. allocations/IO allowed here.
+/// Prepare Landlock ruleset. allocations/IO allowed here. `net_allow_ports` of `Some` builds a
+/// combined FS+NET (TCP-connect allowlist) ruleset; `None` is FS-only (unchanged behaviour).
 pub fn prepare_landlock(
     policy: &crate::policy::Policy,
     scoped_tmp: &std::path::Path,
+    net_allow_ports: Option<&[u16]>,
 ) -> anyhow::Result<LandlockEnforcer> {
     #[cfg(target_os = "linux")]
     {
-        let ruleset = landlock_impl::create_ruleset(policy, scoped_tmp)?;
+        let ruleset = landlock_impl::create_ruleset(policy, scoped_tmp, net_allow_ports)?;
         Ok(LandlockEnforcer {
             ruleset: Some(ruleset),
         })
@@ -108,6 +110,7 @@ pub fn prepare_landlock(
     {
         let _ = policy;
         let _ = scoped_tmp;
+        let _ = net_allow_ports;
         Ok(LandlockEnforcer {})
     }
 }
@@ -118,8 +121,8 @@ pub fn prepare_landlock(
 #[cfg(target_os = "linux")]
 mod landlock_impl {
     use landlock::{
-        Access, AccessFs, BitFlags, PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreated,
-        RulesetCreatedAttr, RulesetStatus, ABI,
+        Access, AccessFs, AccessNet, BitFlags, CompatLevel, Compatible, NetPort, PathBeneath,
+        PathFd, Ruleset, RulesetAttr, RulesetCreated, RulesetCreatedAttr, RulesetStatus, ABI,
     };
     use std::path::Path;
 
@@ -200,10 +203,15 @@ mod landlock_impl {
         }
     }
 
-    /// Create Landlock ruleset from policy.
+    /// Create Landlock ruleset from policy. When `net_allow_ports` is `Some`, a combined FS+NET
+    /// ruleset is built in ONE ruleset: `LANDLOCK_ACCESS_NET_CONNECT_TCP` is handled as a hard
+    /// requirement (no best-effort downgrade for an enforcement claim) and a `NetPort` allow rule is
+    /// added for each port. An empty port list is a valid deny-all-TCP-connect. When `None`, the
+    /// ruleset is FS-only and unchanged.
     pub(super) fn create_ruleset(
         policy: &crate::policy::Policy,
         scoped_tmp: &Path,
+        net_allow_ports: Option<&[u16]>,
     ) -> anyhow::Result<RulesetCreated> {
         let (_, abi_level) = probe_abi();
         let abi = match abi_level {
@@ -218,9 +226,23 @@ mod landlock_impl {
         // FS rules (ABI V1-V3)
         ruleset = ruleset.handle_access(AccessFs::from_all(abi))?;
 
-        // TODO(landlock-net): NET rules (ABI V4) when abi_level >= 4
+        // NET rules (ABI V4): handle CONNECT_TCP as a hard requirement so an unsupported host fails
+        // rather than silently enforcing nothing. Allowlist-only: once handled, TCP connects are
+        // denied unless a NetPort rule below grants the destination port.
+        if net_allow_ports.is_some() {
+            ruleset = ruleset
+                .set_compatibility(CompatLevel::HardRequirement)
+                .handle_access(AccessNet::ConnectTcp)?
+                .set_compatibility(CompatLevel::BestEffort);
+        }
 
         let mut ruleset = ruleset.create()?;
+
+        if let Some(ports) = net_allow_ports {
+            for &port in ports {
+                ruleset = ruleset.add_rule(NetPort::new(port, AccessNet::ConnectTcp))?;
+            }
+        }
 
         // 1. Allow CWD (RX only by default, safe containment)
         if let Ok(cwd) = std::env::current_dir() {

--- a/crates/assay-cli/src/cli/args/runtime.rs
+++ b/crates/assay-cli/src/cli/args/runtime.rs
@@ -164,6 +164,17 @@ pub struct SandboxArgs {
     #[arg(long)]
     pub fail_closed: bool,
 
+    /// Enforce the network policy as a Landlock TCP-connect port allowlist (ABI >= 4). Allowlist-only:
+    /// `net.allow` must be explicit TCP ports; any IP/CIDR, host, non-TCP protocol, range, deny rule,
+    /// or port 0 fails closed. Requires --enforce.
+    #[arg(long = "enforce-net", requires = "enforce")]
+    pub enforce_net: bool,
+
+    /// Write the `assay.enforcement_health.v1` artifact (Landlock TCP-connect domain) to this path.
+    /// A requested artifact that cannot be written is a command failure, never a silent absence.
+    #[arg(long = "enforcement-health")]
+    pub enforcement_health: Option<PathBuf>,
+
     /// Strict env mode: only safe base vars + explicit allows
     #[arg(long = "env-strict")]
     pub env_strict: bool,

--- a/crates/assay-cli/src/cli/commands/sandbox.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox.rs
@@ -258,6 +258,8 @@ mod tests {
             enforce: true,
             dry_run: false,
             fail_closed: false,
+            enforce_net: false,
+            enforcement_health: None,
             env_strict: false,
             env_strip_exec: false,
             env_allow: None,

--- a/crates/assay-cli/src/cli/commands/sandbox/child.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox/child.rs
@@ -57,9 +57,47 @@ pub(super) async fn run_child(
     cmd.env("TMP", tmp_dir);
     cmd.env("TEMP", tmp_dir);
 
+    // Landlock-net enforcement plan. `Some(ports)` builds a combined FS+NET ruleset; a rejected
+    // policy fails closed BEFORE spawn with a `failed` enforcement_health.v1 artifact.
+    #[cfg(target_os = "linux")]
+    let net_allow_ports: Option<Vec<u16>> = if actual_enforcement && args.enforce_net {
+        let abi = crate::backend::detect_backend().1.abi_version;
+        match crate::landlock_net::plan_landlock_net_ports(&policy.net) {
+            Ok(ports) => Some(ports),
+            Err(rejects) => {
+                let reason = net_reject_to_reason_code(&rejects);
+                let detail = rejects
+                    .iter()
+                    .map(|r| format!("{}: {}", r.reason.as_str(), r.entry))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                let health = crate::enforcement_health_v1::EnforcementHealthV1::landlock_failed(
+                    abi,
+                    reason,
+                    detail,
+                    abi >= 4,
+                    false,
+                );
+                write_enforcement_health_v1(args, &health)?;
+                if !args.quiet {
+                    eprintln!(
+                        "ERROR: network policy is not Landlock-net enforceable (fail-closed)"
+                    );
+                }
+                return Ok(exit_codes::WOULD_BLOCK);
+            }
+        }
+    } else {
+        None
+    };
+
     #[cfg(target_os = "linux")]
     let enforcer_opt = if actual_enforcement {
-        Some(crate::backend::prepare_landlock(policy, tmp_dir)?)
+        Some(crate::backend::prepare_landlock(
+            policy,
+            tmp_dir,
+            net_allow_ports.as_deref(),
+        )?)
     } else {
         None
     };
@@ -76,9 +114,36 @@ pub(super) async fn run_child(
         }
     }
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("failed to spawn child: {}", e))?;
+    // The child→parent ack is std's pre_exec error channel: if `enforce()` (no_new_privs +
+    // restrict_self) returns an error in the child, the closure fails and `spawn()` returns that
+    // error, so we never record `restrict_self_confirmed` on an unenforced child.
+    let spawn_result = cmd.spawn();
+
+    #[cfg(target_os = "linux")]
+    if actual_enforcement && args.enforce_net {
+        let abi = crate::backend::detect_backend().1.abi_version;
+        match &spawn_result {
+            Ok(_) => {
+                let ports = net_allow_ports.clone().unwrap_or_default();
+                let health = crate::enforcement_health_v1::EnforcementHealthV1::landlock_active(
+                    abi, ports, None,
+                );
+                write_enforcement_health_v1(args, &health)?;
+            }
+            Err(_) => {
+                let health = crate::enforcement_health_v1::EnforcementHealthV1::landlock_failed(
+                    abi,
+                    crate::enforcement_health_v1::ReasonCode::RestrictSelfFailed,
+                    "landlock restrict_self failed in the enforcing child",
+                    abi >= 4,
+                    true,
+                );
+                write_enforcement_health_v1(args, &health)?;
+            }
+        }
+    }
+
+    let mut child = spawn_result.map_err(|e| anyhow::anyhow!("failed to spawn child: {}", e))?;
 
     let status_res = if let Some(sec) = args.timeout {
         match tokio::time::timeout(Duration::from_secs(sec), child.wait()).await {
@@ -147,6 +212,35 @@ pub(super) async fn run_child(
             Ok(exit_codes::INTERNAL_ERROR)
         }
     }
+}
+
+/// Write the `assay.enforcement_health.v1` artifact when `--enforcement-health` is set. Fail-closed:
+/// a requested artifact that cannot be written is an error so the caller does not exit successfully
+/// in a state where the evidence is absent on disk (the same rule v0 enforces).
+#[cfg(target_os = "linux")]
+fn write_enforcement_health_v1(
+    args: &SandboxArgs,
+    health: &crate::enforcement_health_v1::EnforcementHealthV1,
+) -> anyhow::Result<()> {
+    use anyhow::Context;
+    if let Some(path) = args.enforcement_health.as_ref() {
+        health.write_to(path).with_context(|| {
+            format!(
+                "failed to write enforcement_health.v1 to {}",
+                path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// All policy-not-expressible rejections collapse to a single reason code; the specific entries and
+/// their per-entry reasons travel in the artifact's `detail` string.
+#[cfg(target_os = "linux")]
+fn net_reject_to_reason_code(
+    _rejects: &[crate::landlock_net::NetReject],
+) -> crate::enforcement_health_v1::ReasonCode {
+    crate::enforcement_health_v1::ReasonCode::PolicyNotExpressible
 }
 
 fn resolve_command_path(cmd_name: &str) -> std::path::PathBuf {

--- a/crates/assay-cli/src/enforcement_health_v1.rs
+++ b/crates/assay-cli/src/enforcement_health_v1.rs
@@ -72,6 +72,9 @@ pub enum ReasonCode {
     RestrictSelfFailed,
     /// The ruleset could not be built (handle-access or add-rule failed).
     RulesetBuildFailed,
+    /// The network policy is not expressible as a Landlock TCP-connect allowlist (IP/CIDR, host,
+    /// non-TCP protocol, port range, deny rule, or port 0). The specific entries are in `detail`.
+    PolicyNotExpressible,
 }
 
 /// The Landlock-specific evidence block. Fields that do not apply to a given status are omitted
@@ -133,7 +136,80 @@ pub struct EnforcementHealthV1 {
     pub non_claims: Vec<String>,
 }
 
+/// The standing non-claims for the Landlock TCP-connect port-allowlist domain.
+fn landlock_non_claims() -> Vec<String> {
+    [
+        "no ip or cidr enforcement",
+        "no hostname enforcement",
+        "no destination identity enforcement",
+        "no udp or quic enforcement",
+        "no http or tls route policy",
+        "not a replacement for cgroup/connect4 endpoint enforcement",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
 impl EnforcementHealthV1 {
+    /// Active Landlock TCP-connect enforcement: the ruleset was applied (`no_new_privs` set and
+    /// `restrict_self` confirmed). `probe` is `Some` only when a real-block probe was actually run;
+    /// `None` records "ruleset applied, no real-block claim".
+    #[must_use]
+    pub fn landlock_active(abi: u32, allowed_ports: Vec<u16>, probe: Option<Probe>) -> Self {
+        Self {
+            schema: SCHEMA_V1.to_string(),
+            status: Status::Active,
+            mechanism: Mechanism::Landlock,
+            scope: SCOPE_TCP_CONNECT_LANDLOCK_PORT.to_string(),
+            policy_semantics: PolicySemantics::Allowlist,
+            failure: None,
+            landlock: LandlockBlock {
+                abi,
+                net_connect_tcp_supported: None,
+                handled_access_net: Some(vec!["connect_tcp".to_string()]),
+                allowed_connect_tcp_ports: Some(allowed_ports),
+                no_new_privs_confirmed: true,
+                restrict_self_confirmed: true,
+            },
+            probe,
+            non_claims: landlock_non_claims(),
+        }
+    }
+
+    /// Failed Landlock TCP-connect enforcement: requested but not installed. Carries the
+    /// machine-readable reason and the partial-capability truth.
+    #[must_use]
+    pub fn landlock_failed(
+        abi: u32,
+        reason_code: ReasonCode,
+        detail: impl Into<String>,
+        net_connect_tcp_supported: bool,
+        no_new_privs_confirmed: bool,
+    ) -> Self {
+        Self {
+            schema: SCHEMA_V1.to_string(),
+            status: Status::Failed,
+            mechanism: Mechanism::Landlock,
+            scope: SCOPE_TCP_CONNECT_LANDLOCK_PORT.to_string(),
+            policy_semantics: PolicySemantics::Allowlist,
+            failure: Some(Failure {
+                reason_code,
+                detail: detail.into(),
+            }),
+            landlock: LandlockBlock {
+                abi,
+                net_connect_tcp_supported: Some(net_connect_tcp_supported),
+                handled_access_net: None,
+                allowed_connect_tcp_ports: None,
+                no_new_privs_confirmed,
+                restrict_self_confirmed: false,
+            },
+            probe: None,
+            non_claims: landlock_non_claims(),
+        }
+    }
+
     pub fn write_to(&self, path: &std::path::Path) -> std::io::Result<()> {
         let json = serde_json::to_string_pretty(self)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;

--- a/crates/assay-cli/src/landlock_net.rs
+++ b/crates/assay-cli/src/landlock_net.rs
@@ -1,0 +1,279 @@
+//! Bridge from assay-cli's string network policy (`crate::policy::NetPolicy`) to the assay-policy
+//! Landlock TCP-connect compile target.
+//!
+//! The sandbox's Landlock-net enforcement is allowlist-only over TCP-connect ports. This module
+//! parses the free-form `net.allow` / `net.deny` strings into a structured
+//! `assay_policy::tiers::NetworkPolicy` and runs `compile_landlock_net`, so the enforcement path
+//! only ever applies an explicit, Landlock-expressible port allowlist and fails closed on everything
+//! else. Forms the structured policy cannot even represent as a TCP-connect ALLOW (a non-TCP
+//! protocol, a port range, or a host/wildcard on the allow side) are rejected here at parse time;
+//! IP/CIDR, any deny rule, and port 0 are rejected by the compiler.
+
+use assay_policy::tiers::{compile_landlock_net, LandlockRejectReason, NetworkPolicy};
+
+/// Why a network policy is not enforceable as a Landlock TCP-connect allowlist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetReject {
+    pub reason: NetRejectReason,
+    pub entry: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetRejectReason {
+    /// A non-TCP protocol on an allow entry (e.g. `udp/53`, `quic/443`). Landlock-net is TCP-only.
+    Protocol,
+    /// A port range (e.g. `443-445`). Only an explicit port list is accepted, never a range.
+    Range,
+    /// An IP literal or CIDR. Landlock network rules are ports, not addresses.
+    Cidr,
+    /// Any deny rule. Landlock is allowlist-only.
+    NegativeDeny,
+    /// A host:port / hostname / wildcard. Landlock has no endpoint identity.
+    Destination,
+    /// Port 0: maps to the kernel-assigned ephemeral range and would widen the allowlist.
+    PortZero,
+    /// An allow entry that is none of the understood forms.
+    Malformed,
+}
+
+impl NetRejectReason {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NetRejectReason::Protocol => "protocol_not_tcp",
+            NetRejectReason::Range => "port_range_not_allowed",
+            NetRejectReason::Cidr => "cidr_not_expressible",
+            NetRejectReason::NegativeDeny => "negative_deny_not_expressible",
+            NetRejectReason::Destination => "destination_not_expressible",
+            NetRejectReason::PortZero => "port_zero_not_allowed",
+            NetRejectReason::Malformed => "malformed_net_entry",
+        }
+    }
+}
+
+fn map_compile_reason(reason: LandlockRejectReason) -> NetRejectReason {
+    match reason {
+        LandlockRejectReason::Cidr => NetRejectReason::Cidr,
+        LandlockRejectReason::NegativeDeny => NetRejectReason::NegativeDeny,
+        LandlockRejectReason::Destination => NetRejectReason::Destination,
+        LandlockRejectReason::PortZero => NetRejectReason::PortZero,
+    }
+}
+
+fn looks_like_cidr_or_ip(s: &str) -> bool {
+    // An address-shaped token: contains a CIDR slash, or parses as a bare IP.
+    if s.contains('/') {
+        return true;
+    }
+    s.parse::<std::net::IpAddr>().is_ok()
+}
+
+/// Parse a single allow entry into either a TCP-connect port (pushed to `allow_ports`, including 0
+/// so the compiler can reject it) or a structured rejection. CIDR-shaped tokens go to `allow_cidrs`
+/// so the compiler reports them uniformly.
+fn classify_allow(entry: &str, network: &mut NetworkPolicy) -> Option<NetReject> {
+    let token = entry.trim();
+
+    // Bare port.
+    if let Ok(port) = token.parse::<u16>() {
+        network.allow_ports.push(port);
+        return None;
+    }
+
+    // `tcp/<port>` or `tcp:<port>`.
+    if let Some(rest) = token
+        .strip_prefix("tcp/")
+        .or_else(|| token.strip_prefix("tcp:"))
+    {
+        return match rest.parse::<u16>() {
+            Ok(port) => {
+                network.allow_ports.push(port);
+                None
+            }
+            Err(_) => Some(NetReject {
+                reason: NetRejectReason::Malformed,
+                entry: entry.to_string(),
+            }),
+        };
+    }
+
+    // An alphabetic scheme before `/` or `:` (e.g. `udp/53`, `quic/443`, `http:80`) is a non-TCP
+    // protocol. `tcp/` is already consumed above, and address forms like `10.0.0.0/8` have a numeric
+    // (non-alphabetic) scheme, so they fall through to the CIDR check below.
+    for sep in ['/', ':'] {
+        if let Some((proto, _)) = token.split_once(sep) {
+            if !proto.is_empty() && proto.chars().all(|c| c.is_ascii_alphabetic()) {
+                return Some(NetReject {
+                    reason: NetRejectReason::Protocol,
+                    entry: entry.to_string(),
+                });
+            }
+        }
+    }
+
+    // Port range like `443-445`.
+    if token
+        .split_once('-')
+        .is_some_and(|(a, b)| a.parse::<u16>().is_ok() && b.parse::<u16>().is_ok())
+    {
+        return Some(NetReject {
+            reason: NetRejectReason::Range,
+            entry: entry.to_string(),
+        });
+    }
+
+    // IP literal or CIDR.
+    if looks_like_cidr_or_ip(token) {
+        network.allow_cidrs.push(token.to_string());
+        return None;
+    }
+
+    // host:port or hostname/wildcard on the allow side has no representable home.
+    if token.contains(':') || token.chars().any(|c| c.is_ascii_alphabetic()) {
+        return Some(NetReject {
+            reason: NetRejectReason::Destination,
+            entry: entry.to_string(),
+        });
+    }
+
+    Some(NetReject {
+        reason: NetRejectReason::Malformed,
+        entry: entry.to_string(),
+    })
+}
+
+/// Plan the Landlock TCP-connect allowlist for a network policy, or fail closed with every reason it
+/// is not Landlock-enforceable. An empty allowlist is valid (deny-all TCP connect).
+///
+/// # Errors
+/// Returns every [`NetReject`] that applies; a non-empty list means the sandbox must not enforce
+/// Landlock-net for this policy.
+pub fn plan_landlock_net_ports(net: &crate::policy::NetPolicy) -> Result<Vec<u16>, Vec<NetReject>> {
+    let mut network = NetworkPolicy::default();
+    let mut rejects: Vec<NetReject> = Vec::new();
+
+    for entry in &net.allow {
+        if let Some(reject) = classify_allow(entry, &mut network) {
+            rejects.push(reject);
+        }
+    }
+
+    // Any deny entry is a negative rule; route it into the structured policy so the compiler reports
+    // it (and add the literal entry for diagnostics).
+    for entry in &net.deny {
+        let token = entry.trim();
+        if token.parse::<u16>().is_ok() {
+            network.deny_ports.push(token.parse().unwrap());
+        } else if looks_like_cidr_or_ip(token) {
+            network.deny_cidrs.push(token.to_string());
+        } else {
+            network.deny_destinations.push(token.to_string());
+        }
+    }
+
+    match compile_landlock_net(&network) {
+        Ok(target) => {
+            if rejects.is_empty() {
+                Ok(target.allowed_connect_tcp_ports)
+            } else {
+                Err(rejects)
+            }
+        }
+        Err(compile_rejects) => {
+            for r in compile_rejects {
+                rejects.push(NetReject {
+                    reason: map_compile_reason(r.reason),
+                    entry: r.detail,
+                });
+            }
+            Err(rejects)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::NetPolicy;
+
+    fn reasons(err: &[NetReject]) -> Vec<NetRejectReason> {
+        let mut r: Vec<NetRejectReason> = err.iter().map(|e| e.reason).collect();
+        r.sort_by_key(|x| x.as_str());
+        r.dedup();
+        r
+    }
+
+    fn allow(entries: &[&str]) -> NetPolicy {
+        NetPolicy {
+            allow: entries.iter().map(|s| s.to_string()).collect(),
+            deny: vec![],
+        }
+    }
+
+    #[test]
+    fn accepts_bare_and_tcp_prefixed_ports_sorted_deduped() {
+        let ports = plan_landlock_net_ports(&allow(&["443", "tcp/80", "443"])).unwrap();
+        assert_eq!(ports, vec![80, 443]);
+    }
+
+    #[test]
+    fn accepts_empty_as_deny_all() {
+        assert_eq!(
+            plan_landlock_net_ports(&allow(&[])).unwrap(),
+            Vec::<u16>::new()
+        );
+    }
+
+    #[test]
+    fn rejects_udp_and_quic_as_protocol() {
+        for e in ["udp/53", "quic/443"] {
+            let err = plan_landlock_net_ports(&allow(&[e])).unwrap_err();
+            assert_eq!(reasons(&err), vec![NetRejectReason::Protocol], "{e}");
+        }
+    }
+
+    #[test]
+    fn rejects_port_range() {
+        let err = plan_landlock_net_ports(&allow(&["443-445"])).unwrap_err();
+        assert_eq!(reasons(&err), vec![NetRejectReason::Range]);
+    }
+
+    #[test]
+    fn rejects_ip_and_cidr() {
+        for e in ["10.0.0.0/8", "203.0.113.10", "::1"] {
+            let err = plan_landlock_net_ports(&allow(&[e])).unwrap_err();
+            assert_eq!(reasons(&err), vec![NetRejectReason::Cidr], "{e}");
+        }
+    }
+
+    #[test]
+    fn rejects_host_and_wildcard_destinations() {
+        for e in ["example.com:443", "*.internal"] {
+            let err = plan_landlock_net_ports(&allow(&[e])).unwrap_err();
+            assert_eq!(reasons(&err), vec![NetRejectReason::Destination], "{e}");
+        }
+    }
+
+    #[test]
+    fn rejects_port_zero() {
+        let err = plan_landlock_net_ports(&allow(&["0"])).unwrap_err();
+        assert_eq!(reasons(&err), vec![NetRejectReason::PortZero]);
+    }
+
+    #[test]
+    fn rejects_any_deny_as_negative() {
+        let net = NetPolicy {
+            allow: vec!["443".to_string()],
+            deny: vec!["4444".to_string()],
+        };
+        let err = plan_landlock_net_ports(&net).unwrap_err();
+        assert_eq!(reasons(&err), vec![NetRejectReason::NegativeDeny]);
+    }
+
+    #[test]
+    fn reason_ids_are_stable() {
+        assert_eq!(NetRejectReason::Protocol.as_str(), "protocol_not_tcp");
+        assert_eq!(NetRejectReason::Range.as_str(), "port_range_not_allowed");
+        assert_eq!(NetRejectReason::PortZero.as_str(), "port_zero_not_allowed");
+    }
+}

--- a/crates/assay-cli/src/main.rs
+++ b/crates/assay-cli/src/main.rs
@@ -10,6 +10,7 @@ mod env_filter;
 pub mod exit_codes;
 pub mod fs;
 pub mod landlock_check;
+pub mod landlock_net;
 pub mod metrics;
 pub mod packs;
 pub mod policy;


### PR DESCRIPTION
## Summary

The capstone of the Landlock-net arc: `assay sandbox --enforce-net` (requires `--enforce`) now **enforces** a TCP-connect port allowlist via Landlock. This is the first PR in the arc allowed to make the enforcement claim.

- Combined FS+NET ruleset in ONE ruleset: `LANDLOCK_ACCESS_NET_CONNECT_TCP` handled as a **hard requirement** (no best-effort downgrade), with a `NetPort` allow rule per explicit TCP port in `net.allow`. All other TCP connects are denied.
- Applied via `restrict_self` in the enforcing child. The **child→parent ack** is std's `pre_exec` error channel: a failed `restrict_self` makes `spawn()` fail, so `restrict_self_confirmed` is never recorded on an unenforced child (no parent assumption).
- A network policy that is **not Landlock-expressible** (IP/CIDR, host, non-TCP protocol, range, deny rule, port 0) **fails closed before spawn** via the PR4 compiler + the net-string planner.
- `--enforcement-health <path>` writes `assay.enforcement_health.v1` (`active` when applied, `failed` with a machine-readable reason otherwise); a requested-but-unwritable artifact is a command failure (the #1588 rule).
- FS-only sandboxing is unchanged (net enforcement is opt-in).

## Claim boundary

Proven: an allowed TCP-connect port succeeds and its listener sees the connection; a denied port fails with **EACCES** and its listener is never reached. **Non-claims** (carried in the artifact): no IP/CIDR, no hostname, no destination identity, no UDP/QUIC, no HTTP/TLS route policy, not a replacement for the cgroup/connect4 endpoint path. Weak signals (timeout, ECONNREFUSED, ENETUNREACH) never count as a block.

## Tests

`cargo test -p assay-cli --bin assay -- landlock_net enforcement_health_v1 sandbox` — 33 passed (net-string planner accept/reject matrix, v1 producer round-trips, sandbox degradation).

## Real-block proof

The enforcement claim requires a real-block proof on an ABI 4 host. **Proof pending**: I will attach the VM run (allowed-port success + denied-port EACCES + listener-not-reached + the `active` enforcement_health.v1 artifact) before merge. Do not merge until that proof is attached.

## Lane

`Gate.NONE` (backend/sandbox/policy paths, no runner-spike/eBPF/monitor/cgroup/Cargo). Host-capability check: not triggered (no `diagnostics/` paths).