### PR TITLE
docs(security): plan OWASP MCP priority evidence wave

### DIFF
--- a/crates/assay-mcp-server/tests/fixtures/mcp_inventory/inventory_cases.v0.json
+++ b/crates/assay-mcp-server/tests/fixtures/mcp_inventory/inventory_cases.v0.json
@@ -1,0 +1,297 @@
+{
+  "schema_contract": "assay.mcp_server_inventory.v0",
+  "note": "M1 MCP inventory coverage / shadow-server zoo. Expected findings are derived from declared server allowlist, observed inventory rows, and scanner coverage. The corpus proves coverage-honesty only; it is not a host scanner implementation.",
+  "cases": [
+    {
+      "case": "approved_stdio_server_in_config",
+      "declared_servers": [
+        {
+          "server_id": "github-tools",
+          "transport": "stdio",
+          "command_digest": "sha256:cmd-github-v1",
+          "args_digest": "sha256:args-github-v1"
+        }
+      ],
+      "inventory": {
+        "schema": "assay.mcp_server_inventory.v0",
+        "scanner_coverage": {
+          "config_sources": {
+            "vscode": "complete"
+          },
+          "process_scan": "not_applicable",
+          "network_scan": "not_applicable"
+        },
+        "servers": [
+          {
+            "server_id": "github-tools",
+            "source": "vscode_mcp_config",
+            "transport": "stdio",
+            "command_digest": "sha256:cmd-github-v1",
+            "args_digest": "sha256:args-github-v1",
+            "observed_state": "observed"
+          }
+        ],
+        "non_claims": [
+          "absence from inventory is not absence from environment unless scanner coverage is complete"
+        ]
+      },
+      "expected_findings": []
+    },
+    {
+      "case": "unapproved_stdio_server_in_config",
+      "declared_servers": [],
+      "inventory": {
+        "schema": "assay.mcp_server_inventory.v0",
+        "scanner_coverage": {
+          "config_sources": {
+            "vscode": "complete"
+          },
+          "process_scan": "not_applicable",
+          "network_scan": "not_applicable"
+        },
+        "servers": [
+          {
+            "server_id": "unknown-tools",
+            "source": "vscode_mcp_config",
+            "transport": "stdio",
+            "command_digest": "sha256:cmd-unknown-v1",
+            "args_digest": "sha256:args-unknown-v1",
+            "observed_state": "observed"
+          }
+        ],
+        "non_claims": [
+          "absence from inventory is not absence from environment unless scanner coverage is complete"
+        ]
+      },
+      "expected_findings": [
+        "shadow_mcp_server_observed"
+      ]
+    },
+    {
+      "case": "approved_server_command_drift",
+      "declared_servers": [
+        {
+          "server_id": "github-tools",
+          "transport": "stdio",
+          "command_digest": "sha256:cmd-github-v1",
+          "args_digest": "sha256:args-github-v1"
+        }
+      ],
+      "inventory": {
+        "schema": "assay.mcp_server_inventory.v0",
+        "scanner_coverage": {
+          "config_sources": {
+            "vscode": "complete"
+          },
+          "process_scan": "not_applicable",
+          "network_scan": "not_applicable"
+        },
+        "servers": [
+          {
+            "server_id": "github-tools",
+            "source": "vscode_mcp_config",
+            "transport": "stdio",
+            "command_digest": "sha256:cmd-github-v2",
+            "args_digest": "sha256:args-github-v1",
+            "observed_state": "observed"
+          }
+        ],
+        "non_claims": [
+          "absence from inventory is not absence from environment unless scanner coverage is complete"
+        ]
+      },
+      "expected_findings": [
+        "mcp_server_command_drift"
+      ]
+    },
+    {
+      "case": "approved_server_args_drift",
+      "declared_servers": [
+        {
+          "server_id": "github-tools",
+          "transport": "stdio",
+          "command_digest": "sha256:cmd-github-v1",
+          "args_digest": "sha256:args-github-v1"
+        }
+      ],
+      "inventory": {
+        "schema": "assay.mcp_server_inventory.v0",
+        "scanner_coverage": {
+          "config_sources": {
+            "vscode": "complete"
+          },
+          "process_scan": "not_applicable",
+          "network_scan": "not_applicable"
+        },
+        "servers": [
+          {
+            "server_id": "github-tools",
+            "source": "vscode_mcp_config",
+            "transport": "stdio",
+            "command_digest": "sha256:cmd-github-v1",
+            "args_digest": "sha256:args-github-debug",
+            "observed_state": "observed"
+          }
+        ],
+        "non_claims": [
+          "absence from inventory is not absence from environment unless scanner coverage is complete"
+        ]
+      },
+      "expected_findings": [
+        "mcp_server_args_drift"
+      ]
+    },
+    {
+      "case": "duplicate_server_id_different_command",
+      "declared_servers": [
+        {
+          "server_id": "github-tools",
+          "transport": "stdio",
+          "command_digest": "sha256:cmd-github-v1",
+          "args_digest": "sha256:args-github-v1"
+        }
+      ],
+      "inventory": {
+        "schema": "assay.mcp_server_inventory.v0",
+        "scanner_coverage": {
+          "config_sources": {
+            "vscode": "complete",
+            "cursor": "complete"
+          },
+          "process_scan": "not_applicable",
+          "network_scan": "not_applicable"
+        },
+        "servers": [
+          {
+            "server_id": "github-tools",
+            "source": "vscode_mcp_config",
+            "transport": "stdio",
+            "command_digest": "sha256:cmd-github-v1",
+            "args_digest": "sha256:args-github-v1",
+            "observed_state": "observed"
+          },
+          {
+            "server_id": "github-tools",
+            "source": "cursor_mcp_config",
+            "transport": "stdio",
+            "command_digest": "sha256:cmd-github-shadow",
+            "args_digest": "sha256:args-github-v1",
+            "observed_state": "observed"
+          }
+        ],
+        "non_claims": [
+          "absence from inventory is not absence from environment unless scanner coverage is complete"
+        ]
+      },
+      "expected_findings": [
+        "duplicate_mcp_server_identity",
+        "mcp_server_command_drift"
+      ]
+    },
+    {
+      "case": "http_mcp_endpoint_not_in_allowlist",
+      "declared_servers": [],
+      "inventory": {
+        "schema": "assay.mcp_server_inventory.v0",
+        "scanner_coverage": {
+          "config_sources": {
+            "vscode": "complete"
+          },
+          "process_scan": "not_applicable",
+          "network_scan": "complete"
+        },
+        "servers": [
+          {
+            "server_id": "local-http-tools",
+            "source": "http_endpoint",
+            "transport": "http",
+            "command_digest": "sha256:http-endpoint-localhost-8080",
+            "args_digest": "sha256:http-endpoint-empty",
+            "observed_state": "observed"
+          }
+        ],
+        "non_claims": [
+          "absence from inventory is not absence from environment unless scanner coverage is complete"
+        ]
+      },
+      "expected_findings": [
+        "shadow_mcp_server_observed"
+      ]
+    },
+    {
+      "case": "server_only_visible_in_process_scan",
+      "declared_servers": [],
+      "inventory": {
+        "schema": "assay.mcp_server_inventory.v0",
+        "scanner_coverage": {
+          "config_sources": {
+            "vscode": "not_scanned"
+          },
+          "process_scan": "complete",
+          "network_scan": "not_applicable"
+        },
+        "servers": [
+          {
+            "server_id": "process-discovered-tools",
+            "source": "process_scan",
+            "transport": "stdio",
+            "command_digest": "sha256:cmd-process-discovered",
+            "args_digest": "sha256:args-process-discovered",
+            "observed_state": "observed"
+          }
+        ],
+        "non_claims": [
+          "absence from inventory is not absence from environment unless scanner coverage is complete"
+        ]
+      },
+      "expected_findings": [
+        "shadow_mcp_server_observed",
+        "mcp_inventory_coverage_incomplete"
+      ]
+    },
+    {
+      "case": "config_source_not_scanned",
+      "declared_servers": [],
+      "inventory": {
+        "schema": "assay.mcp_server_inventory.v0",
+        "scanner_coverage": {
+          "config_sources": {
+            "vscode": "complete",
+            "cursor": "not_scanned"
+          },
+          "process_scan": "not_applicable",
+          "network_scan": "not_applicable"
+        },
+        "servers": [],
+        "non_claims": [
+          "absence from inventory is not absence from environment unless scanner coverage is complete"
+        ]
+      },
+      "expected_findings": [
+        "mcp_inventory_coverage_incomplete"
+      ]
+    },
+    {
+      "case": "no_servers_found_but_coverage_incomplete",
+      "declared_servers": [],
+      "inventory": {
+        "schema": "assay.mcp_server_inventory.v0",
+        "scanner_coverage": {
+          "config_sources": {
+            "vscode": "not_scanned",
+            "cursor": "not_scanned"
+          },
+          "process_scan": "unavailable",
+          "network_scan": "not_applicable"
+        },
+        "servers": [],
+        "non_claims": [
+          "absence from inventory is not absence from environment unless scanner coverage is complete"
+        ]
+      },
+      "expected_findings": [
+        "mcp_inventory_coverage_incomplete"
+      ]
+    }
+  ]
+}

--- a/crates/assay-mcp-server/tests/mcp_inventory.rs
+++ b/crates/assay-mcp-server/tests/mcp_inventory.rs
@@ -1,0 +1,151 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+
+fn fixture() -> Value {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/mcp_inventory/inventory_cases.v0.json"
+    );
+    let bytes = std::fs::read(path).expect("fixture readable");
+    serde_json::from_slice(&bytes).expect("fixture is valid json")
+}
+
+fn string_field<'a>(value: &'a Value, key: &str) -> &'a str {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("{key} must be a string in {value:?}"))
+}
+
+fn coverage_incomplete(inventory: &Value) -> bool {
+    let coverage = &inventory["scanner_coverage"];
+    let config_incomplete = coverage["config_sources"]
+        .as_object()
+        .map(|sources| {
+            sources.values().any(|state| {
+                matches!(
+                    state.as_str(),
+                    Some("not_scanned") | Some("unavailable") | Some("partial")
+                )
+            })
+        })
+        .unwrap_or(true);
+
+    let process_incomplete = !matches!(
+        coverage["process_scan"].as_str(),
+        Some("complete") | Some("not_applicable")
+    );
+    let network_incomplete = !matches!(
+        coverage["network_scan"].as_str(),
+        Some("complete") | Some("not_applicable")
+    );
+
+    config_incomplete || process_incomplete || network_incomplete
+}
+
+fn classify(case: &Value) -> BTreeSet<String> {
+    let declared = case["declared_servers"]
+        .as_array()
+        .expect("declared_servers array");
+    let inventory = &case["inventory"];
+    assert_eq!(inventory["schema"], "assay.mcp_server_inventory.v0");
+    assert!(inventory["non_claims"]
+        .as_array()
+        .expect("non_claims array")
+        .iter()
+        .any(|claim| claim
+            .as_str()
+            .is_some_and(|s| s.contains("absence from inventory is not absence"))));
+
+    let mut declared_by_id = BTreeMap::new();
+    for server in declared {
+        declared_by_id.insert(string_field(server, "server_id"), server);
+    }
+
+    let servers = inventory["servers"].as_array().expect("servers array");
+    let mut findings = BTreeSet::new();
+    let mut digests_by_server = BTreeMap::<&str, BTreeSet<&str>>::new();
+
+    for server in servers {
+        let server_id = string_field(server, "server_id");
+        let command_digest = string_field(server, "command_digest");
+        digests_by_server
+            .entry(server_id)
+            .or_default()
+            .insert(command_digest);
+
+        match declared_by_id.get(server_id) {
+            None => {
+                findings.insert("shadow_mcp_server_observed".to_string());
+            }
+            Some(expected) => {
+                if string_field(expected, "command_digest") != command_digest {
+                    findings.insert("mcp_server_command_drift".to_string());
+                }
+                if string_field(expected, "args_digest") != string_field(server, "args_digest") {
+                    findings.insert("mcp_server_args_drift".to_string());
+                }
+            }
+        }
+    }
+
+    if digests_by_server
+        .values()
+        .any(|command_digests| command_digests.len() > 1)
+    {
+        findings.insert("duplicate_mcp_server_identity".to_string());
+    }
+
+    if coverage_incomplete(inventory) {
+        findings.insert("mcp_inventory_coverage_incomplete".to_string());
+    }
+
+    findings
+}
+
+#[test]
+fn mcp_inventory_fixture_reproduces_expected_findings() {
+    let fixture = fixture();
+    assert_eq!(fixture["schema_contract"], "assay.mcp_server_inventory.v0");
+
+    let cases = fixture["cases"].as_array().expect("cases array");
+    assert_eq!(
+        cases.len(),
+        9,
+        "M1 corpus should pin nine shadow-server cases"
+    );
+
+    for case in cases {
+        let name = string_field(case, "case");
+        let expected: BTreeSet<_> = case["expected_findings"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{name} expected_findings array"))
+            .iter()
+            .map(|finding| {
+                finding
+                    .as_str()
+                    .unwrap_or_else(|| panic!("{name} finding must be string"))
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(classify(case), expected, "{name}");
+    }
+}
+
+#[test]
+fn mcp_inventory_incomplete_coverage_never_reads_clean() {
+    let fixture = fixture();
+    let cases = fixture["cases"].as_array().expect("cases array");
+
+    for case in cases {
+        if coverage_incomplete(&case["inventory"]) {
+            let findings = classify(case);
+            assert!(
+                findings.contains("mcp_inventory_coverage_incomplete"),
+                "{} must report incomplete coverage",
+                string_field(case, "case")
+            );
+        }
+    }
+}

--- a/docs/reference/mcp-server-inventory.md
+++ b/docs/reference/mcp-server-inventory.md
@@ -1,0 +1,59 @@
+# MCP Server Inventory Artifact
+
+`assay.mcp_server_inventory.v0` is a bounded inventory artifact for configured or observed MCP
+servers. It supports MCP09 shadow-server review by separating three ideas:
+
+- **observed**: a server was found in a scanned source;
+- **approved**: a declared allowlist contains a matching server identity;
+- **coverage**: the scanner did or did not inspect the relevant sources.
+
+The artifact does **not** prove that no MCP servers exist outside scanned sources.
+
+## Shape
+
+```json
+{
+  "schema": "assay.mcp_server_inventory.v0",
+  "scanner_coverage": {
+    "config_sources": {
+      "claude_desktop": "complete",
+      "vscode": "complete",
+      "cursor": "not_scanned"
+    },
+    "process_scan": "unavailable",
+    "network_scan": "not_scanned"
+  },
+  "servers": [
+    {
+      "server_id": "github-tools",
+      "source": "vscode_mcp_config",
+      "transport": "stdio",
+      "command_digest": "sha256:...",
+      "args_digest": "sha256:...",
+      "observed_state": "observed"
+    }
+  ],
+  "non_claims": [
+    "absence from inventory is not absence from environment unless scanner coverage is complete"
+  ]
+}
+```
+
+## Finding Vocabulary
+
+| Condition | Finding |
+| --- | --- |
+| Observed server has no declared allowlist entry | `shadow_mcp_server_observed` |
+| Declared server command digest differs | `mcp_server_command_drift` |
+| Declared server args digest differs | `mcp_server_args_drift` |
+| Same server id appears with multiple command digests | `duplicate_mcp_server_identity` |
+| Scanner coverage is incomplete and no stronger finding exists | `mcp_inventory_coverage_incomplete` |
+| Approved server unchanged and coverage is complete for scanned sources | clean |
+
+## Non-Claims
+
+- Not observed is not absent unless scanner coverage is complete for the relevant source class.
+- Observed is not approved.
+- Approved is not safe; it only means the observed server matched a declared allowlist entry.
+- Command or args drift is a review condition, not a maliciousness finding.
+- Process and network scans are coverage signals, not endpoint governance.

--- a/docs/security/OWASP-MCP-TOP10-MAPPING.md
+++ b/docs/security/OWASP-MCP-TOP10-MAPPING.md
@@ -1,26 +1,56 @@
 # OWASP MCP Top 10 — Assay Coverage Mapping
 
-How Assay addresses the [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/) security risks.
+How Assay maps to the [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/) security risks.
+
+This mapping is intentionally bounded. Assay can provide strong evidence, gates, and review behavior for
+workflows it observes or wraps. It does not replace an enterprise MCP control plane, secret manager,
+package registry, or endpoint governance platform.
+
+## Coverage Language
+
+| Level | Meaning |
+| --- | --- |
+| None | Assay has no relevant control or evidence today. |
+| Partial | Assay has detection, evidence, or a narrow control, but not end-to-end governance for the risk. |
+| Strong | Assay has deterministic evidence and/or gates for Assay-wrapped or explicitly scanned workflows, with coverage limits reported. |
+| Complete | The risk is fully controlled inside the stated scope. Use sparingly; most MCP risks are broader than Assay's observation boundary. |
+
+## Current Mapping
 
 | OWASP Risk | ID | Assay Coverage | How |
-|-----------|-----|---------------|-----|
-| Token Mismanagement & Secret Exposure | MCP01 | Partial | Evidence lint detects secrets in subjects (`ASSAY-W001`). Policy can deny tools that expose credentials. |
-| Privilege Escalation via Scope Creep | MCP02 | Strong | `restrict_scope` enforcement limits tool arguments at runtime. Policy constraints enforce path/param boundaries. |
-| Tool Poisoning | MCP03 | Strong | Tool signing (`x-assay-sig`), identity verification, tool metadata hashing. [Delegation spoofing experiment](../architecture/RESULTS-EXPERIMENT-DELEGATION-SPOOFING-2026q2.md) tested trust-domain verification. |
-| Supply Chain Attacks & Dependency Tampering | MCP04 | Partial | Pack digest verification (SHA-256/JCS). Adapter identity pinning. Lockfile support in registry client. |
-| Command Injection & Execution | MCP05 | Strong | Policy `deny` rules block `exec`/`shell`/`bash`. Argument validation via regex constraints. Landlock sandbox for runtime isolation. |
-| Intent Flow Subversion | MCP06 | Strong | Sequence policies detect tool-call ordering violations. [Memory poisoning experiment](../architecture/RESULTS-EXPERIMENT-MEMORY-POISON-2026q2.md) tested delayed payload reactivation. |
-| Insufficient Authentication & Authorization | MCP07 | Strong | `approval_required` enforcement, mandate system with revocation, auth context validation. |
-| **Lack of Audit and Telemetry** | **MCP08** | **Complete** | **Evidence bundles, decision logs, replay, diff, lint, SARIF output.** This is Assay's primary value proposition. |
-| Shadow MCP Servers | MCP09 | Partial | `assay mcp discover` lists MCP servers on the machine. Policy enforcement only applies to wrapped servers. |
-| Context Injection & Over-Sharing | MCP10 | Strong | `redact_args` enforcement strips sensitive fields. Context envelope hardening validates completeness. [Protocol evidence experiment](../architecture/RESULTS-EXPERIMENT-PROTOCOL-EVIDENCE-INTERPRETATION-2026q2.md) tested consumer-side interpretation. |
+| --- | --- | --- | --- |
+| Token Mismanagement & Secret Exposure | MCP01 | Partial | Evidence lint and rendered-output hardening reduce leak risk in known artifacts. Strong coverage requires adversarial redaction gates across all public sinks, credential-alias inventory, and explicit no-transport-token-passthrough conformance. Assay should not claim secret lifecycle management, vaulting, or rotation. |
+| Privilege Escalation via Scope Creep | MCP02 | Strong | Runtime policy gates, declared credential scopes, least-privilege review, and privileged-action decision records cover Assay-wrapped tool calls. |
+| Tool Poisoning | MCP03 | Strong | Tool identity, metadata hashing, manifest drift detection, and signed/declared tool surfaces cover observed tool-surface changes. Behavior drift under identical metadata remains out of scope unless separately observed. |
+| Supply Chain Attacks & Dependency Tampering | MCP04 | Partial | Assay verifies some package, pack, adapter, and manifest digests. Strong coverage requires MCP server admission records, runtime-vs-admission digest comparison, and registry/package/source drift fixtures. Assay should not claim registry ecosystem security. |
+| Command Injection & Execution | MCP05 | Strong | Policy deny/restrict rules, argument constraints, and sandbox/degradation evidence cover Assay-run commands and wrapped tool invocations. |
+| Intent Flow Subversion | MCP06 | Strong | Sequence policy checks, delegation/context projections, and review artifacts cover explicit, observed flow violations. Prompt-context attacks outside supplied artifacts remain out of scope. |
+| Insufficient Authentication & Authorization | MCP07 | Strong | Approval, policy, caller, credential-alias, and scope gates cover Assay-wrapped decisions. External provider authorization remains the provider's authority unless imported as evidence. |
+| Lack of Audit and Telemetry | MCP08 | Strong | Evidence bundles, decision logs, replay, diff, lint, SARIF, and Plimsoll review provide strong auditability for Assay-wrapped runs. Not complete for unwrapped/shadow MCP servers or external provider audit unless imported. |
+| Shadow MCP Servers | MCP09 | Partial | Discovery can list some local MCP servers and the enforcing proxy protects wrapped servers. Strong coverage requires inventory artifacts, declared server allowlists, coverage-honest scanning, and review findings for unapproved or drifted servers. Assay should not claim absence outside scanned sources. |
+| Context Injection & Over-Sharing | MCP10 | Strong | Redaction, argument filtering, context-boundary checks, and receipt-boundary guards cover supplied evidence and wrapped calls. Assay does not govern model memory outside observed artifacts. |
 
-## Summary
+## Priority Path To Stronger Coverage
 
-Assay provides **Strong** or **Complete** coverage for 7 of 10 OWASP MCP risks, with **Partial** coverage for the remaining 3.
+The next evidence wave should not immediately relabel MCP01, MCP04, or MCP09 as strong. It should first
+prove the controls with bounded experiments:
 
-The strongest alignment is with **MCP08 (Lack of Audit and Telemetry)** — Assay's evidence bundles, decision logs, and replay capabilities are a direct and comprehensive answer to this risk.
+1. **MCP09 Shadow MCP foundation** — inventory configured MCP servers, report scan coverage, and flag observed unapproved or drifted servers without claiming absence outside scanned sources.
+2. **MCP01 Secret/credential-boundary gate** — run an adversarial leak corpus across public sinks and credential evidence, proving raw secrets and control characters do not render.
+3. **MCP04 MCP server admission/provenance** — compare declared server admission records with observed runtime server and manifest evidence, reporting drift or unknown provenance without maliciousness claims.
 
-## Security Experiments
+## Non-Claims
 
-Assay's coverage claims are backed by [three bounded security experiments](../architecture/SYNTHESIS-TRUST-CHAIN-TRIFECTA-2026q2.md) testing 12 attack vectors across producer, adapter, and consumer perspectives. All experiments achieved zero false positives under the full contract stack.
+- Strong coverage is scoped to Assay-wrapped or explicitly scanned workflows.
+- Not observed is not absent unless coverage is complete for the relevant sources.
+- Admitted is not safe; it only means the server/source matched a declared admission record.
+- Digest match is not benign behavior; digest drift is not maliciousness.
+- Unsigned or unknown provenance is not maliciousness; it is a review/coverage condition.
+- Secret redaction in public sinks does not prove secrets never existed in the source system.
+
+## Sources
+
+- [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top-10/)
+- [OWASP MCP01 Token Mismanagement & Secret Exposure](https://owasp.org/www-project-mcp-top-10/2025/MCP01-2025-Token-Mismanagement-and-Secret-Exposure)
+- [OWASP MCP09 Shadow MCP Servers](https://owasp.org/www-project-mcp-top-10/2025/MCP09-2025%E2%80%93Shadow-MCP-Servers)
+- [Microsoft OWASP MCP Top 10 Security Guidance for Azure](https://microsoft.github.io/mcp-azure-security-guide/)

--- a/docs/security/OWASP-MCP-TOP10-TEST-MAP.md
+++ b/docs/security/OWASP-MCP-TOP10-TEST-MAP.md
@@ -20,3 +20,40 @@ Source taxonomy: <https://owasp.org/www-project-mcp-top-10/>
 
 - Keep Trust Basis external receipt guards mutation-smoke eligible after classifier refactors.
 - Add prompt/context injection fixtures when proxy surfaces new context inputs beyond explicit tool-call args.
+
+## Priority Experiment Wave: MCP01 / MCP04 / MCP09
+
+The current Partial rows should move only after bounded experiments prove observation, classification,
+claim honesty, and fail-closed behavior. The priority is MCP09 first because shadow servers define the
+coverage boundary for MCP01, MCP04, and MCP08.
+
+| Priority | Experiment | Primary risks | First artifact or report | Claim |
+| --- | --- | --- | --- | --- |
+| 1 | M1 — MCP inventory coverage / shadow-server zoo | MCP09 | `assay.mcp_server_inventory.v0` | Configured MCP servers can be inventoried from declared sources; unapproved or drifted observed servers are reportable. |
+| 2 | M3 — Secret sink and credential-boundary corpus | MCP01 | `assay.experiment.mcp01_secret_sink.v0` | Public sinks and credential evidence do not render raw secrets from the adversarial corpus. |
+| 3 | M2 — Declared-vs-observed MCP server admission | MCP09, MCP04 | `assay.mcp_server_admission.v0` | Observed runtime servers can be compared with declared admission records without claiming safety or maliciousness. |
+| 4 | M4 — MCP supply-chain drift zoo | MCP04 | supply-chain drift fixture corpus | Source/package/manifest drift is classified as review evidence, not maliciousness. |
+| 5 | M5 — Cross-risk chain: shadow server → secret exposure → missing audit | MCP09, MCP01, MCP08 | multi-risk review fixture | Multiple bounded findings can be reported without collapsing into one overbroad verdict. |
+| 6 | M6 — OWASP MCP coverage report projection | MCP01, MCP04, MCP09, MCP08 | `plimsoll.owasp_mcp_coverage_report.v0` | Coverage is projected from source artifact digests; incomplete sources never read as complete. |
+
+### Shared Acceptance Rules
+
+- Not observed is not absent unless scanner coverage is complete for the relevant source class.
+- Observed is not approved; admitted is not safe.
+- Digest drift and unsigned source are review conditions, not maliciousness findings.
+- Coverage incomplete means warning/inconclusive/pending, never clean.
+- Every projected coverage statement links back to source artifact digests.
+- Redaction happens before projection/truncation for public sinks.
+
+### First Build Target
+
+Start with **M1 — MCP inventory coverage / shadow-server zoo**.
+
+Minimum acceptance:
+
+- approved server unchanged → no finding;
+- unapproved configured server → `shadow_mcp_server_observed`;
+- approved id with changed command or args digest → drift finding;
+- duplicate server id with different command → identity finding;
+- HTTP MCP endpoint outside allowlist → unapproved endpoint finding;
+- no servers found with incomplete scanner coverage → inconclusive/warning, not clean.

--- a/docs/superpowers/plans/2026-06-15-owasp-mcp-priority-wave.md
+++ b/docs/superpowers/plans/2026-06-15-owasp-mcp-priority-wave.md
@@ -1,0 +1,247 @@
+# OWASP MCP Priority Wave Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the MCP01/MCP04/MCP09 Partial coverage rows into bounded, evidence-backed experiments and then productizable Assay/Plimsoll capabilities, starting with MCP09 inventory coverage.
+
+**Architecture:** Build evidence carriers and fixtures before gates. Each experiment separates observation from approval, reports scanner coverage honestly, and never upgrades incomplete evidence to clean. Plimsoll/report consumers should read source artifacts as truth and produce bounded findings, not broad OWASP compliance claims.
+
+**Tech Stack:** Rust (`assay-mcp-server` / CLI), JSON fixtures, Markdown security docs, shell smoke tests, optional Python fixture generators where existing examples already use Python.
+
+---
+
+## Priority Order
+
+1. **M1 — MCP inventory coverage / shadow-server zoo**: establish the environment boundary for MCP09.
+2. **M3 — MCP secret sink and credential-boundary corpus**: protect new evidence/report sinks before expanding them.
+3. **M2 — Declared-vs-observed MCP server admission**: compare inventory/runtime observations with declared admissions.
+4. **M4 — MCP supply-chain drift zoo**: classify package/source/manifest drift without maliciousness claims.
+5. **M5 — Cross-risk chain**: compose shadow server, secret exposure, and missing audit evidence.
+6. **M6 — OWASP MCP coverage report projection**: render scoped coverage from source artifact digests.
+
+## Shared Claim Rules
+
+- Observed is not approved.
+- Admitted is not safe.
+- Digest match is not benign behavior.
+- Digest drift and unsigned source are not maliciousness findings.
+- Not observed is not absent unless scanner coverage is complete.
+- Coverage incomplete is warning/inconclusive/pending, never clean.
+- Redacted means safe for the sink; it does not mean removed from the source system unless the source contract says so.
+
+## File Structure
+
+- `docs/security/OWASP-MCP-TOP10-MAPPING.md`: public coverage taxonomy and current bounded claims.
+- `docs/security/OWASP-MCP-TOP10-TEST-MAP.md`: representative tests and the M1-M6 experiment backlog.
+- `docs/superpowers/plans/2026-06-15-owasp-mcp-priority-wave.md`: this implementation plan.
+- `crates/assay-mcp-server/src/mcp_inventory.rs`: future M1 producer module for `assay.mcp_server_inventory.v0`.
+- `crates/assay-mcp-server/tests/fixtures/mcp_inventory/`: future M1 fixture corpus.
+- `crates/assay-mcp-server/tests/mcp_inventory.rs`: future M1 producer tests.
+- `docs/reference/mcp-server-inventory.md`: future M1 carrier contract.
+
+## Task 1: Documentation Grounding
+
+**Files:**
+- Modify: `docs/security/OWASP-MCP-TOP10-MAPPING.md`
+- Modify: `docs/security/OWASP-MCP-TOP10-TEST-MAP.md`
+- Create: `docs/superpowers/plans/2026-06-15-owasp-mcp-priority-wave.md`
+
+- [ ] **Step 1: Verify current public mapping**
+
+Run:
+
+```bash
+sed -n '1,220p' docs/security/OWASP-MCP-TOP10-MAPPING.md
+sed -n '1,280p' docs/security/OWASP-MCP-TOP10-TEST-MAP.md
+```
+
+Expected: MCP01, MCP04, and MCP09 are Partial; MCP08 is Strong, not Complete; the M1-M6 wave is listed in priority order.
+
+- [ ] **Step 2: Run markdown sanity checks**
+
+Run:
+
+```bash
+git diff --check
+rg -n "Complete \\| Evidence bundles, decision logs|MCP08 \\| \\*\\*Complete\\*\\*" docs/security || true
+```
+
+Expected: no whitespace errors; no stale MCP08 Complete wording remains in the security mapping.
+
+- [ ] **Step 3: Commit docs**
+
+Run:
+
+```bash
+git add docs/security/OWASP-MCP-TOP10-MAPPING.md docs/security/OWASP-MCP-TOP10-TEST-MAP.md docs/superpowers/plans/2026-06-15-owasp-mcp-priority-wave.md
+git commit -m "docs(security): plan OWASP MCP priority evidence wave"
+```
+
+Expected: one docs commit with no code changes.
+
+## Task 2: M1 Contract Fixture First
+
+**Files:**
+- Create: `docs/reference/mcp-server-inventory.md`
+- Create: `crates/assay-mcp-server/tests/fixtures/mcp_inventory/inventory_cases.v0.json`
+- Create: `crates/assay-mcp-server/tests/mcp_inventory.rs`
+
+- [ ] **Step 1: Write the carrier contract**
+
+Create `docs/reference/mcp-server-inventory.md` with this shape:
+
+```json
+{
+  "schema": "assay.mcp_server_inventory.v0",
+  "scanner_coverage": {
+    "config_sources": {
+      "claude_desktop": "complete",
+      "vscode": "complete",
+      "cursor": "not_scanned"
+    },
+    "process_scan": "unavailable",
+    "network_scan": "not_scanned"
+  },
+  "servers": [
+    {
+      "server_id": "github-tools",
+      "source": "vscode_mcp_config",
+      "transport": "stdio",
+      "command_digest": "sha256:...",
+      "args_digest": "sha256:...",
+      "observed_state": "observed"
+    }
+  ],
+  "non_claims": [
+    "absence from inventory is not absence from environment unless scanner coverage is complete"
+  ]
+}
+```
+
+The contract must say `servers=[]` plus incomplete coverage is not clean.
+
+- [ ] **Step 2: Add fixture cases**
+
+Create `crates/assay-mcp-server/tests/fixtures/mcp_inventory/inventory_cases.v0.json` with cases:
+
+```json
+[
+  {"case": "approved_stdio_server_in_config", "expected": "clean"},
+  {"case": "unapproved_stdio_server_in_config", "expected": "shadow_mcp_server_observed"},
+  {"case": "approved_server_command_drift", "expected": "mcp_server_command_drift"},
+  {"case": "approved_server_args_drift", "expected": "mcp_server_args_drift"},
+  {"case": "duplicate_server_id_different_command", "expected": "duplicate_mcp_server_identity"},
+  {"case": "http_mcp_endpoint_not_in_allowlist", "expected": "shadow_mcp_server_observed"},
+  {"case": "server_only_visible_in_process_scan", "expected": "observed_with_partial_source_context"},
+  {"case": "config_source_not_scanned", "expected": "mcp_inventory_coverage_incomplete"},
+  {"case": "no_servers_found_but_coverage_incomplete", "expected": "mcp_inventory_coverage_incomplete"}
+]
+```
+
+- [ ] **Step 3: Write a fixture parser test**
+
+Create `crates/assay-mcp-server/tests/mcp_inventory.rs` with a test that loads the JSON, asserts every case has `case` and `expected`, and asserts the two coverage-incomplete cases are present.
+
+Run:
+
+```bash
+cargo test -p assay-mcp-server --test mcp_inventory
+```
+
+Expected: PASS.
+
+## Task 3: M1 Producer Prototype
+
+**Files:**
+- Create: `crates/assay-mcp-server/src/mcp_inventory.rs`
+- Modify: `crates/assay-mcp-server/src/lib.rs`
+- Modify: `crates/assay-mcp-server/tests/mcp_inventory.rs`
+
+- [ ] **Step 1: Define inventory data model**
+
+Implement structs for `InventoryRecord`, `ScannerCoverage`, and `InventoryServer`. Hash command and args with the same `sha256:` prefix style used by existing manifest artifacts.
+
+- [ ] **Step 2: Implement config-source scanner adapters**
+
+Start with static JSON fixture input, not host filesystem scanning. The scanner function should accept parsed config entries and produce `InventoryServer` rows. Real host paths are a later slice.
+
+- [ ] **Step 3: Add coverage honesty tests**
+
+Add tests for:
+
+- no servers + incomplete coverage → warning/inconclusive;
+- unapproved server observed → finding;
+- approved server unchanged → clean;
+- duplicate id with different command digest → finding.
+
+Run:
+
+```bash
+cargo test -p assay-mcp-server --test mcp_inventory
+cargo fmt --check
+cargo clippy -p assay-mcp-server --all-targets -- -D warnings
+```
+
+Expected: PASS.
+
+## Task 4: M3 Secret Sink Corpus
+
+**Files:**
+- Create: `crates/assay-mcp-server/tests/fixtures/mcp_secret_sink/`
+- Create: `crates/assay-mcp-server/tests/mcp_secret_sink.rs`
+- Modify only if needed: sink renderers that fail the corpus.
+
+- [ ] **Step 1: Add hostile values fixture**
+
+Include token-like strings, private-key block, AWS-key-like pair, email address, ANSI escape, Unicode bidi override, and an oversized field.
+
+- [ ] **Step 2: Assert public sinks are clean**
+
+Test markdown, SARIF, stdout-safe projection, OTel/log projection, and evidence query report if those sinks are present. If a sink is not present in Assay, mark it absent in the result rather than claiming coverage.
+
+- [ ] **Step 3: Preserve credential alias boundary**
+
+Assert credential aliases may render, but credential values and raw token-like payloads do not.
+
+## Task 5: M2 / M4 Admission and Supply-Chain Fixtures
+
+**Files:**
+- Create: `docs/reference/mcp-server-admission.md`
+- Create: `crates/assay-mcp-server/tests/fixtures/mcp_server_admission/`
+- Create: `crates/assay-mcp-server/tests/mcp_server_admission.rs`
+
+- [ ] **Step 1: Define `assay.mcp_server_admission.v0`**
+
+Use declared server id, source kind, package/version when applicable, source digest, manifest digest, approval timestamp, and non-claims.
+
+- [ ] **Step 2: Add drift zoo**
+
+Cover same package/new digest, same server id/new manifest, tool schema change, tool description change, local binary replacement, container tag drift, unknown registry metadata, and unsigned source.
+
+- [ ] **Step 3: Assert bounded findings**
+
+Digest drift becomes pending/review evidence; unknown source is inconclusive/pending; no case emits maliciousness.
+
+## Task 6: M5 / M6 Review Projection
+
+**Files:**
+- Create: `docs/reference/owasp-mcp-coverage-report.md`
+- Future Plimsoll repo changes for `plimsoll.owasp_mcp_coverage_report.v0`
+
+- [ ] **Step 1: Define source-digest based report contract**
+
+Every coverage row must include source artifact digests and incomplete source list.
+
+- [ ] **Step 2: Add cross-risk chain fixture**
+
+Fixture: unapproved server + secret-like metadata + missing enforcement decision. Expected: multiple bounded findings and no single maliciousness claim.
+
+- [ ] **Step 3: Add no-false-complete invariant**
+
+If any required source is missing, the report row cannot be `complete`.
+
+## Self-Review
+
+- Spec coverage: M1-M6 are represented, with MCP09 first, MCP01 second, MCP04 third.
+- Placeholder scan: no task uses TBD/TODO/fill-in language; later tasks are intentionally scoped as future slices with concrete files and acceptance.
+- Type consistency: inventory uses `assay.mcp_server_inventory.v0`; admission uses `assay.mcp_server_admission.v0`; coverage report uses `plimsoll.owasp_mcp_coverage_report.v0`.


### PR DESCRIPTION
## Summary
- tighten the OWASP MCP Top 10 coverage language so MCP08 is Strong within Assay-wrapped/scanned scope, not broadly Complete
- define the priority path for MCP01/MCP04/MCP09: MCP09 inventory first, MCP01 sink/credential safety second, MCP04 admission/provenance third
- add an implementation plan for the M1-M6 experiment wave, with M1 (`assay.mcp_server_inventory.v0`) as the first build target
- add the first executable M1 corpus: `assay.mcp_server_inventory.v0` contract doc, nine shadow-server fixture cases, and a Rust integration test proving incomplete coverage never reads clean

## Verification
- `cargo test -p assay-mcp-server --test mcp_inventory`
- `cargo fmt --check`
- `cargo clippy -p assay-mcp-server --test mcp_inventory -- -D warnings`
- `git diff --check`
- stale MCP08 Complete wording scan
- pre-commit hooks on both commits
- pre-push hooks on push

## Sources
- OWASP MCP Top 10
- OWASP MCP01 / MCP09 pages
- Microsoft OWASP MCP Top 10 Security Guidance for Azure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked the OWASP MCP Top 10 coverage guide with clearer coverage language, tightened mapping statements, and added prioritized “priority wave” guidance.
  * Added a new prioritized OWASP MCP Top 10 test wave, including shared acceptance rules and first-build targets.
  * Documented the MCP server inventory artifact and how its findings/non-claims should be interpreted.
* **Tests**
  * Added inventory test coverage using JSON fixtures to validate expected findings and ensure “incomplete coverage” is never treated as clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->