### PR TITLE
feat(registry): MCP04a-3.1b accept P-384/SHA-384 Fulcio CA signatures

### DIFF
--- a/crates/assay-registry/src/sigstore_offline.rs
+++ b/crates/assay-registry/src/sigstore_offline.rs
@@ -21,10 +21,16 @@ use crate::supply_chain::CheckStatus;
 /// expects (Fulcio leaf certificates carry this EKU).
 const EKU_CODE_SIGNING: &[u8] = &[0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x03];
 
-/// ECDSA P-256 / SHA-256 — the algorithm Fulcio leaf certificates are signed with. Pinned explicitly so
-/// the verifier accepts only what Sigstore actually uses, not an open set.
-static SUPPORTED_SIG_ALGS: &[&dyn SignatureVerificationAlgorithm] =
-    &[webpki::ring::ECDSA_P256_SHA256];
+/// The ECDSA signature algorithms a Fulcio certificate chain is signed with. The Fulcio leaf KEY is
+/// ECDSA P-256, but per the Fulcio certificate specification the CA chain (intermediate -> root) signs
+/// with ECDSA NIST P-384 / SHA-384 (the spec requires "ECDSA NIST P-384 or stronger, or RSA-4096" for
+/// CAs). Chain validation must therefore accept BOTH P-256/SHA-256 and P-384/SHA-384, otherwise a real
+/// Fulcio chain is rejected. Pinned to exactly this set so the verifier accepts only what Sigstore
+/// actually uses, not an open algorithm set (e.g. Ed25519 / RSA / P-521 are still rejected).
+static SUPPORTED_SIG_ALGS: &[&dyn SignatureVerificationAlgorithm] = &[
+    webpki::ring::ECDSA_P256_SHA256,
+    webpki::ring::ECDSA_P384_SHA384,
+];
 
 /// The outcome of offline chain validation: a `CheckStatus` plus a value-free reason for the carrier.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,7 +120,8 @@ mod tests {
     use super::*;
     use rcgen::{
         BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose,
-        IsCa, Issuer, KeyPair, KeyUsagePurpose, PKCS_ECDSA_P256_SHA256,
+        IsCa, Issuer, KeyPair, KeyUsagePurpose, SignatureAlgorithm, PKCS_ECDSA_P256_SHA256,
+        PKCS_ECDSA_P384_SHA384, PKCS_ED25519,
     };
     use time::{Duration, OffsetDateTime};
 
@@ -165,6 +172,13 @@ mod tests {
     /// valid at NOW. Roots/intermediates carry CA:TRUE + keyCertSign (the Fulcio shape); the leaf carries
     /// the code-signing EKU. Returns `(root_der, intermediate_der, leaf_der)`.
     fn build_three_tier() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        build_three_tier_alg(&PKCS_ECDSA_P256_SHA256)
+    }
+
+    /// As [`build_three_tier`], but every certificate in the chain is keyed/signed with `alg`. Real Fulcio
+    /// chains sign the CA tier with ECDSA P-384/SHA-384, so the P-384 variant exercises the real-world
+    /// algorithm; the Ed25519 variant proves an unsupported algorithm is still rejected.
+    fn build_three_tier_alg(alg: &'static SignatureAlgorithm) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
         let nb = at(NOW as i64) - Duration::days(1);
         let na = at(NOW as i64) + Duration::days(1);
         let ca_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
@@ -178,7 +192,7 @@ mod tests {
         };
 
         // Self-signed root.
-        let root_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let root_key = KeyPair::generate_for(alg).unwrap();
         let mut root_params = CertificateParams::new(Vec::<String>::new()).unwrap();
         root_params.distinguished_name = dn("Assay Test Root CA");
         root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
@@ -190,7 +204,7 @@ mod tests {
         // Intermediate CA, signed by the root. Faithful to the Fulcio profile: CA:TRUE with pathlen:0,
         // CertSign+CRLSign, AND the code-signing EKU. webpki's `Required` EKU check chains through every
         // non-anchor node, so a real Fulcio intermediate (which carries this EKU) is exactly what passes.
-        let int_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let int_key = KeyPair::generate_for(alg).unwrap();
         let mut int_params = CertificateParams::new(Vec::<String>::new()).unwrap();
         int_params.distinguished_name = dn("Assay Test Intermediate CA");
         int_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(0));
@@ -202,7 +216,7 @@ mod tests {
         let int_cert = int_params.signed_by(&int_key, &root_issuer).unwrap();
 
         // Leaf, signed by the intermediate.
-        let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let leaf_key = KeyPair::generate_for(alg).unwrap();
         let mut leaf_params = CertificateParams::new(vec![IDENTITY.to_string()]).unwrap();
         leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::CodeSigning];
         leaf_params.not_before = nb;
@@ -257,6 +271,25 @@ mod tests {
         let (root, intermediate, leaf) = build_three_tier();
         let out = verify_cert_chain_offline(&leaf, &[&intermediate], &[&root], NOW);
         assert_eq!(out.status, CheckStatus::Verified, "{}", out.reason);
+    }
+
+    #[test]
+    fn p384_chain_verifies() {
+        // Real Fulcio CAs sign with ECDSA P-384/SHA-384. A leaf -> intermediate -> root chain signed with
+        // P-384 must validate, otherwise the verifier rejects genuine Fulcio bytes (proven separately by
+        // the real-vector test in tests/fulcio_chain.rs).
+        let (root, intermediate, leaf) = build_three_tier_alg(&PKCS_ECDSA_P384_SHA384);
+        let out = verify_cert_chain_offline(&leaf, &[&intermediate], &[&root], NOW);
+        assert_eq!(out.status, CheckStatus::Verified, "{}", out.reason);
+    }
+
+    #[test]
+    fn unsupported_signature_algorithm_still_fails() {
+        // Adding P-384 must NOT open the verifier to an arbitrary algorithm set: an Ed25519-signed chain
+        // (not in SUPPORTED_SIG_ALGS) is still rejected.
+        let (root, intermediate, leaf) = build_three_tier_alg(&PKCS_ED25519);
+        let out = verify_cert_chain_offline(&leaf, &[&intermediate], &[&root], NOW);
+        assert_eq!(out.status, CheckStatus::Failed, "{}", out.reason);
     }
 
     #[test]

--- a/crates/assay-registry/tests/fulcio_chain.rs
+++ b/crates/assay-registry/tests/fulcio_chain.rs
@@ -1,0 +1,127 @@
+//! MCP04a-3.1b — prove the offline cert-chain + identity primitives validate a REAL Fulcio chain.
+//!
+//! a-3.1 was built and tested only against synthetic ECDSA P-256 chains. Real Fulcio CAs sign with
+//! ECDSA P-384 / SHA-384 (the Fulcio certificate spec requires "ECDSA NIST P-384 or stronger" for CAs),
+//! so the original P-256-only algorithm set silently rejected genuine Fulcio bytes. These tests use an
+//! INDEPENDENT upstream vector (sigstore-conformance `rekor2-dsse-happy-path`, already vendored for the
+//! a-3.3c Rekor work) so the proof is not self-minted: the leaf chains to the pinned Fulcio root through
+//! a P-384 intermediate, and the pinned-identity match works on the real SAN/issuer.
+
+use assay_registry::sigstore_identity::{verify_identity_offline, ExpectedIdentity};
+use assay_registry::sigstore_offline::verify_cert_chain_offline;
+use assay_registry::supply_chain::CheckStatus;
+use base64::{engine::general_purpose::STANDARD as B64, Engine};
+use serde_json::Value;
+
+const VECTOR: &str = "rekor2-dsse-happy-path";
+/// The real leaf's validity window is 2026-05-13T19:23:32Z .. 19:33:32Z; pick a `now` inside it. Cert
+/// validity is what we test here — NOT timestamp freshness (that is a separate, unverified dimension).
+const NOW: u64 = 1_778_700_300; // 2026-05-13T19:25:00Z
+
+// The real Fulcio identity bound into the vector's leaf (OIDC beacon workflow + GitHub Actions issuer).
+const REAL_SAN: &str = "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main";
+const REAL_ISSUER: &str = "https://token.actions.githubusercontent.com";
+
+fn fixture(file: &str) -> Vec<u8> {
+    std::fs::read(format!(
+        "{}/tests/fixtures/rekor_v2/{}/{}",
+        env!("CARGO_MANIFEST_DIR"),
+        VECTOR,
+        file
+    ))
+    .unwrap()
+}
+
+/// Extract `(root_der, intermediate_ders, leaf_der)` from the real bundle + trusted root. The trusted
+/// root `certChain` is `[intermediate, root]`; the bundle supplies only the leaf (trust material is
+/// pinned, never taken from the bundle).
+fn real_chain() -> (Vec<u8>, Vec<Vec<u8>>, Vec<u8>) {
+    let bundle: Value = serde_json::from_slice(&fixture("bundle.sigstore.json")).unwrap();
+    let leaf = B64
+        .decode(
+            bundle["verificationMaterial"]["certificate"]["rawBytes"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap();
+
+    let tr: Value = serde_json::from_slice(&fixture("trusted_root.json")).unwrap();
+    let chain = tr["certificateAuthorities"][0]["certChain"]["certificates"]
+        .as_array()
+        .unwrap();
+    let ders: Vec<Vec<u8>> = chain
+        .iter()
+        .map(|c| B64.decode(c["rawBytes"].as_str().unwrap()).unwrap())
+        .collect();
+    let (root, inters) = ders.split_last().unwrap();
+    (root.clone(), inters.to_vec(), leaf)
+}
+
+fn refs(v: &[Vec<u8>]) -> Vec<&[u8]> {
+    v.iter().map(|x| x.as_slice()).collect()
+}
+
+#[test]
+fn real_fulcio_p384_chain_verifies() {
+    let (root, inters, leaf) = real_chain();
+    let out = verify_cert_chain_offline(&leaf, &refs(&inters), &[&root], NOW);
+    assert_eq!(
+        out.status,
+        CheckStatus::Verified,
+        "real Fulcio P-384 chain must verify: {}",
+        out.reason
+    );
+}
+
+#[test]
+fn real_fulcio_identity_matches_expected() {
+    let (root, inters, leaf) = real_chain();
+    let out = verify_identity_offline(
+        &leaf,
+        &refs(&inters),
+        &[&root],
+        NOW,
+        &ExpectedIdentity {
+            san: REAL_SAN,
+            issuer: REAL_ISSUER,
+        },
+    );
+    assert_eq!(
+        out.status,
+        CheckStatus::Verified,
+        "real Fulcio SAN/issuer must match: {}",
+        out.reason
+    );
+}
+
+#[test]
+fn real_fulcio_wrong_identity_is_mismatch_not_chain_failure() {
+    // The chain is valid, so a wrong expected identity must be IdentityMismatch (not a chain Failed):
+    // this is the pinned-identity axis a-3.4's orthogonality test depends on.
+    let (root, inters, leaf) = real_chain();
+    let out = verify_identity_offline(
+        &leaf,
+        &refs(&inters),
+        &[&root],
+        NOW,
+        &ExpectedIdentity {
+            san: "https://github.com/wrong/identity/.github/workflows/nope.yml@refs/heads/main",
+            issuer: REAL_ISSUER,
+        },
+    );
+    assert_eq!(
+        out.status,
+        CheckStatus::IdentityMismatch,
+        "wrong SAN on a valid chain must be IdentityMismatch: {}",
+        out.reason
+    );
+}
+
+#[test]
+fn real_fulcio_chain_without_pinned_root_is_unavailable() {
+    // No pinned roots -> TrustRootUnavailable, never a silent pass and never an online fetch of the
+    // Fulcio root. (Same no-network invariant as the synthetic tests, on real bytes.)
+    let (_root, inters, leaf) = real_chain();
+    let out = verify_cert_chain_offline(&leaf, &refs(&inters), &[], NOW);
+    assert_eq!(out.status, CheckStatus::TrustRootUnavailable);
+}


### PR DESCRIPTION
## What

The offline Sigstore cert-chain primitive (a-3.1) was tested only against synthetic ECDSA P-256 chains and pinned `SUPPORTED_SIG_ALGS` to `ECDSA_P256_SHA256` alone. Real Fulcio chains sign the CA tier (intermediate → root) with **ECDSA NIST P-384 / SHA-384** — the Fulcio certificate spec requires "ECDSA NIST P-384 or stronger, or RSA-4096" for CAs — so the verifier silently rejected genuine Fulcio bytes.

This adds `webpki::ring::ECDSA_P384_SHA384` to the supported set (already shipped by `rustls-webpki` — **no new dependency, no new crypto stack**) and corrects the misleading algorithm comment. The leaf key stays ECDSA P-256; this only widens which chain-signature algorithms validate.

## Why a separate PR

This touches the security surface of certificate-chain path validation, so it is deliberately isolated from carrier composition. It is a prerequisite for MCP04a-3.4, where the carrier composes the real Sigstore path and needs `cert_chain` / `identity` to verify on genuine Fulcio bytes.

## Proof (independent upstream vector)

A new integration test (`tests/fulcio_chain.rs`) drives the **independent** sigstore-conformance `rekor2-dsse-happy-path` vector (already vendored for the a-3.3c Rekor work — not self-minted):

- real Fulcio P-384 chain → `Verified`
- pinned SAN/issuer → `Verified`
- wrong SAN on a valid chain → `IdentityMismatch` (not a chain failure)
- no pinned root → `TrustRootUnavailable` (no online fetch, no silent pass)

Plus synthetic coverage in `sigstore_offline.rs`: a synthetic P-384 chain verifies, and an Ed25519 chain still **fails** (the supported set is not opened up). All existing P-256 + negative tests stay green.

## Scope

Cert-chain algorithm support + tests only. No carrier integration, no consumer changes, no behavior change for the existing P-256 path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended offline Sigstore trust-chain validation to support both P-256/SHA-256 and P-384/SHA-384 Fulcio signature algorithms.

* **Tests**
  * Added comprehensive integration tests for offline Fulcio certificate-chain validation, including algorithm support verification and identity mismatch detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->