### PR TITLE
feat(assay-canonical): typed Error::DuplicateKey + non-exhaustive Error enum

### DIFF
--- a/crates/assay-canonical/src/lib.rs
+++ b/crates/assay-canonical/src/lib.rs
@@ -41,14 +41,24 @@ pub use parse::parse_strict;
 pub use profile::{ensure_supported_profile, semantic_digest, PROFILE};
 
 /// An error from canonicalizing, parsing, or profiling a value.
+///
+/// Non-exhaustive: new parse or canonicalization failure modes can be added without breaking
+/// downstream consumers, so callers should include a wildcard match arm.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// The value could not be serialized to canonical (RFC 8785) JSON.
     #[error("canonicalization failed: {0}")]
     Canonicalize(String),
-    /// Raw JSON could not be parsed under the strict (duplicate-key-rejecting) rules.
+    /// Raw JSON could not be parsed as JSON (malformed syntax). Duplicate object keys are rejected
+    /// too, but surface as the distinct [`Error::DuplicateKey`] so the two can be told apart.
     #[error("strict JSON parse failed: {0}")]
     Parse(String),
+    /// Raw JSON contained a duplicate object key, rejected at any nesting depth; carries the offending
+    /// key. Split out from [`Error::Parse`] so a consumer can distinguish a duplicate-key rejection
+    /// from ordinary malformed JSON without string-matching the error message.
+    #[error("duplicate object key: {0}")]
+    DuplicateKey(String),
     /// A record was produced under a `canonicalization_profile` this build does not implement; a
     /// consumer must fail closed rather than recompute it under the current rules.
     #[error("unknown canonicalization profile: {0}")]

--- a/crates/assay-canonical/src/parse.rs
+++ b/crates/assay-canonical/src/parse.rs
@@ -13,6 +13,13 @@ use serde_json::{Map, Value};
 
 use crate::Error;
 
+/// Marker prefix the strict map visitor stamps onto its custom serde error for a duplicate key.
+/// [`parse_strict`] matches this once, at the parse boundary, to promote the failure to a typed
+/// [`Error::DuplicateKey`] — the only place the marker string is interpreted, so callers never have
+/// to. Producer ([`StrictVisitor::visit_map`]) and consumer ([`parse_strict`]) share this constant
+/// so they cannot drift apart.
+const DUPLICATE_KEY_MARKER: &str = "duplicate object key: ";
+
 /// A [`serde_json::Value`] parsed with duplicate object keys rejected at every depth.
 struct StrictValue(Value);
 
@@ -82,7 +89,7 @@ impl<'de> Visitor<'de> for StrictVisitor {
         while let Some(key) = map.next_key::<String>()? {
             let StrictValue(val) = map.next_value()?;
             if out.insert(key.clone(), val).is_some() {
-                return Err(de::Error::custom(format!("duplicate object key: {key}")));
+                return Err(de::Error::custom(format!("{DUPLICATE_KEY_MARKER}{key}")));
             }
         }
         Ok(Value::Object(out))
@@ -101,7 +108,32 @@ impl<'de> Visitor<'de> for StrictVisitor {
 pub fn parse_strict(raw: &str) -> Result<Value, Error> {
     serde_json::from_str::<StrictValue>(raw)
         .map(|s| s.0)
-        .map_err(|e| Error::Parse(e.to_string()))
+        .map_err(classify_parse_error)
+}
+
+/// Map a `serde_json` failure to the typed [`Error`], promoting the duplicate-key marker stamped by
+/// [`StrictVisitor::visit_map`] to [`Error::DuplicateKey`]; everything else is generic
+/// [`Error::Parse`]. Matching the marker here, once, keeps the message-sniffing at the boundary so
+/// the public API exposes a clean variant instead of a string a caller has to parse.
+fn classify_parse_error(e: serde_json::Error) -> Error {
+    let msg = e.to_string();
+    match duplicate_key(&msg) {
+        Some(key) => Error::DuplicateKey(key),
+        None => Error::Parse(msg),
+    }
+}
+
+/// Recover the offending key from a duplicate-key marker message, or `None` for an ordinary parse
+/// error. `serde_json` appends ` at line L column C` to custom errors; the last such suffix is
+/// trimmed so the variant carries just the key. Classification stays correct even if that suffix
+/// format ever changes — only the trailing trim depends on it.
+fn duplicate_key(msg: &str) -> Option<String> {
+    let rest = msg.strip_prefix(DUPLICATE_KEY_MARKER)?;
+    let key = match rest.rfind(" at line ") {
+        Some(pos) => &rest[..pos],
+        None => rest,
+    };
+    Some(key.to_owned())
 }
 
 #[cfg(test)]
@@ -113,14 +145,29 @@ mod tests {
     fn rejects_top_level_duplicate_keys() {
         assert!(matches!(
             parse_strict(r#"{"a":1,"a":2}"#),
-            Err(Error::Parse(_))
+            Err(Error::DuplicateKey(k)) if k == "a"
         ));
     }
 
     #[test]
     fn rejects_nested_duplicate_keys() {
-        assert!(parse_strict(r#"{"outer":{"k":1,"k":2}}"#).is_err());
-        assert!(parse_strict(r#"{"xs":[{"k":1,"k":2}]}"#).is_err());
+        assert!(matches!(
+            parse_strict(r#"{"outer":{"k":1,"k":2}}"#),
+            Err(Error::DuplicateKey(k)) if k == "k"
+        ));
+        assert!(matches!(
+            parse_strict(r#"{"xs":[{"k":1,"k":2}]}"#),
+            Err(Error::DuplicateKey(k)) if k == "k"
+        ));
+    }
+
+    #[test]
+    fn malformed_json_stays_a_parse_error() {
+        // Ordinary syntax errors must not be reclassified as duplicate-key rejections: the two map
+        // to distinct reason classes downstream.
+        assert!(matches!(parse_strict("{not json"), Err(Error::Parse(_))));
+        assert!(matches!(parse_strict(""), Err(Error::Parse(_))));
+        assert!(matches!(parse_strict(r#"{"a":}"#), Err(Error::Parse(_))));
     }
 
     #[test]


### PR DESCRIPTION
`assay-canonical::parse_strict` already rejects duplicate object keys at every nesting depth, but folds that rejection into `Error::Parse` alongside ordinary malformed JSON. A consumer that wants to treat a duplicate-key rejection differently from a syntax error has to match on the `"duplicate object key"` substring of the error message.

This adds a distinct `Error::DuplicateKey(String)` carrying the offending key, and marks the `Error` enum `#[non_exhaustive]`.

## Typed duplicate-key variant

The duplicate-key signal originates as a serde custom error inside `visit_map`. `parse_strict` now classifies it at the parse boundary through a shared marker constant, so the message string is interpreted in exactly one place and the public API exposes a clean variant. The carried value is just the key — serde_json's appended ` at line L column C` suffix is stripped. Every other JSON syntax error still maps to `Error::Parse`.

## Why `#[non_exhaustive]` now

The crate is publishable but not yet on crates.io, which makes this the free window to mark the enum `#[non_exhaustive]`: once a version is released, adding it — or any new variant — to the public enum would be a breaking API change. With it in place, this variant and any future parse/canonicalization failure modes stay additive instead of forcing a major bump.

## Compatibility

Additive within the workspace — no code matches `assay_canonical::Error` exhaustively (call sites use `content_id` / `jcs` via anyhow `.context()`), and the in-repo consumer `assay-evidence` compiles unchanged. Canonical digests and golden vectors are untouched; duplicate keys are still rejected exactly as before.

## Verification

- `cargo test -p assay-canonical -p assay-evidence` — green
- `cargo clippy -p assay-canonical -p assay-evidence --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added explicit error type for duplicate JSON object keys with dedicated error messages
  * Enhanced error classification to distinguish duplicate-key failures from malformed JSON syntax
  
* **Tests**
  * Expanded test suite with comprehensive coverage for duplicate key detection in top-level and nested JSON structures
  * Verified malformed JSON syntax remains properly classified as parse errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->