### PR TITLE
fix(render-safety): route on-disk run.json through render_safety (MCP01a-5 completion)

### DIFF
--- a/crates/assay-cli/src/cli/commands/reporting.rs
+++ b/crates/assay-cli/src/cli/commands/reporting.rs
@@ -12,7 +12,7 @@ pub(crate) fn write_error_artifacts(
 ) -> anyhow::Result<i32> {
     let mut o = RunOutcome::from_reason(reason, Some(message), None);
     o.exit_code = reason.exit_code_for(version);
-    if let Err(e) = write_run_json_minimal(&o, &run_json_path.to_path_buf()) {
+    if let Err(e) = write_run_json_minimal(&o, run_json_path) {
         eprintln!("WARNING: failed to write run.json: {}", e);
     }
 

--- a/crates/assay-cli/src/cli/commands/run_output.rs
+++ b/crates/assay-cli/src/cli/commands/run_output.rs
@@ -209,7 +209,7 @@ pub(crate) fn summary_from_outcome(
 pub(crate) fn write_extended_run_json(
     artifacts: &assay_core::report::RunArtifacts,
     outcome: &crate::exit_codes::RunOutcome,
-    path: &PathBuf,
+    path: &Path,
     sarif_omitted: Option<u64>,
 ) -> anyhow::Result<()> {
     // Manually construct the JSON to inject outcome fields
@@ -264,19 +264,23 @@ pub(crate) fn write_extended_run_json(
         }
     }
 
-    // Render-safety (MCP01a-5 completion): the on-disk run.json carries the same untrusted result
-    // `message` / `details.*` content as the `--format json` stdout renderer
-    // (`assay_core::report::json::render_json`), but this file writer serialized the raw artifacts
-    // directly and so bypassed redaction. Route the assembled document through the same render-safety
-    // walk so the file matches the stdout renderer: as a record sink it redacts and control-strips
-    // but does not truncate (`usize::MAX`); assay-owned keys (ids, status, reason_code, exit_code,
-    // digests, seeds) stay byte-stable. `resolution.message` is redacted like any other `message`.
+    write_sanitized_run_json(path, v)
+}
+
+/// Sanitize a run.json document and write it. Render-safety (MCP01a-5): EVERY run.json writer routes
+/// its assembled value through the same `render_details_safe` walk as the `--format json` stdout
+/// renderer (`assay_core::report::json::render_json`), so the untrusted result `message` /
+/// `details.*` / `resolution.message` content is redacted on disk too — the file-writers used to
+/// serialize raw artifacts and bypass redaction. As a record sink it redacts and control-strips but
+/// does not truncate (`usize::MAX`); assay-owned keys (ids, status, reason_code, exit_code, digests,
+/// seeds) stay byte-stable. Shared by both the extended and minimal (early-error) writers so neither
+/// path can drift back to raw.
+fn write_sanitized_run_json(path: &Path, v: serde_json::Value) -> anyhow::Result<()> {
     let v = assay_core::render_safety::render_details_safe(
         assay_core::render_safety::Sink::Json,
         &v,
         usize::MAX,
     );
-
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -286,9 +290,11 @@ pub(crate) fn write_extended_run_json(
 
 pub(crate) fn write_run_json_minimal(
     outcome: &crate::exit_codes::RunOutcome,
-    path: &PathBuf,
+    path: &Path,
 ) -> anyhow::Result<()> {
     // Minimal JSON for early exits (no artifacts available). E7.2: seed fields present for schema stability (null when unknown).
+    // `resolution` carries the outcome (incl. its `message`, which on config/arg errors echoes
+    // external path/parse text), so this goes through the shared sanitizer like the extended writer.
     let v = serde_json::json!({
         "exit_code": outcome.exit_code,
         "reason_code": outcome.reason_code,
@@ -298,11 +304,7 @@ pub(crate) fn write_run_json_minimal(
         "judge_seed": null,
         "resolution": outcome
     });
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(path, serde_json::to_string_pretty(&v)?)?;
-    Ok(())
+    write_sanitized_run_json(path, v)
 }
 
 pub(crate) fn export_baseline(
@@ -401,6 +403,35 @@ mod run_json_render_safety_tests {
         assert_eq!(parsed["results"][0]["test_id"], "t_owned");
         assert_eq!(parsed["results"][0]["fingerprint"], "fp_owned");
         assert_eq!(parsed["reason_code"], "E_TEST_FAILED");
+    }
+
+    /// MCP01a-5 regression: the early-error / replay-failure minimal writer shares the same sanitizer,
+    /// so a config/arg-error `resolution.message` (which can echo external path/parse text) is redacted
+    /// on disk too — not just the artifact-bearing extended writer.
+    #[test]
+    fn minimal_run_json_resolution_message_is_render_safe() {
+        let secret = format!("ghp_{}", "Z".repeat(36));
+        let outcome = RunOutcome::from_reason(
+            ReasonCode::ETraceNotFound,
+            Some(format!("trace not found: {secret}")),
+            None,
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.json");
+        super::write_run_json_minimal(&outcome, &path).unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(
+            !out.contains(&secret),
+            "minimal run.json leaked secret in resolution.message"
+        );
+        assert!(!out.contains("ghp_"));
+        assert!(
+            out.contains("<redacted:"),
+            "minimal run.json fired no redaction"
+        );
+        // Assay-owned reason_code stays byte-stable.
+        assert_eq!(parsed["reason_code"], "E_TRACE_NOT_FOUND");
     }
 }
 

--- a/crates/assay-cli/src/cli/commands/run_output.rs
+++ b/crates/assay-cli/src/cli/commands/run_output.rs
@@ -389,7 +389,7 @@ mod run_json_render_safety_tests {
         // Structure preserved + hostile values gone, markers present.
         let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert!(!out.contains(&secret), "on-disk run.json leaked secret");
-        assert!(!out.contains("ghp_"));
+        assert!(!out.contains("ghp_"), "raw token prefix leaked to run.json");
         assert!(
             !out.contains("alice@example.com"),
             "on-disk run.json leaked pii"
@@ -425,7 +425,7 @@ mod run_json_render_safety_tests {
             !out.contains(&secret),
             "minimal run.json leaked secret in resolution.message"
         );
-        assert!(!out.contains("ghp_"));
+        assert!(!out.contains("ghp_"), "raw token prefix leaked to run.json");
         assert!(
             out.contains("<redacted:"),
             "minimal run.json fired no redaction"

--- a/crates/assay-cli/src/cli/commands/run_output.rs
+++ b/crates/assay-cli/src/cli/commands/run_output.rs
@@ -264,6 +264,19 @@ pub(crate) fn write_extended_run_json(
         }
     }
 
+    // Render-safety (MCP01a-5 completion): the on-disk run.json carries the same untrusted result
+    // `message` / `details.*` content as the `--format json` stdout renderer
+    // (`assay_core::report::json::render_json`), but this file writer serialized the raw artifacts
+    // directly and so bypassed redaction. Route the assembled document through the same render-safety
+    // walk so the file matches the stdout renderer: as a record sink it redacts and control-strips
+    // but does not truncate (`usize::MAX`); assay-owned keys (ids, status, reason_code, exit_code,
+    // digests, seeds) stay byte-stable. `resolution.message` is redacted like any other `message`.
+    let v = assay_core::render_safety::render_details_safe(
+        assay_core::render_safety::Sink::Json,
+        &v,
+        usize::MAX,
+    );
+
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -328,6 +341,67 @@ pub(crate) fn export_baseline(
     b.save(path)?;
     eprintln!("exported baseline to {}", path.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod run_json_render_safety_tests {
+    use super::write_extended_run_json;
+    use crate::exit_codes::{ReasonCode, RunOutcome};
+    use assay_core::model::{TestResultRow, TestStatus};
+    use assay_core::report::RunArtifacts;
+
+    /// MCP01a-5 regression: the on-disk run.json file writer must redact untrusted result
+    /// `message` / `details.*` content, matching the `--format json` stdout renderer. This guards the
+    /// gap where `write_extended_run_json` serialized raw artifacts and leaked secrets to the file.
+    #[test]
+    fn on_disk_run_json_is_render_safe() {
+        let secret = format!("ghp_{}", "A".repeat(36));
+        let artifacts = RunArtifacts {
+            run_id: 7,
+            suite: "owned-suite".into(),
+            results: vec![TestResultRow {
+                test_id: "t_owned".into(),
+                status: TestStatus::Fail,
+                score: Some(0.0),
+                cached: false,
+                message: format!("failed: leaked {secret}"),
+                details: serde_json::json!({
+                    "prompt": format!("ask {secret} alice@example.com"),
+                    "metrics": { "must_contain": { "details": { "message": format!("missing {secret}") } } },
+                }),
+                duration_ms: Some(3),
+                fingerprint: Some("fp_owned".into()),
+                skip_reason: None,
+                attempts: None,
+                error_policy_applied: None,
+            }],
+            order_seed: None,
+            runner_clone_ms: None,
+        };
+        let outcome = RunOutcome::from_reason(ReasonCode::ETestFailed, None, None);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.json");
+        write_extended_run_json(&artifacts, &outcome, &path, None).unwrap();
+        let out = std::fs::read_to_string(&path).unwrap();
+
+        // Structure preserved + hostile values gone, markers present.
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(!out.contains(&secret), "on-disk run.json leaked secret");
+        assert!(!out.contains("ghp_"));
+        assert!(
+            !out.contains("alice@example.com"),
+            "on-disk run.json leaked pii"
+        );
+        assert!(
+            out.contains("<redacted:"),
+            "on-disk run.json fired no redaction"
+        );
+        // Assay-owned fields stay byte-stable.
+        assert_eq!(parsed["suite"], "owned-suite");
+        assert_eq!(parsed["results"][0]["test_id"], "t_owned");
+        assert_eq!(parsed["results"][0]["fingerprint"], "fp_owned");
+        assert_eq!(parsed["reason_code"], "E_TEST_FAILED");
+    }
 }
 
 #[cfg(test)]

--- a/crates/assay-cli/tests/run_json_render_safety.rs
+++ b/crates/assay-cli/tests/run_json_render_safety.rs
@@ -1,0 +1,74 @@
+//! MCP01a-5 real-command regression: a real `assay run` invocation must write a render-safe
+//! `run.json` to disk.
+//!
+//! The original gap was precisely the difference between the safe `--format json` stdout renderer and
+//! the on-disk artifact writer, so a writer-level unit test alone would not have caught it. This drives
+//! the actual binary (`CARGO_BIN_EXE_assay`) over a planted trace whose prompt carries a secret + PII,
+//! reads the on-disk `run.json`, and asserts the file redacts (raw absent AND marker present) while
+//! staying valid JSON.
+
+use std::process::Command;
+
+#[test]
+fn assay_run_writes_render_safe_run_json_to_disk() {
+    let secret = format!("ghp_{}", "A".repeat(36));
+    let email = "alice@example.com";
+    let prompt = format!("leak {secret} {email}");
+
+    let dir = tempfile::tempdir().unwrap();
+    // The eval input.prompt is the trace-match key, so config and trace carry the identical string.
+    let cfg = format!(
+        "version: 1\nsuite: rs_witness\nmodel: trace\nsettings:\n  cache: false\ntests:\n  \
+         - id: leak_row\n    input:\n      prompt: {p}\n    expected:\n      type: must_contain\n      \
+         must_contain: [\"ABSENT_TOKEN_NEVER_PRESENT\"]\n",
+        p = serde_json::to_string(&prompt).unwrap()
+    );
+    std::fs::write(dir.path().join("eval.yaml"), cfg).unwrap();
+    let entry = serde_json::json!({
+        "schema_version": 1, "type": "assay.trace", "request_id": "rs_0",
+        "prompt": prompt, "response": "benign assistant reply, no secret",
+        "model": "trace", "provider": "trace", "meta": {}
+    });
+    std::fs::write(dir.path().join("trace.jsonl"), format!("{entry}\n")).unwrap();
+
+    // run.json is written to the cwd regardless of pass/fail, so run inside the temp dir.
+    let status = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .current_dir(dir.path())
+        .args([
+            "run",
+            "--config",
+            "eval.yaml",
+            "--trace-file",
+            "trace.jsonl",
+            "--db",
+            ":memory:",
+        ])
+        .output()
+        .expect("failed to run assay binary");
+    // The test asserts on the artifact, not the exit code (a failing eval is exit 1 by design).
+    let _ = status;
+
+    let run_json = std::fs::read_to_string(dir.path().join("run.json"))
+        .expect("assay run did not write run.json");
+
+    // Structure intact + hostile values gone + redaction actually fired (not silently omitted).
+    let _: serde_json::Value = serde_json::from_str(&run_json).unwrap();
+    assert!(
+        !run_json.contains(&secret),
+        "real `assay run` leaked the secret to run.json on disk"
+    );
+    assert!(!run_json.contains("ghp_"));
+    assert!(
+        !run_json.contains(email),
+        "real `assay run` leaked PII to run.json on disk"
+    );
+    assert!(
+        run_json.contains("<redacted:"),
+        "run.json shows no redaction marker (field rendered raw or silently omitted)"
+    );
+    // Non-vacuity: the planted prompt actually reached the rendered field (its benign part survives).
+    assert!(
+        run_json.contains("leak "),
+        "planted prompt did not reach run.json details"
+    );
+}

--- a/crates/assay-cli/tests/run_json_render_safety.rs
+++ b/crates/assay-cli/tests/run_json_render_safety.rs
@@ -57,7 +57,10 @@ fn assay_run_writes_render_safe_run_json_to_disk() {
         !run_json.contains(&secret),
         "real `assay run` leaked the secret to run.json on disk"
     );
-    assert!(!run_json.contains("ghp_"));
+    assert!(
+        !run_json.contains("ghp_"),
+        "real `assay run` leaked a raw token prefix to run.json on disk"
+    );
     assert!(
         !run_json.contains(email),
         "real `assay run` leaked PII to run.json on disk"


### PR DESCRIPTION
## What

The MCP01a-5 wiring ([#1693](https://github.com/Rul1an/assay/pull/1693)) routed `assay-core::report::json::render_json` — the `--format json` **stdout** renderer — through the render-safety pipeline. But the on-disk **`run.json` file** is written by a different function, `write_extended_run_json` in assay-cli, which serialized the raw `RunArtifacts` directly and so bypassed redaction.

Both `assay run` and `assay ci` write the file via that function, so the shipped `run.json` leaked raw result `message` / `details.*` content (secrets, PII) even though the stdout path was safe.

## Fix

Route the assembled run.json document through the same `render_details_safe(Sink::Json, …, usize::MAX)` walk as the stdout renderer, just before writing. As a record sink it redacts and control-strips but does not truncate; assay-owned keys (ids, status, `reason_code`, `exit_code`, seeds, fingerprint) stay byte-stable, and `resolution.message` is redacted like any other `message`.

## How it was found

The MCP01a-6 real-artifact witness (private experiments harness) drives a real `assay ci` over a planted hostile corpus and verifies the four CLI sinks from the generated bytes. Console, SARIF and JUnit were clean; `run.json` still carried the raw secret — which surfaced this file-writer gap that the unit-level conformance (which tested `render_json`) could not see.

## Verification

New regression test `on_disk_run_json_is_render_safe` builds artifacts with a planted secret in `message` + `details.*`, calls `write_extended_run_json`, and asserts the file redacts (no raw secret/PII, markers present) while assay-owned fields stay byte-stable. `cargo test -p assay-cli` green; `cargo clippy -p assay-cli --all-targets -- -D warnings` clean; `cargo fmt` applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved on-disk `run.json` generation to reliably sanitize and redact untrusted content (including nested fields) so secrets and sensitive text aren’t written, while keeping system-owned metadata intact.

* **Tests**
  * Added regression coverage for both extended and minimal JSON outputs, including nested redaction behavior.
  * Added an end-to-end CLI test that runs `assay run`, verifies the output is valid JSON, confirms the planted secret/email are removed, ensures a redaction marker appears, and checks that the expected rendered prompt content is still reachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->