### PR TITLE
docs(reference): reconcile tool-decision-truth + otel-projection with shipped surfaces

### DIFF
--- a/docs/reference/otel-projection.md
+++ b/docs/reference/otel-projection.md
@@ -105,8 +105,9 @@ assay project-otel --evidence-bundle tdt.tar.gz
 The bundle is verified first — `verify-tool-decision-truth` pairs each recipe row with the carrier it
 cites by content digest and runs the fail-closed check — and **the projection is only produced if every
 row verifies**. On a failed verification nothing is serialized or written, not even to `--out`: this is
-a view over verified evidence, never a best-effort trace extractor. `--evidence-bundle` and
-`--capability-surface` are mutually exclusive.
+a view over verified evidence, never a best-effort trace extractor. `--evidence-bundle` is mutually
+exclusive with the capability-surface inputs: `--capability-surface`, `--observation-health`, and
+`--enforcement-health`.
 
 Each verified decision becomes one `TOOL` span (`gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`,
 `openinference.span.kind=TOOL`). The verdict and the digests ride in `assay.tdt.*`

--- a/docs/reference/tool-decision-truth.md
+++ b/docs/reference/tool-decision-truth.md
@@ -47,7 +47,9 @@ semantically correct.
 - does not expose raw tool arguments, secrets, tokens, or key material;
 - does not provide an OTLP exporter or live telemetry path; the experimental OTel projection is a
   lossy view over verified evidence;
-- does not integrate with the pack writer yet; the recipe-row primitive exists separately;
+- does not yet emit into a production pack; the import path binds the carrier and recipe row into an
+  evidence bundle and the verifier checks them, but writing into a production pack is a separate
+  follow-up;
 - does not provide a stable external schema until the experimental marker is removed.
 
 ## Three zones

--- a/docs/reference/tool-decision-truth.md
+++ b/docs/reference/tool-decision-truth.md
@@ -45,7 +45,8 @@ semantically correct.
 - mints carriers as evidence only; the live producer takes no action on the verdict and never proves provider-side execution or side effects;
 - does not claim complete coverage when required evidence is absent;
 - does not expose raw tool arguments, secrets, tokens, or key material;
-- does not provide an OpenTelemetry projection or pinned OTel snapshot;
+- does not provide an OTLP exporter or live telemetry path; the experimental OTel projection is a
+  lossy view over verified evidence;
 - does not integrate with the pack writer yet; the recipe-row primitive exists separately;
 - does not provide a stable external schema until the experimental marker is removed.
 
@@ -273,11 +274,12 @@ Green:
 - declared digest and verdict-gate coherence;
 - carrier-content pack-row primitive;
 - fail-closed verifier;
-- conformance vectors with recompute-from-bytes guard; and
+- conformance vectors with recompute-from-bytes guard;
+- import, verify, and OTel projection over a verified evidence bundle; and
 - live carrier producer, opt-in and evidence-only.
 
 Open:
 
-- OpenTelemetry export against a pinned snapshot;
-- integrated pack emission; and
+- OTLP export or a live telemetry path;
+- production pack-emission path; and
 - promotion from experimental names to a stable public schema.


### PR DESCRIPTION
A docs-only reconciliation: two reference pages still described surfaces that have since shipped as experimental. This brings the prose in line with what is on `main`, factually, without overclaiming.

## tool-decision-truth.md

The import/verify path and the OTel projection over a verified evidence bundle now exist as experimental surfaces, so they are no longer described as absent:

- the OTel non-claim is reframed from "does not provide an OpenTelemetry projection" to "does not provide an OTLP exporter or live telemetry path; the experimental OTel projection is a lossy view over verified evidence" (the projection exists; an exporter / live path does not);
- the pack non-claim is reframed from "does not integrate with the pack writer yet" to "does not yet emit into a production pack; the import path binds the carrier and recipe row into an evidence bundle and the verifier checks them, but writing into a production pack is a separate follow-up";
- the green status list adds "import, verify, and OTel projection over a verified evidence bundle";
- the open status list keeps the genuinely-open items: an OTLP export / live telemetry path, a production pack-emission path, and promotion from experimental names to a stable public schema.

The boundary is held deliberately: what exists is stated as existing and experimental, and full promotion to a stable schema stays open. Nothing here claims completeness.

## otel-projection.md

`--evidence-bundle` is mutually exclusive with all three capability-surface inputs (`--capability-surface`, `--observation-health`, `--enforcement-health`), matching `conflicts_with_all` in the CLI args, rather than naming only `--capability-surface` (CodeRabbit flagged this on the projection PR).

Docs only, no code change. Held for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Clarified that `--evidence-bundle` is mutually exclusive with all capability-surface inputs (including `--capability-surface`, `--observation-health`, and `--enforcement-health`)
- Updated guidance on OpenTelemetry projection behavior, emphasizing it as a lossy view over verified evidence
- Revised the “Current public status” section to more precisely describe available items and remove references to OTLP export or live telemetry paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->