### PR TITLE
chore(release): assay v3.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.21.0] - 2026-06-10
+
 ### Added
 - Landlock TCP-connect egress enforcement for `assay sandbox` (`--enforce-net`, requires
   `--enforce`): builds a combined FS+NET Landlock ruleset that allows only the explicit TCP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.20.0"
+version = "3.21.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Minor release prep: bumps workspace version 3.20.0 -> 3.21.0, anchors the CHANGELOG `[3.21.0] - 2026-06-10` section, refreshes Cargo.lock. No code changes.

Carries (all merged since v3.20.0, additive/backward-compatible):
- Landlock TCP-connect egress enforcement (`assay sandbox --enforce-net`) with a real-block EACCES proof on an ABI 4 host (#1594)
- `assay.enforcement_health.v1` carrier (#1592) + Landlock port-allowlist compile target (#1593)
- Host-capability proof gate, now a required check (#1588/#1589/#1590 + #1591 trigger)
- Diagnostics: Landlock ABI via syscall + preflight fields + CONNECT_TCP usability smoke (#1586/#1587)
- Fix: `assay monitor` fails when a requested `enforcement_health` artifact cannot be written (#1588)

After merge: tag `v3.21.0` to trigger the release workflow (binaries + crates.io + PyPI).