### PR TITLE
chore: discoverability pass

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.2.0
+message: "If you use Assay in research or reference its evidence format, please cite it as below."
+title: "Assay: policy-as-code and verifiable evidence for MCP agents"
+type: software
+authors:
+  - name: "The Assay authors"
+repository-code: "https://github.com/Rul1an/assay"
+url: "https://getassay.dev"
+license: MIT
+keywords:
+  - mcp
+  - ai-agents
+  - policy-as-code
+  - evidence
+  - ebpf

--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ Tool-decision path latency on an M1 Pro fragmented-IPI harness: main protection 
 
 </details>
 
+## Ecosystem
+
+Repositories that compose with Assay's evidence layer:
+
+- [assay-action](https://github.com/Rul1an/assay-action) — GitHub Action: verify bundles, PR summaries, SARIF ([Marketplace](https://github.com/marketplace/actions/assay-ai-agent-security)).
+- [Assay-Harness](https://github.com/Rul1an/Assay-Harness) — recipe, gate, and report layer over canonical evidence artifacts.
+- [observed-effect-v0](https://github.com/Rul1an/observed-effect-v0) — worked examples of the bounded observed-effect evidence record and its neutral carriers (in-toto, SCITT, MCP evidenceRef).
+- [gateway-evidence-replay](https://github.com/Rul1an/gateway-evidence-replay) — deterministic offline replay verifier for gateway-path evidence bundles.
+- [RGE-Bench](https://github.com/rge-bench/rge-bench) — a neutral, externally reproduced conformance kit for evidence reviewability, maintained separately under its own machine-checked neutrality guard.
+
 ## Contributing
 
 ```bash

--- a/assay-python-sdk/pyproject.toml
+++ b/assay-python-sdk/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Quality Assurance",
 ]
-keywords = ["assay", "policy", "testing", "coverage", "tracing"]
+keywords = ["assay", "policy", "testing", "coverage", "tracing", "mcp", "ai-agents", "agent-security", "evidence"]
 dynamic = ["version"]
 
 [project.urls]

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,25 @@
+# Assay
+
+> Policy-as-code for MCP agents: a deterministic, fail-closed gate for MCP tool calls, with kernel-level (eBPF/LSM) enforcement on Linux and offline-verifiable evidence bundles. CI-native, no hosted backend. Every claim carries its basis (verified, self_reported, inferred, absent) and never exceeds what was observed.
+
+Assay answers two questions: how do I deny a risky MCP tool call before it runs, and how do I prove afterwards what an AI agent actually did, without taking the agent's own report on trust. A tool returning "success" is the provider's assertion, never proof; recomputing a record confirms what its issuer recorded, and signing raises tamper-evidence, not vantage.
+
+## Docs
+
+- [README](https://github.com/Rul1an/assay/blob/main/README.md): overview, quickstart, enforce/prove/stay-honest model
+- [OWASP MCP Top 10 mapping](https://github.com/Rul1an/assay/blob/main/docs/security/OWASP-MCP-TOP10-MAPPING.md): per-risk mapping of the gate and the evidence layer
+- [MCP quickstart](https://github.com/Rul1an/assay/tree/main/examples/mcp-quickstart): wrap any MCP server with a policy in one command
+- [CI guide](https://github.com/Rul1an/assay/blob/main/docs/guides/github-action.md): PR gates, SARIF, evidence artifacts
+
+## Install
+
+- Rust CLI: `cargo install assay-cli` (the crate is assay-cli; the unrelated crate named assay is a test macro by another author)
+- Python SDK: `pip install assay-it`
+- GitHub Action: https://github.com/marketplace/actions/assay-ai-agent-security
+- MCP registry: io.github.Rul1an/assay-mcp-server
+
+## Ecosystem
+
+- [observed-effect-v0](https://github.com/Rul1an/observed-effect-v0): bounded, recomputable observed-effect evidence records with neutral carriers
+- [gateway-evidence-replay](https://github.com/Rul1an/gateway-evidence-replay): deterministic offline replay verifier for gateway-path evidence
+- [RGE-Bench](https://github.com/rge-bench/rge-bench): neutral, externally reproduced conformance kit for evidence reviewability


### PR DESCRIPTION
Four small discoverability additions, no code changes.

- **README Ecosystem section**: the five composing repositories were invisible from the hub; each line states what the repo is, and the RGE-Bench line is worded to respect that kit's neutrality guard.
- **CITATION.cff**: makes the repo citable (GitHub renders the cite button; feeds scholarly indexing).
- **llms.txt**: the July-2026 discovery layer; AI assistants answering "how do I firewall MCP tool calls" or "prove what my agent did" get a canonical, bounded summary with install paths (including the assay-cli vs assay crate-name disambiguation).
- **PyPI keywords**: adds mcp / ai-agents / agent-security / evidence to assay-it (takes effect on next publish).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new ecosystem section in the README with links to related integrations and companion projects.
  * Added a new policy-and-docs reference file with quick access to setup, usage, and ecosystem resources.
* **Chores**
  * Added project citation metadata for easier academic and tooling references.
  * Updated package metadata keywords to improve discoverability around agent security and evidence-related topics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->