### PR TITLE
feat(evidence): add coding-agent evidence primitive

### DIFF
--- a/crates/assay-evidence/src/coding_agent.rs
+++ b/crates/assay-evidence/src/coding_agent.rs
@@ -1,0 +1,145 @@
+//! Coding-agent evidence pack primitives.
+//!
+//! These types model the Assay-side facts for one coding-agent run: declared scope,
+//! observed effects, coverage, source class, and non-claims. They deliberately do not
+//! carry a pass/fail verdict. Downstream consumers may compute a bounded verdict from
+//! these facts, but the evidence event itself stays an observed-effect record.
+
+use crate::crypto::id::compute_content_hash;
+use crate::types::EvidenceEvent;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// Event type for the v0 coding-agent evidence pack payload.
+pub const CODING_AGENT_EVIDENCE_EVENT_TYPE: &str = "assay.coding_agent.evidence_pack.v0";
+
+/// Default event source for coding-agent evidence emitted by Assay.
+pub const CODING_AGENT_EVIDENCE_SOURCE: &str = "urn:assay:coding-agent";
+
+const DEFAULT_NON_CLAIMS: &[&str] = &[
+    "does_not_prove_code_correctness",
+    "does_not_prove_agent_intent",
+    "does_not_replace_human_review",
+];
+
+/// Declared network policy for the coding-agent run.
+///
+/// This is deliberately non-optional: a high-blast-radius surface cannot be omitted from a reviewable
+/// coding-agent evidence pack.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CodingAgentNetworkPolicy {
+    Allowed,
+    Denied,
+}
+
+/// Coverage state for a coding-agent evidence surface.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CodingAgentCoverageState {
+    Observed,
+    Unavailable,
+    SelfReported,
+    Absent,
+    Partial,
+}
+
+/// Source class for the observed effects in a coding-agent evidence pack.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CodingAgentSourceClass {
+    BoundaryObserved,
+    IndependentlyObserved,
+    ThirdPartyObserved,
+    ProducerReported,
+    IssuerAttested,
+    ReceiverReceipt,
+}
+
+/// Declared authorization and scope for one coding-agent run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodingAgentDeclaredScope {
+    pub allowed_files: Vec<String>,
+    pub allowed_commands: Vec<String>,
+    pub network: CodingAgentNetworkPolicy,
+    pub allowed_mcp_tools: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_test_command: Option<String>,
+    pub authorized: bool,
+}
+
+/// Effects observed for one coding-agent run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodingAgentObservedEffects {
+    pub files_changed: Vec<String>,
+    pub commands_executed: Vec<String>,
+    pub network_attempts: Vec<String>,
+    pub mcp_tool_calls: Vec<String>,
+    pub test_observed: bool,
+}
+
+/// Coverage for the core coding-agent surfaces.
+///
+/// A clean downstream verdict should require observed coverage for files, commands, network, and MCP tools.
+/// Test coverage is meaningful when a test command was declared.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodingAgentCoverage {
+    pub files: CodingAgentCoverageState,
+    pub commands: CodingAgentCoverageState,
+    pub network: CodingAgentCoverageState,
+    pub mcp_tools: CodingAgentCoverageState,
+    pub test: CodingAgentCoverageState,
+}
+
+/// Assay-side evidence payload for one coding-agent run.
+///
+/// This payload carries facts and explicit non-claims. It does not carry a verdict or sufficiency conclusion.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodingAgentEvidencePayload {
+    pub declared_scope: CodingAgentDeclaredScope,
+    pub observed_effects: CodingAgentObservedEffects,
+    pub coverage: CodingAgentCoverage,
+    pub source_class: CodingAgentSourceClass,
+    pub non_claims: Vec<String>,
+}
+
+impl CodingAgentEvidencePayload {
+    /// Build a v0 coding-agent evidence payload with the default non-claims.
+    pub fn new(
+        declared_scope: CodingAgentDeclaredScope,
+        observed_effects: CodingAgentObservedEffects,
+        coverage: CodingAgentCoverage,
+        source_class: CodingAgentSourceClass,
+    ) -> Self {
+        Self {
+            declared_scope,
+            observed_effects,
+            coverage,
+            source_class,
+            non_claims: DEFAULT_NON_CLAIMS
+                .iter()
+                .map(|claim| (*claim).to_string())
+                .collect(),
+        }
+    }
+}
+
+/// Create a content-addressed EvidenceEvent carrying a coding-agent evidence payload.
+///
+/// The resulting event contains the typed payload as `data` and computes the hard `content_hash` immediately.
+/// It does not compute or carry any verdict; consumers may review the facts separately.
+pub fn coding_agent_evidence_event(
+    run_id: impl Into<String>,
+    seq: u64,
+    payload: CodingAgentEvidencePayload,
+) -> Result<EvidenceEvent> {
+    let mut event = EvidenceEvent::new(
+        CODING_AGENT_EVIDENCE_EVENT_TYPE,
+        CODING_AGENT_EVIDENCE_SOURCE,
+        run_id,
+        seq,
+        serde_json::to_value(payload)?,
+    );
+    event.content_hash = Some(compute_content_hash(&event)?);
+    Ok(event)
+}

--- a/crates/assay-evidence/src/lib.rs
+++ b/crates/assay-evidence/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod attestation;
 pub mod bundle;
+pub mod coding_agent;
 pub mod crypto;
 pub mod diff;
 pub mod g3_authorization_context;
@@ -18,6 +19,12 @@ pub use bundle::{
     verify_bundle, verify_bundle_with_limits, AlgorithmMeta, BundleInfo, BundleReader,
     BundleWriter, ErrorClass, ErrorCode, FileMeta, Manifest, VerifyError, VerifyLimits,
     VerifyLimitsOverrides, VerifyResult,
+};
+pub use coding_agent::{
+    coding_agent_evidence_event, CodingAgentCoverage, CodingAgentCoverageState,
+    CodingAgentDeclaredScope, CodingAgentEvidencePayload, CodingAgentNetworkPolicy,
+    CodingAgentObservedEffects, CodingAgentSourceClass, CODING_AGENT_EVIDENCE_EVENT_TYPE,
+    CODING_AGENT_EVIDENCE_SOURCE,
 };
 pub use lint::packs::{load_pack, load_packs, LoadedPack, PackError, PackSource};
 pub use ndjson::{read_events, write_events, NdjsonEvents};

--- a/crates/assay-evidence/src/types.rs
+++ b/crates/assay-evidence/src/types.rs
@@ -282,10 +282,11 @@ impl EvidenceEvent {
 // -- Strongly Typed Payload Helpers --
 
 /// Typed payload variants (for convenience, not enforced by contract)
-#[expect(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "payload")]
 pub enum Payload {
+    #[serde(rename = "assay.coding_agent.evidence_pack.v0")]
+    CodingAgentEvidencePack(crate::coding_agent::CodingAgentEvidencePayload),
     #[serde(rename = "assay.env.filtered")]
     EnvFiltered(PayloadEnvFiltered),
     #[serde(rename = "assay.tool.decision")]

--- a/crates/assay-evidence/tests/coding_agent_evidence_pack.rs
+++ b/crates/assay-evidence/tests/coding_agent_evidence_pack.rs
@@ -1,0 +1,138 @@
+use assay_evidence::{
+    coding_agent_evidence_event, types::Payload, CodingAgentCoverage, CodingAgentCoverageState,
+    CodingAgentDeclaredScope, CodingAgentEvidencePayload, CodingAgentNetworkPolicy,
+    CodingAgentObservedEffects, CodingAgentSourceClass, CODING_AGENT_EVIDENCE_EVENT_TYPE,
+};
+use serde_json::json;
+
+fn complete_payload() -> CodingAgentEvidencePayload {
+    CodingAgentEvidencePayload::new(
+        CodingAgentDeclaredScope {
+            allowed_files: vec!["src/foo.py".to_string()],
+            allowed_commands: vec!["pytest".to_string()],
+            network: CodingAgentNetworkPolicy::Denied,
+            allowed_mcp_tools: vec!["fs.read".to_string()],
+            expected_test_command: Some("pytest".to_string()),
+            authorized: true,
+        },
+        CodingAgentObservedEffects {
+            files_changed: vec!["src/foo.py".to_string()],
+            commands_executed: vec!["pytest".to_string()],
+            network_attempts: vec![],
+            mcp_tool_calls: vec!["fs.read".to_string()],
+            test_observed: true,
+        },
+        CodingAgentCoverage {
+            files: CodingAgentCoverageState::Observed,
+            commands: CodingAgentCoverageState::Observed,
+            network: CodingAgentCoverageState::Observed,
+            mcp_tools: CodingAgentCoverageState::Observed,
+            test: CodingAgentCoverageState::Observed,
+        },
+        CodingAgentSourceClass::BoundaryObserved,
+    )
+}
+
+#[test]
+fn coding_agent_payload_serializes_without_verdict_fields() {
+    let payload = complete_payload();
+    let value = serde_json::to_value(&payload).expect("payload should serialize");
+
+    assert!(value.get("schema").is_none());
+    assert_eq!(value["source_class"], "boundary_observed");
+    assert_eq!(value["declared_scope"]["network"], "denied");
+    assert_eq!(value["coverage"]["network"], "observed");
+    assert_eq!(
+        value["non_claims"],
+        json!([
+            "does_not_prove_code_correctness",
+            "does_not_prove_agent_intent",
+            "does_not_replace_human_review"
+        ])
+    );
+    assert!(value.get("verdict").is_none());
+    assert!(value.get("effect_sufficiency").is_none());
+}
+
+#[test]
+fn coding_agent_event_is_content_addressed_and_has_no_verdict() {
+    let event = coding_agent_evidence_event("run_ca", 0, complete_payload())
+        .expect("event should be content-addressed");
+
+    assert_eq!(event.type_, CODING_AGENT_EVIDENCE_EVENT_TYPE);
+    assert_eq!(event.run_id, "run_ca");
+    assert_eq!(event.seq, 0);
+    assert!(event
+        .content_hash
+        .as_deref()
+        .unwrap()
+        .starts_with("sha256:"));
+    assert_eq!(
+        event.content_hash.as_deref(),
+        Some("sha256:47d0f0e367e32403af9d2f53fc7b547fb8c6ba27a4cdd7c532b2d8632af4fe42")
+    );
+
+    let payload = &event.payload;
+    assert!(payload.get("schema").is_none());
+    assert!(payload.get("verdict").is_none());
+    assert!(payload.get("effect_sufficiency").is_none());
+}
+
+#[test]
+fn source_class_is_carried_as_input_not_collapsed_to_verdict() {
+    let mut payload = complete_payload();
+    payload.source_class = CodingAgentSourceClass::ProducerReported;
+
+    let event = coding_agent_evidence_event("run_ca", 1, payload)
+        .expect("producer-reported payload should still be recordable evidence");
+
+    assert_eq!(event.payload["source_class"], "producer_reported");
+    assert!(event.payload.get("verdict").is_none());
+}
+
+#[test]
+fn observed_absence_is_explicit_coverage_not_missing_field() {
+    let mut payload = complete_payload();
+    payload.coverage.network = CodingAgentCoverageState::Absent;
+    payload.observed_effects.network_attempts = vec![];
+
+    let event = coding_agent_evidence_event("run_ca", 2, payload)
+        .expect("absence coverage should serialize as explicit input");
+
+    assert_eq!(event.payload["coverage"]["network"], "absent");
+    assert_eq!(
+        event.payload["observed_effects"]["network_attempts"],
+        json!([])
+    );
+}
+
+#[test]
+fn expected_test_command_none_is_omitted() {
+    let mut payload = complete_payload();
+    payload.declared_scope.expected_test_command = None;
+
+    let event = coding_agent_evidence_event("run_ca", 3, payload)
+        .expect("payload without expected test command should serialize");
+
+    assert!(event.payload["declared_scope"]
+        .get("expected_test_command")
+        .is_none());
+}
+
+#[test]
+fn coding_agent_payload_is_available_through_typed_payload_enum() {
+    let tagged = json!({
+        "type": CODING_AGENT_EVIDENCE_EVENT_TYPE,
+        "payload": complete_payload()
+    });
+
+    let payload: Payload =
+        serde_json::from_value(tagged).expect("typed payload should deserialize");
+
+    match payload {
+        Payload::CodingAgentEvidencePack(inner) => {
+            assert_eq!(inner.source_class, CodingAgentSourceClass::BoundaryObserved);
+        }
+        other => panic!("expected CodingAgentEvidencePack payload, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Adds the v0 coding-agent evidence primitive to `assay-evidence`:

- `assay.coding_agent.evidence_pack.v0` payload types for declared scope, observed effects, coverage, source class, and non-claims
- a `coding_agent_evidence_event(...)` helper that emits a content-addressed `EvidenceEvent`
- a typed `Payload::CodingAgentEvidencePack` variant for serde round-trips

This is deliberately Assay-side capture only. It records review inputs; it does not compute or carry a pass/fail verdict, effect sufficiency result, or policy decision. Downstream consumers can compute bounded verdicts from the captured facts.

## Contract boundaries

- `content_hash` is computed immediately for the emitted event.
- the payload does not embed a duplicate `schema` field; the CloudEvents `type` / typed payload tag is the schema identity.
- `network` is mandatory in both declared scope and coverage.
- coverage and source class are carried as first-class inputs.
- observed absence is represented explicitly (`coverage.network = absent` plus `network_attempts = []`), never by dropping the field.
- default non-claims state that the record does not prove code correctness, agent intent, or replace human review.

## Verification

- `cargo fmt --check`
- `cargo clippy -p assay-evidence --all-targets -- -D warnings`
- `cargo test -p assay-evidence --test coding_agent_evidence_pack`
- `cargo test -p assay-evidence`
- pre-push hooks: workspace clippy + linux compile gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new coding-agent evidence pack (v0) with structured declared scope, observed effects, coverage, and non-claims.
  * Introduced a content-addressed evidence event helper for this payload type.

* **Bug Fixes**
  * Improved typed payload serialization/deserialization for the new evidence pack variant.
  * Ensured source classification is preserved, and correctly handled absent network coverage and optional test-command omission.

* **Tests**
  * Added tests covering JSON serialization, payload variant recognition, and content-hash behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->