### PR TITLE
ci: add trusted sanitizer hash layer

### DIFF
--- a/.github/workflows/sanitize-public-artifacts.yml
+++ b/.github/workflows/sanitize-public-artifacts.yml
@@ -27,3 +27,10 @@ jobs:
 
       - name: Scan tracked public artifacts
         run: python3 scripts/ci/check-public-artifact-sanitization.py
+
+      - name: Trusted private-list hash scan
+        env:
+          PUBLIC_ARTIFACT_DENYLIST_SHA256: ${{ secrets.PUBLIC_ARTIFACT_DENYLIST_SHA256 }}
+        run: >
+          python3 scripts/ci/check-public-artifact-sanitization.py
+          --trusted-hash-env PUBLIC_ARTIFACT_DENYLIST_SHA256

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -171,6 +171,11 @@ Required-gate split:
 - The trusted hashed-list layer is part of the sanitizer workflow, not a
   separate required context, until a future context-capture/import review says
   otherwise.
+- The trusted list must enumerate every spelling, casing, and spacing variant of
+  a term. Normalization lowercases, splits on non-alphanumerics, and hashes
+  one-to-five-token windows per line, so a compound spelling and a spaced or
+  hyphenated spelling of the same term produce different hashes. Variant
+  completeness is a property of the trusted list, not the scanner.
 
 Logging contract:
 

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -168,6 +168,9 @@ Required-gate split:
   pushes, and scheduled checks that can access the private source safely.
 - A degraded fork run must say that private-list comparison was skipped without
   exposing the list, while still enforcing structural public-artifact rules.
+- The trusted hashed-list layer is part of the sanitizer workflow, not a
+  separate required context, until a future context-capture/import review says
+  otherwise.
 
 Logging contract:
 

--- a/scripts/ci/check-public-artifact-sanitization.py
+++ b/scripts/ci/check-public-artifact-sanitization.py
@@ -259,7 +259,7 @@ def self_test() -> None:
         assert len(findings) == 1
         assert findings[0].path == Path("README.md")
         assert findings[0].category == "publication_blocker_marker"
-        trusted_hash = hashlib.sha256("alpha beta".encode("utf-8")).hexdigest()
+        trusted_hash = hashlib.sha256(b"alpha beta").hexdigest()
         trusted_findings = scan_trusted_hashes([root / "README.md"], root, {trusted_hash})
         assert len(trusted_findings) == 1
         assert trusted_findings[0].path == Path("README.md")

--- a/scripts/ci/check-public-artifact-sanitization.py
+++ b/scripts/ci/check-public-artifact-sanitization.py
@@ -7,13 +7,16 @@ This check is intentionally safe for public PR logs:
 - it reports only category names and locations;
 - it never prints matched text.
 
-The trusted/private-list comparison described in CI-CONTRACT.md can be layered on
-top later. This script is the required fork-safe structural gate.
+When a trusted workflow provides hashed private-list entries through an
+environment variable, this script can compare normalized token and n-gram hashes
+without printing matched terms or hash values. Without that trusted input, it is
+the required fork-safe structural gate.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import re
 import subprocess
@@ -176,6 +179,56 @@ def scan_files(files: Iterable[Path], root: Path) -> list[Finding]:
     return findings
 
 
+def parse_hashes(raw: str) -> set[str]:
+    hashes: set[str] = set()
+    invalid_count = 0
+    for item in re.split(r"[\s,]+", raw.strip()):
+        if not item:
+            continue
+        value = item.removeprefix("sha256:").lower()
+        if re.fullmatch(r"[0-9a-f]{64}", value):
+            hashes.add(value)
+        else:
+            invalid_count += 1
+    if invalid_count:
+        raise ValueError(f"invalid hashed denylist entries: {invalid_count}")
+    return hashes
+
+
+def normalized_tokens(line: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", line.lower())
+
+
+def candidate_hashes(line: str, max_ngram: int = 5) -> set[str]:
+    tokens = normalized_tokens(line)
+    hashes: set[str] = set()
+    for start in range(len(tokens)):
+        upper = min(len(tokens), start + max_ngram)
+        for end in range(start + 1, upper + 1):
+            phrase = " ".join(tokens[start:end])
+            hashes.add(hashlib.sha256(phrase.encode("utf-8")).hexdigest())
+    return hashes
+
+
+def scan_trusted_hashes(
+    files: Iterable[Path], root: Path, denylist_hashes: set[str]
+) -> list[Finding]:
+    findings: list[Finding] = []
+    if not denylist_hashes:
+        return findings
+    for path in files:
+        if not should_scan(path, root):
+            continue
+        text = read_text(path)
+        if text is None:
+            continue
+        rel = path.relative_to(root)
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if candidate_hashes(line) & denylist_hashes:
+                findings.append(Finding(rel, line_no, "trusted_private_hash_match"))
+    return findings
+
+
 def print_findings(findings: Sequence[Finding]) -> None:
     counts: dict[str, int] = {}
     for finding in findings:
@@ -196,7 +249,7 @@ def self_test() -> None:
         root = Path(tmp)
         marker = "".join(("REDACT", "_BEFORE_PUBLIC"))
         (root / "README.md").write_text(
-            f"hello\n{marker}: placeholder\n", encoding="utf-8"
+            f"hello\n{marker}: placeholder\nalpha beta\n", encoding="utf-8"
         )
         (root / "target").mkdir()
         (root / "target" / "generated.txt").write_text(
@@ -206,12 +259,24 @@ def self_test() -> None:
         assert len(findings) == 1
         assert findings[0].path == Path("README.md")
         assert findings[0].category == "publication_blocker_marker"
+        trusted_hash = hashlib.sha256("alpha beta".encode("utf-8")).hexdigest()
+        trusted_findings = scan_trusted_hashes([root / "README.md"], root, {trusted_hash})
+        assert len(trusted_findings) == 1
+        assert trusted_findings[0].path == Path("README.md")
+        assert trusted_findings[0].category == "trusted_private_hash_match"
     print("self-test=passed")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument(
+        "--trusted-hash-env",
+        help=(
+            "Environment variable containing newline/comma separated sha256 "
+            "hashes for the trusted private-list scan."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.self_test:
@@ -219,10 +284,28 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     root = Path(os.environ.get("GITHUB_WORKSPACE", REPO_ROOT)).resolve()
-    findings = scan_files(git_files(root), root)
+    files = git_files(root)
+    findings = scan_files(files, root)
     if findings:
         print_findings(findings)
         return 1
+    if args.trusted_hash_env:
+        raw_hashes = os.environ.get(args.trusted_hash_env, "")
+        if not raw_hashes.strip():
+            print("trusted-private-list=skipped")
+            print("trusted-private-list-reason=hash_source_unavailable")
+        else:
+            try:
+                denylist_hashes = parse_hashes(raw_hashes)
+            except ValueError as exc:
+                print("trusted-private-list=failed")
+                print(str(exc))
+                return 1
+            trusted_findings = scan_trusted_hashes(files, root, denylist_hashes)
+            if trusted_findings:
+                print_findings(trusted_findings)
+                return 1
+            print("trusted-private-list=passed")
     print("public-artifact-sanitization=passed")
     return 0
 


### PR DESCRIPTION
## Summary
- add an optional trusted hashed-list scan to the public artifact sanitizer
- keep the structural sanitizer as the fork-safe required path
- document that the trusted layer stays inside the sanitizer workflow, not a separate required context

## Safety
- private vocabulary/hash source is not stored in the repo
- logs report only category and file:line locations
- missing secret degrades explicitly with trusted-private-list=skipped

## Validation
- python3 scripts/ci/check-public-artifact-sanitization.py --self-test
- python3 scripts/ci/check-public-artifact-sanitization.py
- python3 scripts/ci/check-public-artifact-sanitization.py --trusted-hash-env PUBLIC_ARTIFACT_DENYLIST_SHA256
- ruby YAML parse for .github/workflows/sanitize-public-artifacts.yml