### PR TITLE
docs(security): MCP09 Partial -> Strong (scoped) in OWASP MCP mapping

### DIFF
--- a/docs/security/OWASP-MCP-TOP10-MAPPING.md
+++ b/docs/security/OWASP-MCP-TOP10-MAPPING.md
@@ -12,12 +12,14 @@ How Assay addresses the [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top
 | Intent Flow Subversion | MCP06 | Strong | Sequence policies detect tool-call ordering violations. [Memory poisoning experiment](../architecture/RESULTS-EXPERIMENT-MEMORY-POISON-2026q2.md) tested delayed payload reactivation. |
 | Insufficient Authentication & Authorization | MCP07 | Strong | `approval_required` enforcement, mandate system with revocation, auth context validation. |
 | **Lack of Audit and Telemetry** | **MCP08** | **Complete** | **Evidence bundles, decision logs, replay, diff, lint, SARIF output.** This is Assay's primary value proposition. |
-| Shadow MCP Servers | MCP09 | Partial | `assay mcp discover` lists MCP servers on the machine. Policy enforcement only applies to wrapped servers. |
+| Shadow MCP Servers | MCP09 | Strong (scoped) | Assay inventory carrier (`assay.mcp_server_inventory.v0`, coverage-honest, command/args hashed) + Plimsoll allowlist review over scanned config/process sources; coverage limits reported. No absence claim outside scanned sources. Plimsoll consumer private. See note below. |
 | Context Injection & Over-Sharing | MCP10 | Strong | `redact_args` enforcement strips sensitive fields. Context envelope hardening validates completeness. [Protocol evidence experiment](../architecture/RESULTS-EXPERIMENT-PROTOCOL-EVIDENCE-INTERPRETATION-2026q2.md) tested consumer-side interpretation. |
+
+> **Note on MCP09 "Strong (scoped)".** "Strong" here means the workflow has deterministic producer evidence and a validated review consumer. The public Assay artifact is the inventory carrier (`assay mcp inventory`); the Plimsoll review consumer is currently private, so public users can reproduce the evidence producer but not the full review/gating path from this repository alone. It does not mean Assay detects all shadow MCP servers, and it is not Complete coverage.
 
 ## Summary
 
-Assay provides **Strong** or **Complete** coverage for 7 of 10 OWASP MCP risks, with **Partial** coverage for the remaining 3.
+Assay provides **Strong** or **Complete** coverage for 8 of 10 OWASP MCP risks, with **Partial** coverage for the remaining 2 (MCP01, MCP04). MCP09 is **Strong (scoped)** — see the note above.
 
 The strongest alignment is with **MCP08 (Lack of Audit and Telemetry)** — Assay's evidence bundles, decision logs, and replay capabilities are a direct and comprehensive answer to this risk.
 


### PR DESCRIPTION
Relabels **MCP09 (Shadow MCP Servers)** from Partial to **Strong (scoped)** in the OWASP MCP Top 10
mapping. This is the final, deliberately tiny step of the MCP09 promotion arc; it lands only after the
producer carrier, the review consumer, and the real-input proof + witness were all in place.

What backs it:
- producer: `assay mcp inventory` -> `assay.mcp_server_inventory.v0` (coverage-honest, command/args
  hashed, explicit per-source coverage) + `--no-process-scan` for deterministic scoped runs;
- review: allowlist-based shadow / drift / duplicate review over the carrier, approval-bound;
- real-input proof + an M6 Strong-with-limits witness (derived from a real run, `strong` never
  `complete`, every non-complete source enumerated as a scope-limit non-claim).

Bounded and honest by construction:
- **Strong (scoped)**, not Complete; no claim that Assay detects all shadow MCP servers;
- Strong over scanned config/process sources, coverage limits reported; no absence claim outside
  scanned sources;
- a note records that the public artifact is the inventory carrier while the review consumer is
  currently private, so public users can reproduce the producer but not the full review/gating path
  from this repository alone.

Diff is two table lines + one note. Summary count updated to 8/10 (MCP01, MCP04 remain Partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OWASP MCP Top 10 security coverage mapping with improved assessment of Shadow MCP Servers protection, upgrading coverage from Partial to Strong (scoped). Added clarifications on coverage classifications, public evidence references, and updated coverage statistics from 7 of 10 to 8 of 10 risks addressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->