### PR TITLE
feat(mcp): rule-based privileged-action classifiers (P57c)

### DIFF
--- a/crates/assay-mcp-server/src/server.rs
+++ b/crates/assay-mcp-server/src/server.rs
@@ -391,6 +391,9 @@ impl Server {
                             let decision = build_decision(&ObservedCall {
                                 server_id: "mcp",
                                 tool_name: name,
+                                // Inspected transiently by the classifier to project named target
+                                // fields (hashed); never copied into the record verbatim.
+                                args,
                                 effect,
                                 status: &status,
                                 rule_id: None,

--- a/crates/assay-mcp-server/src/tool_decision.rs
+++ b/crates/assay-mcp-server/src/tool_decision.rs
@@ -14,9 +14,50 @@
 //! `workspace_admin` classifiers) is P57c. Until then every observed tool is `observed_unknown_tool`,
 //! which is deliberately never read as clean.
 
+use crate::cache::sha256_hex;
 use serde_json::{json, Value};
 
 pub const SCHEMA: &str = "assay.tool_decision_surface.v0";
+
+/// Domain-separated, normalized pseudonym for a sensitive identifier. The value is trimmed and
+/// lowercased, then hashed under a per-field domain (`assay.tool_target.v0:<domain>:<value>`) so a
+/// hash from one field can never collide with another, and the raw value is never stored.
+///
+/// This is pseudonymization, not anonymization: equal inputs yield equal hashes. The only claim is
+/// that the raw argument is not stored, not that the principal is unrecoverable.
+fn target_hash(domain: &str, value: &str) -> String {
+    let normalized = value.trim().to_lowercase();
+    let preimage = format!("assay.tool_target.v0:{domain}:{normalized}");
+    format!("sha256:{}", sha256_hex(preimage.as_bytes()))
+}
+
+/// Argument keys whose values are secret-like. The classifiers never read these for projection and
+/// never hash them (a hash of a public key can still leak correlation; a token hash invites offline
+/// brute force). They are dropped by construction: the classifiers only read the allowlisted target
+/// fields. This list and the detector below exist to TEST that discipline, not to drive it.
+#[cfg(test)]
+const SECRET_LIKE_KEYS: &[&str] = &[
+    "public_key",
+    "private_key",
+    "token",
+    "access_token",
+    "authorization",
+    "secret",
+    "credential",
+    "password",
+    "api_key",
+];
+
+fn str_field<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
+    args.get(key).and_then(|v| v.as_str())
+}
+
+#[cfg(test)]
+fn observed_secret_arg(args: &Value) -> bool {
+    args.as_object()
+        .map(|o| o.keys().any(|k| SECRET_LIKE_KEYS.contains(&k.as_str())))
+        .unwrap_or(false)
+}
 
 /// The effect the proxy decided for the call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,11 +81,199 @@ impl Effect {
 pub struct ObservedCall<'a> {
     pub server_id: &'a str,
     pub tool_name: &'a str,
+    /// Raw call arguments. They are inspected by the classifier to PROJECT named target fields
+    /// (hashing sensitive ids); they are never copied into the record verbatim.
+    pub args: &'a Value,
     pub effect: Effect,
     /// Machine-readable status string (e.g. "success", "blocked", "error", "timeout").
     pub status: &'a str,
     /// Policy rule id if the decision named one; `None` falls back to a neutral marker.
     pub rule_id: Option<&'a str>,
+}
+
+/// Outcome of running the rule-based privileged-action classifiers over one observed call. Total:
+/// every call yields one of the states below, never `None`. An unrecognized tool is still evidence.
+pub struct Classified {
+    /// Tool category (`github_deploy_key` etc.), or `None` for an unrecognized tool.
+    pub category: Option<&'static str>,
+    /// One of: `classified`, `classified_incomplete`, `observed_unknown_tool`, `redaction_failed`.
+    pub state: &'static str,
+    pub class: &'static str,
+    pub verb: Option<&'static str>,
+    pub resource_type: Option<&'static str>,
+    /// Projected target: only named, allowlisted fields, sensitive ids hashed. `Null` when unknown.
+    pub target: Value,
+    /// Machine-readable reason for the state (downstream never parses prose).
+    pub reason_code: &'static str,
+    /// Optional human-readable specifics (e.g. which field was missing).
+    pub detail: Option<String>,
+}
+
+fn unknown() -> Classified {
+    Classified {
+        category: None,
+        state: "observed_unknown_tool",
+        class: "unclassified",
+        verb: None,
+        resource_type: None,
+        target: Value::Null,
+        reason_code: "unknown_tool_name",
+        detail: None,
+    }
+}
+
+fn incomplete(
+    category: &'static str,
+    verb: &'static str,
+    resource_type: &'static str,
+    target: Value,
+    detail: &str,
+) -> Classified {
+    Classified {
+        category: Some(category),
+        state: "classified_incomplete",
+        class: "privileged_admin_action",
+        verb: Some(verb),
+        resource_type: Some(resource_type),
+        target,
+        reason_code: "missing_required_target_field",
+        detail: Some(detail.to_string()),
+    }
+}
+
+/// Rule-based privileged-action classifiers. Explicit name/alias matching only; no model or judge
+/// decides a classification. The classifier reads args ONLY to project allowlisted target fields,
+/// hashing sensitive ids under per-field domains; everything else (including any secret-like key) is
+/// dropped, never copied. A matched tool with a missing required field is `classified_incomplete`
+/// (never silently safe); an unmatched tool is `observed_unknown_tool` (never silently clean).
+pub fn classify(tool_name: &str, args: &Value) -> Classified {
+    let leaf = tool_name.rsplit('.').next().unwrap_or(tool_name);
+
+    // github_deploy_key: owner + repo are required; owner/repo are plain (not sensitive), the key
+    // title is hashed, the public/private key material is dropped (never read).
+    if matches!(leaf, "add_deploy_key" | "create_deploy_key") {
+        let owner = str_field(args, "owner");
+        let repo = str_field(args, "repo");
+        let mut target = json!({ "provider": "github" });
+        if let Some(o) = owner {
+            target["owner"] = json!(sanitize(o));
+        }
+        if let (Some(_), Some(r)) = (owner, repo) {
+            target["repo"] = json!(sanitize(r));
+            if let Some(title) = str_field(args, "title").or_else(|| str_field(args, "key_title")) {
+                target["key_title_hash"] = json!(target_hash("github_key_title", title));
+            }
+            if let Some(ro) = args.get("read_only").and_then(|v| v.as_bool()) {
+                target["read_only"] = json!(ro);
+            }
+            return Classified {
+                category: Some("github_deploy_key"),
+                state: "classified",
+                class: "privileged_admin_action",
+                verb: Some("create"),
+                resource_type: Some("github_deploy_key"),
+                target,
+                reason_code: "classified_github_deploy_key",
+                detail: None,
+            };
+        }
+        return incomplete(
+            "github_deploy_key",
+            "create",
+            "github_deploy_key",
+            target,
+            "missing_github_owner_or_repo",
+        );
+    }
+
+    // slack_add_member: a scope (workspace and/or channel) plus a principal. All ids are hashed
+    // under their own domains; channel is null for workspace-level membership.
+    if matches!(leaf, "add_member" | "invite") {
+        let workspace = str_field(args, "workspace_id");
+        let channel = str_field(args, "channel_id");
+        let principal = str_field(args, "user_id").or_else(|| str_field(args, "user"));
+        if let (true, Some(p)) = (workspace.is_some() || channel.is_some(), principal) {
+            let target = json!({
+                "provider": "slack",
+                "workspace_id_hash": workspace.map(|w| target_hash("slack_workspace", w)),
+                "channel_id_hash": channel.map(|c| target_hash("slack_channel", c)),
+                "principal_hash": target_hash("slack_principal", p),
+            });
+            return Classified {
+                category: Some("slack_add_member"),
+                state: "classified",
+                class: "privileged_admin_action",
+                verb: Some("add"),
+                resource_type: Some("workspace_member"),
+                target,
+                reason_code: "classified_slack_add_member",
+                detail: None,
+            };
+        }
+        let detail = if principal.is_none() {
+            "missing_slack_principal"
+        } else {
+            "missing_slack_scope"
+        };
+        return incomplete(
+            "slack_add_member",
+            "add",
+            "workspace_member",
+            json!({ "provider": "slack" }),
+            detail,
+        );
+    }
+
+    // workspace_admin: a deliberately narrow set of concrete admin verbs. workspace + principal are
+    // hashed; the role is a plain label.
+    let workspace_verb = match leaf {
+        "grant_admin" => Some("grant"),
+        "change_role" => Some("change_role"),
+        "invite_external" => Some("invite"),
+        "modify_org_policy" => Some("modify"),
+        "create_workspace_token" => Some("create"),
+        _ => None,
+    };
+    if let Some(verb) = workspace_verb {
+        let workspace = str_field(args, "workspace_id")
+            .or_else(|| str_field(args, "workspace"))
+            .or_else(|| str_field(args, "org"));
+        let principal = str_field(args, "principal").or_else(|| str_field(args, "user"));
+        if let (Some(w), Some(p)) = (workspace, principal) {
+            let mut target = json!({
+                "provider": "workspace",
+                "workspace_id_hash": target_hash("workspace", w),
+                "principal_hash": target_hash("workspace_principal", p),
+            });
+            if let Some(role) = str_field(args, "role") {
+                target["role"] = json!(sanitize(role));
+            }
+            return Classified {
+                category: Some("workspace_admin"),
+                state: "classified",
+                class: "privileged_admin_action",
+                verb: Some(verb),
+                resource_type: Some("workspace_role"),
+                target,
+                reason_code: "classified_workspace_admin",
+                detail: None,
+            };
+        }
+        let detail = if workspace.is_none() {
+            "missing_workspace_id"
+        } else {
+            "missing_workspace_principal"
+        };
+        return incomplete(
+            "workspace_admin",
+            verb,
+            "workspace_role",
+            json!({ "provider": "workspace" }),
+            detail,
+        );
+    }
+
+    unknown()
 }
 
 /// Replace control characters (other than tab/newline/carriage-return) with U+FFFD, so a hostile
@@ -69,12 +298,24 @@ pub fn build_decision(call: &ObservedCall<'_>) -> Value {
     // A side effect is *asserted* only when the tool was allowed and returned success. It is never
     // *verified* by the proxy.
     let side_effect_asserted = matches!(call.effect, Effect::Allow) && call.status == "success";
-    json!({
+    let c = classify(call.tool_name, call.args);
+    let mut decision = json!({
         "server": { "id": sanitize(call.server_id), "transport": "mcp" },
-        "tool": { "name": sanitize(call.tool_name), "category": Value::Null },
-        // No classifier yet (P57c): an observed-but-unclassified tool is never clean.
-        "classification": "observed_unknown_tool",
-        "action": { "class": "unclassified", "verb": Value::Null, "resource_type": Value::Null, "target": Value::Null },
+        "tool": {
+            "name": sanitize(call.tool_name),
+            "category": c.category.map(Value::from).unwrap_or(Value::Null)
+        },
+        "classification": c.state,
+        // Machine-readable reason for the classification; downstream never parses prose.
+        "reason_code": c.reason_code,
+        "action": {
+            "class": c.class,
+            "verb": c.verb.map(Value::from).unwrap_or(Value::Null),
+            "resource_type": c.resource_type.map(Value::from).unwrap_or(Value::Null),
+            // The target carries only named, allowlisted fields the classifier projected (sensitive
+            // ids hashed under per-field domains); never raw args, never secret material.
+            "target": c.target
+        },
         "decision": {
             "effect": call.effect.as_str(),
             "source": "assay-mcp-server",
@@ -91,7 +332,11 @@ pub fn build_decision(call: &ObservedCall<'_>) -> Value {
             "credential_alias": Value::Null,
             "secret_material_stored": false
         }
-    })
+    });
+    if let Some(detail) = c.detail {
+        decision["detail"] = Value::String(detail);
+    }
+    decision
 }
 
 /// Wrap one or more decisions into the full `assay.tool_decision_surface.v0` surface.
@@ -111,10 +356,16 @@ pub fn surface(decisions: Vec<Value>) -> Value {
 mod tests {
     use super::*;
 
-    fn call<'a>(tool: &'a str, effect: Effect, status: &'a str) -> ObservedCall<'a> {
+    fn call<'a>(
+        tool: &'a str,
+        args: &'a Value,
+        effect: Effect,
+        status: &'a str,
+    ) -> ObservedCall<'a> {
         ObservedCall {
             server_id: "github",
             tool_name: tool,
+            args,
             effect,
             status,
             rule_id: Some("r1"),
@@ -123,44 +374,34 @@ mod tests {
 
     #[test]
     fn allowed_success_asserts_but_never_verifies_the_side_effect() {
-        let d = build_decision(&call("github.add_deploy_key", Effect::Allow, "success"));
+        let a = json!({});
+        let d = build_decision(&call("github.add_deploy_key", &a, Effect::Allow, "success"));
         assert_eq!(d["response"]["side_effect_asserted"], json!(true));
         assert_eq!(d["response"]["side_effect_verified"], json!(false));
     }
 
     #[test]
     fn denied_call_asserts_no_side_effect() {
-        let d = build_decision(&call("github.add_deploy_key", Effect::Deny, "blocked"));
+        let a = json!({"owner": "org", "repo": "prod-repo"});
+        let d = build_decision(&call("github.add_deploy_key", &a, Effect::Deny, "blocked"));
         assert_eq!(d["response"]["side_effect_asserted"], json!(false));
         assert_eq!(d["response"]["side_effect_verified"], json!(false));
     }
 
     #[test]
-    fn arguments_and_secrets_are_never_in_the_record() {
-        // build_decision takes no arguments at all, so a secret in the call cannot leak; the record
-        // states it explicitly.
-        let d = build_decision(&call("misc.do_thing", Effect::Allow, "success"));
-        let text = serde_json::to_string(&d).unwrap();
-        assert!(
-            !text.contains("ghp_"),
-            "no token-shaped material in the record"
-        );
-        assert_eq!(d["redaction"]["arguments_redacted"], json!(true));
-        assert_eq!(d["redaction"]["secret_material_stored"], json!(false));
-        assert_eq!(d["redaction"]["credential_alias"], json!(null));
-    }
-
-    #[test]
     fn unclassified_tool_is_observed_unknown_never_clean() {
-        let d = build_decision(&call("misc.do_thing", Effect::Allow, "success"));
+        let a = json!({});
+        let d = build_decision(&call("misc.do_thing", &a, Effect::Allow, "success"));
         assert_eq!(d["classification"], json!("observed_unknown_tool"));
+        assert_eq!(d["reason_code"], json!("unknown_tool_name"));
         assert_eq!(d["action"]["class"], json!("unclassified"));
     }
 
     #[test]
     fn hostile_strings_are_sanitized() {
+        let a = json!({});
         let hostile = "tool\u{1b}[31m\u{0000}";
-        let d = build_decision(&call(hostile, Effect::Allow, "success"));
+        let d = build_decision(&call(hostile, &a, Effect::Allow, "success"));
         let name = d["tool"]["name"].as_str().unwrap();
         assert!(
             !name.contains('\u{1b}') && !name.contains('\u{0000}'),
@@ -171,12 +412,163 @@ mod tests {
 
     #[test]
     fn surface_carries_schema_and_non_claims() {
-        let s = surface(vec![build_decision(&call("t", Effect::Allow, "success"))]);
+        let a = json!({});
+        let s = surface(vec![build_decision(&call(
+            "t",
+            &a,
+            Effect::Allow,
+            "success",
+        ))]);
         assert_eq!(s["schema"], json!(SCHEMA));
         assert!(s["non_claims"]
             .as_array()
             .map(|a| !a.is_empty())
             .unwrap_or(false));
         assert_eq!(s["observed_tool_decisions"].as_array().unwrap().len(), 1);
+    }
+
+    // ---- P57c classifiers ----
+
+    #[test]
+    fn github_deploy_key_classified_projects_owner_repo_and_hashed_title() {
+        let a = json!({"owner": "org", "repo": "prod-repo", "title": "ci-key", "read_only": true,
+                       "public_key": "ssh-ed25519 AAAA...", "token": "ghp_secret"});
+        let d = build_decision(&call("github.add_deploy_key", &a, Effect::Allow, "success"));
+        assert_eq!(d["classification"], json!("classified"));
+        assert_eq!(d["reason_code"], json!("classified_github_deploy_key"));
+        assert_eq!(d["tool"]["category"], json!("github_deploy_key"));
+        let t = &d["action"]["target"];
+        assert_eq!(t["owner"], json!("org"));
+        assert_eq!(t["repo"], json!("prod-repo"));
+        assert_eq!(t["read_only"], json!(true));
+        assert_eq!(
+            t["key_title_hash"],
+            json!(target_hash("github_key_title", "ci-key"))
+        );
+        // The secret material is dropped, not hashed and not stored.
+        let text = serde_json::to_string(&d).unwrap();
+        assert!(
+            observed_secret_arg(&a),
+            "fixture must include a secret-like arg"
+        );
+        for raw in ["ssh-ed25519", "AAAA", "ghp_secret", "ci-key"] {
+            assert!(
+                !text.contains(raw),
+                "raw value {raw} must not appear in the record"
+            );
+        }
+    }
+
+    #[test]
+    fn github_deploy_key_missing_repo_is_incomplete() {
+        let a = json!({"owner": "org"});
+        let d = build_decision(&call("github.add_deploy_key", &a, Effect::Allow, "success"));
+        assert_eq!(d["classification"], json!("classified_incomplete"));
+        assert_eq!(d["reason_code"], json!("missing_required_target_field"));
+        assert_eq!(d["detail"], json!("missing_github_owner_or_repo"));
+        assert_eq!(d["action"]["target"]["owner"], json!("org"));
+        assert!(d["action"]["target"].get("repo").is_none());
+    }
+
+    #[test]
+    fn slack_add_member_classified_hashes_all_ids() {
+        let a =
+            json!({"workspace_id": "T0123", "channel_id": "C0123", "user": "alice@example.com"});
+        let d = build_decision(&call("slack.add_member", &a, Effect::Allow, "success"));
+        assert_eq!(d["classification"], json!("classified"));
+        assert_eq!(d["reason_code"], json!("classified_slack_add_member"));
+        assert_eq!(d["action"]["resource_type"], json!("workspace_member"));
+        let t = &d["action"]["target"];
+        assert_eq!(
+            t["workspace_id_hash"],
+            json!(target_hash("slack_workspace", "T0123"))
+        );
+        assert_eq!(
+            t["channel_id_hash"],
+            json!(target_hash("slack_channel", "C0123"))
+        );
+        assert_eq!(
+            t["principal_hash"],
+            json!(target_hash("slack_principal", "alice@example.com"))
+        );
+        let text = serde_json::to_string(&d).unwrap();
+        assert!(
+            !text.contains("alice@example.com"),
+            "raw email must not appear"
+        );
+    }
+
+    #[test]
+    fn slack_workspace_level_membership_has_null_channel() {
+        let a = json!({"workspace_id": "T0123", "user_id": "U999"});
+        let d = build_decision(&call("slack.add_member", &a, Effect::Allow, "success"));
+        assert_eq!(d["classification"], json!("classified"));
+        assert_eq!(d["action"]["target"]["channel_id_hash"], json!(null));
+    }
+
+    #[test]
+    fn slack_missing_principal_is_incomplete() {
+        let a = json!({"workspace_id": "T0123"});
+        let d = build_decision(&call("slack.add_member", &a, Effect::Allow, "success"));
+        assert_eq!(d["classification"], json!("classified_incomplete"));
+        assert_eq!(d["detail"], json!("missing_slack_principal"));
+    }
+
+    #[test]
+    fn workspace_admin_classified_hashes_workspace_and_principal() {
+        let a = json!({"workspace_id": "acme", "principal": "bob@example.com", "role": "admin"});
+        let d = build_decision(&call("workspace.grant_admin", &a, Effect::Allow, "success"));
+        assert_eq!(d["classification"], json!("classified"));
+        assert_eq!(d["reason_code"], json!("classified_workspace_admin"));
+        assert_eq!(d["action"]["resource_type"], json!("workspace_role"));
+        let t = &d["action"]["target"];
+        assert_eq!(
+            t["workspace_id_hash"],
+            json!(target_hash("workspace", "acme"))
+        );
+        assert_eq!(
+            t["principal_hash"],
+            json!(target_hash("workspace_principal", "bob@example.com"))
+        );
+        assert_eq!(t["role"], json!("admin"));
+    }
+
+    #[test]
+    fn workspace_admin_unknown_verb_is_observed_unknown() {
+        let a = json!({"workspace_id": "acme", "principal": "x"});
+        let d = build_decision(&call(
+            "workspace.do_random_thing",
+            &a,
+            Effect::Allow,
+            "success",
+        ));
+        assert_eq!(d["classification"], json!("observed_unknown_tool"));
+        assert_eq!(d["reason_code"], json!("unknown_tool_name"));
+    }
+
+    #[test]
+    fn hashes_are_domain_separated() {
+        // The same raw value under two field domains must not collide.
+        assert_ne!(
+            target_hash("slack_principal", "alice@example.com"),
+            target_hash("workspace_principal", "alice@example.com")
+        );
+    }
+
+    #[test]
+    fn extra_and_secret_args_are_ignored_not_copied() {
+        let a = json!({"owner": "org", "repo": "r", "junk": "ignore-me", "api_key": "sk-xyz"});
+        let d = build_decision(&call("github.add_deploy_key", &a, Effect::Allow, "success"));
+        let t = &d["action"]["target"];
+        // Only allowlisted fields appear.
+        let keys: Vec<&str> = t.as_object().unwrap().keys().map(|s| s.as_str()).collect();
+        for k in &keys {
+            assert!(
+                ["provider", "owner", "repo", "key_title_hash", "read_only"].contains(k),
+                "unexpected target field {k}"
+            );
+        }
+        let text = serde_json::to_string(&d).unwrap();
+        assert!(!text.contains("ignore-me") && !text.contains("sk-xyz"));
     }
 }

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_allow.json
@@ -2,15 +2,50 @@
   "schema": "assay.tool_decision_surface.v0",
   "observed_tool_decisions": [
     {
-      "server": {"id": "github", "transport": "mcp", "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
-      "tool": {"name": "github.add_deploy_key", "category": "github_deploy_key"},
+      "server": {
+        "id": "github",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "tool": {
+        "name": "github.add_deploy_key",
+        "category": "github_deploy_key"
+      },
       "classification": "classified",
-      "action": {"class": "privileged_admin_action", "verb": "create", "resource_type": "github_deploy_key",
-                 "target": {"provider": "github", "owner": "org", "repo": "prod-repo", "key_title_hash": "sha256:aaaa", "read_only": false}},
-      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.github.deploy_key.allow.prod", "enforced": true},
-      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
-      "redaction": {"arguments_redacted": true, "credential_alias": "github-prod-admin", "secret_material_stored": false}
+      "reason_code": "classified_github_deploy_key",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "create",
+        "resource_type": "github_deploy_key",
+        "target": {
+          "provider": "github",
+          "owner": "org",
+          "repo": "prod-repo",
+          "key_title_hash": "sha256:a65a94d25524f87fbb5ce6d3fde202c02a5b532f27e1ba3b5708076e1ba75ccf",
+          "read_only": false
+        }
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.github.deploy_key.allow.prod",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": false
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "github-prod-admin",
+        "secret_material_stored": false
+      }
     }
   ],
-  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
 }

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_deny.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_deny.json
@@ -2,15 +2,49 @@
   "schema": "assay.tool_decision_surface.v0",
   "observed_tool_decisions": [
     {
-      "server": {"id": "github", "transport": "mcp", "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
-      "tool": {"name": "github.add_deploy_key", "category": "github_deploy_key"},
+      "server": {
+        "id": "github",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "tool": {
+        "name": "github.add_deploy_key",
+        "category": "github_deploy_key"
+      },
       "classification": "classified",
-      "action": {"class": "privileged_admin_action", "verb": "create", "resource_type": "github_deploy_key",
-                 "target": {"provider": "github", "owner": "org", "repo": "prod-repo", "read_only": false}},
-      "decision": {"effect": "deny", "source": "assay-mcp-server", "rule_id": "tool.github.deploy_key.deny.default", "enforced": true},
-      "response": {"status": "blocked", "side_effect_asserted": false, "side_effect_verified": false},
-      "redaction": {"arguments_redacted": true, "credential_alias": "github-prod-admin", "secret_material_stored": false}
+      "reason_code": "classified_github_deploy_key",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "create",
+        "resource_type": "github_deploy_key",
+        "target": {
+          "provider": "github",
+          "owner": "org",
+          "repo": "prod-repo",
+          "read_only": false
+        }
+      },
+      "decision": {
+        "effect": "deny",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.github.deploy_key.deny.default",
+        "enforced": true
+      },
+      "response": {
+        "status": "blocked",
+        "side_effect_asserted": false,
+        "side_effect_verified": false
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "github-prod-admin",
+        "secret_material_stored": false
+      }
     }
   ],
-  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
 }

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_incomplete.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_incomplete.json
@@ -2,16 +2,48 @@
   "schema": "assay.tool_decision_surface.v0",
   "observed_tool_decisions": [
     {
-      "server": {"id": "github", "transport": "mcp", "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
-      "tool": {"name": "github.add_deploy_key", "category": "github_deploy_key"},
+      "server": {
+        "id": "github",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "tool": {
+        "name": "github.add_deploy_key",
+        "category": "github_deploy_key"
+      },
       "classification": "classified_incomplete",
-      "action": {"class": "privileged_admin_action", "verb": "create", "resource_type": "github_deploy_key",
-                 "target": {"provider": "github", "owner": "org"}},
-      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.github.deploy_key.allow.prod", "enforced": true},
-      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
-      "redaction": {"arguments_redacted": true, "credential_alias": "github-prod-admin", "secret_material_stored": false},
-      "incomplete_reason": "missing required argument: repo"
+      "reason_code": "missing_required_target_field",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "create",
+        "resource_type": "github_deploy_key",
+        "target": {
+          "provider": "github",
+          "owner": "org"
+        }
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.github.deploy_key.allow.prod",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": false
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "github-prod-admin",
+        "secret_material_stored": false
+      },
+      "detail": "missing_github_owner_or_repo"
     }
   ],
-  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
 }

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/redacted_and_sanitized.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/redacted_and_sanitized.json
@@ -2,15 +2,53 @@
   "schema": "assay.tool_decision_surface.v0",
   "observed_tool_decisions": [
     {
-      "server": {"id": "github", "transport": "mcp", "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
-      "tool": {"name": "github.add_deploy_key", "category": "github_deploy_key"},
+      "server": {
+        "id": "github",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "tool": {
+        "name": "github.add_deploy_key",
+        "category": "github_deploy_key"
+      },
       "classification": "classified",
-      "action": {"class": "privileged_admin_action", "verb": "create", "resource_type": "github_deploy_key",
-                 "target": {"provider": "github", "owner": "org", "repo": "prod-repo", "key_title": "ci-key��", "read_only": true}},
-      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.github.deploy_key.allow.prod", "enforced": true},
-      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
-      "redaction": {"arguments_redacted": true, "credential_alias": "github-prod-admin", "secret_material_stored": false, "sanitized_fields": ["action.target.key_title"]}
+      "reason_code": "classified_github_deploy_key",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "create",
+        "resource_type": "github_deploy_key",
+        "target": {
+          "provider": "github",
+          "owner": "org",
+          "repo": "prod-repo",
+          "key_title_hash": "sha256:d71c8f02c8ced33cb74494d0d6a1b3582b332ca82b781b09c362a168e40d85ca",
+          "read_only": true
+        }
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.github.deploy_key.allow.prod",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": false
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "github-prod-admin",
+        "secret_material_stored": false,
+        "sanitized_fields": [
+          "tool.name"
+        ]
+      }
     }
   ],
-  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
 }

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/slack_add_member_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/slack_add_member_allow.json
@@ -2,15 +2,49 @@
   "schema": "assay.tool_decision_surface.v0",
   "observed_tool_decisions": [
     {
-      "server": {"id": "slack", "transport": "mcp", "declared_manifest_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"},
-      "tool": {"name": "slack.add_member", "category": "slack_add_member"},
+      "server": {
+        "id": "slack",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      },
+      "tool": {
+        "name": "slack.add_member",
+        "category": "slack_add_member"
+      },
       "classification": "classified",
-      "action": {"class": "privileged_admin_action", "verb": "add", "resource_type": "slack_membership",
-                 "target": {"provider": "slack", "workspace_id": "T0ALIAS", "channel_id": "C0ALIAS", "user_id_hash": "sha256:bbbb", "role": "member"}},
-      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.slack.add_member.allow", "enforced": true},
-      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
-      "redaction": {"arguments_redacted": true, "credential_alias": "slack-bot", "secret_material_stored": false}
+      "reason_code": "classified_slack_add_member",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "add",
+        "resource_type": "workspace_member",
+        "target": {
+          "provider": "slack",
+          "workspace_id_hash": "sha256:e4cfe2c3698fd59b58fd5a075e378f38d857421174faffe3317d3f86473f0190",
+          "channel_id_hash": "sha256:d7f40313c37246eca3ae64aaa3c65db4fc52d02e73f1d3e01cd9c8650ee42e1a",
+          "principal_hash": "sha256:fccfe5ed09f484c1f7523fd8f9fea1bb2e85ddb0845ad61225e604f2c013620d"
+        }
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.slack.add_member.allow",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": false
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "slack-bot",
+        "secret_material_stored": false
+      }
     }
   ],
-  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
 }

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/unknown_tool_observed.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/unknown_tool_observed.json
@@ -2,14 +2,44 @@
   "schema": "assay.tool_decision_surface.v0",
   "observed_tool_decisions": [
     {
-      "server": {"id": "misc", "transport": "mcp", "declared_manifest_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"},
-      "tool": {"name": "misc.do_thing", "category": null},
+      "server": {
+        "id": "misc",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+      },
+      "tool": {
+        "name": "misc.do_thing",
+        "category": null
+      },
       "classification": "observed_unknown_tool",
-      "action": {"class": "unclassified", "verb": null, "resource_type": null, "target": null},
-      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.default.allow", "enforced": true},
-      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
-      "redaction": {"arguments_redacted": true, "credential_alias": null, "secret_material_stored": false}
+      "reason_code": "unknown_tool_name",
+      "action": {
+        "class": "unclassified",
+        "verb": null,
+        "resource_type": null,
+        "target": null
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.default.allow",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": false
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": null,
+        "secret_material_stored": false
+      }
     }
   ],
-  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
 }

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/workspace_admin_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/workspace_admin_allow.json
@@ -2,15 +2,49 @@
   "schema": "assay.tool_decision_surface.v0",
   "observed_tool_decisions": [
     {
-      "server": {"id": "workspace", "transport": "mcp", "declared_manifest_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"},
-      "tool": {"name": "workspace.grant_admin", "category": "workspace_admin"},
+      "server": {
+        "id": "workspace",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+      },
+      "tool": {
+        "name": "workspace.grant_admin",
+        "category": "workspace_admin"
+      },
       "classification": "classified",
-      "action": {"class": "privileged_admin_action", "verb": "grant", "resource_type": "workspace_role",
-                 "target": {"provider": "workspace", "org": "acme", "principal_hash": "sha256:cccc", "role": "admin"}},
-      "decision": {"effect": "allow", "source": "assay-mcp-server", "rule_id": "tool.workspace.grant_admin.allow", "enforced": true},
-      "response": {"status": "success", "side_effect_asserted": true, "side_effect_verified": false},
-      "redaction": {"arguments_redacted": true, "credential_alias": "workspace-admin", "secret_material_stored": false}
+      "reason_code": "classified_workspace_admin",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "grant",
+        "resource_type": "workspace_role",
+        "target": {
+          "provider": "workspace",
+          "workspace_id_hash": "sha256:2443f42f97a4e38e039eaab087b51040b31f61dfac89d7cf75d397cd2033675b",
+          "principal_hash": "sha256:879a6f5abcca30d0334b3238baac9ea116a195b66d3d56eebf447552f8e1aede",
+          "role": "admin"
+        }
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.workspace.grant_admin.allow",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": false
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "workspace-admin",
+        "secret_material_stored": false
+      }
     }
   ],
-  "non_claims": ["does not prove SaaS-side persistence without external audit evidence","does not infer tool actions outside observed MCP proxy traffic","does not expose raw secrets or tokens"]
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
 }

--- a/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
+++ b/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
@@ -14,7 +14,18 @@ const KNOWN_CLASSIFICATIONS: &[&str] = &[
     "classified",
     "classified_incomplete",
     "observed_unknown_tool",
+    "redaction_failed",
     "not_observed",
+];
+
+const KNOWN_REASON_CODES: &[&str] = &[
+    "classified_github_deploy_key",
+    "classified_slack_add_member",
+    "classified_workspace_admin",
+    "missing_required_target_field",
+    "unknown_tool_name",
+    "redacted_secret_argument",
+    "unsupported_argument_shape",
 ];
 
 #[test]
@@ -59,6 +70,13 @@ fn tool_decision_fixtures_hold_the_spec_invariants() {
                 KNOWN_CLASSIFICATIONS.contains(&classification),
                 "{name}: unknown classification {classification:?} (an unknown tool must be \
                  observed_unknown_tool, never absent/clean)"
+            );
+
+            // Every decision carries a machine-readable reason code from the pinned set.
+            let reason = d["reason_code"].as_str().unwrap_or("");
+            assert!(
+                KNOWN_REASON_CODES.contains(&reason),
+                "{name}: unknown reason_code {reason:?}"
             );
 
             // No raw secret material ever rides in the record.

--- a/docs/reference/tool-decision-surface.md
+++ b/docs/reference/tool-decision-surface.md
@@ -56,7 +56,11 @@ The classifier is honest about what it could and could not determine:
 | `classified` | a known privileged tool was observed and its target projected |
 | `classified_incomplete` | known tool, but required argument fields were missing |
 | `observed_unknown_tool` | a tool call was observed but matched no classifier |
+| `redaction_failed` | a value that had to be projected could not be safely redacted (reserved) |
 | `not_observed` | the tool path was outside the proxy; nothing observed |
+
+The classifier is total: every observed call yields exactly one of these states, never nothing. Each
+decision also carries a machine-readable `reason_code` so downstream never parses prose.
 
 An unknown tool is never silently treated as clean, and missing arguments are never treated as safe.
 "No observed tool calls" does not mean "no tool capability"; only "no observed tool calls plus
@@ -76,11 +80,18 @@ complete tool observation" means "no observed tool use in this run" (see P58 cov
       },
       "tool": { "name": "github.add_deploy_key", "category": "github_deploy_key" },
       "classification": "classified",
+      "reason_code": "classified_github_deploy_key",
       "action": {
         "class": "privileged_admin_action",
         "verb": "create",
         "resource_type": "github_deploy_key",
-        "target": { "provider": "github", "owner": "org", "repo": "prod-repo" }
+        "target": {
+          "provider": "github",
+          "owner": "org",
+          "repo": "prod-repo",
+          "key_title_hash": "sha256:...",
+          "read_only": false
+        }
       },
       "decision": {
         "effect": "allow",
@@ -113,37 +124,58 @@ complete tool observation" means "no observed tool use in this run" (see P58 cov
 Classifiers are rule-based and explicit. No model or judge decides a classification. Start narrow,
 with three concrete cases; broaden only with a fixture per added case.
 
+The classifier reads arguments only to project the named target fields below. Everything else, every
+unknown field and every secret-like value, is dropped, never copied. `owner` and `repo` are plain
+labels; principal-like identifiers are hashed (see Redaction).
+
 ### `github_deploy_key`
 
-- Tool names / aliases: `github.add_deploy_key`, `create_deploy_key`, equivalents.
-- Required argument fields: `owner`, `repo` (a missing one yields `classified_incomplete`).
-- Target projection: `owner`, `repo`, `key_title_hash` (or redacted title), `read_only` flag if
-  present.
+- Tool leaf names: `add_deploy_key`, `create_deploy_key`.
+- Required argument fields: `owner`, `repo` (a missing one yields `classified_incomplete`,
+  `reason_code: missing_required_target_field`, `detail: missing_github_owner_or_repo`).
+- Target projection: `owner`, `repo` (plain), `key_title_hash` (the title is hashed, never stored),
+  `read_only` flag if present. `resource_type: github_deploy_key`.
+- Dropped, never hashed: `public_key`, `private_key`, `token`, and the like.
 - Non-claims: does not store public or private key material; does not prove the key works; does not
   prove GitHub persisted it without audit confirmation.
 
 ### `slack_add_member`
 
-- Tool names / aliases: `slack.add_member`, `conversations.invite`, equivalents.
-- Required fields: workspace or channel identifier, principal identifier.
-- Target projection: `workspace_id` or alias, `channel_id` or user-group, `user_id` hash or redacted
-  principal, role/class if present.
+- Tool leaf names: `add_member`, `invite`.
+- Required fields: a scope (`workspace_id` and/or `channel_id`) plus a principal (`user_id` / `user`).
+- Target projection: `workspace_id_hash`, `channel_id_hash` (null for workspace-level membership),
+  `principal_hash`. All are hashed under their own domains. `resource_type: workspace_member`.
 - Non-claims: does not prove Slack accepted the membership unless verified response/audit evidence;
-  does not store tokens.
+  does not store tokens or raw principals.
 
 ### `workspace_admin`
 
-A category for `grant_admin`, `change_role`, `invite_external`, `create_workspace_token`,
-`modify_org_policy`. Kept deliberately narrow in P57: one concrete tool fixture, not the whole class.
+- Tool leaf names (a deliberately narrow set): `grant_admin`, `change_role`, `invite_external`,
+  `modify_org_policy`, `create_workspace_token`.
+- Required fields: a workspace (`workspace_id` / `workspace` / `org`) plus a principal.
+- Target projection: `workspace_id_hash`, `principal_hash`, `role` (plain label if present).
+  `resource_type: workspace_role`.
+- Anything outside this verb set is `observed_unknown_tool`; the classifier does not guess.
 
 ## Redaction and sanitization
 
 - Raw secrets and tokens never appear in the record. A credential is referenced by a stable alias
   (`credential_alias`), and `secret_material_stored` is always `false`.
-- Argument values that carry sensitive identifiers are redacted or hashed, not stored verbatim
-  (`arguments_redacted: true`).
-- Hostile strings in arguments (terminal escapes, control characters) are sanitized before the record
-  is written, the same discipline the evidence TUI/rendering already applies.
+- Sensitive identifiers (principals, workspace/channel ids, key titles) are not stored verbatim; they
+  are hashed under a **domain-separated** preimage `assay.tool_target.v0:<domain>:<normalized>`, so a
+  hash from one field can never collide with another. This is pseudonymization, not anonymization:
+  equal inputs yield equal hashes, so the only claim is that the raw value is not stored.
+- Secret-like values (`public_key`, `private_key`, `token`, `authorization`, `secret`, `credential`,
+  ...) are **dropped, not hashed**: a hash of a public key can still leak correlation, and a token
+  hash invites offline brute force.
+- Hostile strings (terminal escapes, control characters) are sanitized before the record is written,
+  the same discipline the evidence TUI/rendering already applies.
+
+## Reason codes
+
+Machine-readable, never parsed from prose: `classified_github_deploy_key`,
+`classified_slack_add_member`, `classified_workspace_admin`, `missing_required_target_field`,
+`unknown_tool_name`, `redacted_secret_argument`, `unsupported_argument_shape`.
 
 ## Reference fixtures
 


### PR DESCRIPTION
Third step of the tool-decision arc: the three rule-based classifiers over the P57b observed record. No LLM/judge, explicit tool-leaf matching only.

**Hardened security model (per review):**
- classifier reads args only to project named, allowlisted target fields; every other field and every secret-like value (`public_key`/`private_key`/`token`/`authorization`/...) is **dropped, not hashed, not copied**;
- sensitive ids (principals, workspace/channel ids, key titles) hashed under a **domain-separated** preimage `assay.tool_target.v0:<domain>:<normalized>` (no cross-field collisions; pseudonymization, the only claim is raw value not stored);
- machine-readable `reason_code` on every decision; `classify` is total (classified / classified_incomplete / observed_unknown_tool / redaction_failed); unknown tool stays `observed_unknown_tool`, missing args stay `classified_incomplete`, never silently clean.

Classifiers: `github_deploy_key` (owner/repo plain, title hashed, key material dropped), `slack_add_member` (workspace/channel/principal all hashed, channel null for workspace-level, resource_type `workspace_member`), `workspace_admin` (narrow concrete verb set; workspace+principal hashed; role plain).

Tests: per-classifier golden-by-construction with real hashes, negative string-search (raw email/token/public_key/junk never in the record), domain-separation, incomplete/unknown states, extra/secret args ignored. Fixtures regenerated to the hardened shapes with real hashes; guard test extended.

```
Lane classification: Gate.NONE
- no Cargo.toml/Cargo.lock
- no runner/eBPF/monitor/runner_spike/cgroup paths
- pure rule-based MCP tool classifier + fixtures + docs
```
side effects remain asserted, never SaaS-verified.