### PR TITLE
feat(mcp): experimental live tool-decision-truth carrier producer

### DIFF
--- a/crates/assay-cli/src/cli/args/mcp.rs
+++ b/crates/assay-cli/src/cli/args/mcp.rs
@@ -112,6 +112,15 @@ pub struct McpWrapArgs {
     #[arg(long, value_name = "URI")]
     pub event_source: Option<String>,
 
+    /// EXPERIMENTAL (unstable): opt-in tool-decision-truth carrier producer. Append
+    /// `assay.tool_decision_truth.v0` carriers (one JSON object per line) to this NDJSON file during the
+    /// run, as a separate sink alongside the decision log. Requires ASSAY_TDT_HMAC_KEY and
+    /// ASSAY_TDT_HMAC_KEY_ID in the environment; the producer fails closed at startup if either is
+    /// missing or malformed. The key is read from the environment, held in memory only, and never logged
+    /// or persisted. Evidence-only: no runtime action is taken on the verdict.
+    #[arg(long = "tool-decision-truth-out", value_name = "PATH")]
+    pub tool_decision_truth_out: Option<PathBuf>,
+
     /// Command to wrap (use -- to separate args)
     #[arg(required = true, last = true, allow_hyphen_values = true)]
     pub command: Vec<String>,

--- a/crates/assay-cli/src/cli/commands/mcp.rs
+++ b/crates/assay-cli/src/cli/commands/mcp.rs
@@ -241,6 +241,18 @@ fn tdt_producer_from_material(
             "ASSAY_TDT_HMAC_KEY_ID is empty or malformed (allowed characters: A-Z a-z 0-9 . _ -); the tool-decision-truth producer fails closed."
         );
     }
+    // Fail closed at startup when the opted-in sink cannot be opened. Otherwise a run could proceed with
+    // `--tool-decision-truth-out` enabled while minting no carriers, which is a half-configured producer.
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&out_path)
+        .with_context(|| {
+            format!(
+                "tool-decision-truth sink is not writable at {}; the producer fails closed",
+                out_path.display()
+            )
+        })?;
     Ok(TdtProducer::new(out_path, key.into_bytes(), key_id))
 }
 
@@ -611,6 +623,20 @@ mod tests {
         assert!(
             !dbg.contains("super-secret-key"),
             "Debug must not leak the key: {dbg}"
+        );
+    }
+
+    #[test]
+    fn tdt_producer_fails_closed_when_sink_cannot_be_opened() {
+        let dir = tempdir().unwrap();
+        let out = dir.path().join("missing-parent").join("carriers.ndjson");
+        let err =
+            tdt_producer_from_material(out, Some("super-secret-key".into()), Some("kid-v0".into()))
+                .unwrap_err()
+                .to_string();
+        assert!(
+            err.contains("tool-decision-truth sink is not writable"),
+            "got: {err}"
         );
     }
 

--- a/crates/assay-cli/src/cli/commands/mcp.rs
+++ b/crates/assay-cli/src/cli/commands/mcp.rs
@@ -3,7 +3,7 @@ use super::coverage;
 use super::session_state_window;
 use anyhow::{Context, Result};
 use assay_core::mcp::policy::McpPolicy;
-use assay_core::mcp::proxy::{McpProxy, ProxyConfig, ProxyConfigRaw};
+use assay_core::mcp::proxy::{McpProxy, ProxyConfig, ProxyConfigRaw, TdtProducer};
 use serde_json::{json, Value};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -185,6 +185,65 @@ impl Drop for TempPathGuard {
     }
 }
 
+/// EXPERIMENTAL: build the opt-in tool-decision-truth carrier producer from the environment, failing
+/// closed if the key material is absent or malformed. The HMAC key is read once here, moved into the
+/// producer (held in memory only), and removed from this process's environment so the wrapped child
+/// server — spawned with the inherited environment — cannot read it. The key is never logged or written
+/// to disk.
+fn build_tdt_producer(out_path: PathBuf) -> anyhow::Result<TdtProducer> {
+    const KEY_VAR: &str = "ASSAY_TDT_HMAC_KEY";
+    const KEY_ID_VAR: &str = "ASSAY_TDT_HMAC_KEY_ID";
+
+    let key = std::env::var(KEY_VAR).ok();
+    let key_id = std::env::var(KEY_ID_VAR).ok();
+
+    // Remove the key (and its id) from this process's environment immediately, before the proxy spawns
+    // the wrapped child with an inherited environment, so the child cannot read the key and forge
+    // carriers. The values were captured above; validation happens in the pure helper below.
+    std::env::remove_var(KEY_VAR);
+    std::env::remove_var(KEY_ID_VAR);
+
+    tdt_producer_from_material(out_path, key, key_id)
+}
+
+/// Pure fail-closed validator: turn optional key material into a [`TdtProducer`], or a startup error
+/// naming exactly what is missing or malformed. Split out from the environment read so the fail-closed
+/// contract is testable without mutating process-global state.
+fn tdt_producer_from_material(
+    out_path: PathBuf,
+    key: Option<String>,
+    key_id: Option<String>,
+) -> anyhow::Result<TdtProducer> {
+    let key = key.ok_or_else(|| {
+        anyhow::anyhow!(
+            "--tool-decision-truth-out is set but ASSAY_TDT_HMAC_KEY is missing; the tool-decision-truth producer fails closed. Set the HMAC key in the environment (never on the command line)."
+        )
+    })?;
+    let key_id = key_id.ok_or_else(|| {
+        anyhow::anyhow!(
+            "--tool-decision-truth-out is set but ASSAY_TDT_HMAC_KEY_ID is missing; the tool-decision-truth producer fails closed."
+        )
+    })?;
+    if key.is_empty() {
+        anyhow::bail!(
+            "ASSAY_TDT_HMAC_KEY is empty; the tool-decision-truth producer fails closed."
+        );
+    }
+    // key_id must match the digest-prefix charset the carrier binds (`[A-Za-z0-9._-]`, non-empty), so the
+    // minted args_digest is well-formed and verifiable downstream. This mirrors the core `args_digest`
+    // guard, but here it fails closed loudly at startup instead of silently dropping carriers per call.
+    let key_id_ok = !key_id.is_empty()
+        && key_id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'));
+    if !key_id_ok {
+        anyhow::bail!(
+            "ASSAY_TDT_HMAC_KEY_ID is empty or malformed (allowed characters: A-Z a-z 0-9 . _ -); the tool-decision-truth producer fails closed."
+        );
+    }
+    Ok(TdtProducer::new(out_path, key.into_bytes(), key_id))
+}
+
 async fn cmd_wrap(args: McpWrapArgs) -> anyhow::Result<i32> {
     if args.deny_deprecations {
         std::env::set_var("ASSAY_STRICT_DEPRECATIONS", "1");
@@ -241,7 +300,12 @@ async fn cmd_wrap(args: McpWrapArgs) -> anyhow::Result<i32> {
             .clone()
             .unwrap_or_else(|| "default-mcp-server".into()),
     };
-    let config = ProxyConfig::try_from_raw(raw)?;
+    let mut config = ProxyConfig::try_from_raw(raw)?;
+    // EXPERIMENTAL opt-in: wire the tool-decision-truth carrier producer (separate append-only NDJSON
+    // sink). Fails closed at startup if enabled but the env key material is missing or malformed.
+    if let Some(out_path) = args.tool_decision_truth_out.clone() {
+        config.tdt_producer = Some(build_tdt_producer(out_path)?);
+    }
     let state_window_event_source = config.event_source.clone();
     let state_window_server_id = config.server_id.clone();
 
@@ -475,6 +539,173 @@ mod tests {
                 "assay_check_sequence".to_string(),
                 "assay_policy_decide".to_string(),
             ]
+        );
+    }
+
+    // ── EXPERIMENTAL tool-decision-truth producer: fail-closed key handling ──────────────────────
+
+    #[test]
+    fn tdt_producer_fails_closed_when_key_missing() {
+        let err = tdt_producer_from_material(
+            PathBuf::from("/tmp/carriers.ndjson"),
+            None,
+            Some("kid-v0".into()),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("ASSAY_TDT_HMAC_KEY is missing"), "got: {err}");
+    }
+
+    #[test]
+    fn tdt_producer_fails_closed_when_key_empty() {
+        let err = tdt_producer_from_material(
+            PathBuf::from("/tmp/carriers.ndjson"),
+            Some(String::new()),
+            Some("kid-v0".into()),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("ASSAY_TDT_HMAC_KEY is empty"), "got: {err}");
+    }
+
+    #[test]
+    fn tdt_producer_fails_closed_when_key_id_missing() {
+        let err = tdt_producer_from_material(
+            PathBuf::from("/tmp/carriers.ndjson"),
+            Some("k".into()),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("ASSAY_TDT_HMAC_KEY_ID is missing"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn tdt_producer_fails_closed_when_key_id_malformed() {
+        let err = tdt_producer_from_material(
+            PathBuf::from("/tmp/carriers.ndjson"),
+            Some("k".into()),
+            Some("bad:id".into()),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("malformed"), "got: {err}");
+    }
+
+    #[test]
+    fn tdt_producer_accepts_valid_material_and_debug_redacts_key() {
+        let producer = tdt_producer_from_material(
+            PathBuf::from("/tmp/carriers.ndjson"),
+            Some("super-secret-key".into()),
+            Some("kid-v0".into()),
+        )
+        .expect("valid material");
+        let dbg = format!("{producer:?}");
+        assert!(
+            dbg.contains("<redacted>"),
+            "Debug must redact the key: {dbg}"
+        );
+        assert!(
+            !dbg.contains("super-secret-key"),
+            "Debug must not leak the key: {dbg}"
+        );
+    }
+
+    #[test]
+    fn producer_carrier_line_roundtrips_import_verify_project() {
+        use crate::cli::args::ProjectOtelArgs;
+        use crate::cli::commands::evidence::tool_decision_truth::{
+            cmd_tool_decision_truth, ToolDecisionTruthArgs,
+        };
+        use crate::cli::commands::evidence::verify_tool_decision_truth::{
+            cmd_verify_tool_decision_truth, VerifyFormat, VerifyToolDecisionTruthArgs,
+        };
+        use crate::cli::commands::project_otel;
+        use assay_core::mcp::policy::McpPolicy;
+        use assay_core::mcp::tool_decision_truth as tdt;
+        use assay_core::mcp::tool_decision_truth::DecisionEvidence;
+
+        let policy: McpPolicy = serde_json::from_value(json!({
+            "version": "1",
+            "tools": {"allow": ["deploy"], "deny": ["delete_all"]},
+            "schemas": {"deploy": {"type": "object", "required": ["env"],
+                "properties": {"env": {"enum": ["staging", "prod"]}}}},
+            "enforcement": {"unconstrained_tools": "warn"}
+        }))
+        .unwrap();
+
+        // Build a carrier exactly as the live producer does (same builder + same producer arguments) and
+        // write it as one NDJSON line, mirroring the producer sink.
+        let carrier = tdt::build_classified_record(
+            &policy,
+            "deploy",
+            &json!({"env": "prod", "trace": "ZZSENTINELRAWZZ"}),
+            0,
+            b"producer-test-key-v0",
+            "fixture-kid-v0",
+            "authoritative_boundary",
+            "call-0",
+            "ok",
+            "present",
+            &DecisionEvidence::default(),
+        )
+        .expect("carrier builds");
+
+        let dir = tempdir().unwrap();
+        let sink = dir.path().join("carriers.ndjson");
+        std::fs::write(
+            &sink,
+            format!("{}\n", serde_json::to_string(&carrier).unwrap()),
+        )
+        .unwrap();
+
+        // Extract one line; PR9a imports a single carrier JSON (multi-carrier import is out of scope).
+        let body = std::fs::read_to_string(&sink).unwrap();
+        let line = body.lines().next().unwrap();
+        let carrier_json = dir.path().join("carrier.json");
+        std::fs::write(&carrier_json, line).unwrap();
+
+        let bundle = dir.path().join("tdt.tar.gz");
+        let code = cmd_tool_decision_truth(ToolDecisionTruthArgs {
+            carrier: carrier_json,
+            bundle_out: bundle.clone(),
+            run_id: "producer-roundtrip".to_string(),
+            import_time: Some("2026-06-19T00:00:00Z".to_string()),
+        })
+        .expect("import runs");
+        assert_eq!(code, 0, "import of a producer carrier line should succeed");
+
+        let vcode = cmd_verify_tool_decision_truth(VerifyToolDecisionTruthArgs {
+            bundle: bundle.clone(),
+            format: VerifyFormat::Json,
+        })
+        .expect("verify runs");
+        assert_eq!(
+            vcode, 0,
+            "verify should report ok for a producer-emitted carrier"
+        );
+
+        let proj = dir.path().join("projection.json");
+        let pcode = project_otel::run(ProjectOtelArgs {
+            capability_surface: None,
+            evidence_bundle: Some(bundle),
+            observation_health: None,
+            enforcement_health: None,
+            out: Some(proj.clone()),
+        })
+        .expect("project runs");
+        assert_eq!(pcode, 0, "projection over verified evidence should succeed");
+        let projection = std::fs::read_to_string(&proj).unwrap();
+        assert!(
+            projection.contains("assay.tdt."),
+            "projection should carry tdt identity attributes: {projection}"
+        );
+        assert!(
+            !projection.contains("ZZSENTINELRAWZZ"),
+            "projection must not carry raw arguments"
         );
     }
 }

--- a/crates/assay-core/src/mcp/proxy.rs
+++ b/crates/assay-core/src/mcp/proxy.rs
@@ -30,6 +30,64 @@ pub struct ProxyConfig {
     pub decision_log_path: Option<std::path::PathBuf>,
     /// CloudEvents source URI (validated, required when logging enabled)
     pub event_source: Option<String>,
+    /// EXPERIMENTAL (unstable): opt-in tool-decision-truth carrier producer. `None` disables it. The
+    /// secret HMAC key lives inside [`TdtProducer`], whose manual `Debug` redacts it, so deriving `Debug`
+    /// on this config does not leak the key.
+    pub tdt_producer: Option<TdtProducer>,
+}
+
+/// EXPERIMENTAL (unstable): opt-in producer of `assay.tool_decision_truth.v0` carriers, written
+/// append-only as NDJSON (one carrier per line) to a sink kept separate from — never folded into — the
+/// decision log. The decision log is operational decision output; a carrier is a content-addressed
+/// evidence record with its own HMAC/key semantics and claim ceiling, so the two stay distinct. The
+/// producer is evidence-only: it takes no runtime action on the verdict and never enforces or blocks.
+///
+/// The HMAC key is held in memory only and is never logged or persisted; the manual `Debug` impl redacts
+/// it so it cannot leak through a `{:?}` of the surrounding [`ProxyConfig`].
+#[derive(Clone)]
+pub struct TdtProducer {
+    out_path: std::path::PathBuf,
+    key: Vec<u8>,
+    key_id: String,
+}
+
+impl TdtProducer {
+    /// Build a producer from a sink path and key material. The caller is responsible for failing closed
+    /// (before constructing this) when the producer is enabled but the key/key_id is missing or
+    /// malformed; this type does not re-validate beyond what `tool_decision_truth::args_digest` enforces
+    /// at digest time.
+    pub fn new(out_path: std::path::PathBuf, key: Vec<u8>, key_id: String) -> Self {
+        Self {
+            out_path,
+            key,
+            key_id,
+        }
+    }
+
+    /// Append-only NDJSON sink for minted carriers.
+    pub(crate) fn out_path(&self) -> &std::path::Path {
+        &self.out_path
+    }
+
+    /// HMAC key for `args_digest` (secret; never logged or persisted).
+    pub(crate) fn key(&self) -> &[u8] {
+        &self.key
+    }
+
+    /// Stable key identifier bound into the digest prefix.
+    pub(crate) fn key_id(&self) -> &str {
+        &self.key_id
+    }
+}
+
+impl std::fmt::Debug for TdtProducer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TdtProducer")
+            .field("out_path", &self.out_path)
+            .field("key", &"<redacted>")
+            .field("key_id", &self.key_id)
+            .finish()
+    }
 }
 
 /// Raw config as provided by CLI/config files before validation.
@@ -74,6 +132,9 @@ impl ProxyConfig {
             server_id: raw.server_id,
             decision_log_path: raw.decision_log_path,
             event_source,
+            // Opt-in producer is wired by the caller after validation (env key, fail-closed), never
+            // from the raw CLI/config struct.
+            tdt_producer: None,
         })
     }
 }

--- a/crates/assay-core/src/mcp/proxy/client.rs
+++ b/crates/assay-core/src/mcp/proxy/client.rs
@@ -2,12 +2,13 @@ mod branches;
 
 use self::branches::{handle_policy_decision, BranchOutcome, PolicyBranchContext};
 use super::decisions::extract_tool_call_id;
-use super::ProxyConfig;
+use super::{ProxyConfig, TdtProducer};
 use crate::mcp::audit::AuditLog;
 use crate::mcp::decision::DecisionEmitter;
 use crate::mcp::identity::ToolIdentity;
 use crate::mcp::jsonrpc::JsonRpcRequest;
 use crate::mcp::policy::{McpPolicy, PolicyState};
+use crate::mcp::tool_decision_truth as tdt;
 use crate::mcp::tool_definition::ToolDefinitionBinding;
 use std::{
     collections::HashMap,
@@ -33,6 +34,9 @@ pub(super) fn run_client_to_server(
 
     let mut state = PolicyState::default();
     let mut audit_log = AuditLog::new(config.audit_log_path.as_deref());
+    // Monotonic per-run observed-order counter for tool-decision-truth carriers (only advanced when the
+    // opt-in producer mints a carrier).
+    let mut tdt_order: i64 = 0;
 
     while reader.read_line(&mut line)? > 0 {
         // 1. Try Parse as MCP Request
@@ -72,6 +76,25 @@ pub(super) fn run_client_to_server(
                     &mut state,
                     runtime_id.as_ref(),
                 );
+
+                // EXPERIMENTAL opt-in: mint a tool-decision-truth carrier for this evaluated tool call,
+                // appended to its own NDJSON sink (separate from the decision log). Evidence-only — this
+                // never alters the decision below and never blocks the call, including when the call is
+                // about to be blocked: the carrier records that the decision was observed and classified.
+                if req.is_tool_call() {
+                    if let Some(producer) = config.tdt_producer.as_ref() {
+                        emit_tdt_carrier(
+                            producer,
+                            &policy,
+                            tool_name,
+                            tool_arguments,
+                            tdt_order,
+                            &tool_call_id,
+                            runtime_id.is_some(),
+                        );
+                        tdt_order += 1;
+                    }
+                }
 
                 let branch_outcome = handle_policy_decision(
                     policy_eval.decision,
@@ -121,9 +144,71 @@ pub(super) fn run_client_to_server(
     Ok(())
 }
 
+/// EXPERIMENTAL: mint a tool-decision-truth carrier for one evaluated tool call and append it to the
+/// producer's NDJSON sink. Evidence-only and best-effort: a build or write failure is logged to stderr
+/// and never blocks or alters the call (A1 takes no runtime action on the verdict). The carrier carries
+/// only the keyed `args_digest`, never raw arguments.
+fn emit_tdt_carrier(
+    producer: &TdtProducer,
+    policy: &McpPolicy,
+    tool_name: &str,
+    tool_arguments: &serde_json::Value,
+    order: i64,
+    call_id: &str,
+    identity_present: bool,
+) {
+    // identity_state maps only present/absent here; required_missing/invalid are richer states the proxy
+    // does not yet distinguish at this seam.
+    let identity_state = if identity_present {
+        "present"
+    } else {
+        "absent"
+    };
+    // Minimal evidence: the proxy does not observe class membership / approval / scope / redaction at this
+    // seam, so those axes stay unknown and the verdict gate resolves any DECLARED such constraint to
+    // `incomplete` rather than a guessed `match`.
+    let evidence = tdt::DecisionEvidence::default();
+    let carrier = tdt::build_classified_record(
+        policy,
+        tool_name,
+        tool_arguments,
+        order,
+        producer.key(),
+        producer.key_id(),
+        "authoritative_boundary",
+        call_id,
+        "ok",
+        identity_state,
+        &evidence,
+    );
+    let Some(carrier) = carrier else {
+        eprintln!(
+            "[assay] WARNING: tool-decision-truth carrier could not be built for tool '{tool_name}'; skipping (no carrier emitted)"
+        );
+        return;
+    };
+    if let Err(e) = append_carrier_line(producer.out_path(), &carrier) {
+        eprintln!("[assay] WARNING: failed to append tool-decision-truth carrier: {e}");
+    }
+}
+
+/// Append one carrier as a single NDJSON line to the producer sink, creating the file if absent. The sink
+/// is append-only so concurrent or re-run appends never truncate earlier carriers.
+fn append_carrier_line(path: &std::path::Path, carrier: &serde_json::Value) -> io::Result<()> {
+    let mut line = serde_json::to_string(carrier).map_err(io::Error::other)?;
+    line.push('\n');
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    f.write_all(line.as_bytes())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::{json, Value};
+    use tempfile::tempdir;
 
     #[test]
     fn proxy_contract_client_loop_inputs_remain_private() {
@@ -133,5 +218,155 @@ mod tests {
         assert_send::<Arc<Mutex<HashMap<String, ToolIdentity>>>>();
         assert_send::<Arc<Mutex<HashMap<String, ToolDefinitionBinding>>>>();
         assert_sync::<Arc<dyn DecisionEmitter>>();
+    }
+
+    fn test_policy() -> McpPolicy {
+        serde_json::from_value(json!({
+            "version": "1",
+            "tools": {"allow": ["deploy"], "deny": ["delete_all"]},
+            "schemas": {"deploy": {"type": "object", "required": ["env"],
+                "properties": {"env": {"enum": ["staging", "prod"]}}}},
+            "enforcement": {"unconstrained_tools": "warn"}
+        }))
+        .expect("test policy")
+    }
+
+    fn test_producer(sink: std::path::PathBuf) -> TdtProducer {
+        TdtProducer::new(
+            sink,
+            b"producer-test-key-v0".to_vec(),
+            "fixture-kid-v0".to_string(),
+        )
+    }
+
+    fn first_carrier(sink: &std::path::Path) -> Value {
+        let body = std::fs::read_to_string(sink).expect("read sink");
+        let line = body.lines().next().expect("at least one carrier line");
+        serde_json::from_str(line).expect("carrier parses")
+    }
+
+    #[test]
+    fn producer_emits_carrier_without_raw_args() {
+        let dir = tempdir().unwrap();
+        let sink = dir.path().join("carriers.ndjson");
+        let producer = test_producer(sink.clone());
+        // A sentinel raw argument value that must never reach the carrier (only the keyed digest may).
+        let args = json!({"env": "prod", "trace": "ZZSENTINELRAWZZ"});
+
+        emit_tdt_carrier(
+            &producer,
+            &test_policy(),
+            "deploy",
+            &args,
+            0,
+            "call-0",
+            true,
+        );
+
+        let body = std::fs::read_to_string(&sink).unwrap();
+        assert_eq!(body.lines().count(), 1, "exactly one carrier line");
+        assert!(
+            !body.contains("ZZSENTINELRAWZZ"),
+            "raw argument value leaked into the carrier sink: {body}"
+        );
+
+        let carrier = first_carrier(&sink);
+        assert_eq!(carrier["schema"], json!("assay.tool_decision_truth.v0"));
+        assert_eq!(carrier["source_class"], json!("authoritative_boundary"));
+        assert_eq!(carrier["result_status"], json!("ok"));
+        assert_eq!(carrier["identity_state"], json!("present"));
+        assert_eq!(carrier["call_id"], json!("call-0"));
+        let ad = carrier["args_digest"].as_str().expect("args_digest string");
+        assert!(
+            ad.starts_with("hmac-sha256:fixture-kid-v0:"),
+            "args_digest must be a keyed HMAC over the id, got {ad}"
+        );
+        // No raw-argument container key is ever present in the carrier.
+        for k in ["args", "arguments", "input", "tool_arguments"] {
+            assert!(
+                carrier.get(k).is_none(),
+                "carrier must not carry raw-arg key {k}"
+            );
+        }
+        assert!(
+            carrier.get("decision_verdict").is_some(),
+            "carrier carries a verdict"
+        );
+    }
+
+    #[test]
+    fn producer_appends_are_append_only_and_ordered() {
+        let dir = tempdir().unwrap();
+        let sink = dir.path().join("carriers.ndjson");
+        let producer = test_producer(sink.clone());
+        let p = test_policy();
+
+        emit_tdt_carrier(
+            &producer,
+            &p,
+            "deploy",
+            &json!({"env": "prod"}),
+            0,
+            "c0",
+            true,
+        );
+        emit_tdt_carrier(
+            &producer,
+            &p,
+            "deploy",
+            &json!({"env": "staging"}),
+            1,
+            "c1",
+            false,
+        );
+
+        let body = std::fs::read_to_string(&sink).unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "append-only: the second emit must not truncate the first"
+        );
+        let c0: Value = serde_json::from_str(lines[0]).unwrap();
+        let c1: Value = serde_json::from_str(lines[1]).unwrap();
+        assert_ne!(
+            c0["observed_input_digest"], c1["observed_input_digest"],
+            "distinct order yields distinct observed-input identity"
+        );
+        // identity_state is mapped from runtime-identity presence at this seam.
+        assert_eq!(c0["identity_state"], json!("present"));
+        assert_eq!(c1["identity_state"], json!("absent"));
+    }
+
+    #[test]
+    fn producer_minimal_evidence_does_not_force_match_for_declared_obligation() {
+        // The policy declares an approval obligation the proxy does not observe at this seam, so the
+        // verdict gate must resolve it to `incomplete`, never a guessed `match`.
+        let policy: McpPolicy = serde_json::from_value(json!({
+            "version": "1",
+            "tools": {"allow": ["deploy"], "approval_required": ["deploy"]},
+            "enforcement": {"unconstrained_tools": "warn"}
+        }))
+        .unwrap();
+        let dir = tempdir().unwrap();
+        let sink = dir.path().join("carriers.ndjson");
+        let producer = test_producer(sink.clone());
+
+        emit_tdt_carrier(
+            &producer,
+            &policy,
+            "deploy",
+            &json!({"env": "prod"}),
+            0,
+            "c0",
+            true,
+        );
+
+        let carrier = first_carrier(&sink);
+        assert_eq!(
+            carrier["decision_verdict"],
+            json!("incomplete"),
+            "an unobserved declared obligation must resolve to incomplete"
+        );
     }
 }

--- a/crates/assay-core/src/mcp/proxy/client/branches.rs
+++ b/crates/assay-core/src/mcp/proxy/client/branches.rs
@@ -220,6 +220,7 @@ mod tests {
             server_id: "test-server".to_string(),
             decision_log_path: None,
             event_source: Some("assay://test/client-branches".to_string()),
+            tdt_producer: None,
         }
     }
 


### PR DESCRIPTION
## What

An opt-in producer that mints `assay.tool_decision_truth.v0` carriers during a real `assay mcp wrap` MCP session. Until now the carrier could only be authored after the fact (import a JSON, verify, project); this is the first time the contract is exercised by a live policy evaluation, at the boundary where the decision actually happens.

Carriers are written append-only as NDJSON, one per line, to a sink kept deliberately separate from the decision log. A decision-log entry is operational output ("a policy decision happened"); a carrier is a content-addressed evidence record with its own HMAC/key semantics and claim ceiling ("this observed input was classified against this declared policy"). Folding them together would blur those two, so they stay distinct files.

## How it works

- `assay mcp wrap --tool-decision-truth-out carriers.ndjson -- <server>` turns it on. It requires `ASSAY_TDT_HMAC_KEY` and `ASSAY_TDT_HMAC_KEY_ID` in the environment.
- The producer **fails closed at startup**: if the flag is set but the key or key id is missing, empty, or outside `[A-Za-z0-9._-]`, wrap refuses to start and writes nothing. The key is read once, held in memory only, **removed from the environment before the wrapped child is spawned** (so the child cannot inherit it and forge carriers), and never logged or persisted.
- Carriers are built at the `McpProxy` per-call policy seam via `build_classified_record` with `source_class=authoritative_boundary`, `result_status=ok`, and `identity_state=present|absent` from the runtime identity. Only the keyed `args_digest` is recorded — never raw arguments.
- The proxy does not observe class membership, approval, scope, or redaction at this seam, so those axes stay unknown and any **declared** such obligation resolves to `incomplete`, never a guessed `match`. You can see this live: wrapping a policy that allows a tool but declares no args schema for it mints a carrier with `decision_verdict: incomplete`.

## What it is not

Evidence-only. No runtime action is taken on the verdict and the producer never blocks a call — a carrier is minted even for a call that is about to be denied, recording that the decision was observed and classified. It stays experimental/unstable. The existing `verify-tool-decision-truth` / `project-otel` flow remains the post-hoc reader.

## Verification

Unit tests: the emitted carrier carries no raw arguments; the sink is append-only and ordered; minimal evidence resolves to `incomplete`; the key handling fails closed on missing/empty/malformed material with `Debug` redacting the key; and a minted carrier line round-trips through the existing `import -> verify -> project` path.

Also checked end to end against the built binary: a live `assay mcp wrap` tool call mints exactly one carrier (keyed digest, no raw args, key absent from stderr), and that carrier imports, verifies `ok` (claim ceiling intact), and projects with `assay.tdt.*` + `assay.claim_class=derived` and no raw arguments.

Scope is the producer, its wiring, and tests. A short reference-doc slice describing the producer can follow separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental `--tool-decision-truth-out <PATH>` to `mcp wrap` to emit `assay.tool_decision_truth.v0` evidence as append-only NDJSON.
  * When enabled, it validates required HMAC credentials from the environment and fails securely if missing or invalid.
  * Tool-decision evidence is captured without affecting the underlying policy decisions.

* **Tests**
  * Added unit and end-to-end coverage for fail-closed validation, redaction, append-only ordering, and evidence contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->