### PR TITLE
chore(release): assay v3.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.22.0] - 2026-06-10
+
 ### Added
 - Tool-decision surface (`assay.tool_decision_surface.v0`): the MCP proxy now records each observed
   `tools/call` as a structured per-call decision, the privileged in-application actions kernel and
@@ -21,6 +23,11 @@ All notable changes to this project will be documented in this file.
   so a consumer can ask whether the credential alias the action used was appropriate. Credentials are
   declared metadata and observed aliases, not verified provider grants; no token introspection. Spec:
   `docs/reference/credential-scope.md`.
+- Side-effect receipt spec (`docs/reference/side-effect-receipt.md`, spec + fixtures, experiment):
+  an honesty ladder for privileged side effects (`asserted` -> `observed_confirmed` -> `verified`)
+  and a binding contract. `verified` never means Assay queried the provider; it requires an
+  independently imported provider audit record (`assay.provider_audit_record.v0`) whose binding Assay
+  recomputes from committed bytes via canonical JCS. No producer/verifier yet.
 
 ### Removed
 - The deprecated top-level command shims `assay discover`, `assay kill`, `assay tool`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.21.0"
+version = "3.22.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.21.0"
+version = "3.22.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Minor release consolidating the tool-decision observed-vs-declared arc and this cycle's work.

Headline: privileged-action evidence for the kernel-blind gap — `assay.tool_decision_surface.v0`, three rule-based classifiers, the declared tool surface, credential-scope (`required_scope`), and the side-effect receipt spec (asserted/observed_confirmed/verified, verified = audit-import binding recompute, never a provider query). Plus #1408 OTel span-event characterization, #1601 monitor hardening, `--probe-enforcement`, and the removal of the deprecated hidden command shims.

Version + CHANGELOG + Cargo.lock only. lane-check false-heavy on the workspace bump is expected (admin-merge, as for v3.20.0/v3.21.0).