### PR TITLE
chore(release): v3.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.30.0] - 2026-06-23
+
+### Added
+- `assay-canonical` crate: strict JSON parse (rejects duplicate object keys and non-finite constants),
+  RFC 8785 (JCS) canonicalization, content-id digests, registered set-paths, and the semantic-digest
+  profile. First published in this release. (#1737, #1741)
+- `EvidenceEvent` carries an additive, optional `semantic_digest` + `digest_profile` pair — a soft
+  correlation/equivalence overlay alongside the hard `content_hash`, computed via `assay-canonical`
+  (RFC 8785). It is never included in `content_hash`, never on the verify/admission path, and never
+  substitutes `content_hash`/`mandate_id`. Absent by default (omitted from serialization). (#1750)
+
+### Changed
+- `assay-evidence` routes JCS and content-id digests through `assay-canonical` (byte-identical; goldens
+  unchanged). (#1739)
+- `assay-canonical::Error` is `#[non_exhaustive]` and exposes a typed `Error::DuplicateKey` carrying the
+  offending key, distinct from `Error::Parse`. (#1741)
+
+### Security
+- Bump `quinn-proto` to 0.11.15 for RUSTSEC-2026-0185 (remote memory exhaustion from unbounded
+  out-of-order stream reassembly). (#1742)
+
 ## [3.29.0] - 2026-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "aya",
  "chrono",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.29.0"
+version = "3.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1597,7 +1597,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1769,7 +1769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3083,7 +3083,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4450,7 +4450,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4508,7 +4508,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4913,7 +4913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5083,7 +5083,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5096,7 +5096,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5910,7 +5910,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.29.0"
+version = "3.30.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Release **v3.30.0** — bump `[workspace.package]` 3.29.0 → 3.30.0 + `Cargo.lock` + `CHANGELOG.md`.

## What's in 3.30.0
- **`assay-canonical` crate (first publish):** strict JSON parse (duplicate-key + non-finite rejection), RFC 8785 (JCS) canonicalization, content-id digests, registered set-paths, semantic-digest profile. (#1737, #1741)
- **`EvidenceEvent.semantic_digest` + `digest_profile`:** an additive, optional soft correlation/equivalence overlay beside the hard `content_hash` — never included in `content_hash`, never on the verify/admission path, never substitutes `content_hash`/`mandate_id`, absent by default. (#1750)
- `assay-evidence` routes JCS + content-id through `assay-canonical` (byte-identical; goldens unchanged). (#1739)
- `assay-canonical::Error` is `#[non_exhaustive]` + typed `Error::DuplicateKey`. (#1741)
- **Security:** `quinn-proto` → 0.11.15 (RUSTSEC-2026-0185). (#1742)

Minor bump: additive features + a security fix; no breaking changes.

Cargo.* (workspace dependency surface) PR → `lane-check` requires `gates=all`; a `Runner Spike Delegated` proof for the head SHA follows in this body.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v3.30.0

* **New Features**
  * Introduced strict JSON parsing with RFC 8785 JCS canonicalization and content digesting capabilities.

* **Security**
  * Updated dependencies to address remote memory exhaustion vulnerability in stream reassembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Delegated lane proof

- gate: all
- head SHA: `55d0aa97625978e3543c224f8808b3bf226642c6`
- Runner Spike Delegated (gates=all, build_ebpf=true): https://github.com/Rul1an/assay/actions/runs/28012876213 (success)
