### PR TITLE
docs: add assay CI contract

### DIFF
--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -1,0 +1,400 @@
+# CI Contract: Rul1an/assay
+
+Draft status: review contract before workflow implementation.
+
+`Rul1an/assay` is the public source, release, evidence, runner, and MCP proxy
+repository for Assay. Its CI contract must protect three things at once:
+
+- ordinary Rust, Python, docs, and action quality;
+- release and provenance integrity for crates, PyPI, binaries, and generated
+  artifacts;
+- evidence-honesty boundaries around runtime observation, MCP proxy enforcement,
+  receipts, Trust Basis output, and public docs.
+
+This contract is a diff from today's repository state. The first rule is no
+required-coverage regressions: existing useful gates should stay required or
+visible unless this file is updated with a clear replacement.
+
+## 0. As-Is Inventory
+
+Repository state observed on 2026-06-11:
+
+- Visibility: public.
+- Default branch: `main`.
+- Primary languages: Rust, Python, TypeScript/JavaScript, shell.
+- Rust workspace root: `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`.
+- Core CI workflows:
+  - `.github/workflows/ci.yml` (`CI`)
+  - `.github/workflows/kernel-matrix.yml` (`Kernel Matrix CI`)
+  - `.github/workflows/runner-health.yml` (`Runner Health`)
+  - `.github/workflows/smoke-install.yml` (`Smoke Install (E2E)`)
+  - `.github/workflows/parity.yml` (`Parity Tests`)
+  - `.github/workflows/assay-security.yml` (`MCP Security (Assay)`)
+  - `.github/workflows/workflow-security.yml` (`Workflow Security (zizmor)`)
+  - `.github/workflows/assay-runner-lane-check.yml`
+    (`Assay-Runner Lane Check`)
+  - `.github/workflows/split-wave0-gates.yml` (`Split Wave 0 Gates`)
+- Experiment, docs, perf, and nightly workflows exist separately and should not
+  be promoted into required PR cost by default.
+- Release workflow: `.github/workflows/release.yml`, with binary builds,
+  release creation, SBOM generation, build provenance attestation, crates.io
+  publish through trusted publishing, and PyPI publish through trusted
+  publishing.
+- Existing posture already present:
+  - workflow-level `permissions: {}` in several high-value workflows;
+  - explicit per-job permissions;
+  - widespread `persist-credentials: false`;
+  - third-party actions mostly pinned by commit SHA with version comments;
+  - CODEOWNERS for workflows, release, `assay-action/`, `infra/`, and security
+    policy/config paths;
+  - Dependabot for GitHub Actions, Cargo, and the Python SDK;
+  - actionlint configuration for the self-hosted runner labels;
+  - CI scope detection with internal skip decisions instead of broad trigger
+    skips;
+  - kernel/eBPF gating that avoids self-hosted runner work unless relevant;
+  - delegated runner lane proof for selected runner-sensitive PRs.
+- Existing required-branch-protection guidance in
+  `docs/BRANCH-PROTECTION-SETUP.md` recommends `CI` as the minimal required
+  status check, with other checks visible and reviewed when relevant.
+- Existing public docs and evidence artifacts include guides, references,
+  receipt schemas, MCP proxy docs, runner fixtures, experiment reports, JUnit,
+  SARIF, Trust Basis output, and compressed evidence examples.
+
+No target workflow should downgrade this inventory unless the contract is
+updated with an explicit rationale.
+
+## 1. Required PR Checks
+
+Required PR checks must be cheap enough to stay reliable, broad enough to catch
+cross-crate drift, and honest about what they do not observe. Do not make a
+required check path-filter out of existence at the workflow trigger. If a check
+is required by branch protection, the workflow should start and skip heavy work
+inside jobs with an explicit summary.
+
+### CI
+
+Keep `CI` as the universal merge gate unless branch protection is intentionally
+changed. It should continue to cover:
+
+- dependency security through `cargo-deny` and `cargo-audit`;
+- clippy with warnings denied;
+- public/private boundary vocabulary guard;
+- publish-shape guardrails for public crates;
+- vendored pack sync;
+- MCP registry/package checks;
+- TypeScript checks where action or package surfaces are involved;
+- performance sentinel behavior that is explicitly bounded and summarized;
+- workspace tests across Linux/macOS/Windows with the current exclusions and
+  feature-aware commands;
+- eBPF smoke only when relevant paths require it.
+
+Do not collapse public crate policy, publish-shape, registry, or boundary guards
+into release-only checks. Their value is catching tag-time failures before a tag
+exists.
+
+### Workflow And Action Security
+
+Keep workflow security visible on workflow/action/dependabot changes and weekly
+drift. Add or confirm in implementation PRs:
+
+- `actionlint` for every workflow file.
+- `shellcheck` for workflow shell blocks and helper scripts that are executed
+  by workflows.
+- `zizmor` stays pinned and runs in trusted contexts that can upload SARIF
+  safely.
+- Every job has `timeout-minutes`, including docs, demo, perf, and nightly
+  workflows.
+- Workflow-level default remains `permissions: {}` where possible; jobs request
+  only the permissions they need.
+- `contents: write`, `actions: write`, `security-events: write`,
+  `id-token: write`, and `attestations: write` are treated as high-trust
+  permissions and require a short comment or environment boundary.
+- `pull_request_target` remains absent unless a future PR adds a dedicated
+  threat model and never checks out untrusted head code before trust decisions.
+
+Action pinning contract:
+
+- High-trust actions that can affect release artifacts, provenance, SBOM,
+  security-tab output, dependency update PRs, or workflow-generated commits
+  must use commit-SHA pins with version comments.
+- Ordinary setup/check actions should also stay SHA-pinned where practical.
+- Owned floating major tags are acceptable only for self-test or compatibility
+  checks that do not publish, attest, release, or write repository state.
+
+### Runner And Kernel Gates
+
+Keep the runner-sensitive lanes separate from ordinary PR cost:
+
+- `Kernel Matrix CI` should remain visible for kernel/eBPF/monitor/evidence
+  paths and use explicit internal skip summaries when not applicable.
+- Self-hosted runner jobs must not run on untrusted fork code.
+- The delegated runner lane proof remains the escalation mechanism for PRs that
+  need privileged runner evidence before merge.
+- `Runner Health` stays scheduled/manual and should not become a required PR
+  check.
+- Any queue-management workflow with `actions: write` must stay scheduled/manual
+  or otherwise restricted to trusted events.
+
+Do not make eBPF, LSM, or host-capability tests imply live provider verification
+or Trust Basis truth. They prove the local runner capability and observed
+effects for their specific run boundary only.
+
+### Public Artifact Sanitization Guard
+
+Add a required fail-closed public-artifact sanitization check for the whole
+repository, excluding only generated, vendored, build, dependency, and cache
+output explicitly allowlisted by the implementation. This is a public repo; any
+source file, fixture, doc, test, code comment, sample, workflow, generated
+example, or release note can leak public text.
+
+Hard rule:
+
+- The sensitive vocabulary list must not be present in this public repository
+  and must not be printed in CI logs.
+
+Acceptable implementation patterns:
+
+- Compare normalized tokens or n-grams against hashed entries supplied from a
+  private source.
+- Run plaintext sensitive-list checks only in trusted private contexts where
+  logs are not public and untrusted PR code cannot read the list.
+- On fork PRs, run only the public-safe structural portion.
+
+Required-gate split:
+
+- The public-safe structural portion is required on every PR, including forks.
+- The full hashed-denylist comparison runs only for trusted same-repository PRs,
+  pushes, and scheduled checks that can access the private source safely.
+- A degraded fork run must say that private-list comparison was skipped without
+  exposing the list, while still enforcing structural public-artifact rules.
+
+Logging contract:
+
+- Report only counts and locations, for example `3 matches in README.md:42`.
+- Never print matched text.
+- Never print the sensitive term, phrase, or unhashed denylist entry.
+- Treat printing the matched term as a CI bug and a sanitization failure.
+
+The guard is a backstop, not a guarantee. Human public-artifact review remains
+primary because fixed matchers miss variants, spacing, morphology, and context.
+
+### Claims And Evidence Boundary Guard
+
+Add or keep a lightweight required check for public wording in changed docs,
+examples, schemas, release notes, and generated public artifacts.
+
+Claims should:
+
+- name the artifact, event, fixture, or observation shape being checked;
+- distinguish producer, consumer, verifier, conformance, and release lanes;
+- state whether a check is informational, blocking, deny-only, or forwarding;
+- state degradation/non-claim when evidence cannot support a stronger statement.
+
+Docs and examples must not imply that Assay:
+
+- verifies live provider behavior unless a run actually observes it;
+- turns local runner support into global Trust Basis truth;
+- treats a received receipt as trusted without signature/key/anchor context;
+- treats keyless conformance as issuer trust;
+- treats MCP proxy deny-only modes as allow/forwarding enforcement;
+- treats declared manifests as provider-verified grants;
+- treats OTel/SARIF/JUnit projections as durable evidence records.
+
+For MCP proxy enforcement specifically:
+
+- manifest-observation mode observes `tools/list` and must not forward
+  `tools/call`;
+- deny-only enforcing modes must keep `tools/call` fail-closed until the
+  explicit allow/forward path exists;
+- credential-scope gates are operator configuration unless a later PR adds
+  provider-verified grant evidence;
+- every forwarding-mode PR needs confused-deputy, drift, caller identity,
+  credential scope, and declared/current-manifest gates in the PR description.
+
+## 2. Scheduled Checks
+
+Scheduled checks are for drift, ecosystem security, and lower-frequency
+confidence. They should not become required PR checks unless their failure mode
+is cheap, stable, and actionable.
+
+Keep or add:
+
+- weekly workflow security drift (`zizmor`);
+- OpenSSF Scorecard;
+- OSV-Scanner for Rust, Python, JavaScript, and GitHub Actions dependency
+  surfaces;
+- CodeQL/default code scanning for Rust-adjacent glue where available, Python,
+  JavaScript/TypeScript, shell, and workflow files;
+- ClusterFuzzLite only for small deterministic parsers/canonicalizers and
+  evidence-reference surfaces, with bounded corpora and timeouts;
+- dependency-review or equivalent for PR dependency deltas where GitHub Advanced
+  Security is available;
+- scheduled release-smoke rehearsal that does not publish;
+- scheduled MCP proxy fixture replay with no live providers;
+- scheduled public-artifact sanitization trusted run with the full private
+  hashed source;
+- scheduled stale evidence-artifact inventory for compressed fixtures, large
+  generated docs assets, and run output.
+
+Do not schedule by default:
+
+- live model/provider runs;
+- broad OS/feature matrices without a measured failure class;
+- privileged self-hosted runner jobs that can be replaced by a manual delegated
+  proof;
+- network-dependent smoke tests that cannot distinguish dependency outage from
+  regression.
+
+## 3. Release-Only Checks
+
+Release checks protect artifacts, publication, and provenance. Keep them stricter
+than ordinary PR checks.
+
+Keep:
+
+- tag/manual release version validation;
+- cross-platform binary builds and checksums;
+- MCP server binary builds;
+- SBOM generation;
+- build provenance attestation;
+- crates.io trusted publishing;
+- PyPI trusted publishing;
+- environment protection for release, crates, and PyPI publication;
+- release notes and public docs boundary checks before publishing;
+- post-release smoke/install validation.
+
+Add or confirm:
+
+- release artifact manifest verifies every uploaded archive, checksum, SBOM, and
+  attestation subject.
+- `gh release` calls use explicit file lists, not broad globs that can pick up
+  stale artifacts.
+- release jobs do not reuse untrusted PR artifacts.
+- release dry-run/rehearsal remains non-publishing.
+- any release job with `id-token: write`, `attestations: write`, or
+  `contents: write` has a dedicated job boundary and environment gate.
+
+Current release boundary:
+
+- Attestations bind the workflow identity and release artifact subjects.
+- They do not prove runtime truth, live provider behavior, issuer trust for
+  external receipts, or correctness beyond the artifact and workflow boundary.
+
+## 4. Manual Checks
+
+Manual workflows are acceptable for checks that require judgement, elevated
+runtime cost, privileged runner state, or release rehearsal:
+
+- delegated runner proof;
+- host capability proof;
+- monitor attach smoke;
+- runner OTel experiments;
+- performance forensics;
+- ADR/nightly historical experiments;
+- release dry runs;
+- MCP proxy enforcement staging runs;
+- expanded fuzz/corpus runs.
+
+Manual workflow requirements:
+
+- Inputs must be single-line or structured-validated before use.
+- Downloaded release assets must be checksum-verified.
+- Any generated public artifact must pass sanitization and claims-boundary
+  checks before publication.
+- Manual runs must say whether their output is evidence, fixture, diagnostic
+  metadata, or operational telemetry.
+
+## 5. Non-Goals And Non-Claims
+
+Non-goals:
+
+- No live provider dependency in required PR checks.
+- No self-hosted runner dependency for ordinary PRs.
+- No broad matrix expansion without a measured failure class.
+- No path-filtered required check that can remain pending forever.
+- No release/publish authority in fork PRs.
+- No forwarding-mode MCP enforcement without explicit caller, credential,
+  manifest, drift, and confused-deputy gates.
+- No second evidence semantics layer outside the documented Assay artifact
+  contracts.
+
+Allowed language:
+
+- "Observed runtime evidence."
+- "Deny-only MCP proxy mode."
+- "Conformance check."
+- "Signature verification when signer/key context is supplied."
+- "Attestation over release artifact subjects."
+- "Operational telemetry."
+- "Projection to SARIF/JUnit/OTel."
+
+Disallowed without explicit boundary:
+
+- Claims that Assay verifies all provider behavior.
+- Claims that a local capability proof upgrades every future run.
+- Claims that a digest-only or keyless check proves issuer trust.
+- Claims that receipt arrival over an authorized channel is enough.
+- Claims that OTel/SARIF/JUnit output is the durable evidence record.
+- Claims that a deny-only proxy path forwards safely.
+- Claims that release attestation proves runtime behavior.
+
+The sanitization guard is separate from these claim-boundary rules. It protects
+private strategy vocabulary from appearing in public artifacts and must do so
+without reprinting protected vocabulary.
+
+## 6. Required Context Names
+
+Branch protection is enforced by exact check context names, not by this file.
+Before making any branch-protection changes:
+
+1. Open a draft PR that implements the workflows.
+2. Query the live check runs for that PR.
+3. Copy the exact check names into this section.
+4. Treat future job renames as breaking changes because they can silently
+   un-gate protected branches.
+
+Current documented minimal required context:
+
+- `CI`
+
+Context groups that should stay visible and reviewed when relevant:
+
+- `Workflow Security (zizmor)`
+- `MCP Security (Assay)`
+- `Kernel Matrix CI`
+- `Runner Health`
+- `Smoke Install (E2E)`
+- `Parity Tests`
+- `assay-action-contract-tests`
+- `Assay-Runner Lane Check`
+- `Split Wave 0 Gates`
+
+Do not require a workflow by branch protection if that workflow uses top-level
+path filters that can skip the run entirely. Either keep it advisory or make it
+always start and skip internally.
+
+Exact names for new sanitization, claims-boundary, Scorecard, OSV, CodeQL, or
+ClusterFuzzLite jobs: to be filled from live implementation PRs.
+
+## 7. Target Workflow Files
+
+Expected target workflow set:
+
+- `.github/workflows/ci.yml` kept and tightened, not removed.
+- `.github/workflows/workflow-security.yml` kept.
+- `.github/workflows/kernel-matrix.yml` kept with internal skip summaries.
+- `.github/workflows/assay-runner-lane-check.yml` kept.
+- `.github/workflows/release.yml` kept with high-trust release boundaries.
+- `.github/workflows/sanitize-public-artifacts.yml` for public artifact
+  sanitization, unless folded into `ci.yml`.
+- `.github/workflows/claims-boundary.yml` for public wording and non-claim
+  checks, unless folded into sanitization.
+- `.github/workflows/osv-scorecard.yml` for scheduled OSV/Scorecard if GitHub
+  default/security-tab coverage is not enough.
+- `.github/workflows/codeql.yml` only if GitHub default setup is not enabled or
+  cannot cover the relevant languages.
+- `.github/workflows/clusterfuzzlite.yml` only if bounded deterministic fuzz
+  targets are selected and reviewed.
+
+Implementation should happen in small follow-up PRs after this contract is
+reviewed.

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -53,9 +53,10 @@ Repository state observed on 2026-06-11:
     skips;
   - kernel/eBPF gating that avoids self-hosted runner work unless relevant;
   - delegated runner lane proof for selected runner-sensitive PRs.
-- Existing required-branch-protection guidance in
-  `docs/BRANCH-PROTECTION-SETUP.md` recommends `CI` as the minimal required
-  status check, with other checks visible and reviewed when relevant.
+- Live branch protection on `main`, observed through GitHub on 2026-06-11,
+  requires `CI`, `lane-check`, and `host-capability-check` with strict
+  up-to-date status checks enabled. `docs/BRANCH-PROTECTION-SETUP.md` should
+  stay reconciled with that live state.
 - Existing public docs and evidence artifacts include guides, references,
   receipt schemas, MCP proxy docs, runner fixtures, experiment reports, JUnit,
   SARIF, Trust Basis output, and compressed evidence examples.
@@ -177,6 +178,16 @@ Logging contract:
 
 The guard is a backstop, not a guarantee. Human public-artifact review remains
 primary because fixed matchers miss variants, spacing, morphology, and context.
+
+Relationship to the existing public/private boundary guard:
+
+- The existing CI boundary guard protects repository policy vocabulary and
+  product-boundary drift in source-visible surfaces.
+- The public-artifact sanitization guard is broader: it treats every
+  non-generated public file or emitted public artifact as a publication
+  candidate and prevents private vocabulary from leaving the repo boundary.
+- If both guards inspect the same file, either one may fail the PR; neither
+  should suppress or downgrade the other.
 
 ### Claims And Evidence Boundary Guard
 
@@ -353,9 +364,11 @@ Before making any branch-protection changes:
 4. Treat future job renames as breaking changes because they can silently
    un-gate protected branches.
 
-Current documented minimal required context:
+Currently required live branch-protection contexts:
 
 - `CI`
+- `lane-check`
+- `host-capability-check`
 
 Context groups that should stay visible and reviewed when relevant:
 
@@ -366,7 +379,6 @@ Context groups that should stay visible and reviewed when relevant:
 - `Smoke Install (E2E)`
 - `Parity Tests`
 - `assay-action-contract-tests`
-- `Assay-Runner Lane Check`
 - `Split Wave 0 Gates`
 
 Do not require a workflow by branch protection if that workflow uses top-level

--- a/docs/BRANCH-PROTECTION-SETUP.md
+++ b/docs/BRANCH-PROTECTION-SETUP.md
@@ -1,6 +1,8 @@
 # Branch protection & ruleset (main) — setup
 
-Main is unprotected until you configure branch protection or a ruleset. This doc gives minimal SOTA 2026 settings and how to apply them (UI or `gh` CLI).
+Main is protected by branch protection/ruleset settings. This doc records the
+current required status checks and gives minimal SOTA 2026 settings for keeping
+that protection in sync (UI or `gh` CLI).
 
 **Why:** Without protection, anyone with push access can push directly to `main`, bypassing CI, reviews, and status checks.
 
@@ -10,7 +12,10 @@ Main is unprotected until you configure branch protection or a ruleset. This doc
 
 - **Require a pull request** before merging (no direct pushes to main).
 - **Required approvals:** at least 1–2.
-- **Required status checks:** CI only (see "Required checks: when each is needed" for rationale; optional: Smoke Install, assay-action-contract-tests, MCP Security, Kernel Matrix).
+- **Required status checks:** `CI`, `lane-check`, and `host-capability-check`
+  (observed live on 2026-06-11). See "Required checks: when each is needed" for
+  rationale; optional: Smoke Install, assay-action-contract-tests, MCP Security,
+  Kernel Matrix.
 - **Require branch to be up to date** before merging.
 - **Restrict force-push and branch deletion** (do not allow force-push to main; restrict who can delete the branch).
 
@@ -34,7 +39,10 @@ Ensure `.github/CODEOWNERS` exists and lists the right owners (see repo root).
 4. Enable:
    - Require a pull request before merging.
    - Require approvals (set number, e.g. 1).
-   - Require status checks: add `CI`, `Smoke Install (E2E)`, `assay-action-contract-tests` (or the exact job names your workflows expose; check **Settings → Branches → Branch protection** or the Ruleset UI for the list of available checks).
+   - Require status checks: add `CI`, `lane-check`, and
+     `host-capability-check` (or the exact job names your workflows expose;
+     check **Settings → Branches → Branch protection** or the Ruleset UI for the
+     list of available checks).
    - Require branches to be up to date before merging.
    - Do not allow force pushes / restrict force pushes.
    - Restrict who can push to matching branches (optional; or leave as default).
@@ -49,6 +57,8 @@ Ensure `.github/CODEOWNERS` exists and lists the right owners (see repo root).
 | Context | Workflow file |
 |---------|----------------|
 | `CI` | `.github/workflows/ci.yml` |
+| `lane-check` | `.github/workflows/assay-runner-lane-check.yml` |
+| `host-capability-check` | `.github/workflows/host-capability-check.yml` |
 | `Smoke Install (E2E)` | `.github/workflows/smoke-install.yml` |
 | `assay-action-contract-tests` | `.github/workflows/action-tests.yml` |
 | `MCP Security (Assay)` | `.github/workflows/assay-security.yml` |
@@ -64,12 +74,21 @@ Use **`CI`** (not `CIExpected` or any other variant). No workflow in this repo r
 | Check | What it does | **Dependabot / deps-only PRs** | **Other PRs (features, workflows, action)** |
 |-------|----------------|---------------------------------|---------------------------------------------|
 | **CI** | Build, test, clippy, cargo-deny, cargo-audit, eBPF smoke | **Essential** — new deps must not break build or tests. | **Essential** — same. |
+| **lane-check** | Confirms runner-sensitive PRs have the delegated proof required by the lane classifier. | Required but normally quick/no-op unless the classifier says proof is needed. | Required; becomes load-bearing for runner/evidence-sensitive changes. |
+| **host-capability-check** | Confirms whether the PR requires host-capability proof before privileged runner evidence is trusted. | Required but normally quick/no-op for ordinary dependency updates. | Required; becomes load-bearing for host/kernel/runner capability-sensitive changes. |
 | **Smoke Install (E2E)** | Build from source, run assay, JUnit | Redundant with CI (CI already builds and tests). | Useful — verifies install path. |
 | **assay-action-contract-tests** | Tests GitHub Action in `assay-action/` | Not needed — Cargo.toml/Cargo.lock don't touch the action. | **Essential** if PR touches `assay-action/` or workflows. |
 | **MCP Security (Assay)** | Install assay, run validate with demo config | Redundant with CI for deps-only (CI validates the binary). | Useful — sanity check for security workflow. |
 | **Kernel Matrix CI** | eBPF tests on self-hosted runner | Not needed — kernel-matrix `paths` exclude Cargo.toml/Cargo.lock. | **Essential** if PR touches eBPF/Monitor/evidence. |
 
-**Recommendation:** Require **only CI** for merging. That is enough for Dependabot (deps-only) PRs and keeps the gate meaningful for all PRs. Smoke Install, assay-action-contract-tests, and MCP Security still run and appear on the PR; they are not required to merge. If you merge changes to `assay-action/` or workflows, ensure contract tests and MCP Security have passed before merging (e.g. via review policy or by re-adding them to required checks when needed).
+**Current recommendation:** Keep **`CI`, `lane-check`, and
+`host-capability-check`** required. `CI` is the universal build/security gate;
+`lane-check` and `host-capability-check` are quick for ordinary PRs but preserve
+the runner/evidence proof boundary when a PR touches sensitive paths. Smoke
+Install, assay-action-contract-tests, and MCP Security still run and appear on
+the PR; they are not required to merge. If you merge changes to `assay-action/`
+or workflows, ensure contract tests and MCP Security have passed before merging
+(e.g. via review policy or by re-adding them to required checks when needed).
 
 ---
 
@@ -88,7 +107,7 @@ gh api repos/OWNER/REPO/branches/main/protection -X PUT \
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["CI"]
+    "contexts": ["CI", "lane-check", "host-capability-check"]
   },
   "enforce_admins": false,
   "required_pull_request_reviews": {
@@ -103,7 +122,10 @@ gh api repos/OWNER/REPO/branches/main/protection -X PUT \
 JSON
 ```
 
-Use `required_approving_review_count: 2` in the JSON if you want two approvals. The listed contexts match this repo’s workflows (CI, Smoke Install, action tests, MCP Security); add e.g. `Kernel Matrix CI` if eBPF checks must be required.
+Use `required_approving_review_count: 2` in the JSON if you want two approvals.
+The listed contexts match the currently required live protection. Add e.g.
+`Kernel Matrix CI`, `Smoke Install (E2E)`, action tests, or MCP Security only if
+those checks must become required rather than visible/advisory.
 
 To **inspect** current protection:
 
@@ -137,7 +159,10 @@ See `docs/REVIEWER-PACK.md` (sectie 3, “Environments & approvals”) and the c
 ## Checklist
 
 - [x] Branch protection or ruleset on `main` with: require PR, approvals, status checks, up to date, no force-push.
-- [x] Required status checks: CI only (see "Required checks: when each is needed" above; add Smoke Install / contract tests / MCP Security / Kernel Matrix when stricter gate needed).
+- [x] Required status checks: `CI`, `lane-check`, and
+  `host-capability-check` (see "Required checks: when each is needed" above;
+  add Smoke Install / contract tests / MCP Security / Kernel Matrix only when
+  stricter gates are intentionally needed).
 - [x] CODEOWNERS in place; “Require review from Code Owners” enabled.
 - [ ] Environments `release` / `crates` / `pypi` configured with required reviewers; release workflow uses `environment:` on publish jobs.
 
@@ -147,6 +172,13 @@ See `docs/REVIEWER-PACK.md` (sectie 3, “Environments & approvals”) and the c
 
 If a PR shows a required check **CIExpected** that never completes, branch protection is requiring a context that no workflow reports.
 
-**Fix:** In **Settings → Branches → Branch protection rule for `main`**, under "Require status checks", remove **CIExpected** and add **CI** (from `.github/workflows/ci.yml`). Save.
+**Fix:** In **Settings → Branches → Branch protection rule for `main`**, under
+"Require status checks", remove **CIExpected** and add **CI** (from
+`.github/workflows/ci.yml`) plus the current required live contexts
+`lane-check` and `host-capability-check`. Save.
 
-**Via API:** Inspect with `gh api repos/OWNER/REPO/branches/main/protection`. Ensure `required_status_checks.contexts` contains `"CI"` and not `"CIExpected"`. Re-apply using the JSON in Option B above with `"contexts": ["CI"]`.
+**Via API:** Inspect with `gh api repos/OWNER/REPO/branches/main/protection`.
+Ensure `required_status_checks.contexts` contains `CI`, `lane-check`, and
+`host-capability-check`, and does not contain `CIExpected`. Re-apply using the
+JSON in Option B above with
+`"contexts": ["CI", "lane-check", "host-capability-check"]`.


### PR DESCRIPTION
## Summary

Adds a review-first `CI-CONTRACT.md` for `Rul1an/assay` before changing workflows.

The contract captures the current CI posture and sets rules for future hardening around:

- required-check safety and path-filter behavior
- release/provenance and high-trust permissions
- runner/kernel/self-hosted boundaries
- public artifact sanitization
- claims and evidence-boundary wording
- scheduled OSV/Scorecard/CodeQL/ClusterFuzzLite candidates
- MCP proxy enforcement boundaries

## Scope

Docs only. No workflow behavior changes in this PR.

## Validation

- Local contract sanity check for required sections and forbidden public strategy terms
- pre-commit during commit and push:
  - merge conflict check
  - YAML/TOML skips where irrelevant
  - EOF/trailing whitespace
  - MCP registry local token hygiene
  - typos
  - workflow/actionlint and shellcheck skipped because no workflow files changed
  - cargo fmt
  - cargo deny/audit skipped where path filters did not apply
  - cargo clippy and linux compile gate passed on push hook
