### PR TITLE
feat(monitor): event-size mismatch counter, one-shot warning, observation_health degradation (#1575)

### DIFF
--- a/crates/assay-monitor/src/events.rs
+++ b/crates/assay-monitor/src/events.rs
@@ -57,3 +57,34 @@ pub fn send_parsed(
     // best-effort send
     let _ = tx.blocking_send(ev);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_event_rejects_short_record_with_got_and_need() {
+        // A stale eBPF object emits the previous 40 + 480 = 520 byte layout while userspace now
+        // expects 40 + 512 = 552. The parser must reject the short record (fail-closed), reporting
+        // the observed and expected sizes, rather than decoding a truncated struct.
+        let need = core::mem::size_of::<MonitorEvent>();
+        assert_eq!(
+            need, 552,
+            "MonitorEvent ABI size changed; update the stale-object test"
+        );
+        let stale = vec![0u8; 520];
+        match parse_event(&stale) {
+            Err(MonitorError::InvalidEvent { got, need: n }) => {
+                assert_eq!(got, 520);
+                assert_eq!(n, 552);
+            }
+            other => panic!("expected InvalidEvent for a 520-byte record, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_event_accepts_exact_size_record() {
+        let ev = parse_event(&vec![0u8; core::mem::size_of::<MonitorEvent>()]);
+        assert!(ev.is_ok(), "a record of the exact pinned size must parse");
+    }
+}

--- a/crates/assay-monitor/src/lib.rs
+++ b/crates/assay-monitor/src/lib.rs
@@ -40,6 +40,11 @@ pub struct MonitorStatsSnapshot {
     pub socket_allowed: u64,
     pub socket_events_emitted: u64,
     pub socket_ringbuf_dropped: u64,
+    /// Userspace count of ring-buffer records rejected because their length did not match the
+    /// pinned `MonitorEvent` size. A non-zero value almost always means a stale eBPF object
+    /// (built from an older `MonitorEvent` layout) was loaded against a newer userspace decoder;
+    /// the records are dropped fail-closed, so this is an observation gap, not decoded garbage.
+    pub event_size_mismatch: u64,
 }
 
 impl MonitorStatsSnapshot {

--- a/crates/assay-monitor/src/loader.rs
+++ b/crates/assay-monitor/src/loader.rs
@@ -17,14 +17,29 @@ use aya::{
     programs::{CgroupAttachMode, CgroupSockAddr, Lsm, TracePoint},
     Btf, Ebpf,
 };
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 #[cfg(target_os = "linux")]
+/// One-shot, actionable warning emitted on the first event-size mismatch of a run. Further
+/// mismatches are counted, not logged, so a stale object does not drown the log in per-event noise.
+#[cfg(target_os = "linux")]
+const STALE_OBJECT_WARNING: &str = "WARN: monitor event size mismatch: a ring-buffer record did \
+not match the pinned MonitorEvent size. This almost always means a stale eBPF object (built from \
+an older MonitorEvent layout) was loaded against a newer userspace decoder. Rebuild the eBPF \
+object from the same commit as assay-monitor:\n  scripts/ci/install-ebpf-toolchain.sh\n  cargo \
+xtask build-ebpf --release --no-docker\nMismatched records are dropped fail-closed and counted; \
+further mismatches are not logged individually.";
+
 pub struct LinuxMonitor {
     bpf: Arc<Mutex<Ebpf>>,
     links: Vec<MonitorLink>,
+    /// Userspace counter for ring-buffer records whose length did not match the pinned
+    /// `MonitorEvent` size (almost always a stale eBPF object). Shared with the consumer thread
+    /// spawned in `listen()` and read back in `snapshot_stats`.
+    event_size_mismatch: Arc<AtomicU64>,
 }
 
 #[cfg(target_os = "linux")]
@@ -46,6 +61,7 @@ impl LinuxMonitor {
         Ok(Self {
             bpf: Arc::new(Mutex::new(bpf)),
             links: Vec::new(),
+            event_size_mismatch: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -423,6 +439,9 @@ impl LinuxMonitor {
         stats.socket_events_emitted = array.get(&SOCKET_STAT_EVENTS_EMITTED, 0).unwrap_or(0);
         stats.socket_ringbuf_dropped = array.get(&SOCKET_STAT_RINGBUF_DROPPED, 0).unwrap_or(0);
 
+        // Userspace-tracked: filled by the consumer thread in `listen()`, not a kernel map.
+        stats.event_size_mismatch = self.event_size_mismatch.load(Ordering::Relaxed);
+
         Ok(stats)
     }
 
@@ -443,6 +462,7 @@ impl LinuxMonitor {
             )
         };
 
+        let mismatch = Arc::clone(&self.event_size_mismatch);
         std::thread::spawn(move || {
             let mut ready = false;
             'outer: loop {
@@ -455,6 +475,11 @@ impl LinuxMonitor {
                         continue;
                     }
                     let ev = events::parse_event(&item);
+                    if matches!(&ev, Err(MonitorError::InvalidEvent { .. }))
+                        && mismatch.fetch_add(1, Ordering::Relaxed) == 0
+                    {
+                        eprintln!("{STALE_OBJECT_WARNING}");
+                    }
                     if tx.blocking_send(ev).is_err() {
                         break 'outer;
                     }
@@ -466,6 +491,11 @@ impl LinuxMonitor {
                         continue;
                     }
                     let ev = events::parse_event(&item);
+                    if matches!(&ev, Err(MonitorError::InvalidEvent { .. }))
+                        && mismatch.fetch_add(1, Ordering::Relaxed) == 0
+                    {
+                        eprintln!("{STALE_OBJECT_WARNING}");
+                    }
                     if tx.blocking_send(ev).is_err() {
                         break 'outer;
                     }

--- a/crates/assay-runner-core/src/kernel.rs
+++ b/crates/assay-runner-core/src/kernel.rs
@@ -62,6 +62,10 @@ pub struct KernelLayerCapture {
     pub capability_surface: CapabilitySurface,
     pub event_count: u64,
     pub ringbuf_drops: u64,
+    /// Records dropped because their length did not match the pinned `MonitorEvent` size (stale
+    /// eBPF object). Like `ringbuf_drops`, this is lost events: it degrades kernel-layer
+    /// completeness so a run that silently dropped records is never read as complete.
+    pub event_size_mismatch: u64,
     drop_breakdown: RingbufDropBreakdown,
     emitted_breakdown: RingbufEmittedBreakdown,
     tracepoint_hook_breakdown: TracepointHookBreakdown,
@@ -179,6 +183,9 @@ impl KernelLayerBuilder {
             capability_surface: self.capability_surface,
             event_count: self.next_seq,
             ringbuf_drops: ringbuf_drop_delta(before, after),
+            event_size_mismatch: after
+                .event_size_mismatch
+                .saturating_sub(before.event_size_mismatch),
             drop_breakdown: ringbuf_drop_breakdown(before, after),
             emitted_breakdown: ringbuf_emitted_breakdown(before, after),
             tracepoint_hook_breakdown: tracepoint_hook_breakdown(before, after),
@@ -206,6 +213,7 @@ impl KernelLayerCapture {
             capability_surface,
             event_count,
             ringbuf_drops,
+            event_size_mismatch,
             drop_breakdown,
             emitted_breakdown,
             tracepoint_hook_breakdown,
@@ -228,7 +236,7 @@ impl KernelLayerCapture {
             archive.observation_health.ringbuf_drops =
                 health_ringbuf_drops(ringbuf_drops, cgroup_correlation);
             archive.observation_health.kernel_layer =
-                kernel_layer_for(ringbuf_drops, cgroup_correlation);
+                kernel_layer_for(ringbuf_drops, event_size_mismatch, cgroup_correlation);
             archive.observation_health.cgroup_correlation = cgroup_correlation;
             if archive.observation_health.kernel_layer == KernelLayerStatus::Absent {
                 archive.observation_health.network_protocol_coverage =

--- a/crates/assay-runner-core/src/kernel/health.rs
+++ b/crates/assay-runner-core/src/kernel/health.rs
@@ -40,9 +40,15 @@ pub(super) fn network_endpoint_claim_scope_for(
 
 pub(super) fn kernel_layer_for(
     ringbuf_drops: u64,
+    event_size_mismatch: u64,
     cgroup_correlation: CgroupCorrelationStatus,
 ) -> KernelLayerStatus {
-    match (ringbuf_drops, cgroup_correlation) {
+    // Both ringbuf drops and event-size mismatches are lost events: records that never reached
+    // the decoded stream. Either one makes the kernel layer incomplete. The counts stay separate
+    // on the capture for diagnosis; here we only ask "was anything lost?", so summing for the
+    // 0-vs-nonzero decision is not a reporting conflation.
+    let lost = ringbuf_drops.saturating_add(event_size_mismatch);
+    match (lost, cgroup_correlation) {
         (_, CgroupCorrelationStatus::Failed | CgroupCorrelationStatus::Partial) => {
             KernelLayerStatus::Absent
         }
@@ -59,5 +65,48 @@ pub(super) fn health_ringbuf_drops(
         ringbuf_drops
     } else {
         0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_run_with_no_loss_is_complete() {
+        assert_eq!(
+            kernel_layer_for(0, 0, CgroupCorrelationStatus::Clean),
+            KernelLayerStatus::Complete
+        );
+    }
+
+    #[test]
+    fn event_size_mismatch_alone_degrades_kernel_layer() {
+        // A stale-object size mismatch is lost events, so even with zero ringbuf drops the kernel
+        // layer must not read as complete. "Saw nothing" is not clean if records were dropped.
+        assert_eq!(
+            kernel_layer_for(0, 3, CgroupCorrelationStatus::Clean),
+            KernelLayerStatus::PartialRingbufDrops
+        );
+    }
+
+    #[test]
+    fn ringbuf_drops_alone_still_degrades() {
+        assert_eq!(
+            kernel_layer_for(2, 0, CgroupCorrelationStatus::Clean),
+            KernelLayerStatus::PartialRingbufDrops
+        );
+    }
+
+    #[test]
+    fn non_clean_cgroup_is_absent_regardless_of_loss() {
+        assert_eq!(
+            kernel_layer_for(0, 0, CgroupCorrelationStatus::Partial),
+            KernelLayerStatus::Absent
+        );
+        assert_eq!(
+            kernel_layer_for(0, 9, CgroupCorrelationStatus::Failed),
+            KernelLayerStatus::Absent
+        );
     }
 }


### PR DESCRIPTION
Hardening for #1575 (stale eBPF object emits old MonitorEvent size). Diagnosis confirmed: MonitorEvent is shared via assay-common and size-pinned at 552; a 520-byte record is the old 40+480 layout from a stale object, which the decoder already rejects fail-closed. This makes that failure visible and honest instead of log-noise:

- **assay-monitor**: count size mismatches in `MonitorStatsSnapshot.event_size_mismatch` (userspace counter, incremented in the `listen()` consume loop), and emit **one** actionable stale-object warning per run (with the canonical rebuild command) instead of a per-event size error.
- **assay-runner-core**: the kernel layer treats a size mismatch as lost events, so a run that silently dropped records degrades to `PartialRingbufDrops` and is never read as a complete/clean observation. Counts stay **separate** (ringbuf drops vs size mismatch); only the 0-vs-nonzero kernel-layer decision combines them.
- **Tests**: `parse_event` rejects a 520-byte record reporting got=520/need=552; `kernel_layer_for` degrades when `event_size_mismatch > 0` even with zero ringbuf drops.

Deliberately **not** done: no decoder tolerance for the old 520 layout (no implicit back-compat on a version-less binary ABI), no `MonitorEvent` struct change (shared + pinned, so not the bug), no new observation_health schema field (degradation rides the existing `PartialRingbufDrops` status). Load-time object/userspace ABI provenance is left as a separate follow-up.

Lane: this touches assay-monitor + assay-runner-core, so `gates=all` (delegated runner-spike proof). The proof also validates the Linux-only loader changes. Delegated proof to follow on the head SHA.