### PR TITLE
ci: add required context ruleset

### DIFF
--- a/.github/rulesets/main-required-ci-contexts.json
+++ b/.github/rulesets/main-required-ci-contexts.json
@@ -1,0 +1,46 @@
+{
+  "name": "main-required-ci-contexts",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/release/*"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "CI",
+            "integration_id": 15368
+          },
+          {
+            "context": "lane-check",
+            "integration_id": 15368
+          },
+          {
+            "context": "host-capability-check",
+            "integration_id": 15368
+          },
+          {
+            "context": "public-artifact-sanitization",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ]
+}

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -392,6 +392,9 @@ Proposed required context names for the next branch-protection review:
 - `host-capability-check`
 - `public-artifact-sanitization`
 
+Checked-in ruleset activation lives at
+`.github/rulesets/main-required-ci-contexts.json`.
+
 Do not make these required in this slice:
 
 - Manual, release-only, scheduled-only, or host-capability-specific jobs.

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -395,6 +395,14 @@ Proposed required context names for the next branch-protection review:
 Checked-in ruleset activation lives at
 `.github/rulesets/main-required-ci-contexts.json`.
 
+Import note: the checked-in ruleset is config-as-code only until imported in
+GitHub settings. It intentionally mirrors the current live branch protection for
+`CI`, `lane-check`, and `host-capability-check`, so importing it does not weaken
+the existing required-check set. Add `bypass_actors` only if the repository
+owner intentionally wants to preserve an admin bypass path; otherwise
+`strict_required_status_checks_policy: true` means merges must be rebased-current
+and green.
+
 Do not make these required in this slice:
 
 - Manual, release-only, scheduled-only, or host-capability-specific jobs.


### PR DESCRIPTION
## Summary
- add a checked-in ruleset for the exact required CI contexts captured in CI-CONTRACT.md
- require CI, lane-check, host-capability-check, and public-artifact-sanitization
- keep manual/advisory/matrix leaf jobs out of the required set

## Safety
This is repository-code activation material only. It does not mutate GitHub settings outside the PR. All required candidate workflows already start on pull_request.

## Verification
- jq validation for .github/rulesets/main-required-ci-contexts.json
- git diff --check
- commit/push hooks passed