### PR TITLE
chore(release): assay v3.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.23.0] - 2026-06-10
+
+### Added
+- MCP upstream manifest-observation proxy mode (`assay-mcp-server proxy --upstream-command <cmd>
+  [--upstream-arg <a>]…`). An explicit, opt-in stdio proxy that sits in front of one upstream MCP
+  server, forwards only the session handshake, `ping`, and the `tools/list` /
+  `notifications/tools/list_changed` operations, observes the upstream `tools/list` read-only, and
+  (with `--mcp-manifest-observed-out`) emits `assay.mcp_manifest_observed.v0` with honest completeness
+  (`complete` / `partial` / `unknown` / `not_observed` / `ambiguous`, never read as clean when the
+  observation was incomplete). A non-allowlisted method such as `tools/call` is rejected with a
+  distinct proxy-originated error and is never forwarded upstream. A separate
+  `--proxy-observation-health-out` records how complete the observation was, kept out of the manifest
+  artifact (which stays the exact shape a consumer gates on). Spec:
+  `docs/reference/mcp-upstream-proxy-mode.md`.
+  - Does not support tool execution through the proxy.
+  - Does not enforce `tools/call` policy.
+  - Does not classify maliciousness.
+  - Does not support HTTP upstreams.
+  - Does not support multiple upstreams.
+
 ## [3.22.0] - 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.22.0"
+version = "3.23.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Cuts v3.23.0 with the MCP upstream **manifest-observation proxy mode** package (P61b + P61c + P61d): the safe stdio forwarding skeleton, live `tools/list` manifest observation with `assay.mcp_manifest_observed.v0` emission and honest completeness, and the denied-method matrix hardening.

Adds an explicit stdio MCP upstream manifest-observation proxy mode. The proxy forwards only the session handshake, `ping`, and the `tools/list` / `notifications/tools/list_changed` operations, emits `assay.mcp_manifest_observed.v0` with honest completeness, and rejects non-allowlisted methods such as `tools/call` without forwarding them upstream.

Non-claims (carried in the release notes): does not support tool execution through the proxy; does not enforce `tools/call` policy; does not classify maliciousness; does not support HTTP upstreams; does not support multiple upstreams.

Bumps the workspace version to 3.23.0, refreshes `Cargo.lock`, and moves the CHANGELOG `[Unreleased]` entry under `[3.23.0]`. The Python SDK inherits the workspace version (no separate bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)