### PR TITLE
docs(mcp): experimental tool-decision truth-layer reference + non-claims

### DIFF
--- a/docs/reference/privileged-action-evidence.md
+++ b/docs/reference/privileged-action-evidence.md
@@ -22,6 +22,7 @@ observed tool call
 |--------|-----------------|-----------|
 | `assay.tool_decision_surface.v0` | per-call: server, classified action + projected target, decision, response, redaction | [tool-decision-surface.md](tool-decision-surface.md) |
 | `assay.declared_tool_surface.v0` | declared/allowed privileged actions, for observed-vs-declared review | [declared-tool-surface.md](declared-tool-surface.md) |
+| `assay.tool_decision_truth.v0` | experimental declared-vs-observed policy-decision carrier, digest, verdict, and pack-row primitive | [tool-decision-truth.md](tool-decision-truth.md) |
 | `action.required_scope` (+ declared credentials) | the scope an action requires vs the alias's declared scope | [credential-scope.md](credential-scope.md) |
 | `assay.provider_audit_record.v0` | an imported provider audit entry, bound to an observed call by digest recompute | [side-effect-receipt.md](side-effect-receipt.md) |
 | `assay.mcp_manifest_observed.v0` | an observed MCP tool manifest as canonical digests, for coarse drift review against a declared baseline | [mcp-manifest-drift.md](mcp-manifest-drift.md) |
@@ -74,8 +75,9 @@ emits that artifact with honest completeness, while never executing tools throug
 [mcp-upstream-proxy-mode.md](mcp-upstream-proxy-mode.md)).
 
 **Experiment-only (characterized, not a shipped feature):** the credential-overbreadth distribution
-(the scope lattice is a static model, not a provider-verified taxonomy); MCP tool lifecycle; and an
-OTel log-based event projection.
+(the scope lattice is a static model, not a provider-verified taxonomy); MCP tool lifecycle; the
+tool-decision truth-layer primitives and conformance vectors; and an OTel log-based event
+projection.
 
 **Parked (needs a separate design before any code):** granular per-tool manifest drift; and the
 enforcing `tools/call` proxy (a heavier security boundary — caller authorization, upstream credential

--- a/docs/reference/tool-decision-truth.md
+++ b/docs/reference/tool-decision-truth.md
@@ -1,0 +1,235 @@
+# Tool-decision truth layer (`assay.tool_decision_truth.v0`)
+
+Status: experimental v0 primitives and conformance vectors. Field names, helper names, and digest
+surfaces may change before this is promoted out of experimental. This page documents the current
+claim ceiling for the public primitives; it does not mark the broader design as complete.
+
+## Why this exists
+
+Assay policies say what tool calls and argument shapes are declared. An MCP proxy can observe a
+specific tool call. The tool-decision truth layer binds those two sides together so a consumer can
+ask one narrow question:
+
+> Did this observed tool decision match the declared policy constraints that Assay can evaluate?
+
+The answer is a deterministic lattice verdict over declared and observed data:
+
+```text
+invalid > mismatch > incomplete > match
+```
+
+The layer is intentionally narrower than enforcement. It records and recomputes a decision
+comparison. It does not forward, block, or authorize the tool call.
+
+## Claim
+
+Given a declared policy digest, an observed-input digest, and optional evidence for declared
+constraints such as approval, scope, class, and redaction, Assay can deterministically recompute:
+
+- a per-decision verdict: `match`, `incomplete`, `mismatch`, or `invalid`;
+- a run verdict as the lattice maximum over ordered decisions;
+- a content digest for the carrier record; and
+- a recipe row that cites the carrier by content digest and fails closed on tampering.
+
+A `match` means every declared constraint relevant to that decision was evaluated or proven not
+applicable inside this experimental surface. It does not mean the tool call was safe, compliant, or
+semantically correct.
+
+## Non-claims
+
+- does not prove runtime truth outside the observed MCP/tool-call boundary;
+- does not infer intent, maliciousness, or user authorization;
+- does not prove provider-side side effects happened or persisted;
+- does not certify safety, compliance, or policy quality;
+- does not replace enforcement and does not make an allow/deny decision in the action path;
+- does not claim complete coverage when required evidence is absent;
+- does not expose raw tool arguments, secrets, tokens, or key material;
+- does not provide an OpenTelemetry projection or pinned OTel snapshot;
+- does not integrate with the pack writer yet; the recipe-row primitive exists separately;
+- does not provide a stable external schema until the experimental marker is removed.
+
+## Three zones
+
+The carrier separates identity, provenance, and classification so replay identity stays stable:
+
+| Zone | Fields | In decision identity? |
+|---|---|---|
+| observed-input identity | `tool_name`, `args_digest`, `order`, `observed_input_digest` | yes, through `observed_input_digest` |
+| observation provenance | `source_class`, `call_id`, `result_status`, `identity_state`, `key_id` | no |
+| classification output | `declared_policy_digest`, `decision_identity`, `decision_verdict`, `declared_ref` | declared digest is part of identity; verdict is not |
+
+`decision_identity` is the pair `(observed_input_digest, declared_policy_digest)`. It is the stable
+join key for the logical decision. It is not the full carrier content digest.
+
+## Declared side
+
+`McpPolicy::declared_constraint_digest_experimental()` projects the declared constraint surface:
+
+- `version`;
+- tool allow/deny lists;
+- class, approval, scope, and redaction lists;
+- per-tool `schemas`; and
+- `enforcement`.
+
+Operational knobs such as runtime monitors, limits, discovery, signatures, and tool pins are outside
+this digest. Set-like fields are sorted by canonical bytes so reordering does not move the digest.
+Legacy constraints are normalized into the same view used by the verdict gate, and an explicit
+schema takes precedence over a migrated legacy constraint for the same tool.
+
+Known limitation: schema normalization is flat v0. Top-level `required` and direct
+`properties.*.enum` arrays are normalized; nested schema structures are not recursively normalized
+yet.
+
+## Observed side
+
+`args_digest(args, key, key_id)` drops secret-like argument keys recursively, then computes a
+domain-separated keyed digest. The output includes the key id:
+
+```text
+hmac-sha256:<key_id>:<hex>
+```
+
+The raw arguments are never stored in the carrier. Secret-like keys are dropped rather than hashed,
+because hashing low-entropy or known-format secrets can still invite recovery or correlation.
+
+`observed_input_digest(tool_name, args_digest, order)` hashes only:
+
+```json
+{
+  "tool_name": "deploy",
+  "args_digest": "hmac-sha256:fixture-kid-v0:...",
+  "order": 0
+}
+```
+
+Changing the tool name, non-secret argument content, or order changes the observed-input digest.
+Changing provenance fields does not.
+
+## Verdict gate
+
+`decision_verdict(...)` evaluates the declared policy against one observed decision. It uses the same
+normalized declared view as the declared digest.
+
+The gate evaluates these axes:
+
+- tool name allow/deny, using the policy engine's `*` pattern semantics;
+- per-tool argument schema;
+- identity state: `present`, `absent`, `required_missing`, or `invalid`;
+- tool class allow/deny;
+- declared approval;
+- declared scope; and
+- declared redaction.
+
+The load-bearing rule is conservative: if a declared constraint applies but the caller did not
+provide enough evidence to evaluate it, the axis is `incomplete`, never `match`. Malformed declared
+schemas are `invalid`, not panics and not missing evidence.
+
+`run_verdict(decision_verdicts, orders)` computes the lattice maximum across a run. Duplicate orders
+or mismatched verdict/order lengths are `invalid`.
+
+## Carrier shape
+
+Example carrier, shortened:
+
+```json
+{
+  "schema": "assay.tool_decision_truth.v0",
+  "tool_name": "deploy",
+  "args_digest": "hmac-sha256:fixture-kid-v0:...",
+  "order": 0,
+  "source_class": "authoritative_boundary",
+  "call_id": "deploy_match",
+  "result_status": "ok",
+  "identity_state": "present",
+  "key_id": "fixture-kid-v0",
+  "declared_ref": null,
+  "decision_verdict": "match",
+  "observed_input_digest": "sha256:...",
+  "declared_policy_digest": "sha256:...",
+  "decision_identity": {
+    "observed_input_digest": "sha256:...",
+    "declared_policy_digest": "sha256:..."
+  }
+}
+```
+
+Allowed carrier vocabularies are append-only:
+
+| Field | Current values |
+|---|---|
+| `source_class` | `authoritative_boundary`, `reported_trace`, `inferred` |
+| `result_status` | `ok`, `error`, `n/a` |
+| `identity_state` | `present`, `absent`, `required_missing`, `invalid` |
+
+The carrier builder rejects unknown values rather than minting a label a consumer might trust.
+
+## Pack recipe-row primitive
+
+The recipe-row helper binds a carrier to an Evidence Pack row without defining a new pack version.
+It uses two different digests:
+
+| Digest | Meaning |
+|---|---|
+| `decision_identity_digest` | digest of `(observed_input_digest, declared_policy_digest)`; stable logical join key |
+| `carrier_content_digest` | digest of the full canonical carrier; citation target for the row |
+
+The row cites the carrier by `carrier_content_digest` and carries `decision_identity_digest` as a
+join key. Verification recomputes both from the supplied carrier, checks the row envelope
+(`type`, `schema`, `canonicalization`, `digest_subject`), checks the run verdict vocabulary, and
+rejects a row that claims a less severe verdict than the carrier it cites.
+
+Current scope: the primitive and verifier exist. A production pack-emission path that writes this
+row into real packs is a separate follow-up.
+
+## Conformance vectors
+
+The committed vectors live at:
+
+```text
+crates/assay-core/tests/fixtures/tool_decision_truth/vectors.json
+```
+
+The test generator and reproducer live at:
+
+```text
+crates/assay-core/tests/tool_decision_truth_vectors.rs
+```
+
+The vectors cover:
+
+- verdict cases for `match`, `incomplete`, `mismatch`, and `invalid`;
+- pattern deny matching;
+- missing argument capture;
+- absent, missing, and invalid identity states;
+- approval evidence present, absent, and denied;
+- malformed schema handling;
+- duplicate-order and arity run-lattice failures;
+- real keyed carriers with no raw arguments;
+- positive pack rows over real carriers; and
+- negative pack rows for tampered verdicts, foreign recipe/envelope values, and malformed digests.
+
+Regenerate intentionally with:
+
+```bash
+UPDATE_TDT_VECTORS=1 cargo test -p assay-core --test tool_decision_truth_vectors
+```
+
+The normal test path recomputes the fixture from committed bytes and fails if the fixture drifts from
+the current implementation.
+
+## Current public status
+
+Green:
+
+- contract primitives;
+- runtime helper behavior;
+- declared digest and verdict-gate coherence;
+- carrier-content pack-row primitive;
+- fail-closed verifier; and
+- conformance vectors with recompute-from-bytes guard.
+
+Open:
+
+- OpenTelemetry export against a pinned snapshot;
+- integrated pack emission; and
+- promotion from experimental names to a stable public schema.


### PR DESCRIPTION
## What

Adds a public reference doc for the experimental tool-decision truth-layer at `docs/reference/tool-decision-truth.md`, and cross-links it from the privileged-action evidence family index.

The doc states the bounded claim and the explicit non-claims up front, then documents the 3-zone carrier, the declared-constraint digest, the verdict lattice (`invalid > mismatch > incomplete > match`), the keyed/redacted `args_digest`, and the pack recipe-row binding. It closes with the current status: which parts are green (contract primitives, digest/verdict coherence, carrier-content pack-row, fail-closed verifier, recompute-from-bytes vectors) and which are open (OTel projection, integrated pack-emission, promotion out of experimental).

## Why

The primitives shipped across #1720–#1726 but had no outward reference. This protects the claim ceiling before any further outward surface is added: it is explicit that the layer is an advisory contract/identity primitive with deterministic recompute, not enforcement, intent, or a safety claim, and that `incomplete` is never a pass.

## Scope

Reference documentation only. No code or behavior change. The doc reflects what the merged primitives already do; the two open follow-ups (OTel projection, integrated pack-emission) are named as non-claims, not described as done.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference documentation for the tool-decision truth layer, detailing verdict lattice specifications, input requirements, carrier format definitions, and conformance vector specifications.
  * Expanded existing reference documentation to include a new record type and provide additional clarity on experiment-only components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->