### PR TITLE
docs(release): point the release-notes action example at @v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -572,11 +572,10 @@ jobs:
 
           **GitHub Action:**
           ```yaml
-          - uses: Rul1an/assay-action@v2
+          - uses: Rul1an/assay-action@v3
             with:
-              policy: policies/agent.yaml
-              traces: traces/
-              min-coverage: 80
+              bundles: ".assay/evidence/*.tar.gz"
+              fail_on: error
           ```
 
           **Manual download:**


### PR DESCRIPTION
The release-notes template (`release.yml`) advertised `Rul1an/assay-action@v2` with `policy` / `traces` / `min-coverage` inputs that do not exist on the action. This updates it to `@v3` (the current "AI Agent Security" action) with a minimal, valid invocation (`bundles` + `fail_on`). `@v2` remains available for anyone on the legacy "Evidence Artifacts" action.

Cosmetic, release-notes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->