### PR TITLE
docs(mcp): tool-decision surface spec + reference fixtures (P57a)

### DIFF
--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_allow.json
@@ -1,0 +1,16 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {"id": "github", "transport": "mcp", "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
+      "tool": {"name": "github.add_deploy_key", "category": "github_deploy_key"},
+      "classification": "classified",
+      "action": {"class": "privileged_admin_action", "verb": "create", "resource_type": "github_deploy_key",
+                 "target": {"provider": "github", "owner": "org", "repo": "prod-repo", "key_title_hash": "sha256:aaaa", "read_only": false}},
+      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.github.deploy_key.allow.prod", "enforced": true},
+      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
+      "redaction": {"arguments_redacted": true, "credential_alias": "github-prod-admin", "secret_material_stored": false}
+    }
+  ],
+  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+}

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_deny.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_deny.json
@@ -1,0 +1,16 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {"id": "github", "transport": "mcp", "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
+      "tool": {"name": "github.add_deploy_key", "category": "github_deploy_key"},
+      "classification": "classified",
+      "action": {"class": "privileged_admin_action", "verb": "create", "resource_type": "github_deploy_key",
+                 "target": {"provider": "github", "owner": "org", "repo": "prod-repo", "read_only": false}},
+      "decision": {"effect": "deny", "source": "assay-mcp-server", "rule_id": "tool.github.deploy_key.deny.default", "enforced": true},
+      "response": {"status": "blocked", "side_effect_asserted": false, "side_effect_verified": false},
+      "redaction": {"arguments_redacted": true, "credential_alias": "github-prod-admin", "secret_material_stored": false}
+    }
+  ],
+  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+}

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_incomplete.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_incomplete.json
@@ -1,0 +1,17 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {"id": "github", "transport": "mcp", "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
+      "tool": {"name": "github.add_deploy_key", "category": "github_deploy_key"},
+      "classification": "classified_incomplete",
+      "action": {"class": "privileged_admin_action", "verb": "create", "resource_type": "github_deploy_key",
+                 "target": {"provider": "github", "owner": "org"}},
+      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.github.deploy_key.allow.prod", "enforced": true},
+      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
+      "redaction": {"arguments_redacted": true, "credential_alias": "github-prod-admin", "secret_material_stored": false},
+      "incomplete_reason": "missing required argument: repo"
+    }
+  ],
+  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+}

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/redacted_and_sanitized.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/redacted_and_sanitized.json
@@ -1,0 +1,16 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {"id": "github", "transport": "mcp", "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
+      "tool": {"name": "github.add_deploy_key", "category": "github_deploy_key"},
+      "classification": "classified",
+      "action": {"class": "privileged_admin_action", "verb": "create", "resource_type": "github_deploy_key",
+                 "target": {"provider": "github", "owner": "org", "repo": "prod-repo", "key_title": "ci-key��", "read_only": true}},
+      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.github.deploy_key.allow.prod", "enforced": true},
+      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
+      "redaction": {"arguments_redacted": true, "credential_alias": "github-prod-admin", "secret_material_stored": false, "sanitized_fields": ["action.target.key_title"]}
+    }
+  ],
+  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+}

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/slack_add_member_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/slack_add_member_allow.json
@@ -1,0 +1,16 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {"id": "slack", "transport": "mcp", "declared_manifest_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"},
+      "tool": {"name": "slack.add_member", "category": "slack_add_member"},
+      "classification": "classified",
+      "action": {"class": "privileged_admin_action", "verb": "add", "resource_type": "slack_membership",
+                 "target": {"provider": "slack", "workspace_id": "T0ALIAS", "channel_id": "C0ALIAS", "user_id_hash": "sha256:bbbb", "role": "member"}},
+      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.slack.add_member.allow", "enforced": true},
+      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
+      "redaction": {"arguments_redacted": true, "credential_alias": "slack-bot", "secret_material_stored": false}
+    }
+  ],
+  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+}

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/unknown_tool_observed.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/unknown_tool_observed.json
@@ -1,0 +1,15 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {"id": "misc", "transport": "mcp", "declared_manifest_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"},
+      "tool": {"name": "misc.do_thing", "category": null},
+      "classification": "observed_unknown_tool",
+      "action": {"class": "unclassified", "verb": null, "resource_type": null, "target": null},
+      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.default.allow", "enforced": true},
+      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
+      "redaction": {"arguments_redacted": true, "credential_alias": null, "secret_material_stored": false}
+    }
+  ],
+  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+}

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/workspace_admin_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/workspace_admin_allow.json
@@ -1,0 +1,16 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {"id": "workspace", "transport": "mcp", "declared_manifest_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"},
+      "tool": {"name": "workspace.grant_admin", "category": "workspace_admin"},
+      "classification": "classified",
+      "action": {"class": "privileged_admin_action", "verb": "grant", "resource_type": "workspace_role",
+                 "target": {"provider": "workspace", "org": "acme", "principal_hash": "sha256:cccc", "role": "admin"}},
+      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.workspace.grant_admin.allow", "enforced": true},
+      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
+      "redaction": {"arguments_redacted": true, "credential_alias": "workspace-admin", "secret_material_stored": false}
+    }
+  ],
+  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+}

--- a/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
+++ b/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
@@ -1,0 +1,94 @@
+//! P57a guard: the committed `assay.tool_decision_surface.v0` reference fixtures must hold the
+//! load-bearing invariants of the spec (docs/reference/tool-decision-surface.md). There is no
+//! producer yet (that is P57b/P57c); this only keeps the reference vectors honest so a later
+//! producer has a fixed target and cannot quietly relax the contract.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/tool_decisions")
+}
+
+const KNOWN_CLASSIFICATIONS: &[&str] = &[
+    "classified",
+    "classified_incomplete",
+    "observed_unknown_tool",
+    "not_observed",
+];
+
+#[test]
+fn tool_decision_fixtures_hold_the_spec_invariants() {
+    let dir = fixtures_dir();
+    let mut checked = 0;
+    for entry in fs::read_dir(&dir).expect("fixtures dir") {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap())
+            .unwrap_or_else(|e| {
+                panic!("fixture {} is not valid JSON: {e}", path.display());
+            });
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+
+        assert_eq!(
+            v["schema"].as_str(),
+            Some("assay.tool_decision_surface.v0"),
+            "{name}: wrong schema id"
+        );
+        assert!(
+            v["non_claims"]
+                .as_array()
+                .map(|a| !a.is_empty())
+                .unwrap_or(false),
+            "{name}: non_claims must be present and non-empty"
+        );
+
+        let decisions = v["observed_tool_decisions"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{name}: observed_tool_decisions must be an array"));
+        assert!(
+            !decisions.is_empty(),
+            "{name}: at least one decision expected"
+        );
+
+        for d in decisions {
+            let classification = d["classification"].as_str().unwrap_or("");
+            assert!(
+                KNOWN_CLASSIFICATIONS.contains(&classification),
+                "{name}: unknown classification {classification:?} (an unknown tool must be \
+                 observed_unknown_tool, never absent/clean)"
+            );
+
+            // No raw secret material ever rides in the record.
+            assert_eq!(
+                d["redaction"]["secret_material_stored"].as_bool(),
+                Some(false),
+                "{name}: secret_material_stored must be false"
+            );
+
+            // Asserted is not verified: a fixture must never claim a verified side effect, since
+            // none of these carry independently-checked audit evidence.
+            assert_eq!(
+                d["response"]["side_effect_verified"].as_bool(),
+                Some(false),
+                "{name}: side_effect_verified must be false without verified audit evidence"
+            );
+
+            // A denied decision must not assert a side effect.
+            if d["decision"]["effect"].as_str() == Some("deny") {
+                assert_eq!(
+                    d["response"]["side_effect_asserted"].as_bool(),
+                    Some(false),
+                    "{name}: a denied decision must not assert a side effect"
+                );
+            }
+        }
+        checked += 1;
+    }
+    assert!(
+        checked >= 7,
+        "expected the full reference-vector set, found {checked}"
+    );
+}

--- a/docs/reference/tool-decision-surface.md
+++ b/docs/reference/tool-decision-surface.md
@@ -1,0 +1,158 @@
+# Tool-decision surface (`assay.tool_decision_surface.v0`)
+
+Status: spec + reference fixtures (P57a). No producer wired yet; the `assay-mcp-server` observation
+(P57b) and the classifiers (P57c) build on this shape, and the declared-vs-observed gate (P58)
+consumes it.
+
+## Why this exists
+
+Kernel and network enforcement see that an agent connected to `api.github.com:443`. They do not see
+that the agent, through an MCP tool call, added a deploy key to a production repository or added an
+external user to a Slack workspace. Those privileged in-application actions are the kernel-blind gap.
+The layer that can observe them is the MCP proxy (`assay-mcp-server`), which sees each `tools/call`,
+the policy decision it took, and the response.
+
+`capability_surface.v0` already records observed MCP tools, but only as a flat, deduplicated set of
+tool-name strings plus decision strings (`mcp_tools`, `policy_decisions`). It cannot carry a
+structured per-call record: server identity, the classified action and its target, the
+asserted-versus-verified status of the side effect, or redaction state. So this is a new, explicit
+carrier rather than an overload of the capability surface.
+
+## Claim and non-claims
+
+**Claim:** Assay records observed MCP tool decisions as evidence, including privileged-action
+classification where the proxy can determine it.
+
+**Non-claims (global):**
+
+- does not prove the external SaaS side effect happened or persisted without independently verified
+  audit evidence;
+- does not infer tool actions outside observed MCP proxy traffic;
+- does not expose raw secrets or tokens;
+- does not replace the provider's own audit log.
+
+## The load-bearing rule: asserted vs verified
+
+This is the rule the whole surface is built to keep honest.
+
+| Layer | Status |
+|-------|--------|
+| observed `tools/call` request | observed |
+| proxy policy decision | observed / enforced by the proxy |
+| SaaS side effect | **asserted** unless independently verified |
+| SaaS audit log | external **verified** evidence, only if imported and checked |
+
+A tool returning `"deploy key added"` is the provider's assertion, not proof. The record may carry
+it, but must label it: `response.side_effect_asserted` can be true while
+`response.side_effect_verified` stays false. `side_effect_verified` only becomes true when separate,
+checked audit evidence confirms it. The surface never silently promotes asserted to verified.
+
+## Classification states
+
+The classifier is honest about what it could and could not determine:
+
+| State | Meaning |
+|-------|---------|
+| `classified` | a known privileged tool was observed and its target projected |
+| `classified_incomplete` | known tool, but required argument fields were missing |
+| `observed_unknown_tool` | a tool call was observed but matched no classifier |
+| `not_observed` | the tool path was outside the proxy; nothing observed |
+
+An unknown tool is never silently treated as clean, and missing arguments are never treated as safe.
+"No observed tool calls" does not mean "no tool capability"; only "no observed tool calls plus
+complete tool observation" means "no observed tool use in this run" (see P58 coverage).
+
+## Record shape
+
+```json
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {
+        "id": "github",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:..."
+      },
+      "tool": { "name": "github.add_deploy_key", "category": "github_deploy_key" },
+      "classification": "classified",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "create",
+        "resource_type": "github_deploy_key",
+        "target": { "provider": "github", "owner": "org", "repo": "prod-repo" }
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.github.deploy_key.allow.prod",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": false
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "github-prod-admin",
+        "secret_material_stored": false
+      }
+    }
+  ],
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
+}
+```
+
+## Classifiers (P57c)
+
+Classifiers are rule-based and explicit. No model or judge decides a classification. Start narrow,
+with three concrete cases; broaden only with a fixture per added case.
+
+### `github_deploy_key`
+
+- Tool names / aliases: `github.add_deploy_key`, `create_deploy_key`, equivalents.
+- Required argument fields: `owner`, `repo` (a missing one yields `classified_incomplete`).
+- Target projection: `owner`, `repo`, `key_title_hash` (or redacted title), `read_only` flag if
+  present.
+- Non-claims: does not store public or private key material; does not prove the key works; does not
+  prove GitHub persisted it without audit confirmation.
+
+### `slack_add_member`
+
+- Tool names / aliases: `slack.add_member`, `conversations.invite`, equivalents.
+- Required fields: workspace or channel identifier, principal identifier.
+- Target projection: `workspace_id` or alias, `channel_id` or user-group, `user_id` hash or redacted
+  principal, role/class if present.
+- Non-claims: does not prove Slack accepted the membership unless verified response/audit evidence;
+  does not store tokens.
+
+### `workspace_admin`
+
+A category for `grant_admin`, `change_role`, `invite_external`, `create_workspace_token`,
+`modify_org_policy`. Kept deliberately narrow in P57: one concrete tool fixture, not the whole class.
+
+## Redaction and sanitization
+
+- Raw secrets and tokens never appear in the record. A credential is referenced by a stable alias
+  (`credential_alias`), and `secret_material_stored` is always `false`.
+- Argument values that carry sensitive identifiers are redacted or hashed, not stored verbatim
+  (`arguments_redacted: true`).
+- Hostile strings in arguments (terminal escapes, control characters) are sanitized before the record
+  is written, the same discipline the evidence TUI/rendering already applies.
+
+## Reference fixtures
+
+`crates/assay-mcp-server/tests/fixtures/tool_decisions/`:
+
+- `github_deploy_key_allow.json` — classified, allowed, side effect asserted not verified
+- `github_deploy_key_deny.json` — classified, denied by policy
+- `github_deploy_key_incomplete.json` — `classified_incomplete` (missing `repo`)
+- `slack_add_member_allow.json` — classified, allowed
+- `workspace_admin_allow.json` — classified, allowed (one concrete tool)
+- `unknown_tool_observed.json` — `observed_unknown_tool`, never clean
+- `redacted_and_sanitized.json` — secret alias only, control chars sanitized


### PR DESCRIPTION
First step of the tool-decision observed-vs-declared arc (P57/P58), spec + fixtures only, no producer.

Adds `assay.tool_decision_surface.v0` (`docs/reference/tool-decision-surface.md`): the kernel-blind privileged-action gap (kernel sees `api.github.com:443`, not 'added a deploy key to prod'), the load-bearing **asserted-vs-verified** rule (a tool returning 'deploy key added' is the provider's assertion, never proof; `side_effect_verified` only on checked audit evidence), honest classification states (an unknown tool is `observed_unknown_tool`, never clean; missing args is `classified_incomplete`, never safe), three rule-based classifiers (github_deploy_key / slack_add_member / workspace_admin), and redaction rules (no raw secrets; credential alias only; hostile strings sanitized).

A new carrier is justified: `capability_surface.v0` only carries flat `mcp_tools`/`policy_decisions` string sets, not a structured per-call record.

Adds 7 reference fixtures + a guard test pinning the invariants. Producer is P57b/P57c. Lane: docs + assay-mcp-server fixtures/test only, `gates=none`.