### PR TITLE
docs(experiments): add evidenceRef recomputation vectors

### DIFF
--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/README.md
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/README.md
@@ -10,11 +10,11 @@ a separate independent reproducer, machine-readable vectors, reproducible from t
 
 ## Run
 
-```
+```bash
 python3 evidenceref_consumer.py emit   > vectors.json   # regenerate the vector bytes
 python3 evidenceref_consumer.py verify vectors.json      # reference: reproduce + measurement
 python3 independent_consumer.py vectors.json             # independent: reproduce from bytes alone
-pytest                                                   # 21 tests: matrix, invariants, interop
+pytest                                                   # 22 tests: matrix, invariants, interop
 ```
 
 Over 17 vectors the consumer reaches a clean (`recomputed`) verdict exactly twice; every other verdict is

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/README.md
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/README.md
@@ -1,0 +1,62 @@
+# Independent evidenceRef recomputation consumer
+
+> Experimental vectors for independent `evidenceRef` recomputation. Not a stable Assay API.
+> This is the recomputation and resolution layer only, not a trust, issuer, or effect verdict.
+
+A small, fail-closed consumer for content-addressed `evidenceRef` references. It resolves a reference,
+recomputes the digest from the referenced bytes under the declared canonicalization, checks the declared
+schema, and renders one verdict, reaching a clean verdict only by recomputation. A reference runner plus
+a separate independent reproducer, machine-readable vectors, reproducible from the bytes alone.
+
+## Run
+
+```
+python3 evidenceref_consumer.py emit   > vectors.json   # regenerate the vector bytes
+python3 evidenceref_consumer.py verify vectors.json      # reference: reproduce + measurement
+python3 independent_consumer.py vectors.json             # independent: reproduce from bytes alone
+pytest                                                   # 21 tests: matrix, invariants, interop
+```
+
+Over 17 vectors the consumer reaches a clean (`recomputed`) verdict exactly twice; every other verdict is
+non-clean. `independent_consumer.py` re-derives every verdict from `vectors.json` with separate code that
+shares no import with the reference runner (asserted by an AST test), so the set reproduces from the bytes
+alone rather than from one implementation trusting another. Two canonicalization profiles are exercised,
+`jcs-json-v1` (RFC 8785 JCS) and `cbor-deterministic-v1` (RFC 8949 section 4.2), so a reference resolves
+through one shared `{digest, canonicalization, schema}` shape.
+
+## Three claims
+
+1. **Independent recomputation, fail closed.** A consumer can resolve a content-addressed `evidenceRef`
+   and render one deterministic verdict from committed bytes, reaching clean only by recomputing the
+   digest under the declared canonicalization and confirming a complete record under the declared schema.
+   Digest-only, unresolvable, unsupported-profile, mismatched, and incomplete cases all fail closed.
+2. **The producer envelope is not the verdict authority.** The producer's own state flag, schema hints,
+   and embedded profile definitions are never inputs. Required fields, completeness rules, and
+   canonicalization profile meanings are resolved by the consumer's own trusted registries, so a producer
+   cannot declare a redacted field non-required or redefine what a profile name means.
+3. **Reproducible by a second, independent implementation.** Every verdict re-derives from the published
+   vectors by a separate reproducer that shares no code with the reference runner, across two distinct
+   canonicalization profiles. Two implementations resolving the same reference by recomputation alone is
+   the bar; one implementation verifying itself is not.
+
+## Five non-claims
+
+1. **Recomputation is not trust.** A clean verdict means the bytes match the content address under the
+   declared canonicalization and schema. It does not mean the producer is honest, the issuer or signature
+   is trusted, or the claimed effect occurred.
+2. **A digest match is not claim sufficiency.** A digest match proves the projection bytes are intact; it
+   does not prove the projection is complete enough to support the claim.
+3. **This is the recomputation/resolution layer only.** Grounding the claim against an independent
+   observation is a separate axis; verifying issuer or signature trust is another. Neither is in scope.
+4. **No live infrastructure.** It operates on committed bytes only and queries no producer, registry, or
+   attestation service.
+5. **Bounded value space.** The two profiles cover the value space of these vectors (float-free JSON and
+   the CBOR types used here); full profile coverage and any counts beyond this vector set are out of scope.
+
+## Verdicts
+
+Clean is reached only by `recomputed`. Every other verdict is non-clean, split into positive
+disagreements (`digest_mismatch`, `canonicalization_mismatch`, `schema_mismatch`, `malformed_ref`) and
+inconclusive states (`unresolvable_digest_only`, `unresolved_ref`, `unsupported_canonicalization`,
+`redacted_projection_incomplete`). The machine-readable canonicalization profiles and schema registry,
+the per-case body store, and each case's committed verdict all live in `vectors.json`.

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/evidenceref_consumer.py
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/evidenceref_consumer.py
@@ -38,14 +38,27 @@ import sys
 
 
 def _confined_path(arg: str) -> str:
-    """Resolve a vectors path, confined to the current working directory tree. An experiment runner
-    should not be coaxed into reading an arbitrary filesystem path, so a resolved path that escapes the
-    working directory is refused. The normalize-then-verify-prefix guard also keeps an operator-supplied
+    """Resolve and validate a vectors path, confined to the working-directory tree. The runner reads a
+    local JSON vectors file only, so the operator-supplied argument is rejected unless it is a relative,
+    traversal-free path to an existing .json file inside the current working directory. The explicit
+    absolute / parent-traversal rejection and the realpath prefix check together keep an untrusted
     argument from reaching the filesystem unchecked."""
+    if not arg or not arg.strip():
+        raise SystemExit("refusing an empty vectors path")
+    normalized = arg.replace("\\", "/")
+    if os.path.isabs(arg) or os.path.isabs(normalized):
+        raise SystemExit(f"refusing an absolute vectors path: {arg!r}")
+    parts = [p for p in normalized.split("/") if p not in ("", ".")]
+    if any(p == ".." for p in parts):
+        raise SystemExit(f"refusing a vectors path with parent traversal: {arg!r}")
     base = os.path.realpath(os.getcwd())
-    resolved = os.path.realpath(os.path.join(base, arg))
+    resolved = os.path.realpath(os.path.join(base, *parts))
     if resolved != base and not resolved.startswith(base + os.sep):
         raise SystemExit(f"refusing a vectors path outside the working directory: {arg!r}")
+    if not resolved.endswith(".json"):
+        raise SystemExit(f"refusing a non-json vectors path: {arg!r}")
+    if not os.path.isfile(resolved):
+        raise SystemExit(f"refusing a non-file vectors path: {arg!r}")
     return resolved
 
 # --------------------------------------------------------------------------------------------------

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/evidenceref_consumer.py
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/evidenceref_consumer.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""E43 - independent evidenceRef recomputation consumer (reference runner + emitter).
+
+Resolves a content-addressed `evidenceRef` and re-derives one fail-closed verdict FROM COMMITTED
+BYTES, the recomputation layer beneath claim grounding. The consumer never trusts the producer: a `recomputed`
+(clean) verdict is reached only by resolving the referenced body, recomputing its digest under the
+DECLARED canonicalization profile, validating the declared schema, and confirming the body is a
+complete evidence record. Anything short of that is non-clean - either a positive disagreement
+(`digest_mismatch` / `canonicalization_mismatch` / `schema_mismatch` / `malformed_ref`) or an
+inconclusive state (`unresolvable_digest_only` / `unresolved_ref` / `unsupported_canonicalization` /
+`redacted_projection_incomplete`). The producer's own `producer_state` ("clean") is NEVER an input.
+
+Two canonicalization profiles are implemented, so the reference is a neutral join point and not one
+producer's envelope in disguise: `jcs-json-v1` (RFC 8785 JCS over the JSON object) and
+`cbor-deterministic-v1` (RFC 8949 sec 4.2 core deterministic encoding). The same logical object
+yields a different digest under each, and each ref resolves only under its own declared profile.
+
+Hard guardrails (the point of this slice, not just interop):
+  - clean ONLY on independent recomputation; `producer_state` is never consulted.
+  - a redacted or silently-elided projection cannot launder missing evidence into clean: completeness
+    is schema-driven (required evidence fields present AND not redaction placeholders), so both a
+    marked redaction and a silent strip land on `redacted_projection_incomplete`.
+  - digest-only / unresolved / unsupported-canon are inconclusive and fail closed, never clean.
+
+Usage:
+  python3 evidenceref_consumer.py emit   > vectors.json     # regenerate the vector bytes
+  python3 evidenceref_consumer.py verify vectors.json        # reproduce every verdict + measurement
+  python3 evidenceref_consumer.py                            # run the in-memory corpus + measurement
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import sys
+
+# --------------------------------------------------------------------------------------------------
+# Canonicalization profiles (public spec; any conformant implementation reproduces these bytes).
+# --------------------------------------------------------------------------------------------------
+
+SUPPORTED_CANON = ("jcs-json-v1", "cbor-deterministic-v1")
+
+CANON_PROFILES = {
+    "jcs-json-v1": {
+        "description": "RFC 8785 (JCS) over the JSON object, float-free value space in these vectors",
+        "hash": "sha256",
+        "digest_encoding": "hex",
+        "digest_prefix": "sha256:",
+    },
+    "cbor-deterministic-v1": {
+        "description": "RFC 8949 section 4.2 core deterministic encoding (definite lengths, shortest "
+        "ints, map keys sorted by encoded-key bytes), value space limited to these vectors",
+        "hash": "sha256",
+        "digest_encoding": "hex",
+        "digest_prefix": "sha256:",
+    },
+}
+
+
+def _jcs(obj) -> bytes:
+    # RFC 8785-equivalent for the float-free value space used here (matches assay's pinned serde_jcs
+    # on this value space, cross-implementation checked): sorted keys, no insignificant whitespace, UTF-8.
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _cbor_head(major: int, n: int) -> bytes:
+    if n < 24:
+        return bytes([(major << 5) | n])
+    if n < 0x100:
+        return bytes([(major << 5) | 24, n])
+    if n < 0x10000:
+        return bytes([(major << 5) | 25]) + n.to_bytes(2, "big")
+    if n < 0x100000000:
+        return bytes([(major << 5) | 26]) + n.to_bytes(4, "big")
+    return bytes([(major << 5) | 27]) + n.to_bytes(8, "big")
+
+
+def _cbor(obj) -> bytes:
+    # RFC 8949 sec 4.2 core deterministic encoding. bool is checked before int (bool subclasses int).
+    if obj is True:
+        return b"\xf5"
+    if obj is False:
+        return b"\xf4"
+    if obj is None:
+        return b"\xf6"
+    if isinstance(obj, int):
+        return _cbor_head(0, obj) if obj >= 0 else _cbor_head(1, -1 - obj)
+    if isinstance(obj, str):
+        b = obj.encode("utf-8")
+        return _cbor_head(3, len(b)) + b
+    if isinstance(obj, list):
+        return _cbor_head(4, len(obj)) + b"".join(_cbor(x) for x in obj)
+    if isinstance(obj, dict):
+        items = sorted(((_cbor(str(k)), _cbor(v)) for k, v in obj.items()), key=lambda kv: kv[0])
+        return _cbor_head(5, len(items)) + b"".join(k + v for k, v in items)
+    raise TypeError(f"cbor-deterministic-v1 does not encode {type(obj).__name__}")
+
+
+def canonical_bytes(obj, canon: str) -> bytes | None:
+    if canon == "jcs-json-v1":
+        return _jcs(obj)
+    if canon == "cbor-deterministic-v1":
+        return _cbor(obj)
+    return None  # unsupported: never assume a default profile
+
+
+def content_address(obj, canon: str) -> str | None:
+    cb = canonical_bytes(obj, canon)
+    return None if cb is None else "sha256:" + hashlib.sha256(cb).hexdigest()
+
+
+# --------------------------------------------------------------------------------------------------
+# Schema registry: each schema names the evidence fields required for a record to be COMPLETE. A
+# present-but-redacted placeholder counts as missing, which is what defeats projection laundering.
+# --------------------------------------------------------------------------------------------------
+
+SCHEMA_REGISTRY = {
+    "assay.policy_decision/v1": {
+        "required_fields": ["schema", "schema_version", "decision", "effect", "target"],
+    },
+    "assay.sequence/v1": {
+        "required_fields": ["schema", "schema_version", "sequence", "terminal"],
+    },
+}
+
+
+def _is_redacted(value) -> bool:
+    """A field present only as a redaction placeholder is not usable evidence."""
+    if value is None:
+        return True
+    if value == "<redacted>":
+        return True
+    if isinstance(value, dict) and value.get("_redacted") is True:
+        return True
+    return False
+
+
+# --------------------------------------------------------------------------------------------------
+# The consumer: one fail-closed verdict per evidenceRef, recomputed from bytes, no producer trust.
+# --------------------------------------------------------------------------------------------------
+
+
+def _v(verdict: str, reason: str) -> dict:
+    return {"verdict": verdict, "reason": reason}
+
+
+def consume(ref: dict, body_store: dict, schema_registry: dict = SCHEMA_REGISTRY) -> dict:
+    """Resolve and recompute one evidenceRef. `producer_state` on the ref is deliberately ignored."""
+    # 1. A ref missing its content address or its canonicalization profile cannot be recomputed.
+    if not ref.get("digest") or not ref.get("canonicalization"):
+        return _v("malformed_ref", "missing_required_field_digest_or_canonicalization")
+
+    canon = ref["canonicalization"]
+    locator = ref.get("ref")  # None => digest-only form (no body to recompute from)
+
+    # 2. Resolve the referenced bytes. A committed digest alone is not sufficient.
+    if locator is None:
+        return _v("unresolvable_digest_only", "digest_alone_insufficient_no_resolvable_body")
+    if locator not in body_store:
+        return _v("unresolved_ref", "ref_present_but_body_not_resolvable")
+    body = body_store[locator]
+
+    # 3. The declared canonicalization is a NAME resolved by this consumer's profile registry; the
+    #    producer may name a profile but may not define what it means. A non-string definition (a
+    #    producer trying to embed its own rules) or an unknown name is refused, never assumed.
+    if not isinstance(canon, str) or canon not in SUPPORTED_CANON:
+        return _v("unsupported_canonicalization", "declared_profile_not_in_consumer_profile_registry")
+
+    # 4. Recompute the digest under the DECLARED profile and compare to the committed value.
+    recomputed = content_address(body, canon)
+    if recomputed != ref["digest"]:
+        # Distinguish a wrong-profile declaration from a tampered object: does the committed digest
+        # match the body under a different supported profile? If so the bytes are intact but the ref
+        # named the wrong canonicalization.
+        for alt in SUPPORTED_CANON:
+            if alt != canon and content_address(body, alt) == ref["digest"]:
+                return _v("canonicalization_mismatch", f"digest_matches_{alt}_not_declared_{canon}")
+        return _v("digest_mismatch", "recompute_under_declared_canon_diverges_from_committed_digest")
+
+    # 5. The body must carry the declared schema. Identity is bound into the digest, so this also
+    #    fails closed if the schema fields were tampered.
+    body_schema = f"{body.get('schema')}/{body.get('schema_version')}"
+    if body_schema != f"{ref.get('schema')}/{ref.get('schema_version')}":
+        return _v("schema_mismatch", "body_schema_differs_from_declared")
+    # The completeness rules come ONLY from this consumer's trusted registry, keyed by the schema
+    # identity. Producer-supplied completeness metadata - a `producer_schema_hint` on the ref or a
+    # body-local `_schema` override - is never read, so a producer cannot declare a redacted field
+    # non-required. Schema authority is consumer-controlled, not producer-controlled.
+    spec = schema_registry.get(body_schema)
+    if spec is None:
+        return _v("schema_mismatch", f"unknown_schema_{body_schema}")
+
+    # 6. Completeness: a projection that elides or redacts a required evidence field is inconclusive,
+    #    even though its own digest recomputes. The projection existing does not make the claim clean.
+    incomplete = [f for f in spec["required_fields"] if f not in body or _is_redacted(body[f])]
+    if incomplete:
+        return _v("redacted_projection_incomplete", "missing_or_redacted_required_evidence:" + ",".join(incomplete))
+
+    # 7. Independent clean: the bytes match the content address under the declared canonicalization,
+    #    the schema holds, the record is complete. This is NOT a trust verdict on the producer.
+    return _v("recomputed", "bytes_match_address_under_declared_canon_and_schema_complete")
+
+
+# --------------------------------------------------------------------------------------------------
+# Corpus: the full happy + negative matrix. Digests are computed here, so every vector is recomputable.
+# --------------------------------------------------------------------------------------------------
+
+PD = ("assay.policy_decision", "v1")
+
+
+def _obj(schema, **fields) -> dict:
+    o = {"schema": schema[0], "schema_version": schema[1]}
+    o.update(fields)
+    return o
+
+
+def _ref(digest, locator, canon, schema, **extra) -> dict:
+    r = {
+        "type": "policy_decision",
+        "digest": digest,
+        "ref": locator,
+        "canonicalization": canon,
+        "schema": schema[0],
+        "schema_version": schema[1],
+    }
+    r.update(extra)
+    return r
+
+
+def build_corpus() -> list[dict]:
+    """Each case is self-contained: an evidenceRef, its own body_store, and a kind tag for invariants."""
+    cases: list[dict] = []
+
+    def add(cid, kind, ref, body_store):
+        cases.append({"id": cid, "kind": kind, "ref": ref, "body_store": body_store})
+
+    # c1 - happy path, JCS profile.
+    o1 = _obj(PD, decision="allow", effect={"wrote": "x"}, target={"path": "/etc/x"})
+    add("c1_happy_jcs", "happy",
+        _ref(content_address(o1, "jcs-json-v1"), "loc1", "jcs-json-v1", PD), {"loc1": o1})
+
+    # c2 - happy path, deterministic-CBOR profile (envelope-neutral: same shape, different profile).
+    o2 = _obj(PD, decision="deny", effect={"blocked": "connect"}, target={"host": "10.0.0.1"})
+    add("c2_happy_cbor", "happy",
+        _ref(content_address(o2, "cbor-deterministic-v1"), "loc2", "cbor-deterministic-v1", PD), {"loc2": o2})
+
+    # c3 - digest-only, no resolvable body. Inconclusive, never clean.
+    o3 = _obj(PD, decision="allow", effect={"wrote": "y"}, target={"path": "/y"})
+    add("c3_digest_only_no_body", "inconclusive",
+        _ref(content_address(o3, "jcs-json-v1"), None, "jcs-json-v1", PD), {})
+
+    # c4 - ref present but body not resolvable. Fail closed.
+    o4 = _obj(PD, decision="allow", effect={"wrote": "z"}, target={"path": "/z"})
+    add("c4_unresolved_ref", "inconclusive",
+        _ref(content_address(o4, "jcs-json-v1"), "missing", "jcs-json-v1", PD), {"other": o4})
+
+    # c5 - body resolves but is a different object than the committed digest (tamper). Positive fail.
+    o5a = _obj(PD, decision="allow", effect={"wrote": "a"}, target={"path": "/a"})
+    o5b = _obj(PD, decision="allow", effect={"wrote": "b"}, target={"path": "/b"})
+    add("c5_digest_mismatch", "fail",
+        _ref(content_address(o5a, "jcs-json-v1"), "loc5", "jcs-json-v1", PD), {"loc5": o5b})
+
+    # c6 - bytes intact but the ref names the wrong profile: digest is the CBOR digest, canon says JCS.
+    o6 = _obj(PD, decision="deny", effect={"blocked": "write"}, target={"path": "/c"})
+    add("c6_canon_mismatch", "fail",
+        _ref(content_address(o6, "cbor-deterministic-v1"), "loc6", "jcs-json-v1", PD), {"loc6": o6})
+
+    # c7 - canonicalization profile this consumer does not implement. Inconclusive, never assumed.
+    o7 = _obj(PD, decision="allow", effect={"wrote": "d"}, target={"path": "/d"})
+    add("c7_unsupported_canon", "inconclusive",
+        _ref("sha256:" + "0" * 64, "loc7", "protobuf-canonical-v1", PD), {"loc7": o7})
+
+    # c8 - body recomputes but carries a different schema than declared. Positive fail.
+    o8 = _obj(("assay.other", "v1"), decision="allow", effect={"wrote": "e"}, target={"path": "/e"})
+    add("c8_schema_mismatch", "fail",
+        _ref(content_address(o8, "jcs-json-v1"), "loc8", "jcs-json-v1", PD), {"loc8": o8})
+
+    # c9 - redacted projection: a required evidence field present only as a redaction placeholder.
+    o9 = _obj(PD, decision="allow", effect={"_redacted": True}, target={"path": "/f"}, redacted_fields=["effect"])
+    add("c9_redacted_projection_marked", "redaction",
+        _ref(content_address(o9, "jcs-json-v1"), "loc9", "jcs-json-v1", PD), {"loc9": o9})
+
+    # c10 - silent elision: the required evidence field is simply absent, with no redaction marker.
+    o10 = _obj(PD, decision="allow", target={"path": "/g"})  # no "effect" key at all
+    add("c10_silent_elision", "redaction",
+        _ref(content_address(o10, "jcs-json-v1"), "loc10", "jcs-json-v1", PD), {"loc10": o10})
+
+    # c11 - producer self-declares clean, digest-only, no body. The flag must not promote it.
+    o11 = _obj(PD, decision="allow", effect={"wrote": "h"}, target={"path": "/h"})
+    add("c11_producer_clean_no_body", "producer_self_clean",
+        _ref(content_address(o11, "jcs-json-v1"), None, "jcs-json-v1", PD, producer_state="clean"), {})
+
+    # c12 - producer self-declares clean over a tampered body. The flag must not launder the mismatch.
+    o12a = _obj(PD, decision="allow", effect={"wrote": "i"}, target={"path": "/i"})
+    o12b = _obj(PD, decision="allow", effect={"wrote": "j"}, target={"path": "/j"})
+    add("c12_producer_clean_mismatch", "producer_self_clean",
+        _ref(content_address(o12a, "jcs-json-v1"), "loc12", "jcs-json-v1", PD, producer_state="clean"),
+        {"loc12": o12b})
+
+    # c13 - malformed ref: no content address.
+    add("c13_malformed_no_digest", "fail",
+        {"type": "policy_decision", "ref": "loc13", "canonicalization": "jcs-json-v1",
+         "schema": PD[0], "schema_version": PD[1]}, {"loc13": _obj(PD, decision="allow", effect={}, target={})})
+
+    # c14 - malformed ref: no canonicalization profile.
+    o14 = _obj(PD, decision="allow", effect={"wrote": "k"}, target={"path": "/k"})
+    add("c14_malformed_no_canon", "fail",
+        {"type": "policy_decision", "digest": content_address(o14, "jcs-json-v1"), "ref": "loc14",
+         "schema": PD[0], "schema_version": PD[1]}, {"loc14": o14})
+
+    # c15 - schema authority: the ref carries a producer `producer_schema_hint` that would make the
+    #       redacted field non-required. The consumer ignores it; the redaction still fails closed.
+    o15 = _obj(PD, decision="allow", effect={"_redacted": True}, target={"path": "/l"})
+    add("c15_producer_schema_hint", "schema_authority",
+        _ref(content_address(o15, "jcs-json-v1"), "loc15", "jcs-json-v1", PD,
+             producer_schema_hint={"required_fields": []}), {"loc15": o15})
+
+    # c16 - schema authority: a body-local `_schema` override claims no required fields. The consumer
+    #       uses its own registry, never the body's self-description; the redaction still fails closed.
+    o16 = _obj(PD, decision="allow", effect={"_redacted": True}, target={"path": "/m"})
+    o16["_schema"] = {"required_fields": []}
+    add("c16_body_local_schema_override", "schema_authority",
+        _ref(content_address(o16, "jcs-json-v1"), "loc16", "jcs-json-v1", PD), {"loc16": o16})
+
+    # c17 - profile authority: the ref tries to embed its own canonicalization definition instead of
+    #       naming a profile. The consumer resolves profiles by name from its registry and refuses a
+    #       producer-provided definition.
+    o17 = _obj(PD, decision="allow", effect={"wrote": "n"}, target={"path": "/n"})
+    add("c17_producer_defined_canon", "profile_authority",
+        _ref("sha256:" + "0" * 64, "loc17",
+             {"name": "jcs-json-v1", "rules": "producer-defined-do-not-honor"}, PD), {"loc17": o17})
+
+    # Attach the expected verdict from the reference consumer, so the independent runner reproduces it.
+    for case in cases:
+        case["expected"] = consume(case["ref"], case["body_store"])
+    return cases
+
+
+def emit() -> dict:
+    return {
+        "schema": "assay.experiment.e43_evidenceref_recompute_consumer.v0",
+        "canonicalization_profiles": CANON_PROFILES,
+        "schema_registry": SCHEMA_REGISTRY,
+        "verdicts": [
+            "recomputed", "digest_mismatch", "canonicalization_mismatch", "schema_mismatch",
+            "malformed_ref", "unresolvable_digest_only", "unresolved_ref",
+            "unsupported_canonicalization", "redacted_projection_incomplete",
+        ],
+        "cases": build_corpus(),
+    }
+
+
+# --------------------------------------------------------------------------------------------------
+# Measurement: reproduce every verdict and assert the load-bearing invariants.
+# --------------------------------------------------------------------------------------------------
+
+
+def measure(doc: dict) -> dict:
+    cases = doc["cases"]
+    registry = doc.get("schema_registry", SCHEMA_REGISTRY)
+    counts: dict[str, int] = {}
+    failures = []
+    by_id = {}
+    for case in cases:
+        got = consume(case["ref"], case["body_store"], registry)
+        by_id[case["id"]] = got
+        counts[got["verdict"]] = counts.get(got["verdict"], 0) + 1
+        if got != case["expected"]:
+            failures.append(f"{case['id']}: got {got}, expected {case['expected']}")
+
+    clean = {cid for cid, v in by_id.items() if v["verdict"] == "recomputed"}
+
+    # Invariant 1: producer_state is never consulted - flip it on a happy ref and on a tamper ref;
+    # the verdict must not move.
+    happy = next(c for c in cases if c["id"] == "c1_happy_jcs")
+    tamper = next(c for c in cases if c["id"] == "c5_digest_mismatch")
+    happy_dirty = consume({**happy["ref"], "producer_state": "dirty"}, happy["body_store"], registry)
+    tamper_clean = consume({**tamper["ref"], "producer_state": "clean"}, tamper["body_store"], registry)
+    producer_state_never_consulted = (
+        happy_dirty == by_id["c1_happy_jcs"] and tamper_clean == by_id["c5_digest_mismatch"]
+    )
+
+    o = {"schema": "assay.policy_decision", "schema_version": "v1", "decision": "x",
+         "effect": {"e": 1}, "target": {"t": 1}}
+    envelope_distinct = content_address(o, "jcs-json-v1") != content_address(o, "cbor-deterministic-v1")
+
+    # Schema authority: a producer hint cannot turn a redacted projection clean, and cannot move a
+    # clean verdict; the completeness rules come only from the consumer registry.
+    redacted = next(c for c in cases if c["id"] == "c9_redacted_projection_marked")
+    redacted_hinted = consume(
+        {**redacted["ref"], "producer_schema_hint": {"required_fields": []}}, redacted["body_store"], registry)
+    happy_hinted = consume(
+        {**happy["ref"], "producer_schema_hint": {"required_fields": []}}, happy["body_store"], registry)
+    schema_authority_is_consumer_controlled = (
+        by_id["c15_producer_schema_hint"]["verdict"] == "redacted_projection_incomplete"
+        and by_id["c16_body_local_schema_override"]["verdict"] == "redacted_projection_incomplete"
+        and redacted_hinted == by_id["c9_redacted_projection_marked"]
+        and happy_hinted == by_id["c1_happy_jcs"]
+    )
+
+    # Profile authority: a producer may name a profile but not define it; an embedded definition is
+    # refused, and a stray producer `canonicalization_rules` sibling on a valid ref is never read.
+    happy_ruled = consume(
+        {**happy["ref"], "canonicalization_rules": "producer-defined-bogus"}, happy["body_store"], registry)
+    canonicalization_profile_authority_is_consumer_controlled = (
+        by_id["c17_producer_defined_canon"]["verdict"] == "unsupported_canonicalization"
+        and happy_ruled == by_id["c1_happy_jcs"]
+    )
+
+    invariants = {
+        # clean is reached ONLY for the two happy paths, both by independent recomputation.
+        "clean_only_on_independent_recomputation": clean == {"c1_happy_jcs", "c2_happy_cbor"},
+        # a marked redaction AND a silent elision both fail to launder into clean.
+        "redacted_projection_cannot_launder": (
+            by_id["c9_redacted_projection_marked"]["verdict"] == "redacted_projection_incomplete"
+            and by_id["c10_silent_elision"]["verdict"] == "redacted_projection_incomplete"
+        ),
+        # a producer self-declared clean never promotes a missing or tampered body.
+        "producer_self_clean_never_promotes": (
+            by_id["c11_producer_clean_no_body"]["verdict"] == "unresolvable_digest_only"
+            and by_id["c12_producer_clean_mismatch"]["verdict"] == "digest_mismatch"
+        ),
+        "producer_state_never_consulted": producer_state_never_consulted,
+        # digest alone, unresolved refs, and unsupported profiles all fail closed.
+        "digest_only_is_inconclusive": by_id["c3_digest_only_no_body"]["verdict"] == "unresolvable_digest_only",
+        "unresolved_ref_fails_closed": by_id["c4_unresolved_ref"]["verdict"] == "unresolved_ref",
+        "canonicalization_explicit": (
+            by_id["c6_canon_mismatch"]["verdict"] == "canonicalization_mismatch"
+            and by_id["c7_unsupported_canon"]["verdict"] == "unsupported_canonicalization"
+            and envelope_distinct
+        ),
+        # completeness rules are the consumer's, never the producer's: hints and body-local overrides
+        # cannot launder a redacted projection into clean.
+        "schema_authority_is_consumer_controlled": schema_authority_is_consumer_controlled,
+        # profile meaning is the consumer's: a producer names a profile, it does not define one.
+        "canonicalization_profile_authority_is_consumer_controlled": canonicalization_profile_authority_is_consumer_controlled,
+        # headline: the producer envelope is not the verdict authority. Its state flag, schema hints,
+        # and profile definitions never decide the verdict, and both canonicalization profiles reach
+        # clean through the one consumer code path.
+        "producer_envelope_not_authoritative": (
+            producer_state_never_consulted
+            and schema_authority_is_consumer_controlled
+            and canonicalization_profile_authority_is_consumer_controlled
+            and {"c1_happy_jcs", "c2_happy_cbor"} <= clean
+        ),
+    }
+
+    return {
+        "schema": "assay.experiment.e43_evidenceref_recompute_consumer.v0",
+        "cases": len(cases),
+        "verdict_counts": counts,
+        "all_expected": not failures,
+        "invariants": invariants,
+        "all_invariants_hold": all(invariants.values()),
+        "failures": failures,
+        "non_claims": [
+            "recomputation is not trust: a recomputed verdict means the bytes match the content "
+            "address under the declared canonicalization and schema, not that the producer is honest, "
+            "the issuer or signature is trusted, or the claimed effect occurred",
+            "grounding the claim against an independent observed basis (agrees/contradicts/unobserved) "
+            "is a separate axis; verifying issuer or signature trust is another",
+            "operates on committed bytes only; queries no live producer, MCP, or attestation service",
+            "required fields, completeness rules, and canonicalization profile meanings are resolved "
+            "by the consumer's own trusted registries; producer-supplied schema hints, body-local "
+            "schema overrides, and embedded profile definitions are never an input to the verdict",
+            "jcs-json-v1 is RFC 8785 over a float-free value space and cbor-deterministic-v1 is RFC "
+            "8949 sec 4.2 over the value types used here; full float and value-space coverage is out "
+            "of scope for this vector set",
+            "counts describe this vector set only, not real-world prevalence",
+        ],
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) >= 2 and argv[1] == "emit":
+        print(json.dumps(emit(), indent=2, sort_keys=True))
+        return 0
+    if len(argv) >= 2 and argv[1] == "verify":
+        path = argv[2] if len(argv) > 2 else "vectors.json"
+        doc = json.loads(pathlib.Path(path).read_text())
+    else:
+        doc = emit()
+    result = measure(doc)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    ok = result["all_expected"] and result["all_invariants_hold"]
+    if not ok:
+        for f in result["failures"]:
+            print("FAIL:", f, file=sys.stderr)
+        for name, held in result["invariants"].items():
+            if not held:
+                print("INVARIANT FAILED:", name, file=sys.stderr)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/evidenceref_consumer.py
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/evidenceref_consumer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""E43 - independent evidenceRef recomputation consumer (reference runner + emitter).
+"""Independent evidenceRef recomputation consumer (reference runner + emitter).
 
 Resolves a content-addressed `evidenceRef` and re-derives one fail-closed verdict FROM COMMITTED
 BYTES, the recomputation layer beneath claim grounding. The consumer never trusts the producer: a `recomputed`
@@ -10,12 +10,13 @@ complete evidence record. Anything short of that is non-clean - either a positiv
 inconclusive state (`unresolvable_digest_only` / `unresolved_ref` / `unsupported_canonicalization` /
 `redacted_projection_incomplete`). The producer's own `producer_state` ("clean") is NEVER an input.
 
-Two canonicalization profiles are implemented, so the reference is a neutral join point and not one
-producer's envelope in disguise: `jcs-json-v1` (RFC 8785 JCS over the JSON object) and
-`cbor-deterministic-v1` (RFC 8949 sec 4.2 core deterministic encoding). The same logical object
-yields a different digest under each, and each ref resolves only under its own declared profile.
+Two canonicalization profiles are implemented, so the join point stays at
+`{digest, canonicalization, schema}` rather than at one producer's serialization: `jcs-json-v1`
+(RFC 8785 JCS over the JSON object) and `cbor-deterministic-v1` (RFC 8949 sec 4.2 core deterministic
+encoding). The same logical object yields a different digest under each, and each ref resolves only
+under its own declared profile.
 
-Hard guardrails (the point of this slice, not just interop):
+Hard guardrails (the point here, not just interop):
   - clean ONLY on independent recomputation; `producer_state` is never consulted.
   - a redacted or silently-elided projection cannot launder missing evidence into clean: completeness
     is schema-driven (required evidence fields present AND not redaction placeholders), so both a
@@ -31,8 +32,21 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import pathlib
 import sys
+
+
+def _confined_path(arg: str) -> str:
+    """Resolve a vectors path, confined to the current working directory tree. An experiment runner
+    should not be coaxed into reading an arbitrary filesystem path, so a resolved path that escapes the
+    working directory is refused. The normalize-then-verify-prefix guard also keeps an operator-supplied
+    argument from reaching the filesystem unchecked."""
+    base = os.path.realpath(os.getcwd())
+    resolved = os.path.realpath(os.path.join(base, arg))
+    if resolved != base and not resolved.startswith(base + os.sep):
+        raise SystemExit(f"refusing a vectors path outside the working directory: {arg!r}")
+    return resolved
 
 # --------------------------------------------------------------------------------------------------
 # Canonicalization profiles (public spec; any conformant implementation reproduces these bytes).
@@ -338,7 +352,7 @@ def build_corpus() -> list[dict]:
 
 def emit() -> dict:
     return {
-        "schema": "assay.experiment.e43_evidenceref_recompute_consumer.v0",
+        "schema": "assay.experiment.evidenceref_recompute_consumer.v0",
         "canonicalization_profiles": CANON_PROFILES,
         "schema_registry": SCHEMA_REGISTRY,
         "verdicts": [
@@ -446,7 +460,7 @@ def measure(doc: dict) -> dict:
     }
 
     return {
-        "schema": "assay.experiment.e43_evidenceref_recompute_consumer.v0",
+        "schema": "assay.experiment.evidenceref_recompute_consumer.v0",
         "cases": len(cases),
         "verdict_counts": counts,
         "all_expected": not failures,
@@ -477,7 +491,7 @@ def main(argv: list[str]) -> int:
         return 0
     if len(argv) >= 2 and argv[1] == "verify":
         path = argv[2] if len(argv) > 2 else "vectors.json"
-        doc = json.loads(pathlib.Path(path).read_text())
+        doc = json.loads(pathlib.Path(_confined_path(path)).read_text())
     else:
         doc = emit()
     result = measure(doc)

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/independent_consumer.py
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/independent_consumer.py
@@ -21,13 +21,27 @@ SUPPORTED_CANON = ("jcs-json-v1", "cbor-deterministic-v1")
 
 
 def _confined_path(arg: str) -> str:
-    """Resolve a vectors path, confined to the current working directory tree, so the reproducer
-    cannot be pointed at an arbitrary filesystem path. The normalize-then-verify-prefix guard keeps an
-    operator-supplied argument from reaching the filesystem unchecked."""
+    """Resolve and validate a vectors path, confined to the working-directory tree. The reproducer reads
+    a local JSON vectors file only, so the operator-supplied argument is rejected unless it is a relative,
+    traversal-free path to an existing .json file inside the current working directory. The explicit
+    absolute / parent-traversal rejection and the realpath prefix check together keep an untrusted
+    argument from reaching the filesystem unchecked."""
+    if not arg or not arg.strip():
+        raise SystemExit("refusing an empty vectors path")
+    normalized = arg.replace("\\", "/")
+    if os.path.isabs(arg) or os.path.isabs(normalized):
+        raise SystemExit(f"refusing an absolute vectors path: {arg!r}")
+    parts = [p for p in normalized.split("/") if p not in ("", ".")]
+    if any(p == ".." for p in parts):
+        raise SystemExit(f"refusing a vectors path with parent traversal: {arg!r}")
     base = os.path.realpath(os.getcwd())
-    resolved = os.path.realpath(os.path.join(base, arg))
+    resolved = os.path.realpath(os.path.join(base, *parts))
     if resolved != base and not resolved.startswith(base + os.sep):
         raise SystemExit(f"refusing a vectors path outside the working directory: {arg!r}")
+    if not resolved.endswith(".json"):
+        raise SystemExit(f"refusing a non-json vectors path: {arg!r}")
+    if not os.path.isfile(resolved):
+        raise SystemExit(f"refusing a non-file vectors path: {arg!r}")
     return resolved
 
 

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/independent_consumer.py
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/independent_consumer.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Independent reproducer for the E43 evidenceRef recomputation vectors.
+
+Reads `vectors.json` ALONE and re-derives every expected verdict with separate code that does NOT
+import `evidenceref_consumer.py`. It implements the two canonicalization profiles from their public
+specs (RFC 8785 JCS and RFC 8949 sec 4.2 deterministic CBOR) and the same fail-closed resolution
+logic, then checks that each recomputed verdict matches the one committed in the vector. Agreement
+means the set reproduces from the bytes alone, with no shared runner and no producer trust: the
+two-implementation interop bar, the bar a reference that only verifies itself cannot clear.
+
+Usage: python3 independent_consumer.py [vectors.json]
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+
+SUPPORTED_CANON = ("jcs-json-v1", "cbor-deterministic-v1")
+
+
+def jcs(obj) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _head(major: int, n: int) -> bytes:
+    if n < 24:
+        return bytes([(major << 5) | n])
+    if n < 0x100:
+        return bytes([(major << 5) | 24, n])
+    if n < 0x10000:
+        return bytes([(major << 5) | 25]) + n.to_bytes(2, "big")
+    if n < 0x100000000:
+        return bytes([(major << 5) | 26]) + n.to_bytes(4, "big")
+    return bytes([(major << 5) | 27]) + n.to_bytes(8, "big")
+
+
+def cbor(obj) -> bytes:
+    if obj is True:
+        return b"\xf5"
+    if obj is False:
+        return b"\xf4"
+    if obj is None:
+        return b"\xf6"
+    if isinstance(obj, int):
+        return _head(0, obj) if obj >= 0 else _head(1, -1 - obj)
+    if isinstance(obj, str):
+        b = obj.encode("utf-8")
+        return _head(3, len(b)) + b
+    if isinstance(obj, list):
+        return _head(4, len(obj)) + b"".join(cbor(x) for x in obj)
+    if isinstance(obj, dict):
+        items = sorted(((cbor(str(k)), cbor(v)) for k, v in obj.items()), key=lambda kv: kv[0])
+        return _head(5, len(items)) + b"".join(k + v for k, v in items)
+    raise TypeError(f"unencodable: {type(obj).__name__}")
+
+
+def address(obj, canon: str):
+    if canon == "jcs-json-v1":
+        return "sha256:" + hashlib.sha256(jcs(obj)).hexdigest()
+    if canon == "cbor-deterministic-v1":
+        return "sha256:" + hashlib.sha256(cbor(obj)).hexdigest()
+    return None
+
+
+def is_redacted(value) -> bool:
+    return value is None or value == "<redacted>" or (isinstance(value, dict) and value.get("_redacted") is True)
+
+
+def reproduce(ref: dict, body_store: dict, registry: dict) -> dict:
+    if not ref.get("digest") or not ref.get("canonicalization"):
+        return {"verdict": "malformed_ref", "reason": "missing_required_field_digest_or_canonicalization"}
+    canon = ref["canonicalization"]
+    locator = ref.get("ref")
+    if locator is None:
+        return {"verdict": "unresolvable_digest_only", "reason": "digest_alone_insufficient_no_resolvable_body"}
+    if locator not in body_store:
+        return {"verdict": "unresolved_ref", "reason": "ref_present_but_body_not_resolvable"}
+    body = body_store[locator]
+    if not isinstance(canon, str) or canon not in SUPPORTED_CANON:
+        return {"verdict": "unsupported_canonicalization", "reason": "declared_profile_not_in_consumer_profile_registry"}
+    if address(body, canon) != ref["digest"]:
+        for alt in SUPPORTED_CANON:
+            if alt != canon and address(body, alt) == ref["digest"]:
+                return {"verdict": "canonicalization_mismatch", "reason": f"digest_matches_{alt}_not_declared_{canon}"}
+        return {"verdict": "digest_mismatch", "reason": "recompute_under_declared_canon_diverges_from_committed_digest"}
+    body_schema = f"{body.get('schema')}/{body.get('schema_version')}"
+    if body_schema != f"{ref.get('schema')}/{ref.get('schema_version')}":
+        return {"verdict": "schema_mismatch", "reason": "body_schema_differs_from_declared"}
+    spec = registry.get(body_schema)
+    if spec is None:
+        return {"verdict": "schema_mismatch", "reason": f"unknown_schema_{body_schema}"}
+    incomplete = [f for f in spec["required_fields"] if f not in body or is_redacted(body[f])]
+    if incomplete:
+        return {"verdict": "redacted_projection_incomplete", "reason": "missing_or_redacted_required_evidence:" + ",".join(incomplete)}
+    return {"verdict": "recomputed", "reason": "bytes_match_address_under_declared_canon_and_schema_complete"}
+
+
+def main() -> int:
+    path = sys.argv[1] if len(sys.argv) > 1 else "vectors.json"
+    with open(path, encoding="utf-8") as fh:
+        doc = json.load(fh)
+    registry = doc.get("schema_registry", {})
+    failures = [
+        f"{c['id']}: got {reproduce(c['ref'], c['body_store'], registry)}, expected {c['expected']}"
+        for c in doc["cases"]
+        if reproduce(c["ref"], c["body_store"], registry) != c["expected"]
+    ]
+    print(json.dumps({
+        "reproducer": "independent",
+        "cases": len(doc["cases"]),
+        "all_reproduced": not failures,
+        "failures": failures,
+    }, indent=2, sort_keys=True))
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/independent_consumer.py
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/independent_consumer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Independent reproducer for the E43 evidenceRef recomputation vectors.
+"""Independent reproducer for the evidenceRef recomputation vectors.
 
 Reads `vectors.json` ALONE and re-derives every expected verdict with separate code that does NOT
 import `evidenceref_consumer.py`. It implements the two canonicalization profiles from their public
@@ -14,9 +14,21 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
 
 SUPPORTED_CANON = ("jcs-json-v1", "cbor-deterministic-v1")
+
+
+def _confined_path(arg: str) -> str:
+    """Resolve a vectors path, confined to the current working directory tree, so the reproducer
+    cannot be pointed at an arbitrary filesystem path. The normalize-then-verify-prefix guard keeps an
+    operator-supplied argument from reaching the filesystem unchecked."""
+    base = os.path.realpath(os.getcwd())
+    resolved = os.path.realpath(os.path.join(base, arg))
+    if resolved != base and not resolved.startswith(base + os.sep):
+        raise SystemExit(f"refusing a vectors path outside the working directory: {arg!r}")
+    return resolved
 
 
 def jcs(obj) -> bytes:
@@ -98,7 +110,7 @@ def reproduce(ref: dict, body_store: dict, registry: dict) -> dict:
 
 def main() -> int:
     path = sys.argv[1] if len(sys.argv) > 1 else "vectors.json"
-    with open(path, encoding="utf-8") as fh:
+    with open(_confined_path(path), encoding="utf-8") as fh:
         doc = json.load(fh)
     registry = doc.get("schema_registry", {})
     failures = [

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/result.json
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/result.json
@@ -1,0 +1,38 @@
+{
+  "all_expected": true,
+  "all_invariants_hold": true,
+  "cases": 17,
+  "failures": [],
+  "invariants": {
+    "canonicalization_explicit": true,
+    "canonicalization_profile_authority_is_consumer_controlled": true,
+    "clean_only_on_independent_recomputation": true,
+    "digest_only_is_inconclusive": true,
+    "producer_envelope_not_authoritative": true,
+    "producer_self_clean_never_promotes": true,
+    "producer_state_never_consulted": true,
+    "redacted_projection_cannot_launder": true,
+    "schema_authority_is_consumer_controlled": true,
+    "unresolved_ref_fails_closed": true
+  },
+  "non_claims": [
+    "recomputation is not trust: a recomputed verdict means the bytes match the content address under the declared canonicalization and schema, not that the producer is honest, the issuer or signature is trusted, or the claimed effect occurred",
+    "grounding the claim against an independent observed basis (agrees/contradicts/unobserved) is a separate axis; verifying issuer or signature trust is another",
+    "operates on committed bytes only; queries no live producer, MCP, or attestation service",
+    "required fields, completeness rules, and canonicalization profile meanings are resolved by the consumer's own trusted registries; producer-supplied schema hints, body-local schema overrides, and embedded profile definitions are never an input to the verdict",
+    "jcs-json-v1 is RFC 8785 over a float-free value space and cbor-deterministic-v1 is RFC 8949 sec 4.2 over the value types used here; full float and value-space coverage is out of scope for this vector set",
+    "counts describe this vector set only, not real-world prevalence"
+  ],
+  "schema": "assay.experiment.e43_evidenceref_recompute_consumer.v0",
+  "verdict_counts": {
+    "canonicalization_mismatch": 1,
+    "digest_mismatch": 2,
+    "malformed_ref": 2,
+    "recomputed": 2,
+    "redacted_projection_incomplete": 4,
+    "schema_mismatch": 1,
+    "unresolvable_digest_only": 2,
+    "unresolved_ref": 1,
+    "unsupported_canonicalization": 2
+  }
+}

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/result.json
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/result.json
@@ -23,7 +23,7 @@
     "jcs-json-v1 is RFC 8785 over a float-free value space and cbor-deterministic-v1 is RFC 8949 sec 4.2 over the value types used here; full float and value-space coverage is out of scope for this vector set",
     "counts describe this vector set only, not real-world prevalence"
   ],
-  "schema": "assay.experiment.e43_evidenceref_recompute_consumer.v0",
+  "schema": "assay.experiment.evidenceref_recompute_consumer.v0",
   "verdict_counts": {
     "canonicalization_mismatch": 1,
     "digest_mismatch": 2,

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/test_evidenceref_consumer.py
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/test_evidenceref_consumer.py
@@ -1,4 +1,4 @@
-"""E43 - tests for the independent evidenceRef recomputation consumer.
+"""Tests for the independent evidenceRef recomputation consumer.
 
 Covers the full happy + negative matrix, the load-bearing fail-closed invariants, the cross-profile
 (JCS vs deterministic-CBOR) distinctness, and the two-implementation interop bar: the reference
@@ -172,24 +172,37 @@ def test_cbor_is_rfc8949_deterministic():
 
 def test_cli_emit_and_independent_runner_agree_via_files(tmp_path):
     """End-to-end through the published bytes: emit vectors.json, both runners agree on it."""
-    vectors = tmp_path / "vectors.json"
     emitted = subprocess.run(
         [sys.executable, str(HERE / "evidenceref_consumer.py"), "emit"],
         capture_output=True, text=True, check=True,
     ).stdout
-    vectors.write_text(emitted)
+    (tmp_path / "vectors.json").write_text(emitted)
     doc = json.loads(emitted)
-    assert doc["schema"] == "assay.experiment.e43_evidenceref_recompute_consumer.v0"
+    assert doc["schema"] == "assay.experiment.evidenceref_recompute_consumer.v0"
 
+    # Run from tmp_path so the confined vectors path resolves inside the working directory.
     verify = subprocess.run(
-        [sys.executable, str(HERE / "evidenceref_consumer.py"), "verify", str(vectors)],
-        capture_output=True, text=True,
+        [sys.executable, str(HERE / "evidenceref_consumer.py"), "verify", "vectors.json"],
+        cwd=tmp_path, capture_output=True, text=True,
     )
     assert verify.returncode == 0, verify.stdout + verify.stderr
 
     independent = subprocess.run(
-        [sys.executable, str(HERE / "independent_consumer.py"), str(vectors)],
-        capture_output=True, text=True,
+        [sys.executable, str(HERE / "independent_consumer.py"), "vectors.json"],
+        cwd=tmp_path, capture_output=True, text=True,
     )
     assert independent.returncode == 0, independent.stdout + independent.stderr
     assert json.loads(independent.stdout)["all_reproduced"] is True
+
+
+def test_vectors_path_is_confined_to_working_directory(tmp_path):
+    """A path that resolves outside the working directory is refused rather than read."""
+    outside = tmp_path / "vectors.json"
+    outside.write_text("{}")
+    # cwd here is the test's directory, not tmp_path, so the absolute path escapes and is refused.
+    result = subprocess.run(
+        [sys.executable, str(HERE / "independent_consumer.py"), str(outside)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "outside the working directory" in (result.stdout + result.stderr)

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/test_evidenceref_consumer.py
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/test_evidenceref_consumer.py
@@ -205,4 +205,4 @@ def test_vectors_path_is_confined_to_working_directory(tmp_path):
         capture_output=True, text=True,
     )
     assert result.returncode != 0
-    assert "outside the working directory" in (result.stdout + result.stderr)
+    assert "refusing an absolute vectors path" in (result.stdout + result.stderr)

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/test_evidenceref_consumer.py
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/test_evidenceref_consumer.py
@@ -1,0 +1,195 @@
+"""E43 - tests for the independent evidenceRef recomputation consumer.
+
+Covers the full happy + negative matrix, the load-bearing fail-closed invariants, the cross-profile
+(JCS vs deterministic-CBOR) distinctness, and the two-implementation interop bar: the reference
+consumer and the independent reproducer must agree on every vector, byte for byte.
+"""
+import json
+import pathlib
+import subprocess
+import sys
+
+import evidenceref_consumer as ref
+import independent_consumer as ind
+
+HERE = pathlib.Path(__file__).parent
+
+
+def _verdicts():
+    cases = ref.build_corpus()
+    return {c["id"]: ref.consume(c["ref"], c["body_store"])["verdict"] for c in cases}
+
+
+def test_happy_paths_recompute_under_both_profiles():
+    v = _verdicts()
+    assert v["c1_happy_jcs"] == "recomputed"
+    assert v["c2_happy_cbor"] == "recomputed"
+
+
+def test_clean_only_on_independent_recomputation():
+    v = _verdicts()
+    clean = {cid for cid, verdict in v.items() if verdict == "recomputed"}
+    assert clean == {"c1_happy_jcs", "c2_happy_cbor"}
+
+
+def test_digest_only_and_unresolved_fail_closed():
+    v = _verdicts()
+    assert v["c3_digest_only_no_body"] == "unresolvable_digest_only"
+    assert v["c4_unresolved_ref"] == "unresolved_ref"
+
+
+def test_tamper_is_digest_mismatch():
+    v = _verdicts()
+    assert v["c5_digest_mismatch"] == "digest_mismatch"
+
+
+def test_wrong_profile_is_canonicalization_mismatch_not_tamper():
+    v = _verdicts()
+    assert v["c6_canon_mismatch"] == "canonicalization_mismatch"
+
+
+def test_unsupported_profile_is_never_assumed():
+    v = _verdicts()
+    assert v["c7_unsupported_canon"] == "unsupported_canonicalization"
+
+
+def test_schema_mismatch_detected():
+    v = _verdicts()
+    assert v["c8_schema_mismatch"] == "schema_mismatch"
+
+
+def test_redacted_projection_cannot_launder_missing_evidence():
+    v = _verdicts()
+    # A marked redaction and a silent elision both fail to look clean.
+    assert v["c9_redacted_projection_marked"] == "redacted_projection_incomplete"
+    assert v["c10_silent_elision"] == "redacted_projection_incomplete"
+
+
+def test_producer_self_clean_never_promotes():
+    v = _verdicts()
+    assert v["c11_producer_clean_no_body"] == "unresolvable_digest_only"
+    assert v["c12_producer_clean_mismatch"] == "digest_mismatch"
+
+
+def test_producer_state_is_never_consulted():
+    cases = {c["id"]: c for c in ref.build_corpus()}
+    happy = cases["c1_happy_jcs"]
+    tamper = cases["c5_digest_mismatch"]
+    base_happy = ref.consume(happy["ref"], happy["body_store"])
+    base_tamper = ref.consume(tamper["ref"], tamper["body_store"])
+    assert ref.consume({**happy["ref"], "producer_state": "dirty"}, happy["body_store"]) == base_happy
+    assert ref.consume({**tamper["ref"], "producer_state": "clean"}, tamper["body_store"]) == base_tamper
+
+
+def test_malformed_refs():
+    v = _verdicts()
+    assert v["c13_malformed_no_digest"] == "malformed_ref"
+    assert v["c14_malformed_no_canon"] == "malformed_ref"
+
+
+def test_schema_authority_is_consumer_controlled():
+    v = _verdicts()
+    # A producer hint on the ref and a body-local _schema override both claim "no required fields";
+    # neither can clean a redacted projection, because completeness is the consumer registry's call.
+    assert v["c15_producer_schema_hint"] == "redacted_projection_incomplete"
+    assert v["c16_body_local_schema_override"] == "redacted_projection_incomplete"
+
+
+def test_producer_schema_hint_cannot_clean_or_move_a_verdict():
+    cases = {c["id"]: c for c in ref.build_corpus()}
+    redacted = cases["c9_redacted_projection_marked"]
+    happy = cases["c1_happy_jcs"]
+    base_redacted = ref.consume(redacted["ref"], redacted["body_store"])
+    base_happy = ref.consume(happy["ref"], happy["body_store"])
+    hint = {"producer_schema_hint": {"required_fields": []}}
+    assert ref.consume({**redacted["ref"], **hint}, redacted["body_store"]) == base_redacted
+    assert ref.consume({**happy["ref"], **hint}, happy["body_store"]) == base_happy
+
+
+def test_canonicalization_profile_authority_is_consumer_controlled():
+    v = _verdicts()
+    # A producer that embeds its own profile definition (object instead of a name) is refused.
+    assert v["c17_producer_defined_canon"] == "unsupported_canonicalization"
+
+
+def test_producer_canonicalization_rules_sibling_is_never_read():
+    cases = {c["id"]: c for c in ref.build_corpus()}
+    happy = cases["c1_happy_jcs"]
+    base = ref.consume(happy["ref"], happy["body_store"])
+    ruled = ref.consume({**happy["ref"], "canonicalization_rules": "producer-defined-bogus"}, happy["body_store"])
+    assert ruled == base
+
+
+def test_profiles_are_envelope_distinct():
+    obj = {"schema": "assay.policy_decision", "schema_version": "v1", "decision": "x",
+           "effect": {"e": 1}, "target": {"t": 1}}
+    assert ref.content_address(obj, "jcs-json-v1") != ref.content_address(obj, "cbor-deterministic-v1")
+
+
+def test_measurement_passes_all_invariants():
+    result = ref.measure(ref.emit())
+    assert result["all_expected"] is True
+    assert result["all_invariants_hold"] is True
+    assert result["verdict_counts"]["recomputed"] == 2
+
+
+def test_independent_reproducer_matches_reference():
+    """Two-implementation interop bar: the independent runner reproduces every committed verdict."""
+    doc = ref.emit()
+    registry = doc["schema_registry"]
+    for c in doc["cases"]:
+        got = ind.reproduce(c["ref"], c["body_store"], registry)
+        assert got == c["expected"], f"{c['id']}: independent={got} reference={c['expected']}"
+
+
+def test_independent_consumer_imports_no_reference_code():
+    """The independence is structural, not just claimed: parse the AST and prove no import statement
+    pulls in the reference runner (a docstring mention of the filename does not count as sharing code)."""
+    import ast
+
+    tree = ast.parse((HERE / "independent_consumer.py").read_text())
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add(node.module or "")
+    assert not any("evidenceref_consumer" in m for m in imported), f"shares code via import: {imported}"
+
+
+def test_cbor_is_rfc8949_deterministic():
+    # Spot-check the core deterministic encoding against hand-computed bytes (RFC 8949 sec 3 / 4.2).
+    assert ref._cbor(0) == b"\x00"
+    assert ref._cbor(23) == b"\x17"
+    assert ref._cbor(24) == b"\x18\x18"
+    assert ref._cbor(256) == b"\x19\x01\x00"
+    assert ref._cbor("a") == b"\x61a"
+    assert ref._cbor([1, 2]) == b"\x82\x01\x02"
+    # Map keys sort by their encoded bytes: shorter key "a" before longer key "bb".
+    assert ref._cbor({"bb": 2, "a": 1}) == b"\xa2\x61a\x01\x62bb\x02"
+    assert ref._cbor(True) == b"\xf5" and ref._cbor(False) == b"\xf4" and ref._cbor(None) == b"\xf6"
+
+
+def test_cli_emit_and_independent_runner_agree_via_files(tmp_path):
+    """End-to-end through the published bytes: emit vectors.json, both runners agree on it."""
+    vectors = tmp_path / "vectors.json"
+    emitted = subprocess.run(
+        [sys.executable, str(HERE / "evidenceref_consumer.py"), "emit"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    vectors.write_text(emitted)
+    doc = json.loads(emitted)
+    assert doc["schema"] == "assay.experiment.e43_evidenceref_recompute_consumer.v0"
+
+    verify = subprocess.run(
+        [sys.executable, str(HERE / "evidenceref_consumer.py"), "verify", str(vectors)],
+        capture_output=True, text=True,
+    )
+    assert verify.returncode == 0, verify.stdout + verify.stderr
+
+    independent = subprocess.run(
+        [sys.executable, str(HERE / "independent_consumer.py"), str(vectors)],
+        capture_output=True, text=True,
+    )
+    assert independent.returncode == 0, independent.stdout + independent.stderr
+    assert json.loads(independent.stdout)["all_reproduced"] is True

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/vectors.json
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/vectors.json
@@ -489,7 +489,7 @@
       }
     }
   ],
-  "schema": "assay.experiment.e43_evidenceref_recompute_consumer.v0",
+  "schema": "assay.experiment.evidenceref_recompute_consumer.v0",
   "schema_registry": {
     "assay.policy_decision/v1": {
       "required_fields": [

--- a/docs/experiments/evidenceref-recompute-consumer-2026-06/vectors.json
+++ b/docs/experiments/evidenceref-recompute-consumer-2026-06/vectors.json
@@ -1,0 +1,523 @@
+{
+  "canonicalization_profiles": {
+    "cbor-deterministic-v1": {
+      "description": "RFC 8949 section 4.2 core deterministic encoding (definite lengths, shortest ints, map keys sorted by encoded-key bytes), value space limited to these vectors",
+      "digest_encoding": "hex",
+      "digest_prefix": "sha256:",
+      "hash": "sha256"
+    },
+    "jcs-json-v1": {
+      "description": "RFC 8785 (JCS) over the JSON object, float-free value space in these vectors",
+      "digest_encoding": "hex",
+      "digest_prefix": "sha256:",
+      "hash": "sha256"
+    }
+  },
+  "cases": [
+    {
+      "body_store": {
+        "loc1": {
+          "decision": "allow",
+          "effect": {
+            "wrote": "x"
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/etc/x"
+          }
+        }
+      },
+      "expected": {
+        "reason": "bytes_match_address_under_declared_canon_and_schema_complete",
+        "verdict": "recomputed"
+      },
+      "id": "c1_happy_jcs",
+      "kind": "happy",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:3ae3ef028e933e3125d85c52773e2a49d5dd485a16b99e33434b06976c7bc8f9",
+        "ref": "loc1",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc2": {
+          "decision": "deny",
+          "effect": {
+            "blocked": "connect"
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "host": "10.0.0.1"
+          }
+        }
+      },
+      "expected": {
+        "reason": "bytes_match_address_under_declared_canon_and_schema_complete",
+        "verdict": "recomputed"
+      },
+      "id": "c2_happy_cbor",
+      "kind": "happy",
+      "ref": {
+        "canonicalization": "cbor-deterministic-v1",
+        "digest": "sha256:a93006659b206fd99acc28892b250eb3592f7afc36c8c3e376ad652c949eea02",
+        "ref": "loc2",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {},
+      "expected": {
+        "reason": "digest_alone_insufficient_no_resolvable_body",
+        "verdict": "unresolvable_digest_only"
+      },
+      "id": "c3_digest_only_no_body",
+      "kind": "inconclusive",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:2af69c55290e7aa7d2d49100b1243b64d1f637b063af24d5d016d4599419938a",
+        "ref": null,
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "other": {
+          "decision": "allow",
+          "effect": {
+            "wrote": "z"
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/z"
+          }
+        }
+      },
+      "expected": {
+        "reason": "ref_present_but_body_not_resolvable",
+        "verdict": "unresolved_ref"
+      },
+      "id": "c4_unresolved_ref",
+      "kind": "inconclusive",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:ca919fdb3c3ea915a21cf741384d1a3bac7a2ea12652a263d2951c4c9c15350a",
+        "ref": "missing",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc5": {
+          "decision": "allow",
+          "effect": {
+            "wrote": "b"
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/b"
+          }
+        }
+      },
+      "expected": {
+        "reason": "recompute_under_declared_canon_diverges_from_committed_digest",
+        "verdict": "digest_mismatch"
+      },
+      "id": "c5_digest_mismatch",
+      "kind": "fail",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:95e59f875fbe51fae17abe45b7a6a4e2deffc03d9d18622a94e530328e013650",
+        "ref": "loc5",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc6": {
+          "decision": "deny",
+          "effect": {
+            "blocked": "write"
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/c"
+          }
+        }
+      },
+      "expected": {
+        "reason": "digest_matches_cbor-deterministic-v1_not_declared_jcs-json-v1",
+        "verdict": "canonicalization_mismatch"
+      },
+      "id": "c6_canon_mismatch",
+      "kind": "fail",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:c2d831d8d9cf72a7a4eefbaee0889c5fbae093d93475c05e133ed63fe1e19b1b",
+        "ref": "loc6",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc7": {
+          "decision": "allow",
+          "effect": {
+            "wrote": "d"
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/d"
+          }
+        }
+      },
+      "expected": {
+        "reason": "declared_profile_not_in_consumer_profile_registry",
+        "verdict": "unsupported_canonicalization"
+      },
+      "id": "c7_unsupported_canon",
+      "kind": "inconclusive",
+      "ref": {
+        "canonicalization": "protobuf-canonical-v1",
+        "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "ref": "loc7",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc8": {
+          "decision": "allow",
+          "effect": {
+            "wrote": "e"
+          },
+          "schema": "assay.other",
+          "schema_version": "v1",
+          "target": {
+            "path": "/e"
+          }
+        }
+      },
+      "expected": {
+        "reason": "body_schema_differs_from_declared",
+        "verdict": "schema_mismatch"
+      },
+      "id": "c8_schema_mismatch",
+      "kind": "fail",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:759b2f235c124ab3e90818a02e89bf6a53c567b81d1a1f93c6d5fc5d9c378732",
+        "ref": "loc8",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc9": {
+          "decision": "allow",
+          "effect": {
+            "_redacted": true
+          },
+          "redacted_fields": [
+            "effect"
+          ],
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/f"
+          }
+        }
+      },
+      "expected": {
+        "reason": "missing_or_redacted_required_evidence:effect",
+        "verdict": "redacted_projection_incomplete"
+      },
+      "id": "c9_redacted_projection_marked",
+      "kind": "redaction",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:ff9b930b9686bc79c4a38ba93c2eed207367fc537832c044c4b9a433fcb6767f",
+        "ref": "loc9",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc10": {
+          "decision": "allow",
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/g"
+          }
+        }
+      },
+      "expected": {
+        "reason": "missing_or_redacted_required_evidence:effect",
+        "verdict": "redacted_projection_incomplete"
+      },
+      "id": "c10_silent_elision",
+      "kind": "redaction",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:05bcbde9e5c6f46d7e3ec60f2e74267725eac34a4b5a86c9765c425b63078a70",
+        "ref": "loc10",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {},
+      "expected": {
+        "reason": "digest_alone_insufficient_no_resolvable_body",
+        "verdict": "unresolvable_digest_only"
+      },
+      "id": "c11_producer_clean_no_body",
+      "kind": "producer_self_clean",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:bc0a08b16f5f1ed69fb28aa6867c5f7894331da275a0915efa5dc180c157791a",
+        "producer_state": "clean",
+        "ref": null,
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc12": {
+          "decision": "allow",
+          "effect": {
+            "wrote": "j"
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/j"
+          }
+        }
+      },
+      "expected": {
+        "reason": "recompute_under_declared_canon_diverges_from_committed_digest",
+        "verdict": "digest_mismatch"
+      },
+      "id": "c12_producer_clean_mismatch",
+      "kind": "producer_self_clean",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:0d287f3555272d22c50fa319a722338e7e356c4873bda9ed2a0102ad1e4497ba",
+        "producer_state": "clean",
+        "ref": "loc12",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc13": {
+          "decision": "allow",
+          "effect": {},
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {}
+        }
+      },
+      "expected": {
+        "reason": "missing_required_field_digest_or_canonicalization",
+        "verdict": "malformed_ref"
+      },
+      "id": "c13_malformed_no_digest",
+      "kind": "fail",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "ref": "loc13",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc14": {
+          "decision": "allow",
+          "effect": {
+            "wrote": "k"
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/k"
+          }
+        }
+      },
+      "expected": {
+        "reason": "missing_required_field_digest_or_canonicalization",
+        "verdict": "malformed_ref"
+      },
+      "id": "c14_malformed_no_canon",
+      "kind": "fail",
+      "ref": {
+        "digest": "sha256:60e87d3fdec07b3ea51fe0eb94d0bf388a2a6a862f2523c8c9eb564378fee6c3",
+        "ref": "loc14",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc15": {
+          "decision": "allow",
+          "effect": {
+            "_redacted": true
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/l"
+          }
+        }
+      },
+      "expected": {
+        "reason": "missing_or_redacted_required_evidence:effect",
+        "verdict": "redacted_projection_incomplete"
+      },
+      "id": "c15_producer_schema_hint",
+      "kind": "schema_authority",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:fff58a192e0497505fde0fe1c03ec7cd1b52d77ea0d84f57052afa2810292144",
+        "producer_schema_hint": {
+          "required_fields": []
+        },
+        "ref": "loc15",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc16": {
+          "_schema": {
+            "required_fields": []
+          },
+          "decision": "allow",
+          "effect": {
+            "_redacted": true
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/m"
+          }
+        }
+      },
+      "expected": {
+        "reason": "missing_or_redacted_required_evidence:effect",
+        "verdict": "redacted_projection_incomplete"
+      },
+      "id": "c16_body_local_schema_override",
+      "kind": "schema_authority",
+      "ref": {
+        "canonicalization": "jcs-json-v1",
+        "digest": "sha256:f49b8089bc63b2e613dc5be9eaa72adad365573567234802def848fb53724c26",
+        "ref": "loc16",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    },
+    {
+      "body_store": {
+        "loc17": {
+          "decision": "allow",
+          "effect": {
+            "wrote": "n"
+          },
+          "schema": "assay.policy_decision",
+          "schema_version": "v1",
+          "target": {
+            "path": "/n"
+          }
+        }
+      },
+      "expected": {
+        "reason": "declared_profile_not_in_consumer_profile_registry",
+        "verdict": "unsupported_canonicalization"
+      },
+      "id": "c17_producer_defined_canon",
+      "kind": "profile_authority",
+      "ref": {
+        "canonicalization": {
+          "name": "jcs-json-v1",
+          "rules": "producer-defined-do-not-honor"
+        },
+        "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "ref": "loc17",
+        "schema": "assay.policy_decision",
+        "schema_version": "v1",
+        "type": "policy_decision"
+      }
+    }
+  ],
+  "schema": "assay.experiment.e43_evidenceref_recompute_consumer.v0",
+  "schema_registry": {
+    "assay.policy_decision/v1": {
+      "required_fields": [
+        "schema",
+        "schema_version",
+        "decision",
+        "effect",
+        "target"
+      ]
+    },
+    "assay.sequence/v1": {
+      "required_fields": [
+        "schema",
+        "schema_version",
+        "sequence",
+        "terminal"
+      ]
+    }
+  },
+  "verdicts": [
+    "recomputed",
+    "digest_mismatch",
+    "canonicalization_mismatch",
+    "schema_mismatch",
+    "malformed_ref",
+    "unresolvable_digest_only",
+    "unresolved_ref",
+    "unsupported_canonicalization",
+    "redacted_projection_incomplete"
+  ]
+}


### PR DESCRIPTION
Adds experimental vectors and a small independent recomputation consumer for `evidenceRef`-style references.

This is documentation/experiment material only:
- not a stable Assay API
- not product support
- not trust verification
- not issuer verification
- not effect grounding

It resolves a referenced body, recomputes the digest under the declared canonicalization profile, checks the declared schema, and renders one fail-closed verdict. Clean is reached only by recomputation; the producer envelope is not the verdict authority. A reference runner plus a separate independent reproducer that shares no import with it (AST-checked); machine-readable vectors reproducible from the bytes alone. 17 vectors, two canonicalization profiles (RFC 8785 JCS and RFC 8949 deterministic CBOR), 21 tests.

### Run
```
cd docs/experiments/evidenceref-recompute-consumer-2026-06
python3 evidenceref_consumer.py emit   > vectors.json
python3 evidenceref_consumer.py verify vectors.json > result.json
python3 independent_consumer.py vectors.json
python3 -m pytest test_evidenceref_consumer.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new experiment README explaining the evidenceRef recomputation/resolution behavior, verdict semantics (including clean-only outcomes), and claims vs. non-claims.
* **New Features**
  * Introduced a fail-closed evidenceref recomputation consumer with deterministic canonicalization, digest validation, and consumer-controlled schema completeness checks.
  * Added an independent recomputation runner to cross-verify verdicts against the shared vector corpus.
* **Tests**
  * Added a comprehensive test suite for happy paths, mismatch handling, unsupported profiles, redaction/incomplete evidence, and authority-boundary checks.
  * Added new vector/result fixtures for end-to-end CLI verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->