### PR TITLE
fix(mcp-server): emit GitHub-valid SARIF locations from enforcement-sarif

### DIFF
--- a/crates/assay-mcp-server/src/enforcement_sarif.rs
+++ b/crates/assay-mcp-server/src/enforcement_sarif.rs
@@ -14,6 +14,11 @@ use serde_json::{json, Value};
 /// The carrier this projection consumes.
 pub const ENFORCEMENT_DECISION_SCHEMA: &str = "assay.enforcement_decision.v0";
 
+/// Synthetic, repo-relative location for each finding. An enforcement decision is not tied to a
+/// source line, but GitHub code scanning requires every result to carry a `locations` entry, so each
+/// result points at this stable synthetic path and names the tool as a logical location.
+const SYNTHETIC_LOCATION_URI: &str = ".assay/enforcement-decisions.ndjson";
+
 /// Project enforcement-decision records into a SARIF 2.1.0 document. Deterministic; only `deny`
 /// records produce results.
 pub fn enforcement_decisions_to_sarif(records: &[Value]) -> Value {
@@ -51,7 +56,13 @@ pub fn enforcement_decisions_to_sarif(records: &[Value]) -> Value {
                     action_class.unwrap_or("unclassified")
                 )
             },
-            "logicalLocations": [{ "name": tool, "kind": "function" }],
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": { "uri": SYNTHETIC_LOCATION_URI },
+                    "region": { "startLine": 1, "startColumn": 1 }
+                },
+                "logicalLocations": [{ "name": tool, "kind": "function" }]
+            }],
             "properties": {
                 "decision": "deny",
                 "reason": reason,
@@ -194,6 +205,32 @@ mod tests {
                 "SARIF must not leak `{forbidden}`"
             );
         }
+    }
+
+    #[test]
+    fn result_location_shape_is_github_valid() {
+        // GitHub's SARIF uploader rejects `logicalLocations` placed directly on a result; it must
+        // nest inside `locations[].location` next to a `physicalLocation`. This guards the exact
+        // shape GitHub once rejected (a deny that failed to upload to the Security tab).
+        let recs = vec![deny(
+            "no_declared_allowance",
+            "github.add_deploy_key",
+            "github_deploy_key",
+            "not_evaluated",
+        )];
+        let sarif = enforcement_decisions_to_sarif(&recs);
+        let result = &sarif["runs"][0]["results"][0];
+        assert!(
+            result.get("logicalLocations").is_none(),
+            "logicalLocations must not sit directly on a result"
+        );
+        let loc = &result["locations"][0];
+        assert_eq!(
+            loc["physicalLocation"]["artifactLocation"]["uri"],
+            SYNTHETIC_LOCATION_URI
+        );
+        assert_eq!(loc["physicalLocation"]["region"]["startLine"], 1);
+        assert_eq!(loc["logicalLocations"][0]["name"], "github.add_deploy_key");
     }
 
     #[test]

--- a/crates/assay-mcp-server/tests/fixtures/enforcement_decision_sarif.v0.json
+++ b/crates/assay-mcp-server/tests/fixtures/enforcement_decision_sarif.v0.json
@@ -36,10 +36,23 @@
           "message": {
             "text": "Privileged tool action denied before forward: github.add_deploy_key (github_deploy_key) — no_declared_allowance"
           },
-          "logicalLocations": [
+          "locations": [
             {
-              "name": "github.add_deploy_key",
-              "kind": "function"
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": ".assay/enforcement-decisions.ndjson"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1
+                }
+              },
+              "logicalLocations": [
+                {
+                  "name": "github.add_deploy_key",
+                  "kind": "function"
+                }
+              ]
             }
           ],
           "properties": {
@@ -56,10 +69,23 @@
           "message": {
             "text": "Privileged tool action denied before forward: github.add_deploy_key (github_deploy_key) — credential_scope_insufficient"
           },
-          "logicalLocations": [
+          "locations": [
             {
-              "name": "github.add_deploy_key",
-              "kind": "function"
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": ".assay/enforcement-decisions.ndjson"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1
+                }
+              },
+              "logicalLocations": [
+                {
+                  "name": "github.add_deploy_key",
+                  "kind": "function"
+                }
+              ]
             }
           ],
           "properties": {
@@ -76,10 +102,23 @@
           "message": {
             "text": "Privileged tool action denied before forward: github.add_deploy_key (github_deploy_key) — manifest_drifted_since_approval"
           },
-          "logicalLocations": [
+          "locations": [
             {
-              "name": "github.add_deploy_key",
-              "kind": "function"
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": ".assay/enforcement-decisions.ndjson"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1
+                }
+              },
+              "logicalLocations": [
+                {
+                  "name": "github.add_deploy_key",
+                  "kind": "function"
+                }
+              ]
             }
           ],
           "properties": {


### PR DESCRIPTION
## What

The `enforcement-sarif` projector placed `logicalLocations` directly on a SARIF `result`. That is not valid SARIF 2.1.0 — `logicalLocations` belongs on a `location`, not on a `result` — and GitHub's code-scanning uploader rejects it:

```
instance.runs[0].results[0] is not allowed to have the additional property "logicalLocations"
```

So any decision stream with at least one **deny** failed to upload to the Security tab. A stream with zero denies (an all-green run) produced an empty `results` array and uploaded fine, which is exactly why the bug slipped past the golden-fixture test: that test only checked structural equality against a committed fixture, never schema validity.

## How it surfaced

Caught live by the agent-gate demo: the red PR's gate denied correctly (exit 1, check red) but the SARIF upload step then failed on the invalid document, so the finding never reached the Security tab.

## Fix

Each finding now nests under `locations[].physicalLocation` with a synthetic repo-relative URI (`.assay/enforcement-decisions.ndjson`) and keeps the tool name as a nested `logicalLocations` entry — the same shape the evidence-lint projector already uses and that GitHub accepts. A new regression test asserts no result carries a top-level `logicalLocations` and checks the nested location shape. The golden fixture is regenerated.

Decisions are policy verdicts, not source-line findings, so the physical location is synthetic and stable rather than a real file/line.

## Checks

- `cargo test -p assay-mcp-server` (5 enforcement_sarif tests, incl. the new guard)
- `cargo clippy -p assay-mcp-server --all-targets -- -D warnings`
- `cargo fmt --check`
- verified the actual binary's deny SARIF has no top-level `logicalLocations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SARIF enforcement decision reporting to include standardized location metadata for each finding, improving GitHub tool integration and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->