### PR TITLE
feat(mcp): enforcement_decision.v0 per-call evidence record (P61e-d)

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -64,6 +64,12 @@ enum Mode {
         /// in enforcing mode; a missing/unreadable/malformed/wrong-schema baseline is a startup failure.
         #[arg(long)]
         declared_mcp_manifest: PathBuf,
+        /// Optional NDJSON path for the per-call `assay.enforcement_decision.v0` evidence record
+        /// (P61e-d): one record per `tools/call` decision. The record is a policy decision only and
+        /// never asserts the upstream side effect. An allowed call whose record cannot be written
+        /// fails closed (it is not forwarded).
+        #[arg(long)]
+        enforcement_decision_out: Option<PathBuf>,
     },
 }
 
@@ -108,8 +114,7 @@ async fn main() -> Result<()> {
                 upstream_command,
                 upstream_args,
                 proxy::Mode::Observe,
-                None,
-                None,
+                proxy::enforce::EnforceInputs::default(),
                 mcp_manifest_observed_out,
                 proxy_observation_health_out,
             )
@@ -120,6 +125,7 @@ async fn main() -> Result<()> {
             upstream_args,
             enforce_policy,
             declared_mcp_manifest,
+            enforcement_decision_out,
         }) => {
             // Load + validate BOTH inputs BEFORE starting the proxy. A bad policy or baseline is a
             // misconfigured service: fail startup with a non-zero exit, never start an enforcing proxy
@@ -137,8 +143,11 @@ async fn main() -> Result<()> {
                 upstream_command,
                 upstream_args,
                 proxy::Mode::Enforce,
-                Some(policy),
-                Some(baseline),
+                proxy::enforce::EnforceInputs {
+                    policy: Some(policy),
+                    baseline: Some(baseline),
+                    decision_out: enforcement_decision_out,
+                },
                 None,
                 None,
             )

--- a/crates/assay-mcp-server/src/proxy/enforce.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce.rs
@@ -15,10 +15,20 @@
 use anyhow::{bail, Context, Result};
 use assay_core::mcp::jcs;
 use assay_mcp_server::cache::sha256_hex;
-use assay_mcp_server::tool_decision::{classify, required_scope_for};
+use assay_mcp_server::tool_decision::{classify, required_scope_for, sanitize};
 use serde::Deserialize;
-use serde_json::Value;
-use std::path::Path;
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+
+/// The enforce-mode inputs to the proxy, grouped so `run` stays within a sane arity. All fields are
+/// absent in observe mode; `policy` and `baseline` are always present in enforce mode (loaded at
+/// startup) and `decision_out` is the optional P61e-d evidence path.
+#[derive(Default)]
+pub struct EnforceInputs {
+    pub policy: Option<EnforcePolicy>,
+    pub baseline: Option<DeclaredManifest>,
+    pub decision_out: Option<PathBuf>,
+}
 
 #[derive(Debug, Deserialize)]
 pub struct EnforcePolicy {
@@ -300,6 +310,71 @@ pub fn decide(
         action_class: Some(action_class.to_string()),
         target_digest: Some(tdig),
     }
+}
+
+/// The drift-gate state for the evidence record, derived from the decision (so `decide` stays
+/// unchanged). `satisfied` on allow; the specific drift reason when the drift gate denied;
+/// `not_evaluated` when an earlier gate denied before the drift gate ran.
+fn drift_state(decision: &Decision) -> &'static str {
+    if decision.allow {
+        return "satisfied";
+    }
+    match decision.reason {
+        "manifest_baseline_missing" => "baseline_missing",
+        "manifest_current_observation_incomplete" => "current_observation_incomplete",
+        "manifest_observation_ambiguous" => "observation_ambiguous",
+        "manifest_drifted_since_approval" => "drifted",
+        _ => "not_evaluated",
+    }
+}
+
+/// Build the per-call `assay.enforcement_decision.v0` evidence record (P61e-d). Emitted by the
+/// enforcing path for BOTH allow and deny; deterministic (no timestamp). It records the policy
+/// decision only — it never asserts or verifies the upstream side effect (which stays `asserted` on
+/// the E9 ladder). The credential is referenced by alias, never by value, and the projected target
+/// carries only the classifier's allowlisted fields (sensitive ids already hashed). This is NOT the
+/// observation artifact (`assay.mcp_manifest_observed.v0`) nor the mechanism artifact
+/// (`assay.enforcement_health.v0`); the three carriers stay separate.
+pub fn decision_record(
+    policy: &EnforcePolicy,
+    decision: &Decision,
+    tool_name: &str,
+    args: &Value,
+) -> Value {
+    let c = classify(tool_name, args);
+    json!({
+        "schema": "assay.enforcement_decision.v0",
+        "caller": { "id": sanitize(&policy.caller.id) },
+        "tool": {
+            "name": sanitize(tool_name),
+            "action_class": decision.action_class,
+        },
+        "action": {
+            "verb": c.verb,
+            "resource_type": c.resource_type,
+            // Projected target: allowlisted fields only, sensitive ids hashed by the classifier.
+            "target": c.target,
+            "target_digest": decision.target_digest,
+        },
+        "decision": if decision.allow { "allow" } else { "deny" },
+        "reason": decision.reason,
+        // The PDP is fail-closed by construction: every deny is a fail-closed outcome.
+        "fail_closed": !decision.allow,
+        // Only an allowed call is forwarded to the upstream.
+        "forwarded": decision.allow,
+        "drift_state": drift_state(decision),
+        // Operator config reference only — never the token, never the declared scopes.
+        "credential_alias": policy
+            .upstream_credential
+            .as_ref()
+            .map(|c| sanitize(&c.alias)),
+        "non_claims": [
+            "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+            "credential referenced by alias only, never the token or declared scopes",
+            "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+            "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+    })
 }
 
 /// Coverage of a declared credential's scopes against an action's required scope.
@@ -838,5 +913,61 @@ allowances:
             r#"{"schema":"assay.declared_mcp_manifest.v0","tools":[{"name":"t","tool_digest":"sha256:a"},{"name":"t","tool_digest":"sha256:b"}]}"#
         )
         .is_err());
+    }
+
+    // --- P61e-d: enforcement_decision.v0 record ----------------------------------------------------
+
+    #[test]
+    fn decision_record_for_a_deny_is_shaped_and_leak_free() {
+        let p = policy_from(VALID).unwrap();
+        let d = decide_match(&p, "misc.do_thing", &json!({})); // unclassified -> deny
+        let rec = decision_record(&p, &d, "misc.do_thing", &json!({}));
+        assert_eq!(rec["schema"], "assay.enforcement_decision.v0");
+        assert_eq!(rec["decision"], "deny");
+        assert_eq!(rec["reason"], "unclassified_tool_call");
+        assert_eq!(rec["fail_closed"], true);
+        assert_eq!(rec["forwarded"], false);
+        assert_eq!(rec["drift_state"], "not_evaluated");
+        assert_eq!(rec["caller"]["id"], "ci-agent");
+        assert_eq!(rec["credential_alias"], "gh-deploy");
+        assert!(rec["non_claims"].is_array());
+        // The declared scopes are never serialized into the record (alias only).
+        let s = serde_json::to_string(&rec).unwrap();
+        assert!(
+            !s.contains("repo:deploy_key:write"),
+            "declared credential scopes must not leak into the decision record"
+        );
+    }
+
+    #[test]
+    fn decision_record_for_an_allow_marks_forwarded_and_drift_satisfied() {
+        let p = policy_from(VALID).unwrap();
+        let d = decide_match(&p, "github.add_deploy_key", &acme_call()); // matching -> allow
+        assert!(d.allow);
+        let rec = decision_record(&p, &d, "github.add_deploy_key", &acme_call());
+        assert_eq!(rec["decision"], "allow");
+        assert_eq!(rec["reason"], "allow");
+        assert_eq!(rec["fail_closed"], false);
+        assert_eq!(rec["forwarded"], true);
+        assert_eq!(rec["drift_state"], "satisfied");
+        assert_eq!(rec["tool"]["action_class"], "github_deploy_key");
+        assert_eq!(rec["action"]["target"]["owner"], "acme");
+    }
+
+    #[test]
+    fn decision_record_drift_state_reflects_the_drift_gate() {
+        let p = policy_from(VALID).unwrap();
+        let baseline = baseline_with(TOOL, APPROVED);
+        let d = decide(
+            &p,
+            &baseline,
+            &ObservedToolDigest::Present("sha256:something-else".to_string()),
+            "github.add_deploy_key",
+            &acme_call(),
+        );
+        assert_eq!(d.reason, "manifest_drifted_since_approval");
+        let rec = decision_record(&p, &d, "github.add_deploy_key", &acme_call());
+        assert_eq!(rec["decision"], "deny");
+        assert_eq!(rec["drift_state"], "drifted");
     }
 }

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -332,6 +332,21 @@ fn health_from(manifest: &Value, em: &Emission, obs: &Observer) -> Value {
     })
 }
 
+/// Append one `assay.enforcement_decision.v0` record as an NDJSON line (P61e-d). Per-call streaming,
+/// so a killed proxy still keeps the decisions recorded so far; the record is one compact JSON object
+/// per line. A failure here is surfaced to the caller, which fails an allowed call closed rather than
+/// forwarding it unrecorded.
+fn append_decision_record(path: &Path, record: &Value) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let line = serde_json::to_string(record)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(f, "{line}")
+}
+
 /// Atomic-ish write: serialize to a sibling temp file in the same directory, then rename over the
 /// destination. On Windows `rename` will not replace an existing file, so fall back to remove+rename
 /// (not atomic there, documented). A missing parent directory makes this fail, surfacing as a
@@ -366,16 +381,22 @@ fn write_json_atomic(path: &Path, value: &Value) -> std::io::Result<()> {
 /// enforce (the P61e-c PDP on `tools/call`); the only behavioral difference is how `tools/call` is
 /// answered. `policy` and `baseline` are both required and present in enforce mode (loaded + validated
 /// at startup) and `None` in observe mode: the c3 drift gate compares the current observed per-tool
-/// digest against the approved `baseline`. Manifest emission flags apply to observe only.
+/// digest against the approved `baseline`. `decision_out` (enforce only) is the optional NDJSON path
+/// for the per-call `assay.enforcement_decision.v0` evidence record (P61e-d). Manifest emission flags
+/// apply to observe only.
 pub async fn run(
     upstream_command: String,
     upstream_args: Vec<String>,
     mode: Mode,
-    policy: Option<enforce::EnforcePolicy>,
-    baseline: Option<enforce::DeclaredManifest>,
+    enforce_inputs: enforce::EnforceInputs,
     manifest_out: Option<PathBuf>,
     health_out: Option<PathBuf>,
 ) -> Result<()> {
+    let enforce::EnforceInputs {
+        policy,
+        baseline,
+        decision_out,
+    } = enforce_inputs;
     let spawned = Command::new(&upstream_command)
         .args(&upstream_args)
         .stdin(Stdio::piped())
@@ -541,13 +562,48 @@ pub async fn run(
                     forwarded = decision.allow,
                     note = "diagnostic decision log; not canonical evidence"
                 );
-                if decision.allow {
+                // P61e-d: write the canonical per-call evidence record (NDJSON) before acting. The
+                // safety rule (spec §12): a record-write failure on a requested path must never become
+                // a silent unrecorded forward, so an allowed call that cannot be recorded fails closed.
+                let record_ok = match &decision_out {
+                    Some(path) => {
+                        let record =
+                            enforce::decision_record(policy, &decision, tool_name, call_args);
+                        match append_decision_record(path, &record) {
+                            Ok(()) => true,
+                            Err(e) => {
+                                tracing::error!(
+                                    event = "enforcement_record_write_failed",
+                                    error = %e,
+                                    path = %path.display()
+                                );
+                                false
+                            }
+                        }
+                    }
+                    None => true,
+                };
+                if decision.allow && !record_ok {
+                    // Fail-closed: never forward an allowed call we could not record.
+                    if let Some(id) = v.get("id") {
+                        if !id.is_null() {
+                            let _ = tx.send(proxy_error_line(
+                                id.clone(),
+                                PROXY_FAILED,
+                                "enforcement_record_write_failed",
+                                "enforcement decision could not be recorded; call not forwarded",
+                            ));
+                        }
+                    }
+                } else if decision.allow {
                     // Forward the privileged call; the upstream's response relays verbatim via the
                     // upstream reader (a tools/call response is not a list response, so it is untouched).
                     if forward_line(&mut child_stdin, &line).await.is_err() {
                         break;
                     }
                 } else {
+                    // A deny stands regardless of a record-write failure (the call is fail-closed
+                    // either way); a missing deny-record is a completeness gap, already logged above.
                     match v.get("id") {
                         Some(id) if !id.is_null() => {
                             let _ = tx.send(proxy_error_line(

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -98,6 +98,39 @@ fn spawn_enforce(log: &Path, policy: &Path, baseline: &Path, mode: &str) -> Chil
         .expect("spawn enforce proxy (is python installed?)")
 }
 
+/// Spawn the enforcing proxy that also writes the per-call enforcement-decision NDJSON (P61e-d).
+fn spawn_enforce_with_decisions(
+    log: &Path,
+    policy: &Path,
+    baseline: &Path,
+    mode: &str,
+    decisions: &Path,
+) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            "proxy-enforce",
+            "--upstream-command",
+            python(),
+            "--upstream-arg",
+            "-u",
+            "--upstream-arg",
+            mock_path().to_str().unwrap(),
+            "--enforce-policy",
+            policy.to_str().unwrap(),
+            "--declared-mcp-manifest",
+            baseline.to_str().unwrap(),
+            "--enforcement-decision-out",
+            decisions.to_str().unwrap(),
+        ])
+        .env("MOCK_UPSTREAM_LOG", log)
+        .env("MOCK_UPSTREAM_MODE", mode)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn enforce proxy (is python installed?)")
+}
+
 fn send(stdin: &mut ChildStdin, v: Value) {
     writeln!(stdin, "{v}").expect("write");
     stdin.flush().expect("flush");
@@ -371,6 +404,72 @@ fn fully_allowed_call_is_forwarded_and_response_relayed() {
     assert!(
         methods.contains(&"tools/call".to_string()),
         "the allowed tools/call must reach the upstream: {methods:?}"
+    );
+}
+
+// --- P61e-d: per-call enforcement_decision.v0 records ---------------------------------------------
+
+#[test]
+fn enforcement_decision_records_are_written_for_deny_and_allow() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child =
+        spawn_enforce_with_decisions(&log, &policy, &approved_baseline_path(), "p60a", &decisions);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    // Observe a complete manifest so the allowed call can clear the drift gate.
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    // 1) unclassified -> deny.
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+                           "params": {"name": "echo", "arguments": {}}}),
+    );
+    let _ = read_response(&mut out);
+    // 2) fully allowed -> forward.
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 4, "method": "tools/call",
+                           "params": {"name": "github.add_deploy_key",
+                                      "arguments": {"owner": "acme", "repo": "prod-app"}}}),
+    );
+    let r = read_response(&mut out);
+    assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
+
+    shutdown(child, stdin);
+
+    let body = std::fs::read_to_string(&decisions).expect("decisions file written");
+    let recs: Vec<Value> = body
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("each line is a JSON record"))
+        .collect();
+    assert_eq!(recs.len(), 2, "one record per tools/call decision: {body}");
+
+    assert_eq!(recs[0]["schema"], "assay.enforcement_decision.v0");
+    assert_eq!(recs[0]["decision"], "deny");
+    assert_eq!(recs[0]["reason"], "unclassified_tool_call");
+    assert_eq!(recs[0]["forwarded"], false);
+
+    assert_eq!(recs[1]["decision"], "allow");
+    assert_eq!(recs[1]["forwarded"], true);
+    assert_eq!(recs[1]["drift_state"], "satisfied");
+    assert_eq!(recs[1]["tool"]["action_class"], "github_deploy_key");
+    assert_eq!(recs[1]["credential_alias"], "gh-deploy");
+
+    // The declared credential scopes never appear in the evidence stream (alias only).
+    assert!(
+        !body.contains("repo:deploy_key:write"),
+        "declared scopes must not leak into the decision records"
     );
 }
 

--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -4,11 +4,12 @@ Status: **review-spec, no code.** A new arc and the heaviest risk class in the p
 the shipped, opt-in [manifest-observation proxy](mcp-upstream-proxy-mode.md) (P61a–d, assay v3.23.0)
 from observe-only to **enforcing**: it forwards a privileged `tools/call` only after a fail-closed
 policy decision. Tracked as [#1624]. The binding decisions are agreed (§16, "Resolved decisions"); this
-is the design of record. Shipped: P61e-b (the deny-all enforcing run mode), P61e-c1 (caller-allowance),
-P61e-c2 (credential-scope), and **P61e-c3 (the drift gate + the first allow/forward path)**. As of c3
-the enforcing proxy forwards a privileged `tools/call` — but only after a clear allow from every gate
-(classification, caller-allowance, credential-scope, drift), the narrowest such path; everything else is
-a fail-closed deny. The remaining slice is P61e-d (the `assay.enforcement_decision.v0` evidence record).
+is the design of record. **The arc is complete and shipped:** P61e-b (the deny-all enforcing run mode),
+P61e-c1 (caller-allowance), P61e-c2 (credential-scope), P61e-c3 (the drift gate + the first allow/forward
+path), and **P61e-d (the `assay.enforcement_decision.v0` per-call evidence record)**. The enforcing proxy
+forwards a privileged `tools/call` only after a clear allow from every gate (classification,
+caller-allowance, credential-scope, drift) — the narrowest such path — records every decision as
+evidence, and keeps the forwarded call's side effect *asserted*, never proven.
 
 The one-line scope: **the manifest-observation proxy answers "did this tool surface change?"; the
 enforcing proxy answers "should this specific privileged call be forwarded, right now, for this
@@ -253,16 +254,23 @@ ladder (`asserted` < `observed_confirmed` < `audit_record_bound`) is unchanged. 
 notes the proxy *allowed and forwarded* the call; it never claims the upstream performed or persisted
 the action. Allowing a call and proving its effect are different, and the proxy only does the first.
 
-## 11. Enforcement decision record (separate carrier)
+## 11. Enforcement decision record (separate carrier) — P61e-d, shipped
 
-A new `assay.enforcement_decision.v0` artifact, emitted by the enforcing path and kept **separate** from
+The `assay.enforcement_decision.v0` artifact, emitted by the enforcing path and kept **separate** from
 the manifest-observation artifact (the standing observation/enforcement separation). It records, per
-privileged call: caller identity, the P57c-classified action + projected target (sensitive ids hashed),
-the decision (`allow`/`deny`), the machine reason, the fail-closed flag, the drift-gate state, and the
-credential alias (never the secret). It does not assert the side effect.
+`tools/call`: caller id, the P57c-classified action + projected target (sensitive ids hashed) + target
+digest, the decision (`allow`/`deny`), the machine reason, the `fail_closed` flag, the `forwarded` flag,
+the derived `drift_state` (`satisfied` on allow / the specific drift reason / `not_evaluated` when an
+earlier gate denied), and the credential **alias** (never the token or the declared scopes). It does
+not assert the side effect.
 
-**Deferred to P61e-d** — the record is not in P61e-b. P61e-b proves runtime *denial semantics* first;
-the per-call record follows once those semantics are settled.
+**Implementation (P61e-d):** opt-in via `--enforcement-decision-out <path>`; the proxy appends one
+compact JSON record per decision (NDJSON), for both allow and deny, so a killed proxy still keeps the
+decisions recorded so far. The record is deterministic (no timestamp). The diagnostic `tracing` line
+from c1–c3 stays as operability output; this artifact is the canonical evidence carrier. Safety rule
+(see §12): a record-write failure on an allowed call fails closed — the call is **not** forwarded
+(`proxy_failed` / `enforcement_record_write_failed`), never a silent unrecorded forward; a deny stands
+regardless (a missing deny-record is a completeness gap, logged, not a safety gap).
 
 **Name discipline (no overlap with the existing carrier):**
 - `assay.enforcement_health.v0` = mechanism / runtime-capability state (was enforcement active, did the
@@ -276,8 +284,12 @@ the per-call record follows once those semantics are settled.
 - PDP cannot decide → `proxy_denied` (fail-closed), never forwarded;
 - upstream unreachable on an *allowed* call → `proxy_failed` (the decision stands; the forward failed);
 - malformed upstream response → never trusted (as P61a);
-- the enforcement record is written for both allow and deny; a record-write failure on a requested
-  output path is a non-zero exit, not a silent allow.
+- the enforcement record (P61e-d) is written for both allow and deny when `--enforcement-decision-out`
+  is set; a per-call record-write failure on an **allowed** call fails that call closed
+  (`proxy_failed` / `enforcement_record_write_failed`), so it is never a silent unrecorded forward; a
+  **denied** call's record-write failure is logged but the deny still stands (the call is fail-closed
+  either way). The per-call streaming record fails the individual call closed rather than exiting the
+  whole session.
 
 ## 13. What enforcing-v0 is NOT
 
@@ -305,7 +317,9 @@ P61e-c  split gate-by-gate, each fail-closed and independently tested, NO forwar
         forward path: a call that clears every gate is forwarded; pdp_gate_unavailable is removed.
         (SHIPPED.)
 P61e-d  the assay.enforcement_decision.v0 record + the side-effect-evidence interaction (asserted),
-        kept separate from the observation artifact; Plimsoll consumes it separately (later)
+        kept separate from the observation artifact; Plimsoll consumes it separately (later). (SHIPPED:
+        opt-in --enforcement-decision-out NDJSON, one record per decision, allow+deny, fail-closed on
+        an unrecordable allow.)
 ```
 
 **Implementation note (P61e-c1):** the enforcing subcommand now requires `--enforce-policy <path>` (a


### PR DESCRIPTION
The **last slice of the enforcing-proxy arc** (#1624). The proxy now emits a canonical per-call evidence record for every `tools/call` decision, opt-in via `--enforcement-decision-out <path>` (NDJSON, one record per decision, for both allow and deny). It replaces nothing — the c1–c3 diagnostic `tracing` line stays as operability output; this is the canonical carrier.

### Record (`assay.enforcement_decision.v0`, deterministic — no timestamp)
caller id · the P57c-classified action + projected target (sensitive ids already hashed) + target digest · `decision` (allow/deny) · machine `reason` · `fail_closed` · `forwarded` · derived `drift_state` (`satisfied` / the specific drift reason / `not_evaluated` when an earlier gate denied) · the credential **alias** only — **never the token or the declared scopes**.

It is a **policy decision only** and does not assert or verify the upstream side effect (stays `asserted` on the E9 ladder). Kept distinct from the observation artifact (`assay.mcp_manifest_observed.v0`) and the mechanism artifact (`assay.enforcement_health.v0`) — the three carriers never overlap.

### Safety (spec §12)
A record-write failure on an **allowed** call fails that call **closed** (`proxy_failed` / `enforcement_record_write_failed`) so it is never a silent unrecorded forward; a **denied** call's record-write failure is logged but the deny stands (fail-closed either way). Per-call streaming fails the individual call, not the whole session.

### Note
`run()` grew past the clippy arity limit, so the enforce-mode inputs (policy, baseline, decision_out) are grouped into `enforce::EnforceInputs` — a clean grouping rather than a lint suppression.

### Tests
- 3 `enforce.rs` unit tests: allow / deny / drifted record shape, and **leak-free** (the declared scopes are never serialized into the record).
- An e2e that drives a deny then an allow through `--enforcement-decision-out` and asserts two NDJSON records with the right `decision`/`forwarded`/`drift_state`/`credential_alias` and no scope leakage.
- Full `assay-mcp-server` suite green; clippy `-D warnings` clean. Spec doc §1/§11/§12/§14 marked shipped.

Closes the P61e arc (b + c1 + c2 + c3 + d). Part of #1624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)