### PR TITLE
ci: name the pack-distribution boundary job and script clearly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,8 @@ jobs:
           components: clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
-  open-core-boundary:
-    name: Open Core Boundary Check
+  distribution-boundary:
+    name: Distribution boundary check
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -165,8 +165,8 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
-      - name: Check open core boundary
-        run: ./scripts/ci/check-open-core-boundary.sh
+      - name: Check distribution boundary
+        run: ./scripts/ci/check-distribution-boundary.sh
 
   publish-shape-cli:
     # Guardrail: catch v3.11.0-style regressions where `assay-cli` accumulates
@@ -669,7 +669,7 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     if: always()
-    needs: [scope, deps-security, clippy, open-core-boundary, vendored-packs, mcp-registry-foundation, perf, test, ebpf-smoke-ubuntu]
+    needs: [scope, deps-security, clippy, distribution-boundary, vendored-packs, mcp-registry-foundation, perf, test, ebpf-smoke-ubuntu]
     steps:
       - name: Evaluate required job results
         env:
@@ -677,7 +677,7 @@ jobs:
           LIGHTWEIGHT_ONLY: ${{ needs.scope.outputs.lightweight_only }}
           DEPS_SECURITY_RESULT: ${{ needs.deps-security.result }}
           CLIPPY_RESULT: ${{ needs.clippy.result }}
-          OPEN_CORE_BOUNDARY_RESULT: ${{ needs.open-core-boundary.result }}
+          DISTRIBUTION_BOUNDARY_RESULT: ${{ needs.distribution-boundary.result }}
           VENDORED_PACKS_RESULT: ${{ needs.vendored-packs.result }}
           MCP_REGISTRY_FOUNDATION_RESULT: ${{ needs.mcp-registry-foundation.result }}
           PERF_RESULT: ${{ needs.perf.result }}
@@ -692,7 +692,7 @@ jobs:
             "scope:${SCOPE_RESULT}" \
             "deps-security:${DEPS_SECURITY_RESULT}" \
             "clippy:${CLIPPY_RESULT}" \
-            "open-core-boundary:${OPEN_CORE_BOUNDARY_RESULT}" \
+            "distribution-boundary:${DISTRIBUTION_BOUNDARY_RESULT}" \
             "vendored-packs:${VENDORED_PACKS_RESULT}" \
             "mcp-registry-foundation:${MCP_REGISTRY_FOUNDATION_RESULT}" \
             "perf:${PERF_RESULT}" \

--- a/docs/WORKFLOWS-OVERVIEW.md
+++ b/docs/WORKFLOWS-OVERVIEW.md
@@ -10,7 +10,7 @@ Dit document geeft een uitgebreid overzicht van alle GitHub Actions-workflows in
 
 | Workflow | Bestand | Triggers | Jobs | Doel |
 |----------|---------|----------|------|------|
-| **CI** | `ci.yml` | push (main, debug/**), pull_request (paths-ignore docs), workflow_dispatch | clippy, open-core-boundary, perf, test, ebpf-smoke-ubuntu, ebpf-smoke-self-hosted | Kern-CI: lint, boundary check, Criterion benches, tests (matrix ubuntu/macos/windows), eBPF smoke (Ubuntu + self-hosted). |
+| **CI** | `ci.yml` | push (main, debug/**), pull_request (paths-ignore docs), workflow_dispatch | clippy, distribution-boundary, perf, test, ebpf-smoke-ubuntu, ebpf-smoke-self-hosted | Kern-CI: lint, boundary check, Criterion benches, tests (matrix ubuntu/macos/windows), eBPF smoke (Ubuntu + self-hosted). |
 | **Example CI Gate** | `baseline-gate-demo.yml` | pull_request (paths: examples/baseline-gate/**, workflow) | gate | Demo: baseline-gate PR — cache .eval/.assay, build release, replay traces, baseline check; cache-hit in summary. |
 | **Perf (main baseline)** | `perf_main.yml` | push (main), schedule (nightly 03:00 UTC) | benches | Bencher: Criterion-baseline op main + nightly; benchmarks `sw/50x400b`, `sw/12xlarge` (store_write_heavy) en `sr/wc` (suite_run_worstcase); stdin/pipe-modus; thresholds (t_test, upper_boundary 0.99). |
 | **Perf (PR compare)** | `perf_pr.yml` | pull_request (opened, reopened, edited, synchronize) | benches | Bencher: PR vergelijken met main (start-point, clone-thresholds); zelfde threshold-flags als main; soft (geen --err); alleen same-repo. |
@@ -98,7 +98,7 @@ Detail van `ci.yml`: jobs en volgorde.
 flowchart TB
   subgraph ci["CI (ci.yml)"]
     CLIPPY[clippy]
-    BOUNDARY[open-core-boundary]
+    BOUNDARY[distribution-boundary]
     PERF[perf]
     TEST[test matrix: ubuntu, macos, windows]
     EBPF_UBUNTU[ebpf-smoke-ubuntu]
@@ -111,7 +111,7 @@ flowchart TB
   EBPF_SELF -.->|"if: !fork PR"| only_same_repo[Same-repo only]
 ```
 
-- **Parallel (geen needs):** clippy, open-core-boundary, perf, test — draaien gelijktijdig.
+- **Parallel (geen needs):** clippy, distribution-boundary, perf, test — draaien gelijktijdig.
 - **test** heeft matrix: `ubuntu-latest`, `macos-latest`, `windows-latest`; Linux test volledige workspace (excl. assay-ebpf, assay-it); niet-Linux excl. ook assay-monitor, assay-cli.
 - **ebpf-smoke-ubuntu** en **ebpf-smoke-self-hosted** hebben `needs: [test]`; self-hosted draait alleen als geen fork-PR.
 
@@ -197,7 +197,7 @@ flowchart TB
 |--------|---------------|
 | **Doel** | Elke push/PR (behalve doc-only) linten, testen en Criterion-benches + eBPF smoke uitvoeren. |
 | **Triggers** | `push` naar main of `debug/**`; `pull_request` (paths-ignore: docs, *.md, .gitignore); `workflow_dispatch`. |
-| **Jobs** | **clippy:** `cargo clippy --workspace --all-targets -- -D warnings`. **open-core-boundary:** script check open core boundary. **perf:** `cargo bench` (assay-core, assay-cli) met `--quick`, upload Criterion-artifact, log cache-hit. **test:** matrix ubuntu/macos/windows; sccache + mold (Linux); cargo test (exclusies per OS). **ebpf-smoke-ubuntu:** needs test; LSM verify in Docker (soft skip). **ebpf-smoke-self-hosted:** needs test; alleen non-fork PR; self-hosted runner; LSM strict. |
+| **Jobs** | **clippy:** `cargo clippy --workspace --all-targets -- -D warnings`. **distribution-boundary:** script check distribution boundary. **perf:** `cargo bench` (assay-core, assay-cli) met `--quick`, upload Criterion-artifact, log cache-hit. **test:** matrix ubuntu/macos/windows; sccache + mold (Linux); cargo test (exclusies per OS). **ebpf-smoke-ubuntu:** needs test; LSM verify in Docker (soft skip). **ebpf-smoke-self-hosted:** needs test; alleen non-fork PR; self-hosted runner; LSM strict. |
 | **Afhankelijkheden** | Alleen test → ebpf-smoke-*; overige jobs parallel. |
 | **Cache** | Swatinem/rust-cache; perf-job logt cache-hit in job summary. |
 | **Assessment** | Duidelijke scheiding lint/test/perf/eBPF; paths-ignore voorkomt CI op doc-only wijzigingen; eBPF op twee runners (Ubuntu + self-hosted) voor betere dekking. |

--- a/scripts/ci/check-distribution-boundary.sh
+++ b/scripts/ci/check-distribution-boundary.sh
@@ -9,7 +9,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 errors=0
 
-echo "=== Open Core Boundary Check ==="
+echo "=== Distribution Boundary Check ==="
 echo ""
 
 # 1. Check that packs/enterprise/ contains no pack.yaml files
@@ -82,6 +82,6 @@ if [ $errors -eq 0 ]; then
     exit 0
 else
     echo "Found $errors error(s)."
-    echo "See ADR-016 for open core boundary definition."
+    echo "See ADR-016 for the pack distribution boundary definition."
     exit 1
 fi


### PR DESCRIPTION
## What

Renames the CI boundary job and its script to names that say what the guardrail actually does:

- job id `open-core-boundary` → `distribution-boundary`
- display name → **Distribution boundary check**
- `scripts/ci/check-open-core-boundary.sh` → `scripts/ci/check-distribution-boundary.sh` (via `git mv`, history preserved)
- step name → **Check distribution boundary**

The script verifies that only repository-distributable pack content lands in this repo and that open packs carry an OSS license — "distribution boundary" describes that directly.

## Scope

Naming only. The guardrail logic is byte-for-byte unchanged, including the paths and conventions it validates (`packs/enterprise/`, `packs/open/*`, the `*-pro` pack names and `PRO-` rule-id prefix it greps for, and the LICENSE checks). Also updated: the `CI` aggregate job's `needs:`/result references to the renamed job, and the job's entries in `docs/WORKFLOWS-OVERVIEW.md`.

## Safety

- The renamed job is **not** a required status context — the required gate is the `CI` aggregate (which `needs:` this job), alongside `lane-check` and `host-capability-check`. So the check-run name change does not affect branch protection or create a pending-forever required check.
- Verified locally: `ci.yml` parses, the renamed script runs and exits 0, and no stale references to the old job id remain in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)