### PR TITLE
chore(release): prep v3.27.0 (version + changelog + honest coverage claims)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.27.0] - 2026-06-16
+
+### Added
+- Offline Sigstore-keyless supply-chain verification for MCP packs, composed into the
+  `assay.supply_chain_conformance.v0` carrier with orthogonal per-dimension statuses: Fulcio
+  certificate chain against pinned roots (ECDSA P-256 and P-384), Fulcio identity (SAN + OIDC issuer),
+  DSSE/PAE signature, in-toto subject-digest binding, and Rekor v2 offline inclusion under pinned
+  verifier material. A new `not_checked` status distinguishes deliberately-unverified dimensions
+  (timestamp freshness, log consistency, witnessing) from absent or failed ones. Fully offline: no
+  network, no live transparency-log lookup. (#1701–#1710)
+- Render-safety pipeline for rendered outputs (control-strip → redact → bound → sink-encode) across the
+  Assay CLI sinks (console, `run.json`, SARIF, JUnit), with `assay.render_safety_conformance.v0` and a
+  redaction receipt; redaction precedes bounding so a secret cannot survive as a truncated prefix. Proxy
+  credential-boundary conformance (`assay.token_passthrough_conformance.v0`) shows a consumed inbound
+  auth value is not re-emitted on outbound headers, body, or env. (#1691–#1694)
+
+### Changed
+- OWASP MCP Top 10 mapping: MCP01 and MCP04 promoted to **Strong (scoped)**. The mapping now has no
+  Partial rows — Strong-or-better across all ten risks, with MCP01, MCP04, and MCP09 explicitly scoped
+  to the evidence Assay verifies and carrying explicit coverage limits. This is not a claim that the
+  OWASP MCP Top 10 is solved or eliminated. (#1700, #1711)
+
 ## [3.26.0] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "aya",
  "chrono",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.26.0"
+version = "3.27.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"

--- a/docs/DISTRIBUTION-SUBMISSION-GUIDE.md
+++ b/docs/DISTRIBUTION-SUBMISSION-GUIDE.md
@@ -29,7 +29,7 @@ Per kanaal: link, stappen, en exact wat in te vullen. Laatste verificatie: 2026-
 ```
 Assay is a policy-as-code proxy that sits between AI agents (Cursor, Claude, etc.) and their MCP tool servers. Every tool call gets an explicit ALLOW or DENY, and every decision produces a tamper-evident evidence bundle you can audit, diff, and replay.
 
-The problem: the average MCP server scores 34/100 on security (https://dev.to/elliotllliu/we-scanned-17-popular-mcp-servers-heres-what-we-found-321c). Assay gives you the policy gate and audit trail to fix that. Covers 9 of 10 OWASP MCP Top 10 risks.
+The problem: the average MCP server scores 34/100 on security (https://dev.to/elliotllliu/we-scanned-17-popular-mcp-servers-heres-what-we-found-321c). Assay gives you the policy gate and audit trail to fix that. It maps Strong-or-better coverage across all ten OWASP MCP Top 10 risks (three scoped, with explicit limits), not a claim the Top 10 is solved.
 
 Quick start (2 commands):
   cargo install assay-cli
@@ -91,7 +91,7 @@ assay mcp wrap --policy policy.yaml -- your-mcp-server
 SARIF results in GitHub Security tab.
 
 ## OWASP coverage
-Assay covers 9 of 10 OWASP MCP Top 10 risks. [Full mapping](https://github.com/Rul1an/assay/blob/main/docs/security/OWASP-MCP-TOP10-MAPPING.md).
+Assay maps Strong-or-better coverage across all ten OWASP MCP Top 10 risks (three scoped, with explicit limits). [Full mapping](https://github.com/Rul1an/assay/blob/main/docs/security/OWASP-MCP-TOP10-MAPPING.md).
 
 ## Links
 - [GitHub](https://github.com/Rul1an/assay)
@@ -137,7 +137,7 @@ cargo install assay-cli
 assay mcp wrap --policy policy.yaml -- npx @modelcontextprotocol/server-filesystem /tmp/demo
 ```
 
-**Differentiator:** Deterministic, offline-first, no API keys. Covers 9/10 OWASP MCP Top 10 risks. Evidence bundles are tamper-evident and replayable.
+**Differentiator:** Deterministic, offline-first, no API keys. Strong-or-better across all ten OWASP MCP Top 10 risks (three scoped). Evidence bundles are tamper-evident and replayable.
 
 MIT licensed. [GitHub](https://github.com/Rul1an/assay)
 ```
@@ -192,7 +192,7 @@ MIT licensed. [GitHub](https://github.com/Rul1an/assay)
 | Veld | Waarde |
 |------|--------|
 | **Server name** | `Assay` |
-| **Description** | `The firewall for MCP tool calls. Policy-as-code enforcement with replayable evidence bundles. Block, audit, replay. Covers 9/10 OWASP MCP Top 10.` |
+| **Description** | `The firewall for MCP tool calls. Policy-as-code enforcement with replayable evidence bundles. Block, audit, replay. Strong-or-better across all ten OWASP MCP Top 10 risks (three scoped).` |
 | **Category** | Security / Developer Tools |
 | **Pricing** | Free |
 | **GitHub** | `https://github.com/Rul1an/assay` (zonder www. — `www.github.com` faalt de security scan) |
@@ -337,7 +337,7 @@ Apigene lijkt "vendor-verified official servers" te cureren. Er is geen publiek 
 ### Suggestie
 Stuur mail naar hun contact met:
 - **Onderwerp:** `Request to add Assay to MCP Server Directory`
-- **Body:** Assay is an open-source MCP policy firewall with evidence bundles. GitHub: https://github.com/Rul1an/assay. Covers 9/10 OWASP MCP Top 10. Would like to be listed in the Apigene directory.
+- **Body:** Assay is an open-source MCP policy firewall with evidence bundles. GitHub: https://github.com/Rul1an/assay. Strong-or-better across all ten OWASP MCP Top 10 risks (three scoped). Would like to be listed in the Apigene directory.
 
 ---
 
@@ -371,7 +371,7 @@ Assay is an open-source policy-as-code proxy for MCP tool calls. It sits between
 - MCP02 (Privilege Escalation): restrict_scope enforcement
 - MCP05 (Command Injection): Policy deny, argument validation
 - MCP07 (Auth): approval_required, mandate system
-- Covers 9/10 OWASP MCP Top 10 risks
+- Strong-or-better across all ten OWASP MCP Top 10 risks (three scoped, with explicit limits)
 
 ## Installation
 ```bash
@@ -458,7 +458,7 @@ Geen duidelijk submit-formulier gevonden. Mogelijk via contact of "Add" op de si
 
 ### Suggestie voor contact
 - **Onderwerp:** `Add Assay — MCP policy firewall`
-- **Body:** Assay is an open-source MCP tool-call firewall with replayable evidence bundles. GitHub: https://github.com/Rul1an/assay. Covers 9/10 OWASP MCP Top 10. Would like to be listed.
+- **Body:** Assay is an open-source MCP tool-call firewall with replayable evidence bundles. GitHub: https://github.com/Rul1an/assay. Strong-or-better across all ten OWASP MCP Top 10 risks (three scoped). Would like to be listed.
 
 ---
 


### PR DESCRIPTION
## What

Reversible release prep for **v3.27.0**. No tag, no publish in this PR.

- **Version bump** 3.26.0 → 3.27.0 (`Cargo.toml` + `Cargo.lock`; assay crates only, no dependency churn).
- **CHANGELOG `[3.27.0]`** covering the two arcs shipped since v3.26.0:
  - offline Sigstore-keyless supply-chain verification (Fulcio chain incl. ECDSA P-384, identity, DSSE/PAE, in-toto subject binding, Rekor v2 inclusion) composed into `assay.supply_chain_conformance.v0` with orthogonal per-dimension statuses + a `not_checked` status — fully offline;
  - render-safety pipeline (`render_safety_conformance.v0`) + proxy credential-boundary (`token_passthrough_conformance.v0`);
  - OWASP MCP01 & MCP04 → Strong (scoped).
- **Coverage claims refreshed** in `docs/DISTRIBUTION-SUBMISSION-GUIDE.md`: the seven stale "9/10" lines now read *"Strong-or-better across all ten OWASP MCP Top 10 risks (three scoped, with explicit limits)"* — no "10/10", no "solved", no "complete OWASP coverage".

## Not in this PR

The `v3.27.0` tag (which publishes crates.io + PyPI) is held for an explicit, separate go.

## Verification

`cargo check --workspace` green; `Cargo.lock` diff is only the assay-crate version bumps; no stale `9/10` remains; sanitization clean (no strategy vocab, no em-dash in the rewritten copy).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline supply-chain verification capability for enhanced security.
  * Introduced render-safety pipeline for output protection with redaction receipts.
  * Added token passthrough boundary conformance verification.

* **Documentation**
  * Updated security coverage documentation with refined OWASP mappings and explicit scoping details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->