### PR TITLE
ci: harden workflow token handling and permissions

### DIFF
--- a/.github/workflows/assay.yml
+++ b/.github/workflows/assay.yml
@@ -1,5 +1,7 @@
 name: Assay Gate
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   assay:
     runs-on: ubuntu-latest

--- a/.github/workflows/demo-smoke.yml
+++ b/.github/workflows/demo-smoke.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
       - name: Build assay-mcp-server
         run: cargo build -q -p assay-mcp-server
       - name: Smoke-test the example (verdicts match expected-output.txt)

--- a/.github/workflows/monitor-attach-smoke.yml
+++ b/.github/workflows/monitor-attach-smoke.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Build assay-cli
         run: cargo build -p assay-cli --release

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Validate OSV scanner result
         shell: bash
+        env:
+          OSV_OUTCOME: ${{ steps.osv-scan.outcome }}
         run: |
           set -euo pipefail
 
@@ -128,7 +130,7 @@ jobs:
 
           echo "osv-vulnerability-results=$vuln_count"
 
-          if [ "${{ steps.osv-scan.outcome }}" != "success" ] && [ "$vuln_count" -eq 0 ]; then
+          if [ "$OSV_OUTCOME" != "success" ] && [ "$vuln_count" -eq 0 ]; then
             echo "::error::OSV scanner exited non-zero without vulnerability results; treating this as scanner execution failure"
             exit 1
           fi

--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -11,6 +11,9 @@ on:
         required: false
         default: '30'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary

Resolves the remaining `zizmor` findings across the CI workflows, outside the registry-publish shell-injection fix already tracked in #1771. Together the two PRs bring the workflow set to zero non-suppressed `zizmor` findings.

Three finding classes, all low-blast-radius hardening, no behavior change:

### `artipacked` — credential persistence (2 files)
`demo-smoke.yml` and `monitor-attach-smoke.yml` checked out the repo without `persist-credentials: false`, leaving the job's `GITHUB_TOKEN` credential in the runner's `.git/config` where a later step or a cached artifact could read it. Neither job pushes, so credential persistence is disabled.

### `template-injection` — `steps.*.outcome` in a run block (1 file)
`osv-scanner-scheduled.yml` interpolated `${{ steps.osv-scan.outcome }}` directly into a `run:` block. The value is a GitHub-controlled enum (`success`/`failure`/`cancelled`/`skipped`), so this is low-confidence, but routing it through `env` keeps the `run:` body free of `${{ }}` expansion as a standing rule.

### `token-permissions` — missing top-level block (2 files)
`assay.yml` and `perf_nightly.yml` had no top-level `permissions:` block. Added `permissions: contents: read` so a future-added job cannot silently inherit a broader default. Both existing single jobs already declare `contents: read`, so there is no change to current behavior.

## Verification

- `actionlint`: clean on all five files
- `zizmor`: all five files report **no findings** (the 2 `artipacked` + 1 `template-injection` are resolved)
- YAML parses on all five

## Scope

Workflow YAML only. No Rust, no behavior change, no version bump. The `mcp-registry-publish.yml` template-injection findings are intentionally **not** here; they are fixed in #1771.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use more restrictive access settings and avoid retaining checkout credentials.
  * Improved validation handling in scheduled checks for more consistent results.
  * Aligned workflow permissions across several automation jobs for better security and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->