### PR TITLE
test(monitor): pin monitor-output line shapes via format_monitor_event

### DIFF
--- a/crates/assay-cli/src/cli/commands/monitor_next/output.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/output.rs
@@ -10,13 +10,13 @@ pub(crate) fn err(message: impl AsRef<str>) {
     eprintln!("{}", message.as_ref());
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 pub(crate) fn decode_utf8_cstr(data: &[u8]) -> String {
     let end = data.iter().position(|&b| b == 0).unwrap_or(data.len());
     String::from_utf8_lossy(&data[..end]).to_string()
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 pub(crate) fn dump_prefix_hex(data: &[u8], n: usize) -> String {
     data.iter()
         .take(n)
@@ -25,7 +25,7 @@ pub(crate) fn dump_prefix_hex(data: &[u8], n: usize) -> String {
         .join("")
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 pub(crate) fn decode_file_blocked_payload(data: &[u8]) -> Option<(u64, u64, u64, u32)> {
     if data.len() < 28 {
         return None;
@@ -64,110 +64,103 @@ pub(crate) fn log_kill(
     }
 }
 
-#[cfg(target_os = "linux")]
-pub(crate) fn log_monitor_event(event: &assay_common::MonitorEvent, args: &MonitorArgs) {
+/// Format a monitor event into its human-readable line, or `None` when the event type produces no
+/// output. Pure and platform-independent so the line shapes can be pinned by a unit test;
+/// `log_monitor_event` is the thin stdout wrapper used on the live (Linux) capture path. These
+/// formats are a producer contract: Plimsoll's capture scraper parses these exact shapes.
+#[cfg(any(target_os = "linux", test))]
+pub(crate) fn format_monitor_event(event_type: u32, pid: u32, data: &[u8]) -> Option<String> {
     use assay_common::{EVENT_CONNECT, EVENT_FILE_BLOCKED, EVENT_OPENAT};
 
-    if args.quiet {
-        return;
-    }
-
-    match event.event_type {
-        EVENT_OPENAT => println!(
-            "[PID {}] openat: {}",
-            event.pid,
-            decode_utf8_cstr(&event.data)
-        ),
-        EVENT_CONNECT => println!(
+    let line = match event_type {
+        EVENT_OPENAT => format!("[PID {}] openat: {}", pid, decode_utf8_cstr(data)),
+        EVENT_CONNECT => format!(
             "[PID {}] connect sockaddr[0..32]=0x{}",
-            event.pid,
-            dump_prefix_hex(&event.data, 32)
+            pid,
+            dump_prefix_hex(data, 32)
         ),
-        EVENT_FILE_BLOCKED => match decode_file_blocked_payload(&event.data) {
-            Some((dev, ino, cgroup_id, rule_id)) => println!(
+        EVENT_FILE_BLOCKED => match decode_file_blocked_payload(data) {
+            Some((dev, ino, cgroup_id, rule_id)) => format!(
                 "[PID {}] 🛡️ BLOCKED FILE: dev={} ino={} cgroup={} rule_id={}",
-                event.pid, dev, ino, cgroup_id, rule_id
+                pid, dev, ino, cgroup_id, rule_id
             ),
-            None => println!(
+            None => format!(
                 "[PID {}] 🛡️ BLOCKED FILE: 0x{}",
-                event.pid,
-                dump_prefix_hex(&event.data, 32)
+                pid,
+                dump_prefix_hex(data, 32)
             ),
         },
-        11 => println!(
-            "[PID {}] 🟢 ALLOWED FILE: {}",
-            event.pid,
-            decode_utf8_cstr(&event.data)
-        ),
-        20 => println!(
+        11 => format!("[PID {}] 🟢 ALLOWED FILE: {}", pid, decode_utf8_cstr(data)),
+        20 => format!(
             "[PID {}] 🛡️ BLOCKED NET : {}",
-            event.pid,
-            dump_prefix_hex(&event.data, 20)
+            pid,
+            dump_prefix_hex(data, 20)
         ),
         112 => {
-            let dev_bytes: [u8; 8] = event.data[0..8].try_into().unwrap_or([0; 8]);
-            let ino_bytes: [u8; 8] = event.data[8..16].try_into().unwrap_or([0; 8]);
-            let gen_bytes: [u8; 4] = event.data[16..20].try_into().unwrap_or([0; 4]);
+            let dev_bytes: [u8; 8] = data[0..8].try_into().unwrap_or([0; 8]);
+            let ino_bytes: [u8; 8] = data[8..16].try_into().unwrap_or([0; 8]);
+            let gen_bytes: [u8; 4] = data[16..20].try_into().unwrap_or([0; 4]);
 
             let dev = u64::from_ne_bytes(dev_bytes);
             let ino = u64::from_ne_bytes(ino_bytes);
             let gen = u32::from_ne_bytes(gen_bytes);
 
-            println!(
+            format!(
                 "[PID {}] 🔒 INODE RESOLVED: dev={} (0x{:x}) ino={} gen={}",
-                event.pid, dev, dev, ino, gen
-            );
+                pid, dev, dev, ino, gen
+            )
         }
         101..=104 => {
-            let chunk_idx = event.event_type - 101;
+            let chunk_idx = event_type - 101;
             let start_offset = chunk_idx * 64;
-            let dump = dump_prefix_hex(&event.data, 64);
-            println!(
+            let dump = dump_prefix_hex(data, 64);
+            format!(
                 "[PID {}] 🔍 STRUCT DUMP Part {} (Offset {}-{}): {}",
-                event.pid,
+                pid,
                 chunk_idx + 1,
                 start_offset,
                 start_offset + 64,
                 dump
-            );
+            )
         }
         105 => {
-            let path = decode_utf8_cstr(&event.data);
-            println!(
-                "[PID {}] 📂 FILE OPEN (Manual Resolution): {}",
-                event.pid, path
-            );
+            let path = decode_utf8_cstr(data);
+            format!("[PID {}] 📂 FILE OPEN (Manual Resolution): {}", pid, path)
         }
-        106 => {
-            println!("[PID {}] 🐛 DEBUG: Dentry Pointer NULL", event.pid);
-        }
-        107 => {
-            println!("[PID {}] 🐛 DEBUG: Name Pointer NULL", event.pid);
-        }
-        108 => {
-            println!(
-                "[PID {}] 🐛 DEBUG: LSM Hook Entry (MonitorAll={})",
-                event.pid, event.data[0]
-            );
-        }
-        109 => {
-            println!("[PID {}] 🐛 DEBUG: Passed Monitor Check", event.pid);
-        }
+        106 => format!("[PID {}] 🐛 DEBUG: Dentry Pointer NULL", pid),
+        107 => format!("[PID {}] 🐛 DEBUG: Name Pointer NULL", pid),
+        108 => format!(
+            "[PID {}] 🐛 DEBUG: LSM Hook Entry (MonitorAll={})",
+            pid, data[0]
+        ),
+        109 => format!("[PID {}] 🐛 DEBUG: Passed Monitor Check", pid),
         110 => {
-            let ptr = u64::from_ne_bytes(event.data[0..8].try_into().unwrap());
-            println!("[PID {}] 🐛 DEBUG: Read Dentry Ptr: {:#x}", event.pid, ptr);
+            let ptr = u64::from_ne_bytes(data[0..8].try_into().unwrap());
+            format!("[PID {}] 🐛 DEBUG: Read Dentry Ptr: {:#x}", pid, ptr)
         }
         111 => {
-            let ptr = u64::from_ne_bytes(event.data[0..8].try_into().unwrap());
-            println!("[PID {}] 🐛 DEBUG: Read Name Ptr: {:#x}", event.pid, ptr);
+            let ptr = u64::from_ne_bytes(data[0..8].try_into().unwrap());
+            format!("[PID {}] 🐛 DEBUG: Read Name Ptr: {:#x}", pid, ptr)
         }
-        _ => if args.monitor_all || !args.quiet {},
+        _ => return None,
+    };
+    Some(line)
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn log_monitor_event(event: &assay_common::MonitorEvent, args: &MonitorArgs) {
+    if args.quiet {
+        return;
+    }
+    if let Some(line) = format_monitor_event(event.event_type, event.pid, &event.data) {
+        out(line);
     }
 }
 
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(test)]
 mod tests {
-    use super::decode_file_blocked_payload;
+    use super::{decode_file_blocked_payload, format_monitor_event};
+    use assay_common::{EVENT_CONNECT, EVENT_FILE_BLOCKED, EVENT_OPENAT};
 
     #[test]
     fn decode_file_blocked_payload_reads_binary_layout() {
@@ -179,5 +172,53 @@ mod tests {
 
         let decoded = decode_file_blocked_payload(&data).expect("payload should decode");
         assert_eq!(decoded, (42, 7, 99, 1234));
+    }
+
+    // The line shapes below are the producer contract that Plimsoll's capture scraper parses (see
+    // plimsoll src/plimsoll/capture.py parse_monitor_lines). openat and connect are the two the
+    // scraper extracts, so they are pinned in full; the rest pin the structural payload layout.
+    fn cstr(s: &str) -> Vec<u8> {
+        let mut v = s.as_bytes().to_vec();
+        v.push(0);
+        v
+    }
+
+    #[test]
+    fn openat_event_formats_exact_path_line() {
+        let line = format_monitor_event(EVENT_OPENAT, 4242, &cstr("/etc/passwd")).unwrap();
+        assert_eq!(line, "[PID 4242] openat: /etc/passwd");
+    }
+
+    #[test]
+    fn connect_event_formats_exact_sockaddr_hex_line() {
+        let line = format_monitor_event(EVENT_CONNECT, 4242, &[0x02, 0x00, 0x00, 0x50]).unwrap();
+        assert_eq!(line, "[PID 4242] connect sockaddr[0..32]=0x02000050");
+    }
+
+    #[test]
+    fn file_blocked_event_formats_decoded_payload() {
+        let mut data = [0u8; 32];
+        data[0..8].copy_from_slice(&1u64.to_ne_bytes());
+        data[8..16].copy_from_slice(&2u64.to_ne_bytes());
+        data[16..24].copy_from_slice(&3u64.to_ne_bytes());
+        data[24..28].copy_from_slice(&4u32.to_ne_bytes());
+        let line = format_monitor_event(EVENT_FILE_BLOCKED, 4242, &data).unwrap();
+        assert!(line.starts_with("[PID 4242] "), "{line}");
+        assert!(
+            line.ends_with(" BLOCKED FILE: dev=1 ino=2 cgroup=3 rule_id=4"),
+            "{line}"
+        );
+    }
+
+    #[test]
+    fn allowed_file_event_formats_path_suffix() {
+        let line = format_monitor_event(11, 4242, &cstr("/allowed/path")).unwrap();
+        assert!(line.starts_with("[PID 4242] "), "{line}");
+        assert!(line.ends_with(" ALLOWED FILE: /allowed/path"), "{line}");
+    }
+
+    #[test]
+    fn unknown_event_type_produces_no_line() {
+        assert_eq!(format_monitor_event(999, 4242, &[]), None);
     }
 }

--- a/crates/assay-cli/src/cli/commands/monitor_next/output.rs
+++ b/crates/assay-cli/src/cli/commands/monitor_next/output.rs
@@ -72,6 +72,22 @@ pub(crate) fn log_kill(
 pub(crate) fn format_monitor_event(event_type: u32, pid: u32, data: &[u8]) -> Option<String> {
     use assay_common::{EVENT_CONNECT, EVENT_FILE_BLOCKED, EVENT_OPENAT};
 
+    // The live path always passes a full fixed-size event payload, but the slice contract is also
+    // exercised by unit tests, so read fixed offsets with checked access and a zero fallback rather
+    // than indexing, which would panic on a short buffer.
+    fn read_u64(data: &[u8], start: usize) -> u64 {
+        data.get(start..start + 8)
+            .and_then(|s| <[u8; 8]>::try_from(s).ok())
+            .map(u64::from_ne_bytes)
+            .unwrap_or(0)
+    }
+    fn read_u32(data: &[u8], start: usize) -> u32 {
+        data.get(start..start + 4)
+            .and_then(|s| <[u8; 4]>::try_from(s).ok())
+            .map(u32::from_ne_bytes)
+            .unwrap_or(0)
+    }
+
     let line = match event_type {
         EVENT_OPENAT => format!("[PID {}] openat: {}", pid, decode_utf8_cstr(data)),
         EVENT_CONNECT => format!(
@@ -97,14 +113,9 @@ pub(crate) fn format_monitor_event(event_type: u32, pid: u32, data: &[u8]) -> Op
             dump_prefix_hex(data, 20)
         ),
         112 => {
-            let dev_bytes: [u8; 8] = data[0..8].try_into().unwrap_or([0; 8]);
-            let ino_bytes: [u8; 8] = data[8..16].try_into().unwrap_or([0; 8]);
-            let gen_bytes: [u8; 4] = data[16..20].try_into().unwrap_or([0; 4]);
-
-            let dev = u64::from_ne_bytes(dev_bytes);
-            let ino = u64::from_ne_bytes(ino_bytes);
-            let gen = u32::from_ne_bytes(gen_bytes);
-
+            let dev = read_u64(data, 0);
+            let ino = read_u64(data, 8);
+            let gen = read_u32(data, 16);
             format!(
                 "[PID {}] 🔒 INODE RESOLVED: dev={} (0x{:x}) ino={} gen={}",
                 pid, dev, dev, ino, gen
@@ -131,15 +142,16 @@ pub(crate) fn format_monitor_event(event_type: u32, pid: u32, data: &[u8]) -> Op
         107 => format!("[PID {}] 🐛 DEBUG: Name Pointer NULL", pid),
         108 => format!(
             "[PID {}] 🐛 DEBUG: LSM Hook Entry (MonitorAll={})",
-            pid, data[0]
+            pid,
+            data.first().copied().unwrap_or(0)
         ),
         109 => format!("[PID {}] 🐛 DEBUG: Passed Monitor Check", pid),
         110 => {
-            let ptr = u64::from_ne_bytes(data[0..8].try_into().unwrap());
+            let ptr = read_u64(data, 0);
             format!("[PID {}] 🐛 DEBUG: Read Dentry Ptr: {:#x}", pid, ptr)
         }
         111 => {
-            let ptr = u64::from_ne_bytes(data[0..8].try_into().unwrap());
+            let ptr = read_u64(data, 0);
             format!("[PID {}] 🐛 DEBUG: Read Name Ptr: {:#x}", pid, ptr)
         }
         _ => return None,
@@ -220,5 +232,15 @@ mod tests {
     #[test]
     fn unknown_event_type_produces_no_line() {
         assert_eq!(format_monitor_event(999, 4242, &[]), None);
+    }
+
+    #[test]
+    fn short_buffers_do_not_panic_in_indexed_arms() {
+        // The slice contract must stay bounds-safe: event types that read fixed offsets fall back
+        // to zero on a short buffer instead of panicking (the live path always passes a full one).
+        for event_type in [108u32, 110, 111, 112] {
+            let line = format_monitor_event(event_type, 7, &[]).unwrap();
+            assert!(line.starts_with("[PID 7] "), "{line}");
+        }
     }
 }


### PR DESCRIPTION
## What

The `assay monitor --print` line formats are scraped by an out-of-tree consumer (Plimsoll's capture surface, which turns them into a capability surface). Those formats only lived inside `log_monitor_event`'s `println!` arms with no test, so a change to a shape could not be caught on the producer side. This is the producer half of the parse-contract follow-up from the Plimsoll ReDoS review; the consumer half pins the parser in [plimsoll#55](https://github.com/Rul1an/plimsoll/pull/55).

The formatting moves into a pure, platform-independent `format_monitor_event(event_type, pid, data) -> Option<String>`. `log_monitor_event` becomes the thin Linux stdout wrapper and prints exactly as before. The formatter and its byte helpers are gated `cfg(any(target_os = "linux", test))` so they compile where they are actually used, the Linux capture path and any-platform unit tests, without turning into dead code in a non-Linux release build. The test module drops its Linux gate so the shapes are exercised on every platform.

The unit tests pin the shapes that matter: `openat` and `connect`, the two the consumer extracts, are asserted in full, and the decoded `BLOCKED FILE` / `ALLOWED FILE` payload layout is pinned structurally.

## Scope

Test plus a behaviour-preserving extraction. No runtime behaviour change, no schema, no eBPF change. Verified locally: `cargo fmt --check`, `cargo test -p assay-cli output::tests` (6 pass), `cargo clippy -p assay-cli --all-targets -- -D warnings`, `cargo build -p assay-cli`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked monitor event formatting and output so the CLI only emits user-facing lines for recognized event types and respects the quiet mode.

* **Tests**
  * Strengthened unit tests to lock down exact formatter output for key event types, ensure unknown events produce no output, and verify safety with short/boundary payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->