### PR TITLE
docs(mcp): tool-manifest drift spec + fixtures + digest guard (P60a)

### DIFF
--- a/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/canonicalization_example.json
+++ b/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/canonicalization_example.json
@@ -1,0 +1,47 @@
+{
+  "note": "recomputed in the guard test via assay_core::mcp::jcs; if these drift, verifier and fixtures disagree",
+  "per_tool": {
+    "projection": {
+      "name": "github.add_deploy_key",
+      "description": "Add a deploy key",
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "owner",
+          "repo"
+        ]
+      },
+      "output_schema": null,
+      "annotations": null
+    },
+    "expected_tool_digest": "sha256:03c7e1d546c3440fb100938dcaa7578ac34ae81f28e5762e7f8a3197e272a9f6"
+  },
+  "manifest": {
+    "projection_id": "assay.mcp_manifest_projection.v0",
+    "tools": [
+      {
+        "name": "search",
+        "description": "does a thing",
+        "input_schema": {
+          "type": "object"
+        },
+        "output_schema": null,
+        "annotations": null
+      },
+      {
+        "name": "github.add_deploy_key",
+        "description": "Add a deploy key",
+        "input_schema": {
+          "type": "object",
+          "required": [
+            "owner",
+            "repo"
+          ]
+        },
+        "output_schema": null,
+        "annotations": null
+      }
+    ],
+    "expected_manifest_digest": "sha256:f8a95098345d600f7a2d742c4e941ace5e9594918b2aa82a9a8f48f72f701ffa"
+  }
+}

--- a/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/verdict_corpus.json
+++ b/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/verdict_corpus.json
@@ -1,0 +1,359 @@
+{
+  "projection_id": "assay.mcp_manifest_projection.v0",
+  "cases": [
+    {
+      "id": "same_digest_complete",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "github.get_issue",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "no_finding"
+    },
+    {
+      "id": "different_digest",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "changed",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "github.get_issue",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "pending_tool_manifest_review"
+    },
+    {
+      "id": "description_changed_non_privileged",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "now cached",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "github.get_issue",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "pending_tool_manifest_review"
+    },
+    {
+      "id": "schema_changed",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object",
+              "required": [
+                "q"
+              ]
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "github.get_issue",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "pending_tool_manifest_review"
+    },
+    {
+      "id": "new_privileged_tool",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "github.get_issue",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "github.add_deploy_key",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "pending_tool_manifest_review"
+    },
+    {
+      "id": "tool_removed",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "pending_tool_manifest_review"
+    },
+    {
+      "id": "annotations_changed",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": {
+              "readOnlyHint": true
+            }
+          },
+          {
+            "name": "github.get_issue",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "pending_tool_manifest_review"
+    },
+    {
+      "id": "behavior_only_identical_metadata",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "github.get_issue",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "no_finding"
+    },
+    {
+      "id": "not_observed",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [],
+        "tools_list_observed": false,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "inconclusive_manifest_not_observed"
+    },
+    {
+      "id": "partial_pagination",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "github.get_issue",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "partial"
+      },
+      "expected_verdict": "inconclusive_manifest_partial_observation"
+    },
+    {
+      "id": "digest_match_unknown_completeness",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "github.get_issue",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "unknown"
+      },
+      "expected_verdict": "no_finding_with_coverage_warning"
+    },
+    {
+      "id": "digest_mismatch_unknown_completeness",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "x",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "unknown"
+      },
+      "expected_verdict": "pending_tool_manifest_review"
+    },
+    {
+      "id": "duplicate_tool_names",
+      "baseline_manifest_digest": "sha256:da458611faca8360295bb00e074430d68515bb56475f0b1233458a5347904a2d",
+      "observed": {
+        "tools": [
+          {
+            "name": "search",
+            "description": "does a thing",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          },
+          {
+            "name": "search",
+            "description": "dup",
+            "input_schema": {
+              "type": "object"
+            },
+            "output_schema": null,
+            "annotations": null
+          }
+        ],
+        "tools_list_observed": true,
+        "tools_list_complete": "complete"
+      },
+      "expected_verdict": "manifest_observation_ambiguous"
+    }
+  ]
+}

--- a/crates/assay-mcp-server/tests/mcp_manifest_drift_fixtures.rs
+++ b/crates/assay-mcp-server/tests/mcp_manifest_drift_fixtures.rs
@@ -1,0 +1,188 @@
+//! P60a guard: the MCP tool-manifest drift reference fixtures must reproduce their committed
+//! canonical digests from the documented projection (docs/reference/mcp-manifest-drift.md) via the
+//! same JCS the producer (P60b) and consumer (P60c) will use, and the documented coverage-rule table
+//! must be executable. There is no producer/consumer yet; this keeps the vectors honest and proves
+//! the canonicalization and the verdict rules are sound. Manifest drift is canonical-digest evidence,
+//! not maliciousness evidence.
+
+use assay_core::mcp::jcs;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+fn fx(name: &str) -> Value {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/mcp_manifest_drift")
+        .join(name);
+    serde_json::from_str(&fs::read_to_string(&p).unwrap()).unwrap()
+}
+
+fn digest_of(subject: &Value) -> String {
+    let bytes = jcs::to_vec(subject).expect("jcs");
+    format!("sha256:{}", hex::encode(Sha256::digest(&bytes)))
+}
+
+/// A per-tool projection hashes directly: the fixture tool objects are already in projection shape
+/// (name, description, input_schema, output_schema, annotations).
+fn tool_digest(tool: &Value) -> String {
+    digest_of(tool)
+}
+
+/// Build the manifest projection with the projection id INSIDE the hashed preimage, sorted by name
+/// then tool_digest, and hash it. This is the value the v0 Plimsoll gate compares against baseline.
+fn manifest_digest(tools: &[Value]) -> String {
+    let mut entries: Vec<Value> = tools
+        .iter()
+        .map(|t| json!({"name": t["name"], "tool_digest": tool_digest(t)}))
+        .collect();
+    entries.sort_by(|a, b| {
+        (
+            a["name"].as_str().unwrap(),
+            a["tool_digest"].as_str().unwrap(),
+        )
+            .cmp(&(
+                b["name"].as_str().unwrap(),
+                b["tool_digest"].as_str().unwrap(),
+            ))
+    });
+    digest_of(&json!({
+        "projection": "assay.mcp_manifest_projection.v0",
+        "tools": entries,
+    }))
+}
+
+fn has_duplicate_names(tools: &[Value]) -> bool {
+    let mut seen: HashMap<&str, u32> = HashMap::new();
+    for t in tools {
+        *seen.entry(t["name"].as_str().unwrap()).or_insert(0) += 1;
+    }
+    seen.values().any(|&n| n > 1)
+}
+
+/// Reference verifier for the documented v0 coverage-rule table. The production gate is P60c; this
+/// proves the spec's verdict column is executable and the fixtures agree with it.
+fn verdict(baseline_digest: &str, observed: &Value) -> &'static str {
+    let observed_flag = observed["tools_list_observed"].as_bool().unwrap();
+    if !observed_flag {
+        return "inconclusive_manifest_not_observed";
+    }
+    let tools: Vec<Value> = observed["tools"].as_array().unwrap().clone();
+    if has_duplicate_names(&tools) {
+        return "manifest_observation_ambiguous";
+    }
+    let complete = observed["tools_list_complete"].as_str().unwrap();
+    if complete == "partial" {
+        return "inconclusive_manifest_partial_observation";
+    }
+    let drift = manifest_digest(&tools) != baseline_digest;
+    if drift {
+        // Drift is observed even under `unknown` completeness.
+        return "pending_tool_manifest_review";
+    }
+    // Digest matches: only `complete` completeness is fully clean; `unknown` carries a coverage warning.
+    if complete == "unknown" {
+        "no_finding_with_coverage_warning"
+    } else {
+        "no_finding"
+    }
+}
+
+#[test]
+fn canonicalization_example_recomputes_from_committed_bytes() {
+    // A third implementation must reproduce these digests from the documented projection alone.
+    let ex = fx("canonicalization_example.json");
+    assert_eq!(
+        tool_digest(&ex["per_tool"]["projection"]),
+        ex["per_tool"]["expected_tool_digest"].as_str().unwrap(),
+        "per-tool projection must recompute to its committed tool_digest via canonical JCS"
+    );
+    let tools: Vec<Value> = ex["manifest"]["tools"].as_array().unwrap().clone();
+    assert_eq!(
+        manifest_digest(&tools),
+        ex["manifest"]["expected_manifest_digest"].as_str().unwrap(),
+        "manifest projection must recompute to its committed manifest_digest via canonical JCS"
+    );
+}
+
+#[test]
+fn manifest_digest_is_order_independent() {
+    // The manifest digest must be stable under tool reordering (entries are sorted in the preimage).
+    let ex = fx("canonicalization_example.json");
+    let mut tools: Vec<Value> = ex["manifest"]["tools"].as_array().unwrap().clone();
+    let forward = manifest_digest(&tools);
+    tools.reverse();
+    assert_eq!(
+        forward,
+        manifest_digest(&tools),
+        "manifest digest must not depend on tool order"
+    );
+}
+
+#[test]
+fn projection_id_is_inside_the_preimage() {
+    // Changing the projection id must change the manifest digest (it is hashed, not metadata-only).
+    let ex = fx("canonicalization_example.json");
+    let mut entries: Vec<Value> = ex["manifest"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| json!({"name": t["name"], "tool_digest": tool_digest(t)}))
+        .collect();
+    entries.sort_by(|a, b| {
+        (
+            a["name"].as_str().unwrap(),
+            a["tool_digest"].as_str().unwrap(),
+        )
+            .cmp(&(
+                b["name"].as_str().unwrap(),
+                b["tool_digest"].as_str().unwrap(),
+            ))
+    });
+    let canonical =
+        digest_of(&json!({"projection": "assay.mcp_manifest_projection.v0", "tools": entries}));
+    let tampered = digest_of(&json!({"projection": "assay.other_projection.v0", "tools": entries}));
+    assert_ne!(
+        canonical, tampered,
+        "projection id must be part of the hashed preimage"
+    );
+}
+
+#[test]
+fn verdict_corpus_matches_expected() {
+    let corpus = fx("verdict_corpus.json");
+    let mut failures = Vec::new();
+    for case in corpus["cases"].as_array().unwrap() {
+        let id = case["id"].as_str().unwrap();
+        let baseline = case["baseline_manifest_digest"].as_str().unwrap();
+        let got = verdict(baseline, &case["observed"]);
+        let expected = case["expected_verdict"].as_str().unwrap();
+        if got != expected {
+            failures.push(format!("{id}: expected {expected}, got {got}"));
+        }
+    }
+    assert!(failures.is_empty(), "verdict mismatches: {failures:?}");
+}
+
+#[test]
+fn pinned_verdict_vocabulary() {
+    // No case may carry a verdict outside the documented v0 set.
+    let known = [
+        "no_finding",
+        "no_finding_with_coverage_warning",
+        "pending_tool_manifest_review",
+        "inconclusive_manifest_not_observed",
+        "inconclusive_manifest_partial_observation",
+        "manifest_observation_ambiguous",
+    ];
+    let corpus = fx("verdict_corpus.json");
+    for case in corpus["cases"].as_array().unwrap() {
+        let v = case["expected_verdict"].as_str().unwrap();
+        assert!(
+            known.contains(&v),
+            "{}: unknown verdict {v}",
+            case["id"].as_str().unwrap()
+        );
+    }
+}

--- a/docs/reference/mcp-manifest-drift.md
+++ b/docs/reference/mcp-manifest-drift.md
@@ -1,0 +1,164 @@
+# MCP tool-manifest drift (`assay.mcp_manifest_observed.v0`)
+
+Status: spec + reference fixtures (P60a). No producer/consumer wired yet; the `assay-mcp-server`
+producer (P60b) and the Plimsoll coarse-drift gate (P60c) build on this shape. Part of the
+[privileged-action evidence](privileged-action-evidence.md) set.
+
+## Why this exists
+
+An MCP server that looks safe when its tools are approved can, at runtime, expose different tool
+descriptions, input/output schemas, annotations, or new tools. Most mitigations scan the server
+ahead of time; this one is the opposite, deterministic signal: a proof during the run that the
+observed tool surface drifted from a declared/baselined manifest, by canonical digests, with no
+model judgement. (The threat-model term for the hostile case is tool poisoning; this record does not
+classify maliciousness.)
+
+**Manifest drift is canonical-digest evidence, not maliciousness evidence.** A legitimate manifest
+change also surfaces as drift and resolves to `pending_tool_manifest_review`, never a "malicious"
+verdict.
+
+## Claim and non-claims
+
+**Claim:** Assay/Plimsoll detect that the observed MCP tool surface drifted from a declared/baselined
+manifest, by canonical digests.
+
+**Non-claims:**
+- does not detect behavior drift under identical metadata (digest-invisible, by design);
+- does not classify maliciousness; a legitimate change also surfaces as drift;
+- is not a pre-flight scanner and not an LLM risk score;
+- `privileged` is classifier-derived, not the server's own annotations as source of truth;
+- does not infer tools outside the observed `tools/list`;
+- an unobserved or partially observed manifest is inconclusive, never read as "no drift".
+
+## Canonicalization (`assay.mcp_manifest_projection.v0`)
+
+Digests are reproducible from committed bytes via JCS (RFC 8785, deterministic JSON
+canonicalization). A third implementation must reproduce the same digests from this projection alone.
+
+Per-tool projection:
+```json
+{
+  "name": "<string>",
+  "description": "<string or null>",
+  "input_schema": "<JSON value or null>",
+  "output_schema": "<JSON value or null>",
+  "annotations": "<JSON value or null>"
+}
+```
+`tool_digest = sha256(JCS(per-tool projection))`.
+
+Manifest projection — the projection id is INSIDE the hashed preimage, so a shape change cannot
+happen without a digest bump:
+```json
+{
+  "projection": "assay.mcp_manifest_projection.v0",
+  "tools": [ { "name": "<name>", "tool_digest": "sha256:..." } ]
+}
+```
+Tools are sorted by `name`, then by `tool_digest` if duplicate names ever occur.
+`manifest_digest = sha256(JCS(manifest projection))`.
+
+## Observed manifest record (`assay.mcp_manifest_observed.v0`)
+
+Emitted by the proxy from the observed `tools/list`. The proxy observes **every** `tools/list`
+response and carries the latest. Per-tool digests are diagnostic/supporting detail in v0; the v0
+Plimsoll gate uses only the overall `manifest_digest` (per-tool drift reason codes are P60d/v1).
+
+```json
+{
+  "schema": "assay.mcp_manifest_observed.v0",
+  "server": { "id": "github", "declared_manifest_digest": "sha256:..." },
+  "observed": {
+    "manifest_digest": "sha256:...",
+    "canonicalization": "assay.mcp_manifest_projection.v0",
+    "tool_count": 12,
+    "privileged_tool_count": 2,
+    "tools_list_observed": true,
+    "tools_list_complete": "complete",
+    "tool_digests": [
+      {
+        "name": "github.add_deploy_key",
+        "tool_digest": "sha256:...",
+        "privileged": true,
+        "privilege_classification": "classified",
+        "action_class": "github_deploy_key"
+      }
+    ]
+  },
+  "non_claims": [
+    "does not judge whether a manifest change is malicious",
+    "does not infer tools outside the observed tools/list",
+    "does not detect behavior drift under identical metadata",
+    "privileged is classifier-derived, not the server's own annotations"
+  ]
+}
+```
+
+### `tools_list_complete` (enum: `complete` | `partial` | `unknown`)
+
+MCP list operations are paginated: a single `tools/list` response is not automatically the full
+manifest, and a client continues following `nextCursor` until there is none.
+
+- `complete` — only after the proxy observed the full list operation, including all paginated pages
+  until no `nextCursor` remains;
+- `partial` — pagination started but the chain was not completed (an error interrupted it, or only a
+  subset was observed);
+- `unknown` — the proxy saw a `tools/list`-shaped response but cannot prove the server's list
+  operation was complete.
+
+### `privilege_classification` (never bare bool)
+
+`privileged` is classifier-derived (the P57c classifier leaf-names), and carries its classification so
+`false` is never read as "safe":
+- classified: `{ "privileged": true, "privilege_classification": "classified", "action_class": "github_deploy_key" }`
+- unclassified: `{ "privileged": false, "privilege_classification": "unclassified", "action_class": null }`
+
+## Baseline (v0: policy-map/config)
+
+The baseline is pinned per server in the consumer policy (consistent with `declared_credentials` and
+`network_declared_endpoints`); it is declared/baselined, not intrinsically trusted:
+```yaml
+declared_mcp_manifests:
+  github:
+    manifest_digest: "sha256:..."
+```
+A richer `assay.declared_mcp_manifest.v0` with per-tool expected digests is a later (P60d) artifact.
+
+## Coverage rules and verdicts (Plimsoll, P60c — v0 coarse)
+
+```
+tools_list_observed = false                                  -> inconclusive_manifest_not_observed
+tools_list_observed = true, complete = partial               -> inconclusive_manifest_partial_observation
+                                                                (unless policy allows warning-only)
+duplicate tool names in one observed manifest                -> manifest_observation_ambiguous (inconclusive)
+observed.manifest_digest != baseline                         -> mcp_tool_manifest_drift -> pending_tool_manifest_review
+  (drift is observed even when complete = unknown)
+digest match, complete = unknown                             -> no drift finding, but a coverage warning
+digest match, complete = complete                            -> no finding
+```
+Absence rule: "no observed `tools/list`" is not "no drift"; only "observed complete `tools/list` plus
+a matching digest" is "no drift". A digest mismatch is drift even under `unknown` completeness; a
+digest match under `unknown` completeness may not be claimed fully clean.
+
+## What v0 is NOT
+
+No per-tool granular drift reason codes (P60d/v1), no behavior-drift detection, no LLM risk scoring,
+no automatic block on legitimate description churn, no maliciousness classification, no pre-flight
+scan.
+
+## PR sequence
+
+```
+P60a  this spec + fixtures + canonicalization examples + a digest-recompute guard test
+P60b  producer: assay-mcp-server emits assay.mcp_manifest_observed.v0 (digest-only gate input, coverage)
+P60c  Plimsoll: coarse drift gate -> pending_tool_manifest_review (opt-in, coverage-gated)
+P60d  granular per-tool drift v1 + assay.declared_mcp_manifest.v0 (per-tool expected digests)
+```
+
+## Reference fixtures
+
+`crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/`: canonicalization examples (a per-tool
+projection and a manifest projection with their committed digests, recomputed in the guard test) and
+a verdict corpus (same digest, drift, description/schema/annotations changed, new privileged tool,
+tool removed, behavior-only identical metadata, not observed, partial pagination, duplicate names),
+each labelled with its expected v0 verdict.


### PR DESCRIPTION
Spec + reference fixtures for `assay.mcp_manifest_observed.v0`: a deterministic, canonical-digest signal that the observed MCP tool surface drifted from a declared/baselined manifest. No producer or consumer is wired here — the `assay-mcp-server` producer (P60b) and the coarse-drift gate (P60c) build on this shape.

The discipline carried throughout: **manifest drift is canonical-digest evidence, not maliciousness evidence.** A legitimate manifest change also surfaces as drift and resolves to `pending_tool_manifest_review`, never a "malicious" verdict.

What's in the spec (`docs/reference/mcp-manifest-drift.md`):
- canonicalization (`assay.mcp_manifest_projection.v0`): a per-tool projection over name/description/input_schema/output_schema/annotations yields `tool_digest`; the manifest projection carries its projection id *inside* the hashed preimage so a shape change can't happen without a digest bump, yielding `manifest_digest`, both over JCS (RFC 8785);
- record shape: `tools_list_complete` as an enum (complete/partial/unknown, complete only after the full pagination chain), `privilege_classification` (classified/unclassified) plus `action_class` so `privileged: false` is never read as "safe", per-tool digests as supporting detail while the v0 gate compares `manifest_digest` only;
- baseline pinned per server via the consumer policy-map `declared_mcp_manifests`;
- a coverage-rule table with explicit inconclusive verdicts — an unobserved or partially observed manifest is inconclusive, a digest mismatch is drift even under unknown completeness, and a digest match under unknown completeness is never claimed fully clean.

The guard test recomputes the committed canonical digests through `assay_core::mcp::jcs` (a cross-implementation anchor) and runs the documented coverage-rule table as a reference verifier over the fixture corpus, so the spec's verdict column is executable rather than prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)