### PR TITLE
feat(registry): MCP04a-3.1 offline Sigstore cert-chain primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -124,6 +124,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -435,7 +474,10 @@ dependencies = [
  "hex",
  "pkcs8 0.11.0",
  "rand 0.8.6",
+ "rcgen",
  "reqwest 0.12.28",
+ "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -444,6 +486,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tracing",
  "url",
@@ -789,6 +832,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1404,6 +1456,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,7 +1560,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1666,7 +1732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2954,7 +3020,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3158,6 +3224,15 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -4016,6 +4091,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4266,6 +4355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4275,7 +4373,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4333,7 +4431,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4738,7 +4836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4902,7 +5000,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5717,7 +5815,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6144,6 +6242,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6151,6 +6267,16 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/crates/assay-registry/Cargo.toml
+++ b/crates/assay-registry/Cargo.toml
@@ -37,6 +37,14 @@ base64 = "0.22"
 ed25519-dalek = { version = "2.1", features = ["pkcs8", "rand_core"] }
 pkcs8 = { version = "0.11", features = ["pem"] }
 
+# Sigstore offline verification (MCP04a-3): X.509 path validation only, pinned trust roots, NO network.
+# rustls-webpki is already in the tree (transitive); it does the chain validation so we never hand-roll
+# it. Sigstore policy semantics (identity, Rekor) stay separate.
+rustls-webpki = { version = "0.103", default-features = false, features = ["alloc", "std", "ring"] }
+# The DER/UnixTime/SignatureVerificationAlgorithm types webpki's API speaks live in rustls-pki-types
+# (webpki renames it to `pki_types` internally and does not re-export it). Pin the same version webpki uses.
+rustls-pki-types = "1"
+
 # Pack parsing (reuse from evidence)
 serde_jcs = "=0.2.0"
 
@@ -51,6 +59,9 @@ rand = "0.8"
 
 [dev-dependencies]
 base64 = "0.22"
+# Test-only synthetic PKI for the offline Sigstore cert-chain verifier (hermetic fixtures, no network).
+rcgen = "0.14"
+time = "0.3"
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 wiremock = "0.6"

--- a/crates/assay-registry/src/lib.rs
+++ b/crates/assay-registry/src/lib.rs
@@ -54,6 +54,7 @@ pub mod error;
 pub mod lockfile;
 pub mod reference;
 pub mod resolver;
+pub mod sigstore_offline;
 pub mod supply_chain;
 pub mod trust;
 pub mod types;

--- a/crates/assay-registry/src/sigstore_offline.rs
+++ b/crates/assay-registry/src/sigstore_offline.rs
@@ -1,0 +1,252 @@
+//! MCP04a-3.1 — offline Sigstore trust/cert primitive (cert-chain + validity window).
+//!
+//! Validates a Fulcio-style X.509 certificate chain against PINNED trust roots, entirely OFFLINE.
+//! Path validation is delegated to `rustls-webpki` (we never hand-roll it); this module only maps the
+//! outcome onto the supply-chain `CheckStatus` vocabulary. **No network: the verdict is produced solely
+//! from the certificate bytes passed in plus the pinned root bytes — there is no client, no async, no
+//! lookup.** `cert-chain-valid` is NOT `identity-authorized`: identity extraction + the Sigstore policy
+//! checks (issuer/SAN, Rekor inclusion) are separate slices (a-3.1 identity, a-3.3 Rekor).
+//!
+//! Scope (this increment): chain validation + validity-window. Status mapping (locked in the MCP04
+//! design-of-record): no pinned roots -> `TrustRootUnavailable`; chain does not validate against the
+//! pinned roots -> `Failed`; expired / not-yet-valid -> `Failed`; chain valid -> `Verified`.
+
+use rustls_pki_types::{CertificateDer, SignatureVerificationAlgorithm, UnixTime};
+use webpki::{anchor_from_trusted_cert, EndEntityCert, KeyUsage};
+
+use crate::supply_chain::CheckStatus;
+
+/// Code-signing EKU OID `1.3.6.1.5.5.7.3.3`, encoded as the OID value bytes webpki's `KeyUsage::required`
+/// expects (Fulcio leaf certificates carry this EKU).
+const EKU_CODE_SIGNING: &[u8] = &[0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x03];
+
+/// ECDSA P-256 / SHA-256 — the algorithm Fulcio leaf certificates are signed with. Pinned explicitly so
+/// the verifier accepts only what Sigstore actually uses, not an open set.
+static SUPPORTED_SIG_ALGS: &[&dyn SignatureVerificationAlgorithm] =
+    &[webpki::ring::ECDSA_P256_SHA256];
+
+/// The outcome of offline chain validation: a `CheckStatus` plus a value-free reason for the carrier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CertChainOutcome {
+    pub status: CheckStatus,
+    pub reason: &'static str,
+}
+
+impl CertChainOutcome {
+    fn new(status: CheckStatus, reason: &'static str) -> Self {
+        Self { status, reason }
+    }
+}
+
+/// Verify a leaf certificate chains to one of the PINNED roots and is within its validity window at
+/// `now_unix_secs`, fully offline. `intermediates` may be empty for a directly-issued leaf.
+///
+/// This function performs NO I/O: it reads only its byte arguments. An empty `pinned_roots` is
+/// `TrustRootUnavailable` (we hold no trust material), never a silent pass.
+pub fn verify_cert_chain_offline(
+    leaf_der: &[u8],
+    intermediates: &[&[u8]],
+    pinned_roots: &[&[u8]],
+    now_unix_secs: u64,
+) -> CertChainOutcome {
+    if pinned_roots.is_empty() {
+        return CertChainOutcome::new(CheckStatus::TrustRootUnavailable, "no pinned trust roots");
+    }
+
+    let root_ders: Vec<CertificateDer<'_>> = pinned_roots
+        .iter()
+        .map(|r| CertificateDer::from(*r))
+        .collect();
+    let mut anchors = Vec::with_capacity(root_ders.len());
+    for der in &root_ders {
+        match anchor_from_trusted_cert(der) {
+            Ok(a) => anchors.push(a),
+            Err(_) => {
+                return CertChainOutcome::new(
+                    CheckStatus::TrustRootUnavailable,
+                    "pinned trust root is not a parseable certificate",
+                )
+            }
+        }
+    }
+
+    let leaf = CertificateDer::from(leaf_der);
+    let ee = match EndEntityCert::try_from(&leaf) {
+        Ok(e) => e,
+        Err(_) => return CertChainOutcome::new(CheckStatus::Failed, "malformed leaf certificate"),
+    };
+    let inter: Vec<CertificateDer<'_>> = intermediates
+        .iter()
+        .map(|i| CertificateDer::from(*i))
+        .collect();
+    let time = UnixTime::since_unix_epoch(std::time::Duration::from_secs(now_unix_secs));
+
+    match ee.verify_for_usage(
+        SUPPORTED_SIG_ALGS,
+        &anchors,
+        &inter,
+        time,
+        KeyUsage::required(EKU_CODE_SIGNING),
+        None,
+        None,
+    ) {
+        Ok(_) => CertChainOutcome::new(CheckStatus::Verified, "chain valid"),
+        Err(webpki::Error::CertExpired { .. }) => {
+            CertChainOutcome::new(CheckStatus::Failed, "certificate expired")
+        }
+        Err(webpki::Error::CertNotValidYet { .. }) => {
+            CertChainOutcome::new(CheckStatus::Failed, "certificate not yet valid")
+        }
+        Err(webpki::Error::UnknownIssuer) => CertChainOutcome::new(
+            CheckStatus::Failed,
+            "chain does not validate against pinned roots",
+        ),
+        Err(_) => CertChainOutcome::new(CheckStatus::Failed, "certificate chain invalid"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rcgen::{
+        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
+        PKCS_ECDSA_P256_SHA256,
+    };
+    use time::{Duration, OffsetDateTime};
+
+    const NOW: u64 = 1_750_000_000; // fixed verification time for determinism
+    const IDENTITY: &str =
+        "https://github.com/example/repo/.github/workflows/release.yml@refs/tags/v1";
+
+    struct Pki {
+        ca_der: Vec<u8>,
+        leaf_der: Vec<u8>,
+    }
+
+    /// Build a synthetic CA + ECDSA-P256 leaf (code-signing EKU, SAN = IDENTITY) with the given validity
+    /// window, all in-memory. `offset_now` is the rcgen `OffsetDateTime` matching NOW for the window.
+    fn build_pki(not_before: OffsetDateTime, not_after: OffsetDateTime) -> Pki {
+        let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut leaf_params = CertificateParams::new(vec![IDENTITY.to_string()]).unwrap();
+        leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::CodeSigning];
+        leaf_params.not_before = not_before;
+        leaf_params.not_after = not_after;
+        let issuer = Issuer::from_params(&ca_params, &ca_key);
+        let leaf_cert = leaf_params.signed_by(&leaf_key, &issuer).unwrap();
+
+        Pki {
+            ca_der: ca_cert.der().to_vec(),
+            leaf_der: leaf_cert.der().to_vec(),
+        }
+    }
+
+    fn at(secs: i64) -> OffsetDateTime {
+        OffsetDateTime::from_unix_timestamp(secs).unwrap()
+    }
+
+    fn valid_window() -> Pki {
+        build_pki(
+            at(NOW as i64) - Duration::days(1),
+            at(NOW as i64) + Duration::days(1),
+        )
+    }
+
+    #[test]
+    fn valid_chain_verifies() {
+        let pki = valid_window();
+        let out = verify_cert_chain_offline(&pki.leaf_der, &[], &[&pki.ca_der], NOW);
+        assert_eq!(out.status, CheckStatus::Verified, "{}", out.reason);
+    }
+
+    #[test]
+    fn missing_trust_root_is_trust_root_unavailable() {
+        let pki = valid_window();
+        // No pinned roots at all -> we hold no trust material -> never a silent pass.
+        let out = verify_cert_chain_offline(&pki.leaf_der, &[], &[], NOW);
+        assert_eq!(out.status, CheckStatus::TrustRootUnavailable);
+    }
+
+    #[test]
+    fn bad_chain_with_unrelated_root_fails() {
+        let pki = valid_window();
+        let other = valid_window(); // a different, valid CA that did NOT sign pki.leaf
+        let out = verify_cert_chain_offline(&pki.leaf_der, &[], &[&other.ca_der], NOW);
+        assert_eq!(out.status, CheckStatus::Failed, "{}", out.reason);
+    }
+
+    #[test]
+    fn expired_cert_fails() {
+        let pki = build_pki(
+            at(NOW as i64) - Duration::days(10),
+            at(NOW as i64) - Duration::days(1),
+        );
+        let out = verify_cert_chain_offline(&pki.leaf_der, &[], &[&pki.ca_der], NOW);
+        assert_eq!(out.status, CheckStatus::Failed);
+        assert_eq!(out.reason, "certificate expired");
+    }
+
+    #[test]
+    fn not_yet_valid_cert_fails() {
+        let pki = build_pki(
+            at(NOW as i64) + Duration::days(1),
+            at(NOW as i64) + Duration::days(10),
+        );
+        let out = verify_cert_chain_offline(&pki.leaf_der, &[], &[&pki.ca_der], NOW);
+        assert_eq!(out.status, CheckStatus::Failed);
+        assert_eq!(out.reason, "certificate not yet valid");
+    }
+
+    #[test]
+    fn malformed_leaf_fails() {
+        let pki = valid_window();
+        let out = verify_cert_chain_offline(b"not a certificate", &[], &[&pki.ca_der], NOW);
+        assert_eq!(out.status, CheckStatus::Failed);
+    }
+
+    /// No-network guard (NEGATIVE): the verdict is sourced solely from the bytes passed in — the leaf,
+    /// the intermediates, and the pinned roots — never from an ambient or online trust store. The proof
+    /// is that the *same leaf* flips Verified <-> Failed purely on which root bytes we hand it:
+    ///
+    /// * correct root present       -> Verified   (succeeds entirely from bundled bytes)
+    /// * only an unrelated root      -> Failed     (the real issuer is NOT discovered/fetched)
+    /// * no roots at all             -> TrustRootUnavailable (no online fallback, no silent pass)
+    ///
+    /// A client that consulted the network (e.g. fetched the Fulcio root from TUF) could "rescue" the
+    /// unrelated-root and no-root cases into Verified. Because we never do, those cases must fail. The
+    /// trust anchor is exactly the bytes the caller pins — a pure function of its inputs.
+    #[test]
+    fn verdict_is_produced_only_from_bundled_bytes() {
+        let pki = valid_window();
+        let unrelated = valid_window(); // a different, valid CA that did NOT sign pki.leaf
+
+        // Determinism: identical inputs -> identical verdict, no hidden state or wall clock
+        // (verification time is an explicit argument).
+        let a = verify_cert_chain_offline(&pki.leaf_der, &[], &[&pki.ca_der], NOW);
+        let b = verify_cert_chain_offline(&pki.leaf_der, &[], &[&pki.ca_der], NOW);
+        assert_eq!(a, b);
+        assert_eq!(a.status, CheckStatus::Verified, "{}", a.reason);
+
+        // Same leaf, only the pinned-root set differs -> verdict flips. The trust decision comes from
+        // the passed-in roots, not from anywhere the process could reach.
+        let with_wrong_root =
+            verify_cert_chain_offline(&pki.leaf_der, &[], &[&unrelated.ca_der], NOW);
+        assert_eq!(
+            with_wrong_root.status,
+            CheckStatus::Failed,
+            "withholding the real root must fail, not trigger an online lookup: {}",
+            with_wrong_root.reason
+        );
+
+        // No roots at all -> we hold no trust material -> unavailable, never an online attempt or a
+        // silent pass.
+        assert_eq!(
+            verify_cert_chain_offline(&pki.leaf_der, &[], &[], NOW).status,
+            CheckStatus::TrustRootUnavailable
+        );
+    }
+}

--- a/crates/assay-registry/src/sigstore_offline.rs
+++ b/crates/assay-registry/src/sigstore_offline.rs
@@ -7,9 +7,10 @@
 //! lookup.** `cert-chain-valid` is NOT `identity-authorized`: identity extraction + the Sigstore policy
 //! checks (issuer/SAN, Rekor inclusion) are separate slices (a-3.1 identity, a-3.3 Rekor).
 //!
-//! Scope (this increment): chain validation + validity-window. Status mapping (locked in the MCP04
-//! design-of-record): no pinned roots -> `TrustRootUnavailable`; chain does not validate against the
-//! pinned roots -> `Failed`; expired / not-yet-valid -> `Failed`; chain valid -> `Verified`.
+//! Scope (this increment): chain validation + validity-window + the code-signing EKU requirement.
+//! Status mapping (locked in the MCP04 design-of-record): no pinned roots -> `TrustRootUnavailable`;
+//! chain does not validate against the pinned roots -> `Failed`; expired / not-yet-valid -> `Failed`;
+//! leaf lacks the required code-signing EKU -> `Failed`; chain valid -> `Verified`.
 
 use rustls_pki_types::{CertificateDer, SignatureVerificationAlgorithm, UnixTime};
 use webpki::{anchor_from_trusted_cert, EndEntityCert, KeyUsage};
@@ -101,6 +102,9 @@ pub fn verify_cert_chain_offline(
             CheckStatus::Failed,
             "chain does not validate against pinned roots",
         ),
+        Err(webpki::Error::RequiredEkuNotFoundContext(_)) => {
+            CertChainOutcome::new(CheckStatus::Failed, "required code-signing EKU absent")
+        }
         Err(_) => CertChainOutcome::new(CheckStatus::Failed, "certificate chain invalid"),
     }
 }
@@ -109,8 +113,8 @@ pub fn verify_cert_chain_offline(
 mod tests {
     use super::*;
     use rcgen::{
-        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
-        PKCS_ECDSA_P256_SHA256,
+        BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose,
+        IsCa, Issuer, KeyPair, KeyUsagePurpose, PKCS_ECDSA_P256_SHA256,
     };
     use time::{Duration, OffsetDateTime};
 
@@ -124,8 +128,18 @@ mod tests {
     }
 
     /// Build a synthetic CA + ECDSA-P256 leaf (code-signing EKU, SAN = IDENTITY) with the given validity
-    /// window, all in-memory. `offset_now` is the rcgen `OffsetDateTime` matching NOW for the window.
+    /// window, all in-memory.
     fn build_pki(not_before: OffsetDateTime, not_after: OffsetDateTime) -> Pki {
+        build_pki_with_eku(not_before, not_after, true)
+    }
+
+    /// As [`build_pki`], but `code_signing` controls whether the leaf carries the code-signing EKU. The
+    /// `false` variant exists to prove the EKU requirement is load-bearing.
+    fn build_pki_with_eku(
+        not_before: OffsetDateTime,
+        not_after: OffsetDateTime,
+        code_signing: bool,
+    ) -> Pki {
         let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
         ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
@@ -133,7 +147,9 @@ mod tests {
 
         let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let mut leaf_params = CertificateParams::new(vec![IDENTITY.to_string()]).unwrap();
-        leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::CodeSigning];
+        if code_signing {
+            leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::CodeSigning];
+        }
         leaf_params.not_before = not_before;
         leaf_params.not_after = not_after;
         let issuer = Issuer::from_params(&ca_params, &ca_key);
@@ -143,6 +159,62 @@ mod tests {
             ca_der: ca_cert.der().to_vec(),
             leaf_der: leaf_cert.der().to_vec(),
         }
+    }
+
+    /// A realistic three-tier chain `leaf -> intermediate CA -> self-signed root`, all ECDSA-P256 and
+    /// valid at NOW. Roots/intermediates carry CA:TRUE + keyCertSign (the Fulcio shape); the leaf carries
+    /// the code-signing EKU. Returns `(root_der, intermediate_der, leaf_der)`.
+    fn build_three_tier() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let nb = at(NOW as i64) - Duration::days(1);
+        let na = at(NOW as i64) + Duration::days(1);
+        let ca_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+
+        // Distinct subject names so webpki can build the path unambiguously (an empty DN on both CAs
+        // would make root and intermediate indistinguishable to name-based chain building).
+        let dn = |cn: &str| {
+            let mut d = DistinguishedName::new();
+            d.push(DnType::CommonName, cn);
+            d
+        };
+
+        // Self-signed root.
+        let root_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut root_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        root_params.distinguished_name = dn("Assay Test Root CA");
+        root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        root_params.key_usages = ca_usages.clone();
+        root_params.not_before = nb;
+        root_params.not_after = na;
+        let root_cert = root_params.self_signed(&root_key).unwrap();
+
+        // Intermediate CA, signed by the root. Faithful to the Fulcio profile: CA:TRUE with pathlen:0,
+        // CertSign+CRLSign, AND the code-signing EKU. webpki's `Required` EKU check chains through every
+        // non-anchor node, so a real Fulcio intermediate (which carries this EKU) is exactly what passes.
+        let int_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut int_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        int_params.distinguished_name = dn("Assay Test Intermediate CA");
+        int_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(0));
+        int_params.key_usages = ca_usages;
+        int_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::CodeSigning];
+        int_params.not_before = nb;
+        int_params.not_after = na;
+        let root_issuer = Issuer::from_params(&root_params, &root_key);
+        let int_cert = int_params.signed_by(&int_key, &root_issuer).unwrap();
+
+        // Leaf, signed by the intermediate.
+        let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut leaf_params = CertificateParams::new(vec![IDENTITY.to_string()]).unwrap();
+        leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::CodeSigning];
+        leaf_params.not_before = nb;
+        leaf_params.not_after = na;
+        let int_issuer = Issuer::from_params(&int_params, &int_key);
+        let leaf_cert = leaf_params.signed_by(&leaf_key, &int_issuer).unwrap();
+
+        (
+            root_cert.der().to_vec(),
+            int_cert.der().to_vec(),
+            leaf_cert.der().to_vec(),
+        )
     }
 
     fn at(secs: i64) -> OffsetDateTime {
@@ -177,6 +249,46 @@ mod tests {
         let other = valid_window(); // a different, valid CA that did NOT sign pki.leaf
         let out = verify_cert_chain_offline(&pki.leaf_der, &[], &[&other.ca_der], NOW);
         assert_eq!(out.status, CheckStatus::Failed, "{}", out.reason);
+    }
+
+    #[test]
+    fn leaf_via_intermediate_to_pinned_root_verifies() {
+        // The realistic Sigstore/Fulcio shape: leaf -> intermediate -> pinned root.
+        let (root, intermediate, leaf) = build_three_tier();
+        let out = verify_cert_chain_offline(&leaf, &[&intermediate], &[&root], NOW);
+        assert_eq!(out.status, CheckStatus::Verified, "{}", out.reason);
+    }
+
+    #[test]
+    fn missing_intermediate_fails() {
+        // Same chain, but the intermediate is withheld: the leaf cannot reach the pinned root, and we
+        // do not fetch the missing link.
+        let (root, _intermediate, leaf) = build_three_tier();
+        let out = verify_cert_chain_offline(&leaf, &[], &[&root], NOW);
+        assert_eq!(out.status, CheckStatus::Failed, "{}", out.reason);
+    }
+
+    #[test]
+    fn wrong_intermediate_fails() {
+        // An intermediate from an unrelated chain does not bridge this leaf to the pinned root.
+        let (root, _intermediate, leaf) = build_three_tier();
+        let (_other_root, other_int, _other_leaf) = build_three_tier();
+        let out = verify_cert_chain_offline(&leaf, &[&other_int], &[&root], NOW);
+        assert_eq!(out.status, CheckStatus::Failed, "{}", out.reason);
+    }
+
+    #[test]
+    fn leaf_without_code_signing_eku_fails() {
+        // An otherwise-valid leaf -> root chain, but the leaf lacks the code-signing EKU. The required
+        // EKU is load-bearing: the verifier must reject it rather than accept any end-entity cert.
+        let pki = build_pki_with_eku(
+            at(NOW as i64) - Duration::days(1),
+            at(NOW as i64) + Duration::days(1),
+            false,
+        );
+        let out = verify_cert_chain_offline(&pki.leaf_der, &[], &[&pki.ca_der], NOW);
+        assert_eq!(out.status, CheckStatus::Failed, "{}", out.reason);
+        assert_eq!(out.reason, "required code-signing EKU absent");
     }
 
     #[test]


### PR DESCRIPTION
## MCP04a-3.1 — offline Sigstore cert-chain primitive

First crypto slice of the supply-chain conformance work. Adds a small,
self-contained offline X.509 path-validation primitive for Fulcio-style
code-signing leaf certificates and maps the outcome onto the existing
`supply_chain::CheckStatus` vocabulary.

### What it does

`sigstore_offline::verify_cert_chain_offline(leaf, intermediates, pinned_roots, now)`:

- delegates path validation to `rustls-webpki` (we never hand-roll it)
- pins the algorithm set to ECDSA P-256 / SHA-256 and requires the
  code-signing EKU — only what Sigstore actually uses, not an open set
- translates the result into the carrier status:

  | situation | status |
  |---|---|
  | no pinned roots | `TrustRootUnavailable` (no silent pass) |
  | expired / not-yet-valid | `Failed` |
  | chain invalid / unrelated CA | `Failed` |
  | leaf lacks code-signing EKU | `Failed` (`required code-signing EKU absent`) |
  | chain valid against a pinned root | `Verified` |

The `Required` EKU check chains through every non-anchor node, which
matches the Fulcio certificate profile exactly: the root (trust anchor)
carries no EKU, the intermediate carries Code Signing, and so does the leaf.

### What this PR proves — and what it explicitly does not

Proves: **offline X.509 certificate path validation over pinned roots**,
plus the validity window and the code-signing EKU requirement. The verdict
is a pure function of the bytes passed in (leaf, intermediates, pinned
roots) plus an explicit verification time — no network, no client, no
async, no ambient trust store.

Does **not** prove (each is a separate later slice, never implied here):

- authorized Sigstore identity (SAN / issuer binding) — a-3.2
- Rekor transparency-log inclusion — a-3.3
- SCT / CT proof
- subject-digest binding to an artifact
- attestation validity

A valid certificate chain is a necessary but not sufficient layer:
**cert-chain-valid is not identity-authorized.**

### Tests

Eleven hermetic tests over a synthetic in-memory PKI (rcgen, dev-only):
valid direct chain, a realistic `leaf -> intermediate -> pinned root` chain
plus withheld/unrelated-intermediate negatives, missing root, unrelated
root, expired, not-yet-valid, malformed leaf, a load-bearing
no-code-signing-EKU rejection, and a **negative no-network guard** — the
same leaf flips `Verified` <-> `Failed` purely on which root bytes it is
handed, and withholding the real root fails rather than discovering it.

### Deps

- `rustls-pki-types` promoted to a direct dependency (webpki's public API
  speaks its types but does not re-export them; same version webpki uses).
- `rcgen` + `time` are dev-only, for the synthetic-PKI fixtures.
- `cargo deny` (licenses, bans, advisories, sources) passes.
