### PR TITLE
fix(deps): migrate PyO3 0.24 → 0.29, clear RUSTSEC-2026-0176/0177

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,7 @@ jobs:
         run: |
           rm -rf ~/.cargo/advisory-db
           # RUSTSEC-2023-0071 (rsa Marvin Attack): no fixed upgrade; assay-mcp-server JWT (see deny.toml)
-          # RUSTSEC-2026-0176 (pyo3 nth/nth_back OOB): not reachable in assay; pyo3 0.29 migration tracked in #1651
-          # RUSTSEC-2026-0177 (pyo3 PyCFunction::new_closure missing Sync bound): not reachable — assay
-          # never calls PyCFunction::new_closure. TEMPORARY ignore, removed by the pyo3 0.29 migration (#1651).
-          cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0176 --ignore RUSTSEC-2026-0177
+          cargo audit --ignore RUSTSEC-2023-0071
 
   clippy:
     name: Clippy (deny warnings)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,37 +3601,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3639,9 +3634,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3651,22 +3646,21 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "pythonize"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5bcac0d0b71821f0d69e42654f1e15e5c94b85196446c4de9588951a2117e7b"
+checksum = "6ec376e1216e0c929a74964ce2020012a1a39f32d80e78aa688721219ea7fb89"
 dependencies = [
  "pyo3",
  "serde",
@@ -5276,12 +5270,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/assay-python-sdk/Cargo.toml
+++ b/assay-python-sdk/Cargo.toml
@@ -15,9 +15,9 @@ name = "assay"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 assay-core.workspace = true
 serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 serde_yaml.workspace = true
-pythonize = "0.24"
+pythonize = "0.29"

--- a/assay-python-sdk/src/lib.rs
+++ b/assay-python-sdk/src/lib.rs
@@ -49,7 +49,7 @@ impl CoverageAnalyzer {
 
     fn analyze(
         &self,
-        traces: Vec<Vec<PyObject>>,
+        traces: Vec<Vec<Py<PyAny>>>,
         threshold: f64,
         py: Python<'_>,
     ) -> PyResult<String> {
@@ -123,7 +123,7 @@ impl TraceExplainer {
         }
     }
 
-    fn explain(&self, traces: Vec<PyObject>, py: Python<'_>) -> PyResult<String> {
+    fn explain(&self, traces: Vec<Py<PyAny>>, py: Python<'_>) -> PyResult<String> {
         let mut tool_calls = Vec::new();
         for obj in traces {
             let bound = obj.bind(py);
@@ -189,7 +189,7 @@ impl AssayClient {
     /// Raises:
     ///     RuntimeError: If no trace_file was configured or writing fails.
     ///     ValueError: If the trace object cannot be serialized to JSON.
-    fn record_trace(&self, trace: PyObject, py: Python<'_>) -> PyResult<()> {
+    fn record_trace(&self, trace: Py<PyAny>, py: Python<'_>) -> PyResult<()> {
         if let Some(mutex) = &self.writer {
             let mut writer = mutex
                 .lock()

--- a/deny.toml
+++ b/deny.toml
@@ -27,13 +27,6 @@ ignore = [
     # rsa: transitive via jsonwebtoken (assay-mcp-server). No safe upgrade; timing sidechannel.
     # JWT verification is server-side; accept risk for MCP auth until jsonwebtoken/rsa offer a fix.
     "RUSTSEC-2023-0071",
-    # pyo3 OOB reads in BoundList/TupleIterator nth/nth_back (large n). Not reachable: assay-python-sdk
-    # iterates via .iter().enumerate(), never .nth() on pyo3 iterators. Fix = pyo3 0.29 migration (#1651);
-    # remove this ignore when that lands.
-    "RUSTSEC-2026-0176",
-    # pyo3 missing `Sync` bound on `PyCFunction::new_closure` closures. Not reachable: assay never calls
-    # PyCFunction::new_closure. TEMPORARY ignore until the pyo3 0.29 migration (#1651) — remove it then.
-    "RUSTSEC-2026-0177",
 ]
 
 # =============================================================================


### PR DESCRIPTION
Closes #1651.

## Why now
The migration was blocked on `pythonize` lagging pyo3 0.29. That's resolved: `pythonize 0.29.0` (and `pyo3 0.29.0`) are on crates.io now.

## Change
- `assay-python-sdk`: `pyo3` and `pythonize` `0.24` → `0.29`.
- One source change: `PyObject` → `Py<PyAny>` (the `PyObject` alias was removed in 0.29). The bindings already used the Bound API, so nothing else moved.
- Drop the temporary `RUSTSEC-2026-0176` and `RUSTSEC-2026-0177` ignores from `deny.toml` and the `cargo audit` step. Both are pyo3 advisories patched in 0.29; `RUSTSEC-2023-0071` (rsa) stays.

Neither advisory was reachable in assay today (the SDK iterates with `.enumerate()`, never `.nth()`, and never calls `PyCFunction::new_closure`), so this is hygiene plus clearing the ignores, not an active exposure.

## Verified locally
- `cargo check` / `cargo build` (cdylib) / `cargo clippy --all-targets -D warnings`
- `cargo deny check advisories` → `advisories ok` with the two ignores removed
- 13/13 `assay-python-sdk` pytest cases pass against a maturin-built 0.29 extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust dependencies for improved compatibility and performance.
  * Removed exemptions for two security advisories in CI configuration to enhance security oversight.
  * Updated Python binding implementation to use improved type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->