### PR TITLE
docs(mcp): side-effect receipt spec + fixtures + binding guard (Ea)

### DIFF
--- a/crates/assay-mcp-server/tests/fixtures/side_effect/asserted.json
+++ b/crates/assay-mcp-server/tests/fixtures/side_effect/asserted.json
@@ -1,0 +1,58 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {
+        "id": "github",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:1111"
+      },
+      "tool": {
+        "name": "github.add_deploy_key",
+        "category": "github_deploy_key"
+      },
+      "classification": "classified",
+      "reason_code": "classified_github_deploy_key",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "create",
+        "resource_type": "github_deploy_key",
+        "target": {
+          "provider": "github",
+          "owner": "org",
+          "repo": "prod-repo",
+          "key_title_hash": "sha256:a65a94d25524f87fbb5ce6d3fde202c02a5b532f27e1ba3b5708076e1ba75ccf",
+          "read_only": false
+        },
+        "required_scope": "repo:deploy_key:write"
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.github.deploy_key.allow.prod",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": false,
+        "side_effect": {
+          "asserted": true,
+          "level": "asserted",
+          "verification_source": null,
+          "verification_subject_digest": null
+        }
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "github-prod-admin",
+        "secret_material_stored": false
+      }
+    }
+  ],
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
+}

--- a/crates/assay-mcp-server/tests/fixtures/side_effect/audit_record_github_deploy_key.json
+++ b/crates/assay-mcp-server/tests/fixtures/side_effect/audit_record_github_deploy_key.json
@@ -1,0 +1,19 @@
+{
+  "schema": "assay.provider_audit_record.v0",
+  "provider": "github",
+  "record_id": "audit-log-entry-9931",
+  "subject": {
+    "action_class": "github_deploy_key",
+    "verb": "create",
+    "target": {
+      "owner": "org",
+      "repo": "prod-repo",
+      "key_title_hash": "sha256:a65a94d25524f87fbb5ce6d3fde202c02a5b532f27e1ba3b5708076e1ba75ccf"
+    }
+  },
+  "binding_digest": "sha256:31f2007b91477601789c8803c3e32912a8a4510851cc55397d49a65bbc5e4ec3",
+  "non_claims": [
+    "imported from a provider audit export; Assay did not query the provider",
+    "verifies that an audit entry binds to the observed call, not that the entry is authentic beyond its own signature"
+  ]
+}

--- a/crates/assay-mcp-server/tests/fixtures/side_effect/audit_record_mismatch.json
+++ b/crates/assay-mcp-server/tests/fixtures/side_effect/audit_record_mismatch.json
@@ -1,0 +1,18 @@
+{
+  "schema": "assay.provider_audit_record.v0",
+  "provider": "github",
+  "record_id": "audit-log-entry-0000",
+  "subject": {
+    "action_class": "github_deploy_key",
+    "verb": "create",
+    "target": {
+      "owner": "org",
+      "repo": "other-repo",
+      "key_title_hash": "sha256:a65a94d25524f87fbb5ce6d3fde202c02a5b532f27e1ba3b5708076e1ba75ccf"
+    }
+  },
+  "binding_digest": "sha256:3546cc0feefe1a918cd2498c03c341a2e003527e815c51cd1b4aa0acb7774484",
+  "non_claims": [
+    "imported from a provider audit export; Assay did not query the provider"
+  ]
+}

--- a/crates/assay-mcp-server/tests/fixtures/side_effect/observed_confirmed.json
+++ b/crates/assay-mcp-server/tests/fixtures/side_effect/observed_confirmed.json
@@ -1,0 +1,58 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {
+        "id": "github",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:1111"
+      },
+      "tool": {
+        "name": "github.add_deploy_key",
+        "category": "github_deploy_key"
+      },
+      "classification": "classified",
+      "reason_code": "classified_github_deploy_key",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "create",
+        "resource_type": "github_deploy_key",
+        "target": {
+          "provider": "github",
+          "owner": "org",
+          "repo": "prod-repo",
+          "key_title_hash": "sha256:a65a94d25524f87fbb5ce6d3fde202c02a5b532f27e1ba3b5708076e1ba75ccf",
+          "read_only": false
+        },
+        "required_scope": "repo:deploy_key:write"
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.github.deploy_key.allow.prod",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": false,
+        "side_effect": {
+          "asserted": true,
+          "level": "observed_confirmed",
+          "verification_source": "observed_read_followup",
+          "verification_subject_digest": "sha256:31f2007b91477601789c8803c3e32912a8a4510851cc55397d49a65bbc5e4ec3"
+        }
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "github-prod-admin",
+        "secret_material_stored": false
+      }
+    }
+  ],
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
+}

--- a/crates/assay-mcp-server/tests/fixtures/side_effect/verified.json
+++ b/crates/assay-mcp-server/tests/fixtures/side_effect/verified.json
@@ -1,0 +1,58 @@
+{
+  "schema": "assay.tool_decision_surface.v0",
+  "observed_tool_decisions": [
+    {
+      "server": {
+        "id": "github",
+        "transport": "mcp",
+        "declared_manifest_digest": "sha256:1111"
+      },
+      "tool": {
+        "name": "github.add_deploy_key",
+        "category": "github_deploy_key"
+      },
+      "classification": "classified",
+      "reason_code": "classified_github_deploy_key",
+      "action": {
+        "class": "privileged_admin_action",
+        "verb": "create",
+        "resource_type": "github_deploy_key",
+        "target": {
+          "provider": "github",
+          "owner": "org",
+          "repo": "prod-repo",
+          "key_title_hash": "sha256:a65a94d25524f87fbb5ce6d3fde202c02a5b532f27e1ba3b5708076e1ba75ccf",
+          "read_only": false
+        },
+        "required_scope": "repo:deploy_key:write"
+      },
+      "decision": {
+        "effect": "allow",
+        "source": "assay-mcp-server",
+        "rule_id": "tool.github.deploy_key.allow.prod",
+        "enforced": true
+      },
+      "response": {
+        "status": "success",
+        "side_effect_asserted": true,
+        "side_effect_verified": true,
+        "side_effect": {
+          "asserted": true,
+          "level": "verified",
+          "verification_source": "provider_audit_import",
+          "verification_subject_digest": "sha256:31f2007b91477601789c8803c3e32912a8a4510851cc55397d49a65bbc5e4ec3"
+        }
+      },
+      "redaction": {
+        "arguments_redacted": true,
+        "credential_alias": "github-prod-admin",
+        "secret_material_stored": false
+      }
+    }
+  ],
+  "non_claims": [
+    "does not prove SaaS-side persistence without external audit evidence",
+    "does not infer tool actions outside observed MCP proxy traffic",
+    "does not expose raw secrets or tokens"
+  ]
+}

--- a/crates/assay-mcp-server/tests/side_effect_fixtures.rs
+++ b/crates/assay-mcp-server/tests/side_effect_fixtures.rs
@@ -1,0 +1,110 @@
+//! Ea guard: the side-effect receipt reference fixtures must hold the honesty-ladder invariants
+//! (docs/reference/side-effect-receipt.md) and the binding must be reproducible from committed bytes
+//! by the canonical JCS digest the future verifier (Eb) will use. There is no producer/verifier yet;
+//! this keeps the vectors honest and proves the binding math is sound.
+
+use assay_core::mcp::jcs;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::PathBuf;
+
+fn fx(name: &str) -> Value {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/side_effect")
+        .join(name);
+    serde_json::from_str(&fs::read_to_string(&p).unwrap()).unwrap()
+}
+
+fn binding_of(subject: &Value) -> String {
+    let bytes = jcs::to_vec(subject).expect("jcs");
+    format!("sha256:{}", hex::encode(Sha256::digest(&bytes)))
+}
+
+fn decision0(v: &Value) -> Value {
+    v["observed_tool_decisions"][0].clone()
+}
+
+#[test]
+fn audit_record_binding_recomputes_from_committed_bytes() {
+    // The binding the verifier will recompute (jcs over the canonical subject) equals the committed
+    // binding_digest. If this drifts, the verifier and the fixtures disagree.
+    let rec = fx("audit_record_github_deploy_key.json");
+    assert_eq!(
+        binding_of(&rec["subject"]),
+        rec["binding_digest"].as_str().unwrap(),
+        "audit record binding_digest must recompute from its subject via canonical JCS"
+    );
+}
+
+#[test]
+fn verified_level_is_bound_to_the_matching_audit_record() {
+    let verified = decision0(&fx("verified.json"));
+    let rec = fx("audit_record_github_deploy_key.json");
+    let se = &verified["response"]["side_effect"];
+    assert_eq!(se["level"], "verified");
+    assert_eq!(se["verification_source"], "provider_audit_import");
+    // The verified decision's subject digest is exactly the audit record's binding.
+    assert_eq!(
+        se["verification_subject_digest"].as_str().unwrap(),
+        rec["binding_digest"].as_str().unwrap(),
+        "a verified side effect must carry the binding of the imported audit record"
+    );
+    // And side_effect_verified (the compat boolean) agrees with the level.
+    assert_eq!(verified["response"]["side_effect_verified"], true);
+}
+
+#[test]
+fn mismatched_audit_record_does_not_bind() {
+    // An audit record for a different target produces a different binding, so it could never promote
+    // the verified.json decision: its binding must not equal the verified decision's digest.
+    let mm = fx("audit_record_mismatch.json");
+    let verified = decision0(&fx("verified.json"));
+    assert_eq!(
+        binding_of(&mm["subject"]),
+        mm["binding_digest"].as_str().unwrap()
+    );
+    assert_ne!(
+        mm["binding_digest"].as_str().unwrap(),
+        verified["response"]["side_effect"]["verification_subject_digest"]
+            .as_str()
+            .unwrap(),
+        "a mismatched audit record must not share the verified call's binding"
+    );
+}
+
+#[test]
+fn asserted_never_claims_verified() {
+    let a = decision0(&fx("asserted.json"));
+    let se = &a["response"]["side_effect"];
+    assert_eq!(se["level"], "asserted");
+    assert!(se["verification_source"].is_null());
+    assert!(se["verification_subject_digest"].is_null());
+    // asserted is not verified: the compat boolean must stay false.
+    assert_eq!(a["response"]["side_effect_verified"], false);
+}
+
+#[test]
+fn observed_confirmed_is_sequence_not_audit() {
+    let oc = decision0(&fx("observed_confirmed.json"));
+    let se = &oc["response"]["side_effect"];
+    assert_eq!(se["level"], "observed_confirmed");
+    assert_eq!(se["verification_source"], "observed_read_followup");
+    // observed_confirmed is sequence evidence within the run, NOT external verification.
+    assert_eq!(oc["response"]["side_effect_verified"], false);
+}
+
+#[test]
+fn levels_are_from_the_pinned_set() {
+    let known = ["asserted", "observed_confirmed", "verified"];
+    for name in ["asserted.json", "observed_confirmed.json", "verified.json"] {
+        let level = decision0(&fx(name))["response"]["side_effect"]["level"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            known.contains(&level.as_str()),
+            "{name}: unknown level {level}"
+        );
+    }
+}

--- a/docs/reference/side-effect-receipt.md
+++ b/docs/reference/side-effect-receipt.md
@@ -1,0 +1,107 @@
+# Side-effect receipt
+
+Status: Ea (spec + fixtures). Defines the honesty ladder and the binding contract; the recompute
+verifier and the consumer rendering are later slices.
+
+The [tool-decision surface](tool-decision-surface.md) already records that a privileged tool returned
+success as the provider's *assertion*: `response.side_effect_asserted` may be true while
+`response.side_effect_verified` stays false. This spec defines what it takes to honestly move past
+asserted, and the one rule that keeps it safe.
+
+## The one rule
+
+> Verified never means "Assay queried the provider." It means an independently produced audit record,
+> whose binding Assay recomputes from committed bytes, matches the observed call.
+
+Assay does not hold read credentials for the providers it observes and does not call back to them.
+Making the proxy a privileged prober would turn it into the confused-deputy the MCP threat model warns
+about, and would break the only identity worth having here: the verifier that reproduces a verdict
+from committed bytes, not the actor that re-fetches state. So verification is an *import + recompute*,
+never a *query*.
+
+## The ladder
+
+`response.side_effect` carries one `level`, never a bare boolean:
+
+| level | meaning | cost / source |
+|-------|---------|---------------|
+| `asserted` | the tool returned success | free; the provider's claim, not proof |
+| `observed_confirmed` | a later observed read tool-call in the same run returned state consistent with the write | free; pure sequence reasoning over observed calls, no new credentials |
+| `verified` | an imported, independently produced provider audit record binds to this call, and Assay recomputed the binding | needs the audit record; never a provider query |
+
+`asserted` never auto-promotes. A higher level is only reached by the evidence its row names, and the
+record always says which: `verification_source` is `null`, `observed_read_followup`, or
+`provider_audit_import`, and `verification_subject_digest` carries the recomputed binding for the top
+two rungs.
+
+## Shape
+
+```json
+{
+  "response": {
+    "status": "success",
+    "side_effect": {
+      "asserted": true,
+      "level": "verified",
+      "verification_source": "provider_audit_import",
+      "verification_subject_digest": "sha256:..."
+    }
+  }
+}
+```
+
+`side_effect.asserted` mirrors the existing `side_effect_asserted` (kept for compatibility);
+`level` is the new honest axis.
+
+## The imported audit record and the binding
+
+A `verified` level requires an `assay.provider_audit_record.v0`, produced independently of the run
+(exported from the provider's own audit log, then imported), never fetched by Assay:
+
+```json
+{
+  "schema": "assay.provider_audit_record.v0",
+  "provider": "github",
+  "record_id": "audit-log-entry-9931",
+  "subject": {
+    "action_class": "github_deploy_key",
+    "verb": "create",
+    "target": { "owner": "org", "repo": "prod-repo", "key_title_hash": "sha256:..." }
+  },
+  "binding_digest": "sha256:...",
+  "non_claims": [
+    "imported from a provider audit export; Assay did not query the provider",
+    "verifies that an audit entry binds to the observed call, not that the entry itself is authentic beyond its own signature"
+  ]
+}
+```
+
+The binding is `sha256(jcs({action_class, verb, target}))` over the canonical subject. Verification
+(Eb) recomputes that digest from the imported record's `subject` and requires:
+
+1. the recomputed digest equals the record's `binding_digest` (the record is internally consistent);
+2. the same digest equals the digest of the observed tool-decision's `action` projection (the audit
+   record binds to *this* call, not merely to some call of the same shape).
+
+Only when both hold does the consumer move the level to `verified`. A record that fails either check
+leaves the level at `asserted` and is reported, never silently promoted.
+
+## Non-claims
+
+- does not query providers or hold provider read credentials;
+- `verified` proves an imported audit record binds to the observed call, not that the audit record is
+  authentic beyond whatever signature it carries (signature trust is a separate, later concern);
+- `observed_confirmed` is sequence evidence within the run, not external verification;
+- side effects are never promoted past what their evidence supports.
+
+## Reference fixtures
+
+`crates/assay-mcp-server/tests/fixtures/side_effect/`:
+
+- `asserted.json` — allowed success, `level: asserted`, no verification source
+- `observed_confirmed.json` — a later read tool-call confirmed the state, `level: observed_confirmed`
+- `verified.json` — a matching imported audit record, `level: verified`
+- `audit_record_github_deploy_key.json` — the imported `assay.provider_audit_record.v0` whose binding
+  matches `verified.json`
+- `audit_record_mismatch.json` — an audit record for a different target; binding does not match, so
+  the level must stay `asserted`


### PR DESCRIPTION
First slice of the side-effect receipt experiment: the honesty ladder + the binding contract, spec + fixtures only.

**The ladder** (`response.side_effect.level`, never a bare boolean): `asserted` (the provider's claim) → `observed_confirmed` (a later observed read tool-call in the same run; pure sequence evidence, no new credentials) → `verified` (an independently imported provider audit record whose binding Assay recomputes).

**The one rule:** verified never means Assay queried the provider. It is import + recompute, never a query, so the proxy never becomes the confused-deputy privileged prober the MCP threat model warns about, and stays the verifier that reproduces a verdict from committed bytes.

Adds `docs/reference/side-effect-receipt.md`, the `assay.provider_audit_record.v0` import format, the binding contract `sha256(jcs({action_class,verb,target}))`, 5 fixtures, and a guard test that **recomputes the binding via `assay_core::mcp::jcs` and proves it matches the committed fixtures** (and that a mismatched record cannot bind). The verifier (Eb) and consumer rendering (Ec) are later. Lane: docs + assay-mcp-server fixtures/test, `gates=none`.