### PR TITLE
feat(otel): project verified tool-decision-truth evidence to OTel (PR10)

### DIFF
--- a/crates/assay-cli/src/cli/args/project_otel.rs
+++ b/crates/assay-cli/src/cli/args/project_otel.rs
@@ -15,16 +15,19 @@ pub struct ProjectOtelArgs {
 
     /// EXPERIMENTAL: project verified tool-decision-truth recipe rows from an evidence bundle (.tar.gz).
     /// The bundle is verified first; nothing is written unless every row verifies.
-    #[arg(long = "evidence-bundle")]
+    #[arg(
+        long = "evidence-bundle",
+        conflicts_with_all = ["capability_surface", "observation_health", "enforcement_health"]
+    )]
     pub evidence_bundle: Option<PathBuf>,
 
     /// Optional path to an `assay.runner.observation_health.v0` JSON file.
-    #[arg(long = "observation-health")]
+    #[arg(long = "observation-health", conflicts_with = "evidence_bundle")]
     pub observation_health: Option<PathBuf>,
 
     /// Optional path to an `assay.enforcement_health.v0` JSON file. Absent means no enforcement
     /// claim is made (it does NOT assert that enforcement was absent — that lives in the carrier).
-    #[arg(long = "enforcement-health")]
+    #[arg(long = "enforcement-health", conflicts_with = "evidence_bundle")]
     pub enforcement_health: Option<PathBuf>,
 
     /// Write the projection JSON here instead of stdout. On success stdout stays empty.

--- a/crates/assay-cli/src/cli/args/project_otel.rs
+++ b/crates/assay-cli/src/cli/args/project_otel.rs
@@ -8,9 +8,15 @@ use std::path::PathBuf;
 /// `docs/reference/otel-projection.md`.
 #[derive(clap::Args, Debug, Clone)]
 pub struct ProjectOtelArgs {
-    /// Path to an `assay.runner.capability_surface.v0` JSON file (required).
-    #[arg(long = "capability-surface")]
-    pub capability_surface: PathBuf,
+    /// Path to an `assay.runner.capability_surface.v0` JSON file. Mutually exclusive with
+    /// `--evidence-bundle`; exactly one input is required.
+    #[arg(long = "capability-surface", conflicts_with = "evidence_bundle")]
+    pub capability_surface: Option<PathBuf>,
+
+    /// EXPERIMENTAL: project verified tool-decision-truth recipe rows from an evidence bundle (.tar.gz).
+    /// The bundle is verified first; nothing is written unless every row verifies.
+    #[arg(long = "evidence-bundle")]
+    pub evidence_bundle: Option<PathBuf>,
 
     /// Optional path to an `assay.runner.observation_health.v0` JSON file.
     #[arg(long = "observation-health")]

--- a/crates/assay-cli/src/cli/commands/evidence/verify_tool_decision_truth.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_tool_decision_truth.rs
@@ -9,6 +9,7 @@
 use crate::exit_codes;
 use anyhow::{Context, Result};
 use assay_core::mcp::tool_decision_truth as tdt;
+use assay_core::otel::projection::TdtDecision;
 use assay_evidence::bundle::BundleReader;
 use assay_evidence::types::EvidenceEvent;
 use clap::{Args, ValueEnum};
@@ -50,21 +51,21 @@ pub enum VerifyFormat {
 }
 
 #[derive(Debug, Serialize)]
-struct Report {
-    schema: &'static str,
-    ok: bool,
-    carrier_count: usize,
-    row_count: usize,
-    verified_rows: usize,
-    checks: Vec<Check>,
-    claims_not_made: Vec<&'static str>,
+pub(crate) struct Report {
+    pub(crate) schema: &'static str,
+    pub(crate) ok: bool,
+    pub(crate) carrier_count: usize,
+    pub(crate) row_count: usize,
+    pub(crate) verified_rows: usize,
+    pub(crate) checks: Vec<Check>,
+    pub(crate) claims_not_made: Vec<&'static str>,
 }
 
 #[derive(Debug, Serialize)]
-struct Check {
-    id: String,
-    ok: bool,
-    detail: String,
+pub(crate) struct Check {
+    pub(crate) id: String,
+    pub(crate) ok: bool,
+    pub(crate) detail: String,
 }
 
 pub fn cmd_verify_tool_decision_truth(args: VerifyToolDecisionTruthArgs) -> Result<i32> {
@@ -85,6 +86,12 @@ pub fn cmd_verify_tool_decision_truth(args: VerifyToolDecisionTruthArgs) -> Resu
 }
 
 fn build_report(events: &[EvidenceEvent]) -> Report {
+    verify_and_collect(events).0
+}
+
+/// The single pairing + fail-closed verification pass. Returns the report AND the verified decisions
+/// (the projector consumes these typed pairs, so projection never re-scans a bundle or re-pairs).
+pub(crate) fn verify_and_collect(events: &[EvidenceEvent]) -> (Report, Vec<TdtDecision>) {
     let mut checks = Vec::new();
 
     // 1. Index carriers by content digest. Two carriers with the same content digest are ambiguous, so
@@ -122,6 +129,7 @@ fn build_report(events: &[EvidenceEvent]) -> Report {
     //    citing one digest are ambiguous; a row citing no present carrier fails.
     let mut row_count = 0usize;
     let mut verified_rows = 0usize;
+    let mut verified: Vec<TdtDecision> = Vec::new();
     let mut cited_digests: HashSet<String> = HashSet::new();
     for ev in events.iter().filter(|e| e.type_ == ROW_EVENT_TYPE) {
         row_count += 1;
@@ -157,6 +165,16 @@ fn build_report(events: &[EvidenceEvent]) -> Report {
         let ok = tdt::verify_recipe_row(row, carrier, run_verdict);
         if ok {
             verified_rows += 1;
+            verified.push(TdtDecision {
+                carrier: (**carrier).clone(),
+                carrier_content_digest: cited.to_string(),
+                decision_identity_digest: row
+                    .get("decision_identity_digest")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                run_verdict: run_verdict.to_string(),
+            });
         }
         checks.push(Check {
             id: format!("row_{}_verifies", ev.id),
@@ -179,7 +197,7 @@ fn build_report(events: &[EvidenceEvent]) -> Report {
     }
 
     let ok = checks.iter().all(|c| c.ok);
-    Report {
+    let report = Report {
         schema: "assay.tool_decision_truth.verify.report.v0",
         ok,
         carrier_count,
@@ -187,7 +205,8 @@ fn build_report(events: &[EvidenceEvent]) -> Report {
         verified_rows,
         checks,
         claims_not_made: CLAIMS_NOT_MADE.to_vec(),
-    }
+    };
+    (report, verified)
 }
 
 fn fail(id: &str, detail: String) -> Check {

--- a/crates/assay-cli/src/cli/commands/evidence/verify_tool_decision_truth.rs
+++ b/crates/assay-cli/src/cli/commands/evidence/verify_tool_decision_truth.rs
@@ -197,6 +197,9 @@ pub(crate) fn verify_and_collect(events: &[EvidenceEvent]) -> (Report, Vec<TdtDe
     }
 
     let ok = checks.iter().all(|c| c.ok);
+    if !ok {
+        verified.clear();
+    }
     let report = Report {
         schema: "assay.tool_decision_truth.verify.report.v0",
         ok,
@@ -345,6 +348,22 @@ mod tests {
             .checks
             .iter()
             .any(|c| c.id.ends_with("_duplicate_citation")));
+    }
+
+    #[test]
+    fn failed_report_returns_no_verified_decisions() {
+        let c = carrier("deploy", json!({"env": "prod"}), 0, "c0");
+        let r = row_for(&c);
+        let (report, verified) = verify_and_collect(&[
+            ev(CARRIER_EVENT_TYPE, c, 0),
+            ev(ROW_EVENT_TYPE, r.clone(), 1),
+            ev(ROW_EVENT_TYPE, r, 2), // duplicate citation makes the report fail
+        ]);
+        assert!(!report.ok);
+        assert!(
+            verified.is_empty(),
+            "failed semantic verification must not expose verified decisions to projection callers"
+        );
     }
 
     #[test]

--- a/crates/assay-cli/src/cli/commands/project_otel.rs
+++ b/crates/assay-cli/src/cli/commands/project_otel.rs
@@ -24,7 +24,14 @@ fn read_json(path: &Path) -> anyhow::Result<Value> {
 /// `EXIT_CONFIG_ERROR`, leaving stdout empty; on success the projection is the only thing written to
 /// stdout (or to `--out`), as pure JSON.
 pub fn run(args: ProjectOtelArgs) -> anyhow::Result<i32> {
-    let capability_surface = match read_json(&args.capability_surface) {
+    if let Some(bundle) = args.evidence_bundle.as_deref() {
+        return run_tool_decision_truth(bundle, args.out.as_deref());
+    }
+    let Some(capability_surface_path) = args.capability_surface.as_deref() else {
+        eprintln!("error: one of --capability-surface or --evidence-bundle is required");
+        return Ok(EXIT_CONFIG_ERROR);
+    };
+    let capability_surface = match read_json(capability_surface_path) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("error: {e}");
@@ -73,4 +80,150 @@ pub fn run(args: ProjectOtelArgs) -> anyhow::Result<i32> {
         None => println!("{json}"),
     }
     Ok(EXIT_SUCCESS)
+}
+
+/// Project verified tool-decision-truth recipe rows from an evidence bundle. The bundle is verified in
+/// full FIRST; if the semantic report is not `ok`, nothing is serialized or written (not even to
+/// `--out`). This stays a view over verified evidence, never a best-effort trace extractor.
+fn run_tool_decision_truth(bundle: &Path, out: Option<&Path>) -> anyhow::Result<i32> {
+    let file = match std::fs::File::open(bundle) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("error: cannot open bundle {}: {e}", bundle.display());
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+    // BundleReader::open verifies bundle integrity (manifest hashes + Merkle root).
+    let reader = match assay_evidence::bundle::BundleReader::open(file) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: bundle integrity verification failed: {e}");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+    let events = match reader.events_vec() {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("error: cannot read bundle events: {e}");
+            return Ok(EXIT_CONFIG_ERROR);
+        }
+    };
+
+    // Verify FULLY before serializing anything. Projection runs only over verified pairs.
+    let (report, verified) =
+        crate::cli::commands::evidence::verify_tool_decision_truth::verify_and_collect(&events);
+    if !report.ok {
+        eprintln!("error: tool-decision-truth verification failed; refusing to project unverified evidence");
+        for check in report.checks.iter().filter(|c| !c.ok) {
+            eprintln!("  fail: {} — {}", check.id, check.detail);
+        }
+        return Ok(EXIT_CONFIG_ERROR);
+    }
+
+    let projection = assay_core::otel::projection::project_tool_decision_truth(&verified);
+    let json = serde_json::to_string_pretty(&projection)?;
+    match out {
+        Some(path) => {
+            if let Err(e) = std::fs::write(path, format!("{json}\n")) {
+                eprintln!("error: cannot write {}: {e}", path.display());
+                return Ok(EXIT_CONFIG_ERROR);
+            }
+        }
+        None => println!("{json}"),
+    }
+    Ok(EXIT_SUCCESS)
+}
+
+#[cfg(test)]
+mod tdt_bundle_tests {
+    use super::*;
+    use assay_core::mcp::policy::McpPolicy;
+    use assay_core::mcp::tool_decision_truth::{self as tdt, DecisionEvidence};
+    use assay_evidence::bundle::BundleWriter;
+    use assay_evidence::types::EvidenceEvent;
+    use serde_json::{json, Value};
+
+    fn carrier() -> Value {
+        let policy: McpPolicy = serde_json::from_value(json!({
+            "version": "1",
+            "tools": {"allow": ["deploy"], "deny": ["delete_all"]},
+            "schemas": {"deploy": {"type": "object", "required": ["env"],
+                "properties": {"env": {"enum": ["staging", "prod"]}}}},
+            "enforcement": {"unconstrained_tools": "warn"}
+        }))
+        .unwrap();
+        tdt::build_classified_record(
+            &policy,
+            "deploy",
+            &json!({"env": "prod"}),
+            0,
+            b"project-otel-test-key-v0",
+            "fixture-kid-v0",
+            "authoritative_boundary",
+            "c0",
+            "ok",
+            "present",
+            &DecisionEvidence::default(),
+        )
+        .unwrap()
+    }
+
+    fn ev(type_: &str, payload: Value, seq: u64) -> EvidenceEvent {
+        EvidenceEvent::new(type_, "urn:assay:test", "run", seq, payload)
+    }
+
+    fn write_bundle(path: &Path, events: Vec<EvidenceEvent>) {
+        let f = std::fs::File::create(path).unwrap();
+        let mut w = BundleWriter::new(f);
+        for e in events {
+            w.add_event(e);
+        }
+        w.finish().unwrap();
+    }
+
+    #[test]
+    fn projects_a_verified_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = dir.path().join("tdt.tar.gz");
+        let out = dir.path().join("projection.json");
+        let c = carrier();
+        let row = tdt::pack_recipe_row(
+            &c,
+            c["decision_verdict"].as_str().unwrap(),
+            "assay://evidence-event/run/0",
+        )
+        .unwrap();
+        write_bundle(
+            &bundle,
+            vec![
+                ev("assay.tool_decision_truth.v0", c, 0),
+                ev("assay.tool_decision_truth.recipe_row.v0", row, 1),
+            ],
+        );
+
+        let code = run_tool_decision_truth(&bundle, Some(&out)).unwrap();
+        assert_eq!(code, EXIT_SUCCESS);
+        let p: Value = serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+        let attrs = &p["spans"][0]["attributes"];
+        assert_eq!(attrs["assay.claim_class"], json!("derived"));
+        assert_eq!(attrs["openinference.span.kind"], json!("TOOL"));
+        assert!(attrs["assay.tdt.carrier_content_digest"].is_string());
+    }
+
+    #[test]
+    fn refuses_to_write_an_unverified_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = dir.path().join("tdt.tar.gz");
+        let out = dir.path().join("projection.json");
+        // A carrier with no recipe row fails semantic verification (rows_present).
+        write_bundle(
+            &bundle,
+            vec![ev("assay.tool_decision_truth.v0", carrier(), 0)],
+        );
+
+        let code = run_tool_decision_truth(&bundle, Some(&out)).unwrap();
+        assert_eq!(code, EXIT_CONFIG_ERROR);
+        // The hard rule: nothing is written when verification fails, not even to --out.
+        assert!(!out.exists());
+    }
 }

--- a/crates/assay-cli/tests/project_otel_cli.rs
+++ b/crates/assay-cli/tests/project_otel_cli.rs
@@ -153,3 +153,25 @@ fn out_flag_writes_file_and_leaves_stdout_empty() {
         "--out file must match the committed golden projection"
     );
 }
+
+#[test]
+fn evidence_bundle_rejects_capability_surface_context_flags() {
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("project_otel_arg_conflict");
+    fs::create_dir_all(&dir).unwrap();
+    let bundle = dir.join("tdt.tar.gz");
+    let observation = dir.join("observation-health.json");
+
+    Command::cargo_bin("assay")
+        .unwrap()
+        .args([
+            "project-otel",
+            "--evidence-bundle",
+            bundle.to_str().unwrap(),
+            "--observation-health",
+            observation.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("cannot be used with"));
+}

--- a/crates/assay-core/src/otel/projection.rs
+++ b/crates/assay-core/src/otel/projection.rs
@@ -28,6 +28,9 @@ use serde_json::{Map, Value};
 /// Schema id of this projection artifact.
 pub const PROJECTION_SCHEMA: &str = "assay.otel_projection.v0";
 
+/// Schema id of the tool-decision-truth projection artifact (EXPERIMENTAL).
+pub const TDT_PROJECTION_SCHEMA: &str = "assay.tool_decision_truth.otel_projection.v0";
+
 /// Pinned OTel GenAI semconv target, flagged Development to match upstream status. This projection
 /// targets the GenAI *agent/tool* span surface (`execute_tool`, `gen_ai.tool.*`), which is newer than
 /// the LLM-*client* span surface the rest of the `otel` module pins at 1.28.0 (`semconv::V1_28_0`):
@@ -244,5 +247,216 @@ pub fn project(
         lossy: true,
         source_of_truth: SOURCE_OF_TRUTH.to_string(),
         non_claims,
+    }
+}
+
+/// One verified tool-decision-truth decision to project. The pairing and the fail-closed verification
+/// happened in the verifier; this carries the already-verified carrier plus the two digests the row
+/// bound, so the projector never re-pairs, re-verifies, or re-scans a bundle.
+#[derive(Debug, Clone)]
+pub struct TdtDecision {
+    /// The verified carrier payload (`assay.tool_decision_truth.v0`).
+    pub carrier: Value,
+    /// The carrier content digest the row cited (from the verified row).
+    pub carrier_content_digest: String,
+    /// The decision identity digest (from the verified row).
+    pub decision_identity_digest: String,
+    /// The run verdict the row bound (from the verified row).
+    pub run_verdict: String,
+}
+
+/// Project VERIFIED tool-decision-truth decisions into the OTel GenAI + OpenInference view (EXPERIMENTAL).
+///
+/// Each decision becomes one `TOOL` span (`gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`,
+/// `openinference.span.kind=TOOL`), with the verdict and the four digests in `assay.tdt.*`. The honesty
+/// qualifier `assay.claim_class="derived"` marks the span as a derived comparison over observed and
+/// declared data, not a raw observation (like the capability-surface tool spans) and not enforcement. No
+/// raw tool arguments are ever projected: only specific carrier fields are read, never the args.
+pub fn project_tool_decision_truth(decisions: &[TdtDecision]) -> Projection {
+    let mut resource: Map<String, Value> = Map::new();
+    resource.insert("service.name".into(), Value::String("assay".into()));
+
+    let mut spans: Vec<ProjectedSpan> = Vec::new();
+    for d in decisions {
+        let carrier = &d.carrier;
+        let tool = str_field(carrier, "tool_name").unwrap_or_default();
+
+        let mut attrs = Map::new();
+        attrs.insert(
+            "gen_ai.operation.name".into(),
+            Value::String("execute_tool".into()),
+        );
+        if !tool.is_empty() {
+            attrs.insert("gen_ai.tool.name".into(), Value::String(tool.clone()));
+            attrs.insert("tool.name".into(), Value::String(tool.clone()));
+        }
+        attrs.insert(
+            "openinference.span.kind".into(),
+            Value::String("TOOL".into()),
+        );
+        // A verdict is a derived comparison over observed + declared, not a raw observation, not
+        // enforcement, and not an intent/safety judgement.
+        attrs.insert("assay.claim_class".into(), Value::String("derived".into()));
+
+        // tool-decision-truth specifics the standard vocabulary has no field for stay in assay.tdt.*.
+        for (carrier_key, attr_key) in [
+            ("schema", "assay.tdt.schema"),
+            ("decision_verdict", "assay.tdt.decision_verdict"),
+            ("observed_input_digest", "assay.tdt.observed_input_digest"),
+            ("declared_policy_digest", "assay.tdt.declared_policy_digest"),
+            ("source_class", "assay.tdt.source_class"),
+        ] {
+            if let Some(v) = str_field(carrier, carrier_key) {
+                attrs.insert(attr_key.into(), Value::String(v));
+            }
+        }
+        attrs.insert(
+            "assay.tdt.run_verdict".into(),
+            Value::String(d.run_verdict.clone()),
+        );
+        attrs.insert(
+            "assay.tdt.decision_identity_digest".into(),
+            Value::String(d.decision_identity_digest.clone()),
+        );
+        attrs.insert(
+            "assay.tdt.carrier_content_digest".into(),
+            Value::String(d.carrier_content_digest.clone()),
+        );
+
+        spans.push(ProjectedSpan {
+            name: format!("execute_tool {tool}"),
+            kind: "INTERNAL".into(),
+            attributes: attrs,
+        });
+    }
+
+    let non_claims = vec![
+        "This projection is a one-directional, lossy view; the assay artifacts remain authoritative."
+            .to_string(),
+        "gen_ai.* and openinference.* fields are a projection, not the source of truth.".to_string(),
+        "A tool-decision-truth verdict is a derived comparison over observed and declared data \
+         (assay.claim_class=derived); it is not a raw observation, not enforcement, and not an intent \
+         or safety judgement."
+            .to_string(),
+        "Raw tool arguments and the keyed args_digest are not projected; this view carries only the \
+         higher-level observed-input, declared-policy, decision-identity, and carrier-content digests."
+            .to_string(),
+        format!(
+            "Pinned to OTel GenAI semconv {OTEL_GENAI_SEMCONV} and OpenInference {OPENINFERENCE_SEMCONV}; \
+             a version bump is explicit."
+        ),
+    ];
+
+    Projection {
+        schema: TDT_PROJECTION_SCHEMA.to_string(),
+        semconv: Semconv {
+            otel_genai: OTEL_GENAI_SEMCONV.to_string(),
+            openinference: OPENINFERENCE_SEMCONV.to_string(),
+        },
+        spans,
+        resource_attributes: resource,
+        lossy: true,
+        source_of_truth: SOURCE_OF_TRUTH.to_string(),
+        non_claims,
+    }
+}
+
+#[cfg(test)]
+mod tdt_tests {
+    use super::*;
+    use crate::mcp::policy::McpPolicy;
+    use crate::mcp::tool_decision_truth::{self as tdt, DecisionEvidence};
+    use serde_json::json;
+
+    // Build the projector input from a REAL carrier so the test tracks the actual primitive (the digests
+    // are genuine, not placeholder shapes) without duplicating any pairing logic.
+    fn decision() -> TdtDecision {
+        let policy: McpPolicy = serde_json::from_value(json!({
+            "version": "1",
+            "tools": {"allow": ["deploy"], "deny": ["delete_all"]},
+            "schemas": {"deploy": {"type": "object", "required": ["env"],
+                "properties": {"env": {"enum": ["staging", "prod"]}}}},
+            "enforcement": {"unconstrained_tools": "warn"}
+        }))
+        .unwrap();
+        let carrier = tdt::build_classified_record(
+            &policy,
+            "deploy",
+            &json!({"env": "prod"}),
+            0,
+            b"projection-test-key-v0",
+            "fixture-kid-v0",
+            "authoritative_boundary",
+            "c0",
+            "ok",
+            "present",
+            &DecisionEvidence::default(),
+        )
+        .unwrap();
+        let carrier_content_digest = tdt::carrier_content_digest(&carrier).unwrap();
+        let decision_identity_digest = tdt::decision_identity_digest(
+            carrier["observed_input_digest"].as_str().unwrap(),
+            carrier["declared_policy_digest"].as_str().unwrap(),
+        )
+        .unwrap();
+        let run_verdict = carrier["decision_verdict"].as_str().unwrap().to_string();
+        TdtDecision {
+            carrier,
+            carrier_content_digest,
+            decision_identity_digest,
+            run_verdict,
+        }
+    }
+
+    #[test]
+    fn projects_a_derived_tool_span_with_tdt_attrs() {
+        let d = decision();
+        let p = project_tool_decision_truth(std::slice::from_ref(&d));
+        assert_eq!(p.schema, TDT_PROJECTION_SCHEMA);
+        assert!(p.lossy);
+        assert_eq!(p.spans.len(), 1);
+        let a = &p.spans[0].attributes;
+        assert_eq!(a["gen_ai.operation.name"], json!("execute_tool"));
+        assert_eq!(a["gen_ai.tool.name"], json!("deploy"));
+        assert_eq!(a["openinference.span.kind"], json!("TOOL"));
+        assert_eq!(a["assay.claim_class"], json!("derived"));
+        assert_eq!(a["assay.tdt.decision_verdict"], json!("match"));
+        assert_eq!(a["assay.tdt.source_class"], json!("authoritative_boundary"));
+        // The projected digests equal the real primitive's digests, not placeholder shapes.
+        assert_eq!(
+            a["assay.tdt.observed_input_digest"],
+            d.carrier["observed_input_digest"]
+        );
+        assert_eq!(
+            a["assay.tdt.declared_policy_digest"],
+            d.carrier["declared_policy_digest"]
+        );
+        assert_eq!(
+            a["assay.tdt.carrier_content_digest"],
+            json!(d.carrier_content_digest)
+        );
+        assert_eq!(
+            a["assay.tdt.decision_identity_digest"],
+            json!(d.decision_identity_digest)
+        );
+    }
+
+    #[test]
+    fn never_projects_raw_arguments_or_args_digest() {
+        let d = decision();
+        let args_digest_value = d.carrier["args_digest"].as_str().unwrap().to_string();
+        let p = project_tool_decision_truth(std::slice::from_ref(&d));
+        // The projection carries only identity/content digests: no args_digest attribute and no raw
+        // arguments. (The word "args_digest" appears only in the honest non_claims text, never as data.)
+        for span in &p.spans {
+            assert!(!span.attributes.contains_key("assay.tdt.args_digest"));
+            assert!(!span.attributes.contains_key("gen_ai.tool.call.arguments"));
+            for value in span.attributes.values() {
+                assert_ne!(value.as_str(), Some(args_digest_value.as_str()));
+            }
+        }
+        let serialized = serde_json::to_string(&p).unwrap();
+        assert!(!serialized.contains(&args_digest_value));
+        assert!(!serialized.contains("\"arguments\""));
     }
 }

--- a/crates/assay-core/tests/fixtures/tdt_otel_projection/expected.json
+++ b/crates/assay-core/tests/fixtures/tdt_otel_projection/expected.json
@@ -1,0 +1,59 @@
+{
+  "schema": "assay.tool_decision_truth.otel_projection.v0",
+  "semconv": {
+    "otel_genai": "1.37.0-development",
+    "openinference": "pinned"
+  },
+  "spans": [
+    {
+      "name": "execute_tool deploy",
+      "kind": "INTERNAL",
+      "attributes": {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "deploy",
+        "tool.name": "deploy",
+        "openinference.span.kind": "TOOL",
+        "assay.claim_class": "derived",
+        "assay.tdt.schema": "assay.tool_decision_truth.v0",
+        "assay.tdt.decision_verdict": "match",
+        "assay.tdt.observed_input_digest": "sha256:3e8b231ffc03c2653a2cb1034aa3ae805d8c01596c00f7bc0250b3f753c41125",
+        "assay.tdt.declared_policy_digest": "sha256:8804c617ffa59298111f5961f506d170102444ef61771d06a1103d64a6d37430",
+        "assay.tdt.source_class": "authoritative_boundary",
+        "assay.tdt.run_verdict": "match",
+        "assay.tdt.decision_identity_digest": "sha256:79d73560d15ef51c57e9fd430da114f4fb7854d2985185676e09501c94ded415",
+        "assay.tdt.carrier_content_digest": "sha256:8165dcbd5e76fa84d6d068915857d0abae00333f9de4b7eb2f39d0db6e5e72e9"
+      }
+    },
+    {
+      "name": "execute_tool delete_all",
+      "kind": "INTERNAL",
+      "attributes": {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "delete_all",
+        "tool.name": "delete_all",
+        "openinference.span.kind": "TOOL",
+        "assay.claim_class": "derived",
+        "assay.tdt.schema": "assay.tool_decision_truth.v0",
+        "assay.tdt.decision_verdict": "mismatch",
+        "assay.tdt.observed_input_digest": "sha256:cb6ec84420714fb3e904aa4ccff3551b01e5dc874cf77f5491723a7c287aec95",
+        "assay.tdt.declared_policy_digest": "sha256:8804c617ffa59298111f5961f506d170102444ef61771d06a1103d64a6d37430",
+        "assay.tdt.source_class": "authoritative_boundary",
+        "assay.tdt.run_verdict": "mismatch",
+        "assay.tdt.decision_identity_digest": "sha256:8334bebd58341ff1636d0f6bd25e2ec3e372d0573b31808381662204f746745c",
+        "assay.tdt.carrier_content_digest": "sha256:98edb0d2ae052fe2fdbf90b0e8740812a98fb2b0d84e1c17d4a358398f84de1f"
+      }
+    }
+  ],
+  "resource_attributes": {
+    "service.name": "assay"
+  },
+  "lossy": true,
+  "source_of_truth": "assay artifacts",
+  "non_claims": [
+    "This projection is a one-directional, lossy view; the assay artifacts remain authoritative.",
+    "gen_ai.* and openinference.* fields are a projection, not the source of truth.",
+    "A tool-decision-truth verdict is a derived comparison over observed and declared data (assay.claim_class=derived); it is not a raw observation, not enforcement, and not an intent or safety judgement.",
+    "Raw tool arguments and the keyed args_digest are not projected; this view carries only the higher-level observed-input, declared-policy, decision-identity, and carrier-content digests.",
+    "Pinned to OTel GenAI semconv 1.37.0-development and OpenInference pinned; a version bump is explicit."
+  ]
+}

--- a/crates/assay-core/tests/tdt_otel_projection.rs
+++ b/crates/assay-core/tests/tdt_otel_projection.rs
@@ -1,0 +1,100 @@
+//! Blessed snapshot for the EXPERIMENTAL tool-decision-truth OTel projection.
+//!
+//! Builds verified `TdtDecision`s from real carriers and pins the projected output byte-for-byte, so any
+//! drift in the span shape or the `assay.tdt.*` attribute set is caught. The carriers are keyed with a
+//! fixed test key, so the digests (and therefore the projection) are deterministic. Regenerate with
+//! `BLESS=1 cargo test -p assay-core --test tdt_otel_projection`.
+
+use assay_core::mcp::policy::McpPolicy;
+use assay_core::mcp::tool_decision_truth::{self as tdt, DecisionEvidence};
+use assay_core::otel::projection::{project_tool_decision_truth, TdtDecision};
+use serde_json::{json, Value};
+use std::path::PathBuf;
+
+const KEY: &[u8] = b"tdt-otel-snapshot-key-v0";
+const KID: &str = "fixture-kid-v0";
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/tdt_otel_projection/expected.json")
+}
+
+fn policy() -> McpPolicy {
+    serde_json::from_value(json!({
+        "version": "1",
+        "tools": {"allow": ["deploy"], "deny": ["delete_all"]},
+        "schemas": {"deploy": {"type": "object", "required": ["env"],
+            "properties": {"env": {"enum": ["staging", "prod"]}}}},
+        "enforcement": {"unconstrained_tools": "warn"}
+    }))
+    .unwrap()
+}
+
+fn decision(tool: &str, args: Value, order: i64, call_id: &str) -> TdtDecision {
+    let carrier = tdt::build_classified_record(
+        &policy(),
+        tool,
+        &args,
+        order,
+        KEY,
+        KID,
+        "authoritative_boundary",
+        call_id,
+        "ok",
+        "present",
+        &DecisionEvidence::default(),
+    )
+    .unwrap();
+    let carrier_content_digest = tdt::carrier_content_digest(&carrier).unwrap();
+    let decision_identity_digest = tdt::decision_identity_digest(
+        carrier["observed_input_digest"].as_str().unwrap(),
+        carrier["declared_policy_digest"].as_str().unwrap(),
+    )
+    .unwrap();
+    let run_verdict = carrier["decision_verdict"].as_str().unwrap().to_string();
+    TdtDecision {
+        carrier,
+        carrier_content_digest,
+        decision_identity_digest,
+        run_verdict,
+    }
+}
+
+fn decisions() -> Vec<TdtDecision> {
+    vec![
+        decision("deploy", json!({"env": "prod"}), 0, "c0"), // match
+        decision("delete_all", json!({}), 1, "c1"),          // mismatch
+    ]
+}
+
+#[test]
+fn golden_projection_roundtrip() {
+    let fresh = serde_json::to_value(project_tool_decision_truth(&decisions())).unwrap();
+    let path = fixture_path();
+    if std::env::var("BLESS").is_ok() {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            format!("{}\n", serde_json::to_string_pretty(&fresh).unwrap()),
+        )
+        .unwrap();
+    }
+    let expected: Value = serde_json::from_str(
+        &std::fs::read_to_string(&path).expect("expected.json present (regenerate with BLESS=1)"),
+    )
+    .unwrap();
+    assert_eq!(
+        fresh, expected,
+        "TDT OTel projection drifted from the committed golden; regenerate with BLESS=1"
+    );
+
+    // Belt-and-suspenders: the golden carries the honesty contract and never raw args.
+    assert_eq!(expected["lossy"], json!(true));
+    assert_eq!(expected["source_of_truth"], json!("assay artifacts"));
+    let serialized = serde_json::to_string(&expected).unwrap();
+    assert!(!serialized.contains("\"arguments\""));
+    for span in expected["spans"].as_array().unwrap() {
+        assert_eq!(span["attributes"]["assay.claim_class"], json!("derived"));
+        assert_eq!(span["attributes"]["openinference.span.kind"], json!("TOOL"));
+    }
+}

--- a/docs/reference/otel-projection.md
+++ b/docs/reference/otel-projection.md
@@ -96,8 +96,7 @@ contract and its fixtures stand on their own first.
 ## Tool-decision-truth projection (`assay.tool_decision_truth.otel_projection.v0`, experimental)
 
 A second, experimental projection turns VERIFIED tool-decision-truth recipe rows into the same OTel
-GenAI + OpenInference view (see [tool-decision-truth.md](tool-decision-truth.md)). It runs over an
-evidence bundle, not loose carriers:
+GenAI + OpenInference view. It runs over an evidence bundle, not loose carriers:
 
 ```bash
 assay project-otel --evidence-bundle tdt.tar.gz

--- a/docs/reference/otel-projection.md
+++ b/docs/reference/otel-projection.md
@@ -92,3 +92,29 @@ projection JSON document, it does not export OTLP, open a network connection, or
 This is the projection function, its fixtures, and the read-only `assay project-otel` CLI wrapper.
 There is no OTLP exporter and no live telemetry path yet; those are later slices, kept separate so the
 contract and its fixtures stand on their own first.
+
+## Tool-decision-truth projection (`assay.tool_decision_truth.otel_projection.v0`, experimental)
+
+A second, experimental projection turns VERIFIED tool-decision-truth recipe rows into the same OTel
+GenAI + OpenInference view (see [tool-decision-truth.md](tool-decision-truth.md)). It runs over an
+evidence bundle, not loose carriers:
+
+```bash
+assay project-otel --evidence-bundle tdt.tar.gz
+```
+
+The bundle is verified first — `verify-tool-decision-truth` pairs each recipe row with the carrier it
+cites by content digest and runs the fail-closed check — and **the projection is only produced if every
+row verifies**. On a failed verification nothing is serialized or written, not even to `--out`: this is
+a view over verified evidence, never a best-effort trace extractor. `--evidence-bundle` and
+`--capability-surface` are mutually exclusive.
+
+Each verified decision becomes one `TOOL` span (`gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`,
+`openinference.span.kind=TOOL`). The verdict and the digests ride in `assay.tdt.*`
+(`decision_verdict`, `run_verdict`, `observed_input_digest`, `declared_policy_digest`,
+`decision_identity_digest`, `carrier_content_digest`, `source_class`), and `assay.claim_class="derived"`
+marks the span as a derived comparison over observed and declared data — not a raw observation (unlike
+the capability-surface tool spans) and not enforcement. **No raw arguments and no `args_digest` are
+projected**; the view carries only the higher-level identity and content digests. The same `lossy:true`
+/ `source_of_truth` / pinned-semconv discipline applies. Golden fixture:
+`crates/assay-core/tests/fixtures/tdt_otel_projection/`.


### PR DESCRIPTION
## What

PR10 of the follow-up arc: a lossy, read-only OpenTelemetry GenAI + OpenInference projection of **verified** tool-decision-truth evidence. Evidence first (PR9a/PR9b), projection second.

- **Core projector** (`assay-core`): `project_tool_decision_truth(&[TdtDecision]) -> Projection`. Each verified decision becomes one `TOOL` span (`gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, `openinference.span.kind=TOOL`), with the verdict and the four digests in `assay.tdt.*` and `assay.claim_class="derived"` (a derived comparison over observed + declared — not a raw observation, not enforcement). **No raw args and no `args_digest`** are projected; only the identity/content digests. Reuses the existing `lossy:true` / `source_of_truth` / pinned-semconv discipline.
- **Single pairing source:** the verifier gains `verify_and_collect`, which runs the one pairing + fail-closed pass and returns both the report and the verified `TdtDecision` pairs. The projector consumes those typed pairs, so it never re-scans a bundle or re-pairs.
- **CLI:** `assay project-otel --evidence-bundle <tdt.tar.gz>` (mutually exclusive with `--capability-surface`). It verifies the bundle in full first; **if the semantic report is not ok, nothing is serialized or written, not even to `--out`** — a view over verified evidence, never a best-effort extractor.

## Why

This completes the arc without letting the observability view become the authority: the content-addressed evidence (the carrier and its recipe row) is the record; this projection is a derived, lossy view that only runs over already-verified pairs.

## Tests

Core: a derived `TOOL` span carries the `assay.tdt.*` set and never the args/`args_digest` (built from a real carrier). CLI: a verified bundle projects; an unverified bundle (carrier with no row) writes nothing and exits non-zero. A **blessed snapshot** (`BLESS=1`) pins the projection byte-for-byte over a match and a mismatch.

## Stacking

Stacked on PR9b (base = `codex/p1-tdt-pack-verify`). Merge order: PR9a → PR9b → PR10; this rebases to main after they land. No OTLP exporter, no live telemetry path — that stays a later slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--evidence-bundle` flag to the `assay project-otel` command for verifying and projecting tool-decision-truth evidence bundles with fail-closed semantics
  * Introduced new experimental OpenTelemetry projection format for tool-decision-truth data

* **Documentation**
  * Added reference documentation for the new tool-decision-truth projection format and command usage

* **Tests**
  * Added integration and contract tests for evidence bundle verification and CLI argument validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->