### PR TITLE
docs(mcp): reconcile proxy/manifest docs with the v3.23.0 release

### DIFF
--- a/docs/reference/mcp-manifest-drift.md
+++ b/docs/reference/mcp-manifest-drift.md
@@ -2,8 +2,8 @@
 
 Status: coarse path shipped — spec + fixtures + digest guard (P60a), the `assay-mcp-server` producer
 module (P60b), and the consumer coarse-drift gate (P60c, released in Plimsoll v0.8.0). Live upstream
-observation is parked behind a separate passthrough/proxy-mode design (see the topology finding below).
-Part of the [privileged-action evidence](privileged-action-evidence.md) set.
+observation now ships too, as the opt-in [manifest-observation proxy mode](mcp-upstream-proxy-mode.md)
+(assay v3.23.0). Part of the [privileged-action evidence](privileged-action-evidence.md) set.
 
 ## Why this exists
 
@@ -61,10 +61,11 @@ Tools are sorted by `name`, then by `tool_digest` if duplicate names ever occur.
 
 ## Observed manifest record (`assay.mcp_manifest_observed.v0`)
 
-Built by the producer from observed tool definitions. (The intended live source is the latest fully
-observed `tools/list`; capturing that on the wire is parked behind the passthrough/proxy-mode design —
-see the topology finding below.) Per-tool digests are diagnostic/supporting detail in v0; the v0
-consumer gate uses only the overall `manifest_digest` (per-tool drift reason codes are P60d/v1).
+Built by the producer from observed tool definitions. The live source is the latest fully observed
+`tools/list`, captured on the wire by the [manifest-observation proxy mode](mcp-upstream-proxy-mode.md)
+(assay v3.23.0); the producer also serves supplied-artifact review. Per-tool digests are
+diagnostic/supporting detail in v0; the v0 consumer gate uses only the overall `manifest_digest`
+(per-tool drift reason codes are P60d/v1).
 
 ```json
 {
@@ -189,14 +190,13 @@ A read-only investigation of `assay-mcp-server` settled where an observed `tools
 Conclusion: live manifest observation is **not** a small tap on an existing seam; it requires a new
 MCP upstream passthrough/proxy mode (config naming an upstream, a connection/child manager, a
 forwarding handler, and a `tools/list` that observes the upstream response and its pagination chain).
-That is its own design, specified separately before any code — see
-[mcp-upstream-proxy-mode.md](mcp-upstream-proxy-mode.md) (a manifest-observation proxy mode that
-forwards a tiny method allowlist only and never forwards privileged `tools/call`). Until such a mode
-exists, this feature
-stays artifact/file-based: a producer builds `assay.mcp_manifest_observed.v0` from observed tool
-definitions, and the consumer reviews a supplied artifact against a declared baseline. The producer is
-deliberately not wired to `tools::list_tools()` — the server's own served tools are not an observed
-upstream manifest, and emitting them as one would misstate what was observed.
+That was its own design, specified separately before any code, and **shipped in assay v3.23.0** as the
+opt-in [manifest-observation proxy mode](mcp-upstream-proxy-mode.md) (it forwards a tiny method
+allowlist only and never forwards privileged `tools/call`). The artifact/file-based path remains too: a
+producer builds `assay.mcp_manifest_observed.v0` from observed tool definitions, and the consumer
+reviews a supplied artifact against a declared baseline. The producer is deliberately not wired to
+`tools::list_tools()` — the server's own served tools are not an observed upstream manifest, and
+emitting them as one would misstate what was observed.
 
 ## PR sequence
 
@@ -204,7 +204,7 @@ upstream manifest, and emitting them as one would misstate what was observed.
 P60a   spec + fixtures + canonicalization examples + a digest-recompute guard test
 P60b   producer: assay-mcp-server manifest_observed module emits assay.mcp_manifest_observed.v0
 P60c   Plimsoll: coarse drift gate -> pending_tool_manifest_review (opt-in, coverage-gated)
-P60b2  live observation: topology finding (above) -> requires a separate MCP passthrough/proxy mode
+P60b2  live observation: topology finding (above) -> manifest-observation proxy mode (SHIPPED v3.23.0)
 P60d   granular per-tool drift v1 + assay.declared_mcp_manifest.v0 (per-tool expected digests)
 ```
 

--- a/docs/reference/mcp-upstream-proxy-mode.md
+++ b/docs/reference/mcp-upstream-proxy-mode.md
@@ -1,11 +1,16 @@
-# MCP upstream proxy mode — manifest-observation v0 (P61a)
+# MCP upstream proxy mode — manifest-observation v0 (P61)
 
-Status: review-spec, no code (P61a). This is a **new arc (P61), not a P60 slice.** It answers the
-question the P60 manifest-drift work parked: how does Assay observe a live upstream MCP tool surface at
-all? The answer requires a proxy, and a credential-bearing proxy is a security-load-bearing component,
-so the design is fixed here before any code. Related: [mcp-manifest-drift.md](mcp-manifest-drift.md)
-(the artifact this mode would feed) and the [privileged-action evidence](privileged-action-evidence.md)
-set.
+Status: **shipped in assay v3.23.0** — manifest-observation v0 (P61a design, P61b forwarding skeleton,
+P61c live `tools/list` observation + `assay.mcp_manifest_observed.v0` emission, P61d denied-method
+hardening). The enforcing `tools/call` proxy (P61e) is a separate, not-yet-specified arc — a heavier
+security boundary (caller authorization, upstream credential use, a policy decision before forwarding,
+confused-deputy prevention, `proxy_denied` semantics, side-effect-evidence interaction) that needs its
+own review-spec before any code. This doc remains the design of record for the shipped manifest-
+observation mode. Related: [mcp-manifest-drift.md](mcp-manifest-drift.md) (the artifact this mode
+feeds) and the [privileged-action evidence](privileged-action-evidence.md) set.
+
+The P61 v0 proxy is an opt-in manifest-observation proxy. It observes upstream `tools/list` traffic
+and emits manifest evidence with honest completeness. It does not execute tools through the proxy.
 
 ## The decision (Q1): terminating server vs upstream proxy
 
@@ -207,14 +212,14 @@ classification.
 ## PR sequence (P61) — no privileged `tools/call` forwarding in P61b–d
 
 ```
-P61a  this proxy-mode spec (design doc, no code)
+P61a  this proxy-mode spec (design doc, no code)                                            [SHIPPED v3.23.0]
 P61b  stdio upstream connection manager + initialize/initialized + tools/list forwarding (allowlist),
-      no-token-passthrough invariant + failure semantics + the negative forwarding invariant tested
-P61c  tools/list pagination tracker + emit assay.mcp_manifest_observed.v0 + proxy observation-health
+      no-token-passthrough invariant + failure semantics + the negative forwarding invariant tested  [SHIPPED v3.23.0]
+P61c  tools/list pagination tracker + emit assay.mcp_manifest_observed.v0 + proxy observation-health   [SHIPPED v3.23.0]
 P61d  explicit proxy_unsupported behavior for tools/call (and non-allowlisted methods) in
-      manifest-observation mode, with tests proving privileged calls are never forwarded
+      manifest-observation mode, with tests proving privileged calls are never forwarded               [SHIPPED v3.23.0]
 P61e  LATER, separate arc: enforcing tools/call proxy with a fail-closed policy decision point and the
-      full confused-deputy mitigations — only if/when specified
+      full confused-deputy mitigations — only if/when specified (review-spec first)                    [NOT STARTED]
 ```
 
 P61b carries the **negative forwarding invariant test from day one**: a `tools/call` sent in

--- a/docs/reference/privileged-action-evidence.md
+++ b/docs/reference/privileged-action-evidence.md
@@ -68,20 +68,24 @@ declared-vs-observed gate; credential-scope evidence; the side-effect receipt sp
 that ranks the side-effect ladder (`asserted` / `observed_confirmed` / `audit_record_bound`); and the
 MCP tool-manifest **coarse** drift path — a producer that builds `assay.mcp_manifest_observed.v0` from
 observed tool definitions and a consumer that reviews a supplied artifact against a declared
-manifest-digest baseline, resolving a mismatch to `pending_tool_manifest_review`.
+manifest-digest baseline, resolving a mismatch to `pending_tool_manifest_review`; and (assay v3.23.0)
+the **MCP upstream manifest-observation proxy mode**, which observes a live upstream `tools/list` and
+emits that artifact with honest completeness, while never executing tools through the proxy (see
+[mcp-upstream-proxy-mode.md](mcp-upstream-proxy-mode.md)).
 
 **Experiment-only (characterized, not a shipped feature):** the credential-overbreadth distribution
 (the scope lattice is a static model, not a provider-verified taxonomy); MCP tool lifecycle; and an
 OTel log-based event projection.
 
-**Parked (needs a separate design before any code):** live upstream manifest observation, and
-granular per-tool manifest drift.
+**Parked (needs a separate design before any code):** granular per-tool manifest drift; and the
+enforcing `tools/call` proxy (a heavier security boundary — caller authorization, upstream credential
+use, a policy decision before forwarding, confused-deputy prevention — that needs its own review-spec).
 
-The load-bearing boundary for the manifest line: **the tool-manifest path is complete for supplied
-artifacts. Live upstream observation is not a small wiring step — `assay-mcp-server` today terminates
-the protocol and serves its own tools, so observing an upstream manifest on the wire requires a
-separate MCP upstream passthrough/proxy-mode design (JSON-RPC forwarding, the auth/token boundary,
-server identity, `tools/list` pagination, the policy decision point, response observation, and
-confused-deputy risks).** Until that mode exists, the manifest path stays artifact/file-based, and the
-producer is deliberately not wired to the server's own served tools — they are not an observed
-upstream manifest. See [mcp-manifest-drift.md](mcp-manifest-drift.md) for the topology finding.
+The load-bearing boundary for the manifest line: **live upstream observation was not a small wiring
+step.** `assay-mcp-server` terminates the protocol and serves its own tools, so observing an upstream
+manifest on the wire needed a dedicated mode, delivered in v3.23.0 as the opt-in
+[manifest-observation proxy](mcp-upstream-proxy-mode.md) (it forwards a tiny allowlist, observes
+`tools/list` with honest completeness, and never forwards `tools/call`). The artifact/file-based path
+remains for supplied artifacts, and the producer is still not wired to the server's own served tools —
+they are not an observed upstream manifest. See [mcp-manifest-drift.md](mcp-manifest-drift.md) for the
+topology finding that led here.


### PR DESCRIPTION
Consolidation after shipping the manifest-observation proxy in v3.23.0 — no code, no schema change. Several docs still said live upstream observation was "parked behind a separate proxy-mode design", which is now stale: that mode shipped (P61a–d).

- `mcp-upstream-proxy-mode.md`: status → shipped in v3.23.0; title → (P61); PR-sequence rows marked SHIPPED; P61e marked NOT STARTED (separate review-spec); adds the closing boundary sentence.
- `privileged-action-evidence.md`: moves live upstream manifest observation from Parked to Shipped; Parked now holds granular per-tool drift and the enforcing `tools/call` proxy; the boundary paragraph reflects the shipped proxy.
- `mcp-manifest-drift.md`: top status, record section, topology-finding, and PR sequence all note the proxy shipped in v3.23.0; the artifact/file path remains.

Lane classification: Gate.NONE — docs only, no runner/eBPF/monitor paths, no Cargo changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)