### PR TITLE
feat(mcp): enforcing-proxy drift gate + first allow/forward path (P61e-c3)

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -41,13 +41,13 @@ enum Mode {
         #[arg(long)]
         proxy_observation_health_out: Option<PathBuf>,
     },
-    /// Run as an MCP upstream ENFORCING proxy (P61e-c1): an explicit, separate run mode — a different
-    /// risk class from `proxy`, never a variant of it. Every `tools/call` runs through the c1
-    /// caller-allowance policy decision point and is denied with the precedence-pinned reason of the
-    /// first gate that fails; a call that passes the c1 gates is still denied with
-    /// `pdp_gate_unavailable` (there is deliberately no allow / forward path before c3). The handshake,
-    /// `ping`, and `tools/list` still forward; other methods stay `proxy_unsupported`. A missing,
-    /// unreadable, or malformed `--enforce-policy` fails startup (non-zero exit) — never a runtime deny.
+    /// Run as an MCP upstream ENFORCING proxy (P61e-c): an explicit, separate run mode — a different
+    /// risk class from `proxy`, never a variant of it. Every `tools/call` runs through the policy
+    /// decision point (caller-allowance, credential-scope, drift); a call that clears every gate is
+    /// forwarded, otherwise it is denied with the precedence-pinned reason of the first gate that fails.
+    /// The handshake, `ping`, and `tools/list` still forward; other methods stay `proxy_unsupported`.
+    /// A missing/unreadable/malformed `--enforce-policy` OR `--declared-mcp-manifest` fails startup
+    /// (non-zero exit) — never a runtime deny: in enforcing mode both inputs are required.
     ProxyEnforce {
         /// The upstream MCP server command to spawn (stdio transport).
         #[arg(long)]
@@ -55,10 +55,15 @@ enum Mode {
         /// Arguments passed to the upstream command (repeatable). Hyphen-led values are allowed.
         #[arg(long = "upstream-arg", allow_hyphen_values = true)]
         upstream_args: Vec<String>,
-        /// Path to the enforce policy (YAML): the static `caller.id` and the caller's allowances. A
-        /// missing/unreadable/malformed policy is a startup failure, not a runtime deny.
+        /// Path to the enforce policy (YAML): the static `caller.id`, the upstream credential, and the
+        /// caller's allowances. A missing/unreadable/malformed policy is a startup failure.
         #[arg(long)]
         enforce_policy: PathBuf,
+        /// Path to the approved declared-manifest baseline (`assay.declared_mcp_manifest.v0`, JSON):
+        /// the per-tool `tool_digest` the caller approved, against which the drift gate compares. Required
+        /// in enforcing mode; a missing/unreadable/malformed/wrong-schema baseline is a startup failure.
+        #[arg(long)]
+        declared_mcp_manifest: PathBuf,
     },
 }
 
@@ -104,6 +109,7 @@ async fn main() -> Result<()> {
                 upstream_args,
                 proxy::Mode::Observe,
                 None,
+                None,
                 mcp_manifest_observed_out,
                 proxy_observation_health_out,
             )
@@ -113,22 +119,26 @@ async fn main() -> Result<()> {
             upstream_command,
             upstream_args,
             enforce_policy,
+            declared_mcp_manifest,
         }) => {
-            // Load + validate the policy BEFORE starting the proxy. A bad policy is a misconfigured
-            // service: fail startup with a non-zero exit, never start an enforcing proxy that cannot
-            // decide (and never degrade to a runtime deny).
+            // Load + validate BOTH inputs BEFORE starting the proxy. A bad policy or baseline is a
+            // misconfigured service: fail startup with a non-zero exit, never start an enforcing proxy
+            // that cannot decide (and never degrade to a runtime deny).
             let policy = proxy::enforce::load(&enforce_policy)?;
+            let baseline = proxy::enforce::load_declared_manifest(&declared_mcp_manifest)?;
             tracing::info!(
                 event = "proxy_start",
                 upstream_command = %upstream_command,
-                mode = "enforce_pdp_c1",
-                caller = %policy.caller.id
+                mode = "enforce_pdp_c3",
+                caller = %policy.caller.id,
+                baseline_tools = baseline.tools.len()
             );
             proxy::run(
                 upstream_command,
                 upstream_args,
                 proxy::Mode::Enforce,
                 Some(policy),
+                Some(baseline),
                 None,
                 None,
             )

--- a/crates/assay-mcp-server/src/proxy/enforce.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce.rs
@@ -1,12 +1,12 @@
-//! P61e-c1/c2: the enforcing-proxy policy decision point — caller-allowance + credential-scope gates,
-//! deny-only. Spec: docs/reference/mcp-upstream-proxy-enforcement.md.
+//! P61e-c1/c2/c3: the enforcing-proxy policy decision point — caller-allowance + credential-scope +
+//! drift gates, plus the first allow/forward path. Spec: docs/reference/mcp-upstream-proxy-enforcement.md.
 //!
-//! Scope so far: parse the `--enforce-policy` file, classify an observed `tools/call`, and decide a
-//! DENY with a precedence-pinned reason. c1 added the caller-allowance gate; c2 adds the
-//! credential-scope gate (the declared upstream credential must cover the action's required scope).
-//! There is still no allow path and no forwarding (that arrives in c3, with the drift gate). A
-//! `tools/call` that passes every enabled gate is still denied with `pdp_gate_unavailable`, a temporary
-//! rollout reason removed when c3 lands.
+//! Scope: parse the `--enforce-policy` file and the `--declared-mcp-manifest` baseline, classify an
+//! observed `tools/call`, and decide. c1 added the caller-allowance gate; c2 the credential-scope gate;
+//! c3 the drift gate (the current observed per-tool digest must equal the approved baseline digest,
+//! with both a baseline and a current COMPLETE observation required) AND the first allow path: a call
+//! that clears every gate is forwarded. The temporary `pdp_gate_unavailable` reason is gone — every
+//! outcome is now either a precedence-pinned deny or an allow.
 //!
 //! Caller identity is the static `caller.id` from the policy only — no transport/env/request
 //! inference — so a single stdio session is bound to one configured caller and `unknown_caller`
@@ -61,6 +61,79 @@ pub struct Target {
     pub repo: String,
 }
 
+const DECLARED_MANIFEST_SCHEMA: &str = "assay.declared_mcp_manifest.v0";
+
+/// The operator-pinned approval-time baseline (`assay.declared_mcp_manifest.v0`): the per-tool
+/// `tool_digest` the caller approved. The drift gate (c3) compares the current observed per-tool digest
+/// against this. It is the ONLY source of the approval baseline — never the first observed session
+/// manifest (spec §16-B).
+#[derive(Debug, Deserialize)]
+pub struct DeclaredManifest {
+    pub schema: String,
+    #[serde(default)]
+    pub tools: Vec<BaselineTool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BaselineTool {
+    pub name: String,
+    pub tool_digest: String,
+}
+
+impl DeclaredManifest {
+    /// The approved `tool_digest` for `name`, or `None` if this tool has no approved baseline.
+    pub fn tool_digest_for(&self, name: &str) -> Option<&str> {
+        self.tools
+            .iter()
+            .find(|t| t.name == name)
+            .map(|t| t.tool_digest.as_str())
+    }
+}
+
+/// The current observed per-tool digest for the invoked tool, computed by the proxy from its own
+/// observed `tools/list` (P61c). Distinguishes "no complete manifest observed this session" from
+/// "observed complete but this tool is absent" — both are fail-closed, never an allow.
+pub enum ObservedToolDigest {
+    /// No COMPLETE `tools/list` has been observed in this session.
+    NoCompleteManifest,
+    /// A complete manifest was observed, but it does not contain the invoked tool.
+    CompleteButToolAbsent,
+    /// The current observed `tool_digest` for the invoked tool.
+    Present(String),
+}
+
+/// Load + STRICTLY validate the declared-manifest baseline. Like the enforce policy, any failure here
+/// is a STARTUP failure (non-zero exit), never a runtime deny: in enforcing mode an approval baseline
+/// is required, and a proxy that would forward privileged calls without a valid baseline must not start.
+pub fn load_declared_manifest(path: &Path) -> Result<DeclaredManifest> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading --declared-mcp-manifest {}", path.display()))?;
+    let manifest: DeclaredManifest =
+        serde_json::from_str(&text).with_context(|| "parsing --declared-mcp-manifest JSON")?;
+    if manifest.schema != DECLARED_MANIFEST_SCHEMA {
+        bail!(
+            "--declared-mcp-manifest: schema must be {DECLARED_MANIFEST_SCHEMA}, got {:?}",
+            manifest.schema
+        );
+    }
+    if manifest.tools.is_empty() {
+        bail!("--declared-mcp-manifest: tools must be a non-empty array");
+    }
+    for t in &manifest.tools {
+        if t.name.trim().is_empty() {
+            bail!("--declared-mcp-manifest: every tool must have a non-empty name");
+        }
+        if !t.tool_digest.starts_with("sha256:") {
+            bail!(
+                "--declared-mcp-manifest: tool {:?} tool_digest must be a sha256: digest, got {:?}",
+                t.name,
+                t.tool_digest
+            );
+        }
+    }
+    Ok(manifest)
+}
+
 /// Load + validate the enforce policy. Any failure here is a STARTUP failure (the caller surfaces it
 /// as a non-zero exit), never a runtime deny: an enforcing proxy without a valid policy is a
 /// misconfigured service and must not start.
@@ -83,38 +156,60 @@ pub fn target_digest(target: &Value) -> String {
     format!("sha256:{}", sha256_hex(&preimage))
 }
 
-/// A c1 decision. There is no `Allow` in c1 — every outcome is a deny with a reason.
+/// A PDP decision. `allow == true` means forward the call to the upstream; otherwise `reason` is the
+/// precedence-pinned deny reason. When `allow` is true `reason` is the constant `"allow"`.
 pub struct Decision {
+    pub allow: bool,
     pub reason: &'static str,
     pub action_class: Option<String>,
     pub target_digest: Option<String>,
 }
 
-/// The PDP. Precedence (first failing gate wins), all still deny (no allow/forward before c3):
+impl Decision {
+    fn deny(
+        reason: &'static str,
+        action_class: Option<String>,
+        target_digest: Option<String>,
+    ) -> Decision {
+        Decision {
+            allow: false,
+            reason,
+            action_class,
+            target_digest,
+        }
+    }
+}
+
+/// The PDP. Precedence (first failing gate wins); only a call that clears EVERY gate is allowed:
 /// 1. classification (before allowance, so a missing-target call reads as classification_incomplete,
 ///    never as a target mismatch);
 /// 2. caller-allowance match (github_deploy_key {owner, repo} only so far);
 /// 3. credential-scope (c2): the declared upstream credential must cover the action's required scope,
 ///    else credential_scope_insufficient / credential_scope_unknown;
-/// 4. all enabled gates passed -> pdp_gate_unavailable (the drift gate c3 + allow path are not enabled).
-pub fn decide(policy: &EnforcePolicy, tool_name: &str, args: &Value) -> Decision {
+/// 4. drift (c3): the current observed per-tool digest must equal the approved baseline digest, with
+///    BOTH a baseline (else manifest_baseline_missing) and a current complete observation (else
+///    manifest_current_observation_incomplete) required; a digest change is manifest_drifted_since_approval;
+/// 5. all gates passed -> ALLOW (forward). There is no `pdp_gate_unavailable` — c3 removed it.
+pub fn decide(
+    policy: &EnforcePolicy,
+    baseline: &DeclaredManifest,
+    observed: &ObservedToolDigest,
+    tool_name: &str,
+    args: &Value,
+) -> Decision {
     let c = classify(tool_name, args);
 
     // 1. classification gate — fail-closed before any allowance matching.
     if c.category.is_none() {
-        return Decision {
-            reason: "unclassified_tool_call",
-            action_class: None,
-            target_digest: None,
-        };
+        return Decision::deny("unclassified_tool_call", None, None);
     }
     if c.state != "classified" {
         // classified_incomplete / redaction_failed / any non-final state -> not enough to authorize.
-        return Decision {
-            reason: "classification_incomplete",
-            action_class: c.category.map(|s| s.to_string()),
-            target_digest: Some(target_digest(&c.target)),
-        };
+        return Decision::deny(
+            "classification_incomplete",
+            c.category.map(|s| s.to_string()),
+            Some(target_digest(&c.target)),
+        );
     }
 
     let action_class = c.category.unwrap();
@@ -126,28 +221,59 @@ pub fn decide(policy: &EnforcePolicy, tool_name: &str, args: &Value) -> Decision
         .iter()
         .any(|a| a.action_class == action_class && allowance_matches(a, action_class, &c.target));
     if !matched {
-        return Decision {
-            reason: "no_declared_allowance",
-            action_class: Some(action_class.to_string()),
-            target_digest: Some(tdig),
-        };
+        return Decision::deny(
+            "no_declared_allowance",
+            Some(action_class.to_string()),
+            Some(tdig),
+        );
     }
 
     // 3. credential-scope gate (c2): the declared upstream credential must cover the action's required
     // scope. Fail-closed — an absent credential, an unrecognized scope, or a too-coarse scope is a
     // credential_scope_unknown (coverage cannot be determined), never a silent pass.
     if let Some(reason) = credential_scope_gate(policy, action_class) {
-        return Decision {
-            reason,
-            action_class: Some(action_class.to_string()),
-            target_digest: Some(tdig),
-        };
+        return Decision::deny(reason, Some(action_class.to_string()), Some(tdig));
     }
 
-    // 4. c2 stops here: the drift gate (c3) and the allow/forward path are not enabled yet, so a call
-    // that clears every enabled gate is still denied.
+    // 4. drift gate (c3): the tool the caller is invoking must be the one approved. Both inputs are
+    // required and fail-closed: the approved baseline (never the first observed session manifest) AND a
+    // current COMPLETE observation of this tool's surface. "no drift observed" is never "no drift".
+    let baseline_digest = match baseline.tool_digest_for(tool_name) {
+        Some(d) => d,
+        None => {
+            return Decision::deny(
+                "manifest_baseline_missing",
+                Some(action_class.to_string()),
+                Some(tdig),
+            )
+        }
+    };
+    let observed_digest = match observed {
+        ObservedToolDigest::Present(d) => d.as_str(),
+        // No complete observation, or the tool is absent from the complete manifest: either way there
+        // is no current digest to compare, so drift cannot be ruled out -> fail closed.
+        ObservedToolDigest::NoCompleteManifest | ObservedToolDigest::CompleteButToolAbsent => {
+            return Decision::deny(
+                "manifest_current_observation_incomplete",
+                Some(action_class.to_string()),
+                Some(tdig),
+            )
+        }
+    };
+    if baseline_digest != observed_digest {
+        return Decision::deny(
+            "manifest_drifted_since_approval",
+            Some(action_class.to_string()),
+            Some(tdig),
+        );
+    }
+
+    // 5. every gate passed -> ALLOW (forward). This is the only allow path, and it is deliberately the
+    // narrowest one: exact caller allowance + covered credential scope + an approved baseline whose
+    // per-tool digest exactly equals the current complete observed digest.
     Decision {
-        reason: "pdp_gate_unavailable",
+        allow: true,
+        reason: "allow",
         action_class: Some(action_class.to_string()),
         target_digest: Some(tdig),
     }
@@ -309,6 +435,32 @@ allowances:
         json!({"owner": "acme", "repo": "prod-app"})
     }
 
+    const TOOL: &str = "github.add_deploy_key";
+    const APPROVED: &str = "sha256:approved-digest";
+
+    /// A single-tool declared baseline (loaded + strictly validated like at startup).
+    fn baseline_with(name: &str, digest: &str) -> DeclaredManifest {
+        let j = format!(
+            r#"{{"schema":"assay.declared_mcp_manifest.v0","tools":[{{"name":"{name}","tool_digest":"{digest}"}}]}}"#
+        );
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(j.as_bytes()).unwrap();
+        load_declared_manifest(f.path()).unwrap()
+    }
+
+    /// `decide` with a baseline + observed digest that MATCH for `github.add_deploy_key`, so only the
+    /// gates BEFORE the drift gate can produce a deny (the classification/allowance/credential tests).
+    /// A call that also clears those earlier gates therefore reaches an ALLOW here.
+    fn decide_match(p: &EnforcePolicy, tool: &str, args: &Value) -> Decision {
+        decide(
+            p,
+            &baseline_with(TOOL, APPROVED),
+            &ObservedToolDigest::Present(APPROVED.to_string()),
+            tool,
+            args,
+        )
+    }
+
     #[test]
     fn loads_a_valid_policy() {
         let p = policy_from(VALID).unwrap();
@@ -331,7 +483,7 @@ allowances:
     #[test]
     fn unclassified_tool_is_denied_unclassified() {
         let p = policy_from(VALID).unwrap();
-        let d = decide(&p, "misc.do_thing", &json!({}));
+        let d = decide_match(&p, "misc.do_thing", &json!({}));
         assert_eq!(d.reason, "unclassified_tool_call");
     }
 
@@ -340,14 +492,14 @@ allowances:
         // Missing repo -> classified_incomplete; must read as classification_incomplete, NOT
         // no_declared_allowance/target-mismatch.
         let p = policy_from(VALID).unwrap();
-        let d = decide(&p, "github.add_deploy_key", &json!({"owner": "acme"}));
+        let d = decide_match(&p, "github.add_deploy_key", &json!({"owner": "acme"}));
         assert_eq!(d.reason, "classification_incomplete");
     }
 
     #[test]
     fn classified_without_allowance_is_denied_no_declared_allowance() {
         let p = policy_from(VALID).unwrap();
-        let d = decide(
+        let d = decide_match(
             &p,
             "github.add_deploy_key",
             &json!({"owner": "other", "repo": "x"}),
@@ -357,15 +509,13 @@ allowances:
     }
 
     #[test]
-    fn matching_allowance_and_covering_scope_reaches_pdp_gate_unavailable() {
-        // VALID declares a credential whose scope exactly covers the required scope, so the call
-        // clears the allowance AND credential-scope gates — and is still denied (no allow path yet).
+    fn all_gates_pass_with_matching_digest_allows() {
+        // VALID clears classification + allowance + credential-scope; with a baseline + observed digest
+        // that match (decide_match), the drift gate passes too -> the one and only allow path fires.
         let p = policy_from(VALID).unwrap();
-        let d = decide(&p, "github.add_deploy_key", &acme_call());
-        assert_eq!(
-            d.reason, "pdp_gate_unavailable",
-            "every enabled gate passed; there is no allow path before c3"
-        );
+        let d = decide_match(&p, "github.add_deploy_key", &acme_call());
+        assert!(d.allow, "every gate passed -> forward");
+        assert_eq!(d.reason, "allow");
     }
 
     // --- c2 credential-scope gate (runs only after the allowance matches) -----------------------
@@ -374,7 +524,7 @@ allowances:
     fn no_declared_credential_is_credential_scope_unknown() {
         // Allowance matches, but no credential is declared -> coverage cannot be determined.
         let p = allow_acme_with_cred("");
-        let d = decide(&p, "github.add_deploy_key", &acme_call());
+        let d = decide_match(&p, "github.add_deploy_key", &acme_call());
         assert_eq!(d.reason, "credential_scope_unknown");
     }
 
@@ -383,7 +533,7 @@ allowances:
         let p = allow_acme_with_cred(
             "upstream_credential:\n  alias: \"gh\"\n  scopes: [\"repo:read\"]\n",
         );
-        let d = decide(&p, "github.add_deploy_key", &acme_call());
+        let d = decide_match(&p, "github.add_deploy_key", &acme_call());
         assert_eq!(d.reason, "credential_scope_insufficient");
     }
 
@@ -394,7 +544,7 @@ allowances:
         // -> unknown, never silently covered and never "insufficient".
         let p =
             allow_acme_with_cred("upstream_credential:\n  alias: \"gh\"\n  scopes: [\"repo\"]\n");
-        let d = decide(&p, "github.add_deploy_key", &acme_call());
+        let d = decide_match(&p, "github.add_deploy_key", &acme_call());
         assert_eq!(d.reason, "credential_scope_unknown");
     }
 
@@ -402,7 +552,7 @@ allowances:
     fn unrecognized_scope_is_credential_scope_unknown() {
         let p =
             allow_acme_with_cred("upstream_credential:\n  alias: \"gh\"\n  scopes: [\"banana\"]\n");
-        let d = decide(&p, "github.add_deploy_key", &acme_call());
+        let d = decide_match(&p, "github.add_deploy_key", &acme_call());
         assert_eq!(d.reason, "credential_scope_unknown");
     }
 
@@ -413,19 +563,20 @@ allowances:
         let p = allow_acme_with_cred(
             "upstream_credential:\n  alias: \"gh\"\n  scopes: [\"repo:write\"]\n",
         );
-        let d = decide(&p, "github.add_deploy_key", &acme_call());
+        let d = decide_match(&p, "github.add_deploy_key", &acme_call());
         assert_eq!(d.reason, "credential_scope_unknown");
     }
 
     #[test]
-    fn repo_admin_covers_and_reaches_pdp() {
-        // repo:admin is a documented covering (admin-breadth) scope; overbroad still covers and is a
-        // recommendation, never a block in v0.
+    fn repo_admin_covers_then_matching_digest_allows() {
+        // repo:admin covers the credential gate (admin breadth); with a matching baseline + observed
+        // digest the drift gate passes too -> allow.
         let p = allow_acme_with_cred(
             "upstream_credential:\n  alias: \"gh\"\n  scopes: [\"repo:admin\"]\n",
         );
-        let d = decide(&p, "github.add_deploy_key", &acme_call());
-        assert_eq!(d.reason, "pdp_gate_unavailable");
+        let d = decide_match(&p, "github.add_deploy_key", &acme_call());
+        assert!(d.allow);
+        assert_eq!(d.reason, "allow");
     }
 
     #[test]
@@ -446,7 +597,7 @@ allowances:
         let p = allow_acme_with_cred(
             "upstream_credential:\n  alias: \"gh\"\n  scopes: [\"repo:read\"]\n",
         );
-        let d = decide(
+        let d = decide_match(
             &p,
             "github.add_deploy_key",
             &json!({"owner": "other", "repo": "x"}),
@@ -524,5 +675,127 @@ allowances:
             a, raw,
             "domain prefix must change the digest vs a bare hash"
         );
+    }
+
+    // --- c3 drift gate (runs only after classification + allowance + credential-scope pass) ---------
+
+    /// `decide` for the acme call with VALID, a given baseline, and a given observed digest state.
+    fn decide_drift(baseline: &DeclaredManifest, observed: &ObservedToolDigest) -> Decision {
+        let p = policy_from(VALID).unwrap();
+        decide(
+            &p,
+            baseline,
+            observed,
+            "github.add_deploy_key",
+            &acme_call(),
+        )
+    }
+
+    #[test]
+    fn baseline_missing_when_tool_absent_from_baseline() {
+        // A baseline that has SOME tool but not the invoked one -> this tool has no approved baseline.
+        let baseline = baseline_with("other.tool", APPROVED);
+        let d = decide_drift(
+            &baseline,
+            &ObservedToolDigest::Present(APPROVED.to_string()),
+        );
+        assert!(!d.allow);
+        assert_eq!(d.reason, "manifest_baseline_missing");
+    }
+
+    #[test]
+    fn current_observation_incomplete_when_no_complete_manifest() {
+        let baseline = baseline_with(TOOL, APPROVED);
+        let d = decide_drift(&baseline, &ObservedToolDigest::NoCompleteManifest);
+        assert!(!d.allow);
+        assert_eq!(d.reason, "manifest_current_observation_incomplete");
+    }
+
+    #[test]
+    fn current_observation_incomplete_when_tool_absent_from_observed() {
+        // A complete manifest that does not contain the invoked tool: no current digest to compare,
+        // so drift cannot be ruled out -> fail closed (not an allow).
+        let baseline = baseline_with(TOOL, APPROVED);
+        let d = decide_drift(&baseline, &ObservedToolDigest::CompleteButToolAbsent);
+        assert!(!d.allow);
+        assert_eq!(d.reason, "manifest_current_observation_incomplete");
+    }
+
+    #[test]
+    fn drifted_when_observed_digest_differs_from_baseline() {
+        let baseline = baseline_with(TOOL, APPROVED);
+        let d = decide_drift(
+            &baseline,
+            &ObservedToolDigest::Present("sha256:something-else".to_string()),
+        );
+        assert!(!d.allow);
+        assert_eq!(d.reason, "manifest_drifted_since_approval");
+    }
+
+    #[test]
+    fn allows_only_when_baseline_and_observed_digests_match_exactly() {
+        let baseline = baseline_with(TOOL, APPROVED);
+        let d = decide_drift(
+            &baseline,
+            &ObservedToolDigest::Present(APPROVED.to_string()),
+        );
+        assert!(
+            d.allow,
+            "exact digest match clears the drift gate -> forward"
+        );
+        assert_eq!(d.reason, "allow");
+    }
+
+    // --- declared-manifest baseline loader (strict, startup-validated) ------------------------------
+
+    fn manifest_from(json: &str) -> Result<DeclaredManifest> {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(json.as_bytes()).unwrap();
+        load_declared_manifest(f.path())
+    }
+
+    #[test]
+    fn valid_baseline_loads() {
+        let m = manifest_from(
+            r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"github.add_deploy_key","tool_digest":"sha256:abc"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            m.tool_digest_for("github.add_deploy_key"),
+            Some("sha256:abc")
+        );
+        assert_eq!(m.tool_digest_for("nope"), None);
+    }
+
+    #[test]
+    fn wrong_schema_baseline_fails() {
+        assert!(manifest_from(
+            r#"{"schema":"assay.mcp_manifest_observed.v0","tools":[{"name":"t","tool_digest":"sha256:abc"}]}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn empty_tools_baseline_fails() {
+        assert!(
+            manifest_from(r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[]}"#).is_err()
+        );
+    }
+
+    #[test]
+    fn non_sha256_digest_fails() {
+        assert!(manifest_from(
+            r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"t","tool_digest":"deadbeef"}]}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn tool_without_digest_fails() {
+        // tool_digest is required (not Option) -> a tool missing it fails to parse.
+        assert!(manifest_from(
+            r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"t"}]}"#
+        )
+        .is_err());
     }
 }

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -42,19 +42,19 @@ const ALLOWLIST: &[&str] = &[
 // are unambiguously distinguishable from upstream errors regardless of code.
 const PROXY_UNSUPPORTED: i32 = -32040;
 const PROXY_FAILED: i32 = -32041;
-// PROXY_DENIED: a P61e enforcing-mode policy denial. P61e-c1 replaces the single deny-all boundary
-// with the caller-allowance PDP, so the `reason` is now the precedence-pinned gate that fired
-// (unclassified_tool_call / classification_incomplete / no_declared_allowance / pdp_gate_unavailable).
+// PROXY_DENIED: a P61e enforcing-mode policy denial. The `reason` is the precedence-pinned gate that
+// fired (unclassified_tool_call / classification_incomplete / no_declared_allowance /
+// credential_scope_insufficient / credential_scope_unknown / manifest_baseline_missing /
+// manifest_current_observation_incomplete / manifest_drifted_since_approval).
 const PROXY_DENIED: i32 = -32042;
 
 const HEALTH_SCHEMA: &str = "assay.proxy_observation_health.v0";
 
 /// Proxy run mode. Observe (P61a-d, shipped) forwards the allowlist and answers `tools/call` with
-/// `proxy_unsupported`. Enforce runs the c1 caller-allowance PDP on every `tools/call`: the call is
-/// classified and denied with the precedence-pinned reason of the first gate that fails; a call that
-/// passes the c1 gates is still denied with `pdp_gate_unavailable` (there is deliberately no allow /
-/// forward path before c3). Everything other than `tools/call` is identical to Observe. The c1 deny
-/// reasons supersede the P61e-b `enforcing_mode_deny_all` boundary.
+/// `proxy_unsupported`. Enforce runs the P61e-c PDP on every `tools/call` — classification,
+/// caller-allowance, credential-scope, and drift gates — denying with the precedence-pinned reason of
+/// the first gate that fails and FORWARDING only a call that clears every gate (the single allow path).
+/// Everything other than `tools/call` is identical to Observe.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
     Observe,
@@ -203,6 +203,32 @@ impl Observer {
         self.tools_list_changed_observed = true;
     }
 
+    /// The current observed per-tool `tool_digest` for `tool_name`, from the latest COMPLETE observed
+    /// manifest (P61c). Read-only. Used by the enforcing drift gate (P61e-c3): no complete manifest
+    /// observed this session, or the tool absent from a complete manifest, are both fail-closed (the
+    /// gate cannot establish a current digest), never an allow.
+    fn observed_tool_digest(&self, tool_name: &str) -> enforce::ObservedToolDigest {
+        let tools = match &self.latest_complete {
+            Some(t) => t,
+            None => return enforce::ObservedToolDigest::NoCompleteManifest,
+        };
+        let server = self
+            .server_id
+            .clone()
+            .unwrap_or_else(|| "upstream".to_string());
+        let manifest = manifest_observed::build_observed(&server, tools, Completeness::Complete);
+        if let Some(arr) = manifest["observed"]["tool_digests"].as_array() {
+            for e in arr {
+                if e.get("name").and_then(|n| n.as_str()) == Some(tool_name) {
+                    if let Some(d) = e.get("tool_digest").and_then(|d| d.as_str()) {
+                        return enforce::ObservedToolDigest::Present(d.to_string());
+                    }
+                }
+            }
+        }
+        enforce::ObservedToolDigest::CompleteButToolAbsent
+    }
+
     /// Compute the final emission: latest complete wins; otherwise the best observed; otherwise
     /// not_observed. Closes any still-active chain as incomplete first.
     fn finalize(&mut self) -> Emission {
@@ -316,14 +342,16 @@ fn write_json_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
 }
 
 /// Run the proxy against one stdio upstream. `mode` selects observe (manifest-observation, P61a-d) or
-/// enforce (the c1 caller-allowance PDP on `tools/call`, P61e-c1); the only behavioral difference is
-/// how `tools/call` is answered. `policy` is required and present in enforce mode (loaded + validated
-/// at startup) and `None` in observe mode. Manifest emission flags apply to observe only.
+/// enforce (the P61e-c PDP on `tools/call`); the only behavioral difference is how `tools/call` is
+/// answered. `policy` and `baseline` are both required and present in enforce mode (loaded + validated
+/// at startup) and `None` in observe mode: the c3 drift gate compares the current observed per-tool
+/// digest against the approved `baseline`. Manifest emission flags apply to observe only.
 pub async fn run(
     upstream_command: String,
     upstream_args: Vec<String>,
     mode: Mode,
     policy: Option<enforce::EnforcePolicy>,
+    baseline: Option<enforce::DeclaredManifest>,
     manifest_out: Option<PathBuf>,
     health_out: Option<PathBuf>,
 ) -> Result<()> {
@@ -459,50 +487,73 @@ pub async fn run(
                     break;
                 }
             }
+            Some(method) if mode == Mode::Enforce && method == "tools/call" => {
+                // The enforcing PDP runs on every tools/call. policy + baseline are always Some in
+                // enforce mode (loaded + validated at startup). This is the ONLY path that forwards a
+                // privileged call — and only after a clear allow (the confused-deputy discipline).
+                let policy = policy
+                    .as_ref()
+                    .expect("enforce mode without a loaded policy is a startup bug");
+                let baseline = baseline
+                    .as_ref()
+                    .expect("enforce mode without a loaded baseline is a startup bug");
+                let tool_name = v
+                    .pointer("/params/name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or("");
+                let empty = json!({});
+                let call_args = v.pointer("/params/arguments").unwrap_or(&empty);
+                // The current observed per-tool digest, from this session's observed tools/list
+                // (read-only). The guard is dropped before any await below.
+                let observed = observer.lock().await.observed_tool_digest(tool_name);
+                let decision = enforce::decide(policy, baseline, &observed, tool_name, call_args);
+                // Diagnostic decision log — operability/correlation only, NOT the canonical
+                // assay.enforcement_decision.v0 evidence artifact (that is P61e-d).
+                tracing::info!(
+                    event = "enforce_decision",
+                    caller = %policy.caller.id,
+                    tool = %tool_name,
+                    action_class = decision.action_class.as_deref().unwrap_or("none"),
+                    target_digest = decision.target_digest.as_deref().unwrap_or("none"),
+                    decision = if decision.allow { "allow" } else { "deny" },
+                    reason = decision.reason,
+                    forwarded = decision.allow,
+                    note = "diagnostic decision log; not canonical evidence"
+                );
+                if decision.allow {
+                    // Forward the privileged call; the upstream's response relays verbatim via the
+                    // upstream reader (a tools/call response is not a list response, so it is untouched).
+                    if forward_line(&mut child_stdin, &line).await.is_err() {
+                        break;
+                    }
+                } else {
+                    match v.get("id") {
+                        Some(id) if !id.is_null() => {
+                            let _ = tx.send(proxy_error_line(
+                                id.clone(),
+                                PROXY_DENIED,
+                                decision.reason,
+                                &format!(
+                                    "tools/call denied by enforcing proxy: {}",
+                                    decision.reason
+                                ),
+                            ));
+                        }
+                        _ => { /* denied notification: nothing to answer, drop it */ }
+                    }
+                }
+            }
             Some(method) => {
-                // Denied: tools/call and every other non-allowlisted method. Never sent upstream. In
-                // enforce mode a tools/call goes through the c1 caller-allowance PDP and is denied with
-                // the precedence-pinned reason of the first gate that fires (proxy_denied); every other
-                // non-allowlisted method — and all of observe mode — stays proxy_unsupported.
-                let (code, reason, message): (i32, &str, String) =
-                    if mode == Mode::Enforce && method == "tools/call" {
-                        // policy is always Some in enforce mode (loaded + validated at startup).
-                        let policy = policy
-                            .as_ref()
-                            .expect("enforce mode without a loaded policy is a startup bug");
-                        let tool_name = v
-                            .pointer("/params/name")
-                            .and_then(|n| n.as_str())
-                            .unwrap_or("");
-                        let empty = json!({});
-                        let call_args = v.pointer("/params/arguments").unwrap_or(&empty);
-                        let decision = enforce::decide(policy, tool_name, call_args);
-                        // Diagnostic decision log — for operability/correlation only, NOT a canonical
-                        // evidence artifact (the enforcement_decision record is a later slice, P61e-d).
-                        tracing::info!(
-                            event = "enforce_decision",
-                            caller = %policy.caller.id,
-                            tool = %tool_name,
-                            action_class = decision.action_class.as_deref().unwrap_or("none"),
-                            target_digest = decision.target_digest.as_deref().unwrap_or("none"),
-                            reason = decision.reason,
-                            note = "diagnostic decision log; not canonical evidence"
-                        );
-                        (
-                            PROXY_DENIED,
-                            decision.reason,
-                            format!("tools/call denied by enforcing proxy: {}", decision.reason),
-                        )
-                    } else {
-                        (
-                            PROXY_UNSUPPORTED,
-                            "method_not_allowlisted",
-                            format!("method {method:?} is not forwarded in this proxy mode"),
-                        )
-                    };
+                // Every other non-allowlisted method — and observe mode's tools/call — is never sent
+                // upstream and stays proxy_unsupported (distinct from the enforce-mode proxy_denied).
                 match v.get("id") {
                     Some(id) if !id.is_null() => {
-                        let _ = tx.send(proxy_error_line(id.clone(), code, reason, &message));
+                        let _ = tx.send(proxy_error_line(
+                            id.clone(),
+                            PROXY_UNSUPPORTED,
+                            "method_not_allowlisted",
+                            &format!("method {method:?} is not forwarded in this proxy mode"),
+                        ));
                     }
                     _ => { /* denied notification: nothing to answer, drop it */ }
                 }

--- a/crates/assay-mcp-server/tests/fixtures/proxy/mock_upstream.py
+++ b/crates/assay-mcp-server/tests/fixtures/proxy/mock_upstream.py
@@ -132,9 +132,17 @@ def main():
             _send({"jsonrpc": "2.0", "id": mid, "result": {}})
         elif method == "tools/list":
             _handle_tools_list(mid, (msg.get("params") or {}).get("cursor"))
+        elif method == "tools/call":
+            # Only the enforcing proxy's allow path forwards tools/call to us (P61e-c3). Answer with a
+            # canned success so the test can assert the upstream's reply was relayed verbatim.
+            _send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {"content": [{"type": "text", "text": "forwarded-ok"}], "isError": False},
+            })
         elif method is not None and mid is not None:
-            # Should never happen: the proxy denies non-allowlisted methods before they reach us. If a
-            # request slips through, fail loudly rather than silently accept it.
+            # Should never happen for other methods: the proxy denies non-allowlisted methods before
+            # they reach us. If a request slips through, fail loudly rather than silently accept it.
             _send({
                 "jsonrpc": "2.0",
                 "id": mid,

--- a/crates/assay-mcp-server/tests/proxy_enforce_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_e2e.rs
@@ -61,7 +61,15 @@ fn spawn_observe(log: &std::path::Path) -> Child {
         .expect("spawn observe proxy (is python installed?)")
 }
 
-/// Spawn the enforcing proxy ("proxy-enforce" subcommand) with the given policy file.
+/// The committed approved baseline (`assay.declared_mcp_manifest.v0`). Enforcing mode requires
+/// `--declared-mcp-manifest`; these deny tests never reach the drift gate (echo is unclassified), so
+/// any valid baseline suffices.
+fn baseline_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline.json")
+}
+
+/// Spawn the enforcing proxy ("proxy-enforce" subcommand) with the given policy + the required baseline.
 fn spawn_enforce(log: &std::path::Path, policy: &std::path::Path) -> Child {
     Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
         .args([
@@ -74,6 +82,8 @@ fn spawn_enforce(log: &std::path::Path, policy: &std::path::Path) -> Child {
             mock_path().to_str().unwrap(),
             "--enforce-policy",
             policy.to_str().unwrap(),
+            "--declared-mcp-manifest",
+            baseline_path().to_str().unwrap(),
         ])
         .env("MOCK_UPSTREAM_LOG", log)
         .env("MOCK_UPSTREAM_MODE", "normal")

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -1,11 +1,10 @@
-//! P61e-c1: the enforcing-proxy caller-allowance PDP, end to end through the spawned binary.
-//! Spec: docs/reference/mcp-upstream-proxy-enforcement.md.
+//! P61e-c3: the enforcing-proxy PDP end to end — caller-allowance + credential-scope + drift gates,
+//! and the first allow/forward path. Spec: docs/reference/mcp-upstream-proxy-enforcement.md.
 //!
-//! These tests exercise the gate matrix with the real classifier and a real policy file. They are
-//! deliberately negative-first: c1 has NO allow path, so the strongest assertion is that no `tools/call`
-//! ever reaches the upstream regardless of the deny reason. A call that passes every c1 gate is denied
-//! with `pdp_gate_unavailable` (the temporary rollout reason removed when c3 lands). Startup failures
-//! (missing/malformed policy, missing caller.id) are asserted as a non-zero exit, never a runtime deny.
+//! Deny-first: the deny matrix is asserted first, and across all of it no `tools/call` ever reaches the
+//! upstream. The ONE happy path (full policy + approved baseline + a current complete observation whose
+//! per-tool digest matches) is the only case that forwards. `--declared-mcp-manifest` is required in
+//! enforcing mode; a missing/invalid policy OR baseline fails startup, never a runtime deny.
 
 use serde_json::Value;
 use std::io::{BufRead, BufReader, Write};
@@ -26,8 +25,15 @@ fn mock_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/proxy/mock_upstream.py")
 }
 
-/// A policy that allows github_deploy_key on exactly acme/prod-app, with a credential whose scope
-/// exactly covers the required scope (so a matching call clears the c2 credential-scope gate too).
+/// The committed P60a per-tool baseline. Its `github.add_deploy_key` tool_digest equals what the mock's
+/// `p60a` mode produces (the same canonical tools), so it is the approved baseline for the happy path.
+fn approved_baseline_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/mcp_manifest_drift/declared_per_tool_baseline.json")
+}
+
+/// A policy that allows github_deploy_key on acme/prod-app with a credential that exactly covers the
+/// required scope.
 const ALLOW_ACME: &str = r#"
 caller:
   id: "ci-agent"
@@ -40,7 +46,6 @@ allowances:
       - { owner: "acme", repo: "prod-app" }
 "#;
 
-/// Same allowance, but the declared credential does NOT cover the required scope.
 const ALLOW_ACME_INSUFFICIENT_CRED: &str = r#"
 caller:
   id: "ci-agent"
@@ -53,7 +58,6 @@ allowances:
       - { owner: "acme", repo: "prod-app" }
 "#;
 
-/// Same allowance, but no credential is declared at all (coverage cannot be determined).
 const ALLOW_ACME_NO_CRED: &str = r#"
 caller:
   id: "ci-agent"
@@ -63,13 +67,14 @@ allowances:
       - { owner: "acme", repo: "prod-app" }
 "#;
 
-fn write_policy(dir: &Path, yaml: &str) -> PathBuf {
-    let p = dir.join("enforce.yaml");
-    std::fs::write(&p, yaml).expect("write policy");
+fn write_file(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, content).expect("write");
     p
 }
 
-fn spawn_enforce(log: &Path, policy: &Path) -> Child {
+/// Spawn the enforcing proxy with a policy + baseline and the given mock mode.
+fn spawn_enforce(log: &Path, policy: &Path, baseline: &Path, mode: &str) -> Child {
     Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
         .args([
             "proxy-enforce",
@@ -81,9 +86,11 @@ fn spawn_enforce(log: &Path, policy: &Path) -> Child {
             mock_path().to_str().unwrap(),
             "--enforce-policy",
             policy.to_str().unwrap(),
+            "--declared-mcp-manifest",
+            baseline.to_str().unwrap(),
         ])
         .env("MOCK_UPSTREAM_LOG", log)
-        .env("MOCK_UPSTREAM_MODE", "normal")
+        .env("MOCK_UPSTREAM_MODE", mode)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -134,13 +141,13 @@ fn shutdown(mut child: Child, stdin: ChildStdin) {
     let _ = child.wait();
 }
 
-/// Drive one tools/call through a freshly spawned enforcing proxy and return the deny reason plus the
-/// upstream method log. Always asserts proxy_denied (c1 has no allow path).
+/// init -> tools/call (NO tools/list first), with the approved baseline. Returns the deny reason and
+/// the upstream method log. Asserts proxy_denied and that tools/call never reached the upstream.
 fn deny_reason_for(policy_yaml: &str, call_params: Value) -> (String, Vec<String>) {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("methods.log");
-    let policy = write_policy(dir.path(), policy_yaml);
-    let mut child = spawn_enforce(&log, &policy);
+    let policy = write_file(dir.path(), "enforce.yaml", policy_yaml);
+    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "normal");
     let mut stdin = child.stdin.take().unwrap();
     let mut out = BufReader::new(child.stdout.take().unwrap());
 
@@ -154,7 +161,7 @@ fn deny_reason_for(policy_yaml: &str, call_params: Value) -> (String, Vec<String
     assert_eq!(r["id"], 9);
     assert_eq!(
         r["error"]["code"], PROXY_DENIED,
-        "every c1 outcome is a proxy_denied; got {r}"
+        "every deny outcome is proxy_denied; got {r}"
     );
     assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
     let reason = r["error"]["data"]["reason"]
@@ -166,12 +173,12 @@ fn deny_reason_for(policy_yaml: &str, call_params: Value) -> (String, Vec<String
     let methods = read_methods(&log);
     assert!(
         !methods.contains(&"tools/call".to_string()),
-        "INVARIANT: tools/call must never reach the upstream: {methods:?}"
+        "INVARIANT: a denied tools/call must never reach the upstream: {methods:?}"
     );
     (reason, methods)
 }
 
-// --- gate matrix (deny-only) --------------------------------------------------------------------
+// --- pre-drift gates (classification / allowance / credential), no observation needed --------------
 
 #[test]
 fn unclassified_tool_call_denied_unclassified() {
@@ -184,8 +191,6 @@ fn unclassified_tool_call_denied_unclassified() {
 
 #[test]
 fn classification_incomplete_denied_before_allowance() {
-    // Missing repo -> classified_incomplete. Must read as classification_incomplete, NOT a target
-    // mismatch — the classification gate runs before allowance matching.
     let (reason, _) = deny_reason_for(
         ALLOW_ACME,
         serde_json::json!({"name": "github.add_deploy_key", "arguments": {"owner": "acme"}}),
@@ -205,7 +210,6 @@ fn classified_privileged_without_matching_allowance_denied() {
 
 #[test]
 fn allowance_target_mismatch_denied_no_declared_allowance() {
-    // Right owner, wrong repo: a target mismatch is no_declared_allowance, not a partial match.
     let (reason, _) = deny_reason_for(
         ALLOW_ACME,
         serde_json::json!({"name": "github.add_deploy_key",
@@ -213,24 +217,6 @@ fn allowance_target_mismatch_denied_no_declared_allowance() {
     );
     assert_eq!(reason, "no_declared_allowance");
 }
-
-#[test]
-fn matching_allowance_and_covering_scope_reaches_pdp_gate_unavailable() {
-    // The one path that clears every enabled gate (allowance + credential-scope) is still denied:
-    // there is no allow/forward path before c3.
-    let (reason, methods) = deny_reason_for(
-        ALLOW_ACME,
-        serde_json::json!({"name": "github.add_deploy_key",
-                           "arguments": {"owner": "acme", "repo": "prod-app"}}),
-    );
-    assert_eq!(reason, "pdp_gate_unavailable");
-    assert!(
-        !methods.contains(&"tools/call".to_string()),
-        "even a fully-allowed call does not forward before c3"
-    );
-}
-
-// --- c2 credential-scope gate (runs after the allowance matches) --------------------------------
 
 #[test]
 fn insufficient_credential_scope_denied() {
@@ -244,7 +230,6 @@ fn insufficient_credential_scope_denied() {
 
 #[test]
 fn no_declared_credential_is_scope_unknown() {
-    // Coverage cannot be determined -> unknown, never a silent pass and never "insufficient".
     let (reason, _) = deny_reason_for(
         ALLOW_ACME_NO_CRED,
         serde_json::json!({"name": "github.add_deploy_key",
@@ -253,7 +238,143 @@ fn no_declared_credential_is_scope_unknown() {
     assert_eq!(reason, "credential_scope_unknown");
 }
 
-// --- startup failures (non-zero exit, never a runtime deny) -------------------------------------
+// --- drift gate (runs after the pre-drift gates pass) ---------------------------------------------
+
+#[test]
+fn matching_gates_without_observation_deny_current_observation_incomplete() {
+    // Allowance + credential pass, but no tools/list was observed this session, so there is no current
+    // complete manifest to compare -> fail closed (NOT an allow, and NOT pdp_gate_unavailable, gone).
+    let (reason, _) = deny_reason_for(
+        ALLOW_ACME,
+        serde_json::json!({"name": "github.add_deploy_key",
+                           "arguments": {"owner": "acme", "repo": "prod-app"}}),
+    );
+    assert_eq!(reason, "manifest_current_observation_incomplete");
+}
+
+#[test]
+fn tool_absent_from_baseline_denies_baseline_missing() {
+    // A valid baseline that does not contain the invoked tool -> this tool has no approved baseline.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let baseline = write_file(
+        dir.path(),
+        "baseline.json",
+        r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"search","tool_digest":"sha256:abc"}]}"#,
+    );
+    let mut child = spawn_enforce(&log, &policy, &baseline, "p60a");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                           "params": {"name": "github.add_deploy_key",
+                                      "arguments": {"owner": "acme", "repo": "prod-app"}}}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_DENIED);
+    assert_eq!(r["error"]["data"]["reason"], "manifest_baseline_missing");
+    shutdown(child, stdin);
+    assert!(!read_methods(&log).contains(&"tools/call".to_string()));
+}
+
+#[test]
+fn observed_digest_differs_from_baseline_denies_drifted() {
+    // A baseline whose github.add_deploy_key digest differs from what the p60a mock advertises -> drift.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let baseline = write_file(
+        dir.path(),
+        "baseline.json",
+        r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"github.add_deploy_key","tool_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000"}]}"#,
+    );
+    let mut child = spawn_enforce(&log, &policy, &baseline, "p60a");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                           "params": {"name": "github.add_deploy_key",
+                                      "arguments": {"owner": "acme", "repo": "prod-app"}}}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_DENIED);
+    assert_eq!(
+        r["error"]["data"]["reason"],
+        "manifest_drifted_since_approval"
+    );
+    shutdown(child, stdin);
+    assert!(!read_methods(&log).contains(&"tools/call".to_string()));
+}
+
+// --- the ONE happy path: every gate passes -> forward ---------------------------------------------
+
+#[test]
+fn fully_allowed_call_is_forwarded_and_response_relayed() {
+    // Approved baseline + a current complete observation whose github.add_deploy_key digest matches +
+    // matching allowance + covering credential -> the single allow path forwards, and the upstream's
+    // reply relays back verbatim.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "p60a");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    // Observe a complete tools/list so the drift gate has a current digest for the tool.
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let lst = read_response(&mut out);
+    assert!(lst["result"]["tools"].is_array(), "tools/list relayed");
+
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                           "params": {"name": "github.add_deploy_key",
+                                      "arguments": {"owner": "acme", "repo": "prod-app"}}}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["id"], 3);
+    assert!(
+        r.get("error").is_none(),
+        "an allowed call is forwarded, not denied; got {r}"
+    );
+    assert_eq!(
+        r["result"]["content"][0]["text"], "forwarded-ok",
+        "the upstream's reply is relayed verbatim"
+    );
+
+    shutdown(child, stdin);
+    let methods = read_methods(&log);
+    assert!(
+        methods.contains(&"tools/call".to_string()),
+        "the allowed tools/call must reach the upstream: {methods:?}"
+    );
+}
+
+// --- startup failures (non-zero exit; both inputs required in enforcing mode) ---------------------
 
 fn startup_status(args: &[&str]) -> std::process::ExitStatus {
     Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
@@ -265,18 +386,34 @@ fn startup_status(args: &[&str]) -> std::process::ExitStatus {
         .expect("spawn")
 }
 
+/// The fixed upstream-command args shared by the startup-failure cases.
+fn upstream_args() -> Vec<String> {
+    vec![
+        "proxy-enforce".into(),
+        "--upstream-command".into(),
+        python().into(),
+        "--upstream-arg".into(),
+        "-u".into(),
+        "--upstream-arg".into(),
+        mock_path().to_str().unwrap().into(),
+    ]
+}
+
+fn run_startup(extra: &[&str]) -> std::process::ExitStatus {
+    let mut args = upstream_args();
+    for e in extra {
+        args.push((*e).into());
+    }
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    startup_status(&arg_refs)
+}
+
 #[test]
 fn missing_enforce_policy_flag_fails_startup() {
-    // No --enforce-policy at all: clap rejects it as a usage error (non-zero), never starts the proxy.
-    let status = startup_status(&[
-        "proxy-enforce",
-        "--upstream-command",
-        python(),
-        "--upstream-arg",
-        "-u",
-        "--upstream-arg",
-        mock_path().to_str().unwrap(),
-    ]);
+    let dir = tempfile::tempdir().unwrap();
+    let baseline = approved_baseline_path();
+    let status = run_startup(&["--declared-mcp-manifest", baseline.to_str().unwrap()]);
+    let _ = dir;
     assert!(
         !status.success(),
         "missing --enforce-policy must fail startup"
@@ -284,58 +421,76 @@ fn missing_enforce_policy_flag_fails_startup() {
 }
 
 #[test]
+fn missing_declared_manifest_flag_fails_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let status = run_startup(&["--enforce-policy", policy.to_str().unwrap()]);
+    assert!(
+        !status.success(),
+        "missing --declared-mcp-manifest must fail startup in enforcing mode"
+    );
+}
+
+#[test]
 fn missing_policy_file_fails_startup() {
     let dir = tempfile::tempdir().unwrap();
-    let missing = dir.path().join("does-not-exist.yaml");
-    let status = startup_status(&[
-        "proxy-enforce",
-        "--upstream-command",
-        python(),
-        "--upstream-arg",
-        "-u",
-        "--upstream-arg",
-        mock_path().to_str().unwrap(),
+    let missing = dir.path().join("nope.yaml");
+    let status = run_startup(&[
         "--enforce-policy",
         missing.to_str().unwrap(),
+        "--declared-mcp-manifest",
+        approved_baseline_path().to_str().unwrap(),
     ]);
     assert!(!status.success(), "unreadable policy must fail startup");
 }
 
 #[test]
-fn malformed_policy_fails_startup() {
-    let dir = tempfile::tempdir().unwrap();
-    let p = write_policy(dir.path(), "caller: : :\n");
-    let status = startup_status(&[
-        "proxy-enforce",
-        "--upstream-command",
-        python(),
-        "--upstream-arg",
-        "-u",
-        "--upstream-arg",
-        mock_path().to_str().unwrap(),
-        "--enforce-policy",
-        p.to_str().unwrap(),
-    ]);
-    assert!(!status.success(), "malformed policy must fail startup");
-}
-
-#[test]
 fn missing_caller_id_fails_startup() {
     let dir = tempfile::tempdir().unwrap();
-    let p = write_policy(dir.path(), "allowances: []\n");
-    let status = startup_status(&[
-        "proxy-enforce",
-        "--upstream-command",
-        python(),
-        "--upstream-arg",
-        "-u",
-        "--upstream-arg",
-        mock_path().to_str().unwrap(),
+    let policy = write_file(dir.path(), "enforce.yaml", "allowances: []\n");
+    let status = run_startup(&[
         "--enforce-policy",
-        p.to_str().unwrap(),
+        policy.to_str().unwrap(),
+        "--declared-mcp-manifest",
+        approved_baseline_path().to_str().unwrap(),
     ]);
     assert!(
         !status.success(),
         "policy without caller.id must fail startup"
+    );
+}
+
+#[test]
+fn missing_declared_manifest_file_fails_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let missing = dir.path().join("nope.json");
+    let status = run_startup(&[
+        "--enforce-policy",
+        policy.to_str().unwrap(),
+        "--declared-mcp-manifest",
+        missing.to_str().unwrap(),
+    ]);
+    assert!(!status.success(), "unreadable baseline must fail startup");
+}
+
+#[test]
+fn wrong_schema_declared_manifest_fails_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let baseline = write_file(
+        dir.path(),
+        "baseline.json",
+        r#"{"schema":"assay.mcp_manifest_observed.v0","tools":[{"name":"t","tool_digest":"sha256:abc"}]}"#,
+    );
+    let status = run_startup(&[
+        "--enforce-policy",
+        policy.to_str().unwrap(),
+        "--declared-mcp-manifest",
+        baseline.to_str().unwrap(),
+    ]);
+    assert!(
+        !status.success(),
+        "a wrong-schema baseline must fail startup"
     );
 }

--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -4,11 +4,11 @@ Status: **review-spec, no code.** A new arc and the heaviest risk class in the p
 the shipped, opt-in [manifest-observation proxy](mcp-upstream-proxy-mode.md) (P61a–d, assay v3.23.0)
 from observe-only to **enforcing**: it forwards a privileged `tools/call` only after a fail-closed
 policy decision. Tracked as [#1624]. The binding decisions are agreed (§16, "Resolved decisions"); this
-is the design of record. Shipped so far: P61e-b (the deny-all enforcing run mode), P61e-c1 (the
-caller-allowance policy decision point), and **P61e-c2 (the credential-scope gate)** — all deny-only, no
-`tools/call` is forwarded yet. The arc forwards privileged calls only after the c3 drift gate and the
-first allow path land, because forwarding with an upstream credential makes the proxy a confused deputy
-unless every dimension here is locked first.
+is the design of record. Shipped: P61e-b (the deny-all enforcing run mode), P61e-c1 (caller-allowance),
+P61e-c2 (credential-scope), and **P61e-c3 (the drift gate + the first allow/forward path)**. As of c3
+the enforcing proxy forwards a privileged `tools/call` — but only after a clear allow from every gate
+(classification, caller-allowance, credential-scope, drift), the narrowest such path; everything else is
+a fail-closed deny. The remaining slice is P61e-d (the `assay.enforcement_decision.v0` evidence record).
 
 The one-line scope: **the manifest-observation proxy answers "did this tool surface change?"; the
 enforcing proxy answers "should this specific privileged call be forwarded, right now, for this
@@ -162,21 +162,17 @@ unclassified_tool_call                  no_declared_allowance
 credential_scope_insufficient           credential_scope_unknown
 manifest_baseline_missing               manifest_current_observation_incomplete
 manifest_drifted_since_approval         policy_unavailable
-policy_error                            pdp_gate_unavailable      (pre-c3 rollout only; c1/c2)
-enforcing_mode_deny_all   (SUPERSEDED — see below)
+policy_error
 ```
 A denied call never reaches the upstream. `credential_scope_unknown` is distinct from
 `credential_scope_insufficient`: when coverage cannot be determined the denial reason is *unknown*, not
 *insufficient* (see §8).
 
-**Reason history across the slices.** P61e-b used exactly one reason — `enforcing_mode_deny_all` (the
-whole `tools/call` surface denied before any gate existed). **P61e-c1 supersedes it** with the
-caller-allowance PDP: a `tools/call` is now denied with the precedence-pinned reason of the first gate
-that fires — `unclassified_tool_call`, then `classification_incomplete`, then `no_declared_allowance`.
-A call that clears every c1 gate is still denied with **`pdp_gate_unavailable`**, a temporary rollout
-reason that exists only because there is deliberately no allow / forward path before c3 (the
-credential-scope gate is c2, the drift gate and the first allow are c3). `pdp_gate_unavailable` is
-removed when c3 lands; `enforcing_mode_deny_all` is retired and no longer emitted.
+**Reason history across the slices.** P61e-b used a single `enforcing_mode_deny_all`; c1 superseded it
+with per-gate reasons (`unclassified_tool_call` → `classification_incomplete` → `no_declared_allowance`),
+and while c1/c2 had no allow path a fully-cleared call denied with a temporary `pdp_gate_unavailable`.
+**c3 removes both**: `enforcing_mode_deny_all` and `pdp_gate_unavailable` are retired and no longer
+emitted — a call that clears every gate is now forwarded, and every deny is a real gate reason.
 
 ## 8. Credential boundary (locked from P61a, extended)
 
@@ -203,22 +199,29 @@ removed when c3 lands; `enforcing_mode_deny_all` is retired and no longer emitte
   caller authority. v0 need not implement token minting, but it must state and enforce that the proxy
   does not broaden authority.
 
-## 9. Drift-aware enforcement (the novel contribution)
+## 9. Drift-aware enforcement (the novel contribution) — P61e-c3, shipped
 
 Enforcement is tied to the manifest-drift state, connecting P60 (manifest drift), E12 (tool lifecycle),
 and P61e (enforcement): a privileged call to a tool whose **contract digest changed since the caller
 approved it** is invoking something other than what was approved — the post-approval-mutation payoff.
-The drift gate (P61e-c) needs **both** of two evidence inputs, and is fail-closed without either:
+The drift gate needs **both** of two evidence inputs, and is fail-closed without either:
 
 - **the approval-time baseline comes from a declared approved manifest artifact only** — the
   `assay.declared_mcp_manifest.v0` baseline (or a future approval record that references it), **never
   the first observed complete manifest of the session**. A first-observed baseline can already be a
-  post-rug-pull state, so pinning it and calling it "approval-time" would pin the wrong state. No
-  declared approved baseline → `proxy_denied` (`manifest_baseline_missing`);
-- **a current complete observed manifest is required** — if the session has no complete current
-  observation of the invoked tool's surface, the drift state is `proxy_denied`
-  (`manifest_current_observation_incomplete`), because you cannot compare against a baseline without a
-  current complete view.
+  post-rug-pull state, so pinning it and calling it "approval-time" would pin the wrong state. The
+  baseline is the required `--declared-mcp-manifest` startup input (a missing/invalid/wrong-schema
+  baseline fails startup, like the policy); a baseline that lacks the invoked tool → `proxy_denied`
+  (`manifest_baseline_missing`);
+- **a current complete observed manifest is required** — the proxy reads it from its own observed
+  `tools/list` (P61c). If the session has no complete current observation, or the invoked tool is absent
+  from a complete one, the drift state is `proxy_denied` (`manifest_current_observation_incomplete`),
+  because you cannot compare against a baseline without a current complete view of that tool.
+
+The comparison is the per-tool `tool_digest`, looked up by tool name in both the baseline and the
+current observed manifest (the same canonical P60 projection on both sides; server id is not part of the
+per-tool digest). It compares the tool's *contract*, never the call arguments (those are the allowance
+gate). An exact digest match clears the gate; any difference is `manifest_drifted_since_approval`.
 
 With both in hand:
 - current contract digest **equals** the declared approved baseline → the drift gate is satisfied
@@ -288,6 +291,7 @@ P61e-c  split gate-by-gate, each fail-closed and independently tested, NO forwar
         (P59); credential_scope_insufficient / credential_scope_unknown. Still no forwarding. (SHIPPED.)
   c3    drift-aware gate (declared baseline + current complete manifest, P60/E12) + the FIRST allow /
         forward path: a call that clears every gate is forwarded; pdp_gate_unavailable is removed.
+        (SHIPPED.)
 P61e-d  the assay.enforcement_decision.v0 record + the side-effect-evidence interaction (asserted),
         kept separate from the observation artifact; Plimsoll consumes it separately (later)
 ```
@@ -318,9 +322,25 @@ denies (`credential_scope_unknown`), never a silent pass. Only `github_deploy_ke
 lattice today; any other classified class is fail-closed `credential_scope_unknown` until its own
 contract slice lands (and is unreachable anyway — c1's allowance matcher only admits `github_deploy_key`).
 The policy grows an optional `upstream_credential: {alias, scopes}` block; the alias is reserved for the
-P61e-d evidence record and is not read by the gate. Still no allow path — a call that clears the
-credential-scope gate
-is denied with `pdp_gate_unavailable`.
+P61e-d evidence record and is not read by the gate. (In c2 a call that cleared the credential-scope gate
+was still denied with the temporary `pdp_gate_unavailable`; c3 replaces that with the drift gate and the
+allow path.)
+
+**Implementation note (P61e-c3):** the PDP gains the fourth and final v0 gate — drift — and the first
+allow/forward path. The enforcing subcommand now ALSO requires `--declared-mcp-manifest <path>` (the
+`assay.declared_mcp_manifest.v0` JSON baseline); a missing/unreadable/malformed/wrong-schema baseline
+fails startup, exactly like the policy — in enforcing mode both inputs are required, so the proxy never
+"enforces" without an approval baseline. The drift gate compares the invoked tool's approved baseline
+`tool_digest` against the current observed `tool_digest` (read from the proxy's own complete `tools/list`
+observation), denying `manifest_baseline_missing` (tool absent from the baseline),
+`manifest_current_observation_incomplete` (no complete current observation of the tool), or
+`manifest_drifted_since_approval` (digests differ). Precedence is classification → allowance →
+credential-scope → drift → ALLOW. A call that clears every gate is forwarded to the upstream and the
+upstream's reply is relayed verbatim — the single, narrowest allow path (exact allowance + covered
+credential + an approved baseline whose per-tool digest exactly equals the current complete observed
+digest), and the only place a privileged `tools/call` is forwarded. `pdp_gate_unavailable` is gone. The
+per-decision diagnostic `tracing` line now also carries `decision=allow|deny` and `forwarded`; it
+remains operability-only, NOT the canonical `assay.enforcement_decision.v0` record (that is P61e-d).
 
 **P61e-b is deliberately just a deny-all enforcing proxy** — no policy decision point, no inputs, no
 allow path. It lands the enforcement *boundary* so "fail-closed" and the `proxy_denied`-vs-


### PR DESCRIPTION
Completes the enforcing-proxy PDP and **crosses the forward boundary for the first time**. The precedence is now **classification → caller-allowance → credential-scope → drift → ALLOW**: a call that clears every gate is forwarded to the upstream; everything else is a fail-closed deny. `pdp_gate_unavailable` is removed — every outcome is a real gate reason or an allow.

Built deny-first, with the narrowest possible first allow (per the review guidance).

### Drift gate (both inputs required, spec §9)
- `proxy-enforce` now **also requires `--declared-mcp-manifest <path>`** (the `assay.declared_mcp_manifest.v0` approval baseline). A missing/unreadable/malformed/wrong-schema baseline **fails startup**, exactly like `--enforce-policy` — in enforcing mode both inputs are required, so the proxy never "enforces" without an approval baseline (strict schema/type validation at load).
- Compares the invoked tool's **approved baseline `tool_digest`** against the **current observed `tool_digest`** (read from the proxy's own complete `tools/list`; the canonical P60 projection on both sides; server id is not part of the per-tool digest). It compares the tool **contract**, never the call arguments.
- Deny reasons: `manifest_baseline_missing` (tool absent from baseline), `manifest_current_observation_incomplete` (no complete current observation, or tool absent from a complete one), `manifest_drifted_since_approval` (digests differ). The approval baseline is the **declared artifact only**, never the first observed session manifest (§16-B).

### The first allow path (narrowest)
Exact caller allowance + covered credential scope (exact/admin) + an approved baseline whose per-tool digest **exactly equals** the current complete observed digest. It is the only place a privileged `tools/call` is forwarded, and only after a clear allow (confused-deputy discipline). The diagnostic `tracing` line gains `decision`/`forwarded`; it is still **not** the `assay.enforcement_decision.v0` record (P61e-d).

### Tests
- `enforce.rs` unit → **27**: the drift matrix (baseline-missing, two current-observation-incomplete cases, drifted, allow-on-exact-match) + strict baseline-loader tests (wrong schema, empty tools, non-sha256 digest, missing digest).
- `proxy_enforce_pdp_e2e.rs`: migrated to require `--declared-mcp-manifest`; deny matrix first (no `tools/call` ever reaches the upstream), then the **one happy-forward test** — the mock's `p60a` `tools/list` advertises `github.add_deploy_key` whose digest equals the committed baseline, so the allowed call reaches the upstream and its reply relays verbatim — plus new startup-fail cases for the baseline flag.
- `proxy_enforce_e2e.rs` migrated; mock gains a `tools/call` success handler. Full `assay-mcp-server` suite green; clippy `-D warnings` clean.

### Non-claims
A forwarded call's side effect stays **asserted**, never proven (E9 ladder unchanged). The drift gate compares contract digests, not behaviour or maliciousness. No `assay.enforcement_decision.v0` evidence record yet (P61e-d). Spec: `docs/reference/mcp-upstream-proxy-enforcement.md` (§9 drift gate, §14 c3 + implementation note).

Part of #1624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)