### PR TITLE
feat(mcp): proxy manifest observation — pagination tracker + emission (P61c)

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -21,7 +21,8 @@ struct Args {
 enum Mode {
     /// Run as an MCP upstream proxy (manifest-observation v0): forward a tiny method allowlist to a
     /// stdio upstream and deny everything else (tools/call included). This mode does NOT execute tool
-    /// calls through the proxy and emits no manifest artifact yet. --policy-root is unused here.
+    /// calls through the proxy; it observes the upstream tools/list and (with --mcp-manifest-observed-out)
+    /// emits manifest evidence only. --policy-root is unused here.
     Proxy {
         /// The upstream MCP server command to spawn (stdio transport).
         #[arg(long)]
@@ -30,6 +31,15 @@ enum Mode {
         /// upstream command can take its own flags (e.g. `--upstream-arg -u`).
         #[arg(long = "upstream-arg", allow_hyphen_values = true)]
         upstream_args: Vec<String>,
+        /// Write the observed tool manifest (assay.mcp_manifest_observed.v0) to this path at shutdown
+        /// (and on each completed tools/list chain). When set and no tools/list is observed, a
+        /// status:not_observed artifact is written — never an absent file.
+        #[arg(long)]
+        mcp_manifest_observed_out: Option<PathBuf>,
+        /// Write a small proxy observation-health record (assay.proxy_observation_health.v0) to this
+        /// path at shutdown: how complete the observation was, separate from the manifest itself.
+        #[arg(long)]
+        proxy_observation_health_out: Option<PathBuf>,
     },
 }
 
@@ -62,13 +72,21 @@ async fn main() -> Result<()> {
         Some(Mode::Proxy {
             upstream_command,
             upstream_args,
+            mcp_manifest_observed_out,
+            proxy_observation_health_out,
         }) => {
             tracing::info!(
                 event = "proxy_start",
                 upstream_command = %upstream_command,
                 mode = "manifest_observation_v0"
             );
-            proxy::run(upstream_command, upstream_args).await
+            proxy::run(
+                upstream_command,
+                upstream_args,
+                mcp_manifest_observed_out,
+                proxy_observation_health_out,
+            )
+            .await
         }
         None => {
             tracing::info!(

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -1,30 +1,33 @@
-//! P61b: MCP upstream proxy mode — manifest-observation v0. A safe stdio forwarding skeleton with
-//! hard denials. Spec: docs/reference/mcp-upstream-proxy-mode.md.
+//! P61b + P61c: MCP upstream proxy mode — manifest-observation v0. A safe stdio forwarding skeleton
+//! with hard denials (P61b) that also observes the upstream `tools/list` and emits manifest evidence
+//! (P61c). Spec: docs/reference/mcp-upstream-proxy-mode.md.
 //!
-//! What this is: an explicit, opt-in proxy that spawns one stdio upstream MCP server, forwards a tiny
-//! exhaustive method allowlist (the handshake and `tools/list`), relays the upstream's output back to
-//! the client verbatim, and denies everything else — first of all `tools/call` — with a
-//! proxy-originated error. The upstream never receives a denied method.
+//! P61b — forwarding skeleton: spawn one stdio upstream, forward a tiny exhaustive method allowlist
+//! (the handshake and `tools/list`), relay upstream output verbatim, deny everything else — first of
+//! all `tools/call` — with a proxy-originated error the upstream never sees.
 //!
-//! What this is NOT (P61b is a forwarding skeleton, not manifest evidence and not tool execution
-//! through the proxy): no manifest artifact is emitted, no pagination is tracked, no policy decision is
-//! made, no tool-decision evidence is produced. Those are later slices (P61c+). A privileged
-//! `tools/call` is never forwarded — not even observe-only — because a credential-bearing proxy that
-//! relays privileged calls without a blocking decision is the confused-deputy trap.
+//! P61c — manifest observation: read-only tap on `tools/list` responses, track the pagination chain
+//! (complete / partial / unknown), select latest-complete-else-best-observed, and emit
+//! `assay.mcp_manifest_observed.v0` (via the P60b producer) plus a small observation-health record.
 //!
-//! Credential boundary: the proxy injects no transport authentication of its own into forwarded
-//! traffic. Allowlisted client requests are forwarded verbatim; the upstream's own credentials come
-//! only from how the operator configured the spawned command's environment.
+//! What this is NOT: tool execution through the proxy, policy enforcement, per-tool drift, or any
+//! maliciousness claim. A privileged `tools/call` is never forwarded — not even observe-only — because
+//! a credential-bearing proxy relaying privileged calls without a blocking decision is the
+//! confused-deputy trap. The manifest artifact is exactly the P60b shape the consumer already gates on;
+//! "how completely was it observed" lives in the separate observation-health artifact, never folded in.
 
 use anyhow::{Context, Result};
+use assay_mcp_server::manifest_observed::{self, Completeness};
 use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 
-/// The exhaustive v0 allowlist of client→upstream methods. Everything else is denied. This is
-/// deliberately tiny: v0 enables live manifest observation, not general read-only MCP forwarding.
+/// The exhaustive v0 allowlist of client→upstream methods. Everything else is denied.
 const ALLOWLIST: &[&str] = &[
     "initialize",
     "notifications/initialized",
@@ -33,11 +36,13 @@ const ALLOWLIST: &[&str] = &[
     "notifications/tools/list_changed",
 ];
 
-// Proxy-originated JSON-RPC error codes (private server-error range). The `data.origin` marker makes a
-// proxy-originated error unambiguously distinguishable from an upstream error regardless of code.
+// Proxy-originated JSON-RPC error codes (private server-error range). `data.origin` marks them so they
+// are unambiguously distinguishable from upstream errors regardless of code.
 const PROXY_UNSUPPORTED: i32 = -32040;
 const PROXY_FAILED: i32 = -32041;
 // PROXY_DENIED (-32042) is reserved for the future enforcing arc (P61e); it never occurs in v0.
+
+const HEALTH_SCHEMA: &str = "assay.proxy_observation_health.v0";
 
 fn proxy_error_line(id: Value, code: i32, reason: &str, message: &str) -> String {
     json!({
@@ -52,9 +57,254 @@ fn proxy_error_line(id: Value, code: i32, reason: &str, message: &str) -> String
     .to_string()
 }
 
-/// Run the manifest-observation proxy against one stdio upstream. Returns when the client closes
-/// stdin (EOF) or the upstream connection ends.
-pub async fn run(upstream_command: String, upstream_args: Vec<String>) -> Result<()> {
+// ---------------------------------------------------------------------------------------------------
+// Observer: a read-only model of the upstream tool-surface observation. One active tools/list chain
+// per session in v0; a new cursorless tools/list starts a new operation, leaving any unfinished chain
+// partial. complete requires a start (no-cursor request) through a terminal page (no nextCursor); a
+// chain whose start was never observed is unknown; an unfinished started chain is partial.
+// ---------------------------------------------------------------------------------------------------
+
+#[derive(Default)]
+struct Observer {
+    server_id: Option<String>,
+    /// tools/list request ids seen (so a response can be recognized as a list response).
+    list_req_ids: HashMap<String, bool>,
+    acc: Vec<Value>,
+    chain_started: bool,
+    outstanding_cursor: bool,
+    op_active: bool,
+    latest_complete: Option<Vec<Value>>,
+    /// Most recent non-complete accumulation and its kind ("partial" | "unknown").
+    best_incomplete: Option<(Vec<Value>, &'static str)>,
+    observed_list_operations: u64,
+    tools_list_changed_observed: bool,
+    later_incomplete_chain_observed: bool,
+    any_tools_list_observed: bool,
+}
+
+struct Emission {
+    server_id: String,
+    tools: Option<Vec<Value>>,
+    completeness: Option<Completeness>,
+    source: &'static str,
+}
+
+impl Observer {
+    fn id_key(id: &Value) -> String {
+        id.to_string()
+    }
+
+    /// An active operation ended without a terminal page (superseded, or shutdown): record it as the
+    /// best non-complete observation, and note honestly if it came after a complete chain.
+    fn close_active_as_incomplete(&mut self) {
+        if !self.op_active {
+            return;
+        }
+        let kind = if self.chain_started {
+            "partial"
+        } else {
+            "unknown"
+        };
+        self.best_incomplete = Some((self.acc.clone(), kind));
+        if self.latest_complete.is_some() {
+            self.later_incomplete_chain_observed = true;
+        }
+        self.op_active = false;
+    }
+
+    /// Tap a forwarded client tools/list request. `had_cursor` is whether `params.cursor` was present.
+    fn on_client_tools_list(&mut self, id: Option<&Value>, had_cursor: bool) {
+        self.any_tools_list_observed = true;
+        if !had_cursor {
+            // A cursorless request starts a new operation; an unfinished prior chain becomes partial.
+            if self.op_active && self.outstanding_cursor {
+                self.close_active_as_incomplete();
+            }
+            self.acc.clear();
+            self.chain_started = true;
+            self.outstanding_cursor = false;
+            self.op_active = true;
+            self.observed_list_operations += 1;
+        } else if !self.op_active {
+            // A cursored request with no active operation: joined mid-stream, start unprovable.
+            self.acc.clear();
+            self.chain_started = false;
+            self.outstanding_cursor = false;
+            self.op_active = true;
+            self.observed_list_operations += 1;
+        }
+        if let Some(id) = id {
+            self.list_req_ids.insert(Self::id_key(id), had_cursor);
+        }
+    }
+
+    /// Tap an upstream response. Returns true iff a chain just COMPLETED (so the caller may write the
+    /// latest-complete manifest mid-run).
+    fn on_upstream_response(&mut self, v: &Value) -> bool {
+        if self.server_id.is_none() {
+            if let Some(name) = v
+                .pointer("/result/serverInfo/name")
+                .and_then(|n| n.as_str())
+            {
+                self.server_id = Some(name.to_string());
+            }
+        }
+        let id = match v.get("id") {
+            Some(i) if !i.is_null() => Self::id_key(i),
+            _ => return false,
+        };
+        if !self.list_req_ids.contains_key(&id) {
+            return false;
+        }
+        if let Some(tools) = v.pointer("/result/tools").and_then(|t| t.as_array()) {
+            self.acc.extend(tools.iter().cloned());
+        }
+        let has_next = v
+            .pointer("/result/nextCursor")
+            .map(|c| !c.is_null())
+            .unwrap_or(false);
+        if has_next {
+            self.outstanding_cursor = true;
+            return false;
+        }
+        // Terminal page.
+        self.outstanding_cursor = false;
+        self.op_active = false;
+        if self.chain_started {
+            self.latest_complete = Some(self.acc.clone());
+            true
+        } else {
+            self.best_incomplete = Some((self.acc.clone(), "unknown"));
+            if self.latest_complete.is_some() {
+                self.later_incomplete_chain_observed = true;
+            }
+            false
+        }
+    }
+
+    fn on_list_changed(&mut self) {
+        self.tools_list_changed_observed = true;
+    }
+
+    /// Compute the final emission: latest complete wins; otherwise the best observed; otherwise
+    /// not_observed. Closes any still-active chain as incomplete first.
+    fn finalize(&mut self) -> Emission {
+        if self.op_active {
+            self.close_active_as_incomplete();
+        }
+        let server_id = self
+            .server_id
+            .clone()
+            .unwrap_or_else(|| "upstream".to_string());
+        if !self.any_tools_list_observed {
+            return Emission {
+                server_id,
+                tools: None,
+                completeness: None,
+                source: "not_observed",
+            };
+        }
+        if let Some(tools) = &self.latest_complete {
+            return Emission {
+                server_id,
+                tools: Some(tools.clone()),
+                completeness: Some(Completeness::Complete),
+                source: "latest_complete",
+            };
+        }
+        if let Some((tools, kind)) = &self.best_incomplete {
+            let (c, src) = if *kind == "partial" {
+                (Completeness::Partial, "best_partial")
+            } else {
+                (Completeness::Unknown, "best_unknown")
+            };
+            return Emission {
+                server_id,
+                tools: Some(tools.clone()),
+                completeness: Some(c),
+                source: src,
+            };
+        }
+        // tools/list seen but nothing accumulated/finalized: inconclusive, never clean.
+        Emission {
+            server_id,
+            tools: Some(vec![]),
+            completeness: Some(Completeness::Unknown),
+            source: "best_unknown",
+        }
+    }
+}
+
+fn manifest_from(em: &Emission) -> Value {
+    match (&em.tools, em.completeness) {
+        (Some(tools), Some(c)) => manifest_observed::build_observed(&em.server_id, tools, c),
+        _ => manifest_observed::not_observed(&em.server_id),
+    }
+}
+
+fn health_from(manifest: &Value, em: &Emission, obs: &Observer) -> Value {
+    let status = manifest["status"].as_str().unwrap_or("not_observed");
+    // emitted_state_source reflects WHY this manifest was written; ambiguous overrides the chain source.
+    let source = if status == "ambiguous" {
+        "ambiguous"
+    } else {
+        em.source
+    };
+    json!({
+        "schema": HEALTH_SCHEMA,
+        "manifest_observation": {
+            "tools_list_observed": manifest["observed"]["tools_list_observed"],
+            "tools_list_complete": manifest["observed"]["tools_list_complete"],
+            "status": status,
+            "emitted_state_source": source,
+            "observed_list_operations": obs.observed_list_operations,
+            "tools_list_changed_observed": obs.tools_list_changed_observed,
+            "later_incomplete_chain_observed": obs.later_incomplete_chain_observed
+        },
+        "non_claims": [
+            "does not imply tool-call forwarding",
+            "does not prove the upstream full tool set if observation was partial or unknown"
+        ]
+    })
+}
+
+/// Atomic-ish write: serialize to a sibling temp file in the same directory, then rename over the
+/// destination. On Windows `rename` will not replace an existing file, so fall back to remove+rename
+/// (not atomic there, documented). A missing parent directory makes this fail, surfacing as a
+/// non-zero exit for a requested artifact.
+fn write_json_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
+    let bytes = serde_json::to_vec_pretty(value)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("artifact");
+    let tmp_name = format!("{file_name}.tmp.{}", std::process::id());
+    let tmp = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.join(tmp_name),
+        _ => PathBuf::from(tmp_name),
+    };
+    std::fs::write(&tmp, &bytes)?;
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(_) if path.exists() => {
+            std::fs::remove_file(path)?;
+            std::fs::rename(&tmp, path)
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
+/// Run the manifest-observation proxy against one stdio upstream.
+pub async fn run(
+    upstream_command: String,
+    upstream_args: Vec<String>,
+    manifest_out: Option<PathBuf>,
+    health_out: Option<PathBuf>,
+) -> Result<()> {
     let spawned = Command::new(&upstream_command)
         .args(&upstream_args)
         .stdin(Stdio::piped())
@@ -65,18 +315,21 @@ pub async fn run(upstream_command: String, upstream_args: Vec<String>) -> Result
     let mut child = match spawned {
         Ok(c) => c,
         Err(e) => {
-            // Fail-closed honesty: the upstream is unavailable, so never forward; answer every client
-            // request with a proxy-originated failure rather than silence or a fabricated success.
+            // Fail-closed: the upstream is unavailable, so never forward. Answer requests with a
+            // proxy failure and (if requested) emit an honest not_observed artifact.
             tracing::error!(event = "proxy_upstream_spawn_failed", error = %e);
-            return degraded_loop("upstream_spawn_failed").await;
+            degraded_loop("upstream_spawn_failed").await;
+            return emit_not_observed(manifest_out, health_out);
         }
     };
 
     let mut child_stdin = child.stdin.take().context("upstream stdin")?;
     let child_stdout = child.stdout.take().context("upstream stdout")?;
 
-    // A single writer owns the client's stdout; both the upstream relay and proxy-originated errors
-    // funnel through it so their lines never interleave.
+    let observer = Arc::new(Mutex::new(Observer::default()));
+
+    // Single writer owns client stdout; the upstream relay and proxy-originated errors funnel through
+    // it so their lines never interleave.
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
     let writer = tokio::spawn(async move {
         let mut out = tokio::io::stdout();
@@ -91,9 +344,11 @@ pub async fn run(upstream_command: String, upstream_args: Vec<String>) -> Result
         }
     });
 
-    // Upstream → client: relay valid JSON verbatim. A non-JSON upstream line is never relayed as a
-    // success; it surfaces as a proxy-originated failure (malformed upstream is not trusted).
+    // Upstream → client: tap (read-only) then relay verbatim. A non-JSON upstream line is never
+    // relayed as success.
     let up_tx = tx.clone();
+    let up_obs = observer.clone();
+    let up_manifest_out = manifest_out.clone();
     let upstream_reader = tokio::spawn(async move {
         let mut lines = BufReader::new(child_stdout).lines();
         while let Ok(Some(line)) = lines.next_line().await {
@@ -101,7 +356,38 @@ pub async fn run(upstream_command: String, upstream_args: Vec<String>) -> Result
                 continue;
             }
             match serde_json::from_str::<Value>(&line) {
-                Ok(_) => {
+                Ok(v) => {
+                    let completed = {
+                        let mut o = up_obs.lock().await;
+                        if v.get("method").and_then(|m| m.as_str())
+                            == Some("notifications/tools/list_changed")
+                        {
+                            o.on_list_changed();
+                            false
+                        } else {
+                            o.on_upstream_response(&v)
+                        }
+                    };
+                    // Best-effort mid-run write so a killed proxy still leaves the latest complete.
+                    if completed {
+                        if let Some(path) = &up_manifest_out {
+                            let (server, tools) = {
+                                let o = up_obs.lock().await;
+                                (
+                                    o.server_id
+                                        .clone()
+                                        .unwrap_or_else(|| "upstream".to_string()),
+                                    o.latest_complete.clone().unwrap_or_default(),
+                                )
+                            };
+                            let m = manifest_observed::build_observed(
+                                &server,
+                                &tools,
+                                Completeness::Complete,
+                            );
+                            let _ = write_json_atomic(path, &m);
+                        }
+                    }
                     let _ = up_tx.send(line);
                 }
                 Err(_) => {
@@ -116,8 +402,7 @@ pub async fn run(upstream_command: String, upstream_args: Vec<String>) -> Result
         }
     });
 
-    // Client → upstream: gate by the allowlist. Denied requests get a proxy_unsupported error and are
-    // never sent upstream; denied notifications are dropped (no id to answer).
+    // Client → upstream: gate by the allowlist; tap tools/list requests for pagination tracking.
     let mut client = BufReader::new(tokio::io::stdin()).lines();
     while let Ok(Some(line)) = client.next_line().await {
         if line.trim().is_empty() {
@@ -138,13 +423,22 @@ pub async fn run(upstream_command: String, upstream_args: Vec<String>) -> Result
 
         match v.get("method").and_then(|m| m.as_str()) {
             Some(method) if ALLOWLIST.contains(&method) => {
-                // Forward the original bytes verbatim — the proxy injects nothing of its own.
+                if method == "tools/list" {
+                    let had_cursor = v
+                        .pointer("/params/cursor")
+                        .map(|c| !c.is_null())
+                        .unwrap_or(false);
+                    observer
+                        .lock()
+                        .await
+                        .on_client_tools_list(v.get("id"), had_cursor);
+                }
                 if forward_line(&mut child_stdin, &line).await.is_err() {
                     break;
                 }
             }
             Some(method) => {
-                // Denied: tools/call and every other non-allowlisted method. The upstream never sees it.
+                // Denied: tools/call and every other non-allowlisted method. Never sent upstream.
                 match v.get("id") {
                     Some(id) if !id.is_null() => {
                         let _ = tx.send(proxy_error_line(
@@ -160,8 +454,7 @@ pub async fn run(upstream_command: String, upstream_args: Vec<String>) -> Result
                 }
             }
             None => {
-                // No method: a client response to an upstream-initiated request. It cannot invoke a
-                // tool, so relay it verbatim to keep the session working.
+                // A client response to an upstream-initiated request: cannot invoke a tool, relay it.
                 if forward_line(&mut child_stdin, &line).await.is_err() {
                     break;
                 }
@@ -169,13 +462,56 @@ pub async fn run(upstream_command: String, upstream_args: Vec<String>) -> Result
         }
     }
 
-    // Client EOF: close the upstream's stdin, tear down, and drain.
+    // Client EOF: tear down, drain, then emit the authoritative artifacts.
     drop(child_stdin);
     let _ = child.start_kill();
     drop(tx);
     let _ = upstream_reader.await;
     let _ = writer.await;
     let _ = child.wait().await;
+
+    if manifest_out.is_none() && health_out.is_none() {
+        return Ok(());
+    }
+    let mut obs = observer.lock().await;
+    let em = obs.finalize();
+    let manifest = manifest_from(&em);
+    if let Some(path) = &manifest_out {
+        write_json_atomic(path, &manifest)
+            .with_context(|| format!("writing manifest artifact to {}", path.display()))?;
+    }
+    if let Some(path) = &health_out {
+        let health = health_from(&manifest, &em, &obs);
+        write_json_atomic(path, &health).with_context(|| {
+            format!("writing observation-health artifact to {}", path.display())
+        })?;
+    }
+    Ok(())
+}
+
+/// Emit a not_observed manifest/health pair (upstream never produced a tools/list).
+fn emit_not_observed(manifest_out: Option<PathBuf>, health_out: Option<PathBuf>) -> Result<()> {
+    if manifest_out.is_none() && health_out.is_none() {
+        return Ok(());
+    }
+    let obs = Observer::default();
+    let em = Emission {
+        server_id: "upstream".to_string(),
+        tools: None,
+        completeness: None,
+        source: "not_observed",
+    };
+    let manifest = manifest_from(&em);
+    if let Some(path) = &manifest_out {
+        write_json_atomic(&path.clone(), &manifest)
+            .with_context(|| format!("writing manifest artifact to {}", path.display()))?;
+    }
+    if let Some(path) = &health_out {
+        let health = health_from(&manifest, &em, &obs);
+        write_json_atomic(path, &health).with_context(|| {
+            format!("writing observation-health artifact to {}", path.display())
+        })?;
+    }
     Ok(())
 }
 
@@ -187,7 +523,7 @@ async fn forward_line<W: AsyncWriteExt + Unpin>(w: &mut W, line: &str) -> std::i
 
 /// Upstream unavailable: never forward, never fabricate. Answer every client request with a
 /// proxy-originated failure until the client closes stdin.
-async fn degraded_loop(reason: &str) -> Result<()> {
+async fn degraded_loop(reason: &str) {
     let mut out = tokio::io::stdout();
     let mut client = BufReader::new(tokio::io::stdin()).lines();
     while let Ok(Some(line)) = client.next_line().await {
@@ -212,5 +548,4 @@ async fn degraded_loop(reason: &str) -> Result<()> {
             }
         }
     }
-    Ok(())
 }

--- a/crates/assay-mcp-server/tests/fixtures/proxy/mock_upstream.py
+++ b/crates/assay-mcp-server/tests/fixtures/proxy/mock_upstream.py
@@ -18,6 +18,9 @@ LOG = os.environ.get("MOCK_UPSTREAM_LOG")
 RAW_LOG = os.environ.get("MOCK_UPSTREAM_RAW_LOG")
 MODE = os.environ.get("MOCK_UPSTREAM_MODE", "normal")
 
+# Count of cursorless tools/list starts (for the complete_then_partial mode).
+_LIST_STARTS = 0
+
 
 def _append(path, text):
     if path:
@@ -29,6 +32,66 @@ def _append(path, text):
 def _send(obj):
     sys.stdout.write(json.dumps(obj) + "\n")
     sys.stdout.flush()
+
+
+def _tool(name, description="echoes input", input_schema=None):
+    return {
+        "name": name,
+        "description": description,
+        "inputSchema": input_schema if input_schema is not None else {"type": "object"},
+    }
+
+
+def _result(mid, tools, next_cursor=None):
+    result = {"tools": tools}
+    if next_cursor is not None:
+        result["nextCursor"] = next_cursor
+    _send({"jsonrpc": "2.0", "id": mid, "result": result})
+
+
+# The two tools whose canonical projection equals the committed P60a canonicalization example, so the
+# emitted manifest_digest matches the P60a/P60b committed digest.
+_P60A_TOOLS = [
+    _tool("search", "does a thing", {"type": "object"}),
+    _tool(
+        "github.add_deploy_key",
+        "Add a deploy key",
+        {"type": "object", "required": ["owner", "repo"]},
+    ),
+]
+
+
+def _handle_tools_list(mid, cursor):
+    if MODE == "malformed":
+        # A non-JSON line: the proxy must not relay this as a successful response.
+        sys.stdout.write("THIS IS NOT JSON-RPC\n")
+        sys.stdout.flush()
+    elif MODE == "p60a":
+        _result(mid, _P60A_TOOLS)
+    elif MODE == "paginated":
+        if cursor is None:
+            _result(mid, [_tool("alpha")], next_cursor="c1")
+        else:
+            _result(mid, [_tool("beta")])  # terminal
+    elif MODE == "partial":
+        # Always advertises a next page; the test never follows it, so the chain stays unfinished.
+        _result(mid, [_tool("alpha")], next_cursor="c1")
+    elif MODE == "duplicate":
+        _result(mid, [_tool("dup"), _tool("dup", "second with same name")])
+    elif MODE == "complete_then_partial":
+        # First cursorless start completes; a later cursorless start advertises a next page (the test
+        # never follows it), so the run ends with a complete chain plus a later incomplete one.
+        global _LIST_STARTS
+        if cursor is None:
+            _LIST_STARTS += 1
+            if _LIST_STARTS == 1:
+                _result(mid, [_tool("echo")])  # complete
+            else:
+                _result(mid, [_tool("alpha")], next_cursor="c1")  # partial start
+        else:
+            _result(mid, [_tool("beta")])
+    else:  # normal
+        _result(mid, [_tool("echo")])
 
 
 def main():
@@ -62,27 +125,13 @@ def main():
                     "serverInfo": {"name": "mock-upstream", "version": "0.0.0"},
                 },
             })
+            if MODE == "changed":
+                # An unsolicited list-changed notification (a run fact the proxy should observe).
+                _send({"jsonrpc": "2.0", "method": "notifications/tools/list_changed"})
         elif method == "ping":
             _send({"jsonrpc": "2.0", "id": mid, "result": {}})
         elif method == "tools/list":
-            if MODE == "malformed":
-                # A non-JSON line: the proxy must not relay this as a successful response.
-                sys.stdout.write("THIS IS NOT JSON-RPC\n")
-                sys.stdout.flush()
-            else:
-                _send({
-                    "jsonrpc": "2.0",
-                    "id": mid,
-                    "result": {
-                        "tools": [
-                            {
-                                "name": "echo",
-                                "description": "echoes input",
-                                "inputSchema": {"type": "object"},
-                            }
-                        ]
-                    },
-                })
+            _handle_tools_list(mid, (msg.get("params") or {}).get("cursor"))
         elif method is not None and mid is not None:
             # Should never happen: the proxy denies non-allowlisted methods before they reach us. If a
             # request slips through, fail loudly rather than silently accept it.

--- a/crates/assay-mcp-server/tests/proxy_forwarding_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_forwarding_e2e.rs
@@ -334,18 +334,31 @@ fn default_mode_spawns_no_upstream_and_serves_local_tools() {
 }
 
 #[test]
-fn no_manifest_artifact_is_emitted_in_p61b() {
-    // P61b is a forwarding skeleton: there is no --mcp-manifest-observed-out flag and no artifact is
-    // written. The flag must not exist yet.
-    let out = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
-        .args(["proxy", "--help"])
-        .output()
-        .unwrap();
-    let help = String::from_utf8_lossy(&out.stdout);
-    // The help text legitimately describes "manifest-observation mode"; what must be absent is any
-    // artifact-emission flag.
+fn no_artifact_is_written_without_the_out_flag() {
+    // The manifest-observation flag exists (P61c) but is opt-in: with no --mcp-manifest-observed-out,
+    // the proxy writes no artifact. (Manifest emission itself is covered in proxy_manifest_e2e.rs.)
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn_proxy(&log, None, "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    shutdown(child, stdin);
+
+    let stray: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.contains("manifest") || n.contains("observed"))
+        .collect();
     assert!(
-        !help.contains("mcp-manifest-observed-out") && !help.contains("--out"),
-        "P61b must not expose any manifest emission flag"
+        stray.is_empty(),
+        "no artifact without the out flag: {stray:?}"
     );
 }

--- a/crates/assay-mcp-server/tests/proxy_manifest_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_manifest_e2e.rs
@@ -1,0 +1,353 @@
+//! P61c: MCP upstream proxy mode — manifest-observation. End-to-end tests for the pagination tracker,
+//! the emitted artifact (assay.mcp_manifest_observed.v0), and the separate observation-health record.
+//! Spec: docs/reference/mcp-upstream-proxy-mode.md.
+//!
+//! Two invariants are asserted first: a `tools/call` still never reaches the upstream in this mode
+//! (no regression of the P61b denial), and the emitted manifest digest equals the committed P60a/P60b
+//! digest for the canonical-example tools (the producer the proxy feeds is the same one). Honest
+//! completeness is then exercised across complete / partial / unknown / not_observed / ambiguous, and
+//! the latest-complete-wins rule is checked together with the observation-health context.
+
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+const PROXY_UNSUPPORTED: i64 = -32040;
+
+fn python() -> &'static str {
+    if cfg!(windows) {
+        "python"
+    } else {
+        "python3"
+    }
+}
+
+fn mock_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/mock_upstream.py")
+}
+
+struct Proxy {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    out: BufReader<ChildStdout>,
+}
+
+fn spawn(mode: &str, manifest_out: Option<&Path>, health_out: Option<&Path>) -> Proxy {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"));
+    cmd.arg("proxy")
+        .args(["--upstream-command", python()])
+        .args(["--upstream-arg", "-u"])
+        .args(["--upstream-arg", mock_path().to_str().unwrap()])
+        .env("MOCK_UPSTREAM_MODE", mode)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    if let Some(p) = manifest_out {
+        cmd.args(["--mcp-manifest-observed-out", p.to_str().unwrap()]);
+    }
+    if let Some(p) = health_out {
+        cmd.args(["--proxy-observation-health-out", p.to_str().unwrap()]);
+    }
+    let mut child = cmd.spawn().expect("spawn proxy (is python installed?)");
+    let stdin = child.stdin.take().unwrap();
+    let out = BufReader::new(child.stdout.take().unwrap());
+    Proxy {
+        child,
+        stdin: Some(stdin),
+        out,
+    }
+}
+
+fn send(p: &mut Proxy, v: Value) {
+    let s = p.stdin.as_mut().unwrap();
+    writeln!(s, "{v}").unwrap();
+    s.flush().unwrap();
+}
+
+/// Read the next JSON-RPC RESPONSE (has an id, no method); skip notifications/requests from upstream.
+fn read_response(p: &mut Proxy) -> Value {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = p.out.read_line(&mut line).expect("read");
+        assert!(n > 0, "proxy closed stdout before responding");
+        let t = line.trim();
+        if t.is_empty() {
+            continue;
+        }
+        let v: Value = serde_json::from_str(t).expect("parse JSON");
+        if v.get("method").is_some() {
+            continue; // a notification or upstream-initiated request; not our response
+        }
+        return v;
+    }
+}
+
+fn init() -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "t", "version": "1"}}
+    })
+}
+
+/// Send initialize and consume its response, so subsequent reads line up with the tools/list traffic.
+fn handshake(p: &mut Proxy) {
+    send(p, init());
+    let _ = read_response(p);
+}
+
+/// Drive a tools/list chain from a cursorless start, following nextCursor to the terminal page.
+fn drive_full_list(p: &mut Proxy, mut next_id: i64) {
+    send(
+        p,
+        serde_json::json!({"jsonrpc": "2.0", "id": next_id, "method": "tools/list"}),
+    );
+    loop {
+        let r = read_response(p);
+        let cursor = r["result"]["nextCursor"].as_str().map(|s| s.to_string());
+        match cursor {
+            Some(c) => {
+                next_id += 1;
+                send(
+                    p,
+                    serde_json::json!({"jsonrpc": "2.0", "id": next_id, "method": "tools/list", "params": {"cursor": c}}),
+                );
+            }
+            None => break,
+        }
+    }
+}
+
+fn shutdown(mut p: Proxy) -> std::process::ExitStatus {
+    drop(p.stdin.take()); // client EOF
+    p.child.wait().expect("wait")
+}
+
+fn read_artifact(path: &Path) -> Value {
+    serde_json::from_str(&std::fs::read_to_string(path).expect("artifact written")).expect("json")
+}
+
+// --- the two anchors, first --------------------------------------------------------------------
+
+#[test]
+fn tools_call_still_not_forwarded_in_manifest_mode() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let mut p = spawn("normal", Some(&manifest), None);
+    handshake(&mut p);
+    send(
+        &mut p,
+        serde_json::json!({"jsonrpc": "2.0", "id": 9, "method": "tools/call",
+                           "params": {"name": "echo", "arguments": {}}}),
+    );
+    let r = read_response(&mut p);
+    assert_eq!(r["error"]["code"], PROXY_UNSUPPORTED);
+    assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
+    shutdown(p);
+}
+
+#[test]
+fn p60a_digest_anchor() {
+    // The proxy feeds the same P60b producer, so the emitted manifest_digest for the canonical-example
+    // tools equals the committed P60a digest.
+    let expected_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/mcp_manifest_drift/canonicalization_example.json");
+    let expected: Value =
+        serde_json::from_str(&std::fs::read_to_string(expected_path).unwrap()).unwrap();
+    let expected_digest = expected["manifest"]["expected_manifest_digest"]
+        .as_str()
+        .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let mut p = spawn("p60a", Some(&manifest), None);
+    handshake(&mut p);
+    drive_full_list(&mut p, 2);
+    shutdown(p);
+
+    let m = read_artifact(&manifest);
+    assert_eq!(m["schema"], "assay.mcp_manifest_observed.v0");
+    assert_eq!(m["status"], "observed");
+    assert_eq!(m["observed"]["tools_list_complete"], "complete");
+    assert_eq!(
+        m["observed"]["manifest_digest"].as_str().unwrap(),
+        expected_digest,
+        "proxy-emitted manifest_digest must equal the committed P60a digest"
+    );
+}
+
+// --- completeness semantics --------------------------------------------------------------------
+
+#[test]
+fn single_non_paginated_list_is_complete() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let mut p = spawn("normal", Some(&manifest), None);
+    handshake(&mut p);
+    drive_full_list(&mut p, 2);
+    shutdown(p);
+    let m = read_artifact(&manifest);
+    assert_eq!(m["status"], "observed");
+    assert_eq!(m["observed"]["tools_list_complete"], "complete");
+    assert_eq!(m["observed"]["tool_count"], 1);
+}
+
+#[test]
+fn multi_page_chain_is_complete_and_accumulates() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let mut p = spawn("paginated", Some(&manifest), None);
+    handshake(&mut p);
+    drive_full_list(&mut p, 2); // follows c1 to the terminal page
+    shutdown(p);
+    let m = read_artifact(&manifest);
+    assert_eq!(m["observed"]["tools_list_complete"], "complete");
+    assert_eq!(m["observed"]["tool_count"], 2, "both pages accumulated");
+}
+
+#[test]
+fn unfinished_chain_at_shutdown_is_partial() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let health = dir.path().join("h.json");
+    let mut p = spawn("partial", Some(&manifest), Some(&health));
+    handshake(&mut p);
+    // Start the chain but do NOT follow the advertised nextCursor.
+    send(
+        &mut p,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let r = read_response(&mut p);
+    assert!(r["result"]["nextCursor"].is_string());
+    shutdown(p);
+    let m = read_artifact(&manifest);
+    assert_eq!(m["observed"]["tools_list_complete"], "partial");
+    assert_ne!(m["status"], "not_observed");
+    let h = read_artifact(&health);
+    assert_eq!(
+        h["manifest_observation"]["emitted_state_source"],
+        "best_partial"
+    );
+}
+
+#[test]
+fn mid_stream_join_is_unknown() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let mut p = spawn("normal", Some(&manifest), None);
+    handshake(&mut p);
+    // First observed tools/list already carries a cursor: the chain start was never observed.
+    send(
+        &mut p,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {"cursor": "joined-midway"}}),
+    );
+    let _ = read_response(&mut p);
+    shutdown(p);
+    let m = read_artifact(&manifest);
+    assert_eq!(m["observed"]["tools_list_complete"], "unknown");
+}
+
+#[test]
+fn no_tools_list_writes_not_observed_artifact() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let mut p = spawn("normal", Some(&manifest), None);
+    handshake(&mut p);
+    shutdown(p); // never sent tools/list
+    let m = read_artifact(&manifest);
+    assert_eq!(m["status"], "not_observed", "artifact present, not absent");
+    assert!(m["observed"]["manifest_digest"].is_null());
+}
+
+#[test]
+fn duplicate_tool_names_is_ambiguous() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let health = dir.path().join("h.json");
+    let mut p = spawn("duplicate", Some(&manifest), Some(&health));
+    handshake(&mut p);
+    drive_full_list(&mut p, 2);
+    shutdown(p);
+    let m = read_artifact(&manifest);
+    assert_eq!(m["status"], "ambiguous");
+    assert!(m["observed"]["manifest_digest"].is_null());
+    let h = read_artifact(&health);
+    assert_eq!(
+        h["manifest_observation"]["emitted_state_source"],
+        "ambiguous"
+    );
+}
+
+#[test]
+fn complete_then_later_partial_keeps_latest_complete_with_health_context() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let health = dir.path().join("h.json");
+    let mut p = spawn("complete_then_partial", Some(&manifest), Some(&health));
+    handshake(&mut p);
+    // First chain: cursorless, terminal -> complete.
+    send(
+        &mut p,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let r1 = read_response(&mut p);
+    assert!(r1["result"]["nextCursor"].is_null());
+    // Second chain: cursorless start that advertises a next page; do not follow it.
+    send(
+        &mut p,
+        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/list"}),
+    );
+    let r2 = read_response(&mut p);
+    assert!(r2["result"]["nextCursor"].is_string());
+    shutdown(p);
+
+    let m = read_artifact(&manifest);
+    assert_eq!(
+        m["observed"]["tools_list_complete"], "complete",
+        "latest complete wins"
+    );
+    assert_eq!(m["observed"]["tool_digests"][0]["name"], "echo");
+    let h = read_artifact(&health);
+    assert_eq!(
+        h["manifest_observation"]["emitted_state_source"],
+        "latest_complete"
+    );
+    assert_eq!(
+        h["manifest_observation"]["later_incomplete_chain_observed"],
+        true
+    );
+    assert_eq!(h["manifest_observation"]["observed_list_operations"], 2);
+}
+
+#[test]
+fn list_changed_notification_is_observed_in_health() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("m.json");
+    let health = dir.path().join("h.json");
+    let mut p = spawn("changed", Some(&manifest), Some(&health));
+    handshake(&mut p);
+    drive_full_list(&mut p, 2);
+    shutdown(p);
+    let h = read_artifact(&health);
+    assert_eq!(
+        h["manifest_observation"]["tools_list_changed_observed"],
+        true
+    );
+}
+
+#[test]
+fn artifact_write_failure_exits_nonzero() {
+    // Deterministic failure: the output path's parent directory does not exist.
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("does-not-exist").join("m.json");
+    let mut p = spawn("normal", Some(&manifest), None);
+    handshake(&mut p);
+    drive_full_list(&mut p, 2);
+    let status = shutdown(p);
+    assert!(
+        !status.success(),
+        "a requested-artifact write failure must yield a non-zero exit"
+    );
+    assert!(!manifest.exists());
+}


### PR DESCRIPTION
P61c connects the P61b forwarding skeleton to the P60 manifest evidence loop. The proxy now taps allowlisted `tools/list` responses read-only, tracks the pagination chain, and emits `assay.mcp_manifest_observed.v0` through the **existing P60b producer**, plus a separate observation-health record.

The review boundary holds: **P61c observes upstream manifest completeness; it does not enable tool execution through the proxy.** Explicitly:

- **P61c does not forward `tools/call`** (the P61b denial is asserted again, first test, in manifest mode);
- **P61c adds no Plimsoll logic** and emits supplied-artifact evidence only;
- **P61c does not classify maliciousness or per-tool drift.**

What it adds:

- two opt-in flags on `proxy`: `--mcp-manifest-observed-out <path>` and `--proxy-observation-health-out <path>`. No flag → no artifact.
- pagination semantics: `complete` = a cursorless start through a terminal page (no `nextCursor`); `partial` = a started chain with an outstanding `nextCursor` at shutdown; `unknown` = a `tools/list` response whose start was never observed. **partial/unknown are never read as clean.** One active chain per session — a new cursorless `tools/list` starts a new operation and leaves any unfinished chain `partial`.
- selection: **latest complete wins**; else best observed; else (requested but no list seen) `status: not_observed` — artifact present, never absent. Duplicate names → `ambiguous` via the producer.
- the manifest artifact is **exactly the P60b shape** Plimsoll already gates on. `emitted_state_source`, `observed_list_operations`, `tools_list_changed_observed`, and `later_incomplete_chain_observed` live **only** in the separate `assay.proxy_observation_health.v0` artifact — never folded into the manifest.
- `write_json_atomic`: temp-in-same-dir + rename, with a remove+rename fallback on Windows (documented non-atomic there); a requested-artifact write failure (e.g. missing parent dir) → non-zero exit, never silent.
- server identity captured from the upstream `initialize` `serverInfo.name`.

Eleven e2e tests (committed python mock extended with cursor paging + modes — **no Cargo touch**): `tools_call_still_not_forwarded_in_manifest_mode` and `p60a_digest_anchor` first — the emitted `manifest_digest` equals the committed P60a value, since the proxy feeds the same producer — then single/multi-page complete, partial, mid-stream unknown, `not_observed` file, duplicate `ambiguous`, complete-then-later-partial (latest complete wins + `later_incomplete_chain_observed: true`), `tools_list_changed` observed, and artifact-write-failure → non-zero. The P61b help-flag test now asserts no artifact is written without the flag. fmt, clippy, and the full crate suite (113 tests) are green; `Cargo.toml`/`Cargo.lock` untouched; the proxy module stays bin-crate-private.

Lane classification: Gate.NONE

Reason:
- assay-mcp-server source + tests + a test fixture only
- no runner/eBPF/monitor paths
- no Cargo.toml/Cargo.lock changes
- no delegated proof paths

I'll confirm the real lane-check output on this PR and that CI is green across linux/macOS/windows (the python mock runs on all three) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)