### PR TITLE
feat(mcp): producer emits optional field_digests (P60d-v2-a)

### DIFF
--- a/crates/assay-mcp-server/src/manifest_observed.rs
+++ b/crates/assay-mcp-server/src/manifest_observed.rs
@@ -25,6 +25,17 @@ use serde_json::{json, Value};
 
 pub const SCHEMA: &str = "assay.mcp_manifest_observed.v0";
 pub const CANONICALIZATION: &str = "assay.mcp_manifest_projection.v0";
+/// P60d-v2: domain for per-field digests. OPTIONAL attribution metadata — field_digests never enter
+/// the tool_digest or manifest_digest preimages, so adding them moves no existing digest.
+pub const FIELD_PROJECTION: &str = "assay.mcp_tool_field.v0";
+/// The four mutable per-tool fields P60d-v2 attributes. A name change is a remove+add, not a field
+/// change, so name is not among them.
+const FIELD_NAMES: [&str; 4] = [
+    "description",
+    "input_schema",
+    "output_schema",
+    "annotations",
+];
 
 /// Completeness of the observed `tools/list`. Never guessed: `complete` is only legitimate when the
 /// full pagination chain (until no `nextCursor`) was observed.
@@ -82,8 +93,21 @@ fn tool_digest(projection: &Value) -> String {
     digest_of(projection)
 }
 
+/// P60d-v2: a per-field digest (optional attribution metadata). Domain-separated with the projection
+/// id AND the field name inside the hashed preimage, so a null `description` and a null `annotations`
+/// can never collide. `value` is the canonical field value the per-tool projection already carries
+/// (or null), so each field_digest is over the same bytes that feed `tool_digest`.
+fn field_digest(field: &str, value: &Value) -> String {
+    digest_of(&json!({
+        "projection": FIELD_PROJECTION,
+        "field": field,
+        "value": value,
+    }))
+}
+
 /// `manifest_digest` over the manifest projection, with the projection id INSIDE the hashed preimage
-/// and entries sorted by `(name, tool_digest)` — order-independent, shape-pinned.
+/// and entries sorted by `(name, tool_digest)` — order-independent, shape-pinned. NOTE: the preimage
+/// is `{name, tool_digest}` only; P60d-v2 `field_digests` are deliberately NOT included here.
 fn manifest_digest(name_digests: &[(String, String)]) -> String {
     let mut entries: Vec<(String, String)> = name_digests.to_vec();
     entries.sort();
@@ -118,12 +142,23 @@ fn tool_digest_entry(tool: &Value) -> (String, String, Value) {
     // annotations can never decide it.
     let category = classify(&raw, &Value::Null).category;
     let privileged = category.is_some();
+    // P60d-v2: per-field digests over the SAME canonical field values that feed tool_digest, so they
+    // are consistent with tool_digest while remaining outside its (and the manifest's) preimage.
+    let mut field_digests = serde_json::Map::new();
+    for field in FIELD_NAMES {
+        field_digests.insert(
+            field.to_string(),
+            Value::String(field_digest(field, &projection[field])),
+        );
+    }
+    let field_digests = Value::Object(field_digests);
     let entry = json!({
         "name": sanitize(&raw),
         "tool_digest": digest.clone(),
         "privileged": privileged,
         "privilege_classification": if privileged { "classified" } else { "unclassified" },
         "action_class": category.map(Value::from).unwrap_or(Value::Null),
+        "field_digests": field_digests,
     });
     (raw, digest, entry)
 }
@@ -376,5 +411,95 @@ mod tests {
         assert_eq!(rec["schema"], json!(SCHEMA));
         assert_eq!(rec["observed"]["canonicalization"], json!(CANONICALIZATION));
         assert!(!rec["non_claims"].as_array().unwrap().is_empty());
+    }
+
+    // ---- P60d-v2: optional field_digests (additive) ----
+
+    #[test]
+    fn field_digests_carry_all_four_fields_and_recompute() {
+        // The producer emits a field_digest for each of the four mutable fields, each recomputing from
+        // the same canonical value the per-tool projection carries.
+        let tool = json!({
+            "name": "github.add_deploy_key",
+            "description": "Add a deploy key",
+            "inputSchema": {"type": "object", "required": ["owner", "repo"]}
+        });
+        let rec = build_observed(
+            "github",
+            std::slice::from_ref(&tool),
+            Completeness::Complete,
+        );
+        let fd = &rec["observed"]["tool_digests"][0]["field_digests"];
+        let proj = tool_projection(&tool);
+        for field in FIELD_NAMES {
+            assert_eq!(
+                fd[field].as_str().unwrap(),
+                field_digest(field, &proj[field]),
+                "{field} digest must recompute from the projected value"
+            );
+        }
+        assert_eq!(fd.as_object().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn adding_field_digests_does_not_move_tool_or_manifest_digest() {
+        // The load-bearing invariant: field_digests are outside both preimages. Reuse the committed
+        // P60a anchor — the producer (now emitting field_digests) must still reproduce it byte-for-byte.
+        let ex = p60a_fixture();
+        let rec = build_observed("github", &p60a_raw_tools(), Completeness::Complete);
+        assert_eq!(
+            rec["observed"]["manifest_digest"].as_str().unwrap(),
+            ex["manifest"]["expected_manifest_digest"].as_str().unwrap(),
+            "manifest_digest must be unchanged after adding field_digests"
+        );
+        let deploy = rec["observed"]["tool_digests"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["name"] == json!("github.add_deploy_key"))
+            .unwrap();
+        assert_eq!(
+            deploy["tool_digest"].as_str().unwrap(),
+            ex["per_tool"]["expected_tool_digest"].as_str().unwrap(),
+            "tool_digest must be unchanged after adding field_digests"
+        );
+    }
+
+    #[test]
+    fn null_and_missing_fields_canonicalize_deterministically() {
+        // A tool with no description/output_schema/annotations: those fields project to null and their
+        // field_digests are stable and equal across two independent builds.
+        let bare = json!({"name": "x", "inputSchema": {"type": "object"}});
+        let r1 = build_observed("s", std::slice::from_ref(&bare), Completeness::Complete);
+        let r2 = build_observed("s", std::slice::from_ref(&bare), Completeness::Complete);
+        let f1 = &r1["observed"]["tool_digests"][0]["field_digests"];
+        let f2 = &r2["observed"]["tool_digests"][0]["field_digests"];
+        assert_eq!(f1, f2, "null-field digests must be deterministic");
+        // A null description and a null annotations must NOT collide (domain separation).
+        assert_ne!(f1["description"], f1["annotations"]);
+        assert_eq!(
+            f1["description"].as_str().unwrap(),
+            field_digest("description", &Value::Null)
+        );
+    }
+
+    #[test]
+    fn field_digests_expose_no_raw_field_values() {
+        // field_digests are sha256 hex; a hostile/secret-looking description must not appear verbatim.
+        let tool = json!({
+            "name": "t",
+            "description": "SECRET-MARKER-9f3a do not leak",
+            "inputSchema": {"type": "object", "properties": {"token": {"const": "RAW-SCHEMA-MARKER"}}}
+        });
+        let rec = build_observed("s", &[tool], Completeness::Complete);
+        let text = serde_json::to_string(&rec["observed"]["tool_digests"]).unwrap();
+        assert!(
+            !text.contains("SECRET-MARKER-9f3a"),
+            "raw description must not appear"
+        );
+        assert!(
+            !text.contains("RAW-SCHEMA-MARKER"),
+            "raw schema value must not appear"
+        );
     }
 }

--- a/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/canonicalization_example.json
+++ b/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/canonicalization_example.json
@@ -14,7 +14,13 @@
       "output_schema": null,
       "annotations": null
     },
-    "expected_tool_digest": "sha256:03c7e1d546c3440fb100938dcaa7578ac34ae81f28e5762e7f8a3197e272a9f6"
+    "expected_tool_digest": "sha256:03c7e1d546c3440fb100938dcaa7578ac34ae81f28e5762e7f8a3197e272a9f6",
+    "expected_field_digests": {
+      "description": "sha256:7e326787191c47250d1541c8dd2e5c8e9e8c5345ef3da8b66694e32788a29d99",
+      "input_schema": "sha256:52e5c928edb4433b517b5410a20c6a8a2ed87ff90b7931c000ba2a43fca3644c",
+      "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+      "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+    }
   },
   "manifest": {
     "projection_id": "assay.mcp_manifest_projection.v0",

--- a/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline.json
+++ b/crates/assay-mcp-server/tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline.json
@@ -12,14 +12,26 @@
       "tool_digest": "sha256:2318d9fd63878b81e992300635172e75053e086db757e31b7ebc917a7c721697",
       "privileged": false,
       "privilege_classification": "unclassified",
-      "action_class": null
+      "action_class": null,
+      "field_digests": {
+        "description": "sha256:44c1a1350496d95897e53865330ee56cbf07b02ee54450c191d7d72b2d7005ea",
+        "input_schema": "sha256:e0522e896196457208cca527b92ed8155a72673ccb7723ade56ef69f57230290",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+      }
     },
     {
       "name": "github.add_deploy_key",
       "tool_digest": "sha256:03c7e1d546c3440fb100938dcaa7578ac34ae81f28e5762e7f8a3197e272a9f6",
       "privileged": true,
       "privilege_classification": "classified",
-      "action_class": "github_deploy_key"
+      "action_class": "github_deploy_key",
+      "field_digests": {
+        "description": "sha256:7e326787191c47250d1541c8dd2e5c8e9e8c5345ef3da8b66694e32788a29d99",
+        "input_schema": "sha256:52e5c928edb4433b517b5410a20c6a8a2ed87ff90b7931c000ba2a43fca3644c",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+      }
     }
   ]
 }

--- a/crates/assay-mcp-server/tests/mcp_manifest_drift_fixtures.rs
+++ b/crates/assay-mcp-server/tests/mcp_manifest_drift_fixtures.rs
@@ -30,6 +30,34 @@ fn tool_digest(tool: &Value) -> String {
     digest_of(tool)
 }
 
+/// P60d-v2 per-field digest: projection id + field name inside the hashed preimage.
+fn field_digest(field: &str, value: &Value) -> String {
+    digest_of(&json!({"projection": "assay.mcp_tool_field.v0", "field": field, "value": value}))
+}
+
+#[test]
+fn field_digests_anchor_recomputes_from_committed_bytes() {
+    // The committed per-field anchor recomputes via the same JCS the producer uses (cross-impl), and
+    // it is independent of tool_digest/manifest_digest (which the other tests pin unchanged).
+    let ex = fx("canonicalization_example.json");
+    let proj = &ex["per_tool"]["projection"];
+    let expected = &ex["per_tool"]["expected_field_digests"];
+    for field in [
+        "description",
+        "input_schema",
+        "output_schema",
+        "annotations",
+    ] {
+        assert_eq!(
+            field_digest(field, &proj[field]),
+            expected[field].as_str().unwrap(),
+            "{field} field_digest must recompute from the committed projection"
+        );
+    }
+    // Domain separation: a null output_schema and a null annotations must not collide.
+    assert_ne!(expected["output_schema"], expected["annotations"]);
+}
+
 /// Build the manifest projection with the projection id INSIDE the hashed preimage, sorted by name
 /// then tool_digest, and hash it. This is the value the v0 Plimsoll gate compares against baseline.
 fn manifest_digest(tools: &[Value]) -> String {

--- a/crates/assay-mcp-server/tests/mcp_manifest_granular_fixtures.rs
+++ b/crates/assay-mcp-server/tests/mcp_manifest_granular_fixtures.rs
@@ -180,6 +180,37 @@ fn declared_baseline_is_self_consistent_and_anchored_to_p60a() {
 }
 
 #[test]
+fn declared_baseline_carries_field_digests_consistent_with_the_anchor() {
+    // P60d-v2: the declared baseline gains optional field_digests (additive — the v1 manifest_digest
+    // self-consistency test above still passes, since field_digests are outside that preimage).
+    let base = fx("declared_per_tool_baseline.json");
+    let anchor = fx("canonicalization_example.json");
+    for t in base["tools"].as_array().unwrap() {
+        let fd = &t["field_digests"];
+        assert!(fd.is_object(), "each declared tool carries field_digests");
+        for field in [
+            "description",
+            "input_schema",
+            "output_schema",
+            "annotations",
+        ] {
+            assert!(fd[field].is_string(), "{field} present");
+        }
+    }
+    // The privileged deploy tool's per-field digests equal the committed anchor (same canonical tool).
+    let deploy = base["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["name"] == "github.add_deploy_key")
+        .unwrap();
+    assert_eq!(
+        deploy["field_digests"], anchor["per_tool"]["expected_field_digests"],
+        "baseline field_digests must match the committed anchor for the same tool"
+    );
+}
+
+#[test]
 fn granular_diff_corpus_matches_expected() {
     let corpus = fx("granular_diff_cases.json");
     let mut failures = Vec::new();


### PR DESCRIPTION
The producer half of field-level attribution. `assay-mcp-server` now emits optional per-field digests in the observed manifest, **purely additively** — `tool_digest` and `manifest_digest` are byte-unchanged, so P60a/b/c/d-v1 all keep their exact committed values. Assay producer only: no Plimsoll, no field-level findings, no schema `v1`.

The load-bearing invariant is the headline: **adding `field_digests` moves no existing digest.** `field_digests` are deliberately outside the `manifest_digest` preimage (which stays `{name, tool_digest}`) and outside `tool_digest` (the 5-field projection).

- `field_digest(field, value) = sha256(JCS({projection: "assay.mcp_tool_field.v0", field, value}))` — projection id **and** field name inside the hashed preimage, so a null `description` and a null `annotations` cannot collide. Computed over the same canonical field values that feed `tool_digest`, so the two are consistent.
- each per-tool entry gains `field_digests` = `{description, input_schema, output_schema, annotations}`; the declared baseline fixture gains the same optional shape (its `manifest_digest` is unchanged); `canonicalization_example.json` gains a committed per-field anchor.
- guard tests: field digests recompute for all four fields (inline + cross-impl via `assay_core::mcp::jcs`); `adding_field_digests_does_not_move_tool_or_manifest_digest` reuses the committed P60a anchor to prove the invariant; null/missing fields canonicalize deterministically with domain separation; no raw field values appear (digests only); the P60a (6) and P60d-v1 (4) guards still pass byte-for-byte.

fmt, clippy, and the full crate suite are green; `Cargo.toml`/`Cargo.lock` are untouched.

*P60d-v2-a makes field-level attribution available; P60d-v2-b decides how Plimsoll uses it. P60d-v2 explains which field's canonical bytes changed; it does not explain how the field changed or whether the change is malicious.*

Lane classification: Gate.NONE

Reason:
- assay-mcp-server src + tests + fixtures only
- no runner/eBPF/monitor paths
- no Cargo.toml/Cargo.lock changes
- no delegated proof paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)