### PR TITLE
feat(mcp): enforcing-proxy caller-allowance PDP — deny-only (P61e-c1)

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -41,11 +41,13 @@ enum Mode {
         #[arg(long)]
         proxy_observation_health_out: Option<PathBuf>,
     },
-    /// Run as an MCP upstream ENFORCING proxy (P61e-b, deny-all): an explicit, separate run mode — a
-    /// different risk class from `proxy`, never a variant of it. Every `tools/call` is denied with
-    /// `proxy_denied` (`enforcing_mode_deny_all`) and never forwarded upstream; the handshake, `ping`,
-    /// and `tools/list` still forward; other methods stay `proxy_unsupported`. There is no allow path,
-    /// no policy decision point, no credential or drift gate in v0 (those are P61e-c).
+    /// Run as an MCP upstream ENFORCING proxy (P61e-c1): an explicit, separate run mode — a different
+    /// risk class from `proxy`, never a variant of it. Every `tools/call` runs through the c1
+    /// caller-allowance policy decision point and is denied with the precedence-pinned reason of the
+    /// first gate that fails; a call that passes the c1 gates is still denied with
+    /// `pdp_gate_unavailable` (there is deliberately no allow / forward path before c3). The handshake,
+    /// `ping`, and `tools/list` still forward; other methods stay `proxy_unsupported`. A missing,
+    /// unreadable, or malformed `--enforce-policy` fails startup (non-zero exit) — never a runtime deny.
     ProxyEnforce {
         /// The upstream MCP server command to spawn (stdio transport).
         #[arg(long)]
@@ -53,6 +55,10 @@ enum Mode {
         /// Arguments passed to the upstream command (repeatable). Hyphen-led values are allowed.
         #[arg(long = "upstream-arg", allow_hyphen_values = true)]
         upstream_args: Vec<String>,
+        /// Path to the enforce policy (YAML): the static `caller.id` and the caller's allowances. A
+        /// missing/unreadable/malformed policy is a startup failure, not a runtime deny.
+        #[arg(long)]
+        enforce_policy: PathBuf,
     },
 }
 
@@ -97,6 +103,7 @@ async fn main() -> Result<()> {
                 upstream_command,
                 upstream_args,
                 proxy::Mode::Observe,
+                None,
                 mcp_manifest_observed_out,
                 proxy_observation_health_out,
             )
@@ -105,16 +112,23 @@ async fn main() -> Result<()> {
         Some(Mode::ProxyEnforce {
             upstream_command,
             upstream_args,
+            enforce_policy,
         }) => {
+            // Load + validate the policy BEFORE starting the proxy. A bad policy is a misconfigured
+            // service: fail startup with a non-zero exit, never start an enforcing proxy that cannot
+            // decide (and never degrade to a runtime deny).
+            let policy = proxy::enforce::load(&enforce_policy)?;
             tracing::info!(
                 event = "proxy_start",
                 upstream_command = %upstream_command,
-                mode = "enforce_deny_all_v0"
+                mode = "enforce_pdp_c1",
+                caller = %policy.caller.id
             );
             proxy::run(
                 upstream_command,
                 upstream_args,
                 proxy::Mode::Enforce,
+                Some(policy),
                 None,
                 None,
             )

--- a/crates/assay-mcp-server/src/proxy/enforce.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce.rs
@@ -1,0 +1,253 @@
+//! P61e-c1: the enforcing-proxy policy decision point — caller-allowance gate, deny-only.
+//! Spec: docs/reference/mcp-upstream-proxy-enforcement.md.
+//!
+//! c1 scope: parse the `--enforce-policy` file, classify an observed `tools/call`, and decide a DENY
+//! with a precedence-pinned reason. There is no allow path and no forwarding in c1 (that arrives in
+//! c3, after the credential-scope gate in c2). A `tools/call` that passes the c1 gates is still denied
+//! with `pdp_gate_unavailable`, a temporary rollout reason removed when c3 lands.
+//!
+//! Caller identity is the static `caller.id` from the policy only — no transport/env/request
+//! inference — so a single stdio session is bound to one configured caller and `unknown_caller`
+//! cannot occur at runtime (a policy without `caller.id` fails startup).
+
+use anyhow::{bail, Context, Result};
+use assay_core::mcp::jcs;
+use assay_mcp_server::cache::sha256_hex;
+use assay_mcp_server::tool_decision::classify;
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+pub struct EnforcePolicy {
+    pub caller: Caller,
+    /// Parsed but UNUSED in c1; the credential-scope gate (c2) consumes it. Accepted now so a c2
+    /// policy validates and loads unchanged when the gate lands.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub upstream_credential: Option<UpstreamCredential>,
+    #[serde(default)]
+    pub allowances: Vec<Allowance>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Caller {
+    pub id: String,
+}
+
+/// Parsed but UNUSED in c1; the credential-scope gate (c2) reads `scopes`.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct UpstreamCredential {
+    pub alias: String,
+    #[serde(default)]
+    pub scopes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Allowance {
+    pub action_class: String,
+    #[serde(default)]
+    pub targets: Vec<Target>,
+}
+
+/// c1 supports the `github_deploy_key` target shape only.
+#[derive(Debug, Deserialize)]
+pub struct Target {
+    pub owner: String,
+    pub repo: String,
+}
+
+/// Load + validate the enforce policy. Any failure here is a STARTUP failure (the caller surfaces it
+/// as a non-zero exit), never a runtime deny: an enforcing proxy without a valid policy is a
+/// misconfigured service and must not start.
+pub fn load(path: &Path) -> Result<EnforcePolicy> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading --enforce-policy {}", path.display()))?;
+    let policy: EnforcePolicy =
+        serde_yaml::from_str(&text).with_context(|| "parsing --enforce-policy YAML")?;
+    if policy.caller.id.trim().is_empty() {
+        bail!("--enforce-policy: caller.id must be a non-empty string");
+    }
+    Ok(policy)
+}
+
+/// Domain-separated, canonical digest of a projected target for the DIAGNOSTIC decision log only.
+/// Stable for correlation, never a raw target, never an evidence artifact.
+pub fn target_digest(target: &Value) -> String {
+    let mut preimage = b"assay.mcp.target.v0\0".to_vec();
+    preimage.extend_from_slice(&jcs::to_vec(target).unwrap_or_default());
+    format!("sha256:{}", sha256_hex(&preimage))
+}
+
+/// A c1 decision. There is no `Allow` in c1 — every outcome is a deny with a reason.
+pub struct Decision {
+    pub reason: &'static str,
+    pub action_class: Option<String>,
+    pub target_digest: Option<String>,
+}
+
+/// The c1 PDP. Precedence (first failing gate wins), all deny in c1:
+/// 1. classification (before allowance, so a missing-target call reads as classification_incomplete,
+///    never as a target mismatch);
+/// 2. caller-allowance match (github_deploy_key {owner, repo} only in c1);
+/// 3. all c1 gates passed -> pdp_gate_unavailable (the later gates are not enabled yet).
+pub fn decide(policy: &EnforcePolicy, tool_name: &str, args: &Value) -> Decision {
+    let c = classify(tool_name, args);
+
+    // 1. classification gate — fail-closed before any allowance matching.
+    if c.category.is_none() {
+        return Decision {
+            reason: "unclassified_tool_call",
+            action_class: None,
+            target_digest: None,
+        };
+    }
+    if c.state != "classified" {
+        // classified_incomplete / redaction_failed / any non-final state -> not enough to authorize.
+        return Decision {
+            reason: "classification_incomplete",
+            action_class: c.category.map(|s| s.to_string()),
+            target_digest: Some(target_digest(&c.target)),
+        };
+    }
+
+    let action_class = c.category.unwrap();
+    let tdig = target_digest(&c.target);
+
+    // 2. caller-allowance gate.
+    let matched = policy
+        .allowances
+        .iter()
+        .any(|a| a.action_class == action_class && allowance_matches(a, action_class, &c.target));
+    if !matched {
+        return Decision {
+            reason: "no_declared_allowance",
+            action_class: Some(action_class.to_string()),
+            target_digest: Some(tdig),
+        };
+    }
+
+    // 3. c1 stops here: the credential-scope (c2) and drift (c3) gates are not enabled, and there is
+    // deliberately no allow/forward path before c3.
+    Decision {
+        reason: "pdp_gate_unavailable",
+        action_class: Some(action_class.to_string()),
+        target_digest: Some(tdig),
+    }
+}
+
+/// c1 only knows the `github_deploy_key` target shape ({owner, repo}, projected plain by the P57c
+/// classifier — owner/repo are sanitized for control chars only, never hashed, so a plain string
+/// compare against the declared allowance is correct). Any other action_class has no verifiable
+/// matcher in c1, so it is fail-closed (no match) and its allowance arrives with that class's own slice.
+fn allowance_matches(a: &Allowance, action_class: &str, target: &Value) -> bool {
+    if action_class != "github_deploy_key" {
+        return false;
+    }
+    let owner = target.get("owner").and_then(|v| v.as_str());
+    let repo = target.get("repo").and_then(|v| v.as_str());
+    match (owner, repo) {
+        (Some(o), Some(r)) => a.targets.iter().any(|t| t.owner == o && t.repo == r),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::Write;
+
+    fn policy_from(yaml: &str) -> Result<EnforcePolicy> {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(yaml.as_bytes()).unwrap();
+        load(f.path())
+    }
+
+    const VALID: &str = r#"
+caller:
+  id: "ci-agent"
+allowances:
+  - action_class: "github_deploy_key"
+    targets:
+      - { owner: "acme", repo: "prod-app" }
+"#;
+
+    #[test]
+    fn loads_a_valid_policy() {
+        let p = policy_from(VALID).unwrap();
+        assert_eq!(p.caller.id, "ci-agent");
+        assert_eq!(p.allowances.len(), 1);
+    }
+
+    #[test]
+    fn missing_caller_id_fails_load() {
+        assert!(policy_from("allowances: []\n").is_err());
+        assert!(policy_from("caller:\n  id: \"\"\n").is_err());
+    }
+
+    #[test]
+    fn malformed_yaml_fails_load() {
+        assert!(policy_from("caller: : :\n").is_err());
+    }
+
+    #[test]
+    fn unclassified_tool_is_denied_unclassified() {
+        let p = policy_from(VALID).unwrap();
+        let d = decide(&p, "misc.do_thing", &json!({}));
+        assert_eq!(d.reason, "unclassified_tool_call");
+    }
+
+    #[test]
+    fn incomplete_classification_is_denied_before_allowance() {
+        // Missing repo -> classified_incomplete; must read as classification_incomplete, NOT
+        // no_declared_allowance/target-mismatch.
+        let p = policy_from(VALID).unwrap();
+        let d = decide(&p, "github.add_deploy_key", &json!({"owner": "acme"}));
+        assert_eq!(d.reason, "classification_incomplete");
+    }
+
+    #[test]
+    fn classified_without_allowance_is_denied_no_declared_allowance() {
+        let p = policy_from(VALID).unwrap();
+        let d = decide(
+            &p,
+            "github.add_deploy_key",
+            &json!({"owner": "other", "repo": "x"}),
+        );
+        assert_eq!(d.reason, "no_declared_allowance");
+        assert_eq!(d.action_class.as_deref(), Some("github_deploy_key"));
+    }
+
+    #[test]
+    fn matching_allowance_reaches_pdp_gate_unavailable() {
+        let p = policy_from(VALID).unwrap();
+        let d = decide(
+            &p,
+            "github.add_deploy_key",
+            &json!({"owner": "acme", "repo": "prod-app"}),
+        );
+        assert_eq!(
+            d.reason, "pdp_gate_unavailable",
+            "c1 has no allow path; passed gates still deny"
+        );
+    }
+
+    #[test]
+    fn target_digest_is_domain_separated_and_stable() {
+        let a = target_digest(&json!({"owner": "acme", "repo": "prod-app"}));
+        let b = target_digest(&json!({"repo": "prod-app", "owner": "acme"}));
+        assert_eq!(a, b, "canonical: key order independent");
+        assert!(a.starts_with("sha256:"));
+        // Domain separation: the same bytes under a different domain would differ (sanity).
+        let raw = format!(
+            "sha256:{}",
+            sha256_hex(&jcs::to_vec(&json!({"owner": "acme", "repo": "prod-app"})).unwrap())
+        );
+        assert_ne!(
+            a, raw,
+            "domain prefix must change the digest vs a bare hash"
+        );
+    }
+}

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -16,6 +16,8 @@
 //! confused-deputy trap. The manifest artifact is exactly the P60b shape the consumer already gates on;
 //! "how completely was it observed" lives in the separate observation-health artifact, never folded in.
 
+pub mod enforce;
+
 use anyhow::{Context, Result};
 use assay_mcp_server::manifest_observed::{self, Completeness};
 use serde_json::{json, Value};
@@ -40,16 +42,19 @@ const ALLOWLIST: &[&str] = &[
 // are unambiguously distinguishable from upstream errors regardless of code.
 const PROXY_UNSUPPORTED: i32 = -32040;
 const PROXY_FAILED: i32 = -32041;
-// PROXY_DENIED: a P61e enforcing-mode policy denial. In P61e-b the only reason is the deny-all
-// boundary; gate-specific reasons arrive with the allow path (P61e-c).
+// PROXY_DENIED: a P61e enforcing-mode policy denial. P61e-c1 replaces the single deny-all boundary
+// with the caller-allowance PDP, so the `reason` is now the precedence-pinned gate that fired
+// (unclassified_tool_call / classification_incomplete / no_declared_allowance / pdp_gate_unavailable).
 const PROXY_DENIED: i32 = -32042;
 
 const HEALTH_SCHEMA: &str = "assay.proxy_observation_health.v0";
 
 /// Proxy run mode. Observe (P61a-d, shipped) forwards the allowlist and answers `tools/call` with
-/// `proxy_unsupported`. Enforce (P61e-b) is deny-all: a `tools/call` is denied with `proxy_denied`
-/// (`enforcing_mode_deny_all`) and never forwarded; everything else is identical to Observe. The allow
-/// path / policy decision point is a later slice (P61e-c).
+/// `proxy_unsupported`. Enforce runs the c1 caller-allowance PDP on every `tools/call`: the call is
+/// classified and denied with the precedence-pinned reason of the first gate that fails; a call that
+/// passes the c1 gates is still denied with `pdp_gate_unavailable` (there is deliberately no allow /
+/// forward path before c3). Everything other than `tools/call` is identical to Observe. The c1 deny
+/// reasons supersede the P61e-b `enforcing_mode_deny_all` boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
     Observe,
@@ -311,12 +316,14 @@ fn write_json_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
 }
 
 /// Run the proxy against one stdio upstream. `mode` selects observe (manifest-observation, P61a-d) or
-/// enforce (deny-all `tools/call`, P61e-b); the only behavioral difference is how `tools/call` is
-/// answered. Manifest emission flags apply to observe only.
+/// enforce (the c1 caller-allowance PDP on `tools/call`, P61e-c1); the only behavioral difference is
+/// how `tools/call` is answered. `policy` is required and present in enforce mode (loaded + validated
+/// at startup) and `None` in observe mode. Manifest emission flags apply to observe only.
 pub async fn run(
     upstream_command: String,
     upstream_args: Vec<String>,
     mode: Mode,
+    policy: Option<enforce::EnforcePolicy>,
     manifest_out: Option<PathBuf>,
     health_out: Option<PathBuf>,
 ) -> Result<()> {
@@ -454,24 +461,45 @@ pub async fn run(
             }
             Some(method) => {
                 // Denied: tools/call and every other non-allowlisted method. Never sent upstream. In
-                // enforce mode a tools/call is a POLICY denial (proxy_denied, enforcing_mode_deny_all);
-                // every other non-allowlisted method — and all of observe mode — stays proxy_unsupported.
-                let (code, reason, message): (i32, &str, String) = if mode == Mode::Enforce
-                    && method == "tools/call"
-                {
-                    (
+                // enforce mode a tools/call goes through the c1 caller-allowance PDP and is denied with
+                // the precedence-pinned reason of the first gate that fires (proxy_denied); every other
+                // non-allowlisted method — and all of observe mode — stays proxy_unsupported.
+                let (code, reason, message): (i32, &str, String) =
+                    if mode == Mode::Enforce && method == "tools/call" {
+                        // policy is always Some in enforce mode (loaded + validated at startup).
+                        let policy = policy
+                            .as_ref()
+                            .expect("enforce mode without a loaded policy is a startup bug");
+                        let tool_name = v
+                            .pointer("/params/name")
+                            .and_then(|n| n.as_str())
+                            .unwrap_or("");
+                        let empty = json!({});
+                        let call_args = v.pointer("/params/arguments").unwrap_or(&empty);
+                        let decision = enforce::decide(policy, tool_name, call_args);
+                        // Diagnostic decision log — for operability/correlation only, NOT a canonical
+                        // evidence artifact (the enforcement_decision record is a later slice, P61e-d).
+                        tracing::info!(
+                            event = "enforce_decision",
+                            caller = %policy.caller.id,
+                            tool = %tool_name,
+                            action_class = decision.action_class.as_deref().unwrap_or("none"),
+                            target_digest = decision.target_digest.as_deref().unwrap_or("none"),
+                            reason = decision.reason,
+                            note = "diagnostic decision log; not canonical evidence"
+                        );
+                        (
                             PROXY_DENIED,
-                            "enforcing_mode_deny_all",
-                            "tools/call is denied in enforcing proxy mode (deny-all; no allow path yet)"
-                                .to_string(),
+                            decision.reason,
+                            format!("tools/call denied by enforcing proxy: {}", decision.reason),
                         )
-                } else {
-                    (
-                        PROXY_UNSUPPORTED,
-                        "method_not_allowlisted",
-                        format!("method {method:?} is not forwarded in this proxy mode"),
-                    )
-                };
+                    } else {
+                        (
+                            PROXY_UNSUPPORTED,
+                            "method_not_allowlisted",
+                            format!("method {method:?} is not forwarded in this proxy mode"),
+                        )
+                    };
                 match v.get("id") {
                     Some(id) if !id.is_null() => {
                         let _ = tx.send(proxy_error_line(id.clone(), code, reason, &message));

--- a/crates/assay-mcp-server/tests/proxy_enforce_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_e2e.rs
@@ -1,11 +1,14 @@
-//! P61e-b: MCP upstream ENFORCING proxy mode (deny-all). End-to-end tests.
+//! P61e-c1: MCP upstream ENFORCING proxy mode — the caller-allowance PDP. End-to-end tests.
 //! Spec: docs/reference/mcp-upstream-proxy-enforcement.md.
 //!
-//! The load-bearing invariant, asserted first: in `proxy-enforce` mode a `tools/call` is denied with
-//! `proxy_denied` (`enforcing_mode_deny_all`) and NEVER reaches the upstream. The two error codes stay
-//! distinct: `proxy_denied` is the enforcing-mode policy denial for `tools/call`; `proxy_unsupported`
-//! remains for non-allowlisted non-`tools/call` methods. The shipped `proxy` (observe) mode is
-//! unchanged. There is no allow path, no policy decision point, no gate in this slice.
+//! These were the P61e-b deny-all tests; c1 retired the single `enforcing_mode_deny_all` reason for
+//! the per-gate PDP reasons, and `proxy-enforce` now requires `--enforce-policy`. The load-bearing
+//! invariant is unchanged and asserted first: in `proxy-enforce` mode a `tools/call` is denied with
+//! `proxy_denied` and NEVER reaches the upstream. The two error codes stay distinct: `proxy_denied` is
+//! the enforcing-mode policy denial for `tools/call`; `proxy_unsupported` remains for non-allowlisted
+//! non-`tools/call` methods. The shipped `proxy` (observe) mode is unchanged. There is still no allow
+//! path and no forwarding of `tools/call` in this slice — a call that passes every c1 gate is denied
+//! with `pdp_gate_unavailable`.
 
 use serde_json::Value;
 use std::io::{BufRead, BufReader, Write};
@@ -27,11 +30,21 @@ fn mock_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/mock_upstream.py")
 }
 
-/// Spawn the proxy in the given top-level subcommand mode ("proxy" or "proxy-enforce").
-fn spawn(subcommand: &str, log: &std::path::Path) -> Child {
+/// A minimal valid enforce policy: one caller, no allowances. Enough for the load-bearing deny tests —
+/// `echo` is an unclassified tool, so it denies regardless of allowances.
+const MINIMAL_POLICY: &str = "caller:\n  id: \"test-agent\"\nallowances: []\n";
+
+fn write_policy(dir: &std::path::Path, yaml: &str) -> PathBuf {
+    let p = dir.join("enforce.yaml");
+    std::fs::write(&p, yaml).expect("write policy");
+    p
+}
+
+/// Spawn the observe proxy ("proxy" subcommand).
+fn spawn_observe(log: &std::path::Path) -> Child {
     Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
         .args([
-            subcommand,
+            "proxy",
             "--upstream-command",
             python(),
             "--upstream-arg",
@@ -45,7 +58,30 @@ fn spawn(subcommand: &str, log: &std::path::Path) -> Child {
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()
-        .expect("spawn proxy (is python installed?)")
+        .expect("spawn observe proxy (is python installed?)")
+}
+
+/// Spawn the enforcing proxy ("proxy-enforce" subcommand) with the given policy file.
+fn spawn_enforce(log: &std::path::Path, policy: &std::path::Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            "proxy-enforce",
+            "--upstream-command",
+            python(),
+            "--upstream-arg",
+            "-u",
+            "--upstream-arg",
+            mock_path().to_str().unwrap(),
+            "--enforce-policy",
+            policy.to_str().unwrap(),
+        ])
+        .env("MOCK_UPSTREAM_LOG", log)
+        .env("MOCK_UPSTREAM_MODE", "normal")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn enforce proxy (is python installed?)")
 }
 
 fn send(stdin: &mut ChildStdin, v: Value) {
@@ -97,7 +133,8 @@ fn shutdown(mut child: Child, stdin: ChildStdin) {
 fn enforcing_mode_tools_call_denied_and_not_forwarded() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn("proxy-enforce", &log);
+    let policy = write_policy(dir.path(), MINIMAL_POLICY);
+    let mut child = spawn_enforce(&log, &policy);
     let mut stdin = child.stdin.take().unwrap();
     let mut out = BufReader::new(child.stdout.take().unwrap());
 
@@ -121,7 +158,11 @@ fn enforcing_mode_tools_call_denied_and_not_forwarded() {
         "tools/call is a policy denial in enforce mode"
     );
     assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
-    assert_eq!(r["error"]["data"]["reason"], "enforcing_mode_deny_all");
+    // `echo` is not a privileged classifier target, so the classification gate fires first.
+    assert_eq!(
+        r["error"]["data"]["reason"], "unclassified_tool_call",
+        "an unclassified tool denies at the classification gate"
+    );
 
     shutdown(child, stdin);
 
@@ -140,7 +181,8 @@ fn enforcing_mode_unknown_method_is_unsupported_not_denied() {
     // codes are distinct: proxy_denied is only for the tools/call policy denial.
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn("proxy-enforce", &log);
+    let policy = write_policy(dir.path(), MINIMAL_POLICY);
+    let mut child = spawn_enforce(&log, &policy);
     let mut stdin = child.stdin.take().unwrap();
     let mut out = BufReader::new(child.stdout.take().unwrap());
 
@@ -165,7 +207,8 @@ fn enforcing_mode_unknown_method_is_unsupported_not_denied() {
 fn enforcing_mode_list_methods_still_forward() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn("proxy-enforce", &log);
+    let policy = write_policy(dir.path(), MINIMAL_POLICY);
+    let mut child = spawn_enforce(&log, &policy);
     let mut stdin = child.stdin.take().unwrap();
     let mut out = BufReader::new(child.stdout.take().unwrap());
 
@@ -194,7 +237,7 @@ fn observe_mode_tools_call_still_unsupported() {
     // The shipped observe mode is unchanged: a tools/call is proxy_unsupported, NOT proxy_denied.
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn("proxy", &log);
+    let mut child = spawn_observe(&log);
     let mut stdin = child.stdin.take().unwrap();
     let mut out = BufReader::new(child.stdout.take().unwrap());
 
@@ -217,7 +260,7 @@ fn existing_proxy_invocation_still_observes() {
     // handshake and tools/list reach the upstream, tools/call does not.
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let mut child = spawn("proxy", &log);
+    let mut child = spawn_observe(&log);
     let mut stdin = child.stdin.take().unwrap();
     let mut out = BufReader::new(child.stdout.take().unwrap());
 

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -1,0 +1,290 @@
+//! P61e-c1: the enforcing-proxy caller-allowance PDP, end to end through the spawned binary.
+//! Spec: docs/reference/mcp-upstream-proxy-enforcement.md.
+//!
+//! These tests exercise the gate matrix with the real classifier and a real policy file. They are
+//! deliberately negative-first: c1 has NO allow path, so the strongest assertion is that no `tools/call`
+//! ever reaches the upstream regardless of the deny reason. A call that passes every c1 gate is denied
+//! with `pdp_gate_unavailable` (the temporary rollout reason removed when c3 lands). Startup failures
+//! (missing/malformed policy, missing caller.id) are asserted as a non-zero exit, never a runtime deny.
+
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+const PROXY_DENIED: i64 = -32042;
+
+fn python() -> &'static str {
+    if cfg!(windows) {
+        "python"
+    } else {
+        "python3"
+    }
+}
+
+fn mock_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/mock_upstream.py")
+}
+
+/// A policy that allows github_deploy_key on exactly acme/prod-app.
+const ALLOW_ACME: &str = r#"
+caller:
+  id: "ci-agent"
+allowances:
+  - action_class: "github_deploy_key"
+    targets:
+      - { owner: "acme", repo: "prod-app" }
+"#;
+
+fn write_policy(dir: &Path, yaml: &str) -> PathBuf {
+    let p = dir.join("enforce.yaml");
+    std::fs::write(&p, yaml).expect("write policy");
+    p
+}
+
+fn spawn_enforce(log: &Path, policy: &Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            "proxy-enforce",
+            "--upstream-command",
+            python(),
+            "--upstream-arg",
+            "-u",
+            "--upstream-arg",
+            mock_path().to_str().unwrap(),
+            "--enforce-policy",
+            policy.to_str().unwrap(),
+        ])
+        .env("MOCK_UPSTREAM_LOG", log)
+        .env("MOCK_UPSTREAM_MODE", "normal")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn enforce proxy (is python installed?)")
+}
+
+fn send(stdin: &mut ChildStdin, v: Value) {
+    writeln!(stdin, "{v}").expect("write");
+    stdin.flush().expect("flush");
+}
+
+fn read_response(reader: &mut BufReader<ChildStdout>) -> Value {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).expect("read");
+        assert!(n > 0, "proxy closed stdout before responding");
+        let t = line.trim();
+        if t.is_empty() {
+            continue;
+        }
+        let v: Value = serde_json::from_str(t).expect("parse JSON");
+        if v.get("method").is_some() {
+            continue;
+        }
+        return v;
+    }
+}
+
+fn init() -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "t", "version": "1"}}
+    })
+}
+
+fn read_methods(log: &Path) -> Vec<String> {
+    std::fs::read_to_string(log)
+        .unwrap_or_default()
+        .lines()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn shutdown(mut child: Child, stdin: ChildStdin) {
+    drop(stdin);
+    let _ = child.wait();
+}
+
+/// Drive one tools/call through a freshly spawned enforcing proxy and return the deny reason plus the
+/// upstream method log. Always asserts proxy_denied (c1 has no allow path).
+fn deny_reason_for(policy_yaml: &str, call_params: Value) -> (String, Vec<String>) {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let policy = write_policy(dir.path(), policy_yaml);
+    let mut child = spawn_enforce(&log, &policy);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 9, "method": "tools/call", "params": call_params}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["id"], 9);
+    assert_eq!(
+        r["error"]["code"], PROXY_DENIED,
+        "every c1 outcome is a proxy_denied; got {r}"
+    );
+    assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
+    let reason = r["error"]["data"]["reason"]
+        .as_str()
+        .expect("reason string")
+        .to_string();
+
+    shutdown(child, stdin);
+    let methods = read_methods(&log);
+    assert!(
+        !methods.contains(&"tools/call".to_string()),
+        "INVARIANT: tools/call must never reach the upstream: {methods:?}"
+    );
+    (reason, methods)
+}
+
+// --- gate matrix (deny-only) --------------------------------------------------------------------
+
+#[test]
+fn unclassified_tool_call_denied_unclassified() {
+    let (reason, _) = deny_reason_for(
+        ALLOW_ACME,
+        serde_json::json!({"name": "echo", "arguments": {}}),
+    );
+    assert_eq!(reason, "unclassified_tool_call");
+}
+
+#[test]
+fn classification_incomplete_denied_before_allowance() {
+    // Missing repo -> classified_incomplete. Must read as classification_incomplete, NOT a target
+    // mismatch — the classification gate runs before allowance matching.
+    let (reason, _) = deny_reason_for(
+        ALLOW_ACME,
+        serde_json::json!({"name": "github.add_deploy_key", "arguments": {"owner": "acme"}}),
+    );
+    assert_eq!(reason, "classification_incomplete");
+}
+
+#[test]
+fn classified_privileged_without_matching_allowance_denied() {
+    let (reason, _) = deny_reason_for(
+        ALLOW_ACME,
+        serde_json::json!({"name": "github.add_deploy_key",
+                           "arguments": {"owner": "evil", "repo": "x"}}),
+    );
+    assert_eq!(reason, "no_declared_allowance");
+}
+
+#[test]
+fn allowance_target_mismatch_denied_no_declared_allowance() {
+    // Right owner, wrong repo: a target mismatch is no_declared_allowance, not a partial match.
+    let (reason, _) = deny_reason_for(
+        ALLOW_ACME,
+        serde_json::json!({"name": "github.add_deploy_key",
+                           "arguments": {"owner": "acme", "repo": "staging-app"}}),
+    );
+    assert_eq!(reason, "no_declared_allowance");
+}
+
+#[test]
+fn matching_allowance_reaches_pdp_gate_unavailable() {
+    // The one path that clears every c1 gate is still denied: c1 has no allow/forward path.
+    let (reason, methods) = deny_reason_for(
+        ALLOW_ACME,
+        serde_json::json!({"name": "github.add_deploy_key",
+                           "arguments": {"owner": "acme", "repo": "prod-app"}}),
+    );
+    assert_eq!(reason, "pdp_gate_unavailable");
+    assert!(
+        !methods.contains(&"tools/call".to_string()),
+        "even a fully-allowed call does not forward before c3"
+    );
+}
+
+// --- startup failures (non-zero exit, never a runtime deny) -------------------------------------
+
+fn startup_status(args: &[&str]) -> std::process::ExitStatus {
+    Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("spawn")
+}
+
+#[test]
+fn missing_enforce_policy_flag_fails_startup() {
+    // No --enforce-policy at all: clap rejects it as a usage error (non-zero), never starts the proxy.
+    let status = startup_status(&[
+        "proxy-enforce",
+        "--upstream-command",
+        python(),
+        "--upstream-arg",
+        "-u",
+        "--upstream-arg",
+        mock_path().to_str().unwrap(),
+    ]);
+    assert!(
+        !status.success(),
+        "missing --enforce-policy must fail startup"
+    );
+}
+
+#[test]
+fn missing_policy_file_fails_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("does-not-exist.yaml");
+    let status = startup_status(&[
+        "proxy-enforce",
+        "--upstream-command",
+        python(),
+        "--upstream-arg",
+        "-u",
+        "--upstream-arg",
+        mock_path().to_str().unwrap(),
+        "--enforce-policy",
+        missing.to_str().unwrap(),
+    ]);
+    assert!(!status.success(), "unreadable policy must fail startup");
+}
+
+#[test]
+fn malformed_policy_fails_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let p = write_policy(dir.path(), "caller: : :\n");
+    let status = startup_status(&[
+        "proxy-enforce",
+        "--upstream-command",
+        python(),
+        "--upstream-arg",
+        "-u",
+        "--upstream-arg",
+        mock_path().to_str().unwrap(),
+        "--enforce-policy",
+        p.to_str().unwrap(),
+    ]);
+    assert!(!status.success(), "malformed policy must fail startup");
+}
+
+#[test]
+fn missing_caller_id_fails_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let p = write_policy(dir.path(), "allowances: []\n");
+    let status = startup_status(&[
+        "proxy-enforce",
+        "--upstream-command",
+        python(),
+        "--upstream-arg",
+        "-u",
+        "--upstream-arg",
+        mock_path().to_str().unwrap(),
+        "--enforce-policy",
+        p.to_str().unwrap(),
+    ]);
+    assert!(
+        !status.success(),
+        "policy without caller.id must fail startup"
+    );
+}

--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -3,10 +3,11 @@
 Status: **review-spec, no code.** A new arc and the heaviest risk class in the proxy line. It extends
 the shipped, opt-in [manifest-observation proxy](mcp-upstream-proxy-mode.md) (P61a–d, assay v3.23.0)
 from observe-only to **enforcing**: it forwards a privileged `tools/call` only after a fail-closed
-policy decision. Tracked as [#1624]. The binding decisions are now agreed (§16, "Resolved decisions");
-this is the design of record. No code lands in this doc — P61e-b (a deny-all enforcing mode) is the
-next slice — because forwarding privileged calls with an upstream credential makes the proxy a confused
-deputy unless every dimension here is locked first.
+policy decision. Tracked as [#1624]. The binding decisions are agreed (§16, "Resolved decisions"); this
+is the design of record. Shipped so far: P61e-b (the deny-all enforcing run mode) and **P61e-c1 (the
+caller-allowance policy decision point, deny-only — no `tools/call` is forwarded yet)**. The arc forwards
+privileged calls only after the c2 credential-scope and c3 drift gates land, because forwarding with an
+upstream credential makes the proxy a confused deputy unless every dimension here is locked first.
 
 The one-line scope: **the manifest-observation proxy answers "did this tool surface change?"; the
 enforcing proxy answers "should this specific privileged call be forwarded, right now, for this
@@ -112,13 +113,19 @@ allowed to do** — not merely "the proxy can reach the upstream."
 
 - **Caller identity is declared, not inferred (decided).** Over stdio there is no transport identity,
   so v0 is **one caller per stdio session**, declared via explicit config — never inferred from the
-  transport, no multi-caller, no OAuth, no token introspection:
+  transport, no multi-caller, no OAuth, no token introspection. The shipped c1 `--enforce-policy` shape:
   ```yaml
   caller:
     id: "ci-agent"
+  allowances:
+    - action_class: "github_deploy_key"   # c1 knows this class only
+      targets:
+        - { owner: "acme", repo: "prod-app" }   # exact owner+repo; no wildcard in c1
   ```
-  A privileged call with no declared caller id → `proxy_denied` (`unknown_caller`). Multi-caller is a
-  later arc.
+  A missing `caller.id` fails **startup** (not a runtime deny — see §14), so `unknown_caller` cannot
+  occur at runtime under the static-config model. Multi-caller is a later arc. The allowance uses
+  `targets:` (not `allowed_effects:`); an `action_class` other than `github_deploy_key` has no verifiable
+  matcher in c1 and is fail-closed (`no_declared_allowance`) until its own gate slice.
 - **Per-caller consent/authorization.** The proxy keeps a per-caller registry of allowed privileged
   action classes/targets (operator-declared, consistent with the [declared tool surface](declared-tool-surface.md),
   P58). A privileged call with no matching per-caller allowance is denied, never forwarded.
@@ -150,13 +157,21 @@ unclassified_tool_call                  no_declared_allowance
 credential_scope_insufficient           credential_scope_unknown
 manifest_baseline_missing               manifest_current_observation_incomplete
 manifest_drifted_since_approval         policy_unavailable
-policy_error                            enforcing_mode_deny_all   (P61e-b only)
+policy_error                            pdp_gate_unavailable      (P61e-c1 only)
+enforcing_mode_deny_all   (SUPERSEDED — see below)
 ```
-A denied call never reaches the upstream. **P61e-b** uses exactly one reason — `enforcing_mode_deny_all`
-(the whole `tools/call` surface is denied before any allow path exists); the gate-specific reasons
-arrive with the gates in P61e-c. `credential_scope_unknown` is distinct from
+A denied call never reaches the upstream. `credential_scope_unknown` is distinct from
 `credential_scope_insufficient`: when coverage cannot be determined the denial reason is *unknown*, not
 *insufficient* (see §8).
+
+**Reason history across the slices.** P61e-b used exactly one reason — `enforcing_mode_deny_all` (the
+whole `tools/call` surface denied before any gate existed). **P61e-c1 supersedes it** with the
+caller-allowance PDP: a `tools/call` is now denied with the precedence-pinned reason of the first gate
+that fires — `unclassified_tool_call`, then `classification_incomplete`, then `no_declared_allowance`.
+A call that clears every c1 gate is still denied with **`pdp_gate_unavailable`**, a temporary rollout
+reason that exists only because there is deliberately no allow / forward path before c3 (the
+credential-scope gate is c2, the drift gate and the first allow are c3). `pdp_gate_unavailable` is
+removed when c3 lands; `enforcing_mode_deny_all` is retired and no longer emitted.
 
 ## 8. Credential boundary (locked from P61a, extended)
 
@@ -251,12 +266,30 @@ P61e-a  this review-spec (design doc, no code)
 P61e-b  the enforcing run mode exists and is DENY-ALL: every tools/call -> proxy_denied
         (enforcing_mode_deny_all), the upstream receives nothing, the allowlisted list methods still
         forward, an unknown method is proxy_unsupported. NO PDP skeleton, NO inputs, NO allow path.
-P61e-c  the allow path + PDP: caller identity (config) + per-caller authorization (P58 declared
-        allowance) + credential-scope gate (P59) + the drift-aware gate (declared baseline + current
-        complete manifest, P60/E12) — every gate fail-closed and independently tested
+        (SHIPPED, superseded by c1.)
+P61e-c  split gate-by-gate, each fail-closed and independently tested, NO forwarding before c3:
+  c1    caller-allowance gate (deny-only): --enforce-policy with caller.id + per-caller allowances
+        (P58); the PDP classifies each tools/call and denies with the first-failing-gate reason
+        (classification gate before allowance); a fully-allowed call is still denied
+        (pdp_gate_unavailable). github_deploy_key {owner, repo} only; no wildcard. (SHIPPED.)
+  c2    credential-scope gate (deny-only): the call's required scope vs the declared credential scope
+        (P59); credential_scope_insufficient / credential_scope_unknown. Still no forwarding.
+  c3    drift-aware gate (declared baseline + current complete manifest, P60/E12) + the FIRST allow /
+        forward path: a call that clears every gate is forwarded; pdp_gate_unavailable is removed.
 P61e-d  the assay.enforcement_decision.v0 record + the side-effect-evidence interaction (asserted),
         kept separate from the observation artifact; Plimsoll consumes it separately (later)
 ```
+
+**Implementation note (P61e-c1):** the enforcing subcommand now requires `--enforce-policy <path>` (a
+YAML file with `caller.id` and the caller's `allowances`). A missing, unreadable, or malformed policy —
+or one without `caller.id` — is a **startup failure (non-zero exit), never a runtime deny**: an
+enforcing proxy that cannot decide is a misconfigured service and must not start. Caller identity is the
+static `caller.id` only (no transport/env inference), so `unknown_caller` cannot occur at runtime. The
+PDP precedence is classification → allowance → `pdp_gate_unavailable`; the classification gate runs
+*before* allowance so a missing-target call reads as `classification_incomplete`, never as a target
+mismatch. The proxy emits a per-decision `tracing` line (caller, action class, a domain-separated target
+digest, reason) **for operability only — it is a diagnostic log, not the canonical
+`assay.enforcement_decision.v0` evidence artifact** (that is P61e-d). c1 still forwards no `tools/call`.
 **P61e-b is deliberately just a deny-all enforcing proxy** — no policy decision point, no inputs, no
 allow path. It lands the enforcement *boundary* so "fail-closed" and the `proxy_denied`-vs-
 `proxy_unsupported` distinction are testable the moment the mode exists (the same discipline as P61b's


### PR DESCRIPTION
## P61e-c1: enforcing-proxy caller-allowance PDP (deny-only)

Replaces the P61e-b single deny-all boundary with the first real gate of the enforcing proxy's policy decision point. Every `tools/call` is now classified and denied with the precedence-pinned reason of the first gate that fails — but there is still **no allow or forward path**. A call that clears every c1 gate is denied with `pdp_gate_unavailable`, a temporary rollout reason that goes away when c3 lands.

This is the first of the gate-by-gate split of the old P61e-c (c1 caller-allowance → c2 credential-scope → c3 drift + first allow). No `tools/call` is forwarded before c3, by design.

### What changed
- `proxy-enforce` now requires `--enforce-policy <path>` (YAML: `caller.id` + `allowances`). A missing, unreadable, or malformed policy — or one without `caller.id` — **fails startup with a non-zero exit, never a runtime deny.** An enforcing proxy that cannot decide is a misconfigured service and must not start.
- Caller identity is the static `caller.id` only (no transport/env inference), so `unknown_caller` cannot occur at runtime under the static-config model.
- PDP precedence is classification → allowance → `pdp_gate_unavailable`. The classification gate runs **before** allowance, so a missing-target call reads as `classification_incomplete`, never as a target mismatch.
- c1 knows the `github_deploy_key {owner, repo}` target shape only (projected plain by the P57c classifier — owner/repo are sanitized for control chars, never hashed, so a plain compare is correct). Other action classes are fail-closed (`no_declared_allowance`) until their own gate slice. No wildcard in c1.
- The proxy emits a per-decision `tracing` line (caller, action class, a domain-separated `sha256("assay.mcp.target.v0\0" + canonical_target_json)` digest, reason). This is a **diagnostic log for operability only — not** the canonical `assay.enforcement_decision.v0` evidence artifact, which is P61e-d.
- `enforcing_mode_deny_all` is retired/superseded by the c1 PDP reasons. The P61e-b deny-all e2e tests are migrated to supply a minimal policy and assert the new reasons.

### Tests
- 8 PDP unit tests (load/validate, gate precedence, domain-separated target digest).
- 9 c1 e2e tests through the spawned binary: the deny matrix (`unclassified_tool_call`, `classification_incomplete`, `no_declared_allowance`, target mismatch, `pdp_gate_unavailable`) plus four startup-failure cases (missing flag, missing file, malformed YAML, missing `caller.id`).
- The migrated deny-all e2e suite still asserts the load-bearing invariant: no `tools/call` reaches the upstream in enforce mode, and observe mode is unchanged.

### Non-claims
No `tools/call` is forwarded. No allow path, no credential-scope gate (c2), no drift gate (c3), no enforcement-decision evidence record (P61e-d). The diagnostic log is not evidence. Spec: `docs/reference/mcp-upstream-proxy-enforcement.md` (§5 policy shape, §7 reason set, §14 c1/c2/c3 split + implementation note).

Part of #1624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
