### PR TITLE
ci: fix workflow action pin labels

### DIFF
--- a/.github/workflows/host-capability-proof.yml
+++ b/.github/workflows/host-capability-proof.yml
@@ -70,7 +70,7 @@ jobs:
           python3 -c "import json; print(json.dumps(json.load(open('proof-out/doctor.json'))['landlock'], indent=2))"
 
       - name: Upload proof artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: host-capability-proof
           path: proof-out/

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run OSV scanner
         id: osv-scan
-        uses: google/osv-scanner-action/osv-scanner-action@fa4ff678dd5d0a4fa3d628e57af8162873e93cd6 # v2.3.8
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
           scan-args: ${{ steps.osv-targets.outputs.scan_args }}
         continue-on-error: true
@@ -136,7 +136,7 @@ jobs:
           fi
 
       - name: Build advisory SARIF
-        uses: google/osv-scanner-action/osv-reporter-action@fa4ff678dd5d0a4fa3d628e57af8162873e93cd6 # v2.3.8
+        uses: google/osv-scanner-action/osv-reporter-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
           scan-args: |-
             --output=osv-results.sarif


### PR DESCRIPTION
## Summary\n\n- correct the host-capability upload-artifact comment to the pinned v7.0.1 SHA\n- repin the scheduled OSV scanner/reporter actions to the actual v2.3.8 tag SHA instead of an untagged commit labelled as v2.3.8\n- move the OSV scan outcome expression into env before shell use so zizmor no longer reports template-injection risk\n\n## Verification\n\n- uvx --with pyyaml python3 YAML parse for the touched workflows\n- actionlint .github/workflows/host-capability-proof.yml .github/workflows/osv-scanner-scheduled.yml\n- zizmor .github/workflows/host-capability-proof.yml .github/workflows/osv-scanner-scheduled.yml\n- git diff --check\n\n## Scope\n\nNo OSV target scoping change in this PR. The examples/runner-fixtures scan decision is policy-level and should stay separate from this pin hygiene fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a few automated workflow components to newer versions.
  * Kept the same artifact handling, scheduling, and reporting behavior while refreshing behind-the-scenes maintenance steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->