### PR TITLE
feat(mcp-server): Increment 5b plan + declared-annotation extraction (5b-1)

### DIFF
--- a/crates/assay-mcp-server/src/proxy/annotation_conformance.rs
+++ b/crates/assay-mcp-server/src/proxy/annotation_conformance.rs
@@ -18,6 +18,19 @@ pub struct DeclaredToolAnnotations {
     pub open_world: Option<bool>,
 }
 
+/// Extract the v0 declared annotation hints from a raw MCP `annotations` value. Absent, null,
+/// non-object, or non-boolean hints all read as `None`: the carrier records what the server actually
+/// declared, and an absent hint is undeclared, never the MCP schema default.
+pub fn extract_declared_annotations(annotations: &Value) -> DeclaredToolAnnotations {
+    let hint = |key: &str| annotations.get(key).and_then(Value::as_bool);
+    DeclaredToolAnnotations {
+        read_only: hint("readOnlyHint"),
+        destructive: hint("destructiveHint"),
+        idempotent: hint("idempotentHint"),
+        open_world: hint("openWorldHint"),
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ObservedBehavior {
     Mutating,
@@ -297,6 +310,84 @@ mod tests {
             !text.contains("ci-key"),
             "raw sensitive argument values must not be copied into the record"
         );
+    }
+
+    // ---- Declared-annotation extraction (Increment 5b-1) --------------------------------------
+
+    #[test]
+    fn extract_reads_declared_boolean_hints() {
+        let declared = extract_declared_annotations(&json!({
+            "readOnlyHint": true,
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false,
+        }));
+        assert_eq!(declared.read_only, Some(true));
+        assert_eq!(declared.destructive, Some(false));
+        assert_eq!(declared.idempotent, Some(true));
+        assert_eq!(declared.open_world, Some(false));
+    }
+
+    #[test]
+    fn extract_absent_hints_are_none_not_default() {
+        // MCP defines schema defaults (e.g. readOnlyHint false), but the carrier records what the
+        // server actually declared: an absent hint is undeclared, never the default.
+        let declared = extract_declared_annotations(&json!({"title": "Add deploy key"}));
+        assert_eq!(declared.read_only, None);
+        assert_eq!(declared.destructive, None);
+        assert_eq!(declared.idempotent, None);
+        assert_eq!(declared.open_world, None);
+    }
+
+    #[test]
+    fn extract_null_or_non_object_annotations_are_all_none() {
+        for value in [
+            json!(null),
+            json!("readOnlyHint"),
+            json!(["readOnlyHint"]),
+            json!(42),
+        ] {
+            let declared = extract_declared_annotations(&value);
+            assert_eq!(
+                (
+                    declared.read_only,
+                    declared.destructive,
+                    declared.idempotent,
+                    declared.open_world
+                ),
+                (None, None, None, None),
+                "non-object annotations must not declare any hint: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_non_boolean_hint_values_are_none() {
+        // A hint declared with a non-boolean value is not a trustworthy boolean; record None.
+        let declared = extract_declared_annotations(&json!({
+            "readOnlyHint": "true",
+            "destructiveHint": 1,
+            "idempotentHint": null,
+            "openWorldHint": {},
+        }));
+        assert_eq!(
+            (
+                declared.read_only,
+                declared.destructive,
+                declared.idempotent,
+                declared.open_world
+            ),
+            (None, None, None, None)
+        );
+    }
+
+    #[test]
+    fn extract_partial_hints_keep_declared_and_drop_absent() {
+        let declared = extract_declared_annotations(&json!({"readOnlyHint": false}));
+        assert_eq!(declared.read_only, Some(false));
+        assert_eq!(declared.destructive, None);
+        assert_eq!(declared.idempotent, None);
+        assert_eq!(declared.open_world, None);
     }
 
     // ---- Shared producer/consumer contract fixture (Increment 5) ------------------------------

--- a/docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5b.md
+++ b/docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5b.md
@@ -8,7 +8,9 @@ pure producer contract. 5b wires it into the enforcing proxy.
 Capture the declared MCP tool annotation hints from the observed `tools/list` snapshot, and emit one
 `assay.tool_annotation_conformance.v0` record per enforced `tools/call`, beside the existing
 `assay.enforcement_decision.v0` (verdict) and `assay.manifest_establish.v0` (journey) carriers. The
-conformance carrier stays orthogonal: it never changes the verdict and never gates the call.
+conformance carrier stays orthogonal: its outcome never changes the verdict and never gates the call
+(an evidence-write failure can still fail closed before delivery, like the other carriers; see
+record-write ordering below).
 
 ## Grounding and future hook
 
@@ -74,9 +76,12 @@ When `--tool-conformance-out <path>` is set, the proxy writes one NDJSON record 
 
 ## Non-correlation
 
-The conformance record is computed at the `tools/call` boundary and never changes the verdict or
-gates the call. It covers the call, not any asynchronous task execution a server may start.
-UI-driven tool calls route through the same call path and are covered without special handling.
+The conformance outcome is computed at the `tools/call` boundary: the record contents never change
+the verdict, and a mismatch never gates the call. A failure to write a requested record is a separate
+evidence-integrity rule that can fail closed before delivery, the same rule the other carriers follow
+(see record-write ordering). It covers the call, not any asynchronous task execution a server may
+start. UI-driven tool calls route through the same call path and are covered without special
+handling.
 
 ## Slices
 
@@ -101,7 +106,7 @@ UI-driven tool calls route through the same call path and are covered without sp
 
 ## Non-claims
 
-- tool annotations are untrusted hints, read only to compare, never to decide privilege or the
+- tool annotations are untrusted hints, read-only to compare, never to decide privilege or the
   verdict;
 - a `consistent` record is not trust certification; a `mismatched` record is not a maliciousness
   verdict or an enforcement decision;

--- a/docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5b.md
+++ b/docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5b.md
@@ -1,0 +1,111 @@
+# Increment 5b — live wiring for `assay.tool_annotation_conformance.v0`
+
+Follows Increment 5a (`2026-06-13-tool-annotation-conformance-increment5.md`), which shipped the
+pure producer contract. 5b wires it into the enforcing proxy.
+
+## Goal
+
+Capture the declared MCP tool annotation hints from the observed `tools/list` snapshot, and emit one
+`assay.tool_annotation_conformance.v0` record per enforced `tools/call`, beside the existing
+`assay.enforcement_decision.v0` (verdict) and `assay.manifest_establish.v0` (journey) carriers. The
+conformance carrier stays orthogonal: it never changes the verdict and never gates the call.
+
+## Grounding and future hook
+
+5b is grounded in the current MCP tools contract: `tools/list` (paginated), `tools/list_changed`, the
+optional Tool `annotations` object, and the rule that clients must treat tool annotations as
+untrusted unless they come from a trusted server. There is no trusted-server signing mechanism today,
+so every annotation is untrusted and an independent declared-vs-observed comparison is always
+meaningful.
+
+Future hook: the July 28 release-candidate track is treated only as a future compatibility hook. It
+may add adjacent task and server-discovery surfaces, but 5b deliberately sources only from the
+current `tools/list` annotations snapshot. Tasks and `server/discover` are not source inputs for 5b;
+they remain follow-up surfaces if that line lands.
+
+## Single observation source
+
+The proxy observer already retains the latest complete `tools/list` snapshot (`latest_complete`) and
+answers the drift gate through `observed_tool_digest(tool_name)`, which reads that snapshot under the
+supersede and ambiguity rules. 5b derives the declared annotations from the SAME effective snapshot,
+so the conformance record can never read a different manifest view than the verdict did:
+
+- a single observer helper returns, for a tool name, both the observed `tool_digest` and the raw
+  declared `annotations`, from the effective `latest_complete`;
+- because `latest_complete` is updated by the establish re-list (the same accumulation path), the
+  conformance record is automatically based on the post-establish, re-decided observation, not the
+  original pre-establish view.
+
+`extract_declared_annotations` parses the raw `annotations` value into the four v0 hint fields.
+Absent, null, non-object, or non-boolean hints all read as `None`: the carrier records what the
+server actually declared, and 5a treats an absent hint as undeclared, never the MCP schema default.
+
+## Observation basis (honest v0 extension)
+
+Behavior classification is manifest-independent (it reads the tool name and arguments), so a call can
+be classified even when the manifest was not completely observed. In that case the declared
+annotations are not reliably observed, and running the 5a logic blind would emit `undeclared`,
+falsely implying the server declared nothing when really nothing was observed.
+
+5b therefore adds one append-only field to the v0 record, `observation_basis`:
+
+- `complete` — the called tool was present in the effective complete manifest; the real per-tool
+  `tool_digest` is recorded and the 5a conformance logic applies;
+- `incomplete` — no complete manifest, an ambiguous manifest, or the tool absent from an otherwise
+  complete manifest; `conformance` is forced to `inconclusive`, declared hints are all null, and
+  `tool_digest` is null, with a non-claim that annotations were not observed.
+
+This is an append-only shape change made while there is still no consumer; the 5a producer fixture
+and its exact-key assertion are regenerated in the same change. `observation_basis` and `tool_digest`
+move together, which also makes both the populated and null `tool_digest` forms appear in the
+contract.
+
+## Emission and record-write ordering
+
+When `--tool-conformance-out <path>` is set, the proxy writes one NDJSON record per enforced
+`tools/call`, after `assay.enforcement_decision.v0` and `assay.manifest_establish.v0`:
+
+- on an allow, all carrier writes must succeed or the call becomes `proxy_failed` and is not
+  forwarded — an allow is the decision to forward, never the delivery, so a failed conformance write
+  must not let an unrecorded call through;
+- on a deny, a conformance write failure is logged only and the deny stands; the carrier may still be
+  emitted on a deny, where declared annotation versus observed behavior is useful forensics on a
+  refused call.
+
+## Non-correlation
+
+The conformance record is computed at the `tools/call` boundary and never changes the verdict or
+gates the call. It covers the call, not any asynchronous task execution a server may start.
+UI-driven tool calls route through the same call path and are covered without special handling.
+
+## Slices
+
+- 5b-1: `extract_declared_annotations` and its tests (absent / null / non-object / non-boolean /
+  partial hints). Pure, no wiring.
+- 5b-2: the single-source observer helper (tool_digest plus annotations from the effective snapshot),
+  the `--tool-conformance-out` flag, carrier emission with `observation_basis`, fail-closed evidence
+  on allow and logged-only on deny, the producer-fixture regeneration, and a verb-sync guard test
+  asserting every classifier verb maps to an observed behavior.
+- 5c (Plimsoll): vendor the regenerated fixture, add a CLI acceptance test, and extend the combined
+  acceptance fixture to three carriers, proving the conformance signal promotes to neither the
+  verdict nor the establish journey.
+
+## Tests (5b-2)
+
+- complete manifest, annotation mismatch, allow verdict → `mismatched` record, verdict stays allow;
+- incomplete manifest → `observation_basis: incomplete`, `inconclusive`, null `tool_digest`;
+- flag off → no file written;
+- allow with a conformance write failure → `proxy_failed`, not forwarded;
+- deny with a conformance write failure → deny stands;
+- verb-sync guard.
+
+## Non-claims
+
+- tool annotations are untrusted hints, read only to compare, never to decide privilege or the
+  verdict;
+- a `consistent` record is not trust certification; a `mismatched` record is not a maliciousness
+  verdict or an enforcement decision;
+- observed behavior is the call classification, not verification of the upstream side effect;
+- `observation_basis: incomplete` means the annotations were not observed, not that the server
+  declared none;
+- `idempotentHint` and `openWorldHint` are recorded but not assessed in v0.


### PR DESCRIPTION
## What

Increment 5b wires the 5a `assay.tool_annotation_conformance.v0` contract into the enforcing proxy. This PR is the plan plus the first pure slice (5b-1); the live emission lands in 5b-2.

### Plan ([doc](docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5b.md))

- **Single observation source.** The declared annotations come from the same effective `tools/list` snapshot the verdict reads (`latest_complete`, updated by the establish re-list), so the conformance record can never read a different manifest view than the decision did.
- **Observation basis.** Behaviour classification is manifest-independent, so a call can classify even when the manifest was not completely observed. An append-only `observation_basis` (`complete` | `incomplete`) lets the carrier say "annotations were not observed" (`inconclusive`, null `tool_digest`) instead of a false `undeclared`. The 5a producer fixture and its exact-key assertion are regenerated in 5b-2, where the field lands.
- **Emission.** Under `--tool-conformance-out`, one NDJSON record per enforced `tools/call`, after the decision and establish carriers, with fail-closed evidence on allow (a failed conformance write makes the call `proxy_failed`, never a forwarded-but-unrecorded call) and logged-only on deny.
- **Orthogonal.** The carrier never changes the verdict and never gates the call.
- **Future hook only.** The July 28 release-candidate track is a future compatibility hook; 5b deliberately sources only from the current `tools/list` annotations snapshot. Tasks and `server/discover` are not source inputs.

### Code (5b-1)

`extract_declared_annotations` parses the raw `annotations` value into the four v0 hint fields. Absent, null, non-object, and non-boolean hints all read as `None`, so the carrier records what the server actually declared rather than the MCP schema default. Pure, no wiring.

## Scope

Plan doc plus a pure function and its tests (absent / null / non-object / non-boolean / partial hints). No relay behaviour change, no schema change yet. Verified: `cargo fmt --check`, `cargo test -p assay-mcp-server annotation_conformance` (12 pass), `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added annotation hint extraction to improve tool conformance checking; non-boolean, null, or missing hints are treated as absent (no defaulting).

* **Documentation**
  * Added planning doc describing wiring, observation basis semantics (complete vs incomplete), emission ordering, and fail-closed/write-failure behaviors.

* **Tests**
  * Added unit tests covering boolean parsing, absent/null/non-object inputs, and partial hint scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->