### PR TITLE
docs(otel): characterize span-event limit behavior (#1408)

### DIFF
--- a/crates/assay-core/tests/fixtures/otel_span_event_limit/result.v0.json
+++ b/crates/assay-core/tests/fixtures/otel_span_event_limit/result.v0.json
@@ -1,0 +1,139 @@
+{
+  "schema": "assay.experiment.otel_span_event_limit.v0",
+  "otel_sdk": {
+    "language": "python",
+    "package": "opentelemetry-sdk",
+    "version": "1.42.1"
+  },
+  "default_max_events": 128,
+  "routes": {
+    "default": {
+      "max_events": 128,
+      "cases": [
+        {
+          "events_in": 0,
+          "events_exported": 0,
+          "events_dropped": 0,
+          "event_order_policy_observed": "n/a",
+          "first_kept": null,
+          "last_kept": null
+        },
+        {
+          "events_in": 1,
+          "events_exported": 1,
+          "events_dropped": 0,
+          "event_order_policy_observed": "first_n",
+          "first_kept": "ev_0",
+          "last_kept": "ev_0"
+        },
+        {
+          "events_in": 127,
+          "events_exported": 127,
+          "events_dropped": 0,
+          "event_order_policy_observed": "first_n",
+          "first_kept": "ev_0",
+          "last_kept": "ev_126"
+        },
+        {
+          "events_in": 128,
+          "events_exported": 128,
+          "events_dropped": 0,
+          "event_order_policy_observed": "first_n",
+          "first_kept": "ev_0",
+          "last_kept": "ev_127"
+        },
+        {
+          "events_in": 129,
+          "events_exported": 128,
+          "events_dropped": 1,
+          "event_order_policy_observed": "last_n",
+          "first_kept": "ev_1",
+          "last_kept": "ev_128"
+        },
+        {
+          "events_in": 256,
+          "events_exported": 128,
+          "events_dropped": 128,
+          "event_order_policy_observed": "last_n",
+          "first_kept": "ev_128",
+          "last_kept": "ev_255"
+        },
+        {
+          "events_in": 512,
+          "events_exported": 128,
+          "events_dropped": 384,
+          "event_order_policy_observed": "last_n",
+          "first_kept": "ev_384",
+          "last_kept": "ev_511"
+        }
+      ]
+    },
+    "configured_512": {
+      "max_events": 512,
+      "cases": [
+        {
+          "events_in": 0,
+          "events_exported": 0,
+          "events_dropped": 0,
+          "event_order_policy_observed": "n/a",
+          "first_kept": null,
+          "last_kept": null
+        },
+        {
+          "events_in": 1,
+          "events_exported": 1,
+          "events_dropped": 0,
+          "event_order_policy_observed": "first_n",
+          "first_kept": "ev_0",
+          "last_kept": "ev_0"
+        },
+        {
+          "events_in": 127,
+          "events_exported": 127,
+          "events_dropped": 0,
+          "event_order_policy_observed": "first_n",
+          "first_kept": "ev_0",
+          "last_kept": "ev_126"
+        },
+        {
+          "events_in": 128,
+          "events_exported": 128,
+          "events_dropped": 0,
+          "event_order_policy_observed": "first_n",
+          "first_kept": "ev_0",
+          "last_kept": "ev_127"
+        },
+        {
+          "events_in": 129,
+          "events_exported": 129,
+          "events_dropped": 0,
+          "event_order_policy_observed": "first_n",
+          "first_kept": "ev_0",
+          "last_kept": "ev_128"
+        },
+        {
+          "events_in": 256,
+          "events_exported": 256,
+          "events_dropped": 0,
+          "event_order_policy_observed": "first_n",
+          "first_kept": "ev_0",
+          "last_kept": "ev_255"
+        },
+        {
+          "events_in": 512,
+          "events_exported": 512,
+          "events_dropped": 0,
+          "event_order_policy_observed": "first_n",
+          "first_kept": "ev_0",
+          "last_kept": "ev_511"
+        }
+      ]
+    }
+  },
+  "non_claims": [
+    "characterized behavior of one SDK (python opentelemetry-sdk), not all OTel SDKs",
+    "does not prove backend-specific retention or drop reporting",
+    "does not change assay.otel_projection.v0 semantics",
+    "the assay projection emits spans, not span-events, so this limit does not apply to it today"
+  ]
+}

--- a/crates/assay-core/tests/otel_projection.rs
+++ b/crates/assay-core/tests/otel_projection.rs
@@ -284,3 +284,40 @@ fn bless_golden_fixture() {
     )
     .unwrap();
 }
+
+/// #1408: the projection must map high-volume evidence to SPANS, never to span-events on a single
+/// span. The OTel span-event count limit (default 128) silently drops events beyond the cap, and
+/// (per the characterization in docs/reference/otel-span-event-limit.md) drops the OLDEST first. By
+/// emitting one span per tool/decision and carrying detail in attributes, the projection never relies
+/// on span-events, so that limit does not apply to it. This test guards that invariant: a future
+/// change that introduced an `events` array on a span would regress it.
+#[test]
+fn projection_maps_volume_to_spans_not_span_events() {
+    let tools: Vec<String> = (0..200).map(|i| format!("tool_{i}")).collect();
+    let surface = json!({
+        "schema": "assay.runner.capability_surface.v0",
+        "mcp_tools": tools,
+        "policy_decisions": []
+    });
+    let p = project(&surface, None, None);
+    // High tool count becomes many spans, not many events on one span.
+    let tool_spans = p
+        .spans
+        .iter()
+        .filter(|s| s.name.starts_with("execute_tool "))
+        .count();
+    assert_eq!(
+        tool_spans, 200,
+        "each observed tool must project to its own span"
+    );
+
+    // No span carries an `events` array: the projection has no span-event surface to overflow.
+    let value = serde_json::to_value(&p).unwrap();
+    for span in value["spans"].as_array().unwrap() {
+        assert!(
+            span.get("events").is_none(),
+            "projected spans must not carry span-events (would be subject to the OTel 128-event \
+             drop limit); found events on span {span:?}"
+        );
+    }
+}

--- a/docs/reference/otel-span-event-limit.md
+++ b/docs/reference/otel-span-event-limit.md
@@ -1,0 +1,133 @@
+# OTel span-event limit: characterized behavior
+
+This note characterizes how OTel-shaped evidence behaves around the span-event count limit, and
+records the recommended exporter strategy. It is scoped narrowly.
+
+**Claim:** Assay has characterized how its projected OTel-shaped evidence behaves around span-event
+limits, and records the recommended exporter strategy.
+
+**Non-claims:** Assay does not export OTLP live, is not fully OTel-compatible, does not preserve all
+evidence through span-events, and this does not change `assay.otel_projection.v0` semantics.
+
+## The load-bearing fact: the projection emits spans, not span-events
+
+`assay project-otel` maps each observed tool and each policy decision to its own span (a tool span,
+a guardrail span), with detail carried in span attributes. It never appends span-events to a span.
+A `ProjectedSpan` has `name`, `kind`, and `attributes`, and no events array. So the OTel span-event
+count limit does not apply to the projection as it stands today. High evidence volume becomes more
+spans, not more events on one span. The regression guard for this invariant lives in
+`crates/assay-core/tests/otel_projection.rs`
+(`projection_maps_volume_to_spans_not_span_events`).
+
+The limit matters for a future live OTLP exporter only if that exporter were to represent
+high-volume correlated detail (many tool calls, many sub-steps) as span-events on a single span.
+This note characterizes that path so the exporter design avoids the trap.
+
+## Measured behavior
+
+Measured with the Python `opentelemetry-sdk` 1.42.1. Full machine-readable result:
+`crates/assay-core/tests/fixtures/otel_span_event_limit/result.v0.json`
+(`schema: assay.experiment.otel_span_event_limit.v0`).
+
+Default span-event limit (`OTEL_SPAN_EVENT_COUNT_LIMIT` / `SpanLimits.max_events` = 128):
+
+| events added | events retained | events dropped | which were kept |
+|--------------|-----------------|----------------|-----------------|
+| 0            | 0               | 0              | n/a             |
+| 1            | 1               | 0              | all             |
+| 127          | 127             | 0              | all             |
+| 128          | 128             | 0              | all             |
+| 129          | 128             | 1              | the most recent 128 (oldest dropped) |
+| 256          | 128             | 128            | the most recent 128 (oldest dropped) |
+| 512          | 128             | 384            | the most recent 128 (oldest dropped) |
+
+With `max_events = 512`, all counts up to 512 are retained with zero drops.
+
+Two observations worth keeping:
+
+1. Beyond the limit the SDK keeps the most recent N and drops the **oldest** events. For an audit
+   trail that is the wrong end to lose: the earliest actions in a run are often the ones a reviewer
+   most needs. Silent loss of the first events would make a long run look like it started later than
+   it did.
+2. This SDK does expose a `dropped_events` count on the in-memory span, so the loss is at least
+   observable locally. Whether that count survives OTLP export and is surfaced by a given backend is
+   a separate question this note does not test.
+
+## Recommendation for a future live exporter
+
+- Keep span-events for bounded timeline breadcrumbs only.
+- Do not put high-volume evidence detail in span-events. The Assay source artifacts remain the
+  source of truth; the projection should carry summaries, references, counts, and bounded samples,
+  not an unbounded event stream.
+- Continue mapping discrete evidence items (tools, decisions, effects) to their own spans and
+  attributes, which is what the projection already does.
+- For high-volume correlated detail, prefer log-based events with trace context, in line with the
+  OTel direction of moving new event instrumentation toward logs while existing span-events stay
+  compatible.
+- If span-events are ever used, set and document the limit explicitly rather than relying on the
+  default 128, and treat a non-zero `dropped_events` as an observation gap, never as clean.
+
+## Non-claims
+
+- This characterizes one SDK (Python `opentelemetry-sdk`), not all OTel SDKs; another SDK may keep
+  the first N rather than the last N, or report drops differently.
+- It does not prove backend-specific retention or drop reporting.
+- It does not change `assay.otel_projection.v0` semantics.
+- The projection emits spans, not span-events, so the limit does not apply to it today.
+
+## Reproduction
+
+No production dependency is added for this; the measurement runs in a throwaway virtualenv.
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate
+pip install opentelemetry-sdk
+python3 characterize.py > result.v0.json
+```
+
+```python
+# characterize.py
+import json
+from opentelemetry.sdk.trace import TracerProvider, SpanLimits
+
+COUNTS = [0, 1, 127, 128, 129, 256, 512]
+LIMITS = {"default": None, "configured_512": 512}
+
+def measure(events_in, max_events):
+    sl = SpanLimits() if max_events is None else SpanLimits(max_events=max_events)
+    tracer = TracerProvider(span_limits=sl).get_tracer("char")
+    span = tracer.start_span("s")
+    for i in range(events_in):
+        span.add_event(f"ev_{i}")
+    span.end()
+    names = [e.name for e in span.events]
+    order = "n/a"
+    if names:
+        order = "first_n" if names[0] == "ev_0" else (
+            "last_n" if names[-1] == f"ev_{events_in-1}" else "other")
+    return {
+        "events_in": events_in,
+        "events_exported": len(names),
+        "events_dropped": getattr(span, "dropped_events", None),
+        "event_order_policy_observed": order,
+        "first_kept": names[0] if names else None,
+        "last_kept": names[-1] if names else None,
+    }
+
+default_max = SpanLimits().max_events
+import opentelemetry.sdk.version as v
+print(json.dumps({
+    "schema": "assay.experiment.otel_span_event_limit.v0",
+    "otel_sdk": {"language": "python", "package": "opentelemetry-sdk", "version": v.__version__},
+    "default_max_events": default_max,
+    "routes": {label: {"max_events": (default_max if lim is None else lim),
+                       "cases": [measure(n, lim) for n in COUNTS]}
+               for label, lim in LIMITS.items()},
+    "non_claims": [
+        "characterized behavior of one SDK (python opentelemetry-sdk), not all OTel SDKs",
+        "does not prove backend-specific retention or drop reporting",
+        "does not change assay.otel_projection.v0 semantics",
+        "the assay projection emits spans, not span-events, so this limit does not apply to it today",
+    ],
+}, indent=2))
+```


### PR DESCRIPTION
Closes #1408.

Characterizes how OTel-shaped evidence behaves around the span-event count limit and records the recommended exporter strategy.

**Key finding:** the `assay project-otel` projection emits one span per tool/decision with detail in attributes, never span-events, so the OTel 128-event limit does not apply to it today. The concern is forward-looking, for a future live OTLP exporter.

**Measured** (python `opentelemetry-sdk` 1.42.1, committed as `crates/assay-core/tests/fixtures/otel_span_event_limit/result.v0.json`, schema `assay.experiment.otel_span_event_limit.v0`): at the default limit of 128, records beyond 128 are dropped keeping the most recent 128 and dropping the **oldest**, with a `dropped_events` count; `max_events=512` retains all. For an audit trail the oldest end is the wrong end to lose, so a future exporter must not map high-volume evidence to span-events.

**Adds:** `docs/reference/otel-span-event-limit.md` (findings + recommendation + non-claims + inline reproduction), the measured fixture, and a regression-guard test (`projection_maps_volume_to_spans_not_span_events`).

**Not done (bounded):** no live OTLP exporter, no new production dependency, no `assay.otel_projection.v0` schema change, no GenAI semconv upgrade.

Lane: docs + assay-core test/fixture only, so `gates=none`.