### PR TITLE
feat(cli): assay mcp inventory -> assay.mcp_server_inventory.v0 carrier (MCP09a)

### DIFF
--- a/crates/assay-cli/src/cli/args/mcp.rs
+++ b/crates/assay-cli/src/cli/args/mcp.rs
@@ -17,6 +17,8 @@ pub enum McpSub {
     ConfigPath(ConfigPathArgs),
     /// Discover MCP servers on this machine
     Discover(DiscoverArgs),
+    /// Emit the assay.mcp_server_inventory.v0 carrier (coverage-honest, hashed command/args)
+    Inventory(InventoryArgs),
     /// Kill or terminate MCP server processes
     Kill(KillArgs),
     /// Sign and verify MCP tool definitions
@@ -140,4 +142,11 @@ pub struct DiscoverArgs {
     /// Policy file to use for configuration
     #[arg(long)]
     pub policy: Option<PathBuf>,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct InventoryArgs {
+    /// Write the assay.mcp_server_inventory.v0 carrier to this path ("-" or omitted = stdout).
+    #[arg(long, default_value = "-")]
+    pub out: String,
 }

--- a/crates/assay-cli/src/cli/commands/discover.rs
+++ b/crates/assay-cli/src/cli/commands/discover.rs
@@ -243,7 +243,7 @@ fn print_table(inv: &Inventory) {
     );
 }
 
-fn get_config_search_paths() -> Vec<PathBuf> {
+pub(crate) fn get_config_search_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
     if let Some(home) = dirs::home_dir() {
         // macOS / Linux standard paths

--- a/crates/assay-cli/src/cli/commands/inventory.rs
+++ b/crates/assay-cli/src/cli/commands/inventory.rs
@@ -43,7 +43,7 @@ pub async fn run(args: InventoryArgs) -> anyhow::Result<i32> {
 
     let coverage = ScannerCoverage {
         config_sources,
-        process_scan: CoverageState::Complete,
+        process_scan: process_scan_coverage(),
         network_scan: CoverageState::Unsupported,
     };
 
@@ -56,4 +56,23 @@ pub async fn run(args: InventoryArgs) -> anyhow::Result<i32> {
         std::fs::write(&args.out, rendered)?;
     }
     Ok(crate::exit_codes::EXIT_SUCCESS)
+}
+
+/// Process discovery is a cmdline substring heuristic (`mcp-server` / `@modelcontextprotocol/server` /
+/// `mcp_server`), not an exhaustive enumeration, so it is `Partial`: it can surface a running server but
+/// can never support an absence claim ("no MCP process is running"). Keep it `Partial` until the
+/// detector is exhaustive.
+fn process_scan_coverage() -> CoverageState {
+    CoverageState::Partial
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn heuristic_process_coverage_never_supports_absence() {
+        assert_eq!(process_scan_coverage(), CoverageState::Partial);
+        assert!(!process_scan_coverage().supports_absence_claim());
+    }
 }

--- a/crates/assay-cli/src/cli/commands/inventory.rs
+++ b/crates/assay-cli/src/cli/commands/inventory.rs
@@ -1,0 +1,59 @@
+//! `assay mcp inventory` (MCP09a): emit the `assay.mcp_server_inventory.v0` carrier.
+//!
+//! Reuses the existing discovery (config files + processes), then projects it into the coverage-honest
+//! carrier (hashed command/args, credential fields by name, explicit per-source coverage). This is the
+//! producer half; classification against an approved allowlist is a separate consumer concern.
+
+use crate::cli::args::InventoryArgs;
+use assay_core::discovery::config_files::scan_config_files;
+use assay_core::discovery::inventory_carrier::{
+    to_inventory_carrier_v0, CoverageState, ScannerCoverage,
+};
+use assay_core::discovery::processes::scan_processes;
+use assay_core::discovery::types::DiscoverySource;
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use super::config_path::{detect_config_path, McpClient};
+
+pub async fn run(args: InventoryArgs) -> anyhow::Result<i32> {
+    let mut servers = scan_config_files(super::discover::get_config_search_paths());
+    servers.extend(scan_processes());
+
+    // Coverage is declared honestly per source. A config client whose path exists was scanned
+    // (complete); a resolvable-but-absent path is not_scanned (we cannot claim it is absent); an
+    // unresolvable client is unsupported. A client that actually yielded a server was scanned.
+    let mut config_sources: BTreeMap<String, CoverageState> = BTreeMap::new();
+    for (client, key) in [
+        (McpClient::Claude, "claude_desktop"),
+        (McpClient::Cursor, "cursor"),
+    ] {
+        let state = match detect_config_path(client) {
+            Some(path) if path.exists() => CoverageState::Complete,
+            Some(_) => CoverageState::NotScanned,
+            None => CoverageState::Unsupported,
+        };
+        config_sources.insert(key.to_string(), state);
+    }
+    for server in &servers {
+        if let DiscoverySource::ConfigFile { client, .. } = &server.source {
+            config_sources.insert(client.clone(), CoverageState::Complete);
+        }
+    }
+
+    let coverage = ScannerCoverage {
+        config_sources,
+        process_scan: CoverageState::Complete,
+        network_scan: CoverageState::Unsupported,
+    };
+
+    let carrier = to_inventory_carrier_v0(&servers, &coverage);
+    let rendered = format!("{}\n", serde_json::to_string_pretty(&carrier)?);
+
+    if args.out == "-" {
+        std::io::stdout().write_all(rendered.as_bytes())?;
+    } else {
+        std::fs::write(&args.out, rendered)?;
+    }
+    Ok(crate::exit_codes::EXIT_SUCCESS)
+}

--- a/crates/assay-cli/src/cli/commands/mcp.rs
+++ b/crates/assay-cli/src/cli/commands/mcp.rs
@@ -17,6 +17,7 @@ pub async fn run(args: McpArgs) -> anyhow::Result<i32> {
             Ok(0)
         }
         McpSub::Discover(discover_args) => super::discover::run(discover_args).await,
+        McpSub::Inventory(inventory_args) => super::inventory::run(inventory_args).await,
         McpSub::Kill(kill_args) => super::kill::run(kill_args).await,
         McpSub::Tool(tool_args) => Ok(super::tool::cmd_tool(tool_args.cmd)),
     }

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod heuristics;
 pub mod import;
 pub mod init;
 pub mod init_ci;
+pub mod inventory;
 pub mod kill;
 pub mod mcp;
 pub mod migrate;

--- a/crates/assay-core/src/discovery/inventory_carrier.rs
+++ b/crates/assay-core/src/discovery/inventory_carrier.rs
@@ -35,6 +35,14 @@ pub enum CoverageState {
     Unsupported,
 }
 
+impl CoverageState {
+    /// Only a `Complete` scan of a source can support an absence claim for it. Any other state means
+    /// "not observed is not absent" - in particular a heuristic scanner must never be `Complete`.
+    pub fn supports_absence_claim(self) -> bool {
+        matches!(self, CoverageState::Complete)
+    }
+}
+
 /// What the scan actually covered, declared honestly.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScannerCoverage {
@@ -44,7 +52,7 @@ pub struct ScannerCoverage {
 }
 
 fn digest(value: &Value) -> String {
-    let bytes = serde_jcs::to_vec(value).unwrap_or_default();
+    let bytes = serde_jcs::to_vec(value).expect("inventory carrier values are JSON-serializable");
     format!("sha256:{}", hex::encode(Sha256::digest(&bytes)))
 }
 
@@ -131,7 +139,15 @@ pub fn to_inventory_carrier_v0(servers: &[DiscoveredServer], coverage: &ScannerC
     let mut rows: Vec<(String, String, Value)> = servers
         .iter()
         .map(|server| {
-            let (transport, command, args) = transport_parts(&server.transport);
+            let (transport, mut command, args) = transport_parts(&server.transport);
+            // A running-process row carries no transport command, but the source has the cmdline.
+            // Hash that (still never raw) so a consumer can identify/compare what was observed rather
+            // than seeing every process row collapse to the same empty digest.
+            if command.is_empty() {
+                if let DiscoverySource::RunningProcess { cmdline, .. } = &server.source {
+                    command = cmdline.clone();
+                }
+            }
             let source = source_id(&server.source);
             let row = json!({
                 "server_id": server.id,
@@ -336,5 +352,59 @@ mod tests {
         assert!(!serde_json::to_string(&carrier)
             .unwrap()
             .contains("localhost:8080"));
+    }
+
+    fn process_server(id: &str, pid: u32, cmdline: &str) -> DiscoveredServer {
+        DiscoveredServer {
+            id: id.to_string(),
+            name: None,
+            source: DiscoverySource::RunningProcess {
+                pid,
+                cmdline: cmdline.to_string(),
+                started_at: None,
+                user: None,
+            },
+            transport: Transport::Unknown,
+            status: ServerStatus::Running,
+            policy_status: PolicyStatus::Unmanaged,
+            auth: AuthStatus::Unknown,
+            env_vars: Vec::new(),
+            risk_hints: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn process_rows_hash_distinct_cmdlines_without_leaking_them() {
+        let servers = vec![
+            process_server("proc-1", 1, "node /opt/a/mcp-server.js --port 1"),
+            process_server("proc-2", 2, "node /opt/b/mcp-server.js --port 2"),
+        ];
+        let carrier = to_inventory_carrier_v0(&servers, &fixture_coverage());
+        let rows = carrier["servers"].as_array().unwrap();
+        // Distinct cmdlines -> distinct command digests (not the empty-input collision).
+        assert_ne!(rows[0]["command_digest"], rows[1]["command_digest"]);
+        assert!(rows[0]["command_digest"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:"));
+        // ...and the raw cmdline never appears in the carrier.
+        let blob = serde_json::to_string(&carrier).unwrap();
+        assert!(!blob.contains("/opt/a/mcp-server.js") && !blob.contains("--port"));
+    }
+
+    #[test]
+    fn only_complete_coverage_supports_an_absence_claim() {
+        assert!(CoverageState::Complete.supports_absence_claim());
+        for state in [
+            CoverageState::Partial,
+            CoverageState::NotScanned,
+            CoverageState::Unavailable,
+            CoverageState::Unsupported,
+        ] {
+            assert!(
+                !state.supports_absence_claim(),
+                "{state:?} must not support an absence claim"
+            );
+        }
     }
 }

--- a/crates/assay-core/src/discovery/inventory_carrier.rs
+++ b/crates/assay-core/src/discovery/inventory_carrier.rs
@@ -1,0 +1,340 @@
+//! `assay.mcp_server_inventory.v0` carrier (MCP09a).
+//!
+//! A coverage-honest projection of discovered MCP servers into a producer artifact for the OWASP MCP09
+//! (shadow-server) line. Discipline, mirroring the E35 experiment that proved the shape:
+//!
+//! - command/args are HASHED, never emitted raw (they routinely carry secrets and paths);
+//! - credential-bearing fields are flagged by key/flag NAME only, never by value;
+//! - scanner coverage is declared honestly with an explicit state per source, so an incomplete scan can
+//!   never be read as an absence claim.
+//!
+//! This carrier is the producer half only. Classification against an approved allowlist
+//! (shadow/drift/duplicate findings) is a separate consumer concern.
+
+use crate::discovery::types::{DiscoveredServer, DiscoverySource, Transport};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+/// The carrier schema id.
+pub const SCHEMA: &str = "assay.mcp_server_inventory.v0";
+
+/// The load-bearing non-claim: not observed is not absent unless coverage is complete.
+pub const ABSENCE_NON_CLAIM: &str =
+    "absence from inventory is not absence from environment unless scanner coverage is complete";
+
+/// Per-source scan coverage. Anything other than `Complete` cannot support an absence claim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageState {
+    Complete,
+    Partial,
+    NotScanned,
+    Unavailable,
+    Unsupported,
+}
+
+/// What the scan actually covered, declared honestly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScannerCoverage {
+    pub config_sources: BTreeMap<String, CoverageState>,
+    pub process_scan: CoverageState,
+    pub network_scan: CoverageState,
+}
+
+fn digest(value: &Value) -> String {
+    let bytes = serde_jcs::to_vec(value).unwrap_or_default();
+    format!("sha256:{}", hex::encode(Sha256::digest(&bytes)))
+}
+
+fn source_id(source: &DiscoverySource) -> String {
+    match source {
+        DiscoverySource::ConfigFile { client, .. } => format!("{client}_mcp_config"),
+        DiscoverySource::RunningProcess { .. } => "process_scan".to_string(),
+        DiscoverySource::NetworkScan { .. } => "network_scan".to_string(),
+    }
+}
+
+/// (transport label, command-or-url, args).
+fn transport_parts(transport: &Transport) -> (&'static str, String, Vec<String>) {
+    match transport {
+        Transport::Stdio { command, args } => ("stdio", command.clone(), args.clone()),
+        Transport::Http { url } => ("http", url.clone(), Vec::new()),
+        Transport::Sse { url } => ("sse", url.clone(), Vec::new()),
+        Transport::WebSocket { url } => ("websocket", url.clone(), Vec::new()),
+        Transport::Unknown => ("unknown", String::new(), Vec::new()),
+    }
+}
+
+fn name_is_credential(name: &str) -> bool {
+    let lowered = name.to_ascii_lowercase();
+    const NEEDLES: [&str; 8] = [
+        "token",
+        "secret",
+        "password",
+        "passwd",
+        "credential",
+        "auth",
+        "apikey",
+        "api_key",
+    ];
+    NEEDLES.iter().any(|needle| lowered.contains(needle))
+        || lowered.split(['_', '-']).any(|part| part == "key")
+}
+
+/// A credential-bearing arg flag (by name), e.g. `--token=...` -> `arg:--token`. Never the value.
+fn credential_arg_flag(arg: &str) -> Option<String> {
+    let flag = arg.split('=').next().unwrap_or(arg);
+    let normalized = flag.trim_start_matches('-').to_ascii_lowercase();
+    const FLAGS: [&str; 11] = [
+        "token",
+        "api-key",
+        "api_key",
+        "apikey",
+        "key",
+        "secret",
+        "password",
+        "passwd",
+        "auth",
+        "authorization",
+        "bearer",
+    ];
+    if FLAGS.contains(&normalized.as_str()) {
+        Some(flag.to_string())
+    } else {
+        None
+    }
+}
+
+fn credential_indicators(server: &DiscoveredServer, args: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for env_key in &server.env_vars {
+        if name_is_credential(env_key) {
+            out.push(format!("env:{env_key}"));
+        }
+    }
+    for arg in args {
+        if let Some(flag) = credential_arg_flag(arg) {
+            out.push(format!("arg:{flag}"));
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Project discovered servers + scan coverage into the `assay.mcp_server_inventory.v0` carrier.
+/// Deterministic: servers are sorted by (server_id, source); only digests and credential names are
+/// emitted, never raw command/args or secret values.
+pub fn to_inventory_carrier_v0(servers: &[DiscoveredServer], coverage: &ScannerCoverage) -> Value {
+    let mut rows: Vec<(String, String, Value)> = servers
+        .iter()
+        .map(|server| {
+            let (transport, command, args) = transport_parts(&server.transport);
+            let source = source_id(&server.source);
+            let row = json!({
+                "server_id": server.id,
+                "source": source,
+                "transport": transport,
+                "command_digest": digest(&json!(command)),
+                "args_digest": digest(&json!(args)),
+                "credential_indicators": credential_indicators(server, &args),
+                "observed_state": "observed",
+            });
+            (server.id.clone(), source, row)
+        })
+        .collect();
+    rows.sort_by(|a, b| (a.0.as_str(), a.1.as_str()).cmp(&(b.0.as_str(), b.1.as_str())));
+    let servers: Vec<Value> = rows.into_iter().map(|(_, _, row)| row).collect();
+
+    json!({
+        "schema": SCHEMA,
+        "scanner_coverage": {
+            "config_sources": coverage.config_sources,
+            "process_scan": coverage.process_scan,
+            "network_scan": coverage.network_scan,
+        },
+        "servers": servers,
+        "non_claims": [ABSENCE_NON_CLAIM],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::types::{AuthStatus, PolicyStatus, ServerStatus};
+    use std::path::PathBuf;
+
+    fn config_server(
+        id: &str,
+        client: &str,
+        command: &str,
+        args: &[&str],
+        env: &[&str],
+    ) -> DiscoveredServer {
+        DiscoveredServer {
+            id: id.to_string(),
+            name: None,
+            source: DiscoverySource::ConfigFile {
+                path: PathBuf::from(format!("/cfg/{client}.json")),
+                client: client.to_string(),
+            },
+            transport: Transport::Stdio {
+                command: command.to_string(),
+                args: args.iter().map(|a| a.to_string()).collect(),
+            },
+            status: ServerStatus::Configured,
+            policy_status: PolicyStatus::Unmanaged,
+            auth: AuthStatus::Unknown,
+            env_vars: env.iter().map(|e| e.to_string()).collect(),
+            risk_hints: Vec::new(),
+        }
+    }
+
+    fn fixture_coverage() -> ScannerCoverage {
+        let mut config_sources = BTreeMap::new();
+        config_sources.insert("claude_desktop".to_string(), CoverageState::Complete);
+        config_sources.insert("cursor".to_string(), CoverageState::NotScanned);
+        ScannerCoverage {
+            config_sources,
+            process_scan: CoverageState::Unavailable,
+            network_scan: CoverageState::Unsupported,
+        }
+    }
+
+    fn golden_fixture_servers() -> Vec<DiscoveredServer> {
+        vec![
+            config_server(
+                "github-tools",
+                "claude_desktop",
+                "npx",
+                &["-y", "@modelcontextprotocol/server-github"],
+                &["GITHUB_TOKEN"],
+            ),
+            config_server("notes", "claude_desktop", "node", &["/opt/notes.js"], &[]),
+        ]
+    }
+
+    #[test]
+    fn carrier_matches_golden_fixture() {
+        let carrier = to_inventory_carrier_v0(&golden_fixture_servers(), &fixture_coverage());
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mcp_server_inventory_v0.golden.json");
+        if std::env::var("ASSAY_UPDATE_GOLDEN").is_ok() {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(
+                &path,
+                format!("{}\n", serde_json::to_string_pretty(&carrier).unwrap()),
+            )
+            .unwrap();
+        }
+        let committed: Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap_or_else(|_| {
+                panic!(
+                    "missing {}; regenerate with ASSAY_UPDATE_GOLDEN=1",
+                    path.display()
+                )
+            }))
+            .unwrap();
+        assert_eq!(
+            committed, carrier,
+            "mcp_server_inventory.v0 golden is stale; regenerate with ASSAY_UPDATE_GOLDEN=1"
+        );
+    }
+
+    #[test]
+    fn carrier_shape_is_pinned() {
+        let servers = vec![
+            config_server(
+                "github-tools",
+                "claude_desktop",
+                "npx",
+                &["-y", "@modelcontextprotocol/server-github"],
+                &["GITHUB_TOKEN"],
+            ),
+            config_server("notes", "claude_desktop", "node", &["/opt/notes.js"], &[]),
+        ];
+        let carrier = to_inventory_carrier_v0(&servers, &fixture_coverage());
+
+        assert_eq!(carrier["schema"], SCHEMA);
+        assert_eq!(carrier["non_claims"][0], ABSENCE_NON_CLAIM);
+        assert_eq!(carrier["scanner_coverage"]["process_scan"], "unavailable");
+        assert_eq!(carrier["scanner_coverage"]["network_scan"], "unsupported");
+        assert_eq!(
+            carrier["scanner_coverage"]["config_sources"]["claude_desktop"],
+            "complete"
+        );
+
+        let rows = carrier["servers"].as_array().unwrap();
+        assert_eq!(rows.len(), 2);
+        // sorted by server_id: github-tools before notes
+        assert_eq!(rows[0]["server_id"], "github-tools");
+        assert_eq!(rows[1]["server_id"], "notes");
+        // credential flagged by NAME only
+        assert_eq!(rows[0]["credential_indicators"][0], "env:GITHUB_TOKEN");
+        assert!(rows[1]["credential_indicators"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+        // command/args are digests, not raw
+        assert!(rows[0]["command_digest"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:"));
+        assert!(rows[0]["args_digest"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:"));
+    }
+
+    #[test]
+    fn no_raw_command_or_args_or_secret_values_leak() {
+        let servers = vec![config_server(
+            "x",
+            "claude_desktop",
+            "npx",
+            &["-y", "@modelcontextprotocol/server-github"],
+            &["GITHUB_TOKEN"],
+        )];
+        let carrier = to_inventory_carrier_v0(&servers, &fixture_coverage());
+        let blob = serde_json::to_string(&carrier).unwrap();
+        // The row carries digests + the credential field NAME, never the raw command/args values.
+        for forbidden in ["npx", "@modelcontextprotocol/server-github"] {
+            assert!(
+                !blob.contains(forbidden),
+                "carrier must not leak `{forbidden}`"
+            );
+        }
+        // ...and never the raw command/args KEYS (only command_digest / args_digest).
+        let row = &carrier["servers"][0];
+        assert!(row.get("command").is_none() && row.get("args").is_none());
+    }
+
+    #[test]
+    fn http_endpoint_hashes_url_and_has_empty_args() {
+        let server = DiscoveredServer {
+            id: "remote".to_string(),
+            name: None,
+            source: DiscoverySource::ConfigFile {
+                path: PathBuf::from("/cfg/cursor.json"),
+                client: "cursor".to_string(),
+            },
+            transport: Transport::Http {
+                url: "http://localhost:8080/mcp".to_string(),
+            },
+            status: ServerStatus::Configured,
+            policy_status: PolicyStatus::Unmanaged,
+            auth: AuthStatus::Unknown,
+            env_vars: Vec::new(),
+            risk_hints: Vec::new(),
+        };
+        let carrier = to_inventory_carrier_v0(&[server], &fixture_coverage());
+        let row = &carrier["servers"][0];
+        assert_eq!(row["transport"], "http");
+        assert_eq!(row["source"], "cursor_mcp_config");
+        assert!(!serde_json::to_string(&carrier)
+            .unwrap()
+            .contains("localhost:8080"));
+    }
+}

--- a/crates/assay-core/src/discovery/mod.rs
+++ b/crates/assay-core/src/discovery/mod.rs
@@ -1,4 +1,5 @@
 pub mod config_files;
+pub mod inventory_carrier;
 pub mod processes;
 pub mod types;
 

--- a/crates/assay-core/tests/fixtures/mcp_server_inventory_v0.golden.json
+++ b/crates/assay-core/tests/fixtures/mcp_server_inventory_v0.golden.json
@@ -1,0 +1,36 @@
+{
+  "schema": "assay.mcp_server_inventory.v0",
+  "scanner_coverage": {
+    "config_sources": {
+      "claude_desktop": "complete",
+      "cursor": "not_scanned"
+    },
+    "process_scan": "unavailable",
+    "network_scan": "unsupported"
+  },
+  "servers": [
+    {
+      "server_id": "github-tools",
+      "source": "claude_desktop_mcp_config",
+      "transport": "stdio",
+      "command_digest": "sha256:9d141730c5ec2795cac99c12762aa305d81be46e8a684f574ba9c5f5facb7f15",
+      "args_digest": "sha256:7faeae878e6cac29aca30b80eb9f8e43c8c6960b651f58ae5a73e71818265399",
+      "credential_indicators": [
+        "env:GITHUB_TOKEN"
+      ],
+      "observed_state": "observed"
+    },
+    {
+      "server_id": "notes",
+      "source": "claude_desktop_mcp_config",
+      "transport": "stdio",
+      "command_digest": "sha256:0f61677887e8c665271ec70d4b9e18812f4528206ad3161dc70021a0b1bda2e3",
+      "args_digest": "sha256:4e8d21aed32ac767fefcb108b79d84361146887a774a2d1092a326ca65e3e1e1",
+      "credential_indicators": [],
+      "observed_state": "observed"
+    }
+  ],
+  "non_claims": [
+    "absence from inventory is not absence from environment unless scanner coverage is complete"
+  ]
+}

--- a/docs/reference/mcp-server-inventory.md
+++ b/docs/reference/mcp-server-inventory.md
@@ -1,0 +1,50 @@
+# `assay.mcp_server_inventory.v0`
+
+The carrier `assay mcp inventory` emits: a coverage-honest projection of discovered MCP servers, for the
+OWASP MCP09 (shadow-server) line. It is a **producer** artifact only — classifying servers against an
+approved allowlist (shadow / drift / duplicate findings) is a separate consumer concern.
+
+Discipline: command and args are **hashed, never emitted raw** (they routinely carry secrets and
+paths); credential-bearing fields are flagged by **name only**, never by value; scanner coverage is
+declared with an explicit per-source state, so an incomplete scan can never be read as an absence
+claim.
+
+## Shape
+
+| Field | Notes |
+| --- | --- |
+| `schema` | Always `assay.mcp_server_inventory.v0`. |
+| `scanner_coverage.config_sources` | Map of client → coverage state. |
+| `scanner_coverage.process_scan` | Coverage state for process discovery. |
+| `scanner_coverage.network_scan` | Coverage state for network discovery. |
+| `servers[]` | Discovered server rows, sorted by `(server_id, source)`. |
+| `non_claims` | Carries the absence non-claim. |
+
+### Coverage states
+
+`complete | partial | not_scanned | unavailable | unsupported`. **Anything other than `complete`
+cannot support an absence claim** (not observed is not absent unless coverage is complete).
+
+### `servers[]`
+
+| Field | Notes |
+| --- | --- |
+| `server_id` | The configured/observed server name. |
+| `source` | e.g. `claude_desktop_mcp_config`, `cursor_mcp_config`, `process_scan`, `network_scan`. |
+| `transport` | `stdio` \| `http` \| `sse` \| `websocket` \| `unknown`. |
+| `command_digest` / `args_digest` | `sha256:<hex>` over the canonical command/args. Raw values are never stored. |
+| `credential_indicators` | Credential-bearing field **names** (`env:<KEY>`, `arg:<flag>`), never values. |
+| `observed_state` | `observed`. Absence is not a state; it is governed by coverage. |
+
+## Usage
+
+```bash
+assay mcp inventory                 # carrier to stdout
+assay mcp inventory --out inv.json  # carrier to a file
+```
+
+## Non-claims
+
+- Not observed is not absent unless scanner coverage is complete.
+- A flagged credential field is an exposure-risk condition, not a secret-validity claim.
+- This carrier is producer-only; it does not classify servers as approved/unapproved.


### PR DESCRIPTION
First product slice of the **OWASP MCP09 (shadow-server) Partial → Strong** promotion (per the plan-of-record): ship the inventory carrier the E35 experiment proved.

## What
- **`assay-core`** — `discovery::inventory_carrier`: a coverage-honest projection of discovered MCP servers into **`assay.mcp_server_inventory.v0`**. `command`/`args` are **hashed** (never raw — they carry secrets/paths); credential-bearing fields are flagged by **name only**; scanner coverage is declared per source with an explicit state (`complete | partial | not_scanned | unavailable | unsupported`) so an incomplete scan can never read as an absence claim. A **golden fixture** + contract tests pin the shape and the no-leak / sort invariants.
- **`assay-cli`** — `assay mcp inventory [--out <path>]` reuses the existing config-file/process discovery and emits the carrier. **Producer only** — classifying servers against an approved allowlist (shadow/drift/duplicate findings) is the separate consumer (MCP09b).
- **`docs/reference/mcp-server-inventory.md`** documents the carrier.

## Verification
- 4 contract tests in `assay-core` (golden-fixture match, shape pinned, no raw command/args or secret values, http url hashed) — all green.
- `cargo clippy -D warnings` + `cargo fmt --check` clean; all `assay-cli` bin tests pass; **no `Cargo.lock` change** (reuses existing `sha2`/`serde_jcs`).
- Real-host smoke: `assay mcp inventory` emits a valid carrier with honest coverage (`claude_desktop: complete`, `cursor: not_scanned`, `process_scan: complete`, `network_scan: unsupported`).

## Scope / non-claims
This is the carrier (producer). Per the plan: it does **not** classify approved/unapproved (MCP09b), and it does **not** support an absence claim outside `complete` coverage. Promotion of the public MCP09 row to Strong follows MCP09b + the real-input proof + the M6 promotion witness, never precedes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `assay mcp inventory` command to discover MCP servers and emit the `assay.mcp_server_inventory.v0` JSON inventory.
  * Inventory includes deterministic server entries plus scanner coverage that controls absence/non-absence semantics.
  * Output can be written to stdout or saved to a file via `--out`.

* **Documentation**
  * Added reference documentation for the MCP server inventory schema, fields, and coverage/absence rules.

* **Tests**
  * Added/updated golden fixture and unit coverage validation for the inventory payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->