### PR TITLE
feat(mcp): add experimental declared-constraint digest projection

### DIFF
--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -123,6 +123,11 @@ fn sort_by_canon(arr: &mut [Value]) {
     });
 }
 
+/// Sorts the set-like fields of a JSON-Schema fragment: the top-level `required`, and `enum` within each
+/// direct child of `properties`. KNOWN LIMITATION (acceptable for the experimental status): nested schema
+/// structures are NOT recursed. `items`, `additionalProperties`, `allOf`/`anyOf`/`oneOf`, and nested
+/// object properties keep their given order, so a reordered-but-equal nested schema could still move the
+/// digest. v0 declared schemas are flat; recursive normalization is a v-next refinement.
 fn normalize_schema(sch: &Value) -> Value {
     let mut out = match sch.as_object() {
         Some(o) => o.clone(),
@@ -221,8 +226,9 @@ mod declared_constraint_digest_experimental_tests {
 
     #[test]
     fn reorder_class_and_scope_lists_are_semantically_stable() {
+        // `extra` fully overrides the base `tools` object below, so the first (allow) arg is unused here.
         let a = policy(
-            json!(["read_file"]),
+            json!([]),
             json!({"tools": {
                 "allow": ["read_file"],
                 "deny": ["delete_all"],
@@ -233,7 +239,7 @@ mod declared_constraint_digest_experimental_tests {
         )
         .declared_constraint_digest_experimental();
         let b = policy(
-            json!(["read_file"]),
+            json!([]),
             json!({"tools": {
                 "allow": ["read_file"],
                 "deny": ["delete_all"],

--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -63,6 +63,25 @@ impl McpPolicy {
         Some(format!("sha256:{}", sha256_hex(&canonical)))
     }
 
+    /// EXPERIMENTAL (unstable, may change): the declared-CONSTRAINT digest for the tool-decision
+    /// truth-layer. Unlike `policy_digest` (the whole policy, Vec-structural), this projects to the
+    /// declared-constraint surface only — `version`, the `tools` allow/deny + class/approval/scope lists,
+    /// per-tool `schemas`, and `enforcement` — excluding operational knobs (`runtime_monitor`,
+    /// `kill_switch`, `limits`, `discovery`, `signatures`, `tool_pins`, taxonomy), and SEMANTICALLY
+    /// NORMALIZES the set-like fields (sorts them by canonical bytes) so a reordered-but-equal policy
+    /// yields the same digest while a real membership/constraint change still moves it. Legacy v1 shapes
+    /// are normalized first. Not a stability guarantee: names/shape may change until promoted out of
+    /// experimental.
+    pub fn declared_constraint_digest_experimental(&self) -> Option<String> {
+        let mut p = self.clone();
+        p.normalize_legacy_shapes();
+        p.migrate_constraints_to_schemas();
+        let full = serde_json::to_value(&p).ok()?;
+        let proj = project_and_normalize_declared(&full);
+        let canonical = jcs::to_string(&proj).ok()?;
+        Some(format!("sha256:{}", sha256_hex(&canonical)))
+    }
+
     /// Single evaluation entry point for CLI and Server
     pub fn evaluate(
         &self,
@@ -88,5 +107,165 @@ impl McpPolicy {
     // Proxy-specific check method (Legacy compatibility wrapper)
     pub fn check(&self, request: &JsonRpcRequest, state: &mut PolicyState) -> PolicyDecision {
         engine::check(self, request, state)
+    }
+}
+
+// ── Declared-constraint projection + semantic normalization (EXPERIMENTAL) ───────────────────────
+// Project to the declared-constraint surface, then sort the set-like fields by canonical bytes so a
+// reordered-but-semantically-equal policy does not move the digest. Mirrors the tool-decision
+// truth-layer reference-spec; unstable until promoted out of experimental.
+
+fn sort_by_canon(arr: &mut [Value]) {
+    arr.sort_by(|a, b| {
+        jcs::to_string(a)
+            .unwrap_or_default()
+            .cmp(&jcs::to_string(b).unwrap_or_default())
+    });
+}
+
+fn normalize_schema(sch: &Value) -> Value {
+    let mut out = match sch.as_object() {
+        Some(o) => o.clone(),
+        None => return sch.clone(),
+    };
+    if let Some(req) = out.get("required").and_then(|r| r.as_array()) {
+        let mut r = req.clone();
+        sort_by_canon(&mut r);
+        out.insert("required".to_string(), Value::Array(r));
+    }
+    if let Some(props) = out.get("properties").and_then(|p| p.as_object()) {
+        let mut p = props.clone();
+        for (field, spec) in props {
+            if let Some(en) = spec.get("enum").and_then(|e| e.as_array()) {
+                let mut e = en.clone();
+                sort_by_canon(&mut e);
+                let mut so = spec.as_object().cloned().unwrap_or_default();
+                so.insert("enum".to_string(), Value::Array(e));
+                p.insert(field.clone(), Value::Object(so));
+            }
+        }
+        out.insert("properties".to_string(), Value::Object(p));
+    }
+    Value::Object(out)
+}
+
+fn project_and_normalize_declared(full: &Value) -> Value {
+    let mut proj = serde_json::Map::new();
+    if let Some(o) = full.as_object() {
+        for key in ["version", "enforcement"] {
+            if let Some(v) = o.get(key) {
+                proj.insert(key.to_string(), v.clone());
+            }
+        }
+        if let Some(tools) = o.get("tools").and_then(|t| t.as_object()) {
+            let mut t = tools.clone();
+            for k in [
+                "allow",
+                "deny",
+                "allow_classes",
+                "deny_classes",
+                "approval_required",
+                "approval_required_classes",
+                "restrict_scope",
+                "restrict_scope_classes",
+            ] {
+                if let Some(arr) = t.get(k).and_then(|a| a.as_array()) {
+                    let mut a = arr.clone();
+                    sort_by_canon(&mut a);
+                    t.insert(k.to_string(), Value::Array(a));
+                }
+            }
+            proj.insert("tools".to_string(), Value::Object(t));
+        }
+        if let Some(schemas) = o.get("schemas").and_then(|s| s.as_object()) {
+            let mut s = serde_json::Map::new();
+            for (name, sch) in schemas {
+                s.insert(name.clone(), normalize_schema(sch));
+            }
+            proj.insert("schemas".to_string(), Value::Object(s));
+        }
+    }
+    Value::Object(proj)
+}
+
+#[cfg(test)]
+mod declared_constraint_digest_experimental_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn policy(allow: Value, extra: Value) -> McpPolicy {
+        let mut v = json!({
+            "version": "1",
+            "tools": {"allow": allow, "deny": ["delete_all"]},
+            "schemas": {"deploy": {"required": ["env"],
+                "properties": {"env": {"type": "string", "enum": ["staging", "prod"]}}}},
+            "enforcement": {"unconstrained_tools": "warn"}
+        });
+        if let (Some(o), Some(e)) = (v.as_object_mut(), extra.as_object()) {
+            for (k, val) in e {
+                o.insert(k.clone(), val.clone());
+            }
+        }
+        serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn reorder_allow_is_semantically_stable() {
+        let a = policy(json!(["read_file", "list_dir", "deploy"]), json!({}))
+            .declared_constraint_digest_experimental();
+        let b = policy(json!(["deploy", "list_dir", "read_file"]), json!({}))
+            .declared_constraint_digest_experimental();
+        assert!(a.is_some());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn reorder_class_and_scope_lists_are_semantically_stable() {
+        let a = policy(
+            json!(["read_file"]),
+            json!({"tools": {
+                "allow": ["read_file"],
+                "deny": ["delete_all"],
+                "allow_classes": ["fs", "read"],
+                "approval_required_classes": ["release", "prod"],
+                "restrict_scope_classes": ["workspace", "repo"]
+            }}),
+        )
+        .declared_constraint_digest_experimental();
+        let b = policy(
+            json!(["read_file"]),
+            json!({"tools": {
+                "allow": ["read_file"],
+                "deny": ["delete_all"],
+                "allow_classes": ["read", "fs"],
+                "approval_required_classes": ["prod", "release"],
+                "restrict_scope_classes": ["repo", "workspace"]
+            }}),
+        )
+        .declared_constraint_digest_experimental();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn membership_change_moves_digest() {
+        let a = policy(json!(["read_file", "list_dir", "deploy"]), json!({}))
+            .declared_constraint_digest_experimental();
+        let b = policy(json!(["read_file"]), json!({})).declared_constraint_digest_experimental();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn operational_change_is_stable() {
+        let a = policy(
+            json!(["read_file"]),
+            json!({"runtime_monitor": {"enabled": true}, "limits": {"max_tool_calls_total": 100}}),
+        )
+        .declared_constraint_digest_experimental();
+        let b = policy(
+            json!(["read_file"]),
+            json!({"runtime_monitor": {"enabled": false}, "limits": {"max_tool_calls_total": 1}}),
+        )
+        .declared_constraint_digest_experimental();
+        assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
## What

Adds `McpPolicy::declared_constraint_digest_experimental()`, an additive, read-only digest over the
declared *constraint* surface of a policy: `version`, the `tools` allow/deny plus the class / approval /
scope lists, per-tool `schemas`, and `enforcement`. Operational knobs (`runtime_monitor`, `kill_switch`,
`limits`, `discovery`, `signatures`, `tool_pins`, taxonomy) are excluded.

Unlike the existing `policy_digest()`, which serializes the whole policy as-is, this one:

- projects to the constraint surface only, so an operational-only change does not move the digest, and
- semantically normalizes the set-like fields (it sorts `allow`/`deny`, the class / approval / scope
  lists, and each schema's `required` / `enum` by canonical bytes), so reordering a semantically-equal
  policy yields the same digest while a real membership or constraint change still moves it.

## Why

A stable, projection-based declared digest is the foundation for relating an agent's observed tool
decisions to its declared/allowed set. This is the first, deliberately small slice of that work.

## Experimental

The method is named and documented as experimental and unstable: the name and shape may change until it
is promoted out of experimental. No existing behavior changes, and `policy_digest()` is untouched.

## Tests

`cargo test -p assay-core declared_constraint_digest` covers four cases: reordering a semantically-equal
allow-list keeps the digest, a membership change moves it, an operational-only change keeps it, and the
class lists are sorted too. `cargo clippy -p assay-core --lib -- -D warnings` is clean.

## Non-claims

The digest is a contract and identity primitive, not a safety or enforcement statement. The
canonicalization is `serde_jcs`; cross-language digest equivalence is not asserted here. Semantic
normalization covers the set-like constraint fields only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental method to generate a stable digest for declared policy constraints, enabling reliable comparison and change detection while ignoring operational settings.
* **Tests**
  * Added unit tests ensuring digest stability under reordering and verifying the digest changes when constraint memberships or tool schemas are updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->