### PR TITLE
release: assay 3.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.25.0] - 2026-06-13
+
+### Added
+- Pre-call manifest-establish for the enforcing proxy (P61e Increment 2). When a `tools/call` would
+  be denied solely because no current complete `tools/list` was observed for the tool, the proxy runs
+  one bounded, proxy-originated re-list against a single total deadline, then re-decides on the
+  effective observation and acts on that verdict. It never relaxes a gate: ambiguous observations, a
+  missing baseline, and real digest drift stay denied, and a failed or timed-out re-list leaves the
+  deny standing. The journey is emitted as a separate `assay.manifest_establish.v0` carrier (establish
+  path + run outcome, never the allow/deny verdict) under `--manifest-establish-out`, with a
+  `--manifest-establish-budget-ms` operator flag (default 5000).
+- `assay.tool_annotation_conformance.v0`, a carrier comparing the server's untrusted declared tool
+  annotations (`readOnlyHint` / `destructiveHint`) against Assay's own observed call classification.
+  Emitted per `tools/call` under `--tool-conformance-out`, read from the same effective observation as
+  the verdict, with an `observation_basis` (`complete` / `incomplete`) that keeps an unobserved
+  manifest honest rather than reporting a false "undeclared". It is descriptive and orthogonal: a
+  mismatch is never a verdict and never gates the call, and the allow/deny verdict stays in
+  `assay.enforcement_decision.v0`.
+- Pinned producer contracts for downstream consumers: golden fixtures for `assay.manifest_establish.v0`,
+  `assay.tool_annotation_conformance.v0`, and a combined `assay.combined_carrier_acceptance.v0`
+  fixture, each regenerated from the real producer builders and proving the verdict / journey /
+  conformance carriers stay non-correlated.
+- The `assay monitor` output line shapes are pinned by a pure, platform-independent
+  `format_monitor_event` plus a contract test, so a change to the scraped lines is caught at the
+  producer.
+
 ## [3.24.0] - 2026-06-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.24.0"
+version = "3.25.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
## What

Release prep for **3.25.0**: workspace version bump (`Cargo.toml` + `Cargo.lock`, workspace crates only) and CHANGELOG finalize. **No tag is pushed by this PR** — the release tag `v3.25.0` (which triggers the binaries + crates.io + PyPI publish via `release.yml`) is pushed separately on an explicit go.

### Highlights since 3.24.0
- **Pre-call manifest-establish** for the enforcing proxy (P61e Increment 2): when a `tools/call` would be denied solely on the manifest-availability gap, the proxy runs one bounded, proxy-originated re-list against a single total deadline and re-decides on the effective observation. It never relaxes a gate. The journey is emitted as a separate `assay.manifest_establish.v0` carrier under `--manifest-establish-out` (with `--manifest-establish-budget-ms`), never the verdict.
- **`assay.tool_annotation_conformance.v0`** — the server's untrusted declared tool annotations vs Assay's observed call classification, emitted per `tools/call` under `--tool-conformance-out`, read from the same effective observation as the verdict, with an honest `observation_basis`. Descriptive and orthogonal: a mismatch is never a verdict and never gates.
- **Pinned producer-contract golden fixtures** (`manifest_establish`, combined-carrier, `tool_annotation_conformance`), each regenerated from the real producer builders, proving the verdict / journey / conformance carriers stay non-correlated.
- **`assay monitor` output line shapes** pinned via a pure, platform-independent `format_monitor_event` plus a contract test.

## Scope

Metadata + changelog only; no code change. `Cargo.lock` diff is the workspace crates bumped to 3.25.0 (no registry-dependency changes). Pre-commit `cargo fmt --check` and `cargo deny` pass. The publish is gated: `v3.25.0` is tagged only after explicit go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 3.25.0

* **New Features**
  * Enhanced proxy behavior for handling missing baseline observations with bounded re-listing
  * Added per-tool annotation conformance tracking
  * Improved monitoring output consistency with pinned contract fixtures

* **Chores**
  * Version bumped to 3.25.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->