### PR TITLE
fix(mcp): enforcement_decision record must not claim delivery (forwarded honesty)

### DIFF
--- a/crates/assay-mcp-server/src/proxy/enforce.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce.rs
@@ -356,12 +356,14 @@ pub fn decision_record(
             "target": c.target,
             "target_digest": decision.target_digest,
         },
+        // The proxy's POLICY decision, true at write time. It is written before the forward (so an
+        // allowed call is never forwarded unrecorded), and therefore deliberately does NOT carry a
+        // transport-outcome field: it must not claim the call reached the upstream. A forward that
+        // then fails surfaces to the caller as `proxy_failed` (§12), never as a delivery claim here.
         "decision": if decision.allow { "allow" } else { "deny" },
         "reason": decision.reason,
         // The PDP is fail-closed by construction: every deny is a fail-closed outcome.
         "fail_closed": !decision.allow,
-        // Only an allowed call is forwarded to the upstream.
-        "forwarded": decision.allow,
         "drift_state": drift_state(decision),
         // Operator config reference only — never the token, never the declared scopes.
         "credential_alias": policy
@@ -370,6 +372,7 @@ pub fn decision_record(
             .map(|c| sanitize(&c.alias)),
         "non_claims": [
             "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+            "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
             "credential referenced by alias only, never the token or declared scopes",
             "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
             "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
@@ -926,11 +929,15 @@ allowances:
         assert_eq!(rec["decision"], "deny");
         assert_eq!(rec["reason"], "unclassified_tool_call");
         assert_eq!(rec["fail_closed"], true);
-        assert_eq!(rec["forwarded"], false);
         assert_eq!(rec["drift_state"], "not_evaluated");
         assert_eq!(rec["caller"]["id"], "ci-agent");
         assert_eq!(rec["credential_alias"], "gh-deploy");
         assert!(rec["non_claims"].is_array());
+        // The record carries no transport-outcome field — it must not claim delivery.
+        assert!(
+            rec.get("forwarded").is_none(),
+            "no transport claim in the decision record"
+        );
         // The declared scopes are never serialized into the record (alias only).
         let s = serde_json::to_string(&rec).unwrap();
         assert!(
@@ -940,7 +947,7 @@ allowances:
     }
 
     #[test]
-    fn decision_record_for_an_allow_marks_forwarded_and_drift_satisfied() {
+    fn decision_record_for_an_allow_is_policy_decision_not_a_delivery_claim() {
         let p = policy_from(VALID).unwrap();
         let d = decide_match(&p, "github.add_deploy_key", &acme_call()); // matching -> allow
         assert!(d.allow);
@@ -948,10 +955,14 @@ allowances:
         assert_eq!(rec["decision"], "allow");
         assert_eq!(rec["reason"], "allow");
         assert_eq!(rec["fail_closed"], false);
-        assert_eq!(rec["forwarded"], true);
         assert_eq!(rec["drift_state"], "satisfied");
         assert_eq!(rec["tool"]["action_class"], "github_deploy_key");
         assert_eq!(rec["action"]["target"]["owner"], "acme");
+        // The decision (allow) is the durable fact; the record never asserts the call was delivered.
+        assert!(
+            rec.get("forwarded").is_none(),
+            "an allow decision must not be a transport/delivery claim"
+        );
     }
 
     #[test]

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -559,7 +559,6 @@ pub async fn run(
                     target_digest = decision.target_digest.as_deref().unwrap_or("none"),
                     decision = if decision.allow { "allow" } else { "deny" },
                     reason = decision.reason,
-                    forwarded = decision.allow,
                     note = "diagnostic decision log; not canonical evidence"
                 );
                 // P61e-d: write the canonical per-call evidence record (NDJSON) before acting. The

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -458,13 +458,23 @@ fn enforcement_decision_records_are_written_for_deny_and_allow() {
     assert_eq!(recs[0]["schema"], "assay.enforcement_decision.v0");
     assert_eq!(recs[0]["decision"], "deny");
     assert_eq!(recs[0]["reason"], "unclassified_tool_call");
-    assert_eq!(recs[0]["forwarded"], false);
 
     assert_eq!(recs[1]["decision"], "allow");
-    assert_eq!(recs[1]["forwarded"], true);
     assert_eq!(recs[1]["drift_state"], "satisfied");
     assert_eq!(recs[1]["tool"]["action_class"], "github_deploy_key");
     assert_eq!(recs[1]["credential_alias"], "gh-deploy");
+
+    // The record carries no transport-outcome field — an allow is the policy decision, not a delivery
+    // claim. The actual delivery is proven separately: only the allowed call reaches the upstream.
+    assert!(
+        body.lines().all(|l| !l.contains("\"forwarded\"")),
+        "decision records must not claim transport delivery: {body}"
+    );
+    let methods = read_methods(&log);
+    assert!(
+        methods.contains(&"tools/call".to_string()),
+        "the allowed call really reached the upstream: {methods:?}"
+    );
 
     // The declared credential scopes never appear in the evidence stream (alias only).
     assert!(

--- a/docs/reference/mcp-upstream-proxy-enforcement.md
+++ b/docs/reference/mcp-upstream-proxy-enforcement.md
@@ -259,10 +259,14 @@ the action. Allowing a call and proving its effect are different, and the proxy 
 The `assay.enforcement_decision.v0` artifact, emitted by the enforcing path and kept **separate** from
 the manifest-observation artifact (the standing observation/enforcement separation). It records, per
 `tools/call`: caller id, the P57c-classified action + projected target (sensitive ids hashed) + target
-digest, the decision (`allow`/`deny`), the machine reason, the `fail_closed` flag, the `forwarded` flag,
-the derived `drift_state` (`satisfied` on allow / the specific drift reason / `not_evaluated` when an
-earlier gate denied), and the credential **alias** (never the token or the declared scopes). It does
-not assert the side effect.
+digest, the decision (`allow`/`deny`), the machine reason, the `fail_closed` flag, the derived
+`drift_state` (`satisfied` on allow / the specific drift reason / `not_evaluated` when an earlier gate
+denied), and the credential **alias** (never the token or the declared scopes). It records the **policy
+decision only** — it does not assert the side effect, and it deliberately carries **no transport-outcome
+field**: because it is written *before* the forward (so an allowed call is never forwarded unrecorded),
+it cannot honestly claim delivery, so an `allow` is the decision to forward and never a claim that the
+call reached or was performed by the upstream. A forward that then fails surfaces to the caller as
+`proxy_failed` (§12), never as a delivery claim in the record.
 
 **Implementation (P61e-d):** opt-in via `--enforcement-decision-out <path>`; the proxy appends one
 compact JSON record per decision (NDJSON), for both allow and deny, so a killed proxy still keeps the


### PR DESCRIPTION
Follow-up to the Codex [P1] on #1639. The `assay.enforcement_decision.v0` record is written **before** the upstream forward (to keep the no-unrecorded-allow safety rule from §12), but it carried `forwarded: true` (literally `= decision.allow`). If the record append succeeds and `forward_line` then fails (upstream closed / stdin broke), the record **falsely claims the call was forwarded** while it never reached the upstream — contradicting §12 ("upstream unreachable on an allowed call → `proxy_failed`; the forward failed") and the asserted-vs-verified discipline the whole arc rests on.

### Fix — model the policy decision and the forward outcome apart (the review's first option)
The record now carries the **policy decision only** (`decision: allow|deny`), true at write time, and **drops the transport-outcome field entirely**. `forwarded` was both redundant with `decision` and over-claiming: an `allow` is the *decision to forward*, never a claim the call reached or was performed by the upstream. A forward that then fails still surfaces to the caller as `proxy_failed` (§12) and in tracing — never as a false delivery claim in the evidence. The write-before-forward safety rule (an allowed call is never forwarded unrecorded) is unchanged.

Also dropped the now-redundant `forwarded=` field from the diagnostic `tracing` line.

### Tests
- Unit: the record has **no** `forwarded`/transport field for both deny and allow.
- e2e: delivery is proven the honest way — the allowed call appears in the **upstream method log** while the records carry no transport claim (and the denied call neither appears upstream nor claims forwarding).
- Full `assay-mcp-server` suite green; clippy `-D warnings` clean. Doc §11 updated.

Part of #1624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)