### PR TITLE
feat(mcp): enforcing proxy mode — deny-all (P61e-b)

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -41,6 +41,19 @@ enum Mode {
         #[arg(long)]
         proxy_observation_health_out: Option<PathBuf>,
     },
+    /// Run as an MCP upstream ENFORCING proxy (P61e-b, deny-all): an explicit, separate run mode — a
+    /// different risk class from `proxy`, never a variant of it. Every `tools/call` is denied with
+    /// `proxy_denied` (`enforcing_mode_deny_all`) and never forwarded upstream; the handshake, `ping`,
+    /// and `tools/list` still forward; other methods stay `proxy_unsupported`. There is no allow path,
+    /// no policy decision point, no credential or drift gate in v0 (those are P61e-c).
+    ProxyEnforce {
+        /// The upstream MCP server command to spawn (stdio transport).
+        #[arg(long)]
+        upstream_command: String,
+        /// Arguments passed to the upstream command (repeatable). Hyphen-led values are allowed.
+        #[arg(long = "upstream-arg", allow_hyphen_values = true)]
+        upstream_args: Vec<String>,
+    },
 }
 
 use tracing_subscriber::{fmt, EnvFilter};
@@ -83,8 +96,27 @@ async fn main() -> Result<()> {
             proxy::run(
                 upstream_command,
                 upstream_args,
+                proxy::Mode::Observe,
                 mcp_manifest_observed_out,
                 proxy_observation_health_out,
+            )
+            .await
+        }
+        Some(Mode::ProxyEnforce {
+            upstream_command,
+            upstream_args,
+        }) => {
+            tracing::info!(
+                event = "proxy_start",
+                upstream_command = %upstream_command,
+                mode = "enforce_deny_all_v0"
+            );
+            proxy::run(
+                upstream_command,
+                upstream_args,
+                proxy::Mode::Enforce,
+                None,
+                None,
             )
             .await
         }

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -40,9 +40,21 @@ const ALLOWLIST: &[&str] = &[
 // are unambiguously distinguishable from upstream errors regardless of code.
 const PROXY_UNSUPPORTED: i32 = -32040;
 const PROXY_FAILED: i32 = -32041;
-// PROXY_DENIED (-32042) is reserved for the future enforcing arc (P61e); it never occurs in v0.
+// PROXY_DENIED: a P61e enforcing-mode policy denial. In P61e-b the only reason is the deny-all
+// boundary; gate-specific reasons arrive with the allow path (P61e-c).
+const PROXY_DENIED: i32 = -32042;
 
 const HEALTH_SCHEMA: &str = "assay.proxy_observation_health.v0";
+
+/// Proxy run mode. Observe (P61a-d, shipped) forwards the allowlist and answers `tools/call` with
+/// `proxy_unsupported`. Enforce (P61e-b) is deny-all: a `tools/call` is denied with `proxy_denied`
+/// (`enforcing_mode_deny_all`) and never forwarded; everything else is identical to Observe. The allow
+/// path / policy decision point is a later slice (P61e-c).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Observe,
+    Enforce,
+}
 
 fn proxy_error_line(id: Value, code: i32, reason: &str, message: &str) -> String {
     json!({
@@ -298,10 +310,13 @@ fn write_json_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
     }
 }
 
-/// Run the manifest-observation proxy against one stdio upstream.
+/// Run the proxy against one stdio upstream. `mode` selects observe (manifest-observation, P61a-d) or
+/// enforce (deny-all `tools/call`, P61e-b); the only behavioral difference is how `tools/call` is
+/// answered. Manifest emission flags apply to observe only.
 pub async fn run(
     upstream_command: String,
     upstream_args: Vec<String>,
+    mode: Mode,
     manifest_out: Option<PathBuf>,
     health_out: Option<PathBuf>,
 ) -> Result<()> {
@@ -438,17 +453,28 @@ pub async fn run(
                 }
             }
             Some(method) => {
-                // Denied: tools/call and every other non-allowlisted method. Never sent upstream.
+                // Denied: tools/call and every other non-allowlisted method. Never sent upstream. In
+                // enforce mode a tools/call is a POLICY denial (proxy_denied, enforcing_mode_deny_all);
+                // every other non-allowlisted method — and all of observe mode — stays proxy_unsupported.
+                let (code, reason, message): (i32, &str, String) = if mode == Mode::Enforce
+                    && method == "tools/call"
+                {
+                    (
+                            PROXY_DENIED,
+                            "enforcing_mode_deny_all",
+                            "tools/call is denied in enforcing proxy mode (deny-all; no allow path yet)"
+                                .to_string(),
+                        )
+                } else {
+                    (
+                        PROXY_UNSUPPORTED,
+                        "method_not_allowlisted",
+                        format!("method {method:?} is not forwarded in this proxy mode"),
+                    )
+                };
                 match v.get("id") {
                     Some(id) if !id.is_null() => {
-                        let _ = tx.send(proxy_error_line(
-                            id.clone(),
-                            PROXY_UNSUPPORTED,
-                            "method_not_allowlisted",
-                            &format!(
-                                "method {method:?} is not forwarded in manifest-observation proxy mode"
-                            ),
-                        ));
+                        let _ = tx.send(proxy_error_line(id.clone(), code, reason, &message));
                     }
                     _ => { /* denied notification: nothing to answer, drop it */ }
                 }

--- a/crates/assay-mcp-server/tests/proxy_enforce_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_e2e.rs
@@ -1,0 +1,242 @@
+//! P61e-b: MCP upstream ENFORCING proxy mode (deny-all). End-to-end tests.
+//! Spec: docs/reference/mcp-upstream-proxy-enforcement.md.
+//!
+//! The load-bearing invariant, asserted first: in `proxy-enforce` mode a `tools/call` is denied with
+//! `proxy_denied` (`enforcing_mode_deny_all`) and NEVER reaches the upstream. The two error codes stay
+//! distinct: `proxy_denied` is the enforcing-mode policy denial for `tools/call`; `proxy_unsupported`
+//! remains for non-allowlisted non-`tools/call` methods. The shipped `proxy` (observe) mode is
+//! unchanged. There is no allow path, no policy decision point, no gate in this slice.
+
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+const PROXY_UNSUPPORTED: i64 = -32040;
+const PROXY_DENIED: i64 = -32042;
+
+fn python() -> &'static str {
+    if cfg!(windows) {
+        "python"
+    } else {
+        "python3"
+    }
+}
+
+fn mock_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/mock_upstream.py")
+}
+
+/// Spawn the proxy in the given top-level subcommand mode ("proxy" or "proxy-enforce").
+fn spawn(subcommand: &str, log: &std::path::Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            subcommand,
+            "--upstream-command",
+            python(),
+            "--upstream-arg",
+            "-u",
+            "--upstream-arg",
+            mock_path().to_str().unwrap(),
+        ])
+        .env("MOCK_UPSTREAM_LOG", log)
+        .env("MOCK_UPSTREAM_MODE", "normal")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn proxy (is python installed?)")
+}
+
+fn send(stdin: &mut ChildStdin, v: Value) {
+    writeln!(stdin, "{v}").expect("write");
+    stdin.flush().expect("flush");
+}
+
+fn read_response(reader: &mut BufReader<ChildStdout>) -> Value {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).expect("read");
+        assert!(n > 0, "proxy closed stdout before responding");
+        let t = line.trim();
+        if t.is_empty() {
+            continue;
+        }
+        let v: Value = serde_json::from_str(t).expect("parse JSON");
+        if v.get("method").is_some() {
+            continue; // skip notifications/upstream-initiated requests
+        }
+        return v;
+    }
+}
+
+fn init() -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "t", "version": "1"}}
+    })
+}
+
+fn read_methods(log: &std::path::Path) -> Vec<String> {
+    std::fs::read_to_string(log)
+        .unwrap_or_default()
+        .lines()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn shutdown(mut child: Child, stdin: ChildStdin) {
+    drop(stdin);
+    let _ = child.wait();
+}
+
+// --- the load-bearing test, first ---------------------------------------------------------------
+
+#[test]
+fn enforcing_mode_tools_call_denied_and_not_forwarded() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn("proxy-enforce", &log);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                           "params": {"name": "echo", "arguments": {}}}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["id"], 3);
+    assert_eq!(
+        r["error"]["code"], PROXY_DENIED,
+        "tools/call is a policy denial in enforce mode"
+    );
+    assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
+    assert_eq!(r["error"]["data"]["reason"], "enforcing_mode_deny_all");
+
+    shutdown(child, stdin);
+
+    let methods = read_methods(&log);
+    assert!(methods.contains(&"initialize".to_string()));
+    assert!(methods.contains(&"tools/list".to_string()));
+    assert!(
+        !methods.contains(&"tools/call".to_string()),
+        "INVARIANT VIOLATED: tools/call reached the upstream in enforce mode: {methods:?}"
+    );
+}
+
+#[test]
+fn enforcing_mode_unknown_method_is_unsupported_not_denied() {
+    // A non-allowlisted, non-tools/call method stays proxy_unsupported even in enforce mode — the two
+    // codes are distinct: proxy_denied is only for the tools/call policy denial.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn("proxy-enforce", &log);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 7, "method": "resources/list"}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(
+        r["error"]["code"], PROXY_UNSUPPORTED,
+        "non-tools/call stays unsupported, not denied"
+    );
+    assert_eq!(r["error"]["data"]["reason"], "method_not_allowlisted");
+
+    shutdown(child, stdin);
+    assert!(!read_methods(&log).contains(&"resources/list".to_string()));
+}
+
+#[test]
+fn enforcing_mode_list_methods_still_forward() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn("proxy-enforce", &log);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let r = read_response(&mut out);
+    assert_eq!(
+        r["result"]["serverInfo"]["name"], "mock-upstream",
+        "initialize relayed"
+    );
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let r = read_response(&mut out);
+    assert!(r["result"]["tools"].is_array(), "tools/list relayed");
+
+    shutdown(child, stdin);
+    let methods = read_methods(&log);
+    assert!(
+        methods.contains(&"initialize".to_string()) && methods.contains(&"tools/list".to_string())
+    );
+}
+
+#[test]
+fn observe_mode_tools_call_still_unsupported() {
+    // The shipped observe mode is unchanged: a tools/call is proxy_unsupported, NOT proxy_denied.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn("proxy", &log);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                           "params": {"name": "echo", "arguments": {}}}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_UNSUPPORTED);
+    assert_eq!(r["error"]["data"]["reason"], "method_not_allowlisted");
+    shutdown(child, stdin);
+}
+
+#[test]
+fn existing_proxy_invocation_still_observes() {
+    // The shipped `proxy --upstream-command ...` invocation is untouched and still observes: the
+    // handshake and tools/list reach the upstream, tools/call does not.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let mut child = spawn("proxy", &log);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "echo"}}),
+    );
+    let _ = read_response(&mut out);
+
+    shutdown(child, stdin);
+    let methods = read_methods(&log);
+    assert!(methods.contains(&"initialize".to_string()));
+    assert!(methods.contains(&"tools/list".to_string()));
+    assert!(!methods.contains(&"tools/call".to_string()));
+}

--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -40,8 +40,14 @@ assay-mcp-server proxy enforce ...   # enforcing tools/call (P61e)
 ```
 Nested `proxy observe` / `proxy enforce` subcommands; if the clap layout makes nesting awkward, two
 top-level subcommands `proxy-observe` / `proxy-enforce`. Either way the enforcing mode is its own
-command, never implicit. A deployment that does not run `proxy enforce` keeps P61b–d's behavior (every
-`tools/call` → `proxy_unsupported`).
+command, never implicit. A deployment that does not run the enforcing mode keeps P61b–d's behavior
+(every `tools/call` → `proxy_unsupported`).
+
+**Implementation note (v0, P61e-b):** the shipped CLI spelling is the top-level **`proxy-enforce`**
+subcommand (a sibling of the existing `proxy`), chosen so the shipped `proxy --upstream-command …`
+invocation is untouched and the enforcing slice stays the smallest possible change in a
+security-load-bearing PR. The design concept is unchanged — an explicit, separate enforcing proxy mode;
+folding it into nested `proxy observe` / `proxy enforce` is a later ergonomic change, not a v0 concern.
 
 ## 2. Claim, non-claims, boundary
 


### PR DESCRIPTION
The first code slice of the enforcing-proxy arc, kept deliberately tiny. Adds an explicit, separate **`proxy-enforce`** run mode — a top-level sibling of `proxy`, so the shipped `proxy --upstream-command …` invocation is byte-for-byte untouched (the chosen CLI shape: smallest change in a security-load-bearing PR, no clap nesting). Spec: `docs/reference/mcp-upstream-proxy-enforcement.md`.

**Deny-all v0:** every `tools/call` is denied with `proxy_denied` (`enforcing_mode_deny_all`) and never forwarded upstream; the handshake, `ping`, and `tools/list` still forward; other non-allowlisted methods stay `proxy_unsupported`. There is **no allow path, no policy decision point, no caller config, no credential-scope gate, no drift gate, and no `enforcement_decision` record** — those are P61e-c/d. This lands the enforcement *boundary* so "fail-closed" and the `proxy_denied`-vs-`proxy_unsupported` distinction are testable the moment the mode exists, mirroring P61b's negative-forwarding discipline.

Implementation is minimal: `Mode { Observe, Enforce }` threaded into the existing `run()`, and the **only** behavioral delta is the `tools/call` branch — Enforce → `proxy_denied` (−32042, the code reserved since P61b), Observe → `proxy_unsupported` (unchanged). Everything else (allowlist forwarding, notifications, verbatim relay, no-token-passthrough, failure semantics) is shared.

Tests (`tools/call`-denied first): `enforcing_mode_tools_call_denied_and_not_forwarded` (asserts `proxy_denied` + the mock upstream's method log shows `initialize`/`tools/list` but not `tools/call`), `enforcing_mode_unknown_method_is_unsupported_not_denied` (the two codes stay distinct), `enforcing_mode_list_methods_still_forward`, `observe_mode_tools_call_still_unsupported`, and `existing_proxy_invocation_still_observes` (the shipped observe CLI is unchanged). The full P61b/c/d suite stays green.

Lane classification: Gate.NONE

Reason:
- assay-mcp-server source + tests + a doc note only
- no runner/eBPF/monitor paths
- no Cargo.toml/Cargo.lock changes
- no delegated proof paths

I'll confirm the real lane-check and CI green across linux/macOS/windows before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)