### PR TITLE
release: prepare v3.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.29.0] - 2026-06-18
+
 ### Added
 - `assay registry supply-chain-conformance` now supports the `dsse` provenance kind: it verifies a local
   DSSE-wrapped in-toto/SLSA provenance envelope against caller-supplied pinned Ed25519 key material

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "aya",
  "chrono",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.28.0"
+version = "3.29.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.28.0"
+version = "3.29.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"

--- a/README.md
+++ b/README.md
@@ -252,6 +252,18 @@ assay registry supply-chain-conformance \
 
 The example descriptor ships in the source distribution and the repository test fixtures; binary release archives ship the `assay` binary, README, and LICENSE, and do not bundle fixture descriptors. The command reports per-dimension carrier status from local input — it does not assert supply-chain safety, policy approval, compliance, Sigstore trust, Rekor inclusion, issuer identity, or runtime integrity.
 
+The `dsse` provenance kind verifies a local DSSE-wrapped in-toto/SLSA envelope against caller-supplied pinned Ed25519 key material:
+
+```bash
+assay registry supply-chain-conformance \
+  --input crates/assay-cli/tests/fixtures/supply_chain_conformance_dsse/input.dsse.example.json \
+  --out supply-chain-conformance.json \
+  --offline
+# -> supply-chain-conformance.json (assay.supply_chain_conformance.v0)
+```
+
+The DSSE example uses local fixture evidence and caller-supplied pinned Ed25519 key material. It emits an `assay.supply_chain_conformance.v0` carrier with carrier status derived from the supplied evidence. It does not assert ecosystem trust, Sigstore trust, Rekor inclusion, issuer identity, policy approval, compliance, supply-chain safety, or runtime integrity.
+
 ## Add to Cursor in 30 Seconds
 
 Assay ships a helper that finds your local Cursor MCP config path and prints a ready-to-paste entry:


### PR DESCRIPTION
## Release prep: v3.29.0

Reversible release-prep only — **no tag, no publish** in this PR. It carries the `assay registry supply-chain-conformance` **DSSE descriptor path** (merged in #1718) into a tagged release.

### Changes
- **Version:** workspace `3.28.0` → `3.29.0` (`Cargo.toml` + `Cargo.lock`). The lock diff is 20 assay-crate version lines only; no third-party dependency churn.
- **CHANGELOG:** `[Unreleased]` → `[3.29.0]`. The `dsse` provenance kind verifies a local DSSE-wrapped in-toto/SLSA envelope against caller-supplied pinned Ed25519 key material, offline; the carrier and `…input.v0` schema are unchanged.
- **README:** short, claim-safe DSSE usage snippet next to the existing none/unsupported example.

### Out of scope (intentionally)
- No DSSE implementation, fixture, release-workflow, packaging, or Harness changes.
- No Sigstore/Rekor additions.

### Verification (pre-release checklist, local release build)
- CHANGELOG + `--help` describe the behavior with bounded claims and an explicit non-claim list ("caller-supplied pinned Ed25519 key material," not "trusted provenance").
- The release-profile binary carries the DSSE path and emits `policy_result: pass` from the committed DSSE example (`dsse_signature: verified`, `checks.integrity.subject_digest_binding: verified`, `dsse_pae`/`rekor: not_applicable`).
- The committed DSSE fixtures ship in the source package; `require_rekor_inclusion` still yields `incomplete`, never a magic pass.
- The authoritative release-asset digest will come from the release CI run, not a local build.

Version bump is minor (a new supported provenance mode on the CLI surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supply-chain conformance documentation with DSSE provenance example details.

* **Chores**
  * Version bumped to 3.29.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->