### PR TITLE
feat(mcp): credential-scope evidence — required_scope on tool decisions (P59a+b)

### DIFF
--- a/crates/assay-mcp-server/src/tool_decision.rs
+++ b/crates/assay-mcp-server/src/tool_decision.rs
@@ -122,6 +122,20 @@ fn unknown() -> Classified {
     }
 }
 
+/// The scope a classified action requires, derived deterministically from the action category. This
+/// is Assay's static claim about what the action needs, NOT a provider-verified grant requirement and
+/// NOT inferred from arguments. `None` for an unclassified tool (the consumer reads that as
+/// `required_scope_unknown`, never as "no scope needed"). A consumer compares this against the scopes
+/// an operator declared for the credential alias (see docs/reference/credential-scope.md).
+fn required_scope_for(category: Option<&str>) -> Option<&'static str> {
+    match category {
+        Some("github_deploy_key") => Some("repo:deploy_key:write"),
+        Some("slack_add_member") => Some("conversations:members:write"),
+        Some("workspace_admin") => Some("workspace:admin"),
+        _ => None,
+    }
+}
+
 fn incomplete(
     category: &'static str,
     verb: &'static str,
@@ -314,7 +328,10 @@ pub fn build_decision(call: &ObservedCall<'_>) -> Value {
             "resource_type": c.resource_type.map(Value::from).unwrap_or(Value::Null),
             // The target carries only named, allowlisted fields the classifier projected (sensitive
             // ids hashed under per-field domains); never raw args, never secret material.
-            "target": c.target
+            "target": c.target,
+            // Static scope this action requires (from the category, not the args). Null when
+            // unclassified: the consumer reads that as required_scope_unknown, never "no scope".
+            "required_scope": required_scope_for(c.category).map(Value::from).unwrap_or(Value::Null)
         },
         "decision": {
             "effect": call.effect.as_str(),
@@ -531,6 +548,43 @@ mod tests {
             json!(target_hash("workspace_principal", "bob@example.com"))
         );
         assert_eq!(t["role"], json!("admin"));
+    }
+
+    #[test]
+    fn required_scope_is_derived_from_category_not_args() {
+        let gh = build_decision(&call(
+            "github.add_deploy_key",
+            &json!({"owner": "org", "repo": "r"}),
+            Effect::Allow,
+            "success",
+        ));
+        assert_eq!(
+            gh["action"]["required_scope"],
+            json!("repo:deploy_key:write")
+        );
+
+        let sl = build_decision(&call(
+            "slack.add_member",
+            &json!({"workspace_id": "T", "user_id": "U"}),
+            Effect::Allow,
+            "success",
+        ));
+        assert_eq!(
+            sl["action"]["required_scope"],
+            json!("conversations:members:write")
+        );
+
+        let wa = build_decision(&call(
+            "workspace.grant_admin",
+            &json!({"workspace_id": "a", "principal": "p"}),
+            Effect::Allow,
+            "success",
+        ));
+        assert_eq!(wa["action"]["required_scope"], json!("workspace:admin"));
+
+        // Unclassified tool: null, never a scope and never "no scope needed".
+        let unk = build_decision(&call("misc.do_thing", &json!({}), Effect::Allow, "success"));
+        assert_eq!(unk["action"]["required_scope"], Value::Null);
     }
 
     #[test]

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_allow.json
@@ -23,7 +23,8 @@
           "repo": "prod-repo",
           "key_title_hash": "sha256:a65a94d25524f87fbb5ce6d3fde202c02a5b532f27e1ba3b5708076e1ba75ccf",
           "read_only": false
-        }
+        },
+        "required_scope": "repo:deploy_key:write"
       },
       "decision": {
         "effect": "allow",

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_deny.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_deny.json
@@ -22,7 +22,8 @@
           "owner": "org",
           "repo": "prod-repo",
           "read_only": false
-        }
+        },
+        "required_scope": "repo:deploy_key:write"
       },
       "decision": {
         "effect": "deny",

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_incomplete.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/github_deploy_key_incomplete.json
@@ -20,7 +20,8 @@
         "target": {
           "provider": "github",
           "owner": "org"
-        }
+        },
+        "required_scope": "repo:deploy_key:write"
       },
       "decision": {
         "effect": "allow",

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/redacted_and_sanitized.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/redacted_and_sanitized.json
@@ -23,7 +23,8 @@
           "repo": "prod-repo",
           "key_title_hash": "sha256:d71c8f02c8ced33cb74494d0d6a1b3582b332ca82b781b09c362a168e40d85ca",
           "read_only": true
-        }
+        },
+        "required_scope": "repo:deploy_key:write"
       },
       "decision": {
         "effect": "allow",

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/slack_add_member_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/slack_add_member_allow.json
@@ -22,7 +22,8 @@
           "workspace_id_hash": "sha256:e4cfe2c3698fd59b58fd5a075e378f38d857421174faffe3317d3f86473f0190",
           "channel_id_hash": "sha256:d7f40313c37246eca3ae64aaa3c65db4fc52d02e73f1d3e01cd9c8650ee42e1a",
           "principal_hash": "sha256:fccfe5ed09f484c1f7523fd8f9fea1bb2e85ddb0845ad61225e604f2c013620d"
-        }
+        },
+        "required_scope": "conversations:members:write"
       },
       "decision": {
         "effect": "allow",

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/unknown_tool_observed.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/unknown_tool_observed.json
@@ -17,7 +17,8 @@
         "class": "unclassified",
         "verb": null,
         "resource_type": null,
-        "target": null
+        "target": null,
+        "required_scope": null
       },
       "decision": {
         "effect": "allow",

--- a/crates/assay-mcp-server/tests/fixtures/tool_decisions/workspace_admin_allow.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_decisions/workspace_admin_allow.json
@@ -22,7 +22,8 @@
           "workspace_id_hash": "sha256:2443f42f97a4e38e039eaab087b51040b31f61dfac89d7cf75d397cd2033675b",
           "principal_hash": "sha256:879a6f5abcca30d0334b3238baac9ea116a195b66d3d56eebf447552f8e1aede",
           "role": "admin"
-        }
+        },
+        "required_scope": "workspace:admin"
       },
       "decision": {
         "effect": "allow",

--- a/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
+++ b/crates/assay-mcp-server/tests/tool_decision_fixtures.rs
@@ -86,6 +86,21 @@ fn tool_decision_fixtures_hold_the_spec_invariants() {
                 "{name}: secret_material_stored must be false"
             );
 
+            // A classified privileged tool carries a derived required_scope (non-null string); an
+            // unclassified tool carries null (read downstream as required_scope_unknown, not "none").
+            let req = &d["action"]["required_scope"];
+            if d["tool"]["category"].is_string() {
+                assert!(
+                    req.as_str().map(|s| !s.is_empty()).unwrap_or(false),
+                    "{name}: a classified action must carry a non-empty required_scope"
+                );
+            } else {
+                assert!(
+                    req.is_null(),
+                    "{name}: an unclassified action must carry required_scope=null, got {req}"
+                );
+            }
+
             // Asserted is not verified: a fixture must never claim a verified side effect, since
             // none of these carry independently-checked audit evidence.
             assert_eq!(

--- a/docs/reference/credential-scope.md
+++ b/docs/reference/credential-scope.md
@@ -1,0 +1,101 @@
+# Credential-scope evidence
+
+Status: P59. Producer side (the `required_scope` field on each tool decision) lands with this spec;
+the consumer side (scope matching and findings) lives in the review/gate layer.
+
+This builds directly on the [tool-decision surface](tool-decision-surface.md): an observed privileged
+tool action already carries a `credential_alias` (the alias the call used, never the token) and a
+`category`. Credential-scope adds the question an auditor actually asks: *was this credential
+appropriate for what the action required?*
+
+## The load-bearing rule
+
+> Credentials are declared metadata and observed aliases, not verified provider grants.
+
+`required_scope` is Assay's deterministic static claim about what an action class needs. The declared
+scopes of an alias are operator-provided metadata. Neither is a provider-verified grant: Assay does
+not introspect tokens or query the provider. The evidence is "this alias, declared to hold these
+scopes, was used for an action that statically requires this scope", and the match between them.
+
+## Producer: `required_scope` (this PR)
+
+Each classified tool decision now carries `action.required_scope`, derived from the action
+`category` (never from arguments):
+
+| category | required_scope |
+|----------|----------------|
+| `github_deploy_key` | `repo:deploy_key:write` |
+| `slack_add_member` | `conversations:members:write` |
+| `workspace_admin` | `workspace:admin` |
+| (unclassified) | `null` |
+
+`null` means the tool was not classified, read downstream as `required_scope_unknown`, never as "no
+scope needed". The `credential_alias` stays where it was, in the redaction block, and is `null`
+unless the proxy was configured to map the call to an alias. No raw token ever appears.
+
+## Consumer: declared credentials as policy, scope coverage, findings
+
+### Declared credentials are policy, not a runtime artifact
+
+The scopes an alias is declared to hold are operator configuration, the same shape as the network
+declared endpoints. They are a policy map, not a new evidence carrier:
+
+```yaml
+declared_credentials:
+  github-prod-admin:
+    scopes: [repo:admin, repo:deploy_key:write]
+  github-readonly:
+    scopes: [repo:read]
+```
+
+(Modeled internally as `CredentialDeclaration { alias, scopes, metadata? }` so it can migrate to a
+carrier later if the scope taxonomy stabilizes, but it stays a policy map in v0.)
+
+### Scope coverage is a small deterministic lattice, not set membership
+
+A declared scope can cover a required scope it is not string-equal to. Matching is an explicit,
+deterministic coverage relation, never a plain `required in declared` test:
+
+```text
+covers(declared_scopes, required_scope) -> sufficient | insufficient | unknown
+```
+
+The initial GitHub lattice, kept deliberately small:
+
+```text
+required repo:deploy_key:write is covered by:  repo:deploy_key:write, repo:admin
+required repo:deploy_key:write is NOT covered by: repo:read, repo:metadata, repo:contents:read
+unrecognized scope string -> unknown (never silently "covered")
+```
+
+Broadening the lattice is a deliberate, fixture-backed change, not a guess.
+
+### Findings
+
+| condition | result |
+|-----------|--------|
+| alias declared and `covers` is sufficient | no finding |
+| alias declared and `covers` is insufficient | finding: `credential_scope_insufficient` |
+| alias not in `declared_credentials` | finding: `credential_alias_unknown` (never clean) |
+| `required_scope` is null (unclassified action) | inconclusive: `required_scope_unknown` |
+| an unrecognized scope string in the lattice | inconclusive, never "covered" |
+| declared scopes far broader than required | warning: `credential_scope_overbroad` (recommendation, not blocking) |
+| a high-privilege admin alias used for the action | informational: `privileged_action_used_admin_alias` |
+
+`overbroad` is least-privilege hygiene, not a regression: without provider introspection it cannot be
+proven, so it stays a recommendation. A future policy may opt in to
+`treat_overbroad_as_blocking: true`; not in v0.
+
+## Non-claims
+
+- does not introspect tokens or verify provider-side grants;
+- `required_scope` is a static claim about the action class, not a provider-verified requirement;
+- declared scopes are operator metadata, not proof the alias actually holds them;
+- `overbroad` is a recommendation, not a proven least-privilege violation;
+- does not expose raw secrets, tokens, or credentials.
+
+## Kill criteria
+
+Stop before token introspection (provider-specific and risky). Static `action_class → required_scope`
+mapping plus declared alias metadata only. Start with GitHub; add a provider only with its lattice
+entries and fixtures.


### PR DESCRIPTION
First half of credential-scope evidence (producer + spec); the Plimsoll scope_match/findings is the separate consumer PR.

Builds on the tool-decision surface: each classified privileged decision now carries `action.required_scope`, derived from the action category, never from args (github_deploy_key→`repo:deploy_key:write`, slack_add_member→`conversations:members:write`, workspace_admin→`workspace:admin`, unclassified→`null`=required_scope_unknown).

Load-bearing rule (`docs/reference/credential-scope.md`): **credentials are declared metadata and observed aliases, not verified provider grants.** No token introspection. The consumer (next PR) compares required_scope against operator-declared alias scopes via a small deterministic **scope-coverage lattice** (`covers()`, not set membership: `repo:admin` covers `repo:deploy_key:write`); `overbroad` is a recommendation, not blocking.

Fixtures + guard test carry required_scope (non-null for classified, null for unclassified); a producer test pins the category→scope derivation. Lane: docs + assay-mcp-server only, `gates=none`.