### PR TITLE
docs(mcp): declared tool surface spec + fixtures (P58a)

### DIFF
--- a/crates/assay-mcp-server/tests/declared_tool_surface_fixtures.rs
+++ b/crates/assay-mcp-server/tests/declared_tool_surface_fixtures.rs
@@ -1,0 +1,75 @@
+//! P58a guard: the committed `assay.declared_tool_surface.v0` reference fixtures must hold the
+//! structural invariants of the spec (docs/reference/declared-tool-surface.md). The diff and gate
+//! (P58b) live in the downstream review layer; this only keeps the declared-side contract fixed.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/declared_tool_surface")
+}
+
+const KNOWN_ACTION_CLASSES: &[&str] = &["github_deploy_key", "slack_add_member", "workspace_admin"];
+
+#[test]
+fn declared_tool_surface_fixtures_hold_the_spec_invariants() {
+    let dir = fixtures_dir();
+    let mut checked = 0;
+    for entry in fs::read_dir(&dir).expect("fixtures dir") {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap())
+            .unwrap_or_else(|e| {
+                panic!("fixture {} is not valid JSON: {e}", path.display());
+            });
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+
+        assert_eq!(
+            v["schema"].as_str(),
+            Some("assay.declared_tool_surface.v0"),
+            "{name}: wrong schema id"
+        );
+        let actions = v["declared_tool_actions"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{name}: declared_tool_actions must be an array"));
+
+        for a in actions {
+            for key in ["id", "provider", "action_class", "required_decision"] {
+                assert!(
+                    a[key].as_str().map(|s| !s.is_empty()).unwrap_or(false),
+                    "{name}: action field {key} must be a non-empty string"
+                );
+            }
+            assert!(
+                KNOWN_ACTION_CLASSES.contains(&a["action_class"].as_str().unwrap()),
+                "{name}: unknown action_class {:?}",
+                a["action_class"]
+            );
+            assert!(
+                a["allowed_targets"].is_array(),
+                "{name}: allowed_targets must be an array (possibly empty)"
+            );
+            let effects = a["allowed_effects"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{name}: allowed_effects must be an array"));
+            assert!(
+                !effects.is_empty(),
+                "{name}: allowed_effects must be non-empty"
+            );
+            for e in effects {
+                let s = e.as_str().unwrap_or("");
+                assert!(
+                    s == "allow" || s == "deny",
+                    "{name}: allowed_effects entries must be allow|deny, got {s:?}"
+                );
+            }
+        }
+        checked += 1;
+    }
+    assert!(
+        checked >= 2,
+        "expected both declared-surface fixtures, found {checked}"
+    );
+}

--- a/crates/assay-mcp-server/tests/fixtures/declared_tool_surface/declared_empty.json
+++ b/crates/assay-mcp-server/tests/fixtures/declared_tool_surface/declared_empty.json
@@ -1,0 +1,4 @@
+{
+  "schema": "assay.declared_tool_surface.v0",
+  "declared_tool_actions": []
+}

--- a/crates/assay-mcp-server/tests/fixtures/declared_tool_surface/declared_prod_allowlist.json
+++ b/crates/assay-mcp-server/tests/fixtures/declared_tool_surface/declared_prod_allowlist.json
@@ -1,0 +1,29 @@
+{
+  "schema": "assay.declared_tool_surface.v0",
+  "declared_tool_actions": [
+    {
+      "id": "github.deploy_key.prod",
+      "provider": "github",
+      "action_class": "github_deploy_key",
+      "allowed_targets": [ { "owner": "org", "repo": "prod-repo" } ],
+      "allowed_effects": ["allow", "deny"],
+      "required_decision": "explicit_policy"
+    },
+    {
+      "id": "slack.add_member.acme",
+      "provider": "slack",
+      "action_class": "slack_add_member",
+      "allowed_targets": [ { "workspace_id": "T0123" } ],
+      "allowed_effects": ["allow", "deny"],
+      "required_decision": "explicit_policy"
+    },
+    {
+      "id": "workspace.grant_admin.acme",
+      "provider": "workspace",
+      "action_class": "workspace_admin",
+      "allowed_targets": [ { "workspace_id": "acme" } ],
+      "allowed_effects": ["allow", "deny"],
+      "required_decision": "explicit_policy"
+    }
+  ]
+}

--- a/docs/reference/declared-tool-surface.md
+++ b/docs/reference/declared-tool-surface.md
@@ -1,0 +1,97 @@
+# Declared tool surface (`assay.declared_tool_surface.v0`)
+
+Status: spec + reference fixtures (P58a). The declared-vs-observed diff and gate (P58b) consume this
+alongside the observed `assay.tool_decision_surface.v0`.
+
+P57 records what privileged tool actions actually happened. P58 compares that to what was declared.
+This is the declared side: the set of privileged tool actions an operator says are expected and
+allowed for a run.
+
+## What "declared" is and is not
+
+A declared tool surface is an **allowance / expected surface**. It is not enforcement, and it is not
+proof. It states "these privileged actions, against these targets, are expected here." Whether a run
+actually stayed within it is decided by the diff (P58b), and whether enforcement was active is a
+separate carrier (`enforcement_health`). Declaring an action does not make it safe; it only makes its
+appearance unsurprising.
+
+## Shape
+
+```json
+{
+  "schema": "assay.declared_tool_surface.v0",
+  "declared_tool_actions": [
+    {
+      "id": "github.deploy_key.prod",
+      "provider": "github",
+      "action_class": "github_deploy_key",
+      "allowed_targets": [
+        { "owner": "org", "repo": "prod-repo" }
+      ],
+      "allowed_effects": ["allow", "deny"],
+      "required_decision": "explicit_policy"
+    }
+  ]
+}
+```
+
+- `action_class` matches the observed record's `tool.category` (`github_deploy_key`,
+  `slack_add_member`, `workspace_admin`).
+- `allowed_targets` is a list of target constraints. A field set to `"*"` or omitted means "any
+  value for that field". An empty list means "the action is declared, with no target constraint".
+- `allowed_effects` is a subset of `["allow", "deny"]`.
+- `required_decision` records the expected decision discipline (e.g. `explicit_policy`); it is
+  metadata for review, not a match key.
+
+## Matching an observed decision against a declared action
+
+An observed tool decision **matches** a declared action when all hold:
+
+1. `provider` is equal;
+2. the observed `tool.category` equals the declared `action_class`;
+3. the observed `action.target` satisfies at least one `allowed_targets` entry;
+4. the observed `decision.effect` is in `allowed_effects`.
+
+Target satisfaction is field-wise. A declared field of `"*"` or absent matches anything. For plain
+fields (github `owner`, `repo`) the declared value must equal the observed value. For fields the
+observed record carries **hashed** (slack and workspace ids, principals), the declared value is the
+plain value, and the matcher hashes it with the same domain-separated function
+(`assay.tool_target.v0:<domain>:<normalized>`) before comparing to the observed hash. A declared
+hash (`sha256:...`) may also be given directly. This keeps the declared surface writable in plain
+terms while the observed record never stores the raw value.
+
+## Diff outcomes (implemented in P58b)
+
+The diff is honest about coverage; it never reads absence as safety.
+
+| Situation | Outcome |
+|-----------|---------|
+| observed, declared, allowed target | no finding |
+| observed undeclared privileged action | finding: `new_privileged_tool_action` |
+| observed action with incomplete target | `inconclusive_tool_target` |
+| observed denied privileged action | `attempted_privileged_tool_action_denied` (finding or warning) |
+| declared but unobserved | no regression finding |
+| observation gap in the MCP proxy | `inconclusive_observation_gap` |
+| unknown tool with high-risk shape | `unclassified_tool_action` |
+
+The load-bearing rule: **no observed tool calls is not the same as no tool capability**. Only
+"no observed tool calls plus complete tool observation" is "no observed tool use in this run". The
+diff and gate therefore depend on a coverage signal (`tool_observation_health`: proxy seen, tool
+calls observed, policy layer active, classifier version, unknown-tool count, redaction active),
+reusing `observation_health.policy_layer` where it can express the gap rather than inventing a
+second health carrier.
+
+## Non-claims
+
+- a declared action is an allowance, not enforcement and not proof of safety;
+- a declared-but-unobserved action is not a regression and not proof the action cannot happen;
+- the diff does not prove SaaS-side persistence and does not infer tool calls outside observed proxy
+  traffic.
+
+## Reference fixtures
+
+`crates/assay-mcp-server/tests/fixtures/declared_tool_surface/`:
+
+- `declared_prod_allowlist.json` — declares the github deploy-key (prod repo), slack add_member, and
+  workspace_admin actions, so the matching observed allows produce no finding.
+- `declared_empty.json` — declares nothing, so every observed privileged action is undeclared.


### PR DESCRIPTION
Declared side of the observed-vs-declared arc. `assay.declared_tool_surface.v0`: the expected/allowed privileged tool actions the P58b diff compares observed decisions against.

- **declared = allowance, never enforcement and never proof of safety.**
- Matching contract: provider + `action_class` (= observed `tool.category`) + target satisfaction + `allowed_effects`. A declared **plain** value is hashed with the same domain-separated function before comparing to an observed **hashed** id, so declared surfaces stay writable in plain terms while the observed record never stores raw values.
- Diff outcomes spelled out for P58b (new_privileged_tool_action / inconclusive_tool_target / attempted_privileged_tool_action_denied / inconclusive_observation_gap / unclassified_tool_action), with the load-bearing rule: no observed tool calls is not no tool capability.

Two fixtures (prod allowlist + empty surface) + guard test. The diff/gate is P58b (downstream review layer).

Lane: docs + assay-mcp-server fixtures/test only, `gates=none`.