### PR TITLE
docs(mcp): enrich tool definitions for Glama TDQS

### DIFF
--- a/crates/assay-mcp-server/src/tools/mod.rs
+++ b/crates/assay-mcp-server/src/tools/mod.rs
@@ -60,99 +60,152 @@ pub fn list_tools() -> Vec<Value> {
     let mut list: Vec<Value> = vec![
         serde_json::json!({
             "name": "assay_check_args",
-            "description": "Validate one proposed MCP tool call against an Assay policy file. Checks the tool name and JSON arguments against allow/deny rules and per-tool schemas, then returns an allow/deny decision with violations. This tool does not execute the target tool.",
+            "description": "Pre-flight review for one proposed MCP tool call. Use this before executing a tool when you have the exact tool name, the JSON arguments that would be sent, and an Assay policy file. It evaluates allow/deny rules plus the matching per-tool JSON schema and returns allowed=true/false, warnings, violations, and a suggested-fix slot. It never invokes the target tool and never proves the provider executed anything.",
             "inputSchema": {
                 "type": "object",
+                "title": "Tool argument policy check request",
+                "description": "Request body for validating one MCP tool call against a local Assay policy.",
                 "properties": {
                     "tool": {
                         "type": "string",
-                        "description": "Exact MCP tool name to evaluate, for example `github.add_deploy_key`."
+                        "description": "Exact MCP tool name to evaluate, using the same name that would appear in the client tool call.",
+                        "minLength": 1,
+                        "examples": ["github.add_deploy_key", "filesystem.write_file"]
                     },
                     "arguments": {
                         "type": "object",
-                        "description": "JSON object that would be sent to the tool. Assay validates this object against the matching policy schema."
+                        "description": "JSON object that would be sent to the target tool. Assay validates this object against the policy schema for the named tool.",
+                        "examples": [
+                            { "repository": "owner/repo", "key": "ssh-ed25519 AAAA..." },
+                            { "path": "docs/report.md", "content": "draft" }
+                        ]
                     },
                     "policy": {
                         "type": "string",
-                        "description": "Policy file path relative to the configured policy root, for example `policy.yaml`."
+                        "description": "Assay policy file path relative to the server policy root.",
+                        "minLength": 1,
+                        "examples": ["policy.yaml", "policies/mcp-production.yaml"]
                     }
                 },
                 "required": ["tool", "arguments", "policy"],
+                "examples": [
+                    {
+                        "tool": "github.add_deploy_key",
+                        "arguments": { "repository": "owner/repo", "key": "ssh-ed25519 AAAA..." },
+                        "policy": "policy.yaml"
+                    }
+                ],
                 "additionalProperties": false
             }
         }),
         serde_json::json!({
             "name": "assay_check_sequence",
-            "description": "Check whether a proposed next tool call is allowed by the sequence rules in an Assay policy. Provide the prior tool-name history and the next tool name; Assay returns sequence violations without executing any tools.",
+            "description": "Pre-flight review for tool-call order. Use this when an agent is about to make another MCP tool call and you need to check the proposed next tool against policy sequence rules such as required predecessors, forbidden orderings, or deadline windows. It returns allowed=true/false and sequence violations for the trace-so-far plus next_tool. It does not execute tools and does not assert that the workflow is complete.",
             "inputSchema": {
                 "type": "object",
+                "title": "Tool sequence policy check request",
+                "description": "Request body for validating whether next_tool is allowed after the observed history.",
                 "properties": {
                     "history": {
                         "type": "array",
-                        "description": "Tool names already observed in order before the proposed next call.",
-                        "items": { "type": "string" }
+                        "description": "Tool names already observed in chronological order before the proposed next call.",
+                        "items": { "type": "string", "minLength": 1 },
+                        "examples": [["github.get_repository", "github.list_branches"]]
                     },
                     "next_tool": {
                         "type": "string",
-                        "description": "Tool name being considered as the next call."
+                        "description": "Exact MCP tool name being considered as the next call.",
+                        "minLength": 1,
+                        "examples": ["github.create_pull_request"]
                     },
                     "policy": {
                         "type": "string",
-                        "description": "Policy file path relative to the configured policy root."
+                        "description": "Assay sequence or full policy file path relative to the server policy root.",
+                        "minLength": 1,
+                        "examples": ["policy.yaml", "policies/release-flow.yaml"]
                     }
                 },
                 "required": ["history", "next_tool", "policy"],
+                "examples": [
+                    {
+                        "history": ["github.get_repository", "github.list_branches"],
+                        "next_tool": "github.create_pull_request",
+                        "policy": "policy.yaml"
+                    }
+                ],
                 "additionalProperties": false
             }
         }),
         serde_json::json!({
             "name": "assay_policy_decide",
-            "description": "Return a lightweight allow/deny decision for a tool name using the policy blocklist. Use this for quick tool-name gating; use `assay_check_args` when argument/schema validation is needed.",
+            "description": "Fast name-only policy decision for an MCP tool. Use this for inexpensive routing or UI gating when only the tool name is known. It checks the policy blocklist and returns allowed=true/false plus a short reason or match. It intentionally does not validate arguments, schemas, sequence rules, runtime delivery, or provider behavior; use assay_check_args for argument-aware review.",
             "inputSchema": {
                 "type": "object",
+                "title": "Tool name policy decision request",
+                "description": "Request body for checking a tool name against the local policy blocklist.",
                 "properties": {
                     "tool": {
                         "type": "string",
-                        "description": "Exact MCP tool name to check against the policy blocklist."
+                        "description": "Exact MCP tool name to check against the policy blocklist.",
+                        "minLength": 1,
+                        "examples": ["shell.exec", "github.delete_repository"]
                     },
                     "policy": {
                         "type": "string",
-                        "description": "Policy file path relative to the configured policy root."
+                        "description": "Policy file path relative to the server policy root.",
+                        "minLength": 1,
+                        "examples": ["policy.yaml"]
                     }
                 },
                 "required": ["tool", "policy"],
+                "examples": [
+                    {
+                        "tool": "shell.exec",
+                        "policy": "policy.yaml"
+                    }
+                ],
                 "additionalProperties": false
             }
         }),
         serde_json::json!({
             "name": "assay_check_coverage",
-            "description": "Measure how well one or more recorded tool-call traces cover an Assay policy. Returns coverage percentages, unseen tools or rules, and whether the supplied threshold is met; it does not claim runtime safety or provider truth.",
+            "description": "Coverage report for policy test traces. Use this after collecting one or more tool-call traces to see which policy tools or rules were exercised, what remains unseen, and whether the requested coverage threshold was met. It returns JSON by default or a Markdown/GitHub annotation summary. This is evidence about trace coverage only, not runtime safety, provider truth, or compliance.",
             "inputSchema": {
                 "type": "object",
+                "title": "Policy trace coverage request",
+                "description": "Request body for comparing recorded tool-call traces with policy coverage expectations.",
                 "properties": {
                     "policy": {
                         "type": "string",
-                        "description": "Policy file path relative to the configured policy root."
+                        "description": "Full Assay policy file path relative to the server policy root.",
+                        "minLength": 1,
+                        "examples": ["policy.yaml", "policies/mcp-production.yaml"]
                     },
                     "traces": {
                         "type": "array",
-                        "description": "Trace records to compare against the policy.",
+                        "description": "Recorded traces to compare against the policy. Each trace should list the tools observed in execution order and may list policy rules observed as triggered.",
+                        "minItems": 1,
                         "items": {
                             "type": "object",
+                            "title": "Coverage trace record",
                             "properties": {
                                 "id": {
                                     "type": "string",
-                                    "description": "Optional trace identifier used in reports."
+                                    "description": "Optional stable trace identifier used in reports.",
+                                    "examples": ["trace-pr-42-happy-path"]
                                 },
                                 "tools": {
                                     "type": "array",
                                     "description": "Tool names observed in this trace.",
-                                    "items": { "type": "string" }
+                                    "minItems": 1,
+                                    "items": { "type": "string", "minLength": 1 },
+                                    "examples": [["github.get_repository", "github.create_pull_request"]]
                                 },
                                 "rules_triggered": {
                                     "type": "array",
                                     "description": "Optional policy rule identifiers observed as triggered in this trace.",
-                                    "items": { "type": "string" }
+                                    "items": { "type": "string", "minLength": 1 },
+                                    "examples": [["require_review_before_merge"]]
                                 }
                             },
                             "required": ["tools"],
@@ -164,42 +217,67 @@ pub fn list_tools() -> Vec<Value> {
                         "description": "Minimum acceptable coverage percentage from 0 to 100. Defaults to 80.",
                         "minimum": 0,
                         "maximum": 100,
-                        "default": 80
+                        "default": 80,
+                        "examples": [80, 95]
                     },
                     "format": {
                         "type": "string",
                         "description": "Response format for the coverage report.",
                         "enum": ["json", "markdown", "github"],
-                        "default": "json"
+                        "default": "json",
+                        "examples": ["json", "markdown"]
                     }
                 },
                 "required": ["policy", "traces"],
+                "examples": [
+                    {
+                        "policy": "policy.yaml",
+                        "traces": [
+                            {
+                                "id": "trace-pr-42-happy-path",
+                                "tools": ["github.get_repository", "github.create_pull_request"],
+                                "rules_triggered": ["require_review_before_merge"]
+                            }
+                        ],
+                        "threshold": 80,
+                        "format": "json"
+                    }
+                ],
                 "additionalProperties": false
             }
         }),
         serde_json::json!({
             "name": "assay_explain_trace",
-            "description": "Explain how an ordered trace of tool calls evaluates against an Assay policy. Produces step-by-step rule evaluation and blocked-step counts in JSON, Markdown, terminal text, or HTML.",
+            "description": "Human-readable explanation of a recorded MCP tool-call trace. Use this when you need to debug or review why a sequence of tool calls was allowed, warned, or blocked by an Assay policy. It evaluates the supplied ordered trace and returns step-by-step rule reasoning, blocked-step counts, and formatted output. It is an offline explanation of supplied evidence, not a live telemetry exporter.",
             "inputSchema": {
                 "type": "object",
+                "title": "Trace explanation request",
+                "description": "Request body for explaining how a recorded tool-call trace evaluates against an Assay policy.",
                 "properties": {
                     "policy": {
                         "type": "string",
-                        "description": "Policy file path relative to the configured policy root."
+                        "description": "Assay policy file path relative to the server policy root.",
+                        "minLength": 1,
+                        "examples": ["policy.yaml"]
                     },
                     "trace": {
                         "type": "array",
-                        "description": "Ordered tool-call trace to explain.",
+                        "description": "Ordered tool-call trace to explain. Each item is one observed MCP tool call.",
+                        "minItems": 1,
                         "items": {
                             "type": "object",
+                            "title": "Trace step",
                             "properties": {
                                 "tool": {
                                     "type": "string",
-                                    "description": "Tool name for this trace step."
+                                    "description": "Tool name for this trace step.",
+                                    "minLength": 1,
+                                    "examples": ["github.create_pull_request"]
                                 },
                                 "args": {
                                     "type": "object",
-                                    "description": "Optional JSON arguments observed for this trace step."
+                                    "description": "Optional JSON arguments observed for this trace step. This is used only for explanation and policy evaluation; the tool is not invoked.",
+                                    "examples": [{ "repository": "owner/repo", "title": "Update policy docs" }]
                                 }
                             },
                             "required": ["tool"],
@@ -210,10 +288,23 @@ pub fn list_tools() -> Vec<Value> {
                         "type": "string",
                         "description": "Response format for the explanation.",
                         "enum": ["json", "markdown", "terminal", "html"],
-                        "default": "json"
+                        "default": "json",
+                        "examples": ["markdown", "json"]
                     }
                 },
                 "required": ["policy", "trace"],
+                "examples": [
+                    {
+                        "policy": "policy.yaml",
+                        "trace": [
+                            {
+                                "tool": "github.create_pull_request",
+                                "args": { "repository": "owner/repo", "title": "Update policy docs" }
+                            }
+                        ],
+                        "format": "markdown"
+                    }
+                ],
                 "additionalProperties": false
             }
         }),


### PR DESCRIPTION
What
- Enrich the five public assay MCP tool definitions with scanner-friendly, task-oriented descriptions.
- Add JSON Schema metadata that Glama and MCP clients can use: titles, schema descriptions, examples, minLength/minItems, and clearer field descriptions.
- Keep the changes limited to the MCP tool catalog in `list_tools()`.

Why
- After #1731, Glama now recognizes `glama.json`, but Tool Definition Quality remains C across the public tools.
- The remaining gap appears to be tool definition clarity rather than ownership metadata.
- This PR gives each tool a clearer use case, input shape, return expectation, and non-claim boundary for directory scanners and users.

Impact
- Discovery/schema metadata only.
- No handler logic, policy evaluation behavior, proxy behavior, or runtime evidence semantics change.
- The descriptions continue to avoid enforcement/runtime-truth/provider-verification/compliance claims.

Validation
- `cargo fmt -p assay-mcp-server --check`
- `cargo test -p assay-mcp-server`
- `git diff --check`
- pre-commit/pre-push hooks passed, including cargo fmt, workspace clippy deny-warnings, and linux compile gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced tool descriptions and JSON Schema definitions for improved clarity and usability.
  * Added comprehensive examples for tool requests and parameters.
  * Implemented stricter validation schemas with better field documentation and default values.
  * Improved overall developer experience when integrating with tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->