### PR TITLE
docs(mcp): granular per-tool drift spec + fixtures + guard (P60d-a)

### DIFF
--- a/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline.json
+++ b/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline.json
@@ -1,0 +1,25 @@
+{
+  "note": "operator-pinned per-tool baseline; manifest_digest recomputes from tools via the guard test and equals the committed P60a manifest_digest (same canonical tools)",
+  "schema": "assay.declared_mcp_manifest.v0",
+  "server": {
+    "id": "github"
+  },
+  "canonicalization": "assay.mcp_manifest_projection.v0",
+  "manifest_digest": "sha256:f8a95098345d600f7a2d742c4e941ace5e9594918b2aa82a9a8f48f72f701ffa",
+  "tools": [
+    {
+      "name": "search",
+      "tool_digest": "sha256:2318d9fd63878b81e992300635172e75053e086db757e31b7ebc917a7c721697",
+      "privileged": false,
+      "privilege_classification": "unclassified",
+      "action_class": null
+    },
+    {
+      "name": "github.add_deploy_key",
+      "tool_digest": "sha256:03c7e1d546c3440fb100938dcaa7578ac34ae81f28e5762e7f8a3197e272a9f6",
+      "privileged": true,
+      "privilege_classification": "classified",
+      "action_class": "github_deploy_key"
+    }
+  ]
+}

--- a/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/granular_diff_cases.json
+++ b/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/granular_diff_cases.json
@@ -1,0 +1,908 @@
+{
+  "canonicalization": "assay.mcp_manifest_projection.v0",
+  "cases": [
+    {
+      "id": "identical_no_findings",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": []
+      }
+    },
+    {
+      "id": "tool_added_non_privileged",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            },
+            {
+              "name": "misc.echo",
+              "tool_digest": "sha256:34c7e831a42550d80b92e4089c1edea507f91132855e35efe265f412891d0988",
+              "privileged": false
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [
+          {
+            "name": "misc.echo",
+            "reason_code": "mcp_tool_added"
+          }
+        ],
+        "inconclusive": []
+      }
+    },
+    {
+      "id": "new_privileged_tool",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            },
+            {
+              "name": "slack.add_member",
+              "tool_digest": "sha256:572794972d4751584b31553d126db4da487c1896a3b1ae627182befe661774c7",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [
+          {
+            "name": "slack.add_member",
+            "reason_code": "mcp_new_privileged_tool"
+          }
+        ],
+        "inconclusive": []
+      }
+    },
+    {
+      "id": "tool_changed_non_privileged",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:45ec3246881aa16e54678e87563418a34ef9049441483ae7f9ecd54069b0eb26",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [
+          {
+            "name": "search",
+            "reason_code": "mcp_tool_changed"
+          }
+        ],
+        "inconclusive": []
+      }
+    },
+    {
+      "id": "privileged_tool_changed",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:8898aafda90ab0fb1c06bea6c0fc8cf381032e39c8068eac2e92ee1cfb45ae18",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [
+          {
+            "name": "github.add_deploy_key",
+            "reason_code": "mcp_privileged_tool_changed"
+          }
+        ],
+        "inconclusive": []
+      }
+    },
+    {
+      "id": "tool_removed_complete_non_privileged",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [
+          {
+            "name": "search",
+            "reason_code": "mcp_tool_removed"
+          }
+        ],
+        "inconclusive": []
+      }
+    },
+    {
+      "id": "privileged_tool_removed_complete",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [
+          {
+            "name": "github.add_deploy_key",
+            "reason_code": "mcp_privileged_tool_removed"
+          }
+        ],
+        "inconclusive": []
+      }
+    },
+    {
+      "id": "removal_under_partial_no_per_tool_finding",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "partial",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": [
+          "inconclusive_manifest_partial_observation"
+        ]
+      }
+    },
+    {
+      "id": "removal_under_unknown_no_per_tool_finding",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "unknown",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": [
+          "inconclusive_manifest_partial_observation"
+        ]
+      }
+    },
+    {
+      "id": "added_under_partial_still_asserted",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "partial",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            },
+            {
+              "name": "slack.add_member",
+              "tool_digest": "sha256:572794972d4751584b31553d126db4da487c1896a3b1ae627182befe661774c7",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [
+          {
+            "name": "slack.add_member",
+            "reason_code": "mcp_new_privileged_tool"
+          }
+        ],
+        "inconclusive": []
+      }
+    },
+    {
+      "id": "declared_self_inconsistent",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": [
+          "declared_manifest_digest_mismatch"
+        ]
+      }
+    },
+    {
+      "id": "server_id_mismatch",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "gitlab"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": [
+          "mcp_manifest_server_mismatch"
+        ]
+      }
+    },
+    {
+      "id": "canonicalization_mismatch",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.other.v9",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": [
+          "mcp_manifest_canonicalization_mismatch"
+        ]
+      }
+    },
+    {
+      "id": "duplicate_observed_names",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "search",
+              "tool_digest": "sha256:9eb6203435cb3e0033f544e3bf6f1b74b138c765fc489a38a092e8f7adbd9638",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": [
+          "mcp_manifest_observation_ambiguous"
+        ]
+      }
+    },
+    {
+      "id": "duplicate_declared_names",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": [
+            {
+              "name": "search",
+              "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+              "privileged": false
+            },
+            {
+              "name": "github.add_deploy_key",
+              "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+              "privileged": true
+            }
+          ]
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:8a3fac05c93fe195bdb343817358f5c0757df1169ea787f7609f6b7a5445e8e2",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "search",
+            "tool_digest": "sha256:6059d4788210fbfb95dc5695570304467e078b8b09fcfad430cbd77a914724d1",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": [
+          "declared_mcp_manifest_ambiguous"
+        ]
+      }
+    },
+    {
+      "id": "observed_not_observed",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "not_observed",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": false,
+          "tools_list_complete": "unknown",
+          "tool_digests": []
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": [
+          "inconclusive_manifest_not_observed"
+        ]
+      }
+    },
+    {
+      "id": "observed_ambiguous_status",
+      "observed": {
+        "schema": "assay.mcp_manifest_observed.v0",
+        "status": "ambiguous",
+        "server": {
+          "id": "github"
+        },
+        "observed": {
+          "canonicalization": "assay.mcp_manifest_projection.v0",
+          "tools_list_observed": true,
+          "tools_list_complete": "complete",
+          "tool_digests": []
+        }
+      },
+      "declared": {
+        "schema": "assay.declared_mcp_manifest.v0",
+        "server": {
+          "id": "github"
+        },
+        "canonicalization": "assay.mcp_manifest_projection.v0",
+        "manifest_digest": "sha256:f91fb844b0b68133d26d8955d96b1dfea1e7492c697fbab57f7165ee65376174",
+        "tools": [
+          {
+            "name": "search",
+            "tool_digest": "sha256:f69acbb7bce749bcef576c0a99c7eb34f3c18204ad1a2e53dd24d71f0c0a1fcf",
+            "privileged": false
+          },
+          {
+            "name": "github.add_deploy_key",
+            "tool_digest": "sha256:d03045bf0eaf02288a02ba0fd116867972fb64ce14f05075ea0eafcbb1a87cb1",
+            "privileged": true
+          }
+        ]
+      },
+      "expected": {
+        "findings": [],
+        "inconclusive": [
+          "mcp_manifest_observation_ambiguous"
+        ]
+      }
+    }
+  ]
+}

--- a/crates/assay-mcp-server/tests/mcp_manifest_granular_fixtures.rs
+++ b/crates/assay-mcp-server/tests/mcp_manifest_granular_fixtures.rs
@@ -1,0 +1,267 @@
+//! P60d-a guard: granular per-tool MCP manifest drift (Option A — presence + per-tool digest, no
+//! producer change). Spec: docs/reference/mcp-manifest-drift.md. There is no consumer code yet (that
+//! is P60d-b in Plimsoll); this proves the declared baseline is self-consistent (its manifest_digest
+//! recomputes via the same JCS the producer uses, anchored to the committed P60a value) and that the
+//! documented per-tool finding matrix + validity checks are executable. P60d explains which tool digest
+//! drifted; it does not explain which field changed or whether the change is malicious.
+
+use assay_core::mcp::jcs;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::path::PathBuf;
+
+fn fx(name: &str) -> Value {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/mcp_manifest_drift")
+        .join(name);
+    serde_json::from_str(&fs::read_to_string(&p).unwrap()).unwrap()
+}
+
+/// Recompute a manifest_digest from per-tool {name, tool_digest} entries via the documented JCS
+/// canonicalization (projection id inside the hashed preimage, entries sorted by name then digest).
+fn recompute_manifest_digest(tools: &[Value]) -> String {
+    let mut entries: Vec<(String, String)> = tools
+        .iter()
+        .map(|t| {
+            (
+                t["name"].as_str().unwrap().to_string(),
+                t["tool_digest"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    entries.sort();
+    let arr: Vec<Value> = entries
+        .into_iter()
+        .map(|(n, d)| json!({"name": n, "tool_digest": d}))
+        .collect();
+    let bytes = jcs::to_vec(&json!({
+        "projection": "assay.mcp_manifest_projection.v0",
+        "tools": arr,
+    }))
+    .unwrap();
+    format!("sha256:{}", hex::encode(Sha256::digest(&bytes)))
+}
+
+fn dup_names(tools: &[Value]) -> bool {
+    let mut seen = std::collections::HashSet::new();
+    tools
+        .iter()
+        .any(|t| !seen.insert(t["name"].as_str().unwrap()))
+}
+
+/// Reference verifier for the documented P60d-a granular-diff matrix + validity checks. The production
+/// consumer is P60d-b (Plimsoll); this proves the spec's columns are executable.
+fn diff(observed: &Value, declared: &Value) -> (Vec<(String, String)>, Vec<String>) {
+    let dtools = declared["tools"].as_array().unwrap();
+
+    // Baseline validity first — never diff against an invalid/inconsistent baseline.
+    if recompute_manifest_digest(dtools) != declared["manifest_digest"].as_str().unwrap() {
+        return (vec![], vec!["declared_manifest_digest_mismatch".into()]);
+    }
+    if dup_names(dtools) {
+        return (vec![], vec!["declared_mcp_manifest_ambiguous".into()]);
+    }
+    if observed["server"]["id"] != declared["server"]["id"] {
+        return (vec![], vec!["mcp_manifest_server_mismatch".into()]);
+    }
+    if observed["observed"]["canonicalization"] != declared["canonicalization"] {
+        return (
+            vec![],
+            vec!["mcp_manifest_canonicalization_mismatch".into()],
+        );
+    }
+
+    // Observed validity.
+    let status = observed["status"].as_str().unwrap();
+    if status == "not_observed" {
+        return (vec![], vec!["inconclusive_manifest_not_observed".into()]);
+    }
+    let otools = observed["observed"]["tool_digests"].as_array().unwrap();
+    if status == "ambiguous" || dup_names(otools) {
+        return (vec![], vec!["mcp_manifest_observation_ambiguous".into()]);
+    }
+
+    // Per-tool diff.
+    let complete = observed["observed"]["tools_list_complete"]
+        .as_str()
+        .unwrap()
+        == "complete";
+    let obs: HashMap<&str, (&str, bool)> = otools
+        .iter()
+        .map(|t| {
+            (
+                t["name"].as_str().unwrap(),
+                (
+                    t["tool_digest"].as_str().unwrap(),
+                    t["privileged"].as_bool().unwrap(),
+                ),
+            )
+        })
+        .collect();
+    let dec: HashMap<&str, (&str, bool)> = dtools
+        .iter()
+        .map(|t| {
+            (
+                t["name"].as_str().unwrap(),
+                (
+                    t["tool_digest"].as_str().unwrap(),
+                    t["privileged"].as_bool().unwrap(),
+                ),
+            )
+        })
+        .collect();
+    let names: BTreeSet<&str> = obs.keys().chain(dec.keys()).copied().collect();
+
+    let mut findings = Vec::new();
+    let mut inconclusive = Vec::new();
+    let mut removal_inconclusive = false;
+    for name in names {
+        match (obs.get(name), dec.get(name)) {
+            (Some((_, opriv)), None) => {
+                // observed-only -> added
+                let code = if *opriv {
+                    "mcp_new_privileged_tool"
+                } else {
+                    "mcp_tool_added"
+                };
+                findings.push((name.to_string(), code.to_string()));
+            }
+            (None, Some((_, dpriv))) => {
+                // declared-only -> removed, but only assertable under complete observation
+                if complete {
+                    let code = if *dpriv {
+                        "mcp_privileged_tool_removed"
+                    } else {
+                        "mcp_tool_removed"
+                    };
+                    findings.push((name.to_string(), code.to_string()));
+                } else if !removal_inconclusive {
+                    inconclusive.push("inconclusive_manifest_partial_observation".to_string());
+                    removal_inconclusive = true;
+                }
+            }
+            (Some((od, opriv)), Some((dd, dpriv))) => {
+                if od != dd {
+                    let code = if *opriv || *dpriv {
+                        "mcp_privileged_tool_changed"
+                    } else {
+                        "mcp_tool_changed"
+                    };
+                    findings.push((name.to_string(), code.to_string()));
+                }
+            }
+            (None, None) => unreachable!(),
+        }
+    }
+    (findings, inconclusive)
+}
+
+#[test]
+fn declared_baseline_is_self_consistent_and_anchored_to_p60a() {
+    let base = fx("declared_per_tool_baseline.json");
+    assert_eq!(base["schema"], "assay.declared_mcp_manifest.v0");
+    // Self-consistency: manifest_digest recomputes from the per-tool entries.
+    assert_eq!(
+        recompute_manifest_digest(base["tools"].as_array().unwrap()),
+        base["manifest_digest"].as_str().unwrap(),
+        "declared baseline manifest_digest must recompute from its tools"
+    );
+    // Anchor: the same canonical tools yield the committed P60a manifest_digest.
+    let p60a = fx("canonicalization_example.json");
+    assert_eq!(
+        base["manifest_digest"].as_str().unwrap(),
+        p60a["manifest"]["expected_manifest_digest"]
+            .as_str()
+            .unwrap(),
+        "a clean per-tool baseline equals the committed P60a manifest_digest"
+    );
+}
+
+#[test]
+fn granular_diff_corpus_matches_expected() {
+    let corpus = fx("granular_diff_cases.json");
+    let mut failures = Vec::new();
+    for case in corpus["cases"].as_array().unwrap() {
+        let id = case["id"].as_str().unwrap();
+        let (findings, inconclusive) = diff(&case["observed"], &case["declared"]);
+
+        let mut got: Vec<String> = findings.iter().map(|(n, c)| format!("{n}:{c}")).collect();
+        got.sort();
+        let mut want: Vec<String> = case["expected"]["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|f| {
+                format!(
+                    "{}:{}",
+                    f["name"].as_str().unwrap(),
+                    f["reason_code"].as_str().unwrap()
+                )
+            })
+            .collect();
+        want.sort();
+        if got != want {
+            failures.push(format!("{id}: findings expected {want:?}, got {got:?}"));
+        }
+
+        let mut got_inc = inconclusive.clone();
+        got_inc.sort();
+        let mut want_inc: Vec<String> = case["expected"]["inconclusive"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c.as_str().unwrap().to_string())
+            .collect();
+        want_inc.sort();
+        if got_inc != want_inc {
+            failures.push(format!(
+                "{id}: inconclusive expected {want_inc:?}, got {got_inc:?}"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "granular diff mismatches: {failures:#?}"
+    );
+}
+
+#[test]
+fn pinned_p60d_vocabulary() {
+    let known_findings = [
+        "mcp_tool_added",
+        "mcp_new_privileged_tool",
+        "mcp_tool_removed",
+        "mcp_privileged_tool_removed",
+        "mcp_tool_changed",
+        "mcp_privileged_tool_changed",
+    ];
+    let known_inconclusive = [
+        "declared_manifest_digest_mismatch",
+        "declared_mcp_manifest_ambiguous",
+        "mcp_manifest_server_mismatch",
+        "mcp_manifest_canonicalization_mismatch",
+        "inconclusive_manifest_not_observed",
+        "mcp_manifest_observation_ambiguous",
+        "inconclusive_manifest_partial_observation",
+    ];
+    let corpus = fx("granular_diff_cases.json");
+    for case in corpus["cases"].as_array().unwrap() {
+        let id = case["id"].as_str().unwrap();
+        for f in case["expected"]["findings"].as_array().unwrap() {
+            let c = f["reason_code"].as_str().unwrap();
+            assert!(
+                known_findings.contains(&c),
+                "{id}: unknown finding code {c}"
+            );
+        }
+        for c in case["expected"]["inconclusive"].as_array().unwrap() {
+            let c = c.as_str().unwrap();
+            assert!(
+                known_inconclusive.contains(&c),
+                "{id}: unknown inconclusive code {c}"
+            );
+        }
+    }
+}

--- a/docs/reference/mcp-manifest-drift.md
+++ b/docs/reference/mcp-manifest-drift.md
@@ -153,11 +153,76 @@ Absence rule: "no observed `tools/list`" is not "no drift"; only "observed compl
 a matching digest" is "no drift". A digest mismatch is drift even under `unknown` completeness; a
 digest match under `unknown` completeness may not be claimed fully clean.
 
+## Granular per-tool drift (P60d, `assay.declared_mcp_manifest.v0`)
+
+The coarse gate (above) compares one overall `manifest_digest`. P60d adds **per-tool** drift: which
+tool was added, removed, or changed, with privileged tools flagged. **P60d explains which tool digest
+drifted; it still does not explain which field changed or whether the change is malicious.** Field-level
+attribution (description vs schema vs annotations) is P60d-v2.
+
+P60d v1 is **Option A — presence + per-tool digest, consumer-only**: it diffs the observed
+`tool_digests[]` (already in `assay.mcp_manifest_observed.v0`, P60b) against a declared per-tool
+baseline. **No producer change** — the observed artifact already carries `{name, tool_digest,
+privileged, privilege_classification, action_class}` per tool.
+
+### Baseline: `assay.declared_mcp_manifest.v0`
+
+Operator-pinned, declared-not-trusted (same discipline as the coarse `declared_mcp_manifests` map). It
+is structurally the `observed` block of a known-good complete run:
+```json
+{
+  "schema": "assay.declared_mcp_manifest.v0",
+  "server": { "id": "github" },
+  "canonicalization": "assay.mcp_manifest_projection.v0",
+  "manifest_digest": "sha256:...",
+  "tools": [
+    { "name": "github.add_deploy_key", "tool_digest": "sha256:...",
+      "privileged": true, "privilege_classification": "classified", "action_class": "github_deploy_key" }
+  ]
+}
+```
+`manifest_digest` recomputes from `tools[].{name, tool_digest}` via the same JCS canonicalization as the
+observed manifest (so a clean baseline's digest equals the P60a-anchored value). v1 baselines are
+hand-authored or copied from a clean observed run — no `promote` helper in v1.
+
+### Validity checks (each is inconclusive — never a per-tool diff against a bad baseline)
+
+```
+recompute(declared.tools) != declared.manifest_digest   -> declared_manifest_digest_mismatch
+duplicate names in declared.tools                        -> declared_mcp_manifest_ambiguous
+observed.server.id != declared.server.id                 -> mcp_manifest_server_mismatch
+observed.canonicalization != declared.canonicalization   -> mcp_manifest_canonicalization_mismatch
+observed.status = not_observed                           -> inconclusive_manifest_not_observed
+observed.status = ambiguous OR duplicate observed names  -> mcp_manifest_observation_ambiguous
+```
+And a consumer (P60d-b) check when BOTH baselines are supplied: the coarse
+`declared_mcp_manifests[server].manifest_digest` must equal `declared_mcp_manifest.manifest_digest`,
+else `declared_manifest_baseline_conflict` (two declared truths → inconclusive).
+
+### Per-tool finding matrix
+
+```
+observed name not in declared        -> observed privileged ? mcp_new_privileged_tool : mcp_tool_added
+declared name not in observed:
+  observed complete                  -> declared privileged ? mcp_privileged_tool_removed : mcp_tool_removed
+  observed partial/unknown           -> NO per-tool removal finding; one inconclusive_manifest_partial_observation
+                                        ("removals are not evaluable: the manifest observation was incomplete")
+name in both, tool_digest differs    -> (observed OR declared privileged) ? mcp_privileged_tool_changed : mcp_tool_changed
+name in both, tool_digest equal      -> no finding
+```
+Every per-tool finding contributes to `pending_tool_manifest_review`. Severity: the privileged variants
+(`mcp_new_privileged_tool`, `mcp_privileged_tool_changed`, `mcp_privileged_tool_removed`) are high; the
+non-privileged variants (`mcp_tool_added`, `mcp_tool_changed`, `mcp_tool_removed`) are findings too, at
+lower severity — a non-privileged tool's surface change can still affect prompt/tool behavior, so it is
+reviewable, just not as loud. Additions and changes among observed tools are assertable even under
+partial observation; **only removals are suppressed under partial/unknown** (a "missing" tool could be
+on an unobserved page).
+
 ## What v0 is NOT
 
-No per-tool granular drift reason codes (P60d/v1), no behavior-drift detection, no LLM risk scoring,
-no automatic block on legitimate description churn, no maliciousness classification, no pre-flight
-scan.
+No per-field attribution (which field changed) — that is P60d-v2; no behavior-drift detection, no LLM
+risk scoring, no automatic block on legitimate churn, no maliciousness classification, no pre-flight
+scan, no producer change in P60d v1.
 
 ## Producer (P60b)
 
@@ -205,13 +270,18 @@ P60a   spec + fixtures + canonicalization examples + a digest-recompute guard te
 P60b   producer: assay-mcp-server manifest_observed module emits assay.mcp_manifest_observed.v0
 P60c   Plimsoll: coarse drift gate -> pending_tool_manifest_review (opt-in, coverage-gated)
 P60b2  live observation: topology finding (above) -> manifest-observation proxy mode (SHIPPED v3.23.0)
-P60d   granular per-tool drift v1 + assay.declared_mcp_manifest.v0 (per-tool expected digests)
+P60d-a granular drift spec + assay.declared_mcp_manifest.v0 fixtures + guard test (NO producer change)
+P60d-b Plimsoll granular consumer (--declared-mcp-manifest) -> per-tool reason codes + coarse-consistency
+P60d-v2 LATER: field-level attribution (per-field digests in producer + baseline + consumer)
 ```
 
 ## Reference fixtures
 
 `crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/`: canonicalization examples (a per-tool
-projection and a manifest projection with their committed digests, recomputed in the guard test) and
-a verdict corpus (same digest, drift, description/schema/annotations changed, new privileged tool,
-tool removed, behavior-only identical metadata, not observed, partial pagination, duplicate names),
-each labelled with its expected v0 verdict.
+projection and a manifest projection with their committed digests, recomputed in the guard test); a
+coarse verdict corpus (same digest, drift, schema/annotations changed, new privileged tool, tool
+removed, not observed, partial pagination, duplicate names), each labelled with its expected v0
+verdict; and for P60d, a P60a-anchored per-tool baseline (`declared_per_tool_baseline.json`, whose
+`manifest_digest` the guard test recomputes and equals the committed P60a value) plus a granular-diff
+corpus (`granular_diff_cases.json`) covering the per-tool matrix and every validity check, each
+labelled with its expected findings and inconclusive codes.


### PR DESCRIPTION
P60d-a is the assay-side spec, fixtures, and guard test for **granular per-tool manifest drift** — no producer change, no Plimsoll code (that is P60d-b). The boundary holds: **P60d explains which tool digest drifted; it does not explain which field changed (that is P60d-v2) or whether the change is malicious.**

P60d v1 is **Option A — presence + per-tool digest, consumer-only granularity.** It works because the observed `assay.mcp_manifest_observed.v0` artifact already carries `{name, tool_digest, privileged, privilege_classification, action_class}` per tool (P60b), so no producer change is needed.

What's in this PR:

- the `assay.declared_mcp_manifest.v0` baseline shape (operator-pinned, declared-not-trusted; its `manifest_digest` recomputes from `tools[].{name, tool_digest}` via the same JCS as the observed manifest);
- the per-tool finding matrix — `mcp_tool_added` / `mcp_new_privileged_tool`, `mcp_tool_removed` / `mcp_privileged_tool_removed`, `mcp_tool_changed` / `mcp_privileged_tool_changed` — all contributing to `pending_tool_manifest_review`, with the privileged variants louder and non-privileged changes still findings (lower severity);
- the validity checks, each inconclusive rather than a diff against a bad baseline: `declared_manifest_digest_mismatch`, `declared_mcp_manifest_ambiguous`, `mcp_manifest_server_mismatch`, `mcp_manifest_canonicalization_mismatch`, observed `not_observed` / `ambiguous`, plus the P60d-b consumer-side `declared_manifest_baseline_conflict` when both a coarse map and a declared artifact are supplied;
- the coverage-honesty rule: under **partial/unknown** observation, no per-tool removal finding is emitted — one `inconclusive_manifest_partial_observation` says removals are not evaluable — while additions and changes stay assertable (a "missing" tool could be on an unobserved page);
- fixtures: a P60a-anchored per-tool baseline (its `manifest_digest` recomputes to the committed P60a value) and a 17-case granular-diff corpus covering the full matrix and every validity check;
- a guard test that recomputes the baseline digest through `assay_core::mcp::jcs` (self-consistency + P60a anchor) and runs the finding matrix as a reference verifier.

fmt, clippy, and the full crate suite are green; `Cargo.toml`/`Cargo.lock` are untouched.

Lane classification: Gate.NONE

Reason:
- docs + tests + fixtures only (assay-mcp-server)
- no runner/eBPF/monitor paths
- no Cargo.toml/Cargo.lock changes
- no delegated proof paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)