### PR TITLE
release: assay 3.24.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,10 @@ repos:
 
       - id: cargo-audit
         name: cargo audit (RustSec)
-        entry: bash -lc 'cargo audit'
+        # Keep the ignore list in lockstep with .github/workflows/ci.yml and deny.toml: these
+        # advisories are triaged as not reachable (rsa Marvin Attack; pyo3 0.24 nth/nth_back and
+        # PyCFunction::new_closure), retired by the pyo3 0.29 migration (#1651).
+        entry: bash -lc 'cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0176 --ignore RUSTSEC-2026-0177'
         language: system
         pass_filenames: false
         files: ^Cargo\.lock$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.24.0] - 2026-06-12
+
+### Added
+- Enforcing-proxy policy decision point (P61e-c), an explicit opt-in `assay-mcp-server proxy-enforce`
+  mode that decides each `tools/call` before forwarding. It is fail-closed by construction and runs
+  three gates in fixed precedence: a caller-allowance gate, a credential-scope gate (c2) that denies
+  when the declared upstream credential does not cover the action's required scope, and a manifest
+  drift gate (c3) that requires both an approval-time baseline and a current complete observation and
+  denies when the invoked tool's digest drifted since approval. Only a call clearing every gate is
+  forwarded; there is no observe-only forwarding and no allow path without a current complete manifest.
+  - It is not an authorization server and makes no grant decision of its own.
+  - An allow is the decision to forward; it is not proof the call was delivered or that a side effect
+    occurred (a transport failure surfaces to the caller, never as a delivery claim).
+  - It decides per call; it does not reason about multi-step or sequential behaviour.
+- `assay.enforcement_decision.v0` per-call evidence record (P61e-d): a deterministic record emitted for
+  both allow and deny, carrying the decision, the precedence-pinned reason, `fail_closed`, the
+  `drift_state`, and the credential alias (never the token or scopes). It records the policy decision
+  only and carries no `forwarded` / delivery field.
+- PDP golden corpus: an in-repo deterministic truth table over `enforce.rs::decide` covering every gate
+  outcome, with reason precedence pinned and the emitted record shape asserted per case — the oracle the
+  decision logic is regression-locked against.
+- Canonical `assay.enforcement_decision.v0` contract fixture regenerated from `decision_record`, so a
+  downstream consumer can vendor the exact producer output rather than a hand-authored mirror.
+
+### Changed
+- Supply-chain and public-artifact hardening: scheduled supply-chain posture, an HMAC-based trusted
+  sanitizer layer, RUSTSEC advisory triage (`RUSTSEC-2026-0176`/`-0177` documented as not reachable,
+  pending the pyo3 0.29 migration), and a `--locked` from-source smoke install.
+
 ## [3.23.0] - 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.23.0"
+version = "3.24.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.23.0"
+version = "3.24.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Workspace version bump (3.23.0 → 3.24.0) + CHANGELOG finalize. **No tag pushed and no release workflow triggered.** This PR only prepares a clean, reviewable version point; tagging `v3.24.0` (which triggers binaries + **crates.io / PyPI** — public and practically irreversible) stays gated on an explicit final go.

## What 3.24.0 captures (merged since 3.23.0), bounded

- **Enforcing-proxy policy decision point (P61e-c)** — an opt-in `assay-mcp-server proxy-enforce` mode that decides each `tools/call` before forwarding. Fail-closed; three gates in fixed precedence (caller-allowance, credential-scope c2, manifest-drift c3); only an all-gates-pass call forwards, with no allow path without a current complete manifest. Non-claims kept explicit: it is not an authorization server; an allow is the decision to forward, not proof of delivery or a side effect; it decides per call and does not reason about multi-step behaviour.
- **`assay.enforcement_decision.v0` per-call evidence record (P61e-d)** — emitted for allow and deny, carrying decision / precedence-pinned reason / `fail_closed` / `drift_state` / credential alias (never token or scopes), with no `forwarded` / delivery field.
- **PDP golden corpus** — an in-repo deterministic truth table over `enforce.rs::decide`, the oracle the decision logic is regression-locked against; plus the canonical `enforcement_decision.v0` contract fixture regenerated from `decision_record` (so a consumer vendors exact producer output).
- **Supply-chain / sanitizer hardening** — scheduled supply-chain posture, HMAC trusted-sanitizer layer, RUSTSEC triage (`-0176`/`-0177` not reachable, pending the pyo3 0.29 migration #1651), `--locked` smoke install.

## Mechanics

- Only `[workspace.package] version` bumped (3.24.0); internal dep pins stay at their `3.19.1` lower bound as in prior releases. `Cargo.lock` refreshed for workspace members only (103 externals unchanged).
- CHANGELOG `[Unreleased]` → `[3.24.0] - 2026-06-12`.
- Also aligns the pre-push `cargo-audit` hook ignores with CI / `deny.toml` (the bare hook tripped on the triaged advisories when the lockfile bumped).

Order agreed: prepare both release PRs, no tags; plimsoll `v0.11.0` (private, GH-release) tags first; assay `v3.24.0` only after explicit final go because crates.io/PyPI is public and irreversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)