### PR TITLE
docs(security): MCP01 Partial → Strong (scoped) in OWASP MCP mapping

### DIFF
--- a/docs/DISTRIBUTION-SUBMISSION-GUIDE.md
+++ b/docs/DISTRIBUTION-SUBMISSION-GUIDE.md
@@ -29,7 +29,7 @@ Per kanaal: link, stappen, en exact wat in te vullen. Laatste verificatie: 2026-
 ```
 Assay is a policy-as-code proxy that sits between AI agents (Cursor, Claude, etc.) and their MCP tool servers. Every tool call gets an explicit ALLOW or DENY, and every decision produces a tamper-evident evidence bundle you can audit, diff, and replay.
 
-The problem: the average MCP server scores 34/100 on security (https://dev.to/elliotllliu/we-scanned-17-popular-mcp-servers-heres-what-we-found-321c). Assay gives you the policy gate and audit trail to fix that. Covers 7 of 10 OWASP MCP Top 10 risks.
+The problem: the average MCP server scores 34/100 on security (https://dev.to/elliotllliu/we-scanned-17-popular-mcp-servers-heres-what-we-found-321c). Assay gives you the policy gate and audit trail to fix that. Covers 9 of 10 OWASP MCP Top 10 risks.
 
 Quick start (2 commands):
   cargo install assay-cli
@@ -91,7 +91,7 @@ assay mcp wrap --policy policy.yaml -- your-mcp-server
 SARIF results in GitHub Security tab.
 
 ## OWASP coverage
-Assay covers 7 of 10 OWASP MCP Top 10 risks. [Full mapping](https://github.com/Rul1an/assay/blob/main/docs/security/OWASP-MCP-TOP10-MAPPING.md).
+Assay covers 9 of 10 OWASP MCP Top 10 risks. [Full mapping](https://github.com/Rul1an/assay/blob/main/docs/security/OWASP-MCP-TOP10-MAPPING.md).
 
 ## Links
 - [GitHub](https://github.com/Rul1an/assay)
@@ -137,7 +137,7 @@ cargo install assay-cli
 assay mcp wrap --policy policy.yaml -- npx @modelcontextprotocol/server-filesystem /tmp/demo
 ```
 
-**Differentiator:** Deterministic, offline-first, no API keys. Covers 7/10 OWASP MCP Top 10 risks. Evidence bundles are tamper-evident and replayable.
+**Differentiator:** Deterministic, offline-first, no API keys. Covers 9/10 OWASP MCP Top 10 risks. Evidence bundles are tamper-evident and replayable.
 
 MIT licensed. [GitHub](https://github.com/Rul1an/assay)
 ```
@@ -192,7 +192,7 @@ MIT licensed. [GitHub](https://github.com/Rul1an/assay)
 | Veld | Waarde |
 |------|--------|
 | **Server name** | `Assay` |
-| **Description** | `The firewall for MCP tool calls. Policy-as-code enforcement with replayable evidence bundles. Block, audit, replay. Covers 7/10 OWASP MCP Top 10.` |
+| **Description** | `The firewall for MCP tool calls. Policy-as-code enforcement with replayable evidence bundles. Block, audit, replay. Covers 9/10 OWASP MCP Top 10.` |
 | **Category** | Security / Developer Tools |
 | **Pricing** | Free |
 | **GitHub** | `https://github.com/Rul1an/assay` (zonder www. — `www.github.com` faalt de security scan) |
@@ -337,7 +337,7 @@ Apigene lijkt "vendor-verified official servers" te cureren. Er is geen publiek 
 ### Suggestie
 Stuur mail naar hun contact met:
 - **Onderwerp:** `Request to add Assay to MCP Server Directory`
-- **Body:** Assay is an open-source MCP policy firewall with evidence bundles. GitHub: https://github.com/Rul1an/assay. Covers 7/10 OWASP MCP Top 10. Would like to be listed in the Apigene directory.
+- **Body:** Assay is an open-source MCP policy firewall with evidence bundles. GitHub: https://github.com/Rul1an/assay. Covers 9/10 OWASP MCP Top 10. Would like to be listed in the Apigene directory.
 
 ---
 
@@ -371,7 +371,7 @@ Assay is an open-source policy-as-code proxy for MCP tool calls. It sits between
 - MCP02 (Privilege Escalation): restrict_scope enforcement
 - MCP05 (Command Injection): Policy deny, argument validation
 - MCP07 (Auth): approval_required, mandate system
-- Covers 7/10 OWASP MCP Top 10 risks
+- Covers 9/10 OWASP MCP Top 10 risks
 
 ## Installation
 ```bash
@@ -458,7 +458,7 @@ Geen duidelijk submit-formulier gevonden. Mogelijk via contact of "Add" op de si
 
 ### Suggestie voor contact
 - **Onderwerp:** `Add Assay — MCP policy firewall`
-- **Body:** Assay is an open-source MCP tool-call firewall with replayable evidence bundles. GitHub: https://github.com/Rul1an/assay. Covers 7/10 OWASP MCP Top 10. Would like to be listed.
+- **Body:** Assay is an open-source MCP tool-call firewall with replayable evidence bundles. GitHub: https://github.com/Rul1an/assay. Covers 9/10 OWASP MCP Top 10. Would like to be listed.
 
 ---
 

--- a/docs/security/OWASP-MCP-TOP10-MAPPING.md
+++ b/docs/security/OWASP-MCP-TOP10-MAPPING.md
@@ -16,7 +16,7 @@ How Assay addresses the [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top
 | Context Injection & Over-Sharing | MCP10 | Strong | `redact_args` enforcement strips sensitive fields. Context envelope hardening validates completeness. [Protocol evidence experiment](../architecture/RESULTS-EXPERIMENT-PROTOCOL-EVIDENCE-INTERPRETATION-2026q2.md) tested consumer-side interpretation. |
 
 > **Note on MCP01 "Strong (scoped)".** "Strong" here means rendered outputs carry no raw credential / PII / terminal-control values. A render-safety pipeline redacts before bounding (so a secret cannot survive as a truncated prefix) across the Assay CLI rendered sinks (console, `run.json`, SARIF, JUnit) and the Plimsoll review sinks, proven by render-safety conformance over a hostile corpus; the proxy does not re-emit a consumed inbound auth value (token-passthrough conformance). Detection is pattern-based and may miss a novel secret format. Scope is rendered sinks — not capture-side redaction, and not token lifecycle / rotation / vaulting. The Assay CLI render-safety is public; the Plimsoll review consumer is currently private. It is not Complete coverage.
-
+>
 > **Note on MCP09 "Strong (scoped)".** "Strong" here means the workflow has deterministic producer evidence and a validated review consumer. The public Assay artifact is the inventory carrier (`assay mcp inventory`); the Plimsoll review consumer is currently private, so public users can reproduce the evidence producer but not the full review/gating path from this repository alone. It does not mean Assay detects all shadow MCP servers, and it is not Complete coverage.
 
 ## Summary

--- a/docs/security/OWASP-MCP-TOP10-MAPPING.md
+++ b/docs/security/OWASP-MCP-TOP10-MAPPING.md
@@ -4,7 +4,7 @@ How Assay addresses the [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top
 
 | OWASP Risk | ID | Assay Coverage | How |
 |-----------|-----|---------------|-----|
-| Token Mismanagement & Secret Exposure | MCP01 | Partial | Evidence lint detects secrets in subjects (`ASSAY-W001`). Policy can deny tools that expose credentials. |
+| Token Mismanagement & Secret Exposure | MCP01 | Strong (scoped) | Render-safety pipeline (control-strip → redact → bound → sink-encode) over the Assay CLI rendered sinks (console, `run.json`, SARIF, JUnit) and the Plimsoll review sinks, conformance-verified; redaction precedes bounding so a secret cannot survive as a truncated prefix. Proxy credential-boundary conformance (`assay.token_passthrough_conformance.v0`) shows a consumed inbound auth value is not re-emitted on outbound headers/body/env. Evidence lint also flags secrets in subjects (`ASSAY-W001`); policy can deny credential-exposing tools. Pattern-based detection, scoped to rendered sinks. Plimsoll consumer private. See note below. |
 | Privilege Escalation via Scope Creep | MCP02 | Strong | `restrict_scope` enforcement limits tool arguments at runtime. Policy constraints enforce path/param boundaries. |
 | Tool Poisoning | MCP03 | Strong | Tool signing (`x-assay-sig`), identity verification, tool metadata hashing. [Delegation spoofing experiment](../architecture/RESULTS-EXPERIMENT-DELEGATION-SPOOFING-2026q2.md) tested trust-domain verification. |
 | Supply Chain Attacks & Dependency Tampering | MCP04 | Partial | Pack digest verification (SHA-256/JCS). Adapter identity pinning. Lockfile support in registry client. |
@@ -15,11 +15,13 @@ How Assay addresses the [OWASP MCP Top 10](https://owasp.org/www-project-mcp-top
 | Shadow MCP Servers | MCP09 | Strong (scoped) | Assay inventory carrier (`assay.mcp_server_inventory.v0`, coverage-honest, command/args hashed) + Plimsoll allowlist review over scanned config/process sources; coverage limits reported. No absence claim outside scanned sources. Plimsoll consumer private. See note below. |
 | Context Injection & Over-Sharing | MCP10 | Strong | `redact_args` enforcement strips sensitive fields. Context envelope hardening validates completeness. [Protocol evidence experiment](../architecture/RESULTS-EXPERIMENT-PROTOCOL-EVIDENCE-INTERPRETATION-2026q2.md) tested consumer-side interpretation. |
 
+> **Note on MCP01 "Strong (scoped)".** "Strong" here means rendered outputs carry no raw credential / PII / terminal-control values. A render-safety pipeline redacts before bounding (so a secret cannot survive as a truncated prefix) across the Assay CLI rendered sinks (console, `run.json`, SARIF, JUnit) and the Plimsoll review sinks, proven by render-safety conformance over a hostile corpus; the proxy does not re-emit a consumed inbound auth value (token-passthrough conformance). Detection is pattern-based and may miss a novel secret format. Scope is rendered sinks — not capture-side redaction, and not token lifecycle / rotation / vaulting. The Assay CLI render-safety is public; the Plimsoll review consumer is currently private. It is not Complete coverage.
+
 > **Note on MCP09 "Strong (scoped)".** "Strong" here means the workflow has deterministic producer evidence and a validated review consumer. The public Assay artifact is the inventory carrier (`assay mcp inventory`); the Plimsoll review consumer is currently private, so public users can reproduce the evidence producer but not the full review/gating path from this repository alone. It does not mean Assay detects all shadow MCP servers, and it is not Complete coverage.
 
 ## Summary
 
-Assay provides **Strong** or **Complete** coverage for 8 of 10 OWASP MCP risks, with **Partial** coverage for the remaining 2 (MCP01, MCP04). MCP09 is **Strong (scoped)** — see the note above.
+Assay provides **Strong** or **Complete** coverage for 9 of 10 OWASP MCP risks, with **Partial** coverage for the remaining 1 (MCP04). MCP01 and MCP09 are **Strong (scoped)** — see the notes above.
 
 The strongest alignment is with **MCP08 (Lack of Audit and Telemetry)** — Assay's evidence bundles, decision logs, and replay capabilities are a direct and comprehensive answer to this risk.
 


### PR DESCRIPTION
## What

Widens the MCP01 (Token Mismanagement & Secret Exposure) row in the OWASP MCP Top 10 mapping from **Partial** to **Strong (scoped)**, with a bounded note — mirroring the MCP09 treatment.

## Why it's earned now

The render-safety arc is wired and conformance-verified end to end:

- **Render-safety primitive + conformance** ([#1691](https://github.com/Rul1an/assay/pull/1691)) — `control-strip → redact → bound → sink-encode`, redaction before bounding so a secret cannot survive as a truncated prefix.
- **Assay CLI sinks wired** ([#1693](https://github.com/Rul1an/assay/pull/1693)) — console, run.json, SARIF, JUnit route untrusted result `message` / `details.*` through the pipeline.
- **On-disk run.json file writer** ([#1694](https://github.com/Rul1an/assay/pull/1694)) — closed the gap where the run.json *file* bypassed the renderer the stdout path used.
- **Proxy credential boundary** ([#1692](https://github.com/Rul1an/assay/pull/1692)) — `assay.token_passthrough_conformance.v0`: a consumed inbound auth value is not re-emitted on outbound headers/body/env.

A render-safety conformance over a hostile corpus confirms the rendered sinks carry no raw credential / PII / terminal-control values.

## Scope (the "scoped" qualifier)

The note states the bounds plainly: detection is pattern-based and may miss a novel secret format; scope is **rendered sinks**, not capture-side redaction and not token lifecycle / rotation / vaulting. The Assay CLI render-safety is public; the Plimsoll review consumer is currently private. It is not Complete coverage.

Docs-only; one row + one note + the summary count (now 9 of 10 Strong/Complete, MCP04 remains Partial).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Strengthened the OWASP MCP Top 10 “Assay Coverage Mapping” for MCP01, changing it to **“Strong (scoped)”** with clearer boundaries and an explicit “not complete” statement.
  * Refined MCP09 “Strong (scoped)” wording to clarify what the public artifact supports and that full review remains gated/private.
  * Updated overall coverage reporting from **8/10 to 9/10** (leaving only MCP04 as Partial).
  * Revised distribution/submission guidance and pre-filled outreach text to reflect the **9/10** coverage figure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->