### PR TITLE
feat(mcp): upstream proxy mode — manifest-observation forwarding skeleton (P61b)

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -1,14 +1,36 @@
 use anyhow::Result;
 use assay_mcp_server::config;
 use assay_mcp_server::server::Server;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
+
+// P61b: upstream proxy mode lives in the binary crate only (not exposed in the library's public API),
+// because it is invoked solely from here. See docs/reference/mcp-upstream-proxy-mode.md.
+mod proxy;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
     #[arg(long, default_value = "policies")]
     policy_root: PathBuf,
+    #[command(subcommand)]
+    mode: Option<Mode>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Mode {
+    /// Run as an MCP upstream proxy (manifest-observation v0): forward a tiny method allowlist to a
+    /// stdio upstream and deny everything else (tools/call included). This mode does NOT execute tool
+    /// calls through the proxy and emits no manifest artifact yet. --policy-root is unused here.
+    Proxy {
+        /// The upstream MCP server command to spawn (stdio transport).
+        #[arg(long)]
+        upstream_command: String,
+        /// Arguments passed to the upstream command (repeatable). Hyphen-led values are allowed so an
+        /// upstream command can take its own flags (e.g. `--upstream-arg -u`).
+        #[arg(long = "upstream-arg", allow_hyphen_values = true)]
+        upstream_args: Vec<String>,
+    },
 }
 
 use tracing_subscriber::{fmt, EnvFilter};
@@ -36,11 +58,25 @@ async fn main() -> Result<()> {
 
     init_logging(&cfg.log_level);
 
-    tracing::info!(
-        event = "server_start",
-        policy_root = ?args.policy_root,
-        config = ?cfg
-    );
-
-    Server::run(args.policy_root, cfg).await
+    match args.mode {
+        Some(Mode::Proxy {
+            upstream_command,
+            upstream_args,
+        }) => {
+            tracing::info!(
+                event = "proxy_start",
+                upstream_command = %upstream_command,
+                mode = "manifest_observation_v0"
+            );
+            proxy::run(upstream_command, upstream_args).await
+        }
+        None => {
+            tracing::info!(
+                event = "server_start",
+                policy_root = ?args.policy_root,
+                config = ?cfg
+            );
+            Server::run(args.policy_root, cfg).await
+        }
+    }
 }

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -1,0 +1,216 @@
+//! P61b: MCP upstream proxy mode — manifest-observation v0. A safe stdio forwarding skeleton with
+//! hard denials. Spec: docs/reference/mcp-upstream-proxy-mode.md.
+//!
+//! What this is: an explicit, opt-in proxy that spawns one stdio upstream MCP server, forwards a tiny
+//! exhaustive method allowlist (the handshake and `tools/list`), relays the upstream's output back to
+//! the client verbatim, and denies everything else — first of all `tools/call` — with a
+//! proxy-originated error. The upstream never receives a denied method.
+//!
+//! What this is NOT (P61b is a forwarding skeleton, not manifest evidence and not tool execution
+//! through the proxy): no manifest artifact is emitted, no pagination is tracked, no policy decision is
+//! made, no tool-decision evidence is produced. Those are later slices (P61c+). A privileged
+//! `tools/call` is never forwarded — not even observe-only — because a credential-bearing proxy that
+//! relays privileged calls without a blocking decision is the confused-deputy trap.
+//!
+//! Credential boundary: the proxy injects no transport authentication of its own into forwarded
+//! traffic. Allowlisted client requests are forwarded verbatim; the upstream's own credentials come
+//! only from how the operator configured the spawned command's environment.
+
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+
+/// The exhaustive v0 allowlist of client→upstream methods. Everything else is denied. This is
+/// deliberately tiny: v0 enables live manifest observation, not general read-only MCP forwarding.
+const ALLOWLIST: &[&str] = &[
+    "initialize",
+    "notifications/initialized",
+    "ping",
+    "tools/list",
+    "notifications/tools/list_changed",
+];
+
+// Proxy-originated JSON-RPC error codes (private server-error range). The `data.origin` marker makes a
+// proxy-originated error unambiguously distinguishable from an upstream error regardless of code.
+const PROXY_UNSUPPORTED: i32 = -32040;
+const PROXY_FAILED: i32 = -32041;
+// PROXY_DENIED (-32042) is reserved for the future enforcing arc (P61e); it never occurs in v0.
+
+fn proxy_error_line(id: Value, code: i32, reason: &str, message: &str) -> String {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message,
+            "data": { "origin": "assay-proxy", "reason": reason }
+        }
+    })
+    .to_string()
+}
+
+/// Run the manifest-observation proxy against one stdio upstream. Returns when the client closes
+/// stdin (EOF) or the upstream connection ends.
+pub async fn run(upstream_command: String, upstream_args: Vec<String>) -> Result<()> {
+    let spawned = Command::new(&upstream_command)
+        .args(&upstream_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn();
+
+    let mut child = match spawned {
+        Ok(c) => c,
+        Err(e) => {
+            // Fail-closed honesty: the upstream is unavailable, so never forward; answer every client
+            // request with a proxy-originated failure rather than silence or a fabricated success.
+            tracing::error!(event = "proxy_upstream_spawn_failed", error = %e);
+            return degraded_loop("upstream_spawn_failed").await;
+        }
+    };
+
+    let mut child_stdin = child.stdin.take().context("upstream stdin")?;
+    let child_stdout = child.stdout.take().context("upstream stdout")?;
+
+    // A single writer owns the client's stdout; both the upstream relay and proxy-originated errors
+    // funnel through it so their lines never interleave.
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+    let writer = tokio::spawn(async move {
+        let mut out = tokio::io::stdout();
+        while let Some(line) = rx.recv().await {
+            if out.write_all(line.as_bytes()).await.is_err() {
+                break;
+            }
+            if out.write_all(b"\n").await.is_err() {
+                break;
+            }
+            let _ = out.flush().await;
+        }
+    });
+
+    // Upstream → client: relay valid JSON verbatim. A non-JSON upstream line is never relayed as a
+    // success; it surfaces as a proxy-originated failure (malformed upstream is not trusted).
+    let up_tx = tx.clone();
+    let upstream_reader = tokio::spawn(async move {
+        let mut lines = BufReader::new(child_stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Value>(&line) {
+                Ok(_) => {
+                    let _ = up_tx.send(line);
+                }
+                Err(_) => {
+                    let _ = up_tx.send(proxy_error_line(
+                        Value::Null,
+                        PROXY_FAILED,
+                        "malformed_upstream_response",
+                        "upstream emitted a non-JSON line; not relayed",
+                    ));
+                }
+            }
+        }
+    });
+
+    // Client → upstream: gate by the allowlist. Denied requests get a proxy_unsupported error and are
+    // never sent upstream; denied notifications are dropped (no id to answer).
+    let mut client = BufReader::new(tokio::io::stdin()).lines();
+    while let Ok(Some(line)) = client.next_line().await {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let v: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => {
+                let _ = tx.send(proxy_error_line(
+                    Value::Null,
+                    PROXY_FAILED,
+                    "malformed_client_request",
+                    "client sent a non-JSON line",
+                ));
+                continue;
+            }
+        };
+
+        match v.get("method").and_then(|m| m.as_str()) {
+            Some(method) if ALLOWLIST.contains(&method) => {
+                // Forward the original bytes verbatim — the proxy injects nothing of its own.
+                if forward_line(&mut child_stdin, &line).await.is_err() {
+                    break;
+                }
+            }
+            Some(method) => {
+                // Denied: tools/call and every other non-allowlisted method. The upstream never sees it.
+                match v.get("id") {
+                    Some(id) if !id.is_null() => {
+                        let _ = tx.send(proxy_error_line(
+                            id.clone(),
+                            PROXY_UNSUPPORTED,
+                            "method_not_allowlisted",
+                            &format!(
+                                "method {method:?} is not forwarded in manifest-observation proxy mode"
+                            ),
+                        ));
+                    }
+                    _ => { /* denied notification: nothing to answer, drop it */ }
+                }
+            }
+            None => {
+                // No method: a client response to an upstream-initiated request. It cannot invoke a
+                // tool, so relay it verbatim to keep the session working.
+                if forward_line(&mut child_stdin, &line).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Client EOF: close the upstream's stdin, tear down, and drain.
+    drop(child_stdin);
+    let _ = child.start_kill();
+    drop(tx);
+    let _ = upstream_reader.await;
+    let _ = writer.await;
+    let _ = child.wait().await;
+    Ok(())
+}
+
+async fn forward_line<W: AsyncWriteExt + Unpin>(w: &mut W, line: &str) -> std::io::Result<()> {
+    w.write_all(line.as_bytes()).await?;
+    w.write_all(b"\n").await?;
+    w.flush().await
+}
+
+/// Upstream unavailable: never forward, never fabricate. Answer every client request with a
+/// proxy-originated failure until the client closes stdin.
+async fn degraded_loop(reason: &str) -> Result<()> {
+    let mut out = tokio::io::stdout();
+    let mut client = BufReader::new(tokio::io::stdin()).lines();
+    while let Ok(Some(line)) = client.next_line().await {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let v: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if let Some(id) = v.get("id") {
+            if !id.is_null() {
+                let msg = proxy_error_line(
+                    id.clone(),
+                    PROXY_FAILED,
+                    reason,
+                    "upstream MCP server is unavailable",
+                );
+                let _ = out.write_all(msg.as_bytes()).await;
+                let _ = out.write_all(b"\n").await;
+                let _ = out.flush().await;
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/assay-mcp-server/tests/fixtures/proxy/mock_upstream.py
+++ b/crates/assay-mcp-server/tests/fixtures/proxy/mock_upstream.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Deterministic mock upstream MCP server (stdio) for the P61b proxy-forwarding tests.
+
+It speaks newline-delimited JSON-RPC over stdin/stdout, records every received method (and, if asked,
+the raw received line) so a test can assert what did and did not reach the upstream, and answers a
+fixed set of methods with canned results. It uses no network and performs no auth/header handling.
+
+Environment:
+  MOCK_UPSTREAM_LOG       append each received `method` (one per line) to this path
+  MOCK_UPSTREAM_RAW_LOG   append each raw received line to this path (to prove verbatim forwarding)
+  MOCK_UPSTREAM_MODE      "normal" (default) or "malformed" (emit a non-JSON line for tools/list)
+"""
+import json
+import os
+import sys
+
+LOG = os.environ.get("MOCK_UPSTREAM_LOG")
+RAW_LOG = os.environ.get("MOCK_UPSTREAM_RAW_LOG")
+MODE = os.environ.get("MOCK_UPSTREAM_MODE", "normal")
+
+
+def _append(path, text):
+    if path:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(text + "\n")
+            f.flush()
+
+
+def _send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def main():
+    # readline() (not `for line in sys.stdin`) so lines are handled as they arrive, not after a full
+    # buffer fills; the proxy invokes this script with python -u for unbuffered streams.
+    while True:
+        raw = sys.stdin.readline()
+        if not raw:
+            break
+        line = raw.strip()
+        if not line:
+            continue
+        _append(RAW_LOG, line)
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            # The proxy should only ever forward valid JSON; record nothing actionable.
+            continue
+        method = msg.get("method")
+        if method:
+            _append(LOG, method)
+        mid = msg.get("id")
+
+        if method == "initialize":
+            _send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mock-upstream", "version": "0.0.0"},
+                },
+            })
+        elif method == "ping":
+            _send({"jsonrpc": "2.0", "id": mid, "result": {}})
+        elif method == "tools/list":
+            if MODE == "malformed":
+                # A non-JSON line: the proxy must not relay this as a successful response.
+                sys.stdout.write("THIS IS NOT JSON-RPC\n")
+                sys.stdout.flush()
+            else:
+                _send({
+                    "jsonrpc": "2.0",
+                    "id": mid,
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "echo",
+                                "description": "echoes input",
+                                "inputSchema": {"type": "object"},
+                            }
+                        ]
+                    },
+                })
+        elif method is not None and mid is not None:
+            # Should never happen: the proxy denies non-allowlisted methods before they reach us. If a
+            # request slips through, fail loudly rather than silently accept it.
+            _send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "error": {"code": -32601, "message": "method not found"},
+            })
+        # Notifications (no id) get logged but no response.
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/assay-mcp-server/tests/proxy_forwarding_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_forwarding_e2e.rs
@@ -1,0 +1,351 @@
+//! P61b: MCP upstream proxy mode — manifest-observation v0. End-to-end forwarding-skeleton tests.
+//! Spec: docs/reference/mcp-upstream-proxy-mode.md.
+//!
+//! The load-bearing invariant, asserted first: a `tools/call` sent in proxy mode is denied with a
+//! proxy-originated error and NEVER reaches the upstream. The upstream is a deterministic stdio mock
+//! (tests/fixtures/proxy/mock_upstream.py) that records every method it receives, so "the upstream
+//! received nothing" is a checkable fact, not an assumption.
+
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+const PROXY_UNSUPPORTED: i64 = -32040;
+const PROXY_FAILED: i64 = -32041;
+
+fn python() -> &'static str {
+    // GitHub-hosted Windows exposes `python`; Linux/macOS expose `python3`.
+    if cfg!(windows) {
+        "python"
+    } else {
+        "python3"
+    }
+}
+
+fn mock_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/mock_upstream.py")
+}
+
+/// Spawn the proxy against the python mock upstream. `mode` is the mock's MOCK_UPSTREAM_MODE.
+/// `log` records received methods; `raw_log` (optional) records raw received lines.
+fn spawn_proxy(log: &std::path::Path, raw_log: Option<&std::path::Path>, mode: &str) -> Child {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"));
+    cmd.args([
+        "proxy",
+        "--upstream-command",
+        python(),
+        "--upstream-arg",
+        "-u",
+        "--upstream-arg",
+        mock_path().to_str().unwrap(),
+    ])
+    .env("MOCK_UPSTREAM_LOG", log)
+    .env("MOCK_UPSTREAM_MODE", mode)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::inherit());
+    if let Some(rl) = raw_log {
+        cmd.env("MOCK_UPSTREAM_RAW_LOG", rl);
+    }
+    cmd.spawn().expect("spawn proxy (is python installed?)")
+}
+
+fn send(stdin: &mut ChildStdin, v: Value) {
+    writeln!(stdin, "{v}").expect("write request");
+    stdin.flush().expect("flush request");
+}
+
+/// Read the next non-empty JSON line from the proxy's stdout.
+fn read_response(reader: &mut BufReader<ChildStdout>) -> Value {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).expect("read response");
+        assert!(n > 0, "proxy closed stdout before responding");
+        if !line.trim().is_empty() {
+            return serde_json::from_str(line.trim()).expect("parse response JSON");
+        }
+    }
+}
+
+fn init() -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "t", "version": "1"}}
+    })
+}
+
+fn read_methods(log: &std::path::Path) -> Vec<String> {
+    std::fs::read_to_string(log)
+        .unwrap_or_default()
+        .lines()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn shutdown(mut child: Child, stdin: ChildStdin) {
+    drop(stdin); // client EOF
+    let _ = child.wait();
+}
+
+// --- the load-bearing test, first ---------------------------------------------------------------
+
+#[test]
+fn tools_call_never_reaches_upstream() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn_proxy(&log, None, "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let r = read_response(&mut out);
+    assert_eq!(r["result"]["serverInfo"]["name"], "mock-upstream");
+
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let r = read_response(&mut out);
+    assert!(r["result"]["tools"].is_array());
+
+    // The denied call: the proxy must answer proxy_unsupported and the upstream must never see it.
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                           "params": {"name": "echo", "arguments": {}}}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["id"], 3);
+    assert_eq!(r["error"]["code"], PROXY_UNSUPPORTED);
+    assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
+
+    shutdown(child, stdin);
+
+    let methods = read_methods(&log);
+    assert!(
+        methods.contains(&"initialize".to_string()),
+        "upstream saw initialize"
+    );
+    assert!(
+        methods.contains(&"tools/list".to_string()),
+        "upstream saw tools/list"
+    );
+    assert!(
+        !methods.contains(&"tools/call".to_string()),
+        "INVARIANT VIOLATED: tools/call reached the upstream: {methods:?}"
+    );
+}
+
+#[test]
+fn non_allowlisted_method_is_denied_and_not_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn_proxy(&log, None, "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 7, "method": "resources/list"}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_UNSUPPORTED);
+    assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
+
+    shutdown(child, stdin);
+    assert!(!read_methods(&log).contains(&"resources/list".to_string()));
+}
+
+#[test]
+fn proxy_does_not_inject_inbound_transport_auth() {
+    // Option 1 (verbatim forwarding): the proxy injects no Authorization/header/token of its own. We
+    // send a clean initialize and assert the upstream received exactly those bytes — nothing added.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let raw = dir.path().join("raw.log");
+    let mut child = spawn_proxy(&log, Some(&raw), "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    let sent = init();
+    send(&mut stdin, sent.clone());
+    let _ = read_response(&mut out);
+    shutdown(child, stdin);
+
+    let raw_lines = std::fs::read_to_string(&raw).unwrap_or_default();
+    let received: Value =
+        serde_json::from_str(raw_lines.lines().next().expect("upstream received a line")).unwrap();
+    // The proxy added no transport-auth envelope: the upstream got exactly what the client sent.
+    assert_eq!(
+        received, sent,
+        "proxy must forward verbatim, injecting nothing"
+    );
+    let text = raw_lines.to_lowercase();
+    assert!(
+        !text.contains("authorization") && !text.contains("\"token\""),
+        "proxy must not inject an auth/token field"
+    );
+}
+
+#[test]
+fn initialize_and_tools_list_forward_and_response_is_unmutated() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn_proxy(&log, None, "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let r = read_response(&mut out);
+    // The upstream's canned serverInfo is relayed unmutated.
+    assert_eq!(r["result"]["serverInfo"]["version"], "0.0.0");
+
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["result"]["tools"][0]["name"], "echo");
+
+    shutdown(child, stdin);
+    let methods = read_methods(&log);
+    assert!(methods.contains(&"initialize".to_string()));
+    assert!(methods.contains(&"tools/list".to_string()));
+}
+
+#[test]
+fn ping_is_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn_proxy(&log, None, "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 5, "method": "ping"}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["id"], 5);
+    assert!(r["result"].is_object());
+
+    shutdown(child, stdin);
+    assert!(read_methods(&log).contains(&"ping".to_string()));
+}
+
+#[test]
+fn upstream_spawn_failure_yields_proxy_failed() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    // An upstream command that cannot be spawned.
+    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            "proxy",
+            "--upstream-command",
+            "this-binary-does-not-exist-assay-test",
+        ])
+        .env("MOCK_UPSTREAM_LOG", &log)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_FAILED);
+    assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
+    assert_eq!(r["error"]["data"]["reason"], "upstream_spawn_failed");
+
+    shutdown(child, stdin);
+}
+
+#[test]
+fn malformed_upstream_response_is_not_trusted() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn_proxy(&log, None, "malformed");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out); // initialize is normal
+
+    // tools/list: the mock emits a non-JSON line; the proxy must surface a proxy_failed, never relay
+    // the garbage as a successful result.
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_FAILED);
+    assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
+    assert_eq!(r["error"]["data"]["reason"], "malformed_upstream_response");
+
+    shutdown(child, stdin);
+}
+
+#[test]
+fn default_mode_spawns_no_upstream_and_serves_local_tools() {
+    // No `proxy` subcommand: the terminating server is unchanged and must not spawn an upstream. We
+    // point at a sentinel log that must stay absent/empty because no mock can have been spawned.
+    let dir = tempfile::tempdir().unwrap();
+    let sentinel = dir.path().join("must_stay_absent.log");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args(["--policy-root", "../../tests/fixtures/mcp"])
+        .env("MOCK_UPSTREAM_LOG", &sentinel)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let r = read_response(&mut out);
+    // The default server answers initialize itself (its own serverInfo, not the mock's).
+    assert_ne!(r["result"]["serverInfo"]["name"], "mock-upstream");
+
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let r = read_response(&mut out);
+    assert!(
+        r["result"]["tools"].is_array(),
+        "default server serves its own tools"
+    );
+
+    shutdown(child, stdin);
+    assert!(
+        !sentinel.exists(),
+        "default mode must not spawn any upstream (mock log must not exist)"
+    );
+}
+
+#[test]
+fn no_manifest_artifact_is_emitted_in_p61b() {
+    // P61b is a forwarding skeleton: there is no --mcp-manifest-observed-out flag and no artifact is
+    // written. The flag must not exist yet.
+    let out = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args(["proxy", "--help"])
+        .output()
+        .unwrap();
+    let help = String::from_utf8_lossy(&out.stdout);
+    // The help text legitimately describes "manifest-observation mode"; what must be absent is any
+    // artifact-emission flag.
+    assert!(
+        !help.contains("mcp-manifest-observed-out") && !help.contains("--out"),
+        "P61b must not expose any manifest emission flag"
+    );
+}


### PR DESCRIPTION
The first code slice of the P61 upstream proxy arc, and a different risk class from the docs that preceded it: a credential-adjacent forwarding component. So it is deliberately a **safe forwarding skeleton with hard denials** — manifest evidence and tool execution through the proxy are explicitly out.

`assay-mcp-server proxy --upstream-command <cmd> [--upstream-arg <a>]…` spawns one stdio upstream MCP server and forwards an exhaustive method allowlist — `initialize`, `notifications/initialized`, `ping`, `tools/list`, `notifications/tools/list_changed` — relaying the upstream's output back verbatim. Everything else, first of all `tools/call`, is denied with a proxy-originated error and **never reaches the upstream**. The load-bearing line holds: a credential-bearing proxy that relays privileged calls without a blocking decision is the confused-deputy trap, so privileged `tools/call` is never forwarded — not even observe-only.

The invariants from the P61a spec, locked here:

- **opt-in and explicit** — a clap subcommand; with no subcommand the terminating server is byte-for-byte unchanged and spawns no upstream (proven by a test).
- **exhaustive allowlist, default-deny** — the five methods above; anything else → `proxy_unsupported`.
- **`tools/call` never forwarded** — the first test drives a `tools/call` and asserts the deterministic mock upstream's received-method log contains `initialize` and `tools/list` but never `tools/call`.
- **no transport-auth injection** — allowlisted requests are forwarded verbatim; a verbatim-forwarding test proves the upstream received exactly what the client sent, with no proxy-added `Authorization`/token.
- **distinct proxy error space** — `proxy_unsupported` (−32040), `proxy_failed` (−32041), `proxy_denied` (−32042, reserved/unused in v0), each tagged `data.origin = "assay-proxy"` so it can't be confused with an upstream error.
- **fail-closed** — an upstream that won't spawn yields `proxy_failed` for every request, never a fabricated success; a malformed upstream line is never relayed as success.
- **no manifest artifact** — there is no emission flag; a test asserts `proxy --help` exposes none. Pagination, manifest emission, policy decisions, and tool-decision evidence are all P61c+.

Implementation notes honoring the review: the proxy module is **bin-crate-private** (declared in `main.rs`, not in the library's public API), and **`Cargo.toml`/`Cargo.lock` are untouched** — `tokio = ["full"]` already provides `process` + `io-std`, and the mock upstream is a committed Python script (`tests/fixtures/proxy/mock_upstream.py`), not a feature-gated Rust bin. Nine e2e tests pass locally (`tools_call_never_reaches_upstream` first); fmt, clippy, and the full crate suite are green.

Lane classification: Gate.NONE

Reason:
- assay-mcp-server source + tests + a test fixture only
- no runner/eBPF/monitor paths
- no Cargo.toml/Cargo.lock changes
- no delegated proof paths

I'll confirm the real lane-check output on this PR rather than assume, and verify CI is green across linux/macOS/windows (the Python mock runs on all three) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)