### PR TITLE
docs: surface tool-decision + credential-scope evidence (README + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Tool-decision surface (`assay.tool_decision_surface.v0`): the MCP proxy now records each observed
+  `tools/call` as a structured per-call decision, the privileged in-application actions kernel and
+  network enforcement cannot see (a deploy key added, a workspace member invited). Each record
+  carries the server identity, the rule-based privileged-action classification, a projected target
+  (sensitive ids hashed under per-field domains, raw args and secrets never stored), the policy
+  decision, and the response. The load-bearing rule travels in the shape: a tool returning success is
+  the provider's assertion (`side_effect_asserted`), never proof (`side_effect_verified` stays false
+  without independently checked audit evidence). Three rule-based classifiers ship
+  (`github_deploy_key`, `slack_add_member`, `workspace_admin`); no model or judge decides a
+  classification, and an unknown tool is `observed_unknown_tool`, never read as clean. Spec:
+  `docs/reference/tool-decision-surface.md`.
+- Credential-scope evidence: each classified privileged tool decision carries
+  `action.required_scope`, derived deterministically from the action category (never from arguments),
+  so a consumer can ask whether the credential alias the action used was appropriate. Credentials are
+  declared metadata and observed aliases, not verified provider grants; no token introspection. Spec:
+  `docs/reference/credential-scope.md`.
+
 ### Removed
 - The deprecated top-level command shims `assay discover`, `assay kill`, `assay tool`,
   `assay generate`, and `assay record` were retired. They had been hidden and printed a

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The core workflow is intentionally small: import or record a bounded outcome, bu
 
 For observed runtime evidence specifically, the same boundary discipline runs end to end: a coverage descriptor declares what the capture can and cannot support, claim-class cells record each claim as `claim_strength` x `claim_basis`, and a gate refuses to let a claim exceed what was observed. See the [coverage-honesty walkthrough](examples/coverage-honesty-walkthrough/) and the [claim-class semantics](docs/reference/observability/claim-semantics-overview.md).
 
+For privileged tool actions specifically, the MCP proxy records each observed `tools/call` as a structured tool-decision (`assay.tool_decision_surface.v0`): the privileged in-application actions kernel and network enforcement cannot see, such as a deploy key added or a workspace member invited. Rule-based classifiers tag the action and project a target with sensitive ids hashed and raw arguments never stored, and the shape keeps the asserted-versus-verified line honest: a tool returning success is the provider's assertion, never proof, until independently checked audit evidence confirms it. See [tool-decision surface](docs/reference/tool-decision-surface.md) and [credential-scope](docs/reference/credential-scope.md).
+
 ```text
 Trust Basis Gate
 Status: OK


### PR DESCRIPTION
Outward-docs update for the recent tool-decision observed-vs-declared work (P57–P59), which the README and CHANGELOG did not yet reflect.

- README: a bounded paragraph on `assay.tool_decision_surface.v0` (privileged in-application actions the kernel cannot see; rule-based classifiers; hashed targets, raw args never stored; asserted-vs-verified kept honest), linking the tool-decision and credential-scope specs.
- CHANGELOG [Unreleased]: entries for the tool-decision surface + the three classifiers, and credential-scope (`action.required_scope`).

Docs only, no enforcement overclaim, no strategy vocab, lane none.