### PR TITLE
fix(mcp): close c3 drift-gate observation-integrity gaps (rug-pull window)

### DIFF
--- a/crates/assay-mcp-server/src/proxy/enforce.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce.rs
@@ -94,8 +94,12 @@ impl DeclaredManifest {
 /// observed `tools/list` (P61c). Distinguishes "no complete manifest observed this session" from
 /// "observed complete but this tool is absent" — both are fail-closed, never an allow.
 pub enum ObservedToolDigest {
-    /// No COMPLETE `tools/list` has been observed in this session.
+    /// No COMPLETE `tools/list` has been observed this session, or the last complete observation was
+    /// invalidated by a later `tools/list_changed` and not yet re-observed.
     NoCompleteManifest,
+    /// The complete observed manifest has duplicate tool names (`status: ambiguous`): inconclusive, so
+    /// the drift gate must deny rather than pick one of the colliding per-tool digests.
+    Ambiguous,
     /// A complete manifest was observed, but it does not contain the invoked tool.
     CompleteButToolAbsent,
     /// The current observed `tool_digest` for the invoked tool.
@@ -119,6 +123,7 @@ pub fn load_declared_manifest(path: &Path) -> Result<DeclaredManifest> {
     if manifest.tools.is_empty() {
         bail!("--declared-mcp-manifest: tools must be a non-empty array");
     }
+    let mut seen = std::collections::HashSet::new();
     for t in &manifest.tools {
         if t.name.trim().is_empty() {
             bail!("--declared-mcp-manifest: every tool must have a non-empty name");
@@ -128,6 +133,14 @@ pub fn load_declared_manifest(path: &Path) -> Result<DeclaredManifest> {
                 "--declared-mcp-manifest: tool {:?} tool_digest must be a sha256: digest, got {:?}",
                 t.name,
                 t.tool_digest
+            );
+        }
+        // Duplicate declared names are `declared_mcp_manifest_ambiguous` (manifest-drift contract): a
+        // first-match-wins lookup over an ambiguous approval baseline is unsafe, so fail startup.
+        if !seen.insert(t.name.as_str()) {
+            bail!(
+                "--declared-mcp-manifest: duplicate tool name {:?} (an approval baseline must be unambiguous)",
+                t.name
             );
         }
     }
@@ -250,8 +263,18 @@ pub fn decide(
     };
     let observed_digest = match observed {
         ObservedToolDigest::Present(d) => d.as_str(),
-        // No complete observation, or the tool is absent from the complete manifest: either way there
-        // is no current digest to compare, so drift cannot be ruled out -> fail closed.
+        // A duplicate-name (ambiguous) observed manifest is inconclusive — deny with a distinct reason
+        // rather than compare against one of the colliding digests.
+        ObservedToolDigest::Ambiguous => {
+            return Decision::deny(
+                "manifest_observation_ambiguous",
+                Some(action_class.to_string()),
+                Some(tdig),
+            )
+        }
+        // No complete observation (or one invalidated by a later tools/list_changed), or the tool is
+        // absent from the complete manifest: either way there is no current digest to compare, so
+        // drift cannot be ruled out -> fail closed.
         ObservedToolDigest::NoCompleteManifest | ObservedToolDigest::CompleteButToolAbsent => {
             return Decision::deny(
                 "manifest_current_observation_incomplete",
@@ -722,6 +745,15 @@ allowances:
     }
 
     #[test]
+    fn ambiguous_observation_denies_observation_ambiguous() {
+        // A duplicate-name (ambiguous) observed manifest is inconclusive -> deny, never pick a digest.
+        let baseline = baseline_with(TOOL, APPROVED);
+        let d = decide_drift(&baseline, &ObservedToolDigest::Ambiguous);
+        assert!(!d.allow);
+        assert_eq!(d.reason, "manifest_observation_ambiguous");
+    }
+
+    #[test]
     fn drifted_when_observed_digest_differs_from_baseline() {
         let baseline = baseline_with(TOOL, APPROVED);
         let d = decide_drift(
@@ -795,6 +827,15 @@ allowances:
         // tool_digest is required (not Option) -> a tool missing it fails to parse.
         assert!(manifest_from(
             r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"t"}]}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn duplicate_baseline_tool_names_fail_load() {
+        // An approval baseline must be unambiguous: duplicate names fail startup (no first-match-wins).
+        assert!(manifest_from(
+            r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"t","tool_digest":"sha256:a"},{"name":"t","tool_digest":"sha256:b"}]}"#
         )
         .is_err());
     }

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -45,7 +45,8 @@ const PROXY_FAILED: i32 = -32041;
 // PROXY_DENIED: a P61e enforcing-mode policy denial. The `reason` is the precedence-pinned gate that
 // fired (unclassified_tool_call / classification_incomplete / no_declared_allowance /
 // credential_scope_insufficient / credential_scope_unknown / manifest_baseline_missing /
-// manifest_current_observation_incomplete / manifest_drifted_since_approval).
+// manifest_current_observation_incomplete / manifest_observation_ambiguous /
+// manifest_drifted_since_approval).
 const PROXY_DENIED: i32 = -32042;
 
 const HEALTH_SCHEMA: &str = "assay.proxy_observation_health.v0";
@@ -91,6 +92,11 @@ struct Observer {
     outstanding_cursor: bool,
     op_active: bool,
     latest_complete: Option<Vec<Value>>,
+    /// True once a `tools/list_changed` is observed AFTER `latest_complete` was set, until a fresh
+    /// complete chain replaces it. The enforcing drift gate (P61e-c3) must not authorize against a
+    /// stale manifest: a post-approval `tools/list_changed` is exactly the rug-pull signal, so the
+    /// current complete observation is invalidated until a fresh complete `tools/list` is observed.
+    complete_superseded_by_change: bool,
     /// Most recent non-complete accumulation and its kind ("partial" | "unknown").
     best_incomplete: Option<(Vec<Value>, &'static str)>,
     observed_list_operations: u64,
@@ -189,6 +195,8 @@ impl Observer {
         self.op_active = false;
         if self.chain_started {
             self.latest_complete = Some(self.acc.clone());
+            // A fresh complete observation supersedes any prior list_changed invalidation.
+            self.complete_superseded_by_change = false;
             true
         } else {
             self.best_incomplete = Some((self.acc.clone(), "unknown"));
@@ -201,22 +209,35 @@ impl Observer {
 
     fn on_list_changed(&mut self) {
         self.tools_list_changed_observed = true;
+        // Invalidate the current complete observation for the enforcing drift gate: the surface may
+        // have mutated, so a stale digest must not authorize a privileged call until re-observed.
+        self.complete_superseded_by_change = true;
     }
 
     /// The current observed per-tool `tool_digest` for `tool_name`, from the latest COMPLETE observed
-    /// manifest (P61c). Read-only. Used by the enforcing drift gate (P61e-c3): no complete manifest
-    /// observed this session, or the tool absent from a complete manifest, are both fail-closed (the
-    /// gate cannot establish a current digest), never an allow.
+    /// manifest (P61c). Read-only. Used by the enforcing drift gate (P61e-c3); every non-`Present`
+    /// outcome is fail-closed (the gate cannot establish a current digest), never an allow:
+    /// - no complete manifest observed, OR one invalidated by a later `tools/list_changed` -> NoCompleteManifest;
+    /// - a duplicate-name (ambiguous) observed manifest -> Ambiguous (the observation is inconclusive,
+    ///   per the manifest-drift contract — never pick one of the colliding digests);
+    /// - the tool absent from an otherwise-clean complete manifest -> CompleteButToolAbsent.
     fn observed_tool_digest(&self, tool_name: &str) -> enforce::ObservedToolDigest {
+        // A post-approval list_changed invalidates the current complete view until it is re-observed.
         let tools = match &self.latest_complete {
-            Some(t) => t,
-            None => return enforce::ObservedToolDigest::NoCompleteManifest,
+            Some(t) if !self.complete_superseded_by_change => t,
+            _ => return enforce::ObservedToolDigest::NoCompleteManifest,
         };
         let server = self
             .server_id
             .clone()
             .unwrap_or_else(|| "upstream".to_string());
         let manifest = manifest_observed::build_observed(&server, tools, Completeness::Complete);
+        // A duplicate-name manifest is `status: ambiguous` (manifest_digest withheld): the observation
+        // is inconclusive, so the drift gate must deny rather than pick one of the colliding per-tool
+        // digests. See docs/reference/mcp-manifest-drift.md.
+        if manifest["status"].as_str() != Some("observed") {
+            return enforce::ObservedToolDigest::Ambiguous;
+        }
         if let Some(arr) = manifest["observed"]["tool_digests"].as_array() {
             for e in arr {
                 if e.get("name").and_then(|n| n.as_str()) == Some(tool_name) {
@@ -652,5 +673,82 @@ async fn degraded_loop(reason: &str) {
                 let _ = out.flush().await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn tool(name: &str) -> Value {
+        json!({"name": name, "description": "d", "inputSchema": {"type": "object"}})
+    }
+
+    /// Drive a single complete cursorless tools/list (request + terminal response) into the observer.
+    fn observe_complete(obs: &mut Observer, id: i64, tools: Vec<Value>) {
+        let idv = json!(id);
+        obs.on_client_tools_list(Some(&idv), false);
+        let _ = obs.on_upstream_response(&json!({"id": id, "result": {"tools": tools}}));
+    }
+
+    #[test]
+    fn observed_digest_none_when_no_complete_manifest() {
+        let obs = Observer::default();
+        assert!(matches!(
+            obs.observed_tool_digest("github.add_deploy_key"),
+            enforce::ObservedToolDigest::NoCompleteManifest
+        ));
+    }
+
+    #[test]
+    fn observed_digest_present_then_invalidated_by_list_changed_then_restored() {
+        let mut obs = Observer::default();
+        observe_complete(&mut obs, 2, vec![tool("github.add_deploy_key")]);
+        assert!(matches!(
+            obs.observed_tool_digest("github.add_deploy_key"),
+            enforce::ObservedToolDigest::Present(_)
+        ));
+
+        // A post-approval tools/list_changed invalidates the current complete observation: the drift
+        // gate must NOT authorize against the prior (possibly rug-pulled) manifest until re-observed.
+        obs.on_list_changed();
+        assert!(
+            matches!(
+                obs.observed_tool_digest("github.add_deploy_key"),
+                enforce::ObservedToolDigest::NoCompleteManifest
+            ),
+            "stale-after-change must not authorize against the prior manifest"
+        );
+
+        // A fresh complete observation restores a usable current digest.
+        observe_complete(&mut obs, 4, vec![tool("github.add_deploy_key")]);
+        assert!(matches!(
+            obs.observed_tool_digest("github.add_deploy_key"),
+            enforce::ObservedToolDigest::Present(_)
+        ));
+    }
+
+    #[test]
+    fn observed_digest_ambiguous_on_duplicate_tool_names() {
+        let mut obs = Observer::default();
+        observe_complete(&mut obs, 2, vec![tool("dup"), tool("dup")]);
+        assert!(
+            matches!(
+                obs.observed_tool_digest("dup"),
+                enforce::ObservedToolDigest::Ambiguous
+            ),
+            "a duplicate-name observed manifest is inconclusive -> Ambiguous, never a picked digest"
+        );
+    }
+
+    #[test]
+    fn observed_digest_tool_absent_is_complete_but_tool_absent() {
+        let mut obs = Observer::default();
+        observe_complete(&mut obs, 2, vec![tool("search")]);
+        assert!(matches!(
+            obs.observed_tool_digest("github.add_deploy_key"),
+            enforce::ObservedToolDigest::CompleteButToolAbsent
+        ));
     }
 }

--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -161,8 +161,8 @@ unknown_caller                          classification_incomplete
 unclassified_tool_call                  no_declared_allowance
 credential_scope_insufficient           credential_scope_unknown
 manifest_baseline_missing               manifest_current_observation_incomplete
-manifest_drifted_since_approval         policy_unavailable
-policy_error
+manifest_observation_ambiguous          manifest_drifted_since_approval
+policy_unavailable                      policy_error
 ```
 A denied call never reaches the upstream. `credential_scope_unknown` is distinct from
 `credential_scope_insufficient`: when coverage cannot be determined the denial reason is *unknown*, not
@@ -217,6 +217,18 @@ The drift gate needs **both** of two evidence inputs, and is fail-closed without
   `tools/list` (P61c). If the session has no complete current observation, or the invoked tool is absent
   from a complete one, the drift state is `proxy_denied` (`manifest_current_observation_incomplete`),
   because you cannot compare against a baseline without a current complete view of that tool.
+
+Two observation-integrity rules close the rug-pull window (both fail-closed):
+- **a post-approval `tools/list_changed` invalidates the current complete observation** — the surface
+  may have mutated, which is exactly the rug-pull signal, so the proxy will not authorize against the
+  prior manifest until a fresh complete `tools/list` is re-observed
+  (`manifest_current_observation_incomplete` until then). Observing a clean manifest then receiving a
+  `list_changed` must never leave a stale digest authorizing a privileged call;
+- **a duplicate-name (ambiguous) observed manifest is inconclusive** — when the observed `tools/list`
+  has colliding tool names the manifest is `status: ambiguous` (its `manifest_digest` is withheld; see
+  [mcp-manifest-drift.md](mcp-manifest-drift.md)), so the gate denies `manifest_observation_ambiguous`
+  rather than pick one of the colliding per-tool digests. Likewise, **a duplicate-name declared baseline
+  fails startup** (an approval baseline must be unambiguous — no first-match-wins).
 
 The comparison is the per-tool `tool_digest`, looked up by tool name in both the baseline and the
 current observed manifest (the same canonical P60 projection on both sides; server id is not part of the


### PR DESCRIPTION
Follow-up to the Codex review on #1635 — two **P1** and one **P2**, all closing holes in the c3 drift gate's rug-pull boundary. These matter because the drift gate's whole purpose is to refuse a call to a tool that changed since approval; the gaps let a changed/ambiguous surface slip through.

### [P1] Stale manifest after `tools/list_changed`
The Observer recorded `notifications/tools/list_changed` but the drift gate still authorized against the previous `latest_complete` manifest. So **observe-clean → `list_changed` → a privileged call could still be allowed against a stale digest** — the exact rug-pull the gate exists to stop. Fix: a post-approval `tools/list_changed` now **invalidates the current complete observation** (`complete_superseded_by_change`) until a fresh complete `tools/list` is re-observed → `manifest_current_observation_incomplete` until then.

### [P1] Ambiguous observed manifest
`observed_tool_digest` ignored `status: ambiguous` and returned the first matching per-tool digest, so a duplicate-name (inconclusive) manifest could authorize. Fix: a non-`observed` status → `ObservedToolDigest::Ambiguous` → deny with a distinct reason **`manifest_observation_ambiguous`**, never picking one of the colliding digests (consistent with the manifest-drift contract).

### [P2] Duplicate declared baseline names
`load_declared_manifest` validated tools individually but allowed duplicate `tools[].name` with first-match-wins. Fix: duplicate names now **fail startup** — an approval baseline must be unambiguous.

### Tests
- New deterministic **Observer unit tests** (`proxy/mod.rs`): present → invalidated-by-`list_changed` → restored; ambiguous-on-duplicate-names; tool-absent; no-complete-manifest.
- `enforce.rs`: `ambiguous → manifest_observation_ambiguous` deny + duplicate-baseline-fail-load.
- The stale-invalidation is **unit-proven rather than e2e** on purpose: a trailing `list_changed` emitted by a subprocess races the client's next call, so a subprocess test would be flaky; the Observer unit test exercises the exact ordering deterministically.
- Full `assay-mcp-server` suite green; clippy `-D warnings` clean. Spec doc updated (§7 pinned reasons, §9 observation-integrity rules).

Part of #1624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)