### PR TITLE
fix(mcp): make declared digest and verdict gate coherent per review

### DIFF
--- a/crates/assay-core/src/mcp/policy/mod.rs
+++ b/crates/assay-core/src/mcp/policy/mod.rs
@@ -80,8 +80,8 @@ impl McpPolicy {
 
     /// EXPERIMENTAL (unstable, may change): the declared-CONSTRAINT digest for the tool-decision
     /// truth-layer. Unlike `policy_digest` (the whole policy, Vec-structural), this projects to the
-    /// declared-constraint surface only — `version`, the `tools` allow/deny + class/approval/scope lists,
-    /// per-tool `schemas`, and `enforcement` — excluding operational knobs (`runtime_monitor`,
+    /// declared-constraint surface only — `version`, the `tools` allow/deny + class/approval/scope/redaction
+    /// lists, per-tool `schemas`, and `enforcement` — excluding operational knobs (`runtime_monitor`,
     /// `kill_switch`, `limits`, `discovery`, `signatures`, `tool_pins`, taxonomy), and SEMANTICALLY
     /// NORMALIZES the set-like fields (sorts them by canonical bytes) so a reordered-but-equal policy
     /// yields the same digest while a real membership/constraint change still moves it. Legacy v1 shapes
@@ -95,19 +95,26 @@ impl McpPolicy {
     /// refinement. Returns `None` if any fragment fails to canonicalize. Not a stability guarantee:
     /// names/shape may change until promoted out of experimental.
     pub fn declared_constraint_digest_experimental(&self) -> Option<String> {
-        let mut p = self.clone();
-        p.normalize_legacy_shapes();
-        // Explicit schemas are more authoritative than a legacy constraint that migrates to the same
-        // tool. Capture them before migration and re-apply after, so an explicitly declared schema always
-        // wins over a migrated one (migration would otherwise overwrite it) and the digest reflects the
-        // enforced constraint.
-        let explicit_schemas = p.schemas.clone();
-        p.migrate_constraints_to_schemas();
-        p.schemas.extend(explicit_schemas);
+        let p = self.normalized_declared_view_experimental();
         let full = serde_json::to_value(&p).ok()?;
         let proj = project_and_normalize_declared(&full)?;
         let canonical = jcs::to_string(&proj).ok()?;
         Some(format!("sha256:{}", sha256_hex(&canonical)))
+    }
+
+    /// EXPERIMENTAL: the single normalized declared view that BOTH the declared digest and the
+    /// tool-decision verdict gate evaluate, so the two can never disagree about what is declared. Legacy
+    /// root-level allow/deny are normalized, legacy `constraints` are migrated into per-tool schemas, and
+    /// an explicitly declared schema takes precedence over a migrated one (migration would otherwise
+    /// overwrite it). Without this shared view a legacy-constraint-only policy would bind a migrated schema
+    /// in the digest while the verdict saw "no schema" and could pass it.
+    pub fn normalized_declared_view_experimental(&self) -> McpPolicy {
+        let mut p = self.clone();
+        p.normalize_legacy_shapes();
+        let explicit_schemas = p.schemas.clone();
+        p.migrate_constraints_to_schemas();
+        p.schemas.extend(explicit_schemas);
+        p
     }
 
     /// Single evaluation entry point for CLI and Server
@@ -224,6 +231,8 @@ fn project_and_normalize_declared(full: &Value) -> Option<Value> {
                 "approval_required_classes",
                 "restrict_scope",
                 "restrict_scope_classes",
+                "redact_args",
+                "redact_args_classes",
             ] {
                 if let Some(arr) = tools.get(k).and_then(|a| a.as_array()) {
                     let mut a = arr.clone();
@@ -327,9 +336,10 @@ mod declared_constraint_digest_experimental_tests {
     }
 
     #[test]
-    fn non_surface_tools_field_does_not_move_digest() {
-        // Fields outside the declared-constraint surface (e.g. redact_args) are projected out, so they
-        // cannot move the digest; a surface field (allow) still moves it.
+    fn redaction_lists_are_in_surface_but_contract_is_not() {
+        // redact_args / redact_args_classes ARE declared constraints the verdict gate evaluates, so they
+        // must move the digest (digest binds exactly what the verdict decides). The redact_args_contract
+        // operational detail is NOT in the surface and does not move it.
         let base = policy(
             json!([]),
             json!({"tools": {"allow": ["read_file"], "deny": ["delete_all"]}}),
@@ -341,7 +351,17 @@ mod declared_constraint_digest_experimental_tests {
                 "redact_args": ["password", "token"], "redact_args_classes": ["secret"]}}),
         )
         .declared_constraint_digest_experimental();
-        assert_eq!(base, with_redact);
+        assert_ne!(base, with_redact); // redaction lists now move the digest
+
+        let with_contract = policy(
+            json!([]),
+            json!({"tools": {"allow": ["read_file"], "deny": ["delete_all"],
+                "redact_args_contract": {"redaction_target": "args.token",
+                    "redaction_mode": "drop", "redaction_scope": "request"}}}),
+        )
+        .declared_constraint_digest_experimental();
+        assert_eq!(base, with_contract); // the operational contract is non-surface
+
         let with_more_allow = policy(
             json!([]),
             json!({"tools": {"allow": ["read_file", "deploy"], "deny": ["delete_all"]}}),

--- a/crates/assay-core/src/mcp/tool_decision_truth.rs
+++ b/crates/assay-core/src/mcp/tool_decision_truth.rs
@@ -502,9 +502,12 @@ fn is_verdict(s: &str) -> bool {
 /// claim `match` while the carrier it cites recorded `mismatch`. A carrier with no (or null) decision
 /// verdict imposes no constraint.
 fn run_verdict_covers_carrier(carrier: &Value, run_verdict: &str) -> bool {
-    match carrier.get("decision_verdict").and_then(|v| v.as_str()) {
-        Some(cv) if is_verdict(cv) => verdict_rank(run_verdict) >= verdict_rank(cv),
-        _ => true,
+    match carrier.get("decision_verdict") {
+        // Only a genuinely absent verdict imposes no constraint.
+        None | Some(Value::Null) => true,
+        Some(Value::String(cv)) if is_verdict(cv) => verdict_rank(run_verdict) >= verdict_rank(cv),
+        // A present-but-malformed carrier verdict fails closed rather than passing unconstrained.
+        _ => false,
     }
 }
 
@@ -1384,5 +1387,12 @@ mod pack_tests {
             &mismatch_carrier,
             "match"
         ));
+
+        // A carrier carrying a malformed (non-lattice) decision_verdict fails closed: it imposes a
+        // constraint no run verdict can satisfy, so no row may cite it.
+        let mut malformed = carrier();
+        malformed["decision_verdict"] = json!("approved");
+        assert!(pack_recipe_row(&malformed, "match", REF).is_none());
+        assert!(pack_recipe_row(&malformed, "invalid", REF).is_none());
     }
 }

--- a/crates/assay-core/src/mcp/tool_decision_truth.rs
+++ b/crates/assay-core/src/mcp/tool_decision_truth.rs
@@ -163,6 +163,11 @@ pub fn build_record(
     {
         return None;
     }
+    // The declared digest is supplied by the caller; reject a malformed one so a carrier cannot embed a
+    // bogus `declared_policy_digest` that later passes pack verification.
+    if !is_sha256_digest(declared_policy_digest) {
+        return None;
+    }
     let ad = args_digest(args, key, key_id)?;
     let oid = observed_input_digest(tool_name, &ad, order)?;
     Some(json!({
@@ -367,8 +372,10 @@ pub fn decision_verdict(
     identity_state: &str,
     evidence: &DecisionEvidence,
 ) -> &'static str {
-    let mut p = policy.clone();
-    p.normalize_legacy_shapes();
+    // Use the SAME normalized+migrated view as the declared digest, so a legacy-constraint-only policy
+    // (whose constraint the digest binds as a migrated schema) is actually evaluated here, instead of the
+    // gate seeing "no schema" and passing it.
+    let p = policy.normalized_declared_view_experimental();
     let tc = evidence.tool_classes.as_deref();
     let approval = applicability(
         nonempty(&p.tools.approval_required),
@@ -484,6 +491,23 @@ fn is_sha256_digest(s: &str) -> bool {
     }
 }
 
+/// Whether `s` is one of the four lattice verdicts. A pack row may only bind a real verdict, not an
+/// arbitrary label like `approved`.
+fn is_verdict(s: &str) -> bool {
+    matches!(s, "match" | "incomplete" | "mismatch" | "invalid")
+}
+
+/// Whether `run_verdict` is consistent with the carrier's own `decision_verdict`. A run verdict is the
+/// lattice-max over its decisions, so it must be at least as severe as any single decision: a row may not
+/// claim `match` while the carrier it cites recorded `mismatch`. A carrier with no (or null) decision
+/// verdict imposes no constraint.
+fn run_verdict_covers_carrier(carrier: &Value, run_verdict: &str) -> bool {
+    match carrier.get("decision_verdict").and_then(|v| v.as_str()) {
+        Some(cv) if is_verdict(cv) => verdict_rank(run_verdict) >= verdict_rank(cv),
+        _ => true,
+    }
+}
+
 /// Digest over the decision identity (the two pinned digests). This is the stable logical handle that
 /// JOINS a pack row to a carrier; it is NOT the carrier content digest (see [`carrier_content_digest`]).
 pub fn decision_identity_digest(
@@ -529,12 +553,18 @@ pub fn evidence_ref(carrier_content_digest: &str, reference: &str) -> Value {
 /// identity, and the run verdict together. EXPERIMENTAL. `None` if the carrier lacks its identity digests
 /// or canonicalization fails.
 pub fn pack_recipe_row(carrier: &Value, run_verdict: &str, reference: &str) -> Option<Value> {
+    if !is_verdict(run_verdict) || !run_verdict_covers_carrier(carrier, run_verdict) {
+        return None;
+    }
     let oid = carrier
         .get("observed_input_digest")
         .and_then(|v| v.as_str())?;
     let dpd = carrier
         .get("declared_policy_digest")
         .and_then(|v| v.as_str())?;
+    if !is_sha256_digest(oid) || !is_sha256_digest(dpd) {
+        return None;
+    }
     let content = carrier_content_digest(carrier)?;
     let identity = decision_identity_digest(oid, dpd)?;
     let er = evidence_ref(&content, reference);
@@ -581,6 +611,11 @@ pub fn verify_recipe_row(row: &Value, carrier: &Value, run_verdict: &str) -> boo
     if row.get("run_verdict").and_then(|v| v.as_str()) != Some(run_verdict) {
         return false;
     }
+    // The verdict must be a real lattice verdict and at least as severe as the carrier's own decision, so
+    // a row cannot bind a bogus label or claim a cleaner verdict than the carrier it cites.
+    if !is_verdict(run_verdict) || !run_verdict_covers_carrier(carrier, run_verdict) {
+        return false;
+    }
     // Digests must be well-formed before they are trusted as citations.
     let Some(er_digest) = er.get("digest").and_then(|d| d.as_str()) else {
         return false;
@@ -607,6 +642,9 @@ pub fn verify_recipe_row(row: &Value, carrier: &Value, run_verdict: &str) -> boo
     ) else {
         return false;
     };
+    if !is_sha256_digest(oid) || !is_sha256_digest(dpd) {
+        return false;
+    }
     match decision_identity_digest(oid, dpd) {
         Some(i) if i == row_identity => {}
         _ => return false,
@@ -632,6 +670,8 @@ mod tests {
     const KEY: &[u8] = b"reference-test-key-v0";
     const KID: &str = "test-key-v0";
     const PROV: (&str, &str, &str, &str) = ("authoritative_boundary", "c1", "ok", "present");
+    // A well-formed declared digest (build_record now rejects malformed ones).
+    const DECL: &str = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
 
     fn ad(args: Value) -> String {
         args_digest(&args, KEY, KID).unwrap()
@@ -639,16 +679,7 @@ mod tests {
 
     fn rec(tool: &str, args: Value, order: i64, prov: (&str, &str, &str, &str)) -> Value {
         build_record(
-            tool,
-            &args,
-            order,
-            "sha256:decl",
-            KEY,
-            KID,
-            prov.0,
-            prov.1,
-            prov.2,
-            prov.3,
+            tool, &args, order, DECL, KEY, KID, prov.0, prov.1, prov.2, prov.3,
         )
         .unwrap()
     }
@@ -735,23 +766,34 @@ mod tests {
     fn build_record_rejects_out_of_contract_provenance() {
         let args = json!({"path": "/x"});
         let mk = |sc: &str, rs: &str, id: &str| {
-            build_record(
-                "read_file",
-                &args,
-                0,
-                "sha256:d",
-                KEY,
-                KID,
-                sc,
-                "c1",
-                rs,
-                id,
-            )
+            build_record("read_file", &args, 0, DECL, KEY, KID, sc, "c1", rs, id)
         };
         assert!(mk("authoritative_boundary", "ok", "present").is_some());
         assert!(mk("made_up_source", "ok", "present").is_none());
         assert!(mk("authoritative_boundary", "maybe", "present").is_none());
         assert!(mk("authoritative_boundary", "ok", "unknown_state").is_none());
+    }
+
+    #[test]
+    fn build_record_rejects_malformed_declared_digest() {
+        let args = json!({"path": "/x"});
+        let mk = |decl: &str| {
+            build_record(
+                "read_file",
+                &args,
+                0,
+                decl,
+                KEY,
+                KID,
+                "authoritative_boundary",
+                "c1",
+                "ok",
+                "present",
+            )
+        };
+        assert!(mk(DECL).is_some()); // well-formed sha256
+        assert!(mk("sha256:decl").is_none()); // too short
+        assert!(mk("not-a-digest").is_none()); // wrong prefix
     }
 
     #[test]
@@ -1022,6 +1064,34 @@ mod gate_tests {
     }
 
     #[test]
+    fn legacy_constraints_are_evaluated_by_the_verdict() {
+        // A legacy-constraint-only policy: the declared digest binds a migrated schema, and the verdict
+        // must evaluate that SAME migrated schema rather than seeing "no schema" and passing under
+        // unconstrained = allow. Before the shared normalized view, the second case was a false `match`.
+        let p = p_from(json!({
+            "version": "1",
+            "tools": {"allow": ["deploy"]},
+            "constraints": [{"tool": "deploy", "params": {"env": {"matches": "^prod$"}}}],
+            "enforcement": {"unconstrained_tools": "allow"}
+        }));
+        let e = DecisionEvidence::default();
+        assert_eq!(
+            decision_verdict(&p, "deploy", Some(&json!({"env": "prod"})), "present", &e),
+            "match"
+        );
+        assert_eq!(
+            decision_verdict(
+                &p,
+                "deploy",
+                Some(&json!({"env": "staging"})),
+                "present",
+                &e
+            ),
+            "mismatch"
+        );
+    }
+
+    #[test]
     fn run_lattice_and_order_integrity() {
         assert_eq!(run_verdict(&["match", "incomplete"], &[0, 1]), "incomplete");
         assert_eq!(run_verdict(&["match", "mismatch"], &[0, 1]), "mismatch");
@@ -1078,19 +1148,32 @@ mod pack_tests {
 
     const REF: &str = "audit://decision/c1";
 
-    /// A real carrier: a row cites THIS, not synthetic digest strings.
+    fn pack_policy(allow: &str, deny: &str) -> McpPolicy {
+        serde_json::from_value(json!({
+            "version": "1",
+            "tools": {"allow": [allow], "deny": [deny]},
+            "schemas": {"deploy": {"type": "object", "required": ["env"],
+                "properties": {"env": {"enum": ["staging", "prod"]}}}},
+            "enforcement": {"unconstrained_tools": "warn"}
+        }))
+        .unwrap()
+    }
+
+    /// A real, fully-classified carrier (real declared digest + decision_verdict): a row cites THIS, not
+    /// synthetic digest strings.
     fn carrier() -> Value {
-        build_record(
+        build_classified_record(
+            &pack_policy("deploy", "delete_all"),
             "deploy",
             &json!({"env": "prod"}),
             0,
-            "sha256:decl",
             b"reference-test-key-v0",
             "test-key-v0",
             "authoritative_boundary",
             "c1",
             "ok",
             "present",
+            &DecisionEvidence::default(),
         )
         .unwrap()
     }
@@ -1241,6 +1324,64 @@ mod pack_tests {
         assert!(!verify_recipe_row(
             &coherent_row(RECIPE, good_er, "not-a-digest", "match"),
             &c,
+            "match"
+        ));
+    }
+
+    #[test]
+    fn verify_rejects_carrier_with_malformed_embedded_digest() {
+        // Even if a row cites the carrier's content + identity perfectly, a malformed embedded digest in
+        // the carrier is rejected: identity recomputation must not trust an ill-formed input.
+        let mut bad = carrier();
+        bad["observed_input_digest"] = json!("sha256:bad"); // not 64 hex
+        let content = carrier_content_digest(&bad).unwrap();
+        let identity = decision_identity_digest(
+            "sha256:bad",
+            bad["declared_policy_digest"].as_str().unwrap(),
+        )
+        .unwrap();
+        let row = coherent_row(RECIPE, evidence_ref(&content, REF), &identity, "match");
+        assert!(!verify_recipe_row(&row, &bad, "match"));
+    }
+
+    #[test]
+    fn pack_row_rejects_bogus_or_understated_verdict() {
+        let c = carrier();
+        assert_eq!(c["decision_verdict"], json!("match"));
+        // A non-verdict label is refused outright.
+        assert!(pack_recipe_row(&c, "approved", REF).is_none());
+
+        // A carrier whose own decision is `mismatch` cannot be cited with a cleaner run verdict.
+        let mismatch_carrier = build_classified_record(
+            &pack_policy("deploy", "delete_all"),
+            "delete_all",
+            &json!({}),
+            0,
+            b"reference-test-key-v0",
+            "test-key-v0",
+            "authoritative_boundary",
+            "c1",
+            "ok",
+            "present",
+            &DecisionEvidence::default(),
+        )
+        .unwrap();
+        assert_eq!(mismatch_carrier["decision_verdict"], json!("mismatch"));
+        assert!(pack_recipe_row(&mismatch_carrier, "match", REF).is_none()); // understated -> refused
+        let row = pack_recipe_row(&mismatch_carrier, "mismatch", REF).unwrap(); // >= carrier verdict
+        assert!(verify_recipe_row(&row, &mismatch_carrier, "mismatch"));
+
+        // verify also rejects a hand-crafted row that understates the carrier verdict.
+        let content = carrier_content_digest(&mismatch_carrier).unwrap();
+        let identity = decision_identity_digest(
+            mismatch_carrier["observed_input_digest"].as_str().unwrap(),
+            mismatch_carrier["declared_policy_digest"].as_str().unwrap(),
+        )
+        .unwrap();
+        let understating = coherent_row(RECIPE, evidence_ref(&content, REF), &identity, "match");
+        assert!(!verify_recipe_row(
+            &understating,
+            &mismatch_carrier,
             "match"
         ));
     }


### PR DESCRIPTION
## What

A follow-up to #1725 closing four coherence and validation gaps a deeper review found in the experimental tool-decision truth-layer.

- **Legacy constraints are now evaluated by the verdict.** The declared digest migrates legacy `constraints` into per-tool schemas, but the verdict path only normalized legacy shapes, so a legacy-constraint-only policy could bind a migrated schema in the digest while the gate saw no schema and passed the call under `unconstrained_tools = allow`. Both paths now go through one `normalized_declared_view_experimental` (normalize + migrate + explicit-schema precedence), so the digest and the verdict can never disagree about what is declared.
- **Redaction is in the declared digest.** The gate evaluates `redact_args`/`redact_args_classes`, but the digest did not bind them, so two policies could share a `declared_policy_digest` yet behave differently. The redaction lists now sit in the digest surface alongside approval and scope; the operational `redact_args_contract` stays out.
- **Embedded carrier digests are shape-checked.** `build_record` accepted an arbitrary `declared_policy_digest`, and `verify_recipe_row` never validated the carrier's own embedded digests before recomputing identity. Both now require `sha256:<64hex>`.
- **Pack rows can only bind a real, non-understated verdict.** `pack_recipe_row` accepted any string and a row could claim `match` over a carrier whose own `decision_verdict` was `mismatch`. Both build and verify now require one of the four lattice verdicts and reject a run verdict less severe than the carrier's decision.

## Why

These keep the story honest: the verdict really does cover everything the declared digest binds, and a pack row really is bound to the carrier it cites. The redaction fix flips the earlier `non_surface_tools_field` test (redaction now moves the digest), which is the correct behavior now that the gate evaluates it.

## Tests

`cargo test -p assay-core tool_decision_truth` plus the declared-digest tests: legacy-constraint evaluated by the verdict, redaction lists move the digest while the contract does not, `build_record`/`verify_recipe_row` reject malformed embedded digests, and pack rows reject bogus or understated verdicts. fmt + clippy clean.

## Experimental

Additive and behind the experimental surface; no new dependency. The conformance vectors (#1724) will be rebuilt on top of this so they pin the corrected behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of declared policy digests and evidence-pack verdicts to reject malformed or inconsistent values.
  * Strengthened verification of carrier/join-key digests and run verdict “coverage” before trusting pack rows.
  * Ensured legacy-constraint-only policies are evaluated against the normalized declared view.

* **Improvements**
  * Refactored experimental policy digest computation for more consistent legacy/modern handling.
  * Updated digest sensitivity to include additional tool redaction configuration fields (`redact_args`, `redact_args_classes`).

* **Tests**
  * Updated and extended experimental and evidence-pack test coverage to match the new validation/digest behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->