### PR TITLE
refactor(cli): retire deprecated top-level command shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+- The deprecated top-level command shims `assay discover`, `assay kill`, `assay tool`,
+  `assay generate`, and `assay record` were retired. They had been hidden and printed a
+  deprecation warning since the command-grouping pass; use the canonical paths instead:
+  `assay mcp discover`, `assay mcp kill`, `assay mcp tool`, `assay policy generate`, and
+  `assay policy record`. The underlying behavior, flags, output, and exit codes are unchanged.
+
 ### Added
 - `assay sandbox --probe-enforcement` (with `--enforce-net`): runs a self-probe before the
   workload that, from inside the enforcing ruleset, attempts one connect to an ephemeral denied

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -87,20 +87,8 @@ pub enum Command {
     Version,
     /// Validate, format, and migrate policies
     Policy(PolicyArgs),
-    /// Discover MCP servers on this machine
-    #[command(hide = true)]
-    Discover(DiscoverArgs),
-    /// Kill/Terminate MCP servers
-    #[command(hide = true)]
-    Kill(super::commands::kill::KillArgs),
     /// Runtime eBPF Monitor (Linux only)
     Monitor(super::commands::monitor::MonitorArgs),
-    /// Learning Mode: Generate policy from trace or profile
-    #[command(hide = true)]
-    Generate(super::commands::generate::GenerateArgs),
-    /// Learning Mode: Capture and Generate in one flow
-    #[command(hide = true)]
-    Record(super::commands::record::RecordArgs),
     /// Internal Assay-Runner Phase 1 spike command
     #[cfg(feature = "runner")]
     #[command(name = "runner-spike", hide = true)]
@@ -120,9 +108,6 @@ pub enum Command {
     Sim(SimArgs),
     /// Interactive installer and environment setup
     Setup(SetupArgs),
-    /// Tool signing and verification
-    #[command(hide = true)]
-    Tool(ToolArgs),
     /// Generate canonical trust-basis artifacts from verified evidence bundles
     #[command(name = "trust-basis")]
     TrustBasis(TrustBasisArgs),

--- a/crates/assay-cli/src/cli/args/tests.rs
+++ b/crates/assay-cli/src/cli/args/tests.rs
@@ -49,7 +49,7 @@ fn trust_card_command_accepts_canonical_and_legacy_names() {
 }
 
 #[test]
-fn mcp_group_accepts_canonical_paths_and_legacy_shims_are_hidden() {
+fn mcp_group_accepts_canonical_paths_and_legacy_shims_are_removed() {
     let visible: Vec<_> = Cli::command()
         .get_subcommands()
         .filter(|cmd| !cmd.is_hide_set())
@@ -88,21 +88,14 @@ fn mcp_group_accepts_canonical_paths_and_legacy_shims_are_hidden() {
         })
     ));
 
-    let legacy_discover = Cli::try_parse_from(["assay", "discover", "--format", "json"])
-        .expect("legacy discover shim should parse");
-    assert!(matches!(legacy_discover.cmd, Command::Discover(_)));
-
-    let legacy_kill =
-        Cli::try_parse_from(["assay", "kill", "proc-123"]).expect("legacy kill shim should parse");
-    assert!(matches!(legacy_kill.cmd, Command::Kill(_)));
-
-    let legacy_tool = Cli::try_parse_from(["assay", "tool", "keygen", "--out", "keys"])
-        .expect("legacy tool shim should parse");
-    assert!(matches!(legacy_tool.cmd, Command::Tool(_)));
+    // The legacy top-level shims were retired; only the canonical `assay mcp ...` paths remain.
+    assert!(Cli::try_parse_from(["assay", "discover", "--format", "json"]).is_err());
+    assert!(Cli::try_parse_from(["assay", "kill", "proc-123"]).is_err());
+    assert!(Cli::try_parse_from(["assay", "tool", "keygen", "--out", "keys"]).is_err());
 }
 
 #[test]
-fn policy_group_accepts_authoring_paths_and_legacy_shims_are_hidden() {
+fn policy_group_accepts_authoring_paths_and_legacy_shims_are_removed() {
     let visible: Vec<_> = Cli::command()
         .get_subcommands()
         .filter(|cmd| !cmd.is_hide_set())
@@ -138,14 +131,11 @@ fn policy_group_accepts_authoring_paths_and_legacy_shims_are_hidden() {
         })
     ));
 
-    let legacy_generate =
-        Cli::try_parse_from(["assay", "generate", "--input", "trace.jsonl", "--dry-run"])
-            .expect("legacy generate shim should parse");
-    assert!(matches!(legacy_generate.cmd, Command::Generate(_)));
-
-    let legacy_record = Cli::try_parse_from(["assay", "record", "--", "echo", "hello"])
-        .expect("legacy record shim should parse");
-    assert!(matches!(legacy_record.cmd, Command::Record(_)));
+    // The legacy top-level shims were retired; only the canonical `assay policy ...` paths remain.
+    assert!(
+        Cli::try_parse_from(["assay", "generate", "--input", "trace.jsonl", "--dry-run"]).is_err()
+    );
+    assert!(Cli::try_parse_from(["assay", "record", "--", "echo", "hello"]).is_err());
 }
 
 #[cfg(feature = "sim")]

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -1,14 +1,6 @@
 use super::super::args::*;
 use crate::exit_codes::EXIT_SUCCESS;
 
-fn warn_legacy_mcp_path(old: &str, new: &str) {
-    eprintln!("warning: `assay {old}` is deprecated; use `assay mcp {new}` instead");
-}
-
-fn warn_legacy_policy_path(old: &str, new: &str) {
-    eprintln!("warning: `assay {old}` is deprecated; use `assay policy {new}` instead");
-}
-
 pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
     match cli.cmd {
         Command::Init(args) => super::init::run(args).await,
@@ -40,24 +32,8 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         Command::Demo(args) => super::demo::cmd_demo(args).await,
         Command::InitCi(args) => super::init_ci::cmd_init_ci(args),
         Command::Mcp(args) => super::mcp::run(args).await,
-        Command::Discover(args) => {
-            warn_legacy_mcp_path("discover", "discover");
-            super::discover::run(args).await
-        }
-        Command::Kill(args) => {
-            warn_legacy_mcp_path("kill", "kill");
-            super::kill::run(args).await
-        }
         Command::Monitor(args) => super::monitor::run(args).await,
         Command::Policy(args) => super::policy::run(args).await,
-        Command::Generate(args) => {
-            warn_legacy_policy_path("generate", "generate");
-            super::generate::run(args)
-        }
-        Command::Record(args) => {
-            warn_legacy_policy_path("record", "record");
-            super::record::run(args).await
-        }
         #[cfg(feature = "runner")]
         Command::RunnerSpike(args) => super::runner_spike::run(args).await,
         Command::Profile(args) => super::profile::run(args),
@@ -68,10 +44,6 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         #[cfg(feature = "sim")]
         Command::Sim(args) => super::sim::run(args),
         Command::Setup(args) => super::setup::run(args).await,
-        Command::Tool(args) => {
-            warn_legacy_mcp_path("tool", "tool");
-            Ok(super::tool::cmd_tool(args.cmd))
-        }
         Command::TrustBasis(args) => super::trust_basis::run(args),
         Command::TrustCard(args) => super::trust_card::run(args),
         Command::Version => {

--- a/crates/assay-cli/src/cli/commands/generate.rs
+++ b/crates/assay-cli/src/cli/commands/generate.rs
@@ -3,11 +3,11 @@
 //! # Usage
 //! ```bash
 //! # Single-run mode
-//! assay generate -i trace.jsonl --heuristics
+//! assay policy generate -i trace.jsonl --heuristics
 //!
 //! # Profile mode (stability analysis)
-//! assay generate --profile profile.yaml --min-stability 0.8
-//! assay generate --profile profile.yaml --min-stability 0.8 --new-is-risky
+//! assay policy generate --profile profile.yaml --min-stability 0.8
+//! assay policy generate --profile profile.yaml --min-stability 0.8 --new-is-risky
 //! ```
 
 use anyhow::Result;

--- a/crates/assay-cli/tests/mcp_command_grouping_test.rs
+++ b/crates/assay-cli/tests/mcp_command_grouping_test.rs
@@ -23,12 +23,14 @@ fn mcp_group_is_visible_and_legacy_flat_commands_are_hidden() {
 }
 
 #[test]
-fn legacy_flat_mcp_command_prints_deprecation_warning() {
+fn retired_flat_mcp_command_is_rejected() {
+    // `assay kill` was a deprecated shim for `assay mcp kill`; the shim is retired, so the flat
+    // path is now rejected as an unrecognized subcommand rather than warning and running.
     let output = assay_cmd().arg("kill").output().unwrap();
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("`assay kill` is deprecated; use `assay mcp kill` instead"),
-        "missing legacy MCP deprecation warning: {stderr}"
+        stderr.contains("unrecognized subcommand"),
+        "expected the retired flat `kill` shim to be rejected as an unrecognized subcommand: {stderr}"
     );
 }

--- a/crates/assay-cli/tests/policy_command_grouping_test.rs
+++ b/crates/assay-cli/tests/policy_command_grouping_test.rs
@@ -24,12 +24,14 @@ fn policy_group_exposes_authoring_commands_and_legacy_flat_commands_are_hidden()
 }
 
 #[test]
-fn legacy_flat_policy_generate_prints_deprecation_warning() {
+fn retired_flat_policy_generate_is_rejected() {
+    // `assay generate` was a deprecated shim for `assay policy generate`; the shim is retired, so
+    // the flat path is now rejected as an unrecognized subcommand rather than warning and running.
     let output = assay_cmd().arg("generate").output().unwrap();
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("`assay generate` is deprecated; use `assay policy generate` instead"),
-        "missing legacy policy deprecation warning: {stderr}"
+        stderr.contains("unrecognized subcommand"),
+        "expected the retired flat `generate` shim to be rejected as an unrecognized subcommand: {stderr}"
     );
 }

--- a/crates/assay-core/src/discovery/types.rs
+++ b/crates/assay-core/src/discovery/types.rs
@@ -148,7 +148,7 @@ impl Inventory {
         None
     }
 
-    /// Convenience for `assay kill --all`
+    /// Convenience for `assay mcp kill --all`
     pub fn running_process_servers(&self) -> Vec<RunningProcessServer> {
         let mut out: Vec<RunningProcessServer> = self
             .servers

--- a/docs/AIcontext/code-map.md
+++ b/docs/AIcontext/code-map.md
@@ -157,13 +157,13 @@ The GitHub Action lives in this monorepo under `assay-action/` and is referenced
 - **`init.rs`**: `assay init` command
 - **`import.rs`**: `assay import` command
 - **`trace.rs`**: `assay trace` command
-- **`generate/mod.rs`**: `assay generate` orchestrator (RFC-003 G6)
+- **`generate/mod.rs`**: `assay policy generate` orchestrator (RFC-003 G6)
   - **`generate/args.rs`**: `GenerateArgs` and validation (G2)
   - **`generate/model.rs`**: `Policy`, `Meta`, `Section`, `Entry` DTOs (G2)
   - **`generate/ingest.rs`**: `read_events`, `aggregate`, `Stats` (G3)
   - **`generate/profile.rs`**: Profile classification (Wilson scoring) (G4)
   - **`generate/diff.rs`**: Policy diffing and reporting (G5)
-- **`record.rs`**: `assay record` command
+- **`record.rs`**: `assay policy record` command
 - **`migrate.rs`**: `assay migrate` command
 - **`doctor.rs`**: `assay doctor` command
 - **`explain.rs`**: `assay explain` command

--- a/docs/AIcontext/decision-trees.md
+++ b/docs/AIcontext/decision-trees.md
@@ -89,8 +89,8 @@ flowchart TD
     START[Developing policy?] --> EXISTING{Have existing<br/>behavior to model?}
 
     EXISTING -->|Yes| LEARNING[Learning mode]
-    LEARNING --> RECORD[assay record -- your-command]
-    RECORD --> GENERATE[assay generate -i trace.jsonl]
+    LEARNING --> RECORD[assay policy record -- your-command]
+    RECORD --> GENERATE[assay policy generate -i trace.jsonl]
     GENERATE --> REVIEW[Review and refine]
 
     EXISTING -->|No| MANUAL[Manual policy writing]
@@ -178,8 +178,8 @@ flowchart TD
 | CI gate (strict) | `assay ci` | `--trace-file`, `--sarif` |
 | Debug setup | `assay doctor` | (no options needed) |
 | Explain failures | `assay explain` | `--trace`, `--policy` |
-| Generate policy | `assay generate` | `--from-profile` |
-| Record behavior | `assay record` | `--output <policy.yaml> -- <command>` |
+| Generate policy | `assay policy generate` | `--from-profile` |
+| Record behavior | `assay policy record` | `--output <policy.yaml> -- <command>` |
 | Check coverage | `assay coverage` | `--min-coverage 80` |
 | MCP enforcement | `assay mcp wrap` | `--policy`, `--dry-run` |
 | Export evidence | `assay evidence export` | `--profile`, `--out` |
@@ -216,7 +216,7 @@ flowchart TD
 
 ### For Policy Development
 - **From scratch**: Write `policy.yaml` manually
-- **From behavior**: `assay generate --from-profile profile.json`
+- **From behavior**: `assay policy generate --from-profile profile.json`
 - **Test coverage**: `assay coverage --trace-file traces.jsonl`
 
 ### For Debugging

--- a/docs/AIcontext/entry-points.md
+++ b/docs/AIcontext/entry-points.md
@@ -74,7 +74,7 @@ All CLI commands are defined in `crates/assay-cli/src/cli/args.rs` and dispatche
 
 ### Policy Management
 
-#### `assay generate`
+#### `assay policy generate`
 **Purpose**: Generate policy from traces (learning mode)
 **Entry**: `crates/assay-cli/src/cli/commands/generate.rs::run()`
 **Flow**: Analyze traces → generate policy constraints → write `policy.yaml`
@@ -84,7 +84,7 @@ All CLI commands are defined in `crates/assay-cli/src/cli/args.rs` and dispatche
 - `--from-trace <PATH>`: Generate from trace file
 - `--output <PATH>`: Output policy file
 
-#### `assay record`
+#### `assay policy record`
 **Purpose**: Capture and generate in one flow
 **Entry**: `crates/assay-cli/src/cli/commands/record.rs::run()`
 **Flow**: Capture traces → generate policy → save both

--- a/docs/AIcontext/quick-reference.md
+++ b/docs/AIcontext/quick-reference.md
@@ -229,8 +229,8 @@ assay run --config eval.yaml --trace-file traces.jsonl --baseline baseline.json
 
 ### Pattern 2: Learning Mode
 ```bash
-assay record --output policy.yaml -- your-agent-command
-assay generate -i traces/session.jsonl --output policy.yaml
+assay policy record --output policy.yaml -- your-agent-command
+assay policy generate -i traces/session.jsonl --output policy.yaml
 ```
 
 ### Pattern 3: Debug Violation

--- a/docs/AIcontext/user-flows.md
+++ b/docs/AIcontext/user-flows.md
@@ -155,7 +155,7 @@ assay run --config eval.yaml --trace-file traces.jsonl
 ```mermaid
 flowchart TD
     start[Start Policy Development] --> profile[Capture Command Behavior]
-    profile --> record[assay record --output policy.yaml -- command]
+    profile --> record[assay policy record --output policy.yaml -- command]
     record --> policy[Generated policy.yaml]
     policy --> review[Review & Refine]
     review --> test[Test with traces]
@@ -167,8 +167,8 @@ flowchart TD
 
 **Learning Mode Commands:**
 
-1. **Capture + generate policy**: `assay record --output policy.yaml -- <your-command>`
-2. **Optional generate from existing trace**: `assay generate -i traces.jsonl --output policy.yaml`
+1. **Capture + generate policy**: `assay policy record --output policy.yaml -- <your-command>`
+2. **Optional generate from existing trace**: `assay policy generate -i traces.jsonl --output policy.yaml`
 3. **Review**: Edit generated policy to add custom constraints
 4. **Test**: `assay validate --config eval.yaml --trace-file traces.jsonl`
 5. **Deploy**: Commit policy.yaml to repository
@@ -442,7 +442,7 @@ See [CI Infrastructure](ci-infrastructure.md) for detailed documentation.
 | First-time setup | Flow 1 | `assay init` |
 | CI integration | Flow 2 | `Rul1an/assay/assay-action@v2` |
 | Recording traces | Flow 3 | `AssayClient` or `assay import` |
-| Policy development | Flow 4 | `assay generate` |
+| Policy development | Flow 4 | `assay policy generate` |
 | Production security | Flow 5 | `assay mcp wrap` + `assay monitor` |
 | Regression testing | Flow 6 | `assay run --baseline` |
 | Python development | Flow 7 | Python SDK |

--- a/docs/DX-ROADMAP.md
+++ b/docs/DX-ROADMAP.md
@@ -149,8 +149,8 @@ Files changed:
 When regenerating policy from new traces, show what changed.
 
 ```bash
-assay generate --input trace.jsonl --diff           # Compare with existing policy.yaml
-assay generate --input trace.jsonl --diff --dry-run  # Preview without writing
+assay policy generate --input trace.jsonl --diff           # Compare with existing policy.yaml
+assay policy generate --input trace.jsonl --diff --dry-run  # Preview without writing
 ```
 
 Output:

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,13 +138,13 @@ Generate policies from observed behavior instead of writing them by hand:
 
 ```bash
 # From a single trace
-assay generate -i trace.jsonl --heuristics
+assay policy generate -i trace.jsonl --heuristics
 
 # From multiple runs (stability analysis)
 assay profile init --output profile.yaml --name my-app
 assay profile update --profile profile.yaml -i run1.jsonl --run-id run-1
 assay profile update --profile profile.yaml -i run2.jsonl --run-id run-2
-assay generate --profile profile.yaml --min-stability 0.8
+assay policy generate --profile profile.yaml --min-stability 0.8
 ```
 
 ### Diagnostics

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -193,8 +193,8 @@ artifact schemas, Trust Basis semantics, or MCP policy behavior.
 
 The `v3.14.0` release line also includes the Tier 2a policy-authoring grouping:
 `assay policy generate` and `assay policy record` are canonical, while the
-previous top-level `assay generate` and `assay record` paths remain hidden
-compatibility shims with `stderr` deprecation warnings. It also adds
+previous top-level `assay generate` and `assay record` paths were hidden
+compatibility shims (since retired in favor of the canonical `assay policy` paths). It also adds
 `assay evidence verify-mcp-records` as a downstream verifier for SEP-2787
 attestation and server execution-record fixture pairing. The rest of the CLI
 grouping RFC remains deliberately trigger-gated: `trust` and `replay` should

--- a/docs/architecture/PLAN-P56B-TOOL-DEFINITION-DIGEST-BINDING-2026q2.md
+++ b/docs/architecture/PLAN-P56B-TOOL-DEFINITION-DIGEST-BINDING-2026q2.md
@@ -37,7 +37,7 @@ Assay already has three related surfaces:
   drift detection.
 - MCP proxy discovery, which computes tool identity from `tools/list` responses
   and caches it for later `tools/call` decisions.
-- `assay tool sign` / `assay tool verify`, which use `x-assay-sig`, JCS, and
+- `assay mcp tool sign` / `assay mcp tool verify`, which use `x-assay-sig`, JCS, and
   DSSE-style PAE over a tool definition with the signature field removed.
 
 Those seams are useful but not yet the same as a single, self-describing

--- a/docs/archive/handoff_v2.3.md
+++ b/docs/archive/handoff_v2.3.md
@@ -91,7 +91,7 @@ Assay can now learn “stable behavior” across repeated runs (Multi-Run).
 ### Profile Workflow
 1.  `assay profile init`
 2.  `assay profile update --run-id <id>` (Idempotent merge)
-3.  `assay generate --profile profile.yaml`
+3.  `assay policy generate --profile profile.yaml`
 
 ### Safety Belts
 *   **Confidence-Aware Gating**: Uses **Wilson Lower Bound** (95% CI) as default gate to filter noise.

--- a/docs/reference/cli/command-grouping-rfc.md
+++ b/docs/reference/cli/command-grouping-rfc.md
@@ -189,8 +189,9 @@ assay policy generate   # was: generate  ("Learning Mode: Generate policy from t
 assay policy record     # was: record    ("Learning Mode: Capture and Generate in one flow")
 ```
 
-Status: implemented. The old top-level `assay generate` and `assay record`
-paths remain hidden compatibility shims with stderr deprecation warnings.
+Status: implemented, then tightened. The grouped `assay policy ...` paths are
+canonical; the old top-level `assay generate` / `assay record` shims were
+subsequently removed.
 
 Optional, weaker fit:
 

--- a/docs/reference/cli/generate.md
+++ b/docs/reference/cli/generate.md
@@ -2,9 +2,7 @@
 
 Generate policy scaffolding from trace or profile inputs.
 
-The legacy top-level form `assay generate` remains available as a hidden
-compatibility shim and prints a deprecation warning. New usage should prefer
-`assay policy generate`.
+The legacy top-level form `assay generate` was removed; use `assay policy generate`.
 
 ---
 

--- a/docs/reference/cli/policy.md
+++ b/docs/reference/cli/policy.md
@@ -2,9 +2,9 @@
 
 Policy authoring, validation, formatting, and migration commands.
 
-The policy family now owns policy-authoring commands. The legacy top-level
-forms `assay generate` and `assay record` remain available as hidden
-compatibility shims and print deprecation warnings.
+The policy family owns policy-authoring commands. The legacy top-level forms
+`assay generate` and `assay record` were removed; use `assay policy generate`
+and `assay policy record`.
 
 ---
 
@@ -52,9 +52,7 @@ assay policy validate --input policy.yaml
 
 ## Compatibility
 
-- `assay generate ...` still runs as a hidden compatibility shim for
-  `assay policy generate ...`.
-- `assay record ...` still runs as a hidden compatibility shim for
-  `assay policy record ...`.
+- The legacy top-level `assay generate ...` and `assay record ...` paths were
+  removed; use `assay policy generate ...` and `assay policy record ...`.
 - Output shapes, exit codes, generated policy behavior, and policy schema
   semantics are unchanged.

--- a/examples/mcp-quickstart/README.md
+++ b/examples/mcp-quickstart/README.md
@@ -76,4 +76,4 @@ schemas:
 
 - **Export evidence**: `assay evidence export --profile profile.yaml --out evidence.tar.gz`
 - **Add to CI**: copy the [GitHub Action snippet](../../README.md#gate-your-ci) to your workflow
-- **Generate policy from behavior**: `assay generate --from-trace trace.jsonl`
+- **Generate policy from behavior**: `assay policy generate --from-trace trace.jsonl`


### PR DESCRIPTION
From the redundancy review: the only genuine cruft was 5 hidden deprecated top-level shims (`assay discover`/`kill`/`tool`/`generate`/`record`) that printed a deprecation warning and routed to the canonical `assay mcp ...` / `assay policy ...` paths. This retires them.

- Removes the 5 enum variants + dispatch arms + the 2 now-unused legacy-path warning helpers. The underlying command modules are KEPT (the `mcp` and `policy` subcommands use them); behavior, flags, output, and exit codes are unchanged.
- Tests inverted: the old top-level paths are now asserted to be rejected.
- Docs + in-code examples updated to the canonical paths; reference docs no longer claim the shims still exist.

Breaking only for anyone scripting the long-deprecated hidden top-level spellings; the canonical grouped paths have been the documented form since the command-grouping pass.