### PR TITLE
ci: restore green after upstream dependency churn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,9 @@ jobs:
           rm -rf ~/.cargo/advisory-db
           # RUSTSEC-2023-0071 (rsa Marvin Attack): no fixed upgrade; assay-mcp-server JWT (see deny.toml)
           # RUSTSEC-2026-0176 (pyo3 nth/nth_back OOB): not reachable in assay; pyo3 0.29 migration tracked in #1651
-          cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0176
+          # RUSTSEC-2026-0177 (pyo3 PyCFunction::new_closure missing Sync bound): not reachable — assay
+          # never calls PyCFunction::new_closure. TEMPORARY ignore, removed by the pyo3 0.29 migration (#1651).
+          cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0176 --ignore RUSTSEC-2026-0177
 
   clippy:
     name: Clippy (deny warnings)

--- a/.github/workflows/smoke-install.yml
+++ b/.github/workflows/smoke-install.yml
@@ -27,7 +27,11 @@ jobs:
 
       - name: Build and Install Assay (from source)
         run: |
-          cargo install --path crates/assay-cli --debug
+          # --locked: install with the committed Cargo.lock, not a fresh resolution. Without it
+          # `cargo install` re-resolves to the newest semver-compatible deps, which can pull a broken
+          # upstream combination (e.g. ratatui-widgets 0.3.1 + time 0.3.48 -> E0119) that the pinned
+          # lockfile avoids. Matches the --locked the other `cargo install` calls in CI already use.
+          cargo install --path crates/assay-cli --debug --locked
           assay --version
 
       - name: Migrate config (check-only, strict)

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,9 @@ ignore = [
     # iterates via .iter().enumerate(), never .nth() on pyo3 iterators. Fix = pyo3 0.29 migration (#1651);
     # remove this ignore when that lands.
     "RUSTSEC-2026-0176",
+    # pyo3 missing `Sync` bound on `PyCFunction::new_closure` closures. Not reachable: assay never calls
+    # PyCFunction::new_closure. TEMPORARY ignore until the pyo3 0.29 migration (#1651) — remove it then.
+    "RUSTSEC-2026-0177",
 ]
 
 # =============================================================================


### PR DESCRIPTION
Two independent, time-based upstream regressions broke CI on every current PR (and a fresh `main` run would hit them too). Neither is caused by any source change; both are external churn from 2026-06-11/12. Kept deliberately separate below.

### 1. Smoke Install (E2E): pin the from-source install

`smoke-install.yml` ran `cargo install --path crates/assay-cli --debug` without `--locked`, so it re-resolved to the newest semver-compatible dependencies and pulled a broken upstream combination — `ratatui-widgets 0.3.1` + `time 0.3.48`, which conflict (`E0119`). The committed `Cargo.lock` pins the working `ratatui-widgets 0.3.0` / `time 0.3.47`.

Fix: add `--locked` so the install uses the committed lockfile. This matches the `--locked` the other `cargo install` invocations in CI already use.

### 2. Dependency Security: triage RUSTSEC-2026-0177

[RUSTSEC-2026-0177](https://rustsec.org/advisories/RUSTSEC-2026-0177) (published 2026-06-11) flags `pyo3 0.24.2` for a missing `Sync` bound on `PyCFunction::new_closure` closures. `cargo audit` fetches a fresh advisory DB each run, so it appeared after `main` last went green.

- **Not reachable:** assay never calls `PyCFunction::new_closure` (verified, no usage anywhere in the tree).
- Added as a **temporary** ignore in both `ci.yml` (the `cargo audit` flags) and `deny.toml`, with the same rationale in both places.
- Removed by the pyo3 0.29 migration (#1651), the same path that retires RUSTSEC-2026-0176.
- No broad `pyo3` allow and no severity downgrade.

Verified locally: `cargo deny check advisories` and `cargo audit` (with the three ignores) both exit 0; YAML parses; actionlint pre-commit passes.

Refs #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)