### PR TITLE
ci: skip symlinks in public artifact sanitizer

### DIFF
--- a/scripts/ci/check-public-artifact-sanitization.py
+++ b/scripts/ci/check-public-artifact-sanitization.py
@@ -149,7 +149,7 @@ def should_scan(path: Path, root: Path) -> bool:
             return False
         if path.stat().st_size > TEXT_BYTES_LIMIT:
             return False
-    except OSError:
+    except FileNotFoundError:
         return False
     return True
 

--- a/scripts/ci/check-public-artifact-sanitization.py
+++ b/scripts/ci/check-public-artifact-sanitization.py
@@ -23,7 +23,6 @@ import io
 import os
 import re
 import subprocess
-import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -146,9 +145,11 @@ def should_scan(path: Path, root: Path) -> bool:
     if path.suffix.lower() in EXCLUDED_SUFFIXES:
         return False
     try:
+        if path.is_symlink():
+            return False
         if path.stat().st_size > TEXT_BYTES_LIMIT:
             return False
-    except FileNotFoundError:
+    except OSError:
         return False
     return True
 
@@ -279,7 +280,17 @@ def self_test() -> None:
         (root / "target" / "generated.txt").write_text(
             "DO NOT PUBLISH\n", encoding="utf-8"
         )
-        findings = scan_files([root / "README.md", root / "target" / "generated.txt"], root)
+        files = [root / "README.md", root / "target" / "generated.txt"]
+        outside = root.parent / "outside-marker.txt"
+        outside.write_text(f"{marker}\n", encoding="utf-8")
+        symlink = root / "linked-marker.txt"
+        try:
+            symlink.symlink_to(outside)
+        except (OSError, NotImplementedError):
+            pass
+        else:
+            files.append(symlink)
+        findings = scan_files(files, root)
         assert len(findings) == 1
         assert findings[0].path == Path("README.md")
         assert findings[0].category == "publication_blocker_marker"


### PR DESCRIPTION
## Summary
- skip symlinks in the public artifact sanitizer before reading file contents
- treat filesystem metadata errors as a non-scannable path
- add self-test coverage proving a symlink to marked content outside the repo is ignored

## Verification
- `python3 <sanitizer> --self-test`
- `python3 -m py_compile <sanitizer>`
- `uvx ruff check <sanitizer>`

## Notes
This does not change sanitizer categories, matched-text handling, trusted HMAC behavior, or log output. It is defense-in-depth for the path handling reviewed in Slice 6.
