### PR TITLE
feat(render-safety): MCP01a-5 wire assay run formatters through render_safety

### DIFF
--- a/crates/assay-core/src/render_safety/mod.rs
+++ b/crates/assay-core/src/render_safety/mod.rs
@@ -204,6 +204,76 @@ pub fn render_safe(sink: Sink, input: &str, max_len: usize) -> String {
     render_safe_with_outcome(sink, input, max_len).0
 }
 
+/// Object keys whose string values carry untrusted model / agent / tool / user content and must be
+/// rendered sink-safe wherever they appear in a `details` tree or result row. Everything not on this
+/// list (assay-owned ids, schema names, reason codes, status enums, artifact digests, timestamps,
+/// counts, policy ids, fingerprints) stays raw. The list IS the safety boundary: a key matches by
+/// name at any depth, and once inside an untrusted-keyed subtree every string leaf is untrusted (so a
+/// structured `expected`/`actual`/`assertions[].message` is covered without enumerating its shape).
+pub const UNTRUSTED_FIELDS: &[&str] = &[
+    "prompt",
+    "response",
+    "output",
+    "error",
+    "rationale",
+    "message",
+    "expected",
+    "actual",
+    "diff",
+    "tool_output",
+    "stdout",
+    "stderr",
+];
+
+fn is_untrusted_key(key: &str) -> bool {
+    UNTRUSTED_FIELDS.contains(&key)
+}
+
+/// Recursively render the untrusted string leaves of a `details` / result JSON value safe for `sink`,
+/// leaving assay-owned keys structurally untouched (byte-stable, not merely no-op'd). A string leaf is
+/// untrusted when its own key — or any ancestor key — is in [`UNTRUSTED_FIELDS`]; numbers, bools and
+/// null pass through unchanged. This is the recursive allowlist-by-key-name companion to
+/// [`render_safe`], for whole-blob sinks (the `run.json` serializer) where each field cannot be wired
+/// by hand. `max_len` bounds each rendered leaf; pass [`usize::MAX`] for a record sink that must keep
+/// full (redacted) content rather than a truncated preview.
+pub fn render_details_safe(
+    sink: Sink,
+    value: &serde_json::Value,
+    max_len: usize,
+) -> serde_json::Value {
+    render_details_inner(sink, value, max_len, false)
+}
+
+fn render_details_inner(
+    sink: Sink,
+    value: &serde_json::Value,
+    max_len: usize,
+    in_untrusted: bool,
+) -> serde_json::Value {
+    use serde_json::Value;
+    match value {
+        Value::String(s) if in_untrusted => Value::String(render_safe(sink, s, max_len)),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|v| render_details_inner(sink, v, max_len, in_untrusted))
+                .collect(),
+        ),
+        Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                let child_untrusted = in_untrusted || is_untrusted_key(k);
+                out.insert(
+                    k.clone(),
+                    render_details_inner(sink, v, max_len, child_untrusted),
+                );
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
 /// DELIBERATELY WRONG order (truncate raw input FIRST, then redact): used only by the differential
 /// test to prove that this order leaks a truncated secret prefix. Never call this in product code.
 #[doc(hidden)]
@@ -291,6 +361,59 @@ mod tests {
         assert_eq!(Sink::Markdown.encoding(), "markdown_neutralize");
         // Structured sinks defer escaping to their serializer (no in-adapter pre-escape).
         assert_eq!(Sink::Sarif.encoding(), "json_serializer");
+    }
+
+    #[test]
+    fn details_walker_redacts_untrusted_keeps_owned_byte_stable() {
+        let secret = format!("ghp_{}", "D".repeat(36));
+        let email = "alice@example.com";
+        let details = serde_json::json!({
+            "prompt": format!("ask {secret}"),
+            "assertions": [{ "message": format!("got {email}") }, { "passed": true }],
+            "expected": "uuid 123e4567-e89b-12d3-a456-426614174000",
+            "skip": { "fingerprint": "abc123def456", "reason": "fingerprint_match" },
+            "score_pct": 42,
+        });
+        let safe = render_details_safe(Sink::Json, &details, usize::MAX);
+        let blob = safe.to_string();
+        // Untrusted leaves redacted (prompt at any depth, assertions[].message nested).
+        assert!(!blob.contains(&secret), "prompt secret leaked");
+        assert!(!blob.contains(email), "nested assertion pii leaked");
+        assert!(blob.contains("<redacted:"), "no redaction markers fired");
+        // Benign content UNDER an untrusted key survives (no over-redaction).
+        assert_eq!(
+            safe["expected"],
+            serde_json::json!("uuid 123e4567-e89b-12d3-a456-426614174000")
+        );
+        // Assay-owned keys are structurally untouched (not merely a render_safe no-op).
+        assert_eq!(
+            safe["skip"]["fingerprint"],
+            serde_json::json!("abc123def456")
+        );
+        assert_eq!(
+            safe["skip"]["reason"],
+            serde_json::json!("fingerprint_match")
+        );
+        assert_eq!(safe["score_pct"], serde_json::json!(42));
+        // A non-string leaf under an untrusted-keyed subtree passes through.
+        assert_eq!(safe["assertions"][1]["passed"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn details_walker_record_sink_keeps_full_length_but_strips_secret() {
+        // run.json is a record sink: redact + control-strip, but no truncation marker (usize::MAX).
+        let secret = format!("ghp_{}", "E".repeat(36));
+        let long = format!("{} {secret}", "z".repeat(400));
+        let details = serde_json::json!({ "response": long });
+        let safe = render_details_safe(Sink::Json, &details, usize::MAX);
+        let rendered = safe["response"].as_str().unwrap();
+        assert!(!rendered.contains(&secret), "record sink leaked secret");
+        assert!(rendered.contains("<redacted:github-token>"));
+        assert!(
+            !rendered.contains("(truncated)"),
+            "record sink must not truncate"
+        );
+        assert!(rendered.len() > 400, "record sink preserved full length");
     }
 
     #[test]

--- a/crates/assay-core/src/report/console.rs
+++ b/crates/assay-core/src/report/console.rs
@@ -1,8 +1,27 @@
 use crate::model::{TestResultRow, TestStatus};
+use crate::render_safety::{render_safe, Sink, MAX_RENDER_FIELD};
 use crate::report::progress::{ProgressEvent, ProgressSink};
 use crate::report::summary::{JudgeMetrics, Seeds};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+/// Inline-preview bound for a failing test's prompt on the console.
+const CONSOLE_PROMPT_MAX: usize = 100;
+
+/// Render a failing test's prompt for the console preview. Render-safety (MCP01a): the prompt is
+/// untrusted model/agent content, so it is redacted and control-stripped BEFORE the 100-char display
+/// bound (the load-bearing redact-before-truncate order — a secret can never survive as a truncated
+/// prefix). Char-based bounding also removes the prior `&prompt[..100]` UTF-8 boundary panic. Pure and
+/// unit-testable.
+pub fn console_prompt_preview(prompt: &str) -> String {
+    render_safe(Sink::Stdout, prompt, CONSOLE_PROMPT_MAX)
+}
+
+/// Render an untrusted result/assertion message safe for the terminal sink (redact, control-strip,
+/// bound). Used for every model-derived string the console prints.
+fn safe_msg(s: &str) -> String {
+    render_safe(Sink::Stdout, s, MAX_RENDER_FIELD)
+}
 
 // --- E4.3 Progress N/M (throttled, completion-order) ---
 
@@ -196,46 +215,45 @@ pub fn print_summary(results: &[TestResultRow], explain_skip: bool) {
                 flaky += 1;
                 eprintln!("⚠️  {:<20} FLAKY {}", r.test_id, duration);
                 if !r.message.is_empty() {
-                    eprintln!("    {}", r.message);
+                    eprintln!("    {}", safe_msg(&r.message));
                 }
             }
             TestStatus::Unstable => {
                 unstable += 1;
                 eprintln!("⚠️  {:<20} UNSTABLE {}", r.test_id, duration);
                 if !r.message.is_empty() {
-                    eprintln!("    {}", r.message);
+                    eprintln!("    {}", safe_msg(&r.message));
                 }
             }
             TestStatus::Warn => {
                 warn += 1;
                 eprintln!("⚠️  {:<20} WARN {}", r.test_id, duration);
                 if !r.message.is_empty() {
-                    eprintln!("    {}", r.message);
+                    eprintln!("    {}", safe_msg(&r.message));
                 }
             }
             TestStatus::Fail => {
                 fail += 1;
-                eprintln!("❌ {:<20} {}  {}", r.test_id, r.message, duration);
+                eprintln!(
+                    "❌ {:<20} {}  {}",
+                    r.test_id,
+                    safe_msg(&r.message),
+                    duration
+                );
                 if let Some(prompt) = r.details.get("prompt").and_then(|p| p.as_str()) {
-                    // Truncate if extremely long, but typically we want to see it
-                    let display_prompt = if prompt.len() > 100 {
-                        format!("{}...", &prompt[..100])
-                    } else {
-                        prompt.to_string()
-                    };
-                    eprintln!("      Prompt: \"{}\"", display_prompt);
+                    eprintln!("      Prompt: \"{}\"", console_prompt_preview(prompt));
                 }
                 if let Some(failures) = r.details.get("assertions").and_then(|a| a.as_array()) {
                     for f in failures {
                         if let Some(msg) = f.get("message").and_then(|m| m.as_str()) {
-                            eprintln!("      → {}", msg);
+                            eprintln!("      → {}", safe_msg(msg));
                         }
                     }
                 }
             }
             TestStatus::Error => {
                 error += 1;
-                eprintln!("💥 {:<20} ERROR: {}", r.test_id, r.message);
+                eprintln!("💥 {:<20} ERROR: {}", r.test_id, safe_msg(&r.message));
             }
         }
     }

--- a/crates/assay-core/src/report/console.rs
+++ b/crates/assay-core/src/report/console.rs
@@ -162,7 +162,7 @@ pub fn print_summary(results: &[TestResultRow], explain_skip: bool) {
                 };
                 eprintln!("{} {:<20} {}  {}", icon, r.test_id, score_str, duration);
                 if r.status == TestStatus::AllowedOnError {
-                    eprintln!("    (Allowed by error policy: {})", r.message);
+                    eprintln!("    (Allowed by error policy: {})", safe_msg(&r.message));
                 }
             }
             TestStatus::Skipped => {
@@ -208,7 +208,7 @@ pub fn print_summary(results: &[TestResultRow], explain_skip: bool) {
                     }
                     eprintln!("    To rerun: assay run --refresh-cache");
                 } else {
-                    eprintln!("⏭️  {:<20} SKIPPED ({})", r.test_id, r.message);
+                    eprintln!("⏭️  {:<20} SKIPPED ({})", r.test_id, safe_msg(&r.message));
                 }
             }
             TestStatus::Flaky => {

--- a/crates/assay-core/src/report/json.rs
+++ b/crates/assay-core/src/report/json.rs
@@ -1,3 +1,4 @@
+use crate::render_safety::{render_details_safe, Sink};
 use crate::report::RunArtifacts;
 use std::path::Path;
 
@@ -6,13 +7,20 @@ use std::path::Path;
 /// Single source of truth for the JSON report shape: both the file writer
 /// ([`write_json`]) and stdout emission (`assay run --format json`) use it,
 /// so the on-disk and piped representations never diverge.
+///
+/// Render-safety (MCP01a): the untrusted model / agent / tool content carried in result `message`
+/// and `details.*` is rendered through the render-safety pipeline before serialization, so a raw
+/// credential / PII / terminal-control value never reaches `run.json`. As a record sink it redacts
+/// and control-strips but does NOT truncate (`usize::MAX`): the eval record keeps full, redacted
+/// content. Assay-owned keys (ids, status, score, fingerprint, skip.*) stay byte-stable.
 pub fn render_json(artifacts: &RunArtifacts) -> anyhow::Result<String> {
     let v = serde_json::json!({
         "run_id": artifacts.run_id,
         "suite": artifacts.suite,
         "results": artifacts.results,
     });
-    Ok(serde_json::to_string_pretty(&v)?)
+    let safe = render_details_safe(Sink::Json, &v, usize::MAX);
+    Ok(serde_json::to_string_pretty(&safe)?)
 }
 
 pub fn write_json(artifacts: &RunArtifacts, out: &Path) -> anyhow::Result<()> {

--- a/crates/assay-core/src/report/junit.rs
+++ b/crates/assay-core/src/report/junit.rs
@@ -1,5 +1,15 @@
 use crate::model::{TestResultRow, TestStatus};
+use crate::render_safety::{render_safe, Sink, MAX_RENDER_FIELD};
 use std::path::Path;
+
+/// Render-safety (MCP01a): an untrusted result `message` carries model content, so it is rendered
+/// through the render-safety pipeline (redact, control-strip, bound) which also performs the JUnit
+/// XML-escape itself. This REPLACES the plain [`escape`] call on these fields rather than wrapping it,
+/// so the value is never XML-escaped twice. Assay/config-owned `suite` and `test_id` keep plain
+/// [`escape`] (XML-escape only, no redaction).
+fn safe_message(s: &str) -> String {
+    render_safe(Sink::Junit, s, MAX_RENDER_FIELD)
+}
 
 pub fn write_junit(suite: &str, results: &[TestResultRow], out: &Path) -> anyhow::Result<()> {
     let mut xml = String::new();
@@ -12,9 +22,10 @@ pub fn write_junit(suite: &str, results: &[TestResultRow], out: &Path) -> anyhow
         xml.push_str(&format!(r#"  <testcase name="{}">"#, escape(&r.test_id)));
         match r.status {
             TestStatus::Pass | TestStatus::AllowedOnError => {}
-            TestStatus::Skipped => {
-                xml.push_str(&format!(r#"<skipped message="{}"/>"#, escape(&r.message)))
-            }
+            TestStatus::Skipped => xml.push_str(&format!(
+                r#"<skipped message="{}"/>"#,
+                safe_message(&r.message)
+            )),
             TestStatus::Warn | TestStatus::Flaky | TestStatus::Unstable => {
                 // Use clear warning label in system-out
                 let label = match r.status {
@@ -25,15 +36,17 @@ pub fn write_junit(suite: &str, results: &[TestResultRow], out: &Path) -> anyhow
                 xml.push_str(&format!(
                     r#"<system-out>{}: {}</system-out>"#,
                     label,
-                    escape(&r.message)
+                    safe_message(&r.message)
                 ));
             }
-            TestStatus::Fail => {
-                xml.push_str(&format!(r#"<failure message="{}"/>"#, escape(&r.message)))
-            }
-            TestStatus::Error => {
-                xml.push_str(&format!(r#"<error message="{}"/>"#, escape(&r.message)))
-            }
+            TestStatus::Fail => xml.push_str(&format!(
+                r#"<failure message="{}"/>"#,
+                safe_message(&r.message)
+            )),
+            TestStatus::Error => xml.push_str(&format!(
+                r#"<error message="{}"/>"#,
+                safe_message(&r.message)
+            )),
         }
         xml.push_str("</testcase>\n");
     }

--- a/crates/assay-core/src/report/sarif.rs
+++ b/crates/assay-core/src/report/sarif.rs
@@ -1,4 +1,5 @@
 use crate::model::{TestResultRow, TestStatus};
+use crate::render_safety::{render_safe, Sink, MAX_RENDER_FIELD};
 use std::path::Path;
 
 /// Default maximum number of results to include in SARIF output.
@@ -102,7 +103,16 @@ pub fn write_sarif_with_limit(
             serde_json::json!({
                 "ruleId": "assay",
                 "level": level,
-                "message": { "text": format!("{}: {}", r.test_id, r.message) },
+                // Render-safety (MCP01a): `test_id` is assay/config-owned (serde-escaped raw);
+                // `r.message` carries untrusted model content, so it is rendered sink-safe (redacted,
+                // control-stripped, bounded) before serde escapes the final value text.
+                "message": {
+                    "text": format!(
+                        "{}: {}",
+                        r.test_id,
+                        render_safe(Sink::Sarif, &r.message, MAX_RENDER_FIELD)
+                    )
+                },
                 "locations": [{
                     "physicalLocation": {
                         "artifactLocation": { "uri": SYNTHETIC_LOCATION_URI },

--- a/crates/assay-core/tests/render_safe_run_formatters.rs
+++ b/crates/assay-core/tests/render_safe_run_formatters.rs
@@ -1,0 +1,245 @@
+//! MCP01a-5 in-slice conformance: the real `assay run` formatters render untrusted model/agent
+//! content sink-safe.
+//!
+//! This drives the actual `assay-core::report::{json,sarif,junit}` writers and the console
+//! prompt-preview helper over a planted hostile corpus and proves, end to end, the render-safety
+//! invariants for the Assay CLI sinks (the CLI analog of the Plimsoll render-safety proof):
+//!   - hostile probes (secret / PII / terminal-control) are redacted or stripped, never raw;
+//!   - control-strip precedes redaction (a control byte glued inside a token cannot hide it);
+//!   - redact-before-truncate on the bounded console preview (a secret cannot survive as a prefix);
+//!   - benign content under an untrusted key survives (no over-redaction);
+//!   - assay-owned ids / suite / fingerprint stay byte-stable;
+//!   - structured sinks stay valid (serde-escaped, never double-encoded);
+//!   - a clean (benign) row introduces no redaction markers.
+
+use assay_core::model::{TestResultRow, TestStatus};
+use assay_core::render_safety::{render_truncate_first_unsafe, Sink};
+use assay_core::report::console::console_prompt_preview;
+use assay_core::report::json::render_json;
+use assay_core::report::junit::write_junit;
+use assay_core::report::sarif::write_sarif;
+use assay_core::report::RunArtifacts;
+
+const EMAIL: &str = "alice@example.com";
+const BENIGN: &str = "uuid 123e4567-e89b-12d3-a456-426614174000";
+const ANSI: &str = "\u{1b}[31mRED\u{1b}[0m";
+const OWNED_FP: &str = "ownedfp123";
+const SUITE: &str = "owned-suite";
+
+fn secret() -> String {
+    format!("ghp_{}", "A".repeat(36))
+}
+
+/// Secret with a terminal-control sequence glued INSIDE the token: only control-strip-before-redact
+/// re-forms `ghp_…` so the rule fires. The anti-evasion case.
+fn secret_control_glued() -> String {
+    format!("ghp\u{1b}[0m_{}", "A".repeat(36))
+}
+
+/// A prompt whose secret straddles the console 100-char preview boundary: redact-first kills it,
+/// truncate-first would cut it into a non-matching `ghp_` fragment that leaks.
+fn straddling_prompt() -> String {
+    format!("{} {} tail", "x".repeat(90), secret())
+}
+
+fn row(
+    test_id: &str,
+    status: TestStatus,
+    message: String,
+    details: serde_json::Value,
+) -> TestResultRow {
+    TestResultRow {
+        test_id: test_id.to_string(),
+        status,
+        score: Some(0.0),
+        cached: false,
+        message,
+        details,
+        duration_ms: Some(5),
+        fingerprint: Some(OWNED_FP.to_string()),
+        skip_reason: None,
+        attempts: None,
+        error_policy_applied: None,
+    }
+}
+
+fn hostile_artifacts() -> RunArtifacts {
+    let fail = row(
+        "t_fail",
+        TestStatus::Fail,
+        format!("fail {ANSI} {EMAIL}"),
+        serde_json::json!({
+            "prompt": straddling_prompt(),
+            "response": secret_control_glued(),
+            "assertions": [{ "message": format!("got {}", secret()) }, { "passed": true }],
+            "expected": BENIGN,
+            "actual": format!("val {EMAIL}"),
+            "skip": { "fingerprint": OWNED_FP, "reason": "fingerprint_match" },
+            "owned_count": 7,
+        }),
+    );
+    let error = row(
+        "t_error",
+        TestStatus::Error,
+        format!("boom {}", secret()),
+        serde_json::json!({}),
+    );
+    let pass = row(
+        "t_pass",
+        TestStatus::Pass,
+        "ok".to_string(),
+        serde_json::json!({ "prompt": "benign prompt", "response": "all good" }),
+    );
+    RunArtifacts {
+        run_id: 1,
+        suite: SUITE.to_string(),
+        results: vec![fail, error, pass],
+        order_seed: None,
+        runner_clone_ms: None,
+    }
+}
+
+fn assert_no_hostile_values(haystack: &str, ctx: &str) {
+    assert!(!haystack.contains(&secret()), "{ctx}: raw secret leaked");
+    assert!(!haystack.contains("ghp_"), "{ctx}: raw token prefix leaked");
+    assert!(!haystack.contains(EMAIL), "{ctx}: raw pii leaked");
+    assert!(
+        !haystack.contains('\u{1b}'),
+        "{ctx}: raw terminal control leaked"
+    );
+}
+
+#[test]
+fn run_json_record_sink_is_render_safe() {
+    let artifacts = hostile_artifacts();
+    let out = render_json(&artifacts).unwrap();
+
+    // Structure preserved: still valid JSON (no double-encode / no broken serialization).
+    let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+    assert_no_hostile_values(&out, "run.json");
+    assert!(out.contains("<redacted:"), "run.json fired no redaction");
+
+    // Assay-owned values are byte-stable.
+    assert!(out.contains(SUITE), "suite mutated");
+    assert!(out.contains(OWNED_FP), "fingerprint mutated");
+    assert_eq!(
+        parsed["results"][0]["details"]["skip"]["fingerprint"],
+        OWNED_FP
+    );
+    assert_eq!(
+        parsed["results"][0]["details"]["skip"]["reason"],
+        "fingerprint_match"
+    );
+    assert_eq!(parsed["results"][0]["details"]["owned_count"], 7);
+    assert_eq!(parsed["results"][0]["test_id"], "t_fail");
+
+    // Benign content under an untrusted key survives (no over-redaction).
+    assert_eq!(parsed["results"][0]["details"]["expected"], BENIGN);
+
+    // Anti-evasion: a control byte glued inside the token still redacts to a clean placeholder.
+    assert_eq!(
+        parsed["results"][0]["details"]["response"],
+        "<redacted:github-token>"
+    );
+
+    // "Beyond the console's 100-char view": the record sink keeps full content, so the deep prompt
+    // secret must be REDACTED here (not merely truncated away as on the console), and not truncated.
+    let prompt = parsed["results"][0]["details"]["prompt"].as_str().unwrap();
+    assert!(
+        prompt.contains("<redacted:github-token>"),
+        "deep prompt secret not redacted"
+    );
+    assert!(!prompt.contains("ghp_"));
+    assert!(
+        !prompt.contains("(truncated)"),
+        "record sink must not truncate"
+    );
+}
+
+#[test]
+fn console_prompt_preview_redacts_before_truncating() {
+    let prompt = straddling_prompt();
+    let preview = console_prompt_preview(&prompt);
+
+    assert!(!preview.contains("ghp_"), "console preview leaked secret");
+    assert!(
+        preview.contains("<redacted"),
+        "console preview did not redact"
+    );
+    assert!(
+        preview.contains("(truncated)"),
+        "console preview did not bound"
+    );
+
+    // Differential: the OLD truncate-first order leaks a raw `ghp_` fragment at the same bound.
+    let unsafe_preview = render_truncate_first_unsafe(Sink::Stdout, &prompt, 100);
+    assert!(
+        unsafe_preview.contains("ghp_"),
+        "truncate-first is expected to leak (proves the order matters)"
+    );
+}
+
+#[test]
+fn sarif_report_sink_is_render_safe() {
+    let artifacts = hostile_artifacts();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.sarif");
+    write_sarif("assay", &artifacts.results, &path).unwrap();
+    let s = std::fs::read_to_string(&path).unwrap();
+
+    // Structure preserved.
+    let _: serde_json::Value = serde_json::from_str(&s).unwrap();
+
+    assert_no_hostile_values(&s, "sarif");
+    assert!(s.contains("redacted"), "sarif fired no redaction");
+    // Assay-owned test_id is rendered raw (serde-escaped), un-redacted.
+    assert!(s.contains("t_fail"), "sarif dropped assay-owned test_id");
+}
+
+#[test]
+fn junit_report_sink_is_render_safe_without_double_escape() {
+    let artifacts = hostile_artifacts();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.xml");
+    write_junit(SUITE, &artifacts.results, &path).unwrap();
+    let j = std::fs::read_to_string(&path).unwrap();
+
+    assert_no_hostile_values(&j, "junit");
+    // The redaction placeholder is XML-escaped exactly once (`<` -> `&lt;`), never double-escaped
+    // (`&amp;lt;`): the render-safety adapter performs the escape, replacing the plain escape().
+    assert!(
+        j.contains("&lt;redacted"),
+        "junit redaction marker not xml-escaped"
+    );
+    assert!(
+        !j.contains("&amp;lt;redacted"),
+        "junit double-escaped the marker"
+    );
+    // Assay/config-owned suite + test_id render raw (XML-escaped only).
+    assert!(j.contains(r#"name="owned-suite""#), "junit mutated suite");
+    assert!(j.contains(r#"name="t_fail""#), "junit mutated test_id");
+}
+
+#[test]
+fn benign_only_run_introduces_no_redaction_markers() {
+    // Negative control / absence assertion: a clean run must not gain any redaction marker.
+    let clean = RunArtifacts {
+        run_id: 2,
+        suite: SUITE.to_string(),
+        results: vec![row(
+            "t_clean",
+            TestStatus::Fail,
+            "expected greeting, got farewell".to_string(),
+            serde_json::json!({ "prompt": "say hello", "response": "goodbye" }),
+        )],
+        order_seed: None,
+        runner_clone_ms: None,
+    };
+    let out = render_json(&clean).unwrap();
+    assert!(
+        !out.contains("<redacted:"),
+        "benign run over-redacted: {out}"
+    );
+    assert!(out.contains("say hello") && out.contains("goodbye"));
+}

--- a/crates/assay-core/tests/render_safe_run_formatters.rs
+++ b/crates/assay-core/tests/render_safe_run_formatters.rs
@@ -90,10 +90,18 @@ fn hostile_artifacts() -> RunArtifacts {
         "ok".to_string(),
         serde_json::json!({ "prompt": "benign prompt", "response": "all good" }),
     );
+    // AllowedOnError carries the underlying provider/config error in its message (rendered raw on the
+    // console before this slice). Its message must be render-safe everywhere it surfaces.
+    let allowed = row(
+        "t_allowed",
+        TestStatus::AllowedOnError,
+        format!("allowed by error policy: provider 500 {}", secret()),
+        serde_json::json!({}),
+    );
     RunArtifacts {
         run_id: 1,
         suite: SUITE.to_string(),
-        results: vec![fail, error, pass],
+        results: vec![fail, error, pass, allowed],
         order_seed: None,
         runner_clone_ms: None,
     }
@@ -136,6 +144,16 @@ fn run_json_record_sink_is_render_safe() {
 
     // Benign content under an untrusted key survives (no over-redaction).
     assert_eq!(parsed["results"][0]["details"]["expected"], BENIGN);
+
+    // Every status's top-level message is render-safe, incl. AllowedOnError (the console paths at
+    // console.rs:165/211 route the same message through safe_msg).
+    let allowed_msg = parsed["results"][3]["message"].as_str().unwrap();
+    assert_eq!(parsed["results"][3]["test_id"], "t_allowed");
+    assert!(
+        !allowed_msg.contains("ghp_"),
+        "AllowedOnError message leaked secret"
+    );
+    assert!(allowed_msg.contains("<redacted:github-token>"));
 
     // Anti-evasion: a control byte glued inside the token still redacts to a clean placeholder.
     assert_eq!(


### PR DESCRIPTION
## What

Wires the `assay run` result formatters through the `render_safety` pipeline (shipped in #1691) so the untrusted model / agent / tool content they render is redacted, control-stripped and bounded before it reaches a sink. A raw credential, PII or terminal-control value no longer reaches the console, `run.json`, SARIF or JUnit output.

This closes a concrete gap: the console failing-test path rendered `details.prompt` raw and truncated it with `&prompt[..100]` — both un-redacted and in the wrong order (truncate before any redaction, so a secret could survive as a prefix), and a latent UTF-8 byte-slice panic.

## Sink-specific, not blanket

The wiring routes only the untrusted fields, leaving Assay's own structured ids/labels raw so structure is never broken and assay-owned values stay byte-stable.

- **console** (`report::console`): prompt preview redacted + control-stripped **before** the 100-char display bound (correct redact-before-truncate order, char-based bound removes the panic); result + assertion messages rendered safe.
- **run.json** (`report::json`): one recursive allowlist-by-key-name walk over the whole artifact. Untrusted string leaves — result `message` wherever it occurs, plus `details.*` (`prompt`/`response`/`output`/`error`/`rationale`/`expected`/`actual`/`diff`/`tool_output`/`stdout`/`stderr`) — are rendered safe; assay-owned keys (ids, status, score, fingerprint, `skip.*`) stay byte-stable. As a record sink it redacts but does **not** truncate, so the eval record keeps full (redacted) content.
- **SARIF / JUnit** (`report::sarif`, `report::junit`): the rendered result message is render-safe (bounded report sinks). For JUnit the adapter performs the XML-escape itself, **replacing** the plain `escape()` on that field so it is never escaped twice; assay/config-owned `suite` + `test_id` keep plain `escape()`.

Structured sinks (json/sarif) return value-safe text and let serde escape it — no pre-escape, no double-encode (the same discipline as the slice-1 sink adapters).

## New primitive

`render_details_safe` + the `UNTRUSTED_FIELDS` allowlist in `render_safety`. The list **is** the safety boundary: a key matches by name at any depth, and once inside an untrusted-keyed subtree every string leaf is treated as untrusted (so structured `expected`/`actual`/`assertions[].message` are covered without enumerating their shape).

## Conformance (in-slice)

`tests/render_safe_run_formatters.rs` drives the real json/sarif/junit writers and the console preview helper over a planted hostile corpus and proves, end to end:
- hostile probes (secret / PII / terminal-control) redacted or stripped, never raw;
- control-strip precedes redaction (a control byte glued **inside** a token still redacts cleanly — anti-evasion);
- redact-before-truncate on the bounded console preview, with a truncate-first differential that **does** leak (proving the order matters);
- benign content under an untrusted key survives (no over-redaction);
- assay-owned ids / suite / fingerprint byte-stable;
- structured sinks stay valid JSON;
- a benign run introduces no redaction markers (absence assertion).

## Scope / non-claims

Technical change only: the render-safety primitive, the four result formatters, and the conformance. No mapping or docs row changes here.

Explicitly **not** wired in this slice (next-widen surfaces): `summary.json` (its message is assay-owned reason text; only config-error path strings carry external content) and the OTel export (which has its own `redact_prompts` / `otel/redaction.rs` layer).

## Verification

`cargo test -p assay-core` (incl. the new conformance) and `cargo test -p assay-cli` green; `cargo clippy -p assay-core -p assay-cli --all-targets -- -D warnings` clean; `cargo fmt` applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safe rendering for report outputs (JSON, console, JUnit/XML, SARIF) to redact secrets/PII from untrusted fields while preserving legitimate identifiers.
  * Strips terminal control characters from untrusted text.
  * Console prompt previews now sanitize before truncation to avoid preview boundary leaks.

* **Tests**
  * Added end-to-end coverage verifying redaction and control-character handling across all supported formats, including truncation-order and escaping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->