### PR TITLE
feat(registry): MCP04a-3.2a offline Sigstore identity extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "tracing",
  "url",
  "wiremock",
+ "x509-cert",
 ]
 
 [[package]]
@@ -1440,6 +1441,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468 0.7.0",
  "zeroize",
 ]
@@ -1467,6 +1470,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1844,6 +1858,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -6240,6 +6260,17 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
 
 [[package]]
 name = "x509-parser"

--- a/crates/assay-registry/Cargo.toml
+++ b/crates/assay-registry/Cargo.toml
@@ -44,6 +44,9 @@ rustls-webpki = { version = "0.103", default-features = false, features = ["allo
 # The DER/UnixTime/SignatureVerificationAlgorithm types webpki's API speaks live in rustls-pki-types
 # (webpki renames it to `pki_types` internally and does not re-export it). Pin the same version webpki uses.
 rustls-pki-types = "1"
+# MCP04a-3.2 identity extraction: DER parse of the Fulcio leaf SAN + issuer OID extension. der/spki/
+# const-oid are already in the tree at the versions x509-cert 0.2 pins, so this adds no new crypto stack.
+x509-cert = { version = "0.2", default-features = false, features = ["pem"] }
 
 # Pack parsing (reuse from evidence)
 serde_jcs = "=0.2.0"

--- a/crates/assay-registry/src/lib.rs
+++ b/crates/assay-registry/src/lib.rs
@@ -54,6 +54,7 @@ pub mod error;
 pub mod lockfile;
 pub mod reference;
 pub mod resolver;
+pub mod sigstore_identity;
 pub mod sigstore_offline;
 pub mod supply_chain;
 pub mod trust;

--- a/crates/assay-registry/src/sigstore_identity.rs
+++ b/crates/assay-registry/src/sigstore_identity.rs
@@ -1,0 +1,396 @@
+//! MCP04a-3.2a — offline Sigstore identity extraction + expected-identity match.
+//!
+//! Builds on the a-3.1 cert-chain primitive. Once the leaf chains to a pinned root, this layer reads the
+//! identity facts the Fulcio profile binds into the leaf — the single Subject Alternative Name (the
+//! workflow / signer identity) and the OIDC issuer (Fulcio issuer **v2** extension) — and compares them
+//! against the caller's EXPECTED identity. Still fully OFFLINE: it parses and compares the leaf bytes,
+//! with no network, no Rekor, and no signature / subject-digest binding (that is a-3.2b).
+//!
+//! **cert-chain-valid is NOT identity-authorized.** A leaf that chains cleanly but carries a different
+//! SAN / issuer than expected is `IdentityMismatch`, never `Verified`. The chain is a prerequisite, not a
+//! sufficient condition — so this function runs the chain check first and only looks at identity once the
+//! chain is `Verified`.
+//!
+//! Status mapping (locked in the MCP04 design-of-record):
+//! - chain does not validate -> the chain status is returned verbatim (`Failed` / `TrustRootUnavailable`)
+//! - non-empty subject -> `Failed` (Fulcio issued certs MUST have an empty subject; identity lives in SAN)
+//! - not exactly one SAN, or an unsupported SAN type -> `UnsupportedFormat`
+//! - only the deprecated v1 issuer extension present -> `UnsupportedFormat`
+//! - SAN or issuer absent, or different from expected -> `IdentityMismatch`
+//! - SAN and issuer both match -> `Verified`
+
+use x509_cert::der::asn1::Utf8StringRef;
+use x509_cert::der::oid::{AssociatedOid, ObjectIdentifier};
+use x509_cert::der::Decode;
+use x509_cert::ext::pkix::name::GeneralName;
+use x509_cert::ext::pkix::SubjectAltName;
+use x509_cert::Certificate;
+
+use crate::sigstore_offline::verify_cert_chain_offline;
+use crate::supply_chain::CheckStatus;
+
+/// Fulcio issuer **v2** extension (`1.3.6.1.4.1.57264.1.8`): the OIDC token issuer as a DER-encoded
+/// string. This is the form we accept.
+const FULCIO_ISSUER_V2: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.57264.1.8");
+/// Fulcio issuer **v1** extension (`1.3.6.1.4.1.57264.1.1`): the deprecated raw-value form. Present only
+/// so we can report `UnsupportedFormat` rather than silently treating a v1-only cert as missing identity.
+const FULCIO_ISSUER_V1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.57264.1.1");
+
+/// The identity a caller expects the signing certificate to bind to. Both fields are matched exactly;
+/// this slice performs no pattern/policy authorization beyond exact comparison.
+#[derive(Debug, Clone, Copy)]
+pub struct ExpectedIdentity<'a> {
+    /// Expected Subject Alternative Name value — a URI or email (the Fulcio workflow / signer identity).
+    pub san: &'a str,
+    /// Expected OIDC issuer (the Fulcio issuer v2 extension value).
+    pub issuer: &'a str,
+}
+
+/// The outcome of offline identity verification: a `CheckStatus` plus a value-free reason for the carrier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentityOutcome {
+    pub status: CheckStatus,
+    pub reason: &'static str,
+}
+
+impl IdentityOutcome {
+    fn new(status: CheckStatus, reason: &'static str) -> Self {
+        Self { status, reason }
+    }
+}
+
+/// Verify that a leaf certificate chains to a pinned root (a-3.1) AND binds to the `expected` identity,
+/// fully offline. The chain is checked first; identity is only examined once the chain is `Verified`.
+///
+/// Reads only its byte arguments — no network, no Rekor, no signature/subject-digest binding.
+pub fn verify_identity_offline(
+    leaf_der: &[u8],
+    intermediates: &[&[u8]],
+    pinned_roots: &[&[u8]],
+    now_unix_secs: u64,
+    expected: &ExpectedIdentity<'_>,
+) -> IdentityOutcome {
+    // The chain is a prerequisite. If it does not validate, identity is not even considered: a forged or
+    // untrusted cert's SAN means nothing.
+    let chain = verify_cert_chain_offline(leaf_der, intermediates, pinned_roots, now_unix_secs);
+    if chain.status != CheckStatus::Verified {
+        return IdentityOutcome::new(chain.status, chain.reason);
+    }
+
+    let cert = match Certificate::from_der(leaf_der) {
+        Ok(c) => c,
+        Err(_) => return IdentityOutcome::new(CheckStatus::Failed, "malformed leaf certificate"),
+    };
+    let tbs = &cert.tbs_certificate;
+
+    // Fulcio profile: issued certs MUST have an empty subject; the identity lives in the SAN.
+    if !tbs.subject.0.is_empty() {
+        return IdentityOutcome::new(CheckStatus::Failed, "certificate has a non-empty subject");
+    }
+
+    let extensions = match &tbs.extensions {
+        Some(exts) => exts.as_slice(),
+        None => {
+            return IdentityOutcome::new(CheckStatus::IdentityMismatch, "no certificate extensions")
+        }
+    };
+
+    // --- Subject Alternative Name (the signer identity) ---
+    let san_ext = match extensions.iter().find(|e| e.extn_id == SubjectAltName::OID) {
+        Some(e) => e,
+        None => {
+            return IdentityOutcome::new(
+                CheckStatus::IdentityMismatch,
+                "no subject alternative name",
+            )
+        }
+    };
+    let san = match SubjectAltName::from_der(san_ext.extn_value.as_bytes()) {
+        Ok(s) => s,
+        Err(_) => {
+            return IdentityOutcome::new(CheckStatus::Failed, "malformed subject alternative name")
+        }
+    };
+    // Fulcio profile: exactly one SAN.
+    if san.0.len() != 1 {
+        return IdentityOutcome::new(
+            CheckStatus::UnsupportedFormat,
+            "certificate does not carry exactly one SAN",
+        );
+    }
+    let san_value = match &san.0[0] {
+        GeneralName::UniformResourceIdentifier(uri) => uri.as_str(),
+        GeneralName::Rfc822Name(email) => email.as_str(),
+        _ => return IdentityOutcome::new(CheckStatus::UnsupportedFormat, "unsupported SAN type"),
+    };
+    if san_value != expected.san {
+        return IdentityOutcome::new(
+            CheckStatus::IdentityMismatch,
+            "SAN does not match expected identity",
+        );
+    }
+
+    // --- OIDC issuer (Fulcio v2 extension) ---
+    let issuer_ext = match extensions.iter().find(|e| e.extn_id == FULCIO_ISSUER_V2) {
+        Some(e) => e,
+        None => {
+            if extensions.iter().any(|e| e.extn_id == FULCIO_ISSUER_V1) {
+                return IdentityOutcome::new(
+                    CheckStatus::UnsupportedFormat,
+                    "only the deprecated v1 issuer extension is present",
+                );
+            }
+            return IdentityOutcome::new(CheckStatus::IdentityMismatch, "no issuer extension");
+        }
+    };
+    let issuer_value = match Utf8StringRef::from_der(issuer_ext.extn_value.as_bytes()) {
+        Ok(s) => s.as_str(),
+        Err(_) => {
+            return IdentityOutcome::new(
+                CheckStatus::UnsupportedFormat,
+                "issuer extension is not a DER-encoded string",
+            )
+        }
+    };
+    if issuer_value != expected.issuer {
+        return IdentityOutcome::new(
+            CheckStatus::IdentityMismatch,
+            "issuer does not match expected identity",
+        );
+    }
+
+    IdentityOutcome::new(
+        CheckStatus::Verified,
+        "chain valid and identity matches expected SAN and issuer",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rcgen::{
+        BasicConstraints, CertificateParams, CustomExtension, DistinguishedName, DnType,
+        ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType,
+        PKCS_ECDSA_P256_SHA256,
+    };
+    use time::{Duration, OffsetDateTime};
+
+    use crate::sigstore_offline::verify_cert_chain_offline;
+
+    const NOW: u64 = 1_750_000_000;
+    const SAN_URI: &str =
+        "https://github.com/example/repo/.github/workflows/release.yml@refs/tags/v1";
+    const ISSUER: &str = "https://token.actions.githubusercontent.com";
+    const FULCIO_V2_OID: &[u64] = &[1, 3, 6, 1, 4, 1, 57264, 1, 8];
+    const FULCIO_V1_OID: &[u64] = &[1, 3, 6, 1, 4, 1, 57264, 1, 1];
+
+    fn at(secs: i64) -> OffsetDateTime {
+        OffsetDateTime::from_unix_timestamp(secs).unwrap()
+    }
+
+    fn uri_san(s: &str) -> SanType {
+        SanType::URI(s.try_into().unwrap())
+    }
+
+    fn expected() -> ExpectedIdentity<'static> {
+        ExpectedIdentity {
+            san: SAN_URI,
+            issuer: ISSUER,
+        }
+    }
+
+    /// DER-encode a short UTF8String (tag 0x0C, short-form length). Matches the Fulcio v2 issuer shape
+    /// (the OIDC issuer as a DER-encoded string). Sufficient for the issuer values used in tests.
+    fn der_utf8(s: &str) -> Vec<u8> {
+        let b = s.as_bytes();
+        assert!(b.len() < 128, "test issuer too long for short-form length");
+        let mut v = vec![0x0c, b.len() as u8];
+        v.extend_from_slice(b);
+        v
+    }
+
+    /// How to shape the leaf's identity fields for a given test.
+    struct LeafSpec {
+        sans: Vec<SanType>,
+        /// `(oid, issuer-value)`; the value is DER-UTF8-encoded into the extension content.
+        issuer_ext: Option<(&'static [u64], &'static str)>,
+        empty_subject: bool,
+    }
+
+    impl LeafSpec {
+        /// A well-formed Fulcio-shaped leaf: one URI SAN, v2 issuer extension, empty subject.
+        fn fulcio() -> Self {
+            Self {
+                sans: vec![uri_san(SAN_URI)],
+                issuer_ext: Some((FULCIO_V2_OID, ISSUER)),
+                empty_subject: true,
+            }
+        }
+    }
+
+    /// Build a root CA + a leaf signed by it from `spec`, all ECDSA-P256 and valid at NOW. The leaf
+    /// always carries the code-signing EKU so the a-3.1 chain check passes; identity shape varies per
+    /// spec. Returns `(root_der, leaf_der)`.
+    fn build(spec: &LeafSpec) -> (Vec<u8>, Vec<u8>) {
+        let nb = at(NOW as i64) - Duration::days(1);
+        let na = at(NOW as i64) + Duration::days(1);
+
+        let root_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut root_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        let mut root_dn = DistinguishedName::new();
+        root_dn.push(DnType::CommonName, "Assay Test Root CA");
+        root_params.distinguished_name = root_dn;
+        root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        root_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        root_params.not_before = nb;
+        root_params.not_after = na;
+        let root_cert = root_params.self_signed(&root_key).unwrap();
+
+        let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut leaf_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        // rcgen defaults the subject to a CN; Fulcio leaves have an empty subject, so clear it unless the
+        // test specifically wants a (profile-violating) non-empty subject.
+        if spec.empty_subject {
+            leaf_params.distinguished_name = DistinguishedName::new();
+        }
+        leaf_params.subject_alt_names = spec.sans.clone();
+        leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::CodeSigning];
+        if let Some((oid, value)) = spec.issuer_ext {
+            leaf_params
+                .custom_extensions
+                .push(CustomExtension::from_oid_content(oid, der_utf8(value)));
+        }
+        leaf_params.not_before = nb;
+        leaf_params.not_after = na;
+        let issuer = Issuer::from_params(&root_params, &root_key);
+        let leaf_cert = leaf_params.signed_by(&leaf_key, &issuer).unwrap();
+
+        (root_cert.der().to_vec(), leaf_cert.der().to_vec())
+    }
+
+    #[test]
+    fn matching_san_and_issuer_verifies() {
+        let (root, leaf) = build(&LeafSpec::fulcio());
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::Verified, "{}", out.reason);
+    }
+
+    #[test]
+    fn wrong_san_is_identity_mismatch() {
+        let mut spec = LeafSpec::fulcio();
+        spec.sans = vec![uri_san(
+            "https://github.com/evil/repo/.github/workflows/x.yml@refs/heads/main",
+        )];
+        let (root, leaf) = build(&spec);
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::IdentityMismatch, "{}", out.reason);
+    }
+
+    #[test]
+    fn absent_san_is_identity_mismatch() {
+        let mut spec = LeafSpec::fulcio();
+        spec.sans = vec![]; // no SAN extension emitted at all
+        let (root, leaf) = build(&spec);
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::IdentityMismatch, "{}", out.reason);
+    }
+
+    #[test]
+    fn wrong_issuer_is_identity_mismatch() {
+        let mut spec = LeafSpec::fulcio();
+        spec.issuer_ext = Some((FULCIO_V2_OID, "https://accounts.google.com"));
+        let (root, leaf) = build(&spec);
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::IdentityMismatch, "{}", out.reason);
+    }
+
+    #[test]
+    fn absent_issuer_is_identity_mismatch() {
+        let mut spec = LeafSpec::fulcio();
+        spec.issuer_ext = None;
+        let (root, leaf) = build(&spec);
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::IdentityMismatch, "{}", out.reason);
+    }
+
+    #[test]
+    fn v1_only_issuer_is_unsupported_format() {
+        let mut spec = LeafSpec::fulcio();
+        spec.issuer_ext = Some((FULCIO_V1_OID, ISSUER));
+        let (root, leaf) = build(&spec);
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::UnsupportedFormat, "{}", out.reason);
+    }
+
+    #[test]
+    fn multiple_sans_is_unsupported_format() {
+        let mut spec = LeafSpec::fulcio();
+        spec.sans = vec![
+            uri_san(SAN_URI),
+            uri_san("https://github.com/example/repo/second"),
+        ];
+        let (root, leaf) = build(&spec);
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::UnsupportedFormat, "{}", out.reason);
+    }
+
+    #[test]
+    fn unsupported_san_type_is_unsupported_format() {
+        let mut spec = LeafSpec::fulcio();
+        spec.sans = vec![SanType::DnsName("example.com".try_into().unwrap())];
+        let (root, leaf) = build(&spec);
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::UnsupportedFormat, "{}", out.reason);
+    }
+
+    #[test]
+    fn nonempty_subject_fails() {
+        let mut spec = LeafSpec::fulcio();
+        spec.empty_subject = false; // keep rcgen's default CN -> non-empty subject (profile violation)
+        let (root, leaf) = build(&spec);
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::Failed, "{}", out.reason);
+        assert_eq!(out.reason, "certificate has a non-empty subject");
+    }
+
+    /// The headline non-claim: a leaf that chains cleanly to the pinned root but carries the WRONG
+    /// identity is `IdentityMismatch`, never `Verified`. cert-chain-valid != identity-authorized.
+    #[test]
+    fn valid_chain_wrong_identity_is_not_verified() {
+        let mut spec = LeafSpec::fulcio();
+        spec.sans = vec![uri_san(
+            "https://github.com/evil/repo/.github/workflows/x.yml@refs/heads/main",
+        )];
+        let (root, leaf) = build(&spec);
+        // The chain itself is genuinely valid...
+        assert_eq!(
+            verify_cert_chain_offline(&leaf, &[], &[&root], NOW).status,
+            CheckStatus::Verified,
+        );
+        // ...yet the identity layer refuses it.
+        let out = verify_identity_offline(&leaf, &[], &[&root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::IdentityMismatch, "{}", out.reason);
+    }
+
+    /// Identity is only examined once the chain is valid: a correct identity over an UNTRUSTED chain
+    /// returns the chain failure, not `Verified`.
+    #[test]
+    fn correct_identity_bad_chain_fails() {
+        let (_root, leaf) = build(&LeafSpec::fulcio());
+        let (other_root, _other_leaf) = build(&LeafSpec::fulcio()); // unrelated CA
+        let out = verify_identity_offline(&leaf, &[], &[&other_root], NOW, &expected());
+        assert_eq!(out.status, CheckStatus::Failed, "{}", out.reason);
+    }
+
+    #[test]
+    fn no_pinned_roots_is_trust_root_unavailable() {
+        let (_root, leaf) = build(&LeafSpec::fulcio());
+        let out = verify_identity_offline(&leaf, &[], &[], NOW, &expected());
+        assert_eq!(
+            out.status,
+            CheckStatus::TrustRootUnavailable,
+            "{}",
+            out.reason
+        );
+    }
+}

--- a/crates/assay-registry/src/sigstore_offline.rs
+++ b/crates/assay-registry/src/sigstore_offline.rs
@@ -5,7 +5,7 @@
 //! outcome onto the supply-chain `CheckStatus` vocabulary. **No network: the verdict is produced solely
 //! from the certificate bytes passed in plus the pinned root bytes — there is no client, no async, no
 //! lookup.** `cert-chain-valid` is NOT `identity-authorized`: identity extraction + the Sigstore policy
-//! checks (issuer/SAN, Rekor inclusion) are separate slices (a-3.1 identity, a-3.3 Rekor).
+//! checks (issuer/SAN, Rekor inclusion) are separate slices (a-3.2 identity, a-3.3 Rekor).
 //!
 //! Scope (this increment): chain validation + validity-window + the code-signing EKU requirement.
 //! Status mapping (locked in the MCP04 design-of-record): no pinned roots -> `TrustRootUnavailable`;


### PR DESCRIPTION
## MCP04a-3.2a — offline Sigstore identity extraction

Second slice of the offline Sigstore verifier, on top of the a-3.1
cert-chain primitive (#1702). Once a leaf chains to a pinned root, this
layer extracts the Fulcio identity facts and compares them to a
caller-supplied expected identity — fully offline.

This is the **identity** half of a-3.2. ECDSA signature verification and
subject-digest binding follow in **a-3.2b**; carrier integration is a-3.4.

### What it does

`sigstore_identity::verify_identity_offline(leaf, intermediates, roots, now, expected)`:

- runs the a-3.1 chain check **first** — identity is only examined once the
  chain is `Verified` (a forged or untrusted cert's SAN means nothing)
- parses the leaf with `x509-cert` and enforces the Fulcio certificate
  profile: empty subject, exactly one SAN (URI or email), OIDC issuer in
  the **v2** extension (`1.3.6.1.4.1.57264.1.8`)
- maps onto the carrier `CheckStatus`:

  | situation | status |
  |---|---|
  | chain does not validate | the chain status verbatim (`Failed` / `TrustRootUnavailable`) |
  | non-empty subject | `Failed` |
  | not exactly one SAN, or unsupported SAN type | `UnsupportedFormat` |
  | only the deprecated v1 issuer extension | `UnsupportedFormat` |
  | SAN or issuer absent, or != expected | `IdentityMismatch` |
  | SAN and issuer both match | `Verified` |

### The headline non-claim — enforced and tested

A leaf that chains cleanly to the pinned root but carries the **wrong**
SAN/issuer is `IdentityMismatch`, never `Verified`. The test asserts the
chain is genuinely `Verified` and yet the identity layer refuses it:

**cert-chain-valid is not identity-authorized.**

### Tests

Twelve hermetic tests over a synthetic Fulcio-shaped PKI (rcgen, dev-only):
matching SAN+issuer verifies; wrong/absent SAN and wrong/absent issuer are
`IdentityMismatch`; multiple SANs, unsupported SAN type, and a v1-only
issuer extension are `UnsupportedFormat`; a non-empty subject is `Failed`;
the valid-chain-wrong-identity headline; correct-identity-over-bad-chain
returns the chain failure; no pinned roots is `TrustRootUnavailable`.

### Deps

`x509-cert` 0.2 for the DER parse of the SAN + issuer extension. `der`,
`spki`, `const-oid` are already in-tree at the versions it pins, so no new
crypto stack lands. `cargo deny` (licenses, bans, advisories, sources)
passes. Also fixes the a-3.1 -> a-3.2 slice-number typo in the
`sigstore_offline` doc comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added offline Sigstore identity verification for X.509 certificates, enabling certificate chain validation and identity extraction without external connections.

* **Documentation**
  * Clarified certificate chain verification documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->