### PR TITLE
feat(mcp-server): manifest-establish carrier + operator budget flag (P61e, Increment 2c)

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -70,6 +70,16 @@ enum Mode {
         /// fails closed (it is not forwarded).
         #[arg(long)]
         enforcement_decision_out: Option<PathBuf>,
+        /// Optional NDJSON path for the per-call `assay.manifest_establish.v0` carrier (Increment 2c):
+        /// one record per `tools/call` describing the establish JOURNEY (path + run_outcome), sibling to
+        /// and separate from `assay.enforcement_decision.v0` (the verdict carrier). It carries no raw
+        /// scope/target/token. On an allowed call a write failure fails closed (not forwarded).
+        #[arg(long)]
+        manifest_establish_out: Option<PathBuf>,
+        /// Total deadline (ms) for one pre-call manifest-establish run. Default 5000; must be greater
+        /// than 0, and is capped at 60000.
+        #[arg(long, default_value_t = 5000)]
+        manifest_establish_budget_ms: u64,
     },
 }
 
@@ -126,18 +136,34 @@ async fn main() -> Result<()> {
             enforce_policy,
             declared_mcp_manifest,
             enforcement_decision_out,
+            manifest_establish_out,
+            manifest_establish_budget_ms,
         }) => {
             // Load + validate BOTH inputs BEFORE starting the proxy. A bad policy or baseline is a
             // misconfigured service: fail startup with a non-zero exit, never start an enforcing proxy
             // that cannot decide (and never degrade to a runtime deny).
             let policy = proxy::enforce::load(&enforce_policy)?;
             let baseline = proxy::enforce::load_declared_manifest(&declared_mcp_manifest)?;
+            // Validate the establish budget at startup (a misconfig fails fast, never a runtime deny):
+            // 0 is rejected, and the value is capped at 60_000 ms.
+            if manifest_establish_budget_ms == 0 {
+                anyhow::bail!("--manifest-establish-budget-ms must be greater than 0");
+            }
+            let budget_ms = manifest_establish_budget_ms.min(60_000);
+            if budget_ms != manifest_establish_budget_ms {
+                tracing::warn!(
+                    event = "establish_budget_capped",
+                    requested_ms = manifest_establish_budget_ms,
+                    capped_ms = budget_ms
+                );
+            }
             tracing::info!(
                 event = "proxy_start",
                 upstream_command = %upstream_command,
                 mode = "enforce_pdp_c3",
                 caller = %policy.caller.id,
-                baseline_tools = baseline.tools.len()
+                baseline_tools = baseline.tools.len(),
+                establish_budget_ms = budget_ms
             );
             proxy::run(
                 upstream_command,
@@ -147,6 +173,8 @@ async fn main() -> Result<()> {
                     policy: Some(policy),
                     baseline: Some(baseline),
                     decision_out: enforcement_decision_out,
+                    establish_out: manifest_establish_out,
+                    establish_budget: std::time::Duration::from_millis(budget_ms),
                 },
                 None,
                 None,

--- a/crates/assay-mcp-server/src/proxy/enforce.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce.rs
@@ -22,12 +22,16 @@ use std::path::{Path, PathBuf};
 
 /// The enforce-mode inputs to the proxy, grouped so `run` stays within a sane arity. All fields are
 /// absent in observe mode; `policy` and `baseline` are always present in enforce mode (loaded at
-/// startup) and `decision_out` is the optional P61e-d evidence path.
+/// startup), `decision_out` is the optional P61e-d evidence path, `establish_out` is the optional
+/// `assay.manifest_establish.v0` carrier path (Increment 2c), and `establish_budget` is the one total
+/// deadline for a pre-call establish run.
 #[derive(Default)]
 pub struct EnforceInputs {
     pub policy: Option<EnforcePolicy>,
     pub baseline: Option<DeclaredManifest>,
     pub decision_out: Option<PathBuf>,
+    pub establish_out: Option<PathBuf>,
+    pub establish_budget: std::time::Duration,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/assay-mcp-server/src/proxy/establish.rs
+++ b/crates/assay-mcp-server/src/proxy/establish.rs
@@ -125,18 +125,28 @@ pub fn establish_path(
     }
 }
 
+/// The diagnostic outcome of the establish run for the carrier. `not_performed` when no establish ran
+/// (the carrier's `establish_attempted` is derived from this). The other values are the snake_case
+/// `EstablishRunOutcome` variants. It is journey/operability only, NEVER a verdict — the allow/deny
+/// lives in `assay.enforcement_decision.v0`.
+pub const RUN_OUTCOME_NOT_PERFORMED: &str = "not_performed";
+
 /// Build the sibling `assay.manifest_establish.v0` carrier record. Kept intentionally small and
-/// separate from the enforcement-decision record.
+/// separate from the enforcement-decision record. `establish_attempted` is DERIVED from `run_outcome`
+/// (true iff an establish actually ran), so the two fields can never disagree — the invariant
+/// `establish_attempted == (run_outcome != "not_performed")` holds by construction.
 pub fn build_manifest_establish_record(
     path: EstablishPath,
     action_class: Option<&str>,
-    establish_attempted: bool,
+    run_outcome: &str,
 ) -> Value {
+    let establish_attempted = run_outcome != RUN_OUTCOME_NOT_PERFORMED;
     json!({
         "schema": MANIFEST_ESTABLISH_SCHEMA,
         "establish_path": path.as_str(),
         "establish_attempted": establish_attempted,
         "action_class": action_class,
+        "run_outcome": run_outcome,
     })
 }
 
@@ -324,13 +334,32 @@ mod tests {
         let rec = build_manifest_establish_record(
             EstablishPath::EstablishedThenAllowed,
             Some("github_deploy_key"),
-            true,
+            "complete",
         );
         assert_eq!(rec["schema"], json!("assay.manifest_establish.v0"));
         assert_ne!(rec["schema"], json!("assay.enforcement_decision.v0"));
         assert_eq!(rec["establish_path"], json!("established_then_allowed"));
+        assert_eq!(rec["run_outcome"], json!("complete"));
+        // establish_attempted is DERIVED from run_outcome -> true here (an establish ran).
         assert_eq!(rec["establish_attempted"], json!(true));
         assert_eq!(rec["action_class"], json!("github_deploy_key"));
+    }
+
+    #[test]
+    fn carrier_record_derives_not_performed_as_not_attempted() {
+        // run_outcome "not_performed" must derive establish_attempted = false (the invariant).
+        let rec = build_manifest_establish_record(
+            EstablishPath::NoEstablishNeeded,
+            Some("github_deploy_key"),
+            "not_performed",
+        );
+        assert_eq!(rec["run_outcome"], json!("not_performed"));
+        assert_eq!(rec["establish_attempted"], json!(false));
+        // immediate_deny with no establish (ambiguous) is also not_performed -> not attempted.
+        let rec2 =
+            build_manifest_establish_record(EstablishPath::ImmediateDeny, None, "not_performed");
+        assert_eq!(rec2["establish_attempted"], json!(false));
+        assert_eq!(rec2["action_class"], json!(null));
     }
 
     #[test]

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -59,20 +59,6 @@ const PROXY_DENIED: i32 = -32042;
 
 const HEALTH_SCHEMA: &str = "assay.proxy_observation_health.v0";
 
-/// The one total deadline for a pre-call manifest-establish run (Increment 2b). The operator-facing
-/// CLI surface lands in slice 2c; for now this is a private default, with an internal env override
-/// (`ASSAY_ESTABLISH_BUDGET_MS`) used only to keep the timeout acceptance test fast and deterministic —
-/// it is not an operator interface.
-const DEFAULT_ESTABLISH_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
-
-fn establish_budget() -> std::time::Duration {
-    std::env::var("ASSAY_ESTABLISH_BUDGET_MS")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .map(std::time::Duration::from_millis)
-        .unwrap_or(DEFAULT_ESTABLISH_BUDGET)
-}
-
 /// Proxy run mode. Observe (P61a-d, shipped) forwards the allowlist and answers `tools/call` with
 /// `proxy_unsupported`. Enforce runs the P61e-c PDP on every `tools/call` — classification,
 /// caller-allowance, credential-scope, and drift gates — denying with the precedence-pinned reason of
@@ -423,6 +409,8 @@ pub async fn run(
         policy,
         baseline,
         decision_out,
+        establish_out,
+        establish_budget,
     } = enforce_inputs;
     let spawned = Command::new(&upstream_command)
         .args(&upstream_args)
@@ -467,10 +455,9 @@ pub async fn run(
     // single upstream reader. In slice 1 nothing registers a reserved id, so routing is a no-op and the
     // relay is behavior-identical to before.
     let establish_registry = relay_routing::EstablishRegistry::default();
-    // Monotonic reserved-id source for proxy-originated establish requests (one per page), and the one
-    // total establish deadline (Increment 2b).
+    // Monotonic reserved-id source for proxy-originated establish requests (one per page). The total
+    // establish deadline arrives via EnforceInputs (operator `--manifest-establish-budget-ms`, 2c).
     let establish_id_counter = std::sync::atomic::AtomicU64::new(1);
-    let establish_budget = establish_budget();
 
     // Upstream → client: tap (read-only) then relay verbatim. A non-JSON upstream line is never
     // relayed as success.
@@ -634,6 +621,7 @@ pub async fn run(
                 // establish and stay denied, and a failed/timed-out establish leaves the deny standing.
                 // enforcement_decision.v0 records only the EFFECTIVE (re-decided) decision below.
                 let est_action = establish::establish_action(&observed);
+                let mut run_outcome: Option<EstablishRunOutcome> = None;
                 if !decision.allow
                     && decision.reason == "manifest_current_observation_incomplete"
                     && matches!(
@@ -641,7 +629,7 @@ pub async fn run(
                         establish::EstablishAction::ReList | establish::EstablishAction::ReListOnce
                     )
                 {
-                    let run_outcome = run_establish(
+                    let outcome = run_establish(
                         &mut child_stdin,
                         &establish_registry,
                         &observer,
@@ -649,17 +637,28 @@ pub async fn run(
                         establish_budget,
                     )
                     .await;
+                    run_outcome = Some(outcome);
                     let observed2 = observer.lock().await.observed_tool_digest(tool_name);
                     decision = enforce::decide(policy, baseline, &observed2, tool_name, call_args);
                     tracing::info!(
                         event = "establish_attempted",
                         tool = %tool_name,
-                        run_outcome = ?run_outcome,
+                        run_outcome = ?outcome,
                         effective_decision = if decision.allow { "allow" } else { "deny" },
                         reason = decision.reason,
                         note = "pre-call manifest-establish; verdict lives in enforcement_decision.v0"
                     );
                 }
+                // Establish-journey carrier inputs (Increment 2c): the path the call took and the
+                // diagnostic run outcome. `not_performed` when no establish ran (NotNeeded / Ambiguous).
+                let est_outcome = run_outcome
+                    .map(|r| r.to_carrier())
+                    .unwrap_or(establish::EstablishOutcome::NotPerformed);
+                let establish_path =
+                    establish::establish_path(est_action, est_outcome, decision.allow);
+                let run_outcome_str = run_outcome
+                    .map(|r| r.as_str())
+                    .unwrap_or(establish::RUN_OUTCOME_NOT_PERFORMED);
                 // Diagnostic decision log — operability/correlation only, NOT the canonical
                 // assay.enforcement_decision.v0 evidence artifact (that is P61e-d).
                 tracing::info!(
@@ -675,7 +674,7 @@ pub async fn run(
                 // P61e-d: write the canonical per-call evidence record (NDJSON) before acting. The
                 // safety rule (spec §12): a record-write failure on a requested path must never become
                 // a silent unrecorded forward, so an allowed call that cannot be recorded fails closed.
-                let record_ok = match &decision_out {
+                let decision_record_ok = match &decision_out {
                     Some(path) => {
                         let record =
                             enforce::decision_record(policy, &decision, tool_name, call_args);
@@ -693,15 +692,41 @@ pub async fn run(
                     }
                     None => true,
                 };
-                if decision.allow && !record_ok {
-                    // Fail-closed: never forward an allowed call we could not record.
+                // Increment 2c: write the sibling assay.manifest_establish.v0 carrier AFTER the verdict
+                // record, never mixed into it. Same fail-closed rule: on an allowed call a carrier-write
+                // failure must not silently forward; on a denied call the deny stands and the failure is
+                // a logged completeness gap.
+                let establish_record_ok = match &establish_out {
+                    Some(path) => {
+                        let record = establish::build_manifest_establish_record(
+                            establish_path,
+                            decision.action_class.as_deref(),
+                            run_outcome_str,
+                        );
+                        match append_decision_record(path, &record) {
+                            Ok(()) => true,
+                            Err(e) => {
+                                tracing::error!(
+                                    event = "manifest_establish_record_write_failed",
+                                    error = %e,
+                                    path = %path.display()
+                                );
+                                false
+                            }
+                        }
+                    }
+                    None => true,
+                };
+                let records_ok = decision_record_ok && establish_record_ok;
+                if decision.allow && !records_ok {
+                    // Fail-closed: never forward an allowed call whose required record(s) we could not write.
                     if let Some(id) = v.get("id") {
                         if !id.is_null() {
                             let _ = tx.send(proxy_error_line(
                                 id.clone(),
                                 PROXY_FAILED,
                                 "enforcement_record_write_failed",
-                                "enforcement decision could not be recorded; call not forwarded",
+                                "a required enforcement/establish record could not be written; call not forwarded",
                             ));
                         }
                     }
@@ -837,11 +862,23 @@ enum EstablishRunOutcome {
 impl EstablishRunOutcome {
     /// Map the detailed run result to the coarse carrier outcome. Only `Complete` is an establish
     /// success; everything else fails closed.
-    #[allow(dead_code)] // wired into the tools/call path by slice 2b.
     fn to_carrier(self) -> establish::EstablishOutcome {
         match self {
             EstablishRunOutcome::Complete => establish::EstablishOutcome::EstablishedComplete,
             _ => establish::EstablishOutcome::EstablishFailed,
+        }
+    }
+
+    /// snake_case label for the `run_outcome` field of `assay.manifest_establish.v0`. Diagnostic only;
+    /// never a verdict. The no-establish case (`not_performed`) is supplied by the caller, not here.
+    fn as_str(self) -> &'static str {
+        match self {
+            EstablishRunOutcome::Complete => "complete",
+            EstablishRunOutcome::TimedOut => "timed_out",
+            EstablishRunOutcome::Partial => "partial",
+            EstablishRunOutcome::TransportError => "transport_error",
+            EstablishRunOutcome::ErrorResponse => "error_response",
+            EstablishRunOutcome::RegisterRefused => "register_refused",
         }
     }
 }

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -720,10 +720,11 @@ fn establish_timeout_denies_to_client_within_budget() {
             policy.to_str().unwrap(),
             "--declared-mcp-manifest",
             approved_baseline_path().to_str().unwrap(),
+            "--manifest-establish-budget-ms",
+            "300",
         ])
         .env("MOCK_UPSTREAM_LOG", &log)
         .env("MOCK_UPSTREAM_MODE", "drop_list")
-        .env("ASSAY_ESTABLISH_BUDGET_MS", "300")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
@@ -834,5 +835,313 @@ fn establish_completes_but_tool_absent_denies() {
     assert!(
         !methods.contains(&"tools/call".to_string()),
         "an absent tool is never forwarded; methods={methods:?}"
+    );
+}
+
+// =================================================================================================
+// Increment 2c: assay.manifest_establish.v0 carrier emission + operator budget flag.
+// =================================================================================================
+
+/// Spawn the enforcing proxy writing BOTH the enforcement-decision NDJSON and the manifest-establish
+/// carrier NDJSON, with an optional establish budget (ms).
+fn spawn_enforce_recording(
+    log: &Path,
+    policy: &Path,
+    baseline: &Path,
+    mode: &str,
+    decisions: &Path,
+    establish: &Path,
+    budget_ms: Option<u64>,
+) -> Child {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"));
+    cmd.arg("proxy-enforce")
+        .args(["--upstream-command", python()])
+        .args(["--upstream-arg", "-u"])
+        .args(["--upstream-arg", mock_path().to_str().unwrap()])
+        .args(["--enforce-policy", policy.to_str().unwrap()])
+        .args(["--declared-mcp-manifest", baseline.to_str().unwrap()])
+        .args(["--enforcement-decision-out", decisions.to_str().unwrap()])
+        .args(["--manifest-establish-out", establish.to_str().unwrap()]);
+    if let Some(ms) = budget_ms {
+        cmd.args(["--manifest-establish-budget-ms", &ms.to_string()]);
+    }
+    cmd.env("MOCK_UPSTREAM_LOG", log)
+        .env("MOCK_UPSTREAM_MODE", mode)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn enforce proxy (is python installed?)")
+}
+
+fn read_establish_records(path: &Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("establish record JSON"))
+        .collect()
+}
+
+/// The carrier carries no raw scope/target/token/credential/caller/args — journey only.
+fn assert_no_secrets(rec: &Value) {
+    let s = serde_json::to_string(rec).unwrap();
+    for forbidden in [
+        "target_digest",
+        "scope",
+        "token",
+        "credential",
+        "caller",
+        "arguments",
+        "owner",
+        "repo",
+    ] {
+        assert!(
+            !s.contains(forbidden),
+            "manifest_establish record must not carry `{forbidden}`: {s}"
+        );
+    }
+    // Exactly the five v0 fields, nothing more.
+    let obj = rec.as_object().expect("record is an object");
+    let mut keys: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        [
+            "action_class",
+            "establish_attempted",
+            "establish_path",
+            "run_outcome",
+            "schema"
+        ]
+    );
+}
+
+#[test]
+fn no_establish_needed_allow_writes_carrier_and_decision() {
+    // A client tools/list establishes a current complete manifest the old way; the call is allowed with
+    // NO establish run -> carrier is no_establish_needed / not_performed / not attempted, alongside an
+    // allowed enforcement decision (the two carriers are orthogonal).
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let establish = dir.path().join("establish.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_recording(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "p60a",
+        &decisions,
+        &establish,
+        None,
+    );
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
+
+    shutdown(child, stdin);
+    let recs = read_establish_records(&establish);
+    assert_eq!(recs.len(), 1, "one establish record per tools/call");
+    let rec = &recs[0];
+    assert_eq!(rec["establish_path"], "no_establish_needed");
+    assert_eq!(rec["run_outcome"], "not_performed");
+    assert_eq!(rec["establish_attempted"], serde_json::json!(false));
+    assert_no_secrets(rec);
+    // Orthogonal allowed decision in the separate verdict carrier.
+    let dec = std::fs::read_to_string(&decisions).unwrap_or_default();
+    assert!(dec.contains("assay.enforcement_decision.v0") && dec.contains("allow"));
+}
+
+#[test]
+fn establish_then_allow_writes_established_then_allowed() {
+    // No client list -> establish runs, p60a completes a matching manifest -> allow + forward. Carrier
+    // is established_then_allowed / complete / attempted.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let establish = dir.path().join("establish.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_recording(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "p60a",
+        &decisions,
+        &establish,
+        None,
+    );
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
+
+    shutdown(child, stdin);
+    let recs = read_establish_records(&establish);
+    assert_eq!(recs.len(), 1);
+    let rec = &recs[0];
+    assert_eq!(rec["establish_path"], "established_then_allowed");
+    assert_eq!(rec["run_outcome"], "complete");
+    assert_eq!(rec["establish_attempted"], serde_json::json!(true));
+    assert_eq!(rec["action_class"], "github_deploy_key");
+    assert_no_secrets(rec);
+}
+
+#[test]
+fn establish_complete_but_absent_writes_established_then_denied() {
+    // normal mode completes a manifest WITHOUT the tool -> CompleteButToolAbsent -> deny. The establish
+    // ran and completed, so run_outcome is complete and the path is established_then_denied.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let establish = dir.path().join("establish.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_recording(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "normal",
+        &decisions,
+        &establish,
+        None,
+    );
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_DENIED);
+
+    shutdown(child, stdin);
+    let recs = read_establish_records(&establish);
+    assert_eq!(recs.len(), 1);
+    let rec = &recs[0];
+    assert_eq!(rec["establish_path"], "established_then_denied");
+    assert_eq!(rec["run_outcome"], "complete");
+    assert_eq!(rec["establish_attempted"], serde_json::json!(true));
+    assert_no_secrets(rec);
+}
+
+#[test]
+fn establish_timeout_writes_immediate_deny_timed_out() {
+    // drop_list never answers the synthetic list -> establish times out within the budget -> deny. The
+    // establish was attempted (run_outcome timed_out) but produced no completion -> immediate_deny.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let establish = dir.path().join("establish.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_recording(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "drop_list",
+        &decisions,
+        &establish,
+        Some(300),
+    );
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["code"], PROXY_DENIED);
+
+    shutdown(child, stdin);
+    let recs = read_establish_records(&establish);
+    assert_eq!(recs.len(), 1);
+    let rec = &recs[0];
+    assert_eq!(rec["establish_path"], "immediate_deny");
+    assert_eq!(rec["run_outcome"], "timed_out");
+    assert_eq!(rec["establish_attempted"], serde_json::json!(true));
+    assert_no_secrets(rec);
+}
+
+#[test]
+fn ambiguous_writes_immediate_deny_not_performed_no_synthetic_list() {
+    // Ambiguous observation -> deny WITHOUT establish. Carrier is immediate_deny / not_performed / not
+    // attempted, and the upstream saw only the client's tools/list (no synthetic establish list).
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let establish = dir.path().join("establish.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_recording(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "duplicate",
+        &decisions,
+        &establish,
+        None,
+    );
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(
+        r["error"]["data"]["reason"],
+        "manifest_observation_ambiguous"
+    );
+
+    shutdown(child, stdin);
+    let recs = read_establish_records(&establish);
+    assert_eq!(recs.len(), 1);
+    let rec = &recs[0];
+    assert_eq!(rec["establish_path"], "immediate_deny");
+    assert_eq!(rec["run_outcome"], "not_performed");
+    assert_eq!(rec["establish_attempted"], serde_json::json!(false));
+    assert_no_secrets(rec);
+    let lists = read_methods(&log)
+        .iter()
+        .filter(|m| m.as_str() == "tools/list")
+        .count();
+    assert_eq!(
+        lists, 1,
+        "ambiguous must not originate a synthetic establish list"
+    );
+}
+
+#[test]
+fn establish_budget_zero_fails_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let status = run_startup(&[
+        "--enforce-policy",
+        policy.to_str().unwrap(),
+        "--declared-mcp-manifest",
+        approved_baseline_path().to_str().unwrap(),
+        "--manifest-establish-budget-ms",
+        "0",
+    ]);
+    assert!(
+        !status.success(),
+        "a zero establish budget must be rejected at startup"
     );
 }

--- a/docs/superpowers/plans/2026-06-13-manifest-establish-increment3.md
+++ b/docs/superpowers/plans/2026-06-13-manifest-establish-increment3.md
@@ -60,7 +60,7 @@ Plimsoll consumer side:
 ## Contract Shape
 
 > **Increment 2c amendment (run_outcome) — SUPERSEDES the 4-field shape.** The carrier landed in 2c
-> (`assay#1664`/2c) with **five** fields: `run_outcome` is added. `build_manifest_establish_record`
+> (`assay#1665`, slice 2c) with **five** fields: `run_outcome` is added. `build_manifest_establish_record`
 > now takes `run_outcome: &str` (not a bool), and **`establish_attempted` is DERIVED** from it
 > (`establish_attempted == (run_outcome != "not_performed")`) so the two can never disagree. Valid
 > `run_outcome` values: `complete | timed_out | partial | transport_error | error_response |
@@ -974,12 +974,45 @@ Create `$PLIMSOLL_ROOT/tests/fixtures/manifest_establish_consumer_rejection.v0.j
       "expected": "malformed"
     },
     {
+      "case": "missing_run_outcome",
+      "record": {
+        "schema": "assay.manifest_establish.v0",
+        "establish_path": "no_establish_needed",
+        "establish_attempted": false,
+        "action_class": "github_deploy_key"
+      },
+      "expected": "malformed"
+    },
+    {
+      "case": "invalid_run_outcome",
+      "record": {
+        "schema": "assay.manifest_establish.v0",
+        "establish_path": "no_establish_needed",
+        "establish_attempted": false,
+        "action_class": "github_deploy_key",
+        "run_outcome": "succeeded"
+      },
+      "expected": "malformed"
+    },
+    {
       "case": "attempted_flag_contradicts_path",
       "record": {
         "schema": "assay.manifest_establish.v0",
         "establish_path": "established_then_allowed",
         "establish_attempted": false,
-        "action_class": "github_deploy_key"
+        "action_class": "github_deploy_key",
+        "run_outcome": "complete"
+      },
+      "expected": "inconsistent"
+    },
+    {
+      "case": "attempted_flag_contradicts_run_outcome",
+      "record": {
+        "schema": "assay.manifest_establish.v0",
+        "establish_path": "immediate_deny",
+        "establish_attempted": true,
+        "action_class": "github_deploy_key",
+        "run_outcome": "not_performed"
       },
       "expected": "inconsistent"
     },
@@ -990,6 +1023,7 @@ Create `$PLIMSOLL_ROOT/tests/fixtures/manifest_establish_consumer_rejection.v0.j
         "establish_path": "no_establish_needed",
         "establish_attempted": false,
         "action_class": "github_deploy_key",
+        "run_outcome": "not_performed",
         "decision": "allow"
       },
       "expected": "inconsistent"
@@ -1001,6 +1035,7 @@ Create `$PLIMSOLL_ROOT/tests/fixtures/manifest_establish_consumer_rejection.v0.j
         "establish_path": "no_establish_needed",
         "establish_attempted": false,
         "action_class": "github_deploy_key",
+        "run_outcome": "not_performed",
         "forwarded": true
       },
       "expected": "inconsistent"

--- a/docs/superpowers/plans/2026-06-13-manifest-establish-increment3.md
+++ b/docs/superpowers/plans/2026-06-13-manifest-establish-increment3.md
@@ -59,7 +59,21 @@ Plimsoll consumer side:
 
 ## Contract Shape
 
-The producer fixture contains one real record per stable establish path:
+> **Increment 2c amendment (run_outcome) — SUPERSEDES the 4-field shape.** The carrier landed in 2c
+> (`assay#1664`/2c) with **five** fields: `run_outcome` is added. `build_manifest_establish_record`
+> now takes `run_outcome: &str` (not a bool), and **`establish_attempted` is DERIVED** from it
+> (`establish_attempted == (run_outcome != "not_performed")`) so the two can never disagree. Valid
+> `run_outcome` values: `complete | timed_out | partial | transport_error | error_response |
+> register_refused | not_performed` (`not_performed` ⇔ no establish ran). Per-path values:
+> `no_establish_needed → not_performed`; `established_then_allowed → complete`;
+> `established_then_denied → complete`; `immediate_deny` → `not_performed` (ambiguous / no attempt)
+> OR a failed-run value (`timed_out` / `partial` / `transport_error` / `error_response` /
+> `register_refused`) when a re-list was attempted but failed. The classifier MUST validate
+> `run_outcome` against that set and enforce the derived `establish_attempted` invariant; a
+> missing/invalid `run_outcome` is `malformed`. Every 4-field record example below is illustrative of
+> the path/attempted logic only — the real record carries `run_outcome` as the fifth field.
+
+The producer fixture contains one real record per stable (establish_path, run_outcome) shape:
 
 ```json
 {
@@ -73,7 +87,8 @@ The producer fixture contains one real record per stable establish path:
         "schema": "assay.manifest_establish.v0",
         "establish_path": "no_establish_needed",
         "establish_attempted": false,
-        "action_class": "github_deploy_key"
+        "action_class": "github_deploy_key",
+        "run_outcome": "not_performed"
       }
     },
     {
@@ -82,7 +97,8 @@ The producer fixture contains one real record per stable establish path:
         "schema": "assay.manifest_establish.v0",
         "establish_path": "established_then_allowed",
         "establish_attempted": true,
-        "action_class": "github_deploy_key"
+        "action_class": "github_deploy_key",
+        "run_outcome": "complete"
       }
     },
     {
@@ -91,7 +107,8 @@ The producer fixture contains one real record per stable establish path:
         "schema": "assay.manifest_establish.v0",
         "establish_path": "established_then_denied",
         "establish_attempted": true,
-        "action_class": "github_deploy_key"
+        "action_class": "github_deploy_key",
+        "run_outcome": "complete"
       }
     },
     {
@@ -100,7 +117,8 @@ The producer fixture contains one real record per stable establish path:
         "schema": "assay.manifest_establish.v0",
         "establish_path": "immediate_deny",
         "establish_attempted": false,
-        "action_class": "github_deploy_key"
+        "action_class": "github_deploy_key",
+        "run_outcome": "not_performed"
       }
     },
     {
@@ -109,7 +127,8 @@ The producer fixture contains one real record per stable establish path:
         "schema": "assay.manifest_establish.v0",
         "establish_path": "immediate_deny",
         "establish_attempted": false,
-        "action_class": null
+        "action_class": null,
+        "run_outcome": "not_performed"
       }
     },
     {
@@ -118,16 +137,23 @@ The producer fixture contains one real record per stable establish path:
         "schema": "assay.manifest_establish.v0",
         "establish_path": "immediate_deny",
         "establish_attempted": true,
-        "action_class": "github_deploy_key"
+        "action_class": "github_deploy_key",
+        "run_outcome": "timed_out"
       }
     }
   ]
 }
 ```
 
-`immediate_deny` is the only path that pairs with BOTH `establish_attempted` values: `false` when no establish was attempted (an inconclusive/ambiguous observation that establish cannot resolve), and `true` when a re-list WAS attempted but failed (timeout, partial/incomplete list, transport error, or an unusable/ambiguous fresh observation — the `EstablishFailed` outcome). Both are valid producer output and both must round-trip; the consumer must not assume `immediate_deny ⇒ not attempted`.
+`immediate_deny` is the only path that pairs with BOTH `establish_attempted` values: `false` /
+`run_outcome:not_performed` when no establish was attempted (an inconclusive/ambiguous observation that
+establish cannot resolve), and `true` with a failed `run_outcome` (`timed_out`/`partial`/
+`transport_error`/`error_response`/`register_refused`) when a re-list WAS attempted but failed. Both are
+valid producer output and both must round-trip; the consumer must not assume `immediate_deny ⇒ not
+attempted`.
 
-This deliberately carries no caller id, tool name, target digest, credential alias, transport, delivery, side-effect, or `decision` field. Those belong to `assay.enforcement_decision.v0`.
+This deliberately carries no caller id, tool name, target digest, credential alias, transport, delivery,
+side-effect, or `decision` field. Those belong to `assay.enforcement_decision.v0`.
 
 ## Task 1: Assay Producer Contract Fixture
 
@@ -197,13 +223,15 @@ fn manifest_establish_contract_fixture_path() -> std::path::PathBuf {
 }
 
 fn manifest_establish_contract_records() -> Vec<Value> {
+    // build_manifest_establish_record takes run_outcome (&str) and DERIVES establish_attempted
+    // (true iff run_outcome != "not_performed") — see Increment 2c.
     vec![
         json!({
             "case": "no_establish_needed",
             "record": build_manifest_establish_record(
                 EstablishPath::NoEstablishNeeded,
                 Some("github_deploy_key"),
-                false,
+                "not_performed",
             ),
         }),
         json!({
@@ -211,7 +239,7 @@ fn manifest_establish_contract_records() -> Vec<Value> {
             "record": build_manifest_establish_record(
                 EstablishPath::EstablishedThenAllowed,
                 Some("github_deploy_key"),
-                true,
+                "complete",
             ),
         }),
         json!({
@@ -219,7 +247,7 @@ fn manifest_establish_contract_records() -> Vec<Value> {
             "record": build_manifest_establish_record(
                 EstablishPath::EstablishedThenDenied,
                 Some("github_deploy_key"),
-                true,
+                "complete",
             ),
         }),
         json!({
@@ -227,7 +255,7 @@ fn manifest_establish_contract_records() -> Vec<Value> {
             "record": build_manifest_establish_record(
                 EstablishPath::ImmediateDeny,
                 Some("github_deploy_key"),
-                false,
+                "not_performed",
             ),
         }),
         json!({
@@ -235,17 +263,18 @@ fn manifest_establish_contract_records() -> Vec<Value> {
             "record": build_manifest_establish_record(
                 EstablishPath::ImmediateDeny,
                 None,
-                false,
+                "not_performed",
             ),
         }),
         json!({
             // immediate_deny is also reached when a re-list WAS attempted but failed
-            // (EstablishFailed: timeout/partial/transport/unusable). establish_attempted = true.
+            // (EstablishFailed: timeout/partial/transport/unusable) -> run_outcome != not_performed,
+            // so the derived establish_attempted = true.
             "case": "immediate_deny_after_failed_establish",
             "record": build_manifest_establish_record(
                 EstablishPath::ImmediateDeny,
                 Some("github_deploy_key"),
-                true,
+                "timed_out",
             ),
         }),
     ]
@@ -373,12 +402,17 @@ from plimsoll.review import (
 )
 
 
-def _rec(path="no_establish_needed", attempted=False, action_class="github_deploy_key"):
+def _rec(path="no_establish_needed", attempted=False, action_class="github_deploy_key", run_outcome=None):
+    # run_outcome defaults coherently with `attempted` (complete if attempted else not_performed); pass
+    # it explicitly to test a failed-establish immediate_deny (e.g. run_outcome="timed_out").
+    if run_outcome is None:
+        run_outcome = "complete" if attempted else "not_performed"
     return {
         "schema": "assay.manifest_establish.v0",
         "establish_path": path,
         "establish_attempted": attempted,
         "action_class": action_class,
+        "run_outcome": run_outcome,
     }
 
 
@@ -512,6 +546,19 @@ _MANIFEST_ESTABLISH_ATTEMPTED = {
     "established_then_denied": True,
 }
 
+# Increment 2c: the diagnostic run outcome. `not_performed` ⇔ no establish ran. The producer derives
+# `establish_attempted` from this (true iff run_outcome != "not_performed"), and the consumer enforces
+# that invariant below.
+_MANIFEST_ESTABLISH_RUN_OUTCOMES = {
+    "complete",
+    "timed_out",
+    "partial",
+    "transport_error",
+    "error_response",
+    "register_refused",
+    "not_performed",
+}
+
 
 def _classify_manifest_establish_record(rec) -> str:
     if not isinstance(rec, dict):
@@ -520,7 +567,12 @@ def _classify_manifest_establish_record(rec) -> str:
         return "unsupported_schema"
     path = rec.get("establish_path")
     attempted = rec.get("establish_attempted")
-    if path not in _MANIFEST_ESTABLISH_PATHS or not isinstance(attempted, bool):
+    run_outcome = rec.get("run_outcome")
+    if (
+        path not in _MANIFEST_ESTABLISH_PATHS
+        or not isinstance(attempted, bool)
+        or run_outcome not in _MANIFEST_ESTABLISH_RUN_OUTCOMES
+    ):
         return "malformed"
     action_class = rec.get("action_class")
     if action_class is not None and not (isinstance(action_class, str) and action_class):
@@ -541,7 +593,11 @@ def _classify_manifest_establish_record(rec) -> str:
     expected_attempted = _MANIFEST_ESTABLISH_ATTEMPTED.get(path)
     if expected_attempted is not None and attempted is not expected_attempted:
         return "inconsistent"
-    # immediate_deny accepts either attempted value (ambiguous vs failed establish); no extra check.
+    # Derived invariant: establish_attempted iff an establish actually ran (run_outcome != not_performed).
+    if attempted != (run_outcome != "not_performed"):
+        return "inconsistent"
+    # immediate_deny accepts either attempted value (ambiguous vs failed establish); the run_outcome
+    # invariant above already constrains the pair.
     return "valid"
 ```
 


### PR DESCRIPTION
Closes Increment 2: makes the live establish (2b) **auditable and operator-controllable**. No new PDP logic — `enforce::decide()` unchanged, `enforcement_decision.v0` byte-identical.

## Operator surface
- `--manifest-establish-out <path>` — NDJSON, one `assay.manifest_establish.v0` record per `tools/call`.
- `--manifest-establish-budget-ms` — default 5000, **rejects 0**, capped at 60000. The hidden `ASSAY_ESTABLISH_BUDGET_MS` env override is **removed**; the budget is threaded via `EnforceInputs`.

## Carrier shape (5 fields, agreed)
`{schema, establish_path, establish_attempted, action_class, run_outcome}`. `run_outcome` is the snake_case `EstablishRunOutcome` (`complete/timed_out/partial/transport_error/error_response/register_refused`) or `not_performed` when no establish ran. **`establish_attempted` is DERIVED** from `run_outcome` in the builder, so the invariant `establish_attempted == (run_outcome != "not_performed")` holds by construction. Journey/diagnostic only — never a verdict.

## Safety / ordering
On an allowed call the `enforcement_decision.v0` record is written **first**, then the `manifest_establish.v0` carrier; if **either** write fails → `proxy_failed`, not forwarded. On a deny, a carrier-write failure is logged and the deny stands. The carriers are never mixed.

## Acceptance (e2e: real binary + python mock)
`no_establish_needed + allow` → `not_performed`; `established_then_allowed` (record before forward); `established_then_denied` (complete-but-absent); `immediate_deny + timed_out` (timeout, via the CLI budget flag); `immediate_deny + not_performed` (ambiguous, zero synthetic list). Plus **zero-budget startup rejection** and a **contract guard** (no raw scope/target/token/credential/caller/args; exactly the 5 v0 fields).

## Producer/consumer agreement
Updates the **Increment 3 plan (#1662)** contract shape, classifier (validates `run_outcome` + the derived-attempted invariant), fixture generator, and test helper to the 5-field shape — so the producer (this PR) and the planned consumer don't drift on v0.

Full `assay-mcp-server` suite green; clippy `-D warnings` + fmt clean; `enforcement_decision.v0` byte-identical.

This closes Increment 2. Next: **Increment 3** (the now-corrected #1662 plan) — Plimsoll vendors + validates + gates the carrier, against a producer that now actually emits it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI options to set a manifest-establish time budget and emit per-establish carrier records; startup validates budget (non-zero, capped) and rejects invalid values.

* **Bug Fixes**
  * Enforced fail-closed behavior for record-write failures when forwarding allowed calls; establish outcome now consistently derived and used in decisions.

* **Tests**
  * New end-to-end harness and tests covering establish outcomes, emission, timeout behavior, and startup rejection of zero budget.

* **Documentation**
  * Updated manifest-establish contract to add run_outcome and derive establish_attempted from it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->