### PR TITLE
feat(mcp-server): establish request-routing scaffold (P61e, Increment 2 slice 1)

### DIFF
--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -20,6 +20,11 @@ pub mod enforce;
 // Pre-call manifest-establish decision layer (P61e, Increment 1). Pure logic + the
 // `assay.manifest_establish.v0` sibling carrier; not yet wired into the relay (Increment 2).
 pub mod establish;
+// Internal request routing for the establish flow (P61e, Increment 2 slice 1): reserved-id namespace,
+// pending registry, single-reader suppression routing, and client-id collision rejection. The
+// suppression decision and collision guard are wired below (behavior-preserving); proxy-originated
+// re-list lands in slice 2.
+pub mod relay_routing;
 
 use anyhow::{Context, Result};
 use assay_mcp_server::manifest_observed::{self, Completeness};
@@ -439,11 +444,17 @@ pub async fn run(
         }
     });
 
+    // Establish registry (P61e Increment 2): shared between the establish caller (slice 2) and the
+    // single upstream reader. In slice 1 nothing registers a reserved id, so routing is a no-op and the
+    // relay is behavior-identical to before.
+    let establish_registry = relay_routing::EstablishRegistry::default();
+
     // Upstream → client: tap (read-only) then relay verbatim. A non-JSON upstream line is never
     // relayed as success.
     let up_tx = tx.clone();
     let up_obs = observer.clone();
     let up_manifest_out = manifest_out.clone();
+    let up_registry = establish_registry.clone();
     let upstream_reader = tokio::spawn(async move {
         let mut lines = BufReader::new(child_stdout).lines();
         while let Ok(Some(line)) = lines.next_line().await {
@@ -483,7 +494,18 @@ pub async fn run(
                             let _ = write_json_atomic(path, &m);
                         }
                     }
-                    let _ = up_tx.send(line);
+                    // Single-reader routing: a response to a pending proxy-originated establish request
+                    // is diverted to the registry and SUPPRESSED from the client stream; everything
+                    // else (and a reserved id that is not pending) relays verbatim. In slice 1 nothing
+                    // is ever pending, so this always relays.
+                    match relay_routing::route_upstream(&v, |id| up_registry.is_pending(id)) {
+                        relay_routing::UpstreamRoute::DivertToEstablish(id) => {
+                            up_registry.resolve(&id, v);
+                        }
+                        relay_routing::UpstreamRoute::RelayToClient => {
+                            let _ = up_tx.send(line);
+                        }
+                    }
                 }
                 Err(_) => {
                     let _ = up_tx.send(proxy_error_line(
@@ -515,6 +537,20 @@ pub async fn run(
                 continue;
             }
         };
+
+        // Reserved-id collision guard (P61e Increment 2): the proxy reserves the `assay-establish-` id
+        // namespace for its own originated requests. A client request whose id lands in that namespace
+        // is rejected, never forwarded — otherwise a colliding client id could cause a real client
+        // response to be routed into (and swallowed by) the establish registry.
+        if relay_routing::client_id_is_reserved(&v) {
+            let _ = tx.send(proxy_error_line(
+                v.get("id").cloned().unwrap_or(Value::Null),
+                PROXY_FAILED,
+                "reserved_id_namespace",
+                "client request id collides with the proxy's reserved establish id namespace; rejected",
+            ));
+            continue;
+        }
 
         match v.get("method").and_then(|m| m.as_str()) {
             Some(method) if ALLOWLIST.contains(&method) => {

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -539,10 +539,12 @@ pub async fn run(
         };
 
         // Reserved-id collision guard (P61e Increment 2): the proxy reserves the `assay-establish-` id
-        // namespace for its own originated requests. A client request whose id lands in that namespace
+        // namespace for its own originated requests. A client REQUEST whose id lands in that namespace
         // is rejected, never forwarded — otherwise a colliding client id could cause a real client
-        // response to be routed into (and swallowed by) the establish registry.
-        if relay_routing::client_id_is_reserved(&v) {
+        // response to be routed into (and swallowed by) the establish registry. Only requests are
+        // gated: a client RESPONSE to an upstream-initiated request (no `method`) still relays verbatim
+        // via the response path below, so the relay stays behavior-preserving for it.
+        if relay_routing::is_reserved_client_request(&v) {
             let _ = tx.send(proxy_error_line(
                 v.get("id").cloned().unwrap_or(Value::Null),
                 PROXY_FAILED,

--- a/crates/assay-mcp-server/src/proxy/relay_routing.rs
+++ b/crates/assay-mcp-server/src/proxy/relay_routing.rs
@@ -1,0 +1,232 @@
+// Internal request routing for the proxy-originated establish flow (P61e, Increment 2 slice 1).
+//
+// The proxy spawns a single upstream stdio child and runs exactly ONE task that owns the child's
+// stdout (the upstream reader). The establish flow (slice 2) needs the proxy to originate its own
+// `tools/list` to the child and read the matching response WITHOUT adding a second stdout consumer
+// (two readers would race and lose/misroute frames). This module is the routing scaffold the single
+// reader uses: a reserved request-id namespace, a pending-request registry, the pure routing decision
+// that diverts a matching response to an internal channel (suppressing it from the client stream), and
+// a guard that rejects client requests whose id collides with the reserved namespace.
+//
+// Slice 1 wires the suppression decision and the collision guard into the live relay in a strictly
+// BEHAVIOR-PRESERVING way: nothing registers a reserved id yet, so `is_pending` is always false and
+// every upstream line relays to the client exactly as before; no legitimate client uses the reserved
+// prefix. The registration side (`mint_reserved_id`, `register`, `await_establish`) is exercised by the
+// tests and wired by slice 2; it carries `allow(dead_code)` until then.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::sync::oneshot;
+
+/// Reserved id namespace for proxy-originated requests. A high-entropy nonce is appended per request
+/// (slice 2). A client request whose id is a string in this namespace is rejected, so a client id can
+/// never be mistaken for — or swallow — an establish response.
+pub const RESERVED_ID_PREFIX: &str = "assay-establish-";
+
+/// True iff `id` is a JSON string in the reserved namespace. Numeric ids and non-prefixed string ids
+/// (the only forms a normal client or upstream uses) are never reserved.
+pub fn is_reserved_id(id: &Value) -> bool {
+    id.as_str()
+        .is_some_and(|s| s.starts_with(RESERVED_ID_PREFIX))
+}
+
+/// Mint a reserved request id from a high-entropy nonce (the caller supplies the nonce; slice 2 uses a
+/// CSPRNG). Pure/deterministic for testability.
+#[allow(dead_code)] // registration side: wired by slice 2.
+pub fn mint_reserved_id(nonce: &str) -> String {
+    format!("{RESERVED_ID_PREFIX}{nonce}")
+}
+
+/// Does this client request carry a reserved id? Such a request MUST be rejected, never forwarded:
+/// otherwise a malicious or unlucky client id collision could route a real client response into (and be
+/// swallowed by) the establish registry.
+pub fn client_id_is_reserved(v: &Value) -> bool {
+    v.get("id").map(is_reserved_id).unwrap_or(false)
+}
+
+/// Where the single upstream reader should send a parsed upstream line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum UpstreamRoute {
+    /// Relay verbatim to the client (the default for all normal traffic).
+    RelayToClient,
+    /// Divert to the establish registry under this reserved id; suppress from the client stream.
+    DivertToEstablish(String),
+}
+
+/// Pure routing decision. A line is diverted ONLY when it carries a reserved id that is CURRENTLY
+/// PENDING in the registry. A reserved id that is not pending still relays to the client (never
+/// silently swallowed), and everything else (normal responses, notifications without an id) relays.
+pub fn route_upstream(v: &Value, is_pending: impl Fn(&str) -> bool) -> UpstreamRoute {
+    match v.get("id") {
+        Some(id) if is_reserved_id(id) => {
+            let id = id.as_str().unwrap_or_default().to_string();
+            if !id.is_empty() && is_pending(&id) {
+                UpstreamRoute::DivertToEstablish(id)
+            } else {
+                UpstreamRoute::RelayToClient
+            }
+        }
+        _ => UpstreamRoute::RelayToClient,
+    }
+}
+
+/// Registry of in-flight proxy-originated establish requests, shared between the establish caller
+/// (registers an id and awaits the response, slice 2) and the single upstream reader (resolves it).
+/// One sender per reserved id. The map uses a std mutex: every critical section is a tiny insert /
+/// contains / remove with no `.await` held.
+#[derive(Clone, Default)]
+pub struct EstablishRegistry {
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<Value>>>>,
+}
+
+impl EstablishRegistry {
+    /// Register a reserved id; returns the receiver the caller awaits (slice 2).
+    #[allow(dead_code)] // registration side: wired by slice 2.
+    pub fn register(&self, id: String) -> oneshot::Receiver<Value> {
+        let (tx, rx) = oneshot::channel();
+        self.pending
+            .lock()
+            .expect("establish registry mutex")
+            .insert(id, tx);
+        rx
+    }
+
+    /// Is this reserved id currently awaiting a response? Drives the reader's routing decision.
+    pub fn is_pending(&self, id: &str) -> bool {
+        self.pending
+            .lock()
+            .expect("establish registry mutex")
+            .contains_key(id)
+    }
+
+    /// Deliver a matching upstream response to its waiting caller and remove the entry. Returns true if
+    /// a waiter was found (so the reader suppresses the line from the client), false otherwise (so the
+    /// reader falls back to relaying — never silently dropping a non-pending line). A dropped receiver
+    /// (caller already timed out) still counts as resolved/suppressed.
+    pub fn resolve(&self, id: &str, value: Value) -> bool {
+        let sender = self
+            .pending
+            .lock()
+            .expect("establish registry mutex")
+            .remove(id);
+        match sender {
+            Some(tx) => {
+                let _ = tx.send(value);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+/// Await an establish response under one per-operation timeout. `None` on timeout or a dropped sender,
+/// which the caller treats as a failed establish (fail-closed). Wired by slice 2.
+#[allow(dead_code)] // registration side: wired by slice 2.
+pub async fn await_establish(rx: oneshot::Receiver<Value>, budget: Duration) -> Option<Value> {
+    match tokio::time::timeout(budget, rx).await {
+        Ok(Ok(v)) => Some(v),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- reserved id namespace ---
+
+    #[test]
+    fn reserved_id_recognizes_only_prefixed_strings() {
+        assert!(is_reserved_id(&json!("assay-establish-abc123")));
+        assert!(!is_reserved_id(&json!("tools-list-1")));
+        assert!(!is_reserved_id(&json!(42)));
+        assert!(!is_reserved_id(&json!(null)));
+    }
+
+    #[test]
+    fn mint_reserved_id_uses_the_prefix() {
+        let id = mint_reserved_id("nonce-deadbeef");
+        assert!(id.starts_with(RESERVED_ID_PREFIX));
+        assert!(is_reserved_id(&json!(id)));
+    }
+
+    #[test]
+    fn client_request_with_reserved_id_is_flagged() {
+        assert!(client_id_is_reserved(
+            &json!({"id": "assay-establish-x", "method": "tools/call"})
+        ));
+        assert!(!client_id_is_reserved(
+            &json!({"id": 7, "method": "tools/call"})
+        ));
+        assert!(!client_id_is_reserved(
+            &json!({"id": "client-7", "method": "tools/call"})
+        ));
+        // a notification (no id) is never reserved
+        assert!(!client_id_is_reserved(
+            &json!({"method": "notifications/initialized"})
+        ));
+    }
+
+    // --- routing decision ---
+
+    #[test]
+    fn non_reserved_response_relays_to_client() {
+        let v = json!({"id": 12, "result": {"tools": []}});
+        assert_eq!(route_upstream(&v, |_| true), UpstreamRoute::RelayToClient);
+    }
+
+    #[test]
+    fn notification_without_id_relays_to_client() {
+        let v = json!({"method": "notifications/tools/list_changed"});
+        assert_eq!(route_upstream(&v, |_| true), UpstreamRoute::RelayToClient);
+    }
+
+    #[test]
+    fn reserved_response_diverts_only_when_pending() {
+        let v = json!({"id": "assay-establish-abc", "result": {"tools": []}});
+        // pending -> divert (suppressed from client)
+        assert_eq!(
+            route_upstream(&v, |id| id == "assay-establish-abc"),
+            UpstreamRoute::DivertToEstablish("assay-establish-abc".to_string())
+        );
+        // reserved but NOT pending -> relay, never silently swallow
+        assert_eq!(route_upstream(&v, |_| false), UpstreamRoute::RelayToClient);
+    }
+
+    // --- registry + timeout ---
+
+    #[tokio::test]
+    async fn register_then_resolve_delivers_value_and_suppresses() {
+        let reg = EstablishRegistry::default();
+        let id = "assay-establish-1".to_string();
+        let rx = reg.register(id.clone());
+        assert!(reg.is_pending(&id));
+        let resolved = reg.resolve(&id, json!({"result": {"tools": []}}));
+        assert!(
+            resolved,
+            "a pending id resolves (line suppressed from client)"
+        );
+        assert!(!reg.is_pending(&id), "entry removed after resolve");
+        let got = await_establish(rx, Duration::from_secs(1)).await;
+        assert_eq!(got, Some(json!({"result": {"tools": []}})));
+    }
+
+    #[tokio::test]
+    async fn resolving_unknown_id_returns_false_so_reader_relays() {
+        let reg = EstablishRegistry::default();
+        assert!(!reg.resolve("assay-establish-missing", json!({})));
+    }
+
+    #[tokio::test]
+    async fn establish_times_out_fail_closed_when_never_resolved() {
+        let reg = EstablishRegistry::default();
+        let rx = reg.register("assay-establish-timeout".to_string());
+        // never resolved -> the per-operation timeout elapses -> None (caller fails closed)
+        let got = await_establish(rx, Duration::from_millis(20)).await;
+        assert_eq!(got, None);
+    }
+}

--- a/crates/assay-mcp-server/src/proxy/relay_routing.rs
+++ b/crates/assay-mcp-server/src/proxy/relay_routing.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use serde_json::Value;
 use tokio::sync::oneshot;
 
-/// Reserved id namespace for proxy-originated requests. A high-entropy nonce is appended per request
+/// Reserved id namespace for proxy-originated requests. A high-entropy suffix is appended per request
 /// (slice 2). A client request whose id is a string in this namespace is rejected, so a client id can
 /// never be mistaken for — or swallow — an establish response.
 pub const RESERVED_ID_PREFIX: &str = "assay-establish-";
@@ -33,18 +33,25 @@ pub fn is_reserved_id(id: &Value) -> bool {
         .is_some_and(|s| s.starts_with(RESERVED_ID_PREFIX))
 }
 
-/// Mint a reserved request id from a high-entropy nonce (the caller supplies the nonce; slice 2 uses a
+/// Mint a reserved request id from a high-entropy suffix (the caller supplies it; slice 2 uses a
 /// CSPRNG). Pure/deterministic for testability.
 #[allow(dead_code)] // registration side: wired by slice 2.
-pub fn mint_reserved_id(nonce: &str) -> String {
-    format!("{RESERVED_ID_PREFIX}{nonce}")
+pub fn mint_reserved_id(entropy: &str) -> String {
+    format!("{RESERVED_ID_PREFIX}{entropy}")
 }
 
-/// Does this client request carry a reserved id? Such a request MUST be rejected, never forwarded:
-/// otherwise a malicious or unlucky client id collision could route a real client response into (and be
-/// swallowed by) the establish registry.
+/// Pure id-only check: does this message carry a reserved id? Used by `is_reserved_client_request`.
 pub fn client_id_is_reserved(v: &Value) -> bool {
     v.get("id").map(is_reserved_id).unwrap_or(false)
+}
+
+/// True iff `v` is a client REQUEST (has a `method`) carrying a reserved id. ONLY requests are
+/// rejected: a client RESPONSE to an upstream-initiated request has no `method`, so it is never matched
+/// even with a reserved id and still relays to the upstream via the normal response path. Rejecting
+/// such requests prevents a malicious or unlucky client id from routing a real response into — and being
+/// swallowed by — the establish registry.
+pub fn is_reserved_client_request(v: &Value) -> bool {
+    v.get("method").is_some() && client_id_is_reserved(v)
 }
 
 /// Where the single upstream reader should send a parsed upstream line.
@@ -83,15 +90,36 @@ pub struct EstablishRegistry {
 }
 
 impl EstablishRegistry {
-    /// Register a reserved id; returns the receiver the caller awaits (slice 2).
+    /// Register a reserved id; returns a `PendingEstablish` guard (removes the id on drop) and the
+    /// receiver the caller awaits (slice 2). Returns `None` if the id is ALREADY pending: the registry
+    /// is one-id/one-waiter, so a duplicate is refused rather than clobbering the existing waiter — the
+    /// caller treats `None` as a failed establish and fails closed.
     #[allow(dead_code)] // registration side: wired by slice 2.
-    pub fn register(&self, id: String) -> oneshot::Receiver<Value> {
+    pub fn register(&self, id: String) -> Option<(PendingEstablish, oneshot::Receiver<Value>)> {
         let (tx, rx) = oneshot::channel();
+        {
+            let mut pending = self.pending.lock().expect("establish registry mutex");
+            if pending.contains_key(&id) {
+                return None;
+            }
+            pending.insert(id.clone(), tx);
+        }
+        Some((
+            PendingEstablish {
+                registry: self.clone(),
+                id,
+            },
+            rx,
+        ))
+    }
+
+    /// Remove a pending id without delivering a value (idempotent). Used by `PendingEstablish::drop`, so
+    /// a timed-out or abandoned establish can never leave a stale entry growing the map unbounded.
+    pub fn cancel(&self, id: &str) {
         self.pending
             .lock()
             .expect("establish registry mutex")
-            .insert(id, tx);
-        rx
+            .remove(id);
     }
 
     /// Is this reserved id currently awaiting a response? Drives the reader's routing decision.
@@ -122,8 +150,25 @@ impl EstablishRegistry {
     }
 }
 
+/// RAII guard for an in-flight establish request: removes its id from the registry on drop, so a
+/// timed-out or abandoned request can never leave the `pending` map growing unbounded. A successful
+/// `resolve` already removed the id, which makes the drop a no-op.
+#[allow(dead_code)] // registration side: wired by slice 2.
+pub struct PendingEstablish {
+    registry: EstablishRegistry,
+    id: String,
+}
+
+impl Drop for PendingEstablish {
+    fn drop(&mut self) {
+        self.registry.cancel(&self.id);
+    }
+}
+
 /// Await an establish response under one per-operation timeout. `None` on timeout or a dropped sender,
-/// which the caller treats as a failed establish (fail-closed). Wired by slice 2.
+/// which the caller treats as a failed establish (fail-closed). The caller keeps the `PendingEstablish`
+/// guard alive across this await and drops it afterward, so the registry entry is always reclaimed —
+/// on success (via `resolve`) or on timeout/abandon (via the guard's drop). Wired by slice 2.
 #[allow(dead_code)] // registration side: wired by slice 2.
 pub async fn await_establish(rx: oneshot::Receiver<Value>, budget: Duration) -> Option<Value> {
     match tokio::time::timeout(budget, rx).await {
@@ -149,24 +194,27 @@ mod tests {
 
     #[test]
     fn mint_reserved_id_uses_the_prefix() {
-        let id = mint_reserved_id("nonce-deadbeef");
+        let id = mint_reserved_id("unit-sample-id");
         assert!(id.starts_with(RESERVED_ID_PREFIX));
         assert!(is_reserved_id(&json!(id)));
     }
 
     #[test]
-    fn client_request_with_reserved_id_is_flagged() {
-        assert!(client_id_is_reserved(
+    fn reserved_client_request_matches_only_requests_not_responses() {
+        // a REQUEST (has method) with a reserved id is rejected
+        assert!(is_reserved_client_request(
             &json!({"id": "assay-establish-x", "method": "tools/call"})
         ));
-        assert!(!client_id_is_reserved(
-            &json!({"id": 7, "method": "tools/call"})
+        // a RESPONSE (no method) with a reserved id is NOT matched -> still relays via the response path
+        assert!(!is_reserved_client_request(
+            &json!({"id": "assay-establish-x", "result": {"ok": true}})
         ));
-        assert!(!client_id_is_reserved(
+        // a request with a normal id is not matched
+        assert!(!is_reserved_client_request(
             &json!({"id": "client-7", "method": "tools/call"})
         ));
-        // a notification (no id) is never reserved
-        assert!(!client_id_is_reserved(
+        // a notification (no id) is never matched
+        assert!(!is_reserved_client_request(
             &json!({"method": "notifications/initialized"})
         ));
     }
@@ -203,7 +251,7 @@ mod tests {
     async fn register_then_resolve_delivers_value_and_suppresses() {
         let reg = EstablishRegistry::default();
         let id = "assay-establish-1".to_string();
-        let rx = reg.register(id.clone());
+        let (guard, rx) = reg.register(id.clone()).expect("first register succeeds");
         assert!(reg.is_pending(&id));
         let resolved = reg.resolve(&id, json!({"result": {"tools": []}}));
         assert!(
@@ -213,6 +261,8 @@ mod tests {
         assert!(!reg.is_pending(&id), "entry removed after resolve");
         let got = await_establish(rx, Duration::from_secs(1)).await;
         assert_eq!(got, Some(json!({"result": {"tools": []}})));
+        drop(guard); // idempotent: entry already removed by resolve
+        assert!(!reg.is_pending(&id));
     }
 
     #[tokio::test]
@@ -222,11 +272,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn establish_times_out_fail_closed_when_never_resolved() {
+    async fn establish_times_out_fail_closed_and_guard_reclaims_entry() {
         let reg = EstablishRegistry::default();
-        let rx = reg.register("assay-establish-timeout".to_string());
+        let id = "assay-establish-timeout".to_string();
+        let (guard, rx) = reg.register(id.clone()).expect("register succeeds");
+        assert!(reg.is_pending(&id));
         // never resolved -> the per-operation timeout elapses -> None (caller fails closed)
         let got = await_establish(rx, Duration::from_millis(20)).await;
         assert_eq!(got, None);
+        // the guard's drop reclaims the entry, so a non-responsive upstream cannot grow the map.
+        drop(guard);
+        assert!(
+            !reg.is_pending(&id),
+            "timed-out establish must not leave a stale pending entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_register_is_refused_and_does_not_clobber_the_first_waiter() {
+        let reg = EstablishRegistry::default();
+        let id = "assay-establish-dup".to_string();
+        let (_guard, rx1) = reg.register(id.clone()).expect("first register succeeds");
+        // a second register for the same id is refused (one-id/one-waiter), not a silent overwrite.
+        assert!(reg.register(id.clone()).is_none());
+        // the first waiter is intact: resolving delivers to it.
+        assert!(reg.resolve(&id, json!({"result": {"tools": []}})));
+        let got = await_establish(rx1, Duration::from_secs(1)).await;
+        assert_eq!(got, Some(json!({"result": {"tools": []}})));
     }
 }


### PR DESCRIPTION
First of the two Increment 2 slices (per review: split the dangerous relay plumbing small). This is the **request-routing scaffold** — behavior-preserving, no proxy-originated re-list yet.

## Why this shape (review [P1])
The proxy runs exactly one task that owns the upstream child's stdout. Draining that stream from the `tools/call` path would create a second consumer and race/lose frames. So instead: keep the single reader, add a pending-request registry, and have the reader **divert** matching establish responses to an internal channel while **suppressing** them from the client stream.

## What's in
- `relay_routing`: reserved id namespace (`assay-establish-`), pending registry (std-mutex map of `oneshot` senders), pure `route_upstream()` decision, `await_establish()` per-operation timeout helper.
- **Single-reader suppression** wired into the upstream reader: a *pending* reserved-id response is routed to the registry and suppressed from the client; a reserved id that is *not* pending still relays (never silently swallowed).
- **Reserved-id collision guard** (review [P1]): a client request whose id is in the reserved namespace is rejected (`reserved_id_namespace`), never forwarded — so a malicious/unlucky client id can't have its response swallowed by the registry.

## Behavior-preserving
Nothing registers a reserved id in slice 1, so `is_pending` is always false and every upstream line relays exactly as before. The registration side (`mint_reserved_id`/`register`/`await_establish`) is exercised by tests and wired by slice 2 (`allow(dead_code)` until then). The only new runtime behavior is the collision rejection, which no legitimate client triggers.

## Verification
9 `relay_routing` unit tests (incl. register/resolve/suppress, resolve-unknown-relays, fail-closed timeout); full `assay-mcp-server` suite green incl. the proxy forwarding/e2e/drift integration tests (behavior unchanged); `cargo clippy --all-targets -- -D warnings` clean; fmt clean; `assay.enforcement_decision.v0` fixture byte-identical. DCO-signed.

Slice 2: send the `tools/list`, paginate to complete, update the `Observer`, re-run `decide()`, emit the `assay.manifest_establish.v0` sibling carrier, then forward or deny — with a fake-upstream integration test for the non-leakage and timeout cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved proxy routing and coordination for the establish flow, ensuring establish-related upstream responses are handled separately.
  * Suppresses proxy-resolved establish responses from being forwarded to clients.
  * Adds early rejection of client requests that collide with reserved proxy IDs to prevent accidental conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->