### PR TITLE
feat(registry): MCP04a-3.4 compose Sigstore-keyless carrier dimensions (producer-only)

### DIFF
--- a/crates/assay-registry/src/rekor.rs
+++ b/crates/assay-registry/src/rekor.rs
@@ -650,4 +650,52 @@ mod tests {
         // leaf index >= tree size is impossible -> None.
         assert!(rfc6962_root([0u8; 32], 5, 5, &[]).is_none());
     }
+
+    #[test]
+    fn checkpoint_signed_text_includes_extension_lines() {
+        // Regression (carried from a-3.3c): a C2SP checkpoint may carry optional extension lines after the
+        // root-hash line. parse_checkpoint must extract the fields from the first three lines yet PRESERVE
+        // the extension lines in `signed_text`, because the checkpoint signature covers the whole note text
+        // (everything up to the blank line). Truncating the signed body at the root hash would silently
+        // break signature verification for any real checkpoint that uses extensions.
+        use ed25519_dalek::ed25519::signature::Signer;
+        use ed25519_dalek::SigningKey;
+
+        let origin = "rekor.example.dev";
+        let tree_size = 42u64;
+        let root_hash = [0x11u8; 32];
+        let b64root = BASE64.encode(root_hash);
+        // Note text = origin / tree_size / base64(root) / two extension lines, each terminated by '\n'.
+        let text = format!(
+            "{origin}\n{tree_size}\n{b64root}\nTimestamp: 1700000000\nVendor: assay-regression\n"
+        );
+
+        // Sign the FULL note text (extensions included), as a real log signs the checkpoint.
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let vk = sk.verifying_key();
+        let sig = sk.sign(text.as_bytes());
+
+        // Envelope = text, a blank line, then a C2SP signature line "— <name> base64(keyhint||sig)".
+        let mut hinted = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        hinted.extend_from_slice(&sig.to_bytes());
+        let envelope = format!("{text}\n\u{2014} {origin} {}\n", BASE64.encode(&hinted));
+
+        let cp = parse_checkpoint(&envelope).expect("checkpoint with extension lines must parse");
+
+        // Fields come from the first three lines; the extension lines do not disturb them.
+        assert_eq!(cp.origin, origin);
+        assert_eq!(cp.tree_size, tree_size);
+        assert_eq!(cp.root_hash, root_hash.to_vec());
+
+        // The signed text preserves the extension lines verbatim (up to and including the newline before
+        // the blank line), so the signature over the full text verifies.
+        assert_eq!(cp.signed_text, text.as_bytes());
+        assert!(vk.verify_strict(&cp.signed_text, &sig).is_ok());
+
+        // A signature computed over only the 3-line body (extensions dropped) must NOT verify against the
+        // preserved signed text — this is precisely what the regression guards against.
+        let truncated = format!("{origin}\n{tree_size}\n{b64root}\n");
+        let sig_trunc = sk.sign(truncated.as_bytes());
+        assert!(vk.verify_strict(&cp.signed_text, &sig_trunc).is_err());
+    }
 }

--- a/crates/assay-registry/src/supply_chain.rs
+++ b/crates/assay-registry/src/supply_chain.rs
@@ -17,6 +17,11 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use ed25519_dalek::{Signature, Verifier};
 use serde::{Deserialize, Serialize};
 
+use crate::dsse::verify_dsse_envelope_offline;
+use crate::rekor::{verify_rekor_v2_inclusion_offline, TransparencyRequirement};
+use crate::sigstore_identity::{verify_identity_offline, ExpectedIdentity};
+use crate::sigstore_offline::verify_cert_chain_offline;
+use crate::sigstore_signature::bind_in_toto_subject_digest;
 use crate::trust::TrustStore;
 use crate::types::DsseEnvelope;
 
@@ -40,6 +45,12 @@ pub enum CheckStatus {
     PolicyNotSatisfied,
     SubjectDigestMismatch,
     IdentityMismatch,
+    /// A dimension that is relevant but deliberately NOT verified in this slice (e.g. timestamp
+    /// freshness / log consistency / witness cosignatures are not computed offline). Distinct from
+    /// `NotApplicable` (does not apply) and `NotPresent` (applies but is absent). Append-only addition
+    /// (MCP04a-3.4): a consumer that has not been updated must NOT read it as `verified` — see the paired
+    /// Plimsoll a-3.4b consumer.
+    NotChecked,
 }
 
 impl CheckStatus {
@@ -103,6 +114,21 @@ pub struct ProvenanceChecks {
     pub builder_identity: CheckStatus,
     pub sigstore_bundle: CheckStatus,
     pub rekor_inclusion: CheckStatus,
+    // --- MCP04a-3.4 append-only Sigstore-keyless dimensions ---
+    /// Fulcio leaf chains to a pinned root (a-3.1). Distinct from `dsse_signature` (pinned-key Ed25519).
+    pub cert_chain: CheckStatus,
+    /// Fulcio SAN + OIDC issuer match the expected identity (a-3.2a). DISTINCT from `builder_identity`
+    /// (the SLSA builder id) — this is the keyless signer identity.
+    pub identity: CheckStatus,
+    /// DSSE PAE signature verifies under the leaf key (a-3.3a). Distinct from `dsse_signature` (the
+    /// pinned-key in-toto/SLSA path).
+    pub dsse_pae: CheckStatus,
+    /// Signing-time freshness (RFC3161 TSA). Not computed offline in this slice -> `NotChecked`.
+    pub timestamp_freshness: CheckStatus,
+    /// Transparency-log consistency proof. Not computed offline in this slice -> `NotChecked`.
+    pub consistency: CheckStatus,
+    /// Witness cosignatures on the checkpoint. Not computed offline in this slice -> `NotChecked`.
+    pub witnessing: CheckStatus,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -159,20 +185,101 @@ pub struct SupplyChainConformance {
 
 // ---- Inputs -------------------------------------------------------------------------------------
 
-/// Provenance encountered on the artifact. `Dsse` is the pinned-key in-toto/SLSA path this slice
-/// verifies; `Unsupported` is recorded `unsupported_format` (the MCP04a-3 surfaces).
+/// Provenance encountered on the artifact. `Dsse` is the pinned-key in-toto/SLSA path; `SigstoreBundle`
+/// is the MCP04a-3.4 keyless path (Fulcio + DSSE + Rekor v2), composed from the a-3.1..a-3.3c primitives;
+/// `Unsupported` is recorded `unsupported_format`.
 pub enum ProvenanceInput {
     None,
     Dsse(DsseEnvelope),
+    SigstoreBundle(Box<SigstoreBundleInput>),
     Unsupported(UnsupportedProvenance),
 }
 
 #[derive(Debug, Clone, Copy)]
 pub enum UnsupportedProvenance {
-    SigstoreBundle,
     Pep740,
     NpmProvenance,
     UnknownPredicate,
+}
+
+/// A keyless Sigstore DSSE bundle plus the PINNED trust material needed to verify it offline. The bundle
+/// supplies only the leaf certificate + DSSE content; Fulcio roots/intermediates and the Rekor trusted
+/// root are the verifier's own pinned material (never taken from the bundle).
+pub struct SigstoreBundleInput {
+    pub bundle_json: Vec<u8>,
+    pub fulcio_roots: Vec<Vec<u8>>,
+    pub fulcio_intermediates: Vec<Vec<u8>>,
+    pub rekor_trusted_root_json: Vec<u8>,
+    /// Verification time for the cert-chain validity window (cert validity, NOT timestamp freshness).
+    pub now_unix_secs: u64,
+    pub expected_san: String,
+    pub expected_issuer: String,
+    /// Whether transparency-log inclusion is required (drives the Rekor verifier's missing-proof status).
+    pub rekor_requirement: TransparencyRequirement,
+}
+
+/// A Sigstore bundle parsed exactly ONCE into neutral evidence (a-3.4 design-of-record): every Sigstore
+/// dimension is computed from the SAME bytes, so `identity` can never read one leaf while `rekor` binds
+/// another. The raw bundle bytes go to the Rekor verifier directly (it parses its own tlog section).
+struct ParsedSigstoreBundleEvidence {
+    leaf_der: Vec<u8>,
+    dsse_envelope_bytes: Vec<u8>,
+    statement_payload: Vec<u8>,
+}
+
+const BUNDLE_MEDIA_TYPE_V0_3: &str = "application/vnd.dev.sigstore.bundle.v0.3+json";
+
+/// Shape/availability gate for the Sigstore DSSE path. Returns the neutral evidence on success, or the
+/// `sigstore_bundle` `CheckStatus` to record on failure: `UnsupportedFormat` for a well-formed but
+/// unsupported shape (wrong mediaType, `messageSignature`, `x509CertificateChain`/`publicKey` material,
+/// missing certificate), `Failed` for bytes that should have parsed but did not (malformed JSON, missing
+/// content, un-decodable leaf). Mirrors the a-3.3b shape gate, but a-3.4 owns the parse so the dimensions
+/// share one evidence object. NOT a trust verdict — the trust verdicts are the orthogonal dimensions.
+fn parse_sigstore_bundle(bundle_json: &[u8]) -> Result<ParsedSigstoreBundleEvidence, CheckStatus> {
+    let bundle: serde_json::Value =
+        serde_json::from_slice(bundle_json).map_err(|_| CheckStatus::Failed)?;
+
+    if bundle.get("mediaType").and_then(|v| v.as_str()) != Some(BUNDLE_MEDIA_TYPE_V0_3) {
+        return Err(CheckStatus::UnsupportedFormat);
+    }
+    if bundle.get("messageSignature").is_some() {
+        return Err(CheckStatus::UnsupportedFormat);
+    }
+    let dsse = match bundle.get("dsseEnvelope") {
+        Some(v) => v,
+        None => return Err(CheckStatus::Failed), // no content
+    };
+    let material = match bundle.get("verificationMaterial") {
+        Some(v) => v,
+        None => return Err(CheckStatus::Failed),
+    };
+    if material.get("x509CertificateChain").is_some() || material.get("publicKey").is_some() {
+        return Err(CheckStatus::UnsupportedFormat);
+    }
+    let raw_bytes = match material
+        .pointer("/certificate/rawBytes")
+        .and_then(|v| v.as_str())
+    {
+        Some(s) => s,
+        None => return Err(CheckStatus::UnsupportedFormat),
+    };
+    let leaf_der = BASE64
+        .decode(raw_bytes.as_bytes())
+        .map_err(|_| CheckStatus::Failed)?;
+    let dsse_envelope_bytes = serde_json::to_vec(dsse).map_err(|_| CheckStatus::Failed)?;
+    // Best-effort: the in-toto statement payload for subject binding. A missing/undecodable payload is not
+    // a shape failure here (the dsse_pae / subject dimensions report it); bind over empty -> Failed.
+    let statement_payload = dsse
+        .get("payload")
+        .and_then(|v| v.as_str())
+        .and_then(|p| BASE64.decode(p.as_bytes()).ok())
+        .unwrap_or_default();
+
+    Ok(ParsedSigstoreBundleEvidence {
+        leaf_der,
+        dsse_envelope_bytes,
+        statement_payload,
+    })
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -193,6 +300,16 @@ pub struct PinningInput {
 pub struct Policy {
     pub required_builder_id: Option<String>,
     pub required_slsa_build_level: SlsaLevel,
+    // --- MCP04a-3.4 transparency-extension requirements (offline-first: false = report-only) ---
+    /// Require transparency-log inclusion: a non-`Verified` `rekor_inclusion` is then Incomplete.
+    pub require_rekor_inclusion: bool,
+    /// Require signing-time freshness: `timestamp_freshness` is `NotChecked` offline, so requiring it
+    /// yields Incomplete (never a magic pass).
+    pub require_timestamp_freshness: bool,
+    /// Require a log-consistency proof: `consistency` is `NotChecked` offline -> Incomplete when required.
+    pub require_consistency: bool,
+    /// Require witness cosignatures: `witnessing` is `NotChecked` offline -> Incomplete when required.
+    pub require_witnessing: bool,
 }
 
 pub struct VerifyInput<'a> {
@@ -306,16 +423,25 @@ fn verify_provenance(input: &VerifyInput<'_>) -> ProvenanceOutcome {
                 builder_identity: CheckStatus::NotPresent,
                 sigstore_bundle: CheckStatus::NotPresent,
                 rekor_inclusion: CheckStatus::NotPresent,
+                cert_chain: CheckStatus::NotPresent,
+                identity: CheckStatus::NotPresent,
+                dsse_pae: CheckStatus::NotPresent,
+                timestamp_freshness: na,
+                consistency: na,
+                witnessing: na,
             },
             subject_digest_binding: CheckStatus::NotPresent,
             verified_level: SlsaLevel(0),
         },
+        ProvenanceInput::SigstoreBundle(sb) => {
+            verify_sigstore_bundle_provenance(sb, &input.subject)
+        }
         ProvenanceInput::Unsupported(kind) => {
-            // Sigstore-based formats land in MCP04a-3; report unsupported, never pass.
+            // PEP740 / npm adapters are not yet supported; report unsupported, never pass.
             let sigstore = match kind {
-                UnsupportedProvenance::SigstoreBundle
-                | UnsupportedProvenance::Pep740
-                | UnsupportedProvenance::NpmProvenance => CheckStatus::UnsupportedFormat,
+                UnsupportedProvenance::Pep740 | UnsupportedProvenance::NpmProvenance => {
+                    CheckStatus::UnsupportedFormat
+                }
                 UnsupportedProvenance::UnknownPredicate => CheckStatus::NotApplicable,
             };
             ProvenanceOutcome {
@@ -325,6 +451,12 @@ fn verify_provenance(input: &VerifyInput<'_>) -> ProvenanceOutcome {
                     builder_identity: CheckStatus::UnsupportedFormat,
                     sigstore_bundle: sigstore,
                     rekor_inclusion: CheckStatus::NotApplicable,
+                    cert_chain: CheckStatus::UnsupportedFormat,
+                    identity: CheckStatus::UnsupportedFormat,
+                    dsse_pae: CheckStatus::UnsupportedFormat,
+                    timestamp_freshness: na,
+                    consistency: na,
+                    witnessing: na,
                 },
                 subject_digest_binding: CheckStatus::NotApplicable,
                 verified_level: SlsaLevel(0),
@@ -407,9 +539,97 @@ fn verify_provenance(input: &VerifyInput<'_>) -> ProvenanceOutcome {
                     builder_identity,
                     sigstore_bundle: CheckStatus::NotApplicable,
                     rekor_inclusion: CheckStatus::NotApplicable,
+                    // The keyless Sigstore dimensions do not apply to the pinned-key DSSE path.
+                    cert_chain: na,
+                    identity: na,
+                    dsse_pae: na,
+                    timestamp_freshness: na,
+                    consistency: na,
+                    witnessing: na,
                 },
                 subject_digest_binding,
                 verified_level,
+            }
+        }
+    }
+}
+
+/// Compose the offline Sigstore-keyless primitives (a-3.1 chain, a-3.2a identity, a-3.3a DSSE/PAE,
+/// a-3.2b subject binding, a-3.3c Rekor v2 inclusion) into the provenance dimensions, computed ORTHOGONALLY
+/// from a single shared parse of the bundle. A failing dimension never short-circuits the others; the only
+/// early-exit is a bundle shape/parse failure (then the dependent dimensions inherit that status). DSSE/PAE
+/// and Rekor inclusion are cryptographically coupled by the Rekor v2 leaf-bind; identity is the independent
+/// policy axis Rekor does not bind. `sigstore_bundle=Verified` means the shape was decomposable, NOT a
+/// trust verdict.
+fn verify_sigstore_bundle_provenance(
+    sb: &SigstoreBundleInput,
+    subject: &Subject,
+) -> ProvenanceOutcome {
+    let na = CheckStatus::NotApplicable;
+    let want = hex_of(&subject.digest);
+    match parse_sigstore_bundle(&sb.bundle_json) {
+        Err(status) => ProvenanceOutcome {
+            checks: ProvenanceChecks {
+                dsse_signature: na,
+                slsa_provenance: na,
+                builder_identity: na,
+                sigstore_bundle: status,
+                rekor_inclusion: status,
+                cert_chain: status,
+                identity: status,
+                dsse_pae: status,
+                timestamp_freshness: CheckStatus::NotChecked,
+                consistency: CheckStatus::NotChecked,
+                witnessing: CheckStatus::NotChecked,
+            },
+            subject_digest_binding: status,
+            verified_level: SlsaLevel(0),
+        },
+        Ok(ev) => {
+            let roots: Vec<&[u8]> = sb.fulcio_roots.iter().map(|v| v.as_slice()).collect();
+            let inters: Vec<&[u8]> = sb
+                .fulcio_intermediates
+                .iter()
+                .map(|v| v.as_slice())
+                .collect();
+            let expected = ExpectedIdentity {
+                san: &sb.expected_san,
+                issuer: &sb.expected_issuer,
+            };
+
+            let cert_chain =
+                verify_cert_chain_offline(&ev.leaf_der, &inters, &roots, sb.now_unix_secs).status;
+            let identity =
+                verify_identity_offline(&ev.leaf_der, &inters, &roots, sb.now_unix_secs, &expected)
+                    .status;
+            let dsse_pae =
+                verify_dsse_envelope_offline(&ev.leaf_der, &ev.dsse_envelope_bytes, want).status;
+            let subject_digest_binding =
+                bind_in_toto_subject_digest(&ev.statement_payload, want).status;
+            let rekor_inclusion = verify_rekor_v2_inclusion_offline(
+                &sb.bundle_json,
+                &sb.rekor_trusted_root_json,
+                sb.rekor_requirement,
+            )
+            .status;
+
+            ProvenanceOutcome {
+                checks: ProvenanceChecks {
+                    // The pinned-key in-toto/SLSA fields do not apply to the keyless path.
+                    dsse_signature: na,
+                    slsa_provenance: na,
+                    builder_identity: na,
+                    sigstore_bundle: CheckStatus::Verified,
+                    rekor_inclusion,
+                    cert_chain,
+                    identity,
+                    dsse_pae,
+                    timestamp_freshness: CheckStatus::NotChecked,
+                    consistency: CheckStatus::NotChecked,
+                    witnessing: CheckStatus::NotChecked,
+                },
+                subject_digest_binding,
+                verified_level: SlsaLevel(0),
             }
         }
     }
@@ -459,6 +679,12 @@ fn all_statuses(c: &Checks) -> Vec<CheckStatus> {
         c.provenance.builder_identity,
         c.provenance.sigstore_bundle,
         c.provenance.rekor_inclusion,
+        c.provenance.cert_chain,
+        c.provenance.identity,
+        c.provenance.dsse_pae,
+        c.provenance.timestamp_freshness,
+        c.provenance.consistency,
+        c.provenance.witnessing,
         c.pinning.version_pinned,
         c.pinning.digest_pinned,
         c.pinning.lockfile_subject_matches_artifact,
@@ -467,19 +693,55 @@ fn all_statuses(c: &Checks) -> Vec<CheckStatus> {
     ]
 }
 
-/// Producer-side policy summary. Plimsoll (MCP04a-2) applies the nuanced, policy-aware mapping; this is
-/// the carrier's own coarse verdict: any blocking status -> Fail; else a required-but-unverified
-/// provenance or any pending status -> Incomplete; else Pass.
+/// All statuses EXCEPT the transparency-extension dimensions (rekor_inclusion + timestamp/consistency/
+/// witnessing). Those are optional-by-default (offline-first) and gated by `require_*`, so they are not
+/// swept by the generic "any pending -> Incomplete" rule.
+fn non_transparency_statuses(c: &Checks) -> Vec<CheckStatus> {
+    vec![
+        c.integrity.artifact_digest,
+        c.integrity.subject_digest_binding,
+        c.provenance.dsse_signature,
+        c.provenance.slsa_provenance,
+        c.provenance.builder_identity,
+        c.provenance.sigstore_bundle,
+        c.provenance.cert_chain,
+        c.provenance.identity,
+        c.provenance.dsse_pae,
+        c.pinning.version_pinned,
+        c.pinning.digest_pinned,
+        c.pinning.lockfile_subject_matches_artifact,
+        c.pinning.no_floating_source_ref,
+        c.pinning.no_tag_only_container_ref,
+    ]
+}
+
+/// Producer-side policy summary. Plimsoll (MCP04a-2 / a-3.4b) applies the nuanced, policy-aware mapping;
+/// this is the carrier's own coarse verdict: any blocking status -> Fail; else a required transparency
+/// dimension that is not verified, a required-but-unverified SLSA provenance, or any non-transparency
+/// pending status -> Incomplete; else Pass. Transparency dimensions are offline-first: not-verified only
+/// uncleans when the policy requires it (a `NotChecked` timestamp/consistency/witness is otherwise a
+/// coverage limit, never a magic pass).
 fn compute_policy_result(checks: &Checks, policy: &Policy) -> PolicyResult {
-    let statuses = all_statuses(checks);
-    if statuses.iter().any(|s| s.is_blocking()) {
+    if all_statuses(checks).iter().any(|s| s.is_blocking()) {
         return PolicyResult::Fail;
     }
-    let provenance_required = policy.required_slsa_build_level > SlsaLevel(0);
-    if provenance_required && checks.provenance.slsa_provenance != CheckStatus::Verified {
+    let p = &checks.provenance;
+    let required_unverified = (policy.require_rekor_inclusion
+        && p.rekor_inclusion != CheckStatus::Verified)
+        || (policy.require_timestamp_freshness && p.timestamp_freshness != CheckStatus::Verified)
+        || (policy.require_consistency && p.consistency != CheckStatus::Verified)
+        || (policy.require_witnessing && p.witnessing != CheckStatus::Verified);
+    if required_unverified {
         return PolicyResult::Incomplete;
     }
-    if statuses.iter().any(|s| s.is_pending()) {
+    let provenance_required = policy.required_slsa_build_level > SlsaLevel(0);
+    if provenance_required && p.slsa_provenance != CheckStatus::Verified {
+        return PolicyResult::Incomplete;
+    }
+    if non_transparency_statuses(checks)
+        .iter()
+        .any(|s| s.is_pending())
+    {
         return PolicyResult::Incomplete;
     }
     PolicyResult::Pass
@@ -505,6 +767,21 @@ pub fn verify_supply_chain(input: VerifyInput<'_>) -> SupplyChainConformance {
     };
     let policy_result = compute_policy_result(&checks, &input.policy);
 
+    // The keyless Sigstore path is in play exactly when the transparency extensions are NotChecked; only
+    // then do we record the freshness/consistency/witness coverage gaps (honest, not over-claimed).
+    let sigstore_path = checks.provenance.timestamp_freshness == CheckStatus::NotChecked;
+    let mut limits = vec![
+        "transitive dependencies not re-fetched".to_string(),
+        "PEP 740 / npm provenance adapters not verified in this slice".to_string(),
+        "live transparency-log lookup not performed offline".to_string(),
+    ];
+    if sigstore_path {
+        limits
+            .push("timestamp freshness not checked (RFC3161; Rekor v2 issues no SET)".to_string());
+        limits.push("transparency-log consistency proof not checked".to_string());
+        limits.push("witness cosignatures not checked".to_string());
+    }
+
     SupplyChainConformance {
         schema: SCHEMA.to_string(),
         subject: input.subject,
@@ -522,12 +799,7 @@ pub fn verify_supply_chain(input: VerifyInput<'_>) -> SupplyChainConformance {
                 "lockfile".to_string(),
                 "provenance".to_string(),
             ],
-            limits: vec![
-                "transitive dependencies not re-fetched".to_string(),
-                "sigstore keyless / PEP 740 / npm provenance not verified in this slice"
-                    .to_string(),
-                "live transparency-log lookup not performed offline".to_string(),
-            ],
+            limits,
         },
         non_claims: vec![
             "provenance verification does not prove code safety".to_string(),
@@ -635,6 +907,10 @@ mod tests {
         Policy {
             required_builder_id: Some(BUILDER.to_string()),
             required_slsa_build_level: SlsaLevel(level),
+            require_rekor_inclusion: false,
+            require_timestamp_freshness: false,
+            require_consistency: false,
+            require_witnessing: false,
         }
     }
 
@@ -696,10 +972,9 @@ mod tests {
     }
 
     #[test]
-    fn sigstore_pep740_npm_are_unsupported_format_never_pass() {
+    fn pep740_npm_are_unsupported_format_never_pass() {
         let store = TrustStore::new();
         for kind in [
-            UnsupportedProvenance::SigstoreBundle,
             UnsupportedProvenance::Pep740,
             UnsupportedProvenance::NpmProvenance,
         ] {
@@ -938,5 +1213,40 @@ mod tests {
         assert_eq!(v["verified"]["slsa_build_level"], "L0");
         assert!(v["policy_result"].is_string());
         assert!(v["non_claims"].as_array().unwrap().len() >= 4);
+    }
+
+    #[test]
+    fn sigstore_bundle_parse_failure_is_failed_never_verified() {
+        // Hermetic (no fixture): a malformed Sigstore bundle must mark `sigstore_bundle` and every
+        // dependent dimension Failed, the transparency extensions NotChecked, and never be `is_clean`.
+        let store = TrustStore::new();
+        let report = verify_supply_chain(VerifyInput {
+            subject: subject(),
+            expected_artifact_digest: None,
+            provenance: ProvenanceInput::SigstoreBundle(Box::new(SigstoreBundleInput {
+                bundle_json: b"not a bundle".to_vec(),
+                fulcio_roots: vec![],
+                fulcio_intermediates: vec![],
+                rekor_trusted_root_json: b"{}".to_vec(),
+                now_unix_secs: 1_750_000_000,
+                expected_san: "x".to_string(),
+                expected_issuer: "y".to_string(),
+                rekor_requirement: TransparencyRequirement::Optional,
+            })),
+            pinning: clean_pinning(),
+            policy: policy(0),
+            trust_store: &store,
+        });
+        let p = &report.checks.provenance;
+        assert_eq!(p.sigstore_bundle, CheckStatus::Failed);
+        assert_eq!(p.cert_chain, CheckStatus::Failed);
+        assert_eq!(p.identity, CheckStatus::Failed);
+        assert_eq!(p.dsse_pae, CheckStatus::Failed);
+        assert_eq!(p.rekor_inclusion, CheckStatus::Failed);
+        assert_eq!(p.timestamp_freshness, CheckStatus::NotChecked);
+        assert_eq!(p.consistency, CheckStatus::NotChecked);
+        assert_eq!(p.witnessing, CheckStatus::NotChecked);
+        assert_eq!(report.policy_result, PolicyResult::Fail);
+        assert!(!is_clean(&report));
     }
 }

--- a/crates/assay-registry/src/supply_chain.rs
+++ b/crates/assay-registry/src/supply_chain.rs
@@ -17,11 +17,12 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use ed25519_dalek::{Signature, Verifier};
 use serde::{Deserialize, Serialize};
 
-use crate::dsse::verify_dsse_envelope_offline;
 use crate::rekor::{verify_rekor_v2_inclusion_offline, TransparencyRequirement};
 use crate::sigstore_identity::{verify_identity_offline, ExpectedIdentity};
 use crate::sigstore_offline::verify_cert_chain_offline;
-use crate::sigstore_signature::bind_in_toto_subject_digest;
+use crate::sigstore_signature::{
+    bind_in_toto_subject_digest, verify_leaf_ecdsa_signature_over_bytes,
+};
 use crate::trust::TrustStore;
 use crate::types::DsseEnvelope;
 
@@ -219,10 +220,19 @@ pub struct SigstoreBundleInput {
 /// A Sigstore bundle parsed exactly ONCE into neutral evidence (a-3.4 design-of-record): every Sigstore
 /// dimension is computed from the SAME bytes, so `identity` can never read one leaf while `rekor` binds
 /// another. The raw bundle bytes go to the Rekor verifier directly (it parses its own tlog section).
+///
+/// `dsse_pae` is computed as a SIGNATURE-only check (PAE over `payload_type` + `statement_payload`,
+/// verified under the leaf key) — kept separate from `subject_digest_binding`, so a validly-signed
+/// statement for the wrong artifact reads `dsse_pae=verified` + `subject_digest_binding=subject_digest_mismatch`,
+/// not a conflated `dsse_pae=subject_digest_mismatch`.
 struct ParsedSigstoreBundleEvidence {
     leaf_der: Vec<u8>,
-    dsse_envelope_bytes: Vec<u8>,
+    /// DSSE `payloadType`, if present (one input to the PAE).
+    payload_type: Option<String>,
+    /// Decoded DSSE `payload` (the in-toto Statement bytes): the PAE payload AND the subject-binding input.
     statement_payload: Vec<u8>,
+    /// Decoded DSSE signature bytes, present only when the envelope carries exactly one signature.
+    dsse_signature: Option<Vec<u8>>,
 }
 
 const BUNDLE_MEDIA_TYPE_V0_3: &str = "application/vnd.dev.sigstore.bundle.v0.3+json";
@@ -266,19 +276,32 @@ fn parse_sigstore_bundle(bundle_json: &[u8]) -> Result<ParsedSigstoreBundleEvide
     let leaf_der = BASE64
         .decode(raw_bytes.as_bytes())
         .map_err(|_| CheckStatus::Failed)?;
-    let dsse_envelope_bytes = serde_json::to_vec(dsse).map_err(|_| CheckStatus::Failed)?;
-    // Best-effort: the in-toto statement payload for subject binding. A missing/undecodable payload is not
-    // a shape failure here (the dsse_pae / subject dimensions report it); bind over empty -> Failed.
+    // Best-effort envelope-internal fields. A missing/undecodable payloadType/payload/signature is not a
+    // bundle-shape failure here (the dsse_pae / subject dimensions report it); bind over empty -> Failed,
+    // and an absent payloadType/signature -> dsse_pae UnsupportedFormat.
+    let payload_type = dsse
+        .get("payloadType")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
     let statement_payload = dsse
         .get("payload")
         .and_then(|v| v.as_str())
         .and_then(|p| BASE64.decode(p.as_bytes()).ok())
         .unwrap_or_default();
+    // Exactly one signature (matches the a-3.3a DSSE shape); 0 or >1 -> no signature -> dsse_pae Unsupported.
+    let dsse_signature = match dsse.get("signatures").and_then(|v| v.as_array()) {
+        Some(sigs) if sigs.len() == 1 => sigs[0]
+            .get("sig")
+            .and_then(|v| v.as_str())
+            .and_then(|s| BASE64.decode(s.as_bytes()).ok()),
+        _ => None,
+    };
 
     Ok(ParsedSigstoreBundleEvidence {
         leaf_der,
-        dsse_envelope_bytes,
+        payload_type,
         statement_payload,
+        dsse_signature,
     })
 }
 
@@ -611,8 +634,20 @@ fn verify_sigstore_bundle_provenance(
             let identity =
                 verify_identity_offline(&ev.leaf_der, &inters, &roots, sb.now_unix_secs, &expected)
                     .status;
-            let dsse_pae =
-                verify_dsse_envelope_offline(&ev.leaf_der, &ev.dsse_envelope_bytes, want).status;
+            // dsse_pae is SIGNATURE-only: the leaf-key ECDSA signature over the DSSE PAE
+            // (payloadType + payload). It deliberately does NOT bind the subject digest -- that is the
+            // orthogonal `subject_digest_binding` dimension, so a validly-signed statement for the wrong
+            // artifact reads dsse_pae=Verified + subject_digest_binding=SubjectDigestMismatch. We do not
+            // route this through verify_dsse_envelope_offline (which also binds the subject and would
+            // conflate the two layers).
+            let dsse_pae = match (&ev.payload_type, &ev.dsse_signature) {
+                (Some(pt), Some(sig)) if !ev.statement_payload.is_empty() => {
+                    let pae = build_pae(pt, &ev.statement_payload);
+                    verify_leaf_ecdsa_signature_over_bytes(&ev.leaf_der, &pae, sig).status
+                }
+                // Missing payloadType / payload / exactly-one-signature -> malformed envelope shape.
+                _ => CheckStatus::UnsupportedFormat,
+            };
             let subject_digest_binding =
                 bind_in_toto_subject_digest(&ev.statement_payload, want).status;
             let rekor_inclusion = verify_rekor_v2_inclusion_offline(

--- a/crates/assay-registry/src/supply_chain.rs
+++ b/crates/assay-registry/src/supply_chain.rs
@@ -639,17 +639,33 @@ fn verify_sigstore_bundle_provenance(
             // orthogonal `subject_digest_binding` dimension, so a validly-signed statement for the wrong
             // artifact reads dsse_pae=Verified + subject_digest_binding=SubjectDigestMismatch. We do not
             // route this through verify_dsse_envelope_offline (which also binds the subject and would
-            // conflate the two layers).
+            // conflate the two layers). The payloadType MUST be the in-toto type: the signer controls it,
+            // and accepting any type would let a valid signature over a different DSSE payload (carrying a
+            // lookalike `subject`) pass -- the payload-type-confusion guard the DSSE PAE exists to enforce.
             let dsse_pae = match (&ev.payload_type, &ev.dsse_signature) {
-                (Some(pt), Some(sig)) if !ev.statement_payload.is_empty() => {
+                (Some(pt), Some(sig))
+                    if pt == DSSE_PAYLOAD_TYPE && !ev.statement_payload.is_empty() =>
+                {
                     let pae = build_pae(pt, &ev.statement_payload);
                     verify_leaf_ecdsa_signature_over_bytes(&ev.leaf_der, &pae, sig).status
                 }
-                // Missing payloadType / payload / exactly-one-signature -> malformed envelope shape.
+                // Wrong/missing payloadType, missing payload, or not exactly one signature -> unsupported.
                 _ => CheckStatus::UnsupportedFormat,
             };
-            let subject_digest_binding =
-                bind_in_toto_subject_digest(&ev.statement_payload, want).status;
+            // subject_digest_binding is the in-toto Statement layer: only meaningful for an in-toto
+            // payloadType carrying a Statement/v1 document. A non-in-toto payload has no in-toto subject.
+            let subject_digest_binding = match ev.payload_type.as_deref() {
+                Some(DSSE_PAYLOAD_TYPE) => {
+                    match serde_json::from_slice::<InTotoStatement>(&ev.statement_payload) {
+                        Ok(s) if s.type_ == STATEMENT_TYPE_V1 => {
+                            bind_in_toto_subject_digest(&ev.statement_payload, want).status
+                        }
+                        Ok(_) => CheckStatus::UnsupportedFormat,
+                        Err(_) => CheckStatus::Failed,
+                    }
+                }
+                _ => CheckStatus::UnsupportedFormat,
+            };
             let rekor_inclusion = verify_rekor_v2_inclusion_offline(
                 &sb.bundle_json,
                 &sb.rekor_trusted_root_json,

--- a/crates/assay-registry/src/supply_chain.rs
+++ b/crates/assay-registry/src/supply_chain.rs
@@ -214,8 +214,6 @@ pub struct SigstoreBundleInput {
     pub now_unix_secs: u64,
     pub expected_san: String,
     pub expected_issuer: String,
-    /// Whether transparency-log inclusion is required (drives the Rekor verifier's missing-proof status).
-    pub rekor_requirement: TransparencyRequirement,
 }
 
 /// A Sigstore bundle parsed exactly ONCE into neutral evidence (a-3.4 design-of-record): every Sigstore
@@ -245,9 +243,11 @@ fn parse_sigstore_bundle(bundle_json: &[u8]) -> Result<ParsedSigstoreBundleEvide
     if bundle.get("messageSignature").is_some() {
         return Err(CheckStatus::UnsupportedFormat);
     }
-    let dsse = match bundle.get("dsseEnvelope") {
+    // Require the content to be a JSON object: `serde_json::to_vec` succeeds for null/strings too, so a
+    // non-object dsseEnvelope must not reach `sigstore_bundle: Verified`.
+    let dsse = match bundle.get("dsseEnvelope").filter(|v| v.is_object()) {
         Some(v) => v,
-        None => return Err(CheckStatus::Failed), // no content
+        None => return Err(CheckStatus::Failed), // no (object) content
     };
     let material = match bundle.get("verificationMaterial") {
         Some(v) => v,
@@ -434,7 +434,7 @@ fn verify_provenance(input: &VerifyInput<'_>) -> ProvenanceOutcome {
             verified_level: SlsaLevel(0),
         },
         ProvenanceInput::SigstoreBundle(sb) => {
-            verify_sigstore_bundle_provenance(sb, &input.subject)
+            verify_sigstore_bundle_provenance(sb, &input.subject, &input.policy)
         }
         ProvenanceInput::Unsupported(kind) => {
             // PEP740 / npm adapters are not yet supported; report unsupported, never pass.
@@ -564,9 +564,18 @@ fn verify_provenance(input: &VerifyInput<'_>) -> ProvenanceOutcome {
 fn verify_sigstore_bundle_provenance(
     sb: &SigstoreBundleInput,
     subject: &Subject,
+    policy: &Policy,
 ) -> ProvenanceOutcome {
     let na = CheckStatus::NotApplicable;
     let want = hex_of(&subject.digest);
+    // Policy is the single source of truth for whether inclusion is required: it drives both the Rekor
+    // verifier's missing-proof status here AND the Incomplete decision in compute_policy_result, so the
+    // two can never disagree.
+    let rekor_requirement = if policy.require_rekor_inclusion {
+        TransparencyRequirement::Required
+    } else {
+        TransparencyRequirement::Optional
+    };
     match parse_sigstore_bundle(&sb.bundle_json) {
         Err(status) => ProvenanceOutcome {
             checks: ProvenanceChecks {
@@ -609,7 +618,7 @@ fn verify_sigstore_bundle_provenance(
             let rekor_inclusion = verify_rekor_v2_inclusion_offline(
                 &sb.bundle_json,
                 &sb.rekor_trusted_root_json,
-                sb.rekor_requirement,
+                rekor_requirement,
             )
             .status;
 
@@ -1231,7 +1240,6 @@ mod tests {
                 now_unix_secs: 1_750_000_000,
                 expected_san: "x".to_string(),
                 expected_issuer: "y".to_string(),
-                rekor_requirement: TransparencyRequirement::Optional,
             })),
             pinning: clean_pinning(),
             policy: policy(0),

--- a/crates/assay-registry/tests/supply_chain_sigstore.rs
+++ b/crates/assay-registry/tests/supply_chain_sigstore.rs
@@ -1,0 +1,373 @@
+//! MCP04a-3.4 — the Sigstore-keyless path of the supply-chain carrier producer, driven by the INDEPENDENT
+//! upstream vector (sigstore-conformance `rekor2-dsse-happy-path`) plus surgical serde_json mutations. No
+//! synthetic PKI: every dimension is exercised on real Fulcio/DSSE/Rekor-v2 bytes.
+//!
+//! PRODUCER-ONLY NOTE (a-3.4): this carrier adds append-only provenance dimensions (cert_chain, identity,
+//! dsse_pae, timestamp_freshness, consistency, witnessing) and a new `not_checked` status. The existing
+//! Plimsoll a-2 consumer is forward-tolerant but clean-by-omission for these, so this carrier is NOT
+//! Plimsoll-consumable until the paired a-3.4b consumer lands; no witness/relabel may rely on the new
+//! fields until then.
+
+use assay_registry::rekor::TransparencyRequirement;
+use assay_registry::supply_chain::{
+    verify_supply_chain, CheckStatus, ContainerRef, PinningInput, Policy, ProvenanceInput,
+    SigstoreBundleInput, SlsaLevel, Subject, VerifyInput,
+};
+use assay_registry::trust::TrustStore;
+use base64::{engine::general_purpose::STANDARD as B64, Engine};
+use serde_json::Value;
+
+const VECTOR: &str = "rekor2-dsse-happy-path";
+/// Inside the real leaf validity window (2026-05-13T19:23:32Z .. 19:33:32Z). Cert validity only.
+const NOW: u64 = 1_778_700_300;
+const REAL_SAN: &str = "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main";
+const REAL_ISSUER: &str = "https://token.actions.githubusercontent.com";
+/// The in-toto subject digest carried by the vector's DSSE statement (artifact `a.txt`).
+const SUBJECT_DIGEST: &str =
+    "sha256:a0cfc71271d6e278e57cd332ff957c3f7043fdda354c4cbb190a30d56efa01bf";
+
+fn fixture(file: &str) -> Vec<u8> {
+    std::fs::read(format!(
+        "{}/tests/fixtures/rekor_v2/{}/{}",
+        env!("CARGO_MANIFEST_DIR"),
+        VECTOR,
+        file
+    ))
+    .unwrap()
+}
+
+/// `(roots, intermediates)` from the trusted root: `certChain` is `[intermediate, root]`.
+fn fulcio_material() -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
+    let tr: Value = serde_json::from_slice(&fixture("trusted_root.json")).unwrap();
+    let chain = tr["certificateAuthorities"][0]["certChain"]["certificates"]
+        .as_array()
+        .unwrap();
+    let ders: Vec<Vec<u8>> = chain
+        .iter()
+        .map(|c| B64.decode(c["rawBytes"].as_str().unwrap()).unwrap())
+        .collect();
+    let (root, inters) = ders.split_last().unwrap();
+    (vec![root.clone()], inters.to_vec())
+}
+
+fn base_bundle_input(bundle_json: Vec<u8>, req: TransparencyRequirement) -> SigstoreBundleInput {
+    let (roots, inters) = fulcio_material();
+    SigstoreBundleInput {
+        bundle_json,
+        fulcio_roots: roots,
+        fulcio_intermediates: inters,
+        rekor_trusted_root_json: fixture("trusted_root.json"),
+        now_unix_secs: NOW,
+        expected_san: REAL_SAN.to_string(),
+        expected_issuer: REAL_ISSUER.to_string(),
+        rekor_requirement: req,
+    }
+}
+
+fn subject() -> Subject {
+    Subject {
+        name: "mcp-pack".to_string(),
+        version: "1.0.0".to_string(),
+        digest: SUBJECT_DIGEST.to_string(),
+    }
+}
+
+fn clean_pinning() -> PinningInput {
+    PinningInput {
+        version_pinned: true,
+        digest_pinned: Some(true),
+        lockfile_digest: Some(SUBJECT_DIGEST.to_string()),
+        floating_source_ref: false,
+        container_ref: Some(ContainerRef::DigestPinned),
+    }
+}
+
+fn policy() -> Policy {
+    Policy {
+        required_builder_id: None,
+        required_slsa_build_level: SlsaLevel(0), // SLSA-level is the pinned-key model, not the keyless path
+        require_rekor_inclusion: false,
+        require_timestamp_freshness: false,
+        require_consistency: false,
+        require_witnessing: false,
+    }
+}
+
+fn run(
+    sb: SigstoreBundleInput,
+    policy: Policy,
+) -> assay_registry::supply_chain::SupplyChainConformance {
+    let store = TrustStore::new();
+    verify_supply_chain(VerifyInput {
+        subject: subject(),
+        expected_artifact_digest: None,
+        provenance: ProvenanceInput::SigstoreBundle(Box::new(sb)),
+        pinning: clean_pinning(),
+        policy,
+        trust_store: &store,
+    })
+}
+
+/// Parse the real bundle so a test can mutate it before re-serializing.
+fn bundle_value() -> Value {
+    serde_json::from_slice(&fixture("bundle.sigstore.json")).unwrap()
+}
+
+// --- Test 1: real happy path -> every dimension Verified, transparency NotChecked, Pass ---
+#[test]
+fn real_sigstore_dsse_happy_path_is_pass() {
+    let report = run(
+        base_bundle_input(
+            fixture("bundle.sigstore.json"),
+            TransparencyRequirement::Required,
+        ),
+        policy(),
+    );
+    let p = &report.checks.provenance;
+    assert_eq!(p.cert_chain, CheckStatus::Verified, "cert_chain");
+    assert_eq!(p.identity, CheckStatus::Verified, "identity");
+    assert_eq!(p.dsse_pae, CheckStatus::Verified, "dsse_pae");
+    assert_eq!(p.rekor_inclusion, CheckStatus::Verified, "rekor_inclusion");
+    assert_eq!(
+        p.sigstore_bundle,
+        CheckStatus::Verified,
+        "sigstore_bundle shape"
+    );
+    assert_eq!(
+        report.checks.integrity.subject_digest_binding,
+        CheckStatus::Verified,
+        "subject_digest_binding"
+    );
+    // The pinned-key fields do not apply to the keyless path.
+    assert_eq!(p.dsse_signature, CheckStatus::NotApplicable);
+    assert_eq!(p.slsa_provenance, CheckStatus::NotApplicable);
+    assert_eq!(p.builder_identity, CheckStatus::NotApplicable);
+    // Transparency extensions are deliberately not checked offline.
+    assert_eq!(p.timestamp_freshness, CheckStatus::NotChecked);
+    assert_eq!(p.consistency, CheckStatus::NotChecked);
+    assert_eq!(p.witnessing, CheckStatus::NotChecked);
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Pass
+    );
+    assert!(report
+        .coverage
+        .limits
+        .iter()
+        .any(|l| l.contains("timestamp freshness not checked")));
+}
+
+// --- Test 2 (LOAD-BEARING orthogonality): wrong identity, but Rekor + DSSE still Verified -> Fail ---
+#[test]
+fn wrong_identity_with_rekor_and_dsse_verified_is_fail() {
+    let mut sb = base_bundle_input(
+        fixture("bundle.sigstore.json"),
+        TransparencyRequirement::Required,
+    );
+    sb.expected_san =
+        "https://github.com/attacker/evil/.github/workflows/x.yml@refs/heads/main".to_string();
+    let report = run(sb, policy());
+    let p = &report.checks.provenance;
+    assert_eq!(p.identity, CheckStatus::IdentityMismatch, "wrong identity");
+    // Rekor=Verified can NOT launder a wrong identity; the other dimensions are computed independently.
+    assert_eq!(
+        p.rekor_inclusion,
+        CheckStatus::Verified,
+        "rekor still verified"
+    );
+    assert_eq!(p.dsse_pae, CheckStatus::Verified, "dsse still verified");
+    assert_eq!(p.cert_chain, CheckStatus::Verified, "chain still verified");
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Fail
+    );
+}
+
+// --- Test 3 (accepted coupling): tampering the DSSE signature breaks BOTH dsse_pae and rekor ---
+#[test]
+fn tampered_dsse_signature_fails_both_dsse_and_rekor() {
+    let mut b = bundle_value();
+    // Flip the lowest-order byte of the ECDSA `s` value: `s` stays a valid in-range scalar (so the
+    // signature is still well-formed DER and p256 accepts the encoding) but no longer verifies ->
+    // dsse_pae = Failed (crypto-invalid), not UnsupportedFormat (which would mean a malformed encoding).
+    let sig = b["dsseEnvelope"]["signatures"][0]["sig"].as_str().unwrap();
+    let mut raw = B64.decode(sig).unwrap();
+    let last = raw.len() - 1;
+    raw[last] ^= 0x01;
+    b["dsseEnvelope"]["signatures"][0]["sig"] = Value::String(B64.encode(&raw));
+    let bundle_json = serde_json::to_vec(&b).unwrap();
+
+    let report = run(
+        base_bundle_input(bundle_json, TransparencyRequirement::Required),
+        policy(),
+    );
+    let p = &report.checks.provenance;
+    assert_eq!(p.dsse_pae, CheckStatus::Failed, "dsse_pae must fail");
+    // Coupling: the Rekor v2 entry binds the DSSE signature (canonicalizedBody.signature.content), so a
+    // tampered DSSE signature also breaks inclusion. This is accepted coupling, not lost orthogonality.
+    assert_ne!(
+        p.rekor_inclusion,
+        CheckStatus::Verified,
+        "rekor must not stay verified once the DSSE signature is tampered"
+    );
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Fail
+    );
+}
+
+// --- Test 4: timestamp freshness required -> NotChecked yields Incomplete (no magic pass) ---
+#[test]
+fn timestamp_freshness_required_is_incomplete() {
+    let mut pol = policy();
+    pol.require_timestamp_freshness = true;
+    let report = run(
+        base_bundle_input(
+            fixture("bundle.sigstore.json"),
+            TransparencyRequirement::Required,
+        ),
+        pol,
+    );
+    assert_eq!(
+        report.checks.provenance.timestamp_freshness,
+        CheckStatus::NotChecked
+    );
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Incomplete
+    );
+}
+
+// --- Test 5: unsupported bundle shape -> sigstore_bundle + dependent dims UnsupportedFormat, Incomplete ---
+#[test]
+fn unsupported_bundle_shape_is_incomplete() {
+    let mut b = bundle_value();
+    b["mediaType"] = Value::String("application/vnd.dev.sigstore.bundle.v0.1+json".to_string());
+    let report = run(
+        base_bundle_input(
+            serde_json::to_vec(&b).unwrap(),
+            TransparencyRequirement::Required,
+        ),
+        policy(),
+    );
+    let p = &report.checks.provenance;
+    assert_eq!(p.sigstore_bundle, CheckStatus::UnsupportedFormat);
+    assert_eq!(p.cert_chain, CheckStatus::UnsupportedFormat);
+    assert_eq!(p.identity, CheckStatus::UnsupportedFormat);
+    assert_eq!(p.dsse_pae, CheckStatus::UnsupportedFormat);
+    assert_eq!(p.rekor_inclusion, CheckStatus::UnsupportedFormat);
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Incomplete
+    );
+}
+
+// --- Test 6: malformed bundle bytes -> sigstore_bundle Failed (blocking), Fail ---
+#[test]
+fn malformed_bundle_bytes_is_fail() {
+    let report = run(
+        base_bundle_input(
+            b"{ not valid json".to_vec(),
+            TransparencyRequirement::Required,
+        ),
+        policy(),
+    );
+    let p = &report.checks.provenance;
+    assert_eq!(p.sigstore_bundle, CheckStatus::Failed);
+    assert_eq!(p.cert_chain, CheckStatus::Failed);
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Fail
+    );
+}
+
+// --- Test 7: required Rekor inclusion but proof absent -> OnlineRequired -> Incomplete ---
+#[test]
+fn required_rekor_absent_is_incomplete() {
+    let mut b = bundle_value();
+    b["verificationMaterial"]
+        .as_object_mut()
+        .unwrap()
+        .remove("tlogEntries");
+    let mut pol = policy();
+    pol.require_rekor_inclusion = true;
+    let report = run(
+        base_bundle_input(
+            serde_json::to_vec(&b).unwrap(),
+            TransparencyRequirement::Required,
+        ),
+        pol,
+    );
+    let p = &report.checks.provenance;
+    // Chain/identity/dsse remain verified; only inclusion is absent.
+    assert_eq!(p.cert_chain, CheckStatus::Verified);
+    assert_eq!(p.identity, CheckStatus::Verified);
+    assert_eq!(p.dsse_pae, CheckStatus::Verified);
+    assert_eq!(p.rekor_inclusion, CheckStatus::OnlineRequired);
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Incomplete
+    );
+}
+
+// --- Test 8: optional Rekor absent -> offline-first: NotPresent, still Pass with a coverage limit ---
+#[test]
+fn optional_rekor_absent_is_pass_offline_first() {
+    let mut b = bundle_value();
+    b["verificationMaterial"]
+        .as_object_mut()
+        .unwrap()
+        .remove("tlogEntries");
+    let report = run(
+        base_bundle_input(
+            serde_json::to_vec(&b).unwrap(),
+            TransparencyRequirement::Optional,
+        ),
+        policy(),
+    );
+    let p = &report.checks.provenance;
+    assert_eq!(p.rekor_inclusion, CheckStatus::NotPresent);
+    assert_eq!(p.cert_chain, CheckStatus::Verified);
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Pass
+    );
+}
+
+// --- Contract: the carrier shape is append-only v0 with the new dimensions + not_checked serialized ---
+#[test]
+fn carrier_shape_is_append_only_v0_with_new_dimensions() {
+    let report = run(
+        base_bundle_input(
+            fixture("bundle.sigstore.json"),
+            TransparencyRequirement::Required,
+        ),
+        policy(),
+    );
+    let v = serde_json::to_value(&report).unwrap();
+    assert_eq!(v["schema"], "assay.supply_chain_conformance.v0");
+    let prov = &v["checks"]["provenance"];
+    // Existing v0 fields still present.
+    for f in [
+        "dsse_signature",
+        "slsa_provenance",
+        "builder_identity",
+        "sigstore_bundle",
+        "rekor_inclusion",
+    ] {
+        assert!(prov.get(f).is_some(), "missing existing field {f}");
+    }
+    // New append-only dimensions present, snake_case.
+    for f in [
+        "cert_chain",
+        "identity",
+        "dsse_pae",
+        "timestamp_freshness",
+        "consistency",
+        "witnessing",
+    ] {
+        assert!(prov.get(f).is_some(), "missing new field {f}");
+    }
+    // The new status value serializes as snake_case `not_checked`.
+    assert_eq!(prov["timestamp_freshness"], "not_checked");
+}

--- a/crates/assay-registry/tests/supply_chain_sigstore.rs
+++ b/crates/assay-registry/tests/supply_chain_sigstore.rs
@@ -8,7 +8,6 @@
 //! Plimsoll-consumable until the paired a-3.4b consumer lands; no witness/relabel may rely on the new
 //! fields until then.
 
-use assay_registry::rekor::TransparencyRequirement;
 use assay_registry::supply_chain::{
     verify_supply_chain, CheckStatus, ContainerRef, PinningInput, Policy, ProvenanceInput,
     SigstoreBundleInput, SlsaLevel, Subject, VerifyInput,
@@ -50,7 +49,7 @@ fn fulcio_material() -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
     (vec![root.clone()], inters.to_vec())
 }
 
-fn base_bundle_input(bundle_json: Vec<u8>, req: TransparencyRequirement) -> SigstoreBundleInput {
+fn base_bundle_input(bundle_json: Vec<u8>) -> SigstoreBundleInput {
     let (roots, inters) = fulcio_material();
     SigstoreBundleInput {
         bundle_json,
@@ -60,7 +59,6 @@ fn base_bundle_input(bundle_json: Vec<u8>, req: TransparencyRequirement) -> Sigs
         now_unix_secs: NOW,
         expected_san: REAL_SAN.to_string(),
         expected_issuer: REAL_ISSUER.to_string(),
-        rekor_requirement: req,
     }
 }
 
@@ -116,13 +114,7 @@ fn bundle_value() -> Value {
 // --- Test 1: real happy path -> every dimension Verified, transparency NotChecked, Pass ---
 #[test]
 fn real_sigstore_dsse_happy_path_is_pass() {
-    let report = run(
-        base_bundle_input(
-            fixture("bundle.sigstore.json"),
-            TransparencyRequirement::Required,
-        ),
-        policy(),
-    );
+    let report = run(base_bundle_input(fixture("bundle.sigstore.json")), policy());
     let p = &report.checks.provenance;
     assert_eq!(p.cert_chain, CheckStatus::Verified, "cert_chain");
     assert_eq!(p.identity, CheckStatus::Verified, "identity");
@@ -160,10 +152,7 @@ fn real_sigstore_dsse_happy_path_is_pass() {
 // --- Test 2 (LOAD-BEARING orthogonality): wrong identity, but Rekor + DSSE still Verified -> Fail ---
 #[test]
 fn wrong_identity_with_rekor_and_dsse_verified_is_fail() {
-    let mut sb = base_bundle_input(
-        fixture("bundle.sigstore.json"),
-        TransparencyRequirement::Required,
-    );
+    let mut sb = base_bundle_input(fixture("bundle.sigstore.json"));
     sb.expected_san =
         "https://github.com/attacker/evil/.github/workflows/x.yml@refs/heads/main".to_string();
     let report = run(sb, policy());
@@ -197,10 +186,7 @@ fn tampered_dsse_signature_fails_both_dsse_and_rekor() {
     b["dsseEnvelope"]["signatures"][0]["sig"] = Value::String(B64.encode(&raw));
     let bundle_json = serde_json::to_vec(&b).unwrap();
 
-    let report = run(
-        base_bundle_input(bundle_json, TransparencyRequirement::Required),
-        policy(),
-    );
+    let report = run(base_bundle_input(bundle_json), policy());
     let p = &report.checks.provenance;
     assert_eq!(p.dsse_pae, CheckStatus::Failed, "dsse_pae must fail");
     // Coupling: the Rekor v2 entry binds the DSSE signature (canonicalizedBody.signature.content), so a
@@ -221,13 +207,7 @@ fn tampered_dsse_signature_fails_both_dsse_and_rekor() {
 fn timestamp_freshness_required_is_incomplete() {
     let mut pol = policy();
     pol.require_timestamp_freshness = true;
-    let report = run(
-        base_bundle_input(
-            fixture("bundle.sigstore.json"),
-            TransparencyRequirement::Required,
-        ),
-        pol,
-    );
+    let report = run(base_bundle_input(fixture("bundle.sigstore.json")), pol);
     assert_eq!(
         report.checks.provenance.timestamp_freshness,
         CheckStatus::NotChecked
@@ -243,13 +223,7 @@ fn timestamp_freshness_required_is_incomplete() {
 fn unsupported_bundle_shape_is_incomplete() {
     let mut b = bundle_value();
     b["mediaType"] = Value::String("application/vnd.dev.sigstore.bundle.v0.1+json".to_string());
-    let report = run(
-        base_bundle_input(
-            serde_json::to_vec(&b).unwrap(),
-            TransparencyRequirement::Required,
-        ),
-        policy(),
-    );
+    let report = run(base_bundle_input(serde_json::to_vec(&b).unwrap()), policy());
     let p = &report.checks.provenance;
     assert_eq!(p.sigstore_bundle, CheckStatus::UnsupportedFormat);
     assert_eq!(p.cert_chain, CheckStatus::UnsupportedFormat);
@@ -265,13 +239,7 @@ fn unsupported_bundle_shape_is_incomplete() {
 // --- Test 6: malformed bundle bytes -> sigstore_bundle Failed (blocking), Fail ---
 #[test]
 fn malformed_bundle_bytes_is_fail() {
-    let report = run(
-        base_bundle_input(
-            b"{ not valid json".to_vec(),
-            TransparencyRequirement::Required,
-        ),
-        policy(),
-    );
+    let report = run(base_bundle_input(b"{ not valid json".to_vec()), policy());
     let p = &report.checks.provenance;
     assert_eq!(p.sigstore_bundle, CheckStatus::Failed);
     assert_eq!(p.cert_chain, CheckStatus::Failed);
@@ -291,13 +259,7 @@ fn required_rekor_absent_is_incomplete() {
         .remove("tlogEntries");
     let mut pol = policy();
     pol.require_rekor_inclusion = true;
-    let report = run(
-        base_bundle_input(
-            serde_json::to_vec(&b).unwrap(),
-            TransparencyRequirement::Required,
-        ),
-        pol,
-    );
+    let report = run(base_bundle_input(serde_json::to_vec(&b).unwrap()), pol);
     let p = &report.checks.provenance;
     // Chain/identity/dsse remain verified; only inclusion is absent.
     assert_eq!(p.cert_chain, CheckStatus::Verified);
@@ -318,13 +280,7 @@ fn optional_rekor_absent_is_pass_offline_first() {
         .as_object_mut()
         .unwrap()
         .remove("tlogEntries");
-    let report = run(
-        base_bundle_input(
-            serde_json::to_vec(&b).unwrap(),
-            TransparencyRequirement::Optional,
-        ),
-        policy(),
-    );
+    let report = run(base_bundle_input(serde_json::to_vec(&b).unwrap()), policy());
     let p = &report.checks.provenance;
     assert_eq!(p.rekor_inclusion, CheckStatus::NotPresent);
     assert_eq!(p.cert_chain, CheckStatus::Verified);
@@ -337,13 +293,7 @@ fn optional_rekor_absent_is_pass_offline_first() {
 // --- Contract: the carrier shape is append-only v0 with the new dimensions + not_checked serialized ---
 #[test]
 fn carrier_shape_is_append_only_v0_with_new_dimensions() {
-    let report = run(
-        base_bundle_input(
-            fixture("bundle.sigstore.json"),
-            TransparencyRequirement::Required,
-        ),
-        policy(),
-    );
+    let report = run(base_bundle_input(fixture("bundle.sigstore.json")), policy());
     let v = serde_json::to_value(&report).unwrap();
     assert_eq!(v["schema"], "assay.supply_chain_conformance.v0");
     let prov = &v["checks"]["provenance"];

--- a/crates/assay-registry/tests/supply_chain_sigstore.rs
+++ b/crates/assay-registry/tests/supply_chain_sigstore.rs
@@ -203,6 +203,36 @@ fn valid_signature_wrong_subject_isolates_to_subject_binding() {
     );
 }
 
+// --- Test 1c: payload-type-confusion guard. A non-in-toto payloadType must NOT verify, even though the
+// bundle shape decomposes. dsse_pae/subject_digest_binding -> UnsupportedFormat; sigstore_bundle stays
+// Verified (shape vs trust separation). ---
+#[test]
+fn non_in_toto_payload_type_is_unsupported_not_verified() {
+    let mut b = bundle_value();
+    b["dsseEnvelope"]["payloadType"] = Value::String("application/vnd.evil+json".to_string());
+    let report = run(base_bundle_input(serde_json::to_vec(&b).unwrap()), policy());
+    let p = &report.checks.provenance;
+    assert_eq!(
+        p.dsse_pae,
+        CheckStatus::UnsupportedFormat,
+        "a non-in-toto payloadType must not yield dsse_pae=Verified"
+    );
+    assert_eq!(
+        report.checks.integrity.subject_digest_binding,
+        CheckStatus::UnsupportedFormat,
+        "no in-toto subject to bind for a non-in-toto payload"
+    );
+    assert_eq!(
+        p.sigstore_bundle,
+        CheckStatus::Verified,
+        "bundle shape still decomposes; the type is an envelope-internal trust concern"
+    );
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Incomplete
+    );
+}
+
 // --- Test 2 (LOAD-BEARING orthogonality): wrong identity, but Rekor + DSSE still Verified -> Fail ---
 #[test]
 fn wrong_identity_with_rekor_and_dsse_verified_is_fail() {

--- a/crates/assay-registry/tests/supply_chain_sigstore.rs
+++ b/crates/assay-registry/tests/supply_chain_sigstore.rs
@@ -149,6 +149,60 @@ fn real_sigstore_dsse_happy_path_is_pass() {
         .any(|l| l.contains("timestamp freshness not checked")));
 }
 
+// --- Test 1b (LOAD-BEARING): valid DSSE signature, but the EVALUATED artifact != the statement subject.
+// dsse_pae is signature-only, so it stays Verified (the signature over the real statement is valid); the
+// mismatch isolates to subject_digest_binding. Rekor stays Verified (the bundle entry is unchanged) -- the
+// mismatch is "evaluated artifact vs statement subject", not "bundle vs log". ---
+#[test]
+fn valid_signature_wrong_subject_isolates_to_subject_binding() {
+    let wrong = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+    let store = TrustStore::new();
+    let report = verify_supply_chain(VerifyInput {
+        subject: Subject {
+            name: "mcp-pack".to_string(),
+            version: "1.0.0".to_string(),
+            digest: wrong.to_string(),
+        },
+        expected_artifact_digest: None,
+        provenance: ProvenanceInput::SigstoreBundle(Box::new(base_bundle_input(fixture(
+            "bundle.sigstore.json",
+        )))),
+        // Pin the lockfile to the (wrong) evaluated digest so pinning is clean and the ONLY failure is
+        // the subject binding.
+        pinning: PinningInput {
+            version_pinned: true,
+            digest_pinned: Some(true),
+            lockfile_digest: Some(wrong.to_string()),
+            floating_source_ref: false,
+            container_ref: Some(ContainerRef::DigestPinned),
+        },
+        policy: policy(),
+        trust_store: &store,
+    });
+    let p = &report.checks.provenance;
+    assert_eq!(
+        p.dsse_pae,
+        CheckStatus::Verified,
+        "signature is valid over the statement; dsse_pae must not absorb the subject mismatch"
+    );
+    assert_eq!(
+        report.checks.integrity.subject_digest_binding,
+        CheckStatus::SubjectDigestMismatch,
+        "the subject mismatch isolates here"
+    );
+    assert_eq!(
+        p.rekor_inclusion,
+        CheckStatus::Verified,
+        "rekor entry unchanged"
+    );
+    assert_eq!(p.cert_chain, CheckStatus::Verified);
+    assert_eq!(p.identity, CheckStatus::Verified);
+    assert_eq!(
+        report.policy_result,
+        assay_registry::supply_chain::PolicyResult::Fail
+    );
+}
+
 // --- Test 2 (LOAD-BEARING orthogonality): wrong identity, but Rekor + DSSE still Verified -> Fail ---
 #[test]
 fn wrong_identity_with_rekor_and_dsse_verified_is_fail() {


### PR DESCRIPTION
## What

Composes the offline Sigstore-keyless verifier primitives (a-3.1 chain, a-3.2a identity, a-3.3a DSSE/PAE, a-3.2b subject binding, a-3.3c Rekor v2 inclusion) into `assay.supply_chain_conformance.v0` as **orthogonal evidence dimensions**. No new crypto, no new dependency, no `sigstore_verified` boolean.

Carrier changes are **append-only** (schema stays `...v0`):
- `CheckStatus::NotChecked` — a relevant-but-deliberately-not-verified dimension (distinct from `NotApplicable` / `NotPresent`).
- `ProvenanceChecks` gains `cert_chain`, `identity`, `dsse_pae`, `timestamp_freshness`, `consistency`, `witnessing`. The keyless `identity` (Fulcio SAN/issuer) is distinct from `builder_identity` (the SLSA builder id).
- `ProvenanceInput::SigstoreBundle` parses the bundle **once** into a shared evidence object so every dimension reads the same leaf/DSSE/statement bytes (no drift where identity sees one leaf and Rekor binds another).

## Design decisions

- **`sigstore_bundle` = shape/availability only**, never a trust verdict (`Verified` = decomposable v0.3 DSSE bundle; `UnsupportedFormat` = well-formed but unsupported shape; `Failed` = bytes that should have parsed but didn't).
- **Orthogonal computation** from the sub-primitives directly (not the early-returning bundle verifier), so a wrong `identity` coexists with `dsse_pae=Verified` + `rekor_inclusion=Verified` — Rekor inclusion can never launder a wrong identity.
- **Coupling is honest**: the Rekor v2 entry binds the DSSE signature, so `dsse_pae` and `rekor_inclusion` both fail on a tampered DSSE signature. Dimensions are reported separately, but not all are independent.
- **`policy_result` stays `Pass`/`Fail`/`Incomplete`.** Transparency dimensions are offline-first: a non-verified `rekor_inclusion`/`timestamp_freshness`/`consistency`/`witnessing` uncleans only when the policy requires it; otherwise it is a coverage limit, never a magic pass.

## Tests

9 integration cases over the **independent** `rekor2-dsse-happy-path` conformance vector (real Fulcio/DSSE/Rekor-v2 bytes — proven verifiable by the merged a-3.1b P-384 support):
- real happy path → all dimensions Verified, transparency `NotChecked`, `Pass`
- **wrong identity** + Rekor/DSSE still Verified → `Fail` (load-bearing orthogonality)
- **tampered DSSE signature** → `dsse_pae=Failed` and `rekor_inclusion` not Verified → `Fail` (accepted coupling)
- timestamp freshness required + `NotChecked` → `Incomplete`
- unsupported bundle shape → `Incomplete`; malformed bytes → `Fail`
- required vs optional Rekor when the proof is absent → `Incomplete` vs offline-first `Pass`

Plus a hermetic parse-failure unit test and an append-only-v0 shape contract. Full `assay-registry` suite green; no `Cargo.toml`/`Cargo.lock` change.

## Paired consumer required

This producer is not Plimsoll-consumable until a-3.4b lands; existing Plimsoll a-2 is forward-tolerant but clean-by-omission for the new fields. No witness/relabel may rely on the new dimensions until the paired a-3.4b consumer is merged. MCP04 stays Partial.

The first commit is the carried-over a-3.3c checkpoint extension-lines regression (behaviour already correct; locks it before the carrier composes Rekor inclusion).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sigstore “keyless” supply-chain conformance verification with a new `NotChecked` check state and expanded policy controls for Rekor inclusion and transparency-extension checks (timestamp freshness, consistency, witnessing).

* **Bug Fixes**
  * Improved checkpoint parsing to preserve extension lines in signed text, keeping checkpoint signature verification correctly enforced.

* **Tests**
  * Added unit tests for checkpoint extension preservation.
  * Added integration tests for keyless Sigstore verification, policy combinations, tampering, and malformed/unsupported inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->