### PR TITLE
feat(mcp-server): emit tool_annotation_conformance.v0 carrier (Increment 5b relay)

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -76,6 +76,12 @@ enum Mode {
         /// scope/target/token. On an allowed call a write failure fails closed (not forwarded).
         #[arg(long)]
         manifest_establish_out: Option<PathBuf>,
+        /// Optional NDJSON path for the per-call `assay.tool_annotation_conformance.v0` carrier
+        /// (Increment 5b): one record per `tools/call` comparing the server's declared annotation
+        /// hints with Assay's observed call classification. Orthogonal to the verdict (its outcome
+        /// never changes allow/deny); on an allowed call a write failure fails closed (not forwarded).
+        #[arg(long)]
+        tool_conformance_out: Option<PathBuf>,
         /// Total deadline (ms) for one pre-call manifest-establish run. Default 5000; must be greater
         /// than 0, and is capped at 60000.
         #[arg(long, default_value_t = 5000)]
@@ -137,6 +143,7 @@ async fn main() -> Result<()> {
             declared_mcp_manifest,
             enforcement_decision_out,
             manifest_establish_out,
+            tool_conformance_out,
             manifest_establish_budget_ms,
         }) => {
             // Load + validate BOTH inputs BEFORE starting the proxy. A bad policy or baseline is a
@@ -174,6 +181,7 @@ async fn main() -> Result<()> {
                     baseline: Some(baseline),
                     decision_out: enforcement_decision_out,
                     establish_out: manifest_establish_out,
+                    tool_conformance_out,
                     establish_budget: std::time::Duration::from_millis(budget_ms),
                 },
                 None,

--- a/crates/assay-mcp-server/src/proxy/annotation_conformance.rs
+++ b/crates/assay-mcp-server/src/proxy/annotation_conformance.rs
@@ -3,7 +3,6 @@
 //! This carrier compares untrusted MCP ToolAnnotations against Assay's own rule-based call
 //! classification. It is deliberately orthogonal to the enforcement verdict: a mismatch is a
 //! conformance signal, never a deny, and a consistent record is not trust certification.
-#![allow(dead_code)]
 
 use assay_mcp_server::tool_decision::{classify, sanitize};
 use serde_json::{json, Value};
@@ -80,8 +79,9 @@ fn push_axis(axes: &mut Vec<&'static str>, axis: &'static str) {
     }
 }
 
-/// Build one record with a `Complete` observation basis and no recorded digest. Convenience for
-/// unit tests that exercise the conformance logic against a known declaration.
+/// Build one record with a `Complete` observation basis and no recorded digest. Test-only
+/// convenience that exercises the conformance logic against a known declaration.
+#[cfg(test)]
 pub fn conformance_for(declared: &DeclaredToolAnnotations, tool_name: &str, args: &Value) -> Value {
     build_tool_annotation_conformance_record(
         ObservationBasis::Complete,

--- a/crates/assay-mcp-server/src/proxy/enforce.rs
+++ b/crates/assay-mcp-server/src/proxy/enforce.rs
@@ -31,6 +31,11 @@ pub struct EnforceInputs {
     pub baseline: Option<DeclaredManifest>,
     pub decision_out: Option<PathBuf>,
     pub establish_out: Option<PathBuf>,
+    /// Optional NDJSON path for the per-call `assay.tool_annotation_conformance.v0` carrier
+    /// (Increment 5b): the server's declared annotation hints vs Assay's observed call
+    /// classification. Orthogonal to the verdict; on an allowed call a write failure fails closed,
+    /// the same evidence rule as the other carriers.
+    pub tool_conformance_out: Option<PathBuf>,
     pub establish_budget: std::time::Duration,
 }
 

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -266,6 +266,30 @@ impl Observer {
         enforce::ObservedToolDigest::CompleteButToolAbsent
     }
 
+    /// The effective per-tool observation for `tool_name`, from the SAME current complete manifest
+    /// the drift gate reads via `observed_tool_digest`: the digest outcome plus, when the tool is
+    /// `Present`, its raw declared `annotations` (`Value::Null` when the tool declared none).
+    /// Read-only. Used by the Increment 5b tool-annotation conformance carrier so it cannot read a
+    /// different manifest view than the verdict did. A non-`Present` digest yields `None`
+    /// annotations: the declared annotations were not observed, so the conformance basis is incomplete.
+    fn effective_tool_observation(
+        &self,
+        tool_name: &str,
+    ) -> (enforce::ObservedToolDigest, Option<Value>) {
+        let digest = self.observed_tool_digest(tool_name);
+        let annotations = if matches!(digest, enforce::ObservedToolDigest::Present(_)) {
+            self.latest_complete.as_ref().and_then(|tools| {
+                tools
+                    .iter()
+                    .find(|t| t.get("name").and_then(|n| n.as_str()) == Some(tool_name))
+                    .map(|t| t.get("annotations").cloned().unwrap_or(Value::Null))
+            })
+        } else {
+            None
+        };
+        (digest, annotations)
+    }
+
     /// Compute the final emission: latest complete wins; otherwise the best observed; otherwise
     /// not_observed. Closes any still-active chain as incomplete first.
     fn finalize(&mut self) -> Emission {
@@ -413,6 +437,7 @@ pub async fn run(
         baseline,
         decision_out,
         establish_out,
+        tool_conformance_out,
         establish_budget,
     } = enforce_inputs;
     let spawned = Command::new(&upstream_command)
@@ -720,7 +745,46 @@ pub async fn run(
                     }
                     None => true,
                 };
-                let records_ok = decision_record_ok && establish_record_ok;
+                // Increment 5b: write the assay.tool_annotation_conformance.v0 carrier AFTER the
+                // verdict and establish carriers. Its OUTCOME is orthogonal to the verdict, but a
+                // requested-record write failure follows the same fail-closed-on-allow evidence rule.
+                // Declared annotations are read from the SAME effective snapshot the decision used.
+                let conformance_record_ok = match &tool_conformance_out {
+                    Some(path) => {
+                        let (eff_digest, eff_annotations) =
+                            observer.lock().await.effective_tool_observation(tool_name);
+                        let basis = if matches!(eff_digest, enforce::ObservedToolDigest::Present(_))
+                        {
+                            annotation_conformance::ObservationBasis::Complete
+                        } else {
+                            annotation_conformance::ObservationBasis::Incomplete
+                        };
+                        let declared = annotation_conformance::extract_declared_annotations(
+                            eff_annotations.as_ref().unwrap_or(&Value::Null),
+                        );
+                        let digest = match &eff_digest {
+                            enforce::ObservedToolDigest::Present(d) => Some(d.as_str()),
+                            _ => None,
+                        };
+                        let record =
+                            annotation_conformance::build_tool_annotation_conformance_record(
+                                basis, &declared, tool_name, digest, call_args,
+                            );
+                        match append_decision_record(path, &record) {
+                            Ok(()) => true,
+                            Err(e) => {
+                                tracing::error!(
+                                    event = "tool_conformance_record_write_failed",
+                                    error = %e,
+                                    path = %path.display()
+                                );
+                                false
+                            }
+                        }
+                    }
+                    None => true,
+                };
+                let records_ok = decision_record_ok && establish_record_ok && conformance_record_ok;
                 if decision.allow && !records_ok {
                     // Fail-closed: never forward an allowed call whose required record(s) we could not write.
                     if let Some(id) = v.get("id") {

--- a/crates/assay-mcp-server/src/proxy/mod.rs
+++ b/crates/assay-mcp-server/src/proxy/mod.rs
@@ -666,12 +666,19 @@ pub async fn run(
                     )
                     .await;
                     run_outcome = Some(outcome);
-                    let observed2 = observer.lock().await.observed_tool_digest(tool_name);
-                    decision = enforce::decide(policy, baseline, &observed2, tool_name, call_args);
+                }
+                // Capture ONE effective observation after establish has run or been skipped, and decide
+                // the FINAL verdict from it. The Increment 5b conformance carrier reads its declared
+                // annotations and digest from this SAME snapshot, so the verdict and the carrier can
+                // never diverge even if the upstream reader mutates observer state between two reads.
+                let (eff_digest, eff_annotations) =
+                    observer.lock().await.effective_tool_observation(tool_name);
+                decision = enforce::decide(policy, baseline, &eff_digest, tool_name, call_args);
+                if run_outcome.is_some() {
                     tracing::info!(
                         event = "establish_attempted",
                         tool = %tool_name,
-                        run_outcome = ?outcome,
+                        run_outcome = ?run_outcome,
                         effective_decision = if decision.allow { "allow" } else { "deny" },
                         reason = decision.reason,
                         note = "pre-call manifest-establish; verdict lives in enforcement_decision.v0"
@@ -748,11 +755,9 @@ pub async fn run(
                 // Increment 5b: write the assay.tool_annotation_conformance.v0 carrier AFTER the
                 // verdict and establish carriers. Its OUTCOME is orthogonal to the verdict, but a
                 // requested-record write failure follows the same fail-closed-on-allow evidence rule.
-                // Declared annotations are read from the SAME effective snapshot the decision used.
+                // `eff_digest` / `eff_annotations` are the SAME snapshot the verdict was decided from.
                 let conformance_record_ok = match &tool_conformance_out {
                     Some(path) => {
-                        let (eff_digest, eff_annotations) =
-                            observer.lock().await.effective_tool_observation(tool_name);
                         let basis = if matches!(eff_digest, enforce::ObservedToolDigest::Present(_))
                         {
                             annotation_conformance::ObservationBasis::Complete
@@ -793,7 +798,7 @@ pub async fn run(
                                 id.clone(),
                                 PROXY_FAILED,
                                 "enforcement_record_write_failed",
-                                "a required enforcement/establish record could not be written; call not forwarded",
+                                "a required evidence record (enforcement_decision / manifest_establish / tool_annotation_conformance) could not be written; call not forwarded",
                             ));
                         }
                     }

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -1359,4 +1359,11 @@ fn conformance_write_failure_on_allow_fails_closed() {
         "enforcement_record_write_failed"
     );
     shutdown(child, stdin);
+    // The silent-unrecorded-forward regression this guards: a fail-closed allow must never reach
+    // the upstream.
+    let methods = read_methods(&log);
+    assert!(
+        !methods.contains(&"tools/call".to_string()),
+        "a fail-closed allow must never reach the upstream: {methods:?}"
+    );
 }

--- a/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
+++ b/crates/assay-mcp-server/tests/proxy_enforce_pdp_e2e.rs
@@ -1145,3 +1145,218 @@ fn establish_budget_zero_fails_startup() {
         "a zero establish budget must be rejected at startup"
     );
 }
+
+// =================================================================================================
+// Increment 5b: assay.tool_annotation_conformance.v0 carrier emission (relay wiring).
+// =================================================================================================
+
+/// Spawn the enforcing proxy writing the enforcement-decision NDJSON and, optionally, the
+/// tool-annotation conformance carrier NDJSON, with an optional establish budget (ms).
+fn spawn_enforce_conformance(
+    log: &Path,
+    policy: &Path,
+    baseline: &Path,
+    mode: &str,
+    decisions: &Path,
+    conformance: Option<&Path>,
+    budget_ms: Option<u64>,
+) -> Child {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay-mcp-server"));
+    cmd.arg("proxy-enforce")
+        .args(["--upstream-command", python()])
+        .args(["--upstream-arg", "-u"])
+        .args(["--upstream-arg", mock_path().to_str().unwrap()])
+        .args(["--enforce-policy", policy.to_str().unwrap()])
+        .args(["--declared-mcp-manifest", baseline.to_str().unwrap()])
+        .args(["--enforcement-decision-out", decisions.to_str().unwrap()]);
+    if let Some(c) = conformance {
+        cmd.args(["--tool-conformance-out", c.to_str().unwrap()]);
+    }
+    if let Some(ms) = budget_ms {
+        cmd.args(["--manifest-establish-budget-ms", &ms.to_string()]);
+    }
+    cmd.env("MOCK_UPSTREAM_LOG", log)
+        .env("MOCK_UPSTREAM_MODE", mode)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn enforce proxy (is python installed?)")
+}
+
+fn read_conformance_records(path: &Path) -> Vec<Value> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("conformance record JSON"))
+        .collect()
+}
+
+#[test]
+fn complete_manifest_allow_emits_conformance_record() {
+    // A client tools/list completes a matching manifest -> allow + forward. The conformance carrier
+    // records observation_basis=complete with the real per-tool digest; the mock declares no
+    // annotations, so conformance is `undeclared`, orthogonal to the allow verdict.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let conformance = dir.path().join("conformance.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_conformance(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "p60a",
+        &decisions,
+        Some(&conformance),
+        None,
+    );
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(r["result"]["content"][0]["text"], "forwarded-ok");
+    shutdown(child, stdin);
+
+    let recs = read_conformance_records(&conformance);
+    assert_eq!(recs.len(), 1, "one conformance record per tools/call");
+    let rec = &recs[0];
+    assert_eq!(rec["schema"], "assay.tool_annotation_conformance.v0");
+    assert_eq!(rec["observation_basis"], "complete");
+    assert!(
+        rec["tool"]["tool_digest"]
+            .as_str()
+            .is_some_and(|d| d.starts_with("sha256:")),
+        "complete basis records the real per-tool digest: {rec}"
+    );
+    assert_eq!(rec["conformance"], "undeclared");
+    // Orthogonal allow in the separate verdict carrier.
+    let dec = std::fs::read_to_string(&decisions).unwrap_or_default();
+    assert!(dec.contains("assay.enforcement_decision.v0") && dec.contains("allow"));
+}
+
+#[test]
+fn incomplete_manifest_emits_inconclusive_conformance() {
+    // No client list + drop_list: the establish re-list times out, the effective observation is
+    // never complete, so the call is denied AND the conformance carrier records
+    // observation_basis=incomplete with a null digest and inconclusive conformance (annotations were
+    // not observed, never a false `undeclared`).
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let conformance = dir.path().join("conformance.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_conformance(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "drop_list",
+        &decisions,
+        Some(&conformance),
+        Some(300),
+    );
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(
+        r["error"]["data"]["reason"],
+        "manifest_current_observation_incomplete"
+    );
+    shutdown(child, stdin);
+
+    let recs = read_conformance_records(&conformance);
+    assert_eq!(recs.len(), 1);
+    let rec = &recs[0];
+    assert_eq!(rec["observation_basis"], "incomplete");
+    assert_eq!(rec["conformance"], "inconclusive");
+    assert_eq!(rec["tool"]["tool_digest"], Value::Null);
+}
+
+#[test]
+fn conformance_flag_off_writes_no_file() {
+    // Without --tool-conformance-out, no carrier file is produced.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let conformance = dir.path().join("conformance.ndjson");
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_conformance(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "p60a",
+        &decisions,
+        None,
+        None,
+    );
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let _ = read_response(&mut out);
+    shutdown(child, stdin);
+
+    assert!(
+        !conformance.exists(),
+        "no conformance file is written when the flag is off"
+    );
+}
+
+#[test]
+fn conformance_write_failure_on_allow_fails_closed() {
+    // The conformance path is a directory, so the append fails. On an allow that must fail closed
+    // (proxy_failed): an allow is the decision to forward, never a forwarded-but-unrecorded call.
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("methods.log");
+    let decisions = dir.path().join("decisions.ndjson");
+    let conformance_dir = dir.path().join("conformance_is_a_dir");
+    std::fs::create_dir(&conformance_dir).unwrap();
+    let policy = write_file(dir.path(), "enforce.yaml", ALLOW_ACME);
+    let mut child = spawn_enforce_conformance(
+        &log,
+        &policy,
+        &approved_baseline_path(),
+        "p60a",
+        &decisions,
+        Some(&conformance_dir),
+        None,
+    );
+    let mut stdin = child.stdin.take().unwrap();
+    let mut out = BufReader::new(child.stdout.take().unwrap());
+
+    send(&mut stdin, init());
+    let _ = read_response(&mut out);
+    send(
+        &mut stdin,
+        serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let _ = read_response(&mut out);
+    send(&mut stdin, deploy_key_call());
+    let r = read_response(&mut out);
+    assert_eq!(r["error"]["data"]["origin"], "assay-proxy");
+    assert_eq!(
+        r["error"]["data"]["reason"],
+        "enforcement_record_write_failed"
+    );
+    shutdown(child, stdin);
+}


### PR DESCRIPTION
## What

The second 5b slice: wires the `assay.tool_annotation_conformance.v0` carrier into the enforcing `tools/call` path, after the contract landed in [#1671](https://github.com/Rul1an/assay/pull/1671). Follows the [5b plan](docs/superpowers/plans/2026-06-13-tool-annotation-conformance-increment5b.md).

- **Single observation source.** A new `Observer::effective_tool_observation` returns a tool's digest and its raw declared `annotations` from the **same** current complete manifest the drift gate reads via `observed_tool_digest`, so the conformance record cannot read a different manifest view than the verdict. Since `latest_complete` is updated by the establish re-list, the record is based on the post-establish, re-decided observation.
- **Emission.** Under `--tool-conformance-out`, one NDJSON record per enforced `tools/call`, after the `enforcement_decision` and `manifest_establish` carriers. `observation_basis` is `complete` when the tool is `Present` (real digest, 5a logic applies) and `incomplete` otherwise (`inconclusive`, null declared hints and digest, with the classifier's observed behaviour still recorded).
- **Orthogonal, with fail-closed evidence.** The carrier outcome never changes the verdict and never gates the call, but a requested-record write failure follows the same fail-closed-on-allow rule as the other carriers (an allow whose conformance write fails becomes `proxy_failed`, never a forwarded-but-unrecorded call). On a deny the deny stands and the failure is logged.
- **Cleanup.** `annotation_conformance` drops its module-wide `allow(dead_code)` now that it is wired; `conformance_for` becomes a test-only convenience.

## Tests

Four e2e cases on the real proxy + mock upstream: a complete-manifest allow emits the carrier with the real digest, orthogonal to the allow verdict; an incomplete manifest (drop_list, establish times out) emits `observation_basis: incomplete` / `inconclusive` / null digest; the flag off writes no file; an allow whose conformance write fails (path is a directory) is `proxy_failed`, not forwarded.

The annotation-vs-behaviour **mismatch** logic itself is unit-covered (5a and the 5b contract); a mismatch e2e needs an annotation-bearing mock and a matching baseline digest (annotations are part of the per-tool digest), which is a focused follow-up rather than part of this wiring slice.

## Scope

Verified: `cargo fmt --check`, `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`, `cargo test -p assay-mcp-server --bins` (88 pass), `cargo test -p assay-mcp-server --test proxy_enforce_pdp_e2e` (31 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional CLI output to record per-call tool annotation conformance as NDJSON; proxy captures a single effective observation snapshot and emits a conformance evidence record alongside enforcement decisions.

* **Bug Fixes**
  * Fail-closed behavior: allowed calls are denied if required conformance evidence cannot be written.

* **Tests**
  * End-to-end tests cover complete/incomplete observations, omitted-output, and write-failure deny-close scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->