### PR TITLE
refactor(evidence): adopt assay-canonical for JCS + content-id digests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ name = "assay-evidence"
 version = "3.29.0"
 dependencies = [
  "anyhow",
+ "assay-canonical",
  "assert_fs",
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ assay-monitor = { path = "crates/assay-monitor", version = "3.19.1" }
 assay-metrics = { path = "crates/assay-metrics", version = "3.19.1" }
 assay-policy = { path = "crates/assay-policy", version = "3.19.1" }
 assay-mcp-server = { path = "crates/assay-mcp-server", version = "3.19.1" }
+assay-canonical = { path = "crates/assay-canonical", version = "3.19.1" }
 assay-evidence = { path = "crates/assay-evidence", version = "3.19.1" }
 assay-sim = { path = "crates/assay-sim", version = "3.19.1" }
 assay-registry = { path = "crates/assay-registry", version = "3.19.1" }

--- a/crates/assay-canonical/Cargo.toml
+++ b/crates/assay-canonical/Cargo.toml
@@ -5,10 +5,6 @@ edition.workspace = true
 description = "Deterministic canonicalization: RFC 8785 (JCS) bytes, sha256 content-addressed IDs, and schema-aware set-path normalization for semantic digests."
 license.workspace = true
 repository.workspace = true
-# Not published yet: nothing in the published surface depends on it. When a published crate (e.g.
-# assay-evidence) adopts it, that PR flips this to publishable and adds it to the publish order, the
-# same flow the runner crates followed.
-publish = false
 
 [lints]
 workspace = true

--- a/crates/assay-evidence/Cargo.toml
+++ b/crates/assay-evidence/Cargo.toml
@@ -9,6 +9,9 @@ description = "Tamper-evident, cryptographically verifiable evidence bundles for
 readme.workspace = true
 
 [dependencies]
+# Internal: shared canonicalization (JCS + content-id). Same serde_jcs pin, so the bytes (and every
+# content/mandate digest) are unchanged; this is a deduplication, not a behaviour change.
+assay-canonical = { workspace = true }
 # Core serialization
 serde = { workspace = true, features = ["derive", "std", "alloc"] }
 serde_json = { workspace = true, features = ["preserve_order", "std", "alloc"] }

--- a/crates/assay-evidence/src/crypto/id.rs
+++ b/crates/assay-evidence/src/crypto/id.rs
@@ -11,9 +11,8 @@
 //! 2. Hash inputs use JCS (RFC 8785) canonical JSON.
 //! 3. All hashes are SHA-256 with "sha256:" prefix.
 
-use crate::crypto::jcs;
 use crate::types::EvidenceEvent;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
@@ -96,10 +95,7 @@ pub fn compute_content_hash(event: &EvidenceEvent) -> Result<String> {
         payload: &event.payload,
     };
 
-    let canonical_bytes = jcs::to_vec(&input)?;
-    let hash = Sha256::digest(&canonical_bytes);
-
-    Ok(format!("sha256:{}", hex::encode(hash)))
+    assay_canonical::content_id(&input).context("failed to compute content hash")
 }
 
 /// Calculate the Stream Identity ID.

--- a/crates/assay-evidence/src/crypto/jcs.rs
+++ b/crates/assay-evidence/src/crypto/jcs.rs
@@ -1,7 +1,8 @@
-//! JSON Canonicalization Scheme (RFC 8785) implementation.
+//! JSON Canonicalization Scheme (RFC 8785) for cryptographic operations.
 //!
-//! Provides deterministic JSON serialization for cryptographic operations.
-//! Uses `serde_jcs` which guarantees:
+//! Thin wrapper that delegates to [`assay_canonical::jcs`] (the shared canonicalization crate, pinned
+//! to the same `serde_jcs`), so the byte output here is identical to before this crate adopted it.
+//! Guarantees:
 //!
 //! - Lexicographic key ordering
 //! - No insignificant whitespace
@@ -31,7 +32,7 @@ use serde::Serialize;
 /// assert_eq!(bytes, br#"{"a":1,"b":2}"#);
 /// ```
 pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>> {
-    serde_jcs::to_vec(value).context("failed to serialize canonical json")
+    assay_canonical::jcs::to_vec(value).context("failed to serialize canonical json")
 }
 
 /// Serialize to JCS Canonical JSON string.
@@ -47,7 +48,7 @@ pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>> {
 /// assert_eq!(s, r#"{"a":2,"z":1}"#);
 /// ```
 pub fn to_string<T: Serialize>(value: &T) -> Result<String> {
-    serde_jcs::to_string(value).context("failed to serialize canonical json string")
+    assay_canonical::jcs::to_string(value).context("failed to serialize canonical json string")
 }
 
 #[cfg(test)]

--- a/crates/assay-evidence/src/mandate/id.rs
+++ b/crates/assay-evidence/src/mandate/id.rs
@@ -13,10 +13,8 @@
 //!
 //! Where `hashable_content` excludes both `mandate_id` and `signature`.
 
-use crate::crypto::jcs;
 use crate::mandate::types::MandateContent;
 use anyhow::{Context as _, Result};
-use sha2::{Digest, Sha256};
 
 /// Compute the mandate_id from mandate content.
 ///
@@ -55,14 +53,7 @@ use sha2::{Digest, Sha256};
 /// assert_eq!(id.len(), 71);
 /// ```
 pub fn compute_mandate_id(content: &MandateContent) -> Result<String> {
-    // Serialize to JCS canonical form
-    let canonical_bytes = jcs::to_vec(content).context("failed to canonicalize mandate content")?;
-
-    // Compute SHA-256
-    let hash = Sha256::digest(&canonical_bytes);
-
-    // Format as sha256:hex
-    Ok(format!("sha256:{}", hex::encode(hash)))
+    assay_canonical::content_id(content).context("failed to compute mandate_id")
 }
 
 /// Verify that a mandate_id matches its content.
@@ -89,10 +80,7 @@ pub fn verify_mandate_id(content: &MandateContent, claimed_id: &str) -> Result<b
 /// transaction_ref = "sha256:" + hex(SHA256(JCS(transaction_object)))
 /// ```
 pub fn compute_transaction_ref<T: serde::Serialize>(transaction: &T) -> Result<String> {
-    let canonical_bytes =
-        jcs::to_vec(transaction).context("failed to canonicalize transaction object")?;
-    let hash = Sha256::digest(&canonical_bytes);
-    Ok(format!("sha256:{}", hex::encode(hash)))
+    assay_canonical::content_id(transaction).context("failed to compute transaction_ref")
 }
 
 #[cfg(test)]

--- a/scripts/ci/check-public-crate-policy.sh
+++ b/scripts/ci/check-public-crate-policy.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 public_crates=(
   assay-common
   assay-registry
+  assay-canonical
   assay-evidence
   assay-core
   assay-metrics
@@ -38,9 +39,6 @@ public_crates=(
 )
 
 non_crates_io_crates=(
-  # publish = false until a published crate depends on it; then it moves to public_crates
-  # and the publish order (same flow as the runner crates).
-  assay-canonical
   assay-adapter-api
   assay-adapter-acp
   assay-adapter-a2a

--- a/scripts/ci/publish_idempotent.sh
+++ b/scripts/ci/publish_idempotent.sh
@@ -18,6 +18,7 @@ echo "📦 Starting Idempotent Publisher..."
 CRATES=(
   "assay-common"
   "assay-registry"
+  "assay-canonical"
   "assay-evidence"
   "assay-core"
   "assay-metrics"


### PR DESCRIPTION
Wires `assay-canonical` (merged in #1737) into `assay-evidence` as the shared canonicalization source, and flips it to a published crate. This is the byte-identical "adopt the module" step; it makes no behaviour change.

## What changes

- `assay-evidence`'s `compute_content_hash`, `compute_mandate_id`, and `compute_transaction_ref` now call `assay_canonical::content_id`; the `crypto::jcs` wrapper delegates to `assay_canonical::jcs`. Same pinned `serde_jcs =0.2.0`, so the canonical bytes and every digest are identical.
- `compute_run_root` and `compute_stream_id` are untouched (run_root is a hash-chain, not a JCS digest).
- `assay-canonical` flips to publishable and is added to the publish order and the public-crate policy before `assay-evidence` (a published crate cannot depend on an unpublished one).

## Acceptance proof: digests unchanged

The mandate golden vectors (`tests/fixtures/mandate_golden_vectors.json`, which pin exact JCS bytes and SHA-256 digests) pass without regeneration. `mandate_golden_test` (7), `mandate_crypto_vectors` (10), the `crypto::id` content-hash tests, and `assay-sim`'s `differential_bundle_matches_legacy_bytes` are all green. The fixture file is not modified by this PR.

## Explicit non-claims

No set-path normalization and no profile binding are wired onto any evidence payload here. `assay_canonical::semantic_digest` is deliberately not called: introducing it would move a digest and is a separate, breaking step (a profiled old/new golden plus an evidence-contract version bump). This PR is purely a deduplication of the existing canonicalization onto a shared, published crate.

## Out of scope

Parallel `sha256(jcs(...))` implementations elsewhere (for example assay-core's transaction-ref and its mcp jcs wrapper) are not consolidated here; that is a separate follow-up.

## Assay-Runner delegated proof

This PR touches the workspace dependency surface (`Cargo.toml` / `Cargo.lock` + publish scripts), so the lane check expects a delegated runner gate. The change does not touch the runner, eBPF, or monitor; the full delegated gate set was run to satisfy the gate.

```text
Assay-Runner delegated proof:
- gate: all
- run: https://github.com/Rul1an/assay/actions/runs/27958186746
- sha: 81f2c780ea114a4cb338f4a86372a617b3d48579
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal canonicalization architecture across crates for improved maintainability.

* **Chores**
  * Updated build and CI configurations to support revised crate structure. All existing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->