### PR TITLE
fix(render-safety): strip C1 terminal controls

### DIFF
--- a/crates/assay-core/src/render_safety/corpus.rs
+++ b/crates/assay-core/src/render_safety/corpus.rs
@@ -48,6 +48,7 @@ lazy_static! {
             p("email", "pii", "alice@example.com".to_string(), "alice@example.com".to_string()),
             p("slack_user_id", "pii", "U01ABCDEFG".to_string(), "U01ABCDEFG".to_string()),
             p("ansi_escape", "control", "\u{1b}[31mRED\u{1b}[0m".to_string(), "\u{1b}".to_string()),
+            p("c1_csi", "control", "\u{009b}31mRED".to_string(), "\u{009b}".to_string()),
             p("unicode_bidi", "control", "\u{202e}reversed\u{202c}".to_string(), "\u{202e}".to_string()),
             // Secret near the truncation boundary: guards redact-before-truncate.
             p("long_secret_prefix", "secret", boundary, "ghp_".to_string()),

--- a/crates/assay-core/src/render_safety/mod.rs
+++ b/crates/assay-core/src/render_safety/mod.rs
@@ -120,7 +120,7 @@ lazy_static! {
     static ref LONE_ESC: Regex = Regex::new(r"\x1b").unwrap();
     // C0/C1 control (keep \t \n \r), DEL, and Unicode bidi formatting overrides.
     static ref CONTROL_RE: Regex =
-        Regex::new(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\u{202a}-\u{202e}\u{2066}-\u{2069}]").unwrap();
+        Regex::new(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\u{80}-\u{9f}\u{202a}-\u{202e}\u{2066}-\u{2069}]").unwrap();
 }
 
 /// Strip terminal-control: ANSI/OSC sequences, BEL, other C0/C1 controls (keeping tab/newline/CR),
@@ -141,6 +141,7 @@ pub fn has_residual_control(s: &str) -> bool {
             || c == '\u{0b}'
             || c == '\u{0c}'
             || ('\u{0e}'..='\u{1f}').contains(&c)
+            || ('\u{80}'..='\u{9f}').contains(&c)
             || ('\u{202a}'..='\u{202e}').contains(&c)
             || ('\u{2066}'..='\u{2069}').contains(&c)
     })

--- a/crates/assay-core/tests/bombadil_no_raw_control_rendered.rs
+++ b/crates/assay-core/tests/bombadil_no_raw_control_rendered.rs
@@ -1,0 +1,42 @@
+//! Runnable example for the Bombadil-style `noRawControlRendered` property.
+//!
+//! The property is intentionally smaller than Assay's full chrome/viewer proof: after untrusted
+//! content is rendered for a sink, raw terminal-control bytes must not reach the rendered cell.
+
+use assay_core::render_safety::{has_residual_control, render_safe, Sink, MAX_RENDER_FIELD};
+
+#[test]
+fn no_raw_control_rendered_blocks_esc_bel_and_c1_csi() {
+    let probes = [
+        ("ansi_esc_csi", "\u{1b}[31mred\u{1b}[0m"),
+        ("bel", "status\u{7}done"),
+        ("c1_csi", "\u{009b}31mred"),
+    ];
+
+    for sink in Sink::ALL {
+        for (name, input) in probes {
+            let rendered = render_safe(sink, input, MAX_RENDER_FIELD);
+
+            assert!(
+                !rendered.contains('\u{1b}'),
+                "{name} leaked raw ESC in {}: {rendered:?}",
+                sink.as_str()
+            );
+            assert!(
+                !rendered.contains('\u{7}'),
+                "{name} leaked raw BEL in {}: {rendered:?}",
+                sink.as_str()
+            );
+            assert!(
+                !rendered.contains('\u{009b}'),
+                "{name} leaked raw 8-bit CSI in {}: {rendered:?}",
+                sink.as_str()
+            );
+            assert!(
+                !has_residual_control(&rendered),
+                "{name} left residual terminal control in {}: {rendered:?}",
+                sink.as_str()
+            );
+        }
+    }
+}

--- a/crates/assay-core/tests/fixtures/render_safety_conformance.v0.golden.json
+++ b/crates/assay-core/tests/fixtures/render_safety_conformance.v0.golden.json
@@ -1,11 +1,11 @@
 {
   "schema": "assay.render_safety_conformance.v0",
-  "corpus_digest": "sha256:c903b6ec1246f0b4298f3e07f41346c0803873cf5f91a0a63cb1e75e5652eb5c",
+  "corpus_digest": "sha256:685c3e43b896be810c9ac218953352b5ca39386562d9cff9f0719f030760accd",
   "sinks": [
     {
       "sink": "stdout",
       "renderer": "assay-core",
-      "hostile_probe_count": 10,
+      "hostile_probe_count": 11,
       "benign_control_count": 5,
       "raw_secret_leak_count": 0,
       "raw_pii_leak_count": 0,
@@ -17,7 +17,7 @@
     {
       "sink": "json",
       "renderer": "assay-core",
-      "hostile_probe_count": 10,
+      "hostile_probe_count": 11,
       "benign_control_count": 5,
       "raw_secret_leak_count": 0,
       "raw_pii_leak_count": 0,
@@ -29,7 +29,7 @@
     {
       "sink": "sarif",
       "renderer": "assay-core",
-      "hostile_probe_count": 10,
+      "hostile_probe_count": 11,
       "benign_control_count": 5,
       "raw_secret_leak_count": 0,
       "raw_pii_leak_count": 0,
@@ -41,7 +41,7 @@
     {
       "sink": "junit",
       "renderer": "assay-core",
-      "hostile_probe_count": 10,
+      "hostile_probe_count": 11,
       "benign_control_count": 5,
       "raw_secret_leak_count": 0,
       "raw_pii_leak_count": 0,
@@ -53,7 +53,7 @@
     {
       "sink": "markdown",
       "renderer": "assay-core",
-      "hostile_probe_count": 10,
+      "hostile_probe_count": 11,
       "benign_control_count": 5,
       "raw_secret_leak_count": 0,
       "raw_pii_leak_count": 0,
@@ -65,7 +65,7 @@
     {
       "sink": "otel",
       "renderer": "assay-core",
-      "hostile_probe_count": 10,
+      "hostile_probe_count": 11,
       "benign_control_count": 5,
       "raw_secret_leak_count": 0,
       "raw_pii_leak_count": 0,

--- a/docs/examples/render-safety-no-raw-control-rendered.md
+++ b/docs/examples/render-safety-no-raw-control-rendered.md
@@ -1,0 +1,32 @@
+# Render Safety: no raw control rendered
+
+This is the Assay runnable example for the narrow `noRawControlRendered`
+property: untrusted content may contain terminal control bytes, but raw control
+must not reach a rendered sink cell.
+
+The example is deliberately smaller than Assay's full terminal-viewer proof. It
+does not assert anything about chrome layout, header stability, cursor position,
+or a particular terminal UI. It only asserts the reusable sink boundary:
+
+- raw ESC (`0x1b`) does not survive rendering;
+- raw BEL (`0x07`) does not survive rendering;
+- raw C1 / 8-bit CSI (`0x9b`) does not survive rendering;
+- the same property holds across Assay's stdout, JSON, SARIF, JUnit, Markdown,
+  and OTel render sinks.
+
+The test drives the real `assay-core` render-safety pipeline:
+
+```bash
+cargo test -p assay-core no_raw_control_rendered_blocks_esc_bel_and_c1_csi -- --nocapture
+```
+
+The broader release-gate witness is pinned separately as
+`assay.render_safety_conformance.v0`. It runs the shared hostile/benign corpus
+through every sink and requires `terminal_control_leak_count == 0` for each sink:
+
+```bash
+cargo test -p assay-core conformance_matches_golden_fixture -- --nocapture
+```
+
+The conformance corpus includes a C1 CSI probe, so the golden digest changes if
+that coverage is removed.


### PR DESCRIPTION
## Summary

Adds the OSS runnable example for the narrow `noRawControlRendered` property and hardens Assay's real render-safety path to cover C1 terminal controls.

Root cause: the render-safety comments described C0/C1 control stripping, but the implementation and residual-control predicate only covered C0, DEL, ESC-introduced ANSI/OSC, and bidi controls. A raw C1 / 8-bit CSI byte (`0x9b`, represented as `U+009B`) could survive rendering.

## Changes

- Strip C1 control characters (`U+0080..U+009F`) in the shared render-safety pipeline.
- Treat C1 controls as residual terminal control in the leak predicate.
- Add a C1 CSI hostile probe to `assay.render_safety_conformance.v0` and repin the golden fixture.
- Add a focused runnable example test for ESC, BEL, and C1 CSI across every render sink.
- Add docs for the narrow property and the exact commands to run it.

## Scope

This is not a chrome/layout/viewer proof. It only asserts the reusable sink boundary: raw terminal-control bytes must not reach rendered cells after untrusted content is rendered.

## Verification

- `cargo test -p assay-core no_raw_control_rendered_blocks_esc_bel_and_c1_csi -- --nocapture`
- `ASSAY_UPDATE_GOLDEN=1 cargo test -p assay-core conformance_matches_golden_fixture -- --nocapture`
- `cargo test -p assay-core --test bombadil_no_raw_control_rendered -- --nocapture`
- `cargo test -p assay-core --test render_safety_conformance -- --nocapture`
- `cargo test -p assay-core render_safe_never_leaks_across_sinks -- --nocapture`
- `cargo fmt --all -- --check`
- pre-push hooks: cargo fmt check, clippy workspace deny warnings, linux compile gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new render-safety example that shows how to verify control characters do not appear in rendered output across supported formats.

* **Bug Fixes**
  * Improved control-character handling so additional C1/8-bit control bytes are recognized and stripped correctly.
  * Expanded safety checks to cover an extra hostile control-sequence case.

* **Tests**
  * Added broader validation to ensure rendered output contains no raw terminal control bytes or leftover control sequences across all render destinations.

* **Documentation**
  * Added guidance and commands for running the new render-safety example and conformance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->