### PR TITLE
feat(mcp): experimental tool-decision-truth observed-input digest and carrier

### DIFF
--- a/crates/assay-core/src/mcp/mod.rs
+++ b/crates/assay-core/src/mcp/mod.rs
@@ -15,6 +15,7 @@ pub mod proxy;
 pub mod runtime_features;
 pub mod signing;
 pub mod tool_call_handler;
+pub mod tool_decision_truth;
 pub mod tool_definition;
 pub mod tool_match;
 pub mod tool_taxonomy;

--- a/crates/assay-core/src/mcp/tool_decision_truth.rs
+++ b/crates/assay-core/src/mcp/tool_decision_truth.rs
@@ -34,20 +34,23 @@ const SECRET_DROP: &[&str] = &[
     "private_key",
 ];
 
-/// The projection that feeds the argument digest: secret-like keys dropped; object keys are canonicalized
-/// by JCS at digest time. A non-object value is passed through unchanged.
-fn project_args_for_digest(args: &Value) -> Value {
-    match args.as_object() {
-        Some(obj) => {
+/// The projection that feeds the argument digest: secret-like keys are dropped RECURSIVELY (at every
+/// nesting level, both in objects and inside arrays), so a nested `token`/`password` never reaches the
+/// digest input. Object keys are canonicalized by JCS at digest time.
+fn project_args_for_digest(value: &Value) -> Value {
+    match value {
+        Value::Object(obj) => {
             let mut out = Map::new();
             for (k, v) in obj {
-                if !SECRET_DROP.contains(&k.as_str()) {
-                    out.insert(k.clone(), v.clone());
+                if SECRET_DROP.contains(&k.as_str()) {
+                    continue;
                 }
+                out.insert(k.clone(), project_args_for_digest(v));
             }
             Value::Object(out)
         }
-        None => args.clone(),
+        Value::Array(arr) => Value::Array(arr.iter().map(project_args_for_digest).collect()),
+        other => other.clone(),
     }
 }
 
@@ -55,28 +58,31 @@ fn project_args_for_digest(args: &Value) -> Value {
 /// keys and a verifier can tell which key produced it. A low-entropy argument cannot be dictionary-
 /// recovered from the digest by anyone without the key. The raw arguments never enter the record.
 ///
-/// This is the shape of the primitive; real key provisioning, rotation, and per-tool domain scoping are
-/// a later concern.
-pub fn args_digest(args: &Value, key: &[u8], key_id: &str) -> String {
+/// Returns `None` on canonicalization failure rather than defaulting to an empty preimage (which would
+/// collapse distinct inputs to the same digest and break identity correctness). This is the shape of the
+/// primitive; real key provisioning, rotation, and per-tool domain scoping are a later concern.
+pub fn args_digest(args: &Value, key: &[u8], key_id: &str) -> Option<String> {
     let proj = project_args_for_digest(args);
-    let canonical = jcs::to_string(&proj).unwrap_or_default();
+    let canonical = jcs::to_string(&proj).ok()?;
     let preimage = format!("{ARGS_DIGEST_DOMAIN}:{key_id}:{canonical}");
     let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts a key of any length");
     mac.update(preimage.as_bytes());
-    format!(
+    Some(format!(
         "hmac-sha256:{key_id}:{}",
         hex::encode(mac.finalize().into_bytes())
-    )
+    ))
 }
 
 /// Digest over the stable observed-input identity triple only (`tool_name`, `args_digest`, `order`).
-pub fn observed_input_digest(tool_name: &str, args_digest: &str, order: i64) -> String {
+/// Returns `None` on canonicalization failure (never a silent empty-preimage digest).
+pub fn observed_input_digest(tool_name: &str, args_digest: &str, order: i64) -> Option<String> {
     let v = json!({"tool_name": tool_name, "args_digest": args_digest, "order": order});
-    let canonical = jcs::to_string(&v).unwrap_or_default();
-    format!("sha256:{}", sha256_hex(&canonical))
+    let canonical = jcs::to_string(&v).ok()?;
+    Some(format!("sha256:{}", sha256_hex(&canonical)))
 }
 
-/// Build a 3-zone tool-decision-truth carrier record (experimental).
+/// Build a 3-zone tool-decision-truth carrier record (experimental). Returns `None` if a digest cannot
+/// be canonicalized.
 ///
 /// Zone (i) observed-input identity is the only thing inside `observed_input_digest`. Zone (ii)
 /// observation provenance and zone (iii) classification output are recorded but excluded from the
@@ -95,10 +101,10 @@ pub fn build_record(
     call_id: &str,
     result_status: &str,
     identity_state: &str,
-) -> Value {
-    let ad = args_digest(args, key, key_id);
-    let oid = observed_input_digest(tool_name, &ad, order);
-    json!({
+) -> Option<Value> {
+    let ad = args_digest(args, key, key_id)?;
+    let oid = observed_input_digest(tool_name, &ad, order)?;
+    Some(json!({
         "schema": SCHEMA,
         // (i) observed-input identity — the ONLY fields inside observed_input_digest
         "tool_name": tool_name,
@@ -120,7 +126,7 @@ pub fn build_record(
             "observed_input_digest": oid,
             "declared_policy_digest": declared_policy_digest,
         },
-    })
+    }))
 }
 
 #[cfg(test)]
@@ -129,21 +135,58 @@ mod tests {
 
     const KEY: &[u8] = b"reference-test-key-v0";
     const KID: &str = "test-key-v0";
+    const PROV: (&str, &str, &str, &str) = ("authoritative_boundary", "c1", "ok", "present");
+
+    fn ad(args: Value) -> String {
+        args_digest(&args, KEY, KID).unwrap()
+    }
+
+    fn rec(tool: &str, args: Value, order: i64, prov: (&str, &str, &str, &str)) -> Value {
+        build_record(
+            tool,
+            &args,
+            order,
+            "sha256:decl",
+            KEY,
+            KID,
+            prov.0,
+            prov.1,
+            prov.2,
+            prov.3,
+        )
+        .unwrap()
+    }
 
     #[test]
-    fn args_digest_drops_secret_fields() {
-        // A SECRET_DROP field never affects the digest (it is dropped, not hashed).
-        let with_a = args_digest(&json!({"path": "/x", "token": "aaa"}), KEY, KID);
-        let with_b = args_digest(&json!({"path": "/x", "token": "bbb"}), KEY, KID);
-        let without = args_digest(&json!({"path": "/x"}), KEY, KID);
-        assert_eq!(with_a, with_b);
-        assert_eq!(with_a, without);
+    fn args_digest_drops_secret_fields_recursively() {
+        // SECRET_DROP keys never affect the digest, at the top level AND nested in objects/arrays.
+        assert_eq!(
+            ad(json!({"path": "/x", "token": "aaa"})),
+            ad(json!({"path": "/x", "token": "bbb"}))
+        );
+        assert_eq!(
+            ad(json!({"path": "/x", "token": "aaa"})),
+            ad(json!({"path": "/x"}))
+        );
+        // nested object:
+        assert_eq!(
+            ad(json!({"cfg": {"host": "h", "token": "aaa"}})),
+            ad(json!({"cfg": {"host": "h", "token": "bbb"}}))
+        );
+        assert_eq!(
+            ad(json!({"cfg": {"host": "h", "token": "aaa"}})),
+            ad(json!({"cfg": {"host": "h"}}))
+        );
+        // inside an array:
+        assert_eq!(
+            ad(json!({"items": [{"password": "p1"}, {"k": "v"}]})),
+            ad(json!({"items": [{"password": "p2"}, {"k": "v"}]}))
+        );
     }
 
     #[test]
     fn args_digest_carries_key_id() {
-        let d = args_digest(&json!({"path": "/x"}), KEY, KID);
-        assert!(d.starts_with("hmac-sha256:test-key-v0:"), "{d}");
+        assert!(ad(json!({"path": "/x"})).starts_with("hmac-sha256:test-key-v0:"));
     }
 
     #[test]
@@ -153,110 +196,50 @@ mod tests {
         let truth = args_digest(&json!({"admin": true}), KEY, KID);
         let space = [json!({"admin": true}), json!({"admin": false})];
         assert!(space.iter().any(|c| args_digest(c, KEY, KID) == truth));
-        let attacker = b"attacker-guess";
-        assert!(!space.iter().any(|c| args_digest(c, attacker, KID) == truth));
+        assert!(!space
+            .iter()
+            .any(|c| args_digest(c, b"attacker-guess", KID) == truth));
     }
 
     #[test]
-    fn observed_input_digest_stable_under_provenance_changes() {
+    fn identity_stable_under_provenance_changes() {
         // Same observed inputs, different provenance / labels => identical identity (replay-stable).
-        let a = build_record(
+        let a = rec("read_file", json!({"path": "/a"}), 0, PROV);
+        let b = rec(
             "read_file",
-            &json!({"path": "/a"}),
+            json!({"path": "/a"}),
             0,
-            "sha256:decl",
-            KEY,
-            KID,
-            "authoritative_boundary",
-            "c1",
-            "ok",
-            "present",
-        );
-        let b = build_record(
-            "read_file",
-            &json!({"path": "/a"}),
-            0,
-            "sha256:decl",
-            KEY,
-            KID,
-            "reported_trace",
-            "c2",
-            "error",
-            "absent",
+            ("reported_trace", "c2", "error", "absent"),
         );
         assert_eq!(a["observed_input_digest"], b["observed_input_digest"]);
         assert_eq!(a["decision_identity"], b["decision_identity"]);
     }
 
     #[test]
-    fn observed_input_digest_changes_with_inputs() {
-        let base = build_record(
-            "read_file",
-            &json!({"path": "/a"}),
-            0,
-            "sha256:decl",
-            KEY,
-            KID,
-            "authoritative_boundary",
-            "c1",
-            "ok",
-            "present",
-        );
-        let tool = build_record(
-            "list_dir",
-            &json!({"path": "/a"}),
-            0,
-            "sha256:decl",
-            KEY,
-            KID,
-            "authoritative_boundary",
-            "c1",
-            "ok",
-            "present",
-        );
-        let args = build_record(
-            "read_file",
-            &json!({"path": "/b"}),
-            0,
-            "sha256:decl",
-            KEY,
-            KID,
-            "authoritative_boundary",
-            "c1",
-            "ok",
-            "present",
-        );
-        let order = build_record(
-            "read_file",
-            &json!({"path": "/a"}),
-            5,
-            "sha256:decl",
-            KEY,
-            KID,
-            "authoritative_boundary",
-            "c1",
-            "ok",
-            "present",
-        );
+    fn identity_changes_with_observed_inputs() {
+        let base = rec("read_file", json!({"path": "/a"}), 0, PROV);
         let oid = &base["observed_input_digest"];
-        assert_ne!(oid, &tool["observed_input_digest"]);
-        assert_ne!(oid, &args["observed_input_digest"]);
-        assert_ne!(oid, &order["observed_input_digest"]);
+        assert_ne!(
+            oid,
+            &rec("list_dir", json!({"path": "/a"}), 0, PROV)["observed_input_digest"]
+        );
+        assert_ne!(
+            oid,
+            &rec("read_file", json!({"path": "/b"}), 0, PROV)["observed_input_digest"]
+        );
+        assert_ne!(
+            oid,
+            &rec("read_file", json!({"path": "/a"}), 5, PROV)["observed_input_digest"]
+        );
     }
 
     #[test]
     fn record_never_carries_raw_args() {
-        let r = build_record(
+        let r = rec(
             "read_file",
-            &json!({"path": "/a", "token": "secret"}),
+            json!({"path": "/a", "token": "secret"}),
             0,
-            "sha256:decl",
-            KEY,
-            KID,
-            "authoritative_boundary",
-            "c1",
-            "ok",
-            "present",
+            PROV,
         );
         assert!(r.get("args").is_none() && r.get("arguments").is_none());
         assert!(r["args_digest"]
@@ -267,18 +250,7 @@ mod tests {
 
     #[test]
     fn decision_identity_is_the_two_digests_only() {
-        let r = build_record(
-            "read_file",
-            &json!({"path": "/a"}),
-            0,
-            "sha256:decl",
-            KEY,
-            KID,
-            "authoritative_boundary",
-            "c1",
-            "ok",
-            "present",
-        );
+        let r = rec("read_file", json!({"path": "/a"}), 0, PROV);
         let di = r["decision_identity"].as_object().unwrap();
         let mut keys: Vec<&String> = di.keys().collect();
         keys.sort();

--- a/crates/assay-core/src/mcp/tool_decision_truth.rs
+++ b/crates/assay-core/src/mcp/tool_decision_truth.rs
@@ -1,0 +1,290 @@
+//! EXPERIMENTAL (unstable, may change): the observed-input side of the tool-decision truth-layer
+//! carrier. It provides a keyed, domain-separated `args_digest` (raw arguments are never stored), an
+//! `observed_input_digest` over the stable `{tool_name, args_digest, order}` triple, and a 3-zone
+//! carrier record whose decision identity is the `(observed_input_digest, declared_policy_digest)` pair.
+//! The declared side is [`super::policy::McpPolicy::declared_constraint_digest_experimental`].
+//!
+//! This slice carries the record shape only; no verdict is computed here (a later slice owns the gate),
+//! so the classification zone is carried but not decided. Not a stability guarantee: the schema, field
+//! names, and digests may change until this is promoted out of experimental.
+
+use super::jcs;
+use crate::fingerprint::sha256_hex;
+use hmac::{Hmac, KeyInit, Mac};
+use serde_json::{json, Map, Value};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Experimental schema id for the carrier record.
+pub const SCHEMA: &str = "assay.tool_decision_truth.v0";
+
+/// Domain tag mixed into the keyed argument digest.
+const ARGS_DIGEST_DOMAIN: &str = "assay.tool_args.v0";
+
+/// Argument keys whose values are dropped entirely before the digest (never even keyed): a token or a
+/// password is not something a consumer needs to compare, so dropping is strictly safer than hashing.
+const SECRET_DROP: &[&str] = &[
+    "token",
+    "access_token",
+    "password",
+    "api_key",
+    "secret",
+    "authorization",
+    "private_key",
+];
+
+/// The projection that feeds the argument digest: secret-like keys dropped; object keys are canonicalized
+/// by JCS at digest time. A non-object value is passed through unchanged.
+fn project_args_for_digest(args: &Value) -> Value {
+    match args.as_object() {
+        Some(obj) => {
+            let mut out = Map::new();
+            for (k, v) in obj {
+                if !SECRET_DROP.contains(&k.as_str()) {
+                    out.insert(k.clone(), v.clone());
+                }
+            }
+            Value::Object(out)
+        }
+        None => args.clone(),
+    }
+}
+
+/// Domain-separated, keyed argument digest. The `key_id` rides in the digest so a deployment can rotate
+/// keys and a verifier can tell which key produced it. A low-entropy argument cannot be dictionary-
+/// recovered from the digest by anyone without the key. The raw arguments never enter the record.
+///
+/// This is the shape of the primitive; real key provisioning, rotation, and per-tool domain scoping are
+/// a later concern.
+pub fn args_digest(args: &Value, key: &[u8], key_id: &str) -> String {
+    let proj = project_args_for_digest(args);
+    let canonical = jcs::to_string(&proj).unwrap_or_default();
+    let preimage = format!("{ARGS_DIGEST_DOMAIN}:{key_id}:{canonical}");
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts a key of any length");
+    mac.update(preimage.as_bytes());
+    format!(
+        "hmac-sha256:{key_id}:{}",
+        hex::encode(mac.finalize().into_bytes())
+    )
+}
+
+/// Digest over the stable observed-input identity triple only (`tool_name`, `args_digest`, `order`).
+pub fn observed_input_digest(tool_name: &str, args_digest: &str, order: i64) -> String {
+    let v = json!({"tool_name": tool_name, "args_digest": args_digest, "order": order});
+    let canonical = jcs::to_string(&v).unwrap_or_default();
+    format!("sha256:{}", sha256_hex(&canonical))
+}
+
+/// Build a 3-zone tool-decision-truth carrier record (experimental).
+///
+/// Zone (i) observed-input identity is the only thing inside `observed_input_digest`. Zone (ii)
+/// observation provenance and zone (iii) classification output are recorded but excluded from the
+/// identity, so adapter labels and a later verdict never perturb replay. `decision_identity` is the
+/// `(observed_input_digest, declared_policy_digest)` pair; the declared digest is supplied by the caller
+/// (from `McpPolicy::declared_constraint_digest_experimental`). No verdict is decided here.
+#[allow(clippy::too_many_arguments)]
+pub fn build_record(
+    tool_name: &str,
+    args: &Value,
+    order: i64,
+    declared_policy_digest: &str,
+    key: &[u8],
+    key_id: &str,
+    source_class: &str,
+    call_id: &str,
+    result_status: &str,
+    identity_state: &str,
+) -> Value {
+    let ad = args_digest(args, key, key_id);
+    let oid = observed_input_digest(tool_name, &ad, order);
+    json!({
+        "schema": SCHEMA,
+        // (i) observed-input identity — the ONLY fields inside observed_input_digest
+        "tool_name": tool_name,
+        "args_digest": ad,
+        "order": order,
+        // (ii) observation provenance — recorded, excluded from the identity digest
+        "source_class": source_class,
+        "call_id": call_id,
+        "result_status": result_status,
+        "identity_state": identity_state,
+        "key_id": key_id,
+        // (iii) classification output — owned by a later verdict slice; carried, excluded from identity
+        "declared_ref": Value::Null,
+        "decision_verdict": Value::Null,
+        // digest-bound identity
+        "observed_input_digest": oid,
+        "declared_policy_digest": declared_policy_digest,
+        "decision_identity": {
+            "observed_input_digest": oid,
+            "declared_policy_digest": declared_policy_digest,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &[u8] = b"reference-test-key-v0";
+    const KID: &str = "test-key-v0";
+
+    #[test]
+    fn args_digest_drops_secret_fields() {
+        // A SECRET_DROP field never affects the digest (it is dropped, not hashed).
+        let with_a = args_digest(&json!({"path": "/x", "token": "aaa"}), KEY, KID);
+        let with_b = args_digest(&json!({"path": "/x", "token": "bbb"}), KEY, KID);
+        let without = args_digest(&json!({"path": "/x"}), KEY, KID);
+        assert_eq!(with_a, with_b);
+        assert_eq!(with_a, without);
+    }
+
+    #[test]
+    fn args_digest_carries_key_id() {
+        let d = args_digest(&json!({"path": "/x"}), KEY, KID);
+        assert!(d.starts_with("hmac-sha256:test-key-v0:"), "{d}");
+    }
+
+    #[test]
+    fn low_entropy_arg_not_recoverable_without_the_key() {
+        // The true value matches WITH the key; an attacker without the key cannot reproduce the digest
+        // even over the tiny value space.
+        let truth = args_digest(&json!({"admin": true}), KEY, KID);
+        let space = [json!({"admin": true}), json!({"admin": false})];
+        assert!(space.iter().any(|c| args_digest(c, KEY, KID) == truth));
+        let attacker = b"attacker-guess";
+        assert!(!space.iter().any(|c| args_digest(c, attacker, KID) == truth));
+    }
+
+    #[test]
+    fn observed_input_digest_stable_under_provenance_changes() {
+        // Same observed inputs, different provenance / labels => identical identity (replay-stable).
+        let a = build_record(
+            "read_file",
+            &json!({"path": "/a"}),
+            0,
+            "sha256:decl",
+            KEY,
+            KID,
+            "authoritative_boundary",
+            "c1",
+            "ok",
+            "present",
+        );
+        let b = build_record(
+            "read_file",
+            &json!({"path": "/a"}),
+            0,
+            "sha256:decl",
+            KEY,
+            KID,
+            "reported_trace",
+            "c2",
+            "error",
+            "absent",
+        );
+        assert_eq!(a["observed_input_digest"], b["observed_input_digest"]);
+        assert_eq!(a["decision_identity"], b["decision_identity"]);
+    }
+
+    #[test]
+    fn observed_input_digest_changes_with_inputs() {
+        let base = build_record(
+            "read_file",
+            &json!({"path": "/a"}),
+            0,
+            "sha256:decl",
+            KEY,
+            KID,
+            "authoritative_boundary",
+            "c1",
+            "ok",
+            "present",
+        );
+        let tool = build_record(
+            "list_dir",
+            &json!({"path": "/a"}),
+            0,
+            "sha256:decl",
+            KEY,
+            KID,
+            "authoritative_boundary",
+            "c1",
+            "ok",
+            "present",
+        );
+        let args = build_record(
+            "read_file",
+            &json!({"path": "/b"}),
+            0,
+            "sha256:decl",
+            KEY,
+            KID,
+            "authoritative_boundary",
+            "c1",
+            "ok",
+            "present",
+        );
+        let order = build_record(
+            "read_file",
+            &json!({"path": "/a"}),
+            5,
+            "sha256:decl",
+            KEY,
+            KID,
+            "authoritative_boundary",
+            "c1",
+            "ok",
+            "present",
+        );
+        let oid = &base["observed_input_digest"];
+        assert_ne!(oid, &tool["observed_input_digest"]);
+        assert_ne!(oid, &args["observed_input_digest"]);
+        assert_ne!(oid, &order["observed_input_digest"]);
+    }
+
+    #[test]
+    fn record_never_carries_raw_args() {
+        let r = build_record(
+            "read_file",
+            &json!({"path": "/a", "token": "secret"}),
+            0,
+            "sha256:decl",
+            KEY,
+            KID,
+            "authoritative_boundary",
+            "c1",
+            "ok",
+            "present",
+        );
+        assert!(r.get("args").is_none() && r.get("arguments").is_none());
+        assert!(r["args_digest"]
+            .as_str()
+            .unwrap()
+            .starts_with("hmac-sha256:"));
+    }
+
+    #[test]
+    fn decision_identity_is_the_two_digests_only() {
+        let r = build_record(
+            "read_file",
+            &json!({"path": "/a"}),
+            0,
+            "sha256:decl",
+            KEY,
+            KID,
+            "authoritative_boundary",
+            "c1",
+            "ok",
+            "present",
+        );
+        let di = r["decision_identity"].as_object().unwrap();
+        let mut keys: Vec<&String> = di.keys().collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["declared_policy_digest", "observed_input_digest"]
+        );
+    }
+}


### PR DESCRIPTION
## What

Adds an experimental `mcp::tool_decision_truth` module (assay-core) with the observed-input side of the
tool-decision truth-layer carrier:

- `args_digest(args, key, key_id)`: a domain-separated, keyed (HMAC-SHA256) argument digest. Secret-like
  keys are dropped before the digest; the rest are keyed, so a low-entropy argument cannot be
  dictionary-recovered from the digest by anyone without the key. The `key_id` rides in the digest for
  rotation. Raw arguments never enter the record.
- `observed_input_digest(tool_name, args_digest, order)`: a digest over the stable observed-input triple.
- `build_record(...)`: a 3-zone carrier record (`assay.tool_decision_truth.v0`, experimental). Zone (i)
  observed-input identity is the only thing inside `observed_input_digest`; zone (ii) provenance and zone
  (iii) classification are recorded but excluded from the identity, so adapter labels and a later verdict
  never perturb replay. `decision_identity` is the `(observed_input_digest, declared_policy_digest)` pair,
  pairing this observed side with the declared digest from #1720
  (`McpPolicy::declared_constraint_digest_experimental`).

## Why

This is the second slice of the experimental tool-decision truth-layer. It establishes the observed-input
identity and the carrier shape; the verdict gate is a later slice.

## Experimental

The module, schema, field names, and digests are marked experimental and unstable. Additive only, no
existing behavior changes, and no new dependency (it reuses the workspace `hmac`/`sha2`).

## Tests

`cargo test -p assay-core tool_decision_truth` (7 cases): secret fields are dropped before the digest, the
`key_id` is carried, a low-entropy argument is not recoverable without the key, the identity is stable
under provenance/label changes and changes with the observed inputs, the record never carries raw
arguments, and `decision_identity` is exactly the two digests. `cargo clippy -p assay-core --lib -- -D
warnings` is clean.

## Non-claims

No verdict is decided here. The digests are contract and identity primitives, not a safety or enforcement
statement. The `args_digest` privacy claim is non-recovery without the key only; key management is a later
concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental tool-decision identity mechanism that computes replay-stable digests for observed tool inputs.
  * Records now include derived digests and a decision identity while omitting raw tool arguments/inputs from the stored payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->