### PR TITLE
feat(mcp-server): add tool annotation conformance contract

### DIFF
--- a/crates/assay-mcp-server/src/proxy/annotation_conformance.rs
+++ b/crates/assay-mcp-server/src/proxy/annotation_conformance.rs
@@ -1,0 +1,497 @@
+//! Pure producer contract for `assay.tool_annotation_conformance.v0` (Increment 5a).
+//!
+//! This carrier compares untrusted MCP ToolAnnotations against Assay's own rule-based call
+//! classification. It is deliberately orthogonal to the enforcement verdict: a mismatch is a
+//! conformance signal, never a deny, and a consistent record is not trust certification.
+#![allow(dead_code)]
+
+use assay_mcp_server::tool_decision::{classify, sanitize};
+use serde_json::{json, Value};
+
+pub const TOOL_ANNOTATION_CONFORMANCE_SCHEMA: &str = "assay.tool_annotation_conformance.v0";
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DeclaredToolAnnotations {
+    pub read_only: Option<bool>,
+    pub destructive: Option<bool>,
+    pub idempotent: Option<bool>,
+    pub open_world: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ObservedBehavior {
+    Mutating,
+    Destructive,
+}
+
+impl ObservedBehavior {
+    fn as_str(self) -> &'static str {
+        match self {
+            ObservedBehavior::Mutating => "mutating",
+            ObservedBehavior::Destructive => "destructive",
+        }
+    }
+}
+
+fn observed_behavior(verb: Option<&str>) -> Option<ObservedBehavior> {
+    match verb {
+        // Destructive means the call may overwrite/remove/reconfigure existing state. Additive admin
+        // actions are still mutating, but they do not contradict `destructiveHint:false`.
+        Some("change_role" | "modify") => Some(ObservedBehavior::Destructive),
+        Some("create" | "add" | "grant" | "invite") => Some(ObservedBehavior::Mutating),
+        _ => None,
+    }
+}
+
+fn push_axis(axes: &mut Vec<&'static str>, axis: &'static str) {
+    if !axes.contains(&axis) {
+        axes.push(axis);
+    }
+}
+
+/// Build one `assay.tool_annotation_conformance.v0` record from declared annotations and the
+/// rule-based classification of the call. `tool_digest` is not available until the live observer
+/// wiring slice, so 5a emits it as null while pinning the append-only field in the v0 shape.
+pub fn conformance_for(declared: &DeclaredToolAnnotations, tool_name: &str, args: &Value) -> Value {
+    build_tool_annotation_conformance_record(declared, tool_name, None, args)
+}
+
+pub fn build_tool_annotation_conformance_record(
+    declared: &DeclaredToolAnnotations,
+    tool_name: &str,
+    tool_digest: Option<&str>,
+    args: &Value,
+) -> Value {
+    let classified = classify(tool_name, args);
+    let behavior = if classified.state == "classified" {
+        observed_behavior(classified.verb)
+    } else {
+        None
+    };
+
+    let mut assessed_axes = Vec::new();
+    let mut mismatch_kind: Option<&'static str> = None;
+
+    if let Some(read_only) = declared.read_only {
+        if behavior.is_some() {
+            push_axis(&mut assessed_axes, "read_only");
+            if read_only {
+                mismatch_kind = Some("declared_read_only_observed_mutating");
+            }
+        }
+    }
+
+    if declared.read_only != Some(true) {
+        if let Some(destructive) = declared.destructive {
+            if let Some(observed) = behavior {
+                push_axis(&mut assessed_axes, "destructive");
+                if !destructive && observed == ObservedBehavior::Destructive {
+                    mismatch_kind = Some("declared_non_destructive_observed_destructive");
+                }
+            }
+        }
+    }
+
+    let conformance = if behavior.is_none() {
+        "inconclusive"
+    } else if assessed_axes.is_empty() {
+        "undeclared"
+    } else if mismatch_kind.is_some() {
+        "mismatched"
+    } else {
+        "consistent"
+    };
+
+    let mut unassessed_axes = Vec::new();
+    if declared.idempotent.is_some() {
+        unassessed_axes.push("idempotent");
+    }
+    if declared.open_world.is_some() {
+        unassessed_axes.push("open_world");
+    }
+
+    json!({
+        "schema": TOOL_ANNOTATION_CONFORMANCE_SCHEMA,
+        "tool": {
+            "name": sanitize(tool_name),
+            "tool_digest": tool_digest,
+            "action_class": classified.category,
+        },
+        "declared": {
+            "read_only": declared.read_only,
+            "destructive": declared.destructive,
+            "idempotent": declared.idempotent,
+            "open_world": declared.open_world,
+        },
+        "observed": {
+            "classification_state": classified.state,
+            "verb": classified.verb,
+            "behavior_class": behavior.map(ObservedBehavior::as_str),
+        },
+        "conformance": conformance,
+        "mismatch_kind": mismatch_kind,
+        "assessed_axes": assessed_axes,
+        "unassessed_axes": unassessed_axes,
+        "non_claims": [
+            "tool annotations are untrusted hints, not security guarantees",
+            "consistent does not certify the server or the annotation as trustworthy",
+            "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
+            "observed behavior is Assay's call classification, not verification of the upstream side effect",
+            "idempotentHint and openWorldHint are recorded but not assessed in v0"
+        ]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    fn github_args() -> Value {
+        json!({"owner": "acme", "repo": "prod-app", "title": "ci-key"})
+    }
+
+    fn workspace_args() -> Value {
+        json!({"workspace_id": "acme", "principal": "alice@example.com"})
+    }
+
+    #[test]
+    fn declared_read_only_true_mismatches_observed_mutating() {
+        let rec = conformance_for(
+            &DeclaredToolAnnotations {
+                read_only: Some(true),
+                destructive: None,
+                idempotent: None,
+                open_world: None,
+            },
+            "github.add_deploy_key",
+            &github_args(),
+        );
+
+        assert_eq!(rec["schema"], json!(TOOL_ANNOTATION_CONFORMANCE_SCHEMA));
+        assert_eq!(rec["conformance"], json!("mismatched"));
+        assert_eq!(
+            rec["mismatch_kind"],
+            json!("declared_read_only_observed_mutating")
+        );
+        assert_eq!(rec["assessed_axes"], json!(["read_only"]));
+    }
+
+    #[test]
+    fn declared_non_destructive_mismatches_observed_destructive() {
+        let rec = conformance_for(
+            &DeclaredToolAnnotations {
+                read_only: Some(false),
+                destructive: Some(false),
+                idempotent: None,
+                open_world: None,
+            },
+            "workspace.modify_org_policy",
+            &workspace_args(),
+        );
+
+        assert_eq!(rec["conformance"], json!("mismatched"));
+        assert_eq!(
+            rec["mismatch_kind"],
+            json!("declared_non_destructive_observed_destructive")
+        );
+        assert_eq!(rec["observed"]["behavior_class"], json!("destructive"));
+    }
+
+    #[test]
+    fn compatible_assessed_hints_are_consistent_not_certified() {
+        let rec = conformance_for(
+            &DeclaredToolAnnotations {
+                read_only: Some(false),
+                destructive: Some(false),
+                idempotent: None,
+                open_world: None,
+            },
+            "github.add_deploy_key",
+            &github_args(),
+        );
+
+        assert_eq!(rec["conformance"], json!("consistent"));
+        assert_eq!(rec["mismatch_kind"], Value::Null);
+        assert_eq!(rec["observed"]["behavior_class"], json!("mutating"));
+        assert!(rec["non_claims"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| { v.as_str().unwrap().contains("consistent does not certify") }));
+    }
+
+    #[test]
+    fn missing_assessed_hints_are_undeclared_not_consistent() {
+        let rec = conformance_for(
+            &DeclaredToolAnnotations {
+                read_only: None,
+                destructive: None,
+                idempotent: Some(true),
+                open_world: Some(false),
+            },
+            "github.add_deploy_key",
+            &github_args(),
+        );
+
+        assert_eq!(rec["conformance"], json!("undeclared"));
+        assert_eq!(rec["assessed_axes"], json!([]));
+        assert_eq!(rec["declared"]["idempotent"], json!(true));
+        assert_eq!(rec["declared"]["open_world"], json!(false));
+        assert_eq!(rec["unassessed_axes"], json!(["idempotent", "open_world"]));
+    }
+
+    #[test]
+    fn unclassified_or_incomplete_calls_are_inconclusive() {
+        for (tool, args) in [
+            ("unknown.tool", json!({})),
+            ("github.add_deploy_key", json!({"owner": "acme"})),
+        ] {
+            let rec = conformance_for(
+                &DeclaredToolAnnotations {
+                    read_only: Some(true),
+                    destructive: Some(false),
+                    idempotent: None,
+                    open_world: None,
+                },
+                tool,
+                &args,
+            );
+
+            assert_eq!(rec["conformance"], json!("inconclusive"));
+            assert_eq!(rec["mismatch_kind"], Value::Null);
+            assert_eq!(rec["assessed_axes"], json!([]));
+        }
+    }
+
+    #[test]
+    fn record_has_no_verdict_delivery_or_sensitive_identity_fields() {
+        let rec = conformance_for(
+            &DeclaredToolAnnotations {
+                read_only: Some(false),
+                destructive: Some(false),
+                idempotent: None,
+                open_world: None,
+            },
+            "github.add_deploy_key",
+            &github_args(),
+        );
+
+        let text = serde_json::to_string(&rec).unwrap();
+        for forbidden in [
+            "decision",
+            "reason",
+            "forwarded",
+            "delivered",
+            "credential_alias",
+            "scopes",
+            "target_digest",
+            "caller_id",
+        ] {
+            assert!(
+                rec.get(forbidden).is_none(),
+                "annotation conformance record must not carry field {forbidden}"
+            );
+        }
+        assert!(
+            !text.contains("ci-key"),
+            "raw sensitive argument values must not be copied into the record"
+        );
+    }
+
+    // ---- Shared producer/consumer contract fixture (Increment 5) ------------------------------
+    //
+    // The canonical `assay.tool_annotation_conformance.v0` contract is REAL output of
+    // `build_tool_annotation_conformance_record`, not a hand-authored mirror. Plimsoll will vendor
+    // the same file in a later slice and assert its consumer accepts each record.
+    // Regenerate after an intentional producer change: ASSAY_UPDATE_GOLDEN=1 cargo test -p
+    // assay-mcp-server tool_annotation_conformance_contract_fixture.
+
+    fn contract_fixture_path() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/tool_annotation_conformance_contract.v0.json")
+    }
+
+    fn contract_records() -> Vec<Value> {
+        let cases: &[(&str, DeclaredToolAnnotations, &str, Value, Option<&str>)] = &[
+            (
+                "consistent_read_only_false_additive",
+                DeclaredToolAnnotations {
+                    read_only: Some(false),
+                    destructive: None,
+                    idempotent: None,
+                    open_world: None,
+                },
+                "github.add_deploy_key",
+                json!({"owner": "acme", "repo": "prod-app", "title": "ci-key"}),
+                Some("sha256:tooldigest-consistent-readonly-false"),
+            ),
+            (
+                "consistent_destructive_false_additive",
+                DeclaredToolAnnotations {
+                    read_only: Some(false),
+                    destructive: Some(false),
+                    idempotent: None,
+                    open_world: None,
+                },
+                "github.add_deploy_key",
+                json!({"owner": "acme", "repo": "prod-app"}),
+                Some("sha256:tooldigest-consistent-nondestructive"),
+            ),
+            (
+                "mismatched_read_only_mutating",
+                DeclaredToolAnnotations {
+                    read_only: Some(true),
+                    destructive: None,
+                    idempotent: None,
+                    open_world: None,
+                },
+                "github.add_deploy_key",
+                json!({"owner": "acme", "repo": "prod-app"}),
+                Some("sha256:tooldigest-readonly-mismatch"),
+            ),
+            (
+                "mismatched_non_destructive_destructive",
+                DeclaredToolAnnotations {
+                    read_only: Some(false),
+                    destructive: Some(false),
+                    idempotent: None,
+                    open_world: None,
+                },
+                "workspace.modify_org_policy",
+                json!({"workspace_id": "acme", "principal": "alice@example.com"}),
+                Some("sha256:tooldigest-destructive-mismatch"),
+            ),
+            (
+                "undeclared",
+                DeclaredToolAnnotations {
+                    read_only: None,
+                    destructive: None,
+                    idempotent: None,
+                    open_world: None,
+                },
+                "github.add_deploy_key",
+                json!({"owner": "acme", "repo": "prod-app"}),
+                Some("sha256:tooldigest-undeclared"),
+            ),
+            (
+                "inconclusive_unknown_tool",
+                DeclaredToolAnnotations {
+                    read_only: Some(true),
+                    destructive: Some(false),
+                    idempotent: None,
+                    open_world: None,
+                },
+                "unknown.tool",
+                json!({}),
+                Some("sha256:tooldigest-unknown"),
+            ),
+            (
+                "unassessed_axes_recorded",
+                DeclaredToolAnnotations {
+                    read_only: None,
+                    destructive: None,
+                    idempotent: Some(true),
+                    open_world: Some(false),
+                },
+                "github.add_deploy_key",
+                json!({"owner": "acme", "repo": "prod-app"}),
+                Some("sha256:tooldigest-unassessed"),
+            ),
+        ];
+
+        cases
+            .iter()
+            .map(|(case, declared, tool, args, tool_digest)| {
+                json!({
+                    "case": case,
+                    "record": build_tool_annotation_conformance_record(
+                        declared,
+                        tool,
+                        *tool_digest,
+                        args
+                    ),
+                })
+            })
+            .collect()
+    }
+
+    fn contract_document() -> Value {
+        json!({
+            "schema_contract": TOOL_ANNOTATION_CONFORMANCE_SCHEMA,
+            "generated_by": "assay crates/assay-mcp-server proxy::annotation_conformance::build_tool_annotation_conformance_record (tool_annotation_conformance_contract_fixture)",
+            "note": "Canonical producer output, regenerated from build_tool_annotation_conformance_record. Consumers vendor this file verbatim. Regenerate with ASSAY_UPDATE_GOLDEN=1.",
+            "records": contract_records(),
+        })
+    }
+
+    #[test]
+    fn tool_annotation_conformance_contract_fixture() {
+        let generated = contract_document();
+        let path = contract_fixture_path();
+
+        if std::env::var("ASSAY_UPDATE_GOLDEN").is_ok() {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let pretty = serde_json::to_string_pretty(&generated).unwrap();
+            std::fs::write(&path, format!("{pretty}\n")).unwrap();
+        }
+
+        let committed_text = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+            panic!(
+                "missing {}; regenerate with ASSAY_UPDATE_GOLDEN=1",
+                path.display()
+            )
+        });
+        let committed: Value = serde_json::from_str(&committed_text).unwrap();
+        assert_eq!(
+            committed, generated,
+            "the committed tool-annotation conformance contract fixture is stale; regenerate with ASSAY_UPDATE_GOLDEN=1"
+        );
+
+        let records = generated["records"].as_array().unwrap();
+        assert_eq!(records.len(), 7);
+        for entry in records {
+            let rec = &entry["record"];
+            assert_eq!(rec["schema"], json!(TOOL_ANNOTATION_CONFORMANCE_SCHEMA));
+            let obj = rec.as_object().unwrap();
+            let mut keys: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+            keys.sort_unstable();
+            assert_eq!(
+                keys,
+                [
+                    "assessed_axes",
+                    "conformance",
+                    "declared",
+                    "mismatch_kind",
+                    "non_claims",
+                    "observed",
+                    "schema",
+                    "tool",
+                    "unassessed_axes"
+                ]
+            );
+            for forbidden in [
+                "decision",
+                "reason",
+                "forwarded",
+                "delivered",
+                "credential_alias",
+                "scopes",
+                "target_digest",
+                "caller_id",
+            ] {
+                assert!(
+                    rec.get(forbidden).is_none(),
+                    "carrier must not carry `{forbidden}`"
+                );
+            }
+            let text = serde_json::to_string(rec).unwrap();
+            for raw in ["ci-key", "alice@example.com"] {
+                assert!(
+                    !text.contains(raw),
+                    "raw argument value {raw} must not appear in the contract fixture"
+                );
+            }
+        }
+    }
+}

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -17,6 +17,9 @@
 //! "how completely was it observed" lives in the separate observation-health artifact, never folded in.
 
 pub mod enforce;
+// Pure producer contract for assay.tool_annotation_conformance.v0 (Increment 5a).
+// Live annotation capture/emission lands in a later slice.
+pub mod annotation_conformance;
 // Pre-call manifest-establish decision layer (P61e, Increment 1). Pure logic + the
 // `assay.manifest_establish.v0` sibling carrier; not yet wired into the relay (Increment 2).
 pub mod establish;

--- a/crates/assay-mcp-server/tests/fixtures/tool_annotation_conformance_contract.v0.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_annotation_conformance_contract.v0.json
@@ -1,0 +1,251 @@
+{
+  "schema_contract": "assay.tool_annotation_conformance.v0",
+  "generated_by": "assay crates/assay-mcp-server proxy::annotation_conformance::build_tool_annotation_conformance_record (tool_annotation_conformance_contract_fixture)",
+  "note": "Canonical producer output, regenerated from build_tool_annotation_conformance_record. Consumers vendor this file verbatim. Regenerate with ASSAY_UPDATE_GOLDEN=1.",
+  "records": [
+    {
+      "case": "consistent_read_only_false_additive",
+      "record": {
+        "schema": "assay.tool_annotation_conformance.v0",
+        "tool": {
+          "name": "github.add_deploy_key",
+          "tool_digest": "sha256:tooldigest-consistent-readonly-false",
+          "action_class": "github_deploy_key"
+        },
+        "declared": {
+          "read_only": false,
+          "destructive": null,
+          "idempotent": null,
+          "open_world": null
+        },
+        "observed": {
+          "classification_state": "classified",
+          "verb": "create",
+          "behavior_class": "mutating"
+        },
+        "conformance": "consistent",
+        "mismatch_kind": null,
+        "assessed_axes": [
+          "read_only"
+        ],
+        "unassessed_axes": [],
+        "non_claims": [
+          "tool annotations are untrusted hints, not security guarantees",
+          "consistent does not certify the server or the annotation as trustworthy",
+          "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
+          "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "idempotentHint and openWorldHint are recorded but not assessed in v0"
+        ]
+      }
+    },
+    {
+      "case": "consistent_destructive_false_additive",
+      "record": {
+        "schema": "assay.tool_annotation_conformance.v0",
+        "tool": {
+          "name": "github.add_deploy_key",
+          "tool_digest": "sha256:tooldigest-consistent-nondestructive",
+          "action_class": "github_deploy_key"
+        },
+        "declared": {
+          "read_only": false,
+          "destructive": false,
+          "idempotent": null,
+          "open_world": null
+        },
+        "observed": {
+          "classification_state": "classified",
+          "verb": "create",
+          "behavior_class": "mutating"
+        },
+        "conformance": "consistent",
+        "mismatch_kind": null,
+        "assessed_axes": [
+          "read_only",
+          "destructive"
+        ],
+        "unassessed_axes": [],
+        "non_claims": [
+          "tool annotations are untrusted hints, not security guarantees",
+          "consistent does not certify the server or the annotation as trustworthy",
+          "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
+          "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "idempotentHint and openWorldHint are recorded but not assessed in v0"
+        ]
+      }
+    },
+    {
+      "case": "mismatched_read_only_mutating",
+      "record": {
+        "schema": "assay.tool_annotation_conformance.v0",
+        "tool": {
+          "name": "github.add_deploy_key",
+          "tool_digest": "sha256:tooldigest-readonly-mismatch",
+          "action_class": "github_deploy_key"
+        },
+        "declared": {
+          "read_only": true,
+          "destructive": null,
+          "idempotent": null,
+          "open_world": null
+        },
+        "observed": {
+          "classification_state": "classified",
+          "verb": "create",
+          "behavior_class": "mutating"
+        },
+        "conformance": "mismatched",
+        "mismatch_kind": "declared_read_only_observed_mutating",
+        "assessed_axes": [
+          "read_only"
+        ],
+        "unassessed_axes": [],
+        "non_claims": [
+          "tool annotations are untrusted hints, not security guarantees",
+          "consistent does not certify the server or the annotation as trustworthy",
+          "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
+          "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "idempotentHint and openWorldHint are recorded but not assessed in v0"
+        ]
+      }
+    },
+    {
+      "case": "mismatched_non_destructive_destructive",
+      "record": {
+        "schema": "assay.tool_annotation_conformance.v0",
+        "tool": {
+          "name": "workspace.modify_org_policy",
+          "tool_digest": "sha256:tooldigest-destructive-mismatch",
+          "action_class": "workspace_admin"
+        },
+        "declared": {
+          "read_only": false,
+          "destructive": false,
+          "idempotent": null,
+          "open_world": null
+        },
+        "observed": {
+          "classification_state": "classified",
+          "verb": "modify",
+          "behavior_class": "destructive"
+        },
+        "conformance": "mismatched",
+        "mismatch_kind": "declared_non_destructive_observed_destructive",
+        "assessed_axes": [
+          "read_only",
+          "destructive"
+        ],
+        "unassessed_axes": [],
+        "non_claims": [
+          "tool annotations are untrusted hints, not security guarantees",
+          "consistent does not certify the server or the annotation as trustworthy",
+          "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
+          "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "idempotentHint and openWorldHint are recorded but not assessed in v0"
+        ]
+      }
+    },
+    {
+      "case": "undeclared",
+      "record": {
+        "schema": "assay.tool_annotation_conformance.v0",
+        "tool": {
+          "name": "github.add_deploy_key",
+          "tool_digest": "sha256:tooldigest-undeclared",
+          "action_class": "github_deploy_key"
+        },
+        "declared": {
+          "read_only": null,
+          "destructive": null,
+          "idempotent": null,
+          "open_world": null
+        },
+        "observed": {
+          "classification_state": "classified",
+          "verb": "create",
+          "behavior_class": "mutating"
+        },
+        "conformance": "undeclared",
+        "mismatch_kind": null,
+        "assessed_axes": [],
+        "unassessed_axes": [],
+        "non_claims": [
+          "tool annotations are untrusted hints, not security guarantees",
+          "consistent does not certify the server or the annotation as trustworthy",
+          "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
+          "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "idempotentHint and openWorldHint are recorded but not assessed in v0"
+        ]
+      }
+    },
+    {
+      "case": "inconclusive_unknown_tool",
+      "record": {
+        "schema": "assay.tool_annotation_conformance.v0",
+        "tool": {
+          "name": "unknown.tool",
+          "tool_digest": "sha256:tooldigest-unknown",
+          "action_class": null
+        },
+        "declared": {
+          "read_only": true,
+          "destructive": false,
+          "idempotent": null,
+          "open_world": null
+        },
+        "observed": {
+          "classification_state": "observed_unknown_tool",
+          "verb": null,
+          "behavior_class": null
+        },
+        "conformance": "inconclusive",
+        "mismatch_kind": null,
+        "assessed_axes": [],
+        "unassessed_axes": [],
+        "non_claims": [
+          "tool annotations are untrusted hints, not security guarantees",
+          "consistent does not certify the server or the annotation as trustworthy",
+          "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
+          "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "idempotentHint and openWorldHint are recorded but not assessed in v0"
+        ]
+      }
+    },
+    {
+      "case": "unassessed_axes_recorded",
+      "record": {
+        "schema": "assay.tool_annotation_conformance.v0",
+        "tool": {
+          "name": "github.add_deploy_key",
+          "tool_digest": "sha256:tooldigest-unassessed",
+          "action_class": "github_deploy_key"
+        },
+        "declared": {
+          "read_only": null,
+          "destructive": null,
+          "idempotent": true,
+          "open_world": false
+        },
+        "observed": {
+          "classification_state": "classified",
+          "verb": "create",
+          "behavior_class": "mutating"
+        },
+        "conformance": "undeclared",
+        "mismatch_kind": null,
+        "assessed_axes": [],
+        "unassessed_axes": [
+          "idempotent",
+          "open_world"
+        ],
+        "non_claims": [
+          "tool annotations are untrusted hints, not security guarantees",
+          "consistent does not certify the server or the annotation as trustworthy",
+          "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
+          "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "idempotentHint and openWorldHint are recorded but not assessed in v0"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5.md
+++ b/docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5.md
@@ -1,0 +1,211 @@
+# Tool Annotation Conformance Increment 5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fourth orthogonal carrier, `assay.tool_annotation_conformance.v0`, that compares untrusted MCP tool annotation hints with Assay's own call classification without affecting enforcement verdicts.
+
+**Architecture:** Increment 5 starts with a pure producer contract: a new `proxy::annotation_conformance` module evaluates `readOnlyHint` and `destructiveHint` against `tool_decision::classify` output and emits a small append-only conformance record. Later slices will capture annotations from `tools/list`, emit the carrier beside the existing per-call carriers, and vendor/consume it in Plimsoll. `assay.enforcement_decision.v0` remains the only verdict carrier.
+
+**Tech Stack:** Rust (`assay-mcp-server`, `serde_json`, Cargo tests), golden JSON fixtures, later Python/Plimsoll vendor freshness guards.
+
+---
+
+## Scope Boundaries
+
+Increment 5a does **not** wire the carrier into the live proxy, does not read `tools/list` annotations yet, and does not change `enforce::decide()` or any allow/deny behavior. It creates only pure logic, tests, a canonical producer fixture, and this plan.
+
+`assay.tool_annotation_conformance.v0` answers: *did untrusted server-declared tool annotation hints contradict Assay's own classified behavior for this call?*
+
+It does **not** answer:
+
+- whether the server is trusted;
+- whether a side effect occurred;
+- whether the call should be allowed or denied;
+- whether descriptions/prompts were malicious;
+- whether `idempotentHint` or `openWorldHint` are true.
+
+## Contract Semantics
+
+v0 assesses only axes that a single classified call can honestly compare:
+
+- `readOnlyHint`: `true` contradicts any classified mutating/destructive call.
+- `destructiveHint`: only `false` can be contradicted, and only by an observed destructive class. `true` means "may be destructive", so one non-destructive observation cannot refute it.
+
+`idempotentHint` and `openWorldHint` are recorded as declared values when present, but they are not assessed in v0.
+
+Conformance states:
+
+- `undeclared`: no assessed hints were present.
+- `consistent`: assessed hints were not contradicted by the observed classification. This is **not** trust certification.
+- `mismatched`: at least one assessed hint contradicts observed behavior.
+- `inconclusive`: the call was not fully classified, so no conformance claim is made.
+
+Absent hints remain `null`; v0 does not apply MCP schema defaults as if the server declared them.
+
+## Files
+
+Assay producer side:
+
+- Create: `crates/assay-mcp-server/src/proxy/annotation_conformance.rs`
+- Modify: `crates/assay-mcp-server/src/proxy/mod.rs`
+- Create: `crates/assay-mcp-server/tests/fixtures/tool_annotation_conformance_contract.v0.json`
+- Create: `docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5.md`
+
+Later slices:
+
+- 5b: capture annotations from `tools/list`, emit `--tool-annotation-conformance-out <path>`, and fail closed on allow if a required record write fails.
+- 5c: vendor the producer fixture in Plimsoll, add freshness guard, classifier, summary/findings, and CLI/review wire-in.
+- 5d: extend combined carrier acceptance to include conformance as a third independent per-call carrier.
+
+## Task 1: Plan of Record
+
+- [ ] **Step 1: Save this plan**
+
+Write this file to:
+
+```bash
+docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5.md
+```
+
+Expected: plan is private engineering documentation, not public spec positioning.
+
+- [ ] **Step 2: Commit the plan with the producer slice**
+
+The plan should land in the same PR as 5a so reviewers see the bounded claim before the carrier shape.
+
+## Task 2: Pure Producer Module and Unit Tests
+
+**Files:**
+
+- Create: `crates/assay-mcp-server/src/proxy/annotation_conformance.rs`
+- Modify: `crates/assay-mcp-server/src/proxy/mod.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests first for:
+
+- read-only declared true + observed mutating -> `mismatched` / `declared_read_only_observed_mutating`
+- non-destructive declared false + observed destructive -> `mismatched` / `declared_non_destructive_observed_destructive`
+- no assessed hints -> `undeclared`
+- classified additive/mutating + read-only false/destructive false -> `consistent`
+- unknown or incomplete classification -> `inconclusive`
+- idempotent/open-world are recorded but not assessed
+- record contains no verdict/delivery/credential/target fields
+
+Run:
+
+```bash
+cargo test -p assay-mcp-server annotation_conformance -- --nocapture
+```
+
+Expected before implementation: tests fail because the module does not exist.
+
+- [ ] **Step 2: Implement minimal module**
+
+Create a small API:
+
+```rust
+pub const TOOL_ANNOTATION_CONFORMANCE_SCHEMA: &str = "assay.tool_annotation_conformance.v0";
+
+pub struct DeclaredToolAnnotations {
+    pub read_only: Option<bool>,
+    pub destructive: Option<bool>,
+    pub idempotent: Option<bool>,
+    pub open_world: Option<bool>,
+}
+
+pub fn conformance_for(declared: &DeclaredToolAnnotations, tool_name: &str, args: &serde_json::Value) -> serde_json::Value;
+```
+
+The builder calls `tool_decision::classify`, derives `observed.behavior_class`, assesses only read-only/destructive, and emits a carrier record.
+
+- [ ] **Step 3: Verify focused tests pass**
+
+Run:
+
+```bash
+cargo test -p assay-mcp-server annotation_conformance -- --nocapture
+```
+
+Expected: tests pass.
+
+## Task 3: Canonical Producer Fixture
+
+**Files:**
+
+- Modify: `crates/assay-mcp-server/src/proxy/annotation_conformance.rs`
+- Create: `crates/assay-mcp-server/tests/fixtures/tool_annotation_conformance_contract.v0.json`
+
+- [ ] **Step 1: Add golden fixture helpers**
+
+Inside the test module, generate one real record per stable producer state:
+
+- `consistent_read_only_false_additive`
+- `consistent_destructive_false_additive`
+- `mismatched_read_only_mutating`
+- `mismatched_non_destructive_destructive`
+- `undeclared`
+- `inconclusive_unknown_tool`
+- `unassessed_axes_recorded`
+
+- [ ] **Step 2: Regenerate fixture**
+
+Run:
+
+```bash
+ASSAY_UPDATE_GOLDEN=1 cargo test -p assay-mcp-server tool_annotation_conformance_contract_fixture
+```
+
+Expected: fixture file is written.
+
+- [ ] **Step 3: Verify fixture without update env**
+
+Run:
+
+```bash
+cargo test -p assay-mcp-server tool_annotation_conformance_contract_fixture
+```
+
+Expected: committed fixture equals generated fixture.
+
+## Task 4: Full Verification and PR
+
+- [ ] **Step 1: Run local verification**
+
+Run:
+
+```bash
+cargo test -p assay-mcp-server annotation_conformance
+cargo test -p assay-mcp-server --bins
+cargo fmt --check
+cargo clippy -p assay-mcp-server --all-targets -- -D warnings
+git diff --check
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Confirm existing carrier fixtures are untouched**
+
+Run:
+
+```bash
+git diff -- crates/assay-mcp-server/tests/fixtures/enforcement_decision_contract.v0.json crates/assay-mcp-server/tests/fixtures/manifest_establish_contract.v0.json
+```
+
+Expected: no diff.
+
+- [ ] **Step 3: Commit and open PR**
+
+Use a technical commit message:
+
+```bash
+git add docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5.md \
+  crates/assay-mcp-server/src/proxy/mod.rs \
+  crates/assay-mcp-server/src/proxy/annotation_conformance.rs \
+  crates/assay-mcp-server/tests/fixtures/tool_annotation_conformance_contract.v0.json
+git commit -s -m "feat(mcp-server): add tool annotation conformance contract"
+git push -u origin codex/tool-annotation-conformance
+gh pr create --title "feat(mcp-server): add tool annotation conformance contract" --body "..."
+```
+
+Expected: PR is ready for review; no live proxy behavior changes.


### PR DESCRIPTION
## What

Adds Increment 5a for `assay.tool_annotation_conformance.v0`: a pure producer contract that compares untrusted MCP ToolAnnotations (`readOnlyHint` / `destructiveHint`) against Assay's own rule-based call classification.

This is deliberately orthogonal to enforcement:
- no `enforce::decide()` change,
- no live proxy wiring,
- no allow/deny effect,
- no write path or CLI flag yet,
- no change to `assay.enforcement_decision.v0` or `assay.manifest_establish.v0`.

## Contract discipline

The v0 states are bounded:
- `undeclared` — no assessed hints were present;
- `consistent` — assessed hints were not contradicted, **not** trust certification;
- `mismatched` — a hint contradicts observed behavior;
- `inconclusive` — the call was not fully classified.

Only single-call-verifiable axes are assessed in v0: `readOnlyHint` and `destructiveHint`. `idempotentHint` and `openWorldHint` are recorded when present but explicitly unassessed. Absent hints stay `null`; the carrier does not apply spec defaults as if the server declared them.

The fixture is generated from the real `build_tool_annotation_conformance_record` builder: `tool_annotation_conformance_contract.v0.json` has 7 canonical records covering consistent, mismatched, undeclared, inconclusive, and unassessed-axis shapes.

## Verification

Local gates green:
- `cargo test -p assay-mcp-server annotation_conformance`
- `cargo test -p assay-mcp-server --bins`
- `cargo fmt --check`
- `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`
- `git diff --check`
- confirmed existing `enforcement_decision` and `manifest_establish` contract fixtures are untouched

## Next slices

5b will capture annotations from `tools/list` and emit the carrier via a new opt-in output path. 5c will vendor/consume the fixture in Plimsoll. 5d can extend combined-carrier acceptance to prove non-correlation across all three per-call carriers.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced documentation for tool annotation conformance schema and multi-phase implementation roadmap.

* **Tests**
  * Added comprehensive test suite and golden contract fixtures validating tool annotation conformance across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->