### PR TITLE
test(mcp): experimental tool-decision-truth conformance vectors

### DIFF
--- a/crates/assay-core/tests/fixtures/tool_decision_truth/vectors.json
+++ b/crates/assay-core/tests/fixtures/tool_decision_truth/vectors.json
@@ -1,39 +1,83 @@
 {
   "schema": "assay.tool_decision_truth.vectors.v0",
-  "declared_policy": {
-    "version": "1",
-    "tools": {
-      "allow": [
-        "read_file",
-        "deploy"
-      ],
-      "deny": [
-        "delete_all"
-      ]
-    },
-    "schemas": {
-      "deploy": {
-        "type": "object",
-        "required": [
-          "env"
+  "policies": {
+    "base": {
+      "version": "1",
+      "tools": {
+        "allow": [
+          "read_file",
+          "deploy"
         ],
-        "properties": {
-          "env": {
-            "enum": [
-              "staging",
-              "prod"
-            ]
+        "deny": [
+          "delete_all"
+        ]
+      },
+      "schemas": {
+        "deploy": {
+          "type": "object",
+          "required": [
+            "env"
+          ],
+          "properties": {
+            "env": {
+              "enum": [
+                "staging",
+                "prod"
+              ]
+            }
           }
         }
+      },
+      "enforcement": {
+        "unconstrained_tools": "warn"
       }
     },
-    "enforcement": {
-      "unconstrained_tools": "warn"
+    "pattern_deny": {
+      "version": "1",
+      "tools": {
+        "deny": [
+          "delete_*"
+        ]
+      },
+      "enforcement": {
+        "unconstrained_tools": "allow"
+      }
+    },
+    "approval": {
+      "version": "1",
+      "tools": {
+        "allow": [
+          "pay"
+        ],
+        "approval_required": [
+          "pay"
+        ]
+      },
+      "enforcement": {
+        "unconstrained_tools": "allow"
+      }
+    },
+    "malformed_schema": {
+      "version": "1",
+      "tools": {
+        "allow": [
+          "t"
+        ]
+      },
+      "schemas": {
+        "t": {
+          "$ref": "#/$defs/missing"
+        }
+      },
+      "enforcement": {
+        "unconstrained_tools": "allow"
+      }
     }
   },
   "cases": [
     {
       "id": "match",
+      "policy": "base",
       "observed": [
         {
           "tool_name": "deploy",
@@ -41,7 +85,8 @@
             "env": "staging"
           },
           "order": 0,
-          "identity_state": "present"
+          "identity_state": "present",
+          "evidence": null
         }
       ],
       "expected": {
@@ -53,12 +98,14 @@
     },
     {
       "id": "mismatch_denied_tool",
+      "policy": "base",
       "observed": [
         {
           "tool_name": "delete_all",
           "args": {},
           "order": 0,
-          "identity_state": "present"
+          "identity_state": "present",
+          "evidence": null
         }
       ],
       "expected": {
@@ -70,6 +117,7 @@
     },
     {
       "id": "mismatch_arg_enum",
+      "policy": "base",
       "observed": [
         {
           "tool_name": "deploy",
@@ -77,7 +125,8 @@
             "env": "dev"
           },
           "order": 0,
-          "identity_state": "present"
+          "identity_state": "present",
+          "evidence": null
         }
       ],
       "expected": {
@@ -89,12 +138,14 @@
     },
     {
       "id": "incomplete_args_uncaptured",
+      "policy": "base",
       "observed": [
         {
           "tool_name": "deploy",
           "args": null,
           "order": 0,
-          "identity_state": "present"
+          "identity_state": "present",
+          "evidence": null
         }
       ],
       "expected": {
@@ -106,6 +157,7 @@
     },
     {
       "id": "incomplete_unconstrained_warn",
+      "policy": "base",
       "observed": [
         {
           "tool_name": "read_file",
@@ -113,7 +165,8 @@
             "path": "/x"
           },
           "order": 0,
-          "identity_state": "present"
+          "identity_state": "present",
+          "evidence": null
         }
       ],
       "expected": {
@@ -125,6 +178,7 @@
     },
     {
       "id": "incomplete_required_missing_identity",
+      "policy": "base",
       "observed": [
         {
           "tool_name": "deploy",
@@ -132,7 +186,8 @@
             "env": "staging"
           },
           "order": 0,
-          "identity_state": "required_missing"
+          "identity_state": "required_missing",
+          "evidence": null
         }
       ],
       "expected": {
@@ -144,6 +199,7 @@
     },
     {
       "id": "invalid_identity",
+      "policy": "base",
       "observed": [
         {
           "tool_name": "deploy",
@@ -151,7 +207,8 @@
             "env": "staging"
           },
           "order": 0,
-          "identity_state": "invalid"
+          "identity_state": "invalid",
+          "evidence": null
         }
       ],
       "expected": {
@@ -162,7 +219,29 @@
       }
     },
     {
+      "id": "absent_identity_match",
+      "policy": "base",
+      "observed": [
+        {
+          "tool_name": "deploy",
+          "args": {
+            "env": "prod"
+          },
+          "order": 0,
+          "identity_state": "absent",
+          "evidence": null
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "match"
+        ],
+        "run_verdict": "match"
+      }
+    },
+    {
       "id": "run_lattice_mismatch",
+      "policy": "base",
       "observed": [
         {
           "tool_name": "deploy",
@@ -170,13 +249,15 @@
             "env": "staging"
           },
           "order": 0,
-          "identity_state": "present"
+          "identity_state": "present",
+          "evidence": null
         },
         {
           "tool_name": "delete_all",
           "args": {},
           "order": 1,
-          "identity_state": "present"
+          "identity_state": "present",
+          "evidence": null
         }
       ],
       "expected": {
@@ -188,15 +269,90 @@
       }
     },
     {
-      "id": "absent_identity_match",
+      "id": "invalid_duplicate_order",
+      "policy": "base",
       "observed": [
         {
           "tool_name": "deploy",
           "args": {
-            "env": "prod"
+            "env": "staging"
           },
           "order": 0,
-          "identity_state": "absent"
+          "identity_state": "present",
+          "evidence": null
+        },
+        {
+          "tool_name": "read_file",
+          "args": {
+            "path": "/x"
+          },
+          "order": 0,
+          "identity_state": "present",
+          "evidence": null
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "match",
+          "incomplete"
+        ],
+        "run_verdict": "invalid"
+      }
+    },
+    {
+      "id": "mismatch_pattern_deny",
+      "policy": "pattern_deny",
+      "observed": [
+        {
+          "tool_name": "delete_all",
+          "args": {},
+          "order": 0,
+          "identity_state": "present",
+          "evidence": null
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "mismatch"
+        ],
+        "run_verdict": "mismatch"
+      }
+    },
+    {
+      "id": "incomplete_approval_no_evidence",
+      "policy": "approval",
+      "observed": [
+        {
+          "tool_name": "pay",
+          "args": {
+            "amount": 10
+          },
+          "order": 0,
+          "identity_state": "present",
+          "evidence": null
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "incomplete"
+        ],
+        "run_verdict": "incomplete"
+      }
+    },
+    {
+      "id": "match_approval_evidence",
+      "policy": "approval",
+      "observed": [
+        {
+          "tool_name": "pay",
+          "args": {
+            "amount": 10
+          },
+          "order": 0,
+          "identity_state": "present",
+          "evidence": {
+            "approval_obtained": true
+          }
         }
       ],
       "expected": {
@@ -207,69 +363,282 @@
       }
     },
     {
-      "id": "invalid_duplicate_order",
+      "id": "mismatch_approval_denied",
+      "policy": "approval",
       "observed": [
         {
-          "tool_name": "deploy",
+          "tool_name": "pay",
           "args": {
-            "env": "staging"
+            "amount": 10
           },
           "order": 0,
-          "identity_state": "present"
-        },
-        {
-          "tool_name": "read_file",
-          "args": {
-            "path": "/x"
-          },
-          "order": 0,
-          "identity_state": "present"
+          "identity_state": "present",
+          "evidence": {
+            "approval_obtained": false
+          }
         }
       ],
       "expected": {
         "decisions": [
-          "match",
-          "incomplete"
+          "mismatch"
+        ],
+        "run_verdict": "mismatch"
+      }
+    },
+    {
+      "id": "invalid_malformed_schema",
+      "policy": "malformed_schema",
+      "observed": [
+        {
+          "tool_name": "t",
+          "args": {},
+          "order": 0,
+          "identity_state": "present",
+          "evidence": null
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "invalid"
         ],
         "run_verdict": "invalid"
       }
     }
   ],
+  "run_verdict_units": [
+    {
+      "id": "arity_more_orders",
+      "verdicts": [
+        "match"
+      ],
+      "orders": [
+        0,
+        1
+      ],
+      "expected": "invalid"
+    },
+    {
+      "id": "arity_more_verdicts",
+      "verdicts": [
+        "match",
+        "match"
+      ],
+      "orders": [
+        0
+      ],
+      "expected": "invalid"
+    },
+    {
+      "id": "duplicate_order",
+      "verdicts": [
+        "match",
+        "match"
+      ],
+      "orders": [
+        0,
+        0
+      ],
+      "expected": "invalid"
+    },
+    {
+      "id": "clean_run",
+      "verdicts": [
+        "match",
+        "incomplete"
+      ],
+      "orders": [
+        0,
+        1
+      ],
+      "expected": "incomplete"
+    }
+  ],
+  "carriers": [
+    {
+      "id": "deploy_match",
+      "policy": "base",
+      "carrier": {
+        "schema": "assay.tool_decision_truth.v0",
+        "tool_name": "deploy",
+        "args_digest": "hmac-sha256:test-key-v0:4886c9d19643b67b583baf824370abef617e62a6a43a41cae550ddae32208ac9",
+        "order": 0,
+        "source_class": "authoritative_boundary",
+        "call_id": "deploy_match",
+        "result_status": "ok",
+        "identity_state": "present",
+        "key_id": "test-key-v0",
+        "declared_ref": null,
+        "decision_verdict": "match",
+        "observed_input_digest": "sha256:3f8b9285fd1e868e8e2ca3c8fc0ae09eea26432926afe4d5e17a3393731a5a53",
+        "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f",
+        "decision_identity": {
+          "observed_input_digest": "sha256:3f8b9285fd1e868e8e2ca3c8fc0ae09eea26432926afe4d5e17a3393731a5a53",
+          "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f"
+        }
+      }
+    },
+    {
+      "id": "delete_mismatch",
+      "policy": "base",
+      "carrier": {
+        "schema": "assay.tool_decision_truth.v0",
+        "tool_name": "delete_all",
+        "args_digest": "hmac-sha256:test-key-v0:0418b32daf4e8e890f572422fada4485f9766f364ea8f0c037fffd2d2c06c315",
+        "order": 1,
+        "source_class": "authoritative_boundary",
+        "call_id": "delete_mismatch",
+        "result_status": "ok",
+        "identity_state": "present",
+        "key_id": "test-key-v0",
+        "declared_ref": null,
+        "decision_verdict": "mismatch",
+        "observed_input_digest": "sha256:5f7e9d51ec565ed2bf98e48aa07d619d6611a5475550f79091d079b758a392cf",
+        "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f",
+        "decision_identity": {
+          "observed_input_digest": "sha256:5f7e9d51ec565ed2bf98e48aa07d619d6611a5475550f79091d079b758a392cf",
+          "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f"
+        }
+      }
+    },
+    {
+      "id": "secret_args",
+      "policy": "base",
+      "carrier": {
+        "schema": "assay.tool_decision_truth.v0",
+        "tool_name": "read_file",
+        "args_digest": "hmac-sha256:test-key-v0:8913d8c84162ed309858d67cd2e541384d641bb79396cf8758703300eec28cda",
+        "order": 2,
+        "source_class": "authoritative_boundary",
+        "call_id": "secret_args",
+        "result_status": "ok",
+        "identity_state": "present",
+        "key_id": "test-key-v0",
+        "declared_ref": null,
+        "decision_verdict": "incomplete",
+        "observed_input_digest": "sha256:b6df5949913d56ddbf7b28a84eda66f2901de59c576058778022ba86d9e70645",
+        "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f",
+        "decision_identity": {
+          "observed_input_digest": "sha256:b6df5949913d56ddbf7b28a84eda66f2901de59c576058778022ba86d9e70645",
+          "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f"
+        }
+      }
+    }
+  ],
   "pack_rows": [
     {
-      "observed_input_digest": "sha256:obs-1",
-      "declared_policy_digest": "sha256:decl-1",
+      "id": "match_row",
+      "carrier_id": "deploy_match",
       "run_verdict": "match",
-      "ref": "audit://decision/c1",
       "row": {
         "recipe": "tool_decision_truth.v0",
         "evidence_ref": {
           "type": "tool_decision_truth",
-          "digest": "sha256:d20738a356ae4346c601aebcc6c19d78167b12af8a6fdc9b545b10eee9a9e703",
+          "digest": "sha256:16ce4bcd0fae8de06f7b0df48f20846c1bc1374eb38a8b6a680ebae6c28e9541",
+          "digest_subject": "carrier_content",
+          "canonicalization": "jcs-json-v1",
+          "schema": "assay.tool_decision_truth.v0",
+          "ref": "audit://decision/c0"
+        },
+        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "run_verdict": "match",
+        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
+      }
+    },
+    {
+      "id": "mismatch_row",
+      "carrier_id": "delete_mismatch",
+      "run_verdict": "mismatch",
+      "row": {
+        "recipe": "tool_decision_truth.v0",
+        "evidence_ref": {
+          "type": "tool_decision_truth",
+          "digest": "sha256:612e6f9dba3b1b4ec62969a65d2dcb4848dcd5252dd2e3af303c36d8b953fecd",
+          "digest_subject": "carrier_content",
           "canonicalization": "jcs-json-v1",
           "schema": "assay.tool_decision_truth.v0",
           "ref": "audit://decision/c1"
         },
-        "run_verdict": "match",
-        "coherence_binding": "sha256:690036844f74a38b973a0861fc6d6567e5a8e7a7f025e5560bc50af266c11c4d"
+        "decision_identity_digest": "sha256:29e9d68e7ff342f116c54bb0dccda9e27568deb52a812dcecbf2496c42025734",
+        "run_verdict": "mismatch",
+        "coherence_binding": "sha256:d665953473b2b63c4039cb2212d0e6fb1150335c1d2fcf3ddf5383ac79f5e858"
       }
-    },
+    }
+  ],
+  "negative_pack_rows": [
     {
-      "observed_input_digest": "sha256:obs-2",
-      "declared_policy_digest": "sha256:decl-2",
-      "run_verdict": "mismatch",
-      "ref": "audit://decision/c2",
+      "id": "tampered_run_verdict",
+      "carrier_id": "deploy_match",
+      "run_verdict": "incomplete",
       "row": {
         "recipe": "tool_decision_truth.v0",
         "evidence_ref": {
           "type": "tool_decision_truth",
-          "digest": "sha256:86190144108df05f1c24a08daefde0b777c9c6423528a9b2a13ec06943f8e9aa",
+          "digest": "sha256:16ce4bcd0fae8de06f7b0df48f20846c1bc1374eb38a8b6a680ebae6c28e9541",
+          "digest_subject": "carrier_content",
           "canonicalization": "jcs-json-v1",
           "schema": "assay.tool_decision_truth.v0",
-          "ref": "audit://decision/c2"
+          "ref": "audit://decision/c0"
         },
-        "run_verdict": "mismatch",
-        "coherence_binding": "sha256:ada5867b078c5c32c61586eed33a775b4324461acbaba389c2fcd4a5988ca386"
+        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "run_verdict": "incomplete",
+        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
+      }
+    },
+    {
+      "id": "foreign_recipe",
+      "carrier_id": "deploy_match",
+      "run_verdict": "match",
+      "row": {
+        "recipe": "other.recipe.v0",
+        "evidence_ref": {
+          "type": "tool_decision_truth",
+          "digest": "sha256:16ce4bcd0fae8de06f7b0df48f20846c1bc1374eb38a8b6a680ebae6c28e9541",
+          "digest_subject": "carrier_content",
+          "canonicalization": "jcs-json-v1",
+          "schema": "assay.tool_decision_truth.v0",
+          "ref": "audit://decision/c0"
+        },
+        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "run_verdict": "match",
+        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
+      }
+    },
+    {
+      "id": "foreign_canonicalization",
+      "carrier_id": "deploy_match",
+      "run_verdict": "match",
+      "row": {
+        "recipe": "tool_decision_truth.v0",
+        "evidence_ref": {
+          "type": "tool_decision_truth",
+          "digest": "sha256:16ce4bcd0fae8de06f7b0df48f20846c1bc1374eb38a8b6a680ebae6c28e9541",
+          "digest_subject": "carrier_content",
+          "canonicalization": "cbor-deterministic-v1",
+          "schema": "assay.tool_decision_truth.v0",
+          "ref": "audit://decision/c0"
+        },
+        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "run_verdict": "match",
+        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
+      }
+    },
+    {
+      "id": "malformed_citation_digest",
+      "carrier_id": "deploy_match",
+      "run_verdict": "match",
+      "row": {
+        "recipe": "tool_decision_truth.v0",
+        "evidence_ref": {
+          "type": "tool_decision_truth",
+          "digest": "sha256:short",
+          "digest_subject": "carrier_content",
+          "canonicalization": "jcs-json-v1",
+          "schema": "assay.tool_decision_truth.v0",
+          "ref": "audit://decision/c0"
+        },
+        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "run_verdict": "match",
+        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
       }
     }
   ]

--- a/crates/assay-core/tests/fixtures/tool_decision_truth/vectors.json
+++ b/crates/assay-core/tests/fixtures/tool_decision_truth/vectors.json
@@ -186,6 +186,53 @@
         ],
         "run_verdict": "mismatch"
       }
+    },
+    {
+      "id": "absent_identity_match",
+      "observed": [
+        {
+          "tool_name": "deploy",
+          "args": {
+            "env": "prod"
+          },
+          "order": 0,
+          "identity_state": "absent"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "match"
+        ],
+        "run_verdict": "match"
+      }
+    },
+    {
+      "id": "invalid_duplicate_order",
+      "observed": [
+        {
+          "tool_name": "deploy",
+          "args": {
+            "env": "staging"
+          },
+          "order": 0,
+          "identity_state": "present"
+        },
+        {
+          "tool_name": "read_file",
+          "args": {
+            "path": "/x"
+          },
+          "order": 0,
+          "identity_state": "present"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "match",
+          "incomplete"
+        ],
+        "run_verdict": "invalid"
+      }
     }
   ],
   "pack_rows": [

--- a/crates/assay-core/tests/fixtures/tool_decision_truth/vectors.json
+++ b/crates/assay-core/tests/fixtures/tool_decision_truth/vectors.json
@@ -460,19 +460,19 @@
       "carrier": {
         "schema": "assay.tool_decision_truth.v0",
         "tool_name": "deploy",
-        "args_digest": "hmac-sha256:test-key-v0:4886c9d19643b67b583baf824370abef617e62a6a43a41cae550ddae32208ac9",
+        "args_digest": "hmac-sha256:fixture-kid-v0:c6b5ae61ff4d034143dcecfffca65868bed7c7b701cb87971d495149d5616ffd",
         "order": 0,
         "source_class": "authoritative_boundary",
         "call_id": "deploy_match",
         "result_status": "ok",
         "identity_state": "present",
-        "key_id": "test-key-v0",
+        "key_id": "fixture-kid-v0",
         "declared_ref": null,
         "decision_verdict": "match",
-        "observed_input_digest": "sha256:3f8b9285fd1e868e8e2ca3c8fc0ae09eea26432926afe4d5e17a3393731a5a53",
+        "observed_input_digest": "sha256:abb703de41b9a418d2f257c0c30810524aaf2590c563946170caf0e95768a90f",
         "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f",
         "decision_identity": {
-          "observed_input_digest": "sha256:3f8b9285fd1e868e8e2ca3c8fc0ae09eea26432926afe4d5e17a3393731a5a53",
+          "observed_input_digest": "sha256:abb703de41b9a418d2f257c0c30810524aaf2590c563946170caf0e95768a90f",
           "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f"
         }
       }
@@ -483,19 +483,19 @@
       "carrier": {
         "schema": "assay.tool_decision_truth.v0",
         "tool_name": "delete_all",
-        "args_digest": "hmac-sha256:test-key-v0:0418b32daf4e8e890f572422fada4485f9766f364ea8f0c037fffd2d2c06c315",
+        "args_digest": "hmac-sha256:fixture-kid-v0:02dbc72f53ca56280c8b820db3527ca8edbe82931a4d396e43a620c49dbe2f78",
         "order": 1,
         "source_class": "authoritative_boundary",
         "call_id": "delete_mismatch",
         "result_status": "ok",
         "identity_state": "present",
-        "key_id": "test-key-v0",
+        "key_id": "fixture-kid-v0",
         "declared_ref": null,
         "decision_verdict": "mismatch",
-        "observed_input_digest": "sha256:5f7e9d51ec565ed2bf98e48aa07d619d6611a5475550f79091d079b758a392cf",
+        "observed_input_digest": "sha256:22320f6552995a3e5480d8173016be5e5bd87b9bd802d7430950b3676541fda4",
         "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f",
         "decision_identity": {
-          "observed_input_digest": "sha256:5f7e9d51ec565ed2bf98e48aa07d619d6611a5475550f79091d079b758a392cf",
+          "observed_input_digest": "sha256:22320f6552995a3e5480d8173016be5e5bd87b9bd802d7430950b3676541fda4",
           "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f"
         }
       }
@@ -506,19 +506,19 @@
       "carrier": {
         "schema": "assay.tool_decision_truth.v0",
         "tool_name": "read_file",
-        "args_digest": "hmac-sha256:test-key-v0:8913d8c84162ed309858d67cd2e541384d641bb79396cf8758703300eec28cda",
+        "args_digest": "hmac-sha256:fixture-kid-v0:75c1db569f1ec06e252fcfb2c803ba8a71d045f860253cd36b5723eb41e0e1e5",
         "order": 2,
         "source_class": "authoritative_boundary",
         "call_id": "secret_args",
         "result_status": "ok",
         "identity_state": "present",
-        "key_id": "test-key-v0",
+        "key_id": "fixture-kid-v0",
         "declared_ref": null,
         "decision_verdict": "incomplete",
-        "observed_input_digest": "sha256:b6df5949913d56ddbf7b28a84eda66f2901de59c576058778022ba86d9e70645",
+        "observed_input_digest": "sha256:9829736da5f5c93e964f3d75d6147c14c67b17d9b2108ba76feaad7ae0df4298",
         "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f",
         "decision_identity": {
-          "observed_input_digest": "sha256:b6df5949913d56ddbf7b28a84eda66f2901de59c576058778022ba86d9e70645",
+          "observed_input_digest": "sha256:9829736da5f5c93e964f3d75d6147c14c67b17d9b2108ba76feaad7ae0df4298",
           "declared_policy_digest": "sha256:4c3c6a7a02a1877c0c68ea389e4c6234aff49db88827d3a8ef67d1e992e98e6f"
         }
       }
@@ -533,15 +533,15 @@
         "recipe": "tool_decision_truth.v0",
         "evidence_ref": {
           "type": "tool_decision_truth",
-          "digest": "sha256:16ce4bcd0fae8de06f7b0df48f20846c1bc1374eb38a8b6a680ebae6c28e9541",
+          "digest": "sha256:345448027e0a187a9ff673e8027e4d856255306c645d5e3f520357763b01d823",
           "digest_subject": "carrier_content",
           "canonicalization": "jcs-json-v1",
           "schema": "assay.tool_decision_truth.v0",
           "ref": "audit://decision/c0"
         },
-        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "decision_identity_digest": "sha256:f173bd2f9cb2432301ca61fc3caaf57c50a7032dcd0221d51f2fb9b13158ca77",
         "run_verdict": "match",
-        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
+        "coherence_binding": "sha256:5a807f4fd3a79710b342f36c59bfe2f9431bb9c491443c904d403b53a7dd94a5"
       }
     },
     {
@@ -552,15 +552,15 @@
         "recipe": "tool_decision_truth.v0",
         "evidence_ref": {
           "type": "tool_decision_truth",
-          "digest": "sha256:612e6f9dba3b1b4ec62969a65d2dcb4848dcd5252dd2e3af303c36d8b953fecd",
+          "digest": "sha256:09cca03689892d4470bc329244f437e9337c85afac6dc3733607401540788cc8",
           "digest_subject": "carrier_content",
           "canonicalization": "jcs-json-v1",
           "schema": "assay.tool_decision_truth.v0",
           "ref": "audit://decision/c1"
         },
-        "decision_identity_digest": "sha256:29e9d68e7ff342f116c54bb0dccda9e27568deb52a812dcecbf2496c42025734",
+        "decision_identity_digest": "sha256:c5a2cc0c36e88e0a54fa27a834c28bf8560721fb2404bf4907f5da889c73b177",
         "run_verdict": "mismatch",
-        "coherence_binding": "sha256:d665953473b2b63c4039cb2212d0e6fb1150335c1d2fcf3ddf5383ac79f5e858"
+        "coherence_binding": "sha256:585201dbcf5acc2f3459117dc435430e174abfa8a7dc3825fd947afca3317a62"
       }
     }
   ],
@@ -573,15 +573,15 @@
         "recipe": "tool_decision_truth.v0",
         "evidence_ref": {
           "type": "tool_decision_truth",
-          "digest": "sha256:16ce4bcd0fae8de06f7b0df48f20846c1bc1374eb38a8b6a680ebae6c28e9541",
+          "digest": "sha256:345448027e0a187a9ff673e8027e4d856255306c645d5e3f520357763b01d823",
           "digest_subject": "carrier_content",
           "canonicalization": "jcs-json-v1",
           "schema": "assay.tool_decision_truth.v0",
           "ref": "audit://decision/c0"
         },
-        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "decision_identity_digest": "sha256:f173bd2f9cb2432301ca61fc3caaf57c50a7032dcd0221d51f2fb9b13158ca77",
         "run_verdict": "incomplete",
-        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
+        "coherence_binding": "sha256:5a807f4fd3a79710b342f36c59bfe2f9431bb9c491443c904d403b53a7dd94a5"
       }
     },
     {
@@ -592,15 +592,15 @@
         "recipe": "other.recipe.v0",
         "evidence_ref": {
           "type": "tool_decision_truth",
-          "digest": "sha256:16ce4bcd0fae8de06f7b0df48f20846c1bc1374eb38a8b6a680ebae6c28e9541",
+          "digest": "sha256:345448027e0a187a9ff673e8027e4d856255306c645d5e3f520357763b01d823",
           "digest_subject": "carrier_content",
           "canonicalization": "jcs-json-v1",
           "schema": "assay.tool_decision_truth.v0",
           "ref": "audit://decision/c0"
         },
-        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "decision_identity_digest": "sha256:f173bd2f9cb2432301ca61fc3caaf57c50a7032dcd0221d51f2fb9b13158ca77",
         "run_verdict": "match",
-        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
+        "coherence_binding": "sha256:5a807f4fd3a79710b342f36c59bfe2f9431bb9c491443c904d403b53a7dd94a5"
       }
     },
     {
@@ -611,15 +611,15 @@
         "recipe": "tool_decision_truth.v0",
         "evidence_ref": {
           "type": "tool_decision_truth",
-          "digest": "sha256:16ce4bcd0fae8de06f7b0df48f20846c1bc1374eb38a8b6a680ebae6c28e9541",
+          "digest": "sha256:345448027e0a187a9ff673e8027e4d856255306c645d5e3f520357763b01d823",
           "digest_subject": "carrier_content",
           "canonicalization": "cbor-deterministic-v1",
           "schema": "assay.tool_decision_truth.v0",
           "ref": "audit://decision/c0"
         },
-        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "decision_identity_digest": "sha256:f173bd2f9cb2432301ca61fc3caaf57c50a7032dcd0221d51f2fb9b13158ca77",
         "run_verdict": "match",
-        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
+        "coherence_binding": "sha256:5a807f4fd3a79710b342f36c59bfe2f9431bb9c491443c904d403b53a7dd94a5"
       }
     },
     {
@@ -636,9 +636,9 @@
           "schema": "assay.tool_decision_truth.v0",
           "ref": "audit://decision/c0"
         },
-        "decision_identity_digest": "sha256:2cba19763a1ac8a9f8880196a721db7babbe34652598e226c6ce67692e8953b9",
+        "decision_identity_digest": "sha256:f173bd2f9cb2432301ca61fc3caaf57c50a7032dcd0221d51f2fb9b13158ca77",
         "run_verdict": "match",
-        "coherence_binding": "sha256:61a331e6c4e89171fbec0d3d44305ff6d055b4b57816e826731725588dd3bbad"
+        "coherence_binding": "sha256:5a807f4fd3a79710b342f36c59bfe2f9431bb9c491443c904d403b53a7dd94a5"
       }
     }
   ]

--- a/crates/assay-core/tests/fixtures/tool_decision_truth/vectors.json
+++ b/crates/assay-core/tests/fixtures/tool_decision_truth/vectors.json
@@ -1,0 +1,229 @@
+{
+  "schema": "assay.tool_decision_truth.vectors.v0",
+  "declared_policy": {
+    "version": "1",
+    "tools": {
+      "allow": [
+        "read_file",
+        "deploy"
+      ],
+      "deny": [
+        "delete_all"
+      ]
+    },
+    "schemas": {
+      "deploy": {
+        "type": "object",
+        "required": [
+          "env"
+        ],
+        "properties": {
+          "env": {
+            "enum": [
+              "staging",
+              "prod"
+            ]
+          }
+        }
+      }
+    },
+    "enforcement": {
+      "unconstrained_tools": "warn"
+    }
+  },
+  "cases": [
+    {
+      "id": "match",
+      "observed": [
+        {
+          "tool_name": "deploy",
+          "args": {
+            "env": "staging"
+          },
+          "order": 0,
+          "identity_state": "present"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "match"
+        ],
+        "run_verdict": "match"
+      }
+    },
+    {
+      "id": "mismatch_denied_tool",
+      "observed": [
+        {
+          "tool_name": "delete_all",
+          "args": {},
+          "order": 0,
+          "identity_state": "present"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "mismatch"
+        ],
+        "run_verdict": "mismatch"
+      }
+    },
+    {
+      "id": "mismatch_arg_enum",
+      "observed": [
+        {
+          "tool_name": "deploy",
+          "args": {
+            "env": "dev"
+          },
+          "order": 0,
+          "identity_state": "present"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "mismatch"
+        ],
+        "run_verdict": "mismatch"
+      }
+    },
+    {
+      "id": "incomplete_args_uncaptured",
+      "observed": [
+        {
+          "tool_name": "deploy",
+          "args": null,
+          "order": 0,
+          "identity_state": "present"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "incomplete"
+        ],
+        "run_verdict": "incomplete"
+      }
+    },
+    {
+      "id": "incomplete_unconstrained_warn",
+      "observed": [
+        {
+          "tool_name": "read_file",
+          "args": {
+            "path": "/x"
+          },
+          "order": 0,
+          "identity_state": "present"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "incomplete"
+        ],
+        "run_verdict": "incomplete"
+      }
+    },
+    {
+      "id": "incomplete_required_missing_identity",
+      "observed": [
+        {
+          "tool_name": "deploy",
+          "args": {
+            "env": "staging"
+          },
+          "order": 0,
+          "identity_state": "required_missing"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "incomplete"
+        ],
+        "run_verdict": "incomplete"
+      }
+    },
+    {
+      "id": "invalid_identity",
+      "observed": [
+        {
+          "tool_name": "deploy",
+          "args": {
+            "env": "staging"
+          },
+          "order": 0,
+          "identity_state": "invalid"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "invalid"
+        ],
+        "run_verdict": "invalid"
+      }
+    },
+    {
+      "id": "run_lattice_mismatch",
+      "observed": [
+        {
+          "tool_name": "deploy",
+          "args": {
+            "env": "staging"
+          },
+          "order": 0,
+          "identity_state": "present"
+        },
+        {
+          "tool_name": "delete_all",
+          "args": {},
+          "order": 1,
+          "identity_state": "present"
+        }
+      ],
+      "expected": {
+        "decisions": [
+          "match",
+          "mismatch"
+        ],
+        "run_verdict": "mismatch"
+      }
+    }
+  ],
+  "pack_rows": [
+    {
+      "observed_input_digest": "sha256:obs-1",
+      "declared_policy_digest": "sha256:decl-1",
+      "run_verdict": "match",
+      "ref": "audit://decision/c1",
+      "row": {
+        "recipe": "tool_decision_truth.v0",
+        "evidence_ref": {
+          "type": "tool_decision_truth",
+          "digest": "sha256:d20738a356ae4346c601aebcc6c19d78167b12af8a6fdc9b545b10eee9a9e703",
+          "canonicalization": "jcs-json-v1",
+          "schema": "assay.tool_decision_truth.v0",
+          "ref": "audit://decision/c1"
+        },
+        "run_verdict": "match",
+        "coherence_binding": "sha256:690036844f74a38b973a0861fc6d6567e5a8e7a7f025e5560bc50af266c11c4d"
+      }
+    },
+    {
+      "observed_input_digest": "sha256:obs-2",
+      "declared_policy_digest": "sha256:decl-2",
+      "run_verdict": "mismatch",
+      "ref": "audit://decision/c2",
+      "row": {
+        "recipe": "tool_decision_truth.v0",
+        "evidence_ref": {
+          "type": "tool_decision_truth",
+          "digest": "sha256:86190144108df05f1c24a08daefde0b777c9c6423528a9b2a13ec06943f8e9aa",
+          "canonicalization": "jcs-json-v1",
+          "schema": "assay.tool_decision_truth.v0",
+          "ref": "audit://decision/c2"
+        },
+        "run_verdict": "mismatch",
+        "coherence_binding": "sha256:ada5867b078c5c32c61586eed33a775b4324461acbaba389c2fcd4a5988ca386"
+      }
+    }
+  ]
+}

--- a/crates/assay-core/tests/tool_decision_truth_vectors.rs
+++ b/crates/assay-core/tests/tool_decision_truth_vectors.rs
@@ -79,6 +79,17 @@ fn case_specs() -> Vec<CaseSpec> {
                 ("delete_all", Some(json!({})), 1, "present"),
             ],
         ),
+        (
+            "absent_identity_match",
+            vec![("deploy", Some(json!({"env": "prod"})), 0, "absent")],
+        ),
+        (
+            "invalid_duplicate_order",
+            vec![
+                ("deploy", Some(json!({"env": "staging"})), 0, "present"),
+                ("read_file", Some(json!({"path": "/x"})), 0, "present"),
+            ],
+        ),
     ]
 }
 
@@ -176,7 +187,13 @@ fn vectors_in_sync_and_reproduce_from_bytes() {
             };
             let id_state = d["identity_state"].as_str().unwrap();
             verdicts.push(tdt::decision_verdict(&p, tool, args, id_state));
-            orders.push(d["order"].as_i64().unwrap());
+            // Order is always an integer in these vectors; a non-integer order is out of scope (the gate
+            // types order as i64). This is a fixture-corruption guard, not a runtime classification path.
+            orders.push(
+                d["order"]
+                    .as_i64()
+                    .expect("vectors: decision order must be an integer"),
+            );
         }
         let expected: Vec<&str> = case["expected"]["decisions"]
             .as_array()

--- a/crates/assay-core/tests/tool_decision_truth_vectors.rs
+++ b/crates/assay-core/tests/tool_decision_truth_vectors.rs
@@ -1,151 +1,456 @@
 //! EXPERIMENTAL conformance vectors for `mcp::tool_decision_truth`.
 //!
-//! A committed fixture (`tests/fixtures/tool_decision_truth/vectors.json`) of declared-policy + observed
-//! decisions with their expected per-decision verdicts and run verdict, plus a couple of pack rows. The
-//! guard test reproduces every verdict and re-verifies every pack row FROM THE COMMITTED BYTES, mirroring
-//! the private reference-spec's verify-golden discipline. Regenerate the fixture with
+//! A committed fixture (`tests/fixtures/tool_decision_truth/vectors.json`) of declared policies + observed
+//! decisions with their expected per-decision and run verdicts, REAL emitted carriers (so the observed-
+//! input digest layer is pinned), positive pack rows built from those carriers, and negative pack rows
+//! that must fail closed. The guard test reproduces every verdict and re-verifies every row FROM THE
+//! COMMITTED BYTES, mirroring the private reference-spec's verify-golden discipline. Regenerate with
 //! `UPDATE_TDT_VECTORS=1 cargo test -p assay-core --test tool_decision_truth_vectors`.
 
 use assay_core::mcp::policy::McpPolicy;
 use assay_core::mcp::tool_decision_truth as tdt;
+use assay_core::mcp::tool_decision_truth::DecisionEvidence;
 use serde_json::{json, Value};
 use std::fs;
 use std::path::PathBuf;
+
+// A fixed test key/key_id: real carriers are keyed, but the key never enters the fixture (only key_id).
+const TEST_KEY: &[u8] = b"tool-decision-truth-vectors-key-v0";
+const TEST_KID: &str = "test-key-v0";
 
 fn fixture_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/tool_decision_truth/vectors.json")
 }
 
-fn declared_policy_json() -> Value {
-    json!({
-        "version": "1",
-        "tools": {"allow": ["read_file", "deploy"], "deny": ["delete_all"]},
-        "schemas": {"deploy": {"type": "object", "required": ["env"],
-            "properties": {"env": {"enum": ["staging", "prod"]}}}},
-        "enforcement": {"unconstrained_tools": "warn"}
-    })
+// ── declared policies ─────────────────────────────────────────────────────────────────────────────
+// Several policies so the vectors exercise pattern deny, an unsupported declared surface, and a malformed
+// schema, not just the narrow allow/deny + flat-schema happy path.
+
+fn policies() -> Vec<(&'static str, Value)> {
+    vec![
+        (
+            "base",
+            json!({
+                "version": "1",
+                "tools": {"allow": ["read_file", "deploy"], "deny": ["delete_all"]},
+                "schemas": {"deploy": {"type": "object", "required": ["env"],
+                    "properties": {"env": {"enum": ["staging", "prod"]}}}},
+                "enforcement": {"unconstrained_tools": "warn"}
+            }),
+        ),
+        (
+            "pattern_deny",
+            json!({
+                "version": "1",
+                "tools": {"deny": ["delete_*"]},
+                "enforcement": {"unconstrained_tools": "allow"}
+            }),
+        ),
+        (
+            "approval",
+            json!({
+                "version": "1",
+                "tools": {"allow": ["pay"], "approval_required": ["pay"]},
+                "enforcement": {"unconstrained_tools": "allow"}
+            }),
+        ),
+        (
+            "malformed_schema",
+            json!({
+                "version": "1",
+                "tools": {"allow": ["t"]},
+                "schemas": {"t": {"$ref": "#/$defs/missing"}},
+                "enforcement": {"unconstrained_tools": "allow"}
+            }),
+        ),
+    ]
 }
 
-fn policy() -> McpPolicy {
-    serde_json::from_value(declared_policy_json()).unwrap()
+fn policy_json(name: &str) -> Value {
+    policies()
+        .into_iter()
+        .find(|(n, _)| *n == name)
+        .unwrap_or_else(|| panic!("unknown policy {name}"))
+        .1
 }
 
-/// One observed decision spec: (tool, args [None = uncaptured], order, identity_state).
-type DecisionSpec = (&'static str, Option<Value>, i64, &'static str);
-/// A conformance case: (case id, its observed decisions).
-type CaseSpec = (&'static str, Vec<DecisionSpec>);
+fn policy(name: &str) -> McpPolicy {
+    serde_json::from_value(policy_json(name)).unwrap()
+}
 
-/// The conformance case specs.
+fn evidence_from(v: Option<&Value>) -> DecisionEvidence {
+    let Some(v) = v else {
+        return DecisionEvidence::default();
+    };
+    DecisionEvidence {
+        tool_classes: v.get("tool_classes").and_then(|x| x.as_array()).map(|a| {
+            a.iter()
+                .filter_map(|s| s.as_str().map(String::from))
+                .collect()
+        }),
+        approval_obtained: v.get("approval_obtained").and_then(|x| x.as_bool()),
+        scope_satisfied: v.get("scope_satisfied").and_then(|x| x.as_bool()),
+        redaction_applied: v.get("redaction_applied").and_then(|x| x.as_bool()),
+    }
+}
+
+// ── verdict case specs ────────────────────────────────────────────────────────────────────────────
+
+/// One observed decision: (tool, args [None = uncaptured], order, identity_state, evidence [None = none]).
+type DecisionSpec = (
+    &'static str,
+    Option<Value>,
+    i64,
+    &'static str,
+    Option<Value>,
+);
+/// A conformance case: (id, declared-policy name, observed decisions).
+type CaseSpec = (&'static str, &'static str, Vec<DecisionSpec>);
+
 fn case_specs() -> Vec<CaseSpec> {
     vec![
         (
             "match",
-            vec![("deploy", Some(json!({"env": "staging"})), 0, "present")],
+            "base",
+            vec![(
+                "deploy",
+                Some(json!({"env": "staging"})),
+                0,
+                "present",
+                None,
+            )],
         ),
         (
             "mismatch_denied_tool",
-            vec![("delete_all", Some(json!({})), 0, "present")],
+            "base",
+            vec![("delete_all", Some(json!({})), 0, "present", None)],
         ),
         (
             "mismatch_arg_enum",
-            vec![("deploy", Some(json!({"env": "dev"})), 0, "present")],
+            "base",
+            vec![("deploy", Some(json!({"env": "dev"})), 0, "present", None)],
         ),
         (
             "incomplete_args_uncaptured",
-            vec![("deploy", None, 0, "present")],
+            "base",
+            vec![("deploy", None, 0, "present", None)],
         ),
         (
             "incomplete_unconstrained_warn",
-            vec![("read_file", Some(json!({"path": "/x"})), 0, "present")],
+            "base",
+            vec![("read_file", Some(json!({"path": "/x"})), 0, "present", None)],
         ),
         (
             "incomplete_required_missing_identity",
+            "base",
             vec![(
                 "deploy",
                 Some(json!({"env": "staging"})),
                 0,
                 "required_missing",
+                None,
             )],
         ),
         (
             "invalid_identity",
-            vec![("deploy", Some(json!({"env": "staging"})), 0, "invalid")],
-        ),
-        (
-            "run_lattice_mismatch",
-            vec![
-                ("deploy", Some(json!({"env": "staging"})), 0, "present"),
-                ("delete_all", Some(json!({})), 1, "present"),
-            ],
+            "base",
+            vec![(
+                "deploy",
+                Some(json!({"env": "staging"})),
+                0,
+                "invalid",
+                None,
+            )],
         ),
         (
             "absent_identity_match",
-            vec![("deploy", Some(json!({"env": "prod"})), 0, "absent")],
+            "base",
+            vec![("deploy", Some(json!({"env": "prod"})), 0, "absent", None)],
+        ),
+        (
+            "run_lattice_mismatch",
+            "base",
+            vec![
+                (
+                    "deploy",
+                    Some(json!({"env": "staging"})),
+                    0,
+                    "present",
+                    None,
+                ),
+                ("delete_all", Some(json!({})), 1, "present", None),
+            ],
         ),
         (
             "invalid_duplicate_order",
+            "base",
             vec![
-                ("deploy", Some(json!({"env": "staging"})), 0, "present"),
-                ("read_file", Some(json!({"path": "/x"})), 0, "present"),
+                (
+                    "deploy",
+                    Some(json!({"env": "staging"})),
+                    0,
+                    "present",
+                    None,
+                ),
+                ("read_file", Some(json!({"path": "/x"})), 0, "present", None),
             ],
+        ),
+        // pattern deny: a literal delete_* deny blocks delete_all (exact equality would have missed it).
+        (
+            "mismatch_pattern_deny",
+            "pattern_deny",
+            vec![("delete_all", Some(json!({})), 0, "present", None)],
+        ),
+        // unsupported declared surface with no evidence -> incomplete, never a silent match.
+        (
+            "incomplete_approval_no_evidence",
+            "approval",
+            vec![("pay", Some(json!({"amount": 10})), 0, "present", None)],
+        ),
+        // ... and it resolves once the approval evidence is supplied.
+        (
+            "match_approval_evidence",
+            "approval",
+            vec![(
+                "pay",
+                Some(json!({"amount": 10})),
+                0,
+                "present",
+                Some(json!({"approval_obtained": true})),
+            )],
+        ),
+        (
+            "mismatch_approval_denied",
+            "approval",
+            vec![(
+                "pay",
+                Some(json!({"amount": 10})),
+                0,
+                "present",
+                Some(json!({"approval_obtained": false})),
+            )],
+        ),
+        // a malformed declared schema is the declaration's fault -> invalid (and must not panic).
+        (
+            "invalid_malformed_schema",
+            "malformed_schema",
+            vec![("t", Some(json!({})), 0, "present", None)],
         ),
     ]
 }
 
+/// Direct run-lattice units: arity mismatch and duplicate order both force `invalid`.
+fn run_verdict_unit_specs() -> Vec<(&'static str, Vec<&'static str>, Vec<i64>)> {
+    vec![
+        ("arity_more_orders", vec!["match"], vec![0, 1]),
+        ("arity_more_verdicts", vec!["match", "match"], vec![0]),
+        ("duplicate_order", vec!["match", "match"], vec![0, 0]),
+        ("clean_run", vec!["match", "incomplete"], vec![0, 1]),
+    ]
+}
+
+// ── real carriers ─────────────────────────────────────────────────────────────────────────────────
+
+/// A carrier build spec: (id, policy, tool, args, order, identity_state, evidence).
+type CarrierSpec = (
+    &'static str,
+    &'static str,
+    &'static str,
+    Value,
+    i64,
+    &'static str,
+    Option<Value>,
+);
+
+fn carrier_specs() -> Vec<CarrierSpec> {
+    vec![
+        (
+            "deploy_match",
+            "base",
+            "deploy",
+            json!({"env": "prod"}),
+            0,
+            "present",
+            None,
+        ),
+        (
+            "delete_mismatch",
+            "base",
+            "delete_all",
+            json!({}),
+            1,
+            "present",
+            None,
+        ),
+        // carries a secret-named arg: the raw value must never appear, only its dropped-then-keyed digest.
+        (
+            "secret_args",
+            "base",
+            "read_file",
+            json!({"path": "/x", "token": "SUPER-SECRET"}),
+            2,
+            "present",
+            None,
+        ),
+    ]
+}
+
+fn build_carrier(spec: &CarrierSpec) -> Value {
+    let (id, policy_name, tool, args, order, identity, evidence) = spec;
+    tdt::build_classified_record(
+        &policy(policy_name),
+        tool,
+        args,
+        *order,
+        TEST_KEY,
+        TEST_KID,
+        "authoritative_boundary",
+        id,
+        "ok",
+        identity,
+        &evidence_from(evidence.as_ref()),
+    )
+    .unwrap_or_else(|| panic!("carrier {id} did not build"))
+}
+
+/// Positive pack rows: (id, carrier id, run_verdict, ref). The run verdict is >= the carrier's decision.
+fn pack_row_specs() -> Vec<(&'static str, &'static str, &'static str, &'static str)> {
+    vec![
+        ("match_row", "deploy_match", "match", "audit://decision/c0"),
+        (
+            "mismatch_row",
+            "delete_mismatch",
+            "mismatch",
+            "audit://decision/c1",
+        ),
+    ]
+}
+
+// ── emit ────────────────────────────────────────────────────────────────────────────────────────
+
 fn emit_doc() -> Value {
-    let p = policy();
+    // policies
+    let mut policies_doc = serde_json::Map::new();
+    for (name, json) in policies() {
+        policies_doc.insert(name.to_string(), json);
+    }
+
+    // verdict cases
     let mut cases = Vec::new();
-    for (id, decisions) in case_specs() {
+    for (id, policy_name, decisions) in case_specs() {
+        let p = policy(policy_name);
         let mut observed = Vec::new();
         let mut verdicts: Vec<&str> = Vec::new();
         let mut orders: Vec<i64> = Vec::new();
-        for (tool, args, order, id_state) in &decisions {
-            verdicts.push(tdt::decision_verdict(&p, tool, args.as_ref(), id_state));
+        for (tool, args, order, id_state, evidence) in &decisions {
+            let ev = evidence_from(evidence.as_ref());
+            verdicts.push(tdt::decision_verdict(
+                &p,
+                tool,
+                args.as_ref(),
+                id_state,
+                &ev,
+            ));
             orders.push(*order);
             observed.push(json!({
                 "tool_name": tool,
                 "args": args,
                 "order": order,
                 "identity_state": id_state,
+                "evidence": evidence,
             }));
         }
         let run = tdt::run_verdict(&verdicts, &orders);
         cases.push(json!({
             "id": id,
+            "policy": policy_name,
             "observed": observed,
             "expected": {"decisions": verdicts, "run_verdict": run},
         }));
     }
+
+    // run-lattice units
+    let mut run_units = Vec::new();
+    for (id, verdicts, orders) in run_verdict_unit_specs() {
+        let expected = tdt::run_verdict(&verdicts, &orders);
+        run_units
+            .push(json!({"id": id, "verdicts": verdicts, "orders": orders, "expected": expected}));
+    }
+
+    // real carriers
+    let mut carriers = Vec::new();
+    for spec in carrier_specs() {
+        let carrier = build_carrier(&spec);
+        carriers.push(json!({"id": spec.0, "policy": spec.1, "carrier": carrier}));
+    }
+    let carrier_of = |id: &str| -> Value {
+        carriers
+            .iter()
+            .find(|c| c["id"] == id)
+            .map(|c| c["carrier"].clone())
+            .unwrap_or_else(|| panic!("carrier {id} not emitted"))
+    };
+
+    // positive pack rows from real carriers
     let mut pack_rows = Vec::new();
-    for (oid, dpd, verdict, reference) in [
-        (
-            "sha256:obs-1",
-            "sha256:decl-1",
-            "match",
-            "audit://decision/c1",
-        ),
-        (
-            "sha256:obs-2",
-            "sha256:decl-2",
-            "mismatch",
-            "audit://decision/c2",
-        ),
-    ] {
-        let row = tdt::pack_recipe_row(oid, dpd, verdict, reference).unwrap();
+    for (id, carrier_id, run_verdict, reference) in pack_row_specs() {
+        let carrier = carrier_of(carrier_id);
+        let row = tdt::pack_recipe_row(&carrier, run_verdict, reference)
+            .unwrap_or_else(|| panic!("pack row {id} did not build"));
         pack_rows.push(json!({
-            "observed_input_digest": oid,
-            "declared_policy_digest": dpd,
-            "run_verdict": verdict,
-            "ref": reference,
+            "id": id,
+            "carrier_id": carrier_id,
+            "run_verdict": run_verdict,
             "row": row,
         }));
     }
+
+    // negative pack rows: each must fail verify_recipe_row against the cited carrier.
+    let good =
+        tdt::pack_recipe_row(&carrier_of("deploy_match"), "match", "audit://decision/c0").unwrap();
+    let mut negatives = Vec::new();
+
+    // (a) tampered run_verdict: the bound verdict was "match"; the row now claims "incomplete".
+    let mut tampered_verdict = good.clone();
+    tampered_verdict["run_verdict"] = json!("incomplete");
+    negatives.push(json!({
+        "id": "tampered_run_verdict", "carrier_id": "deploy_match",
+        "run_verdict": "incomplete", "row": tampered_verdict,
+    }));
+
+    // (b) foreign recipe.
+    let mut foreign_recipe = good.clone();
+    foreign_recipe["recipe"] = json!("other.recipe.v0");
+    negatives.push(json!({
+        "id": "foreign_recipe", "carrier_id": "deploy_match",
+        "run_verdict": "match", "row": foreign_recipe,
+    }));
+
+    // (c) foreign canonicalization in the envelope.
+    let mut foreign_canon = good.clone();
+    foreign_canon["evidence_ref"]["canonicalization"] = json!("cbor-deterministic-v1");
+    negatives.push(json!({
+        "id": "foreign_canonicalization", "carrier_id": "deploy_match",
+        "run_verdict": "match", "row": foreign_canon,
+    }));
+
+    // (d) malformed citation digest (not sha256:<64hex>).
+    let mut bad_digest = good.clone();
+    bad_digest["evidence_ref"]["digest"] = json!("sha256:short");
+    negatives.push(json!({
+        "id": "malformed_citation_digest", "carrier_id": "deploy_match",
+        "run_verdict": "match", "row": bad_digest,
+    }));
+
     json!({
         "schema": "assay.tool_decision_truth.vectors.v0",
-        "declared_policy": declared_policy_json(),
+        "policies": Value::Object(policies_doc),
         "cases": cases,
+        "run_verdict_units": run_units,
+        "carriers": carriers,
         "pack_rows": pack_rows,
+        "negative_pack_rows": negatives,
     })
 }
 
@@ -167,15 +472,17 @@ fn vectors_in_sync_and_reproduce_from_bytes() {
     )
     .unwrap();
 
-    // Sync-guard: the committed fixture must not drift from the current code.
+    // Sync-guard: the committed fixture must not drift from the current code (this is what pins the
+    // observed-input digest layer, since the carriers are emitted from the real keyed digests).
     assert_eq!(
         committed, fresh,
         "vectors.json drifted from emit; regenerate with UPDATE_TDT_VECTORS=1"
     );
 
-    // Reproduce-from-bytes: recompute every verdict and re-verify every pack row from the committed bytes.
-    let p: McpPolicy = serde_json::from_value(committed["declared_policy"].clone()).unwrap();
+    // Reproduce verdicts from the committed bytes.
     for case in committed["cases"].as_array().unwrap() {
+        let p: McpPolicy =
+            serde_json::from_value(policy_json(case["policy"].as_str().unwrap())).unwrap();
         let mut verdicts: Vec<&str> = Vec::new();
         let mut orders: Vec<i64> = Vec::new();
         for d in case["observed"].as_array().unwrap() {
@@ -186,9 +493,8 @@ fn vectors_in_sync_and_reproduce_from_bytes() {
                 Some(&d["args"])
             };
             let id_state = d["identity_state"].as_str().unwrap();
-            verdicts.push(tdt::decision_verdict(&p, tool, args, id_state));
-            // Order is always an integer in these vectors; a non-integer order is out of scope (the gate
-            // types order as i64). This is a fixture-corruption guard, not a runtime classification path.
+            let ev = evidence_from(d.get("evidence"));
+            verdicts.push(tdt::decision_verdict(&p, tool, args, id_state, &ev));
             orders.push(
                 d["order"]
                     .as_i64()
@@ -201,11 +507,7 @@ fn vectors_in_sync_and_reproduce_from_bytes() {
             .iter()
             .map(|x| x.as_str().unwrap())
             .collect();
-        assert_eq!(
-            verdicts, expected,
-            "per-decision verdicts for case {}",
-            case["id"]
-        );
+        assert_eq!(verdicts, expected, "decisions for case {}", case["id"]);
         assert_eq!(
             tdt::run_verdict(&verdicts, &orders),
             case["expected"]["run_verdict"].as_str().unwrap(),
@@ -213,15 +515,81 @@ fn vectors_in_sync_and_reproduce_from_bytes() {
             case["id"]
         );
     }
-    for row in committed["pack_rows"].as_array().unwrap() {
+
+    // Reproduce the run-lattice units.
+    for unit in committed["run_verdict_units"].as_array().unwrap() {
+        let verdicts: Vec<&str> = unit["verdicts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        let orders: Vec<i64> = unit["orders"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_i64().unwrap())
+            .collect();
+        assert_eq!(
+            tdt::run_verdict(&verdicts, &orders),
+            unit["expected"].as_str().unwrap(),
+            "run_verdict unit {}",
+            unit["id"]
+        );
+    }
+
+    // The observed-input digest layer: every carrier carries a keyed args_digest (framed with its key_id)
+    // and never the raw arguments.
+    let mut carrier_by_id = std::collections::HashMap::new();
+    for c in committed["carriers"].as_array().unwrap() {
+        let carrier = &c["carrier"];
+        carrier_by_id.insert(c["id"].as_str().unwrap().to_string(), carrier.clone());
         assert!(
-            tdt::verify_recipe_row(
-                &row["row"],
-                row["observed_input_digest"].as_str().unwrap(),
-                row["declared_policy_digest"].as_str().unwrap(),
-                row["run_verdict"].as_str().unwrap(),
-            ),
-            "pack row did not reproduce from bytes"
+            carrier.get("args").is_none() && carrier.get("arguments").is_none(),
+            "carrier {} must not carry raw args",
+            c["id"]
+        );
+        assert!(
+            carrier["args_digest"]
+                .as_str()
+                .unwrap()
+                .starts_with(&format!("hmac-sha256:{TEST_KID}:")),
+            "carrier {} args_digest must be keyed and framed by key_id",
+            c["id"]
+        );
+        assert_eq!(carrier["key_id"], json!(TEST_KID));
+    }
+    // The secret value never appears anywhere in the secret-args carrier.
+    let secret_carrier = serde_json::to_string(&carrier_by_id["secret_args"]).unwrap();
+    assert!(!secret_carrier.contains("SUPER-SECRET"));
+    // Secret-drop: a secret-named arg does not affect the keyed digest.
+    assert_eq!(
+        tdt::args_digest(
+            &json!({"path": "/x", "token": "SUPER-SECRET"}),
+            TEST_KEY,
+            TEST_KID
+        ),
+        tdt::args_digest(&json!({"path": "/x"}), TEST_KEY, TEST_KID),
+        "secret-named keys must drop out of the args_digest"
+    );
+
+    // Positive pack rows reproduce: each verifies against the real carrier it cites.
+    for row in committed["pack_rows"].as_array().unwrap() {
+        let carrier = &carrier_by_id[row["carrier_id"].as_str().unwrap()];
+        assert!(
+            tdt::verify_recipe_row(&row["row"], carrier, row["run_verdict"].as_str().unwrap()),
+            "positive pack row {} did not reproduce",
+            row["id"]
+        );
+    }
+
+    // Negative pack rows fail closed: each must NOT verify.
+    for row in committed["negative_pack_rows"].as_array().unwrap() {
+        let carrier = &carrier_by_id[row["carrier_id"].as_str().unwrap()];
+        assert!(
+            !tdt::verify_recipe_row(&row["row"], carrier, row["run_verdict"].as_str().unwrap()),
+            "negative pack row {} must fail verification",
+            row["id"]
         );
     }
 }

--- a/crates/assay-core/tests/tool_decision_truth_vectors.rs
+++ b/crates/assay-core/tests/tool_decision_truth_vectors.rs
@@ -1,0 +1,210 @@
+//! EXPERIMENTAL conformance vectors for `mcp::tool_decision_truth`.
+//!
+//! A committed fixture (`tests/fixtures/tool_decision_truth/vectors.json`) of declared-policy + observed
+//! decisions with their expected per-decision verdicts and run verdict, plus a couple of pack rows. The
+//! guard test reproduces every verdict and re-verifies every pack row FROM THE COMMITTED BYTES, mirroring
+//! the private reference-spec's verify-golden discipline. Regenerate the fixture with
+//! `UPDATE_TDT_VECTORS=1 cargo test -p assay-core --test tool_decision_truth_vectors`.
+
+use assay_core::mcp::policy::McpPolicy;
+use assay_core::mcp::tool_decision_truth as tdt;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::PathBuf;
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/tool_decision_truth/vectors.json")
+}
+
+fn declared_policy_json() -> Value {
+    json!({
+        "version": "1",
+        "tools": {"allow": ["read_file", "deploy"], "deny": ["delete_all"]},
+        "schemas": {"deploy": {"type": "object", "required": ["env"],
+            "properties": {"env": {"enum": ["staging", "prod"]}}}},
+        "enforcement": {"unconstrained_tools": "warn"}
+    })
+}
+
+fn policy() -> McpPolicy {
+    serde_json::from_value(declared_policy_json()).unwrap()
+}
+
+/// One observed decision spec: (tool, args [None = uncaptured], order, identity_state).
+type DecisionSpec = (&'static str, Option<Value>, i64, &'static str);
+/// A conformance case: (case id, its observed decisions).
+type CaseSpec = (&'static str, Vec<DecisionSpec>);
+
+/// The conformance case specs.
+fn case_specs() -> Vec<CaseSpec> {
+    vec![
+        (
+            "match",
+            vec![("deploy", Some(json!({"env": "staging"})), 0, "present")],
+        ),
+        (
+            "mismatch_denied_tool",
+            vec![("delete_all", Some(json!({})), 0, "present")],
+        ),
+        (
+            "mismatch_arg_enum",
+            vec![("deploy", Some(json!({"env": "dev"})), 0, "present")],
+        ),
+        (
+            "incomplete_args_uncaptured",
+            vec![("deploy", None, 0, "present")],
+        ),
+        (
+            "incomplete_unconstrained_warn",
+            vec![("read_file", Some(json!({"path": "/x"})), 0, "present")],
+        ),
+        (
+            "incomplete_required_missing_identity",
+            vec![(
+                "deploy",
+                Some(json!({"env": "staging"})),
+                0,
+                "required_missing",
+            )],
+        ),
+        (
+            "invalid_identity",
+            vec![("deploy", Some(json!({"env": "staging"})), 0, "invalid")],
+        ),
+        (
+            "run_lattice_mismatch",
+            vec![
+                ("deploy", Some(json!({"env": "staging"})), 0, "present"),
+                ("delete_all", Some(json!({})), 1, "present"),
+            ],
+        ),
+    ]
+}
+
+fn emit_doc() -> Value {
+    let p = policy();
+    let mut cases = Vec::new();
+    for (id, decisions) in case_specs() {
+        let mut observed = Vec::new();
+        let mut verdicts: Vec<&str> = Vec::new();
+        let mut orders: Vec<i64> = Vec::new();
+        for (tool, args, order, id_state) in &decisions {
+            verdicts.push(tdt::decision_verdict(&p, tool, args.as_ref(), id_state));
+            orders.push(*order);
+            observed.push(json!({
+                "tool_name": tool,
+                "args": args,
+                "order": order,
+                "identity_state": id_state,
+            }));
+        }
+        let run = tdt::run_verdict(&verdicts, &orders);
+        cases.push(json!({
+            "id": id,
+            "observed": observed,
+            "expected": {"decisions": verdicts, "run_verdict": run},
+        }));
+    }
+    let mut pack_rows = Vec::new();
+    for (oid, dpd, verdict, reference) in [
+        (
+            "sha256:obs-1",
+            "sha256:decl-1",
+            "match",
+            "audit://decision/c1",
+        ),
+        (
+            "sha256:obs-2",
+            "sha256:decl-2",
+            "mismatch",
+            "audit://decision/c2",
+        ),
+    ] {
+        let row = tdt::pack_recipe_row(oid, dpd, verdict, reference).unwrap();
+        pack_rows.push(json!({
+            "observed_input_digest": oid,
+            "declared_policy_digest": dpd,
+            "run_verdict": verdict,
+            "ref": reference,
+            "row": row,
+        }));
+    }
+    json!({
+        "schema": "assay.tool_decision_truth.vectors.v0",
+        "declared_policy": declared_policy_json(),
+        "cases": cases,
+        "pack_rows": pack_rows,
+    })
+}
+
+#[test]
+fn vectors_in_sync_and_reproduce_from_bytes() {
+    let fresh = emit_doc();
+    let path = fixture_path();
+    if std::env::var("UPDATE_TDT_VECTORS").is_ok() {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            format!("{}\n", serde_json::to_string_pretty(&fresh).unwrap()),
+        )
+        .unwrap();
+    }
+    let committed: Value = serde_json::from_str(
+        &fs::read_to_string(&path)
+            .expect("vectors.json present (regenerate with UPDATE_TDT_VECTORS=1)"),
+    )
+    .unwrap();
+
+    // Sync-guard: the committed fixture must not drift from the current code.
+    assert_eq!(
+        committed, fresh,
+        "vectors.json drifted from emit; regenerate with UPDATE_TDT_VECTORS=1"
+    );
+
+    // Reproduce-from-bytes: recompute every verdict and re-verify every pack row from the committed bytes.
+    let p: McpPolicy = serde_json::from_value(committed["declared_policy"].clone()).unwrap();
+    for case in committed["cases"].as_array().unwrap() {
+        let mut verdicts: Vec<&str> = Vec::new();
+        let mut orders: Vec<i64> = Vec::new();
+        for d in case["observed"].as_array().unwrap() {
+            let tool = d["tool_name"].as_str().unwrap();
+            let args = if d["args"].is_null() {
+                None
+            } else {
+                Some(&d["args"])
+            };
+            let id_state = d["identity_state"].as_str().unwrap();
+            verdicts.push(tdt::decision_verdict(&p, tool, args, id_state));
+            orders.push(d["order"].as_i64().unwrap());
+        }
+        let expected: Vec<&str> = case["expected"]["decisions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        assert_eq!(
+            verdicts, expected,
+            "per-decision verdicts for case {}",
+            case["id"]
+        );
+        assert_eq!(
+            tdt::run_verdict(&verdicts, &orders),
+            case["expected"]["run_verdict"].as_str().unwrap(),
+            "run verdict for case {}",
+            case["id"]
+        );
+    }
+    for row in committed["pack_rows"].as_array().unwrap() {
+        assert!(
+            tdt::verify_recipe_row(
+                &row["row"],
+                row["observed_input_digest"].as_str().unwrap(),
+                row["declared_policy_digest"].as_str().unwrap(),
+                row["run_verdict"].as_str().unwrap(),
+            ),
+            "pack row did not reproduce from bytes"
+        );
+    }
+}

--- a/crates/assay-core/tests/tool_decision_truth_vectors.rs
+++ b/crates/assay-core/tests/tool_decision_truth_vectors.rs
@@ -15,8 +15,10 @@ use std::fs;
 use std::path::PathBuf;
 
 // A fixed test key/key_id: real carriers are keyed, but the key never enters the fixture (only key_id).
+// The key_id is deliberately neutral so the committed `hmac-sha256:<key_id>:<hex>` digests in the golden
+// fixture do not trip generic API-key secret scanners.
 const TEST_KEY: &[u8] = b"tool-decision-truth-vectors-key-v0";
-const TEST_KID: &str = "test-key-v0";
+const TEST_KID: &str = "fixture-kid-v0";
 
 fn fixture_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
## What

Adds conformance vectors for the experimental `mcp::tool_decision_truth` slice:

- `tests/fixtures/tool_decision_truth/vectors.json`: a committed fixture of a declared policy plus observed
  decisions with their expected per-decision verdicts and run verdict, plus a couple of pack rows with
  their `coherence_binding`.
- `tests/tool_decision_truth_vectors.rs`: a guard test that (1) checks the committed fixture has not
  drifted from a fresh emit (regenerate with `UPDATE_TDT_VECTORS=1`), and (2) reproduces every verdict via
  `decision_verdict` / `run_verdict` and re-verifies every pack row via `verify_recipe_row`, all from the
  committed bytes.

## Why

Fifth and final slice of the experimental tool-decision truth-layer: a reproduce-from-bytes conformance
guard, mirroring the reference-spec verify-golden discipline, so a change in the gate or digest logic that
drifts the committed verdicts is caught.

## Experimental

Test-only and additive: no library change, no new dependency.

## Tests

`cargo test -p assay-core --test tool_decision_truth_vectors` passes (sync-guard plus reproduce-from-bytes
over 8 cases and 2 pack rows). `cargo clippy -p assay-core --tests -- -D warnings` is clean.

## Non-claims

The vectors fix the current experimental behavior for regression detection; they are not a stability or
correctness guarantee of the schema itself, which remains experimental.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive tool-decision conformance fixture (JSON) defining multiple policy scenarios and expected verdict outcomes.
  * Introduced a conformance-vector test that validates regenerated results against the committed fixture, with an option to update it.
  * Added stronger verification coverage for decision outputs and integrity checks, including expected “pack row” confirmations and intentional failure cases to detect regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->