### PR TITLE
feat(evidence): additive soft semantic_digest + digest_profile on EvidenceEvent

### DIFF
--- a/crates/assay-evidence/src/crypto/id.rs
+++ b/crates/assay-evidence/src/crypto/id.rs
@@ -198,6 +198,30 @@ mod tests {
         );
     }
 
+    /// PR-B: the SOFT semantic_digest / digest_profile are excluded from content_hash, so adding them
+    /// is additive — the hard hash (and therefore verification) is unaffected.
+    #[test]
+    fn test_content_hash_excludes_soft_semantic_digest() {
+        let mut event = EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "run_test",
+            0,
+            serde_json::json!({"foo": "bar"}),
+        );
+        event.time = Utc.timestamp_opt(1700000000, 0).unwrap();
+        let before = compute_content_hash(&event).unwrap();
+
+        event.semantic_digest = Some("sha256:SOFT_VALUE".to_string());
+        event.digest_profile = Some("assay.semantic-digest.jcs-rfc8785.v1".to_string());
+        let after = compute_content_hash(&event).unwrap();
+
+        assert_eq!(
+            before, after,
+            "soft semantic_digest/digest_profile MUST be excluded from content_hash (additive, soft)"
+        );
+    }
+
     /// Verify that content hash is deterministic (same input = same output)
     #[test]
     fn test_content_hash_determinism() {

--- a/crates/assay-evidence/src/types.rs
+++ b/crates/assay-evidence/src/types.rs
@@ -144,6 +144,22 @@ pub struct EvidenceEvent {
     #[serde(rename = "assaycontenthash")]
     pub content_hash: Option<String>,
 
+    /// SOFT correlation digest: a semantic-equivalence digest over the payload, computed via
+    /// [`assay_canonical::semantic_digest`] under `digest_profile`. **Additive and soft** — it is
+    /// excluded from `content_hash` (adding it never moves the hard hash), is never on the verification
+    /// or admission path, and never substitutes the hard `content_hash` / `mandate_id`. A consumer uses
+    /// it only to correlate / group equivalent payloads.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "assaysemanticdigest"
+    )]
+    pub semantic_digest: Option<String>,
+
+    /// The profile under which `semantic_digest` was computed — soft metadata that travels with the
+    /// digest as part of the correlation key (never integrity). `None` when `semantic_digest` is absent.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "assaydigestprofile")]
+    pub digest_profile: Option<String>,
+
     #[serde(rename = "data")]
     pub payload: serde_json::Value,
 }
@@ -180,8 +196,28 @@ impl EvidenceEvent {
             contains_pii: false,
             contains_secrets: false,
             content_hash: None,
+            semantic_digest: None,
+            digest_profile: None,
             payload,
         }
+    }
+
+    /// Attach the SOFT semantic-equivalence digest: a correlation digest over the payload, computed via
+    /// [`assay_canonical::semantic_digest`] under `profile`. Additive and soft — it is excluded from
+    /// `content_hash`, never on the verification/admission path, and never a substitute for the hard
+    /// `content_hash` / `mandate_id`. Errors only if canonicalization fails (e.g. a malformed set value).
+    pub fn with_semantic_digest(
+        mut self,
+        set_paths: &[assay_canonical::set_paths::SetPath],
+        profile: &str,
+    ) -> Result<Self, assay_canonical::Error> {
+        self.semantic_digest = Some(assay_canonical::semantic_digest(
+            &self.payload,
+            set_paths,
+            profile,
+        )?);
+        self.digest_profile = Some(profile.to_string());
+        Ok(self)
     }
 
     /// Set subject
@@ -388,6 +424,73 @@ mod tests {
             serde_json::json!({}),
         );
         assert_eq!(event.specversion, CE_SPECVERSION);
+    }
+
+    #[test]
+    fn with_semantic_digest_sets_soft_pair_set_order_invariant() {
+        // the soft digest IS the assay-canonical semantic_digest over the payload; set order invariant
+        let paths = vec![vec!["passed_keys".to_string()]];
+        let profile = "assay.semantic-digest.jcs-rfc8785.v1";
+        let e1 = EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "r",
+            0,
+            serde_json::json!({"passed_keys": ["B", "A"]}),
+        )
+        .with_semantic_digest(&paths, profile)
+        .unwrap();
+        let e2 = EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "r",
+            1,
+            serde_json::json!({"passed_keys": ["A", "B"]}),
+        )
+        .with_semantic_digest(&paths, profile)
+        .unwrap();
+        assert_eq!(e1.semantic_digest, e2.semantic_digest); // set order does not move the digest
+        assert_eq!(e1.digest_profile.as_deref(), Some(profile));
+        assert!(e1.semantic_digest.as_ref().unwrap().starts_with("sha256:"));
+    }
+
+    #[test]
+    fn soft_pair_absent_is_backwards_compatible() {
+        // a today's event (no soft pair) serializes WITHOUT the soft keys
+        let event = EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "r",
+            0,
+            serde_json::json!({}),
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains("assaysemanticdigest"));
+        assert!(!json.contains("assaydigestprofile"));
+        let back: EvidenceEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.semantic_digest, None);
+        assert_eq!(back.digest_profile, None);
+    }
+
+    #[test]
+    fn soft_pair_round_trips_when_present() {
+        let mut event = EvidenceEvent::new(
+            "assay.test",
+            "urn:assay:test",
+            "r",
+            0,
+            serde_json::json!({}),
+        );
+        event.semantic_digest = Some("sha256:abc".to_string());
+        event.digest_profile = Some("assay.semantic-digest.jcs-rfc8785.v1".to_string());
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("assaysemanticdigest"));
+        let back: EvidenceEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.semantic_digest.as_deref(), Some("sha256:abc"));
+        assert_eq!(
+            back.digest_profile.as_deref(),
+            Some("assay.semantic-digest.jcs-rfc8785.v1")
+        );
     }
 
     #[test]

--- a/crates/assay-evidence/src/types.rs
+++ b/crates/assay-evidence/src/types.rs
@@ -148,7 +148,8 @@ pub struct EvidenceEvent {
     /// [`assay_canonical::semantic_digest`] under `digest_profile`. **Additive and soft** — it is
     /// excluded from `content_hash` (adding it never moves the hard hash), is never on the verification
     /// or admission path, and never substitutes the hard `content_hash` / `mandate_id`. A consumer uses
-    /// it only to correlate / group equivalent payloads.
+    /// it only to correlate / group equivalent payloads. Set this and `digest_profile` together or
+    /// neither — a consumer treats a digest without its profile as uncorrelatable.
     #[serde(
         skip_serializing_if = "Option::is_none",
         rename = "assaysemanticdigest"
@@ -157,6 +158,8 @@ pub struct EvidenceEvent {
 
     /// The profile under which `semantic_digest` was computed — soft metadata that travels with the
     /// digest as part of the correlation key (never integrity). `None` when `semantic_digest` is absent.
+    /// It MUST be scoped to the payload's schema / equivalence subject: a profile reused across
+    /// unrelated payload shapes would let semantically-different payloads correlate falsely.
     #[serde(skip_serializing_if = "Option::is_none", rename = "assaydigestprofile")]
     pub digest_profile: Option<String>,
 
@@ -206,6 +209,9 @@ impl EvidenceEvent {
     /// [`assay_canonical::semantic_digest`] under `profile`. Additive and soft — it is excluded from
     /// `content_hash`, never on the verification/admission path, and never a substitute for the hard
     /// `content_hash` / `mandate_id`. Errors only if canonicalization fails (e.g. a malformed set value).
+    ///
+    /// `profile` MUST be scoped to this payload's schema / equivalence subject — reusing one profile
+    /// across unrelated payload shapes would let semantically-different payloads correlate falsely.
     pub fn with_semantic_digest(
         mut self,
         set_paths: &[assay_canonical::set_paths::SetPath],

--- a/crates/assay-evidence/tests/export_test.rs
+++ b/crates/assay-evidence/tests/export_test.rs
@@ -73,6 +73,8 @@ fn generate_bundle() -> Vec<u8> {
         contains_pii: false,
         contains_secrets: false,
         content_hash: None, // Optional in v1
+        semantic_digest: None,
+        digest_profile: None,
 
         payload: serde_json::json!({"foo": "bar", "baz": 123}),
     };


### PR DESCRIPTION
Adds an **additive, soft** `semantic_digest` (+ `digest_profile`) to `EvidenceEvent` — a semantic-equivalence digest over the payload, carried beside the existing hard `content_hash`. It is a correlation / equivalence overlay, **never** integrity.

## Compose, not an envelope
Two optional fields on the existing event — no new manifest, no new bundle root, no wrapper. They are excluded from `content_hash` (not part of `ContentHashInput`, alongside `id` / `time` / the privacy flags), so adding them never moves the hard hash, and a current event serializes byte-identically (`skip_serializing_if`). The typed event struct is the schema; nothing new to validate.

## Soft, never integrity (claim ceiling)
- `semantic_digest` is a correlation / equivalence digest, computed via `assay_canonical::semantic_digest` (true RFC 8785). It is **never** on the verification or admission path and **never** substitutes the hard `content_hash` / `mandate_id`.
- `digest_profile` travels with the digest as part of the correlation key — soft metadata, never integrity.
- `EvidenceEvent::with_semantic_digest(set_paths, profile)` populates the pair; producers opt in per their schema's set-paths. Absent by default.

## Verification
- New `content_hash` test: setting the soft pair leaves the content hash unchanged (additive) → bundle verification is unaffected.
- Builder computes the assay-canonical `semantic_digest` (set-order invariant); the pair round-trips; absent → backwards-compatible (no soft keys serialized).
- `cargo test -p assay-evidence` green; `clippy -D warnings` and `fmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional “soft” semantic-correlation fields to evidence events (`semantic_digest` and `digest_profile`) to support semantic-equivalence tracking.
  * Added an API to compute and attach semantic digests using customizable profiles and set-path configurations.

* **Tests**
  * Added coverage to confirm semantic digests are deterministic, round-trip through serialization, and remain backward-compatible when absent.
  * Updated bundle export determinism tests to account for the new optional fields.
  * Verified that semantic-related “soft” fields do not affect the event content hash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->