### PR TITLE
chore(release): prep v3.28.0 (supply-chain-conformance CLI emitter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.28.0] - 2026-06-17
+
 ### Added
 - `assay registry supply-chain-conformance` emits the `assay.supply_chain_conformance.v0` carrier from a
   local input descriptor (`assay.supply_chain_conformance.input.v0`), running the existing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "aya",
  "chrono",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.27.0"
+version = "3.28.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"

--- a/README.md
+++ b/README.md
@@ -238,6 +238,20 @@ The Trust Card is a deterministic render of the same claim rows plus frozen non-
 
 </details>
 
+### Supply-chain conformance carrier
+
+`assay registry supply-chain-conformance` emits an `assay.supply_chain_conformance.v0` carrier from a local input descriptor, entirely offline:
+
+```bash
+assay registry supply-chain-conformance \
+  --input crates/assay-cli/tests/fixtures/supply_chain_conformance_input.example.json \
+  --out supply-chain-conformance.json \
+  --offline
+# -> supply-chain-conformance.json (assay.supply_chain_conformance.v0)
+```
+
+The example descriptor ships in the source distribution and the repository test fixtures; binary release archives ship the `assay` binary, README, and LICENSE, and do not bundle fixture descriptors. The command reports per-dimension carrier status from local input — it does not assert supply-chain safety, policy approval, compliance, Sigstore trust, Rekor inclusion, issuer identity, or runtime integrity.
+
 ## Add to Cursor in 30 Seconds
 
 Assay ships a helper that finds your local Cursor MCP config path and prints a ready-to-paste entry:


### PR DESCRIPTION
## Release prep: v3.28.0

Reversible release-prep only — **no tag, no publish** in this PR. It carries the `assay registry supply-chain-conformance` command (merged in #1715) into a tagged release.

### Changes
- **Version:** workspace `3.27.0` → `3.28.0` (`Cargo.toml` + `Cargo.lock`). The lock diff is 20 assay-crate version lines only; no third-party dependency churn.
- **CHANGELOG:** `[Unreleased]` → `[3.28.0]`. The entry states only what the command does (emits `assay.supply_chain_conformance.v0` from a local descriptor, offline), with an explicit non-claim list; `none`/`unsupported` provenance in v1, `dsse`/`sigstore_bundle` deferred (rejected with a clear error).
- **README:** short usage snippet for the carrier emitter; documents that the example descriptor ships in the source distribution and repository test fixtures, and that binary release archives bundle only the `assay` binary, README, and LICENSE.

### Out of scope (intentionally)
- No change to the binary release-archive layout.
- No DSSE / Sigstore support.
- No command rename, no output-semantics change.

### Pre-release verification (local, release build)
- `--help` and the CHANGELOG describe the command with bounded claims and an explicit non-claim list.
- The release binary contains the command and emits a valid `assay.supply_chain_conformance.v0` carrier from the committed example at exit 0.
- The emitted carrier is coverage-honest: orthogonal per-dimension statuses (no blanket "verified"), `policy_result: incomplete` for unsupported provenance, populated `non_claims`, explicit `coverage.limits`.
- The authoritative release-binary digest will come from the release CI run, not a local build.

Version bump is minor (additive new subcommand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a supply-chain conformance carrier generation feature accessible through a new offline CLI command for generating compliance carriers from local input descriptors.

* **Documentation**
  * Expanded README with detailed documentation of the supply-chain conformance carrier feature, including practical examples and scope clarifications.

* **Chores**
  * Version bumped to 3.28.0 and changelog updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->