### PR TITLE
ci: add scheduled supply-chain posture

### DIFF
--- a/.github/osv/non-rust-manifests.txt
+++ b/.github/osv/non-rust-manifests.txt
@@ -1,0 +1,19 @@
+# Scheduled OSV advisory targets.
+#
+# Keep this list limited to tracked non-Rust dependency inputs. Rust advisory
+# policy is owned by cargo-deny/cargo-audit in PR CI.
+docs/requirements-ci.txt
+examples/agentevals-trajectory-strict-match-evidence/requirements.txt
+examples/autoevals-exactmatch-evidence/requirements.txt
+examples/crewai-event-evidence/requirements.txt
+examples/guardrails-validation-outcome-evidence/requirements.txt
+examples/langgraph-task-evidence/requirements.txt
+examples/langwatch-custom-span-evaluation-evidence/requirements.txt
+examples/mcp-compliance/package-lock.json
+examples/openai-agents-trace-evidence/requirements.txt
+examples/openfeature-evaluation-details-evidence/requirements.txt
+examples/phoenix-span-annotation-evidence/requirements.txt
+examples/promptfoo-assertion-grading-result-evidence/package-lock.json
+examples/pydantic-ai-eval-report-evidence/requirements.txt
+runner-fixtures/gemini-google-genai/requirements.txt
+runner-fixtures/openai-agents/package-lock.json

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -17,6 +17,11 @@ jobs:
       id-token: write
       security-events: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -1,0 +1,31 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+    steps:
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: scorecard.sarif
+          category: openssf-scorecard

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -22,29 +22,116 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve OSV target coverage
+        id: osv-targets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target_file=".github/osv/non-rust-manifests.txt"
+          listed=()
+          while IFS= read -r path; do
+            listed+=("$path")
+          done < <(grep -Ev '^[[:space:]]*(#|$)' "$target_file" | LC_ALL=C sort -u)
+
+          if [ "${#listed[@]}" -eq 0 ]; then
+            echo "::error::OSV target list is empty"
+            exit 1
+          fi
+
+          missing=0
+          for path in "${listed[@]}"; do
+            if ! git ls-files --error-unmatch -- "$path" >/dev/null 2>&1; then
+              echo "::error file=$target_file::listed OSV target is not tracked: $path"
+              missing=1
+            elif [ ! -f "$path" ]; then
+              echo "::error file=$target_file::listed OSV target is missing: $path"
+              missing=1
+            fi
+
+            case "$path" in
+              Cargo.lock|*/Cargo.lock)
+                echo "::error file=$target_file::Rust lockfile belongs to cargo-deny/cargo-audit, not scheduled OSV: $path"
+                missing=1
+                ;;
+            esac
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+          expected="$(mktemp)"
+          discovered="$(mktemp)"
+          printf '%s\n' "${listed[@]}" > "$expected"
+          git ls-files | grep -E '(^|/)(package-lock\.json|requirements[^/]*\.txt)$' | LC_ALL=C sort -u > "$discovered"
+
+          if unlisted="$(comm -13 "$expected" "$discovered")" && [ -n "$unlisted" ]; then
+            while IFS= read -r path; do
+              echo "::error file=$target_file::tracked non-Rust dependency input is not in scheduled OSV target list: $path"
+            done <<< "$unlisted"
+            exit 1
+          fi
+
+          {
+            echo "scan_args<<OSV_SCAN_ARGS"
+            echo "--format=json"
+            echo "--output=osv-results.json"
+            printf '%s\n' "${listed[@]}"
+            echo "OSV_SCAN_ARGS"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "osv-target-count=${#listed[@]}"
+
       - name: Run OSV scanner
+        id: osv-scan
         uses: google/osv-scanner-action/osv-scanner-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8
         with:
-          scan-args: |-
-            --format=json
-            --output=osv-results.json
-            docs/experiments/runner-vs-otel-2026-05/workload/package-lock.json
-            docs/requirements-ci.txt
-            examples/agentevals-trajectory-strict-match-evidence/requirements.txt
-            examples/autoevals-exactmatch-evidence/requirements.txt
-            examples/crewai-event-evidence/requirements.txt
-            examples/guardrails-validation-outcome-evidence/requirements.txt
-            examples/langgraph-task-evidence/requirements.txt
-            examples/langwatch-custom-span-evaluation-evidence/requirements.txt
-            examples/mcp-compliance/package-lock.json
-            examples/openai-agents-trace-evidence/requirements.txt
-            examples/openfeature-evaluation-details-evidence/requirements.txt
-            examples/phoenix-span-annotation-evidence/requirements.txt
-            examples/promptfoo-assertion-grading-result-evidence/package-lock.json
-            examples/pydantic-ai-eval-report-evidence/requirements.txt
-            runner-fixtures/gemini-google-genai/requirements.txt
-            runner-fixtures/openai-agents/package-lock.json
+          scan-args: ${{ steps.osv-targets.outputs.scan_args }}
         continue-on-error: true
+
+      - name: Validate OSV scanner result
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ ! -s osv-results.json ]; then
+            echo "::error::OSV scanner did not produce a JSON result"
+            exit 1
+          fi
+
+          vuln_count="$(
+            python3 - <<'PY'
+          import json
+          import sys
+
+          with open("osv-results.json", "r", encoding="utf-8") as handle:
+              data = json.load(handle)
+
+          count = 0
+
+          def walk(value):
+              global count
+              if isinstance(value, dict):
+                  for key, child in value.items():
+                      if key == "vulnerabilities" and isinstance(child, list):
+                          count += len(child)
+                      walk(child)
+              elif isinstance(value, list):
+                  for item in value:
+                      walk(item)
+
+          walk(data)
+          print(count)
+          PY
+          )"
+
+          echo "osv-vulnerability-results=$vuln_count"
+
+          if [ "${{ steps.osv-scan.outcome }}" != "success" ] && [ "$vuln_count" -eq 0 ]; then
+            echo "::error::OSV scanner exited non-zero without vulnerability results; treating this as scanner execution failure"
+            exit 1
+          fi
 
       - name: Build advisory SARIF
         uses: google/osv-scanner-action/osv-reporter-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -1,0 +1,62 @@
+name: Scheduled OSV Advisory
+
+on:
+  schedule:
+    - cron: "47 5 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  osv-non-rust:
+    name: OSV non-Rust advisory scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run OSV scanner
+        uses: google/osv-scanner-action/osv-scanner-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8
+        with:
+          scan-args: |-
+            --format=json
+            --output=osv-results.json
+            docs/experiments/runner-vs-otel-2026-05/workload/package-lock.json
+            docs/requirements-ci.txt
+            examples/agentevals-trajectory-strict-match-evidence/requirements.txt
+            examples/autoevals-exactmatch-evidence/requirements.txt
+            examples/crewai-event-evidence/requirements.txt
+            examples/guardrails-validation-outcome-evidence/requirements.txt
+            examples/langgraph-task-evidence/requirements.txt
+            examples/langwatch-custom-span-evaluation-evidence/requirements.txt
+            examples/mcp-compliance/package-lock.json
+            examples/openai-agents-trace-evidence/requirements.txt
+            examples/openfeature-evaluation-details-evidence/requirements.txt
+            examples/phoenix-span-annotation-evidence/requirements.txt
+            examples/promptfoo-assertion-grading-result-evidence/package-lock.json
+            examples/pydantic-ai-eval-report-evidence/requirements.txt
+            runner-fixtures/gemini-google-genai/requirements.txt
+            runner-fixtures/openai-agents/package-lock.json
+        continue-on-error: true
+
+      - name: Build advisory SARIF
+        uses: google/osv-scanner-action/osv-reporter-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8
+        with:
+          scan-args: |-
+            --output=osv-results.sarif
+            --new=osv-results.json
+            --gh-annotations=false
+            --fail-on-vuln=false
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: osv-results.sarif
+          category: osv-scanner-non-rust

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -245,9 +245,15 @@ is cheap, stable, and actionable.
 Keep or add:
 
 - weekly workflow security drift (`zizmor`);
-- OpenSSF Scorecard;
-- OSV-Scanner for Rust, Python, JavaScript, and GitHub Actions dependency
-  surfaces;
+- OpenSSF Scorecard as a scheduled advisory. The first implementation uses the
+  default `GITHUB_TOKEN`, which can read repository rulesets but may not fully
+  measure classic branch-protection or webhook settings unless a future
+  read/admin token is intentionally added.
+- OSV-Scanner for non-Rust dependency surfaces with resolved manifests or
+  lockfiles. RustSec remains owned by `cargo-deny` and `cargo-audit`, including
+  any deliberately documented advisory ignores, so scheduled OSV must not
+  resurface `Cargo.lock` with a different verdict unless an `osv-scanner.toml`
+  mirrors the same Rust policy.
 - CodeQL/default code scanning for Rust-adjacent glue where available, Python,
   JavaScript/TypeScript, shell, and workflow files;
 - ClusterFuzzLite only for small deterministic parsers/canonicalizers and
@@ -260,6 +266,11 @@ Keep or add:
   source;
 - scheduled stale evidence-artifact inventory for compressed fixtures, large
   generated docs assets, and run output.
+
+The scheduled supply-chain posture workflows are advisory only. They run on a
+weekly cadence plus manual dispatch, do not run on ordinary pull requests, do
+not mutate rulesets, and must not be added as required contexts without a
+separate context-capture review.
 
 Do not schedule by default:
 

--- a/CI-CONTRACT.md
+++ b/CI-CONTRACT.md
@@ -253,7 +253,9 @@ Keep or add:
   lockfiles. RustSec remains owned by `cargo-deny` and `cargo-audit`, including
   any deliberately documented advisory ignores, so scheduled OSV must not
   resurface `Cargo.lock` with a different verdict unless an `osv-scanner.toml`
-  mirrors the same Rust policy.
+  mirrors the same Rust policy. The explicit non-Rust target list must fail
+  closed when a listed target is removed, or when a new tracked
+  `package-lock.json` or `requirements*.txt` appears outside the list.
 - CodeQL/default code scanning for Rust-adjacent glue where available, Python,
   JavaScript/TypeScript, shell, and workflow files;
 - ClusterFuzzLite only for small deterministic parsers/canonicalizers and
@@ -270,7 +272,9 @@ Keep or add:
 The scheduled supply-chain posture workflows are advisory only. They run on a
 weekly cadence plus manual dispatch, do not run on ordinary pull requests, do
 not mutate rulesets, and must not be added as required contexts without a
-separate context-capture review.
+separate context-capture review. Advisory vulnerability findings should not
+fail the scheduled OSV job, but scanner execution failures, malformed output,
+or target-list coverage drift should fail loudly.
 
 Do not schedule by default:
 


### PR DESCRIPTION
## Summary
- add scheduled/manual OpenSSF Scorecard advisory reporting
- add scheduled/manual OSV advisory reporting for non-Rust resolved dependency inputs
- document the advisory-only boundary, Scorecard token limitation, and RustSec ownership in CI-CONTRACT.md

## Boundaries
- no pull_request or push trigger
- no ruleset or required-context mutation
- Rust advisory policy remains owned by cargo-deny/cargo-audit, not this OSV slice

## Test Plan
- ruby YAML parse for .github/workflows/*.yml
- actionlint on the new workflows
- zizmor --min-confidence high on the new workflows
- git diff --check
- local pre-commit hooks during commit/push
