### PR TITLE
feat(registry): assay registry supply-chain-conformance carrier emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `assay registry supply-chain-conformance` emits the `assay.supply_chain_conformance.v0` carrier from a
+  local input descriptor (`assay.supply_chain_conformance.input.v0`), running the existing
+  `assay-registry` supply-chain producer offline over caller-supplied inputs. It performs offline checks
+  and reports carrier status; it does not assert supply-chain safety, policy approval, compliance,
+  Sigstore trust, Rekor inclusion, issuer identity, or artifact runtime integrity. The descriptor is
+  strict (unknown fields/variants are rejected, not ignored). v1 maps `none` and `unsupported`
+  provenance (exercising the pinning, expected-digest, and policy dimensions); the signature-bearing
+  `dsse` / `sigstore_bundle` paths are modeled but deferred to a follow-up (rejected with a clear error).
+  A carrier is emitted at exit 0 even when `policy_result` is `incomplete`/`fail`; a missing/unreadable/
+  malformed descriptor exits non-zero.
+
 ## [3.27.0] - 2026-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "assay-metrics",
  "assay-monitor",
  "assay-policy",
+ "assay-registry",
  "assay-runner-core",
  "assay-runner-linux",
  "assay-runner-schema",

--- a/crates/assay-cli/Cargo.toml
+++ b/crates/assay-cli/Cargo.toml
@@ -53,6 +53,7 @@ assay-common = { workspace = true, features = ["std"] }
 assay-policy = { workspace = true }
 assay-metrics = { workspace = true }
 assay-evidence = { workspace = true }
+assay-registry = { workspace = true }
 assay-mcp-server = { workspace = true }
 assay-runner-core = { workspace = true, optional = true }
 assay-runner-schema = { workspace = true, optional = true }

--- a/crates/assay-cli/src/cli/args/mod.rs
+++ b/crates/assay-cli/src/cli/args/mod.rs
@@ -9,6 +9,7 @@ pub mod import;
 pub mod mcp;
 pub mod policy;
 pub mod project_otel;
+pub mod registry;
 pub mod replay;
 pub mod run;
 pub mod runtime;
@@ -25,6 +26,7 @@ pub use import::*;
 pub use mcp::*;
 pub use policy::*;
 pub use project_otel::*;
+pub use registry::*;
 pub use replay::*;
 pub use run::*;
 pub use runtime::*;
@@ -83,6 +85,8 @@ pub enum Command {
     Fix(FixArgs),
     /// MCP runtime, discovery, kill-switch, and tool signing commands
     Mcp(McpArgs),
+    /// Registry carrier commands (supply-chain-conformance emitter)
+    Registry(RegistryArgs),
     /// Print Assay version information
     Version,
     /// Validate, format, and migrate policies

--- a/crates/assay-cli/src/cli/args/registry.rs
+++ b/crates/assay-cli/src/cli/args/registry.rs
@@ -1,0 +1,40 @@
+//! `assay registry` — registry-carrier commands.
+//!
+//! Intentionally narrow: this slice exposes only the supply-chain-conformance carrier emitter
+//! (A5a-1). It is not a general registry platform.
+
+use clap::{Args, Subcommand};
+
+#[derive(Args, Debug)]
+pub struct RegistryArgs {
+    #[command(subcommand)]
+    pub sub: RegistrySub,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RegistrySub {
+    /// Emit the assay.supply_chain_conformance.v0 carrier from a local input descriptor.
+    ///
+    /// Performs offline checks over the supplied inputs and reports carrier status. It does not
+    /// assert supply-chain safety, policy approval, compliance, Sigstore trust, Rekor inclusion,
+    /// issuer identity, or artifact runtime integrity.
+    #[command(name = "supply-chain-conformance")]
+    SupplyChainConformance(SupplyChainConformanceArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SupplyChainConformanceArgs {
+    /// Path to the input descriptor (an `assay.supply_chain_conformance.input.v0` JSON file).
+    #[arg(long)]
+    pub input: String,
+
+    /// Output path for the emitted carrier JSON; `-` (default) writes to stdout.
+    #[arg(long, default_value = "-")]
+    pub out: String,
+
+    /// Affirm offline operation. The emitter performs no network I/O by construction; this guard is
+    /// accepted for recipe explicitness and is required to hard-fail before any fetch if a
+    /// fetch-capable path is ever introduced.
+    #[arg(long)]
+    pub offline: bool,
+}

--- a/crates/assay-cli/src/cli/commands/dispatch.rs
+++ b/crates/assay-cli/src/cli/commands/dispatch.rs
@@ -32,6 +32,7 @@ pub async fn dispatch(cli: Cli, legacy_mode: bool) -> anyhow::Result<i32> {
         Command::Demo(args) => super::demo::cmd_demo(args).await,
         Command::InitCi(args) => super::init_ci::cmd_init_ci(args),
         Command::Mcp(args) => super::mcp::run(args).await,
+        Command::Registry(args) => super::registry::run(args).await,
         Command::Monitor(args) => super::monitor::run(args).await,
         Command::Policy(args) => super::policy::run(args).await,
         #[cfg(feature = "runner")]

--- a/crates/assay-cli/src/cli/commands/mod.rs
+++ b/crates/assay-cli/src/cli/commands/mod.rs
@@ -36,6 +36,7 @@ pub mod profile_types;
 pub mod project_otel;
 pub(crate) mod quarantine;
 pub mod record;
+pub mod registry;
 pub(crate) mod reporting;
 pub(crate) mod run;
 pub(crate) mod run_output;
@@ -47,6 +48,7 @@ pub(crate) mod session_state_window;
 pub mod setup;
 #[cfg(feature = "sim")]
 pub mod sim;
+pub mod supply_chain_conformance;
 pub mod tool;
 pub mod trust_basis;
 pub mod trust_card;

--- a/crates/assay-cli/src/cli/commands/registry.rs
+++ b/crates/assay-cli/src/cli/commands/registry.rs
@@ -1,0 +1,9 @@
+//! `assay registry` dispatch. Narrow in this slice: only `supply-chain-conformance`.
+
+use crate::cli::args::{RegistryArgs, RegistrySub};
+
+pub async fn run(args: RegistryArgs) -> anyhow::Result<i32> {
+    match args.sub {
+        RegistrySub::SupplyChainConformance(a) => super::supply_chain_conformance::run(a).await,
+    }
+}

--- a/crates/assay-cli/src/cli/commands/supply_chain_conformance.rs
+++ b/crates/assay-cli/src/cli/commands/supply_chain_conformance.rs
@@ -227,13 +227,33 @@ pub async fn run(args: SupplyChainConformanceArgs) -> anyhow::Result<i32> {
     };
 
     let rendered = format!("{}\n", serde_json::to_string_pretty(&carrier)?);
-    if args.out == "-" {
-        std::io::stdout().write_all(rendered.as_bytes())?;
-    } else if let Err(e) = std::fs::write(&args.out, &rendered) {
-        eprintln!("[infra_error] cannot write {}: {e}", args.out);
-        return Ok(EXIT_INFRA_ERROR);
+    // Output-write failures are an infra/output problem regardless of the target: stdout and file
+    // writes route through the same mapping, so a broken pipe on stdout is EXIT_INFRA_ERROR just like
+    // an unwritable file path (never the generic `?` bubble).
+    let write_result = if args.out == "-" {
+        std::io::stdout().write_all(rendered.as_bytes())
+    } else {
+        std::fs::write(&args.out, &rendered)
+    };
+    let target = if args.out == "-" {
+        "stdout"
+    } else {
+        args.out.as_str()
+    };
+    Ok(map_write_result(target, write_result))
+}
+
+/// Map an output-write result to an exit code. A write failure is an infra/output problem
+/// (`EXIT_INFRA_ERROR`), applied uniformly to stdout and file targets so the exit-code contract is
+/// the same whatever `--out` points at.
+fn map_write_result(target: &str, result: std::io::Result<()>) -> i32 {
+    match result {
+        Ok(()) => EXIT_SUCCESS,
+        Err(e) => {
+            eprintln!("[infra_error] cannot write output ({target}): {e}");
+            EXIT_INFRA_ERROR
+        }
     }
-    Ok(EXIT_SUCCESS)
 }
 
 #[cfg(test)]
@@ -340,6 +360,27 @@ mod tests {
     #[test]
     fn deferred_sigstore_bundle_is_rejected_not_ignored() {
         assert!(build_carrier(&descriptor(json!({ "kind": "sigstore_bundle" }))).is_err());
+    }
+
+    #[test]
+    fn write_failure_maps_to_infra_error_for_any_target() {
+        use std::io::{Error, ErrorKind};
+        // A write failure is EXIT_INFRA_ERROR uniformly — stdout (broken pipe) and file alike.
+        assert_eq!(
+            map_write_result(
+                "stdout",
+                Err(Error::new(ErrorKind::BrokenPipe, "pipe closed"))
+            ),
+            EXIT_INFRA_ERROR
+        );
+        assert_eq!(
+            map_write_result(
+                "/tmp/x.json",
+                Err(Error::new(ErrorKind::PermissionDenied, "nope"))
+            ),
+            EXIT_INFRA_ERROR
+        );
+        assert_eq!(map_write_result("stdout", Ok(())), EXIT_SUCCESS);
     }
 
     #[test]

--- a/crates/assay-cli/src/cli/commands/supply_chain_conformance.rs
+++ b/crates/assay-cli/src/cli/commands/supply_chain_conformance.rs
@@ -1,0 +1,351 @@
+//! `assay registry supply-chain-conformance` (A5a-1): emit the `assay.supply_chain_conformance.v0`
+//! carrier by running the existing `assay_registry::supply_chain::verify_supply_chain` producer over a
+//! local, caller-supplied input descriptor.
+//!
+//! This is a thin CLI boundary around an existing producer. It introduces NO verifier/trust/policy
+//! semantics. It performs OFFLINE checks over the supplied inputs and reports carrier status; it does
+//! not assert supply-chain safety, policy approval, compliance, Sigstore trust, Rekor inclusion, issuer
+//! identity, or artifact runtime integrity.
+//!
+//! v1 scope: `none` and `unsupported` provenance (these exercise the pinning, subject-digest, and
+//! policy dimensions and need no cryptographic material). The signature-bearing provenance paths
+//! (`dsse` pinned-key, `sigstore_bundle` keyless) are modeled in the descriptor but explicitly DEFERRED
+//! to a follow-up: they are rejected with a clear non-zero, never silently ignored.
+
+use std::io::Write;
+
+use assay_registry::supply_chain::{
+    verify_supply_chain, ContainerRef, PinningInput, Policy, ProvenanceInput, SlsaLevel, Subject,
+    SupplyChainConformance, UnsupportedProvenance, VerifyInput,
+};
+use assay_registry::trust::TrustStore;
+use serde::Deserialize;
+
+use crate::cli::args::SupplyChainConformanceArgs;
+use crate::exit_codes::{EXIT_CONFIG_ERROR, EXIT_INFRA_ERROR, EXIT_SUCCESS};
+
+/// The CLI input descriptor schema. NOT a carrier, NOT a trust statement: a local mapping into
+/// `VerifyInput`. Versioned so it can never become an implicit, unversioned format.
+const INPUT_SCHEMA: &str = "assay.supply_chain_conformance.input.v0";
+
+// ---- Input descriptor (strict / fail-closed: unknown fields are rejected, never ignored) --------
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InputDescriptor {
+    schema: String,
+    subject: SubjectInput,
+    #[serde(default)]
+    expected_artifact_digest: Option<String>,
+    provenance: ProvenanceDescriptor,
+    pinning: PinningDescriptor,
+    policy: PolicyDescriptor,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SubjectInput {
+    name: String,
+    version: String,
+    digest: String,
+}
+
+/// `kind` ∈ {none, unsupported, dsse, sigstore_bundle}. `format` is required iff kind==unsupported.
+/// (Modeled as a struct rather than an internally-tagged enum to keep `deny_unknown_fields` robust.)
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProvenanceDescriptor {
+    kind: String,
+    #[serde(default)]
+    format: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PinningDescriptor {
+    version_pinned: bool,
+    #[serde(default)]
+    digest_pinned: Option<bool>,
+    #[serde(default)]
+    lockfile_digest: Option<String>,
+    #[serde(default)]
+    floating_source_ref: bool,
+    /// "digest_pinned" | "tag_only" when present.
+    #[serde(default)]
+    container_ref: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PolicyDescriptor {
+    #[serde(default)]
+    required_builder_id: Option<String>,
+    #[serde(default)]
+    required_slsa_build_level: u8,
+    #[serde(default)]
+    require_rekor_inclusion: bool,
+    #[serde(default)]
+    require_timestamp_freshness: bool,
+    #[serde(default)]
+    require_consistency: bool,
+    #[serde(default)]
+    require_witnessing: bool,
+}
+
+/// A descriptor error: the message is already operator-facing and the code is the process exit code.
+#[derive(Debug)]
+struct EmitErr {
+    code: i32,
+    msg: String,
+}
+fn contract(msg: impl Into<String>) -> EmitErr {
+    EmitErr {
+        code: EXIT_CONFIG_ERROR,
+        msg: format!("[config_error] {}", msg.into()),
+    }
+}
+
+// ---- Build the carrier from descriptor bytes (no file/stdout I/O — unit-testable) ---------------
+
+fn build_carrier(raw: &str) -> Result<SupplyChainConformance, EmitErr> {
+    let d: InputDescriptor = serde_json::from_str(raw)
+        .map_err(|e| contract(format!("malformed input descriptor: {e}")))?;
+    if d.schema != INPUT_SCHEMA {
+        return Err(contract(format!(
+            "input descriptor schema must be \"{INPUT_SCHEMA}\"; got {:?}",
+            d.schema
+        )));
+    }
+
+    let provenance = match d.provenance.kind.as_str() {
+        "none" => {
+            if d.provenance.format.is_some() {
+                return Err(contract("provenance.format is only valid for kind \"unsupported\""));
+            }
+            ProvenanceInput::None
+        }
+        "unsupported" => {
+            let format = d
+                .provenance
+                .format
+                .as_deref()
+                .ok_or_else(|| contract("provenance.format is required for kind \"unsupported\""))?;
+            let kind = match format {
+                "pep740" => UnsupportedProvenance::Pep740,
+                "npm_provenance" => UnsupportedProvenance::NpmProvenance,
+                "unknown_predicate" => UnsupportedProvenance::UnknownPredicate,
+                other => {
+                    return Err(contract(format!(
+                        "unknown provenance.format {other:?} (expected pep740 | npm_provenance | unknown_predicate)"
+                    )))
+                }
+            };
+            ProvenanceInput::Unsupported(kind)
+        }
+        // Modeled but DEFERRED in v1 — rejected explicitly, never silently ignored.
+        deferred @ ("dsse" | "sigstore_bundle") => {
+            return Err(contract(format!(
+                "provenance kind {deferred:?} is not yet wired into this emitter (v1 supports none | unsupported); a follow-up adds the signature-bearing paths"
+            )))
+        }
+        other => {
+            return Err(contract(format!(
+                "unknown provenance.kind {other:?} (expected none | unsupported | dsse | sigstore_bundle)"
+            )))
+        }
+    };
+
+    let container_ref = match d.pinning.container_ref.as_deref() {
+        None => None,
+        Some("digest_pinned") => Some(ContainerRef::DigestPinned),
+        Some("tag_only") => Some(ContainerRef::TagOnly),
+        Some(other) => {
+            return Err(contract(format!(
+                "unknown pinning.container_ref {other:?} (expected digest_pinned | tag_only)"
+            )))
+        }
+    };
+
+    let pinning = PinningInput {
+        version_pinned: d.pinning.version_pinned,
+        digest_pinned: d.pinning.digest_pinned,
+        lockfile_digest: d.pinning.lockfile_digest,
+        floating_source_ref: d.pinning.floating_source_ref,
+        container_ref,
+    };
+
+    let policy = Policy {
+        required_builder_id: d.policy.required_builder_id,
+        required_slsa_build_level: SlsaLevel(d.policy.required_slsa_build_level),
+        require_rekor_inclusion: d.policy.require_rekor_inclusion,
+        require_timestamp_freshness: d.policy.require_timestamp_freshness,
+        require_consistency: d.policy.require_consistency,
+        require_witnessing: d.policy.require_witnessing,
+    };
+
+    let subject = Subject {
+        name: d.subject.name,
+        version: d.subject.version,
+        digest: d.subject.digest,
+    };
+
+    // v1 paths (none/unsupported) never consult the trust store; an empty store is correct.
+    let trust_store = TrustStore::new();
+    Ok(verify_supply_chain(VerifyInput {
+        subject,
+        expected_artifact_digest: d.expected_artifact_digest,
+        provenance,
+        pinning,
+        policy,
+        trust_store: &trust_store,
+    }))
+}
+
+pub async fn run(args: SupplyChainConformanceArgs) -> anyhow::Result<i32> {
+    // `--offline` is a guard, not a mode switch: the producer performs no network I/O by construction.
+    // There is no fetch-capable path in this slice, so the guard is trivially satisfied; if one is ever
+    // introduced it MUST hard-fail here before any fetch.
+    let _ = args.offline;
+
+    let raw = match std::fs::read_to_string(&args.input) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "[config_error] cannot read input descriptor {}: {e}",
+                args.input
+            );
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+
+    let carrier = match build_carrier(&raw) {
+        Ok(c) => c,
+        Err(EmitErr { code, msg }) => {
+            eprintln!("{msg}");
+            return Ok(code);
+        }
+    };
+
+    let rendered = format!("{}\n", serde_json::to_string_pretty(&carrier)?);
+    if args.out == "-" {
+        std::io::stdout().write_all(rendered.as_bytes())?;
+    } else if let Err(e) = std::fs::write(&args.out, &rendered) {
+        eprintln!("[infra_error] cannot write {}: {e}", args.out);
+        return Ok(EXIT_INFRA_ERROR);
+    }
+    Ok(EXIT_SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assay_registry::supply_chain::SCHEMA;
+    use serde_json::{json, Value};
+
+    fn descriptor(provenance: Value) -> String {
+        json!({
+            "schema": INPUT_SCHEMA,
+            "subject": { "name": "demo", "version": "1.0.0", "digest": "sha256:aa" },
+            "provenance": provenance,
+            "pinning": { "version_pinned": true, "digest_pinned": true },
+            "policy": { "required_slsa_build_level": 0 }
+        })
+        .to_string()
+    }
+    fn carrier_value(raw: &str) -> Value {
+        serde_json::to_value(build_carrier(raw).expect("carrier")).expect("value")
+    }
+
+    #[test]
+    fn none_provenance_emits_a_valid_carrier() {
+        let v = carrier_value(&descriptor(json!({ "kind": "none" })));
+        assert_eq!(v["schema"], SCHEMA);
+        // provenance is absent, not verified as trusted.
+        assert_eq!(v["checks"]["provenance"]["slsa_provenance"], "not_present");
+    }
+
+    #[test]
+    fn unsupported_provenance_records_unsupported_format() {
+        let v = carrier_value(&descriptor(
+            json!({ "kind": "unsupported", "format": "pep740" }),
+        ));
+        assert_eq!(v["schema"], SCHEMA);
+        assert_eq!(
+            v["checks"]["provenance"]["slsa_provenance"],
+            "unsupported_format"
+        );
+    }
+
+    #[test]
+    fn expected_artifact_digest_mismatch_fails_the_integrity_check() {
+        // expected_artifact_digest != subject.digest -> integrity.artifact_digest = failed (real check).
+        let mut d: Value = serde_json::from_str(&descriptor(json!({ "kind": "none" }))).unwrap();
+        d["expected_artifact_digest"] = json!("sha256:bb"); // subject.digest is sha256:aa
+        let v = carrier_value(&d.to_string());
+        assert_eq!(v["checks"]["integrity"]["artifact_digest"], "failed");
+    }
+
+    #[test]
+    fn matching_expected_artifact_digest_verifies_the_integrity_check() {
+        let mut d: Value = serde_json::from_str(&descriptor(json!({ "kind": "none" }))).unwrap();
+        d["expected_artifact_digest"] = json!("sha256:aa"); // == subject.digest
+        let v = carrier_value(&d.to_string());
+        assert_eq!(v["checks"]["integrity"]["artifact_digest"], "verified");
+    }
+
+    #[test]
+    fn wrong_input_schema_is_rejected() {
+        let mut d: Value = serde_json::from_str(&descriptor(json!({ "kind": "none" }))).unwrap();
+        d["schema"] = json!("assay.supply_chain_conformance.v0"); // the carrier schema, not the input schema
+        assert_eq!(
+            build_carrier(&d.to_string()).err().unwrap().code,
+            EXIT_CONFIG_ERROR
+        );
+    }
+
+    #[test]
+    fn unknown_top_level_field_is_rejected() {
+        let mut d: Value = serde_json::from_str(&descriptor(json!({ "kind": "none" }))).unwrap();
+        d["trust_me_bro"] = json!(true);
+        assert!(build_carrier(&d.to_string()).is_err());
+    }
+
+    #[test]
+    fn unknown_provenance_kind_is_rejected() {
+        assert!(build_carrier(&descriptor(json!({ "kind": "weird" }))).is_err());
+    }
+
+    #[test]
+    fn unsupported_without_format_is_rejected() {
+        assert!(build_carrier(&descriptor(json!({ "kind": "unsupported" }))).is_err());
+    }
+
+    #[test]
+    fn unknown_unsupported_format_is_rejected() {
+        assert!(build_carrier(&descriptor(
+            json!({ "kind": "unsupported", "format": "made_up" })
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn deferred_dsse_is_rejected_not_ignored() {
+        let e = build_carrier(&descriptor(json!({ "kind": "dsse" })))
+            .err()
+            .unwrap();
+        assert_eq!(e.code, EXIT_CONFIG_ERROR);
+        assert!(e.msg.contains("not yet wired"));
+    }
+
+    #[test]
+    fn deferred_sigstore_bundle_is_rejected_not_ignored() {
+        assert!(build_carrier(&descriptor(json!({ "kind": "sigstore_bundle" }))).is_err());
+    }
+
+    #[test]
+    fn unknown_container_ref_is_rejected() {
+        let mut d: Value = serde_json::from_str(&descriptor(json!({ "kind": "none" }))).unwrap();
+        d["pinning"]["container_ref"] = json!("floating");
+        assert!(build_carrier(&d.to_string()).is_err());
+    }
+}

--- a/crates/assay-cli/tests/fixtures/supply_chain_conformance_input.example.json
+++ b/crates/assay-cli/tests/fixtures/supply_chain_conformance_input.example.json
@@ -1,0 +1,16 @@
+{
+  "schema": "assay.supply_chain_conformance.input.v0",
+  "subject": {
+    "name": "example-pack",
+    "version": "1.0.0",
+    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "expected_artifact_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "provenance": { "kind": "unsupported", "format": "pep740" },
+  "pinning": {
+    "version_pinned": true,
+    "digest_pinned": true,
+    "floating_source_ref": false
+  },
+  "policy": { "required_slsa_build_level": 0 }
+}


### PR DESCRIPTION
## What

Adds `assay registry supply-chain-conformance` — a minimal CLI that emits the
`assay.supply_chain_conformance.v0` carrier by running the existing
`assay_registry::supply_chain::verify_supply_chain` producer **offline** over a local input descriptor.
A thin CLI boundary around an existing producer (the carrier landed in 3.27.0); it introduces **no new
verifier, trust, or policy semantics** — it only exposes the producer for reproducible, released-binary
carrier emission.

## Claim boundary

Performs **offline checks over caller-supplied inputs and reports carrier status**. It does **not**
assert supply-chain safety, policy approval, compliance, Sigstore trust, Rekor inclusion, issuer
identity, or artifact runtime integrity (same non-claims in `--help`).

## Input descriptor (`assay.supply_chain_conformance.input.v0`)

A small, versioned CLI input descriptor mapped 1:1 onto `VerifyInput` (the library input types are
Serialize-only, so a CLI-side descriptor is needed). **Strict / fail-closed**:
`#[serde(deny_unknown_fields)]` throughout; unknown `provenance.kind` / `provenance.format` /
`pinning.container_ref` values are rejected, never ignored.

## v1 scope

Maps `none` and `unsupported` provenance — these already exercise the pinning, expected-digest, and
policy dimensions and need no cryptographic material. The signature-bearing paths (`dsse` pinned-key,
`sigstore_bundle` keyless) are **modeled but deferred** to a follow-up: rejected with a clear non-zero,
never silently ignored.

## Exit codes

- `0` — a carrier was emitted, **including** when `policy_result` is `incomplete`/`fail`.
- non-zero — no faithful carrier could be emitted: missing/unreadable/malformed descriptor, unknown
  field/variant, or a deferred provenance kind (`config_error`); output write failure (`infra_error`).

## Offline

`verify_supply_chain` performs no network I/O by construction. `--offline` is accepted as an explicit
guard (required to hard-fail before any fetch if one is ever introduced).

## Tests

12 unit tests — happy `none`/`unsupported`, expected-digest verify/fail, descriptor strictness, and
deferred `dsse`/`sigstore_bundle` rejection. Committed example descriptor fixture. Build + clippy clean.
`assay-registry` is added as an `assay-cli` dependency to reach the producer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `assay registry supply-chain-conformance` to emit `assay.supply_chain_conformance.v0` carriers from `--input` descriptors.
  * Supports `--out` (stdout by default) and `--offline` for offline-only operation.
  * Adds stricter input validation (unknown fields/variants rejected) and clear rejection for deferred signature-based provenance kinds.
* **Tests**
  * Added command/unit test coverage plus an example descriptor fixture for supply-chain-conformance emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->