### PR TITLE
feat: add gateway evidence replay mvp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,6 +2050,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway-evidence-replay"
+version = "3.31.1"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "assay-python-sdk", "crates/assay-policy", "crates/assay-evidence", "crates/assay-sim",
   "crates/assay-registry",
   "crates/assay-canonical",
+  "crates/gateway-evidence-replay",
   "crates/assay-runner-schema",
   "crates/assay-runner-core",
   "crates/assay-runner-linux",

--- a/crates/gateway-evidence-replay/Cargo.toml
+++ b/crates/gateway-evidence-replay/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
 name = "gateway-evidence-replay"
+# Internal/experimental MVP: a CLI binary shipped via release artifacts, not crates.io. Not a public
+# crate surface (publishing one is a deliberate Gate-D decision); registered in
+# scripts/ci/check-public-crate-policy.sh non_crates_io_crates.
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/gateway-evidence-replay/Cargo.toml
+++ b/crates/gateway-evidence-replay/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "gateway-evidence-replay"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Deterministic replay verifier for gateway-path evidence bundles."
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "gateway-evidence-replay"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+chrono = { workspace = true, features = ["std"] }
+clap.workspace = true
+serde = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/gateway-evidence-replay/README.md
+++ b/crates/gateway-evidence-replay/README.md
@@ -1,0 +1,18 @@
+# Gateway Evidence Replay
+
+`gateway-evidence-replay` is a small offline verifier for `gateway-path.v0` evidence bundles.
+
+It replays retained gateway-path facts: requested route, disclosed fallback, endpoint, policy hash, stream commitment, coverage, source class, and freshness of gateway evidence. It emits a bounded verdict:
+
+- `path_verified`
+- `path_mismatch`
+- `incomplete`
+- `invalid`
+
+Example:
+
+```bash
+gateway-evidence-replay verify fixtures/gateway-path-v0/clean-route.json --format gateway-path.v0 --json
+```
+
+This crate does not run a gateway, call a provider, verify a TEE root, or decide response truth. Signature verification and runtime-measurement verification are input facts in the evidence bundle. The verifier recomputes only whether the retained evidence is sufficient to support the gateway-path claim.

--- a/crates/gateway-evidence-replay/fixtures/gateway-path-v0/clean-route.json
+++ b/crates/gateway-evidence-replay/fixtures/gateway-path-v0/clean-route.json
@@ -1,0 +1,33 @@
+{
+  "request_id": "req-001",
+  "coverage": "complete",
+  "source_class": "boundary_observed",
+  "now": "2026-06-28T10:00:00Z",
+  "claim": {
+    "requested_route": "openai:gpt-4.1",
+    "expected_fallback": null,
+    "expected_endpoint": "https://api.openai.example/v1/responses",
+    "expected_stream_commitment": "stream:aaa"
+  },
+  "policy": {
+    "allowed_routes": [
+      "openai:gpt-4.1"
+    ],
+    "allowed_fallbacks": [
+      "anthropic:claude-4-sonnet"
+    ],
+    "endpoint": "https://api.openai.example/v1/responses",
+    "policy_hash": "sha256:policy-a"
+  },
+  "evidence": {
+    "signature_verified": true,
+    "runtime_measurement_verified": true,
+    "attestation_valid_until": "2026-06-28T10:05:00Z",
+    "selected_route": "openai:gpt-4.1",
+    "fallback_route": null,
+    "endpoint": "https://api.openai.example/v1/responses",
+    "policy_hash": "sha256:policy-a",
+    "stream_commitment": "stream:aaa"
+  },
+  "profile": "gateway-path.v0"
+}

--- a/crates/gateway-evidence-replay/fixtures/gateway-path-v0/vectors.json
+++ b/crates/gateway-evidence-replay/fixtures/gateway-path-v0/vectors.json
@@ -471,6 +471,165 @@
       ]
     },
     {
+      "vector_id": "gw_partial_route_substitution_mismatch",
+      "inputs": {
+        "request_id": "req-014",
+        "coverage": "partial",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:nnn"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-n"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "local:cheap-model",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-n",
+          "stream_commitment": "stream:nnn"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "path_mismatch",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "route_not_allowed",
+        "route_substitution"
+      ]
+    },
+    {
+      "vector_id": "gw_partial_hidden_fallback_mismatch",
+      "inputs": {
+        "request_id": "req-015",
+        "coverage": "partial",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:ooo"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [
+            "anthropic:claude-4-sonnet"
+          ],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-o"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": "anthropic:claude-4-sonnet",
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-o",
+          "stream_commitment": "stream:ooo"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "path_mismatch",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "fallback_mismatch"
+      ]
+    },
+    {
+      "vector_id": "gw_unknown_source_with_mismatch_invalid",
+      "inputs": {
+        "request_id": "req-016",
+        "coverage": "complete",
+        "source_class": "gateway_self_claimed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:ppp"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-p"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "local:cheap-model",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-p",
+          "stream_commitment": "stream:ppp"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "invalid",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "unknown_source_class"
+      ]
+    },
+    {
+      "vector_id": "gw_malformed_attestation_timestamp_invalid",
+      "inputs": {
+        "request_id": "req-017",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:qqq"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-q"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28 10:05:00",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-q",
+          "stream_commitment": "stream:qqq"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "invalid",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "malformed_input"
+      ]
+    },
+    {
       "vector_id": "gw_malformed_top_level_invalid",
       "inputs": "not-an-object",
       "expected_status": "invalid",

--- a/crates/gateway-evidence-replay/fixtures/gateway-path-v0/vectors.json
+++ b/crates/gateway-evidence-replay/fixtures/gateway-path-v0/vectors.json
@@ -1,0 +1,483 @@
+{
+  "vectors": [
+    {
+      "vector_id": "gw_clean_route_verified",
+      "inputs": {
+        "request_id": "req-001",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:aaa"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [
+            "anthropic:claude-4-sonnet"
+          ],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-a"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-a",
+          "stream_commitment": "stream:aaa"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "path_verified",
+      "expected_ceiling": "observed_in_path",
+      "expected_reasons": []
+    },
+    {
+      "vector_id": "gw_disclosed_allowed_fallback_verified",
+      "inputs": {
+        "request_id": "req-002",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": "anthropic:claude-4-sonnet",
+          "expected_endpoint": "https://api.anthropic.example/v1/messages",
+          "expected_stream_commitment": "stream:bbb"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [
+            "anthropic:claude-4-sonnet"
+          ],
+          "endpoint": "https://api.anthropic.example/v1/messages",
+          "policy_hash": "sha256:policy-b"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": "anthropic:claude-4-sonnet",
+          "endpoint": "https://api.anthropic.example/v1/messages",
+          "policy_hash": "sha256:policy-b",
+          "stream_commitment": "stream:bbb"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "path_verified",
+      "expected_ceiling": "observed_in_path",
+      "expected_reasons": []
+    },
+    {
+      "vector_id": "gw_hidden_fallback_mismatch",
+      "inputs": {
+        "request_id": "req-003",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:ccc"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [
+            "anthropic:claude-4-sonnet"
+          ],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-c"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": "anthropic:claude-4-sonnet",
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-c",
+          "stream_commitment": "stream:ccc"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "path_mismatch",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "fallback_mismatch"
+      ]
+    },
+    {
+      "vector_id": "gw_route_substitution_mismatch",
+      "inputs": {
+        "request_id": "req-004",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:ddd"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-d"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "local:cheap-model",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-d",
+          "stream_commitment": "stream:ddd"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "path_mismatch",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "route_not_allowed",
+        "route_substitution"
+      ]
+    },
+    {
+      "vector_id": "gw_endpoint_mismatch",
+      "inputs": {
+        "request_id": "req-005",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:eee"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-e"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://proxy.example/v1/responses",
+          "policy_hash": "sha256:policy-e",
+          "stream_commitment": "stream:eee"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "path_mismatch",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "endpoint_mismatch"
+      ]
+    },
+    {
+      "vector_id": "gw_stale_attestation_incomplete",
+      "inputs": {
+        "request_id": "req-006",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:fff"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-f"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T09:59:59Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-f",
+          "stream_commitment": "stream:fff"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "incomplete",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "attestation_stale"
+      ]
+    },
+    {
+      "vector_id": "gw_stream_commitment_mismatch",
+      "inputs": {
+        "request_id": "req-007",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:expected"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-g"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-g",
+          "stream_commitment": "stream:actual"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "path_mismatch",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "stream_commitment_mismatch"
+      ]
+    },
+    {
+      "vector_id": "gw_missing_stream_evidence_incomplete",
+      "inputs": {
+        "request_id": "req-008",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:hhh"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-h"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-h"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "incomplete",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "stream_evidence_missing"
+      ]
+    },
+    {
+      "vector_id": "gw_policy_hash_mismatch",
+      "inputs": {
+        "request_id": "req-009",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:iii"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-i"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-other",
+          "stream_commitment": "stream:iii"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "path_mismatch",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "policy_hash_mismatch"
+      ]
+    },
+    {
+      "vector_id": "gw_unverified_runtime_incomplete",
+      "inputs": {
+        "request_id": "req-010",
+        "coverage": "complete",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:jjj"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-j"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": false,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-j",
+          "stream_commitment": "stream:jjj"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "incomplete",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "evidence_not_verified"
+      ]
+    },
+    {
+      "vector_id": "gw_partial_coverage_incomplete",
+      "inputs": {
+        "request_id": "req-011",
+        "coverage": "partial",
+        "source_class": "boundary_observed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:kkk"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-k"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-k",
+          "stream_commitment": "stream:kkk"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "incomplete",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "coverage_not_complete"
+      ]
+    },
+    {
+      "vector_id": "gw_unknown_source_invalid",
+      "inputs": {
+        "request_id": "req-012",
+        "coverage": "complete",
+        "source_class": "gateway_self_claimed",
+        "now": "2026-06-28T10:00:00Z",
+        "claim": {
+          "requested_route": "openai:gpt-4.1",
+          "expected_fallback": null,
+          "expected_endpoint": "https://api.openai.example/v1/responses",
+          "expected_stream_commitment": "stream:lll"
+        },
+        "policy": {
+          "allowed_routes": [
+            "openai:gpt-4.1"
+          ],
+          "allowed_fallbacks": [],
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-l"
+        },
+        "evidence": {
+          "signature_verified": true,
+          "runtime_measurement_verified": true,
+          "attestation_valid_until": "2026-06-28T10:05:00Z",
+          "selected_route": "openai:gpt-4.1",
+          "fallback_route": null,
+          "endpoint": "https://api.openai.example/v1/responses",
+          "policy_hash": "sha256:policy-l",
+          "stream_commitment": "stream:lll"
+        },
+        "profile": "gateway-path.v0"
+      },
+      "expected_status": "invalid",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "unknown_source_class"
+      ]
+    },
+    {
+      "vector_id": "gw_malformed_top_level_invalid",
+      "inputs": "not-an-object",
+      "expected_status": "invalid",
+      "expected_ceiling": null,
+      "expected_reasons": [
+        "malformed_input"
+      ]
+    }
+  ]
+}

--- a/crates/gateway-evidence-replay/src/lib.rs
+++ b/crates/gateway-evidence-replay/src/lib.rs
@@ -1,0 +1,9 @@
+//! Deterministic replay verifier for `gateway-path.v0` evidence bundles.
+
+pub mod replay;
+pub mod schema;
+
+pub use replay::{verify_bundle, verify_json_str, verify_json_value, VerifyError};
+pub use schema::{
+    Ceiling, EvidenceBundle, NonClaim, Reason, ReplayResult, SourceClass, Status, PROFILE,
+};

--- a/crates/gateway-evidence-replay/src/main.rs
+++ b/crates/gateway-evidence-replay/src/main.rs
@@ -1,0 +1,62 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use gateway_evidence_replay::schema::PROFILE;
+use gateway_evidence_replay::{verify_json_str, ReplayResult};
+
+#[derive(Debug, Parser)]
+#[command(name = "gateway-evidence-replay")]
+#[command(about = "Verify gateway-path evidence bundles offline")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    Verify {
+        evidence: PathBuf,
+        #[arg(long, default_value = PROFILE)]
+        format: String,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Verify {
+            evidence,
+            format,
+            json,
+        } => verify_command(evidence, &format, json),
+    }
+}
+
+fn verify_command(evidence: PathBuf, format: &str, json: bool) -> Result<()> {
+    let result = if format == PROFILE {
+        let contents = fs::read_to_string(&evidence)
+            .with_context(|| format!("failed to read evidence file {}", evidence.display()))?;
+        verify_json_str(&contents)
+    } else {
+        ReplayResult::invalid()
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!(
+            "{} ceiling={}",
+            serde_json::to_string(&result.status)?,
+            result
+                .ceiling
+                .map(|ceiling| serde_json::to_string(&ceiling).unwrap_or_default())
+                .unwrap_or_else(|| "null".to_string())
+        );
+    }
+
+    Ok(())
+}

--- a/crates/gateway-evidence-replay/src/replay.rs
+++ b/crates/gateway-evidence-replay/src/replay.rs
@@ -28,9 +28,9 @@ pub fn verify_bundle(bundle: &EvidenceBundle) -> ReplayResult {
         return ReplayResult::invalid();
     }
 
-    if bundle.coverage != Coverage::Complete {
-        return ReplayResult::new(Status::Incomplete, None, vec![Reason::CoverageNotComplete]);
-    }
+    let Some(ceiling) = bundle.source_class.ceiling() else {
+        return ReplayResult::new(Status::Invalid, None, vec![Reason::UnknownSourceClass]);
+    };
 
     let evidence = &bundle.evidence;
     if !evidence.signature_verified || !evidence.runtime_measurement_verified {
@@ -49,14 +49,6 @@ pub fn verify_bundle(bundle: &EvidenceBundle) -> ReplayResult {
     };
     if valid_until < now {
         return ReplayResult::new(Status::Incomplete, None, vec![Reason::AttestationStale]);
-    }
-
-    if evidence.stream_commitment.is_none() {
-        return ReplayResult::new(
-            Status::Incomplete,
-            None,
-            vec![Reason::StreamEvidenceMissing],
-        );
     }
 
     let mut mismatches = Vec::new();
@@ -93,7 +85,9 @@ pub fn verify_bundle(bundle: &EvidenceBundle) -> ReplayResult {
         mismatches.push(Reason::PolicyHashMismatch);
     }
     if let Some(expected_stream) = bundle.claim.expected_stream_commitment.as_ref() {
-        if evidence.stream_commitment.as_deref() != Some(expected_stream.as_str()) {
+        if evidence.stream_commitment.is_some()
+            && evidence.stream_commitment.as_deref() != Some(expected_stream.as_str())
+        {
             mismatches.push(Reason::StreamCommitmentMismatch);
         }
     }
@@ -102,9 +96,17 @@ pub fn verify_bundle(bundle: &EvidenceBundle) -> ReplayResult {
         return ReplayResult::new(Status::PathMismatch, None, mismatches);
     }
 
-    let Some(ceiling) = bundle.source_class.ceiling() else {
-        return ReplayResult::new(Status::Invalid, None, vec![Reason::UnknownSourceClass]);
-    };
+    if evidence.stream_commitment.is_none() {
+        return ReplayResult::new(
+            Status::Incomplete,
+            None,
+            vec![Reason::StreamEvidenceMissing],
+        );
+    }
+
+    if bundle.coverage != Coverage::Complete {
+        return ReplayResult::new(Status::Incomplete, None, vec![Reason::CoverageNotComplete]);
+    }
 
     ReplayResult::new(Status::PathVerified, Some(ceiling), Vec::new())
 }

--- a/crates/gateway-evidence-replay/src/replay.rs
+++ b/crates/gateway-evidence-replay/src/replay.rs
@@ -1,0 +1,110 @@
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::schema::{Coverage, EvidenceBundle, Reason, ReplayResult, Status};
+
+#[derive(Debug, Error)]
+pub enum VerifyError {
+    #[error("failed to decode JSON evidence: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+pub fn verify_json_value(value: Value) -> ReplayResult {
+    let Ok(bundle) = serde_json::from_value::<EvidenceBundle>(value) else {
+        return ReplayResult::invalid();
+    };
+    verify_bundle(&bundle)
+}
+
+pub fn verify_json_str(value: &str) -> ReplayResult {
+    match serde_json::from_str::<Value>(value) {
+        Ok(value) => verify_json_value(value),
+        Err(_) => ReplayResult::invalid(),
+    }
+}
+
+pub fn verify_bundle(bundle: &EvidenceBundle) -> ReplayResult {
+    if bundle.validate_shape().is_err() {
+        return ReplayResult::invalid();
+    }
+
+    if bundle.coverage != Coverage::Complete {
+        return ReplayResult::new(Status::Incomplete, None, vec![Reason::CoverageNotComplete]);
+    }
+
+    let evidence = &bundle.evidence;
+    if !evidence.signature_verified || !evidence.runtime_measurement_verified {
+        return ReplayResult::new(Status::Incomplete, None, vec![Reason::EvidenceNotVerified]);
+    }
+
+    let Some(valid_until) = evidence.attestation_valid_until_utc() else {
+        return ReplayResult::new(
+            Status::Incomplete,
+            None,
+            vec![Reason::AttestationFreshnessMissing],
+        );
+    };
+    let Ok(now) = bundle.now_utc() else {
+        return ReplayResult::invalid();
+    };
+    if valid_until < now {
+        return ReplayResult::new(Status::Incomplete, None, vec![Reason::AttestationStale]);
+    }
+
+    if evidence.stream_commitment.is_none() {
+        return ReplayResult::new(
+            Status::Incomplete,
+            None,
+            vec![Reason::StreamEvidenceMissing],
+        );
+    }
+
+    let mut mismatches = Vec::new();
+    if evidence.selected_route != bundle.claim.requested_route {
+        mismatches.push(Reason::RouteSubstitution);
+    }
+    if !bundle
+        .policy
+        .allowed_routes
+        .iter()
+        .any(|route| route == &evidence.selected_route)
+    {
+        mismatches.push(Reason::RouteNotAllowed);
+    }
+    if evidence.fallback_route != bundle.claim.expected_fallback {
+        mismatches.push(Reason::FallbackMismatch);
+    }
+    if let Some(fallback_route) = evidence.fallback_route.as_ref() {
+        if !bundle
+            .policy
+            .allowed_fallbacks
+            .iter()
+            .any(|allowed| allowed == fallback_route)
+        {
+            mismatches.push(Reason::FallbackNotAllowed);
+        }
+    }
+    if evidence.endpoint.as_deref() != Some(bundle.policy.endpoint.as_str())
+        || evidence.endpoint.as_deref() != Some(bundle.claim.expected_endpoint.as_str())
+    {
+        mismatches.push(Reason::EndpointMismatch);
+    }
+    if evidence.policy_hash.as_deref() != Some(bundle.policy.policy_hash.as_str()) {
+        mismatches.push(Reason::PolicyHashMismatch);
+    }
+    if let Some(expected_stream) = bundle.claim.expected_stream_commitment.as_ref() {
+        if evidence.stream_commitment.as_deref() != Some(expected_stream.as_str()) {
+            mismatches.push(Reason::StreamCommitmentMismatch);
+        }
+    }
+
+    if !mismatches.is_empty() {
+        return ReplayResult::new(Status::PathMismatch, None, mismatches);
+    }
+
+    let Some(ceiling) = bundle.source_class.ceiling() else {
+        return ReplayResult::new(Status::Invalid, None, vec![Reason::UnknownSourceClass]);
+    };
+
+    ReplayResult::new(Status::PathVerified, Some(ceiling), Vec::new())
+}

--- a/crates/gateway-evidence-replay/src/schema.rs
+++ b/crates/gateway-evidence-replay/src/schema.rs
@@ -1,0 +1,313 @@
+use std::cmp::Ordering;
+use std::fmt;
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const PROFILE: &str = "gateway-path.v0";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Coverage {
+    Complete,
+    Partial,
+    Absent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceClass {
+    ProducerReported,
+    IssuerAttested,
+    ReceiverReceipt,
+    BoundaryObserved,
+    ThirdPartyObserved,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+pub enum Ceiling {
+    Asserted,
+    AssertedSigned,
+    ObservedAtReceiver,
+    ObservedInPath,
+    IndependentlyConfirmed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    PathVerified,
+    PathMismatch,
+    Incomplete,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+pub enum Reason {
+    RouteSubstitution,
+    RouteNotAllowed,
+    FallbackMismatch,
+    FallbackNotAllowed,
+    EndpointMismatch,
+    PolicyHashMismatch,
+    StreamCommitmentMismatch,
+    AttestationStale,
+    AttestationFreshnessMissing,
+    StreamEvidenceMissing,
+    EvidenceNotVerified,
+    CoverageNotComplete,
+    MalformedInput,
+    UnknownSourceClass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+pub enum NonClaim {
+    NotGatewayEnforcement,
+    NotProviderHonesty,
+    NotResponseTruth,
+    NotTeeRootVerification,
+    NotSafetyOrCompliance,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayResult {
+    pub profile: &'static str,
+    pub status: Status,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ceiling: Option<Ceiling>,
+    pub reasons: Vec<Reason>,
+    pub non_claims: Vec<NonClaim>,
+}
+
+impl ReplayResult {
+    pub fn new(status: Status, ceiling: Option<Ceiling>, mut reasons: Vec<Reason>) -> Self {
+        reasons.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        reasons.dedup();
+        Self {
+            profile: PROFILE,
+            status,
+            ceiling,
+            reasons,
+            non_claims: NonClaim::all().to_vec(),
+        }
+    }
+
+    pub fn invalid() -> Self {
+        Self::new(Status::Invalid, None, vec![Reason::MalformedInput])
+    }
+}
+
+impl Reason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Reason::RouteSubstitution => "route_substitution",
+            Reason::RouteNotAllowed => "route_not_allowed",
+            Reason::FallbackMismatch => "fallback_mismatch",
+            Reason::FallbackNotAllowed => "fallback_not_allowed",
+            Reason::EndpointMismatch => "endpoint_mismatch",
+            Reason::PolicyHashMismatch => "policy_hash_mismatch",
+            Reason::StreamCommitmentMismatch => "stream_commitment_mismatch",
+            Reason::AttestationStale => "attestation_stale",
+            Reason::AttestationFreshnessMissing => "attestation_freshness_missing",
+            Reason::StreamEvidenceMissing => "stream_evidence_missing",
+            Reason::EvidenceNotVerified => "evidence_not_verified",
+            Reason::CoverageNotComplete => "coverage_not_complete",
+            Reason::MalformedInput => "malformed_input",
+            Reason::UnknownSourceClass => "unknown_source_class",
+        }
+    }
+}
+
+impl NonClaim {
+    pub const fn all() -> &'static [NonClaim] {
+        &[
+            NonClaim::NotGatewayEnforcement,
+            NonClaim::NotProviderHonesty,
+            NonClaim::NotResponseTruth,
+            NonClaim::NotTeeRootVerification,
+            NonClaim::NotSafetyOrCompliance,
+        ]
+    }
+}
+
+impl SourceClass {
+    pub const fn ceiling(self) -> Option<Ceiling> {
+        match self {
+            SourceClass::ProducerReported => Some(Ceiling::Asserted),
+            SourceClass::IssuerAttested => Some(Ceiling::AssertedSigned),
+            SourceClass::ReceiverReceipt => Some(Ceiling::ObservedAtReceiver),
+            SourceClass::BoundaryObserved => Some(Ceiling::ObservedInPath),
+            SourceClass::ThirdPartyObserved => Some(Ceiling::IndependentlyConfirmed),
+            SourceClass::Unknown => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvidenceBundle {
+    pub profile: String,
+    pub request_id: String,
+    pub coverage: Coverage,
+    pub source_class: SourceClass,
+    pub now: String,
+    pub claim: Claim,
+    pub policy: Policy,
+    pub evidence: Evidence,
+}
+
+impl EvidenceBundle {
+    pub fn validate_shape(&self) -> Result<(), ShapeError> {
+        if self.profile != PROFILE {
+            return Err(ShapeError);
+        }
+        require_nonempty(&self.request_id)?;
+        parse_utc(&self.now)?;
+        self.claim.validate_shape()?;
+        self.policy.validate_shape()?;
+        self.evidence.validate_shape()?;
+        Ok(())
+    }
+
+    pub fn now_utc(&self) -> Result<DateTime<Utc>, ShapeError> {
+        parse_utc(&self.now)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Claim {
+    pub requested_route: String,
+    pub expected_fallback: Option<String>,
+    pub expected_endpoint: String,
+    pub expected_stream_commitment: Option<String>,
+}
+
+impl Claim {
+    fn validate_shape(&self) -> Result<(), ShapeError> {
+        require_nonempty(&self.requested_route)?;
+        require_optional_nonempty(self.expected_fallback.as_deref())?;
+        require_nonempty(&self.expected_endpoint)?;
+        require_optional_nonempty(self.expected_stream_commitment.as_deref())?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Policy {
+    pub allowed_routes: Vec<String>,
+    pub allowed_fallbacks: Vec<String>,
+    pub endpoint: String,
+    pub policy_hash: String,
+}
+
+impl Policy {
+    fn validate_shape(&self) -> Result<(), ShapeError> {
+        require_nonempty_list(&self.allowed_routes)?;
+        require_nonempty_list_allow_empty(&self.allowed_fallbacks)?;
+        require_nonempty(&self.endpoint)?;
+        require_nonempty(&self.policy_hash)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Evidence {
+    pub signature_verified: bool,
+    pub runtime_measurement_verified: bool,
+    pub attestation_valid_until: Option<String>,
+    pub selected_route: String,
+    pub fallback_route: Option<String>,
+    pub endpoint: Option<String>,
+    pub policy_hash: Option<String>,
+    pub stream_commitment: Option<String>,
+}
+
+impl Evidence {
+    fn validate_shape(&self) -> Result<(), ShapeError> {
+        require_optional_nonempty(self.attestation_valid_until.as_deref())?;
+        require_nonempty(&self.selected_route)?;
+        require_optional_nonempty(self.fallback_route.as_deref())?;
+        require_optional_nonempty(self.endpoint.as_deref())?;
+        require_optional_nonempty(self.policy_hash.as_deref())?;
+        require_optional_nonempty(self.stream_commitment.as_deref())?;
+        Ok(())
+    }
+
+    pub fn attestation_valid_until_utc(&self) -> Option<DateTime<Utc>> {
+        self.attestation_valid_until
+            .as_deref()
+            .and_then(|value| parse_utc(value).ok())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShapeError;
+
+impl fmt::Display for ShapeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("malformed gateway-path evidence")
+    }
+}
+
+impl std::error::Error for ShapeError {}
+
+pub fn parse_utc(value: &str) -> Result<DateTime<Utc>, ShapeError> {
+    if value.trim().is_empty() || !value.ends_with('Z') {
+        return Err(ShapeError);
+    }
+    let stripped = value.strip_suffix('Z').ok_or(ShapeError)?;
+    let naive =
+        NaiveDateTime::parse_from_str(stripped, "%Y-%m-%dT%H:%M:%S").map_err(|_| ShapeError)?;
+    Ok(DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc))
+}
+
+fn require_nonempty(value: &str) -> Result<(), ShapeError> {
+    if value.trim().is_empty() {
+        Err(ShapeError)
+    } else {
+        Ok(())
+    }
+}
+
+fn require_optional_nonempty(value: Option<&str>) -> Result<(), ShapeError> {
+    if let Some(value) = value {
+        require_nonempty(value)?;
+    }
+    Ok(())
+}
+
+fn require_nonempty_list(values: &[String]) -> Result<(), ShapeError> {
+    if values.is_empty() {
+        return Err(ShapeError);
+    }
+    require_nonempty_list_allow_empty(values)
+}
+
+fn require_nonempty_list_allow_empty(values: &[String]) -> Result<(), ShapeError> {
+    if values.iter().all(|value| !value.trim().is_empty()) {
+        Ok(())
+    } else {
+        Err(ShapeError)
+    }
+}
+
+impl Ord for SourceClass {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.ceiling().cmp(&other.ceiling())
+    }
+}
+
+impl PartialOrd for SourceClass {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/crates/gateway-evidence-replay/src/schema.rs
+++ b/crates/gateway-evidence-replay/src/schema.rs
@@ -22,6 +22,8 @@ pub enum SourceClass {
     ReceiverReceipt,
     BoundaryObserved,
     ThirdPartyObserved,
+    // Deliberate exception to the closed schema: unknown provenance is a
+    // typed fail-closed reason, not a generic malformed shape.
     #[serde(other)]
     Unknown,
 }
@@ -234,6 +236,9 @@ pub struct Evidence {
 impl Evidence {
     fn validate_shape(&self) -> Result<(), ShapeError> {
         require_optional_nonempty(self.attestation_valid_until.as_deref())?;
+        if let Some(value) = self.attestation_valid_until.as_deref() {
+            parse_utc(value)?;
+        }
         require_nonempty(&self.selected_route)?;
         require_optional_nonempty(self.fallback_route.as_deref())?;
         require_optional_nonempty(self.endpoint.as_deref())?;

--- a/crates/gateway-evidence-replay/tests/gateway_path_v0.rs
+++ b/crates/gateway-evidence-replay/tests/gateway_path_v0.rs
@@ -25,7 +25,7 @@ struct Vector {
 #[test]
 fn all_gateway_path_vectors_reproduce() {
     let vectors: VectorFile = serde_json::from_str(VECTORS).expect("vectors parse");
-    assert_eq!(vectors.vectors.len(), 13);
+    assert_eq!(vectors.vectors.len(), 17);
 
     for vector in vectors.vectors {
         let got = verify_json_value(vector.inputs);

--- a/crates/gateway-evidence-replay/tests/gateway_path_v0.rs
+++ b/crates/gateway-evidence-replay/tests/gateway_path_v0.rs
@@ -1,0 +1,141 @@
+use std::fs;
+use std::process::Command;
+
+use gateway_evidence_replay::schema::{Ceiling, NonClaim, Reason, Status};
+use gateway_evidence_replay::verify_json_value;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+const VECTORS: &str = include_str!("../fixtures/gateway-path-v0/vectors.json");
+
+#[derive(Debug, Deserialize)]
+struct VectorFile {
+    vectors: Vec<Vector>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Vector {
+    vector_id: String,
+    inputs: Value,
+    expected_status: Status,
+    expected_ceiling: Option<Ceiling>,
+    expected_reasons: Vec<Reason>,
+}
+
+#[test]
+fn all_gateway_path_vectors_reproduce() {
+    let vectors: VectorFile = serde_json::from_str(VECTORS).expect("vectors parse");
+    assert_eq!(vectors.vectors.len(), 13);
+
+    for vector in vectors.vectors {
+        let got = verify_json_value(vector.inputs);
+        assert_eq!(got.status, vector.expected_status, "{}", vector.vector_id);
+        assert_eq!(got.ceiling, vector.expected_ceiling, "{}", vector.vector_id);
+        assert_eq!(got.reasons, vector.expected_reasons, "{}", vector.vector_id);
+    }
+}
+
+#[test]
+fn cli_verifies_clean_route_as_json() {
+    let bin = env!("CARGO_BIN_EXE_gateway-evidence-replay");
+    let fixture = fixture_path("clean-route.json");
+    let output = Command::new(bin)
+        .args([
+            "verify",
+            fixture.to_str().unwrap(),
+            "--format",
+            "gateway-path.v0",
+            "--json",
+        ])
+        .output()
+        .expect("run gateway-evidence-replay");
+
+    assert!(output.status.success());
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output");
+    assert_eq!(body["profile"], "gateway-path.v0");
+    assert_eq!(body["status"], "path_verified");
+    assert_eq!(body["ceiling"], "observed_in_path");
+    assert_eq!(body["reasons"], json!([]));
+}
+
+#[test]
+fn malformed_json_emits_invalid_result() {
+    let bin = env!("CARGO_BIN_EXE_gateway-evidence-replay");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let evidence = dir.path().join("broken.json");
+    fs::write(&evidence, "{not-json").expect("write malformed evidence");
+
+    let output = Command::new(bin)
+        .args([
+            "verify",
+            evidence.to_str().unwrap(),
+            "--format",
+            "gateway-path.v0",
+            "--json",
+        ])
+        .output()
+        .expect("run gateway-evidence-replay");
+
+    assert!(output.status.success());
+    let body: Value = serde_json::from_slice(&output.stdout).expect("json output");
+    assert_eq!(body["status"], "invalid");
+    assert_eq!(body["reasons"], json!(["malformed_input"]));
+}
+
+#[test]
+fn unknown_fields_fail_closed() {
+    let mut input: Value =
+        serde_json::from_str(include_str!("../fixtures/gateway-path-v0/clean-route.json"))
+            .expect("clean fixture");
+    input["provider_honest"] = json!(true);
+
+    let got = verify_json_value(input);
+    assert_eq!(got.status, Status::Invalid);
+    assert_eq!(got.reasons, vec![Reason::MalformedInput]);
+}
+
+#[test]
+fn malformed_timestamp_fails_closed() {
+    let mut input: Value =
+        serde_json::from_str(include_str!("../fixtures/gateway-path-v0/clean-route.json"))
+            .expect("clean fixture");
+    input["now"] = json!("2026-06-28 10:00:00");
+
+    let got = verify_json_value(input);
+    assert_eq!(got.status, Status::Invalid);
+    assert_eq!(got.reasons, vec![Reason::MalformedInput]);
+}
+
+#[test]
+fn unknown_source_class_is_reported_explicitly() {
+    let mut input: Value =
+        serde_json::from_str(include_str!("../fixtures/gateway-path-v0/clean-route.json"))
+            .expect("clean fixture");
+    input["source_class"] = json!("mystery_box");
+
+    let got = verify_json_value(input);
+    assert_eq!(got.status, Status::Invalid);
+    assert_eq!(got.reasons, vec![Reason::UnknownSourceClass]);
+}
+
+#[test]
+fn output_keeps_claim_ceiling_explicit() {
+    let input: Value =
+        serde_json::from_str(include_str!("../fixtures/gateway-path-v0/clean-route.json"))
+            .expect("clean fixture");
+    let got = verify_json_value(input);
+
+    assert_eq!(got.non_claims, NonClaim::all());
+    let output = serde_json::to_value(got).expect("serialize result");
+    assert_eq!(output.get("provider_honest"), None);
+    assert_eq!(output.get("response_true"), None);
+    assert_eq!(output.get("gateway_enforced"), None);
+}
+
+fn fixture_path(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/fixtures/gateway-path-v0/"
+    ))
+    .join(name)
+}

--- a/docs/superpowers/plans/2026-06-28-gateway-evidence-replay-mvp.md
+++ b/docs/superpowers/plans/2026-06-28-gateway-evidence-replay-mvp.md
@@ -1,0 +1,135 @@
+# Gateway Evidence Replay MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone `gateway-evidence-replay` CLI/library that verifies `gateway-path.v0` evidence bundles and emits bounded replay verdicts.
+
+**Architecture:** Add one isolated Rust workspace crate under `crates/gateway-evidence-replay`. The crate owns a strict `gateway-path.v0` schema, a deterministic replay engine, a JSON CLI, fixtures ported from the lab probe, and package-local tests. It does not integrate into `assay` CLI in this increment and does not perform gateway enforcement, provider verification, or TEE root verification.
+
+**Tech Stack:** Rust 2021 workspace crate, `serde`/`serde_json` for closed schema and output, `clap` for the standalone CLI, `chrono` for strict UTC timestamp parsing, package-local fixtures and integration tests.
+
+---
+
+## Context
+
+The lab probe `gateway-path-evidence-replay-2026-06` found a narrow Gate-D candidate: retained gateway-path evidence can be replayed deterministically to distinguish a verified path from route substitution, hidden fallback, endpoint or policy mismatch, missing stream evidence, stale attestation, and malformed evidence.
+
+SOTA positioning as of June 2026:
+
+- EBGP-style gateway evidence makes the path itself a first-class evidence surface.
+- BIV-style declared-vs-actual auditing owns the broad pre-install classifier space, so this MVP must not become BIV-lite.
+- The defensible product slice is the reproducible replay layer: input facts in, bounded verdict plus reason classes out.
+
+## Non-Goals
+
+- No production gateway enforcement.
+- No network access or provider calls.
+- No cryptographic signature verification or TEE root verification; `signature_verified` and `runtime_measurement_verified` are input facts.
+- No response-truth, provider-honesty, safety, or compliance verdict.
+- No integration into `assay` CLI in this increment.
+
+## Output Contract
+
+CLI:
+
+```bash
+gateway-evidence-replay verify evidence.json --format gateway-path.v0 --json
+```
+
+JSON result:
+
+```json
+{
+  "profile": "gateway-path.v0",
+  "status": "path_verified",
+  "ceiling": "observed_in_path",
+  "reasons": [],
+  "non_claims": [
+    "not_gateway_enforcement",
+    "not_provider_honesty",
+    "not_response_truth",
+    "not_tee_root_verification",
+    "not_safety_or_compliance"
+  ]
+}
+```
+
+Statuses:
+
+- `path_verified`
+- `path_mismatch`
+- `incomplete`
+- `invalid`
+
+Reason classes:
+
+- `route_substitution`
+- `route_not_allowed`
+- `fallback_mismatch`
+- `fallback_not_allowed`
+- `endpoint_mismatch`
+- `policy_hash_mismatch`
+- `stream_commitment_mismatch`
+- `attestation_stale`
+- `attestation_freshness_missing`
+- `stream_evidence_missing`
+- `evidence_not_verified`
+- `coverage_not_complete`
+- `malformed_input`
+- `unknown_source_class`
+
+## Implementation Steps
+
+- [ ] Add `crates/gateway-evidence-replay` to the workspace.
+- [ ] Create `Cargo.toml` with package metadata, workspace lints, a `gateway-evidence-replay` binary, and dependencies on workspace `clap`, `serde`, `serde_json`, and `chrono`.
+- [ ] Implement `src/schema.rs`:
+  - closed `EvidenceBundle`, `Claim`, `Policy`, and `Evidence` structs with `#[serde(deny_unknown_fields)]`;
+  - enums for `Coverage`, `SourceClass`, `Status`, `Reason`, `Ceiling`, and `NonClaim`;
+  - strict non-empty string validation;
+  - strict UTC timestamp parsing for `YYYY-MM-DDTHH:MM:SSZ`;
+  - required `profile == "gateway-path.v0"`.
+- [ ] Implement `src/replay.rs`:
+  - coverage must be complete to confirm;
+  - `signature_verified` and `runtime_measurement_verified` must both be true to proceed;
+  - stale or missing attestation freshness returns `incomplete`;
+  - missing stream commitment returns `incomplete`;
+  - mismatches return sorted reason classes and `path_mismatch`;
+  - clean evidence returns `path_verified` with the source-class ceiling.
+- [ ] Implement `src/lib.rs` exports for `verify_bundle`, result types, and constants.
+- [ ] Implement `src/main.rs`:
+  - `verify <path> --format gateway-path.v0 --json`;
+  - file-read failure is a CLI error;
+  - JSON parse or schema failure emits an `invalid` verdict with `malformed_input`;
+  - `--format` mismatch emits `invalid` with `malformed_input`;
+  - output is deterministic JSON.
+- [ ] Port the 13 lab vectors as fixtures under `crates/gateway-evidence-replay/fixtures/gateway-path-v0/`, adding the required `profile` field.
+- [ ] Add package tests:
+  - all fixtures reproduce expected status, ceiling, and reasons;
+  - the CLI emits JSON for a clean fixture;
+  - unknown fields and malformed timestamps fail closed to `invalid`;
+  - claim guard ensures non-claims remain present and no provider-honesty or response-truth claim appears.
+- [ ] Add a small crate README documenting scope, CLI use, claim ceiling, and non-claims.
+
+## Verification
+
+Run:
+
+```bash
+cargo fmt --all
+cargo test -p gateway-evidence-replay
+cargo run -p gateway-evidence-replay -- verify crates/gateway-evidence-replay/fixtures/gateway-path-v0/clean-route.json --format gateway-path.v0 --json
+cargo clippy -p gateway-evidence-replay -- -D warnings
+```
+
+Expected:
+
+- all package tests pass;
+- the CLI demo returns `path_verified` and `observed_in_path`;
+- malformed evidence returns `invalid`, never a panic;
+- no workspace product integration is touched.
+
+## Follow-Up After This MVP
+
+- Add Assay capture integration only behind a separate Gate-D decision.
+- Add Harness conformance packs only after the CLI/library contract is stable.
+- Revisit external reproduction only when a named external reproducer or public bundle surface exists.

--- a/docs/superpowers/plans/2026-06-28-gateway-evidence-replay-mvp.md
+++ b/docs/superpowers/plans/2026-06-28-gateway-evidence-replay-mvp.md
@@ -28,6 +28,24 @@ SOTA positioning as of June 2026:
 - No response-truth, provider-honesty, safety, or compliance verdict.
 - No integration into `assay` CLI in this increment.
 
+## Claim ceiling (thesis-led experimental MVP)
+
+This MVP lands as a deliberate whitespace bet, not a demand-proven product. This is the first time a lab finding
+becomes product code in Assay, so the bar is higher than "tests green"; the merge is a thesis-led product-gate
+decision, recorded here and in the PR body:
+
+- This is an experimental CLI/library MVP.
+- Demand signal not yet proven.
+- Not BIV-lite (arXiv 2605.11770 owns the broad declared-vs-actual audit space; this stays narrow).
+- Not an EBGP replacement (arXiv 2606.22560 owns the attested gateway-runtime mechanism layer).
+- It implements the replay-verdict layer over RETAINED gateway-path evidence: input facts in, a bounded verdict
+  (`path_verified` / `path_mismatch` / `incomplete` / `invalid`) plus reason classes out, runnable by a third
+  party off the gateway runtime.
+
+The wedge is exactly what EBGP does not provide: a portable, deterministic, bounded-verdict replay corpus/CLI a
+relying party can run on retained evidence. Capture integration, conformance packs, and any public/external
+surface remain separate Gate-D decisions (see Follow-Up).
+
 ## Output Contract
 
 CLI:
@@ -78,6 +96,31 @@ Reason classes:
 - `malformed_input`
 - `unknown_source_class`
 
+## Precedence rules (v0 contract)
+
+The verifier evaluates in this fixed order; the FIRST matching rule decides the verdict. This is the hardened v0
+semantic from the lab repair (`gateway-path-evidence-replay-2026-06`, 17 vectors / 9 tests). The MVP must match
+it exactly so the DoR and the product tell the same contract.
+
+1. **Shape is invalid.** A non-object input, a missing/empty required field, or a present-but-unparsable
+   `attestation_valid_until` is `invalid` / `malformed_input`. A malformed timestamp is a SHAPE error, not an
+   incompleteness.
+2. **Unknown provenance fails early.** An unrecognized `source_class` is `invalid` / `unknown_source_class`
+   BEFORE any path-content evaluation, even when the route visibly mismatches.
+3. **Unverified or stale evidence is incomplete.** `signature_verified` / `runtime_measurement_verified` not
+   both true, or missing/stale attestation freshness, returns `incomplete` - the observation is not trusted
+   enough to refute.
+4. **Observed contradictions refute, regardless of coverage.** Route substitution, disallowed route, fallback
+   mismatch/disallowed fallback, endpoint mismatch, policy-hash mismatch, or stream-commitment mismatch returns
+   `path_mismatch`, including under partial coverage.
+5. **Missing stream evidence is incomplete.** No stream commitment returns `incomplete` (stream evidence is
+   load-bearing); a mismatched stream commitment is `path_mismatch` under rule 4.
+6. **Confirmation requires complete coverage.** Only a clean path under `coverage == complete` returns
+   `path_verified`, at the source-class ceiling. A clean partial/absent bundle is `incomplete`.
+
+The load-bearing rule: **partial coverage can refute but never confirm.** A partial bundle with an observed
+contradiction is `path_mismatch`, not `incomplete`.
+
 ## Implementation Steps
 
 - [ ] Add `crates/gateway-evidence-replay` to the workspace.
@@ -88,13 +131,14 @@ Reason classes:
   - strict non-empty string validation;
   - strict UTC timestamp parsing for `YYYY-MM-DDTHH:MM:SSZ`;
   - required `profile == "gateway-path.v0"`.
-- [ ] Implement `src/replay.rs`:
-  - coverage must be complete to confirm;
-  - `signature_verified` and `runtime_measurement_verified` must both be true to proceed;
-  - stale or missing attestation freshness returns `incomplete`;
+- [ ] Implement `src/replay.rs` (follow the Precedence rules section exactly, in that order):
+  - shape failure, including a present-but-unparsable `attestation_valid_until`, returns `invalid` / `malformed_input`;
+  - an unrecognized `source_class` returns `invalid` / `unknown_source_class` BEFORE any path-content evaluation;
+  - `signature_verified` and `runtime_measurement_verified` must both be true, else `incomplete` / `evidence_not_verified`;
+  - missing or stale attestation freshness returns `incomplete`;
+  - observed contradictions return sorted reason classes and `path_mismatch`, regardless of coverage (partial can still refute);
   - missing stream commitment returns `incomplete`;
-  - mismatches return sorted reason classes and `path_mismatch`;
-  - clean evidence returns `path_verified` with the source-class ceiling.
+  - confirmation requires `coverage == complete`: a clean complete bundle returns `path_verified` at the source-class ceiling; a clean partial/absent bundle is `incomplete`.
 - [ ] Implement `src/lib.rs` exports for `verify_bundle`, result types, and constants.
 - [ ] Implement `src/main.rs`:
   - `verify <path> --format gateway-path.v0 --json`;
@@ -102,7 +146,7 @@ Reason classes:
   - JSON parse or schema failure emits an `invalid` verdict with `malformed_input`;
   - `--format` mismatch emits `invalid` with `malformed_input`;
   - output is deterministic JSON.
-- [ ] Port the 13 lab vectors as fixtures under `crates/gateway-evidence-replay/fixtures/gateway-path-v0/`, adding the required `profile` field.
+- [ ] Port the 17 lab vectors as fixtures under `crates/gateway-evidence-replay/fixtures/gateway-path-v0/`, adding the required `profile` field. The lab probe is 17 vectors / 9 tests after the precedence hardening; include the partial-coverage-refute, unknown-source-early, and malformed-attestation-invalid vectors.
 - [ ] Add package tests:
   - all fixtures reproduce expected status, ceiling, and reasons;
   - the CLI emits JSON for a clean fixture;

--- a/scripts/ci/check-public-crate-policy.sh
+++ b/scripts/ci/check-public-crate-policy.sh
@@ -46,6 +46,7 @@ non_crates_io_crates=(
   assay-it
   assay-ebpf
   assay-xtask
+  gateway-evidence-replay
 )
 
 command -v cargo >/dev/null 2>&1 || { echo "cargo missing" >&2; exit 1; }


### PR DESCRIPTION
Adds the standalone `gateway-evidence-replay` CLI/library as the Gate-D v0 for gateway-path evidence replay.

Scope:
- new workspace crate `crates/gateway-evidence-replay`
- strict closed `gateway-path.v0` schema
- deterministic replay engine over route, fallback, endpoint, policy hash, stream commitment, evidence verification facts, coverage, source class, and freshness
- standalone CLI: `gateway-evidence-replay verify evidence.json --format gateway-path.v0 --json`
- 13 fixture vectors ported from the lab probe, with product-level `profile` and explicit `unknown_source_class` reason
- claim guard: no gateway enforcement, provider honesty, response truth, TEE root, safety, or compliance claim

Positioning:
This is not BIV-lite and not a gateway/TEE verifier. It is the deterministic replay layer for retained gateway-path evidence: input facts in, bounded verdict plus reason classes out. Signature and runtime-measurement verification remain input facts.

Verification:
- `cargo fmt --all`
- `cargo test -p gateway-evidence-replay`
- `cargo run -p gateway-evidence-replay -- verify crates/gateway-evidence-replay/fixtures/gateway-path-v0/clean-route.json --format gateway-path.v0 --json`
- `cargo clippy -p gateway-evidence-replay -- -D warnings`
- pre-push hooks: cargo fmt, cargo audit, workspace clippy, linux compile gate

Held for review; no Assay CLI integration in this increment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline evidence replay checker for gateway-path bundles.
  * Introduced a new command-line tool that verifies a bundle from a file and can output either compact or JSON results.
  * Added clear verification outcomes for valid, mismatched, incomplete, and invalid bundles.

* **Documentation**
  * Added usage guidance and output expectations for the new verifier.

* **Tests**
  * Added coverage for verified paths, malformed input, unknown fields, and timestamp handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Claim ceiling (thesis-led experimental MVP)

Merge decision is **thesis-led, not demand-led**: this is the first lab finding to become product code in Assay, so it lands as a deliberate whitespace bet to open the retained-evidence / replay-verdict lane.

- This is an experimental CLI/library MVP.
- Demand signal not yet proven.
- Not BIV-lite (arXiv 2605.11770 owns the broad declared-vs-actual audit space).
- Not an EBGP replacement (arXiv 2606.22560 owns the attested gateway-runtime mechanism layer).
- Implements the replay-verdict layer over retained gateway-path evidence: facts in, bounded verdict (`path_verified` / `path_mismatch` / `incomplete` / `invalid`) + reason classes out, runnable off the gateway runtime.

v0 semantics are hardened to match the lab repair (Rul1an/assay-tunnel-experiments#173, 17 vectors / 9 tests): partial coverage can refute but never confirm; unknown `source_class` is early-invalid; a malformed attestation timestamp is invalid. Capture integration, conformance packs, and any public surface remain separate Gate-D decisions.