### PR TITLE
test(mcp): non-allowlisted method matrix hardening (P61d)

### DIFF
--- a/crates/assay-mcp-server/tests/proxy_forwarding_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_forwarding_e2e.rs
@@ -161,6 +161,98 @@ fn non_allowlisted_method_is_denied_and_not_forwarded() {
     assert!(!read_methods(&log).contains(&"resources/list".to_string()));
 }
 
+// P61d: the non-allowlisted method matrix. Manifest-observation proxy mode is not a general MCP
+// proxy — every method outside the exhaustive allowlist is proxy_unsupported and the upstream
+// receives none of them. No PDP, no proxy_denied, no credential-scope, no Plimsoll.
+const DENIED_METHODS: &[&str] = &[
+    "tools/call",
+    "resources/read",
+    "resources/list",
+    "prompts/get",
+    "prompts/list",
+    "sampling/createMessage",
+    "completion/complete",
+    "custom/frobnicate",
+];
+
+#[test]
+fn non_allowlisted_methods_are_unsupported_and_never_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn_proxy(&log, None, "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+
+    let mut id = 100;
+    for method in DENIED_METHODS {
+        id += 1;
+        send(
+            &mut stdin,
+            serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method}),
+        );
+        let r = read_response(&mut out);
+        assert_eq!(r["id"], id);
+        assert_eq!(
+            r["error"]["code"], PROXY_UNSUPPORTED,
+            "{method} must be unsupported"
+        );
+        assert_eq!(r["error"]["data"]["origin"], "assay-proxy", "{method}");
+        assert_eq!(
+            r["error"]["data"]["reason"], "method_not_allowlisted",
+            "{method}"
+        );
+    }
+
+    shutdown(child, stdin);
+    let methods = read_methods(&log);
+    for method in DENIED_METHODS {
+        assert!(
+            !methods.contains(&method.to_string()),
+            "INVARIANT VIOLATED: {method} reached the upstream: {methods:?}"
+        );
+    }
+}
+
+#[test]
+fn non_allowlisted_client_notification_is_dropped_and_not_forwarded() {
+    // A non-allowlisted client notification (no id) cannot be answered, so it is dropped and never
+    // forwarded. A following allowlisted request still works, proving the stream is intact.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn_proxy(&log, None, "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {}}),
+    );
+    // Liveness: a following allowlisted ping is answered, so the dropped notification broke nothing.
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 50, "method": "ping"}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["id"], 50);
+
+    shutdown(child, stdin);
+    let methods = read_methods(&log);
+    assert!(
+        !methods.contains(&"notifications/cancelled".to_string()),
+        "a non-allowlisted notification must not reach the upstream: {methods:?}"
+    );
+    assert!(
+        methods.contains(&"ping".to_string()),
+        "the allowlisted ping was forwarded"
+    );
+}
+
 #[test]
 fn proxy_does_not_inject_inbound_transport_auth() {
     // Option 1 (verbatim forwarding): the proxy injects no Authorization/header/token of its own. We

--- a/docs/reference/mcp-upstream-proxy-mode.md
+++ b/docs/reference/mcp-upstream-proxy-mode.md
@@ -95,6 +95,25 @@ MCP client  ──stdio──►  assay-mcp-server (proxy mode, v0)  ──stdio
 - **unsupported methods.** a non-allowlisted method (including `tools/call`) gets a `proxy_unsupported`
   error, never a silent relay and never a fabricated success.
 
+### Non-allowlisted method matrix (the denied boundary, P61d)
+
+Manifest-observation proxy mode is **not** a general MCP proxy. Every method outside the exhaustive
+allowlist above is denied and the upstream receives none of it:
+
+| Client message | v0 behavior |
+|----------------|-------------|
+| `tools/call` | `proxy_unsupported` (request), never forwarded |
+| `resources/read`, `resources/list` | `proxy_unsupported`, never forwarded |
+| `prompts/get`, `prompts/list` | `proxy_unsupported`, never forwarded |
+| `sampling/createMessage`, `completion/complete` | `proxy_unsupported`, never forwarded |
+| any unknown/custom method (request) | `proxy_unsupported`, never forwarded |
+| any non-allowlisted client **notification** (no id) | dropped (no id to answer), never forwarded |
+
+A denied request always carries `data.origin: "assay-proxy"` and `data.reason: "method_not_allowlisted"`
+so it is distinguishable from an upstream error. This is hardening of the negative boundary, not a new
+capability: there is no policy decision point, no `proxy_denied`, no credential-scope, and no consumer
+logic here.
+
 ## `tools/list` observation + pagination (the payoff)
 
 - forward `tools/list`; observe the response read-only.


### PR DESCRIPTION
P61d hardens the negative boundary now that P61c made the proxy useful: **manifest-observation proxy mode is not a general MCP proxy.** It is hardening, not a new capability — the proxy already default-denies everything outside the exhaustive allowlist, and this makes that executable and documented.

- a matrix test denies `tools/call`, `resources/read`, `resources/list`, `prompts/get`, `prompts/list`, `sampling/createMessage`, `completion/complete`, and an unknown custom method — each yields `proxy_unsupported` (`data.origin: "assay-proxy"`, `data.reason: "method_not_allowlisted"`) and **the upstream receives none of them**;
- a non-allowlisted client **notification** (no id) is dropped and never forwarded, while a following allowlisted `ping` still works — proving the stream stays intact;
- the spec doc gains the denied-method matrix table.

No PDP, no `proxy_denied`, no credential-scope, no Plimsoll. There is no production logic change (the default-deny already held); `Cargo.toml`/`Cargo.lock` are untouched and the proxy stays bin-crate-private. fmt, clippy, and the full crate suite are green locally.

Lane classification: Gate.NONE

Reason:
- assay-mcp-server tests + one reference doc only
- no runner/eBPF/monitor paths
- no Cargo.toml/Cargo.lock changes
- no delegated proof paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)