### PR TITLE
feat(mcp-server): pre-call manifest-establish decision layer (P61e, Increment 1)

### DIFF
--- a/crates/assay-mcp-server/src/proxy/establish.rs
+++ b/crates/assay-mcp-server/src/proxy/establish.rs
@@ -1,0 +1,325 @@
+// Pre-call manifest-establish decision logic (P61e, Increment 1).
+//
+// This module is the PURE decision layer for the pre-call manifest-establish flow described in the
+// review-spec: before `enforce::decide()`'s drift gate runs on a privileged `tools/call`, decide
+// whether the proxy should try to establish a current complete manifest (a bounded re-list) or deny
+// immediately, and classify which establish path the call took for the sibling observability carrier
+// `assay.manifest_establish.v0`.
+//
+// Increment 1 scope (deliberate): no proxy-originated `tools/list` plumbing, no change to
+// `enforce::decide()`, no change to the live relay, and no change to the pinned
+// `assay.enforcement_decision.v0` contract. The live re-list and the emission of this carrier on the
+// relay path land in Increment 2. The items here are therefore not yet wired into the binary's run
+// path, hence `allow(dead_code)`; they are fully exercised by the unit tests below and consumed by the
+// relay in Increment 2.
+#![allow(dead_code)]
+
+use serde_json::{json, Value};
+
+use super::enforce::ObservedToolDigest;
+
+/// Sibling observability carrier schema. Deliberately SEPARATE from `assay.enforcement_decision.v0`
+/// so that pinned producer/consumer contract stays byte-identical (no re-vendor, no consumer churn).
+pub const MANIFEST_ESTABLISH_SCHEMA: &str = "assay.manifest_establish.v0";
+
+/// What the establish step should do for a given observed manifest state, BEFORE the drift gate.
+///
+/// The mapping is fail-closed and never lets establish overreach: it only targets the observed-side
+/// availability gap. It never tries to supply a declared baseline, resolve an ambiguous observation, or
+/// clear real drift — those remain `enforce::decide()`'s job and stay denials.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EstablishAction {
+    /// A current complete observation of this tool already exists: no establish needed.
+    NotNeeded,
+    /// No current complete observation (or one invalidated by a later `tools/list_changed`): a bounded
+    /// re-list may supply one.
+    ReList,
+    /// A complete manifest was observed but the invoked tool is absent: re-list ONCE (the tool may have
+    /// been added since the last list), deny if still absent.
+    ReListOnce,
+    /// An inconclusive/structural state establish cannot resolve (duplicate-name ambiguity): deny
+    /// without an establish attempt, never allow.
+    DenyWithoutEstablish,
+}
+
+/// Decide the establish action for an observed manifest state. Pure; no I/O.
+pub fn establish_action(observed: &ObservedToolDigest) -> EstablishAction {
+    match observed {
+        ObservedToolDigest::Present(_) => EstablishAction::NotNeeded,
+        ObservedToolDigest::NoCompleteManifest => EstablishAction::ReList,
+        ObservedToolDigest::CompleteButToolAbsent => EstablishAction::ReListOnce,
+        ObservedToolDigest::Ambiguous => EstablishAction::DenyWithoutEstablish,
+    }
+}
+
+/// The result of an establish attempt. Increment 1's run path only ever produces `NotPerformed`
+/// (no live re-list yet); the other two model Increment 2's outcomes so the path resolution and its
+/// never-allow invariant are testable now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EstablishOutcome {
+    /// No establish was attempted (Increment 1 default, or `EstablishAction::DenyWithoutEstablish`).
+    NotPerformed,
+    /// A fresh complete observation was obtained (Increment 2).
+    EstablishedComplete,
+    /// The establish attempt failed: timeout, partial/incomplete list, transport error, or still
+    /// ambiguous / still tool-absent (Increment 2).
+    EstablishFailed,
+}
+
+/// The path a privileged call took through the establish step, for the sibling carrier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EstablishPath {
+    /// A current complete observation already existed; the establish step was a no-op.
+    NoEstablishNeeded,
+    /// Establish produced a complete observation and the re-evaluated decision allowed.
+    EstablishedThenAllowed,
+    /// Establish produced a complete observation but the re-evaluated decision still denied
+    /// (e.g. real drift, or tool still absent).
+    EstablishedThenDenied,
+    /// Denied without (or despite a failed) establish attempt.
+    ImmediateDeny,
+}
+
+impl EstablishPath {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EstablishPath::NoEstablishNeeded => "no_establish_needed",
+            EstablishPath::EstablishedThenAllowed => "established_then_allowed",
+            EstablishPath::EstablishedThenDenied => "established_then_denied",
+            EstablishPath::ImmediateDeny => "immediate_deny",
+        }
+    }
+}
+
+/// Resolve the establish path from the action, the attempt outcome, and the re-evaluated decision.
+///
+/// Load-bearing invariant: the ONLY path that corresponds to an allow is `EstablishedThenAllowed`, and
+/// it requires BOTH an `EstablishedComplete` outcome AND a `decide_allowed` re-evaluation. A
+/// not-performed or failed establish therefore never allows, and `DenyWithoutEstablish` (ambiguous)
+/// never allows regardless of outcome.
+pub fn establish_path(
+    action: EstablishAction,
+    outcome: EstablishOutcome,
+    decide_allowed: bool,
+) -> EstablishPath {
+    match action {
+        EstablishAction::NotNeeded => EstablishPath::NoEstablishNeeded,
+        EstablishAction::DenyWithoutEstablish => EstablishPath::ImmediateDeny,
+        EstablishAction::ReList | EstablishAction::ReListOnce => match outcome {
+            EstablishOutcome::EstablishedComplete if decide_allowed => {
+                EstablishPath::EstablishedThenAllowed
+            }
+            EstablishOutcome::EstablishedComplete => EstablishPath::EstablishedThenDenied,
+            EstablishOutcome::NotPerformed | EstablishOutcome::EstablishFailed => {
+                EstablishPath::ImmediateDeny
+            }
+        },
+    }
+}
+
+/// Build the sibling `assay.manifest_establish.v0` carrier record. Kept intentionally small and
+/// separate from the enforcement-decision record.
+pub fn build_manifest_establish_record(
+    path: EstablishPath,
+    action_class: Option<&str>,
+    establish_attempted: bool,
+) -> Value {
+    json!({
+        "schema": MANIFEST_ESTABLISH_SCHEMA,
+        "establish_path": path.as_str(),
+        "establish_attempted": establish_attempted,
+        "action_class": action_class,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- the agreed establish-action table ---
+
+    #[test]
+    fn no_complete_manifest_triggers_relist() {
+        assert_eq!(
+            establish_action(&ObservedToolDigest::NoCompleteManifest),
+            EstablishAction::ReList
+        );
+    }
+
+    #[test]
+    fn complete_but_tool_absent_triggers_relist_once() {
+        assert_eq!(
+            establish_action(&ObservedToolDigest::CompleteButToolAbsent),
+            EstablishAction::ReListOnce
+        );
+    }
+
+    #[test]
+    fn ambiguous_is_immediate_deny_no_establish() {
+        assert_eq!(
+            establish_action(&ObservedToolDigest::Ambiguous),
+            EstablishAction::DenyWithoutEstablish
+        );
+    }
+
+    #[test]
+    fn present_needs_no_establish() {
+        assert_eq!(
+            establish_action(&ObservedToolDigest::Present("sha256:t".to_string())),
+            EstablishAction::NotNeeded
+        );
+    }
+
+    // --- path resolution ---
+
+    #[test]
+    fn not_needed_path_is_no_establish_needed() {
+        assert_eq!(
+            establish_path(
+                EstablishAction::NotNeeded,
+                EstablishOutcome::NotPerformed,
+                true
+            ),
+            EstablishPath::NoEstablishNeeded
+        );
+    }
+
+    #[test]
+    fn ambiguous_path_is_immediate_deny_regardless_of_outcome() {
+        for outcome in [
+            EstablishOutcome::NotPerformed,
+            EstablishOutcome::EstablishFailed,
+            EstablishOutcome::EstablishedComplete,
+        ] {
+            for allowed in [true, false] {
+                assert_eq!(
+                    establish_path(EstablishAction::DenyWithoutEstablish, outcome, allowed),
+                    EstablishPath::ImmediateDeny
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn established_complete_and_allowed_is_established_then_allowed() {
+        for action in [EstablishAction::ReList, EstablishAction::ReListOnce] {
+            assert_eq!(
+                establish_path(action, EstablishOutcome::EstablishedComplete, true),
+                EstablishPath::EstablishedThenAllowed
+            );
+        }
+    }
+
+    #[test]
+    fn established_complete_but_denied_is_established_then_denied() {
+        for action in [EstablishAction::ReList, EstablishAction::ReListOnce] {
+            assert_eq!(
+                establish_path(action, EstablishOutcome::EstablishedComplete, false),
+                EstablishPath::EstablishedThenDenied
+            );
+        }
+    }
+
+    #[test]
+    fn relist_without_or_failed_establish_is_immediate_deny() {
+        for action in [EstablishAction::ReList, EstablishAction::ReListOnce] {
+            for outcome in [
+                EstablishOutcome::NotPerformed,
+                EstablishOutcome::EstablishFailed,
+            ] {
+                for allowed in [true, false] {
+                    assert_eq!(
+                        establish_path(action, outcome, allowed),
+                        EstablishPath::ImmediateDeny
+                    );
+                }
+            }
+        }
+    }
+
+    // --- acceptance invariants ---
+
+    #[test]
+    fn failed_or_unavailable_establish_never_allows() {
+        // Across the whole cross-product, the only allow path requires EstablishedComplete AND
+        // decide_allowed; a not-performed or failed establish must never produce an allow path.
+        for action in [
+            EstablishAction::NotNeeded,
+            EstablishAction::ReList,
+            EstablishAction::ReListOnce,
+            EstablishAction::DenyWithoutEstablish,
+        ] {
+            for outcome in [
+                EstablishOutcome::NotPerformed,
+                EstablishOutcome::EstablishFailed,
+                EstablishOutcome::EstablishedComplete,
+            ] {
+                for allowed in [true, false] {
+                    let path = establish_path(action, outcome, allowed);
+                    if path == EstablishPath::EstablishedThenAllowed {
+                        assert_eq!(outcome, EstablishOutcome::EstablishedComplete);
+                        assert!(allowed);
+                        assert!(matches!(
+                            action,
+                            EstablishAction::ReList | EstablishAction::ReListOnce
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn establish_never_resolves_ambiguous_baseline_or_drift() {
+        // Ambiguity is the only ObservedToolDigest state establish can see that is inconclusive;
+        // it must always map to a non-establishing deny. Baseline-missing and real drift are decided
+        // by enforce::decide() over a Present digest, so establish (which only yields Present) can
+        // never be the thing that clears them: it has no DenyWithoutEstablish escape hatch back to allow.
+        assert_eq!(
+            establish_action(&ObservedToolDigest::Ambiguous),
+            EstablishAction::DenyWithoutEstablish
+        );
+        // Even a "successful" establish on an ambiguous action cannot allow.
+        assert_eq!(
+            establish_path(
+                EstablishAction::DenyWithoutEstablish,
+                EstablishOutcome::EstablishedComplete,
+                true
+            ),
+            EstablishPath::ImmediateDeny
+        );
+    }
+
+    // --- sibling carrier ---
+
+    #[test]
+    fn carrier_record_uses_sibling_schema_and_does_not_touch_enforcement_decision() {
+        let rec = build_manifest_establish_record(
+            EstablishPath::EstablishedThenAllowed,
+            Some("github_deploy_key"),
+            true,
+        );
+        assert_eq!(rec["schema"], json!("assay.manifest_establish.v0"));
+        assert_ne!(rec["schema"], json!("assay.enforcement_decision.v0"));
+        assert_eq!(rec["establish_path"], json!("established_then_allowed"));
+        assert_eq!(rec["establish_attempted"], json!(true));
+        assert_eq!(rec["action_class"], json!("github_deploy_key"));
+    }
+
+    #[test]
+    fn carrier_path_strings_are_stable() {
+        assert_eq!(
+            EstablishPath::NoEstablishNeeded.as_str(),
+            "no_establish_needed"
+        );
+        assert_eq!(
+            EstablishPath::EstablishedThenAllowed.as_str(),
+            "established_then_allowed"
+        );
+        assert_eq!(
+            EstablishPath::EstablishedThenDenied.as_str(),
+            "established_then_denied"
+        );
+        assert_eq!(EstablishPath::ImmediateDeny.as_str(), "immediate_deny");
+    }
+}

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -17,6 +17,9 @@
 //! "how completely was it observed" lives in the separate observation-health artifact, never folded in.
 
 pub mod enforce;
+// Pre-call manifest-establish decision layer (P61e, Increment 1). Pure logic + the
+// `assay.manifest_establish.v0` sibling carrier; not yet wired into the relay (Increment 2).
+pub mod establish;
 
 use anyhow::{Context, Result};
 use assay_mcp_server::manifest_observed::{self, Completeness};


### PR DESCRIPTION
Increment 1 of the pre-call manifest-establish flow (review-spec agreed). **Pure decision layer only** — deliberately scoped, low-risk, fully testable.

## What this is
When a privileged `tools/call` would be denied because the proxy has no current complete manifest observation, the establish flow lets the proxy obtain a fresh `tools/list` before the drift gate runs, so strict manifest enforcement is usable **without lowering the gate**. This PR lands the decision logic and the observability carrier; the live re-list is Increment 2.

## Scope (held tight)
- `establish_action(&ObservedToolDigest)` — the agreed table: `NoCompleteManifest → ReList`, `CompleteButToolAbsent → ReListOnce`, `Ambiguous → DenyWithoutEstablish`, `Present → NotNeeded`.
- `establish_path(action, outcome, decide_allowed)` — resolves the carrier path. The **only** allow path is `EstablishedThenAllowed`, requiring both `EstablishedComplete` and a re-evaluated allow.
- `assay.manifest_establish.v0` **sibling carrier** for `establish_path` observability — keeps it off the pinned `assay.enforcement_decision.v0` contract, so no fixture regen / no Plimsoll re-vendor.
- 13 unit tests: the table, path resolution, and the acceptance invariants (failed/unavailable establish never allows; ambiguous never resolved by establish; baseline/drift stay `decide()`'s job).

## Explicitly NOT in this PR
- No proxy-originated `tools/list` plumbing (Increment 2).
- No change to `enforce::decide()`.
- No change to the live relay (the module is declared but not yet wired in — `allow(dead_code)` with a comment, exercised by tests, wired in Increment 2).
- No change to `assay.enforcement_decision.v0` (contract fixture byte-identical).

## Verification
`cargo build`, `cargo test -p assay-mcp-server --bins` (13/13), `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` all green. DCO-signed.