### PR TITLE
docs(readme): lead with the policy-gate value prop and MCP threat framing

### DIFF
--- a/.github/social-preview.svg
+++ b/.github/social-preview.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640" font-family="ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" role="img" aria-label="Assay: policy-as-code for MCP agents. Enforce, prove, stay honest.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1117"/>
+      <stop offset="1" stop-color="#161b22"/>
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="640" fill="url(#bg)"/>
+  <rect x="0" y="0" width="1280" height="8" fill="#3fb950"/>
+
+  <text x="80" y="150" fill="#f0f6fc" font-size="92" font-weight="800" letter-spacing="-1">Assay</text>
+  <text x="80" y="226" fill="#58a6ff" font-size="40" font-weight="600">Policy-as-code for MCP agents</text>
+
+  <text x="80" y="312" fill="#c9d1d9" font-size="34" font-weight="700">
+    <tspan fill="#3fb950">Enforce</tspan><tspan fill="#8b949e">  ·  </tspan><tspan fill="#58a6ff">Prove</tspan><tspan fill="#8b949e">  ·  </tspan><tspan fill="#d29922">Stay honest</tspan>
+  </text>
+
+  <text x="80" y="372" fill="#8b949e" font-size="27">A fail-closed gate for tool calls, kernel-level (eBPF/LSM) enforcement,</text>
+  <text x="80" y="408" fill="#8b949e" font-size="27">and offline-verifiable evidence. Never claims more than it can prove.</text>
+
+  <g font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="28">
+    <rect x="80" y="452" width="1120" height="112" rx="12" fill="#010409" stroke="#30363d"/>
+    <text x="108" y="500" fill="#3fb950" font-weight="700">✅ ALLOW</text><text x="250" y="500" fill="#c9d1d9">read_file</text><text x="430" y="500" fill="#8b949e">reason=policy_allow</text>
+    <text x="108" y="540" fill="#f85149" font-weight="700">❌ DENY </text><text x="250" y="540" fill="#c9d1d9">exec</text><text x="430" y="540" fill="#8b949e">reason=tool_denied</text>
+  </g>
+
+  <text x="80" y="610" fill="#6e7681" font-size="24" font-family="ui-monospace,monospace">Rust  ·  eBPF/LSM  ·  CI-native  ·  no backend  ·  MIT</text>
+  <text x="1200" y="610" fill="#6e7681" font-size="24" text-anchor="end">github.com/Rul1an/assay</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <h1 align="center">Assay</h1>
   <p align="center">
-    <strong>Evidence compiler for agent review artifacts</strong><br />
-    <span>Portable evidence receipts, verifiable bundles, and bounded Trust Basis claims for agent systems.</span>
+    <strong>Policy-as-code for MCP agents: enforce what a tool call can do, prove what it did, and stay honest about what you can't.</strong><br />
+    <span>A deterministic, fail-closed policy gate for MCP tool calls, with real kernel-level (eBPF/LSM) enforcement on Linux and offline-verifiable evidence. CI-native, no backend, bounded by design.</span>
   </p>
   <p align="center">
     <a href="https://crates.io/crates/assay-cli"><img src="https://img.shields.io/crates/v/assay-cli.svg" alt="Crates.io"></a>
@@ -10,15 +10,44 @@
     <a href="https://github.com/Rul1an/assay/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/assay-core.svg" alt="License"></a>
   </p>
   <p align="center">
-    <a href="#see-it-work">See It Work</a> ·
-    <a href="docs/use-cases/evidence-receipts-from-promptfoo-jsonl.md">Promptfoo JSONL</a> ·
-    <a href="docs/use-cases/openfeature-evaluationdetails-to-ci-review-artifact.md">OpenFeature</a> ·
-    <a href="docs/use-cases/cyclonedx-mlbom-model-to-inventory-receipt.md">CycloneDX ML-BOM</a> ·
-    <a href="examples/mcp-quickstart/">Quick Start</a> ·
-    <a href="docs/guides/github-action.md">CI Guide</a> ·
+    <a href="#try-it-in-30-seconds">Quickstart</a> ·
+    <a href="#enforce-prove-stay-honest">How it works</a> ·
+    <a href="#see-it-work">See it work</a> ·
+    <a href="examples/mcp-quickstart/">MCP example</a> ·
+    <a href="docs/guides/github-action.md">CI guide</a> ·
+    <a href="docs/security/OWASP-MCP-TOP10-MAPPING.md">OWASP MCP Top 10</a> ·
     <a href="https://github.com/Rul1an/assay/discussions">Discussions</a>
   </p>
 </p>
+
+---
+
+In 2026 agents got real tool access through MCP, and the attacks came with it: tool poisoning, rug pulls, confused-deputy OAuth, dozens of CVEs in the first months alone. Most tools scan a server or filter a prompt. Assay sits at the tool-call boundary and does three things, in order.
+
+### Enforce, prove, stay honest
+
+- **Enforce.** A deterministic, fail-closed policy gate decides every MCP `tools/call` before it runs, with the precise reason for each allow or deny. On Linux it adds real kernel-level enforcement: a proven IPv4/TCP connect-egress block (eBPF/LSM) and a Landlock TCP-connect port allowlist, both opt-in and fail-closed. A policy it cannot express exactly is refused, never half-applied.
+- **Prove.** Every decision and observed effect becomes an offline-verifiable, tamper-evident evidence bundle, alongside pinned per-call carriers: the verdict, the pre-call establish journey, and declared-vs-observed tool-annotation conformance. All reviewable in CI, with no hosted backend.
+- **Stay honest.** Each claim carries its basis (`verified`, `self_reported`, `inferred`, or `absent`), and a gate refuses to let a claim exceed what was actually observed. A tool returning "success" is the provider's assertion, never proof, until evidence confirms it. Assay ships no single safety score and never claims more than it can prove.
+
+### Try it in 30 seconds
+
+```bash
+cargo install assay-cli
+
+mkdir -p /tmp/assay-demo && echo "safe content" > /tmp/assay-demo/safe.txt
+
+assay mcp wrap --policy examples/mcp-quickstart/policy.yaml \
+  -- npx @modelcontextprotocol/server-filesystem /tmp/assay-demo
+```
+
+```
+✅ ALLOW  read_file  path=/tmp/assay-demo/safe.txt  reason=policy_allow
+❌ DENY   read_file  path=/tmp/outside-demo.txt      reason=path_constraint_violation
+❌ DENY   exec       cmd=ls                          reason=tool_denied
+```
+
+Wire it into Cursor, Claude Code, or Codex in one line with `assay mcp config-path <editor>`. New to the threat model? Start with the [OWASP MCP Top 10 mapping](docs/security/OWASP-MCP-TOP10-MAPPING.md), which lays out, per risk, what Assay covers and what it deliberately does not.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ assay mcp wrap --policy examples/mcp-quickstart/policy.yaml \
 ❌ DENY   exec       cmd=ls                          reason=tool_denied
 ```
 
+![Assay decides each MCP tool call before it runs, fail-closed, with the reason](demo/output/screenshots/mcp-wrap-demo.svg)
+
 Wire it into Cursor, Claude Code, or Codex in one line with `assay mcp config-path <editor>`. New to the threat model? Start with the [OWASP MCP Top 10 mapping](docs/security/OWASP-MCP-TOP10-MAPPING.md), which lays out, per risk, what Assay covers and what it deliberately does not.
 
 ---

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -5,7 +5,9 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
-description = "CLI for Assay"
+description = "Policy-as-code gate for MCP agent tool calls, with verifiable evidence and Linux kernel enforcement."
+keywords = ["mcp", "ai-agents", "agent-security", "policy-as-code", "evidence"]
+categories = ["command-line-utilities", "development-tools::testing"]
 
 [lints]
 workspace = true

--- a/demo/mcp-wrap.tape
+++ b/demo/mcp-wrap.tape
@@ -1,0 +1,30 @@
+# Reproducible demo GIF for the README hero.
+# Render with charmbracelet/vhs:  vhs demo/mcp-wrap.tape
+# Prereqs: `assay` on PATH (cargo install assay-cli) and npx available.
+# Output is deterministic given the same assay version + policy fixture.
+
+Output demo/output/mcp-wrap.gif
+
+Set Shell "bash"
+Set FontSize 18
+Set Width 1100
+Set Height 600
+Set Padding 24
+Set Theme "Github Dark"
+Set TypingSpeed 35ms
+
+Hide
+Type "mkdir -p /tmp/assay-demo && echo 'safe content' > /tmp/assay-demo/safe.txt && clear"
+Enter
+Show
+
+Sleep 600ms
+Type "assay mcp wrap --policy examples/mcp-quickstart/policy.yaml \"
+Enter
+Type "  -- npx @modelcontextprotocol/server-filesystem /tmp/assay-demo"
+Enter
+Sleep 2.5s
+
+# The proxy decides each tools/call before it runs (fail-closed, with the reason),
+# and writes an offline-verifiable evidence bundle. Let the allow/deny lines settle.
+Sleep 3s

--- a/demo/output/screenshots/mcp-wrap-demo.svg
+++ b/demo/output/screenshots/mcp-wrap-demo.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 360" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" role="img" aria-label="Assay MCP policy gate: allow and deny decisions on tool calls">
+  <style>
+    .bg{fill:#0d1117}
+    .bar{fill:#161b22}
+    .txt{fill:#c9d1d9;font-size:15px}
+    .dim{fill:#8b949e;font-size:15px}
+    .prompt{fill:#58a6ff;font-size:15px}
+    .allow{fill:#3fb950;font-size:15px;font-weight:600}
+    .deny{fill:#f85149;font-size:15px;font-weight:600}
+    .reason{fill:#8b949e;font-size:14px}
+    .title{fill:#8b949e;font-size:13px}
+  </style>
+  <rect class="bg" x="2" y="2" width="756" height="356" rx="10"/>
+  <rect class="bar" x="2" y="2" width="756" height="34" rx="10"/>
+  <rect class="bar" x="2" y="20" width="756" height="16"/>
+  <circle cx="24" cy="19" r="6" fill="#f85149"/>
+  <circle cx="44" cy="19" r="6" fill="#d29922"/>
+  <circle cx="64" cy="19" r="6" fill="#3fb950"/>
+  <text class="title" x="380" y="24" text-anchor="middle">assay mcp wrap — deterministic policy gate</text>
+
+  <text x="22" y="72"><tspan class="prompt">$</tspan><tspan class="txt" dx="8">assay mcp wrap --policy policy.yaml \</tspan></text>
+  <text x="22" y="96"><tspan class="dim" dx="14">-- npx @modelcontextprotocol/server-filesystem /tmp/demo</tspan></text>
+
+  <text x="22" y="146"><tspan class="allow">✅ ALLOW</tspan><tspan class="txt" dx="14">read_file</tspan><tspan class="dim" dx="14">path=/tmp/demo/safe.txt</tspan><tspan class="reason" dx="14">reason=policy_allow</tspan></text>
+  <text x="22" y="176"><tspan class="allow">✅ ALLOW</tspan><tspan class="txt" dx="14">list_dir </tspan><tspan class="dim" dx="14">path=/tmp/demo/</tspan><tspan class="reason" dx="14">reason=policy_allow</tspan></text>
+  <text x="22" y="206"><tspan class="deny">❌ DENY </tspan><tspan class="txt" dx="14">read_file</tspan><tspan class="dim" dx="14">path=/tmp/outside.txt</tspan><tspan class="reason" dx="14">reason=path_constraint_violation</tspan></text>
+  <text x="22" y="236"><tspan class="deny">❌ DENY </tspan><tspan class="txt" dx="14">exec     </tspan><tspan class="dim" dx="14">cmd=ls</tspan><tspan class="reason" dx="14">reason=tool_denied</tspan></text>
+
+  <text x="22" y="286"><tspan class="dim">Every decision is fail-closed and written to an offline-verifiable evidence bundle.</tspan></text>
+  <text x="22" y="312"><tspan class="dim">No backend. Deterministic: same input, same decision.</tspan></text>
+</svg>


### PR DESCRIPTION
## What

Editorial rework of the README hero and top, to make the value prop graspable in the first few seconds and surface the differentiators a newcomer needs before deciding to try it. **No claim is widened; every existing non-claim and bounded statement is preserved.**

- **Hero** now answers what / why / who in the opening lines: policy-as-code for MCP tool calls; enforce, prove, stay honest. The subline keeps it bounded (fail-closed gate, kernel-level eBPF/LSM enforcement on Linux, offline-verifiable evidence, CI-native, no backend).
- **Threat framing as the hook** — the timely MCP reality (tool poisoning, rug pulls, confused-deputy OAuth, the early-2026 CVE wave), with a link to the existing OWASP MCP Top 10 mapping that states per risk what is covered and what is deliberately not.
- **"Enforce, prove, stay honest"** scannable block surfaces what was previously buried: the fail-closed gate, the proven IPv4/TCP connect-egress block and Landlock TCP-connect allowlist (opt-in, fail-closed, bounded), the verifiable evidence + pinned per-call carriers, and the explicit claim-basis honesty.
- **30-second quickstart** (copy-paste `assay mcp wrap`) moved up top; the deeper `See it work` walkthrough stays below.
- The adoption-path table and the rest of the body are unchanged.

## Scope

Docs only. No code, no claim widening. Local links verified, no em-dashes in the new copy, pre-commit `cargo fmt --check` / `cargo deny` pass. Part of an adoption pass; review and merge/launch on your call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote README hero to clarify product positioning, added threat-model overview and an "Enforce, prove, stay honest" section
  * Added a "Try it in 30 seconds" quickstart with example commands, expected allow/deny output, and demo screenshot; adjusted hero-to-body flow
* **Demo**
  * Added a reproducible terminal demo used to generate the README hero animation
* **Chores**
  * Updated CLI package metadata (description, keywords, categories)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->