### PR TITLE
chore(release): 3.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.26.0] - 2026-06-14
+
+### Added
+- `assay-mcp-server enforcement-sarif`, projecting an `assay.enforcement_decision.v0` NDJSON stream
+  into a SARIF 2.1.0 report for the GitHub Security tab. Only `deny` records become results (level
+  `warning`); `allow` and non-enforcement records are skipped, and the projection reads only the
+  sanitized fields the record already exposes (tool name, action class, reason, drift state), never
+  raw arguments or targets. Reads stdin and writes stdout when paths are omitted.
+- A copy-paste pull-request gate workflow template and a runnable, offline privileged-action example
+  under `examples/privileged-action-gate`: an agent's `tools/call` runs through the enforcing proxy,
+  the per-call decisions are projected to SARIF, and the PR fails when any privileged action is
+  denied. The conformance signal stays out of the gate.
+- Publishing of the MCP registry `server.json` via GitHub OIDC on release, so the registry entry
+  tracks each published version.
+
+### Fixed
+- The `enforcement-sarif` projection now nests the finding under `locations[].physicalLocation` with a
+  nested logical location, instead of placing `logicalLocations` directly on a SARIF result. The
+  previous shape was rejected by GitHub code scanning whenever a report carried at least one deny, so
+  a deny never reached the Security tab; a zero-deny report uploaded cleanly, which is why it was
+  missed. A regression test now forbids the rejected shape.
+
 ## [3.25.0] - 2026-06-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "aya",
  "chrono",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.25.0"
+version = "3.26.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.25.0"
+version = "3.26.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Release prep for **3.26.0**. Bumps the workspace version `3.25.0 -> 3.26.0` (root `Cargo.toml` + `Cargo.lock` workspace members; the Python SDK and registry `server.json` derive their version from this) and adds the changelog section.

### Shipping in 3.26.0

- **`assay-mcp-server enforcement-sarif`** — projects an `assay.enforcement_decision.v0` NDJSON stream to a SARIF 2.1.0 report for the GitHub Security tab. Denies become results; allow and non-enforcement records are skipped; the projection is leak-free.
- **Privileged-action PR gate** — a copy-paste workflow template plus a runnable, offline example (`examples/privileged-action-gate`): an agent's `tools/call` runs through the enforcing proxy, decisions are projected to SARIF, and the PR fails on any deny.
- **MCP registry OIDC publish** — `server.json` is published to the registry on release, so the entry tracks each version.
- **Fix** — `enforcement-sarif` now nests `logicalLocations` under `locations[].physicalLocation`; the previous shape was rejected by GitHub code scanning on any deny-bearing report.

Once merged, tagging `v3.26.0` triggers the release (binaries, GitHub release, crates.io, PyPI, and the registry publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enforcement-sarif projection producing GitHub Security tab–compatible SARIF output with privacy-preserving field selection
  * New privileged-action-gate example workflow for enforcing privileged-action denials
  * MPC registry publication with GitHub OIDC integration for release tracking

* **Bug Fixes**
  * Fixed SARIF result structure issue
  * Added regression test to prevent future occurrences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->