### PR TITLE
feat(sandbox): --probe-enforcement self-probe writes a real-block probe (Plan 2 followup PR C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `assay sandbox --probe-enforcement` (with `--enforce-net`): runs a self-probe before the
+  workload that, from inside the enforcing ruleset, attempts one connect to an ephemeral denied
+  port. Only a proven real block (EACCES and the harness listener never reached) writes the
+  `probe` block into `enforcement_health.v1` (`active` + probe). A probe that does not prove a
+  block is reported and never silently dropped, and never fails the run. Weak signals (timeout,
+  ECONNREFUSED, ENETUNREACH) never count as a block.
+
 ## [3.21.0] - 2026-06-10
 
 ### Added

--- a/crates/assay-cli/src/backend.rs
+++ b/crates/assay-cli/src/backend.rs
@@ -330,6 +330,130 @@ mod landlock_impl {
 
         expanded
     }
+
+    /// Build a NET-only Landlock ruleset that handles `CONNECT_TCP` (hard requirement) and allows the
+    /// given TCP-connect ports. Used by the self-probe: connecting to a port NOT in this list under
+    /// the applied ruleset must be denied. FS is intentionally not handled here (the probe only tests
+    /// the network rule; Landlock FS does not affect sockets).
+    pub(super) fn build_net_ruleset(allowed_ports: &[u16]) -> anyhow::Result<RulesetCreated> {
+        let mut ruleset = Ruleset::default()
+            .set_compatibility(CompatLevel::HardRequirement)
+            .handle_access(AccessNet::ConnectTcp)?
+            .create()?;
+        for &port in allowed_ports {
+            ruleset = ruleset.add_rule(NetPort::new(port, AccessNet::ConnectTcp))?;
+        }
+        Ok(ruleset)
+    }
+}
+
+/// Outcome of the enforcement self-probe: the result of a single connect to a denied port, attempted
+/// from inside a child that applied the Landlock-net ruleset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelfProbeOutcome {
+    /// The denied connect failed with `EACCES`: the block held (the proven-block signal).
+    BlockedEacces,
+    /// The connect SUCCEEDED: the ruleset did NOT block it (block failed).
+    Connected,
+    /// The connect failed with some other errno (a weak signal, never a proven block).
+    OtherErrno(i32),
+    /// The probe could not run (no_new_privs / restrict_self / socket failed). Must be surfaced, not
+    /// silently treated as a block.
+    ProbeInfraError(&'static str),
+}
+
+/// Run the enforcement self-probe: in a throwaway child, set `no_new_privs`, apply a NET ruleset that
+/// allows `allowed_ports`, then attempt a TCP connect to `127.0.0.1:deny_port` (which is NOT allowed).
+/// The child reports the outcome via its exit code; the parent never assumes a block. AS-safe: only
+/// raw syscalls run between fork and `_exit`.
+#[cfg(target_os = "linux")]
+pub fn self_probe_denied_connect(
+    allowed_ports: &[u16],
+    deny_port: u16,
+) -> anyhow::Result<SelfProbeOutcome> {
+    use std::os::fd::AsRawFd;
+
+    // Sentinels well above the connect-errno range so an infra failure is never read as an errno.
+    const EXIT_NNP_FAILED: i32 = 200;
+    const EXIT_RESTRICT_FAILED: i32 = 201;
+    const EXIT_SOCKET_FAILED: i32 = 202;
+    const PR_SET_NO_NEW_PRIVS: libc::c_int = 38;
+
+    let created = landlock_impl::build_net_ruleset(allowed_ports)?;
+    let owned: Option<std::os::fd::OwnedFd> = created.into();
+    let raw_fd = owned.as_ref().map(|f| f.as_raw_fd()).unwrap_or(-1);
+
+    // SAFETY: the child runs only async-signal-safe syscalls (prctl, landlock_restrict_self, socket,
+    // connect, _exit). No allocations, no Rust destructors (we _exit). The parent only waitpid.
+    let outcome = unsafe {
+        let pid = libc::fork();
+        if pid == 0 {
+            if libc::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+                libc::_exit(EXIT_NNP_FAILED);
+            }
+            if libc::syscall(libc::SYS_landlock_restrict_self, raw_fd, 0) != 0 {
+                libc::_exit(EXIT_RESTRICT_FAILED);
+            }
+            let sfd = libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0);
+            if sfd < 0 {
+                libc::_exit(EXIT_SOCKET_FAILED);
+            }
+            let addr = libc::sockaddr_in {
+                sin_family: libc::AF_INET as libc::sa_family_t,
+                sin_port: deny_port.to_be(),
+                sin_addr: libc::in_addr {
+                    s_addr: 0x7f00_0001u32.to_be(), // 127.0.0.1
+                },
+                sin_zero: [0; 8],
+            };
+            let ret = libc::connect(
+                sfd,
+                std::ptr::addr_of!(addr) as *const libc::sockaddr,
+                std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+            );
+            if ret == 0 {
+                libc::_exit(0); // connected => block FAILED
+            }
+            let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            let code = if e <= 0 || e > 199 { 199 } else { e };
+            libc::_exit(code);
+        } else if pid > 0 {
+            let mut status: libc::c_int = 0;
+            if libc::waitpid(pid, &mut status, 0) < 0 {
+                return Err(anyhow::anyhow!("self-probe waitpid failed"));
+            }
+            if !libc::WIFEXITED(status) {
+                SelfProbeOutcome::ProbeInfraError("child terminated by signal")
+            } else {
+                classify_self_probe_exit(libc::WEXITSTATUS(status))
+            }
+        } else {
+            return Err(anyhow::anyhow!("self-probe fork failed"));
+        }
+    };
+    drop(owned);
+    Ok(outcome)
+}
+
+/// Pure mapping of the self-probe child's exit code to an outcome. Unit-tested cross-platform.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn classify_self_probe_exit(code: i32) -> SelfProbeOutcome {
+    match code {
+        0 => SelfProbeOutcome::Connected,
+        200 => SelfProbeOutcome::ProbeInfraError("no_new_privs_failed"),
+        201 => SelfProbeOutcome::ProbeInfraError("restrict_self_failed"),
+        202 => SelfProbeOutcome::ProbeInfraError("socket_failed"),
+        e if e == libc::EACCES => SelfProbeOutcome::BlockedEacces,
+        e => SelfProbeOutcome::OtherErrno(e),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn self_probe_denied_connect(
+    _allowed_ports: &[u16],
+    _deny_port: u16,
+) -> anyhow::Result<SelfProbeOutcome> {
+    Ok(SelfProbeOutcome::ProbeInfraError("not linux"))
 }
 
 // =============================================================================
@@ -354,6 +478,43 @@ mod landlock_impl {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn self_probe_exit_eacces_is_blocked() {
+        assert_eq!(
+            classify_self_probe_exit(libc::EACCES),
+            SelfProbeOutcome::BlockedEacces
+        );
+    }
+
+    #[test]
+    fn self_probe_exit_zero_is_connected_block_failed() {
+        assert_eq!(classify_self_probe_exit(0), SelfProbeOutcome::Connected);
+    }
+
+    #[test]
+    fn self_probe_exit_weak_errno_is_other_not_blocked() {
+        // A weak signal must never read as a proven block.
+        for e in [libc::ECONNREFUSED, libc::ETIMEDOUT, libc::ENETUNREACH] {
+            assert_eq!(classify_self_probe_exit(e), SelfProbeOutcome::OtherErrno(e));
+        }
+    }
+
+    #[test]
+    fn self_probe_exit_sentinels_are_infra_errors_not_errno() {
+        assert!(matches!(
+            classify_self_probe_exit(200),
+            SelfProbeOutcome::ProbeInfraError("no_new_privs_failed")
+        ));
+        assert!(matches!(
+            classify_self_probe_exit(201),
+            SelfProbeOutcome::ProbeInfraError("restrict_self_failed")
+        ));
+        assert!(matches!(
+            classify_self_probe_exit(202),
+            SelfProbeOutcome::ProbeInfraError("socket_failed")
+        ));
+    }
 
     #[test]
     fn test_detect_backend_fallback() {

--- a/crates/assay-cli/src/cli/args/runtime.rs
+++ b/crates/assay-cli/src/cli/args/runtime.rs
@@ -170,6 +170,13 @@ pub struct SandboxArgs {
     #[arg(long = "enforce-net", requires = "enforce")]
     pub enforce_net: bool,
 
+    /// With --enforce-net, run a self-probe before the workload: from inside the enforcing ruleset,
+    /// attempt one connect to an ephemeral denied port. Only a real block (EACCES + the harness
+    /// listener never reached) writes the `probe` block into enforcement_health.v1. A probe that does
+    /// not prove a block does not fail the run; it is reported, never silently dropped.
+    #[arg(long = "probe-enforcement", requires = "enforce_net")]
+    pub probe_enforcement: bool,
+
     /// Write the `assay.enforcement_health.v1` artifact (Landlock TCP-connect domain) to this path.
     /// A requested artifact that cannot be written is a command failure, never a silent absence.
     #[arg(long = "enforcement-health")]

--- a/crates/assay-cli/src/cli/commands/sandbox.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox.rs
@@ -259,6 +259,7 @@ mod tests {
             dry_run: false,
             fail_closed: false,
             enforce_net: false,
+            probe_enforcement: false,
             enforcement_health: None,
             env_strict: false,
             env_strip_exec: false,

--- a/crates/assay-cli/src/cli/commands/sandbox/child.rs
+++ b/crates/assay-cli/src/cli/commands/sandbox/child.rs
@@ -125,8 +125,16 @@ pub(super) async fn run_child(
         match &spawn_result {
             Ok(_) => {
                 let ports = net_allow_ports.clone().unwrap_or_default();
+                // Optional self-probe: only a proven real block (EACCES + listener-not-reached)
+                // writes the probe; a non-proving probe is reported, never silently dropped, and
+                // never fails the run (restrict_self on the workload child was confirmed).
+                let probe = if args.probe_enforcement {
+                    run_enforcement_self_probe(&ports, args.quiet)
+                } else {
+                    None
+                };
                 let health = crate::enforcement_health_v1::EnforcementHealthV1::landlock_active(
-                    abi, ports, None,
+                    abi, ports, probe,
                 );
                 write_enforcement_health_v1(args, &health)?;
             }
@@ -241,6 +249,96 @@ fn net_reject_to_reason_code(
     _rejects: &[crate::landlock_net::NetReject],
 ) -> crate::enforcement_health_v1::ReasonCode {
     crate::enforcement_health_v1::ReasonCode::PolicyNotExpressible
+}
+
+/// Run the enforcement self-probe. Returns `Some(probe)` ONLY when a real block is proven: the
+/// denied connect failed with EACCES AND the harness listener was never reached. Any other outcome
+/// (connect succeeded, weak errno, listener reached, or the probe could not run) returns `None` and
+/// is reported to stderr, never silently dropped, and never fails the run.
+#[cfg(target_os = "linux")]
+fn run_enforcement_self_probe(
+    allowed_ports: &[u16],
+    quiet: bool,
+) -> Option<crate::enforcement_health_v1::Probe> {
+    use crate::backend::SelfProbeOutcome;
+
+    let listener = match bind_denied_listener(allowed_ports) {
+        Some(l) => l,
+        None => {
+            if !quiet {
+                eprintln!("WARN: probe-enforcement: could not bind a denied probe port; no probe");
+            }
+            return None;
+        }
+    };
+    let deny_port = listener.local_addr().ok().map(|a| a.port()).unwrap_or(0);
+
+    let outcome = match crate::backend::self_probe_denied_connect(allowed_ports, deny_port) {
+        Ok(o) => o,
+        Err(e) => {
+            if !quiet {
+                eprintln!("WARN: probe-enforcement: self-probe could not run: {e}");
+            }
+            return None;
+        }
+    };
+
+    // Independent ground truth: did any connection actually reach the listener?
+    let _ = listener.set_nonblocking(true);
+    let listener_reached = listener.accept().is_ok();
+
+    if outcome == SelfProbeOutcome::BlockedEacces && !listener_reached {
+        return Some(crate::enforcement_health_v1::Probe {
+            kind: "real_block".to_string(),
+            transport: "ipv4".to_string(),
+            blocked_action: "tcp_connect".to_string(),
+            blocked_port: deny_port,
+            blocked_errno: "EACCES".to_string(),
+            listener_reached: false,
+        });
+    }
+    if !quiet {
+        eprintln!(
+            "WARN: probe-enforcement: self-probe did not prove a block ({}); the enforcement \
+             ruleset was still applied",
+            describe_probe_nonblock(outcome, listener_reached)
+        );
+    }
+    None
+}
+
+/// Bind an ephemeral loopback listener on a port that is NOT in the allowlist (so a connect to it is
+/// expected to be denied). Retries a few times in the unlikely event the kernel hands back an
+/// allowlisted ephemeral port.
+#[cfg(target_os = "linux")]
+fn bind_denied_listener(allowed_ports: &[u16]) -> Option<std::net::TcpListener> {
+    for _ in 0..8 {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).ok()?;
+        let port = listener.local_addr().ok()?.port();
+        if !allowed_ports.contains(&port) {
+            return Some(listener);
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn describe_probe_nonblock(
+    outcome: crate::backend::SelfProbeOutcome,
+    listener_reached: bool,
+) -> String {
+    use crate::backend::SelfProbeOutcome;
+    if listener_reached {
+        return "the denied connect reached the listener".to_string();
+    }
+    match outcome {
+        SelfProbeOutcome::Connected => "the denied connect succeeded".to_string(),
+        SelfProbeOutcome::OtherErrno(e) => {
+            format!("the denied connect failed with errno {e}, not EACCES")
+        }
+        SelfProbeOutcome::ProbeInfraError(r) => format!("the probe could not run: {r}"),
+        SelfProbeOutcome::BlockedEacces => "blocked, but the listener was reached".to_string(),
+    }
 }
 
 fn resolve_command_path(cmd_name: &str) -> std::path::PathBuf {


### PR DESCRIPTION
Enriches the runtime artifact from `active` (probe: null) to `active + probe` when a real block is actually observed, using the same verdict as the reusable experiments harness (PR B).

**`assay sandbox --enforce-net --probe-enforcement`** runs a self-probe before the workload:
- From inside the enforcing Landlock-net ruleset (no_new_privs + restrict_self applied in a throwaway child), it attempts one connect to an **ephemeral denied port** (bound by the harness, never in the allowlist).
- **Only a proven real block** (EACCES AND the harness listener never reached) writes the `probe` block into `enforcement_health.v1`.
- A probe that does **not** prove a block (connect succeeded, weak errno, listener reached, or the probe could not run) is **reported to stderr, never silently dropped, and never fails the run** — the enforcement ruleset on the workload child was still confirmed.
- Weak signals (timeout, ECONNREFUSED, ENETUNREACH) never count.

**Semantics:** `active` without probe = restrict_self confirmed; `active` with probe = restrict_self confirmed **+ one denied connect proven blocked**.

**Safety:** opt-in only; reuses the PR2 hybrid pattern (parent builds the ruleset, the child runs only async-signal-safe syscalls: prctl, restrict_self, socket, connect, _exit). The denied port is ephemeral and not in the policy, so the probe cannot widen policy or break the workload.

**Tests:** unit tests for the exit-code verdict (EACCES=blocked, weak errno=not-blocked, sentinels=infra-error, connect=block-failed). Live verification on the ABI 4 host attached before merge.

**Lane:** Gate.NONE (backend/sandbox paths). Real-block proof pending (VM).