### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3877,9 +3877,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
A high-severity RustSec advisory published 2026-06-22 fails the required Dependency Security gate across the whole repo — on `main` and every open PR, not any single change.

- **RUSTSEC-2026-0185** — remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly
- `quinn-proto` 0.11.14 · severity 7.5 (high) · fixed in `>=0.11.15`

`quinn-proto` is a purely transitive dependency (nothing in the workspace manifests pins it), so this is a **lockfile-only** update — `0.11.14` → `0.11.15`, the advisory's fixed version. No manifest, source, or API changes; no other dependency moves.

This clears the Dependency Security gate for `main` and unblocks the open PRs that are otherwise clean.

## Verification

- `cargo update -p quinn-proto --precise 0.11.15` — Cargo.lock only (version + checksum lines)
- `cargo audit --ignore RUSTSEC-2023-0071` — clean (mirrors CI; only the pre-existing allowed warnings remain)


## Delegated lane proof

- gate: all
- head SHA: `4d1d7d0a2efdf5337c5ebc5e2d2f8d35cbef9566`
- Runner Spike Delegated (gates=all, build_ebpf=true): https://github.com/Rul1an/assay/actions/runs/27981010741 (success)
