### PR TITLE
ci(deps): triage RUSTSEC-2026-0176 (pyo3) as not reachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,8 @@ jobs:
         run: |
           rm -rf ~/.cargo/advisory-db
           # RUSTSEC-2023-0071 (rsa Marvin Attack): no fixed upgrade; assay-mcp-server JWT (see deny.toml)
-          cargo audit --ignore RUSTSEC-2023-0071
+          # RUSTSEC-2026-0176 (pyo3 nth/nth_back OOB): not reachable in assay; pyo3 0.29 migration tracked in #1651
+          cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0176
 
   clippy:
     name: Clippy (deny warnings)

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,10 @@ ignore = [
     # rsa: transitive via jsonwebtoken (assay-mcp-server). No safe upgrade; timing sidechannel.
     # JWT verification is server-side; accept risk for MCP auth until jsonwebtoken/rsa offer a fix.
     "RUSTSEC-2023-0071",
+    # pyo3 OOB reads in BoundList/TupleIterator nth/nth_back (large n). Not reachable: assay-python-sdk
+    # iterates via .iter().enumerate(), never .nth() on pyo3 iterators. Fix = pyo3 0.29 migration (#1651);
+    # remove this ignore when that lands.
+    "RUSTSEC-2026-0176",
 ]
 
 # =============================================================================


### PR DESCRIPTION
## Why

RUSTSEC-2026-0176 (pyo3, published 2026-06-11) started failing the **Dependency Security (cargo-deny + audit)** gate on every assay PR, including the unrelated symlink-hardening PR (#1650). The advisory: out-of-bounds reads in `BoundListIterator`/`BoundTupleIterator` `nth`/`nth_back` with large `n` (affected 0.24.0–0.28.x, patched 0.29.0). assay pins `pyo3 0.24.2`.

## Reachability: nil

The vulnerable methods are never called here. `assay-python-sdk` iterates with `.iter().enumerate()`, never `.nth()` on a pyo3 list/tuple iterator; every `.nth()` elsewhere in the tree is on a Rust std iterator (string splits, env args), which the advisory doesn't touch. So the advisory **does not affect assay's usage today.**

## What this does

Adds a **documented** ignore to `deny.toml` and the `cargo audit --ignore` line — the same auditable pattern already used for RUSTSEC-2023-0071. This is a triage decision, not a bypass: the gate passes because the advisory is explicitly assessed and recorded, with the rationale and a tracking issue in the comment.

The real fix is the pyo3 0.24 → 0.29 migration (gated on pythonize compatibility), tracked in #1651. **The ignore is temporary** — its comment points at #1651 and says to remove it when the migration lands.

## Effect

Unblocks the Dependency Security gate so #1650 (and other unrelated PRs) can merge. Local `cargo deny check advisories` passes with the ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)