### PR TITLE
ci: use HMAC for trusted sanitizer digests

### DIFF
--- a/.github/sanitizer/trusted-hmac-canary.txt
+++ b/.github/sanitizer/trusted-hmac-canary.txt
@@ -1,0 +1,1 @@
+public sanitizer hmac canary

--- a/.github/workflows/sanitize-public-artifacts.yml
+++ b/.github/workflows/sanitize-public-artifacts.yml
@@ -28,9 +28,11 @@ jobs:
       - name: Scan tracked public artifacts
         run: python3 scripts/ci/check-public-artifact-sanitization.py
 
-      - name: Trusted private-list hash scan
+      - name: Trusted private-list HMAC scan
         env:
-          PUBLIC_ARTIFACT_DENYLIST_SHA256: ${{ secrets.PUBLIC_ARTIFACT_DENYLIST_SHA256 }}
+          PUBLIC_ARTIFACT_DENYLIST_HMAC_SHA256: ${{ secrets.PUBLIC_ARTIFACT_DENYLIST_HMAC_SHA256 }}
+          PUBLIC_ARTIFACT_DENYLIST_HMAC_KEY: ${{ secrets.PUBLIC_ARTIFACT_DENYLIST_HMAC_KEY }}
         run: >
           python3 scripts/ci/check-public-artifact-sanitization.py
-          --trusted-hash-env PUBLIC_ARTIFACT_DENYLIST_SHA256
+          --trusted-hmac-env PUBLIC_ARTIFACT_DENYLIST_HMAC_SHA256
+          --trusted-hmac-key-env PUBLIC_ARTIFACT_DENYLIST_HMAC_KEY

--- a/.github/workflows/sanitize-public-artifacts.yml
+++ b/.github/workflows/sanitize-public-artifacts.yml
@@ -36,3 +36,4 @@ jobs:
           python3 scripts/ci/check-public-artifact-sanitization.py
           --trusted-hmac-env PUBLIC_ARTIFACT_DENYLIST_HMAC_SHA256
           --trusted-hmac-key-env PUBLIC_ARTIFACT_DENYLIST_HMAC_KEY
+          --trusted-hmac-canary-file .github/sanitizer/trusted-hmac-canary.txt

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -155,8 +155,8 @@ Hard rule:
 
 Acceptable implementation patterns:
 
-- Compare normalized tokens or n-grams against hashed entries supplied from a
-  private source.
+- Compare normalized tokens or n-grams against HMAC-SHA256 entries supplied from
+  a private source plus a separate private HMAC key.
 - Run plaintext sensitive-list checks only in trusted private contexts where
   logs are not public and untrusted PR code cannot read the list.
 - On fork PRs, run only the public-safe structural portion.
@@ -164,24 +164,26 @@ Acceptable implementation patterns:
 Required-gate split:
 
 - The public-safe structural portion is required on every PR, including forks.
-- The full hashed-denylist comparison runs only for trusted same-repository PRs,
-  pushes, and scheduled checks that can access the private source safely.
+- The full HMAC-denylist comparison runs only for trusted same-repository PRs,
+  pushes, and scheduled checks that can access the private source and HMAC key
+  safely.
 - A degraded fork run must say that private-list comparison was skipped without
   exposing the list, while still enforcing structural public-artifact rules.
-- The trusted hashed-list layer is part of the sanitizer workflow, not a
+- The trusted HMAC-list layer is part of the sanitizer workflow, not a
   separate required context, until a future context-capture/import review says
   otherwise.
 - The trusted list must enumerate every spelling, casing, and spacing variant of
-  a term. Normalization lowercases, splits on non-alphanumerics, and hashes
+  a term. Normalization lowercases, splits on non-alphanumerics, and HMACs
   one-to-five-token windows per line, so a compound spelling and a spaced or
-  hyphenated spelling of the same term produce different hashes. Variant
+  hyphenated spelling of the same term produce different digests. Variant
   completeness is a property of the trusted list, not the scanner.
 
 Logging contract:
 
 - Report only counts and locations, for example `3 matches in README.md:42`.
 - Never print matched text.
-- Never print the sensitive term, phrase, or unhashed denylist entry.
+- Never print the sensitive term, phrase, unhashed denylist entry, digest, or
+  HMAC key.
 - Treat printing the matched term as a CI bug and a sanitization failure.
 
 The guard is a backstop, not a guarantee. Human public-artifact review remains
@@ -250,8 +252,8 @@ Keep or add:
   Security is available;
 - scheduled release-smoke rehearsal that does not publish;
 - scheduled MCP proxy fixture replay with no live providers;
-- scheduled public-artifact sanitization trusted run with the full private
-  hashed source;
+- scheduled public-artifact sanitization trusted run with the full private HMAC
+  source;
 - scheduled stale evidence-artifact inventory for compressed fixtures, large
   generated docs assets, and run output.
 

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -172,6 +172,10 @@ Required-gate split:
 - The trusted HMAC-list layer is part of the sanitizer workflow, not a
   separate required context, until a future context-capture/import review says
   otherwise.
+- When the trusted HMAC-list layer runs, the list must include the digest for
+  the committed public canary fixture. The scanner fails closed on a canary
+  miss so key encoding, normalization, or generator drift cannot silently turn
+  the trusted layer into a no-op.
 - The trusted list must enumerate every spelling, casing, and spacing variant of
   a term. Normalization lowercases, splits on non-alphanumerics, and HMACs
   one-to-five-token windows per line, so a compound spelling and a spaced or

--- a/scripts/ci/check-public-artifact-sanitization.py
+++ b/scripts/ci/check-public-artifact-sanitization.py
@@ -7,16 +7,17 @@ This check is intentionally safe for public PR logs:
 - it reports only category names and locations;
 - it never prints matched text.
 
-When a trusted workflow provides hashed private-list entries through an
-environment variable, this script can compare normalized token and n-gram hashes
-without printing matched terms or hash values. Without that trusted input, it is
-the required fork-safe structural gate.
+When a trusted workflow provides HMAC-SHA256 private-list entries plus the HMAC
+key through environment variables, this script can compare normalized token and
+n-gram HMACs without printing matched terms, digest values, or key material.
+Without that trusted input, it is the required fork-safe structural gate.
 """
 
 from __future__ import annotations
 
 import argparse
 import hashlib
+import hmac
 import os
 import re
 import subprocess
@@ -179,42 +180,43 @@ def scan_files(files: Iterable[Path], root: Path) -> list[Finding]:
     return findings
 
 
-def parse_hashes(raw: str) -> set[str]:
-    hashes: set[str] = set()
+def parse_digest_set(raw: str) -> set[str]:
+    digests: set[str] = set()
     invalid_count = 0
     for item in re.split(r"[\s,]+", raw.strip()):
         if not item:
             continue
-        value = item.removeprefix("sha256:").lower()
+        value = item.removeprefix("hmac-sha256:").lower()
         if re.fullmatch(r"[0-9a-f]{64}", value):
-            hashes.add(value)
+            digests.add(value)
         else:
             invalid_count += 1
     if invalid_count:
-        raise ValueError(f"invalid hashed denylist entries: {invalid_count}")
-    return hashes
+        raise ValueError(f"invalid HMAC denylist entries: {invalid_count}")
+    return digests
 
 
 def normalized_tokens(line: str) -> list[str]:
     return re.findall(r"[a-z0-9]+", line.lower())
 
 
-def candidate_hashes(line: str, max_ngram: int = 5) -> set[str]:
+def candidate_hmacs(line: str, key: bytes, max_ngram: int = 5) -> set[str]:
     tokens = normalized_tokens(line)
-    hashes: set[str] = set()
+    digests: set[str] = set()
     for start in range(len(tokens)):
         upper = min(len(tokens), start + max_ngram)
         for end in range(start + 1, upper + 1):
             phrase = " ".join(tokens[start:end])
-            hashes.add(hashlib.sha256(phrase.encode("utf-8")).hexdigest())
-    return hashes
+            digest = hmac.new(key, phrase.encode("utf-8"), hashlib.sha256).hexdigest()
+            digests.add(digest)
+    return digests
 
 
-def scan_trusted_hashes(
-    files: Iterable[Path], root: Path, denylist_hashes: set[str]
+def scan_trusted_hmacs(
+    files: Iterable[Path], root: Path, denylist_digests: set[str], key: bytes
 ) -> list[Finding]:
     findings: list[Finding] = []
-    if not denylist_hashes:
+    if not denylist_digests:
         return findings
     for path in files:
         if not should_scan(path, root):
@@ -224,7 +226,7 @@ def scan_trusted_hashes(
             continue
         rel = path.relative_to(root)
         for line_no, line in enumerate(text.splitlines(), start=1):
-            if candidate_hashes(line) & denylist_hashes:
+            if candidate_hmacs(line, key) & denylist_digests:
                 findings.append(Finding(rel, line_no, "trusted_private_hash_match"))
     return findings
 
@@ -259,8 +261,11 @@ def self_test() -> None:
         assert len(findings) == 1
         assert findings[0].path == Path("README.md")
         assert findings[0].category == "publication_blocker_marker"
-        trusted_hash = hashlib.sha256(b"alpha beta").hexdigest()
-        trusted_findings = scan_trusted_hashes([root / "README.md"], root, {trusted_hash})
+        trusted_key = b"trusted-test-key"
+        trusted_digest = hmac.new(trusted_key, b"alpha beta", hashlib.sha256).hexdigest()
+        trusted_findings = scan_trusted_hmacs(
+            [root / "README.md"], root, {trusted_digest}, trusted_key
+        )
         assert len(trusted_findings) == 1
         assert trusted_findings[0].path == Path("README.md")
         assert trusted_findings[0].category == "trusted_private_hash_match"
@@ -271,11 +276,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--self-test", action="store_true")
     parser.add_argument(
-        "--trusted-hash-env",
+        "--trusted-hmac-env",
         help=(
-            "Environment variable containing newline/comma separated sha256 "
-            "hashes for the trusted private-list scan."
+            "Environment variable containing newline/comma separated HMAC-SHA256 "
+            "digests for the trusted private-list scan."
         ),
+    )
+    parser.add_argument(
+        "--trusted-hmac-key-env",
+        help="Environment variable containing the HMAC key for the trusted scan.",
     )
     args = parser.parse_args(argv)
 
@@ -289,19 +298,26 @@ def main(argv: Sequence[str] | None = None) -> int:
     if findings:
         print_findings(findings)
         return 1
-    if args.trusted_hash_env:
-        raw_hashes = os.environ.get(args.trusted_hash_env, "")
-        if not raw_hashes.strip():
+    if args.trusted_hmac_env or args.trusted_hmac_key_env:
+        raw_digests = os.environ.get(args.trusted_hmac_env or "", "")
+        raw_key = os.environ.get(args.trusted_hmac_key_env or "", "")
+        if not raw_digests.strip() and not raw_key.strip():
             print("trusted-private-list=skipped")
-            print("trusted-private-list-reason=hash_source_unavailable")
+            print("trusted-private-list-reason=hmac_source_unavailable")
+        elif not raw_digests.strip() or not raw_key.strip():
+            print("trusted-private-list=failed")
+            print("trusted-private-list-reason=hmac_configuration_incomplete")
+            return 1
         else:
             try:
-                denylist_hashes = parse_hashes(raw_hashes)
+                denylist_digests = parse_digest_set(raw_digests)
             except ValueError as exc:
                 print("trusted-private-list=failed")
                 print(str(exc))
                 return 1
-            trusted_findings = scan_trusted_hashes(files, root, denylist_hashes)
+            trusted_findings = scan_trusted_hmacs(
+                files, root, denylist_digests, raw_key.encode("utf-8")
+            )
             if trusted_findings:
                 print_findings(trusted_findings)
                 return 1

--- a/scripts/ci/check-public-artifact-sanitization.py
+++ b/scripts/ci/check-public-artifact-sanitization.py
@@ -16,8 +16,10 @@ Without that trusted input, it is the required fork-safe structural gate.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import hmac
+import io
 import os
 import re
 import subprocess
@@ -231,6 +233,26 @@ def scan_trusted_hmacs(
     return findings
 
 
+def trusted_hmac_canary_path(root: Path, raw_path: str) -> Path:
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = root / path
+    return path.resolve()
+
+
+def split_canary_findings(
+    findings: Sequence[Finding], canary_rel: Path
+) -> tuple[list[Finding], list[Finding]]:
+    canary_findings: list[Finding] = []
+    real_findings: list[Finding] = []
+    for finding in findings:
+        if finding.path == canary_rel:
+            canary_findings.append(finding)
+        else:
+            real_findings.append(finding)
+    return real_findings, canary_findings
+
+
 def print_findings(findings: Sequence[Finding]) -> None:
     counts: dict[str, int] = {}
     for finding in findings:
@@ -269,6 +291,82 @@ def self_test() -> None:
         assert len(trusted_findings) == 1
         assert trusted_findings[0].path == Path("README.md")
         assert trusted_findings[0].category == "trusted_private_hash_match"
+        canary_findings = [
+            Finding(Path(".github/sanitizer/trusted-hmac-canary.txt"), 1, "trusted_private_hash_match"),
+            Finding(Path("README.md"), 3, "trusted_private_hash_match"),
+        ]
+        real_findings, canary_hits = split_canary_findings(
+            canary_findings, Path(".github/sanitizer/trusted-hmac-canary.txt")
+        )
+        assert len(real_findings) == 1
+        assert len(canary_hits) == 1
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        canary_phrase = " ".join(
+            (
+                "public",
+                "sanitizer",
+                "hmac",
+                "canary",
+            )
+        )
+        (root / ".github" / "sanitizer").mkdir(parents=True)
+        (root / "README.md").write_text("hello\n", encoding="utf-8")
+        (root / ".github" / "sanitizer" / "trusted-hmac-canary.txt").write_text(
+            f"{canary_phrase}\n", encoding="utf-8"
+        )
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        trusted_key = "trusted-test-key"
+        trusted_digest = hmac.new(
+            trusted_key.encode("utf-8"), canary_phrase.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+        old_workspace = os.environ.get("GITHUB_WORKSPACE")
+        old_digests = os.environ.get("TEST_HMAC_DIGESTS")
+        old_key = os.environ.get("TEST_HMAC_KEY")
+        try:
+            os.environ["GITHUB_WORKSPACE"] = str(root)
+
+            def run_with_env(digests: str | None, key: str | None) -> int:
+                if digests is None:
+                    os.environ.pop("TEST_HMAC_DIGESTS", None)
+                else:
+                    os.environ["TEST_HMAC_DIGESTS"] = digests
+                if key is None:
+                    os.environ.pop("TEST_HMAC_KEY", None)
+                else:
+                    os.environ["TEST_HMAC_KEY"] = key
+                with contextlib.redirect_stdout(io.StringIO()):
+                    return main(
+                        [
+                            "--trusted-hmac-env",
+                            "TEST_HMAC_DIGESTS",
+                            "--trusted-hmac-key-env",
+                            "TEST_HMAC_KEY",
+                            "--trusted-hmac-canary-file",
+                            ".github/sanitizer/trusted-hmac-canary.txt",
+                        ]
+                    )
+
+            assert run_with_env(None, None) == 0
+            assert run_with_env(trusted_digest, None) == 1
+            assert run_with_env(None, trusted_key) == 1
+            assert run_with_env("not-a-digest", trusted_key) == 1
+            assert run_with_env(trusted_digest, "wrong-key") == 1
+            assert run_with_env(trusted_digest, trusted_key) == 0
+        finally:
+            if old_workspace is None:
+                os.environ.pop("GITHUB_WORKSPACE", None)
+            else:
+                os.environ["GITHUB_WORKSPACE"] = old_workspace
+            if old_digests is None:
+                os.environ.pop("TEST_HMAC_DIGESTS", None)
+            else:
+                os.environ["TEST_HMAC_DIGESTS"] = old_digests
+            if old_key is None:
+                os.environ.pop("TEST_HMAC_KEY", None)
+            else:
+                os.environ["TEST_HMAC_KEY"] = old_key
     print("self-test=passed")
 
 
@@ -285,6 +383,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--trusted-hmac-key-env",
         help="Environment variable containing the HMAC key for the trusted scan.",
+    )
+    parser.add_argument(
+        "--trusted-hmac-canary-file",
+        help=(
+            "Repository-relative canary fixture that must match the trusted "
+            "HMAC list when trusted config is present."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -318,6 +423,25 @@ def main(argv: Sequence[str] | None = None) -> int:
             trusted_findings = scan_trusted_hmacs(
                 files, root, denylist_digests, raw_key.encode("utf-8")
             )
+            if args.trusted_hmac_canary_file:
+                canary_path = trusted_hmac_canary_path(root, args.trusted_hmac_canary_file)
+                try:
+                    canary_rel = canary_path.relative_to(root)
+                except ValueError:
+                    print("trusted-private-list=failed")
+                    print("trusted-private-list-reason=hmac_canary_outside_workspace")
+                    return 1
+                if not canary_path.exists():
+                    print("trusted-private-list=failed")
+                    print("trusted-private-list-reason=hmac_canary_missing")
+                    return 1
+                trusted_findings, canary_findings = split_canary_findings(
+                    trusted_findings, canary_rel
+                )
+                if not canary_findings:
+                    print("trusted-private-list=failed")
+                    print("trusted-private-list-reason=hmac_canary_mismatch")
+                    return 1
             if trusted_findings:
                 print_findings(trusted_findings)
                 return 1


### PR DESCRIPTION
## Summary
- replace the trusted sanitizer's plain SHA-256 digest comparison with HMAC-SHA256
- use separate workflow secrets for the digest list and HMAC key
- keep the structural sanitizer fork-safe, with no-secret runs explicitly skipped and incomplete trusted config failing closed

## Safety
- private terms, HMAC digests, and key material are never printed
- a leaked digest list alone is no longer dictionary-reversible without the HMAC key
- malformed digest input still fails closed with only a count

## Validation
- python3 scripts/ci/check-public-artifact-sanitization.py --self-test
- python3 scripts/ci/check-public-artifact-sanitization.py
- python3 scripts/ci/check-public-artifact-sanitization.py --trusted-hmac-env PUBLIC_ARTIFACT_DENYLIST_HMAC_SHA256 --trusted-hmac-key-env PUBLIC_ARTIFACT_DENYLIST_HMAC_KEY
- incomplete trusted config fail-closed check
- malformed digest fail-closed check
- ruby YAML parse for .github/workflows/sanitize-public-artifacts.yml