### PR TITLE
feat(render-safety): MCP01a-1 sink render-safety pipeline + conformance + receipt contract

### DIFF
--- a/crates/assay-core/src/lib.rs
+++ b/crates/assay-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod policy_engine;
 pub mod providers;
 pub mod quarantine;
 pub mod redaction;
+pub mod render_safety;
 
 pub mod doctor;
 pub mod validate;

--- a/crates/assay-core/src/render_safety/conformance.rs
+++ b/crates/assay-core/src/render_safety/conformance.rs
@@ -1,0 +1,116 @@
+//! `assay.render_safety_conformance.v0` — the render-sink release-gate witness (MCP01a).
+//!
+//! Runs the shared corpus through the real render-safety pipeline for each sink and records, per sink:
+//! hostile probes neutralised, benign controls preserved, redaction-before-truncation, terminal
+//! control stripped, sink-specific encoding, and zero raw leak counts. The MCP01 Strong claim hangs
+//! on THIS conformance, not on the capture receipt (which proves only that capture redaction ran).
+
+use super::corpus::{corpus_digest, BENIGN, HOSTILE};
+use super::{render_safe, render_truncate_first_unsafe, Sink, MAX_RENDER_FIELD};
+use serde::{Deserialize, Serialize};
+
+pub const SCHEMA: &str = "assay.render_safety_conformance.v0";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SinkConformance {
+    pub sink: String,
+    pub renderer: String,
+    pub hostile_probe_count: usize,
+    pub benign_control_count: usize,
+    pub raw_secret_leak_count: usize,
+    pub raw_pii_leak_count: usize,
+    pub terminal_control_leak_count: usize,
+    pub redaction_before_truncation: bool,
+    pub benign_preserved: bool,
+    pub sink_specific_encoding: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RenderSafetyConformance {
+    pub schema: String,
+    pub corpus_digest: String,
+    pub sinks: Vec<SinkConformance>,
+}
+
+fn sink_conformance(sink: Sink) -> SinkConformance {
+    let mut raw_secret_leak_count = 0;
+    let mut raw_pii_leak_count = 0;
+    let mut terminal_control_leak_count = 0;
+
+    for probe in HOSTILE.iter() {
+        let out = render_safe(sink, &probe.input, MAX_RENDER_FIELD);
+        if out.contains(&probe.needle) {
+            match probe.class {
+                "secret" => raw_secret_leak_count += 1,
+                "pii" => raw_pii_leak_count += 1,
+                "control" => terminal_control_leak_count += 1,
+                _ => {}
+            }
+        }
+    }
+
+    // Benign near-matches must survive rendering (not over-redacted, not encoded away).
+    let benign_preserved = BENIGN
+        .iter()
+        .all(|probe| render_safe(sink, &probe.input, MAX_RENDER_FIELD).contains(&probe.needle));
+
+    // Differential: redact-before-truncate must not leak where truncate-first would, proving order.
+    let boundary = HOSTILE
+        .iter()
+        .find(|x| x.name == "long_secret_prefix")
+        .expect("corpus has long_secret_prefix");
+    let safe = render_safe(sink, &boundary.input, MAX_RENDER_FIELD);
+    let unsafe_out = render_truncate_first_unsafe(sink, &boundary.input, MAX_RENDER_FIELD);
+    let redaction_before_truncation = !safe.contains("ghp_") && unsafe_out.contains("ghp_");
+
+    SinkConformance {
+        sink: sink.as_str().to_string(),
+        renderer: "assay-core".to_string(),
+        hostile_probe_count: HOSTILE.len(),
+        benign_control_count: BENIGN.len(),
+        raw_secret_leak_count,
+        raw_pii_leak_count,
+        terminal_control_leak_count,
+        redaction_before_truncation,
+        benign_preserved,
+        sink_specific_encoding: sink.encoding().to_string(),
+    }
+}
+
+/// Run the corpus through every sink and produce the conformance report.
+pub fn run_conformance() -> RenderSafetyConformance {
+    RenderSafetyConformance {
+        schema: SCHEMA.to_string(),
+        corpus_digest: corpus_digest(),
+        sinks: Sink::ALL.iter().map(|s| sink_conformance(*s)).collect(),
+    }
+}
+
+/// A conformance report is clean only when every sink leaks nothing, preserves benign output, and
+/// honours redaction-before-truncation.
+pub fn is_clean(report: &RenderSafetyConformance) -> bool {
+    report.schema == SCHEMA
+        && !report.sinks.is_empty()
+        && report.sinks.iter().all(|s| {
+            s.raw_secret_leak_count == 0
+                && s.raw_pii_leak_count == 0
+                && s.terminal_control_leak_count == 0
+                && s.benign_preserved
+                && s.redaction_before_truncation
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conformance_is_clean_across_all_sinks() {
+        let report = run_conformance();
+        assert_eq!(report.sinks.len(), Sink::ALL.len());
+        assert!(
+            is_clean(&report),
+            "render-safety conformance not clean: {report:?}"
+        );
+    }
+}

--- a/crates/assay-core/src/render_safety/conformance.rs
+++ b/crates/assay-core/src/render_safety/conformance.rs
@@ -6,7 +6,9 @@
 //! on THIS conformance, not on the capture receipt (which proves only that capture redaction ran).
 
 use super::corpus::{corpus_digest, BENIGN, HOSTILE};
-use super::{render_safe, render_truncate_first_unsafe, Sink, MAX_RENDER_FIELD};
+use super::{
+    has_residual_control, render_safe, render_truncate_first_unsafe, Sink, MAX_RENDER_FIELD,
+};
 use serde::{Deserialize, Serialize};
 
 pub const SCHEMA: &str = "assay.render_safety_conformance.v0";
@@ -39,13 +41,16 @@ fn sink_conformance(sink: Sink) -> SinkConformance {
 
     for probe in HOSTILE.iter() {
         let out = render_safe(sink, &probe.input, MAX_RENDER_FIELD);
-        if out.contains(&probe.needle) {
-            match probe.class {
-                "secret" => raw_secret_leak_count += 1,
-                "pii" => raw_pii_leak_count += 1,
-                "control" => terminal_control_leak_count += 1,
-                _ => {}
+        match probe.class {
+            // Control: reject ANY residual terminal/bidi control, not just this probe's needle.
+            "control" => {
+                if has_residual_control(&out) {
+                    terminal_control_leak_count += 1;
+                }
             }
+            "secret" if out.contains(&probe.needle) => raw_secret_leak_count += 1,
+            "pii" if out.contains(&probe.needle) => raw_pii_leak_count += 1,
+            _ => {}
         }
     }
 

--- a/crates/assay-core/src/render_safety/corpus.rs
+++ b/crates/assay-core/src/render_safety/corpus.rs
@@ -1,0 +1,94 @@
+//! Shared render-safety corpus (MCP01a), mirroring the E38/M3 secret-sink corpus.
+//!
+//! Two-sided by construction: `HOSTILE` probes MUST be neutralised in every sink; `BENIGN` near
+//! matches MUST survive (an over-aggressive renderer must not look "safe" by destroying useful
+//! output). Hostile values are obviously-fake shapes; the PEM marker is assembled from split tokens
+//! so no contiguous private-key marker is committed.
+
+use lazy_static::lazy_static;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+/// A corpus entry. For HOSTILE, `needle` is the dangerous substring that must be ABSENT from rendered
+/// output; for BENIGN, `needle` is an identifying substring that must SURVIVE rendering.
+pub struct Probe {
+    pub name: &'static str,
+    pub class: &'static str, // "secret" | "pii" | "control" | "benign"
+    pub input: String,
+    pub needle: String,
+}
+
+fn p(name: &'static str, class: &'static str, input: String, needle: String) -> Probe {
+    Probe {
+        name,
+        class,
+        input,
+        needle,
+    }
+}
+
+lazy_static! {
+    /// Assembled from split tokens so no contiguous private-key marker is committed to source.
+    static ref FAKE_PEM: String = format!("{}{}{}", "-----BEGIN ", "PRIVATE ", "KEY-----");
+    pub static ref HOSTILE: Vec<Probe> = {
+        let github = format!("ghp_{}", "A".repeat(36));
+        let aws = format!("AKIA{}", "A".repeat(16));
+        // Built from split tokens so no contiguous fake-credential literal is committed to source.
+        let bearer = format!("Bearer {}", "abcdABCD0123".repeat(2));
+        let slack = format!("xoxb-{}", "0123456789abcdef");
+        // A word-separated token near the truncation boundary: redact-first replaces it whole;
+        // truncate-first cuts it so the shape no longer matches and a raw `ghp_` fragment leaks.
+        let boundary = format!("{} ghp_{}", "x".repeat(239), "D".repeat(36));
+        vec![
+            p("github_pat", "secret", github.clone(), github),
+            p("aws_key", "secret", aws.clone(), aws),
+            p("bearer_token", "secret", bearer.clone(), bearer),
+            p("slack_token", "secret", slack.clone(), slack),
+            p("private_key", "secret", FAKE_PEM.clone(), FAKE_PEM.clone()),
+            p("email", "pii", "alice@example.com".to_string(), "alice@example.com".to_string()),
+            p("slack_user_id", "pii", "U01ABCDEFG".to_string(), "U01ABCDEFG".to_string()),
+            p("ansi_escape", "control", "\u{1b}[31mRED\u{1b}[0m".to_string(), "\u{1b}".to_string()),
+            p("unicode_bidi", "control", "\u{202e}reversed\u{202c}".to_string(), "\u{202e}".to_string()),
+            // Secret near the truncation boundary: guards redact-before-truncate.
+            p("long_secret_prefix", "secret", boundary, "ghp_".to_string()),
+        ]
+    };
+    pub static ref BENIGN: Vec<Probe> = vec![
+        p("fake_short_token", "benign", "tok_12345".to_string(), "tok_12345".to_string()),
+        p(
+            "schema_text",
+            "benign",
+            "assay.mcp_server_inventory.v0".to_string(),
+            "mcp_server_inventory".to_string(),
+        ),
+        p(
+            "ordinary_uuid",
+            "benign",
+            "id 123e4567-e89b-12d3-a456-426614174000".to_string(),
+            "123e4567".to_string(),
+        ),
+        p(
+            "content_hash",
+            "benign",
+            format!("digest sha256:{}", "a".repeat(64)),
+            "sha256:".to_string(),
+        ),
+        p(
+            "non_secret_path",
+            "benign",
+            "/usr/local/bin/assay".to_string(),
+            "/usr/local/bin/assay".to_string(),
+        ),
+    ];
+}
+
+/// Deterministic content digest over the corpus (names + inputs), so the conformance report binds the
+/// exact corpus it was run against.
+pub fn corpus_digest() -> String {
+    let value = json!({
+        "hostile": HOSTILE.iter().map(|x| json!({"name": x.name, "input": x.input})).collect::<Vec<_>>(),
+        "benign": BENIGN.iter().map(|x| json!({"name": x.name, "input": x.input})).collect::<Vec<_>>(),
+    });
+    let bytes = serde_jcs::to_vec(&value).expect("corpus is JSON-serializable");
+    format!("sha256:{}", hex::encode(Sha256::digest(&bytes)))
+}

--- a/crates/assay-core/src/render_safety/mod.rs
+++ b/crates/assay-core/src/render_safety/mod.rs
@@ -47,11 +47,14 @@ impl Sink {
         }
     }
 
-    /// The name of the sink-specific final encoding.
+    /// The name of the sink-specific final encoding. Structured sinks (json/sarif/otel) return the
+    /// value-safe text and let their serializer escape it (`*_serializer` / `attribute_value`); the
+    /// adapter must not pre-escape or a downstream serde serializer would double-encode. String-built
+    /// sinks (junit/markdown) neutralize active markup in-adapter.
     pub fn encoding(self) -> &'static str {
         match self {
             Sink::Stdout => "terminal_safe",
-            Sink::Json | Sink::Sarif => "json_string",
+            Sink::Json | Sink::Sarif => "json_serializer",
             Sink::Junit => "xml_escape",
             Sink::Markdown => "markdown_neutralize",
             Sink::Otel => "attribute_value",
@@ -128,6 +131,21 @@ pub fn strip_control(input: &str) -> String {
     CONTROL_RE.replace_all(&no_esc, "\u{fffd}").into_owned()
 }
 
+/// True if any terminal-control or Unicode bidi-formatting character remains (tab/newline/CR are
+/// allowed). The conformance leak predicate for control-class probes: stronger than matching a single
+/// corpus needle, it rejects ANY residual control in rendered output.
+pub fn has_residual_control(s: &str) -> bool {
+    s.chars().any(|c| {
+        c == '\u{7f}'
+            || ('\u{00}'..='\u{08}').contains(&c)
+            || c == '\u{0b}'
+            || c == '\u{0c}'
+            || ('\u{0e}'..='\u{1f}').contains(&c)
+            || ('\u{202a}'..='\u{202e}').contains(&c)
+            || ('\u{2066}'..='\u{2069}').contains(&c)
+    })
+}
+
 fn bound(text: &str, max_len: usize) -> String {
     if text.chars().count() <= max_len {
         return text.to_string();
@@ -154,13 +172,14 @@ fn markdown_neutralize(s: &str) -> String {
 }
 
 /// The sink-specific final encode, applied to already-redacted, control-stripped, bounded text.
+///
+/// Structured sinks (stdout/otel/json/sarif) return the value-safe text unchanged: the value is
+/// placed into a JSON/attribute structure whose serializer (serde) applies escaping, so pre-escaping
+/// here would double-encode. String-built sinks (junit/markdown) neutralize active markup themselves
+/// because their output is often concatenated, not serializer-escaped.
 fn encode(sink: Sink, text: &str) -> String {
     match sink {
-        Sink::Stdout | Sink::Otel => text.to_string(),
-        // JSON / SARIF messages are JSON strings: emit the escaped string literal (with quotes).
-        Sink::Json | Sink::Sarif => {
-            serde_json::to_string(text).unwrap_or_else(|_| "\"\"".to_string())
-        }
+        Sink::Stdout | Sink::Otel | Sink::Json | Sink::Sarif => text.to_string(),
         Sink::Junit => xml_escape(text),
         Sink::Markdown => markdown_neutralize(text),
     }
@@ -200,8 +219,7 @@ mod tests {
     use super::*;
 
     fn has_control(s: &str) -> bool {
-        s.chars()
-            .any(|c| c == '\u{1b}' || c == '\u{07}' || ('\u{202a}'..='\u{202e}').contains(&c))
+        s.contains('\u{1b}') || s.contains('\u{07}') || has_residual_control(s)
     }
 
     #[test]
@@ -271,6 +289,16 @@ mod tests {
     fn sink_encodings_are_distinct_where_expected() {
         assert_eq!(Sink::Junit.encoding(), "xml_escape");
         assert_eq!(Sink::Markdown.encoding(), "markdown_neutralize");
-        assert_eq!(Sink::Sarif.encoding(), "json_string");
+        // Structured sinks defer escaping to their serializer (no in-adapter pre-escape).
+        assert_eq!(Sink::Sarif.encoding(), "json_serializer");
+    }
+
+    #[test]
+    fn structured_sinks_return_unescaped_value_text() {
+        // A benign value with JSON-special chars must come back unescaped, so a downstream serde
+        // serializer does not double-encode it. (Active-markup sinks still neutralize in-adapter.)
+        let v = r#"path "C:\tmp" <ok>"#;
+        assert_eq!(render_safe(Sink::Json, v, MAX_RENDER_FIELD), v);
+        assert!(render_safe(Sink::Junit, v, MAX_RENDER_FIELD).contains("&lt;ok&gt;"));
     }
 }

--- a/crates/assay-core/src/render_safety/mod.rs
+++ b/crates/assay-core/src/render_safety/mod.rs
@@ -1,0 +1,276 @@
+//! Render-side sink safety (MCP01a slice 1).
+//!
+//! A pipeline, not one universal renderer: `strip control -> redact -> truncate -> sink-specific
+//! encode`. Control is stripped BEFORE redaction so an attacker cannot hide a secret from the
+//! detector by gluing terminal-control bytes into it (`ghp\x1b[m_...` would otherwise break the
+//! word boundary, dodge the rule, then surface once control is stripped). The load-bearing invariant
+//! is **redact-before-truncate** (so a secret can never survive as a truncated prefix); the final
+//! encode is the sink boundary, applied to already-stripped, redacted, bounded text. Capture-side
+//! redaction (ADR-034) is a separate, earlier layer; this protects what reaches a rendered sink.
+//!
+//! Scoped value rule: raw credential values must not appear in public/report sinks. This module does
+//! not manage secret lifecycle, rotation or vaulting; detection is pattern-based and may miss a novel
+//! format (see `rules`). It is the producer half of the MCP01a render-safety conformance.
+
+pub mod conformance;
+pub mod corpus;
+pub mod rules;
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::collections::BTreeMap;
+
+/// Default bound for a rendered field, mirroring the Plimsoll sink-safe renderer.
+pub const MAX_RENDER_FIELD: usize = 256;
+const TRUNCATION_MARKER: &str = "(truncated)";
+
+/// A render sink. The pipeline order is shared; only the final encode differs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sink {
+    Stdout,
+    Json,
+    Sarif,
+    Junit,
+    Markdown,
+    Otel,
+}
+
+impl Sink {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Sink::Stdout => "stdout",
+            Sink::Json => "json",
+            Sink::Sarif => "sarif",
+            Sink::Junit => "junit",
+            Sink::Markdown => "markdown",
+            Sink::Otel => "otel",
+        }
+    }
+
+    /// The name of the sink-specific final encoding.
+    pub fn encoding(self) -> &'static str {
+        match self {
+            Sink::Stdout => "terminal_safe",
+            Sink::Json | Sink::Sarif => "json_string",
+            Sink::Junit => "xml_escape",
+            Sink::Markdown => "markdown_neutralize",
+            Sink::Otel => "attribute_value",
+        }
+    }
+
+    pub const ALL: [Sink; 6] = [
+        Sink::Stdout,
+        Sink::Json,
+        Sink::Sarif,
+        Sink::Junit,
+        Sink::Markdown,
+        Sink::Otel,
+    ];
+}
+
+/// The outcome of redaction: the value-free text plus which rule classes fired.
+#[derive(Debug, Clone, Default)]
+pub struct RedactOutcome {
+    pub text: String,
+    pub fired: BTreeMap<String, u64>,
+    pub secret_hits: u64,
+    pub pii_hits: u64,
+}
+
+/// Redact secret/PII shapes, replacing each match with a value-free `<redacted:RULE>` placeholder.
+/// Idempotent over its own placeholders (they carry no secret shape).
+pub fn redact(input: &str) -> RedactOutcome {
+    let mut text = input.to_string();
+    let mut fired: BTreeMap<String, u64> = BTreeMap::new();
+    let mut secret_hits = 0u64;
+    let mut pii_hits = 0u64;
+    for rule in rules::RULES.iter() {
+        let count = rule.re.find_iter(&text).count() as u64;
+        if count == 0 {
+            continue;
+        }
+        *fired.entry(rule.name.to_string()).or_insert(0) += count;
+        match rule.class {
+            "secret" => secret_hits += count,
+            "pii" => pii_hits += count,
+            _ => {}
+        }
+        let placeholder = format!("<redacted:{}>", rule.name);
+        text = rule
+            .re
+            .replace_all(&text, placeholder.as_str())
+            .into_owned();
+    }
+    RedactOutcome {
+        text,
+        fired,
+        secret_hits,
+        pii_hits,
+    }
+}
+
+lazy_static! {
+    // ESC-introduced sequences: CSI (`ESC [ ... final`) and OSC (`ESC ] ... BEL|ESC\`).
+    static ref ANSI_RE: Regex =
+        Regex::new(r"\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)").unwrap();
+    // Any remaining lone ESC.
+    static ref LONE_ESC: Regex = Regex::new(r"\x1b").unwrap();
+    // C0/C1 control (keep \t \n \r), DEL, and Unicode bidi formatting overrides.
+    static ref CONTROL_RE: Regex =
+        Regex::new(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\u{202a}-\u{202e}\u{2066}-\u{2069}]").unwrap();
+}
+
+/// Strip terminal-control: ANSI/OSC sequences, BEL, other C0/C1 controls (keeping tab/newline/CR),
+/// and Unicode bidi overrides. Stripped control becomes U+FFFD so the removal is visible.
+pub fn strip_control(input: &str) -> String {
+    let no_ansi = ANSI_RE.replace_all(input, "");
+    let no_esc = LONE_ESC.replace_all(&no_ansi, "\u{fffd}");
+    CONTROL_RE.replace_all(&no_esc, "\u{fffd}").into_owned()
+}
+
+fn bound(text: &str, max_len: usize) -> String {
+    if text.chars().count() <= max_len {
+        return text.to_string();
+    }
+    let truncated: String = text.chars().take(max_len).collect();
+    format!("{truncated}{TRUNCATION_MARKER}")
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn markdown_neutralize(s: &str) -> String {
+    s.replace('`', "\\`")
+        .replace("](", "\\]\\(")
+        .replace("![", "\\!\\[")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace("javascript:", "javascript\\:")
+}
+
+/// The sink-specific final encode, applied to already-redacted, control-stripped, bounded text.
+fn encode(sink: Sink, text: &str) -> String {
+    match sink {
+        Sink::Stdout | Sink::Otel => text.to_string(),
+        // JSON / SARIF messages are JSON strings: emit the escaped string literal (with quotes).
+        Sink::Json | Sink::Sarif => {
+            serde_json::to_string(text).unwrap_or_else(|_| "\"\"".to_string())
+        }
+        Sink::Junit => xml_escape(text),
+        Sink::Markdown => markdown_neutralize(text),
+    }
+}
+
+/// Render `input` safely for `sink`: strip control -> redact -> truncate -> sink-encode.
+/// Control-strip precedes redaction (anti-evasion); redact-before-truncate is the leak invariant;
+/// encode is the sink boundary on already-safe text. Returns the redaction outcome for accounting.
+pub fn render_safe_with_outcome(
+    sink: Sink,
+    input: &str,
+    max_len: usize,
+) -> (String, RedactOutcome) {
+    let stripped = strip_control(input);
+    let redacted = redact(&stripped);
+    let bounded = bound(&redacted.text, max_len);
+    (encode(sink, &bounded), redacted)
+}
+
+/// Render `input` safely for `sink` (see [`render_safe_with_outcome`]).
+pub fn render_safe(sink: Sink, input: &str, max_len: usize) -> String {
+    render_safe_with_outcome(sink, input, max_len).0
+}
+
+/// DELIBERATELY WRONG order (truncate raw input FIRST, then redact): used only by the differential
+/// test to prove that this order leaks a truncated secret prefix. Never call this in product code.
+#[doc(hidden)]
+pub fn render_truncate_first_unsafe(sink: Sink, input: &str, max_len: usize) -> String {
+    let bounded = bound(input, max_len);
+    let stripped = strip_control(&bounded);
+    let redacted = redact(&stripped);
+    encode(sink, &redacted.text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn has_control(s: &str) -> bool {
+        s.chars()
+            .any(|c| c == '\u{1b}' || c == '\u{07}' || ('\u{202a}'..='\u{202e}').contains(&c))
+    }
+
+    #[test]
+    fn redacts_secret_shapes_value_free() {
+        let token = format!("ghp_{}", "A".repeat(36));
+        let out = redact(&format!("here is {token} ok"));
+        assert!(out.text.contains("<redacted:github-token>"));
+        assert!(!out.text.contains(&token));
+        assert_eq!(out.secret_hits, 1);
+    }
+
+    #[test]
+    fn strips_terminal_control() {
+        let s = "\u{1b}[31mRED\u{1b}[0m\u{07}\u{202e}rev";
+        let out = strip_control(s);
+        assert!(!has_control(&out));
+        assert!(out.contains("RED"));
+    }
+
+    #[test]
+    fn render_safe_never_leaks_across_sinks() {
+        let secret = format!("ghp_{}", "B".repeat(36));
+        let input = format!("\u{1b}[31m{secret}\u{1b}[0m alice@example.com");
+        for sink in Sink::ALL {
+            let out = render_safe(sink, &input, MAX_RENDER_FIELD);
+            assert!(!out.contains(&secret), "{} leaked secret", sink.as_str());
+            assert!(
+                !out.contains("alice@example.com"),
+                "{} leaked pii",
+                sink.as_str()
+            );
+            assert!(!has_control(&out), "{} leaked control", sink.as_str());
+        }
+    }
+
+    #[test]
+    fn redact_before_truncate_does_not_leak_but_wrong_order_does() {
+        // A secret placed near the truncation boundary: truncate-first cuts it so the shape no longer
+        // matches and a raw `ghp_` fragment leaks; redact-first replaces it whole before bounding.
+        let secret = format!("ghp_{}", "C".repeat(36));
+        let input = format!("{} {secret}", "x".repeat(239));
+        let safe = render_safe(Sink::Stdout, &input, MAX_RENDER_FIELD);
+        assert!(
+            !safe.contains("ghp_"),
+            "redact-before-truncate must not leak"
+        );
+        let unsafe_out = render_truncate_first_unsafe(Sink::Stdout, &input, MAX_RENDER_FIELD);
+        assert!(
+            unsafe_out.contains("ghp_"),
+            "truncate-first is expected to leak"
+        );
+    }
+
+    #[test]
+    fn benign_near_matches_survive() {
+        let benign =
+            "uuid 123e4567-e89b-12d3-a456-426614174000 sha256:deadbeef path /usr/bin/assay";
+        let out = redact(benign);
+        assert!(
+            !out.text.contains("<redacted:"),
+            "benign text over-redacted: {}",
+            out.text
+        );
+    }
+
+    #[test]
+    fn sink_encodings_are_distinct_where_expected() {
+        assert_eq!(Sink::Junit.encoding(), "xml_escape");
+        assert_eq!(Sink::Markdown.encoding(), "markdown_neutralize");
+        assert_eq!(Sink::Sarif.encoding(), "json_string");
+    }
+}

--- a/crates/assay-core/src/render_safety/rules.rs
+++ b/crates/assay-core/src/render_safety/rules.rs
@@ -1,0 +1,75 @@
+//! Curated secret/PII shape rules for render-side redaction (MCP01a).
+//!
+//! Patterns mirror the capture-side redactor (`assay-runner-core::redact`) and the Plimsoll detector
+//! (`plimsoll/secrets.py`) so the three layers share one rule vocabulary. High-signal, low false
+//! positive: no generic entropy scan (sha256 digests / content ids are legitimately high-entropy in
+//! evidence and must survive). A match is replaced by a value-free `<redacted:RULE>` placeholder; the
+//! matched value is never emitted.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+/// `(rule name, class, compiled pattern)`. `class` is "secret" or "pii" (drives leak accounting).
+pub struct Rule {
+    pub name: &'static str,
+    pub class: &'static str,
+    pub re: Regex,
+}
+
+lazy_static! {
+    pub static ref RULES: Vec<Rule> = vec![
+        rule(
+            "aws-access-key-id",
+            "secret",
+            r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"
+        ),
+        rule("github-token", "secret", r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"),
+        rule(
+            "openai-key",
+            "secret",
+            r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b"
+        ),
+        rule("slack-token", "secret", r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+        rule("google-api-key", "secret", r"\bAIza[0-9A-Za-z_-]{35}\b"),
+        rule(
+            "stripe-key",
+            "secret",
+            r"\b[sp]k_(?:live|test)_[0-9A-Za-z]{16,}\b"
+        ),
+        rule(
+            "private-key-pem",
+            "secret",
+            r"-----BEGIN (?:[A-Z ]*)PRIVATE KEY-----"
+        ),
+        rule(
+            "jwt",
+            "secret",
+            r"\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b",
+        ),
+        rule(
+            "bearer-token",
+            "secret",
+            r"(?i)\bbearer\s+[A-Za-z0-9._~+/-]{20,}=*"
+        ),
+        rule(
+            "sensitive-query-param",
+            "secret",
+            r#"(?i)\b(?:access[_-]?token|refresh[_-]?token|sig|signature)=[^&\s#"']{6,}"#,
+        ),
+        rule(
+            "credential-assignment",
+            "secret",
+            r#"(?i)\b(?:api[_-]?key|secret|token|password|passwd|access[_-]?key|client[_-]?secret)\b\s*[=:]\s*[^\s'"]{6,}"#,
+        ),
+        rule("email", "pii", r"[\w.+-]+@[\w-]+\.[\w.]+"),
+        rule("slack-user-id", "pii", r"\b[UW][A-Z0-9]{8,10}\b"),
+    ];
+}
+
+fn rule(name: &'static str, class: &'static str, pattern: &str) -> Rule {
+    Rule {
+        name,
+        class,
+        re: Regex::new(pattern).expect("render-safety rule pattern is a valid regex"),
+    }
+}

--- a/crates/assay-core/tests/fixtures/render_safety_conformance.v0.golden.json
+++ b/crates/assay-core/tests/fixtures/render_safety_conformance.v0.golden.json
@@ -1,0 +1,78 @@
+{
+  "schema": "assay.render_safety_conformance.v0",
+  "corpus_digest": "sha256:c903b6ec1246f0b4298f3e07f41346c0803873cf5f91a0a63cb1e75e5652eb5c",
+  "sinks": [
+    {
+      "sink": "stdout",
+      "renderer": "assay-core",
+      "hostile_probe_count": 10,
+      "benign_control_count": 5,
+      "raw_secret_leak_count": 0,
+      "raw_pii_leak_count": 0,
+      "terminal_control_leak_count": 0,
+      "redaction_before_truncation": true,
+      "benign_preserved": true,
+      "sink_specific_encoding": "terminal_safe"
+    },
+    {
+      "sink": "json",
+      "renderer": "assay-core",
+      "hostile_probe_count": 10,
+      "benign_control_count": 5,
+      "raw_secret_leak_count": 0,
+      "raw_pii_leak_count": 0,
+      "terminal_control_leak_count": 0,
+      "redaction_before_truncation": true,
+      "benign_preserved": true,
+      "sink_specific_encoding": "json_string"
+    },
+    {
+      "sink": "sarif",
+      "renderer": "assay-core",
+      "hostile_probe_count": 10,
+      "benign_control_count": 5,
+      "raw_secret_leak_count": 0,
+      "raw_pii_leak_count": 0,
+      "terminal_control_leak_count": 0,
+      "redaction_before_truncation": true,
+      "benign_preserved": true,
+      "sink_specific_encoding": "json_string"
+    },
+    {
+      "sink": "junit",
+      "renderer": "assay-core",
+      "hostile_probe_count": 10,
+      "benign_control_count": 5,
+      "raw_secret_leak_count": 0,
+      "raw_pii_leak_count": 0,
+      "terminal_control_leak_count": 0,
+      "redaction_before_truncation": true,
+      "benign_preserved": true,
+      "sink_specific_encoding": "xml_escape"
+    },
+    {
+      "sink": "markdown",
+      "renderer": "assay-core",
+      "hostile_probe_count": 10,
+      "benign_control_count": 5,
+      "raw_secret_leak_count": 0,
+      "raw_pii_leak_count": 0,
+      "terminal_control_leak_count": 0,
+      "redaction_before_truncation": true,
+      "benign_preserved": true,
+      "sink_specific_encoding": "markdown_neutralize"
+    },
+    {
+      "sink": "otel",
+      "renderer": "assay-core",
+      "hostile_probe_count": 10,
+      "benign_control_count": 5,
+      "raw_secret_leak_count": 0,
+      "raw_pii_leak_count": 0,
+      "terminal_control_leak_count": 0,
+      "redaction_before_truncation": true,
+      "benign_preserved": true,
+      "sink_specific_encoding": "attribute_value"
+    }
+  ]
+}

--- a/crates/assay-core/tests/fixtures/render_safety_conformance.v0.golden.json
+++ b/crates/assay-core/tests/fixtures/render_safety_conformance.v0.golden.json
@@ -24,7 +24,7 @@
       "terminal_control_leak_count": 0,
       "redaction_before_truncation": true,
       "benign_preserved": true,
-      "sink_specific_encoding": "json_string"
+      "sink_specific_encoding": "json_serializer"
     },
     {
       "sink": "sarif",
@@ -36,7 +36,7 @@
       "terminal_control_leak_count": 0,
       "redaction_before_truncation": true,
       "benign_preserved": true,
-      "sink_specific_encoding": "json_string"
+      "sink_specific_encoding": "json_serializer"
     },
     {
       "sink": "junit",

--- a/crates/assay-core/tests/render_safety_conformance.rs
+++ b/crates/assay-core/tests/render_safety_conformance.rs
@@ -1,0 +1,30 @@
+//! Golden contract for `assay.render_safety_conformance.v0` (MCP01a).
+//!
+//! Pins the render-sink conformance report produced by the real render-safety pipeline over the
+//! shared corpus. Regenerate intentionally with `ASSAY_UPDATE_GOLDEN=1`.
+
+use assay_core::render_safety::conformance::{is_clean, run_conformance, RenderSafetyConformance};
+
+const GOLDEN: &str = "tests/fixtures/render_safety_conformance.v0.golden.json";
+
+#[test]
+fn conformance_matches_golden_fixture() {
+    let report = run_conformance();
+    let rendered = format!("{}\n", serde_json::to_string_pretty(&report).unwrap());
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(GOLDEN);
+
+    if std::env::var("ASSAY_UPDATE_GOLDEN").is_ok() {
+        std::fs::write(&path, &rendered).unwrap();
+    }
+
+    let golden = std::fs::read_to_string(&path).expect("golden fixture exists");
+    let golden_report: RenderSafetyConformance = serde_json::from_str(&golden).unwrap();
+    assert_eq!(
+        report, golden_report,
+        "render-safety conformance drifted from golden"
+    );
+    assert!(
+        is_clean(&golden_report),
+        "committed golden conformance is not clean"
+    );
+}

--- a/crates/assay-runner-schema/src/health.rs
+++ b/crates/assay-runner-schema/src/health.rs
@@ -20,6 +20,53 @@ pub struct Redaction {
     pub key_id: String,
 }
 
+/// Schema id for the standalone, versioned capture-side redaction receipt (MCP01a).
+pub const REDACTION_RECEIPT_SCHEMA: &str = "assay.redaction_receipt.v0";
+
+/// Standalone, versioned capture-side redaction receipt: the ADR-034 `Redaction` summary promoted to
+/// a first-class carrier so it can be emitted and consumed on its own, not only nested in
+/// observation_health. Capture evidence ONLY — it proves redaction ran at capture, NOT that rendered
+/// sinks are safe (that is `assay.render_safety_conformance.v0`). MCP01 Strong is not claimed from
+/// this receipt alone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RedactionReceipt {
+    pub schema: String,
+    #[serde(flatten)]
+    pub redaction: Redaction,
+}
+
+/// Expectation-aware consumer reading of a redaction receipt (the value a reviewer gates on).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RedactionReceiptStatus {
+    /// `shape_and_flag` | `shape_only`: capture redaction was active.
+    Active,
+    /// `disabled_unsafe`: redaction was off — hard not-clean, the evidence may carry raw credentials.
+    Blocked,
+    /// An unrecognised mode: not reviewed, never silently clean.
+    Unsupported,
+}
+
+impl RedactionReceipt {
+    pub fn new(redaction: Redaction) -> Self {
+        Self {
+            schema: REDACTION_RECEIPT_SCHEMA.to_string(),
+            redaction,
+        }
+    }
+
+    /// The gate reading. `disabled_unsafe` blocks; a recognised active mode is active; anything else
+    /// is unsupported (never clean). A *missing* receipt is the consumer's concern (incomplete), not
+    /// representable here.
+    pub fn status(&self) -> RedactionReceiptStatus {
+        match self.redaction.mode.as_str() {
+            "shape_and_flag" | "shape_only" => RedactionReceiptStatus::Active,
+            "disabled_unsafe" => RedactionReceiptStatus::Blocked,
+            _ => RedactionReceiptStatus::Unsupported,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum KernelLayerStatus {
@@ -196,6 +243,46 @@ impl ObservationHealth {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_redaction(mode: &str) -> Redaction {
+        Redaction {
+            mode: mode.to_string(),
+            redacted_count: 2,
+            by_rule: BTreeMap::from([("github-token".to_string(), 2u64)]),
+            by_field: BTreeMap::from([("process_execs".to_string(), 2u64)]),
+            key_scope: "host_local".to_string(),
+            key_id: "hmac-sha256:abc123".to_string(),
+        }
+    }
+
+    #[test]
+    fn redaction_receipt_contract_shape_and_roundtrip() {
+        let receipt = RedactionReceipt::new(sample_redaction("shape_and_flag"));
+        let value = serde_json::to_value(&receipt).unwrap();
+        // The schema tag sits alongside the flattened receipt fields (a standalone carrier shape).
+        assert_eq!(value["schema"], "assay.redaction_receipt.v0");
+        assert_eq!(value["mode"], "shape_and_flag");
+        assert_eq!(value["redacted_count"], 2);
+        assert_eq!(value["key_id"], "hmac-sha256:abc123");
+        let back: RedactionReceipt = serde_json::from_value(value).unwrap();
+        assert_eq!(back, receipt);
+    }
+
+    #[test]
+    fn redaction_receipt_status_is_expectation_aware() {
+        assert_eq!(
+            RedactionReceipt::new(sample_redaction("shape_and_flag")).status(),
+            RedactionReceiptStatus::Active
+        );
+        assert_eq!(
+            RedactionReceipt::new(sample_redaction("disabled_unsafe")).status(),
+            RedactionReceiptStatus::Blocked
+        );
+        assert_eq!(
+            RedactionReceipt::new(sample_redaction("future_mode")).status(),
+            RedactionReceiptStatus::Unsupported
+        );
+    }
 
     #[test]
     fn ringbuf_drops_force_partial_kernel_layer() {

--- a/crates/assay-runner-schema/src/lib.rs
+++ b/crates/assay-runner-schema/src/lib.rs
@@ -47,7 +47,8 @@ pub use fidelity::{
 pub use health::{
     CgroupCorrelationStatus, KernelLayerStatus, NetworkEndpointClaimScope,
     NetworkProtocolCoverageStatus, ObservationHealth, ObservationHealthError, PolicyLayerStatus,
-    Redaction, SdkLayerStatus, OBSERVATION_HEALTH_SCHEMA,
+    Redaction, RedactionReceipt, RedactionReceiptStatus, SdkLayerStatus, OBSERVATION_HEALTH_SCHEMA,
+    REDACTION_RECEIPT_SCHEMA,
 };
 pub use sdk_event::{SdkLayerEvent, SDK_EVENT_SCHEMA};
 pub use surface::{CapabilitySurface, CapabilitySurfaceError, CAPABILITY_SURFACE_SCHEMA};


### PR DESCRIPTION
First slice of the MCP01 promotion arc (Token/Secret Exposure). Productises **E38/M3**'s
redaction-before-render guarantee into a reusable, proven render-safety primitive, plus the two-part
gate-1 evidence (capture receipt + render conformance).

## What lands
- **`assay-core::render_safety`** — a pipeline, not one universal renderer:
  `strip control → redact → truncate → sink-specific encode`, with sink adapters for
  stdout / json / sarif / junit / markdown / otel.
- **Control-strip runs before redaction** (anti-evasion): terminal-control bytes glued into a secret
  (`ghp\x1b[m_…`) would otherwise break the detector's word boundary and surface once control is
  stripped. A test pins this.
- **redact-before-truncate** is the leak invariant; a `wrong_order_would_leak` differential proves
  truncate-first leaks a secret prefix.
- **Shared corpus** split into hostile probes (must neutralise) and benign near-matches (must
  survive — `benign_not_overredacted` is first-class). Fake shapes only; no contiguous secret
  literal is committed (PEM marker and fake tokens are assembled from split tokens).
- **`assay.render_safety_conformance.v0`** — a per-sink report over the real pipeline, with a
  committed golden fixture (`ASSAY_UPDATE_GOLDEN` to regenerate). The MCP01 Strong claim hangs on
  this conformance, not on the capture receipt.
- **`assay.redaction_receipt.v0`** — the ADR-034 capture receipt promoted to a standalone versioned
  contract (`RedactionReceipt`) with an expectation-aware `status` (active / blocked on
  `disabled_unsafe` / unsupported) + contract tests. Capture evidence only.

## Scope
MCP01a-1 (assay render-safety primitive + conformance + receipt contract). **Adoption by the existing
CLI formatters is MCP01a-2; the exact-renderer real-input proof + M6 witness is MCP01a-4.** Not in
scope here: Plimsoll consumer, inbound-token args/env conformance, the public OWASP relabel.

Non-claims: detection is pattern-based and may miss a novel format; this does not manage secret
lifecycle, rotation or vaulting; capture redaction (the receipt) is a separate layer from render
safety (the conformance).

Verified: `render_safety` unit tests (7), conformance golden, receipt contract (2); clippy
`-D warnings` and `fmt --check` clean across assay-core + assay-runner-schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-sink render-safety sanitization that redacts secrets and PII and strips harmful terminal/control characters before output encoding.
  * Introduced render-safety conformance reporting (schema versioned) to verify leakage behavior per output sink.
  * Added a versioned redaction receipt schema and status types for capture-side redaction evidence.
* **Tests**
  * Added a render-safety conformance integration test that validates output against a golden fixture (with optional golden update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->