### PR TITLE
feat(examples): C2-1 runnable privileged-action PR-gate example

### DIFF
--- a/examples/privileged-action-gate/README.md
+++ b/examples/privileged-action-gate/README.md
@@ -1,0 +1,57 @@
+# privileged-action PR-gate (runnable, offline)
+
+An agent reaches a GitHub MCP server through the enforcing proxy and tries `github.add_deploy_key` on
+`acme/prod-app` — a privileged in-application write. The proxy decides **per call, before it
+forwards**, and writes a replayable `assay.enforcement_decision.v0` record. Everything here runs
+against a local mock: no real credentials, no real GitHub call.
+
+```bash
+./run.sh
+```
+
+```
+Privileged action under review: github.add_deploy_key on acme/prod-app
+
+❌ DENY   github.add_deploy_key  reason=no_declared_allowance
+❌ DENY   github.add_deploy_key  reason=credential_scope_insufficient
+❌ DENY   github.add_deploy_key  reason=manifest_drifted_since_approval
+✅ ALLOW  github.add_deploy_key  reason=allow
+✅ ALLOW  github.add_deploy_key  reason=allow  + conformance: mismatched (declared_read_only_observed_mutating)  [separate, non-gating]
+```
+
+## What each line shows
+
+| Scenario | Policy / baseline / observed surface | Outcome |
+|---|---|---|
+| not declared | no allowance declares the action | `no_declared_allowance` |
+| credential too narrow | credential lacks the required scope | `credential_scope_insufficient` |
+| changed since approval | the observed tool surface no longer matches the approved baseline | `manifest_drifted_since_approval` |
+| fully declared | declared, scoped, and matching the approved baseline | `allow` (forwarded to the local mock) |
+| conformance signal | allowed, but the tool declares `readOnlyHint:true` while the call is mutating | `allow`, plus a **separate** `assay.tool_annotation_conformance.v0` record (`mismatched`) |
+
+The last line is the one to read twice: the conformance signal is recorded **beside** the verdict
+and never changes or gates it. A tool that calls itself read-only while doing a mutating action is
+worth knowing about; it is evidence, not a denial.
+
+## Bounded non-claims
+
+- a deny is fail-closed caution, not a verdict on intent;
+- an allow is the decision to forward, never proof the action happened;
+- the example runs against a local mock — no real provider, no real side effect;
+- observed behaviour is the proxy's classification of the call, not verification of the upstream
+  side effect.
+
+## How it works
+
+`run.sh` drives `assay-mcp-server proxy-enforce` against `mock_github_mcp.py` for each scenario,
+varying only the policy (`policies/`), the approved baseline (`baseline-approved*.json`), and the
+mock's tool surface (`MOCK_MODE`). It sends one `tools/call`; the proxy's bounded pre-call establish
+observes the surface, the PDP decides, and the decision is written to a temporary
+`enforcement_decision.v0` record that `run.sh` reads back. No client `tools/list` is sent, so the
+observation comes only from the establish step and the run is deterministic.
+
+`./verify.sh` asserts the verdicts and reason codes match `expected-output.txt`.
+
+The example prefers a local build at `../../target/debug/assay-mcp-server`, then an installed
+`assay-mcp-server` on `PATH`, otherwise it builds one. Set `PYTHON` to choose the interpreter for the
+mock.

--- a/examples/privileged-action-gate/README.md
+++ b/examples/privileged-action-gate/README.md
@@ -9,7 +9,7 @@ against a local mock: no real credentials, no real GitHub call.
 ./run.sh
 ```
 
-```
+```text
 Privileged action under review: github.add_deploy_key on acme/prod-app
 
 ❌ DENY   github.add_deploy_key  reason=no_declared_allowance
@@ -47,7 +47,7 @@ worth knowing about; it is evidence, not a denial.
 varying only the policy (`policies/`), the approved baseline (`baseline-approved*.json`), and the
 mock's tool surface (`MOCK_MODE`). It sends one `tools/call`; the proxy's bounded pre-call establish
 observes the surface, the PDP decides, and the decision is written to a temporary
-`enforcement_decision.v0` record that `run.sh` reads back. No client `tools/list` is sent, so the
+`assay.enforcement_decision.v0` record that `run.sh` reads back. No client `tools/list` is sent, so the
 observation comes only from the establish step and the run is deterministic.
 
 `./verify.sh` asserts the verdicts and reason codes match `expected-output.txt`.

--- a/examples/privileged-action-gate/baseline-approved-readonly.json
+++ b/examples/privileged-action-gate/baseline-approved-readonly.json
@@ -1,0 +1,37 @@
+{
+  "note": "GENERATED from manifest_observed::build_observed over the annotated p60a tools (readOnlyHint:true on github.add_deploy_key); regenerate with ASSAY_UPDATE_GOLDEN=1. Pins the live conformance-mismatch e2e baseline.",
+  "schema": "assay.declared_mcp_manifest.v0",
+  "server": {
+    "id": "github"
+  },
+  "canonicalization": "assay.mcp_manifest_projection.v0",
+  "manifest_digest": "sha256:762eccad77020c12a7228018d72f9ab7e6de55f16c89e6e6e38a7739b2908688",
+  "tools": [
+    {
+      "name": "search",
+      "tool_digest": "sha256:2318d9fd63878b81e992300635172e75053e086db757e31b7ebc917a7c721697",
+      "privileged": false,
+      "privilege_classification": "unclassified",
+      "action_class": null,
+      "field_digests": {
+        "description": "sha256:44c1a1350496d95897e53865330ee56cbf07b02ee54450c191d7d72b2d7005ea",
+        "input_schema": "sha256:e0522e896196457208cca527b92ed8155a72673ccb7723ade56ef69f57230290",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+      }
+    },
+    {
+      "name": "github.add_deploy_key",
+      "tool_digest": "sha256:0d928a14e9f8142271f7466c9bd44ac20bfd2863694c09c1f483cc2f404a7d74",
+      "privileged": true,
+      "privilege_classification": "classified",
+      "action_class": "github_deploy_key",
+      "field_digests": {
+        "description": "sha256:7e326787191c47250d1541c8dd2e5c8e9e8c5345ef3da8b66694e32788a29d99",
+        "input_schema": "sha256:52e5c928edb4433b517b5410a20c6a8a2ed87ff90b7931c000ba2a43fca3644c",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:4cbf642e3754d900838b8cd186332eb7eb84069050dbbe442f102f5a28b013e4"
+      }
+    }
+  ]
+}

--- a/examples/privileged-action-gate/baseline-approved.json
+++ b/examples/privileged-action-gate/baseline-approved.json
@@ -1,0 +1,37 @@
+{
+  "note": "operator-pinned per-tool baseline; manifest_digest recomputes from tools via the guard test and equals the committed P60a manifest_digest (same canonical tools)",
+  "schema": "assay.declared_mcp_manifest.v0",
+  "server": {
+    "id": "github"
+  },
+  "canonicalization": "assay.mcp_manifest_projection.v0",
+  "manifest_digest": "sha256:f8a95098345d600f7a2d742c4e941ace5e9594918b2aa82a9a8f48f72f701ffa",
+  "tools": [
+    {
+      "name": "search",
+      "tool_digest": "sha256:2318d9fd63878b81e992300635172e75053e086db757e31b7ebc917a7c721697",
+      "privileged": false,
+      "privilege_classification": "unclassified",
+      "action_class": null,
+      "field_digests": {
+        "description": "sha256:44c1a1350496d95897e53865330ee56cbf07b02ee54450c191d7d72b2d7005ea",
+        "input_schema": "sha256:e0522e896196457208cca527b92ed8155a72673ccb7723ade56ef69f57230290",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+      }
+    },
+    {
+      "name": "github.add_deploy_key",
+      "tool_digest": "sha256:03c7e1d546c3440fb100938dcaa7578ac34ae81f28e5762e7f8a3197e272a9f6",
+      "privileged": true,
+      "privilege_classification": "classified",
+      "action_class": "github_deploy_key",
+      "field_digests": {
+        "description": "sha256:7e326787191c47250d1541c8dd2e5c8e9e8c5345ef3da8b66694e32788a29d99",
+        "input_schema": "sha256:52e5c928edb4433b517b5410a20c6a8a2ed87ff90b7931c000ba2a43fca3644c",
+        "output_schema": "sha256:6969128f97f2ae0b5576343b492d312e1ab80eedf990f4bba8366c4622e808b5",
+        "annotations": "sha256:9d456a3d9cbf04f45cec915bcf7e8f02c034bf81abc077151b74bf5b06c4234b"
+      }
+    }
+  ]
+}

--- a/examples/privileged-action-gate/expected-output.txt
+++ b/examples/privileged-action-gate/expected-output.txt
@@ -1,0 +1,5 @@
+DENY no_declared_allowance
+DENY credential_scope_insufficient
+DENY manifest_drifted_since_approval
+ALLOW allow
+ALLOW allow +conformance:mismatched

--- a/examples/privileged-action-gate/mock_github_mcp.py
+++ b/examples/privileged-action-gate/mock_github_mcp.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Self-contained mock GitHub MCP server (stdio) for the privileged-action-gate example.
+
+Newline-delimited JSON-RPC over stdin/stdout. It exposes two tools: a read-only `search` and the
+privileged `github.add_deploy_key`. No network, no auth, no real GitHub call. The tool definitions
+are byte-for-byte the ones the shipped approved baselines were computed from, so the proxy's drift
+gate allows the matching mode and denies the drifted one.
+
+  MOCK_MODE=approved  github.add_deploy_key as approved (per-tool digest matches baseline-approved.json)
+  MOCK_MODE=drifted   github.add_deploy_key now DECLARES readOnlyHint:true (a post-approval change):
+                      its digest differs from baseline-approved.json (-> drift) and matches
+                      baseline-approved-readonly.json (-> allowed, with a separate conformance signal,
+                      because the call is still a create/mutating action).
+"""
+import json
+import os
+import sys
+
+MODE = os.environ.get("MOCK_MODE", "approved")
+
+
+def _send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def _tool(name, description, input_schema, annotations=None):
+    tool = {"name": name, "description": description, "inputSchema": input_schema}
+    if annotations is not None:
+        tool["annotations"] = annotations
+    return tool
+
+
+_SEARCH = _tool("search", "does a thing", {"type": "object"})
+_DEPLOY_KEY = _tool(
+    "github.add_deploy_key", "Add a deploy key", {"type": "object", "required": ["owner", "repo"]}
+)
+_DEPLOY_KEY_READONLY = _tool(
+    "github.add_deploy_key",
+    "Add a deploy key",
+    {"type": "object", "required": ["owner", "repo"]},
+    annotations={"readOnlyHint": True},
+)
+
+
+def _tools():
+    return [_SEARCH, _DEPLOY_KEY_READONLY if MODE == "drifted" else _DEPLOY_KEY]
+
+
+def main():
+    while True:
+        raw = sys.stdin.readline()
+        if not raw:
+            break
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        method = msg.get("method")
+        mid = msg.get("id")
+        if method == "initialize":
+            _send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "mock-github", "version": "0.0.0"},
+                },
+            })
+        elif method == "ping":
+            _send({"jsonrpc": "2.0", "id": mid, "result": {}})
+        elif method == "tools/list":
+            _send({"jsonrpc": "2.0", "id": mid, "result": {"tools": _tools()}})
+        elif method == "tools/call":
+            # Only the proxy's allow path forwards a tools/call to us. Canned success; no real call.
+            _send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {
+                    "content": [{"type": "text", "text": "forwarded-ok (mock; no real GitHub call)"}],
+                    "isError": False,
+                },
+            })
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/privileged-action-gate/policies/allow.yaml
+++ b/examples/privileged-action-gate/policies/allow.yaml
@@ -1,0 +1,11 @@
+# Fully declared: github_deploy_key is allowed on acme/prod-app, and the credential carries the
+# scope that action requires. With a matching observed manifest this is the only path that forwards.
+caller:
+  id: "ci-agent"
+upstream_credential:
+  alias: "gh-deploy"
+  scopes: ["repo:deploy_key:write"]
+allowances:
+  - action_class: "github_deploy_key"
+    targets:
+      - { owner: "acme", repo: "prod-app" }

--- a/examples/privileged-action-gate/policies/insufficient-credential.yaml
+++ b/examples/privileged-action-gate/policies/insufficient-credential.yaml
@@ -1,0 +1,11 @@
+# The action is allowed, but the declared credential only carries a read scope, not the scope the
+# privileged action requires. The credential-scope gate denies before anything forwards.
+caller:
+  id: "ci-agent"
+upstream_credential:
+  alias: "gh-ro"
+  scopes: ["repo:read"]
+allowances:
+  - action_class: "github_deploy_key"
+    targets:
+      - { owner: "acme", repo: "prod-app" }

--- a/examples/privileged-action-gate/policies/no-allowance.yaml
+++ b/examples/privileged-action-gate/policies/no-allowance.yaml
@@ -1,0 +1,8 @@
+# No allowance declares github_deploy_key, so the caller-allowance gate denies: the action was never
+# declared for this caller, even though a credential is present.
+caller:
+  id: "ci-agent"
+upstream_credential:
+  alias: "gh-deploy"
+  scopes: ["repo:deploy_key:write"]
+allowances: []

--- a/examples/privileged-action-gate/run.sh
+++ b/examples/privileged-action-gate/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# privileged-action-gate — one command, offline.
+#
+# An agent reaches a GitHub MCP server through the enforcing proxy and tries github.add_deploy_key
+# (a privileged write). The proxy decides per call BEFORE forwarding and writes a replayable
+# assay.enforcement_decision.v0 record. Five scenarios show the three deny axes, the allowed path,
+# and the separate (non-gating) conformance signal. Everything runs against a local mock: no real
+# credentials, no real GitHub call.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Locate the enforcing proxy. Prefer a build in this repo; otherwise an installed binary; else build.
+if [ -x "../../target/debug/assay-mcp-server" ]; then
+  ASSAY="$(cd ../.. && pwd)/target/debug/assay-mcp-server"
+elif command -v assay-mcp-server >/dev/null 2>&1; then
+  ASSAY="assay-mcp-server"
+else
+  echo "building assay-mcp-server (first run)..." >&2
+  (cd ../.. && cargo build -q -p assay-mcp-server)
+  ASSAY="$(cd ../.. && pwd)/target/debug/assay-mcp-server"
+fi
+
+PY="${PYTHON:-python3}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"demo","version":"1"}}}'
+CALL='{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}'
+
+# run <policy> <baseline> <mock_mode>
+run() {
+  local policy="$1" baseline="$2" mode="$3"
+  local dec="$WORK/decision.ndjson" conf="$WORK/conformance.ndjson"
+  : >"$dec"
+  : >"$conf"
+  # No client tools/list: the proxy's bounded pre-call establish does the one re-list (internal and
+  # synchronous), so the observation is deterministic and free of client/establish list races.
+  printf '%s\n%s\n' "$INIT" "$CALL" \
+    | MOCK_MODE="$mode" "$ASSAY" proxy-enforce \
+        --upstream-command "$PY" --upstream-arg -u --upstream-arg "mock_github_mcp.py" \
+        --enforce-policy "$policy" \
+        --declared-mcp-manifest "$baseline" \
+        --enforcement-decision-out "$dec" \
+        --tool-conformance-out "$conf" \
+        >/dev/null 2>&1 || true
+  "$PY" - "$dec" "$conf" <<'PYEOF'
+import json, sys
+dec, conf = sys.argv[1], sys.argv[2]
+rows = [json.loads(x) for x in open(dec) if x.strip()]
+mism = ""
+try:
+    for c in (json.loads(x) for x in open(conf) if x.strip()):
+        if c.get("conformance") == "mismatched":
+            mism = f"  + conformance: mismatched ({c.get('mismatch_kind')})  [separate, non-gating]"
+except FileNotFoundError:
+    pass
+for r in rows:
+    d = r.get("decision")
+    name = r.get("tool", {}).get("name", "?")
+    reason = r.get("reason")
+    mark = "✅ ALLOW" if d == "allow" else "❌ DENY "
+    print(f"{mark}  {name}  reason={reason}{mism if d == 'allow' else ''}")
+PYEOF
+}
+
+echo "Privileged action under review: github.add_deploy_key on acme/prod-app"
+echo
+run policies/no-allowance.yaml           baseline-approved.json           approved
+run policies/insufficient-credential.yaml baseline-approved.json          approved
+run policies/allow.yaml                  baseline-approved.json           drifted
+run policies/allow.yaml                  baseline-approved.json           approved
+run policies/allow.yaml                  baseline-approved-readonly.json  drifted
+echo
+echo "Each call wrote an assay.enforcement_decision.v0 record (replayable)."
+echo "Non-claims: a deny is fail-closed caution, not a verdict on intent; an allow is the decision to"
+echo "forward, never proof the action happened; the mock performs no real GitHub call; the conformance"
+echo "signal is recorded beside the verdict and never changes or gates it."

--- a/examples/privileged-action-gate/run.sh
+++ b/examples/privileged-action-gate/run.sh
@@ -43,6 +43,14 @@ run() {
         --enforcement-decision-out "$dec" \
         --tool-conformance-out "$conf" \
         >/dev/null 2>&1 || true
+  # The proxy denies per call (its own non-zero on a denied call is expected and tolerated above),
+  # but a missing decision record means the proxy did not run at all — fail loudly rather than print
+  # a silent, verdict-less demo with exit 0.
+  if [ ! -s "$dec" ]; then
+    echo "ERROR: no enforcement_decision record for ${policy} / ${baseline} / MOCK_MODE=${mode}" >&2
+    echo "  (build assay-mcp-server, and ensure python3 is on PATH for the mock)" >&2
+    exit 1
+  fi
   "$PY" - "$dec" "$conf" <<'PYEOF'
 import json, sys
 dec, conf = sys.argv[1], sys.argv[2]

--- a/examples/privileged-action-gate/verify.sh
+++ b/examples/privileged-action-gate/verify.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Deterministic smoke check: run the example and assert the per-scenario verdicts + reason codes
+# match expected-output.txt. Used by CI and as a self-test for the example.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+actual="$(./run.sh 2>/dev/null | "${PYTHON:-python3}" -c '
+import sys, re
+for line in sys.stdin:
+    m = re.search(r"(DENY|ALLOW).*reason=([a-z_]+)", line)
+    if not m:
+        continue
+    out = f"{m.group(1)} {m.group(2)}"
+    if "conformance: mismatched" in line:
+        out += " +conformance:mismatched"
+    print(out)
+')"
+expected="$(cat expected-output.txt)"
+
+if [ "$actual" = "$expected" ]; then
+  echo "OK: privileged-action-gate verdicts match expected-output.txt"
+else
+  echo "MISMATCH:"
+  diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") || true
+  exit 1
+fi


### PR DESCRIPTION
## What

C2-1 from the [C2 plan](docs/superpowers/plans/2026-06-14-c2-privileged-action-pr-gate-demo.md): a self-contained, **offline** example under `examples/privileged-action-gate/`. An agent tries `github.add_deploy_key` through `assay-mcp-server proxy-enforce`; the proxy decides per call before forwarding and writes a replayable `assay.enforcement_decision.v0` record.

`./run.sh` prints five scenarios with the **exact emitted reason codes**:

```
❌ DENY   github.add_deploy_key  reason=no_declared_allowance
❌ DENY   github.add_deploy_key  reason=credential_scope_insufficient
❌ DENY   github.add_deploy_key  reason=manifest_drifted_since_approval
✅ ALLOW  github.add_deploy_key  reason=allow
✅ ALLOW  github.add_deploy_key  reason=allow  + conformance: mismatched (declared_read_only_observed_mutating)  [separate, non-gating]
```

The last line is the Increment 5 non-correlation property made concrete: an **allow** verdict alongside a **separate, non-gating** `tool_annotation_conformance.v0` `mismatched` record. The conformance signal is framed as evidence beside the verdict, never as a deny reason.

## Determinism + safety

- Runs against a local mock MCP server (`mock_github_mcp.py`) whose tool definitions are byte-for-byte the ones the shipped approved baselines were computed from, so the drift gate allows the matching mode and denies the drifted one.
- No client `tools/list` is sent; the observation comes only from the proxy's bounded pre-call establish (internal, synchronous), so there is no client/establish list race. Verified deterministic across repeated runs.
- No real credentials, no provider side effect. Bounded non-claims are shown in the output and README.
- `verify.sh` asserts the verdicts + reason codes match `expected-output.txt` (the smoke target for the later CI slice).

## Scope

Example only: a mock, three policies, two committed baselines (copied verbatim), a runner, a verifier. No runtime, crate, or schema change. `shellcheck` clean. Next slices: C2-3 (VHS tape + CI smoke + README hero), C2-4 (SARIF projection + sample-repo PR pair).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline, policy-driven privileged-action-gate example for a GitHub MCP action, including an interactive mock server and predefined scenario runs.
  * Added approved baseline manifest artifacts to support consistent authorization/conformance behavior.
* **Documentation**
  * Added a README explaining the expected allow/deny verdicts, reason codes, and how conformance mismatches are reported.
* **Tests**
  * Added deterministic CI smoke testing that runs the scenarios and verifies verdict output against expected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->