### PR TITLE
chore(release): v3.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.31.0] - 2026-06-24
+
+### Added
+- `assay.coding_agent.evidence_pack.v0` evidence primitive in `assay-evidence`: a typed payload for one
+  coding-agent run (declared scope, observed effects, per-surface coverage, source class, non-claims) plus a
+  `coding_agent_evidence_event(...)` helper that sets the hard `content_hash`. Facts only: no verdict, no
+  effect-sufficiency, no policy decision (those stay downstream). `network` is required in the declared scope
+  and in coverage; observed absence stays explicit, never a missing field. (#1754)
+
 ## [3.30.0] - 2026-06-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-a2a"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-acp"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-api"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "assay-evidence",
  "hex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "assay-adapter-ucp"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "assay-adapter-api",
  "assay-evidence",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "assay-canonical"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "hex",
  "serde",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "assay-cli"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "assay-common"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "aya",
  "chrono",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "assay-core"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "assay-ebpf"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "assay-common",
  "aya-ebpf",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "assay-evidence"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "assay-canonical",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "assay-it"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "assay-core",
  "pyo3",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "assay-mcp-server"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "assay-metrics"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "assay-monitor"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "assay-common",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "assay-policy"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "assay-registry"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-core"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "assay-common",
  "assay-monitor",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-linux"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "assay-runner-schema"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "assay-sim"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "assay-adapter-api",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "assay-xtask"
-version = "3.30.0"
+version = "3.31.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ print_stdout = "allow"
 missing_errors_doc = "allow"
 
 [workspace.package]
-version = "3.30.0"
+version = "3.31.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Rul1an/assay"


### PR DESCRIPTION
Version bump 3.30.0 -> 3.31.0 for the v3.31.0 feature release: the `assay.coding_agent.evidence_pack.v0` evidence primitive in `assay-evidence` (from #1754).

## What
- Bumped `[workspace.package].version` (all 21 crates inherit it) and `Cargo.lock` (21 workspace entries 3.30.0 -> 3.31.0). `cargo metadata --offline` confirms lock <-> manifest consistency.
- CHANGELOG: added the v3.31.0 entry.

## Release contents (per CHANGELOG)
The `assay.coding_agent.evidence_pack.v0` primitive: a typed payload for one coding-agent run (declared scope, observed effects, per-surface coverage, source class, non-claims) + a `coding_agent_evidence_event(...)` helper that sets the hard `content_hash`. Facts only: no verdict, no effect-sufficiency, no policy decision. `network` is required in declared scope and coverage.

## Delegated lane proof
Cargo.* (workspace dependency surface) PR -> `lane-check` requires `gates=all` with a `Runner Spike Delegated` proof for the head SHA.
- gate: all
- head SHA: 98f91221608946a52cda2ce68d8fb558618aefbf
- Runner Spike Delegated (gates=all, build_ebpf=true): https://github.com/Rul1an/assay/actions/runs/28119872173 (success)

## Publish step (yours)
After merge, pushing the `v3.31.0` tag triggers `release.yml` (publishes the crates to crates.io + PyPI, and the GitHub release with SBOM / provenance / proof-kit / MCPB). Holding this PR for you to merge and push the tag.
