### PR TITLE
docs(mcp): fix stale §16-D caller-identity decision (P61e-c1 follow-up)

### DIFF
--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -334,7 +334,10 @@ This keeps `proxy_denied` (policy denial, enforcing mode) cleanly separate from 
   must return a concrete decision. A `--decision-mode review` is a later, explicit opt-in, not v0 (§9).
 - **D. Caller identity source — decided:** **one caller per stdio session, declared via explicit
   config** (`caller.id`); no inferred transport identity, no multi-caller, no OAuth, no token
-  introspection. Missing caller → `proxy_denied` (`unknown_caller`) (§5).
+  introspection. A missing `caller.id` **fails startup** (non-zero exit, before the proxy starts — see
+  §14), so under this static one-caller-per-stdio-session model `unknown_caller` cannot occur at
+  runtime. (The `unknown_caller` reason stays reserved in the §7 pinned set for a future multi-caller
+  arc where caller identity is per-request rather than static-config.) (§5, §14)
 - **E. Scope of v0 — decided:** stdio + one upstream + deny-all (P61e-b) then narrow allow (P61e-c);
   no token minting, no OAuth resource-server behavior, no HTTP upstream, no multi-upstream (§13).
 


### PR DESCRIPTION
Follow-up to the Codex review on #1632 (one [P2] finding, docs-only).

§16-D ("Resolved decision D") still said a missing caller becomes `proxy_denied` (`unknown_caller`), but the shipped c1 contract and implementation make a missing `caller.id` a **startup failure** before the proxy starts. §5 and §14 already state this correctly, and the e2e tests assert a non-zero startup for missing `caller.id`, so §16-D was a second, conflicting authoritative contract for operators and for c2/c3 implementers.

§16-D now says a missing `caller.id` fails startup and that `unknown_caller` cannot occur at runtime under the static one-caller-per-stdio-session model. The `unknown_caller` reason stays reserved in the §7 pinned set for a future multi-caller arc (per-request identity), and §16-D now notes that explicitly so the pinned set and the resolved decision no longer read as contradictory.

No code change. Codex confirmed no code-path issues in the c1 PDP and verified the suite locally (5/5 proxy_enforce_e2e, 9/9 proxy_enforce_pdp_e2e).

Part of #1624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)