### PR TITLE
feat(mcp-server): wire pre-call manifest-establish into tools/call (P61e, Increment 2b)

### DIFF
--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -59,6 +59,20 @@ const PROXY_DENIED: i32 = -32042;
 
 const HEALTH_SCHEMA: &str = "assay.proxy_observation_health.v0";
 
+/// The one total deadline for a pre-call manifest-establish run (Increment 2b). The operator-facing
+/// CLI surface lands in slice 2c; for now this is a private default, with an internal env override
+/// (`ASSAY_ESTABLISH_BUDGET_MS`) used only to keep the timeout acceptance test fast and deterministic —
+/// it is not an operator interface.
+const DEFAULT_ESTABLISH_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+
+fn establish_budget() -> std::time::Duration {
+    std::env::var("ASSAY_ESTABLISH_BUDGET_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(std::time::Duration::from_millis)
+        .unwrap_or(DEFAULT_ESTABLISH_BUDGET)
+}
+
 /// Proxy run mode. Observe (P61a-d, shipped) forwards the allowlist and answers `tools/call` with
 /// `proxy_unsupported`. Enforce runs the P61e-c PDP on every `tools/call` — classification,
 /// caller-allowance, credential-scope, and drift gates — denying with the precedence-pinned reason of
@@ -453,6 +467,10 @@ pub async fn run(
     // single upstream reader. In slice 1 nothing registers a reserved id, so routing is a no-op and the
     // relay is behavior-identical to before.
     let establish_registry = relay_routing::EstablishRegistry::default();
+    // Monotonic reserved-id source for proxy-originated establish requests (one per page), and the one
+    // total establish deadline (Increment 2b).
+    let establish_id_counter = std::sync::atomic::AtomicU64::new(1);
+    let establish_budget = establish_budget();
 
     // Upstream → client: tap (read-only) then relay verbatim. A non-JSON upstream line is never
     // relayed as success.
@@ -605,7 +623,43 @@ pub async fn run(
                 // The current observed per-tool digest, from this session's observed tools/list
                 // (read-only). The guard is dropped before any await below.
                 let observed = observer.lock().await.observed_tool_digest(tool_name);
-                let decision = enforce::decide(policy, baseline, &observed, tool_name, call_args);
+                let mut decision =
+                    enforce::decide(policy, baseline, &observed, tool_name, call_args);
+                // Pre-decision recovery for the manifest-availability gap ONLY (Increment 2b): when the
+                // sole reason for the deny is that no current complete manifest was observed for this
+                // tool, attempt ONE bounded proxy-originated re-list, then re-decide over the fresh
+                // observation. The trigger is explicit on BOTH the reason and the establish action so a
+                // future ObservedToolDigest/reason combination can never accidentally establish outside
+                // the gap. This never relaxes a gate: Ambiguous, baseline-missing, and real drift skip
+                // establish and stay denied, and a failed/timed-out establish leaves the deny standing.
+                // enforcement_decision.v0 records only the EFFECTIVE (re-decided) decision below.
+                let est_action = establish::establish_action(&observed);
+                if !decision.allow
+                    && decision.reason == "manifest_current_observation_incomplete"
+                    && matches!(
+                        est_action,
+                        establish::EstablishAction::ReList | establish::EstablishAction::ReListOnce
+                    )
+                {
+                    let run_outcome = run_establish(
+                        &mut child_stdin,
+                        &establish_registry,
+                        &observer,
+                        &establish_id_counter,
+                        establish_budget,
+                    )
+                    .await;
+                    let observed2 = observer.lock().await.observed_tool_digest(tool_name);
+                    decision = enforce::decide(policy, baseline, &observed2, tool_name, call_args);
+                    tracing::info!(
+                        event = "establish_attempted",
+                        tool = %tool_name,
+                        run_outcome = ?run_outcome,
+                        effective_decision = if decision.allow { "allow" } else { "deny" },
+                        reason = decision.reason,
+                        note = "pre-call manifest-establish; verdict lives in enforcement_decision.v0"
+                    );
+                }
                 // Diagnostic decision log — operability/correlation only, NOT the canonical
                 // assay.enforcement_decision.v0 evidence artifact (that is P61e-d).
                 tracing::info!(

--- a/crates/assay-mcp-server/tests/fixtures/proxy/mock_upstream.py
+++ b/crates/assay-mcp-server/tests/fixtures/proxy/mock_upstream.py
@@ -78,6 +78,10 @@ def _handle_tools_list(mid, cursor):
         _result(mid, [_tool("alpha")], next_cursor="c1")
     elif MODE == "duplicate":
         _result(mid, [_tool("dup"), _tool("dup", "second with same name")])
+    elif MODE == "drop_list":
+        # Receive the tools/list but never answer it: the proxy's establish must time out and fail
+        # closed within its deadline. The request is still logged, so "establish was attempted" holds.
+        return
     elif MODE == "complete_then_partial":
         # First cursorless start completes; a later cursorless start advertises a next page (the test
         # never follows it), so the run ends with a complete chain plus a later incomplete one.

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -603,3 +603,236 @@ fn wrong_schema_declared_manifest_fails_startup() {
         "a wrong-schema baseline must fail startup"
     );
 }
+
+// =================================================================================================
+// Increment 2b: pre-call manifest-establish wiring (establish -> re-decide -> forward|deny).
+// =================================================================================================
+
+const DEPLOY_KEY_CALL_ID: i64 = 9;
+
+fn deploy_key_call() -> Value {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": DEPLOY_KEY_CALL_ID, "method": "tools/call",
+        "params": {"name": "github.add_deploy_key", "arguments": {"owner": "acme", "repo": "prod-app"}}
+    })
+}
+
+/// Read every remaining stdout line to EOF (used to prove nothing leaked to the client).
+fn drain_stdout(reader: &mut BufReader<ChildStdout>) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        match reader.read_line(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {
+                let t = buf.trim();
+                if !t.is_empty() {
+                    lines.push(t.to_string());
+                }
+            }
+        }
+    }
+    lines
+}
+
+#[test]
+fn establish_then_allow_forwards_without_a_client_list() {
+    // init -> tools/call with NO client tools/list: observed is NoCompleteManifest, so the proxy runs a
+    // pre-call establish (proxy-originated tools/list). The p60a mock answers a complete manifest whose
+    // github.add_deploy_key digest matches the approved baseline, the re-decided call is ALLOWED and
+    // forwarded, and the EFFECTIVE allow is recorded. The first real establish-derived allow path.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child =
+        spawn_enforce_with_decisions(&log, &policy, &approved_baseline_path(), "p60a", &decisions);
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let init_resp = read_response(&mut out);
+    assert_eq!(init_resp["result"]["serverInfo"]["name"], "mock-upstream");
+
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(r["id"], DEPLOY_KEY_CALL_ID);
+    assert_eq!(
+        r["result"]["content"][0]["text"], "forwarded-ok",
+        "establish completes the manifest and the re-decided call is forwarded; got {r}"
+    );
+
+    shutdown(child, stdin);
+
+    // The upstream saw the synthetic establish tools/list AND the forwarded tools/call.
+    let methods = read_methods(&log);
+    assert!(
+        methods.contains(&"tools/list".to_string()),
+        "establish must originate a tools/list; methods={methods:?}"
+    );
+    assert!(
+        methods.contains(&"tools/call".to_string()),
+        "the allowed call must be forwarded; methods={methods:?}"
+    );
+
+    // Non-leakage (end-to-end): no client-visible line carries a reserved establish id, and nothing
+    // leaks beyond the two responses to the client's own requests.
+    assert!(!serde_json::to_string(&init_resp)
+        .unwrap()
+        .contains("assay-establish-"));
+    assert!(!serde_json::to_string(&r)
+        .unwrap()
+        .contains("assay-establish-"));
+    for line in drain_stdout(&mut out) {
+        assert!(
+            !line.contains("assay-establish-"),
+            "a synthetic establish line leaked to the client: {line}"
+        );
+    }
+
+    // Record-before-forward: the EFFECTIVE (allow) decision was written to enforcement_decision.v0.
+    let recs = std::fs::read_to_string(&decisions).unwrap_or_default();
+    assert!(
+        recs.contains("assay.enforcement_decision.v0") && recs.contains("allow"),
+        "the effective allow decision must be recorded before forwarding; recs={recs}"
+    );
+}
+
+#[test]
+fn establish_timeout_denies_to_client_within_budget() {
+    // The mock receives the establish tools/list but never answers it. The establish must time out
+    // within its (test-shrunk) budget and return a deny to the ORIGINAL tools/call -- the client is
+    // never left hanging behind a blocked establish.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"))
+        .args([
+            "proxy-enforce",
+            "--upstream-command",
+            python(),
+            "--upstream-arg",
+            "-u",
+            "--upstream-arg",
+            mock_path().to_str().unwrap(),
+            "--enforce-policy",
+            policy.to_str().unwrap(),
+            "--declared-mcp-manifest",
+            approved_baseline_path().to_str().unwrap(),
+        ])
+        .env("MOCK_UPSTREAM_LOG", &log)
+        .env("MOCK_UPSTREAM_MODE", "drop_list")
+        .env("ASSAY_ESTABLISH_BUDGET_MS", "300")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn enforce proxy (is python installed?)");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    let start = std::time::Instant::now();
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    let elapsed = start.elapsed();
+
+    assert_eq!(r["id"], DEPLOY_KEY_CALL_ID);
+    assert_eq!(
+        r["error"]["code"], PROXY_DENIED,
+        "establish timeout -> deny; got {r}"
+    );
+    assert_eq!(
+        r["error"]["data"]["reason"],
+        "manifest_current_observation_incomplete"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "the client must get its deny within budget + margin, not hang; took {elapsed:?}"
+    );
+
+    shutdown(child, stdin);
+    let methods = read_methods(&log);
+    assert!(
+        methods.contains(&"tools/list".to_string()),
+        "establish was attempted (synthetic list sent); methods={methods:?}"
+    );
+    assert!(
+        !methods.contains(&"tools/call".to_string()),
+        "a timed-out establish never forwards the call; methods={methods:?}"
+    );
+}
+
+#[test]
+fn ambiguous_observation_denies_without_attempting_establish() {
+    // The client observes a duplicate-name (ambiguous) tools/list, then calls. Ambiguity cannot be
+    // resolved by re-listing, so the proxy denies WITHOUT originating an establish tools/list.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "duplicate");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_DENIED);
+    assert_eq!(
+        r["error"]["data"]["reason"],
+        "manifest_observation_ambiguous"
+    );
+
+    shutdown(child, stdin);
+    let lists = read_methods(&log)
+        .iter()
+        .filter(|m| m.as_str() == "tools/list")
+        .count();
+    assert_eq!(
+        lists, 1,
+        "ambiguous must NOT trigger an establish re-list; only the client's list should appear"
+    );
+}
+
+#[test]
+fn establish_completes_but_tool_absent_denies() {
+    // normal mode returns a complete manifest that lacks github.add_deploy_key. init -> tools/call with
+    // no client list: establish originates a list, gets a complete manifest WITHOUT the tool
+    // (CompleteButToolAbsent) -> re-decide deny. The synthetic list was attempted; the call is not
+    // forwarded.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce(&log, &policy, &approved_baseline_path(), "normal");
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_DENIED);
+    assert_eq!(
+        r["error"]["data"]["reason"],
+        "manifest_current_observation_incomplete"
+    );
+
+    shutdown(child, stdin);
+    let methods = read_methods(&log);
+    assert!(
+        methods.contains(&"tools/list".to_string()),
+        "establish was attempted; methods={methods:?}"
+    );
+    assert!(
+        !methods.contains(&"tools/call".to_string()),
+        "an absent tool is never forwarded; methods={methods:?}"
+    );
+}


### PR DESCRIPTION
Wires the slice-2a establish runner into the enforcing `tools/call` path as **pre-decision recovery for the manifest-availability gap only**, then re-decides. Per your reviewed design + acceptance matrix.

## Behavior
When the *only* reason a privileged call would be denied is that no current complete manifest was observed for the tool, the proxy runs **one bounded** proxy-originated establish, re-observes, and re-decides. The **effective** (re-decided) decision is what gets recorded and acted on.

- **Trigger guard explicit on reason AND action** (your refinement): `!allow && reason == "manifest_current_observation_incomplete" && action ∈ {ReList, ReListOnce}`. `Ambiguous`, `manifest_baseline_missing`, real drift, scope/allowance/unclassified all skip establish and stay denied — establish never relaxes a gate.
- **`enforcement_decision.v0` stays pure**: records only the effective decision; the existing record-before-forward / fail-closed-on-record-write rule is unchanged. No carrier emission, no contract change (that's 2c).
- **One total deadline** via `DEFAULT_ESTABLISH_BUDGET` (5s const). An internal `ASSAY_ESTABLISH_BUDGET_MS` env override exists only to keep the timeout test fast — **not** an operator interface; the CLI flag lands in 2c.

## Acceptance (e2e: real binary + python mock recording methods)
- `establish → allow → forward`, with **end-to-end non-leakage** (no `assay-establish-` id ever reaches the client) and **record-before-forward** (the allow record is written).
- `establish timeout → deny to the client within budget` — the client is never left hanging behind a blocked establish (asserts elapsed < budget + margin).
- `Ambiguous → deny with ZERO synthetic tools/list` (no establish attempted).
- `establish complete but tool absent → deny`.

All 50 prior proxy/enforce e2e tests still green (the guard leaves earlier-gate denies and the `Present` happy path untouched). clippy `-D warnings` + fmt clean; `enforcement_decision.v0` byte-identical.

**Limitation (non-claim):** while establish awaits, the client→upstream loop is suspended at that await (the reader task still resolves it, so no deadlock); bounded by the budget and proven by the timeout-returns-to-client test.

**Next: 2c** — emit `assay.manifest_establish.v0` + the operator `--manifest-establish-out` flag (+ make the budget a CLI flag), kept strictly separate from `enforcement_decision.v0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable manifest establish budget mechanism with environment variable override to control enforcement retry timeouts
  * Implemented automatic manifest refresh during enforcement when encountering incomplete manifest observations, enabling re-decision based on updated data

* **Tests**
  * Added comprehensive end-to-end test suite for manifest establish and enforcement re-decision flows under various operational scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->