### PR TITLE
[codex] unblock quick-xml RustSec advisory gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,11 @@ jobs:
         run: |
           rm -rf ~/.cargo/advisory-db
           # RUSTSEC-2023-0071 (rsa Marvin Attack): no fixed upgrade; assay-mcp-server JWT (see deny.toml)
-          cargo audit --ignore RUSTSEC-2023-0071
+          # RUSTSEC-2026-0194/0195 (quick-xml): transitive via object_store 0.14.0; no compatible upgrade yet (see deny.toml)
+          cargo audit \
+            --ignore RUSTSEC-2023-0071 \
+            --ignore RUSTSEC-2026-0194 \
+            --ignore RUSTSEC-2026-0195
 
   clippy:
     name: Clippy (deny warnings)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,8 +98,9 @@ repos:
         name: cargo audit (RustSec)
         # Keep the ignore list in lockstep with .github/workflows/ci.yml and deny.toml: these
         # advisories are triaged as not reachable (rsa Marvin Attack; pyo3 0.24 nth/nth_back and
-        # PyCFunction::new_closure), retired by the pyo3 0.29 migration (#1651).
-        entry: bash -lc 'cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0176 --ignore RUSTSEC-2026-0177'
+        # PyCFunction::new_closure), retired by the pyo3 0.29 migration (#1651). quick-xml
+        # RUSTSEC-2026-0194/0195 is temporarily blocked by object_store 0.14.0 (see deny.toml).
+        entry: bash -lc 'cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0176 --ignore RUSTSEC-2026-0177 --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195'
         language: system
         pass_filenames: false
         files: ^Cargo\.lock$

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,12 @@ ignore = [
     # rsa: transitive via jsonwebtoken (assay-mcp-server). No safe upgrade; timing sidechannel.
     # JWT verification is server-side; accept risk for MCP auth until jsonwebtoken/rsa offer a fix.
     "RUSTSEC-2023-0071",
+
+    # quick-xml: transitive via object_store 0.14.0. No compatible upgrade yet:
+    # object_store pins quick-xml ^0.40.1, while the fixed quick-xml is >=0.41.0.
+    # Remove both ignores when object_store releases a version that allows quick-xml >=0.41.0.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Temporarily ignore RUSTSEC-2026-0194 and RUSTSEC-2026-0195 in `deny.toml`.
- Keep the CI `cargo audit` command and pre-push `cargo-audit` hook in lockstep with the same quick-xml ignores.
- Document the removal condition: delete the ignores once `object_store` releases a compatible version that allows `quick-xml >=0.41.0`.

## Root Cause
- PR #1776 and new PRs are blocked by dependency-security drift, not by their diffs.
- `quick-xml v0.40.1` is pulled transitively through `object_store v0.14.0 -> assay-evidence`.
- `quick-xml 0.41.0` is fixed, but `object_store 0.14.0` requires `quick-xml = ^0.40.1`, and crates.io currently has no newer `object_store` release.

## Validation
- `cargo info object_store` confirmed `0.14.0` is the latest release.
- `cargo update -p quick-xml --precise 0.41.0` fails because `object_store v0.14.0` requires `^0.40.1`.
- `cargo deny check advisories bans licenses sources`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195`
- `uvx pre-commit run check-yaml --files .github/workflows/ci.yml .pre-commit-config.yaml`
- `uvx pre-commit run cargo-deny --all-files`
- `uvx pre-commit run cargo-audit --all-files --hook-stage pre-push`
- Pre-push hook: fmt, workflow lint, cargo-deny, workspace clippy, linux compile gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency security checks to account for additional known RustSec advisories.
  * Kept automated checks aligned across CI and local pre-commit workflows.
  * Added notes to clarify why the advisories are temporarily ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->