### PR TITLE
test(mcp-server): manifest_establish.v0 producer contract fixture (Increment 3, Task 1)

### DIFF
--- a/crates/assay-mcp-server/src/proxy/establish.rs
+++ b/crates/assay-mcp-server/src/proxy/establish.rs
@@ -378,4 +378,146 @@ mod tests {
         );
         assert_eq!(EstablishPath::ImmediateDeny.as_str(), "immediate_deny");
     }
+
+    // --- producer contract fixture (Increment 3, Task 1) ---
+    //
+    // The canonical `assay.manifest_establish.v0` producer output, one record per stable
+    // (establish_path, run_outcome) shape, regenerated from `build_manifest_establish_record` (the real
+    // producer helper) so a consumer (Rul1an/plimsoll) can vendor it verbatim. After an intentional
+    // producer change: ASSAY_UPDATE_GOLDEN=1 cargo test -p assay-mcp-server --bins
+    // manifest_establish_contract_fixture.
+
+    fn manifest_establish_contract_fixture_path() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/manifest_establish_contract.v0.json")
+    }
+
+    fn manifest_establish_contract_records() -> Vec<Value> {
+        // `establish_attempted` is DERIVED from run_outcome by the builder, so each record's pair is
+        // coherent by construction. Covers every stable shape, including the two distinct immediate_deny
+        // pairs (not_performed = ambiguous/no attempt; a failed run_outcome = re-list attempted-but-failed).
+        let cases: &[(&str, EstablishPath, Option<&str>, &str)] = &[
+            (
+                "no_establish_needed",
+                EstablishPath::NoEstablishNeeded,
+                Some("github_deploy_key"),
+                "not_performed",
+            ),
+            (
+                "established_then_allowed",
+                EstablishPath::EstablishedThenAllowed,
+                Some("github_deploy_key"),
+                "complete",
+            ),
+            (
+                "established_then_denied",
+                EstablishPath::EstablishedThenDenied,
+                Some("github_deploy_key"),
+                "complete",
+            ),
+            (
+                "immediate_deny",
+                EstablishPath::ImmediateDeny,
+                Some("github_deploy_key"),
+                "not_performed",
+            ),
+            (
+                "unclassified_immediate_deny",
+                EstablishPath::ImmediateDeny,
+                None,
+                "not_performed",
+            ),
+            (
+                "immediate_deny_after_failed_establish",
+                EstablishPath::ImmediateDeny,
+                Some("github_deploy_key"),
+                "timed_out",
+            ),
+        ];
+        cases
+            .iter()
+            .map(|(case, path, action_class, run_outcome)| {
+                json!({
+                    "case": case,
+                    "record": build_manifest_establish_record(*path, *action_class, run_outcome),
+                })
+            })
+            .collect()
+    }
+
+    fn manifest_establish_contract_document() -> Value {
+        json!({
+            "schema_contract": MANIFEST_ESTABLISH_SCHEMA,
+            "generated_by": "assay crates/assay-mcp-server proxy::establish::build_manifest_establish_record (manifest_establish_contract_fixture)",
+            "note": "Canonical producer output, regenerated from build_manifest_establish_record. Consumers vendor this file verbatim. Regenerate with ASSAY_UPDATE_GOLDEN=1.",
+            "records": manifest_establish_contract_records(),
+        })
+    }
+
+    #[test]
+    fn manifest_establish_contract_fixture() {
+        let generated = manifest_establish_contract_document();
+        let path = manifest_establish_contract_fixture_path();
+
+        if std::env::var("ASSAY_UPDATE_GOLDEN").is_ok() {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let pretty = serde_json::to_string_pretty(&generated).unwrap();
+            std::fs::write(&path, format!("{pretty}\n")).unwrap();
+        }
+
+        let committed_text = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+            panic!(
+                "missing {}; regenerate with ASSAY_UPDATE_GOLDEN=1",
+                path.display()
+            )
+        });
+        let committed: Value = serde_json::from_str(&committed_text).unwrap();
+        assert_eq!(
+            committed, generated,
+            "the committed manifest-establish contract fixture is stale; regenerate with ASSAY_UPDATE_GOLDEN=1"
+        );
+
+        // Sanity: every record is the v0 carrier, exactly the five journey fields, the derived
+        // establish_attempted invariant holds, and NO verdict/delivery/secret field is present.
+        let records = generated["records"].as_array().unwrap();
+        assert_eq!(records.len(), 6);
+        for entry in records {
+            let rec = &entry["record"];
+            assert_eq!(rec["schema"], json!(MANIFEST_ESTABLISH_SCHEMA));
+            let attempted = rec["establish_attempted"].as_bool().unwrap();
+            let run_outcome = rec["run_outcome"].as_str().unwrap();
+            assert_eq!(
+                attempted,
+                run_outcome != RUN_OUTCOME_NOT_PERFORMED,
+                "establish_attempted must be derived from run_outcome"
+            );
+            let obj = rec.as_object().unwrap();
+            let mut keys: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+            keys.sort_unstable();
+            assert_eq!(
+                keys,
+                [
+                    "action_class",
+                    "establish_attempted",
+                    "establish_path",
+                    "run_outcome",
+                    "schema"
+                ]
+            );
+            for forbidden in [
+                "decision",
+                "reason",
+                "forwarded",
+                "target_digest",
+                "caller_id",
+                "credential_alias",
+                "scopes",
+            ] {
+                assert!(
+                    rec.get(forbidden).is_none(),
+                    "carrier must not carry `{forbidden}`"
+                );
+            }
+        }
+    }
 }

--- a/crates/assay-mcp-server/src/proxy/establish.rs
+++ b/crates/assay-mcp-server/src/proxy/establish.rs
@@ -384,7 +384,7 @@ mod tests {
     // The canonical `assay.manifest_establish.v0` producer output, one record per stable
     // (establish_path, run_outcome) shape, regenerated from `build_manifest_establish_record` (the real
     // producer helper) so a consumer (Rul1an/plimsoll) can vendor it verbatim. After an intentional
-    // producer change: ASSAY_UPDATE_GOLDEN=1 cargo test -p assay-mcp-server --bins
+    // producer change: ASSAY_UPDATE_GOLDEN=1 cargo test -p assay-mcp-server
     // manifest_establish_contract_fixture.
 
     fn manifest_establish_contract_fixture_path() -> std::path::PathBuf {

--- a/crates/assay-mcp-server/tests/fixtures/manifest_establish_contract.v0.json
+++ b/crates/assay-mcp-server/tests/fixtures/manifest_establish_contract.v0.json
@@ -1,0 +1,67 @@
+{
+  "schema_contract": "assay.manifest_establish.v0",
+  "generated_by": "assay crates/assay-mcp-server proxy::establish::build_manifest_establish_record (manifest_establish_contract_fixture)",
+  "note": "Canonical producer output, regenerated from build_manifest_establish_record. Consumers vendor this file verbatim. Regenerate with ASSAY_UPDATE_GOLDEN=1.",
+  "records": [
+    {
+      "case": "no_establish_needed",
+      "record": {
+        "schema": "assay.manifest_establish.v0",
+        "establish_path": "no_establish_needed",
+        "establish_attempted": false,
+        "action_class": "github_deploy_key",
+        "run_outcome": "not_performed"
+      }
+    },
+    {
+      "case": "established_then_allowed",
+      "record": {
+        "schema": "assay.manifest_establish.v0",
+        "establish_path": "established_then_allowed",
+        "establish_attempted": true,
+        "action_class": "github_deploy_key",
+        "run_outcome": "complete"
+      }
+    },
+    {
+      "case": "established_then_denied",
+      "record": {
+        "schema": "assay.manifest_establish.v0",
+        "establish_path": "established_then_denied",
+        "establish_attempted": true,
+        "action_class": "github_deploy_key",
+        "run_outcome": "complete"
+      }
+    },
+    {
+      "case": "immediate_deny",
+      "record": {
+        "schema": "assay.manifest_establish.v0",
+        "establish_path": "immediate_deny",
+        "establish_attempted": false,
+        "action_class": "github_deploy_key",
+        "run_outcome": "not_performed"
+      }
+    },
+    {
+      "case": "unclassified_immediate_deny",
+      "record": {
+        "schema": "assay.manifest_establish.v0",
+        "establish_path": "immediate_deny",
+        "establish_attempted": false,
+        "action_class": null,
+        "run_outcome": "not_performed"
+      }
+    },
+    {
+      "case": "immediate_deny_after_failed_establish",
+      "record": {
+        "schema": "assay.manifest_establish.v0",
+        "establish_path": "immediate_deny",
+        "establish_attempted": true,
+        "action_class": "github_deploy_key",
+        "run_outcome": "timed_out"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
First piece of Increment 3 (the now-2c-corrected #1662 plan): the **producer** half. A canonical `assay.manifest_establish.v0` contract fixture, regenerated from the real producer helper `build_manifest_establish_record` — so a consumer (Rul1an/plimsoll) vendors it verbatim with no hand-authored shape drift. Merge this before the Plimsoll vendor PR.

## What's in
- `tests/fixtures/manifest_establish_contract.v0.json` — six records, one per stable `(establish_path, run_outcome)` shape, including **both** `immediate_deny` pairs (`not_performed` = ambiguous/no attempt; `timed_out` = re-list attempted-but-failed).
- `manifest_establish_contract_fixture` golden test, mirroring `pdp_golden_contract_fixture`: regenerate with `ASSAY_UPDATE_GOLDEN=1`, otherwise assert the committed fixture is byte-equal. Sanity: every record is the v0 carrier with **exactly the five journey fields**, the derived `establish_attempted == (run_outcome != "not_performed")` invariant holds, and **no** verdict/delivery/secret field (`decision`/`forwarded`/`target_digest`/`caller_id`/`credential_alias`/`scopes`) is present.

## Discipline
Matches the 5-field contract shape pinned in #1665/#1662 exactly, so the Plimsoll consumer (Tasks 2–6) can vendor + validate against it without producer/consumer drift. No change to `enforce::decide()` or `assay.enforcement_decision.v0` (byte-identical). Full `assay-mcp-server` suite + clippy `-D warnings` + fmt clean; DCO-signed.

**Next (Increment 3, Plimsoll side):** vendor this fixture into `Rul1an/plimsoll` with the provenance sidecar + vendor-freshness guard, implement the `_classify_manifest_establish_record` classifier + summary/findings, and wire it into the review/CLI — all against this producer fixture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a golden-fixture test suite validating canonical manifest establish scenarios.
  * Covers six case combinations of action class, establish attempt, and run outcomes.
  * Asserts exact fixture equality and enforces record structure and forbidden-field constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->