### PR TITLE
feat(mcp-server): observation_basis + verb-sync for tool conformance (5b-2 contract)

### DIFF
--- a/crates/assay-mcp-server/src/proxy/annotation_conformance.rs
+++ b/crates/assay-mcp-server/src/proxy/annotation_conformance.rs
@@ -31,6 +31,24 @@ pub fn extract_declared_annotations(annotations: &Value) -> DeclaredToolAnnotati
     }
 }
 
+/// Whether the called tool's declared annotations were read from a completely observed manifest.
+/// `Incomplete` (no complete manifest, an ambiguous one, or the tool absent) forces `inconclusive`:
+/// the annotations were not observed, which is distinct from a server that declared none.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObservationBasis {
+    Complete,
+    Incomplete,
+}
+
+impl ObservationBasis {
+    fn as_str(self) -> &'static str {
+        match self {
+            ObservationBasis::Complete => "complete",
+            ObservationBasis::Incomplete => "incomplete",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ObservedBehavior {
     Mutating,
@@ -62,14 +80,24 @@ fn push_axis(axes: &mut Vec<&'static str>, axis: &'static str) {
     }
 }
 
-/// Build one `assay.tool_annotation_conformance.v0` record from declared annotations and the
-/// rule-based classification of the call. `tool_digest` is not available until the live observer
-/// wiring slice, so 5a emits it as null while pinning the append-only field in the v0 shape.
+/// Build one record with a `Complete` observation basis and no recorded digest. Convenience for
+/// unit tests that exercise the conformance logic against a known declaration.
 pub fn conformance_for(declared: &DeclaredToolAnnotations, tool_name: &str, args: &Value) -> Value {
-    build_tool_annotation_conformance_record(declared, tool_name, None, args)
+    build_tool_annotation_conformance_record(
+        ObservationBasis::Complete,
+        declared,
+        tool_name,
+        None,
+        args,
+    )
 }
 
+/// Build one `assay.tool_annotation_conformance.v0` record from the declared annotations and the
+/// rule-based classification of the call. When `basis` is `Incomplete` the declared annotations were
+/// not observed, so the record forces `inconclusive` with null declared hints and digest (the
+/// classifier's observed behavior is still recorded) rather than reading absence as "undeclared".
 pub fn build_tool_annotation_conformance_record(
+    basis: ObservationBasis,
     declared: &DeclaredToolAnnotations,
     tool_name: &str,
     tool_digest: Option<&str>,
@@ -82,30 +110,40 @@ pub fn build_tool_annotation_conformance_record(
         None
     };
 
-    let mut assessed_axes = Vec::new();
+    let complete = basis == ObservationBasis::Complete;
+    let declared = if complete {
+        *declared
+    } else {
+        DeclaredToolAnnotations::default()
+    };
+    let tool_digest = if complete { tool_digest } else { None };
+
+    let mut assessed_axes: Vec<&'static str> = Vec::new();
     let mut mismatch_kind: Option<&'static str> = None;
 
-    if let Some(read_only) = declared.read_only {
-        if behavior.is_some() {
-            push_axis(&mut assessed_axes, "read_only");
-            if read_only {
-                mismatch_kind = Some("declared_read_only_observed_mutating");
+    if complete {
+        if let Some(read_only) = declared.read_only {
+            if behavior.is_some() {
+                push_axis(&mut assessed_axes, "read_only");
+                if read_only {
+                    mismatch_kind = Some("declared_read_only_observed_mutating");
+                }
             }
         }
-    }
 
-    if declared.read_only != Some(true) {
-        if let Some(destructive) = declared.destructive {
-            if let Some(observed) = behavior {
-                push_axis(&mut assessed_axes, "destructive");
-                if !destructive && observed == ObservedBehavior::Destructive {
-                    mismatch_kind = Some("declared_non_destructive_observed_destructive");
+        if declared.read_only != Some(true) {
+            if let Some(destructive) = declared.destructive {
+                if let Some(observed) = behavior {
+                    push_axis(&mut assessed_axes, "destructive");
+                    if !destructive && observed == ObservedBehavior::Destructive {
+                        mismatch_kind = Some("declared_non_destructive_observed_destructive");
+                    }
                 }
             }
         }
     }
 
-    let conformance = if behavior.is_none() {
+    let conformance = if !complete || behavior.is_none() {
         "inconclusive"
     } else if assessed_axes.is_empty() {
         "undeclared"
@@ -115,7 +153,7 @@ pub fn build_tool_annotation_conformance_record(
         "consistent"
     };
 
-    let mut unassessed_axes = Vec::new();
+    let mut unassessed_axes: Vec<&'static str> = Vec::new();
     if declared.idempotent.is_some() {
         unassessed_axes.push("idempotent");
     }
@@ -125,6 +163,7 @@ pub fn build_tool_annotation_conformance_record(
 
     json!({
         "schema": TOOL_ANNOTATION_CONFORMANCE_SCHEMA,
+        "observation_basis": basis.as_str(),
         "tool": {
             "name": sanitize(tool_name),
             "tool_digest": tool_digest,
@@ -150,6 +189,7 @@ pub fn build_tool_annotation_conformance_record(
             "consistent does not certify the server or the annotation as trustworthy",
             "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
             "observed behavior is Assay's call classification, not verification of the upstream side effect",
+            "observation_basis incomplete means annotations were not observed, not that the server declared none",
             "idempotentHint and openWorldHint are recorded but not assessed in v0"
         ]
     })
@@ -390,6 +430,100 @@ mod tests {
         assert_eq!(declared.open_world, None);
     }
 
+    // ---- Observation basis and verb-sync (Increment 5b) ---------------------------------------
+
+    #[test]
+    fn incomplete_basis_forces_inconclusive_with_null_declared_and_digest() {
+        // Declared hints and digest are nulled (annotations were not observed), but the classifier's
+        // observed behavior is still recorded; conformance is forced inconclusive, never undeclared.
+        let rec = build_tool_annotation_conformance_record(
+            ObservationBasis::Incomplete,
+            &DeclaredToolAnnotations {
+                read_only: Some(true),
+                destructive: Some(false),
+                idempotent: None,
+                open_world: None,
+            },
+            "github.add_deploy_key",
+            Some("sha256:ignored-when-incomplete"),
+            &json!({"owner": "acme", "repo": "prod-app"}),
+        );
+        assert_eq!(rec["observation_basis"], json!("incomplete"));
+        assert_eq!(rec["conformance"], json!("inconclusive"));
+        assert_eq!(rec["mismatch_kind"], Value::Null);
+        assert_eq!(rec["assessed_axes"], json!([]));
+        assert_eq!(rec["tool"]["tool_digest"], Value::Null);
+        assert_eq!(rec["declared"]["read_only"], Value::Null);
+        assert_eq!(rec["declared"]["destructive"], Value::Null);
+        assert_eq!(rec["observed"]["behavior_class"], json!("mutating"));
+    }
+
+    #[test]
+    fn complete_basis_records_observation_basis_and_digest() {
+        let rec = build_tool_annotation_conformance_record(
+            ObservationBasis::Complete,
+            &DeclaredToolAnnotations {
+                read_only: Some(true),
+                destructive: None,
+                idempotent: None,
+                open_world: None,
+            },
+            "github.add_deploy_key",
+            Some("sha256:abc"),
+            &json!({"owner": "acme", "repo": "prod-app"}),
+        );
+        assert_eq!(rec["observation_basis"], json!("complete"));
+        assert_eq!(rec["tool"]["tool_digest"], json!("sha256:abc"));
+        assert_eq!(rec["conformance"], json!("mismatched"));
+    }
+
+    #[test]
+    fn every_classifier_verb_maps_to_an_observed_behavior() {
+        // observed_behavior() must stay in sync with the verbs tool_decision::classify can emit.
+        // classify currently emits only privileged mutating/destructive verbs, so each must map; a
+        // new privileged verb added there without a mapping would silently downgrade a contradiction
+        // to inconclusive. A non-mutating verb, if ever added, maps to None by design.
+        let calls = [
+            (
+                "github.add_deploy_key",
+                json!({"owner": "acme", "repo": "prod-app"}),
+            ),
+            (
+                "slack.add_member",
+                json!({"workspace_id": "acme", "user_id": "u1"}),
+            ),
+            (
+                "workspace.grant_admin",
+                json!({"workspace_id": "acme", "principal": "p"}),
+            ),
+            (
+                "workspace.change_role",
+                json!({"workspace_id": "acme", "principal": "p"}),
+            ),
+            (
+                "workspace.invite_external",
+                json!({"workspace_id": "acme", "principal": "p"}),
+            ),
+            (
+                "workspace.modify_org_policy",
+                json!({"workspace_id": "acme", "principal": "p"}),
+            ),
+            (
+                "workspace.create_workspace_token",
+                json!({"workspace_id": "acme", "principal": "p"}),
+            ),
+        ];
+        for (tool, args) in calls {
+            let classified = classify(tool, &args);
+            assert_eq!(classified.state, "classified", "{tool} should classify");
+            assert!(
+                observed_behavior(classified.verb).is_some(),
+                "verb {:?} from {tool} has no observed_behavior mapping",
+                classified.verb
+            );
+        }
+    }
+
     // ---- Shared producer/consumer contract fixture (Increment 5) ------------------------------
     //
     // The canonical `assay.tool_annotation_conformance.v0` contract is REAL output of
@@ -403,10 +537,20 @@ mod tests {
             .join("tests/fixtures/tool_annotation_conformance_contract.v0.json")
     }
 
+    type ContractCase = (
+        &'static str,
+        ObservationBasis,
+        DeclaredToolAnnotations,
+        &'static str,
+        Value,
+        Option<&'static str>,
+    );
+
     fn contract_records() -> Vec<Value> {
-        let cases: &[(&str, DeclaredToolAnnotations, &str, Value, Option<&str>)] = &[
+        let cases: Vec<ContractCase> = vec![
             (
                 "consistent_read_only_false_additive",
+                ObservationBasis::Complete,
                 DeclaredToolAnnotations {
                     read_only: Some(false),
                     destructive: None,
@@ -419,6 +563,7 @@ mod tests {
             ),
             (
                 "consistent_destructive_false_additive",
+                ObservationBasis::Complete,
                 DeclaredToolAnnotations {
                     read_only: Some(false),
                     destructive: Some(false),
@@ -431,6 +576,7 @@ mod tests {
             ),
             (
                 "mismatched_read_only_mutating",
+                ObservationBasis::Complete,
                 DeclaredToolAnnotations {
                     read_only: Some(true),
                     destructive: None,
@@ -443,6 +589,7 @@ mod tests {
             ),
             (
                 "mismatched_non_destructive_destructive",
+                ObservationBasis::Complete,
                 DeclaredToolAnnotations {
                     read_only: Some(false),
                     destructive: Some(false),
@@ -455,6 +602,7 @@ mod tests {
             ),
             (
                 "undeclared",
+                ObservationBasis::Complete,
                 DeclaredToolAnnotations {
                     read_only: None,
                     destructive: None,
@@ -467,6 +615,7 @@ mod tests {
             ),
             (
                 "inconclusive_unknown_tool",
+                ObservationBasis::Complete,
                 DeclaredToolAnnotations {
                     read_only: Some(true),
                     destructive: Some(false),
@@ -479,6 +628,7 @@ mod tests {
             ),
             (
                 "unassessed_axes_recorded",
+                ObservationBasis::Complete,
                 DeclaredToolAnnotations {
                     read_only: None,
                     destructive: None,
@@ -489,14 +639,23 @@ mod tests {
                 json!({"owner": "acme", "repo": "prod-app"}),
                 Some("sha256:tooldigest-unassessed"),
             ),
+            (
+                "incomplete_manifest_inconclusive",
+                ObservationBasis::Incomplete,
+                DeclaredToolAnnotations::default(),
+                "github.add_deploy_key",
+                json!({"owner": "acme", "repo": "prod-app"}),
+                None,
+            ),
         ];
 
         cases
             .iter()
-            .map(|(case, declared, tool, args, tool_digest)| {
+            .map(|(case, basis, declared, tool, args, tool_digest)| {
                 json!({
                     "case": case,
                     "record": build_tool_annotation_conformance_record(
+                        *basis,
                         declared,
                         tool,
                         *tool_digest,
@@ -540,7 +699,7 @@ mod tests {
         );
 
         let records = generated["records"].as_array().unwrap();
-        assert_eq!(records.len(), 7);
+        assert_eq!(records.len(), 8);
         for entry in records {
             let rec = &entry["record"];
             assert_eq!(rec["schema"], json!(TOOL_ANNOTATION_CONFORMANCE_SCHEMA));
@@ -555,6 +714,7 @@ mod tests {
                     "declared",
                     "mismatch_kind",
                     "non_claims",
+                    "observation_basis",
                     "observed",
                     "schema",
                     "tool",

--- a/crates/assay-mcp-server/tests/fixtures/tool_annotation_conformance_contract.v0.json
+++ b/crates/assay-mcp-server/tests/fixtures/tool_annotation_conformance_contract.v0.json
@@ -7,6 +7,7 @@
       "case": "consistent_read_only_false_additive",
       "record": {
         "schema": "assay.tool_annotation_conformance.v0",
+        "observation_basis": "complete",
         "tool": {
           "name": "github.add_deploy_key",
           "tool_digest": "sha256:tooldigest-consistent-readonly-false",
@@ -34,6 +35,7 @@
           "consistent does not certify the server or the annotation as trustworthy",
           "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
           "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "observation_basis incomplete means annotations were not observed, not that the server declared none",
           "idempotentHint and openWorldHint are recorded but not assessed in v0"
         ]
       }
@@ -42,6 +44,7 @@
       "case": "consistent_destructive_false_additive",
       "record": {
         "schema": "assay.tool_annotation_conformance.v0",
+        "observation_basis": "complete",
         "tool": {
           "name": "github.add_deploy_key",
           "tool_digest": "sha256:tooldigest-consistent-nondestructive",
@@ -70,6 +73,7 @@
           "consistent does not certify the server or the annotation as trustworthy",
           "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
           "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "observation_basis incomplete means annotations were not observed, not that the server declared none",
           "idempotentHint and openWorldHint are recorded but not assessed in v0"
         ]
       }
@@ -78,6 +82,7 @@
       "case": "mismatched_read_only_mutating",
       "record": {
         "schema": "assay.tool_annotation_conformance.v0",
+        "observation_basis": "complete",
         "tool": {
           "name": "github.add_deploy_key",
           "tool_digest": "sha256:tooldigest-readonly-mismatch",
@@ -105,6 +110,7 @@
           "consistent does not certify the server or the annotation as trustworthy",
           "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
           "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "observation_basis incomplete means annotations were not observed, not that the server declared none",
           "idempotentHint and openWorldHint are recorded but not assessed in v0"
         ]
       }
@@ -113,6 +119,7 @@
       "case": "mismatched_non_destructive_destructive",
       "record": {
         "schema": "assay.tool_annotation_conformance.v0",
+        "observation_basis": "complete",
         "tool": {
           "name": "workspace.modify_org_policy",
           "tool_digest": "sha256:tooldigest-destructive-mismatch",
@@ -141,6 +148,7 @@
           "consistent does not certify the server or the annotation as trustworthy",
           "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
           "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "observation_basis incomplete means annotations were not observed, not that the server declared none",
           "idempotentHint and openWorldHint are recorded but not assessed in v0"
         ]
       }
@@ -149,6 +157,7 @@
       "case": "undeclared",
       "record": {
         "schema": "assay.tool_annotation_conformance.v0",
+        "observation_basis": "complete",
         "tool": {
           "name": "github.add_deploy_key",
           "tool_digest": "sha256:tooldigest-undeclared",
@@ -174,6 +183,7 @@
           "consistent does not certify the server or the annotation as trustworthy",
           "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
           "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "observation_basis incomplete means annotations were not observed, not that the server declared none",
           "idempotentHint and openWorldHint are recorded but not assessed in v0"
         ]
       }
@@ -182,6 +192,7 @@
       "case": "inconclusive_unknown_tool",
       "record": {
         "schema": "assay.tool_annotation_conformance.v0",
+        "observation_basis": "complete",
         "tool": {
           "name": "unknown.tool",
           "tool_digest": "sha256:tooldigest-unknown",
@@ -207,6 +218,7 @@
           "consistent does not certify the server or the annotation as trustworthy",
           "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
           "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "observation_basis incomplete means annotations were not observed, not that the server declared none",
           "idempotentHint and openWorldHint are recorded but not assessed in v0"
         ]
       }
@@ -215,6 +227,7 @@
       "case": "unassessed_axes_recorded",
       "record": {
         "schema": "assay.tool_annotation_conformance.v0",
+        "observation_basis": "complete",
         "tool": {
           "name": "github.add_deploy_key",
           "tool_digest": "sha256:tooldigest-unassessed",
@@ -243,6 +256,42 @@
           "consistent does not certify the server or the annotation as trustworthy",
           "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
           "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "observation_basis incomplete means annotations were not observed, not that the server declared none",
+          "idempotentHint and openWorldHint are recorded but not assessed in v0"
+        ]
+      }
+    },
+    {
+      "case": "incomplete_manifest_inconclusive",
+      "record": {
+        "schema": "assay.tool_annotation_conformance.v0",
+        "observation_basis": "incomplete",
+        "tool": {
+          "name": "github.add_deploy_key",
+          "tool_digest": null,
+          "action_class": "github_deploy_key"
+        },
+        "declared": {
+          "read_only": null,
+          "destructive": null,
+          "idempotent": null,
+          "open_world": null
+        },
+        "observed": {
+          "classification_state": "classified",
+          "verb": "create",
+          "behavior_class": "mutating"
+        },
+        "conformance": "inconclusive",
+        "mismatch_kind": null,
+        "assessed_axes": [],
+        "unassessed_axes": [],
+        "non_claims": [
+          "tool annotations are untrusted hints, not security guarantees",
+          "consistent does not certify the server or the annotation as trustworthy",
+          "mismatch is a conformance signal, not a maliciousness verdict or an enforcement decision",
+          "observed behavior is Assay's call classification, not verification of the upstream side effect",
+          "observation_basis incomplete means annotations were not observed, not that the server declared none",
           "idempotentHint and openWorldHint are recorded but not assessed in v0"
         ]
       }


### PR DESCRIPTION
## What

First half of Increment 5b. Before the relay emission slice wires the carrier into `tools/call`, the contract gains `observation_basis` so an incompletely observed manifest stays honest. Follows the [5b plan](docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5b.md) merged in [#1670](https://github.com/Rul1an/assay/pull/1670).

- `build_tool_annotation_conformance_record` takes an `ObservationBasis`. `Complete` runs the 5a logic with the real `tool_digest`; `Incomplete` (no complete manifest, an ambiguous one, or the tool absent) forces `inconclusive` with null declared hints and digest, while still recording the classifier's observed behaviour. Behaviour classification is manifest-independent, so without this an unobserved manifest would read as a false `undeclared` rather than the honest "we did not observe the annotations".
- The producer fixture is regenerated with `observation_basis`. Both the populated and the null `tool_digest` forms now appear (closing the 5a note that the digest was always null), and the exact-key assertion is updated.
- A verb-sync guard asserts every verb `tool_decision::classify` currently emits maps to an observed behaviour, so a new privileged verb added there cannot silently downgrade a contradiction to `inconclusive`.

## Scope

Pure contract plus tests; no relay wiring, no flag, no emission yet (that is the next 5b slice). The carrier remains orthogonal to the verdict. Verified: `cargo test -p assay-mcp-server annotation_conformance` (15 pass), `cargo fmt --check`, `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`.

The fixture now carries 8 records: the seven `complete`-basis cases (unchanged conformance outcomes) plus one `incomplete`-basis case showing a classified behaviour with `inconclusive` conformance and null declared hints / digest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Annotation conformance records now include an observation basis field indicating whether tool observations were complete or incomplete.
  * When observations are incomplete, conformance automatically becomes inconclusive and certain metadata fields are cleared.

* **Tests**
  * Updated test fixtures to validate complete and incomplete observation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->