### PR TITLE
test(mcp-server): emit canonical enforcement_decision.v0 contract fixture

### DIFF
--- a/crates/assay-mcp-server/src/proxy/enforce.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce.rs
@@ -1315,4 +1315,90 @@ allowances:
         );
         assert_eq!(d.reason, "credential_scope_unknown", "credential > drift");
     }
+
+    // ---- Shared producer/consumer contract fixture (Rul1an/plimsoll#45) ------------------------
+    //
+    // The canonical `assay.enforcement_decision.v0` contract is the REAL output of `decision_record`,
+    // not a hand-authored mirror. This test regenerates one record per distinct producer outcome (the
+    // allow row plus every deny reason, with real `target_digest` and the full `non_claims`) and
+    // asserts it equals the committed fixture as a serde_json::Value (order-independent). Plimsoll
+    // vendors the SAME file and asserts its consumer accepts every record, so neither side can drift.
+    // Regenerate after an intentional producer change: ASSAY_UPDATE_GOLDEN=1 cargo test -p
+    // assay-mcp-server --bins pdp_golden_contract_fixture.
+
+    fn contract_fixture_path() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/enforcement_decision_contract.v0.json")
+    }
+
+    /// One real producer record per distinct decision outcome (deduped by reason; the two
+    /// current_observation_incomplete cases collapse to one identical record).
+    fn contract_records() -> Vec<Value> {
+        let mut seen = std::collections::BTreeSet::new();
+        let mut out = Vec::new();
+        for c in golden_corpus() {
+            let d = decide(&c.policy, &c.baseline, &c.observed, c.tool, &c.args);
+            if !seen.insert(d.reason) {
+                continue; // one canonical record per reason
+            }
+            let rec = decision_record(&c.policy, &d, c.tool, &c.args);
+            out.push(json!({ "case": c.name, "record": rec }));
+        }
+        out
+    }
+
+    fn contract_document() -> Value {
+        json!({
+            "schema_contract": "assay.enforcement_decision.v0",
+            "generated_by": "assay crates/assay-mcp-server enforce::decision_record (pdp_golden_contract_fixture)",
+            "note": "Canonical producer output, regenerated from decision_record. Consumers (e.g. Rul1an/plimsoll#45) vendor this file verbatim. Regenerate with ASSAY_UPDATE_GOLDEN=1.",
+            "records": contract_records(),
+        })
+    }
+
+    #[test]
+    fn pdp_golden_contract_fixture() {
+        let generated = contract_document();
+        let path = contract_fixture_path();
+
+        if std::env::var("ASSAY_UPDATE_GOLDEN").is_ok() {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let pretty = serde_json::to_string_pretty(&generated).unwrap();
+            std::fs::write(&path, format!("{pretty}\n")).unwrap();
+        }
+
+        let committed_text = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+            panic!(
+                "missing {}; regenerate with ASSAY_UPDATE_GOLDEN=1",
+                path.display()
+            )
+        });
+        let committed: Value = serde_json::from_str(&committed_text).unwrap();
+        assert_eq!(
+            committed, generated,
+            "the committed contract fixture is stale; regenerate with ASSAY_UPDATE_GOLDEN=1"
+        );
+
+        // Sanity: every record is the v0 carrier, carries no `forwarded` field, and references the
+        // credential by alias only (no scopes key) — the discipline the consumer relies on.
+        let records = generated["records"].as_array().unwrap();
+        assert!(!records.is_empty());
+        for entry in records {
+            let rec = &entry["record"];
+            assert_eq!(rec["schema"], "assay.enforcement_decision.v0");
+            assert!(
+                rec.get("forwarded").is_none(),
+                "no record may carry a forwarded field"
+            );
+            let alias = &rec["credential_alias"];
+            assert!(
+                alias.is_null() || alias.is_string(),
+                "credential_alias is alias-or-null"
+            );
+            assert!(
+                rec.get("scopes").is_none(),
+                "a record must not carry a scopes key"
+            );
+        }
+    }
 }

--- a/crates/assay-mcp-server/tests/fixtures/enforcement_decision_contract.v0.json
+++ b/crates/assay-mcp-server/tests/fixtures/enforcement_decision_contract.v0.json
@@ -1,0 +1,352 @@
+{
+  "schema_contract": "assay.enforcement_decision.v0",
+  "generated_by": "assay crates/assay-mcp-server enforce::decision_record (pdp_golden_contract_fixture)",
+  "note": "Canonical producer output, regenerated from decision_record. Consumers (e.g. Rul1an/plimsoll#45) vendor this file verbatim. Regenerate with ASSAY_UPDATE_GOLDEN=1.",
+  "records": [
+    {
+      "case": "unclassified_tool_call",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "misc.do_thing",
+          "action_class": null
+        },
+        "action": {
+          "verb": null,
+          "resource_type": null,
+          "target": null,
+          "target_digest": null
+        },
+        "decision": "deny",
+        "reason": "unclassified_tool_call",
+        "fail_closed": true,
+        "drift_state": "not_evaluated",
+        "credential_alias": "gh-deploy",
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    },
+    {
+      "case": "classification_incomplete",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "github.add_deploy_key",
+          "action_class": "github_deploy_key"
+        },
+        "action": {
+          "verb": "create",
+          "resource_type": "github_deploy_key",
+          "target": {
+            "provider": "github",
+            "owner": "acme"
+          },
+          "target_digest": "sha256:df4be9dfaa840f625ba03f5d577e6276a732f565c9527521138cfee1874546cf"
+        },
+        "decision": "deny",
+        "reason": "classification_incomplete",
+        "fail_closed": true,
+        "drift_state": "not_evaluated",
+        "credential_alias": "gh-deploy",
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    },
+    {
+      "case": "no_declared_allowance",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "github.add_deploy_key",
+          "action_class": "github_deploy_key"
+        },
+        "action": {
+          "verb": "create",
+          "resource_type": "github_deploy_key",
+          "target": {
+            "provider": "github",
+            "owner": "other",
+            "repo": "x"
+          },
+          "target_digest": "sha256:8809c01daec4774b30f8ce69ced56c843546cce9a4d39db437461870678cab84"
+        },
+        "decision": "deny",
+        "reason": "no_declared_allowance",
+        "fail_closed": true,
+        "drift_state": "not_evaluated",
+        "credential_alias": "gh-deploy",
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    },
+    {
+      "case": "credential_scope_unknown",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "github.add_deploy_key",
+          "action_class": "github_deploy_key"
+        },
+        "action": {
+          "verb": "create",
+          "resource_type": "github_deploy_key",
+          "target": {
+            "provider": "github",
+            "owner": "acme",
+            "repo": "prod-app"
+          },
+          "target_digest": "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc"
+        },
+        "decision": "deny",
+        "reason": "credential_scope_unknown",
+        "fail_closed": true,
+        "drift_state": "not_evaluated",
+        "credential_alias": null,
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    },
+    {
+      "case": "credential_scope_insufficient",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "github.add_deploy_key",
+          "action_class": "github_deploy_key"
+        },
+        "action": {
+          "verb": "create",
+          "resource_type": "github_deploy_key",
+          "target": {
+            "provider": "github",
+            "owner": "acme",
+            "repo": "prod-app"
+          },
+          "target_digest": "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc"
+        },
+        "decision": "deny",
+        "reason": "credential_scope_insufficient",
+        "fail_closed": true,
+        "drift_state": "not_evaluated",
+        "credential_alias": "gh-ro",
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    },
+    {
+      "case": "manifest_baseline_missing",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "github.add_deploy_key",
+          "action_class": "github_deploy_key"
+        },
+        "action": {
+          "verb": "create",
+          "resource_type": "github_deploy_key",
+          "target": {
+            "provider": "github",
+            "owner": "acme",
+            "repo": "prod-app"
+          },
+          "target_digest": "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc"
+        },
+        "decision": "deny",
+        "reason": "manifest_baseline_missing",
+        "fail_closed": true,
+        "drift_state": "baseline_missing",
+        "credential_alias": "gh-deploy",
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    },
+    {
+      "case": "manifest_current_observation_incomplete",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "github.add_deploy_key",
+          "action_class": "github_deploy_key"
+        },
+        "action": {
+          "verb": "create",
+          "resource_type": "github_deploy_key",
+          "target": {
+            "provider": "github",
+            "owner": "acme",
+            "repo": "prod-app"
+          },
+          "target_digest": "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc"
+        },
+        "decision": "deny",
+        "reason": "manifest_current_observation_incomplete",
+        "fail_closed": true,
+        "drift_state": "current_observation_incomplete",
+        "credential_alias": "gh-deploy",
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    },
+    {
+      "case": "manifest_observation_ambiguous",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "github.add_deploy_key",
+          "action_class": "github_deploy_key"
+        },
+        "action": {
+          "verb": "create",
+          "resource_type": "github_deploy_key",
+          "target": {
+            "provider": "github",
+            "owner": "acme",
+            "repo": "prod-app"
+          },
+          "target_digest": "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc"
+        },
+        "decision": "deny",
+        "reason": "manifest_observation_ambiguous",
+        "fail_closed": true,
+        "drift_state": "observation_ambiguous",
+        "credential_alias": "gh-deploy",
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    },
+    {
+      "case": "manifest_drifted_since_approval",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "github.add_deploy_key",
+          "action_class": "github_deploy_key"
+        },
+        "action": {
+          "verb": "create",
+          "resource_type": "github_deploy_key",
+          "target": {
+            "provider": "github",
+            "owner": "acme",
+            "repo": "prod-app"
+          },
+          "target_digest": "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc"
+        },
+        "decision": "deny",
+        "reason": "manifest_drifted_since_approval",
+        "fail_closed": true,
+        "drift_state": "drifted",
+        "credential_alias": "gh-deploy",
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    },
+    {
+      "case": "all_gates_pass_allow",
+      "record": {
+        "schema": "assay.enforcement_decision.v0",
+        "caller": {
+          "id": "ci-agent"
+        },
+        "tool": {
+          "name": "github.add_deploy_key",
+          "action_class": "github_deploy_key"
+        },
+        "action": {
+          "verb": "create",
+          "resource_type": "github_deploy_key",
+          "target": {
+            "provider": "github",
+            "owner": "acme",
+            "repo": "prod-app"
+          },
+          "target_digest": "sha256:c3ff823d7fb2ee33b9f1a3f7be6eaf849acb980b6ec960731506436b56384dfc"
+        },
+        "decision": "allow",
+        "reason": "allow",
+        "fail_closed": false,
+        "drift_state": "satisfied",
+        "credential_alias": "gh-deploy",
+        "non_claims": [
+          "policy decision only; does not assert or verify the upstream side effect (stays asserted, E9 ladder)",
+          "an allow is the decision to forward; it does not assert the call reached or was performed by the upstream (a transport failure surfaces as proxy_failed, not here)",
+          "credential referenced by alias only, never the token or declared scopes",
+          "deny is fail-closed caution and allow is a policy decision — neither is a maliciousness verdict",
+          "not the observation artifact (assay.mcp_manifest_observed.v0) and not the mechanism artifact (assay.enforcement_health.v0)"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The producer side of the shared `assay.enforcement_decision.v0` contract. This makes `enforce.rs` the canonical source of the record shape and emits it as a fixture that consumers vendor verbatim, so the producer and the Plimsoll consumer can no longer drift (the class of slip behind Rul1an/plimsoll#39 / #40).

## What it does

A new test, `pdp_golden_contract_fixture`, regenerates one real record per distinct decision outcome (the single `allow` row plus every deny reason) straight from `decision_record`, deduped by reason, and asserts it equals the committed fixture compared as a `serde_json::Value` (order-independent, so it survives the `preserve_order` feature). The fixture is the genuine producer output: real domain-separated `target_digest` values and the full `non_claims`, not hand-authored placeholders.

- Fixture: `crates/assay-mcp-server/tests/fixtures/enforcement_decision_contract.v0.json` (10 records).
- Regenerate after an intentional producer change: `ASSAY_UPDATE_GOLDEN=1 cargo test -p assay-mcp-server --bins pdp_golden_contract_fixture`.
- The test also sanity-checks that no record carries a `forwarded` field or a `scopes` key, and that `credential_alias` is alias-or-null.

## Why

The merged golden corpus (#1654) pins the producer's decision logic. This adds the producer's *serialized record* as a vendored artifact. The Plimsoll consumer PR (Rul1an/plimsoll#45) is being reworked to vendor this exact file and assert its classifier accepts every record, which closes the loop mechanically on both sides: a producer change regenerates this fixture, the changed fixture is vendored into Plimsoll, and the consumer test sees it.

Test-only; no production code changed. `cargo test -p assay-mcp-server --bins` green (39), clippy and fmt clean.

Refs #1649, Rul1an/plimsoll#45

🤖 Generated with [Claude Code](https://claude.com/claude-code)