### PR TITLE
feat(mcp-server): C2-4b enforcement-sarif CLI + PR-gate template

### DIFF
--- a/crates/assay-mcp-server/src/main.rs
+++ b/crates/assay-mcp-server/src/main.rs
@@ -87,6 +87,17 @@ enum Mode {
         #[arg(long, default_value_t = 5000)]
         manifest_establish_budget_ms: u64,
     },
+    /// Project an `assay.enforcement_decision.v0` NDJSON stream into a SARIF 2.1.0 report for the
+    /// GitHub Security tab. Only deny records become results; allow and non-enforcement records are
+    /// skipped. Reads/writes stdin/stdout when the path is omitted or "-".
+    EnforcementSarif {
+        /// Input NDJSON path of enforcement_decision.v0 records ("-" or omitted = stdin).
+        #[arg(long, default_value = "-")]
+        input: String,
+        /// Output SARIF path ("-" or omitted = stdout).
+        #[arg(long, default_value = "-")]
+        output: String,
+    },
 }
 
 use tracing_subscriber::{fmt, EnvFilter};
@@ -188,6 +199,39 @@ async fn main() -> Result<()> {
                 None,
             )
             .await
+        }
+        Some(Mode::EnforcementSarif { input, output }) => {
+            use assay_mcp_server::enforcement_sarif::enforcement_decisions_to_sarif;
+            use std::io::{Read, Write};
+            let raw = if input == "-" {
+                let mut s = String::new();
+                std::io::stdin().read_to_string(&mut s)?;
+                s
+            } else {
+                std::fs::read_to_string(&input)?
+            };
+            // Tolerant NDJSON: skip blank/unparseable lines rather than abort the projection.
+            let records: Vec<serde_json::Value> = raw
+                .lines()
+                .filter_map(|line| {
+                    let line = line.trim();
+                    if line.is_empty() {
+                        None
+                    } else {
+                        serde_json::from_str::<serde_json::Value>(line).ok()
+                    }
+                })
+                .collect();
+            let sarif = enforcement_decisions_to_sarif(&records);
+            let pretty = serde_json::to_string_pretty(&sarif)?;
+            if output == "-" {
+                let mut stdout = std::io::stdout();
+                stdout.write_all(pretty.as_bytes())?;
+                stdout.write_all(b"\n")?;
+            } else {
+                std::fs::write(&output, format!("{pretty}\n"))?;
+            }
+            Ok(())
         }
         None => {
             tracing::info!(

--- a/examples/privileged-action-gate/README.md
+++ b/examples/privileged-action-gate/README.md
@@ -41,6 +41,22 @@ worth knowing about; it is evidence, not a denial.
 - observed behaviour is the proxy's classification of the call, not verification of the upstream
   side effect.
 
+## Wire it into a PR gate
+
+Project the decisions to SARIF and upload them to the GitHub Security tab. A denied privileged
+action becomes a SARIF result; a clean run produces none:
+
+```bash
+./sarif.sh enforcement.sarif        # runs the scenarios, writes the SARIF
+# or, from your own decisions stream:
+assay-mcp-server enforcement-sarif --input decisions.ndjson --output enforcement.sarif
+```
+
+`pr-gate.example.yml` is a copy-paste workflow: run your agent under the enforcing proxy, project the
+decisions to SARIF, upload to the Security tab, and fail the PR when any privileged action is denied.
+The PR is **red** when an action is not declared, scoped, and approved, **green** when every action
+passes the gate. The conformance signal stays out of the gate — it is separate evidence, never a deny.
+
 ## How it works
 
 `run.sh` drives `assay-mcp-server proxy-enforce` against `mock_github_mcp.py` for each scenario,

--- a/examples/privileged-action-gate/pr-gate.example.yml
+++ b/examples/privileged-action-gate/pr-gate.example.yml
@@ -36,7 +36,12 @@ jobs:
       - name: Project decisions to SARIF
         run: assay-mcp-server enforcement-sarif --input decisions.ndjson --output enforcement.sarif
 
+      # Fork PRs run with a read-only GITHUB_TOKEN, so the Security-tab upload is skipped there.
+      # To get SARIF on fork PRs, split this into a pull_request job that uploads the SARIF as an
+      # artifact plus a workflow_run job (security-events: write) that publishes it. The deny gate
+      # below still runs on fork PRs regardless.
       - name: Upload SARIF to the Security tab
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: github/codeql-action/upload-sarif@439137e1b50c27ba9e2f9befc93e43091b449c34 # v3
         with:
           sarif_file: enforcement.sarif

--- a/examples/privileged-action-gate/pr-gate.example.yml
+++ b/examples/privileged-action-gate/pr-gate.example.yml
@@ -1,0 +1,51 @@
+# Copy this into your repository's .github/workflows/ to gate agent PRs on privileged tool actions.
+#
+# Run your MCP agent under the enforcing proxy, project the per-call decisions to SARIF, upload them
+# to the Security tab, and fail the PR if any privileged action was denied. The PR is RED when an
+# action is not declared, scoped, and approved; GREEN when every action passes the gate. The
+# conformance signal (declared-vs-observed annotations) stays out of the gate — it is separate
+# evidence, never a deny.
+name: Agent privileged-action gate
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write # required to upload SARIF to the Security tab
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install assay-mcp-server
+        run: cargo install assay-mcp-server # or download a pinned release binary
+
+      - name: Run your agent through the enforcing proxy
+        run: |
+          # Run your MCP agent under proxy-enforce, recording each tools/call decision:
+          #   assay-mcp-server proxy-enforce \
+          #     --upstream-command <your-mcp-server> --upstream-arg ... \
+          #     --enforce-policy policy.yaml --declared-mcp-manifest baseline.json \
+          #     --enforcement-decision-out decisions.ndjson
+          # See examples/privileged-action-gate for a runnable, offline version (sarif.sh).
+          echo "replace this step with your agent run producing decisions.ndjson"
+
+      - name: Project decisions to SARIF
+        run: assay-mcp-server enforcement-sarif --input decisions.ndjson --output enforcement.sarif
+
+      - name: Upload SARIF to the Security tab
+        uses: github/codeql-action/upload-sarif@439137e1b50c27ba9e2f9befc93e43091b449c34 # v3
+        with:
+          sarif_file: enforcement.sarif
+
+      - name: Fail the PR if any privileged action was denied
+        run: |
+          n="$(jq '.runs[0].results | length' enforcement.sarif)"
+          if [ "$n" != "0" ]; then
+            echo "::error::$n privileged tool action(s) denied before forward — see the Security tab"
+            exit 1
+          fi
+          echo "no privileged action denied"

--- a/examples/privileged-action-gate/sarif.sh
+++ b/examples/privileged-action-gate/sarif.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Produce a SARIF 2.1.0 report from the privileged-action-gate scenarios: run them through the
+# enforcing proxy, collect the assay.enforcement_decision.v0 records, and project the denies to
+# SARIF for the GitHub Security tab. Offline; no real credentials, no real GitHub call.
+#
+#   ./sarif.sh [output.sarif]   (default: enforcement.sarif)
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ -x "../../target/debug/assay-mcp-server" ]; then
+  ASSAY="$(cd ../.. && pwd)/target/debug/assay-mcp-server"
+elif command -v assay-mcp-server >/dev/null 2>&1; then
+  ASSAY="assay-mcp-server"
+else
+  echo "building assay-mcp-server (first run)..." >&2
+  (cd ../.. && cargo build -q -p assay-mcp-server)
+  ASSAY="$(cd ../.. && pwd)/target/debug/assay-mcp-server"
+fi
+
+PY="${PYTHON:-python3}"
+OUT="${1:-enforcement.sarif}"
+DEC="$(mktemp)"
+trap 'rm -f "$DEC"' EXIT
+
+INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"demo","version":"1"}}}'
+CALL='{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"github.add_deploy_key","arguments":{"owner":"acme","repo":"prod-app"}}}'
+
+# emit <policy> <baseline> <mock_mode> — appends one enforcement_decision.v0 record to $DEC.
+emit() {
+  printf '%s\n%s\n' "$INIT" "$CALL" \
+    | MOCK_MODE="$3" "$ASSAY" proxy-enforce \
+        --upstream-command "$PY" --upstream-arg -u --upstream-arg "mock_github_mcp.py" \
+        --enforce-policy "$1" --declared-mcp-manifest "$2" \
+        --enforcement-decision-out "$DEC" \
+        >/dev/null 2>&1 || true
+}
+
+emit policies/no-allowance.yaml           baseline-approved.json           approved
+emit policies/insufficient-credential.yaml baseline-approved.json          approved
+emit policies/allow.yaml                  baseline-approved.json           drifted
+emit policies/allow.yaml                  baseline-approved.json           approved
+emit policies/allow.yaml                  baseline-approved-readonly.json  drifted
+
+if [ ! -s "$DEC" ]; then
+  echo "ERROR: no enforcement_decision records produced (build assay-mcp-server, ensure python3)" >&2
+  exit 1
+fi
+
+"$ASSAY" enforcement-sarif --input "$DEC" --output "$OUT"
+n="$("$PY" -c "import json,sys; print(len(json.load(open('$OUT'))['runs'][0]['results']))")"
+echo "wrote $OUT ($n SARIF result(s) — one per denied privileged action)"

--- a/examples/privileged-action-gate/sarif.sh
+++ b/examples/privileged-action-gate/sarif.sh
@@ -47,5 +47,11 @@ if [ ! -s "$DEC" ]; then
 fi
 
 "$ASSAY" enforcement-sarif --input "$DEC" --output "$OUT"
-n="$("$PY" -c "import json,sys; print(len(json.load(open('$OUT'))['runs'][0]['results']))")"
+# Pass $OUT as argv (not interpolated into the program text) to avoid any code injection.
+n="$("$PY" -c 'import json,sys; print(len(json.load(open(sys.argv[1]))["runs"][0]["results"]))' "$OUT")"
+# The five scenarios produce exactly three denies; fail if that ever stops holding.
+if [ "$n" != "3" ]; then
+  echo "ERROR: expected 3 SARIF results (the three deny axes), got $n" >&2
+  exit 1
+fi
 echo "wrote $OUT ($n SARIF result(s) — one per denied privileged action)"


### PR DESCRIPTION
## What

C2-4b: makes the C2-4a SARIF projection usable as a PR gate.

- **`assay-mcp-server enforcement-sarif --input <ndjson> --output <sarif>`** — a thin CLI wrapper around `enforcement_decisions_to_sarif`. Tolerant NDJSON (skips blank/unparseable lines); stdin/stdout or files.
- **`examples/privileged-action-gate/sarif.sh`** — runs the scenarios and writes `enforcement.sarif` (3 results, one per denied privileged action), offline. shellcheck-clean.
- **`pr-gate.example.yml`** — a copy-paste workflow template (not active in this repo): run your agent under the enforcing proxy → project decisions to SARIF → upload to the Security tab → fail the PR on a deny. The PR is **red** when a privileged action is not declared/scoped/approved, **green** when every action passes. Conformance stays out of the gate (separate evidence).
- **README** — a "Wire it into a PR gate" section with the failing/green framing.

## Verification

`cargo fmt --check`, `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`, the lib tests (4), and `examples/privileged-action-gate/verify.sh` are green. Functional check: piping a deny+allow stream through `enforcement-sarif` yields one SARIF result (the deny); `sarif.sh` yields three (the three deny axes). The literal sample repo with live PRs is left as an opt-in step — the template drops into any repo to produce that failing/green pair.

## Scope

CLI subcommand + example scripts + a workflow template + docs. No PDP or schema change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `enforcement-sarif` subcommand to convert enforcement decision NDJSON into SARIF 2.1.0 JSON reports.

* **Documentation**
  * Added a guide for wiring SARIF output into a pull request gate.
  * Added a GitHub Actions workflow example to upload SARIF and fail when denied results are present.
  * Added an example script for generating SARIF offline and validating output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->