### PR TITLE
fix(ci): close shell-injection in mcp-registry-publish tag resolution

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -37,26 +37,37 @@ jobs:
     steps:
       - name: Resolve release tag
         id: tag
+        # Tag/input values reach the shell only via env, never via ${{ }} inside run:
+        # a release tag name is attacker-influenceable input (git refnames allow quotes
+        # and semicolons), and ${{ }} is substituted before bash parses the script.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "release" ]; then
-            tag="${{ github.event.release.tag_name }}"
+          if [ "$EVENT_NAME" = "release" ]; then
+            tag="$RELEASE_TAG"
           else
-            tag="${{ inputs.version }}"
+            tag="$INPUT_VERSION"
           fi
-          case "$tag" in
-            v[0-9]*) ;;
-            *) echo "::error::expected a vX.Y.Z release tag, got '$tag'"; exit 1 ;;
-          esac
+          # [[ =~ ]] anchors on the whole string (grep -E matches per line, which
+          # would let a newline-bearing dispatch input smuggle a second
+          # GITHUB_OUTPUT line past the check).
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::expected a vX.Y.Z release tag, got '$tag'"
+            exit 1
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Download server.json from the release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          gh release download "${{ steps.tag.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
+          gh release download "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
             --pattern server.json \
             --dir .
           test -s server.json


### PR DESCRIPTION
## Summary

Closes a shell-injection path in the MCP registry publish workflow. `mcp-registry-publish.yml` interpolated `github.event.release.tag_name` and `inputs.version` directly into a `run:` block. `${{ }}` is substituted before bash parses the script, so the `case "$tag" in v[0-9]*)` guard ran *after* the injection point and could not prevent it.

Git refnames permit quotes and semicolons, and this job holds `id-token: write` for OIDC publish to the official MCP registry. A party able to create a release (a leaked PAT with `contents:write`, a GitHub App with releases scope) but without workflow-edit rights could run arbitrary code in a runner that carries registry-publish OIDC. Narrow, but it is exactly the privilege boundary this workflow exists to protect.

## Fix

- Pass every attacker-influenceable value (event name, release tag, dispatch input, repository) through an `env:` block so bash treats them as data, never as script.
- Replace the permissive `case` glob with an anchored `[[ =~ ]]` full-string match: semver plus an optional pre-release suffix.
- The anchored match also rejects newline-bearing inputs. A per-line `grep -E` would let a `workflow_dispatch` input containing a newline smuggle a second `tag=...` line into `GITHUB_OUTPUT`; the whole-string `[[ =~ ]]` refuses it.

No behavior change for valid `vX.Y.Z` tags.

## Verification

- `actionlint`: clean
- `zizmor`: no findings (the template-injection alert is resolved)
- YAML parses; pre-commit fmt gate passed
- Tag-pattern matrix:
  - PASS: `v3.31.1`, `v3.25.0`, `v10.0.0-rc.1`, `v1.2.3-beta`
  - REJECT: `v1`, `v1.2`, `v1"; curl evil`, newline variants, `1.2.3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release tag handling to make publishing more reliable and consistent.
  * Added stricter tag validation to reduce the risk of invalid release data being processed.
  * Simplified release download steps to use the resolved tag value throughout the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->